### PR TITLE
fix(release): bind GitHub and Windows writers

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -955,6 +955,70 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+      - name: Write Windows release approval
+        if: ${{ inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
+        env:
+          RELEASE_PUBLISH_RUN_ATTEMPT: ${{ github.run_attempt }}
+          RELEASE_PUBLISH_RUN_ID: ${{ github.run_id }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TOOLING_FULL_REF: ${{ github.ref }}
+          RELEASE_TOOLING_REF: ${{ github.ref_name }}
+          RELEASE_TOOLING_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
+          WINDOWS_NODE_INSTALLER_DIGESTS: ${{ needs.resolve_release_target.outputs.windows_node_installer_digests }}
+          WINDOWS_NODE_TAG: ${{ inputs.windows_node_tag }}
+        run: |
+          set -euo pipefail
+          approval_dir="${RUNNER_TEMP}/windows-release-approval"
+          mkdir -p "${approval_dir}"
+          node --input-type=module <<'NODE'
+          import { writeFileSync } from "node:fs";
+          import { join } from "node:path";
+
+          const digests = JSON.parse(process.env.WINDOWS_NODE_INSTALLER_DIGESTS);
+          const installerDigests = Object.fromEntries(
+            Object.entries(digests).toSorted(([left], [right]) => left.localeCompare(right)),
+          );
+          const approval = {
+            schema: "windows-release-approval.v1",
+            repository: process.env.GITHUB_REPOSITORY,
+            workflow: "OpenClaw Release Publish",
+            parentRunId: process.env.RELEASE_PUBLISH_RUN_ID,
+            parentRunAttempt: Number(process.env.RELEASE_PUBLISH_RUN_ATTEMPT),
+            tooling: {
+              ref: process.env.RELEASE_TOOLING_REF,
+              fullRef: process.env.RELEASE_TOOLING_FULL_REF,
+              sha: process.env.RELEASE_TOOLING_SHA,
+            },
+            releaseTag: process.env.RELEASE_TAG,
+            targetSha: process.env.TARGET_SHA,
+            windowsSource: {
+              repository: "openclaw/openclaw-windows-node",
+              tag: process.env.WINDOWS_NODE_TAG,
+              installerDigests,
+            },
+          };
+          writeFileSync(
+            join(process.env.RUNNER_TEMP, "windows-release-approval", "approval.json"),
+            `${JSON.stringify(approval, null, 2)}\n`,
+          );
+          NODE
+
+      - name: Attest Windows release approval
+        if: ${{ inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: ${{ runner.temp }}/windows-release-approval/approval.json
+
+      - name: Upload Windows release approval
+        if: ${{ inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: windows-release-approval-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/windows-release-approval/approval.json
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Dispatch publish workflows
         env:
           GH_TOKEN: ${{ github.token }}
@@ -993,6 +1057,22 @@ jobs:
 
           is_android_release() {
             [[ "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]
+          }
+
+          verify_release_tooling_identity() {
+            local -a verify_args=(
+              verify
+              --repository "${GITHUB_REPOSITORY}"
+              --workflow-ref "${PARENT_WORKFLOW_BRANCH}"
+              --workflow-full-ref "${PARENT_WORKFLOW_FULL_REF}"
+              --workflow-sha "${PARENT_WORKFLOW_SHA}"
+              --release-publish-run-id "${GITHUB_RUN_ID}"
+              --release-publish-run-attempt "${GITHUB_RUN_ATTEMPT}"
+            )
+            if [[ "${PARENT_WORKFLOW_BRANCH}" != "main" && ! "${PARENT_WORKFLOW_FULL_REF}" =~ ^refs/tags/release-publish/ ]]; then
+              verify_args+=(--allow-prevalidated-ref)
+            fi
+            node .release-harness/scripts/release-tooling-identity.mjs "${verify_args[@]}" >/dev/null
           }
 
           verify_child_run_sha() {
@@ -1692,12 +1772,14 @@ jobs:
                   return 0
                 fi
               fi
+              verify_release_tooling_identity
               gh release edit "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" \
                 --title "${title}" \
                 --notes-file "${prepared_release_notes_file}" \
                 "${prerelease_arg}" \
                 "${latest_arg}"
             else
+              verify_release_tooling_identity
               gh release create "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" \
                 --verify-tag \
                 --draft \
@@ -1718,6 +1800,7 @@ jobs:
             if is_stable_release; then
               verify_windows_release_asset_contract
             fi
+            verify_release_tooling_identity
             gh release edit "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --draft=false
             release_json="$(gh release view "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease)"
             expected_prerelease="false"
@@ -1874,10 +1957,18 @@ jobs:
               return 0
             fi
 
+            verify_release_tooling_identity
             windows_node_run_id="$(dispatch_workflow windows-node-release.yml \
               -f tag="${RELEASE_TAG}" \
               -f windows_node_tag="${WINDOWS_NODE_TAG}" \
-              -f expected_installer_digests="${WINDOWS_NODE_INSTALLER_DIGESTS}")"
+              -f expected_installer_digests="${WINDOWS_NODE_INSTALLER_DIGESTS}" \
+              -f release_publish_run_id="${GITHUB_RUN_ID}" \
+              -f release_publish_run_attempt="${GITHUB_RUN_ATTEMPT}" \
+              -f release_tooling_ref="${PARENT_WORKFLOW_BRANCH}" \
+              -f release_tooling_full_ref="${PARENT_WORKFLOW_FULL_REF}" \
+              -f release_tooling_sha="${PARENT_WORKFLOW_SHA}" \
+              -f release_target_sha="${TARGET_SHA}" \
+              -f direct_release_recovery=false)"
             # Promotion runs in a background subshell; hand the run id to the
             # parent shell for the release proof links.
             printf '%s' "${windows_node_run_id}" > "${RUNNER_TEMP}/windows-node-run-id.txt"
@@ -1980,6 +2071,7 @@ jobs:
               exit 1
             fi
 
+            verify_release_tooling_identity
             gh release upload "${RELEASE_TAG}" "${source_path}#${asset_name}" --repo "${GITHUB_REPOSITORY}"
           }
 
@@ -1989,6 +2081,7 @@ jobs:
             # Postpublish evidence embeds this run's id, so resumable retries
             # regenerate it; the newest verification replaces the asset while
             # prior copies persist as workflow artifacts.
+            verify_release_tooling_identity
             gh release upload "${RELEASE_TAG}" "${source_path}#${asset_name}" \
               --repo "${GITHUB_REPOSITORY}" --clobber
           }
@@ -2217,6 +2310,7 @@ jobs:
           NODE
 
             render_github_release_notes "${notes_file}" "${proof_file}" "${metadata_file}"
+            verify_release_tooling_identity
             gh release edit "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --notes-file "${notes_file}"
             if jq -e '.verificationIncluded == true' "${metadata_file}" >/dev/null; then
               echo "- Release proof: appended to GitHub release" >> "$GITHUB_STEP_SUMMARY"
@@ -2584,18 +2678,42 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-release
     permissions:
+      actions: read
       contents: write
     steps:
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Publish the verified draft release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TOOLING_FULL_REF: ${{ github.ref }}
+          RELEASE_TOOLING_REF: ${{ github.ref_name }}
+          RELEASE_TOOLING_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           expected_prerelease=false
           if [[ "${RELEASE_TAG}" == *"-alpha."* || "${RELEASE_TAG}" == *"-beta."* ]]; then
             expected_prerelease=true
           fi
+          verify_args=(
+            verify
+            --repository "${GITHUB_REPOSITORY}"
+            --workflow-ref "${RELEASE_TOOLING_REF}"
+            --workflow-full-ref "${RELEASE_TOOLING_FULL_REF}"
+            --workflow-sha "${RELEASE_TOOLING_SHA}"
+            --release-publish-run-id "${GITHUB_RUN_ID}"
+            --release-publish-run-attempt "${GITHUB_RUN_ATTEMPT}"
+          )
+          if [[ "${RELEASE_TOOLING_REF}" != "main" && ! "${RELEASE_TOOLING_FULL_REF}" =~ ^refs/tags/release-publish/ ]]; then
+            verify_args+=(--allow-prevalidated-ref)
+          fi
+          node scripts/release-tooling-identity.mjs "${verify_args[@]}" >/dev/null
           gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
           release_json="$(gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json isDraft,isPrerelease)"
           if [[ "$(printf '%s' "${release_json}" | jq -r '.isDraft')" != "false" ]] || \

--- a/.github/workflows/windows-node-release.yml
+++ b/.github/workflows/windows-node-release.yml
@@ -4,46 +4,172 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing OpenClaw release tag to receive Windows Hub installers, for example v2026.6.1
+        description: Existing OpenClaw release tag to receive Windows Hub installers
         required: true
         type: string
       windows_node_tag:
-        description: Exact openclaw-windows-node release tag to promote, for example v0.6.3
+        description: Exact openclaw-windows-node release tag to promote
         required: true
         type: string
       expected_installer_digests:
         description: Compact JSON map of installer asset names to pinned source sha256 digests
         required: true
         type: string
+      release_publish_run_id:
+        description: OpenClaw Release Publish run that approved this promotion
+        required: true
+        type: string
+      release_publish_run_attempt:
+        description: Exact approving OpenClaw Release Publish run attempt
+        required: true
+        type: string
+      release_tooling_ref:
+        description: Exact ref name of the approving release tooling
+        required: true
+        type: string
+      release_tooling_full_ref:
+        description: Exact full ref of the approving release tooling
+        required: true
+        type: string
+      release_tooling_sha:
+        description: Exact SHA of the approving release tooling
+        required: true
+        type: string
+      release_target_sha:
+        description: Exact OpenClaw release candidate SHA
+        required: true
+        type: string
+      direct_release_recovery:
+        description: Reuse the exact original approval after its parent run completed
+        required: true
+        default: false
+        type: boolean
 
 permissions:
-  contents: write
+  actions: read
+  attestations: read
+  contents: read
 
 concurrency:
   group: windows-node-release-${{ inputs.tag }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.16.0"
+
 jobs:
-  promote_signed_windows_installers:
-    name: Promote signed Windows installers
+  validate_signed_windows_installers:
+    name: Validate signed Windows installers
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-      - name: Validate inputs
+      - name: Checkout exact trusted release tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.release_tooling_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/lib/record-shared.mjs
+            scripts/release-tooling-identity.mjs
+            scripts/validate-release-publish-approval.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Download parent Windows release approval
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: windows-release-approval-${{ inputs.release_publish_run_id }}-${{ inputs.release_publish_run_attempt }}
+          path: ${{ runner.temp }}/windows-release-approval
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.release_publish_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate immutable release approval
         shell: pwsh
         env:
+          APPROVAL_PATH: ${{ runner.temp }}/windows-release-approval/approval.json
+          CHILD_WORKFLOW_FULL_REF: ${{ github.ref }}
+          CHILD_WORKFLOW_REF: ${{ github.ref_name }}
+          CHILD_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          DIRECT_RELEASE_RECOVERY: ${{ inputs.direct_release_recovery && 'true' || 'false' }}
+          EXPECTED_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
+          EXPECTED_WORKFLOW_BRANCH: ${{ inputs.release_tooling_ref }}
+          EXPECTED_WORKFLOW_FULL_REF: ${{ inputs.release_tooling_full_ref }}
+          EXPECTED_WORKFLOW_SHA: ${{ inputs.release_tooling_sha }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_APPROVAL_KIND: windows-release
+          RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TARGET_SHA: ${{ inputs.release_target_sha }}
+          RELEASE_TOOLING_FULL_REF: ${{ inputs.release_tooling_full_ref }}
+          RELEASE_TOOLING_REF: ${{ inputs.release_tooling_ref }}
+          RELEASE_TOOLING_SHA: ${{ inputs.release_tooling_sha }}
+          WINDOWS_NODE_INSTALLER_DIGESTS: ${{ inputs.expected_installer_digests }}
           WINDOWS_NODE_TAG: ${{ inputs.windows_node_tag }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:GITHUB_ACTOR -ne "github-actions[bot]" -and $env:DIRECT_RELEASE_RECOVERY -ne "true") {
+            throw "Manual Windows release recovery must explicitly set direct_release_recovery=true."
+          }
+          if (
+            $env:CHILD_WORKFLOW_REF -ne $env:RELEASE_TOOLING_REF -or
+            $env:CHILD_WORKFLOW_FULL_REF -ne $env:RELEASE_TOOLING_FULL_REF -or
+            $env:CHILD_WORKFLOW_SHA -ne $env:RELEASE_TOOLING_SHA
+          ) {
+            throw "Windows release workflow execution does not match the attested tooling tuple."
+          }
+          $verifyArgs = @(
+            "verify",
+            "--repository", $env:GITHUB_REPOSITORY,
+            "--workflow-ref", $env:RELEASE_TOOLING_REF,
+            "--workflow-full-ref", $env:RELEASE_TOOLING_FULL_REF,
+            "--workflow-sha", $env:RELEASE_TOOLING_SHA
+          )
+          if (
+            $env:RELEASE_TOOLING_REF -ne "main" -and
+            $env:RELEASE_TOOLING_FULL_REF -notmatch '^refs/tags/release-publish/'
+          ) {
+            $verifyArgs += "--allow-prevalidated-ref"
+          }
+          node scripts/release-tooling-identity.mjs @verifyArgs | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows release tooling identity is no longer live."
+          }
+          gh attestation verify $env:APPROVAL_PATH `
+            --repo $env:GITHUB_REPOSITORY `
+            --signer-workflow "$env:GITHUB_REPOSITORY/.github/workflows/openclaw-release-publish.yml" `
+            --source-ref $env:RELEASE_TOOLING_FULL_REF `
+            --source-digest $env:RELEASE_TOOLING_SHA `
+            --deny-self-hosted-runners
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows release approval attestation verification failed."
+          }
+          gh api `
+            "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:RELEASE_PUBLISH_RUN_ID/attempts/$env:EXPECTED_RUN_ATTEMPT" `
+            --jq '{workflowName: .name, headBranch: .head_branch, headSha: .head_sha, event, status, conclusion, url: .html_url, runAttempt: .run_attempt, repository: .repository.full_name, path}' |
+            node scripts/validate-release-publish-approval.mjs
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows release approval does not match the exact parent run."
+          }
+
+      - name: Validate inputs and download installers
+        shell: pwsh
+        env:
+          DIRECT_RELEASE_RECOVERY: ${{ inputs.direct_release_recovery && 'true' || 'false' }}
           EXPECTED_INSTALLER_DIGESTS: ${{ inputs.expected_installer_digests }}
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TARGET_SHA: ${{ inputs.release_target_sha }}
+          WINDOWS_NODE_TAG: ${{ inputs.windows_node_tag }}
         run: |
+          $ErrorActionPreference = "Stop"
           if ($env:RELEASE_TAG -notmatch '^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-(alpha|beta)\.[1-9][0-9]*)|(-[1-9][0-9]*))?$') {
             throw "Invalid OpenClaw release tag: $env:RELEASE_TAG"
           }
-          $stableRelease = -not (
-            $env:RELEASE_TAG.Contains("-alpha.") -or
-            $env:RELEASE_TAG.Contains("-beta.")
-          )
+          if ($env:RELEASE_TARGET_SHA -notmatch '^[a-f0-9]{40}$') {
+            throw "release_target_sha must be a full lowercase commit SHA."
+          }
           if ($env:WINDOWS_NODE_TAG -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$') {
             throw "windows_node_tag must be an explicit openclaw-windows-node release tag, not latest: $env:WINDOWS_NODE_TAG"
           }
@@ -53,7 +179,6 @@ jobs:
           } catch {
             throw "expected_installer_digests must be a JSON object: $_"
           }
-          # Add future signed installer names, such as MSIX x64/ARM64, here.
           $requiredInstallerNames = @(
             "OpenClawCompanion-Setup-x64.exe",
             "OpenClawCompanion-Setup-arm64.exe"
@@ -67,14 +192,24 @@ jobs:
           }
           foreach ($name in $requiredInstallerNames) {
             $digest = [string]$expectedDigests[$name]
-            if ($digest -notmatch '^sha256:[A-Fa-f0-9]{64}$') {
+            if ($digest -notmatch '^sha256:[a-f0-9]{64}$') {
               throw "expected_installer_digests is missing a valid pinned digest for $name."
             }
           }
 
-          $targetRelease = gh release view $env:RELEASE_TAG --repo $env:GITHUB_REPOSITORY --json tagName,isDraft,isPrerelease,assets,url | ConvertFrom-Json
+          $targetSha = gh api "repos/$env:GITHUB_REPOSITORY/commits/$env:RELEASE_TAG" --jq .sha
+          if ($targetSha -ne $env:RELEASE_TARGET_SHA) {
+            throw "OpenClaw release tag no longer resolves to the approved candidate SHA."
+          }
+          $targetRelease = gh release view $env:RELEASE_TAG `
+            --repo $env:GITHUB_REPOSITORY `
+            --json tagName,isDraft,isPrerelease,assets,url |
+            ConvertFrom-Json
           if ($targetRelease.tagName -ne $env:RELEASE_TAG) {
             throw "OpenClaw release tag mismatch: expected $env:RELEASE_TAG, got $($targetRelease.tagName)"
+          }
+          if ($env:DIRECT_RELEASE_RECOVERY -ne "true" -and -not $targetRelease.isDraft) {
+            throw "Normal Windows promotion requires the target GitHub release to remain a draft."
           }
           $unexpectedTargetCompanionAssets = @(
             $targetRelease.assets |
@@ -89,7 +224,14 @@ jobs:
             throw "Target OpenClaw release contains unexpected OpenClawCompanion assets before upload: $($unexpectedTargetCompanionAssets -join ', ')"
           }
 
-          $sourceRelease = gh release view $env:WINDOWS_NODE_TAG --repo openclaw/openclaw-windows-node --json tagName,isDraft,isPrerelease,assets,url | ConvertFrom-Json
+          $stableRelease = -not (
+            $env:RELEASE_TAG.Contains("-alpha.") -or
+            $env:RELEASE_TAG.Contains("-beta.")
+          )
+          $sourceRelease = gh release view $env:WINDOWS_NODE_TAG `
+            --repo openclaw/openclaw-windows-node `
+            --json tagName,isDraft,isPrerelease,assets,url |
+            ConvertFrom-Json
           if ($sourceRelease.tagName -ne $env:WINDOWS_NODE_TAG) {
             throw "Windows source release tag mismatch: expected $env:WINDOWS_NODE_TAG, got $($sourceRelease.tagName)"
           }
@@ -109,52 +251,35 @@ jobs:
             }
           }
 
-      - name: Download Windows Hub release installers
-        shell: pwsh
-        env:
-          WINDOWS_NODE_TAG: ${{ inputs.windows_node_tag }}
-          EXPECTED_INSTALLER_DIGESTS: ${{ inputs.expected_installer_digests }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
-          # Add future signed installer patterns, such as MSIX x64/ARM64, here.
-          # Every matched installer is signature-checked, checksummed, and promoted.
-          $installerPatterns = @(
-            "OpenClawCompanion-Setup-x64.exe",
-            "OpenClawCompanion-Setup-arm64.exe"
-          )
           $downloadArgs = @(
             $env:WINDOWS_NODE_TAG,
             "--repo", "openclaw/openclaw-windows-node",
             "--dir", "dist"
           )
-          foreach ($pattern in $installerPatterns) {
-            $downloadArgs += @("--pattern", $pattern)
+          foreach ($name in $requiredInstallerNames) {
+            $downloadArgs += @("--pattern", $name)
           }
           gh release download @downloadArgs
           if ($LASTEXITCODE -ne 0) {
             throw "Failed to download Windows release assets from $env:WINDOWS_NODE_TAG."
           }
-
-          foreach ($pattern in $installerPatterns) {
-            $patternMatches = @(Get-ChildItem -LiteralPath dist -File | Where-Object Name -Like $pattern)
-            if ($patternMatches.Count -ne 1) {
-              throw "Expected exactly one Windows installer matching '$pattern', found $($patternMatches.Count)."
+          foreach ($name in $requiredInstallerNames) {
+            $matches = @(Get-ChildItem -LiteralPath dist -File | Where-Object Name -eq $name)
+            if ($matches.Count -ne 1) {
+              throw "Expected exactly one Windows installer named '$name', found $($matches.Count)."
             }
-          }
-
-          $expectedDigests = $env:EXPECTED_INSTALLER_DIGESTS | ConvertFrom-Json -AsHashtable
-          foreach ($file in Get-ChildItem -LiteralPath dist -File) {
-            $expectedHash = ([string]$expectedDigests[$file.Name]) -replace '^sha256:', ''
-            $actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $file.FullName).Hash
+            $expectedHash = ([string]$expectedDigests[$name]) -replace '^sha256:', ''
+            $actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $matches[0].FullName).Hash
             if ($actualHash -ne $expectedHash) {
-              throw "Downloaded Windows source asset does not match pinned digest: $($file.Name)"
+              throw "Downloaded Windows source asset does not match pinned digest: $name"
             }
           }
 
       - name: Verify Authenticode signatures
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
           $expectedSignerSubject = "CN=OpenClaw Foundation, O=OpenClaw Foundation, L=Mill Valley, S=California, C=US"
           Get-ChildItem -LiteralPath dist -File | ForEach-Object {
             $signature = Get-AuthenticodeSignature -LiteralPath $_.FullName
@@ -167,11 +292,6 @@ jobs:
             if ($signature.SignerCertificate.Subject -ne $expectedSignerSubject) {
               throw "$($_.Name) has unexpected signer subject $($signature.SignerCertificate.Subject)."
             }
-            [pscustomobject]@{
-              File = $_.Name
-              Signer = $signature.SignerCertificate.Subject
-              Thumbprint = $signature.SignerCertificate.Thumbprint
-            } | Format-List
           }
 
       - name: Write SHA-256 manifest
@@ -184,16 +304,135 @@ jobs:
               "$($hash.Hash.ToLowerInvariant())  $($_.Name)"
             } | Set-Content -Encoding utf8NoBOM -Path dist/OpenClawCompanion-SHA256SUMS.txt
 
+      - name: Upload validated Windows installers
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: windows-release-prepared-${{ github.run_id }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 30
+
+  promote_signed_windows_installers:
+    name: Promote signed Windows installers
+    needs: [validate_signed_windows_installers]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    environment: npm-release
+    permissions:
+      actions: read
+      attestations: read
+      contents: write
+    steps:
+      - name: Checkout exact trusted release tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.release_tooling_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/lib/record-shared.mjs
+            scripts/release-tooling-identity.mjs
+            scripts/validate-release-publish-approval.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Download parent Windows release approval
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: windows-release-approval-${{ inputs.release_publish_run_id }}-${{ inputs.release_publish_run_attempt }}
+          path: ${{ runner.temp }}/windows-release-approval
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.release_publish_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download validated Windows installers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: windows-release-prepared-${{ github.run_id }}
+          path: dist
+
       - name: Upload to OpenClaw release
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ inputs.tag }}
+          APPROVAL_PATH: ${{ runner.temp }}/windows-release-approval/approval.json
+          DIRECT_RELEASE_RECOVERY: ${{ inputs.direct_release_recovery && 'true' || 'false' }}
+          EXPECTED_INSTALLER_DIGESTS: ${{ inputs.expected_installer_digests }}
+          EXPECTED_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
+          EXPECTED_WORKFLOW_BRANCH: ${{ inputs.release_tooling_ref }}
+          EXPECTED_WORKFLOW_FULL_REF: ${{ inputs.release_tooling_full_ref }}
+          EXPECTED_WORKFLOW_SHA: ${{ inputs.release_tooling_sha }}
           GH_TOKEN: ${{ github.token }}
+          RELEASE_APPROVAL_KIND: windows-release
+          RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_TARGET_SHA: ${{ inputs.release_target_sha }}
+          RELEASE_TOOLING_FULL_REF: ${{ inputs.release_tooling_full_ref }}
+          RELEASE_TOOLING_REF: ${{ inputs.release_tooling_ref }}
+          RELEASE_TOOLING_SHA: ${{ inputs.release_tooling_sha }}
+          WINDOWS_NODE_INSTALLER_DIGESTS: ${{ inputs.expected_installer_digests }}
+          WINDOWS_NODE_TAG: ${{ inputs.windows_node_tag }}
         run: |
-          $releaseAssets = @(Get-ChildItem -LiteralPath dist -File | Sort-Object Name | ForEach-Object FullName)
-          gh release upload $env:RELEASE_TAG @releaseAssets --repo $env:GITHUB_REPOSITORY --clobber
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to upload Windows release assets to $env:RELEASE_TAG."
+          $ErrorActionPreference = "Stop"
+          function Assert-ReleaseApproval {
+            $verifyArgs = @(
+              "verify",
+              "--repository", $env:GITHUB_REPOSITORY,
+              "--workflow-ref", $env:RELEASE_TOOLING_REF,
+              "--workflow-full-ref", $env:RELEASE_TOOLING_FULL_REF,
+              "--workflow-sha", $env:RELEASE_TOOLING_SHA
+            )
+            if (
+              $env:RELEASE_TOOLING_REF -ne "main" -and
+              $env:RELEASE_TOOLING_FULL_REF -notmatch '^refs/tags/release-publish/'
+            ) {
+              $verifyArgs += "--allow-prevalidated-ref"
+            }
+            node scripts/release-tooling-identity.mjs @verifyArgs | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+              throw "Windows release tooling identity is no longer live."
+            }
+            gh attestation verify $env:APPROVAL_PATH `
+              --repo $env:GITHUB_REPOSITORY `
+              --signer-workflow "$env:GITHUB_REPOSITORY/.github/workflows/openclaw-release-publish.yml" `
+              --source-ref $env:RELEASE_TOOLING_FULL_REF `
+              --source-digest $env:RELEASE_TOOLING_SHA `
+              --deny-self-hosted-runners
+            if ($LASTEXITCODE -ne 0) {
+              throw "Windows release approval attestation verification failed."
+            }
+            gh api `
+              "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:RELEASE_PUBLISH_RUN_ID/attempts/$env:EXPECTED_RUN_ATTEMPT" `
+              --jq '{workflowName: .name, headBranch: .head_branch, headSha: .head_sha, event, status, conclusion, url: .html_url, runAttempt: .run_attempt, repository: .repository.full_name, path}' |
+              node scripts/validate-release-publish-approval.mjs
+            if ($LASTEXITCODE -ne 0) {
+              throw "Windows release approval does not match the exact parent run."
+            }
+          }
+
+          $expectedDigests = $env:EXPECTED_INSTALLER_DIGESTS | ConvertFrom-Json -AsHashtable
+          $expectedFiles = @(
+            "OpenClawCompanion-Setup-arm64.exe",
+            "OpenClawCompanion-Setup-x64.exe",
+            "OpenClawCompanion-SHA256SUMS.txt"
+          ) | Sort-Object
+          $actualFiles = @(Get-ChildItem -LiteralPath dist -File | ForEach-Object Name | Sort-Object)
+          if (Compare-Object -ReferenceObject $expectedFiles -DifferenceObject $actualFiles) {
+            throw "Validated Windows artifact does not match the canonical file contract."
+          }
+          foreach ($file in Get-ChildItem -LiteralPath dist -File | Sort-Object Name) {
+            if ($file.Name -ne "OpenClawCompanion-SHA256SUMS.txt") {
+              $expectedHash = ([string]$expectedDigests[$file.Name]) -replace '^sha256:', ''
+              $actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $file.FullName).Hash
+              if ($actualHash -ne $expectedHash) {
+                throw "Prepared Windows installer does not match its approved digest: $($file.Name)"
+              }
+            }
+            Assert-ReleaseApproval
+            gh release upload $env:RELEASE_TAG $file.FullName `
+              --repo $env:GITHUB_REPOSITORY `
+              --clobber
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to upload Windows release asset $($file.Name) to $env:RELEASE_TAG."
+            }
           }
 
       - name: Verify promoted release asset contract
@@ -202,10 +441,14 @@ jobs:
           RELEASE_TAG: ${{ inputs.tag }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          $ErrorActionPreference = "Stop"
           New-Item -ItemType Directory -Force -Path verified | Out-Null
           $expectedAssets = @(Get-ChildItem -LiteralPath dist -File | Sort-Object Name)
           $expectedCompanionAssetNames = @($expectedAssets | ForEach-Object Name | Sort-Object)
-          $targetRelease = gh release view $env:RELEASE_TAG --repo $env:GITHUB_REPOSITORY --json assets | ConvertFrom-Json
+          $targetRelease = gh release view $env:RELEASE_TAG `
+            --repo $env:GITHUB_REPOSITORY `
+            --json assets |
+            ConvertFrom-Json
           $actualCompanionAssetNames = @(
             $targetRelease.assets |
               Where-Object { $_.name.StartsWith("OpenClawCompanion-") } |
@@ -233,7 +476,6 @@ jobs:
               throw "Failed to download promoted Windows release asset $($asset.Name)."
             }
           }
-
           $manifestPath = "verified/OpenClawCompanion-SHA256SUMS.txt"
           $manifestEntries = @(Get-Content -LiteralPath $manifestPath | ForEach-Object {
             if ($_ -notmatch '^([A-Fa-f0-9]{64})  ([^\\/]+)$') {
@@ -250,15 +492,9 @@ jobs:
               ForEach-Object Name
           )
           $manifestInstallerNames = @($manifestEntries | ForEach-Object Name | Sort-Object)
-          $contractDiff = @(
-            Compare-Object `
-              -ReferenceObject $expectedInstallerNames `
-              -DifferenceObject $manifestInstallerNames
-          )
-          if ($contractDiff.Count -ne 0) {
+          if (Compare-Object -ReferenceObject $expectedInstallerNames -DifferenceObject $manifestInstallerNames) {
             throw "Promoted Windows SHA-256 manifest does not match the installer asset contract."
           }
-
           foreach ($entry in $manifestEntries) {
             $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath "verified/$($entry.Name)").Hash
             if ($hash -ne $entry.Hash) {

--- a/scripts/validate-release-publish-approval.mjs
+++ b/scripts/validate-release-publish-approval.mjs
@@ -42,8 +42,41 @@ function positiveRunAttempt(value) {
   return Number(value);
 }
 
-if (approvalKind === "clawhub-bootstrap" && !approvalPath) {
-  fail("ClawHub bootstrap approval requires an attested approval artifact.");
+function lowercaseSha(value, label) {
+  if (!/^[a-f0-9]{40}$/u.test(value)) {
+    fail(`${label} must be a full lowercase commit SHA.`);
+  }
+  return value;
+}
+
+function canonicalWindowsInstallerDigests(value) {
+  let digests;
+  try {
+    digests = JSON.parse(value);
+  } catch {
+    fail("Windows release approval installer digests must be valid JSON.");
+  }
+  const requiredNames = ["OpenClawCompanion-Setup-arm64.exe", "OpenClawCompanion-Setup-x64.exe"];
+  if (
+    !digests ||
+    Array.isArray(digests) ||
+    typeof digests !== "object" ||
+    JSON.stringify(Object.keys(digests).toSorted()) !== JSON.stringify(requiredNames) ||
+    requiredNames.some(
+      (name) => typeof digests[name] !== "string" || !/^sha256:[a-f0-9]{64}$/u.test(digests[name]),
+    )
+  ) {
+    fail("Windows release approval installer digests do not match the canonical asset contract.");
+  }
+  return Object.fromEntries(requiredNames.map((name) => [name, digests[name]]));
+}
+
+if (["clawhub-bootstrap", "windows-release"].includes(approvalKind) && !approvalPath) {
+  fail(
+    approvalKind === "clawhub-bootstrap"
+      ? "ClawHub bootstrap approval requires an attested approval artifact."
+      : "Windows release approval requires an attested approval artifact.",
+  );
 }
 
 if (approvalPath) {
@@ -81,6 +114,30 @@ if (approvalPath) {
     };
     mismatchMessage =
       "Attested ClawHub bootstrap approval does not match this release target and package set.";
+  } else if (approvalKind === "windows-release") {
+    expectedApproval = {
+      schema: "windows-release-approval.v1",
+      repository: process.env.GITHUB_REPOSITORY,
+      workflow: "OpenClaw Release Publish",
+      parentRunId: releasePublishRunId,
+      parentRunAttempt: positiveRunAttempt(expectedRunAttempt),
+      tooling: {
+        ref: process.env.RELEASE_TOOLING_REF,
+        fullRef: process.env.RELEASE_TOOLING_FULL_REF,
+        sha: lowercaseSha(process.env.RELEASE_TOOLING_SHA ?? "", "Release tooling SHA"),
+      },
+      releaseTag: process.env.RELEASE_TAG,
+      targetSha: lowercaseSha(process.env.RELEASE_TARGET_SHA ?? "", "Release target SHA"),
+      windowsSource: {
+        repository: "openclaw/openclaw-windows-node",
+        tag: process.env.WINDOWS_NODE_TAG,
+        installerDigests: canonicalWindowsInstallerDigests(
+          process.env.WINDOWS_NODE_INSTALLER_DIGESTS ?? "",
+        ),
+      },
+    };
+    mismatchMessage =
+      "Attested Windows release approval does not match this parent, tooling, release target, or installer set.";
   } else {
     fail(`Unsupported release approval kind: ${approvalKind}`);
   }

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6655,6 +6655,11 @@ describe("package artifact reuse", () => {
     );
     expect(releaseWorkflow).toContain("promote_windows_release_assets()");
     expect(releaseWorkflow).toContain("dispatch_workflow windows-node-release.yml");
+    expect(releaseWorkflow).toContain('schema: "windows-release-approval.v1"');
+    expect(releaseWorkflow).toContain("Attest Windows release approval");
+    expect(releaseWorkflow).toContain(
+      "windows-release-approval-${{ github.run_id }}-${{ github.run_attempt }}",
+    );
     expect(releaseWorkflow).toContain("verify_windows_release_asset_contract");
     expect(releaseWorkflow).toContain("Validate stable Windows source release");
     expect(releaseWorkflow).toContain("id: windows_source");
@@ -6671,6 +6676,9 @@ describe("package artifact reuse", () => {
     expect(releaseWorkflow).toContain(
       '-f expected_installer_digests="${WINDOWS_NODE_INSTALLER_DIGESTS}"',
     );
+    expect(releaseWorkflow).toContain('-f release_publish_run_attempt="${GITHUB_RUN_ATTEMPT}"');
+    expect(releaseWorkflow).toContain('-f release_tooling_sha="${PARENT_WORKFLOW_SHA}"');
+    expect(releaseWorkflow).toContain('-f release_target_sha="${TARGET_SHA}"');
     expect(releaseWorkflow).toContain("missing prevalidated Windows installer digests");
     expect(releaseWorkflow).toContain("does not match its pinned digest");
     expect(releaseWorkflow).toContain(
@@ -6702,17 +6710,30 @@ describe("package artifact reuse", () => {
 
     expect(windowsWorkflow).not.toContain("default: latest");
     expect(windowsWorkflow).toContain("expected_installer_digests:");
+    expect(windowsWorkflow).toContain("release_publish_run_attempt:");
+    expect(windowsWorkflow).toContain("release_tooling_full_ref:");
+    expect(windowsWorkflow).toContain("release_tooling_sha:");
+    expect(windowsWorkflow).toContain("release_target_sha:");
+    expect(windowsWorkflow).toContain("direct_release_recovery:");
+    expect(windowsWorkflow).toContain("validate_signed_windows_installers:");
+    expect(windowsWorkflow).toContain("promote_signed_windows_installers:");
+    expect(windowsWorkflow).toContain("needs: [validate_signed_windows_installers]");
+    expect(windowsWorkflow).toContain("environment: npm-release");
+    expect(windowsWorkflow).toContain(
+      "windows-release-approval-${{ inputs.release_publish_run_id }}-${{ inputs.release_publish_run_attempt }}",
+    );
+    expect(windowsWorkflow).toContain("RELEASE_APPROVAL_KIND: windows-release");
+    expect(windowsWorkflow).toContain("node scripts/release-tooling-identity.mjs @verifyArgs");
+    expect(windowsWorkflow).toContain("Windows release tooling identity is no longer live.");
     expect(windowsWorkflow).toContain("expected_installer_digests must contain exactly");
     expect(windowsWorkflow).toContain("must be an explicit openclaw-windows-node release tag");
-    expect(windowsWorkflow).toContain("$installerPatterns = @(");
-    expect(windowsWorkflow).toContain("Every matched installer is signature-checked");
+    expect(windowsWorkflow).toContain("$requiredInstallerNames = @(");
     expect(windowsWorkflow).toContain("Get-ChildItem -LiteralPath dist -File");
     expect(windowsWorkflow).toContain(
       "Downloaded Windows source asset does not match pinned digest",
     );
-    expect(windowsWorkflow).toContain(
-      "--repo openclaw/openclaw-windows-node --json tagName,isDraft,isPrerelease,assets,url",
-    );
+    expect(windowsWorkflow).toContain("--repo openclaw/openclaw-windows-node");
+    expect(windowsWorkflow).toContain("--json tagName,isDraft,isPrerelease,assets,url");
     expect(windowsWorkflow).toContain(
       "Windows source release must contain exactly one required asset",
     );
@@ -6728,11 +6749,13 @@ describe("package artifact reuse", () => {
     expect(windowsWorkflow).toContain(
       "Promoted OpenClawCompanion asset names do not exactly match the current contract",
     );
-    expect(windowsWorkflow).toContain(
-      "$targetRelease = gh release view $env:RELEASE_TAG --repo $env:GITHUB_REPOSITORY --json assets",
-    );
+    expect(windowsWorkflow).toContain("$targetRelease = gh release view $env:RELEASE_TAG");
+    expect(windowsWorkflow).toContain("--json assets");
     expect(windowsWorkflow).toContain("Promoted Windows SHA-256 manifest does not match");
     expect(windowsWorkflow).toContain("Promoted Windows release asset checksum mismatch");
+    expect(windowsWorkflow.indexOf("Assert-ReleaseApproval")).toBeLessThan(
+      windowsWorkflow.indexOf("gh release upload $env:RELEASE_TAG"),
+    );
     expect(releaseDocs).toContain(
       "the selected `windows_node_tag`, its saved `windows_node_installer_digests`,",
     );

--- a/test/scripts/validate-release-publish-approval.test.ts
+++ b/test/scripts/validate-release-publish-approval.test.ts
@@ -22,9 +22,14 @@ function runApprovalScript(
     GITHUB_REPOSITORY?: string;
     RELEASE_APPROVAL_KIND?: string;
     RELEASE_PACKAGES?: string;
+    RELEASE_TOOLING_FULL_REF?: string;
+    RELEASE_TOOLING_REF?: string;
+    RELEASE_TOOLING_SHA?: string;
     RELEASE_TAG?: string;
     RELEASE_PUBLISH_RUN_ID?: string;
     RELEASE_TARGET_SHA?: string;
+    WINDOWS_NODE_INSTALLER_DIGESTS?: string;
+    WINDOWS_NODE_TAG?: string;
   } = {},
 ) {
   return spawnSync(process.execPath, [SCRIPT_PATH], {
@@ -43,9 +48,14 @@ function runApprovalScript(
       GITHUB_REPOSITORY: env.GITHUB_REPOSITORY ?? "openclaw/openclaw",
       RELEASE_APPROVAL_KIND: env.RELEASE_APPROVAL_KIND ?? "android",
       RELEASE_PACKAGES: env.RELEASE_PACKAGES ?? "",
+      RELEASE_TOOLING_FULL_REF: env.RELEASE_TOOLING_FULL_REF ?? "",
+      RELEASE_TOOLING_REF: env.RELEASE_TOOLING_REF ?? "",
+      RELEASE_TOOLING_SHA: env.RELEASE_TOOLING_SHA ?? "",
       RELEASE_TAG: env.RELEASE_TAG ?? "v2026.6.21",
       RELEASE_PUBLISH_RUN_ID: env.RELEASE_PUBLISH_RUN_ID ?? "123",
       RELEASE_TARGET_SHA: env.RELEASE_TARGET_SHA ?? "a".repeat(40),
+      WINDOWS_NODE_INSTALLER_DIGESTS: env.WINDOWS_NODE_INSTALLER_DIGESTS ?? "",
+      WINDOWS_NODE_TAG: env.WINDOWS_NODE_TAG ?? "",
     },
     input: JSON.stringify(run),
   });
@@ -101,6 +111,40 @@ function writeClawHubApproval(overrides: Record<string, unknown> = {}) {
       releaseTag: "v2026.7.1-beta.3",
       targetSha: "a".repeat(40),
       packages: ["@openclaw/meta-provider", "@openclaw/voice-call"],
+      ...overrides,
+    })}\n`,
+  );
+  return approvalPath;
+}
+
+const windowsInstallerDigests = {
+  "OpenClawCompanion-Setup-arm64.exe": `sha256:${"1".repeat(64)}`,
+  "OpenClawCompanion-Setup-x64.exe": `sha256:${"2".repeat(64)}`,
+};
+
+function writeWindowsApproval(overrides: Record<string, unknown> = {}) {
+  const tempRoot = tempRoots.make("openclaw-windows-release-approval-");
+  const approvalPath = path.join(tempRoot, "approval.json");
+  fs.writeFileSync(
+    approvalPath,
+    `${JSON.stringify({
+      schema: "windows-release-approval.v1",
+      repository: "openclaw/openclaw",
+      workflow: "OpenClaw Release Publish",
+      parentRunId: "123",
+      parentRunAttempt: 2,
+      tooling: {
+        ref: "release-publish/dddddddddddd-111",
+        fullRef: "refs/tags/release-publish/dddddddddddd-111",
+        sha: "d".repeat(40),
+      },
+      releaseTag: "v2026.6.21",
+      targetSha: "a".repeat(40),
+      windowsSource: {
+        repository: "openclaw/openclaw-windows-node",
+        tag: "v0.6.3",
+        installerDigests: windowsInstallerDigests,
+      },
       ...overrides,
     })}\n`,
   );
@@ -279,6 +323,110 @@ describe("scripts/validate-release-publish-approval.mjs", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
       "ClawHub bootstrap approval requires an attested approval artifact.",
+    );
+  });
+
+  it("accepts an exact attested Windows release handoff", () => {
+    const approvalPath = writeWindowsApproval();
+    const workflowSha = "d".repeat(40);
+    const workflowRef = "release-publish/dddddddddddd-111";
+    const workflowFullRef = `refs/tags/${workflowRef}`;
+    const result = runApprovalScript(
+      approvalRun({
+        headBranch: workflowRef,
+        headSha: workflowSha,
+        path: `.github/workflows/openclaw-release-publish.yml@${workflowFullRef}`,
+        runAttempt: 2,
+      }),
+      {
+        APPROVAL_PATH: approvalPath,
+        EXPECTED_RUN_ATTEMPT: "2",
+        EXPECTED_WORKFLOW_BRANCH: workflowRef,
+        EXPECTED_WORKFLOW_FULL_REF: workflowFullRef,
+        EXPECTED_WORKFLOW_SHA: workflowSha,
+        RELEASE_APPROVAL_KIND: "windows-release",
+        RELEASE_TOOLING_FULL_REF: workflowFullRef,
+        RELEASE_TOOLING_REF: workflowRef,
+        RELEASE_TOOLING_SHA: workflowSha,
+        WINDOWS_NODE_INSTALLER_DIGESTS: JSON.stringify(windowsInstallerDigests),
+        WINDOWS_NODE_TAG: "v0.6.3",
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it.each([
+    ["parent run", { parentRunId: "999" }, {}],
+    ["parent attempt", { parentRunAttempt: 1 }, {}],
+    [
+      "tooling tuple",
+      { tooling: { ref: "main", fullRef: "refs/heads/main", sha: "d".repeat(40) } },
+      {},
+    ],
+    ["release target", { targetSha: "c".repeat(40) }, {}],
+    [
+      "Windows source tag",
+      {
+        windowsSource: {
+          repository: "openclaw/openclaw-windows-node",
+          tag: "v0.6.4",
+          installerDigests: windowsInstallerDigests,
+        },
+      },
+      {},
+    ],
+    [
+      "installer digest",
+      {},
+      {
+        WINDOWS_NODE_INSTALLER_DIGESTS: JSON.stringify({
+          ...windowsInstallerDigests,
+          "OpenClawCompanion-Setup-x64.exe": `sha256:${"3".repeat(64)}`,
+        }),
+      },
+    ],
+    ["extra field", { unexpected: true }, {}],
+  ])("rejects a Windows release approval for another %s", (_name, overrides, envOverrides) => {
+    const approvalPath = writeWindowsApproval(overrides);
+    const workflowSha = "d".repeat(40);
+    const workflowRef = "release-publish/dddddddddddd-111";
+    const workflowFullRef = `refs/tags/${workflowRef}`;
+    const result = runApprovalScript(
+      approvalRun({
+        headBranch: workflowRef,
+        headSha: workflowSha,
+        path: `.github/workflows/openclaw-release-publish.yml@${workflowFullRef}`,
+        runAttempt: 2,
+      }),
+      {
+        APPROVAL_PATH: approvalPath,
+        EXPECTED_RUN_ATTEMPT: "2",
+        EXPECTED_WORKFLOW_BRANCH: workflowRef,
+        EXPECTED_WORKFLOW_FULL_REF: workflowFullRef,
+        EXPECTED_WORKFLOW_SHA: workflowSha,
+        RELEASE_APPROVAL_KIND: "windows-release",
+        RELEASE_TOOLING_FULL_REF: workflowFullRef,
+        RELEASE_TOOLING_REF: workflowRef,
+        RELEASE_TOOLING_SHA: workflowSha,
+        WINDOWS_NODE_INSTALLER_DIGESTS: JSON.stringify(windowsInstallerDigests),
+        WINDOWS_NODE_TAG: "v0.6.3",
+        ...envOverrides,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Attested Windows release approval does not match");
+  });
+
+  it("rejects a Windows release handoff without an attested approval artifact", () => {
+    const result = runApprovalScript(approvalRun(), {
+      RELEASE_APPROVAL_KIND: "windows-release",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Windows release approval requires an attested approval artifact.",
     );
   });
 


### PR DESCRIPTION
Related: #126881

## What Problem This Solves

Resolves a release-integrity gap where GitHub Release edits and Windows installer promotion could continue after the approving release-tooling ref moved or without an immutable handoff binding the exact parent attempt, tooling revision, candidate, source release, and installer digests.

## Why This Change Was Made

Every GitHub Release mutation now revalidates the live protected-tooling identity immediately before the write. Stable Windows promotion consumes an attested `windows-release-approval.v1` artifact, validates installers in a read-only job, and performs per-asset writes only in a separate `npm-release` environment job. Recovery must reuse the original attested tuple and cannot substitute current `main`.

## User Impact

Release operators get fail-closed GitHub and Windows publication: moving refs, stale recovery inputs, mismatched parent attempts, changed candidates, changed Windows source tags, or changed installer digests stop before privileged writes.

## Evidence

- Stacked exactly on protected-tooling head `ac8018edcf93489277cd7c0267956518653c07ed`.
- Signed head: `8a09e719535`.
- `actionlint -color .github/workflows/openclaw-release-publish.yml .github/workflows/windows-node-release.yml`
- `node scripts/run-vitest.mjs test/scripts/validate-release-publish-approval.test.ts` - 33 passed.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts -t "gates stable GitHub publication on the Windows Hub release asset contract|rejects unsafe direct Windows recovery before uploading assets|keeps release publish artifacts and release-note ordering wired|resolves broad release evidence and exact-binds every publish child"` - 4 passed.
- Focused `oxlint` passed for the changed script and tests.
- `git diff --check`

Production delta is net +411 lines, justified by the new immutable approval schema, the read-only/promote ownership split, and immediate privileged-writer revalidation. Tests are net +171 lines.
