### PR TITLE
fix(telegram): preserve direct-message topics in config and cron writeback

### DIFF
--- a/extensions/telegram/src/target-writeback.test-shared.ts
+++ b/extensions/telegram/src/target-writeback.test-shared.ts
@@ -29,6 +29,48 @@ type CronStoreWrite = {
   jobs: Array<{ id: string; delivery: { channel: string; to: string } }>;
 };
 
+const scopedTargetWritebackCases = [
+  {
+    name: "channel Direct Messages topic",
+    rawTarget: "@mychannel:direct-topic:77",
+    matchingTarget: "t.me/MyChannel:direct-topic:77",
+    resolvedTarget: "-100123:direct-topic:77",
+    unmatchedTargets: [
+      "@mychannel",
+      "@mychannel:direct-topic:88",
+      "@mychannel:topic:77",
+      "@mychannel:77",
+      "@otherchannel:direct-topic:77",
+    ],
+  },
+  {
+    name: "explicit forum topic",
+    rawTarget: "@mychannel:topic:77",
+    matchingTarget: "t.me/MyChannel:77",
+    resolvedTarget: "-100123:topic:77",
+    unmatchedTargets: ["@mychannel", "@mychannel:direct-topic:77", "@mychannel:topic:88"],
+  },
+  {
+    name: "shorthand forum topic",
+    rawTarget: "@mychannel:77",
+    matchingTarget: "t.me/MyChannel:topic:77",
+    resolvedTarget: "-100123:77",
+    unmatchedTargets: ["@mychannel", "@mychannel:direct-topic:77", "@mychannel:88"],
+  },
+  {
+    name: "unthreaded target",
+    rawTarget: "t.me/mychannel",
+    matchingTarget: "@MyChannel",
+    resolvedTarget: "-100123",
+    unmatchedTargets: [
+      "@mychannel:direct-topic:77",
+      "@mychannel:direct-topic:88",
+      "@mychannel:topic:77",
+      "@mychannel:77",
+    ],
+  },
+] as const;
+
 vi.mock("openclaw/plugin-sdk/config-mutation", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/config-mutation")>(
     "openclaw/plugin-sdk/config-mutation",
@@ -251,33 +293,58 @@ export function installMaybePersistResolvedTelegramTargetTests(params?: {
       ]);
     });
 
