### PR TITLE
perf(channels): coalesce typing starts

### DIFF
--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -109,28 +109,105 @@ describe("createTypingCallbacks", () => {
     }
   });
 
-  it("does not block reply start on a pending typing request", async () => {
+  it("coalesces concurrent starts without blocking and allows a later start", async () => {
     let resolveStart: (() => void) | undefined;
     const { start, callbacks } = createTypingHarness({
-      start: vi.fn(
-        () =>
-          new Promise<void>((resolve) => {
-            resolveStart = resolve;
-          }),
-      ),
+      start: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((resolve) => {
+              resolveStart = resolve;
+            }),
+        )
+        .mockResolvedValue(undefined),
     });
 
     try {
-      await callbacks.onReplyStart();
+      await Promise.all(Array.from({ length: 100 }, () => callbacks.onReplyStart()));
 
       expect(start).toHaveBeenCalledTimes(1);
       if (!resolveStart) {
         throw new Error("Expected typing start resolver to be initialized");
       }
       resolveStart();
+      await flushMicrotasks();
+
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(2);
     } finally {
       callbacks.onCleanup?.();
     }
+  });
+
+  it("coalesces explicit starts with a pending keepalive without shifting cadence", async () => {
+    await withFakeTimers(async () => {
+      let resolvePendingStart: (() => void) | undefined;
+      const { start, callbacks } = createTypingHarness({
+        start: vi
+          .fn()
+          .mockResolvedValueOnce(undefined)
+          .mockImplementationOnce(
+            () =>
+              new Promise<void>((resolve) => {
+                resolvePendingStart = resolve;
+              }),
+          )
+          .mockResolvedValue(undefined),
+      });
+
+      await callbacks.onReplyStart();
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(start).toHaveBeenCalledTimes(2);
+
+      await callbacks.onReplyStart();
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(start).toHaveBeenCalledTimes(2);
+
+      if (!resolvePendingStart) {
+        throw new Error("Expected pending keepalive resolver to be initialized");
+      }
+      resolvePendingStart();
+      await flushMicrotasks();
+
+      await vi.advanceTimersByTimeAsync(2_999);
+      expect(start).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(start).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("does not arm timers or restart after cleanup while a start settles late", async () => {
+    await withFakeTimers(async () => {
+      let resolveStart: (() => void) | undefined;
+      const { start, stop, callbacks } = createTypingHarness({
+        maxDurationMs: 10_000,
+        start: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              resolveStart = resolve;
+            }),
+        ),
+      });
+
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+
+      callbacks.onCleanup?.();
+      if (!resolveStart) {
+        throw new Error("Expected typing start resolver to be initialized");
+      }
+      resolveStart();
+      await flushMicrotasks();
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(20_000);
+      await callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("invokes stop on idle and reports stop errors", async () => {
@@ -219,12 +296,12 @@ describe("createTypingCallbacks", () => {
     });
   });
 
-  it("stops keepalive after consecutive start failures", async () => {
+  it("counts a coalesced rejection once and stops keepalive at the failure breaker", async () => {
     await withFakeTimers(async () => {
       const { start, onStartError, callbacks } = createTypingHarness({
         start: vi.fn().mockRejectedValue(new Error("gone")),
       });
-      await callbacks.onReplyStart();
+      await Promise.all(Array.from({ length: 100 }, () => callbacks.onReplyStart()));
       await flushMicrotasks();
       expect(start).toHaveBeenCalledTimes(1);
       expect(onStartError).toHaveBeenCalledTimes(1);

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -60,9 +60,19 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
       keepaliveLoop.stop();
     },
   });
+  // Explicit refreshes and keepalive ticks share this gate so one stalled
+  // provider request cannot fan out into unbounded concurrent starts.
+  let startInFlight: ReturnType<typeof startGuard.run> | undefined;
 
   const fireStart = async (): Promise<void> => {
-    await startGuard.run(() => params.start());
+    const pending = (startInFlight ??= startGuard.run(() => params.start()));
+    try {
+      await pending;
+    } finally {
+      if (startInFlight === pending) {
+        startInFlight = undefined;
+      }
+    }
   };
 
   const keepaliveLoop = createTypingKeepaliveLoop({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where overlapping typing-start callbacks could launch an unbounded number of provider requests. A stalled channel `start()` operation was protected from overlapping keepalive ticks, but every explicit `onReplyStart()` still launched another request.

## Why This Change Was Made

The shared channel typing lifecycle now owns one in-flight start promise. Explicit reply starts and keepalive ticks reuse that promise until it settles, then a later start can proceed normally. The existing nonblocking callback contract, failure breaker, keepalive cadence, TTL, stop/cleanup behavior, and late-settlement checks remain in the same owner.

The production delta is the lifecycle-local single-flight state and identity-safe settlement cleanup; it does not add a provider/config/public surface.

## User Impact

Repeated reply-start signals no longer fan out stalled typing requests to Discord, Matrix, or other channels using this shared lifecycle. Typing cadence and visible behavior are unchanged when provider calls complete normally.

Production LOC: +11/-1 (net +10) | Tests: +87/-10 (net +77)

AI-assisted: yes. The shared lifecycle, provider siblings, regression coverage, and final diff were reviewed directly.

## Evidence

- Pre-fix boundary regressions: 100 concurrent starts launched 100 provider operations; an explicit start during a pending keepalive launched a third operation; 100 concurrent rejected starts invoked the provider 100 times.
- Post-fix: those same concurrent starts share one provider operation; a later settled start proceeds; rejections count once toward the existing breaker; cleanup prevents timers or restarts after a late settlement.
- Focused benchmark, 10,000 concurrent callbacks: underlying provider starts `10,000 -> 1`; callback batch `17.5 ms -> 16.9 ms` in the same orb.
- `node scripts/run-vitest.mjs src/channels/typing.test.ts src/channels/typing-start-guard.test.ts src/auto-reply/reply/typing-persistence.test.ts` — 36/36 passed before and after rebase.
- Representative Discord message-handler/ack coverage — 17/17 passed.
- Representative Matrix monitor/handler coverage — 171/171 passed.
- Full `pnpm check:changed` — passed, including format, typechecks, lint, dead exports, cycles, boundaries, and guards.
- Exact-head CI exposed a current-main full-lint failure in the oversized cron view suite. [PR #127018](https://github.com/openclaw/openclaw/pull/127018) fixed that independent breakage; this branch was rebased onto the repair and carries no duplicate UI change.
- TruffleHog changed-content scan — clean.
- Fresh autoreview on the final patch — no accepted/actionable findings; patch correct, confidence 0.99.
