### PR TITLE
fix: keep Codex activity ordered when steering active runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.
 - **Onboarding migration menu:** group Claude, Codex, Hermes, and plugin-provided imports under a single **Import from another agent** setup choice while preserving detected source hints, manual paths, and Back navigation before import begins. Fixes #126440. Thanks @shakkernerd.
 - **Onboarding provider hook loading:** scope selected-model hook fallback to the chosen provider so metadata-only setup providers do not load unrelated plugins before configuration completes. Fixes #126408. Thanks @shakkernerd.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.

--- a/extensions/codex/src/app-server/attempt-steering.ts
+++ b/extensions/codex/src/app-server/attempt-steering.ts
@@ -33,6 +33,11 @@ export type CodexSteeringQueueOptions = {
   userTurnTranscriptRecorder?: AgentHarnessQueueMessageOptions["userTurnTranscriptRecorder"];
 };
 
+type CodexSteeringCommitItem = Pick<
+  CodexSteeringQueueOptions,
+  "isInboundUserMessage" | "userTurnTranscriptRecorder"
+>;
+
 /**
  * Creates a queue that batches steer messages while still serializing
  * app-server `turn/steer` requests.
@@ -43,15 +48,18 @@ export function createCodexSteeringQueue(params: {
   turnId: string;
   requestTimeoutMs: number;
   signal: AbortSignal;
+  beforeConfirmConsumed?: (items: readonly CodexSteeringCommitItem[]) => Promise<void>;
 }) {
   type PendingSteerMessage = {
     acceptance: "open" | "accepted" | "rejected";
     text: string;
     images?: EmbeddedRunAttemptParams["images"];
+    isInboundUserMessage?: boolean;
     onQueueAccepted?: (accepted: boolean) => void;
     resolve: () => void;
     reject: (error: unknown) => void;
     settled: boolean;
+    userTurnTranscriptRecorder?: CodexSteeringQueueOptions["userTurnTranscriptRecorder"];
   };
   type PendingSteerBatch = {
     items: PendingSteerMessage[];
@@ -245,10 +253,12 @@ export function createCodexSteeringQueue(params: {
       acceptance: "open" as const,
       text,
       images: options?.images,
+      isInboundUserMessage: options?.isInboundUserMessage,
       onQueueAccepted: options?.onQueueAccepted,
       resolve: resolveDelivery,
       reject: rejectDelivery,
       settled: false,
+      userTurnTranscriptRecorder: options?.userTurnTranscriptRecorder,
     };
     pendingMessages.add(item);
     return { item, delivery };
@@ -290,9 +300,28 @@ export function createCodexSteeringQueue(params: {
       }
       dispatchedBatches.delete(clientUserMessageId);
       for (const item of batch.items) {
-        resolveItem(item);
+        reportItemAcceptance(item, true);
       }
-      return true;
+      const resolveBatch = () => {
+        for (const item of batch.items) {
+          resolveItem(item);
+        }
+        return true;
+      };
+      const rejectBatch = (error: unknown) => {
+        for (const item of batch.items) {
+          rejectItem(item, error);
+        }
+        return true;
+      };
+      if (!params.beforeConfirmConsumed) {
+        return resolveBatch();
+      }
+      try {
+        return params.beforeConfirmConsumed(batch.items).then(resolveBatch, rejectBatch);
+      } catch (error) {
+        return rejectBatch(error);
+      }
     },
     sealAdmission: sealQueueAdmission,
     cancel: cancelQueue,

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -4,6 +4,7 @@ import {
   emitAgentEvent as emitGlobalAgentEvent,
   runAgentHarnessAfterCompactionHook,
   runAgentHarnessBeforeCompactionHook,
+  type AgentMessage,
   type BeforeToolCallFailureDisposition,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -26,6 +27,7 @@ import {
   buildCodexAttemptResult,
   type CodexAppServerToolTelemetry,
 } from "./event-projector-result.js";
+import { buildCodexMessagesSnapshot } from "./event-projector-snapshot.js";
 import { CodexToolProgressProjection } from "./event-projector-tool-progress.js";
 import { CodexToolTranscriptProjection } from "./event-projector-tool-transcript.js";
 import {
@@ -155,6 +157,24 @@ export class CodexAppServerEventProjector {
 
   getCompletedTurnStatus(): CodexTurn["status"] | undefined {
     return this.completedTurn?.status;
+  }
+
+  buildSteeringTranscriptPrefix(): AgentMessage[] {
+    const commentaryMessages = this.assistantProjection
+      .collectCommentaryMessages()
+      .filter(({ itemId }) => this.completedItemIds.has(itemId));
+    return buildCodexMessagesSnapshot({
+      runParams: this.params,
+      turnId: this.turnId,
+      upstreamUserText: this.options.upstreamUserText,
+      reasoningText: undefined,
+      planText: undefined,
+      commentaryMessages,
+      toolMessages: this.toolTranscriptProjection.transcriptMessages,
+      lastAssistant: undefined,
+      createAssistantMirrorMessage: (title, text) =>
+        this.assistantProjection.createAssistantMirrorMessage(title, text),
+    }).filter((message) => message.role !== "user");
   }
 
   hasCompletedTerminalAssistantText(): boolean {

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -23,6 +23,7 @@ import type { CodexAttemptNotificationController } from "./run-attempt-notificat
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
 import {
+  codexTranscriptMirrorRuntime,
   createCodexAppServerUserMessagePersistenceNotifier,
   mirrorPromptAtTurnStartBestEffort,
 } from "./transcript-mirror.js";
@@ -55,6 +56,7 @@ export async function activateCodexAttemptTurn(
     bindingIdentity,
     sessionAgentId,
     sandboxSessionKey,
+    contextSessionKey,
     effectiveCwd,
   } = connection;
   const { dynamicToolParams, compactionPlanState, computerContextEpoch, toolBridge } = attemptTools;
@@ -210,12 +212,53 @@ export async function activateCodexAttemptTurn(
       { threadId: resourceState.thread.threadId, turnId: activeTurnId },
     );
   }
+  const notifyUserMessagePersisted = createCodexAppServerUserMessagePersistenceNotifier(params);
+  const promptMirrorPromise = mirrorPromptAtTurnStartBestEffort({
+    params,
+    agentId: sessionAgentId,
+    notifyUserMessagePersisted,
+    sessionKey: sandboxSessionKey,
+    cwd: effectiveCwd,
+    threadId: resourceState.thread.threadId,
+    turnId: activeTurnId,
+    upstreamUserText: turnState.codexTurnPromptText,
+  });
   const activeSteeringQueue = createCodexSteeringQueue({
     client: resourceState.client,
     threadId: resourceState.thread.threadId,
     turnId: activeTurnId,
     requestTimeoutMs: connection.appServer.requestTimeoutMs,
     signal: runAbortController.signal,
+    beforeConfirmConsumed: async (items) => {
+      const inboundItems = items.filter((item) => item.isInboundUserMessage === true);
+      if (inboundItems.length === 0) {
+        return;
+      }
+      await promptMirrorPromise;
+      const messages = activeProjector.buildSteeringTranscriptPrefix();
+      if (params.sessionTarget && messages.length > 0) {
+        await codexTranscriptMirrorRuntime.mirror({
+          agentId: sessionAgentId,
+          sessionKey: contextSessionKey,
+          sessionId: params.sessionId,
+          storePath: params.sessionTarget.storePath,
+          cwd: effectiveCwd,
+          messages,
+          idempotencyScope: `codex-app-server:${resourceState.thread.threadId}`,
+          config: params.config,
+        });
+      }
+      for (const item of inboundItems) {
+        const recorder = item.userTurnTranscriptRecorder;
+        if (!recorder) {
+          continue;
+        }
+        await recorder.persistApproved();
+        if (!recorder.hasPersisted()) {
+          throw new Error("Codex consumed steering before its user turn was persisted");
+        }
+      }
+    },
   });
   steeringQueueRef.current = activeSteeringQueue;
   const claimPendingUserInputAnswer = async (
@@ -308,17 +351,6 @@ export async function activateCodexAttemptTurn(
     terminalState.terminalOutcomeFrozen = true;
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
   };
-  const notifyUserMessagePersisted = createCodexAppServerUserMessagePersistenceNotifier(params);
-  void mirrorPromptAtTurnStartBestEffort({
-    params,
-    agentId: sessionAgentId,
-    notifyUserMessagePersisted,
-    sessionKey: sandboxSessionKey,
-    cwd: effectiveCwd,
-    threadId: resourceState.thread.threadId,
-    turnId: activeTurnId,
-    upstreamUserText: turnState.codexTurnPromptText,
-  });
   const abortListener = () => {
     if (state.timedOut) {
       void (async () => {

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -98,7 +98,7 @@ export function createCodexAttemptNotificationController(
     if (notificationState.isCurrentTurnNotification && notification.method === "item/completed") {
       const item = readCodexNotificationItem(notification.params);
       if (item?.type === "userMessage" && typeof item.clientId === "string") {
-        steeringQueue?.confirmConsumed(item.clientId);
+        await steeringQueue?.confirmConsumed(item.clientId);
       }
     }
     if (notificationState.isTurnAbortMarker) {

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -1,7 +1,13 @@
 // Codex tests cover run attempt.steering plugin behavior.
 import path from "node:path";
 import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw/plugin-sdk/provider-model-shared";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  appendSessionTranscriptMessageByIdentity,
+  readSessionTranscriptEvents,
+} from "openclaw/plugin-sdk/session-transcript-runtime";
 import { describe, expect, it, vi } from "vitest";
+import type { CodexSteeringQueueOptions } from "./attempt-steering.js";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
 import type { CodexServerNotification } from "./protocol.js";
 import {
@@ -173,13 +179,63 @@ describe("runCodexAppServerAttempt steering", () => {
   it("accepts Gateway transcript-backed steering for the active Codex turn", async () => {
     const { requests, waitForMethod, completeTurn, notify } = createStartedThreadHarness();
     const params = createSteeringParams();
+    const storePath = path.join(tempDir, `${params.sessionId}.sqlite`);
+    const sessionTarget = {
+      agentId: "main",
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey!,
+      storePath,
+    };
     params.taskSuggestionDeliveryMode = "gateway";
+    params.sessionTarget = sessionTarget;
+    await upsertSessionEntry({
+      agentId: "main",
+      sessionKey: params.sessionKey!,
+      storePath,
+      entry: {
+        sessionFile: params.sessionFile,
+        sessionId: params.sessionId,
+        updatedAt: Date.now(),
+      },
+    });
+    let steerPersisted = false;
+    const userTurnTranscriptRecorder = {
+      persistApproved: vi.fn(async () => {
+        if (steerPersisted) {
+          return undefined;
+        }
+        steerPersisted = true;
+        return await appendSessionTranscriptMessageByIdentity({
+          ...sessionTarget,
+          message: {
+            role: "user",
+            content: "steer this active turn",
+            timestamp: Date.now(),
+            idempotencyKey: `${params.runId}:steer:user`,
+          },
+        });
+      }),
+      hasPersisted: () => steerPersisted,
+    } as unknown as NonNullable<CodexSteeringQueueOptions["userTurnTranscriptRecorder"]>;
 
     const run = runCodexAppServerAttempt(params, {
       pluginConfig: { appServer: { mode: "yolo" } },
     });
     await waitForMethod("turn/start");
     const onQueueAccepted = vi.fn();
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "agentMessage",
+          id: "pre-steer-commentary",
+          phase: "commentary",
+          text: "PRE-STEER-COMMENTARY",
+        },
+      },
+    });
 
     await vi.waitFor(() => {
       expect(
@@ -198,6 +254,7 @@ describe("runCodexAppServerAttempt steering", () => {
       taskSuggestionDeliveryMode: "gateway",
       waitForTranscriptCommit: true,
       onQueueAccepted,
+      userTurnTranscriptRecorder,
     });
     await vi.waitFor(
       () => expect(requests.map((entry) => entry.method)).toContain("turn/steer"),
@@ -219,6 +276,20 @@ describe("runCodexAppServerAttempt steering", () => {
         item: { id: "steered-user-message", type: "userMessage", clientId: clientUserMessageId },
       },
     });
+    await userTurnTranscriptRecorder.persistApproved();
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "agentMessage",
+          id: "final-answer",
+          phase: "final_answer",
+          text: "Steering completed.",
+        },
+      },
+    });
     await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
 
@@ -227,6 +298,11 @@ describe("runCodexAppServerAttempt steering", () => {
       expectedTurnId: "turn-1",
       input: [{ type: "text", text: "steer this active turn" }],
     });
+    const roles = (await readSessionTranscriptEvents(sessionTarget)).flatMap((event) => {
+      const message = (event as { message?: { role?: string } }).message;
+      return message?.role ? [message.role] : [];
+    });
+    expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
   });
 
   it("forwards queued text and images to the active app-server turn", async () => {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -26,6 +26,7 @@ import { resolveChatAvatarUrl, selectedChatSessionRow } from "./chat-state-route
 import { buildChatItems } from "./chat-thread-build.ts";
 import { getChatSessionProjection } from "./history-merge.ts";
 import { scheduleControlUiAfterPaint } from "./performance.ts";
+import { applySessionMessagePayload } from "./session-message-apply.ts";
 
 beforeEach(() => {
   vi.spyOn(assistantIdentity, "loadLocalAssistantIdentity").mockReturnValue({
@@ -133,6 +134,45 @@ describe("canonical session message recovery", () => {
     expect(state.chatMessages[0]).toMatchObject({
       __openclaw: { importedFrom: "claude-cli", externalId: "source-local-user", seq: 3 },
     });
+  });
+
+  it("retires live commentary when its durable row arrives during an active run", () => {
+    const runId = "active-run";
+    const itemId = "commentary-1";
+    const text = "Checking the workspace.";
+    const { state } = createSessionEventState({
+      connected: false,
+      chatMessages: [],
+      chatRunId: runId,
+      chatStream: null,
+      chatStreamSegments: [{ text, ts: 1, runId, itemId }],
+      chatToolMessages: [],
+    });
+
+    applySessionMessagePayload(
+      state,
+      {
+        sessionKey: state.sessionKey,
+        messageId: "commentary-message-1",
+        messageSeq: 1,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text }],
+          idempotencyKey: `codex-app-server:thread:turn:commentary:${itemId}`,
+          timestamp: 1,
+          openclawStreamFallback: {
+            replacementText: text,
+            source: "segment",
+            itemId,
+          },
+        },
+      },
+      true,
+      { kind: "history-delta" },
+    );
+
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(renderedTranscript(state)).toEqual([{ role: "assistant", text }]);
   });
 
   it("keeps cumulative assistant output split across an authoritative steer", () => {

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -15,7 +15,7 @@ import {
   chatItemStartsUserTurn,
   safeNormalizeMessage,
 } from "./chat-turn-boundary.ts";
-import { persistedSteerTargetRunId } from "./stream-causal-boundary.ts";
+import { indexTurnContinuations } from "./stream-causal-boundary.ts";
 
 export function isKeyedAssistantStreamFallbackMessage(message: unknown): boolean {
   const record = asRecord(message);
@@ -554,18 +554,17 @@ function isFinalReplyGroup(item: TurnRenderItem): boolean {
   return item.kind === "group" && !item.isStreaming && assistantGroupCanOwnActiveRunStatus(item);
 }
 
-function turnStartsWithSteer(turn: TurnRenderItem[]): boolean {
+function turnUserMessages(turn: TurnRenderItem[]): unknown[] {
   const boundary = turn[0];
   if (!boundary || boundary.kind === "stream-run") {
-    return false;
+    return [];
   }
   if (boundary.kind === "group") {
-    return (
-      boundary.role.toLowerCase() === "user" &&
-      boundary.messages.some(({ message }) => persistedSteerTargetRunId(message) !== null)
-    );
+    return boundary.role.toLowerCase() === "user"
+      ? boundary.messages.map(({ message }) => message)
+      : [];
   }
-  return boundary.kind === "message" && persistedSteerTargetRunId(boundary.message) !== null;
+  return boundary.kind === "message" && chatItemStartsUserTurn(boundary) ? [boundary.message] : [];
 }
 
 /**
@@ -605,11 +604,12 @@ export function collapseCompletedTurnWork(
     turns.push(currentTurn);
   }
 
-  const continuesIntoSteer = turns.map((_, turnIndex) =>
-    turnStartsWithSteer(turns[turnIndex + 1] ?? []),
+  const { continuationTurnIndexes, precedingContinuationTurnIndexes } = indexTurnContinuations(
+    turns,
+    turnUserMessages,
   );
   const finalReplyIndexes = turns.map((turn, turnIndex) => {
-    if (continuesIntoSteer[turnIndex]) {
+    if (continuationTurnIndexes.has(turnIndex)) {
       return -1;
     }
     for (let index = turn.length - 1; index >= 0; index -= 1) {
@@ -624,14 +624,22 @@ export function collapseCompletedTurnWork(
     index >= 0 ? (turns[turnIndex]?.[index] as MessageGroup) : undefined,
   );
   for (let turnIndex = turns.length - 2; turnIndex >= 0; turnIndex -= 1) {
-    if (!terminalReplies[turnIndex] && continuesIntoSteer[turnIndex]) {
-      terminalReplies[turnIndex] = terminalReplies[turnIndex + 1];
+    const continuationTurnIndex = continuationTurnIndexes.get(turnIndex);
+    if (!terminalReplies[turnIndex] && continuationTurnIndex !== undefined) {
+      terminalReplies[turnIndex] = terminalReplies[continuationTurnIndex];
     }
   }
-  let activeRunStartIndex = turns.length - 1;
+  const liveTurnIndexes = new Set<number>();
   if (opts.runWorking) {
-    while (activeRunStartIndex > 0 && turnStartsWithSteer(turns[activeRunStartIndex] ?? [])) {
-      activeRunStartIndex -= 1;
+    let liveTurnIndex = turns.length - 1;
+    liveTurnIndexes.add(liveTurnIndex);
+    for (;;) {
+      const precedingTurnIndex = precedingContinuationTurnIndexes.get(liveTurnIndex);
+      if (precedingTurnIndex === undefined) {
+        break;
+      }
+      liveTurnIndex = precedingTurnIndex;
+      liveTurnIndexes.add(liveTurnIndex);
     }
   }
 
@@ -641,7 +649,7 @@ export function collapseCompletedTurnWork(
     // While the run works, the trailing turn also stays expanded so activity
     // is watchable until the terminal rebuild collapses it.
     const isLive =
-      (opts.runWorking && turnIndex >= activeRunStartIndex) ||
+      liveTurnIndexes.has(turnIndex) ||
       turn.some(
         (item) => item.kind === "stream-run" || (item.kind === "group" && item.isStreaming),
       );
@@ -683,12 +691,14 @@ export function collapseCompletedTurnWork(
     const startTimestamp = boundaryTimestamp == null ? firstGroup.timestamp : boundaryTimestamp;
     const endTimestamp = terminalReply.timestamp;
     const durationMs = endTimestamp > startTimestamp ? endTimestamp - startTimestamp : null;
-    const nextBoundary = turns[turnIndex + 1]?.[0];
+    const continuationBoundary = turns[continuationTurnIndexes.get(turnIndex) ?? -1]?.[0];
     result.push(...turn.slice(0, segmentStart));
     result.push({
       kind: "work-group",
       // The final reply survives older-history prepends; the first work row does not.
-      key: `work:${finalReplyIndex >= 0 || !nextBoundary ? terminalReply.key : nextBoundary.key}`,
+      key: `work:${
+        finalReplyIndex >= 0 || !continuationBoundary ? terminalReply.key : continuationBoundary.key
+      }`,
       groups,
       durationMs,
     });

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -15,6 +15,7 @@ import {
   chatItemStartsUserTurn,
   safeNormalizeMessage,
 } from "./chat-turn-boundary.ts";
+import { persistedSteerTargetRunId } from "./stream-causal-boundary.ts";
 
 export function isKeyedAssistantStreamFallbackMessage(message: unknown): boolean {
   const record = asRecord(message);
@@ -553,6 +554,20 @@ function isFinalReplyGroup(item: TurnRenderItem): boolean {
   return item.kind === "group" && !item.isStreaming && assistantGroupCanOwnActiveRunStatus(item);
 }
 
+function turnStartsWithSteer(turn: TurnRenderItem[]): boolean {
+  const boundary = turn[0];
+  if (!boundary || boundary.kind === "stream-run") {
+    return false;
+  }
+  if (boundary.kind === "group") {
+    return (
+      boundary.role.toLowerCase() === "user" &&
+      boundary.messages.some(({ message }) => persistedSteerTargetRunId(message) !== null)
+    );
+  }
+  return boundary.kind === "message" && persistedSteerTargetRunId(boundary.message) !== null;
+}
+
 /**
  * Once a turn is done, its intermediate work (tool groups and assistant
  * commentary before the final reply) collapses behind one "Worked for X"
@@ -590,13 +605,43 @@ export function collapseCompletedTurnWork(
     turns.push(currentTurn);
   }
 
+  const continuesIntoSteer = turns.map((_, turnIndex) =>
+    turnStartsWithSteer(turns[turnIndex + 1] ?? []),
+  );
+  const finalReplyIndexes = turns.map((turn, turnIndex) => {
+    if (continuesIntoSteer[turnIndex]) {
+      return -1;
+    }
+    for (let index = turn.length - 1; index >= 0; index -= 1) {
+      const candidate = turn[index];
+      if (candidate && isFinalReplyGroup(candidate)) {
+        return index;
+      }
+    }
+    return -1;
+  });
+  const terminalReplies = finalReplyIndexes.map((index, turnIndex) =>
+    index >= 0 ? (turns[turnIndex]?.[index] as MessageGroup) : undefined,
+  );
+  for (let turnIndex = turns.length - 2; turnIndex >= 0; turnIndex -= 1) {
+    if (!terminalReplies[turnIndex] && continuesIntoSteer[turnIndex]) {
+      terminalReplies[turnIndex] = terminalReplies[turnIndex + 1];
+    }
+  }
+  let activeRunStartIndex = turns.length - 1;
+  if (opts.runWorking) {
+    while (activeRunStartIndex > 0 && turnStartsWithSteer(turns[activeRunStartIndex] ?? [])) {
+      activeRunStartIndex -= 1;
+    }
+  }
+
   const result: Array<TurnRenderItem | WorkGroupRenderItem> = [];
   for (const [turnIndex, turn] of turns.entries()) {
     // In-flight content (stream runs, streaming groups) marks the turn live.
     // While the run works, the trailing turn also stays expanded so activity
     // is watchable until the terminal rebuild collapses it.
     const isLive =
-      (opts.runWorking && turnIndex === turns.length - 1) ||
+      (opts.runWorking && turnIndex >= activeRunStartIndex) ||
       turn.some(
         (item) => item.kind === "stream-run" || (item.kind === "group" && item.isStreaming),
       );
@@ -604,21 +649,15 @@ export function collapseCompletedTurnWork(
       result.push(...turn);
       continue;
     }
-    let finalReplyIndex = -1;
-    for (let index = turn.length - 1; index >= 0; index -= 1) {
-      const candidate = turn[index];
-      if (candidate && isFinalReplyGroup(candidate)) {
-        finalReplyIndex = index;
-        break;
-      }
-    }
+    const finalReplyIndex = finalReplyIndexes[turnIndex] ?? -1;
+    const terminalReply = terminalReplies[turnIndex];
     // Without a final reply, the tool rows are the turn's only visible result.
     // Keep them exposed instead of replacing the result with an opaque rollup.
-    if (finalReplyIndex === -1) {
+    if (!terminalReply) {
       result.push(...turn);
       continue;
     }
-    const segmentEnd = finalReplyIndex - 1;
+    const segmentEnd = finalReplyIndex >= 0 ? finalReplyIndex - 1 : turn.length - 1;
     let segmentStart = segmentEnd + 1;
     for (let index = segmentEnd; index >= 0; index -= 1) {
       const candidate = turn[index];
@@ -642,14 +681,14 @@ export function collapseCompletedTurnWork(
         ? boundary.timestamp
         : null;
     const startTimestamp = boundaryTimestamp == null ? firstGroup.timestamp : boundaryTimestamp;
-    const finalReply = turn[finalReplyIndex] as MessageGroup;
-    const endTimestamp = finalReply.timestamp;
+    const endTimestamp = terminalReply.timestamp;
     const durationMs = endTimestamp > startTimestamp ? endTimestamp - startTimestamp : null;
+    const nextBoundary = turns[turnIndex + 1]?.[0];
     result.push(...turn.slice(0, segmentStart));
     result.push({
       kind: "work-group",
       // The final reply survives older-history prepends; the first work row does not.
-      key: `work:${finalReply.key}`,
+      key: `work:${finalReplyIndex >= 0 || !nextBoundary ? terminalReply.key : nextBoundary.key}`,
       groups,
       durationMs,
     });

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -840,11 +840,20 @@ describe("collapseCompletedTurnWork", () => {
 
   it("collapses completed pre-steer work before the steering message", () => {
     const messages = [
-      userMessage("do it", 1_000),
+      userMessage("do it", 1_000, {
+        __openclaw: { idempotencyKey: "active-run:user", senderId: "operator" },
+      }),
       assistantMessage("Checking…", 2_000),
       toolResult("call-1", 3_000),
+      userMessage("queued follow-up", 3_500, {
+        __openclaw: { idempotencyKey: "queued-run:user", senderId: "peer" },
+      }),
       userMessage("continue", 4_000, {
-        __openclaw: { steerTargetRunId: "active-run" },
+        __openclaw: {
+          idempotencyKey: "steer-run:user",
+          senderId: "operator",
+          steerTargetRunId: "active-run",
+        },
       }),
       assistantMessage("All done.", 5_000),
     ];
@@ -856,7 +865,13 @@ describe("collapseCompletedTurnWork", () => {
     ).toBe(false);
 
     const completed = collapsedItems({ messages });
-    expect(completed.map((item) => item.kind)).toEqual(["group", "work-group", "group", "group"]);
+    expect(completed.map((item) => item.kind)).toEqual([
+      "group",
+      "work-group",
+      "group",
+      "group",
+      "group",
+    ]);
     expect(requireWorkGroup(completed[1]).durationMs).toBe(4_000);
   });
 

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -838,6 +838,28 @@ describe("collapseCompletedTurnWork", () => {
     expect(items.some((item) => item.kind === "work-group")).toBe(false);
   });
 
+  it("collapses completed pre-steer work before the steering message", () => {
+    const messages = [
+      userMessage("do it", 1_000),
+      assistantMessage("Checking…", 2_000),
+      toolResult("call-1", 3_000),
+      userMessage("continue", 4_000, {
+        __openclaw: { steerTargetRunId: "active-run" },
+      }),
+      assistantMessage("All done.", 5_000),
+    ];
+
+    expect(
+      collapsedItems({ messages, runWorking: true }, true).some(
+        (item) => item.kind === "work-group",
+      ),
+    ).toBe(false);
+
+    const completed = collapsedItems({ messages });
+    expect(completed.map((item) => item.kind)).toEqual(["group", "work-group", "group", "group"]);
+    expect(requireWorkGroup(completed[1]).durationMs).toBe(4_000);
+  });
+
   it("keeps reply-less turns expanded after the run finishes", () => {
     const messages = [userMessage("do it", 1_000), toolResult("call-1", 2_000)];
 

--- a/ui/src/pages/chat/session-message-apply.ts
+++ b/ui/src/pages/chat/session-message-apply.ts
@@ -13,6 +13,7 @@ import {
   reduceChatSessionProjection,
 } from "./history-merge.ts";
 import { persistedSteerTargetRunId, rolloverChatStream } from "./stream-causal-boundary.ts";
+import { prunePersistedAssistantStreamSegments } from "./stream-segment-pruning.ts";
 
 type SessionMessageApplySource =
   | { kind: "history-delta" }
@@ -129,6 +130,9 @@ export function applySessionMessagePayload(
     },
     { scope, runActive },
   );
+  if (incoming.role === "assistant" && projection.messages.includes(message)) {
+    prunePersistedAssistantStreamSegments(state, message);
+  }
   const steerTargetRunId = persistedSteerTargetRunId(message);
   const currentRunId = state.chatRunId;
   if (

--- a/ui/src/pages/chat/stream-causal-boundary.ts
+++ b/ui/src/pages/chat/stream-causal-boundary.ts
@@ -37,6 +37,68 @@ export function persistedSteerTargetRunId(message: unknown): string | null {
   return normalizeOptionalString(metadata?.steerTargetRunId) ?? null;
 }
 
+function turnRunId(messages: unknown[]): string | null {
+  for (const message of messages) {
+    const identity = userTurnSendIdentity(message);
+    if (identity?.startsWith("send:")) {
+      return identity.slice("send:".length);
+    }
+  }
+  return null;
+}
+
+function turnSteerTargetRunId(messages: unknown[]): string | null {
+  for (const message of messages) {
+    const targetRunId = persistedSteerTargetRunId(message);
+    if (targetRunId) {
+      return targetRunId;
+    }
+  }
+  return null;
+}
+
+export function indexTurnContinuations<T>(
+  turns: T[][],
+  userMessagesForTurn: (turn: T[]) => unknown[],
+): {
+  continuationTurnIndexes: Map<number, number>;
+  precedingContinuationTurnIndexes: Map<number, number>;
+} {
+  const runTurnIndexes = new Map<string, number>();
+  const steerTurnIndexesByTarget = new Map<string, number[]>();
+  for (const [turnIndex, turn] of turns.entries()) {
+    const userMessages = userMessagesForTurn(turn);
+    const runId = turnRunId(userMessages);
+    if (runId && !runTurnIndexes.has(runId)) {
+      runTurnIndexes.set(runId, turnIndex);
+    }
+    const targetRunId = turnSteerTargetRunId(userMessages);
+    if (targetRunId) {
+      const steerTurns = steerTurnIndexesByTarget.get(targetRunId) ?? [];
+      steerTurns.push(turnIndex);
+      steerTurnIndexesByTarget.set(targetRunId, steerTurns);
+    }
+  }
+
+  const continuationTurnIndexes = new Map<number, number>();
+  const precedingContinuationTurnIndexes = new Map<number, number>();
+  for (const [targetRunId, steerTurnIndexes] of steerTurnIndexesByTarget) {
+    let previousTurnIndex = runTurnIndexes.get(targetRunId);
+    if (previousTurnIndex === undefined) {
+      continue;
+    }
+    for (const steerTurnIndex of steerTurnIndexes) {
+      if (steerTurnIndex <= previousTurnIndex) {
+        continue;
+      }
+      continuationTurnIndexes.set(previousTurnIndex, steerTurnIndex);
+      precedingContinuationTurnIndexes.set(steerTurnIndex, previousTurnIndex);
+      previousTurnIndex = steerTurnIndex;
+    }
+  }
+  return { continuationTurnIndexes, precedingContinuationTurnIndexes };
+}
+
 export function latestPersistedSteerBoundary(
   messages: unknown[],
   activeRunId: string,

--- a/ui/src/pages/chat/stream-segment-pruning.ts
+++ b/ui/src/pages/chat/stream-segment-pruning.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   advanceAccumulatedStreamText,
@@ -65,6 +66,23 @@ export function discardStreamSegmentIndexes(
     state.chatStreamSegments,
     (_segment, index) => discarded.has(index),
   );
+}
+
+/** A durable commentary row immediately replaces its keyed live projection.
+ * Waiting for terminal cleanup renders both copies throughout the active run. */
+export function prunePersistedAssistantStreamSegments(
+  state: StreamCausalBoundaryState,
+  message: unknown,
+): void {
+  const fallback = asNullableRecord(asNullableRecord(message)?.openclawStreamFallback);
+  const itemId = normalizeOptionalString(fallback?.itemId);
+  if (!itemId || !state.chatStreamSegments) {
+    return;
+  }
+  const replacedIndexes = state.chatStreamSegments.flatMap((segment, index) =>
+    normalizeOptionalString(segment.itemId) === itemId ? [index] : [],
+  );
+  discardStreamSegmentIndexes(state, replacedIndexes);
 }
 
 export function pruneHistoryReplacedStreamSegments(

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1200,6 +1200,23 @@
   padding-block: 9px;
 }
 
