### PR TITLE
fix(agents): point a missing API key at an auth command, not at agent creation

### DIFF
--- a/src/agents/model-auth-provider.ts
+++ b/src/agents/model-auth-provider.ts
@@ -610,7 +610,7 @@ export async function resolveApiKeyForProviderCore(params: {
     [
       `No API key found for provider "${provider}".`,
       `Auth store: ${authStorePath}${agentDirContext}.`,
-      `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy only portable static auth profiles from the main agentDir.`,
+      `Configure an API key (${formatCliCommand(`openclaw models auth paste-api-key --provider ${provider}`)}; add --agent <id> for a non-default agent) or copy only portable static auth profiles from the main agentDir.`,
     ].join(" "),
   );
 }

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -746,6 +746,10 @@ describe("getApiKeyForModelCore", () => {
         expect((error as Error).message).toContain(
           `Auth store: ${resolveOpenClawStateSqlitePath(state.env)} (agentDir: ${state.agentDir()}).`,
         );
+        expect((error as Error).message).toContain(
+          "openclaw models auth paste-api-key --provider openai",
+        );
+        expect((error as Error).message).not.toContain("openclaw agents add");
       },
     );
 


### PR DESCRIPTION
## What Problem This Solves

The generic provider-missing-auth error recommends a command that cannot fix the problem it describes:

```
$ openclaw memory index
Memory index failed (main): No API key found for provider "openai".
Auth store: <state>/state/openclaw.sqlite (agentDir: <state>/agents/main/agent).
Configure auth for this agent (openclaw agents add <id>) or copy only portable static
auth profiles from the main agentDir. | missing-provider-auth
$ echo $?
1
```

`openclaw agents add <id>` **creates a new agent**. It does nothing about a missing provider credential. An operator who follows it ends up with a second agent that also has no key.

On the install where I reproduced this there is exactly one configured agent, `main`, and it is correctly configured. Nothing about `agents add` applies.

Doctor, diagnosing the *identical* condition on the same install, gets it right:

```
◇  Memory search ───────────────────────────────────────────────────────╮
│  Memory search provider is set to "openai" but no API key was found.  │
│  - Set OPENAI_API_KEY in your environment                             │
│  - To disable: openclaw config set memory.search.enabled false        │
│  Verify: openclaw memory status --deep                                │
```

So the command that actually failed gives worse and more misleading guidance than the advisory check does for the same state.

## Why This Change Was Made

The old sentence conflated two situations and named a command that fits neither:

1. **The provider has no credential anywhere** — needs a real auth command.
2. **This agent has no profile although another does** — the "copy only portable static auth profiles from the main agentDir" clause, which reads like the case the sentence was originally written for.

`models auth paste-api-key --provider <id>` is the suggestion rather than `models auth login`. `login` runs a provider *plugin* auth flow, but this generic fallback is precisely the path taken when no plugin owns the provider, when the model is inline or custom-configured, when `allowAuthProfileFallback` is false, or when a plugin-owned provider returns no specialized message. Pasting a key resolves every "No API key found" case this fallback can produce; `login` does not. The `--agent <id>` hint is folded in for non-default agents, and the whole thing routes through `formatCliCommand` so it stays correct under `--profile` or `--container`.

**One message rather than two.** Distinguishing situation 1 from situation 2 would require reading other agents' auth stores: the `store` in scope is the failing agent's, and `cfg` does not reveal credentials held in another agent's database. That is a real cross-agent read this resolver does not perform today, and it is not worth adding for a message. The combined sentence is correct for both cases, so it stays one sentence.

## User Impact

```
No API key found for provider "openai". Auth store: <path> (agentDir: <path>).
Configure an API key (openclaw models auth paste-api-key --provider openai;
add --agent <id> for a non-default agent) or copy only portable static auth
profiles from the main agentDir.
```

Production LOC: +1/-1, net 0.

## Evidence

Reproduced end to end on a real `pnpm build` dist in an isolated `OPENCLAW_STATE_DIR` + `HOME`, then verified the corrected output on a rebuilt binary. A container-hint probe confirms the profile/container formatting works: `openclaw --container validator-box models auth paste-api-key --provider openai`.

The suggested command was checked against the CLI rather than assumed — `models auth paste-api-key` takes a required `--provider <name>` and an optional `--agent <id>`, and is described as "Paste an API key into auth-profiles.json and update config", which matches the failure exactly.

Tests: `src/agents/model-auth.profiles.test.ts` failed as intended before the fix (1 failed / 79 passed) and passes after (80/80, re-run independently here). A grep-derived sweep of auth and error-consumer suites covered 20 files / 499 tests, all passing. New coverage pins the corrected command and asserts the message no longer contains `openclaw agents add`, so it cannot regress to advice that does not address the failure.

`node scripts/check-changed.mjs`: exit 0 (Testbox run 32446450654, 13m05s). `pnpm build`: passed (3m59s). Formatting and `git diff --check`: pass. `$autoreview`: clean, no accepted or actionable findings, correctness 0.99.

One proof note: on the worker's machine an ambient `OPENAI_API_KEY` masked the condition, so it explicitly set `memory.search.provider=openai` and unset that variable to recreate it. My original reproduction needed neither — `openai` is already the memory-search default on a fresh Anthropic-only install.

No second provider-auth message recommending `agents add` exists; the remaining `openclaw agents add` references in the tree are all about actually creating agents.
