### PR TITLE
fix(macos): isolate profiles and report direct Gateway failures

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -49616,6 +49616,10 @@
       "sites": [
         {
           "kind": "conditional-branch",
+          "path": "apps/macos/Sources/OpenClaw/ControlChannel.swift"
+        },
+        {
+          "kind": "conditional-branch",
           "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift"
         }
       ]

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -49616,10 +49616,6 @@
       "sites": [
         {
           "kind": "conditional-branch",
-          "path": "apps/macos/Sources/OpenClaw/ControlChannel.swift"
-        },
-        {
-          "kind": "conditional-branch",
           "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift"
         }
       ]

--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -47,19 +47,25 @@ enum CommandResolver {
         return ["/bin/sh", "-c", script]
     }
 
-    static func projectRoot() -> URL {
-        if let stored = AppDefaults.standard.string(forKey: projectRootDefaultsKey),
+    static func projectRoot(
+        defaults: UserDefaults = AppDefaults.standard,
+        profile: AppProfile = .current,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL
+    {
+        if let stored = defaults.string(forKey: projectRootDefaultsKey),
            let url = expandPath(stored),
            FileManager().fileExists(atPath: url.path)
         {
             return url
         }
-        let fallback = FileManager().homeDirectoryForCurrentUser
-            .appendingPathComponent("Projects/openclaw")
+        if profile.isActive {
+            return profile.stateDirectoryURL(homeDirectory: homeDirectory)
+        }
+        let fallback = homeDirectory.appendingPathComponent("Projects/openclaw")
         if FileManager().fileExists(atPath: fallback.path) {
             return fallback
         }
-        return FileManager().homeDirectoryForCurrentUser
+        return homeDirectory
     }
 
     static func setProjectRoot(_ path: String) {

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -211,7 +211,7 @@ final class ControlChannel {
             self.setStateThrottled(.connected)
             PresenceReporter.shared.sendImmediate(reason: "connect")
         } catch {
-            let message = self.friendlyGatewayMessage(error)
+            let message = Self.friendlyGatewayMessage(error, configRoot: OpenClawConfigFile.loadDict())
             self.setStateThrottled(.degraded(message))
         }
     }
@@ -237,7 +237,7 @@ final class ControlChannel {
             self.setStateThrottled(.connected)
             return payload
         } catch {
-            let message = self.friendlyGatewayMessage(error)
+            let message = Self.friendlyGatewayMessage(error, configRoot: OpenClawConfigFile.loadDict())
             self.setStateThrottled(.degraded(message))
             throw ControlChannelError.badResponse(message)
         }
@@ -266,7 +266,7 @@ final class ControlChannel {
             self.setStateThrottled(.connected)
             return data
         } catch {
-            let message = self.friendlyGatewayMessage(error)
+            let message = Self.friendlyGatewayMessage(error, configRoot: OpenClawConfigFile.loadDict())
             self.setStateThrottled(.degraded(message))
             throw ControlChannelError.badResponse(message)
         }
@@ -283,13 +283,13 @@ final class ControlChannel {
             self.setStateThrottled(.connected)
             return data
         } catch {
-            let message = self.friendlyGatewayMessage(error)
+            let message = Self.friendlyGatewayMessage(error, configRoot: OpenClawConfigFile.loadDict())
             self.setStateThrottled(.degraded(message))
             throw ControlChannelError.badResponse(message)
         }
     }
 
-    private func friendlyGatewayMessage(_ error: Error) -> String {
+    static func friendlyGatewayMessage(_ error: Error, configRoot: [String: Any]) -> String {
         // Map URLSession/WS errors into user-facing, actionable text.
         if let ctrlErr = error as? ControlChannelError, let desc = ctrlErr.errorDescription {
             return desc
@@ -299,12 +299,24 @@ final class ControlChannel {
             return authIssue.statusMessage
         }
 
+        let mode = ConnectionModeResolver.resolve(root: configRoot).mode
+        let transport = GatewayRemoteConfig.resolveTransportResolution(root: configRoot)
+        let localPort = GatewayEnvironment.gatewayPort()
+        let directURL = mode == .remote && transport.transport == .direct ? transport.directURL : nil
+        let endpoint = if let url = directURL, let host = url.host,
+                          let port = GatewayRemoteConfig.defaultPort(for: url)
+        {
+            "\(host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host):\(port)"
+        } else {
+            "localhost:\(localPort)"
+        }
+
         // If the gateway explicitly rejects the hello (e.g., auth/token mismatch), surface it.
         if let urlErr = error as? URLError,
            urlErr.code == .dataNotAllowed // used for WS close 1008 auth failures
         {
             let reason = urlErr.failureURLString ?? urlErr.localizedDescription
-            let tokenKey = CommandResolver.connectionModeIsRemote()
+            let tokenKey = mode == .remote
                 ? "gateway.remote.token"
                 : "gateway.auth.token"
             return
@@ -320,34 +332,37 @@ final class ControlChannel {
         if nsError.domain == "Gateway",
            nsError.localizedDescription.contains("hello failed (unexpected response)")
         {
-            let port = GatewayEnvironment.gatewayPort()
+            if directURL != nil {
+                return "Gateway handshake got non-gateway data on \(endpoint); check the Gateway URL and server."
+            }
             return """
-            Gateway handshake got non-gateway data on localhost:\(port).
+            Gateway handshake got non-gateway data on \(endpoint).
             Another process is using that port or the SSH forward failed.
-            Stop the local gateway/port-forward on \(port) and retry Remote mode.
+            Stop the local gateway/port-forward on \(localPort) and retry Remote mode.
             """
         }
 
         if let urlError = error as? URLError {
-            let port = GatewayEnvironment.gatewayPort()
             switch urlError.code {
             case .cancelled:
-                return "Gateway connection was closed; start the gateway (localhost:\(port)) and retry."
+                return "Gateway connection was closed; start the gateway (\(endpoint)) and retry."
             case .cannotFindHost, .cannotConnectToHost:
-                let isRemote = CommandResolver.connectionModeIsRemote()
-                if isRemote {
+                if directURL != nil {
+                    return "Cannot reach gateway at \(endpoint); check the Gateway URL and remote gateway."
+                }
+                if mode == .remote {
                     return """
-                    Cannot reach gateway at localhost:\(port).
+                    Cannot reach gateway at \(endpoint).
                     Remote mode uses an SSH tunnel—check the SSH target and that the tunnel is running.
                     """
                 }
-                return "Cannot reach gateway at localhost:\(port); ensure the gateway is running."
+                return "Cannot reach gateway at \(endpoint); ensure the gateway is running."
             case .networkConnectionLost:
                 return "Gateway connection dropped; gateway likely restarted—retry."
             case .timedOut:
-                return "Gateway request timed out; check gateway on localhost:\(port)."
+                return "Gateway request timed out; check gateway on \(endpoint)."
             case .notConnectedToInternet:
-                if Self.isLikelyLocalNetworkPermissionBlock() {
+                if Self.isLikelyLocalNetworkPermissionBlock(configRoot: configRoot) {
                     return """
                     macOS is blocking OpenClaw Local Network access.
                     Allow OpenClaw in System Settings → Privacy & Security → Local Network, then relaunch the app.
@@ -360,8 +375,7 @@ final class ControlChannel {
         }
 
         if nsError.domain == "Gateway", nsError.code == 5 {
-            let port = GatewayEnvironment.gatewayPort()
-            return "Gateway request timed out; check the gateway process on localhost:\(port)."
+            return "Gateway request timed out; check the gateway process on \(endpoint)."
         }
 
         let detail = nsError.localizedDescription.isEmpty ? "unknown gateway error" : nsError.localizedDescription
@@ -370,10 +384,9 @@ final class ControlChannel {
         return "Gateway error: \(trimmed)"
     }
 
-    private static func isLikelyLocalNetworkPermissionBlock() -> Bool {
-        let root = OpenClawConfigFile.loadDict()
-        let resolution = GatewayRemoteConfig.resolveTransportResolution(root: root)
-        guard ConnectionModeResolver.resolve(root: root).mode == .remote,
+    private static func isLikelyLocalNetworkPermissionBlock(configRoot: [String: Any]) -> Bool {
+        let resolution = GatewayRemoteConfig.resolveTransportResolution(root: configRoot)
+        guard ConnectionModeResolver.resolve(root: configRoot).mode == .remote,
               resolution.transport == .direct,
               let url = resolution.directURL,
               url.scheme?.lowercased() == "ws",
@@ -412,10 +425,10 @@ final class ControlChannel {
             if mode == .remote {
                 do {
                     let port = try await GatewayEndpointStore.shared.ensureRemoteControlTunnel()
-                    self.logger.info("control channel recovery ensured SSH tunnel port=\(port, privacy: .public)")
+                    self.logger.info("control channel recovery ensured remote endpoint port=\(port, privacy: .public)")
                 } catch {
                     self.logger.error(
-                        "control channel recovery tunnel failed \(error.localizedDescription, privacy: .public)")
+                        "control channel remote endpoint recovery failed \(error.localizedDescription, privacy: .public)")
                 }
             }
 

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -428,7 +428,7 @@ final class ControlChannel {
                     self.logger.info("control channel recovery ensured remote endpoint port=\(port, privacy: .public)")
                 } catch {
                     self.logger.error(
-                        "control channel remote endpoint recovery failed \(error.localizedDescription, privacy: .public)")
+                        "control channel remote endpoint failed \(error.localizedDescription, privacy: .public)")
                 }
             }
 

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -306,7 +306,7 @@ final class ControlChannel {
         let endpoint = if let url = directURL, let host = url.host,
                           let port = GatewayRemoteConfig.defaultPort(for: url)
         {
-            "\(host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host):\(port)"
+            "\(host.contains(":") && !host.hasPrefix("[") ? "[" + host + "]" : host):\(port)"
         } else {
             "localhost:\(localPort)"
         }

--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -22,6 +22,30 @@ import Testing
         return (tmp, pnpmPath)
     }
 
+    @Test func `named profiles do not inherit the default development checkout`() throws {
+        let home = try makeTempDirForTests()
+        let checkout = home.appendingPathComponent("Projects/openclaw")
+        try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
+        let defaults = self.makeDefaults()
+        let defaultProfile = AppProfile(environment: [:])
+        let namedProfile = AppProfile(environment: ["OPENCLAW_PROFILE": "isolated"])
+
+        #expect(CommandResolver.projectRoot(
+            defaults: defaults,
+            profile: defaultProfile,
+            homeDirectory: home).path == checkout.path)
+        #expect(CommandResolver.projectRoot(
+            defaults: defaults,
+            profile: namedProfile,
+            homeDirectory: home).path == home.appendingPathComponent(".openclaw-isolated").path)
+
+        defaults.set(checkout.path, forKey: "openclaw.gatewayProjectRootPath")
+        #expect(CommandResolver.projectRoot(
+            defaults: defaults,
+            profile: namedProfile,
+            homeDirectory: home).path == checkout.path)
+    }
+
     @Test func `prefers open claw binary`() async throws {
         let defaults = self.makeLocalDefaults()
 

--- a/apps/macos/Tests/OpenClawIPCTests/ControlChannelStateDebouncerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ControlChannelStateDebouncerTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct ControlChannelStateDebouncerTests {
     @Test func `terminal states apply immediately`() {
-        let start = Date(timeIntervalSince1970: 1_000)
+        let start = Date(timeIntervalSince1970: 1000)
         var debouncer = ControlChannelStateDebouncer(interval: 0.5, lastAppliedAt: start)
 
         let degradedDelay = debouncer.delayBeforeApplying(
@@ -27,7 +27,7 @@ struct ControlChannelStateDebouncerTests {
     }
 
     @Test func `nonterminal states are debounced within interval`() {
-        let start = Date(timeIntervalSince1970: 1_000)
+        let start = Date(timeIntervalSince1970: 1000)
         var debouncer = ControlChannelStateDebouncer(interval: 0.5, lastAppliedAt: start)
 
         let soonDelay = debouncer.delayBeforeApplying(
@@ -45,7 +45,7 @@ struct ControlChannelStateDebouncerTests {
     }
 
     @Test func `deferred apply resets debounce window`() {
-        let start = Date(timeIntervalSince1970: 1_000)
+        let start = Date(timeIntervalSince1970: 1000)
         var debouncer = ControlChannelStateDebouncer(interval: 0.5, lastAppliedAt: start)
 
         debouncer.recordDeferredApply(at: start.addingTimeInterval(0.5))
@@ -56,5 +56,136 @@ struct ControlChannelStateDebouncerTests {
             now: start.addingTimeInterval(0.7))
         #expect(delayAfterDeferredUpdate != nil)
         #expect(abs((delayAfterDeferredUpdate ?? 0) - 0.3) < 0.001)
+    }
+}
+
+@MainActor
+struct ControlChannelGatewayMessageTests {
+    @Test(arguments: [
+        URLError.Code.cannotFindHost,
+        URLError.Code.cannotConnectToHost,
+        URLError.Code.cancelled,
+        URLError.Code.timedOut,
+    ])
+    func `direct gateway failures identify their actual endpoint`(code: URLError.Code) {
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "ws://127.0.0.1:42674",
+                ],
+            ],
+        ]
+
+        let message = ControlChannel.friendlyGatewayMessage(URLError(code), configRoot: root)
+
+        #expect(message.contains("127.0.0.1:42674"))
+        #expect(!message.contains("SSH"))
+    }
+
+    @Test func `direct gateway diagnostics never expose URL credentials`() {
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://user:secret@gateway.example:9443/path?token=private",
+                ],
+            ],
+        ]
+
+        let message = ControlChannel.friendlyGatewayMessage(
+            URLError(.cannotConnectToHost),
+            configRoot: root)
+
+        #expect(message.contains("gateway.example:9443"))
+        #expect(!message.contains("secret"))
+        #expect(!message.contains("private"))
+    }
+
+    @Test func `direct secure gateway diagnostics use the default TLS port`() {
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://gateway.example",
+                ],
+            ],
+        ]
+
+        let message = ControlChannel.friendlyGatewayMessage(
+            URLError(.cannotConnectToHost),
+            configRoot: root)
+
+        #expect(message.contains("gateway.example:443"))
+    }
+
+    @Test func `direct IPv6 gateway diagnostics bracket the endpoint host`() {
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://[fd12:3456:789a::1]:9443",
+                ],
+            ],
+        ]
+
+        let message = ControlChannel.friendlyGatewayMessage(
+            URLError(.cannotConnectToHost),
+            configRoot: root)
+
+        #expect(message.contains("[fd12:3456:789a::1]:9443"))
+    }
+
+    @Test func `SSH gateway failures preserve tunnel recovery guidance`() {
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": ["transport": "ssh"],
+            ],
+        ]
+
+        let message = ControlChannel.friendlyGatewayMessage(
+            URLError(.cannotConnectToHost),
+            configRoot: root)
+
+        #expect(message.contains("localhost:"))
+        #expect(message.contains("SSH tunnel"))
+    }
+
+    @Test func `direct gateway handshake failures identify the remote endpoint`() {
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "transport": "direct",
+                    "url": "wss://gateway.example:9443",
+                ],
+            ],
+        ]
+        let error = NSError(
+            domain: "Gateway",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "hello failed (unexpected response)"])
+
+        let message = ControlChannel.friendlyGatewayMessage(error, configRoot: root)
+
+        #expect(message.contains("gateway.example:9443"))
+        #expect(!message.contains("SSH"))
+    }
+
+    @Test func `local gateway failures preserve local recovery guidance`() {
+        let root: [String: Any] = ["gateway": ["mode": "local"]]
+
+        let message = ControlChannel.friendlyGatewayMessage(
+            URLError(.cannotConnectToHost),
+            configRoot: root)
+
+        #expect(message.contains("localhost:"))
+        #expect(message.contains("ensure the gateway is running"))
+        #expect(!message.contains("SSH"))
     }
 }


### PR DESCRIPTION
## Summary

- Keep named macOS app profiles inside their own managed state tree unless the operator explicitly selects a development checkout. Previously, a fresh isolated remote profile without a CLI silently discovered the default development checkout and spawned its source worker, rebuilding unrelated user files.
- Format direct remote Gateway failures from the actual selected endpoint instead of an unrelated local port and SSH-tunnel advice. Preserve SSH/local guidance, bracket IPv6 endpoints, apply the correct default TLS port, and never expose URL userinfo or query credentials.
- Keep recovery logs transport-neutral and cover the shared profile, command-resolution, Gateway, node-worker, remote-probe, and onboarding owner boundaries.

## Root cause

`CommandResolver.projectRoot` inherited the default development-checkout fallback before named app profiles existed. `ControlChannel.friendlyGatewayMessage` likewise assumed every remote route was an SSH tunnel and repeatedly reconstructed its target from the profile's local Gateway port. Both assumptions became invalid when isolated profiles and direct `ws`/`wss` remote transport were introduced.

The fixes repair the canonical project-root and error-formatting owners. The normal default-profile checkout and explicitly selected per-profile checkout remain available. Direct endpoint display is built only from the parsed host and effective port; SSH and local routes retain their existing recovery guidance.

## Verification

- Profile regression failed before the fix because the isolated profile resolved `Projects/openclaw` instead of `.openclaw-isolated`; the default profile and explicit override remain covered.
- Direct-route owner regressions initially recorded nine failures for the wrong endpoint, false SSH remediation, default TLS port, and malformed handshake. Independent review found an additional IPv6-bracketing failure, which was reproduced first and repaired using the existing Dashboard endpoint convention.
- `xcrun swift test --package-path apps/macos --scratch-path <isolated-cache> --skip-update --disable-automatic-resolution --manifest-cache none --disable-build-manifest-caching --filter 'ControlChannelGatewayMessageTests|ControlChannelStateDebouncerTests|CommandResolverTests|AppProfileTests|GatewayEnvironmentTests|GatewayEndpointStoreTests|RemoteGatewayProbeTests|MacNodeHostWorkerTests|OnboardingViewSmokeTests'`: **172 tests across 9 suites passed**.
- Real macOS app compiled, signed with the matching Developer ID, and verified with `codesign --verify --deep --strict`; fresh isolated background profile launched with no CLI, no checkout override, and privileged bridges disabled.
- Signed-app runtime showed `mac node gateway connect failed: OpenClaw Gateway is not installed yet.` without starting a source worker or changing the existing checkout.
- Signed-app direct-connection failure rendered `Cannot reach gateway at 127.0.0.1:42675; check the Gateway URL and remote gateway.` and logged `control channel recovery ensured remote endpoint port=42675`; the running operator app and Gateway were unchanged.
- Independent Codex review: clean, with no accepted or actionable findings. SwiftFormat and `git diff --check`: clean.

Production delta: **+49/-30 (net +19)**; tests: **+158/-3**. The additional production lines establish the profile ownership boundary and credential-safe transport-aware endpoint reporting across all existing error callers.