+@keyframes chat-work-settle-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .chat-group--work {
+    animation: chat-work-settle-in 200ms var(--ease-out) both;
+  }
+}
+
 .chat-work-group .chat-activity-group__label {
   color: inherit;
 }


### PR DESCRIPTION
Related: #126938

## What Problem This Solves

Fixes an issue where steering an active Codex run could preserve prior commentary and tool activity only while the run was live, then rebuild the completed transcript with that work in the wrong position or leave it expanded instead of the normal `Worked for …` disclosure.

## Why This Change Was Made

OpenClaw now mirrors the stable pre-steer activity prefix and commits the steering user turn at Codex's confirmed user-message boundary, before terminal reconciliation can append later output. The Control UI uses the persisted steer marker to keep the linked run expanded while active and collapse its completed work before the steering message.

## User Impact

Users can steer an active Codex run without losing or rearranging previously visible work. After completion, the transcript matches Codex Desktop: pre-steer activity appears under `Worked for …` before the steer, and the final response remains after it.

## Evidence

- Live OCM/Codex reproduction preserved commentary and `sleep 30` above the steer during execution.
- Read-only SQLite inspection confirmed durable order: initial user turn, pre-steer commentary/tool activity, steering user turn, final assistant reply.
- Rebuilt Control UI verified in Chrome that `Worked for 46s` renders before the steering message after completion.
- Testbox: 199 focused Codex and Control UI tests passed, with extension/UI production and test typechecks green.
- Control UI production build passed.
- Autoreview completed with no accepted or actionable findings.


### Visual proof

**Before:** completed work appears after the steering message.

<img width="3720" height="2540" alt="clipboard" src="https://github.com/user-attachments/assets/287a470a-9adb-45c6-94b7-b37d090f0bc8" />


**After:** completed work collapses before the steering message.

<img width="1858" height="1219" alt="clipboard" src="https://github.com/user-attachments/assets/e6c24af7-5b8c-4d83-adf8-ef122a16c5f5" />