-    it("preserves topic suffix style in writeback target", async () => {
+    it.each(
+      scopedTargetWritebackCases.flatMap((testCase) =>
+        (["config", "cron"] as const).map((surface) => ({
+          name: testCase.name,
+          surface,
+          testCase,
+        })),
+      ),
+    )("rewrites only matching $name $surface targets", async ({ surface, testCase }) => {
+      const unmatchedAccounts = Object.fromEntries(
+        testCase.unmatchedTargets.map((target, index) => [`other${index}`, { defaultTo: target }]),
+      );
       readConfigFileSnapshotForWrite.mockResolvedValue({
         snapshot: {
           config: {
             channels: {
               telegram: {
-                defaultTo: "t.me/mychannel:topic:9",
+                defaultTo: testCase.matchingTarget,
+                accounts: unmatchedAccounts,
               },
             },
           },
         },
         writeOptions: {},
       });
-      loadCronStore.mockResolvedValue({ version: 1, jobs: [] });
+      loadCronStore.mockResolvedValue({
+        version: 1,
+        jobs: [testCase.matchingTarget, ...testCase.unmatchedTargets].map((target, index) => ({
+          id: String(index),
+          delivery: { channel: "telegram", to: target },
+        })),
+      });
 
       await maybePersistResolvedTelegramTarget({
         cfg: {} as OpenClawConfig,
-        rawTarget: "t.me/mychannel:topic:9",
+        rawTarget: testCase.rawTarget,
         resolvedChatId: "-100123",
         gatewayClientScopes: undefined,
         trustedInternalWriteback: true,
       });
 
-      expect(writeConfigFile).toHaveBeenCalledTimes(1);
-      const [writtenConfig, writeOptions] = requireWriteConfigCall();
-      expect(writtenConfig.channels?.telegram?.defaultTo).toBe("-100123:topic:9");
-      expect(writeOptions).toEqual({});
+      const persistedTargets =
+        surface === "config"
+          ? [
+              requireWriteConfigCall()[0].channels?.telegram?.defaultTo,
+              ...Object.values(requireWriteConfigCall()[0].channels?.telegram?.accounts ?? {}).map(
+                (account) => account.defaultTo,
+              ),
+            ]
+          : requireSaveCronStoreCall()[1].jobs.map((job) => job.delivery.to);
+
+      expect(persistedTargets).toEqual([testCase.resolvedTarget, ...testCase.unmatchedTargets]);
     });
 
     it("matches username targets case-insensitively", async () => {

--- a/extensions/telegram/src/target-writeback.ts
+++ b/extensions/telegram/src/target-writeback.ts
@@ -11,10 +11,8 @@ import {
 } from "openclaw/plugin-sdk/cron-store-runtime";
 import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { telegramMessagingTargetsMatch } from "./normalize.js";
 import {
   normalizeTelegramChatId,
   normalizeTelegramLookupTarget,
@@ -24,30 +22,15 @@ import {
 const writebackLogger = createSubsystemLogger("telegram/target-writeback");
 const TELEGRAM_ADMIN_SCOPE = "operator.admin";
 
-function normalizeTelegramLookupTargetForMatch(raw: string): string | undefined {
-  const normalized = normalizeTelegramLookupTarget(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  return normalized.startsWith("@") ? normalizeLowercaseStringOrEmpty(normalized) : normalized;
-}
-
-function normalizeTelegramTargetForMatch(raw: string): string | undefined {
-  const parsed = parseTelegramTarget(raw);
-  const normalized = normalizeTelegramLookupTargetForMatch(parsed.chatId);
-  if (!normalized) {
-    return undefined;
-  }
-  const threadKey = parsed.messageThreadId == null ? "" : String(parsed.messageThreadId);
-  return `${normalized}|${threadKey}`;
-}
-
 function buildResolvedTelegramTarget(params: {
   raw: string;
   parsed: ReturnType<typeof parseTelegramTarget>;
   resolvedChatId: string;
 }): string {
   const { raw, parsed, resolvedChatId } = params;
+  if (parsed.directMessagesTopicId != null) {
+    return `${resolvedChatId}:direct-topic:${parsed.directMessagesTopicId}`;
+  }
   if (parsed.messageThreadId == null) {
     return resolvedChatId;
   }
@@ -59,18 +42,13 @@ function buildResolvedTelegramTarget(params: {
 function resolveLegacyRewrite(params: {
   raw: string;
   resolvedChatId: string;
-}): { matchKey: string; resolvedTarget: string } | null {
+}): { sourceTarget: string; resolvedTarget: string } | null {
   const parsed = parseTelegramTarget(params.raw);
-  if (normalizeTelegramChatId(parsed.chatId)) {
+  if (normalizeTelegramChatId(parsed.chatId) || !normalizeTelegramLookupTarget(parsed.chatId)) {
     return null;
   }
-  const normalized = normalizeTelegramLookupTargetForMatch(parsed.chatId);
-  if (!normalized) {
-    return null;
-  }
-  const threadKey = parsed.messageThreadId == null ? "" : String(parsed.messageThreadId);
   return {
-    matchKey: `${normalized}|${threadKey}`,
+    sourceTarget: params.raw,
     resolvedTarget: buildResolvedTelegramTarget({
       raw: params.raw,
       parsed,
@@ -81,7 +59,7 @@ function resolveLegacyRewrite(params: {
 
 function rewriteTargetIfMatch(params: {
   rawValue: unknown;
-  matchKey: string;
+  sourceTarget: string;
   resolvedTarget: string;
 }): string | null {
   if (typeof params.rawValue !== "string" && typeof params.rawValue !== "number") {
@@ -91,7 +69,7 @@ function rewriteTargetIfMatch(params: {
   if (!value) {
     return null;
   }
-  if (normalizeTelegramTargetForMatch(value) !== params.matchKey) {
+  if (!telegramMessagingTargetsMatch(value, params.sourceTarget)) {
     return null;
   }
   return params.resolvedTarget;
@@ -99,7 +77,7 @@ function rewriteTargetIfMatch(params: {
 
 function replaceTelegramDefaultToTargets(params: {
   cfg: OpenClawConfig;
-  matchKey: string;
+  sourceTarget: string;
   resolvedTarget: string;
 }): boolean {
   let changed = false;
@@ -111,7 +89,7 @@ function replaceTelegramDefaultToTargets(params: {
   const maybeReplace = (holder: Record<string, unknown>, key: string) => {
     const nextTarget = rewriteTargetIfMatch({
       rawValue: holder[key],
-      matchKey: params.matchKey,
+      sourceTarget: params.sourceTarget,
       resolvedTarget: params.resolvedTarget,
     });
     if (!nextTarget) {
@@ -155,7 +133,7 @@ export async function maybePersistResolvedTelegramTarget(params: {
   if (!rewrite) {
     return;
   }
-  const { matchKey, resolvedTarget } = rewrite;
+  const { sourceTarget, resolvedTarget } = rewrite;
   const hasGatewayAdminScope = params.gatewayClientScopes?.includes(TELEGRAM_ADMIN_SCOPE) === true;
   const trustedInternalWriteback =
     params.gatewayClientScopes === undefined && params.trustedInternalWriteback === true;
@@ -171,7 +149,7 @@ export async function maybePersistResolvedTelegramTarget(params: {
     const nextConfig = structuredClone(snapshot.config ?? {});
     const configChanged = replaceTelegramDefaultToTargets({
       cfg: nextConfig,
-      matchKey,
+      sourceTarget,
       resolvedTarget,
     });
     if (configChanged) {
@@ -201,7 +179,7 @@ export async function maybePersistResolvedTelegramTarget(params: {
       }
       const nextTarget = rewriteTargetIfMatch({
         rawValue: job.delivery.to,
-        matchKey,
+        sourceTarget,
         resolvedTarget,
       });
       if (!nextTarget) {

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -49,45 +49,23 @@ function findToggleByLabel(container: Element, label: string) {
 }
 
 describe("cron view list pane", () => {
-  it("uses agent-scoped summary values", () => {
+  it.each([
+    { name: "an enabled scheduler", status: { enabled: true }, hasNextWake: true },
+    { name: "a disabled scheduler", status: { enabled: false }, hasNextWake: false },
+    { name: "loading scheduler status", status: null, hasNextWake: true },
+  ])("uses agent-scoped summary values for $name", ({ status, hasNextWake }) => {
     const container = renderView({
       agentScoped: true,
       scopedTotal: 3,
       scopedNextWakeAtMs: Date.now() + 60_000,
-      status: { enabled: true, triggersEnabled: true, jobs: 99, nextWakeAtMs: null },
+      status: status ? { ...status, triggersEnabled: true, jobs: 99, nextWakeAtMs: null } : null,
     });
     const values = [...container.querySelectorAll(".cron-stat__value")].map((entry) =>
       entry.textContent?.trim(),
     );
 
     expect(values[0]).toBe("3");
-    expect(values[2]).not.toBe("n/a");
-  });
-
-  it("hides an agent-scoped next wake while the scheduler is disabled", () => {
-    const container = renderView({
-      agentScoped: true,
-      scopedNextWakeAtMs: Date.now() + 60_000,
-      status: { enabled: false, triggersEnabled: true, jobs: 3, nextWakeAtMs: null },
-    });
-    const values = [...container.querySelectorAll(".cron-stat__value")].map((entry) =>
-      entry.textContent?.trim(),
-    );
-
-    expect(values[2]).toBe("n/a");
-  });
-
-  it("keeps an agent-scoped next wake while scheduler status is loading", () => {
-    const container = renderView({
-      agentScoped: true,
-      scopedNextWakeAtMs: Date.now() + 60_000,
-      status: null,
-    });
-    const values = [...container.querySelectorAll(".cron-stat__value")].map((entry) =>
-      entry.textContent?.trim(),
-    );
-
-    expect(values[2]).not.toBe("n/a");
+    expect(values[2] !== "n/a").toBe(hasNextWake);
   });
 
   it("wires the enabled tabs and marks the active one", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users sending to a channel Direct Messages topic through a username or `t.me` target would lose the topic after chat-ID resolution, while config and cron writeback could also overwrite unrelated direct-topic or unthreaded destinations for the same channel.

## Why This Change Was Made

Telegram writeback maintained a duplicate target matcher that considered forum thread IDs but ignored channel Direct Messages topic IDs, and its resolved-target formatter dropped the direct-topic suffix. Preserve that suffix at the Telegram-owned writeback boundary and reuse the existing canonical Telegram target matcher for both config and cron persistence, removing the obsolete duplicate matching path. This completes the topic routing introduced in #120916 and reuses the canonical target identity from #126625. A test-only, table-driven cron UI cleanup also repairs the existing current-main max-lines regression introduced in #126945, which otherwise fails the required hosted merge gate.

## User Impact

Resolved Telegram Direct Messages destinations retain their original topic, and only the intended config default or scheduled cron delivery target is updated. Ordinary unthreaded targets, explicit forum topics, shorthand forum topics, unrelated accounts, and neighboring channel Direct Messages topics remain unchanged.

Release note: Telegram: preserve channel Direct Messages topic scope while resolving and persisting config and scheduled delivery targets.

## Evidence

- Regression provenance: replacing only the branch production file with the exact current-main implementation caused four failures in the new owner-boundary cases: direct-topic config, direct-topic cron, unthreaded config, and unthreaded cron. The failure showed `-100123` replacing `-100123:direct-topic:77` and incorrectly rewriting neighboring destinations; restoring the branch fixed all four.
- `node scripts/run-vitest.mjs extensions/telegram/src/targets.test.ts extensions/telegram/src/threading-tool-context.test.ts extensions/telegram/src/transport-payload.test.ts extensions/telegram/src/send-mutation-targets.test.ts extensions/telegram/src/topic-conversation.test.ts extensions/telegram/src/session-conversation.test.ts` — 6 files passed; 101 tests passed. Coverage includes config/cron writeback, sibling target matching, conversation persistence, message mutations, and actual grammY/Bot API JSON and multipart payload construction.
- `node scripts/run-vitest.mjs ui/src/pages/cron/view.test.ts` — 1 file passed; 42 cron UI tests passed, preserving enabled/disabled/loading scheduler coverage.
- `node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core --core-stripe=5/5 --threads=1` — first reproduced the existing current-main `eslint(max-lines)` failure, then passed after consolidating three duplicate scheduler tests into one table-driven case.
- `node scripts/check-changed.mjs` — the original Telegram-only diff passed all changed extension and extension-test gates, including formatting, production/test typechecks, extension lint, plugin boundaries, database-first guards, zero runtime import cycles, and 2 files / 5 plugin-doctor tests. After the required UI-test repair expanded scope, the rerun passed every preceding guard and failed only because this linked worktree's shared dependency tree lacks current-main `@panzoom/panzoom` and current `pako` types; its single permitted `pnpm install` refused to purge the shared installation without a TTY. Exact-head hosted CI performs the complete clean dependency/typecheck proof.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex` — clean for the CI-repair test change.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex` — clean; no accepted/actionable findings.
- Production: `+15/-37` (net `-22`); tests/test support: `+82/-37` (net `+45`).
- Build: not required; this is an intra-plugin static owner-boundary change with no package, lazy-loader, generated-artifact, or public SDK boundary changes, and the changed gate verified zero runtime import cycles.
- Proof gap: no authenticated live Telegram bot/account or consenting live channel Direct Messages recipient was supplied. The transport suite verifies the real grammY request serialization against a mocked Telegram Bot API; it is not claimed as live-channel proof.
