### PR TITLE
fix(cron): use selected account for CLI announce delivery

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -589,6 +589,7 @@ function createCronPromptExecutor(params: {
                 cliSessionBinding: guardedCliSessionBinding,
                 skillsSnapshot: params.skillsSnapshot,
                 messageChannel,
+                agentAccountId: params.resolvedDelivery.accountId,
                 sourceReplyDeliveryMode,
                 requireExplicitMessageTarget: sourceDelivery.messageTool.requireExplicitTarget,
                 cliSessionBindingFacts: {

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -796,21 +796,87 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     ).toBeUndefined();
   });
 
-  it("passes the resolved delivery account to CLI-backed announce runs", async () => {
+  it("binds the resolved delivery account to account-implicit CLI message sends", async () => {
     mockCliAnnounceRun();
-    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan({ accountId: "bot-a" }));
-    resolveDeliveryTargetMock.mockResolvedValue(makeResolvedAnnounceTarget({ accountId: "bot-a" }));
-
-    await runCronIsolatedAgentTurn({
-      ...makeParams(),
-      job: makeAnnounceMessageToolJob({ delivery: { accountId: "bot-a" } }),
+    resolveCronDeliveryPlanMock.mockReturnValue(
+      makeAnnounceDeliveryPlan({ channel: "telegram", accountId: "bot-a" }),
+    );
+    resolveDeliveryTargetMock.mockResolvedValue(
+      makeResolvedAnnounceTarget({ channel: "telegram", accountId: "bot-a" }),
+    );
+    let messageActionInput: Record<string, unknown> | undefined;
+    runCliAgentMock.mockImplementation(async (runParams: unknown) => {
+      const [{ buildCliMcpGrantContext }, { createMessageTool }] = await Promise.all([
+        import("../../agents/cli-runner/mcp-grant-context.js"),
+        import("../../agents/tools/message-tool-execution.js"),
+      ]);
+      const grant = buildCliMcpGrantContext({
+        run: runParams as never,
+        config: {},
+        requireExplicitMessageTarget: true,
+        agentId: "default",
+        modelProvider: "openai",
+        modelId: "gpt-5.4",
+      });
+      const tool = createMessageTool({
+        agentAccountId: grant.accountId,
+        currentChannelProvider: grant.messageProvider,
+        requireExplicitTarget: grant.requireExplicitMessageTarget,
+        preparedMessageToolCatalog: { version: 0, channels: [], getChannel: () => undefined },
+        getRuntimeConfig: () => ({}),
+        runMessageAction: async (input) => {
+          messageActionInput = input as unknown as Record<string, unknown>;
+          return {
+            kind: "send",
+            action: "send",
+            channel: "telegram",
+            to: "123",
+            handledBy: "plugin",
+            payload: {},
+            dryRun: false,
+          };
+        },
+      });
+      const messageArgs = {
+        action: "send",
+        channel: "telegram",
+        target: "123",
+        message: "done",
+      };
+      await tool.execute("call-1", messageArgs);
+      return makeMessageToolRunResult([
+        { tool: "message", provider: messageArgs.channel, to: messageArgs.target },
+      ]);
     });
 
-    expectRecordFields(
-      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
-      { agentAccountId: "bot-a" },
-      "CLI run params",
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob({
+        delivery: { channel: "telegram", accountId: "bot-a" },
+      }),
+    });
+
+    expectRecordFields(messageActionInput, { defaultAccountId: "bot-a" }, "message action input");
+    const actionParams = expectRecordFields(
+      messageActionInput?.params,
+      { channel: "telegram", target: "123" },
+      "message action params",
     );
+    expect(actionParams.accountId).toBeUndefined();
+    expect(result.status).toBe("ok");
+    expectDeliveryFields(result.delivery, {
+      intended: { channel: "telegram", to: "123", accountId: "bot-a", source: "explicit" },
+      resolved: {
+        ok: true,
+        channel: "telegram",
+        to: "123",
+        accountId: "bot-a",
+        source: "explicit",
+      },
+      messageToolSentTo: [{ channel: "telegram", to: "123" }],
+      fallbackUsed: false,
+      delivered: true,
+    });
   });
 
   it("propagates restricted toolsAllow to CLI-backed announce runs without target metadata", async () => {

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -796,6 +796,23 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     ).toBeUndefined();
   });
 
+  it("passes the resolved delivery account to CLI-backed announce runs", async () => {
+    mockCliAnnounceRun();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan({ accountId: "bot-a" }));
+    resolveDeliveryTargetMock.mockResolvedValue(makeResolvedAnnounceTarget({ accountId: "bot-a" }));
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob({ delivery: { accountId: "bot-a" } }),
+    });
+
+    expectRecordFields(
+      getMockCallArg(runCliAgentMock, 0, 0, "CLI run"),
+      { agentAccountId: "bot-a" },
+      "CLI run params",
+    );
+  });
+
   it("propagates restricted toolsAllow to CLI-backed announce runs without target metadata", async () => {
     mockCliAnnounceRun();
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where isolated cron announce jobs using a CLI-backed agent could send through the channel's default account instead of the account selected by the job. A successful send through the wrong account could then suppress the scheduler's direct fallback because the delivery evidence otherwise matched the target channel and recipient.

## Why This Change Was Made

Pass the already-resolved delivery account into the CLI agent run, matching the existing embedded-agent path and the CLI message tool's account-scoping contract. This intentionally leaves source-target matching and finalization semantics unchanged.

The follow-up verifier concern about account-less delivery evidence is resolved at the owner boundary rather than by tightening evidence matching: the immutable CLI grant carries the resolved account into `createMessageTool`, whose implicit-account send supplies it as `runMessageAction.defaultAccountId`. Trusted evidence may therefore omit the account even though the actual send is bound to the selected account. Rejecting such evidence would break valid embedded and CLI sends.

## User Impact

Multi-account operators can expect CLI-backed cron announce sends to use the account configured or resolved for that job rather than an unrelated default account.

## Evidence

- Behavior-level regression executes an account-implicit Telegram message-tool send through the real CLI grant builder and message-tool account selector, observes `defaultAccountId: "bot-a"`, and proves trusted account-less evidence suppresses fallback only after that bound send.
- Exact-head owner suite: 58/58 passed; focused behavior repeated 3/3; adjacent grant and delivery-plan suites: 31/31 passed.
- Negative control: removing the production propagation line makes the behavior regression fail with `expected undefined to deeply equal 'bot-a'`.
- `pnpm check:changed` passed all selected lanes on the equivalent immediately pre-rebase two-file patch; the final rebase changed neither affected file.
- Mandated TruffleHog preflight plus exact-head repo autoreview: clean, no actionable findings, confidence 0.99.
- Independent exact-head read-only Codex review: `PASS`, confidence 0.93, no actionable findings. Its isolated checkout had no dependencies for test execution; the exact-head tests above ran in the primary checkout.
- Diff: production +1, tests +83; total +84/-0. No source-target matcher or finalization changes.
