### PR TITLE
fix(release): report blockers before diagnostics finish

### DIFF
--- a/.agents/skills/openclaw-testing/SKILL.md
+++ b/.agents/skills/openclaw-testing/SKILL.md
@@ -340,16 +340,34 @@ lanes are intentionally reserved for the separate `Plugin Prerelease` child so
 PRs, main pushes, and ad hoc broad CI checks do not spend Docker/package time or
 all-plugin runtime time on release-only product coverage.
 
-Use one operator, one transition-only watcher, and at most one investigator for
-the current failed surface. Parent timeout or cancellation leaves adopted exact
-children running; cancel an exact child only by explicit operator action or the
-workflow's identity-mismatch/fail-fast path.
+Use one operator, one foreground owner, and at most one investigator for the
+current failed surface. Do not start `release-ci-summary --watch` while the
+SHA-pinned helper is already watching the same parent. Parent timeout or
+cancellation leaves adopted exact children running; cancel an exact child only
+by explicit operator action or by `fail_fast=true` after Release Decision binds
+the failure to that exact active run.
 
-The child-dispatch jobs record child run ids, and `Verify full validation`
-re-queries them during that parent attempt. A later narrow green run is useful
-recovery evidence but is not publish authorization by itself and there is no
-standalone finalizer. The release owner must reassess the recorded evidence and
-current publish gate.
+The child-dispatch jobs record run ID, run attempt, and URL, then finish. The
+parent seals those tuples, original dispatch titles, gate coverage, reuse
+policy, and original parent attempt in one immutable
+`full-release-execution-plan-<run-id>` artifact. Collector retries restore that
+artifact and adopt its children; they never reconstruct the plan or redispatch
+tests.
+`Release Decision` polls those exact identities and can report
+`blocked_diagnostics_running` before unrelated children finish.
+For reused evidence, it also repeats the canonical target, policy, changed-path,
+and exact-child validation before it can pass.
+`Diagnostic Drain` continues every selected child to terminal with
+`fail_fast=false` unless the collector itself is cancelled or loses API
+access. `orchestration_error` permits collector recovery against the same
+exact children, never test redispatch. Diagnose `blocked_diagnostics_running`
+immediately, but wait for a terminal drain before retrying the failed surface.
+The final `Verify full validation` job consumes and validates the immutable
+execution plan plus the exact Decision and Drain artifacts instead of
+reclassifying child results. A
+later narrow green run is useful recovery evidence but is not publish
+authorization by itself and there is no standalone finalizer. The release owner
+must reassess the recorded evidence and current publish gate.
 
 Once the Code SHA is green, generate and commit only `CHANGELOG.md`. The new
 **Release SHA** is eligible for product-evidence reuse only when GitHub proves

--- a/.agents/skills/openclaw-testing/SKILL.md
+++ b/.agents/skills/openclaw-testing/SKILL.md
@@ -356,7 +356,7 @@ tests.
 `Release Decision` polls those exact identities and can report
 `blocked_diagnostics_running` before unrelated children finish.
 For reused evidence, it also repeats the canonical target, policy, changed-path,
-and exact-child validation before it can pass.
+selected-run, root-run, and exact-child validation before it can pass.
 `Diagnostic Drain` continues every selected child to terminal with
 `fail_fast=false` unless the collector itself is cancelled or loses API
 access. `orchestration_error` permits collector recovery against the same

--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -62,8 +62,8 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
   adopts the same children; missing plan state is an orchestration failure, not
   permission to redispatch.
 - Reused evidence is not trusted merely because plan sealing found it. Release
-  Decision repeats the canonical target, policy, changed-path, and exact-child
-  checks before returning `passed`.
+  Decision repeats the sealed target SHA, evidence SHA, policy, changed paths,
+  selected run, root run, and exact-child checks before returning `passed`.
 - Use one release operator, one transition-only watcher, and at most one
   investigator for the current failed surface. Do not build audit-review-plan
   trees around a single workflow transition.
@@ -284,7 +284,7 @@ node scripts/release-ci-summary.mjs <full-release-run-id> --watch
 
 Do not start this watcher when the SHA-pinned helper is still the foreground
 owner. The helper reads the exact Release Decision artifact itself. On
-`blocked_diagnostics_running`, it returns immediately, keeps the temporary
+`blocked_diagnostics_running`, it exits nonzero immediately, keeps the temporary
 refs, and leaves Diagnostic Drain collecting the remaining terminal evidence.
 The watcher behaves the same way for separately dispatched parents: it reports
 the Release Decision blocker once and exits while the drain continues.

--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -63,7 +63,10 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
   permission to redispatch.
 - Reused evidence is not trusted merely because plan sealing found it. Release
   Decision repeats the sealed target SHA, evidence SHA, policy, changed paths,
-  selected run, root run, and exact-child checks before returning `passed`.
+  selected run, root run, source manifest, trusted tooling identity, and
+  exact-child checks before returning `passed`.
+- Parent retries select the newest Decision and Drain artifacts independently;
+  both must bind the same immutable plan even when their source attempts differ.
 - Use one release operator, one transition-only watcher, and at most one
   investigator for the current failed surface. Do not build audit-review-plan
   trees around a single workflow transition.

--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -48,9 +48,22 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
   entitlement. Mandatory live providers must pass a real completion probe
   before release dispatch. Fix the credential first; do not add an alternate
   auth path merely to bypass a failed release credential.
-- Full Release Validation collects independent child failures to terminal
-  completion by default. Pass `fail_fast=true` only when the shorter
-  first-failure cancellation path is preferable.
+- Full Release Validation separates exact-child dispatch, Release Decision,
+  and Diagnostic Drain. With `fail_fast=false`, it makes zero child
+  cancellation calls; Diagnostic Drain follows every selected child to
+  terminal unless the collector itself is cancelled or loses GitHub API
+  access. With
+  `fail_fast=true`, Release Decision may cancel only the exact still-active
+  child that owns a blocking failure.
+- After dispatch, one immutable execution-plan artifact records the original
+  parent attempt, exact child tuples and titles, selected coverage, gates, and
+  reuse identity. Decision, Drain, manifest writing, evidence validation, and
+  final verification consume that plan. A collector retry restores it and
+  adopts the same children; missing plan state is an orchestration failure, not
+  permission to redispatch.
+- Reused evidence is not trusted merely because plan sealing found it. Release
+  Decision repeats the canonical target, policy, changed-path, and exact-child
+  checks before returning `passed`.
 - Use one release operator, one transition-only watcher, and at most one
   investigator for the current failed surface. Do not build audit-review-plan
   trees around a single workflow transition.
@@ -106,9 +119,10 @@ until their dependent enforcement changes land.
   - `stable-publish`: `release_profile=stable`
 - Keep at most one active parent for the same Validation SHA + Tooling SHA + rerun
   group. Concurrency does not cancel an older exact child automatically.
-- Parent cancellation or timeout leaves an adopted identity-checked child
-  running. The operator must cancel that exact child explicitly when it is no
-  longer useful.
+- Parent cancellation or timeout leaves adopted identity-checked children
+  running. The operator must cancel an exact child explicitly when it is no
+  longer useful. Do not infer a child identity from branch, title prefix, or
+  latest-run order.
 - Recover one failed surface with one diagnosis, one fix when needed, and one
   narrow retry. Then reassess the release decision. Do not automatically
   dispatch `rerun_group=all`.
@@ -268,6 +282,13 @@ Use the transition-only summary watcher instead of repeated raw polling:
 node scripts/release-ci-summary.mjs <full-release-run-id> --watch
 ```
 
+Do not start this watcher when the SHA-pinned helper is still the foreground
+owner. The helper reads the exact Release Decision artifact itself. On
+`blocked_diagnostics_running`, it returns immediately, keeps the temporary
+refs, and leaves Diagnostic Drain collecting the remaining terminal evidence.
+The watcher behaves the same way for separately dispatched parents: it reports
+the Release Decision blocker once and exits while the drain continues.
+
 For a one-shot snapshot:
 
 ```bash
@@ -277,6 +298,27 @@ node scripts/release-ci-summary.mjs <full-release-run-id>
 `release-ci-summary` accepts Full Release Validation parent runs only.
 Diverged release-branch logs: `--first-parent` plus a bounded count.
 Stop watchers before ending the turn or switching strategy.
+
+Interpret state precisely:
+
+- `qualifying`: no decisive blocker yet; selected children are still active.
+- `blocked_diagnostics_running`: publication is blocked; Diagnostic Drain is
+  still collecting independent failures. Diagnose now, but do not retry until
+  the drain is terminal.
+- `passed`: all required policy and exact-child evidence passed.
+- `blocked_complete`: publication is blocked and all selected diagnostics are
+  terminal.
+- `orchestration_error`: GitHub API or collector failure prevented a verdict.
+  This is not a provenance mismatch. Recover the collector against the same
+  exact children; never redispatch tests to repair collection.
+- `cancelled_with_children`: the collector was cancelled while exact children
+  remained active.
+
+The `full-release-diagnostics-<run-id>-<attempt>` artifact is the terminal
+failure and timing manifest. Use it after an early blocker instead of
+restarting `all` merely to discover what the still-running children found.
+The stable `full-release-execution-plan-<run-id>` artifact is the identity
+source for every collector attempt.
 
 ## Failure Triage
 

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1111,6 +1111,7 @@ jobs:
           RERUN_GROUP: ${{ inputs.rerun_group }}
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           EVIDENCE_REUSE: ${{ needs.evidence_reuse.outputs.reuse }}
+          EVIDENCE_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_run_id }}
           EVIDENCE_ROOT_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_root_run_id }}
           EVIDENCE_RUN_URL: ${{ needs.evidence_reuse.outputs.evidence_run_url }}
           EVIDENCE_SHA: ${{ needs.evidence_reuse.outputs.evidence_sha }}
@@ -1155,6 +1156,7 @@ jobs:
               --arg workflowRef "$GITHUB_REF_NAME" \
               --arg workflowSha "$GITHUB_SHA" \
               --arg evidenceReuse "$EVIDENCE_REUSE" \
+              --arg evidenceRunId "$EVIDENCE_RUN_ID" \
               --arg evidenceRootRunId "$EVIDENCE_ROOT_RUN_ID" \
               --arg evidenceRunUrl "$EVIDENCE_RUN_URL" \
               --arg evidenceSha "$EVIDENCE_SHA" \
@@ -1194,6 +1196,7 @@ jobs:
                 workflowRef: $workflowRef,
                 workflowSha: $workflowSha,
                 evidenceReuse: $evidenceReuse,
+                evidenceRunId: $evidenceRunId,
                 evidenceRootRunId: $evidenceRootRunId,
                 evidenceRunUrl: $evidenceRunUrl,
                 evidenceSha: $evidenceSha,

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1117,6 +1117,8 @@ jobs:
           EVIDENCE_SHA: ${{ needs.evidence_reuse.outputs.evidence_sha }}
           EVIDENCE_POLICY: ${{ needs.evidence_reuse.outputs.evidence_policy }}
           EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}
+          EVIDENCE_MANIFEST: ${{ needs.evidence_reuse.outputs.evidence_manifest }}
+          TRUSTED_WORKFLOW_JSON: ${{ needs.resolve_target.outputs.trusted_workflow_json }}
           RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
           PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ inputs.package_acceptance_package_spec }}
           NPM_TELEGRAM_PACKAGE_SPEC: ${{ inputs.npm_telegram_package_spec }}
@@ -1149,12 +1151,14 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$FULL_RELEASE_RESTORE_PLAN" != "true" ]]; then
+            evidence_manifest="${EVIDENCE_MANIFEST:-null}"
             export FULL_RELEASE_PLAN_INPUTS_JSON="$(
             jq -cn \
               --arg parentRunId "$GITHUB_RUN_ID" \
               --arg parentRunAttempt "$GITHUB_RUN_ATTEMPT" \
               --arg workflowRef "$GITHUB_REF_NAME" \
               --arg workflowSha "$GITHUB_SHA" \
+              --argjson trustedWorkflow "$TRUSTED_WORKFLOW_JSON" \
               --arg evidenceReuse "$EVIDENCE_REUSE" \
               --arg evidenceRunId "$EVIDENCE_RUN_ID" \
               --arg evidenceRootRunId "$EVIDENCE_ROOT_RUN_ID" \
@@ -1162,6 +1166,7 @@ jobs:
               --arg evidenceSha "$EVIDENCE_SHA" \
               --arg evidencePolicy "$EVIDENCE_POLICY" \
               --argjson evidenceChangedPaths "$EVIDENCE_CHANGED_PATHS" \
+              --argjson evidenceManifest "$evidence_manifest" \
               --arg rerunGroup "$RERUN_GROUP" \
               --arg releasePackageSpec "$RELEASE_PACKAGE_SPEC" \
               --arg packageAcceptancePackageSpec "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \
@@ -1195,6 +1200,7 @@ jobs:
                 parentRunAttempt: $parentRunAttempt,
                 workflowRef: $workflowRef,
                 workflowSha: $workflowSha,
+                trustedWorkflow: $trustedWorkflow,
                 evidenceReuse: $evidenceReuse,
                 evidenceRunId: $evidenceRunId,
                 evidenceRootRunId: $evidenceRootRunId,
@@ -1202,6 +1208,7 @@ jobs:
                 evidenceSha: $evidenceSha,
                 evidencePolicy: $evidencePolicy,
                 evidenceChangedPaths: $evidenceChangedPaths,
+                evidenceManifest: $evidenceManifest,
                 rerunGroup: $rerunGroup,
                 releasePackageSpec: $releasePackageSpec,
                 packageAcceptancePackageSpec: $packageAcceptancePackageSpec,
@@ -1223,7 +1230,7 @@ jobs:
           node scripts/full-release-validation-state.mjs plan
 
       - name: Upload immutable release execution plan
-        if: ${{ github.run_attempt == 1 }}
+        if: ${{ always() && github.run_attempt == 1 }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-execution-plan-${{ github.run_id }}
@@ -1233,7 +1240,7 @@ jobs:
   release_decision:
     name: Release Decision
     needs: [resolve_target, release_execution_plan]
-    if: always() && needs.release_execution_plan.result == 'success'
+    if: always()
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 720
     outputs:
@@ -1294,7 +1301,7 @@ jobs:
   diagnostic_drain:
     name: Diagnostic Drain
     needs: [resolve_target, release_execution_plan]
-    if: always() && needs.release_execution_plan.result == 'success'
+    if: always()
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 720
     outputs:
@@ -1400,17 +1407,30 @@ jobs:
           name: full-release-execution-plan-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-execution-plan
 
-      - name: Download exact release decision
+      - name: Download release decision attempts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/full-release-decision
+          pattern: full-release-decision-${{ github.run_id }}-*
+          path: ${{ runner.temp }}/full-release-decision-attempts
 
-      - name: Download exact diagnostic drain
+      - name: Download diagnostic drain attempts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: full-release-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/full-release-diagnostics
+          pattern: full-release-diagnostics-${{ github.run_id }}-*
+          path: ${{ runner.temp }}/full-release-diagnostic-attempts
+
+      - name: Select newest compatible release state artifacts
+        id: selected_state
+        env:
+          RELEASE_PROFILE: ${{ inputs.release_profile }}
+          RERUN_GROUP: ${{ inputs.rerun_group }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+          RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
+          RELEASE_DECISION_ATTEMPTS_PATH: ${{ runner.temp }}/full-release-decision-attempts
+          DIAGNOSTIC_DRAIN_ATTEMPTS_PATH: ${{ runner.temp }}/full-release-diagnostic-attempts
+          RELEASE_DECISION_PATH: ${{ runner.temp }}/full-release-decision/full-release-decision.json
+          DIAGNOSTIC_DRAIN_PATH: ${{ runner.temp }}/full-release-diagnostics/full-release-diagnostic-manifest.json
+        run: node scripts/full-release-validation-state.mjs select
 
       - name: Verify exact release state artifacts
         env:
@@ -1429,13 +1449,14 @@ jobs:
           TARGET_REF: ${{ inputs.ref }}
           PACKAGE_SPEC: ${{ inputs.evidence_package_spec || inputs.npm_telegram_package_spec }}
           GITHUB_RUN_ID_VALUE: ${{ github.run_id }}
-          RELEASE_CHECKS_RESULT: ${{ needs.release_checks.result }}
-          EVIDENCE_REUSE: ${{ needs.evidence_reuse.outputs.reuse }}
-          EVIDENCE_ROOT_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_root_run_id }}
-          EVIDENCE_POLICY: ${{ needs.evidence_reuse.outputs.evidence_policy }}
+          RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
         run: |
           set -euo pipefail
-          if [[ "$RELEASE_CHECKS_RESULT" == "skipped" && "$EVIDENCE_REUSE" != "true" ]]; then
+          EVIDENCE_REUSE="$(jq -r '.evidenceReuse.requested' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_ROOT_RUN_ID="$(jq -r '.evidenceReuse.rootRunId // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_POLICY="$(jq -r '.evidenceReuse.policy // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
+          RELEASE_CHECKS_SELECTED="$(jq -r '.children[] | select(.key == "releaseChecks") | .selected' "$RELEASE_EXECUTION_PLAN_PATH")"
+          if [[ "$RELEASE_CHECKS_SELECTED" != "true" && "$EVIDENCE_REUSE" != "true" ]]; then
             echo "Release checks were skipped by rerun group; skipping automatic release evidence update."
             exit 0
           fi
@@ -1511,23 +1532,9 @@ jobs:
         if: ${{ success() }}
         env:
           TARGET_REF: ${{ startsWith(github.ref, 'refs/heads/release-ci/') && needs.resolve_target.outputs.sha || inputs.ref }}
-          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           RELEASE_PROFILE: ${{ inputs.release_profile }}
           RERUN_GROUP: ${{ inputs.rerun_group }}
           RUN_RELEASE_SOAK: ${{ inputs.run_release_soak || inputs.release_profile == 'stable' || inputs.release_profile == 'full' }}
-          NORMAL_CI_RUN_ID: ${{ needs.normal_ci.outputs.run_id }}
-          PLUGIN_PRERELEASE_RUN_ID: ${{ needs.plugin_prerelease.outputs.run_id }}
-          RELEASE_CHECKS_RUN_ID: ${{ needs.release_checks.outputs.run_id }}
-          NPM_TELEGRAM_RUN_ID: ${{ needs.npm_telegram.outputs.run_id }}
-          PERFORMANCE_RUN_ID: ${{ needs.performance.outputs.run_id }}
-          PERFORMANCE_CONCLUSION: ${{ needs.diagnostic_drain.outputs.performance_conclusion }}
-          EVIDENCE_REUSE: ${{ needs.evidence_reuse.outputs.reuse }}
-          EVIDENCE_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_run_id }}
-          EVIDENCE_ROOT_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_root_run_id }}
-          EVIDENCE_SHA: ${{ needs.evidence_reuse.outputs.evidence_sha }}
-          EVIDENCE_POLICY: ${{ needs.evidence_reuse.outputs.evidence_policy }}
-          EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}
-          EVIDENCE_MANIFEST: ${{ needs.evidence_reuse.outputs.evidence_manifest }}
           PROVIDER: ${{ inputs.provider }}
           MODE: ${{ inputs.mode }}
           TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
@@ -1543,10 +1550,12 @@ jobs:
           ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog || (inputs.target_context_ref == '' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main')) }}
           PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON: ${{ inputs.plugin_prerelease_node_exclude_patterns_json }}
           RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
+          DIAGNOSTIC_DRAIN_PATH: ${{ runner.temp }}/full-release-diagnostics/full-release-diagnostic-manifest.json
         run: |
           set -euo pipefail
           manifest_dir="${RUNNER_TEMP}/full-release-validation"
           mkdir -p "$manifest_dir"
+          TARGET_SHA="$(jq -r '.targetSha' "$RELEASE_EXECUTION_PLAN_PATH")"
           NORMAL_CI_RUN_ID="$(jq -r '.children[] | select(.key == "normalCi") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
           PLUGIN_PRERELEASE_RUN_ID="$(jq -r '.children[] | select(.key == "pluginPrerelease") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
           RELEASE_CHECKS_RUN_ID="$(jq -r '.children[] | select(.key == "releaseChecks") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
@@ -1554,6 +1563,14 @@ jobs:
           PERFORMANCE_RUN_ID="$(jq -r '.children[] | select(.key == "productPerformance") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
           EXECUTION_PLAN_SHA256="$(jq -r '.sha256' "$RELEASE_EXECUTION_PLAN_PATH")"
           SOURCE_PARENT_RUN_ATTEMPT="$(jq -r '.parentRunAttempt' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_REUSE="$(jq -r '.evidenceReuse.requested' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_RUN_ID="$(jq -r '.evidenceReuse.selectedRunId // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_ROOT_RUN_ID="$(jq -r '.evidenceReuse.rootRunId // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_SHA="$(jq -r '.evidenceReuse.evidenceSha // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_POLICY="$(jq -r '.evidenceReuse.policy // ""' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_CHANGED_PATHS="$(jq -c '.evidenceReuse.changedPaths // []' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EVIDENCE_MANIFEST="$(jq -c '.evidenceReuse.sourceManifest // empty' "$RELEASE_EXECUTION_PLAN_PATH")"
+          PERFORMANCE_CONCLUSION="$(jq -r '.children.productPerformance.conclusion // ""' "$DIAGNOSTIC_DRAIN_PATH")"
           if [[ "$EVIDENCE_REUSE" == "true" ]]; then
             # Inherit the evidence manifest (profile, soak, child runs) so future
             # reuse lookups and evidence consumers keep resolving the chain root.

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1115,7 +1115,7 @@ jobs:
           EVIDENCE_RUN_URL: ${{ needs.evidence_reuse.outputs.evidence_run_url }}
           EVIDENCE_SHA: ${{ needs.evidence_reuse.outputs.evidence_sha }}
           EVIDENCE_POLICY: ${{ needs.evidence_reuse.outputs.evidence_policy }}
-          EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths }}
+          EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}
           RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
           PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ inputs.package_acceptance_package_spec }}
           NPM_TELEGRAM_PACKAGE_SPEC: ${{ inputs.npm_telegram_package_spec }}
@@ -1523,7 +1523,7 @@ jobs:
           EVIDENCE_ROOT_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_root_run_id }}
           EVIDENCE_SHA: ${{ needs.evidence_reuse.outputs.evidence_sha }}
           EVIDENCE_POLICY: ${{ needs.evidence_reuse.outputs.evidence_policy }}
-          EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths }}
+          EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}
           EVIDENCE_MANIFEST: ${{ needs.evidence_reuse.outputs.evidence_manifest }}
           PROVIDER: ${{ inputs.provider }}
           MODE: ${{ inputs.mode }}

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -66,7 +66,7 @@ on:
         default: false
         type: boolean
       fail_fast:
-        description: Cancel each child workflow after its first failed job; false collects independent failures to completion
+        description: Cancel only an exact active child after its first blocking job; false drains all children to completion
         required: false
         default: false
         type: boolean
@@ -563,7 +563,7 @@ jobs:
   docker_runtime_assets_preflight:
     name: Verify Docker runtime image assets
     needs: [resolve_target, evidence_reuse]
-    if: ${{ always() && needs.resolve_target.result == 'success' && inputs.rerun_group == 'all' && needs.evidence_reuse.outputs.reuse != 'true' }}
+    if: ${{ always() && github.run_attempt == 1 && needs.resolve_target.result == 'success' && inputs.rerun_group == 'all' && needs.evidence_reuse.outputs.reuse != 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
@@ -589,7 +589,7 @@ jobs:
   prepare_release_candidate:
     name: Prepare shared release candidate
     needs: [resolve_target, evidence_reuse]
-    if: ${{ always() && needs.resolve_target.result == 'success' && needs.evidence_reuse.outputs.reuse != 'true' && inputs.release_package_spec == '' && inputs.package_acceptance_package_spec == '' && (contains(fromJSON('["all","plugin-prerelease","cross-os","package"]'), inputs.rerun_group) || (inputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.live_suite_filter == '')) }}
+    if: ${{ always() && github.run_attempt == 1 && needs.resolve_target.result == 'success' && needs.evidence_reuse.outputs.reuse != 'true' && inputs.release_package_spec == '' && inputs.package_acceptance_package_spec == '' && (contains(fromJSON('["all","plugin-prerelease","cross-os","package"]'), inputs.rerun_group) || (inputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.live_suite_filter == '')) }}
     permissions:
       actions: read
       contents: read
@@ -614,16 +614,15 @@ jobs:
   normal_ci:
     name: Run normal full CI
     needs: [resolve_target, evidence_reuse]
-    if: ${{ always() && needs.resolve_target.result == 'success' && contains(fromJSON('["all","ci"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
+    if: ${{ always() && github.run_attempt == 1 && needs.resolve_target.result == 'success' && contains(fromJSON('["all","ci"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
     runs-on: ubuntu-24.04
-    # The child owns lane timeouts; this monitor also covers queue delay and iOS.
-    timeout-minutes: 240
+    timeout-minutes: 15
     outputs:
       run_id: ${{ steps.dispatch.outputs.run_id }}
+      run_attempt: ${{ steps.dispatch.outputs.run_attempt }}
       url: ${{ steps.dispatch.outputs.url }}
-      conclusion: ${{ steps.dispatch.outputs.conclusion }}
     steps:
-      - name: Dispatch and monitor CI
+      - name: Dispatch CI
         id: dispatch
         env:
           GH_TOKEN: ${{ github.token }}
@@ -633,10 +632,8 @@ jobs:
           TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
-          FAIL_FAST: ${{ inputs.fail_fast }}
         run: &full_release_child_dispatch |
           set -euo pipefail
-          FAIL_FAST="${FAIL_FAST:-false}"
 
           gh_with_retry() {
             local output status attempt
@@ -659,10 +656,6 @@ jobs:
             done
             printf '%s\n' "$output" >&2
             return "$status"
-          }
-
-          fetch_child_run_json() {
-            gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
           }
 
           validate_child_run() {
@@ -711,71 +704,11 @@ jobs:
             return 1
           }
 
-          fetch_child_jobs() {
-            if [[ "$workflow" == "npm-telegram-beta-e2e.yml" || "$workflow" == "openclaw-performance.yml" ]]; then
-              gh_with_retry run view "$run_id" --json jobs --jq '.jobs[]'
-              return
-            fi
-            gh_with_retry api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100" --jq '.jobs[]'
-          }
-
-          read_child_run_field() {
-            local field="$1"
-            if [[ "$workflow" == "npm-telegram-beta-e2e.yml" || "$workflow" == "openclaw-performance.yml" ]]; then
-              case "$field" in
-                html_url) field=url ;;
-              esac
-              gh_with_retry run view "$run_id" --json "$field" --jq ".${field} // \"\""
-              return
-            fi
-            fetch_child_run_json | jq -r ".${field} // \"\""
-          }
-
-          release_check_blocking_job() {
-            if [[ "$RELEASE_PROFILE" == "beta" && "$1" == "Run package acceptance / Telegram package acceptance / "* ]]; then
-              return 1
-            fi
-            case "$1" in
-              "resolve_target" | \
-              "Prepare release package artifact" | \
-              "install_smoke_release_checks / "* | \
-              "Run package acceptance" | \
-              "Run package acceptance / "*)
-                return 0
-                ;;
-            esac
-            return 1
-          }
-
-          release_checks_advisory_only() {
-            local run_json="$1"
-            local verifier_conclusion name saw_advisory failed
-            verifier_conclusion="$(
-              jq -r '.jobs[] | select(.name == "Verify release checks") | .conclusion' <<< "$run_json" |
-                tail -n 1
-            )"
-            if [[ "$verifier_conclusion" != "success" ]]; then
-              return 1
-            fi
-            saw_advisory=0
-            failed=0
-            while IFS= read -r name; do
-              [[ -z "${name// }" ]] && continue
-              if release_check_blocking_job "$name"; then
-                echo "::error::${name} is a package-safety Tideclaw alpha release-check lane."
-                failed=1
-              else
-                saw_advisory=1
-              fi
-            done < <(jq -r '.jobs[] | select(.conclusion != "success" and .conclusion != "skipped") | .name' <<< "$run_json")
-            [[ "$saw_advisory" == "1" && "$failed" == "0" ]]
-          }
-
-          dispatch_and_wait() {
+          dispatch_child() {
             local workflow="$1"
             local dispatch_run_name="$2"
             shift 2
-            local dispatch_output dispatch_status dispatch_run_ids matches_json match_count run_id status conclusion url poll_count run_json jobs_json child_head_sha encoded_workflow_ref current_workflow_sha expected_workflow_id started_epoch elapsed_seconds elapsed_minutes
+            local dispatch_output dispatch_status dispatch_run_ids matches_json match_count run_id run_json child_head_sha child_run_attempt url encoded_workflow_ref current_workflow_sha expected_workflow_id
 
             encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF" '$value | @uri')"
             current_workflow_sha="$(
@@ -838,147 +771,31 @@ jobs:
               exit 1
             fi
 
-            cancel_child() {
-              if [[ -n "${run_id:-}" ]]; then
-                echo "Cancelling child workflow ${workflow}: ${run_id}" >&2
-                gh run cancel "$run_id" >/dev/null 2>&1 || true
-              fi
-            }
             run_json="$(validate_child_run "$run_id")"
-            # Generic monitor failures and parent cancellation leave an
-            # identity-checked child running for explicit operator recovery.
             {
               echo "- Adopted child: \`${workflow}\` run \`${run_id}\`"
-              echo "- Parent cancellation leaves this child running; cancel it explicitly if no longer needed."
+              echo "- Release Decision owns blocking policy; Diagnostic Drain owns terminal collection."
             } >> "$GITHUB_STEP_SUMMARY"
 
             child_head_sha="$(jq -r '.head_sha // ""' <<< "$run_json")"
             if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
               echo "::error::${workflow} child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}." >&2
-              cancel_child
               exit 1
             fi
 
             if [[ "$dispatch_status" -ne 0 ]]; then
               echo "::warning::${workflow} dispatch returned status ${dispatch_status}; adopted exact run ${run_id}." >&2
             fi
-            echo "Dispatched ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
+            child_run_attempt="$(jq -r '.run_attempt // ""' <<< "$run_json")"
+            url="$(jq -r '.html_url // ""' <<< "$run_json")"
+            if [[ ! "$child_run_attempt" =~ ^[1-9][0-9]*$ || -z "${url// }" ]]; then
+              echo "::error::${workflow} child run omitted its attempt or URL." >&2
+              exit 1
+            fi
+            echo "Dispatched ${workflow}: ${url} (attempt ${child_run_attempt})"
             echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
-            started_epoch="$(date +%s)"
-
-            fail_fast_failed_jobs() {
-              if [[ "$FAIL_FAST" != "true" ]]; then
-                return 0
-              fi
-              local failed_jobs_json
-              if [[ "$workflow" == "openclaw-release-checks.yml" && "$CHILD_WORKFLOW_REF" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
-                return 0
-              fi
-              if [[ "$workflow" == "npm-telegram-beta-e2e.yml" ]]; then
-                failed_jobs_json="$(
-                  gh_with_retry run view "$run_id" --json jobs \
-                    --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped")]'
-                )"
-              elif ! failed_jobs_json="$(
-                fetch_child_jobs |
-                  jq -s '[.[] | select(.status == "completed" and .conclusion != "success" and .conclusion != "skipped")]'
-              )"; then
-                echo "::warning::Could not list ${workflow} child jobs; continuing with authoritative workflow conclusion."
-                return 0
-              fi
-              if [[ "$workflow" == "openclaw-release-checks.yml" ]]; then
-                # Advisory QA jobs are owned by the child's status-artifact verifier.
-                failed_jobs_json="$(
-                  jq '[.[] | select(
-                    ((.name | startswith("Run QA Lab parity lane ("))
-                      or .name == "Run QA Lab parity report"
-                      or (.name | startswith("Run QA Lab runtime-pair lane ("))
-                      or .name == "Verify QA Lab runtime-pair lanes"
-                      or .name == "Run QA Lab live Discord lane"
-                      or .name == "Run QA Lab live WhatsApp lane"
-                      or .name == "Run QA Lab live Slack lane")
-                    | not)]' <<< "$failed_jobs_json"
-                )"
-                if [[ "$RELEASE_PROFILE" == "beta" ]]; then
-                  # Beta live-provider and Telegram package checks are advisory; repo E2E is blocking.
-                  failed_jobs_json="$(
-                    jq '[.[] | select(
-                      (((.name | startswith("Run repo/live E2E validation / "))
-                        and ((.name | contains("Docker live"))
-                          or (.name | contains("Live media suites"))
-                          or (.name | contains("validate_live_provider_suites"))
-                          or (.name | contains("validate_release_live_cache"))
-                          or (.name | contains("prepare_live_test_image"))))
-                        or (.name | startswith("Run package acceptance / Telegram package acceptance / ")))
-                      | not)]' <<< "$failed_jobs_json"
-                  )"
-                fi
-              fi
-              if jq -e 'length > 0' <<< "$failed_jobs_json" >/dev/null; then
-                if [[ "$workflow" == "npm-telegram-beta-e2e.yml" ]]; then
-                  echo "::error::npm-telegram-beta-e2e.yml has failed child jobs before the workflow completed; cancelling the remaining run."
-                else
-                  echo "::error::${workflow} has failed child jobs before the workflow completed; cancelling the remaining matrix."
-                fi
-                jq '.[] | {name, conclusion, url: (.url // .html_url)}' <<< "$failed_jobs_json"
-                cancel_child
-                exit 1
-              fi
-            }
-
-            poll_count=0
-            while true; do
-              status="$(read_child_run_field status)"
-              if [[ "$status" == "completed" ]]; then
-                break
-              fi
-              poll_count=$((poll_count + 1))
-              if (( poll_count % 5 == 0 )); then
-                fail_fast_failed_jobs
-                elapsed_seconds=$(( $(date +%s) - started_epoch ))
-                elapsed_minutes=$(( elapsed_seconds / 60 ))
-                echo "Still waiting on ${workflow} after ${elapsed_minutes}m: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
-                fetch_child_jobs | jq 'select(.status != "completed") | {name, status, url: (.url // .html_url)}' || true
-              fi
-              sleep 60
-            done
-
-            if [[ "$workflow" == "openclaw-release-checks.yml" ]]; then
-              jobs_json="$(fetch_child_jobs | jq -s '{jobs: [.[] | {name, conclusion, url: .html_url}]}')"
-              run_json="$(
-                jq -s '.[0] + .[1]' \
-                  <(fetch_child_run_json | jq '{conclusion: (.conclusion // ""), url: .html_url}') \
-                  <(printf '%s\n' "$jobs_json")
-              )"
-              conclusion="$(jq -r '.conclusion' <<< "$run_json")"
-              url="$(jq -r '.url' <<< "$run_json")"
-            else
-              conclusion="$(read_child_run_field conclusion)"
-              url="$(read_child_run_field html_url)"
-            fi
-            echo "${workflow} finished with ${conclusion}: ${url}"
+            echo "run_attempt=${child_run_attempt}" >> "$GITHUB_OUTPUT"
             echo "url=${url}" >> "$GITHUB_OUTPUT"
-            echo "conclusion=${conclusion}" >> "$GITHUB_OUTPUT"
-            if [[ "$conclusion" == "success" ]]; then
-              return 0
-            fi
-            if [[ "$workflow" == "openclaw-performance.yml" && "$RELEASE_PROFILE" == "beta" ]]; then
-              echo "::warning::OpenClaw Performance ended with ${conclusion}; advisory for beta: ${url}"
-              return 0
-            fi
-            if [[ "$workflow" == "openclaw-release-checks.yml" ]]; then
-              jq '.jobs[] | select(.conclusion != "success" and .conclusion != "skipped") | {name, conclusion, url}' <<< "$run_json" || true
-              if [[ "$CHILD_WORKFLOW_REF" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]] && release_checks_advisory_only "$run_json"; then
-                echo "::warning::${workflow} ended with ${conclusion}, but Verify release checks accepted Tideclaw alpha advisory lanes."
-                return 0
-              fi
-            else
-              if [[ "$workflow" == "openclaw-performance.yml" ]]; then
-                echo "::error::OpenClaw Performance ended with ${conclusion}: ${url}"
-              fi
-              fetch_child_jobs | jq 'select(.conclusion != "success" and .conclusion != "skipped") | {name, conclusion, url: (.url // .html_url)}' || true
-            fi
-            exit 1
           }
 
           case "$CHILD_WORKFLOW_KIND" in
@@ -999,7 +816,7 @@ jobs:
               elif [[ "$TARGET_CONTEXT_REF" =~ ^(release/[0-9]{4}\.[0-9]+\.[0-9]+|extended-stable/[0-9]{4}\.[0-9]+\.33)$ ]]; then
                 args+=(-f target_context_ref="$TARGET_CONTEXT_REF")
               fi
-              dispatch_and_wait ci.yml "$dispatch_run_name" "${args[@]}"
+              dispatch_child ci.yml "$dispatch_run_name" "${args[@]}"
               ;;
             plugin-prerelease)
               plugin_prerelease_node_exclusions="$(
@@ -1018,7 +835,7 @@ jobs:
               if [[ -n "${CANDIDATE_ARTIFACT_JSON// }" ]]; then
                 args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")
               fi
-              dispatch_and_wait plugin-prerelease.yml "$dispatch_run_name" "${args[@]}"
+              dispatch_child plugin-prerelease.yml "$dispatch_run_name" "${args[@]}"
               ;;
             release-checks)
               {
@@ -1085,7 +902,7 @@ jobs:
               dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-release-checks"
               dispatch_run_name="OpenClaw Release Checks ${dispatch_id}"
               args+=(-f dispatch_id="$dispatch_id")
-              dispatch_and_wait openclaw-release-checks.yml "$dispatch_run_name" "${args[@]}"
+              dispatch_child openclaw-release-checks.yml "$dispatch_run_name" "${args[@]}"
               ;;
             npm-telegram)
               args=(-f package_spec="$PACKAGE_SPEC" -f harness_ref="$TARGET_SHA" -f provider_mode="$PROVIDER_MODE")
@@ -1095,7 +912,7 @@ jobs:
               dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-npm-telegram"
               dispatch_run_name="NPM Telegram Beta E2E ${dispatch_id}"
               args+=(-f dispatch_id="$dispatch_id")
-              dispatch_and_wait npm-telegram-beta-e2e.yml "$dispatch_run_name" "${args[@]}"
+              dispatch_child npm-telegram-beta-e2e.yml "$dispatch_run_name" "${args[@]}"
               ;;
             performance)
               fail_on_regression=true
@@ -1130,7 +947,7 @@ jobs:
                 -f publish_reports=false
                 -f dispatch_id="$dispatch_id"
               )
-              dispatch_and_wait openclaw-performance.yml "$dispatch_run_name" "${args[@]}"
+              dispatch_child openclaw-performance.yml "$dispatch_run_name" "${args[@]}"
               ;;
             *)
               echo "::error::Unsupported full-release child workflow kind ${CHILD_WORKFLOW_KIND}." >&2
@@ -1141,16 +958,15 @@ jobs:
   plugin_prerelease:
     name: Run plugin prerelease validation
     needs: [resolve_target, evidence_reuse, prepare_release_candidate]
-    if: ${{ always() && needs.resolve_target.result == 'success' && (needs.prepare_release_candidate.result == 'success' || needs.prepare_release_candidate.result == 'skipped') && contains(fromJSON('["all","plugin-prerelease"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
+    if: ${{ always() && github.run_attempt == 1 && needs.resolve_target.result == 'success' && (needs.prepare_release_candidate.result == 'success' || needs.prepare_release_candidate.result == 'skipped') && contains(fromJSON('["all","plugin-prerelease"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
     runs-on: ubuntu-24.04
-    # The child owns lane timeouts; this monitor also covers queue delay.
-    timeout-minutes: ${{ inputs.release_profile == 'full' && 300 || 240 }}
+    timeout-minutes: 15
     outputs:
       run_id: ${{ steps.dispatch.outputs.run_id }}
+      run_attempt: ${{ steps.dispatch.outputs.run_attempt }}
       url: ${{ steps.dispatch.outputs.url }}
-      conclusion: ${{ steps.dispatch.outputs.conclusion }}
     steps:
-      - name: Dispatch and monitor plugin prerelease
+      - name: Dispatch plugin prerelease
         id: dispatch
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1161,23 +977,20 @@ jobs:
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
           CANDIDATE_ARTIFACT_JSON: ${{ needs.prepare_release_candidate.outputs.candidate_artifact_json }}
           PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON: ${{ inputs.plugin_prerelease_node_exclude_patterns_json }}
-          FAIL_FAST: ${{ inputs.fail_fast }}
         run: *full_release_child_dispatch
 
   release_checks:
     name: Run release/live/Docker/QA validation
     needs: [resolve_target, evidence_reuse, prepare_release_candidate]
-    if: ${{ always() && needs.resolve_target.result == 'success' && (needs.prepare_release_candidate.result == 'success' || needs.prepare_release_candidate.result == 'skipped') && contains(fromJSON('["all","install-smoke","cross-os","live-e2e","package","qa-parity","qa-live"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
+    if: ${{ always() && github.run_attempt == 1 && needs.resolve_target.result == 'success' && (needs.prepare_release_candidate.result == 'success' || needs.prepare_release_candidate.result == 'skipped') && contains(fromJSON('["all","install-smoke","cross-os","live-e2e","package","qa-parity","qa-live"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # The bounded package critical path tops out at 310 minutes; 420 leaves
-    # queue/API margin. Parent timeout preserves the adopted child for exact cancellation.
-    timeout-minutes: 420
+    timeout-minutes: 15
     outputs:
       run_id: ${{ steps.dispatch.outputs.run_id }}
+      run_attempt: ${{ steps.dispatch.outputs.run_attempt }}
       url: ${{ steps.dispatch.outputs.url }}
-      conclusion: ${{ steps.dispatch.outputs.conclusion }}
     steps:
-      - name: Dispatch and monitor release checks
+      - name: Dispatch release checks
         id: dispatch
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1206,17 +1019,16 @@ jobs:
   npm_telegram:
     name: Run package Telegram E2E
     needs: [resolve_target, evidence_reuse]
-    if: ${{ always() && needs.resolve_target.result == 'success' && contains(fromJSON('["all","npm-telegram"]'), inputs.rerun_group) && (inputs.npm_telegram_package_spec != '' || inputs.release_package_spec != '') && needs.evidence_reuse.outputs.reuse != 'true' }}
+    if: ${{ always() && github.run_attempt == 1 && needs.resolve_target.result == 'success' && contains(fromJSON('["all","npm-telegram"]'), inputs.rerun_group) && (inputs.npm_telegram_package_spec != '' || inputs.release_package_spec != '') && needs.evidence_reuse.outputs.reuse != 'true' }}
     continue-on-error: ${{ startsWith(github.ref, 'refs/heads/tideclaw/alpha/') }}
     runs-on: ubuntu-24.04
-    # The child owns lane timeouts; this monitor also covers queue delay.
-    timeout-minutes: ${{ inputs.release_profile == 'full' && 360 || 120 }}
+    timeout-minutes: 15
     outputs:
       run_id: ${{ steps.dispatch.outputs.run_id }}
+      run_attempt: ${{ steps.dispatch.outputs.run_attempt }}
       url: ${{ steps.dispatch.outputs.url }}
-      conclusion: ${{ steps.dispatch.outputs.conclusion }}
     steps:
-      - name: Dispatch and monitor npm Telegram E2E
+      - name: Dispatch npm Telegram E2E
         id: dispatch
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1227,25 +1039,20 @@ jobs:
           PACKAGE_SPEC: ${{ inputs.npm_telegram_package_spec || inputs.release_package_spec }}
           PROVIDER_MODE: ${{ inputs.npm_telegram_provider_mode }}
           SCENARIO: ${{ inputs.npm_telegram_scenario }}
-          FAIL_FAST: ${{ inputs.fail_fast }}
         run: *full_release_child_dispatch
 
   performance:
     name: Run product performance evidence
     needs: [resolve_target, evidence_reuse]
-    if: ${{ always() && needs.resolve_target.result == 'success' && contains(fromJSON('["all","performance"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
-    # Keep this monitor off the four-slot GitHub-hosted pool so performance starts
-    # with the other child workflows instead of extending the critical path.
+    if: ${{ always() && github.run_attempt == 1 && needs.resolve_target.result == 'success' && contains(fromJSON('["all","performance"]'), inputs.rerun_group) && needs.evidence_reuse.outputs.reuse != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Artifact-only and publish paths top out at 255 and 280 minutes; 360 leaves
-    # queue/API margin. Parent timeout preserves the adopted child for exact cancellation.
-    timeout-minutes: 360
+    timeout-minutes: 15
     outputs:
       run_id: ${{ steps.dispatch.outputs.run_id }}
+      run_attempt: ${{ steps.dispatch.outputs.run_attempt }}
       url: ${{ steps.dispatch.outputs.url }}
-      conclusion: ${{ steps.dispatch.outputs.conclusion }}
     steps:
-      - name: Dispatch and monitor OpenClaw Performance
+      - name: Dispatch OpenClaw Performance
         id: dispatch
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1255,8 +1062,9 @@ jobs:
           CHILD_WORKFLOW_REF: ${{ github.ref_name }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
         run: *full_release_child_dispatch
-  summary:
-    name: Verify full validation
+
+  release_execution_plan:
+    name: Seal release execution plan
     needs:
       [
         resolve_target,
@@ -1270,442 +1078,346 @@ jobs:
         performance,
       ]
     if: always()
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    outputs:
+      sha256: ${{ steps.plan.outputs.sha256 }}
+      source_parent_attempt: ${{ steps.plan.outputs.source_parent_attempt }}
     steps:
-      - name: Verify child workflow results
+      - name: Checkout release execution plan tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: |
+            scripts/full-release-validation-state.mjs
+            scripts/full-release-validation-policy.mjs
+            scripts/release-ci-summary.mjs
+            scripts/lib/plain-gh.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Restore immutable release execution plan
+        if: ${{ github.run_attempt != 1 }}
+        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        with:
+          name: full-release-execution-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/full-release-execution-plan
+
+      - name: Seal immutable release execution plan
+        id: plan
         env:
           GH_TOKEN: ${{ github.token }}
-          NORMAL_CI_RUN_ID: ${{ needs.normal_ci.outputs.run_id }}
-          PLUGIN_PRERELEASE_RUN_ID: ${{ needs.plugin_prerelease.outputs.run_id }}
-          RELEASE_CHECKS_RUN_ID: ${{ needs.release_checks.outputs.run_id }}
-          NPM_TELEGRAM_RUN_ID: ${{ needs.npm_telegram.outputs.run_id }}
-          PERFORMANCE_RUN_ID: ${{ needs.performance.outputs.run_id }}
-          NORMAL_CI_RESULT: ${{ needs.normal_ci.result }}
-          PLUGIN_PRERELEASE_RESULT: ${{ needs.plugin_prerelease.result }}
-          RELEASE_CHECKS_RESULT: ${{ needs.release_checks.result }}
-          NPM_TELEGRAM_RESULT: ${{ needs.npm_telegram.result }}
-          PERFORMANCE_RESULT: ${{ needs.performance.result }}
           RELEASE_PROFILE: ${{ inputs.release_profile }}
-          DOCKER_RUNTIME_ASSETS_PREFLIGHT_RESULT: ${{ needs.docker_runtime_assets_preflight.result }}
-          PREPARE_RELEASE_CANDIDATE_RESULT: ${{ needs.prepare_release_candidate.result }}
-          RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
-          NPM_TELEGRAM_PACKAGE_SPEC: ${{ inputs.npm_telegram_package_spec }}
-          PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ inputs.package_acceptance_package_spec }}
-          LIVE_SUITE_FILTER: ${{ needs.resolve_target.outputs.live_suite_filter }}
-          SKIP_PACKAGE_TELEGRAM_E2E: ${{ inputs.skip_package_telegram_e2e }}
+          RERUN_GROUP: ${{ inputs.rerun_group }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
           EVIDENCE_REUSE: ${{ needs.evidence_reuse.outputs.reuse }}
           EVIDENCE_ROOT_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_root_run_id }}
           EVIDENCE_RUN_URL: ${{ needs.evidence_reuse.outputs.evidence_run_url }}
           EVIDENCE_SHA: ${{ needs.evidence_reuse.outputs.evidence_sha }}
           EVIDENCE_POLICY: ${{ needs.evidence_reuse.outputs.evidence_policy }}
-          EVIDENCE_MANIFEST: ${{ needs.evidence_reuse.outputs.evidence_manifest }}
-          RERUN_GROUP: ${{ inputs.rerun_group }}
-          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
-          CHILD_WORKFLOW_REF: ${{ github.ref_name }}
-          PARENT_WORKFLOW_SHA: ${{ github.sha }}
+          EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths }}
+          RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
+          PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ inputs.package_acceptance_package_spec }}
+          NPM_TELEGRAM_PACKAGE_SPEC: ${{ inputs.npm_telegram_package_spec }}
+          LIVE_SUITE_FILTER: ${{ needs.resolve_target.outputs.live_suite_filter }}
+          NORMAL_CI_RESULT: ${{ needs.normal_ci.result }}
+          NORMAL_CI_RUN_ID: ${{ needs.normal_ci.outputs.run_id }}
+          NORMAL_CI_RUN_ATTEMPT: ${{ needs.normal_ci.outputs.run_attempt }}
+          NORMAL_CI_URL: ${{ needs.normal_ci.outputs.url }}
+          PLUGIN_PRERELEASE_RESULT: ${{ needs.plugin_prerelease.result }}
+          PLUGIN_PRERELEASE_RUN_ID: ${{ needs.plugin_prerelease.outputs.run_id }}
+          PLUGIN_PRERELEASE_RUN_ATTEMPT: ${{ needs.plugin_prerelease.outputs.run_attempt }}
+          PLUGIN_PRERELEASE_URL: ${{ needs.plugin_prerelease.outputs.url }}
+          RELEASE_CHECKS_RESULT: ${{ needs.release_checks.result }}
+          RELEASE_CHECKS_RUN_ID: ${{ needs.release_checks.outputs.run_id }}
+          RELEASE_CHECKS_RUN_ATTEMPT: ${{ needs.release_checks.outputs.run_attempt }}
+          RELEASE_CHECKS_URL: ${{ needs.release_checks.outputs.url }}
+          NPM_TELEGRAM_RESULT: ${{ needs.npm_telegram.result }}
+          NPM_TELEGRAM_RUN_ID: ${{ needs.npm_telegram.outputs.run_id }}
+          NPM_TELEGRAM_RUN_ATTEMPT: ${{ needs.npm_telegram.outputs.run_attempt }}
+          NPM_TELEGRAM_URL: ${{ needs.npm_telegram.outputs.url }}
+          PERFORMANCE_RESULT: ${{ needs.performance.result }}
+          PERFORMANCE_RUN_ID: ${{ needs.performance.outputs.run_id }}
+          PERFORMANCE_RUN_ATTEMPT: ${{ needs.performance.outputs.run_attempt }}
+          PERFORMANCE_URL: ${{ needs.performance.outputs.url }}
+          RESOLVE_TARGET_RESULT: ${{ needs.resolve_target.result }}
+          DOCKER_RUNTIME_ASSETS_PREFLIGHT_RESULT: ${{ needs.docker_runtime_assets_preflight.result }}
+          PREPARE_RELEASE_CANDIDATE_RESULT: ${{ needs.prepare_release_candidate.result }}
+          FULL_RELEASE_RESTORE_PLAN: ${{ github.run_attempt != 1 }}
+          FULL_RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
         run: |
           set -euo pipefail
-
-          gh_with_retry() {
-            local output status attempt
-            for attempt in 1 2 3 4 5 6; do
-              set +e
-              output="$(gh "$@" 2>&1)"
-              status=$?
-              set -e
-              if [[ "$status" -eq 0 ]]; then
-                printf '%s\n' "$output"
-                return 0
-              fi
-              if [[ "$output" == *"Bad credentials"* || "$output" == *"HTTP 401"* || "$output" == *"secondary rate limit"* || "$output" == *"API rate limit"* || "$output" == *"HTTP 429"* || "$output" == *"abuse detection"* || "$output" == *"Sorry. Your account was suspended"* || "$output" =~ $GH_TRANSIENT_SERVER_OR_NETWORK_PATTERN ]]; then
-                echo "::warning::gh $* failed on attempt ${attempt}: ${output}" >&2
-                sleep $((attempt * 10))
-                continue
-              fi
-              printf '%s\n' "$output" >&2
-              return "$status"
-            done
-            printf '%s\n' "$output" >&2
-            return "$status"
-          }
-
-          release_check_blocking_job() {
-            case "$1" in
-              "resolve_target" | \
-              "Prepare release package artifact" | \
-              "install_smoke_release_checks / "* | \
-              "Run package acceptance" | \
-              "Run package acceptance / "*)
-                return 0
-                ;;
-            esac
-            return 1
-          }
-
-          release_checks_advisory_only() {
-            local run_json="$1"
-            local verifier_conclusion name saw_advisory failed
-
-            verifier_conclusion="$(
-              jq -r '.jobs[] | select(.name == "Verify release checks") | .conclusion' <<< "$run_json" |
-                tail -n 1
+          if [[ "$FULL_RELEASE_RESTORE_PLAN" != "true" ]]; then
+            export FULL_RELEASE_PLAN_INPUTS_JSON="$(
+            jq -cn \
+              --arg parentRunId "$GITHUB_RUN_ID" \
+              --arg parentRunAttempt "$GITHUB_RUN_ATTEMPT" \
+              --arg workflowRef "$GITHUB_REF_NAME" \
+              --arg workflowSha "$GITHUB_SHA" \
+              --arg evidenceReuse "$EVIDENCE_REUSE" \
+              --arg evidenceRootRunId "$EVIDENCE_ROOT_RUN_ID" \
+              --arg evidenceRunUrl "$EVIDENCE_RUN_URL" \
+              --arg evidenceSha "$EVIDENCE_SHA" \
+              --arg evidencePolicy "$EVIDENCE_POLICY" \
+              --argjson evidenceChangedPaths "$EVIDENCE_CHANGED_PATHS" \
+              --arg rerunGroup "$RERUN_GROUP" \
+              --arg releasePackageSpec "$RELEASE_PACKAGE_SPEC" \
+              --arg packageAcceptancePackageSpec "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \
+              --arg npmTelegramPackageSpec "$NPM_TELEGRAM_PACKAGE_SPEC" \
+              --arg liveSuiteFilter "$LIVE_SUITE_FILTER" \
+              --arg resolveTargetResult "$RESOLVE_TARGET_RESULT" \
+              --arg dockerPreflightResult "$DOCKER_RUNTIME_ASSETS_PREFLIGHT_RESULT" \
+              --arg prepareCandidateResult "$PREPARE_RELEASE_CANDIDATE_RESULT" \
+              --arg normalCiResult "$NORMAL_CI_RESULT" \
+              --arg normalCiRunId "$NORMAL_CI_RUN_ID" \
+              --arg normalCiRunAttempt "$NORMAL_CI_RUN_ATTEMPT" \
+              --arg normalCiUrl "$NORMAL_CI_URL" \
+              --arg pluginPrereleaseResult "$PLUGIN_PRERELEASE_RESULT" \
+              --arg pluginPrereleaseRunId "$PLUGIN_PRERELEASE_RUN_ID" \
+              --arg pluginPrereleaseRunAttempt "$PLUGIN_PRERELEASE_RUN_ATTEMPT" \
+              --arg pluginPrereleaseUrl "$PLUGIN_PRERELEASE_URL" \
+              --arg releaseChecksResult "$RELEASE_CHECKS_RESULT" \
+              --arg releaseChecksRunId "$RELEASE_CHECKS_RUN_ID" \
+              --arg releaseChecksRunAttempt "$RELEASE_CHECKS_RUN_ATTEMPT" \
+              --arg releaseChecksUrl "$RELEASE_CHECKS_URL" \
+              --arg npmTelegramResult "$NPM_TELEGRAM_RESULT" \
+              --arg npmTelegramRunId "$NPM_TELEGRAM_RUN_ID" \
+              --arg npmTelegramRunAttempt "$NPM_TELEGRAM_RUN_ATTEMPT" \
+              --arg npmTelegramUrl "$NPM_TELEGRAM_URL" \
+              --arg performanceResult "$PERFORMANCE_RESULT" \
+              --arg performanceRunId "$PERFORMANCE_RUN_ID" \
+              --arg performanceRunAttempt "$PERFORMANCE_RUN_ATTEMPT" \
+              --arg performanceUrl "$PERFORMANCE_URL" \
+              '{
+                parentRunId: $parentRunId,
+                parentRunAttempt: $parentRunAttempt,
+                workflowRef: $workflowRef,
+                workflowSha: $workflowSha,
+                evidenceReuse: $evidenceReuse,
+                evidenceRootRunId: $evidenceRootRunId,
+                evidenceRunUrl: $evidenceRunUrl,
+                evidenceSha: $evidenceSha,
+                evidencePolicy: $evidencePolicy,
+                evidenceChangedPaths: $evidenceChangedPaths,
+                rerunGroup: $rerunGroup,
+                releasePackageSpec: $releasePackageSpec,
+                packageAcceptancePackageSpec: $packageAcceptancePackageSpec,
+                npmTelegramPackageSpec: $npmTelegramPackageSpec,
+                liveSuiteFilter: $liveSuiteFilter,
+                resolveTargetResult: $resolveTargetResult,
+                dockerPreflightResult: $dockerPreflightResult,
+                prepareCandidateResult: $prepareCandidateResult,
+                children: {
+                  normalCi: {result: $normalCiResult, runId: $normalCiRunId, runAttempt: $normalCiRunAttempt, url: $normalCiUrl},
+                  pluginPrerelease: {result: $pluginPrereleaseResult, runId: $pluginPrereleaseRunId, runAttempt: $pluginPrereleaseRunAttempt, url: $pluginPrereleaseUrl},
+                  releaseChecks: {result: $releaseChecksResult, runId: $releaseChecksRunId, runAttempt: $releaseChecksRunAttempt, url: $releaseChecksUrl},
+                  npmTelegram: {result: $npmTelegramResult, runId: $npmTelegramRunId, runAttempt: $npmTelegramRunAttempt, url: $npmTelegramUrl},
+                  productPerformance: {result: $performanceResult, runId: $performanceRunId, runAttempt: $performanceRunAttempt, url: $performanceUrl}
+                }
+              }'
             )"
-            if [[ "$verifier_conclusion" != "success" ]]; then
-              return 1
-            fi
-
-            saw_advisory=0
-            failed=0
-            while IFS= read -r name; do
-              [[ -z "${name// }" ]] && continue
-              if release_check_blocking_job "$name"; then
-                echo "::error::${name} is a package-safety Tideclaw alpha release-check lane."
-                failed=1
-              else
-                saw_advisory=1
-              fi
-            done < <(jq -r '.jobs[] | select(.conclusion != "success" and .conclusion != "skipped") | .name' <<< "$run_json")
-
-            [[ "$saw_advisory" == "1" && "$failed" == "0" ]]
-          }
-
-          check_child() {
-            local label="$1"
-            local run_id="$2"
-            local required="$3"
-            local advisory_ok="${4:-0}"
-
-            if [[ -z "${run_id// }" ]]; then
-              if [[ "$required" == "0" ]]; then
-                echo "${label}: skipped"
-                return 0
-              fi
-              echo "::error::${label} did not record a child run id."
-              return 1
-            fi
-
-            local run_json status conclusion url attempt head_sha
-            run_json="$(gh_with_retry run view "$run_id" --json status,conclusion,url,attempt,headSha,jobs)"
-            status="$(jq -r '.status' <<< "$run_json")"
-            conclusion="$(jq -r '.conclusion' <<< "$run_json")"
-            url="$(jq -r '.url' <<< "$run_json")"
-            attempt="$(jq -r '.attempt' <<< "$run_json")"
-            head_sha="$(jq -r '.headSha // ""' <<< "$run_json")"
-            echo "${label}: ${status}/${conclusion} attempt ${attempt} head ${head_sha}: ${url}"
-
-            if [[ "$head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then
-              echo "::error::${label} child run used workflow SHA ${head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}. Use the SHA-pinned release helper when a moving branch cannot stay fixed."
-              return 1
-            fi
-
-            if [[ "$status" != "completed" || "$conclusion" != "success" ]]; then
-              if [[ "$advisory_ok" == "1" && "$label" == "product_performance" && "$status" == "completed" ]]; then
-                echo "::warning::${label} ended with ${conclusion}; advisory for beta: ${url}"
-                return 0
-              fi
-              if [[ "$advisory_ok" == "1" && "$label" == "release_checks" ]]; then
-                if release_checks_advisory_only "$run_json"; then
-                  echo "::warning::${label} child run ended with ${status}/${conclusion}, but Verify release checks accepted Tideclaw alpha advisory lanes: ${url}"
-                  return 0
-                fi
-              fi
-              echo "::error::${label} child run ended with ${status}/${conclusion}: ${url}"
-              jq '.jobs[] | select(.conclusion != "success" and .conclusion != "skipped") | {name, status, conclusion, url}' <<< "$run_json" || true
-              return 1
-            fi
-          }
-
-          append_child_overview() {
-            {
-              echo
-              echo "### Child workflow overview"
-              echo
-              echo "| Child | Result | Minutes | Head SHA | Run |"
-              echo "| --- | --- | ---: | --- | --- |"
-              echo "| \`docker_runtime_assets_preflight\` | \`${DOCKER_RUNTIME_ASSETS_PREFLIGHT_RESULT}\` |  | current workflow |  |"
-            } >> "$GITHUB_STEP_SUMMARY"
-
-            append_child_row() {
-              local label="$1"
-              local run_id="$2"
-              local result="$3"
-
-              if [[ -z "${run_id// }" ]]; then
-                echo "| \`${label}\` | \`${result}\` |  | skipped |" >> "$GITHUB_STEP_SUMMARY"
-                return 0
-              fi
-
-              local run_json row
-              run_json="$(gh_with_retry run view "$run_id" --json status,conclusion,url,createdAt,updatedAt,headSha)"
-              row="$(
-                jq -r --arg label "$label" '
-                  def ts: fromdateiso8601;
-                  . as $run |
-                  ($run.createdAt // "") as $created |
-                  ($run.updatedAt // "") as $updated |
-                  (if ($created | length) > 0 and ($updated | length) > 0
-                    then (((($updated | ts) - ($created | ts)) / 60) * 10 | round / 10 | tostring)
-                    else ""
-                  end) as $minutes |
-                  ($run.headSha // "") as $head |
-                  "| `" + $label + "` | `" + ($run.status // "") + "/" + ($run.conclusion // "") + "` | " + $minutes + " | `" + $head + "` | [run](" + ($run.url // "") + ") |"
-                ' <<< "$run_json"
-              )"
-              echo "$row" >> "$GITHUB_STEP_SUMMARY"
-            }
-
-            append_child_row "normal_ci" "$NORMAL_CI_RUN_ID" "$NORMAL_CI_RESULT"
-            append_child_row "plugin_prerelease" "$PLUGIN_PRERELEASE_RUN_ID" "$PLUGIN_PRERELEASE_RESULT"
-            append_child_row "release_checks" "$RELEASE_CHECKS_RUN_ID" "$RELEASE_CHECKS_RESULT"
-            append_child_row "npm_telegram" "$NPM_TELEGRAM_RUN_ID" "$NPM_TELEGRAM_RESULT"
-            append_child_row "product_performance" "$PERFORMANCE_RUN_ID" "$PERFORMANCE_RESULT"
-          }
-
-          summarize_child_timing() {
-            local label="$1"
-            local run_id="$2"
-            if [[ -z "${run_id// }" ]]; then
-              return 0
-            fi
-
-            {
-              echo
-              echo "### Slowest jobs: ${label}"
-              echo
-              gh_with_retry run view "$run_id" --json jobs --jq '
-                def ts: fromdateiso8601;
-                "| Job | Result | Minutes |",
-                "| --- | --- | ---: |",
-                ([.jobs[]
-                  | select(.startedAt != "0001-01-01T00:00:00Z" and .completedAt != "0001-01-01T00:00:00Z")
-                  | . + {durationMin: ((((.completedAt | ts) - (.startedAt | ts)) / 60) * 10 | round / 10)}
-                  | {name, conclusion, durationMin}]
-                  | sort_by(.durationMin)
-                  | reverse
-                  | .[0:10]
-                  | map("| `" + (.name | gsub("\\|"; "\\|")) + "` | `" + ((.conclusion // "") | tostring) + "` | " + (.durationMin | tostring) + " |")
-                  | .[])
-              ' || echo "_Unable to summarize jobs for run ${run_id}._"
-              echo
-              echo "### Longest start delays: ${label}"
-              echo
-              gh_with_retry api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100" --jq ".jobs[] | @json" | jq -sr '
-                def ts: fromdateiso8601;
-                "| Job | Result | Start delay minutes | Run minutes |",
-                "| --- | --- | ---: | ---: |",
-                ([.[]
-                  | select(.created_at != null and .started_at != null)
-                  | . + {
-                      startDelayMin: ((((.started_at | ts) - (.created_at | ts)) / 60) * 10 | round / 10),
-                      durationMin: (if .completed_at == null then null else ((((.completed_at | ts) - (.started_at | ts)) / 60) * 10 | round / 10) end)
-                    }
-                  | select(.startDelayMin > 0)
-                  | {name, conclusion, startDelayMin, durationMin}]
-                  | sort_by(.startDelayMin)
-                  | reverse
-                  | .[0:10]
-                  | map("| `" + (.name | gsub("\\|"; "\\|")) + "` | `" + ((.conclusion // "") | tostring) + "` | " + (.startDelayMin | tostring) + " | " + ((.durationMin // "") | tostring) + " |")
-                  | .[])
-              ' || echo "_Unable to summarize start delays for run ${run_id}._"
-            } >> "$GITHUB_STEP_SUMMARY"
-          }
-
-          summarize_failed_child() {
-            local label="$1"
-            local run_id="$2"
-            if [[ -z "${run_id// }" ]]; then
-              return 0
-            fi
-
-            local run_json status conclusion artifacts_json
-            run_json="$(gh_with_retry run view "$run_id" --json status,conclusion,url,jobs)"
-            status="$(jq -r '.status' <<< "$run_json")"
-            conclusion="$(jq -r '.conclusion' <<< "$run_json")"
-            if [[ "$status" == "completed" && "$conclusion" == "success" ]]; then
-              return 0
-            fi
-
-            {
-              echo
-              echo "### Failed child detail: ${label}"
-              echo
-              jq -r '
-                "- Run: " + (.url // ""),
-                "- Result: `" + (.status // "") + "/" + (.conclusion // "") + "`",
-                "",
-                "Failed jobs:",
-                (.jobs[]
-                  | select(.conclusion != "success" and .conclusion != "skipped")
-                  | "- `" + (.name | gsub("`"; "\\`")) + "`: `" + ((.conclusion // .status // "") | tostring) + "` " + (.url // ""))
-              ' <<< "$run_json" || true
-              echo
-              echo "Artifacts:"
-              artifacts_json="$(
-                gh_with_retry api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" 2>/dev/null || true
-              )"
-              if [[ -n "${artifacts_json// }" ]]; then
-                jq -r '
-                  if ((.artifacts // []) | length) == 0 then
-                    "- none"
-                  else
-                    (.artifacts[]
-                      | "- `" + (.name | gsub("`"; "\\`")) + "` (" + ((.size_in_bytes // 0) | tostring) + " bytes)")
-                  end
-                ' <<< "$artifacts_json" || echo "- unable to list artifacts"
-              else
-                echo "- unable to list artifacts"
-              fi
-            } >> "$GITHUB_STEP_SUMMARY"
-          }
-
-          failed=0
-          normal_ci_required=0
-          plugin_prerelease_required=0
-          release_checks_required=0
-          npm_telegram_required=0
-          performance_required=0
-          candidate_required=0
-          if [[ "$RERUN_GROUP" == "npm-telegram" || ( "$RERUN_GROUP" == "all" && ( -n "${NPM_TELEGRAM_PACKAGE_SPEC// }" || -n "${RELEASE_PACKAGE_SPEC// }" ) ) ]]; then
-            npm_telegram_required=1
           fi
-          echo "- Package Telegram E2E deferred: \`${SKIP_PACKAGE_TELEGRAM_E2E}\`" >> "$GITHUB_STEP_SUMMARY"
-          if [[ -z "${RELEASE_PACKAGE_SPEC// }" && -z "${PACKAGE_ACCEPTANCE_PACKAGE_SPEC// }" ]]; then
-            case "$RERUN_GROUP" in
-              all|plugin-prerelease|cross-os|package)
-                candidate_required=1
-                ;;
-              live-e2e)
-                [[ -n "${LIVE_SUITE_FILTER// }" ]] || candidate_required=1
-                ;;
-            esac
-          fi
-          if [[ "$candidate_required" == "1" && "$EVIDENCE_REUSE" != "true" && "$PREPARE_RELEASE_CANDIDATE_RESULT" != "success" ]]; then
-            echo "::error::Shared release candidate preparation ended with ${PREPARE_RELEASE_CANDIDATE_RESULT}."
-            failed=1
-          fi
-          if [[ "$RERUN_GROUP" == "all" && "$EVIDENCE_REUSE" == "true" ]]; then
-            # Lanes were skipped because a prior green validation covers this
-            # target; re-verify the chain-root run and its recorded child runs
-            # so evidence that went stale after resolution cannot pass.
-            reused_npm_telegram_run_id="$(jq -r '.childRuns.npmTelegram // ""' <<< "$EVIDENCE_MANIFEST")"
-            if [[ "$npm_telegram_required" == "1" && -z "${reused_npm_telegram_run_id// }" ]]; then
-              echo "::error::Reused evidence did not record the required npm Telegram child run."
-              failed=1
-            fi
-            evidence_state="$(gh_with_retry run view "$EVIDENCE_ROOT_RUN_ID" --json status,conclusion --jq '(.status // "") + "/" + (.conclusion // "")')"
-            if [[ "$evidence_state" != "completed/success" ]]; then
-              echo "::error::Reused evidence run ${EVIDENCE_ROOT_RUN_ID} is ${evidence_state}; evidence is no longer valid."
-              failed=1
-            fi
-            while IFS= read -r evidence_child_run_id; do
-              [[ -n "$evidence_child_run_id" ]] || continue
-              evidence_child_state="$(gh_with_retry run view "$evidence_child_run_id" --json status,conclusion --jq '(.status // "") + "/" + (.conclusion // "")')"
-              if [[ "$evidence_child_state" != "completed/success" ]]; then
-                echo "::error::Reused evidence child run ${evidence_child_run_id} is ${evidence_child_state}; evidence is no longer valid."
-                failed=1
-              fi
-            done < <(jq -r '[.childRuns.normalCi // "", .childRuns.pluginPrerelease // "", .childRuns.releaseChecks // "", .childRuns.npmTelegram // "", (.childRuns.productPerformance.runId // "")] | map(select(. != "")) | .[]' <<< "$EVIDENCE_MANIFEST")
-            if [[ "$failed" == "0" ]]; then
-              emit_reused_child_dispatch() {
-                local workflow="$1"
-                local run_id="$2"
-                if [[ -n "${run_id// }" ]]; then
-                  echo "Dispatched ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
-                fi
-              }
-              emit_reused_child_dispatch "ci.yml" "$(jq -r '.childRuns.normalCi // ""' <<< "$EVIDENCE_MANIFEST")"
-              emit_reused_child_dispatch "plugin-prerelease.yml" "$(jq -r '.childRuns.pluginPrerelease // ""' <<< "$EVIDENCE_MANIFEST")"
-              emit_reused_child_dispatch "openclaw-release-checks.yml" "$(jq -r '.childRuns.releaseChecks // ""' <<< "$EVIDENCE_MANIFEST")"
-              emit_reused_child_dispatch "npm-telegram-beta-e2e.yml" "$(jq -r '.childRuns.npmTelegram // ""' <<< "$EVIDENCE_MANIFEST")"
-              emit_reused_child_dispatch "openclaw-performance.yml" "$(jq -r '.childRuns.productPerformance.runId // ""' <<< "$EVIDENCE_MANIFEST")"
-              {
-                echo "### Reused validation evidence"
-                echo
-                echo "- Evidence run: ${EVIDENCE_RUN_URL}"
-                echo "- Evidence SHA: \`${EVIDENCE_SHA}\`"
-                echo "- Target SHA: \`${TARGET_SHA}\`"
-                echo "- Reuse policy: \`${EVIDENCE_POLICY}\`"
-              } >> "$GITHUB_STEP_SUMMARY"
-            fi
-          elif [[ "$RERUN_GROUP" == "all" && "$DOCKER_RUNTIME_ASSETS_PREFLIGHT_RESULT" != "success" ]]; then
-            echo "::error::Docker runtime-assets preflight ended with ${DOCKER_RUNTIME_ASSETS_PREFLIGHT_RESULT}."
-            failed=1
-          elif [[ "$RERUN_GROUP" == "all" ]]; then
-            normal_ci_required=1
-            plugin_prerelease_required=1
-            release_checks_required=1
-            performance_required=1
-          else
-            case "$RERUN_GROUP" in
-              ci)
-                normal_ci_required=1
-                ;;
-              plugin-prerelease)
-                plugin_prerelease_required=1
-                ;;
-              install-smoke|cross-os|live-e2e|package|qa-parity|qa-live)
-                release_checks_required=1
-                ;;
-              performance)
-                performance_required=1
-                ;;
-            esac
-          fi
+          node scripts/full-release-validation-state.mjs plan
 
-          append_child_overview
+      - name: Upload immutable release execution plan
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: full-release-execution-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/full-release-execution-plan
+          if-no-files-found: error
 
-          if [[ "$NORMAL_CI_RESULT" == "skipped" && -z "${NORMAL_CI_RUN_ID// }" ]]; then
-            check_child "normal_ci" "" "$normal_ci_required" || failed=1
-          else
-            check_child "normal_ci" "$NORMAL_CI_RUN_ID" 1 || failed=1
+  release_decision:
+    name: Release Decision
+    needs: [resolve_target, release_execution_plan]
+    if: always() && needs.release_execution_plan.result == 'success'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 720
+    outputs:
+      state: ${{ steps.state.outputs.state }}
+    steps:
+      - name: Checkout release decision tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: |
+            scripts/full-release-validation-state.mjs
+            scripts/full-release-validation-policy.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download immutable release execution plan
+        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        with:
+          name: full-release-execution-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/full-release-execution-plan
+
+      - name: Evaluate release decision
+        id: state
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FAIL_FAST: ${{ inputs.fail_fast }}
+          RELEASE_PROFILE: ${{ inputs.release_profile }}
+          RERUN_GROUP: ${{ inputs.rerun_group }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+          FULL_RELEASE_STATE_MODE: decision
+          FULL_RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
+          FULL_RELEASE_STATE_PATH: ${{ runner.temp }}/full-release-decision/full-release-decision.json
+        run: &full_release_state |
+          set -euo pipefail
+          node scripts/full-release-validation-state.mjs "$FULL_RELEASE_STATE_MODE"
+
+      - name: Upload release decision
+        if: always() && steps.state.outputs.state != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/full-release-decision
+          if-no-files-found: error
+
+      - name: Enforce release decision
+        if: always()
+        env:
+          RELEASE_DECISION_STATE: ${{ steps.state.outputs.state }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_DECISION_STATE" == "passed" ]]; then
+            exit 0
           fi
+          echo "::error::Release Decision ended in ${RELEASE_DECISION_STATE:-orchestration_error}."
+          exit 1
 
-          if [[ "$PLUGIN_PRERELEASE_RESULT" == "skipped" && -z "${PLUGIN_PRERELEASE_RUN_ID// }" ]]; then
-            check_child "plugin_prerelease" "" "$plugin_prerelease_required" || failed=1
-          else
-            check_child "plugin_prerelease" "$PLUGIN_PRERELEASE_RUN_ID" 1 || failed=1
-          fi
+  diagnostic_drain:
+    name: Diagnostic Drain
+    needs: [resolve_target, release_execution_plan]
+    if: always() && needs.release_execution_plan.result == 'success'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 720
+    outputs:
+      state: ${{ steps.state.outputs.state }}
+      normal_ci_conclusion: ${{ steps.state.outputs.normalCi_conclusion }}
+      plugin_prerelease_conclusion: ${{ steps.state.outputs.pluginPrerelease_conclusion }}
+      release_checks_conclusion: ${{ steps.state.outputs.releaseChecks_conclusion }}
+      npm_telegram_conclusion: ${{ steps.state.outputs.npmTelegram_conclusion }}
+      performance_conclusion: ${{ steps.state.outputs.productPerformance_conclusion }}
+    steps:
+      - name: Checkout diagnostic drain tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: |
+            scripts/full-release-validation-state.mjs
+            scripts/full-release-validation-policy.mjs
+            scripts/release-ci-summary.mjs
+            scripts/lib/plain-gh.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
 
-          if [[ "$RELEASE_CHECKS_RESULT" == "skipped" && -z "${RELEASE_CHECKS_RUN_ID// }" ]]; then
-            check_child "release_checks" "" "$release_checks_required" || failed=1
-          elif [[ "$CHILD_WORKFLOW_REF" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
-            check_child "release_checks" "$RELEASE_CHECKS_RUN_ID" 1 1 || failed=1
-          else
-            check_child "release_checks" "$RELEASE_CHECKS_RUN_ID" 1 || failed=1
-          fi
+      - name: Download immutable release execution plan
+        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        with:
+          name: full-release-execution-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/full-release-execution-plan
 
-          if [[ "$NPM_TELEGRAM_RESULT" == "skipped" && -z "${NPM_TELEGRAM_RUN_ID// }" ]]; then
-            check_child "npm_telegram" "" "$npm_telegram_required" || failed=1
-          elif [[ "$CHILD_WORKFLOW_REF" =~ ^tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
-            check_child "npm_telegram" "$NPM_TELEGRAM_RUN_ID" 0 || echo "::warning::npm_telegram is advisory for Tideclaw alpha validation."
-          else
-            check_child "npm_telegram" "$NPM_TELEGRAM_RUN_ID" 1 || failed=1
-          fi
+      - name: Drain child diagnostics
+        id: state
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FAIL_FAST: "false"
+          RELEASE_PROFILE: ${{ inputs.release_profile }}
+          RERUN_GROUP: ${{ inputs.rerun_group }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+          FULL_RELEASE_STATE_MODE: drain
+          FULL_RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
+          FULL_RELEASE_STATE_PATH: ${{ runner.temp }}/full-release-diagnostics/full-release-diagnostic-manifest.json
+        run: *full_release_state
 
-          if [[ "$PERFORMANCE_RESULT" == "skipped" && -z "${PERFORMANCE_RUN_ID// }" ]]; then
-            check_child "product_performance" "" "$performance_required" || failed=1
-          else
-            performance_advisory=0
-            [[ "$RELEASE_PROFILE" == "beta" ]] && performance_advisory=1
-            check_child "product_performance" "$PERFORMANCE_RUN_ID" "$performance_required" "$performance_advisory" || failed=1
-          fi
+      - name: Upload diagnostic drain manifest
+        if: always() && steps.state.outputs.state != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: full-release-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/full-release-diagnostics
+          if-no-files-found: error
 
-          summarize_child_timing "normal_ci" "$NORMAL_CI_RUN_ID"
-          summarize_child_timing "plugin_prerelease" "$PLUGIN_PRERELEASE_RUN_ID"
-          summarize_child_timing "release_checks" "$RELEASE_CHECKS_RUN_ID"
-          summarize_child_timing "npm_telegram" "$NPM_TELEGRAM_RUN_ID"
-          summarize_child_timing "product_performance" "$PERFORMANCE_RUN_ID"
+      - name: Enforce diagnostic drain integrity
+        if: always()
+        env:
+          DIAGNOSTIC_DRAIN_STATE: ${{ steps.state.outputs.state }}
+        run: |
+          set -euo pipefail
+          case "$DIAGNOSTIC_DRAIN_STATE" in
+            passed|blocked_complete)
+              exit 0
+              ;;
+            *)
+              echo "::error::Diagnostic Drain ended in ${DIAGNOSTIC_DRAIN_STATE:-orchestration_error}."
+              exit 1
+              ;;
+          esac
 
-          if [[ "$failed" != "0" ]]; then
-            summarize_failed_child "normal_ci" "$NORMAL_CI_RUN_ID"
-            summarize_failed_child "plugin_prerelease" "$PLUGIN_PRERELEASE_RUN_ID"
-            summarize_failed_child "release_checks" "$RELEASE_CHECKS_RUN_ID"
-            summarize_failed_child "npm_telegram" "$NPM_TELEGRAM_RUN_ID"
-            summarize_failed_child "product_performance" "$PERFORMANCE_RUN_ID"
-          fi
+  summary:
+    name: Verify full validation
+    needs:
+      [
+        resolve_target,
+        evidence_reuse,
+        docker_runtime_assets_preflight,
+        prepare_release_candidate,
+        normal_ci,
+        plugin_prerelease,
+        release_checks,
+        npm_telegram,
+        performance,
+        release_execution_plan,
+        release_decision,
+        diagnostic_drain,
+      ]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout release state verifier
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          sparse-checkout: |
+            scripts/full-release-validation-state.mjs
+            scripts/full-release-validation-policy.mjs
+            scripts/release-ci-summary.mjs
+            scripts/lib/plain-gh.mjs
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
 
-          exit "$failed"
+      - name: Download immutable release execution plan
+        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        with:
+          name: full-release-execution-plan-${{ github.run_id }}
+          path: ${{ runner.temp }}/full-release-execution-plan
+
+      - name: Download exact release decision
+        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        with:
+          name: full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/full-release-decision
+
+      - name: Download exact diagnostic drain
+        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        with:
+          name: full-release-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/full-release-diagnostics
+
+      - name: Verify exact release state artifacts
+        env:
+          RELEASE_PROFILE: ${{ inputs.release_profile }}
+          RERUN_GROUP: ${{ inputs.rerun_group }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+          RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
+          RELEASE_DECISION_PATH: ${{ runner.temp }}/full-release-decision/full-release-decision.json
+          DIAGNOSTIC_DRAIN_PATH: ${{ runner.temp }}/full-release-diagnostics/full-release-diagnostic-manifest.json
+        run: node scripts/full-release-validation-state.mjs verify
 
       - name: Request release evidence update
         if: ${{ inputs.dispatch_release_evidence }}
@@ -1724,7 +1436,7 @@ jobs:
             echo "Release checks were skipped by rerun group; skipping automatic release evidence update."
             exit 0
           fi
-          notes="Automatically requested by Full Release Validation ${GITHUB_RUN_ID_VALUE} after child workflows completed; the parent summary re-checks current child run conclusions."
+          notes="Automatically requested by Full Release Validation ${GITHUB_RUN_ID_VALUE} after exact Release Decision and Diagnostic Drain artifacts passed shared policy verification."
           if [[ "$EVIDENCE_REUSE" == "true" && -n "${EVIDENCE_ROOT_RUN_ID// }" ]]; then
             notes="Automatically requested by Full Release Validation ${GITHUB_RUN_ID_VALUE}, which reused green product evidence from chain-root run ${EVIDENCE_ROOT_RUN_ID} under policy ${EVIDENCE_POLICY}."
           fi
@@ -1805,7 +1517,7 @@ jobs:
           RELEASE_CHECKS_RUN_ID: ${{ needs.release_checks.outputs.run_id }}
           NPM_TELEGRAM_RUN_ID: ${{ needs.npm_telegram.outputs.run_id }}
           PERFORMANCE_RUN_ID: ${{ needs.performance.outputs.run_id }}
-          PERFORMANCE_CONCLUSION: ${{ needs.performance.outputs.conclusion }}
+          PERFORMANCE_CONCLUSION: ${{ needs.diagnostic_drain.outputs.performance_conclusion }}
           EVIDENCE_REUSE: ${{ needs.evidence_reuse.outputs.reuse }}
           EVIDENCE_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_run_id }}
           EVIDENCE_ROOT_RUN_ID: ${{ needs.evidence_reuse.outputs.evidence_root_run_id }}
@@ -1827,10 +1539,18 @@ jobs:
           SKIP_PACKAGE_TELEGRAM_E2E: ${{ inputs.skip_package_telegram_e2e }}
           ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog || (inputs.target_context_ref == '' && (inputs.ref == 'main' || inputs.ref == 'refs/heads/main')) }}
           PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON: ${{ inputs.plugin_prerelease_node_exclude_patterns_json }}
+          RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
         run: |
           set -euo pipefail
           manifest_dir="${RUNNER_TEMP}/full-release-validation"
           mkdir -p "$manifest_dir"
+          NORMAL_CI_RUN_ID="$(jq -r '.children[] | select(.key == "normalCi") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
+          PLUGIN_PRERELEASE_RUN_ID="$(jq -r '.children[] | select(.key == "pluginPrerelease") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
+          RELEASE_CHECKS_RUN_ID="$(jq -r '.children[] | select(.key == "releaseChecks") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
+          NPM_TELEGRAM_RUN_ID="$(jq -r '.children[] | select(.key == "npmTelegram") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
+          PERFORMANCE_RUN_ID="$(jq -r '.children[] | select(.key == "productPerformance") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"
+          EXECUTION_PLAN_SHA256="$(jq -r '.sha256' "$RELEASE_EXECUTION_PLAN_PATH")"
+          SOURCE_PARENT_RUN_ATTEMPT="$(jq -r '.parentRunAttempt' "$RELEASE_EXECUTION_PLAN_PATH")"
           if [[ "$EVIDENCE_REUSE" == "true" ]]; then
             # Inherit the evidence manifest (profile, soak, child runs) so future
             # reuse lookups and evidence consumers keep resolving the chain root.
@@ -1847,6 +1567,8 @@ jobs:
               --arg evidenceRootRunId "$EVIDENCE_ROOT_RUN_ID" \
               --arg evidenceSha "$EVIDENCE_SHA" \
               --arg evidencePolicy "$EVIDENCE_POLICY" \
+              --arg executionPlanSha256 "$EXECUTION_PLAN_SHA256" \
+              --arg sourceParentRunAttempt "$SOURCE_PARENT_RUN_ATTEMPT" \
               --argjson evidenceChangedPaths "$EVIDENCE_CHANGED_PATHS" \
               '. + {
                 version: 3,
@@ -1867,7 +1589,9 @@ jobs:
                 },
                 controls: ((.controls // {}) + {
                   performanceReportPublication: "artifact-only"
-                })
+                }),
+                executionPlanSha256: $executionPlanSha256,
+                sourceParentRunAttempt: ($sourceParentRunAttempt | tonumber)
               }' <<< "$EVIDENCE_MANIFEST" > "${manifest_dir}/full-release-validation-manifest.json"
             exit 0
           fi
@@ -1890,6 +1614,8 @@ jobs:
             --arg npmTelegramRunId "$NPM_TELEGRAM_RUN_ID" \
             --arg performanceRunId "$PERFORMANCE_RUN_ID" \
             --arg performanceConclusion "$PERFORMANCE_CONCLUSION" \
+            --arg executionPlanSha256 "$EXECUTION_PLAN_SHA256" \
+            --arg sourceParentRunAttempt "$SOURCE_PARENT_RUN_ATTEMPT" \
             --arg provider "$PROVIDER" \
             --arg mode "$MODE" \
             --arg targetContextRef "$TARGET_CONTEXT_REF" \
@@ -1918,6 +1644,8 @@ jobs:
               releaseProfile: $releaseProfile,
               rerunGroup: $rerunGroup,
               runReleaseSoak: $runReleaseSoak,
+              executionPlanSha256: $executionPlanSha256,
+              sourceParentRunAttempt: ($sourceParentRunAttempt | tonumber),
               validationInputs: {
                 provider: $provider,
                 mode: $mode,

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1117,7 +1117,6 @@ jobs:
           EVIDENCE_SHA: ${{ needs.evidence_reuse.outputs.evidence_sha }}
           EVIDENCE_POLICY: ${{ needs.evidence_reuse.outputs.evidence_policy }}
           EVIDENCE_CHANGED_PATHS: ${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}
-          EVIDENCE_MANIFEST: ${{ needs.evidence_reuse.outputs.evidence_manifest }}
           TRUSTED_WORKFLOW_JSON: ${{ needs.resolve_target.outputs.trusted_workflow_json }}
           RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
           PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ inputs.package_acceptance_package_spec }}
@@ -1151,7 +1150,6 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$FULL_RELEASE_RESTORE_PLAN" != "true" ]]; then
-            evidence_manifest="${EVIDENCE_MANIFEST:-null}"
             export FULL_RELEASE_PLAN_INPUTS_JSON="$(
             jq -cn \
               --arg parentRunId "$GITHUB_RUN_ID" \
@@ -1166,7 +1164,6 @@ jobs:
               --arg evidenceSha "$EVIDENCE_SHA" \
               --arg evidencePolicy "$EVIDENCE_POLICY" \
               --argjson evidenceChangedPaths "$EVIDENCE_CHANGED_PATHS" \
-              --argjson evidenceManifest "$evidence_manifest" \
               --arg rerunGroup "$RERUN_GROUP" \
               --arg releasePackageSpec "$RELEASE_PACKAGE_SPEC" \
               --arg packageAcceptancePackageSpec "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" \
@@ -1208,7 +1205,6 @@ jobs:
                 evidenceSha: $evidenceSha,
                 evidencePolicy: $evidencePolicy,
                 evidenceChangedPaths: $evidenceChangedPaths,
-                evidenceManifest: $evidenceManifest,
                 rerunGroup: $rerunGroup,
                 releasePackageSpec: $releasePackageSpec,
                 packageAcceptancePackageSpec: $packageAcceptancePackageSpec,
@@ -1699,6 +1695,15 @@ jobs:
                 }
               }
             }' > "${manifest_dir}/full-release-validation-manifest.json"
+
+      - name: Validate release validation manifest
+        env:
+          RELEASE_PROFILE: ${{ inputs.release_profile }}
+          RERUN_GROUP: ${{ inputs.rerun_group }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+          RELEASE_EXECUTION_PLAN_PATH: ${{ runner.temp }}/full-release-execution-plan/full-release-execution-plan.json
+          RELEASE_VALIDATION_MANIFEST_PATH: ${{ runner.temp }}/full-release-validation/full-release-validation-manifest.json
+        run: node scripts/full-release-validation-state.mjs validate-manifest
 
       - name: Upload release validation manifest
         if: ${{ success() }}

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1098,7 +1098,7 @@ jobs:
 
       - name: Restore immutable release execution plan
         if: ${{ github.run_attempt != 1 }}
-        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-execution-plan-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-execution-plan
@@ -1247,7 +1247,7 @@ jobs:
           persist-credentials: false
 
       - name: Download immutable release execution plan
-        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-execution-plan-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-execution-plan
@@ -1315,7 +1315,7 @@ jobs:
           persist-credentials: false
 
       - name: Download immutable release execution plan
-        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-execution-plan-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-execution-plan
@@ -1392,19 +1392,19 @@ jobs:
           persist-credentials: false
 
       - name: Download immutable release execution plan
-        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-execution-plan-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-execution-plan
 
       - name: Download exact release decision
-        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/full-release-decision
 
       - name: Download exact diagnostic drain
-        uses: actions/download-artifact@3e5f45e4f7c701b9e8e938e3aa0e65cfda5c0037 # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/full-release-diagnostics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
-- **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
+- **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, seal exact child identities in an immutable execution plan, separate early Release Decision from terminal Diagnostic Drain, and record attempt-bound timing/failure manifests without cancelling children when fail-fast is disabled.
 - **macOS app profiles:** isolate named app instances across state, preferences, Keychain, Gateway services, and duplicate-instance ownership while keeping host-global login and node services untouched.
 - **Developer workflow:** remove the obsolete scoped-commit helper and use standard Git commands in isolated worktrees.
 - **Plugin uninstall cleanup:** remove exact recorded install paths from `plugins.load.paths` for marketplace, npm, and other managed installs while preserving parent, child, prefix, and unrelated paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
-- **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, seal exact child identities in an immutable execution plan, separate early Release Decision from terminal Diagnostic Drain, and record attempt-bound timing/failure manifests without cancelling children when fail-fast is disabled.
+- **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **macOS app profiles:** isolate named app instances across state, preferences, Keychain, Gateway services, and duplicate-instance ownership while keeping host-global login and node services untouched.
 - **Developer workflow:** remove the obsolete scoped-commit helper and use standard Git commands in isolated worktrees.
 - **Plugin uninstall cleanup:** remove exact recorded install paths from `plugins.load.paths` for marketplace, npm, and other managed installs while preserving parent, child, prefix, and unrelated paths.

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -410,6 +410,17 @@ The second parent reuses product evidence only when GitHub proves the Release SH
 
 For a fresh Code SHA, the workflow resolves the target, dispatches manual `CI`, then dispatches `OpenClaw Release Checks`. Beta-publish maps to `release_profile=beta` and `run_release_soak=false`; its `all` run excludes broad live/E2E and QA-live lanes. Postpublish-confidence uses the exact published package with soak or explicit focused groups. Stable-publish maps to `release_profile=stable`. The final verifier summary includes slowest-job tables for each child run.
 
+Each dispatcher records the exact child run ID and attempt, then exits. Release
+Decision reports a decisive blocker without waiting for unrelated diagnostic
+tails; with `fail_fast=false`, Diagnostic Drain keeps the selected children
+running to terminal. Diagnose `blocked_diagnostics_running` immediately, but do
+not retry until the drain is terminal. Recover `orchestration_error` against
+the same exact children and never redispatch tests merely to repair collection.
+An immutable run-bound execution plan preserves the original attempt, titles,
+coverage, gates, and child tuples across collector retries. The final verifier
+consumes that plan and the exact attempt-bound Decision and Drain artifacts
+instead of polling or reclassifying child results.
+
 The product-performance child is artifact-only in this release path. The
 umbrella dispatches it with `publish_reports=false`, and validation is rejected
 unless its artifact-only guard proves that the Clawgrit report publisher stayed

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -52,14 +52,14 @@ Decision, Drain, manifest generation, evidence verification, and the final
 verifier consume this artifact. Collector retries restore it and adopt the
 same children; they never rebuild the plan or redispatch tests.
 Release Decision also repeats canonical reuse-chain validation before a reused
-run can pass, so a stale target, policy, changed-path set, or child tuple remains
-blocking even when the plan artifact itself is intact.
+run can pass. The sealed target SHA, evidence SHA, policy, changed-path set,
+selected run, root run, and child tuple must all still match.
 
 The helper creates a temporary `release-ci/*` ref pinned to the Tooling SHA,
 passes the Validation SHA as both the candidate ref and `expected_sha`, and
 deletes the temporary ref after successful validation and strict evidence
 verification. If Release Decision reports a blocker while Diagnostic Drain is
-still collecting failures, the helper returns immediately and keeps both
+still collecting failures, the helper exits nonzero immediately and keeps both
 temporary refs for reruns and diagnosis. The Validation SHA equals the Code
 SHA for product validation or the Release SHA for changelog-only validation; it
 is not a third release identity. The workflow rejects malformed or mismatched

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -39,12 +39,28 @@ exact alpha tags to the `beta` profile and final versions to `stable`. Pass
 alternate workflow inputs with `-f key=value`; use `-f release_profile=full`
 only for the broad advisory sweep.
 `fail_fast` defaults to `false`, so dispatched child workflows finish and expose
-independent failures together. Pass `-f fail_fast=true` when the shorter
-first-failure cancellation path is preferable.
+independent failures together. In that mode, the parent makes no child
+cancellation calls. Pass `-f fail_fast=true` only when the shorter
+first-failure path is preferable; Release Decision then cancels only the exact
+still-active child that owns the blocking failure.
+
+After dispatch, the parent writes one immutable
+`full-release-execution-plan-<run-id>` artifact. It records selected and
+required coverage, gate results, reuse identity, the original parent attempt,
+and every exact child run ID, attempt, title, workflow ref, and Tooling SHA.
+Decision, Drain, manifest generation, evidence verification, and the final
+verifier consume this artifact. Collector retries restore it and adopt the
+same children; they never rebuild the plan or redispatch tests.
+Release Decision also repeats canonical reuse-chain validation before a reused
+run can pass, so a stale target, policy, changed-path set, or child tuple remains
+blocking even when the plan artifact itself is intact.
 
 The helper creates a temporary `release-ci/*` ref pinned to the Tooling SHA,
 passes the Validation SHA as both the candidate ref and `expected_sha`, and
-deletes the temporary ref after validation. The Validation SHA equals the Code
+deletes the temporary ref after successful validation and strict evidence
+verification. If Release Decision reports a blocker while Diagnostic Drain is
+still collecting failures, the helper returns immediately and keeps both
+temporary refs for reruns and diagnosis. The Validation SHA equals the Code
 SHA for product validation or the Release SHA for changelog-only validation; it
 is not a third release identity. The workflow rejects malformed or mismatched
 expected SHAs before child dispatch. Every child must report the same Tooling
@@ -168,7 +184,26 @@ it before dispatching. A narrower `rerun_group` skips this preflight.
 | Release checks          | **Job:** `Run release/live/Docker/QA validation`<br />**Child workflow:** `OpenClaw Release Checks`<br />**Proves:** install smoke, cross-OS package checks, Package Acceptance, and QA Lab parity. QA-live Matrix, Buzz, and Telegram plus gated advisory Discord, WhatsApp, and Slack run for stable/full, beta with `run_release_soak=true`, an explicit `qa-live` controller retry, or the direct child's manual `qa` aggregate. Stable and full profiles also run exhaustive live/E2E suites and Docker release-path chunks.<br />**Rerun:** classify the failed surface and select one concrete release-check group. |
 | Package Telegram        | **Job:** `Run package Telegram E2E`<br />**Child workflow:** `NPM Telegram Beta E2E`<br />**Proves:** a focused published-package Telegram E2E when `release_package_spec` or `npm_telegram_package_spec` is set. Full candidate validation uses the canonical Package Acceptance Telegram E2E instead.<br />**Rerun:** `rerun_group=npm-telegram` with `release_package_spec` or `npm_telegram_package_spec`.                                                                                                                                                                                                             |
 | Product performance     | **Job:** `Run product performance evidence`<br />**Child workflow:** `OpenClaw Performance`<br />**Proves:** release-profile performance run (`profile=release`, `repeat=3`, `fail_on_regression=true`, `publish_reports=false`) against the target SHA. Kova output stays in workflow artifacts and the child must prove its report publisher was skipped. Required (blocking) only for `rerun_group=all` or `rerun_group=performance`; not required for narrower rerun groups.<br />**Rerun:** `rerun_group=performance`.                                                                                                |
-| Umbrella verifier       | **Job:** `Verify full validation`<br />**Child workflow:** none<br />**Proves:** re-checks recorded child run conclusions and appends slowest-job tables from child workflows.<br />**Rerun:** rerun only this job after rerunning a failed child to green.                                                                                                                                                                                                                                                                                                                                                                |
+| Release decision        | **Job:** `Release Decision`<br />**Child workflow:** none<br />**Proves:** polls the exact recorded child run IDs and attempts, enforces release policy, and publishes an attempt-bound decision artifact. A decisive failure becomes `blocked_diagnostics_running` while unrelated child diagnostics continue.<br />**Rerun:** fix or rerun only the blocking surface.                                                                                                                                                                                                                                                    |
+| Diagnostic drain        | **Job:** `Diagnostic Drain`<br />**Child workflow:** none<br />**Proves:** with `fail_fast=false`, follows every selected exact child to terminal without cancellation and writes timing, failed-job, run-attempt, and Tooling-SHA evidence. Collector cancellation instead writes an immediate `cancelled_with_children` handoff containing active child identities.<br />**Rerun:** recover collection only for `orchestration_error`; product failures do not invalidate the drain.                                                                                                                                     |
+| Execution plan          | **Job:** `Seal release execution plan`<br />**Child workflow:** none<br />**Proves:** persists the original parent attempt, exact child identities and titles, required coverage, gates, and reuse identity in a stable run-bound artifact. Attempt-two collector recovery restores this artifact instead of redispatching.<br />**Rerun:** restore the existing plan only; a missing plan is an orchestration error.                                                                                                                                                                                                      |
+| Umbrella verifier       | **Job:** `Verify full validation`<br />**Child workflow:** none<br />**Proves:** downloads the immutable execution plan plus the exact attempt-bound Release Decision and Diagnostic Drain artifacts, verifies their common digest and parent tuple, and accepts only a strict green decision plus terminal drain.<br />**Rerun:** recover the existing collectors or rerun only the failed product surface; the verifier never reclassifies or redispatches children.                                                                                                                                                     |
+
+The five child-dispatch jobs own dispatch and exact identity capture only. They
+emit the child run ID, run attempt, and URL, then finish. Release Decision owns
+the blocking answer; Diagnostic Drain owns complete terminal evidence. The
+immutable execution plan owns child identity across collector attempts. The
+decision state is one of `qualifying`, `blocked_diagnostics_running`, `passed`,
+`blocked_complete`, `orchestration_error`, or `cancelled_with_children`.
+Persistent GitHub API failures are orchestration errors. A child whose workflow
+path, display title, ref, Tooling SHA, run ID, or attempt changes is a distinct
+provenance mismatch.
+
+`blocked_diagnostics_running` is safe for immediate diagnosis but not for a
+retry until Diagnostic Drain is terminal. `orchestration_error` authorizes
+collector recovery against the same exact child identities, never test
+redispatch. `blocked_complete` means diagnostics are complete; it does not
+claim a drain is still running.
 
 The umbrella always dispatches product performance in artifact-only mode.
 `OpenClaw Performance` permits report publication only for scheduled runs or a
@@ -190,9 +225,13 @@ as a transition, it accepts the stable name only for an attempt-1 manifest v2
 producer. It rejects that legacy name for later attempts and manifest v3.
 
 Concurrency is keyed by Validation SHA, Tooling SHA, and rerun group and does
-not cancel an older run. Parent cancellation or timeout leaves an adopted
-identity-checked child running. Cancel that exact child explicitly when it is
-no longer useful.
+not cancel an older run. Parent cancellation or timeout leaves adopted
+identity-checked children running and records `cancelled_with_children` when
+the state collector can complete its cancellation handoff. Cancel an exact
+child explicitly when it is no longer useful. Do not run a second foreground
+watcher when the SHA-pinned helper already owns the parent; use
+`release-ci-summary --watch` only after the helper has returned or when the
+parent was dispatched separately.
 
 ## Release checks stages
 

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -53,7 +53,13 @@ verifier consume this artifact. Collector retries restore it and adopt the
 same children; they never rebuild the plan or redispatch tests.
 Release Decision also repeats canonical reuse-chain validation before a reused
 run can pass. The sealed target SHA, evidence SHA, policy, changed-path set,
-selected run, root run, and child tuple must all still match.
+selected run, root run, source manifest, trusted tooling identity, and child
+tuple must all still match.
+
+On a parent retry, final verification selects the newest available Release
+Decision and Diagnostic Drain artifacts independently. Both must bind the same
+immutable plan and exact child tuple; their source attempts remain recorded in
+the artifacts and may differ when only one collector needed a retry.
 
 The helper creates a temporary `release-ci/*` ref pinned to the Tooling SHA,
 passes the Validation SHA as both the candidate ref and `expected_sha`, and

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -12,6 +12,7 @@ import { pathToFileURL } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { isRecord as isJsonRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import {
+  classifyReleaseGhTransportError,
   formatReleaseStateOutcome,
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
@@ -73,6 +74,13 @@ type CommandOptions = {
   dryRun?: boolean;
   stdio?: "inherit" | ["ignore", "pipe" | "ignore", "pipe" | "inherit" | "ignore"];
   timeoutMs?: number;
+};
+type CommandStatus = {
+  error?: Error;
+  signal?: unknown;
+  status: number | null;
+  stderr: unknown;
+  stdout: unknown;
 };
 type TemporaryRefParams = {
   keepBranch: boolean;
@@ -588,15 +596,20 @@ export function releaseDecisionStopsForeground(state: unknown) {
   ].includes(stringValue(state));
 }
 
-function tryReadReleaseDecision(
+export function tryReadReleaseDecision(
   parentRunId: string,
   parentRunAttempt: number,
   workflowSha: string,
+  runStatusImpl: (
+    command: string,
+    args: string[],
+    options?: CommandOptions,
+  ) => CommandStatus = runStatus,
 ) {
   const artifactName = `full-release-decision-${parentRunId}-${parentRunAttempt}`;
   const downloadDir = mkdtempSync(join(tmpdir(), "openclaw-release-decision-"));
   try {
-    const result = runStatus(
+    const result = runStatusImpl(
       "gh",
       [
         "run",
@@ -618,10 +631,31 @@ function tryReadReleaseDecision(
       ) {
         return undefined;
       }
+      const downloadError = Object.assign(
+        result.error instanceof Error
+          ? result.error
+          : new Error(
+              `Release Decision artifact download failed${
+                stderr.trim() ? `: ${stderr.trim().slice(0, 500)}` : ""
+              }`,
+            ),
+        {
+          signal: result.signal,
+          status: result.status,
+          stderr,
+        },
+      );
+      if (classifyReleaseGhTransportError(downloadError) === "transient") {
+        console.warn(
+          `Release Decision artifact unavailable this poll; retrying: ${downloadError.message}`,
+        );
+        return undefined;
+      }
       throw new Error(
         `Release Decision artifact download failed${
           stderr.trim() ? `: ${stderr.trim().slice(0, 500)}` : ""
         }`,
+        { cause: downloadError },
       );
     }
     const decisionPath = join(downloadDir, RELEASE_DECISION_FILE);

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -5,12 +5,16 @@ import {
   spawnSync,
   type ExecFileSyncOptionsWithStringEncoding,
 } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { isRecord as isJsonRecord } from "../packages/normalization-core/src/record-coerce.ts";
+import {
+  formatReleaseStateOutcome,
+  validateReleaseStateArtifact,
+} from "./full-release-validation-policy.mjs";
 import { execGhRead } from "./lib/plain-gh.mjs";
 
 const WORKFLOW = "full-release-validation.yml";
@@ -25,6 +29,8 @@ const GH_READ_TIMEOUT_MS = 60_000;
 export const FULL_RELEASE_WAIT_TIMEOUT_MINUTES = 720;
 export const FULL_RELEASE_WAIT_POLL_INTERVAL_MS = 45_000;
 const FULL_RELEASE_PROGRESS_INTERVAL_MS = 5 * 60_000;
+const RELEASE_DECISION_FILE = "full-release-decision.json";
+const MAX_RELEASE_DECISION_BYTES = 128 * 1024;
 const GH_READ_OPTIONS = {
   encoding: "utf8",
   killSignal: "SIGKILL",
@@ -65,7 +71,8 @@ type ReleaseInputs = Record<string, string> &
   Partial<Record<"release_profile" | "allow_unreleased_changelog", string>>;
 type CommandOptions = {
   dryRun?: boolean;
-  stdio?: "inherit" | ["ignore", "pipe" | "ignore", "inherit" | "ignore"];
+  stdio?: "inherit" | ["ignore", "pipe" | "ignore", "pipe" | "inherit" | "ignore"];
+  timeoutMs?: number;
 };
 type TemporaryRefParams = {
   keepBranch: boolean;
@@ -89,6 +96,14 @@ function displayValue(value: unknown): string {
   return value === null ? "null" : (JSON.stringify(value) ?? "<undefined>");
 }
 
+function requiredPositiveInteger(value: unknown, label: string): number {
+  const normalized = Number(value);
+  if (!Number.isSafeInteger(normalized) || normalized < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return normalized;
+}
+
 function usage() {
   console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch-or-tag>] [--workflow-sha <trusted-tooling-sha>] [--trusted-workflow-ref <main-or-release-publish-tag>] [--keep-branch] [--dry-run] [-- -f key=value ...]
 
@@ -100,7 +115,8 @@ workflow lineage through the release evidence manifest, then deletes both
 temporary branches by default. --keep-branch retains both branches. Exact-target and changelog-only Release SHA
 evidence reuse stay enabled; pass -f reuse_evidence=false to force a fresh
 run. Child workflows collect independent failures by default; pass
--f fail_fast=true to cancel each child after its first failed job. The release
+-f fail_fast=true to cancel only an exact still-active child after Release
+Decision identifies a blocking failure for that child. The release
 branch accepts only its final package version or a matching beta prerelease.
 Exact alpha tags remain supported for Tideclaw. The release profile defaults to
 beta for beta candidates and exact alpha tags, and stable otherwise; pass
@@ -124,11 +140,13 @@ function run(command: string, args: string[], options: CommandOptions = {}) {
 function runStatus(command: string, args: string[], options: CommandOptions = {}) {
   if (options.dryRun) {
     console.log(["+", command, ...args].join(" "));
-    return { status: 0, stdout: "" };
+    return { status: 0, stderr: "", stdout: "" };
   }
   return spawnSync(command, args, {
     encoding: "utf8",
+    killSignal: "SIGKILL",
     stdio: options.stdio ?? ["ignore", "pipe", "inherit"],
+    timeout: options.timeoutMs ?? GH_READ_TIMEOUT_MS,
   });
 }
 
@@ -542,6 +560,89 @@ function readActiveParentJobs(parentRunId: string) {
     }));
 }
 
+export function validateReleaseDecisionPayload(
+  payload: unknown,
+  expected: {
+    parentRunAttempt: number;
+    parentRunId: string;
+    workflowSha: string;
+  },
+) {
+  return validateReleaseStateArtifact(
+    payload,
+    {
+      parentRunAttempt: expected.parentRunAttempt,
+      parentRunId: expected.parentRunId,
+      workflowSha: expected.workflowSha,
+    },
+    "decision",
+  );
+}
+
+export function releaseDecisionStopsForeground(state: unknown) {
+  return [
+    "blocked_diagnostics_running",
+    "blocked_complete",
+    "orchestration_error",
+    "cancelled_with_children",
+  ].includes(stringValue(state));
+}
+
+function tryReadReleaseDecision(
+  parentRunId: string,
+  parentRunAttempt: number,
+  workflowSha: string,
+) {
+  const artifactName = `full-release-decision-${parentRunId}-${parentRunAttempt}`;
+  const downloadDir = mkdtempSync(join(tmpdir(), "openclaw-release-decision-"));
+  try {
+    const result = runStatus(
+      "gh",
+      [
+        "run",
+        "download",
+        parentRunId,
+        "--repo",
+        "openclaw/openclaw",
+        "--name",
+        artifactName,
+        "--dir",
+        downloadDir,
+      ],
+      { stdio: ["ignore", "ignore", "pipe"], timeoutMs: GH_READ_TIMEOUT_MS },
+    );
+    if (result.status !== 0) {
+      const stderr = stringValue(result.stderr);
+      if (
+        /no valid artifacts found|artifact .* not found|could not find any artifacts/iu.test(stderr)
+      ) {
+        return undefined;
+      }
+      throw new Error(
+        `Release Decision artifact download failed${
+          stderr.trim() ? `: ${stderr.trim().slice(0, 500)}` : ""
+        }`,
+      );
+    }
+    const decisionPath = join(downloadDir, RELEASE_DECISION_FILE);
+    if (!existsSync(decisionPath)) {
+      throw new Error(
+        `Release Decision artifact ${artifactName} omitted ${RELEASE_DECISION_FILE}.`,
+      );
+    }
+    if (statSync(decisionPath).size > MAX_RELEASE_DECISION_BYTES) {
+      throw new Error(`Release Decision artifact ${artifactName} exceeds the size limit.`);
+    }
+    return validateReleaseDecisionPayload(JSON.parse(readFileSync(decisionPath, "utf8")), {
+      parentRunAttempt,
+      parentRunId,
+      workflowSha,
+    });
+  } finally {
+    rmSync(downloadDir, { force: true, recursive: true });
+  }
+}
+
 function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
   let lastSummary = "";
   let consecutiveErrors = 0;
@@ -568,6 +669,18 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
     if (summary !== lastSummary) {
       console.log(`Parent run status: ${summary}`);
       lastSummary = summary;
+    }
+    if (suite) {
+      const releaseDecision = tryReadReleaseDecision(
+        parentRunId,
+        requiredPositiveInteger(suite.run_attempt, "parent run attempt"),
+        workflowSha,
+      );
+      if (releaseDecision && releaseDecisionStopsForeground(releaseDecision.state)) {
+        throw new Error(
+          `${formatReleaseStateOutcome(releaseDecision)}\nhttps://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
+        );
+      }
     }
     if (suite?.status === "completed") {
       if (suite.conclusion === "success") {

--- a/scripts/full-release-validation-policy.d.mts
+++ b/scripts/full-release-validation-policy.d.mts
@@ -1,0 +1,54 @@
+export const RELEASE_DECISION_STATES: readonly string[];
+export function buildReleaseExecutionPlan(input: Record<string, any>): {
+  children: Array<Record<string, any>>;
+  gates: Array<Record<string, any>>;
+};
+export function buildReleaseExecutionPlanArtifact(input: Record<string, any>): Record<string, any>;
+export function validateReleaseExecutionPlanArtifact(
+  payload: unknown,
+  expected?: Record<string, unknown>,
+): Record<string, any>;
+export function releaseExecutionPlanSha256(plan: Record<string, any>): string;
+
+export function isReleaseCheckJobAdvisory(input: {
+  jobName: string;
+  releaseProfile: string;
+  workflowRef: string;
+}): boolean;
+
+export function failedJobsForPolicy(
+  child: Record<string, any>,
+  releaseProfile: string,
+  workflowRef: string,
+): Array<Record<string, any>>;
+
+export function terminalPolicyPass(
+  child: Record<string, any>,
+  releaseProfile: string,
+  workflowRef: string,
+): boolean;
+
+export function classifyReleaseSnapshot(input: Record<string, any>): Record<string, any>;
+export function buildReleaseStateArtifact(input: Record<string, any>): Record<string, any>;
+export function validateReleaseStateArtifact(
+  payload: unknown,
+  expected?: Record<string, unknown>,
+  expectedMode?: string,
+): Record<string, any>;
+export function verifyReleaseStateArtifacts(
+  executionPlanPayload: unknown,
+  decisionPayload: unknown,
+  drainPayload: unknown,
+  expected?: Record<string, unknown>,
+): {
+  decision: Record<string, any>;
+  drain: Record<string, any>;
+  executionPlan: Record<string, any>;
+};
+export function releaseStateDetailLines(payload: Record<string, any>, maxItems?: number): string[];
+export function formatReleaseStateOutcome(payload: Record<string, any>): string;
+export function affectedActiveRunIds(
+  children: Array<Record<string, any>>,
+  blockers: Array<Record<string, any>>,
+  cancelledRunIds?: Set<string>,
+): string[];

--- a/scripts/full-release-validation-policy.d.mts
+++ b/scripts/full-release-validation-policy.d.mts
@@ -1,52 +1,60 @@
-export const RELEASE_DECISION_STATES: readonly string[];
-export function buildReleaseExecutionPlan(input: Record<string, any>): {
-  children: Array<Record<string, any>>;
-  gates: Array<Record<string, any>>;
+export interface ReleaseRecord {
+  [key: string]: unknown;
+}
+export interface ReleaseChild extends ReleaseRecord {
+  key: string;
+  runAttempt: number | null;
+  runId: string;
+}
+export interface ReleaseExecutionPlan extends ReleaseRecord {
+  children: ReleaseChild[];
+  evidenceReuse: ReleaseRecord;
+  gates: ReleaseRecord[];
+}
+export interface ReleaseStateArtifact extends ReleaseRecord {
+  blockers: ReleaseRecord[];
+  children: Record<string, ReleaseRecord>;
+  errors: ReleaseRecord[];
+  parentRunAttempt: number;
+  sourceParentRunAttempt: number;
+  state: string;
+}
+export type ReleaseGhTransportErrorClass = "hard" | "transient";
+export function classifyReleaseGhTransportError(error: unknown): ReleaseGhTransportErrorClass;
+export function buildReleaseExecutionPlan(input: ReleaseRecord): {
+  children: ReleaseChild[];
+  gates: ReleaseRecord[];
 };
-export function buildReleaseExecutionPlanArtifact(input: Record<string, any>): Record<string, any>;
+export function buildReleaseExecutionPlanArtifact(input: ReleaseRecord): ReleaseExecutionPlan;
 export function validateReleaseExecutionPlanArtifact(
   payload: unknown,
   expected?: Record<string, unknown>,
-): Record<string, any>;
-export function releaseExecutionPlanSha256(plan: Record<string, any>): string;
-
-export function isReleaseCheckJobAdvisory(input: {
-  jobName: string;
-  releaseProfile: string;
-  workflowRef: string;
-}): boolean;
-
-export function failedJobsForPolicy(
-  child: Record<string, any>,
-  releaseProfile: string,
-  workflowRef: string,
-): Array<Record<string, any>>;
+): ReleaseExecutionPlan;
+export function releaseExecutionPlanSha256(plan: ReleaseRecord): string;
 
 export function terminalPolicyPass(
-  child: Record<string, any>,
+  child: ReleaseRecord,
   releaseProfile: string,
   workflowRef: string,
 ): boolean;
 
-export function classifyReleaseSnapshot(input: Record<string, any>): Record<string, any>;
-export function releasePlanGateFailures(
-  gates: Array<Record<string, any>>,
-): Array<Record<string, any>>;
-export function buildReleaseStateArtifact(input: Record<string, any>): Record<string, any>;
+export function classifyReleaseSnapshot(input: ReleaseRecord): ReleaseStateArtifact;
+export function releasePlanGateFailures(gates: ReleaseRecord[]): ReleaseRecord[];
+export function buildReleaseStateArtifact(input: ReleaseRecord): ReleaseStateArtifact;
 export function validateReleaseStateArtifact(
   payload: unknown,
   expected?: Record<string, unknown>,
   expectedMode?: string,
-): Record<string, any>;
+): ReleaseStateArtifact;
 export function verifyReleaseStateArtifacts(
   executionPlanPayload: unknown,
   decisionPayload: unknown,
   drainPayload: unknown,
   expected?: Record<string, unknown>,
 ): {
-  decision: Record<string, any>;
-  drain: Record<string, any>;
-  executionPlan: Record<string, any>;
+  decision: ReleaseStateArtifact;
+  drain: ReleaseStateArtifact;
+  executionPlan: ReleaseExecutionPlan;
   sourceAttempts: {
     decision: number;
     drain: number;
@@ -59,19 +67,18 @@ export function selectReleaseStateArtifacts(
   drainCandidates: Array<{ name: string; payload: unknown }>,
   expected?: Record<string, unknown>,
 ): {
-  decision: Record<string, any>;
-  drain: Record<string, any>;
-  executionPlan: Record<string, any>;
+  decision: ReleaseStateArtifact;
+  drain: ReleaseStateArtifact;
+  executionPlan: ReleaseExecutionPlan;
   sourceAttempts: {
     decision: number;
     drain: number;
     executionPlan: number;
   };
 };
-export function releaseStateDetailLines(payload: Record<string, any>, maxItems?: number): string[];
-export function formatReleaseStateOutcome(payload: Record<string, any>): string;
+export function formatReleaseStateOutcome(payload: ReleaseRecord): string;
 export function affectedActiveRunIds(
-  children: Array<Record<string, any>>,
-  blockers: Array<Record<string, any>>,
+  children: ReleaseRecord[],
+  blockers: ReleaseRecord[],
   cancelledRunIds?: Set<string>,
 ): string[];

--- a/scripts/full-release-validation-policy.d.mts
+++ b/scripts/full-release-validation-policy.d.mts
@@ -29,6 +29,9 @@ export function terminalPolicyPass(
 ): boolean;
 
 export function classifyReleaseSnapshot(input: Record<string, any>): Record<string, any>;
+export function releasePlanGateFailures(
+  gates: Array<Record<string, any>>,
+): Array<Record<string, any>>;
 export function buildReleaseStateArtifact(input: Record<string, any>): Record<string, any>;
 export function validateReleaseStateArtifact(
   payload: unknown,
@@ -44,6 +47,26 @@ export function verifyReleaseStateArtifacts(
   decision: Record<string, any>;
   drain: Record<string, any>;
   executionPlan: Record<string, any>;
+  sourceAttempts: {
+    decision: number;
+    drain: number;
+    executionPlan: number;
+  };
+};
+export function selectReleaseStateArtifacts(
+  executionPlanPayload: unknown,
+  decisionCandidates: Array<{ name: string; payload: unknown }>,
+  drainCandidates: Array<{ name: string; payload: unknown }>,
+  expected?: Record<string, unknown>,
+): {
+  decision: Record<string, any>;
+  drain: Record<string, any>;
+  executionPlan: Record<string, any>;
+  sourceAttempts: {
+    decision: number;
+    drain: number;
+    executionPlan: number;
+  };
 };
 export function releaseStateDetailLines(payload: Record<string, any>, maxItems?: number): string[];
 export function formatReleaseStateOutcome(payload: Record<string, any>): string;

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -1,0 +1,757 @@
+import { createHash } from "node:crypto";
+
+const SUCCESSFUL_JOB_CONCLUSIONS = new Set(["neutral", "skipped", "success"]);
+const MAX_REPORTED_ISSUES = 25;
+const MAX_SUMMARY_ISSUES = 5;
+const MAX_LABEL_LENGTH = 200;
+const MAX_MESSAGE_LENGTH = 500;
+const MAX_URL_LENGTH = 1024;
+
+export const RELEASE_DECISION_STATES = Object.freeze([
+  "qualifying",
+  "blocked_diagnostics_running",
+  "passed",
+  "blocked_complete",
+  "orchestration_error",
+  "cancelled_with_children",
+]);
+
+const RELEASE_DECISION_STATE_SET = new Set(RELEASE_DECISION_STATES);
+const CHILD_SPECS = Object.freeze([
+  {
+    dispatchName: "Dispatch CI",
+    displayName: "CI",
+    key: "normalCi",
+    rerunGroups: ["all", "ci"],
+    suffix: "-ci",
+    workflow: "ci.yml",
+  },
+  {
+    dispatchName: "Dispatch plugin prerelease",
+    displayName: "Plugin Prerelease",
+    key: "pluginPrerelease",
+    rerunGroups: ["all", "plugin-prerelease"],
+    suffix: "-plugin-prerelease",
+    workflow: "plugin-prerelease.yml",
+  },
+  {
+    dispatchName: "Dispatch release checks",
+    displayName: "OpenClaw Release Checks",
+    key: "releaseChecks",
+    rerunGroups: [
+      "all",
+      "install-smoke",
+      "cross-os",
+      "live-e2e",
+      "package",
+      "qa-parity",
+      "qa-live",
+    ],
+    suffix: "-release-checks",
+    workflow: "openclaw-release-checks.yml",
+  },
+  {
+    dispatchName: "Dispatch npm Telegram E2E",
+    displayName: "NPM Telegram Beta E2E",
+    key: "npmTelegram",
+    rerunGroups: ["npm-telegram"],
+    suffix: "-npm-telegram",
+    workflow: "npm-telegram-beta-e2e.yml",
+  },
+  {
+    dispatchName: "Dispatch OpenClaw Performance",
+    displayName: "OpenClaw Performance",
+    key: "productPerformance",
+    rerunGroups: ["all", "performance"],
+    suffix: "",
+    workflow: "openclaw-performance.yml",
+  },
+]);
+
+function stringValue(value, fallback = "") {
+  return typeof value === "string" ? value : fallback;
+}
+
+function boundedString(value, maxLength) {
+  return stringValue(value)
+    .replaceAll(/[\r\n\t]+/gu, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function positiveInteger(value) {
+  const normalized = Number(value);
+  return Number.isSafeInteger(normalized) && normalized > 0 ? normalized : undefined;
+}
+
+function booleanValue(value) {
+  return value === true || value === "true";
+}
+
+function candidatePreparationRequired(input) {
+  if (
+    booleanValue(input.evidenceReuse) ||
+    stringValue(input.releasePackageSpec).trim() ||
+    stringValue(input.packageAcceptancePackageSpec).trim()
+  ) {
+    return false;
+  }
+  if (["all", "plugin-prerelease", "cross-os", "package"].includes(input.rerunGroup)) {
+    return true;
+  }
+  return input.rerunGroup === "live-e2e" && !stringValue(input.liveSuiteFilter).trim();
+}
+
+export function buildReleaseExecutionPlan(input) {
+  const parentRunId = stringValue(input.parentRunId).trim();
+  const parentRunAttempt = positiveInteger(input.parentRunAttempt);
+  const rerunGroup = stringValue(input.rerunGroup).trim();
+  if (!parentRunId || parentRunAttempt === undefined || !rerunGroup) {
+    throw new Error("release execution plan identity is invalid");
+  }
+  const reused = booleanValue(input.evidenceReuse);
+  const childInputs =
+    input.children && typeof input.children === "object" && !Array.isArray(input.children)
+      ? input.children
+      : {};
+  const npmTelegramForAll =
+    rerunGroup === "all" &&
+    Boolean(
+      stringValue(input.npmTelegramPackageSpec).trim() ||
+      stringValue(input.releasePackageSpec).trim(),
+    );
+  const children = CHILD_SPECS.map((spec) => {
+    const raw = childInputs[spec.key] ?? {};
+    const required =
+      spec.key === "npmTelegram"
+        ? rerunGroup === "npm-telegram" || npmTelegramForAll
+        : spec.rerunGroups.includes(rerunGroup);
+    const dispatchId = `full-release-validation-${parentRunId}-${parentRunAttempt}${spec.suffix}`;
+    return {
+      dispatchName: spec.dispatchName,
+      displayTitle: `${spec.displayName} ${dispatchId}`,
+      key: spec.key,
+      required,
+      result: stringValue(raw.result, "skipped"),
+      runAttempt: positiveInteger(raw.runAttempt) ?? null,
+      runId: stringValue(raw.runId).trim(),
+      selected: required,
+      source: reused ? "reused" : "fresh",
+      url: stringValue(raw.url).trim(),
+      workflow: spec.workflow,
+      workflowRef: stringValue(input.workflowRef).trim(),
+      workflowSha: stringValue(input.workflowSha).trim(),
+    };
+  });
+  const gates = [
+    {
+      name: "Resolve target ref",
+      required: true,
+      result: stringValue(input.resolveTargetResult, "missing"),
+    },
+    {
+      name: "Verify Docker runtime image assets",
+      required: !reused && rerunGroup === "all",
+      result: stringValue(input.dockerPreflightResult, "skipped"),
+    },
+    {
+      name: "Prepare shared release candidate",
+      required: candidatePreparationRequired(input),
+      result: stringValue(input.prepareCandidateResult, "skipped"),
+    },
+  ];
+  return { children, gates };
+}
+
+function normalizedGate(gate) {
+  return {
+    name: boundedString(gate?.name, MAX_LABEL_LENGTH),
+    required: gate?.required === true,
+    result: boundedString(gate?.result, MAX_LABEL_LENGTH),
+  };
+}
+
+function normalizedEvidenceReuse(evidenceReuse) {
+  if (!evidenceReuse || evidenceReuse.requested !== true) {
+    return { requested: false };
+  }
+  return {
+    changedPaths: Array.isArray(evidenceReuse.changedPaths)
+      ? evidenceReuse.changedPaths
+          .map((value) => boundedString(value, MAX_LABEL_LENGTH))
+          .filter(Boolean)
+      : [],
+    evidenceSha: boundedString(evidenceReuse.evidenceSha, MAX_LABEL_LENGTH),
+    policy: boundedString(evidenceReuse.policy, MAX_LABEL_LENGTH),
+    requested: true,
+    rootRunId: boundedString(evidenceReuse.rootRunId, MAX_LABEL_LENGTH),
+    runUrl: boundedString(evidenceReuse.runUrl, MAX_URL_LENGTH),
+  };
+}
+
+function executionPlanDigestPayload(plan) {
+  return {
+    blockers: plan.blockers,
+    children: plan.children,
+    errors: plan.errors,
+    evidenceReuse: plan.evidenceReuse,
+    gates: plan.gates,
+    kind: plan.kind,
+    parentRunAttempt: plan.parentRunAttempt,
+    parentRunId: plan.parentRunId,
+    releaseProfile: plan.releaseProfile,
+    rerunGroup: plan.rerunGroup,
+    targetSha: plan.targetSha,
+    version: plan.version,
+    workflowRef: plan.workflowRef,
+    workflowSha: plan.workflowSha,
+  };
+}
+
+export function releaseExecutionPlanSha256(plan) {
+  return createHash("sha256")
+    .update(JSON.stringify(executionPlanDigestPayload(plan)))
+    .digest("hex");
+}
+
+export function buildReleaseExecutionPlanArtifact({
+  blockers = [],
+  children,
+  errors = [],
+  evidenceReuse,
+  expected,
+  gates,
+  releaseProfile,
+  rerunGroup,
+}) {
+  const plan = {
+    version: 1,
+    kind: "openclaw.full-release-execution-plan",
+    parentRunId: String(expected.parentRunId),
+    parentRunAttempt: positiveInteger(expected.parentRunAttempt),
+    workflowRef: boundedString(expected.workflowRef, MAX_LABEL_LENGTH),
+    workflowSha: boundedString(expected.workflowSha, MAX_LABEL_LENGTH),
+    targetSha: boundedString(expected.targetSha, MAX_LABEL_LENGTH),
+    releaseProfile: boundedString(releaseProfile, MAX_LABEL_LENGTH),
+    rerunGroup: boundedString(rerunGroup, MAX_LABEL_LENGTH),
+    evidenceReuse: normalizedEvidenceReuse(evidenceReuse),
+    gates: gates.map(normalizedGate),
+    children: children.map(normalizedPlanChild),
+    blockers: normalizeIssues(blockers, "release_blocker"),
+    errors: normalizeIssues(errors, "orchestration_error"),
+  };
+  return { ...plan, sha256: releaseExecutionPlanSha256(plan) };
+}
+
+export function validateReleaseExecutionPlanArtifact(payload, expected = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("release execution plan artifact is invalid");
+  }
+  if (
+    payload.version !== 1 ||
+    payload.kind !== "openclaw.full-release-execution-plan" ||
+    !/^[1-9][0-9]*$/u.test(String(payload.parentRunId ?? "")) ||
+    positiveInteger(payload.parentRunAttempt) === undefined ||
+    !/^[a-f0-9]{40}$/u.test(String(payload.workflowSha ?? "")) ||
+    (payload.targetSha !== "" && !/^[a-f0-9]{40}$/u.test(String(payload.targetSha ?? ""))) ||
+    (expected.parentRunId !== undefined &&
+      String(payload.parentRunId) !== String(expected.parentRunId)) ||
+    (expected.workflowRef !== undefined && payload.workflowRef !== expected.workflowRef) ||
+    (expected.workflowSha !== undefined && payload.workflowSha !== expected.workflowSha) ||
+    (expected.releaseProfile !== undefined && payload.releaseProfile !== expected.releaseProfile) ||
+    (expected.rerunGroup !== undefined && payload.rerunGroup !== expected.rerunGroup) ||
+    (expected.targetSha !== undefined && payload.targetSha !== expected.targetSha)
+  ) {
+    throw new Error("release execution plan artifact binding is invalid");
+  }
+  const plan = {
+    ...payload,
+    parentRunAttempt: positiveInteger(payload.parentRunAttempt),
+    parentRunId: String(payload.parentRunId),
+    children: validatePlan(payload.children),
+    blockers: normalizeIssues(payload.blockers, "release_blocker"),
+    errors: normalizeIssues(payload.errors, "orchestration_error"),
+    evidenceReuse: normalizedEvidenceReuse(payload.evidenceReuse),
+    gates: Array.isArray(payload.gates) ? payload.gates.map(normalizedGate) : [],
+  };
+  const sha256 = releaseExecutionPlanSha256(plan);
+  if (payload.sha256 !== sha256) {
+    throw new Error("release execution plan artifact digest is invalid");
+  }
+  return { ...plan, sha256 };
+}
+
+function normalizeIssue(issue, fallbackKind) {
+  return {
+    child: boundedString(issue?.child, MAX_LABEL_LENGTH),
+    conclusion: boundedString(issue?.conclusion, MAX_LABEL_LENGTH),
+    job: boundedString(issue?.job, MAX_LABEL_LENGTH),
+    kind: boundedString(issue?.kind, MAX_LABEL_LENGTH) || fallbackKind,
+    message: boundedString(issue?.message, MAX_MESSAGE_LENGTH),
+    runId: boundedString(issue?.runId, MAX_LABEL_LENGTH),
+    url: boundedString(issue?.url, MAX_URL_LENGTH),
+  };
+}
+
+function normalizeIssues(issues, fallbackKind) {
+  return (Array.isArray(issues) ? issues : [])
+    .slice(0, MAX_REPORTED_ISSUES)
+    .map((issue) => normalizeIssue(issue, fallbackKind));
+}
+
+export function isReleaseCheckJobAdvisory({ jobName, releaseProfile, workflowRef }) {
+  if (
+    jobName.startsWith("Run QA Lab parity lane (") ||
+    jobName === "Run QA Lab parity report" ||
+    jobName.startsWith("Run QA Lab runtime-pair lane (") ||
+    jobName === "Verify QA Lab runtime-pair lanes" ||
+    jobName === "Run QA Lab live Discord lane" ||
+    jobName === "Run QA Lab live WhatsApp lane" ||
+    jobName === "Run QA Lab live Slack lane"
+  ) {
+    return true;
+  }
+  if (/^tideclaw\/alpha\/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$/u.test(workflowRef)) {
+    return !(
+      jobName === "resolve_target" ||
+      jobName === "Prepare release package artifact" ||
+      jobName.startsWith("install_smoke_release_checks / ") ||
+      jobName === "Run package acceptance" ||
+      jobName.startsWith("Run package acceptance / ")
+    );
+  }
+  return (
+    releaseProfile === "beta" &&
+    (jobName.startsWith("Run package acceptance / Telegram package acceptance / ") ||
+      (jobName.startsWith("Run repo/live E2E validation / ") &&
+        (jobName.includes("Docker live") ||
+          jobName.includes("Live media suites") ||
+          jobName.includes("validate_live_provider_suites") ||
+          jobName.includes("validate_release_live_cache") ||
+          jobName.includes("prepare_live_test_image"))))
+  );
+}
+
+export function failedJobsForPolicy(child, releaseProfile, workflowRef) {
+  return child.jobs.filter((job) => {
+    if (
+      job.status !== "completed" ||
+      SUCCESSFUL_JOB_CONCLUSIONS.has(String(job.conclusion ?? ""))
+    ) {
+      return false;
+    }
+    if (child.key === "releaseChecks") {
+      return !isReleaseCheckJobAdvisory({
+        jobName: stringValue(job.name),
+        releaseProfile,
+        workflowRef,
+      });
+    }
+    return !(child.key === "productPerformance" && releaseProfile === "beta");
+  });
+}
+
+export function terminalPolicyPass(child, releaseProfile, workflowRef) {
+  if (child.status !== "completed") {
+    return false;
+  }
+  if (child.conclusion === "success") {
+    return true;
+  }
+  if (child.key === "productPerformance" && releaseProfile === "beta") {
+    return true;
+  }
+  if (child.key === "releaseChecks") {
+    const verifier = child.jobs.find((job) => job.name === "Verify release checks");
+    return (
+      verifier?.status === "completed" &&
+      verifier.conclusion === "success" &&
+      failedJobsForPolicy(child, releaseProfile, workflowRef).length === 0
+    );
+  }
+  return false;
+}
+
+function dispatchMissingBlockers(children) {
+  return children
+    .filter(
+      (child) =>
+        child.required &&
+        child.selected &&
+        (!/^[1-9][0-9]*$/u.test(String(child.runId ?? "")) ||
+          positiveInteger(child.runAttempt) === undefined),
+    )
+    .map((child) => ({
+      child: child.key,
+      conclusion: stringValue(child.result, "missing"),
+      job: child.dispatchName || `Dispatch ${child.key}`,
+      kind: "dispatch_missing",
+      message: `${child.key} required dispatch did not record an exact run ID and attempt`,
+      runId: stringValue(child.runId),
+      url: stringValue(child.url),
+    }));
+}
+
+function dispatchResultBlockers(children) {
+  return children
+    .filter(
+      (child) =>
+        child.required && child.selected && child.source === "fresh" && child.result !== "success",
+    )
+    .map((child) => ({
+      child: child.key,
+      conclusion: stringValue(child.result, "missing"),
+      job: child.dispatchName || `Dispatch ${child.key}`,
+      kind: "dispatch_failed",
+      message: `${child.key} required dispatch ended with ${stringValue(child.result, "missing")}`,
+      runId: stringValue(child.runId),
+      url: stringValue(child.url),
+    }));
+}
+
+export function classifyReleaseSnapshot({
+  cancelled = false,
+  children,
+  extraBlockers = [],
+  extraErrors = [],
+  localFailures = [],
+  releaseProfile,
+  workflowRef,
+}) {
+  const selected = children.filter((child) => child.selected);
+  const active = selected.filter(
+    (child) => child.runId && child.runAttempt && child.status !== "completed",
+  );
+  const childErrors = selected.flatMap((child) =>
+    (child.errors ?? []).filter((error) => error.kind !== "dispatch_missing"),
+  );
+  const childJobBlockers = selected.flatMap((child) =>
+    failedJobsForPolicy(child, releaseProfile, workflowRef).map((job) => ({
+      child: child.key,
+      conclusion: job.conclusion,
+      job: job.name,
+      kind: "job_failure",
+      message: `${child.key} job failed policy`,
+      runId: child.runId,
+      url: job.html_url ?? job.url ?? child.url,
+    })),
+  );
+  const childJobBlockerKeys = new Set(
+    childJobBlockers.map((blocker) => `${blocker.child}:${blocker.runId}`),
+  );
+  const terminalBlockers = selected
+    .filter(
+      (child) =>
+        child.runId &&
+        child.runAttempt &&
+        child.status === "completed" &&
+        !terminalPolicyPass(child, releaseProfile, workflowRef) &&
+        !childJobBlockerKeys.has(`${child.key}:${child.runId}`),
+    )
+    .map((child) => ({
+      child: child.key,
+      conclusion: child.conclusion,
+      job: "<workflow>",
+      kind: "workflow_failure",
+      message: `${child.key} workflow failed release policy`,
+      runId: child.runId,
+      url: child.url,
+    }));
+  const blockers = normalizeIssues(
+    [
+      ...localFailures,
+      ...extraBlockers,
+      ...dispatchMissingBlockers(selected),
+      ...dispatchResultBlockers(selected),
+      ...childJobBlockers,
+      ...terminalBlockers,
+    ],
+    "release_blocker",
+  );
+  const errors = normalizeIssues([...extraErrors, ...childErrors], "orchestration_error");
+
+  let state;
+  if (cancelled && active.length > 0) {
+    state = "cancelled_with_children";
+  } else if (errors.length > 0) {
+    state = "orchestration_error";
+  } else if (blockers.length > 0) {
+    state = active.length > 0 ? "blocked_diagnostics_running" : "blocked_complete";
+  } else if (active.length > 0) {
+    state = "qualifying";
+  } else {
+    state = "passed";
+  }
+
+  return {
+    activeRunIds: active.map((child) => String(child.runId)),
+    blockers,
+    errors,
+    state,
+  };
+}
+
+function childTiming(child) {
+  const started = Date.parse(child.createdAt);
+  const updated = Date.parse(child.updatedAt);
+  return {
+    durationMinutes:
+      Number.isFinite(started) && Number.isFinite(updated)
+        ? Math.round(((updated - started) / 60_000) * 10) / 10
+        : null,
+    jobs: child.jobs.map((job) => {
+      const jobStarted = Date.parse(job.started_at);
+      const jobCompleted = Date.parse(job.completed_at);
+      return {
+        conclusion: stringValue(job.conclusion),
+        durationMinutes:
+          Number.isFinite(jobStarted) && Number.isFinite(jobCompleted)
+            ? Math.round(((jobCompleted - jobStarted) / 60_000) * 10) / 10
+            : null,
+        name: boundedString(job.name, MAX_LABEL_LENGTH),
+        startedAt: stringValue(job.started_at),
+        status: stringValue(job.status),
+        url: boundedString(job.html_url ?? job.url, MAX_URL_LENGTH),
+      };
+    }),
+  };
+}
+
+function normalizedPlanChild(child) {
+  return {
+    dispatchName: boundedString(child.dispatchName, MAX_LABEL_LENGTH),
+    displayTitle: boundedString(child.displayTitle, MAX_LABEL_LENGTH),
+    key: boundedString(child.key, MAX_LABEL_LENGTH),
+    required: child.required === true,
+    result: boundedString(child.result, MAX_LABEL_LENGTH),
+    runAttempt: positiveInteger(child.runAttempt) ?? null,
+    runId: boundedString(child.runId, MAX_LABEL_LENGTH),
+    selected: child.selected === true,
+    source: child.source === "reused" ? "reused" : "fresh",
+    url: boundedString(child.url, MAX_URL_LENGTH),
+    workflow: boundedString(child.workflow, MAX_LABEL_LENGTH),
+    workflowRef: boundedString(child.workflowRef, MAX_LABEL_LENGTH),
+    workflowSha: boundedString(child.workflowSha, MAX_LABEL_LENGTH),
+  };
+}
+
+export function buildReleaseStateArtifact({
+  cancellation = {},
+  children,
+  decision,
+  executionPlan,
+  expected,
+  mode,
+  releaseProfile,
+  rerunGroup,
+}) {
+  return {
+    version: 2,
+    kind:
+      mode === "decision"
+        ? "openclaw.full-release-decision"
+        : "openclaw.full-release-diagnostic-drain",
+    mode,
+    parentRunId: expected.parentRunId,
+    parentRunAttempt: expected.parentRunAttempt,
+    sourceParentRunAttempt: executionPlan.parentRunAttempt,
+    workflowRef: expected.workflowRef,
+    workflowSha: expected.workflowSha,
+    targetSha: expected.targetSha,
+    releaseProfile,
+    rerunGroup,
+    executionPlanSha256: executionPlan.sha256,
+    state: decision.state,
+    activeRunIds: decision.activeRunIds,
+    blockers: decision.blockers,
+    errors: decision.errors,
+    cancellation: {
+      cancelledRunIds: [...(cancellation.cancelledRunIds ?? [])].map(String),
+      requested: cancellation.requested === true,
+    },
+    children: Object.fromEntries(
+      children
+        .filter((child) => child.selected && child.runId && child.runAttempt)
+        .map((child) => [
+          child.key,
+          {
+            conclusion: stringValue(child.conclusion),
+            displayTitle: boundedString(child.displayTitle, MAX_LABEL_LENGTH),
+            errors: normalizeIssues(child.errors, "orchestration_error"),
+            runAttempt: positiveInteger(child.runAttempt),
+            runId: String(child.runId),
+            status: stringValue(child.status),
+            timing: childTiming(child),
+            url: boundedString(child.url, MAX_URL_LENGTH),
+            workflow: boundedString(child.workflow, MAX_LABEL_LENGTH),
+            workflowRef: boundedString(child.workflowRef, MAX_LABEL_LENGTH),
+            workflowSha: boundedString(child.workflowSha, MAX_LABEL_LENGTH),
+          },
+        ]),
+    ),
+  };
+}
+
+function validatePlan(value) {
+  if (!Array.isArray(value)) {
+    throw new Error("release state plan is invalid");
+  }
+  const keys = new Set();
+  return value.map((child) => {
+    const normalized = normalizedPlanChild(child);
+    if (
+      !normalized.key ||
+      !normalized.workflow ||
+      !normalized.displayTitle ||
+      !normalized.dispatchName ||
+      keys.has(normalized.key) ||
+      (normalized.required && !normalized.selected)
+    ) {
+      throw new Error("release state child plan is invalid");
+    }
+    keys.add(normalized.key);
+    return normalized;
+  });
+}
+
+export function validateReleaseStateArtifact(payload, expected = {}, expectedMode) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("release state artifact is invalid");
+  }
+  const mode = expectedMode ?? payload.mode;
+  const expectedKind =
+    mode === "decision"
+      ? "openclaw.full-release-decision"
+      : "openclaw.full-release-diagnostic-drain";
+  if (
+    payload.version !== 2 ||
+    payload.mode !== mode ||
+    payload.kind !== expectedKind ||
+    !RELEASE_DECISION_STATE_SET.has(stringValue(payload.state)) ||
+    !/^[a-f0-9]{64}$/u.test(String(payload.executionPlanSha256 ?? "")) ||
+    positiveInteger(payload.sourceParentRunAttempt) === undefined ||
+    (expected.parentRunId !== undefined &&
+      String(payload.parentRunId) !== String(expected.parentRunId)) ||
+    (expected.parentRunAttempt !== undefined &&
+      Number(payload.parentRunAttempt) !== Number(expected.parentRunAttempt)) ||
+    (expected.workflowSha !== undefined && payload.workflowSha !== expected.workflowSha) ||
+    (expected.targetSha !== undefined && payload.targetSha !== expected.targetSha) ||
+    (expected.releaseProfile !== undefined && payload.releaseProfile !== expected.releaseProfile) ||
+    (expected.rerunGroup !== undefined && payload.rerunGroup !== expected.rerunGroup)
+  ) {
+    throw new Error("release state artifact binding is invalid");
+  }
+  const blockers = normalizeIssues(payload.blockers, "release_blocker");
+  const errors = normalizeIssues(payload.errors, "orchestration_error");
+  const activeRunIds = Array.isArray(payload.activeRunIds)
+    ? payload.activeRunIds.map(String).filter((runId) => /^[1-9][0-9]*$/u.test(runId))
+    : [];
+  return {
+    ...payload,
+    activeRunIds,
+    blockers,
+    errors,
+    sourceParentRunAttempt: positiveInteger(payload.sourceParentRunAttempt),
+  };
+}
+
+export function verifyReleaseStateArtifacts(
+  executionPlanPayload,
+  decisionPayload,
+  drainPayload,
+  expected = {},
+) {
+  const executionPlan = validateReleaseExecutionPlanArtifact(executionPlanPayload, expected);
+  const decision = validateReleaseStateArtifact(decisionPayload, expected, "decision");
+  const drain = validateReleaseStateArtifact(drainPayload, expected, "drain");
+  if (
+    decision.executionPlanSha256 !== executionPlan.sha256 ||
+    drain.executionPlanSha256 !== executionPlan.sha256 ||
+    decision.sourceParentRunAttempt !== executionPlan.parentRunAttempt ||
+    drain.sourceParentRunAttempt !== executionPlan.parentRunAttempt
+  ) {
+    throw new Error("release decision and diagnostic drain execution plans differ");
+  }
+  if (
+    decision.state !== "passed" ||
+    drain.state !== "passed" ||
+    decision.blockers.length > 0 ||
+    decision.errors.length > 0 ||
+    drain.blockers.length > 0 ||
+    drain.errors.length > 0
+  ) {
+    throw new Error(
+      `release state artifacts are not green: decision=${decision.state} drain=${drain.state}`,
+    );
+  }
+  for (const child of executionPlan.children.filter((entry) => entry.selected)) {
+    if (!child.runId || !child.runAttempt) {
+      throw new Error(`selected release child omitted exact identity: ${child.key}`);
+    }
+    const snapshot = drain.children?.[child.key];
+    if (
+      !snapshot ||
+      String(snapshot.runId) !== child.runId ||
+      Number(snapshot.runAttempt) !== child.runAttempt ||
+      snapshot.status !== "completed"
+    ) {
+      throw new Error(`diagnostic drain child is not terminal and exact: ${child.key}`);
+    }
+  }
+  return { decision, drain, executionPlan };
+}
+
+function issueSummary(prefix, issue) {
+  const label =
+    issue.job || issue.message || issue.child || issue.kind || `${prefix.toLowerCase()} detail`;
+  const result = issue.conclusion ? ` (${issue.conclusion})` : "";
+  const url = issue.url ? ` ${issue.url}` : "";
+  return `- ${prefix}: ${label}${result}${url}`;
+}
+
+export function releaseStateDetailLines(payload, maxItems = MAX_SUMMARY_ISSUES) {
+  const normalizedMax = Math.max(1, Math.min(Number(maxItems) || MAX_SUMMARY_ISSUES, 10));
+  const lines = [];
+  for (const blocker of payload.blockers.slice(0, normalizedMax)) {
+    lines.push(issueSummary("Blocker", blocker));
+  }
+  for (const error of payload.errors.slice(0, normalizedMax)) {
+    lines.push(issueSummary("Collector error", error));
+  }
+  const omitted =
+    Math.max(0, payload.blockers.length - normalizedMax) +
+    Math.max(0, payload.errors.length - normalizedMax);
+  if (omitted > 0) {
+    lines.push(`- ${omitted} additional blocker/error item(s) omitted`);
+  }
+  return lines;
+}
+
+export function formatReleaseStateOutcome(payload) {
+  const lines = [`Full Release Validation state: ${payload.state}`];
+  lines.push(...releaseStateDetailLines(payload));
+  if (payload.state === "blocked_diagnostics_running") {
+    lines.push(
+      "Diagnostic Drain is still collecting terminal evidence; diagnose now, retry later.",
+    );
+  } else if (payload.state === "orchestration_error") {
+    lines.push("Recover the collector against the same exact child runs; do not redispatch tests.");
+  } else if (payload.state === "cancelled_with_children") {
+    lines.push("The collector stopped while exact child runs remained active.");
+  }
+  return lines.join("\n");
+}
+
+export function affectedActiveRunIds(children, blockers, cancelledRunIds = new Set()) {
+  const affected = new Set(
+    blockers.map((blocker) => String(blocker.runId ?? "")).filter((runId) => runId),
+  );
+  return children
+    .filter(
+      (child) =>
+        child.status !== "completed" &&
+        affected.has(String(child.runId)) &&
+        !cancelledRunIds.has(String(child.runId)),
+    )
+    .map((child) => String(child.runId));
+}

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -8,8 +8,12 @@ const MAX_MESSAGE_LENGTH = 500;
 const MAX_URL_LENGTH = 1024;
 const EXACT_TARGET_EVIDENCE_REUSE_POLICY = "exact-target-full-validation-v1";
 const CHANGELOG_ONLY_EVIDENCE_REUSE_POLICY = "changelog-only-release-v1";
+const HARD_GH_TRANSPORT_PATTERN =
+  /HTTP (?:401|403)\b|Bad credentials|authentication required|not authenticated|gh auth login|unknown (?:command|flag)|Usage: gh\b|ENOENT|EACCES/iu;
+const TRANSIENT_GH_TRANSPORT_PATTERN =
+  /HTTP 429\b|HTTP 5[0-9][0-9]\b|Server Error|secondary rate limit|API rate limit|abuse detection|error connecting to|context deadline exceeded|connection reset by peer|connection refused|TLS handshake timeout|i\/o timeout|network is unreachable|unexpected EOF|ETIMEDOUT|ECONNRESET|EAI_AGAIN/iu;
 
-export const RELEASE_DECISION_STATES = Object.freeze([
+const RELEASE_DECISION_STATES = Object.freeze([
   "qualifying",
   "blocked_diagnostics_running",
   "passed",
@@ -69,6 +73,42 @@ const CHILD_SPECS = Object.freeze([
     workflow: "openclaw-performance.yml",
   },
 ]);
+
+function releaseGhTransportErrorText(error) {
+  const values = [error];
+  const seen = new Set();
+  const parts = [];
+  while (values.length > 0) {
+    const value = values.shift();
+    if (value && typeof value === "object") {
+      if (seen.has(value)) {
+        continue;
+      }
+      seen.add(value);
+      if (value instanceof Error) {
+        parts.push(value.name, value.message);
+      }
+      for (const key of ["stderr", "stdout", "code", "signal", "cause"]) {
+        if (key in value && value[key] !== undefined) {
+          values.push(value[key]);
+        }
+      }
+      continue;
+    }
+    if (value !== undefined && value !== null) {
+      parts.push(String(value));
+    }
+  }
+  return parts.join("\n");
+}
+
+export function classifyReleaseGhTransportError(error) {
+  const text = releaseGhTransportErrorText(error);
+  if (HARD_GH_TRANSPORT_PATTERN.test(text)) {
+    return "hard";
+  }
+  return TRANSIENT_GH_TRANSPORT_PATTERN.test(text) ? "transient" : "hard";
+}
 
 function stringValue(value, fallback = "") {
   return typeof value === "string" ? value : fallback;
@@ -193,7 +233,7 @@ function normalizedEvidenceReuse(evidenceReuse) {
       evidenceReuse.sourceManifest &&
       typeof evidenceReuse.sourceManifest === "object" &&
       !Array.isArray(evidenceReuse.sourceManifest)
-        ? JSON.parse(JSON.stringify(evidenceReuse.sourceManifest))
+        ? structuredClone(evidenceReuse.sourceManifest)
         : null,
   };
 }
@@ -356,7 +396,7 @@ function normalizeIssues(issues, fallbackKind) {
     .map((issue) => normalizeIssue(issue, fallbackKind));
 }
 
-export function isReleaseCheckJobAdvisory({ jobName, releaseProfile, workflowRef }) {
+function isReleaseCheckJobAdvisory({ jobName, releaseProfile, workflowRef }) {
   if (
     jobName.startsWith("Run QA Lab parity lane (") ||
     jobName === "Run QA Lab parity report" ||
@@ -389,7 +429,7 @@ export function isReleaseCheckJobAdvisory({ jobName, releaseProfile, workflowRef
   );
 }
 
-export function failedJobsForPolicy(child, releaseProfile, workflowRef) {
+function failedJobsForPolicy(child, releaseProfile, workflowRef) {
   return child.jobs.filter((job) => {
     if (
       job.status !== "completed" ||
@@ -671,7 +711,8 @@ function validatePlan(value) {
   });
 }
 
-export function validateReleaseStateArtifact(payload, expected = {}, expectedMode) {
+export function validateReleaseStateArtifact(payload, expected, expectedMode) {
+  const expectedValues = expected ?? {};
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new Error("release state artifact is invalid");
   }
@@ -688,17 +729,20 @@ export function validateReleaseStateArtifact(payload, expected = {}, expectedMod
     !/^[a-f0-9]{64}$/u.test(String(payload.executionPlanSha256 ?? "")) ||
     positiveInteger(payload.parentRunAttempt) === undefined ||
     positiveInteger(payload.sourceParentRunAttempt) === undefined ||
-    (expected.parentRunId !== undefined &&
-      String(payload.parentRunId) !== String(expected.parentRunId)) ||
-    (expected.parentRunAttempt !== undefined &&
-      Number(payload.parentRunAttempt) !== Number(expected.parentRunAttempt)) ||
-    (expected.maxParentRunAttempt !== undefined &&
-      Number(payload.parentRunAttempt) > Number(expected.maxParentRunAttempt)) ||
-    (expected.workflowRef !== undefined && payload.workflowRef !== expected.workflowRef) ||
-    (expected.workflowSha !== undefined && payload.workflowSha !== expected.workflowSha) ||
-    (expected.targetSha !== undefined && payload.targetSha !== expected.targetSha) ||
-    (expected.releaseProfile !== undefined && payload.releaseProfile !== expected.releaseProfile) ||
-    (expected.rerunGroup !== undefined && payload.rerunGroup !== expected.rerunGroup)
+    (expectedValues.parentRunId !== undefined &&
+      String(payload.parentRunId) !== String(expectedValues.parentRunId)) ||
+    (expectedValues.parentRunAttempt !== undefined &&
+      Number(payload.parentRunAttempt) !== Number(expectedValues.parentRunAttempt)) ||
+    (expectedValues.maxParentRunAttempt !== undefined &&
+      Number(payload.parentRunAttempt) > Number(expectedValues.maxParentRunAttempt)) ||
+    (expectedValues.workflowRef !== undefined &&
+      payload.workflowRef !== expectedValues.workflowRef) ||
+    (expectedValues.workflowSha !== undefined &&
+      payload.workflowSha !== expectedValues.workflowSha) ||
+    (expectedValues.targetSha !== undefined && payload.targetSha !== expectedValues.targetSha) ||
+    (expectedValues.releaseProfile !== undefined &&
+      payload.releaseProfile !== expectedValues.releaseProfile) ||
+    (expectedValues.rerunGroup !== undefined && payload.rerunGroup !== expectedValues.rerunGroup)
   ) {
     throw new Error("release state artifact binding is invalid");
   }
@@ -806,9 +850,7 @@ function verifyStateChildren(state, executionPlan, label) {
     if (snapshot.errors.length > 0) {
       throw new Error(`${label} child contains collector errors: ${child.key}`);
     }
-    return {
-      ...child,
-      ...snapshot,
+    return Object.assign({}, child, snapshot, {
       jobs: snapshot.timing.jobs.map((job) => ({
         conclusion: job.conclusion,
         html_url: job.url,
@@ -816,7 +858,7 @@ function verifyStateChildren(state, executionPlan, label) {
         status: job.status,
         url: job.url,
       })),
-    };
+    });
   });
   const recomputed = classifyReleaseSnapshot({
     children: snapshots,
@@ -929,8 +971,8 @@ function issueSummary(prefix, issue) {
   return `- ${prefix}: ${label}${result}${url}`;
 }
 
-export function releaseStateDetailLines(payload, maxItems = MAX_SUMMARY_ISSUES) {
-  const normalizedMax = Math.max(1, Math.min(Number(maxItems) || MAX_SUMMARY_ISSUES, 10));
+function releaseStateDetailLines(payload, maxItems = MAX_SUMMARY_ISSUES) {
+  const normalizedMax = Math.max(1, Math.min(maxItems || MAX_SUMMARY_ISSUES, 10));
   const lines = [];
   for (const blocker of payload.blockers.slice(0, normalizedMax)) {
     lines.push(issueSummary("Blocker", blocker));

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -6,6 +6,8 @@ const MAX_SUMMARY_ISSUES = 5;
 const MAX_LABEL_LENGTH = 200;
 const MAX_MESSAGE_LENGTH = 500;
 const MAX_URL_LENGTH = 1024;
+const EXACT_TARGET_EVIDENCE_REUSE_POLICY = "exact-target-full-validation-v1";
+const CHANGELOG_ONLY_EVIDENCE_REUSE_POLICY = "changelog-only-release-v1";
 
 export const RELEASE_DECISION_STATES = Object.freeze([
   "qualifying",
@@ -186,7 +188,26 @@ function normalizedEvidenceReuse(evidenceReuse) {
     requested: true,
     rootRunId: boundedString(evidenceReuse.rootRunId, MAX_LABEL_LENGTH),
     runUrl: boundedString(evidenceReuse.runUrl, MAX_URL_LENGTH),
+    selectedRunId: boundedString(evidenceReuse.selectedRunId, MAX_LABEL_LENGTH),
   };
+}
+
+function validEvidenceReuseIdentity(evidenceReuse) {
+  if (!evidenceReuse.requested) {
+    return true;
+  }
+  const validChangedPaths =
+    (evidenceReuse.policy === EXACT_TARGET_EVIDENCE_REUSE_POLICY &&
+      evidenceReuse.changedPaths.length === 0) ||
+    (evidenceReuse.policy === CHANGELOG_ONLY_EVIDENCE_REUSE_POLICY &&
+      evidenceReuse.changedPaths.length === 1 &&
+      evidenceReuse.changedPaths[0] === "CHANGELOG.md");
+  return (
+    /^[a-f0-9]{40}$/u.test(evidenceReuse.evidenceSha) &&
+    /^[1-9][0-9]*$/u.test(evidenceReuse.rootRunId) &&
+    /^[1-9][0-9]*$/u.test(evidenceReuse.selectedRunId) &&
+    validChangedPaths
+  );
 }
 
 function executionPlanDigestPayload(plan) {
@@ -224,6 +245,10 @@ export function buildReleaseExecutionPlanArtifact({
   releaseProfile,
   rerunGroup,
 }) {
+  const normalizedReuse = normalizedEvidenceReuse(evidenceReuse);
+  if (!validEvidenceReuseIdentity(normalizedReuse)) {
+    throw new Error("release execution plan evidence reuse binding is invalid");
+  }
   const plan = {
     version: 1,
     kind: "openclaw.full-release-execution-plan",
@@ -234,7 +259,7 @@ export function buildReleaseExecutionPlanArtifact({
     targetSha: boundedString(expected.targetSha, MAX_LABEL_LENGTH),
     releaseProfile: boundedString(releaseProfile, MAX_LABEL_LENGTH),
     rerunGroup: boundedString(rerunGroup, MAX_LABEL_LENGTH),
-    evidenceReuse: normalizedEvidenceReuse(evidenceReuse),
+    evidenceReuse: normalizedReuse,
     gates: gates.map(normalizedGate),
     children: children.map(normalizedPlanChild),
     blockers: normalizeIssues(blockers, "release_blocker"),
@@ -264,6 +289,10 @@ export function validateReleaseExecutionPlanArtifact(payload, expected = {}) {
   ) {
     throw new Error("release execution plan artifact binding is invalid");
   }
+  const evidenceReuse = normalizedEvidenceReuse(payload.evidenceReuse);
+  if (!validEvidenceReuseIdentity(evidenceReuse)) {
+    throw new Error("release execution plan evidence reuse binding is invalid");
+  }
   const plan = {
     ...payload,
     parentRunAttempt: positiveInteger(payload.parentRunAttempt),
@@ -271,7 +300,7 @@ export function validateReleaseExecutionPlanArtifact(payload, expected = {}) {
     children: validatePlan(payload.children),
     blockers: normalizeIssues(payload.blockers, "release_blocker"),
     errors: normalizeIssues(payload.errors, "orchestration_error"),
-    evidenceReuse: normalizedEvidenceReuse(payload.evidenceReuse),
+    evidenceReuse,
     gates: Array.isArray(payload.gates) ? payload.gates.map(normalizedGate) : [],
   };
   const sha256 = releaseExecutionPlanSha256(plan);

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -189,6 +189,12 @@ function normalizedEvidenceReuse(evidenceReuse) {
     rootRunId: boundedString(evidenceReuse.rootRunId, MAX_LABEL_LENGTH),
     runUrl: boundedString(evidenceReuse.runUrl, MAX_URL_LENGTH),
     selectedRunId: boundedString(evidenceReuse.selectedRunId, MAX_LABEL_LENGTH),
+    sourceManifest:
+      evidenceReuse.sourceManifest &&
+      typeof evidenceReuse.sourceManifest === "object" &&
+      !Array.isArray(evidenceReuse.sourceManifest)
+        ? JSON.parse(JSON.stringify(evidenceReuse.sourceManifest))
+        : null,
   };
 }
 
@@ -206,8 +212,23 @@ function validEvidenceReuseIdentity(evidenceReuse) {
     /^[a-f0-9]{40}$/u.test(evidenceReuse.evidenceSha) &&
     /^[1-9][0-9]*$/u.test(evidenceReuse.rootRunId) &&
     /^[1-9][0-9]*$/u.test(evidenceReuse.selectedRunId) &&
+    evidenceReuse.sourceManifest !== null &&
     validChangedPaths
   );
+}
+
+function normalizedTrustedWorkflow(identity) {
+  const ref = boundedString(identity?.ref, MAX_LABEL_LENGTH);
+  const fullRef = boundedString(identity?.fullRef, MAX_LABEL_LENGTH);
+  const sha = boundedString(identity?.sha, MAX_LABEL_LENGTH);
+  if (
+    !ref ||
+    !/^[a-f0-9]{40}$/u.test(sha) ||
+    (fullRef !== `refs/heads/${ref}` && fullRef !== `refs/tags/${ref}`)
+  ) {
+    throw new Error("release execution plan trusted workflow identity is invalid");
+  }
+  return { fullRef, ref, sha };
 }
 
 function executionPlanDigestPayload(plan) {
@@ -223,6 +244,7 @@ function executionPlanDigestPayload(plan) {
     releaseProfile: plan.releaseProfile,
     rerunGroup: plan.rerunGroup,
     targetSha: plan.targetSha,
+    trustedWorkflow: plan.trustedWorkflow,
     version: plan.version,
     workflowRef: plan.workflowRef,
     workflowSha: plan.workflowSha,
@@ -244,6 +266,7 @@ export function buildReleaseExecutionPlanArtifact({
   gates,
   releaseProfile,
   rerunGroup,
+  trustedWorkflow,
 }) {
   const normalizedReuse = normalizedEvidenceReuse(evidenceReuse);
   if (!validEvidenceReuseIdentity(normalizedReuse)) {
@@ -257,6 +280,7 @@ export function buildReleaseExecutionPlanArtifact({
     workflowRef: boundedString(expected.workflowRef, MAX_LABEL_LENGTH),
     workflowSha: boundedString(expected.workflowSha, MAX_LABEL_LENGTH),
     targetSha: boundedString(expected.targetSha, MAX_LABEL_LENGTH),
+    trustedWorkflow: normalizedTrustedWorkflow(trustedWorkflow),
     releaseProfile: boundedString(releaseProfile, MAX_LABEL_LENGTH),
     rerunGroup: boundedString(rerunGroup, MAX_LABEL_LENGTH),
     evidenceReuse: normalizedReuse,
@@ -281,6 +305,8 @@ export function validateReleaseExecutionPlanArtifact(payload, expected = {}) {
     (payload.targetSha !== "" && !/^[a-f0-9]{40}$/u.test(String(payload.targetSha ?? ""))) ||
     (expected.parentRunId !== undefined &&
       String(payload.parentRunId) !== String(expected.parentRunId)) ||
+    (expected.maxParentRunAttempt !== undefined &&
+      Number(payload.parentRunAttempt) > Number(expected.maxParentRunAttempt)) ||
     (expected.workflowRef !== undefined && payload.workflowRef !== expected.workflowRef) ||
     (expected.workflowSha !== undefined && payload.workflowSha !== expected.workflowSha) ||
     (expected.releaseProfile !== undefined && payload.releaseProfile !== expected.releaseProfile) ||
@@ -293,6 +319,7 @@ export function validateReleaseExecutionPlanArtifact(payload, expected = {}) {
   if (!validEvidenceReuseIdentity(evidenceReuse)) {
     throw new Error("release execution plan evidence reuse binding is invalid");
   }
+  const trustedWorkflow = normalizedTrustedWorkflow(payload.trustedWorkflow);
   const plan = {
     ...payload,
     parentRunAttempt: positiveInteger(payload.parentRunAttempt),
@@ -302,6 +329,7 @@ export function validateReleaseExecutionPlanArtifact(payload, expected = {}) {
     errors: normalizeIssues(payload.errors, "orchestration_error"),
     evidenceReuse,
     gates: Array.isArray(payload.gates) ? payload.gates.map(normalizedGate) : [],
+    trustedWorkflow,
   };
   const sha256 = releaseExecutionPlanSha256(plan);
   if (payload.sha256 !== sha256) {
@@ -658,11 +686,15 @@ export function validateReleaseStateArtifact(payload, expected = {}, expectedMod
     payload.kind !== expectedKind ||
     !RELEASE_DECISION_STATE_SET.has(stringValue(payload.state)) ||
     !/^[a-f0-9]{64}$/u.test(String(payload.executionPlanSha256 ?? "")) ||
+    positiveInteger(payload.parentRunAttempt) === undefined ||
     positiveInteger(payload.sourceParentRunAttempt) === undefined ||
     (expected.parentRunId !== undefined &&
       String(payload.parentRunId) !== String(expected.parentRunId)) ||
     (expected.parentRunAttempt !== undefined &&
       Number(payload.parentRunAttempt) !== Number(expected.parentRunAttempt)) ||
+    (expected.maxParentRunAttempt !== undefined &&
+      Number(payload.parentRunAttempt) > Number(expected.maxParentRunAttempt)) ||
+    (expected.workflowRef !== undefined && payload.workflowRef !== expected.workflowRef) ||
     (expected.workflowSha !== undefined && payload.workflowSha !== expected.workflowSha) ||
     (expected.targetSha !== undefined && payload.targetSha !== expected.targetSha) ||
     (expected.releaseProfile !== undefined && payload.releaseProfile !== expected.releaseProfile) ||
@@ -675,13 +707,135 @@ export function validateReleaseStateArtifact(payload, expected = {}, expectedMod
   const activeRunIds = Array.isArray(payload.activeRunIds)
     ? payload.activeRunIds.map(String).filter((runId) => /^[1-9][0-9]*$/u.test(runId))
     : [];
+  const children =
+    payload.children && typeof payload.children === "object" && !Array.isArray(payload.children)
+      ? Object.fromEntries(
+          Object.entries(payload.children).map(([key, child]) => {
+            if (!child || typeof child !== "object" || Array.isArray(child)) {
+              throw new Error(`release state child snapshot is invalid: ${key}`);
+            }
+            const timingJobs = Array.isArray(child.timing?.jobs)
+              ? child.timing.jobs.map((job) => ({
+                  conclusion: stringValue(job?.conclusion),
+                  durationMinutes:
+                    typeof job?.durationMinutes === "number" ? job.durationMinutes : null,
+                  name: boundedString(job?.name, MAX_LABEL_LENGTH),
+                  startedAt: stringValue(job?.startedAt),
+                  status: stringValue(job?.status),
+                  url: boundedString(job?.url, MAX_URL_LENGTH),
+                }))
+              : [];
+            return [
+              key,
+              {
+                conclusion: stringValue(child.conclusion),
+                displayTitle: boundedString(child.displayTitle, MAX_LABEL_LENGTH),
+                errors: normalizeIssues(child.errors, "orchestration_error"),
+                runAttempt: positiveInteger(child.runAttempt),
+                runId: String(child.runId ?? ""),
+                status: stringValue(child.status),
+                timing: {
+                  durationMinutes:
+                    typeof child.timing?.durationMinutes === "number"
+                      ? child.timing.durationMinutes
+                      : null,
+                  jobs: timingJobs,
+                },
+                url: boundedString(child.url, MAX_URL_LENGTH),
+                workflow: boundedString(child.workflow, MAX_LABEL_LENGTH),
+                workflowRef: boundedString(child.workflowRef, MAX_LABEL_LENGTH),
+                workflowSha: boundedString(child.workflowSha, MAX_LABEL_LENGTH),
+              },
+            ];
+          }),
+        )
+      : {};
   return {
     ...payload,
     activeRunIds,
     blockers,
+    children,
     errors,
+    parentRunAttempt: positiveInteger(payload.parentRunAttempt),
     sourceParentRunAttempt: positiveInteger(payload.sourceParentRunAttempt),
   };
+}
+
+export function releasePlanGateFailures(gates) {
+  return gates
+    .filter((gate) => gate.required && gate.result !== "success")
+    .map((gate) => ({
+      child: "<parent>",
+      conclusion: stringValue(gate.result, "missing"),
+      job: stringValue(gate.name, "parent gate"),
+      kind: "parent_gate_failure",
+      message: `${stringValue(gate.name, "parent gate")} did not succeed`,
+    }));
+}
+
+function verifyStateChildren(state, executionPlan, label) {
+  const selected = executionPlan.children.filter((entry) => entry.selected);
+  const expectedKeys = selected.map((child) => child.key).toSorted();
+  const actualKeys = Object.keys(state.children).toSorted();
+  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`${label} child set differs from the immutable execution plan`);
+  }
+  if (
+    state.activeRunIds.length > 0 ||
+    state.cancellation?.requested === true ||
+    (state.cancellation?.cancelledRunIds?.length ?? 0) > 0
+  ) {
+    throw new Error(`${label} claims passed with active or cancelled children`);
+  }
+  const snapshots = selected.map((child) => {
+    if (!child.runId || !child.runAttempt) {
+      throw new Error(`selected release child omitted exact identity: ${child.key}`);
+    }
+    const snapshot = state.children[child.key];
+    if (
+      !snapshot ||
+      snapshot.runId !== child.runId ||
+      snapshot.runAttempt !== child.runAttempt ||
+      snapshot.displayTitle !== child.displayTitle ||
+      snapshot.workflow !== child.workflow ||
+      snapshot.workflowRef !== child.workflowRef ||
+      snapshot.workflowSha !== child.workflowSha
+    ) {
+      throw new Error(`${label} child provenance differs from the immutable plan: ${child.key}`);
+    }
+    if (snapshot.errors.length > 0) {
+      throw new Error(`${label} child contains collector errors: ${child.key}`);
+    }
+    return {
+      ...child,
+      ...snapshot,
+      jobs: snapshot.timing.jobs.map((job) => ({
+        conclusion: job.conclusion,
+        html_url: job.url,
+        name: job.name,
+        status: job.status,
+        url: job.url,
+      })),
+    };
+  });
+  const recomputed = classifyReleaseSnapshot({
+    children: snapshots,
+    extraBlockers: executionPlan.blockers,
+    extraErrors: executionPlan.errors,
+    localFailures: releasePlanGateFailures(executionPlan.gates),
+    releaseProfile: executionPlan.releaseProfile,
+    workflowRef: executionPlan.workflowRef,
+  });
+  if (
+    state.state !== "passed" ||
+    state.blockers.length > 0 ||
+    state.errors.length > 0 ||
+    recomputed.state !== "passed" ||
+    recomputed.blockers.length > 0 ||
+    recomputed.errors.length > 0
+  ) {
+    throw new Error(`${label} does not satisfy canonical terminal release policy`);
+  }
 }
 
 export function verifyReleaseStateArtifacts(
@@ -701,33 +855,70 @@ export function verifyReleaseStateArtifacts(
   ) {
     throw new Error("release decision and diagnostic drain execution plans differ");
   }
-  if (
-    decision.state !== "passed" ||
-    drain.state !== "passed" ||
-    decision.blockers.length > 0 ||
-    decision.errors.length > 0 ||
-    drain.blockers.length > 0 ||
-    drain.errors.length > 0
-  ) {
-    throw new Error(
-      `release state artifacts are not green: decision=${decision.state} drain=${drain.state}`,
-    );
+  verifyStateChildren(decision, executionPlan, "release decision");
+  verifyStateChildren(drain, executionPlan, "diagnostic drain");
+  return {
+    decision,
+    drain,
+    executionPlan,
+    sourceAttempts: {
+      decision: decision.parentRunAttempt,
+      drain: drain.parentRunAttempt,
+      executionPlan: executionPlan.parentRunAttempt,
+    },
+  };
+}
+
+function newestStateCandidate(candidates, mode, runId, expected) {
+  const prefix = mode === "decision" ? "full-release-decision" : "full-release-diagnostics";
+  const pattern = new RegExp(`^${prefix}-${runId}-([1-9][0-9]*)$`, "u");
+  const maxParentRunAttempt =
+    expected.maxParentRunAttempt === undefined
+      ? Number.POSITIVE_INFINITY
+      : Number(expected.maxParentRunAttempt);
+  const sorted = candidates
+    .map((candidate) => {
+      const match = pattern.exec(String(candidate.name ?? ""));
+      return match ? { ...candidate, attempt: Number(match[1]) } : undefined;
+    })
+    .filter(Boolean)
+    .filter((candidate) => candidate.attempt <= maxParentRunAttempt)
+    .toSorted((left, right) => right.attempt - left.attempt);
+  const newest = sorted[0];
+  if (!newest) {
+    throw new Error(`no ${mode} artifact exists at or before the current parent attempt`);
   }
-  for (const child of executionPlan.children.filter((entry) => entry.selected)) {
-    if (!child.runId || !child.runAttempt) {
-      throw new Error(`selected release child omitted exact identity: ${child.key}`);
-    }
-    const snapshot = drain.children?.[child.key];
-    if (
-      !snapshot ||
-      String(snapshot.runId) !== child.runId ||
-      Number(snapshot.runAttempt) !== child.runAttempt ||
-      snapshot.status !== "completed"
-    ) {
-      throw new Error(`diagnostic drain child is not terminal and exact: ${child.key}`);
-    }
+  const payload = validateReleaseStateArtifact(newest.payload, expected, mode);
+  if (payload.parentRunAttempt !== newest.attempt) {
+    throw new Error(`${mode} artifact name and source attempt differ`);
   }
-  return { decision, drain, executionPlan };
+  return payload;
+}
+
+export function selectReleaseStateArtifacts(
+  executionPlanPayload,
+  decisionCandidates,
+  drainCandidates,
+  expected = {},
+) {
+  const executionPlan = validateReleaseExecutionPlanArtifact(executionPlanPayload, expected);
+  const selectionExpected = {
+    ...expected,
+    parentRunAttempt: undefined,
+  };
+  const decision = newestStateCandidate(
+    decisionCandidates,
+    "decision",
+    executionPlan.parentRunId,
+    selectionExpected,
+  );
+  const drain = newestStateCandidate(
+    drainCandidates,
+    "drain",
+    executionPlan.parentRunId,
+    selectionExpected,
+  );
+  return verifyReleaseStateArtifacts(executionPlan, decision, drain, selectionExpected);
 }
 
 function issueSummary(prefix, issue) {

--- a/scripts/full-release-validation-state.d.mts
+++ b/scripts/full-release-validation-state.d.mts
@@ -1,0 +1,15 @@
+export * from "./full-release-validation-policy.mjs";
+export function validateChildBinding(
+  child: Record<string, unknown>,
+  run: Record<string, unknown>,
+  jobs: Record<string, unknown>[],
+): Record<string, unknown>;
+export function parsePlanInputs(value: string): Record<string, unknown>;
+export function hydrateReusedPlan(
+  plan: Record<string, unknown>[],
+  evidence: Record<string, any>,
+): Record<string, unknown>[];
+export function formatReleaseStateHeartbeat(
+  mode: string,
+  decision: Record<string, unknown>,
+): string;

--- a/scripts/full-release-validation-state.d.mts
+++ b/scripts/full-release-validation-state.d.mts
@@ -7,7 +7,7 @@ export function validateChildBinding(
 export function parsePlanInputs(value: string): Record<string, unknown>;
 export function hydrateReusedPlan(
   plan: Record<string, unknown>[],
-  evidence: Record<string, any>,
+  evidence: Record<string, unknown>,
 ): Record<string, unknown>[];
 export function formatReleaseStateHeartbeat(
   mode: string,

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -1,0 +1,708 @@
+#!/usr/bin/env node
+import { execFile } from "node:child_process";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import {
+  affectedActiveRunIds,
+  buildReleaseExecutionPlan,
+  buildReleaseExecutionPlanArtifact,
+  buildReleaseStateArtifact,
+  classifyReleaseSnapshot,
+  formatReleaseStateOutcome,
+  validateReleaseExecutionPlanArtifact,
+  verifyReleaseStateArtifacts,
+} from "./full-release-validation-policy.mjs";
+
+export * from "./full-release-validation-policy.mjs";
+
+const execFileAsync = promisify(execFile);
+const RELEASE_SUMMARY_PATH = fileURLToPath(new URL("./release-ci-summary.mjs", import.meta.url));
+const TRANSIENT_GH_PATTERN =
+  /HTTP 5[0-9][0-9]|Server Error|secondary rate limit|API rate limit|HTTP 429|abuse detection|error connecting to|context deadline exceeded|connection reset by peer|connection refused|TLS handshake timeout|i\/o timeout|network is unreachable|unexpected EOF|ETIMEDOUT|ECONNRESET|EAI_AGAIN/u;
+const API_ERROR_PATTERN =
+  /HTTP [45][0-9][0-9]|API|Bad credentials|rate limit|network|connection|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN/u;
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 5 * 60_000;
+const GH_TIMEOUT_MS = 60_000;
+
+function stringValue(value, fallback = "") {
+  return typeof value === "string" ? value : fallback;
+}
+
+function requiredString(value, label) {
+  const normalized = stringValue(value).trim();
+  if (!normalized) {
+    throw new Error(`${label} is required`);
+  }
+  return normalized;
+}
+
+function positiveInteger(value, label) {
+  const normalized = Number(value);
+  if (!Number.isSafeInteger(normalized) || normalized < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return normalized;
+}
+
+async function abortableSleep(milliseconds, signal) {
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, milliseconds);
+    const abort = () => {
+      clearTimeout(timer);
+      reject(signal.reason ?? new Error("operation aborted"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+async function runGh(args, options = {}) {
+  const attempts = options.attempts ?? 6;
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const result = await execFileAsync("gh", args, {
+        encoding: "utf8",
+        env: process.env,
+        killSignal: "SIGKILL",
+        maxBuffer: 64 * 1024 * 1024,
+        signal: options.signal,
+        timeout: GH_TIMEOUT_MS,
+      });
+      return result.stdout;
+    } catch (error) {
+      lastError = error;
+      if (options.signal?.aborted) {
+        throw options.signal.reason ?? error;
+      }
+      const stderr = stringValue(error?.stderr) || stringValue(error?.message);
+      if (attempt === attempts || !TRANSIENT_GH_PATTERN.test(stderr)) {
+        throw error;
+      }
+      await abortableSleep(Math.min(attempt * 10_000, 60_000), options.signal);
+    }
+  }
+  throw lastError;
+}
+
+async function githubJson(path, signal) {
+  return JSON.parse(
+    await runGh(["api", `repos/${process.env.GITHUB_REPOSITORY}/${path}`], { signal }),
+  );
+}
+
+async function githubJobs(runId, signal) {
+  return (
+    await runGh(
+      [
+        "api",
+        "--paginate",
+        `repos/${process.env.GITHUB_REPOSITORY}/actions/runs/${runId}/jobs?per_page=100`,
+        "--jq",
+        ".jobs[] | @json",
+      ],
+      { signal },
+    )
+  )
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function issue(kind, child, message, extra = {}) {
+  return {
+    child: child.key,
+    kind,
+    message,
+    runId: stringValue(child.runId),
+    url: stringValue(child.url),
+    ...extra,
+  };
+}
+
+export function validateChildBinding(child, run, jobs) {
+  const errors = [];
+  const path = stringValue(run.path).split("@", 1)[0];
+  if (String(run.id) !== String(child.runId)) {
+    errors.push(issue("provenance_mismatch", child, `${child.key} run ID changed`));
+  }
+  if (run.event !== "workflow_dispatch") {
+    errors.push(issue("provenance_mismatch", child, `${child.key} event changed`));
+  }
+  if (path !== `.github/workflows/${child.workflow}`) {
+    errors.push(issue("provenance_mismatch", child, `${child.key} workflow path changed`));
+  }
+  if (run.display_title !== child.displayTitle) {
+    errors.push(issue("provenance_mismatch", child, `${child.key} display title changed`));
+  }
+  if (run.head_branch !== child.workflowRef) {
+    errors.push(issue("provenance_mismatch", child, `${child.key} workflow ref changed`));
+  }
+  if (run.head_sha !== child.workflowSha) {
+    errors.push(issue("provenance_mismatch", child, `${child.key} tooling SHA changed`));
+  }
+  if (Number(run.run_attempt) !== Number(child.runAttempt)) {
+    errors.push(issue("provenance_mismatch", child, `${child.key} run attempt changed`));
+  }
+  return {
+    ...child,
+    conclusion: stringValue(run.conclusion),
+    createdAt: stringValue(run.created_at),
+    errors,
+    jobs,
+    runAttempt: Number(run.run_attempt),
+    runId: String(run.id),
+    status: stringValue(run.status),
+    updatedAt: stringValue(run.updated_at),
+    url: stringValue(run.html_url, child.url),
+    workflowRef: stringValue(run.head_branch),
+    workflowSha: stringValue(run.head_sha),
+  };
+}
+
+async function readChild(child, previous, signal) {
+  if (!child.selected) {
+    return { ...child, errors: [], jobs: [], status: "skipped" };
+  }
+  if (!child.runId || !child.runAttempt) {
+    return {
+      ...child,
+      errors: [issue("dispatch_missing", child, `${child.key} omitted its exact run identity`)],
+      jobs: [],
+      status: "missing",
+    };
+  }
+  try {
+    const run = await githubJson(`actions/runs/${child.runId}`, signal);
+    return validateChildBinding(child, run, await githubJobs(child.runId, signal));
+  } catch (error) {
+    return {
+      ...child,
+      conclusion: stringValue(previous?.conclusion),
+      createdAt: stringValue(previous?.createdAt),
+      errors: [
+        ...(previous?.errors ?? []).filter((entry) => entry.kind === "provenance_mismatch"),
+        issue(
+          "api_error",
+          child,
+          `${child.key} GitHub read failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        ),
+      ],
+      jobs: previous?.jobs ?? [],
+      status: stringValue(previous?.status, "unknown"),
+      updatedAt: stringValue(previous?.updatedAt),
+    };
+  }
+}
+
+export function parsePlanInputs(value) {
+  const parsed = JSON.parse(requiredString(value, "plan inputs JSON"));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("plan inputs JSON must be an object");
+  }
+  return parsed;
+}
+
+function localFailures(gates) {
+  return gates
+    .filter((gate) => gate.required && gate.result !== "success")
+    .map((gate) => ({
+      child: "<parent>",
+      conclusion: stringValue(gate.result, "missing"),
+      job: stringValue(gate.name, "parent gate"),
+      kind: "parent_gate_failure",
+      message: `${stringValue(gate.name, "parent gate")} did not succeed`,
+    }));
+}
+
+export function hydrateReusedPlan(plan, evidence) {
+  const byRole = new Map((evidence.children ?? []).map((child) => [child.role, child]));
+  return plan.map((child) => {
+    if (!child.selected) {
+      return child;
+    }
+    const reused = byRole.get(child.key);
+    if (!reused) {
+      return child;
+    }
+    return {
+      ...child,
+      displayTitle: reused.displayTitle,
+      result: "success",
+      runAttempt: reused.runAttempt,
+      runId: reused.runId,
+      url: reused.url,
+      workflowRef: reused.headBranch,
+      workflowSha: reused.workflowSha,
+    };
+  });
+}
+
+function changedPathsValue(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  try {
+    const parsed = JSON.parse(stringValue(value, "[]"));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+async function validateReuse(plan, planInputs, signal) {
+  if (!(planInputs.evidenceReuse === true || planInputs.evidenceReuse === "true")) {
+    return { blockers: [], children: plan };
+  }
+  try {
+    const args = [
+      RELEASE_SUMMARY_PATH,
+      "--validate-run",
+      requiredString(planInputs.evidenceRootRunId, "evidence root run ID"),
+      "--repo",
+      requiredString(process.env.GITHUB_REPOSITORY, "GitHub repository"),
+      "--trusted-workflow-ref",
+      "main",
+      "--verifier-source-sha",
+      requiredString(planInputs.workflowSha, "workflow SHA"),
+      "--verifier-source-file",
+      RELEASE_SUMMARY_PATH,
+      "--expected-target-sha",
+      requiredString(process.env.TARGET_SHA, "target SHA"),
+      "--expected-evidence-policy",
+      requiredString(planInputs.evidencePolicy, "evidence policy"),
+      "--expected-evidence-sha",
+      requiredString(planInputs.evidenceSha, "evidence SHA"),
+      "--expected-changed-paths-json",
+      JSON.stringify(changedPathsValue(planInputs.evidenceChangedPaths)),
+      "--json",
+    ];
+    const result = await execFileAsync(process.execPath, args, {
+      encoding: "utf8",
+      env: process.env,
+      killSignal: "SIGKILL",
+      maxBuffer: 64 * 1024 * 1024,
+      signal,
+      timeout: GH_TIMEOUT_MS * 6,
+    });
+    const evidence = JSON.parse(result.stdout);
+    if (
+      evidence.releaseProfile !== process.env.RELEASE_PROFILE ||
+      evidence.rerunGroup !== process.env.RERUN_GROUP
+    ) {
+      throw new Error("reused release evidence no longer matches the requested validation");
+    }
+    return { blockers: [], children: hydrateReusedPlan(plan, evidence) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const entry = {
+      child: "<evidence>",
+      kind: API_ERROR_PATTERN.test(message) ? "api_error" : "reused_evidence_invalid",
+      message,
+      runId: stringValue(planInputs.evidenceRootRunId),
+      url: stringValue(planInputs.evidenceRunUrl),
+    };
+    return API_ERROR_PATTERN.test(message)
+      ? { blockers: [], children: plan, errors: [entry] }
+      : { blockers: [entry], children: plan, errors: [] };
+  }
+}
+
+function writeResult(path, payload) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `state=${payload.state}\n`);
+    for (const [key, child] of Object.entries(payload.children ?? {})) {
+      appendFileSync(process.env.GITHUB_OUTPUT, `${key}_conclusion=${child.conclusion ?? ""}\n`);
+    }
+  }
+}
+
+function writeExecutionPlan(path, payload) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `sha256=${payload.sha256}\n`);
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `source_parent_attempt=${payload.parentRunAttempt}\n`,
+    );
+  }
+}
+
+function appendSummary(mode, payload) {
+  if (!process.env.GITHUB_STEP_SUMMARY) {
+    return;
+  }
+  appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `## ${mode === "decision" ? "Release Decision" : "Diagnostic Drain"}\n\n${formatReleaseStateOutcome(payload)}\n`,
+  );
+}
+
+export function formatReleaseStateHeartbeat(mode, decision) {
+  return `${mode} heartbeat: state=${decision.state} active=${decision.activeRunIds.length} blockers=${decision.blockers.length} errors=${decision.errors.length}`;
+}
+
+async function cancelAffectedChildren(children, blockers, cancelledRunIds, signal) {
+  const errors = [];
+  for (const runId of affectedActiveRunIds(children, blockers, cancelledRunIds)) {
+    const child = children.find((entry) => String(entry.runId) === runId);
+    try {
+      await runGh(["run", "cancel", runId], { attempts: 1, signal });
+      cancelledRunIds.add(runId);
+    } catch (error) {
+      errors.push(
+        issue(
+          "api_error",
+          child ?? { key: "<child>", runId },
+          `exact child cancellation failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        ),
+      );
+    }
+  }
+  return errors;
+}
+
+function readArtifact(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `${label} artifact is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function verifyMode() {
+  const expected = {
+    parentRunAttempt: positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt"),
+    parentRunId: requiredString(process.env.GITHUB_RUN_ID, "parent run ID"),
+    releaseProfile: requiredString(process.env.RELEASE_PROFILE, "release profile"),
+    rerunGroup: requiredString(process.env.RERUN_GROUP, "rerun group"),
+    targetSha: requiredString(process.env.TARGET_SHA, "target SHA"),
+    workflowSha: requiredString(process.env.GITHUB_SHA, "workflow SHA"),
+  };
+  const verified = verifyReleaseStateArtifacts(
+    readArtifact(
+      requiredString(process.env.RELEASE_EXECUTION_PLAN_PATH, "execution plan path"),
+      "execution plan",
+    ),
+    readArtifact(requiredString(process.env.RELEASE_DECISION_PATH, "decision path"), "decision"),
+    readArtifact(requiredString(process.env.DIAGNOSTIC_DRAIN_PATH, "drain path"), "drain"),
+    expected,
+  );
+  appendSummary("decision", verified.decision);
+  appendSummary("drain", verified.drain);
+}
+
+function planExpected() {
+  return {
+    parentRunId: requiredString(process.env.GITHUB_RUN_ID, "parent run ID"),
+    releaseProfile: requiredString(process.env.RELEASE_PROFILE, "release profile"),
+    rerunGroup: requiredString(process.env.RERUN_GROUP, "rerun group"),
+    targetSha: stringValue(process.env.TARGET_SHA),
+    workflowSha: requiredString(process.env.GITHUB_SHA, "workflow SHA"),
+  };
+}
+
+function evidenceReuseFromInputs(planInputs) {
+  return {
+    changedPaths: changedPathsValue(planInputs.evidenceChangedPaths),
+    evidenceSha: stringValue(planInputs.evidenceSha),
+    policy: stringValue(planInputs.evidencePolicy),
+    requested: planInputs.evidenceReuse === true || planInputs.evidenceReuse === "true",
+    rootRunId: stringValue(planInputs.evidenceRootRunId),
+    runUrl: stringValue(planInputs.evidenceRunUrl),
+  };
+}
+
+async function planMode() {
+  const outputPath = requiredString(
+    process.env.FULL_RELEASE_EXECUTION_PLAN_PATH,
+    "execution plan output path",
+  );
+  const expected = planExpected();
+  const currentAttempt = positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt");
+
+  if (process.env.FULL_RELEASE_RESTORE_PLAN === "true") {
+    const restored = validateReleaseExecutionPlanArtifact(
+      readArtifact(outputPath, "execution plan"),
+      expected,
+    );
+    writeExecutionPlan(outputPath, restored);
+    return;
+  }
+  if (currentAttempt !== 1) {
+    throw new Error("collector retry omitted the immutable attempt-one execution plan");
+  }
+
+  const planInputs = parsePlanInputs(process.env.FULL_RELEASE_PLAN_INPUTS_JSON);
+  const built = buildReleaseExecutionPlan(planInputs);
+  const abortController = new AbortController();
+  let finished = false;
+  let plan = buildReleaseExecutionPlanArtifact({
+    children: built.children,
+    evidenceReuse: evidenceReuseFromInputs(planInputs),
+    expected: { ...expected, parentRunAttempt: currentAttempt },
+    gates: built.gates,
+    releaseProfile: expected.releaseProfile,
+    rerunGroup: expected.rerunGroup,
+  });
+  const stop = () => {
+    if (finished) {
+      return;
+    }
+    abortController.abort(new Error("execution plan collection cancelled"));
+    plan = buildReleaseExecutionPlanArtifact({
+      blockers: plan.blockers,
+      children: plan.children,
+      errors: [
+        ...plan.errors,
+        {
+          child: "<collector>",
+          kind: "collector_cancelled",
+          message: "execution plan collector received a termination signal",
+        },
+      ],
+      evidenceReuse: plan.evidenceReuse,
+      expected: { ...expected, parentRunAttempt: currentAttempt },
+      gates: plan.gates,
+      releaseProfile: expected.releaseProfile,
+      rerunGroup: expected.rerunGroup,
+    });
+    writeExecutionPlan(outputPath, plan);
+    finished = true;
+    process.exit(1);
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+
+  const reuse = await validateReuse(built.children, planInputs, abortController.signal);
+  if (finished) {
+    return;
+  }
+  plan = buildReleaseExecutionPlanArtifact({
+    blockers: reuse.blockers,
+    children: reuse.children,
+    errors: reuse.errors,
+    evidenceReuse: evidenceReuseFromInputs(planInputs),
+    expected: { ...expected, parentRunAttempt: currentAttempt },
+    gates: built.gates,
+    releaseProfile: expected.releaseProfile,
+    rerunGroup: expected.rerunGroup,
+  });
+  writeExecutionPlan(outputPath, plan);
+  finished = true;
+  if ((reuse.blockers?.length ?? 0) > 0 || (reuse.errors?.length ?? 0) > 0) {
+    throw new Error("release execution plan could not bind reusable evidence");
+  }
+}
+
+async function collectMode(mode) {
+  const expected = {
+    parentRunAttempt: positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt"),
+    parentRunId: requiredString(process.env.GITHUB_RUN_ID, "parent run ID"),
+    targetSha: stringValue(process.env.TARGET_SHA),
+    workflowRef: requiredString(process.env.GITHUB_REF_NAME, "workflow ref"),
+    workflowSha: requiredString(process.env.GITHUB_SHA, "workflow SHA"),
+  };
+  const releaseProfile = requiredString(process.env.RELEASE_PROFILE, "release profile");
+  const rerunGroup = requiredString(process.env.RERUN_GROUP, "rerun group");
+  const outputPath = requiredString(process.env.FULL_RELEASE_STATE_PATH, "state output path");
+  const executionPlan = validateReleaseExecutionPlanArtifact(
+    readArtifact(
+      requiredString(process.env.FULL_RELEASE_EXECUTION_PLAN_PATH, "execution plan path"),
+      "execution plan",
+    ),
+    {
+      parentRunId: expected.parentRunId,
+      releaseProfile,
+      rerunGroup,
+      targetSha: expected.targetSha,
+      workflowSha: expected.workflowSha,
+    },
+  );
+  const plan = executionPlan.children;
+  const gateFailures = localFailures(executionPlan.gates);
+  const failFast = mode === "decision" && process.env.FAIL_FAST === "true";
+  const pollIntervalMs =
+    Number(process.env.FULL_RELEASE_POLL_INTERVAL_MS) || DEFAULT_POLL_INTERVAL_MS;
+  const heartbeatIntervalMs =
+    Number(process.env.FULL_RELEASE_HEARTBEAT_INTERVAL_MS) || DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const cancelledRunIds = new Set();
+  let snapshots = plan.map((child) => ({
+    ...child,
+    errors: [],
+    jobs: [],
+    status: child.selected && child.runId ? "queued" : child.selected ? "missing" : "skipped",
+  }));
+  let finished = false;
+  const abortController = new AbortController();
+  let decisionReuse = { blockers: [], children: plan, errors: [] };
+
+  const writePayload = (decision, cancellation = {}) => {
+    const payload = buildReleaseStateArtifact({
+      cancellation,
+      children: snapshots,
+      decision,
+      executionPlan,
+      expected,
+      mode,
+      releaseProfile,
+      rerunGroup,
+    });
+    writeResult(outputPath, payload);
+    appendSummary(mode, payload);
+    return payload;
+  };
+  const stop = () => {
+    if (finished) {
+      return;
+    }
+    abortController.abort(new Error(`${mode} collector cancelled`));
+    const decision = classifyReleaseSnapshot({
+      cancelled: true,
+      children: snapshots,
+      extraBlockers: executionPlan.blockers,
+      extraErrors: [
+        ...executionPlan.errors,
+        {
+          child: "<collector>",
+          kind: "collector_cancelled",
+          message: `${mode} collector received a termination signal`,
+        },
+      ],
+      localFailures: gateFailures,
+      releaseProfile,
+      workflowRef: expected.workflowRef,
+    });
+    writePayload(decision, { cancelledRunIds, requested: true });
+    finished = true;
+    process.exit(1);
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+
+  if (mode === "decision" && executionPlan.evidenceReuse.requested) {
+    decisionReuse = await validateReuse(
+      plan,
+      {
+        evidenceChangedPaths: executionPlan.evidenceReuse.changedPaths,
+        evidencePolicy: executionPlan.evidenceReuse.policy,
+        evidenceReuse: true,
+        evidenceRootRunId: executionPlan.evidenceReuse.rootRunId,
+        evidenceRunUrl: executionPlan.evidenceReuse.runUrl,
+        evidenceSha: executionPlan.evidenceReuse.evidenceSha,
+        workflowSha: executionPlan.workflowSha,
+      },
+      abortController.signal,
+    );
+    const exactPlan = JSON.stringify(
+      plan.map(({ key, runAttempt, runId }) => ({ key, runAttempt, runId })),
+    );
+    const revalidatedPlan = JSON.stringify(
+      decisionReuse.children.map(({ key, runAttempt, runId }) => ({ key, runAttempt, runId })),
+    );
+    if (exactPlan !== revalidatedPlan) {
+      decisionReuse = {
+        ...decisionReuse,
+        blockers: [
+          ...decisionReuse.blockers,
+          {
+            child: "<evidence>",
+            kind: "provenance_mismatch",
+            message: "revalidated evidence child identities differ from the immutable plan",
+            runId: executionPlan.evidenceReuse.rootRunId,
+            url: executionPlan.evidenceReuse.runUrl,
+          },
+        ],
+      };
+    }
+  }
+
+  let nextHeartbeat = 0;
+  while (!finished) {
+    snapshots = await Promise.all(
+      plan.map((child, index) => readChild(child, snapshots[index], abortController.signal)),
+    );
+    let decision = classifyReleaseSnapshot({
+      children: snapshots,
+      extraBlockers: [...executionPlan.blockers, ...decisionReuse.blockers],
+      extraErrors: [...executionPlan.errors, ...decisionReuse.errors],
+      localFailures: gateFailures,
+      releaseProfile,
+      workflowRef: expected.workflowRef,
+    });
+    if (Date.now() >= nextHeartbeat) {
+      console.log(formatReleaseStateHeartbeat(mode, decision));
+      nextHeartbeat = Date.now() + heartbeatIntervalMs;
+    }
+    if (failFast && decision.blockers.length > 0) {
+      const cancellationErrors = await cancelAffectedChildren(
+        snapshots,
+        decision.blockers,
+        cancelledRunIds,
+        abortController.signal,
+      );
+      if (cancellationErrors.length > 0) {
+        decision = classifyReleaseSnapshot({
+          children: snapshots,
+          extraBlockers: [
+            ...executionPlan.blockers,
+            ...decisionReuse.blockers,
+            ...decision.blockers,
+          ],
+          extraErrors: [...executionPlan.errors, ...decisionReuse.errors, ...cancellationErrors],
+          localFailures: gateFailures,
+          releaseProfile,
+          workflowRef: expected.workflowRef,
+        });
+      }
+    }
+    const done =
+      mode === "decision"
+        ? decision.state !== "qualifying"
+        : decision.state === "orchestration_error" ||
+          (decision.state !== "qualifying" && decision.activeRunIds.length === 0);
+    if (done) {
+      const payload = writePayload(decision, { cancelledRunIds, requested: false });
+      finished = true;
+      process.exitCode =
+        payload.state === "passed" ? 0 : payload.state === "orchestration_error" ? 2 : 1;
+      return;
+    }
+    await abortableSleep(pollIntervalMs, abortController.signal);
+  }
+}
+
+async function main() {
+  const mode = process.argv[2];
+  if (mode === "plan") {
+    await planMode();
+    return;
+  }
+  if (mode === "verify") {
+    verifyMode();
+    return;
+  }
+  if (!["decision", "drain"].includes(mode)) {
+    throw new Error("usage: full-release-validation-state.mjs <plan|decision|drain|verify>");
+  }
+  await collectMode(mode);
+}
+
+if (process.argv[1]?.endsWith("full-release-validation-state.mjs")) {
+  await main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  });
+}

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -17,6 +17,7 @@ import {
   buildReleaseExecutionPlan,
   buildReleaseExecutionPlanArtifact,
   buildReleaseStateArtifact,
+  classifyReleaseGhTransportError,
   classifyReleaseSnapshot,
   formatReleaseStateOutcome,
   releasePlanGateFailures,
@@ -31,8 +32,6 @@ const execFileAsync = promisify(execFile);
 const RELEASE_SUMMARY_PATH =
   process.env.OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR ??
   fileURLToPath(new URL("./release-ci-summary.mjs", import.meta.url));
-const TRANSIENT_GH_PATTERN =
-  /HTTP 5[0-9][0-9]|Server Error|secondary rate limit|API rate limit|HTTP 429|abuse detection|error connecting to|context deadline exceeded|connection reset by peer|connection refused|TLS handshake timeout|i\/o timeout|network is unreachable|unexpected EOF|ETIMEDOUT|ECONNRESET|EAI_AGAIN/u;
 const API_ERROR_PATTERN =
   /HTTP [45][0-9][0-9]|API|Bad credentials|rate limit|network|connection|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN/u;
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
@@ -60,14 +59,19 @@ function positiveInteger(value, label) {
 }
 
 async function abortableSleep(milliseconds, signal) {
-  await new Promise((resolve, reject) => {
+  let abortError;
+  await new Promise((resolve) => {
     const timer = setTimeout(resolve, milliseconds);
     const abort = () => {
       clearTimeout(timer);
-      reject(signal.reason ?? new Error("operation aborted"));
+      abortError = signal?.reason instanceof Error ? signal.reason : new Error("operation aborted");
+      resolve();
     };
     signal?.addEventListener("abort", abort, { once: true });
   });
+  if (abortError instanceof Error) {
+    throw new Error(abortError.message, { cause: abortError });
+  }
 }
 
 async function runGh(args, options = {}) {
@@ -89,8 +93,7 @@ async function runGh(args, options = {}) {
       if (options.signal?.aborted) {
         throw options.signal.reason ?? error;
       }
-      const stderr = stringValue(error?.stderr) || stringValue(error?.message);
-      if (attempt === attempts || !TRANSIENT_GH_PATTERN.test(stderr)) {
+      if (attempt === attempts || classifyReleaseGhTransportError(error) !== "transient") {
         throw error;
       }
       await abortableSleep(Math.min(attempt * 10_000, 60_000), options.signal);
@@ -410,6 +413,7 @@ function readArtifact(path, label) {
   } catch (error) {
     throw new Error(
       `${label} artifact is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
 }
@@ -915,8 +919,10 @@ async function main() {
 }
 
 if (process.argv[1]?.endsWith("full-release-validation-state.mjs")) {
-  await main().catch((error) => {
+  try {
+    await main();
+  } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(2);
-  });
+  }
 }

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
-import { appendFileSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -247,9 +254,23 @@ function changedPathsValue(value) {
   }
 }
 
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJson);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalJson(entry)]),
+    );
+  }
+  return value;
+}
+
 async function validateReuse(plan, planInputs, signal) {
   if (!(planInputs.evidenceReuse === true || planInputs.evidenceReuse === "true")) {
-    return { blockers: [], children: plan };
+    return { blockers: [], children: plan, errors: [] };
   }
   try {
     const args = [
@@ -293,11 +314,19 @@ async function validateReuse(plan, planInputs, signal) {
     const evidence = JSON.parse(result.stdout);
     if (
       evidence.releaseProfile !== process.env.RELEASE_PROFILE ||
-      evidence.rerunGroup !== process.env.RERUN_GROUP
+      evidence.rerunGroup !== process.env.RERUN_GROUP ||
+      !evidence.manifest ||
+      typeof evidence.manifest !== "object" ||
+      Array.isArray(evidence.manifest)
     ) {
       throw new Error("reused release evidence no longer matches the requested validation");
     }
-    return { blockers: [], children: hydrateReusedPlan(plan, evidence) };
+    return {
+      blockers: [],
+      children: hydrateReusedPlan(plan, evidence),
+      errors: [],
+      sourceManifest: canonicalJson(evidence.manifest),
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const entry = {
@@ -419,7 +448,7 @@ function planExpected() {
   };
 }
 
-function evidenceReuseFromInputs(planInputs) {
+function evidenceReuseFromInputs(planInputs, sourceManifest = {}) {
   return {
     changedPaths: changedPathsValue(planInputs.evidenceChangedPaths),
     evidenceSha: stringValue(planInputs.evidenceSha),
@@ -428,7 +457,7 @@ function evidenceReuseFromInputs(planInputs) {
     rootRunId: stringValue(planInputs.evidenceRootRunId),
     runUrl: stringValue(planInputs.evidenceRunUrl),
     selectedRunId: stringValue(planInputs.evidenceRunId),
-    sourceManifest: planInputs.evidenceManifest,
+    sourceManifest,
   };
 }
 
@@ -507,7 +536,7 @@ async function planMode() {
     blockers: reuse.blockers,
     children: reuse.children,
     errors: reuse.errors,
-    evidenceReuse: evidenceReuseFromInputs(planInputs),
+    evidenceReuse: evidenceReuseFromInputs(planInputs, reuse.sourceManifest),
     expected: { ...expected, parentRunAttempt: currentAttempt },
     gates: built.gates,
     releaseProfile: expected.releaseProfile,
@@ -643,6 +672,24 @@ async function collectMode(mode) {
         ],
       };
     }
+    if (
+      JSON.stringify(canonicalJson(decisionReuse.sourceManifest)) !==
+      JSON.stringify(canonicalJson(executionPlan.evidenceReuse.sourceManifest))
+    ) {
+      decisionReuse = {
+        ...decisionReuse,
+        blockers: [
+          ...decisionReuse.blockers,
+          {
+            child: "<evidence>",
+            kind: "provenance_mismatch",
+            message: "revalidated evidence source manifest differs from the immutable plan",
+            runId: executionPlan.evidenceReuse.rootRunId,
+            url: executionPlan.evidenceReuse.runUrl,
+          },
+        ],
+      };
+    }
   }
 
   let nextHeartbeat = 0;
@@ -700,9 +747,9 @@ async function collectMode(mode) {
   }
 }
 
-function readNewestStateCandidate(root, prefix, runId, maxParentRunAttempt, filename) {
+function readStateCandidates(root, prefix, runId, maxParentRunAttempt, filename) {
   const pattern = new RegExp(`^${prefix}-${runId}-([1-9][0-9]*)$`, "u");
-  const newest = readdirSync(root, { withFileTypes: true })
+  const candidates = readdirSync(root, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => {
       const match = pattern.exec(entry.name);
@@ -710,16 +757,60 @@ function readNewestStateCandidate(root, prefix, runId, maxParentRunAttempt, file
     })
     .filter(Boolean)
     .filter((entry) => entry.attempt <= maxParentRunAttempt)
-    .toSorted((left, right) => right.attempt - left.attempt)[0];
-  if (!newest) {
-    return [];
+    .map((entry) => {
+      const payload = readArtifact(join(root, entry.name, filename), entry.name);
+      if (Number(payload.parentRunAttempt) !== entry.attempt) {
+        throw new Error(`${entry.name} payload attempt differs from its artifact name`);
+      }
+      return { name: entry.name, payload };
+    });
+  const directPath = join(root, filename);
+  if (existsSync(directPath)) {
+    const payload = readArtifact(directPath, filename);
+    const attempt = positiveInteger(payload.parentRunAttempt, `${filename} parent run attempt`);
+    if (attempt <= maxParentRunAttempt) {
+      candidates.push({ name: `${prefix}-${runId}-${attempt}`, payload });
+    }
   }
-  return [
+  return candidates;
+}
+
+async function validateManifestMode() {
+  const manifestPath = requiredString(
+    process.env.RELEASE_VALIDATION_MANIFEST_PATH,
+    "release validation manifest path",
+  );
+  const executionPlan = validateReleaseExecutionPlanArtifact(
+    readArtifact(
+      requiredString(process.env.RELEASE_EXECUTION_PLAN_PATH, "execution plan path"),
+      "execution plan",
+    ),
     {
-      name: newest.name,
-      payload: readArtifact(join(root, newest.name, filename), newest.name),
+      parentRunId: requiredString(process.env.GITHUB_RUN_ID, "parent run ID"),
+      releaseProfile: requiredString(process.env.RELEASE_PROFILE, "release profile"),
+      rerunGroup: requiredString(process.env.RERUN_GROUP, "rerun group"),
+      targetSha: requiredString(process.env.TARGET_SHA, "target SHA"),
+      workflowRef: requiredString(process.env.GITHUB_REF_NAME, "workflow ref"),
+      workflowSha: requiredString(process.env.GITHUB_SHA, "workflow SHA"),
     },
-  ];
+  );
+  const rawManifest = readArtifact(manifestPath, "release validation manifest");
+  const { validateParentManifest } = await import("./release-ci-summary.mjs");
+  const manifest = validateParentManifest(rawManifest, {
+    runAttempt: positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt"),
+    runId: executionPlan.parentRunId,
+    workflowRef: executionPlan.workflowRef,
+    workflowSha: executionPlan.workflowSha,
+  });
+  if (
+    manifest.targetSha !== executionPlan.targetSha ||
+    manifest.releaseProfile !== executionPlan.releaseProfile ||
+    manifest.rerunGroup !== executionPlan.rerunGroup ||
+    rawManifest.executionPlanSha256 !== executionPlan.sha256 ||
+    Number(rawManifest.sourceParentRunAttempt) !== executionPlan.parentRunAttempt
+  ) {
+    throw new Error("release validation manifest differs from the immutable execution plan");
+  }
 }
 
 function selectMode() {
@@ -740,14 +831,14 @@ function selectMode() {
       requiredString(process.env.RELEASE_EXECUTION_PLAN_PATH, "execution plan path"),
       "execution plan",
     ),
-    readNewestStateCandidate(
+    readStateCandidates(
       requiredString(process.env.RELEASE_DECISION_ATTEMPTS_PATH, "decision attempts path"),
       "full-release-decision",
       expected.parentRunId,
       expected.maxParentRunAttempt,
       "full-release-decision.json",
     ),
-    readNewestStateCandidate(
+    readStateCandidates(
       requiredString(process.env.DIAGNOSTIC_DRAIN_ATTEMPTS_PATH, "drain attempts path"),
       "full-release-diagnostics",
       expected.parentRunId,
@@ -790,8 +881,14 @@ async function main() {
     selectMode();
     return;
   }
+  if (mode === "validate-manifest") {
+    await validateManifestMode();
+    return;
+  }
   if (!["decision", "drain"].includes(mode)) {
-    throw new Error("usage: full-release-validation-state.mjs <plan|decision|drain|select|verify>");
+    throw new Error(
+      "usage: full-release-validation-state.mjs <plan|decision|drain|select|validate-manifest|verify>",
+    );
   }
   await collectMode(mode);
 }

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { execFile } from "node:child_process";
-import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { appendFileSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -12,6 +12,8 @@ import {
   buildReleaseStateArtifact,
   classifyReleaseSnapshot,
   formatReleaseStateOutcome,
+  releasePlanGateFailures,
+  selectReleaseStateArtifacts,
   validateReleaseExecutionPlanArtifact,
   verifyReleaseStateArtifacts,
 } from "./full-release-validation-policy.mjs";
@@ -210,18 +212,6 @@ export function parsePlanInputs(value) {
   return parsed;
 }
 
-function localFailures(gates) {
-  return gates
-    .filter((gate) => gate.required && gate.result !== "success")
-    .map((gate) => ({
-      child: "<parent>",
-      conclusion: stringValue(gate.result, "missing"),
-      job: stringValue(gate.name, "parent gate"),
-      kind: "parent_gate_failure",
-      message: `${stringValue(gate.name, "parent gate")} did not succeed`,
-    }));
-}
-
 export function hydrateReusedPlan(plan, evidence) {
   const byRole = new Map((evidence.children ?? []).map((child) => [child.role, child]));
   return plan.map((child) => {
@@ -269,7 +259,11 @@ async function validateReuse(plan, planInputs, signal) {
       "--repo",
       requiredString(process.env.GITHUB_REPOSITORY, "GitHub repository"),
       "--trusted-workflow-ref",
-      "main",
+      requiredString(planInputs.trustedWorkflow?.ref, "trusted workflow ref"),
+      "--trusted-workflow-full-ref",
+      requiredString(planInputs.trustedWorkflow?.fullRef, "trusted workflow full ref"),
+      "--trusted-workflow-sha",
+      requiredString(planInputs.trustedWorkflow?.sha, "trusted workflow SHA"),
       "--verifier-source-sha",
       requiredString(planInputs.workflowSha, "workflow SHA"),
       "--verifier-source-file",
@@ -319,9 +313,13 @@ async function validateReuse(plan, planInputs, signal) {
   }
 }
 
-function writeResult(path, payload) {
+function writeArtifact(path, payload) {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function writeResult(path, payload) {
+  writeArtifact(path, payload);
   if (process.env.GITHUB_OUTPUT) {
     appendFileSync(process.env.GITHUB_OUTPUT, `state=${payload.state}\n`);
     for (const [key, child] of Object.entries(payload.children ?? {})) {
@@ -331,8 +329,7 @@ function writeResult(path, payload) {
 }
 
 function writeExecutionPlan(path, payload) {
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+  writeArtifact(path, payload);
   if (process.env.GITHUB_OUTPUT) {
     appendFileSync(process.env.GITHUB_OUTPUT, `sha256=${payload.sha256}\n`);
     appendFileSync(
@@ -390,11 +387,12 @@ function readArtifact(path, label) {
 
 function verifyMode() {
   const expected = {
-    parentRunAttempt: positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt"),
+    maxParentRunAttempt: positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt"),
     parentRunId: requiredString(process.env.GITHUB_RUN_ID, "parent run ID"),
     releaseProfile: requiredString(process.env.RELEASE_PROFILE, "release profile"),
     rerunGroup: requiredString(process.env.RERUN_GROUP, "rerun group"),
     targetSha: requiredString(process.env.TARGET_SHA, "target SHA"),
+    workflowRef: requiredString(process.env.GITHUB_REF_NAME, "workflow ref"),
     workflowSha: requiredString(process.env.GITHUB_SHA, "workflow SHA"),
   };
   const verified = verifyReleaseStateArtifacts(
@@ -417,6 +415,7 @@ function planExpected() {
     rerunGroup: requiredString(process.env.RERUN_GROUP, "rerun group"),
     targetSha: stringValue(process.env.TARGET_SHA),
     workflowSha: requiredString(process.env.GITHUB_SHA, "workflow SHA"),
+    workflowRef: requiredString(process.env.GITHUB_REF_NAME, "workflow ref"),
   };
 }
 
@@ -429,7 +428,12 @@ function evidenceReuseFromInputs(planInputs) {
     rootRunId: stringValue(planInputs.evidenceRootRunId),
     runUrl: stringValue(planInputs.evidenceRunUrl),
     selectedRunId: stringValue(planInputs.evidenceRunId),
+    sourceManifest: planInputs.evidenceManifest,
   };
+}
+
+function trustedWorkflowFromInputs(planInputs) {
+  return planInputs.trustedWorkflow;
 }
 
 async function planMode() {
@@ -463,6 +467,7 @@ async function planMode() {
     gates: built.gates,
     releaseProfile: expected.releaseProfile,
     rerunGroup: expected.rerunGroup,
+    trustedWorkflow: trustedWorkflowFromInputs(planInputs),
   });
   const stop = () => {
     if (finished) {
@@ -485,6 +490,7 @@ async function planMode() {
       gates: plan.gates,
       releaseProfile: expected.releaseProfile,
       rerunGroup: expected.rerunGroup,
+      trustedWorkflow: plan.trustedWorkflow,
     });
     writeExecutionPlan(outputPath, plan);
     finished = true;
@@ -506,6 +512,7 @@ async function planMode() {
     gates: built.gates,
     releaseProfile: expected.releaseProfile,
     rerunGroup: expected.rerunGroup,
+    trustedWorkflow: trustedWorkflowFromInputs(planInputs),
   });
   writeExecutionPlan(outputPath, plan);
   finished = true;
@@ -539,7 +546,7 @@ async function collectMode(mode) {
     },
   );
   const plan = executionPlan.children;
-  const gateFailures = localFailures(executionPlan.gates);
+  const gateFailures = releasePlanGateFailures(executionPlan.gates);
   const failFast = mode === "decision" && process.env.FAIL_FAST === "true";
   const pollIntervalMs =
     Number(process.env.FULL_RELEASE_POLL_INTERVAL_MS) || DEFAULT_POLL_INTERVAL_MS;
@@ -610,6 +617,7 @@ async function collectMode(mode) {
         evidenceRootRunId: executionPlan.evidenceReuse.rootRunId,
         evidenceRunUrl: executionPlan.evidenceReuse.runUrl,
         evidenceSha: executionPlan.evidenceReuse.evidenceSha,
+        trustedWorkflow: executionPlan.trustedWorkflow,
         workflowSha: executionPlan.workflowSha,
       },
       abortController.signal,
@@ -692,6 +700,82 @@ async function collectMode(mode) {
   }
 }
 
+function readNewestStateCandidate(root, prefix, runId, maxParentRunAttempt, filename) {
+  const pattern = new RegExp(`^${prefix}-${runId}-([1-9][0-9]*)$`, "u");
+  const newest = readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const match = pattern.exec(entry.name);
+      return match ? { attempt: Number(match[1]), name: entry.name } : undefined;
+    })
+    .filter(Boolean)
+    .filter((entry) => entry.attempt <= maxParentRunAttempt)
+    .toSorted((left, right) => right.attempt - left.attempt)[0];
+  if (!newest) {
+    return [];
+  }
+  return [
+    {
+      name: newest.name,
+      payload: readArtifact(join(root, newest.name, filename), newest.name),
+    },
+  ];
+}
+
+function selectMode() {
+  const expected = {
+    maxParentRunAttempt: positiveInteger(
+      process.env.GITHUB_RUN_ATTEMPT,
+      "current parent run attempt",
+    ),
+    parentRunId: requiredString(process.env.GITHUB_RUN_ID, "parent run ID"),
+    releaseProfile: requiredString(process.env.RELEASE_PROFILE, "release profile"),
+    rerunGroup: requiredString(process.env.RERUN_GROUP, "rerun group"),
+    targetSha: requiredString(process.env.TARGET_SHA, "target SHA"),
+    workflowRef: requiredString(process.env.GITHUB_REF_NAME, "workflow ref"),
+    workflowSha: requiredString(process.env.GITHUB_SHA, "workflow SHA"),
+  };
+  const selected = selectReleaseStateArtifacts(
+    readArtifact(
+      requiredString(process.env.RELEASE_EXECUTION_PLAN_PATH, "execution plan path"),
+      "execution plan",
+    ),
+    readNewestStateCandidate(
+      requiredString(process.env.RELEASE_DECISION_ATTEMPTS_PATH, "decision attempts path"),
+      "full-release-decision",
+      expected.parentRunId,
+      expected.maxParentRunAttempt,
+      "full-release-decision.json",
+    ),
+    readNewestStateCandidate(
+      requiredString(process.env.DIAGNOSTIC_DRAIN_ATTEMPTS_PATH, "drain attempts path"),
+      "full-release-diagnostics",
+      expected.parentRunId,
+      expected.maxParentRunAttempt,
+      "full-release-diagnostic-manifest.json",
+    ),
+    expected,
+  );
+  writeArtifact(
+    requiredString(process.env.RELEASE_DECISION_PATH, "selected decision path"),
+    selected.decision,
+  );
+  writeArtifact(
+    requiredString(process.env.DIAGNOSTIC_DRAIN_PATH, "selected drain path"),
+    selected.drain,
+  );
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `decision_source_attempt=${selected.sourceAttempts.decision}\n`,
+    );
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `drain_source_attempt=${selected.sourceAttempts.drain}\n`,
+    );
+  }
+}
+
 async function main() {
   const mode = process.argv[2];
   if (mode === "plan") {
@@ -702,8 +786,12 @@ async function main() {
     verifyMode();
     return;
   }
+  if (mode === "select") {
+    selectMode();
+    return;
+  }
   if (!["decision", "drain"].includes(mode)) {
-    throw new Error("usage: full-release-validation-state.mjs <plan|decision|drain|verify>");
+    throw new Error("usage: full-release-validation-state.mjs <plan|decision|drain|select|verify>");
   }
   await collectMode(mode);
 }

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -19,7 +19,9 @@ import {
 export * from "./full-release-validation-policy.mjs";
 
 const execFileAsync = promisify(execFile);
-const RELEASE_SUMMARY_PATH = fileURLToPath(new URL("./release-ci-summary.mjs", import.meta.url));
+const RELEASE_SUMMARY_PATH =
+  process.env.OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR ??
+  fileURLToPath(new URL("./release-ci-summary.mjs", import.meta.url));
 const TRANSIENT_GH_PATTERN =
   /HTTP 5[0-9][0-9]|Server Error|secondary rate limit|API rate limit|HTTP 429|abuse detection|error connecting to|context deadline exceeded|connection reset by peer|connection refused|TLS handshake timeout|i\/o timeout|network is unreachable|unexpected EOF|ETIMEDOUT|ECONNRESET|EAI_AGAIN/u;
 const API_ERROR_PATTERN =
@@ -263,7 +265,7 @@ async function validateReuse(plan, planInputs, signal) {
     const args = [
       RELEASE_SUMMARY_PATH,
       "--validate-run",
-      requiredString(planInputs.evidenceRootRunId, "evidence root run ID"),
+      requiredString(planInputs.evidenceRunId, "evidence selected run ID"),
       "--repo",
       requiredString(process.env.GITHUB_REPOSITORY, "GitHub repository"),
       "--trusted-workflow-ref",
@@ -278,6 +280,10 @@ async function validateReuse(plan, planInputs, signal) {
       requiredString(planInputs.evidencePolicy, "evidence policy"),
       "--expected-evidence-sha",
       requiredString(planInputs.evidenceSha, "evidence SHA"),
+      "--expected-root-run-id",
+      requiredString(planInputs.evidenceRootRunId, "evidence root run ID"),
+      "--expected-selected-run-id",
+      requiredString(planInputs.evidenceRunId, "evidence selected run ID"),
       "--expected-changed-paths-json",
       JSON.stringify(changedPathsValue(planInputs.evidenceChangedPaths)),
       "--json",
@@ -304,7 +310,7 @@ async function validateReuse(plan, planInputs, signal) {
       child: "<evidence>",
       kind: API_ERROR_PATTERN.test(message) ? "api_error" : "reused_evidence_invalid",
       message,
-      runId: stringValue(planInputs.evidenceRootRunId),
+      runId: stringValue(planInputs.evidenceRunId),
       url: stringValue(planInputs.evidenceRunUrl),
     };
     return API_ERROR_PATTERN.test(message)
@@ -422,6 +428,7 @@ function evidenceReuseFromInputs(planInputs) {
     requested: planInputs.evidenceReuse === true || planInputs.evidenceReuse === "true",
     rootRunId: stringValue(planInputs.evidenceRootRunId),
     runUrl: stringValue(planInputs.evidenceRunUrl),
+    selectedRunId: stringValue(planInputs.evidenceRunId),
   };
 }
 
@@ -599,6 +606,7 @@ async function collectMode(mode) {
         evidenceChangedPaths: executionPlan.evidenceReuse.changedPaths,
         evidencePolicy: executionPlan.evidenceReuse.policy,
         evidenceReuse: true,
+        evidenceRunId: executionPlan.evidenceReuse.selectedRunId,
         evidenceRootRunId: executionPlan.evidenceReuse.rootRunId,
         evidenceRunUrl: executionPlan.evidenceReuse.runUrl,
         evidenceSha: executionPlan.evidenceReuse.evidenceSha,

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -802,10 +802,31 @@ async function validateManifestMode() {
     workflowRef: executionPlan.workflowRef,
     workflowSha: executionPlan.workflowSha,
   });
+  const expectedChildRunIds = Object.fromEntries(
+    ["normalCi", "npmTelegram", "pluginPrerelease", "productPerformance", "releaseChecks"].map(
+      (key) => {
+        const child = executionPlan.children.find((entry) => entry.key === key);
+        return [key, child?.selected ? stringValue(child.runId) : ""];
+      },
+    ),
+  );
+  const expectedEvidenceReuse = executionPlan.evidenceReuse.requested
+    ? {
+        changedPaths: executionPlan.evidenceReuse.changedPaths,
+        evidenceSha: executionPlan.evidenceReuse.evidenceSha,
+        policy: executionPlan.evidenceReuse.policy,
+        runId: executionPlan.evidenceReuse.rootRunId,
+        selectedRunId: executionPlan.evidenceReuse.selectedRunId,
+      }
+    : undefined;
   if (
     manifest.targetSha !== executionPlan.targetSha ||
     manifest.releaseProfile !== executionPlan.releaseProfile ||
     manifest.rerunGroup !== executionPlan.rerunGroup ||
+    JSON.stringify(canonicalJson(manifest.childRunIds)) !==
+      JSON.stringify(canonicalJson(expectedChildRunIds)) ||
+    JSON.stringify(canonicalJson(manifest.evidenceReuse)) !==
+      JSON.stringify(canonicalJson(expectedEvidenceReuse)) ||
     rawManifest.executionPlanSha256 !== executionPlan.sha256 ||
     Number(rawManifest.sourceParentRunAttempt) !== executionPlan.parentRunAttempt
   ) {

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -11,6 +11,7 @@ import { dirname, join, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import {
+  classifyReleaseGhTransportError,
   formatReleaseStateOutcome,
   terminalPolicyPass,
   validateReleaseExecutionPlanArtifact,
@@ -187,7 +188,9 @@ function tryDownloadExecutionPlan(runId, repository = DEFAULT_REPO) {
       ) {
         return undefined;
       }
-      throw new Error(`release execution plan artifact read failed: ${message}`);
+      throw new Error(`release execution plan artifact read failed: ${message}`, {
+        cause: error,
+      });
     }
     const path = join(downloadDir, "full-release-execution-plan.json");
     if (!statSync(path, { throwIfNoEntry: false })) {
@@ -1365,6 +1368,7 @@ export function validateTrustedProducerIdentity(
         `protected tooling tag is unavailable: ${
           error instanceof Error ? error.message : String(error)
         }`,
+        { cause: error },
       );
     }
     if (liveTag?.object?.sha !== trustedIdentity.sha) {
@@ -1751,12 +1755,11 @@ export function validateReleaseRunEvidence(
         ) {
           throw new Error(`execution plan omits required child: ${child.name}`);
         }
-        return {
-          ...child,
+        return Object.assign({}, child, {
           displayTitle: plannedChild.displayTitle,
           headBranch: plannedChild.workflowRef,
           plannedChild,
-        };
+        });
       })
     : expectedSelectedChildDispatches(
         rootEvidence.manifest.runId,
@@ -1969,12 +1972,17 @@ function terminalParentJobFailures(parent) {
     .map((job) => String(job.name || "unnamed parent job"));
 }
 
-function tryReadReleaseDecisionArtifact(parent, runId, repository) {
+export function tryReadReleaseDecisionArtifact(
+  parent,
+  runId,
+  repository,
+  runReleaseCiGhImpl = runReleaseCiGh,
+) {
   const artifactName = `full-release-decision-${runId}-${parent.attempt}`;
   const downloadDir = mkdtempSync(join(tmpdir(), "openclaw-release-decision-watch-"));
   try {
     try {
-      runReleaseCiGh(
+      runReleaseCiGhImpl(
         [
           "run",
           "download",
@@ -1997,7 +2005,11 @@ function tryReadReleaseDecisionArtifact(parent, runId, repository) {
       ) {
         return undefined;
       }
-      throw new Error(`release decision artifact read failed: ${message}`);
+      if (classifyReleaseGhTransportError(error) === "transient") {
+        console.warn(`release decision artifact unavailable this poll; retrying: ${message}`);
+        return undefined;
+      }
+      throw new Error(`release decision artifact read failed: ${message}`, { cause: error });
     }
     const path = join(downloadDir, "full-release-decision.json");
     if (!statSync(path, { throwIfNoEntry: false })) {

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -686,23 +686,79 @@ export function validateEvidenceReuseChain(
 
 export function validateRequestedEvidenceReuse(
   currentManifest,
+  selectedManifest,
   rootManifest,
-  { expectedChangedPaths, expectedEvidencePolicy, expectedEvidenceSha, expectedTargetSha },
+  {
+    expectedChangedPaths,
+    expectedEvidencePolicy,
+    expectedEvidenceSha,
+    expectedRootRunId,
+    expectedSelectedRunId,
+    expectedTargetSha,
+  },
+  compareCommits,
 ) {
+  if (
+    !Array.isArray(expectedChangedPaths) ||
+    expectedChangedPaths.some(
+      (changedPath) => typeof changedPath !== "string" || changedPath.length === 0,
+    ) ||
+    new Set(expectedChangedPaths).size !== expectedChangedPaths.length
+  ) {
+    throw new Error("expected evidence changed paths are invalid");
+  }
+  const requested = {
+    changedPaths: expectedChangedPaths,
+    evidenceSha: normalizeSha(expectedEvidenceSha, "expected evidence SHA"),
+    policy: String(expectedEvidencePolicy ?? ""),
+    runId: normalizeRequiredRunId(expectedRootRunId, "expected evidence root run ID"),
+    selectedRunId: normalizeRequiredRunId(
+      expectedSelectedRunId,
+      "expected evidence selected run ID",
+    ),
+  };
+  const expectedTarget = normalizeSha(expectedTargetSha, "expected target SHA");
   const reuse = currentManifest.evidenceReuse;
   if (!reuse) {
-    throw new Error("requested release validation does not contain evidence reuse");
+    if (
+      currentManifest.runId !== requested.selectedRunId ||
+      selectedManifest.runId !== requested.selectedRunId ||
+      rootManifest.runId !== requested.runId
+    ) {
+      throw new Error("reused release evidence no longer matches the requested validation");
+    }
+    validateEvidenceReuseChain(
+      { ...currentManifest, evidenceReuse: requested, targetSha: expectedTarget },
+      selectedManifest,
+      rootManifest,
+      compareCommits,
+    );
+    return;
   }
-  const changedPaths = Array.isArray(expectedChangedPaths) ? expectedChangedPaths : [];
   if (
-    currentManifest.targetSha !== normalizeSha(expectedTargetSha, "expected target SHA") ||
-    rootManifest.targetSha !== normalizeSha(expectedEvidenceSha, "expected evidence SHA") ||
-    reuse.evidenceSha !== expectedEvidenceSha ||
-    reuse.policy !== expectedEvidencePolicy ||
-    JSON.stringify(reuse.changedPaths) !== JSON.stringify(changedPaths)
+    currentManifest.targetSha !== expectedTarget ||
+    selectedManifest.runId !== requested.selectedRunId ||
+    rootManifest.runId !== requested.runId ||
+    rootManifest.targetSha !== requested.evidenceSha ||
+    reuse.evidenceSha !== requested.evidenceSha ||
+    reuse.policy !== requested.policy ||
+    reuse.runId !== requested.runId ||
+    reuse.selectedRunId !== requested.selectedRunId ||
+    JSON.stringify(reuse.changedPaths) !== JSON.stringify(requested.changedPaths)
   ) {
     throw new Error("reused release evidence no longer matches the requested validation");
   }
+}
+
+function hasRequestedEvidenceReuse(options) {
+  return [
+    options.expectedTargetSha,
+    options.expectedEvidencePolicy,
+    options.expectedEvidenceSha,
+    options.expectedChangedPaths,
+    options.expectedRootRunId,
+    options.expectedSelectedRunId,
+  ].some((value) => value !== undefined);
 }
 
 export function selectedChildKeys(parentJobs) {
@@ -1529,6 +1585,8 @@ function validateStrictChildRun({
  *   expectedChangedPaths?: string[],
  *   expectedEvidencePolicy?: string,
  *   expectedEvidenceSha?: string,
+ *   expectedRootRunId?: string,
+ *   expectedSelectedRunId?: string,
  *   expectedTargetSha?: string,
  *   trustedWorkflowFullRef?: string,
  *   trustedWorkflowRef?: string,
@@ -1545,6 +1603,8 @@ export function validateReleaseRunEvidence(
     expectedChangedPaths,
     expectedEvidencePolicy,
     expectedEvidenceSha,
+    expectedRootRunId,
+    expectedSelectedRunId,
     expectedTargetSha,
     trustedWorkflowFullRef,
     trustedWorkflowRef = "main",
@@ -1573,6 +1633,14 @@ export function validateReleaseRunEvidence(
     repository: normalizedRepository,
     runId: normalizedRunId,
   });
+  const requestedReuse = {
+    expectedChangedPaths,
+    expectedEvidencePolicy,
+    expectedEvidenceSha,
+    expectedRootRunId,
+    expectedSelectedRunId,
+    expectedTargetSha,
+  };
   const producerIdentities = new Map([
     [
       currentEvidence.manifest.runId,
@@ -1610,26 +1678,15 @@ export function validateReleaseRunEvidence(
       rootEvidence.manifest,
       (base, head) => evidenceClient.compareCommits(base, head),
     );
-    if (
-      expectedTargetSha !== undefined ||
-      expectedEvidencePolicy !== undefined ||
-      expectedEvidenceSha !== undefined ||
-      expectedChangedPaths !== undefined
-    ) {
-      validateRequestedEvidenceReuse(currentEvidence.manifest, rootEvidence.manifest, {
-        expectedChangedPaths,
-        expectedEvidencePolicy,
-        expectedEvidenceSha,
-        expectedTargetSha,
-      });
-    }
-  } else if (
-    expectedTargetSha !== undefined ||
-    expectedEvidencePolicy !== undefined ||
-    expectedEvidenceSha !== undefined ||
-    expectedChangedPaths !== undefined
-  ) {
-    throw new Error("requested release validation does not contain evidence reuse");
+  }
+  if (hasRequestedEvidenceReuse(requestedReuse)) {
+    validateRequestedEvidenceReuse(
+      currentEvidence.manifest,
+      selectedEvidence.manifest,
+      rootEvidence.manifest,
+      requestedReuse,
+      (base, head) => evidenceClient.compareCommits(base, head),
+    );
   }
 
   for (const evidence of [currentEvidence, selectedEvidence, rootEvidence]) {
@@ -1768,6 +1825,8 @@ function parseReleaseCiSummaryArgs(argv) {
     expectedChangedPaths: undefined,
     expectedEvidencePolicy: undefined,
     expectedEvidenceSha: undefined,
+    expectedRootRunId: undefined,
+    expectedSelectedRunId: undefined,
     expectedTargetSha: undefined,
     json: false,
     manifestPath: undefined,
@@ -1806,6 +1865,10 @@ function parseReleaseCiSummaryArgs(argv) {
       options.expectedEvidencePolicy = argv[++index];
     } else if (argument === "--expected-evidence-sha") {
       options.expectedEvidenceSha = argv[++index];
+    } else if (argument === "--expected-root-run-id") {
+      options.expectedRootRunId = argv[++index];
+    } else if (argument === "--expected-selected-run-id") {
+      options.expectedSelectedRunId = argv[++index];
     } else if (argument === "--expected-changed-paths-json") {
       const value = argv[++index];
       try {
@@ -1855,7 +1918,7 @@ function printUsage() {
     [
       "usage: release-ci-summary.mjs <full-release-run-id>",
       "       release-ci-summary.mjs <full-release-run-id> --watch [--interval seconds]",
-      "       release-ci-summary.mjs --validate-run <id> [--repo owner/name] [--trusted-workflow-ref main --trusted-workflow-full-ref refs/heads/main] [--trusted-workflow-sha sha] [--manifest path] [--verifier-source-sha sha --verifier-source-file path] --json",
+      "       release-ci-summary.mjs --validate-run <id> [--repo owner/name] [--trusted-workflow-ref main --trusted-workflow-full-ref refs/heads/main] [--trusted-workflow-sha sha] [--manifest path] [--verifier-source-sha sha --verifier-source-file path] [--expected-target-sha sha --expected-evidence-sha sha --expected-evidence-policy policy --expected-root-run-id id --expected-selected-run-id id --expected-changed-paths-json json] --json",
     ].join("\n"),
   );
 }
@@ -2030,6 +2093,8 @@ async function main() {
         expectedChangedPaths: options.expectedChangedPaths,
         expectedEvidencePolicy: options.expectedEvidencePolicy,
         expectedEvidenceSha: options.expectedEvidenceSha,
+        expectedRootRunId: options.expectedRootRunId,
+        expectedSelectedRunId: options.expectedSelectedRunId,
         expectedTargetSha: options.expectedTargetSha,
         manifestPath: options.manifestPath,
         repository,

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -1253,6 +1253,14 @@ export function createReleaseEvidenceClient(repository = DEFAULT_REPO) {
     getParentJobs(runId) {
       return findParentJobsAll(runId, normalizedRepository);
     },
+    getRef(fullRef) {
+      const refPath = String(fullRef)
+        .replace(/^refs\//u, "")
+        .split("/")
+        .map(encodeURIComponent)
+        .join("/");
+      return githubRestJson(`git/ref/${refPath}`, normalizedRepository);
+    },
     getRun(runId) {
       return githubRestJson(`actions/runs/${runId}`, normalizedRepository);
     },
@@ -1349,6 +1357,19 @@ export function validateTrustedProducerIdentity(
   const shaPinned = SHA_PINNED_BRANCH_PATTERN.test(manifest.workflowRef ?? "");
   const protectedTagRoute = trustedIdentity.type === "tag";
   if (protectedTagRoute) {
+    let liveTag;
+    try {
+      liveTag = client.getRef(trustedIdentity.fullRef);
+    } catch (error) {
+      throw new Error(
+        `protected tooling tag is unavailable: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    if (liveTag?.object?.sha !== trustedIdentity.sha) {
+      throw new Error("protected tooling tag moved after release validation was sealed");
+    }
     if (!shaPinned) {
       throw new Error("protected-tag release evidence must use a canonical release-ci branch");
     }

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -10,6 +10,12 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import {
+  formatReleaseStateOutcome,
+  terminalPolicyPass,
+  validateReleaseExecutionPlanArtifact,
+  validateReleaseStateArtifact,
+} from "./full-release-validation-policy.mjs";
 import { execGhRead, plainGhEnv, resolvePlainGhBin } from "./lib/plain-gh.mjs";
 
 const DEFAULT_REPO = process.env.OPENCLAW_RELEASE_REPO || "openclaw/openclaw";
@@ -24,6 +30,8 @@ const MANIFEST_ARTIFACT_ENTRY = "full-release-validation-manifest.json";
 const MAX_MANIFEST_ARTIFACT_ZIP_BYTES = 256 * 1024;
 const MAX_MANIFEST_JSON_BYTES = 128 * 1024;
 const MAX_MANIFEST_ENTRY_LIST_BYTES = 8 * 1024;
+const MAX_RELEASE_STATE_BYTES = 128 * 1024;
+const MAX_EXECUTION_PLAN_BYTES = 128 * 1024;
 // Release evidence lookups run during full release validation, so keep enough
 // headroom for GitHub latency while preventing one stalled read from consuming
 // the workflow budget.
@@ -148,6 +156,49 @@ function downloadArtifactZip(artifactId, destination, repository = DEFAULT_REPO)
     });
   } finally {
     closeSync(output);
+  }
+}
+
+function tryDownloadExecutionPlan(runId, repository = DEFAULT_REPO) {
+  const artifactName = `full-release-execution-plan-${runId}`;
+  const downloadDir = mkdtempSync(join(tmpdir(), "openclaw-release-execution-plan-"));
+  try {
+    try {
+      runReleaseCiGh(
+        [
+          "run",
+          "download",
+          String(runId),
+          "--repo",
+          repository,
+          "--name",
+          artifactName,
+          "--dir",
+          downloadDir,
+        ],
+        { stdio: ["ignore", "ignore", "pipe"] },
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        /no valid artifacts found|artifact .* not found|could not find any artifacts/iu.test(
+          message,
+        )
+      ) {
+        return undefined;
+      }
+      throw new Error(`release execution plan artifact read failed: ${message}`);
+    }
+    const path = join(downloadDir, "full-release-execution-plan.json");
+    if (!statSync(path, { throwIfNoEntry: false })) {
+      throw new Error(`release execution plan artifact ${artifactName} omitted its manifest`);
+    }
+    if (statSync(path).size > MAX_EXECUTION_PLAN_BYTES) {
+      throw new Error(`release execution plan artifact ${artifactName} exceeds the size limit`);
+    }
+    return JSON.parse(readFileSync(path, "utf8"));
+  } finally {
+    rmSync(downloadDir, { force: true, recursive: true });
   }
 }
 
@@ -633,6 +684,27 @@ export function validateEvidenceReuseChain(
   return rootManifest.targetSha;
 }
 
+export function validateRequestedEvidenceReuse(
+  currentManifest,
+  rootManifest,
+  { expectedChangedPaths, expectedEvidencePolicy, expectedEvidenceSha, expectedTargetSha },
+) {
+  const reuse = currentManifest.evidenceReuse;
+  if (!reuse) {
+    throw new Error("requested release validation does not contain evidence reuse");
+  }
+  const changedPaths = Array.isArray(expectedChangedPaths) ? expectedChangedPaths : [];
+  if (
+    currentManifest.targetSha !== normalizeSha(expectedTargetSha, "expected target SHA") ||
+    rootManifest.targetSha !== normalizeSha(expectedEvidenceSha, "expected evidence SHA") ||
+    reuse.evidenceSha !== expectedEvidenceSha ||
+    reuse.policy !== expectedEvidencePolicy ||
+    JSON.stringify(reuse.changedPaths) !== JSON.stringify(changedPaths)
+  ) {
+    throw new Error("reused release evidence no longer matches the requested validation");
+  }
+}
+
 export function selectedChildKeys(parentJobs) {
   return new Set(
     CHILD_DISPATCHES.filter((child) => {
@@ -772,13 +844,23 @@ export function selectManifestParentJob(parentJobs, child, parentManifest, origi
   return currentJob;
 }
 
-function childRunIdsFromParentLog(log, repository = DEFAULT_REPO) {
+function childRunEvidenceFromParentLog(log, repository = DEFAULT_REPO) {
   const escapedRepo = repository.replaceAll(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  const pattern = new RegExp(
+  const exactPattern = new RegExp(
+    `https://github\\.com/${escapedRepo}/actions/runs/([1-9][0-9]*) \\(attempt ([1-9][0-9]*)\\)`,
+    "gu",
+  );
+  const urlPattern = new RegExp(
     `https://github\\.com/${escapedRepo}/actions/runs/([1-9][0-9]*)`,
     "gu",
   );
-  return new Set(Array.from(log.matchAll(pattern), (match) => match[1]));
+  return {
+    exact: Array.from(log.matchAll(exactPattern), (match) => ({
+      runAttempt: Number(match[2]),
+      runId: match[1],
+    })),
+    runIds: [...new Set(Array.from(log.matchAll(urlPattern), (match) => match[1]))],
+  };
 }
 
 export function validateManifestChildRun(
@@ -812,9 +894,19 @@ export function validateManifestChildRun(
     throw new Error(`manifest child workflow mismatch: ${child.name}`);
   }
   selectManifestParentJob(parentJobs, child, parentManifest, originAttempt);
-  const emittedChildRunIds = childRunIdsFromParentLog(selectedParentJobLog, repository);
-  if (emittedChildRunIds.size !== 1 || !emittedChildRunIds.has(String(runId))) {
-    throw new Error(`manifest child run is not uniquely emitted by its parent job: ${child.name}`);
+  const emitted = childRunEvidenceFromParentLog(selectedParentJobLog, repository);
+  const exactBound =
+    emitted.exact.length === 1 &&
+    emitted.exact[0].runId === String(runId) &&
+    emitted.exact[0].runAttempt === Number(run.run_attempt);
+  const historicalUrlBound =
+    emitted.exact.length === 0 &&
+    emitted.runIds.length === 1 &&
+    emitted.runIds[0] === String(runId);
+  if (!exactBound && !historicalUrlBound) {
+    throw new Error(
+      `manifest child run and attempt are not uniquely emitted by its parent job: ${child.name}`,
+    );
   }
   if (
     child.manifestKey !== "npmTelegram" &&
@@ -1122,6 +1214,9 @@ export function createReleaseEvidenceClient(repository = DEFAULT_REPO) {
     loadManifest(runId, runAttempt, manifestPath) {
       return downloadParentManifestEvidence(runId, runAttempt, normalizedRepository, manifestPath);
     },
+    loadExecutionPlan(runId) {
+      return tryDownloadExecutionPlan(runId, normalizedRepository);
+    },
   };
 }
 
@@ -1335,8 +1430,28 @@ export function resolveVerifierIdentity(
   };
 }
 
-function validateStrictChildRun({ child, client, parentEvidence, parentJobs, repository, runId }) {
+function validateStrictChildRun({
+  child,
+  client,
+  parentEvidence,
+  parentJobs,
+  plannedChild,
+  releaseProfile,
+  repository,
+  runId,
+}) {
   const run = client.getRun(runId);
+  if (
+    plannedChild &&
+    (String(run.id) !== plannedChild.runId ||
+      Number(run.run_attempt) !== plannedChild.runAttempt ||
+      run.display_title !== plannedChild.displayTitle ||
+      run.head_branch !== plannedChild.workflowRef ||
+      run.head_sha !== plannedChild.workflowSha ||
+      workflowPath(run) !== `.github/workflows/${plannedChild.workflow}`)
+  ) {
+    throw new Error(`execution plan child dispatch tuple mismatch: ${child.name}`);
+  }
   const originAttempt = resolveManifestChildOriginAttempt(
     run,
     child,
@@ -1361,16 +1476,28 @@ function validateStrictChildRun({ child, client, parentEvidence, parentJobs, rep
     client.getJobLog(parentJob.id),
     repository,
   );
+  const jobs =
+    run.conclusion === "success" && child.manifestKey !== "productPerformance"
+      ? []
+      : client.getParentJobs(runId);
   if (
     run.repository?.full_name !== repository ||
-    run.status !== "completed" ||
-    run.conclusion !== "success" ||
-    run.head_sha !== parentEvidence.manifest.workflowSha
+    run.head_sha !== parentEvidence.manifest.workflowSha ||
+    !terminalPolicyPass(
+      {
+        conclusion: run.conclusion,
+        jobs,
+        key: child.manifestKey,
+        status: run.status,
+      },
+      releaseProfile,
+      parentEvidence.manifest.workflowRef,
+    )
   ) {
-    throw new Error(`manifest child run is not exact completed/success evidence: ${child.name}`);
+    throw new Error(`manifest child run does not pass release policy: ${child.name}`);
   }
   if (child.manifestKey === "productPerformance") {
-    validatePerformanceArtifactOnlyJobs(client.getParentJobs(runId), run.run_attempt);
+    validatePerformanceArtifactOnlyJobs(jobs, run.run_attempt);
   }
 
   return {
@@ -1381,6 +1508,7 @@ function validateStrictChildRun({ child, client, parentEvidence, parentJobs, rep
     headBranch: run.head_branch,
     parentJobId: String(parentJob.id),
     path: workflowPath(run),
+    policyPassed: true,
     role: child.manifestKey,
     runAttempt: normalizePositiveInteger(run.run_attempt, `${child.name} run attempt`),
     runId: String(run.id),
@@ -1398,6 +1526,10 @@ function validateStrictChildRun({ child, client, parentEvidence, parentJobs, rep
  *   manifestPath?: string,
  *   repository?: string,
  *   runId: string,
+ *   expectedChangedPaths?: string[],
+ *   expectedEvidencePolicy?: string,
+ *   expectedEvidenceSha?: string,
+ *   expectedTargetSha?: string,
  *   trustedWorkflowFullRef?: string,
  *   trustedWorkflowRef?: string,
  *   trustedWorkflowSha?: string,
@@ -1410,6 +1542,10 @@ export function validateReleaseRunEvidence(
     manifestPath,
     repository = DEFAULT_REPO,
     runId,
+    expectedChangedPaths,
+    expectedEvidencePolicy,
+    expectedEvidenceSha,
+    expectedTargetSha,
     trustedWorkflowFullRef,
     trustedWorkflowRef = "main",
     trustedWorkflowSha,
@@ -1474,6 +1610,26 @@ export function validateReleaseRunEvidence(
       rootEvidence.manifest,
       (base, head) => evidenceClient.compareCommits(base, head),
     );
+    if (
+      expectedTargetSha !== undefined ||
+      expectedEvidencePolicy !== undefined ||
+      expectedEvidenceSha !== undefined ||
+      expectedChangedPaths !== undefined
+    ) {
+      validateRequestedEvidenceReuse(currentEvidence.manifest, rootEvidence.manifest, {
+        expectedChangedPaths,
+        expectedEvidencePolicy,
+        expectedEvidenceSha,
+        expectedTargetSha,
+      });
+    }
+  } else if (
+    expectedTargetSha !== undefined ||
+    expectedEvidencePolicy !== undefined ||
+    expectedEvidenceSha !== undefined ||
+    expectedChangedPaths !== undefined
+  ) {
+    throw new Error("requested release validation does not contain evidence reuse");
   }
 
   for (const evidence of [currentEvidence, selectedEvidence, rootEvidence]) {
@@ -1492,23 +1648,65 @@ export function validateReleaseRunEvidence(
     }
   }
   const selectedKeys = requiredChildKeysForManifest(rootEvidence.manifest);
-  const expectedChildren = expectedSelectedChildDispatches(
-    rootEvidence.manifest.runId,
-    rootEvidence.manifest.runAttempt,
-    rootEvidence.manifest.workflowRef,
-    selectedKeys,
+  const executionPlanPayload = evidenceClient.loadExecutionPlan?.(rootEvidence.manifest.runId);
+  const executionPlan = executionPlanPayload
+    ? validateReleaseExecutionPlanArtifact(executionPlanPayload, {
+        parentRunId: rootEvidence.manifest.runId,
+        releaseProfile: rootEvidence.manifest.releaseProfile,
+        rerunGroup: rootEvidence.manifest.rerunGroup,
+        targetSha: rootEvidence.manifest.targetSha,
+        workflowRef: rootEvidence.manifest.workflowRef,
+        workflowSha: rootEvidence.manifest.workflowSha,
+      })
+    : undefined;
+  const plannedByKey = new Map(
+    (executionPlan?.children ?? []).map((plannedChild) => [plannedChild.key, plannedChild]),
   );
+  const expectedChildren = executionPlan
+    ? CHILD_DISPATCHES.filter((child) => selectedKeys.has(child.manifestKey)).map((child) => {
+        const plannedChild = plannedByKey.get(child.manifestKey);
+        if (
+          !plannedChild?.selected ||
+          !plannedChild.required ||
+          !plannedChild.runId ||
+          !plannedChild.runAttempt
+        ) {
+          throw new Error(`execution plan omits required child: ${child.name}`);
+        }
+        return {
+          ...child,
+          displayTitle: plannedChild.displayTitle,
+          headBranch: plannedChild.workflowRef,
+          plannedChild,
+        };
+      })
+    : expectedSelectedChildDispatches(
+        rootEvidence.manifest.runId,
+        rootEvidence.manifest.runAttempt,
+        rootEvidence.manifest.workflowRef,
+        selectedKeys,
+      );
   const parentJobs = evidenceClient.getParentJobs(rootEvidence.manifest.runId);
-  const children = manifestChildEntries(rootEvidence.manifest, expectedChildren, selectedKeys).map(
-    ({ child, runId: childRunId }) =>
-      validateStrictChildRun({
-        child,
-        client: evidenceClient,
-        parentEvidence: rootEvidence,
-        parentJobs,
-        repository: normalizedRepository,
-        runId: childRunId,
-      }),
+  const childEntries = executionPlan
+    ? expectedChildren.map((child) => {
+        const manifestRunId = rootEvidence.manifest.childRunIds[child.manifestKey];
+        if (manifestRunId !== child.plannedChild.runId) {
+          throw new Error(`execution plan and manifest child identity differ: ${child.name}`);
+        }
+        return { child, runId: child.plannedChild.runId };
+      })
+    : manifestChildEntries(rootEvidence.manifest, expectedChildren, selectedKeys);
+  const children = childEntries.map(({ child, runId: childRunId }) =>
+    validateStrictChildRun({
+      child,
+      client: evidenceClient,
+      parentEvidence: rootEvidence,
+      parentJobs,
+      plannedChild: child.plannedChild,
+      releaseProfile: rootEvidence.manifest.releaseProfile,
+      repository: normalizedRepository,
+      runId: childRunId,
+    }),
   );
 
   const current = normalizedParentTuple(
@@ -1525,7 +1723,7 @@ export function validateReleaseRunEvidence(
   return canonicalJson({
     children,
     conclusions: {
-      allRequiredSucceeded: children.every((child) => child.conclusion === "success"),
+      allRequiredSucceeded: children.every((child) => child.policyPassed),
       children: childConclusions,
       current: current.conclusion,
       root: root.conclusion,
@@ -1540,6 +1738,12 @@ export function validateReleaseRunEvidence(
           policy: reuse.policy,
           rootRunId: reuse.runId,
           selectedRunId: reuse.selectedRunId,
+        }
+      : null,
+    executionPlan: executionPlan
+      ? {
+          parentRunAttempt: executionPlan.parentRunAttempt,
+          sha256: executionPlan.sha256,
         }
       : null,
     manifest: rootEvidence.manifestJson,
@@ -1561,6 +1765,10 @@ export function validateReleaseRunEvidence(
 function parseReleaseCiSummaryArgs(argv) {
   const options = {
     intervalMs: 30_000,
+    expectedChangedPaths: undefined,
+    expectedEvidencePolicy: undefined,
+    expectedEvidenceSha: undefined,
+    expectedTargetSha: undefined,
     json: false,
     manifestPath: undefined,
     repository: DEFAULT_REPO,
@@ -1592,6 +1800,25 @@ function parseReleaseCiSummaryArgs(argv) {
       options.verifierSourceSha = argv[++index];
     } else if (argument === "--verifier-source-file") {
       options.verifierSourceFile = argv[++index];
+    } else if (argument === "--expected-target-sha") {
+      options.expectedTargetSha = argv[++index];
+    } else if (argument === "--expected-evidence-policy") {
+      options.expectedEvidencePolicy = argv[++index];
+    } else if (argument === "--expected-evidence-sha") {
+      options.expectedEvidenceSha = argv[++index];
+    } else if (argument === "--expected-changed-paths-json") {
+      const value = argv[++index];
+      try {
+        options.expectedChangedPaths = JSON.parse(value);
+      } catch {
+        throw new Error("--expected-changed-paths-json requires a JSON array");
+      }
+      if (
+        !Array.isArray(options.expectedChangedPaths) ||
+        options.expectedChangedPaths.some((entry) => typeof entry !== "string")
+      ) {
+        throw new Error("--expected-changed-paths-json requires a JSON array");
+      }
     } else if (argument === "--json") {
       options.json = true;
     } else if (argument === "--watch") {
@@ -1658,6 +1885,72 @@ function terminalParentJobFailures(parent) {
     .map((job) => String(job.name || "unnamed parent job"));
 }
 
+function tryReadReleaseDecisionArtifact(parent, runId, repository) {
+  const artifactName = `full-release-decision-${runId}-${parent.attempt}`;
+  const downloadDir = mkdtempSync(join(tmpdir(), "openclaw-release-decision-watch-"));
+  try {
+    try {
+      runReleaseCiGh(
+        [
+          "run",
+          "download",
+          String(runId),
+          "--repo",
+          repository,
+          "--name",
+          artifactName,
+          "--dir",
+          downloadDir,
+        ],
+        { stdio: ["ignore", "ignore", "pipe"] },
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        /no valid artifacts found|artifact .* not found|could not find any artifacts/iu.test(
+          message,
+        )
+      ) {
+        return undefined;
+      }
+      throw new Error(`release decision artifact read failed: ${message}`);
+    }
+    const path = join(downloadDir, "full-release-decision.json");
+    if (!statSync(path, { throwIfNoEntry: false })) {
+      throw new Error(`release decision artifact ${artifactName} omitted its manifest`);
+    }
+    if (statSync(path).size > MAX_RELEASE_STATE_BYTES) {
+      throw new Error(`release decision artifact ${artifactName} exceeds the size limit`);
+    }
+    return validateReleaseStateArtifact(
+      JSON.parse(readFileSync(path, "utf8")),
+      {
+        parentRunAttempt: parent.attempt,
+        parentRunId: String(runId),
+        workflowSha: parent.headSha,
+      },
+      "decision",
+    );
+  } finally {
+    rmSync(downloadDir, { force: true, recursive: true });
+  }
+}
+
+function releaseDecisionBlockedDuringDrain(parent, runId, repository) {
+  const jobs = parent.jobs ?? [];
+  const decision = jobs.find((job) => job.name === "Release Decision");
+  const drain = jobs.find((job) => job.name === "Diagnostic Drain");
+  if (
+    decision?.status !== "completed" ||
+    SUCCESSFUL_PARENT_JOB_CONCLUSIONS.has(String(decision.conclusion ?? "")) ||
+    !drain ||
+    drain.status === "completed"
+  ) {
+    return undefined;
+  }
+  return tryReadReleaseDecisionArtifact(parent, runId, repository);
+}
+
 function summarizeReleaseCiRun(options) {
   execFileSync(
     process.execPath,
@@ -1683,12 +1976,22 @@ async function watchReleaseCiRun(options) {
       "--repo",
       options.repository,
       "--json",
-      "status,conclusion,attempt,jobs",
+      "status,conclusion,attempt,headSha,jobs",
     ]);
     const fingerprint = releaseCiWatchFingerprint(parent);
     if (fingerprint !== previousFingerprint) {
       summarizeReleaseCiRun(options);
       previousFingerprint = fingerprint;
+    }
+    const blockedDuringDrain = releaseDecisionBlockedDuringDrain(
+      parent,
+      options.runId,
+      options.repository,
+    );
+    if (blockedDuringDrain) {
+      throw new Error(
+        `full release run ${options.runId} stopped at Release Decision:\n${formatReleaseStateOutcome(blockedDuringDrain)}`,
+      );
     }
     const failedJobs = terminalParentJobFailures(parent);
     if (failedJobs.length > 0) {
@@ -1724,6 +2027,10 @@ async function main() {
   if (options.validate) {
     try {
       const evidence = validateReleaseRunEvidence({
+        expectedChangedPaths: options.expectedChangedPaths,
+        expectedEvidencePolicy: options.expectedEvidencePolicy,
+        expectedEvidenceSha: options.expectedEvidenceSha,
+        expectedTargetSha: options.expectedTargetSha,
         manifestPath: options.manifestPath,
         repository,
         runId,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6811,7 +6811,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     expect(localeStep.run).toBe("pnpm ui:i18n:check");
     expect(readFileSync(".github/workflows/full-release-validation.yml", "utf8")).toContain(
-      'dispatch_and_wait ci.yml "$dispatch_run_name"',
+      'dispatch_child ci.yml "$dispatch_run_name"',
     );
   });
 
@@ -7209,7 +7209,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     const compatibilityJob = workflow.jobs["checks-node-compat"];
     const fullReleaseWorkflow = readWorkflow(".github/workflows/full-release-validation.yml");
     const fullReleaseDispatch = fullReleaseWorkflow.jobs.normal_ci.steps.find(
-      (step: WorkflowStep) => step.name === "Dispatch and monitor CI",
+      (step: WorkflowStep) => step.name === "Dispatch CI",
     );
 
     expect(compatibilityJob.name).toBe("checks-node-compat-node22");
@@ -7217,7 +7217,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "needs.preflight.outputs.run_build_artifacts == 'true' && github.event_name == 'workflow_dispatch'",
     );
     expect(fullReleaseDispatch.env.CHILD_WORKFLOW_KIND).toBe("ci");
-    expect(fullReleaseDispatch.run).toContain('dispatch_and_wait ci.yml "$dispatch_run_name"');
+    expect(fullReleaseDispatch.run).toContain('dispatch_child ci.yml "$dispatch_run_name"');
     expect(fullReleaseDispatch.run).toContain('-f target_ref="$TARGET_SHA"');
   });
 
@@ -8543,7 +8543,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     const telegramWorkflow = readWorkflow(".github/workflows/openclaw-release-telegram-qa.yml");
     const telegramProvenanceHelper = readFileSync("scripts/release-telegram-provenance.sh", "utf8");
     const fullReleaseDispatchStep = fullReleaseWorkflow.jobs.release_checks.steps.find(
-      (step: WorkflowStep) => step.name === "Dispatch and monitor release checks",
+      (step: WorkflowStep) => step.name === "Dispatch release checks",
     );
     const dispatchStep = releaseWorkflow.jobs.qa_live_telegram_release_checks.steps.find(
       (step: WorkflowStep) => step.name === "Dispatch and await trusted Telegram QA",

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -2,7 +2,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 import {
   assertTrustedWorkflowHarness,
@@ -15,6 +15,7 @@ import {
   releaseEvidenceVerifierPath,
   resolveRemoteTargetRefSha,
   shouldDeleteTemporaryWorkflowRef,
+  tryReadReleaseDecision,
   validateReleaseDecisionPayload,
   verifyTargetRef,
   verifyTrustedWorkflowRef,
@@ -612,6 +613,35 @@ describe("full-release-validation-at-sha", () => {
         },
       ),
     ).toThrow("binding is invalid");
+  });
+
+  it("treats only transient Release Decision download failures as unavailable this poll", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        tryReadReleaseDecision("123", 1, "a".repeat(40), () => ({
+          error: undefined,
+          signal: null,
+          status: 1,
+          stderr: "HTTP 503: Server Error",
+          stdout: "",
+        })),
+      ).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Release Decision artifact unavailable this poll"),
+      );
+      expect(() =>
+        tryReadReleaseDecision("123", 1, "a".repeat(40), () => ({
+          error: undefined,
+          signal: null,
+          status: 1,
+          stderr: "HTTP 403: Bad credentials",
+          stdout: "",
+        })),
+      ).toThrow("Release Decision artifact download failed");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -10,10 +10,12 @@ import {
   FULL_RELEASE_WAIT_TIMEOUT_MINUTES,
   parseArgs,
   releaseProfileForTarget,
+  releaseDecisionStopsForeground,
   releaseEvidenceVerificationArgs,
   releaseEvidenceVerifierPath,
   resolveRemoteTargetRefSha,
   shouldDeleteTemporaryWorkflowRef,
+  validateReleaseDecisionPayload,
   verifyTargetRef,
   verifyTrustedWorkflowRef,
 } from "../../scripts/full-release-validation-at-sha.mts";
@@ -160,7 +162,10 @@ if (args[0] === "workflow" && args[1] === "run") {
   }
   console.log("https://github.com/openclaw/openclaw/actions/runs/123");
 } else if (args[0] === "api" && args.at(-1).endsWith("/actions/runs/123")) {
-  console.log(JSON.stringify({ status: "completed", conclusion: "success", head_sha: process.env.MOCK_WORKFLOW_SHA }));
+  console.log(JSON.stringify({ status: "completed", conclusion: "success", head_sha: process.env.MOCK_WORKFLOW_SHA, run_attempt: 1 }));
+} else if (args[0] === "run" && args[1] === "download") {
+  console.error("no valid artifacts found");
+  process.exit(1);
 } else {
   console.error("unexpected gh call: " + args.join(" "));
   process.exit(2);
@@ -560,10 +565,53 @@ describe("full-release-validation-at-sha", () => {
     expect(source).toContain("const remainingMs = deadline - Date.now();");
     expect(source).toContain("Math.min(FULL_RELEASE_WAIT_POLL_INTERVAL_MS, remainingMs)");
     expect(source).toContain("Parent run progress after ${elapsedMinutes}m");
+    expect(source).toContain("formatReleaseStateOutcome(releaseDecision)");
     expect(source).toContain(
       "Timed out after ${FULL_RELEASE_WAIT_TIMEOUT_MINUTES} minutes waiting for Full Release Validation",
     );
     expect(source).not.toContain("attempt < 480");
+  });
+
+  it("binds early release decisions to the exact parent attempt and tooling SHA", () => {
+    const payload = {
+      kind: "openclaw.full-release-decision",
+      mode: "decision",
+      parentRunAttempt: 2,
+      sourceParentRunAttempt: 1,
+      parentRunId: "123",
+      activeRunIds: ["101"],
+      blockers: [{ child: "normalCi", job: "test", runId: "101" }],
+      cancellation: { cancelledRunIds: [], requested: false },
+      children: {},
+      errors: [],
+      executionPlanSha256: "c".repeat(64),
+      releaseProfile: "stable",
+      rerunGroup: "ci",
+      state: "blocked_diagnostics_running",
+      targetSha: "b".repeat(40),
+      version: 2,
+      workflowRef: "main",
+      workflowSha: "a".repeat(40),
+    };
+    expect(
+      validateReleaseDecisionPayload(payload, {
+        parentRunAttempt: 2,
+        parentRunId: "123",
+        workflowSha: "a".repeat(40),
+      }),
+    ).toMatchObject(payload);
+    expect(releaseDecisionStopsForeground("blocked_diagnostics_running")).toBe(true);
+    expect(releaseDecisionStopsForeground("passed")).toBe(false);
+    expect(() =>
+      validateReleaseDecisionPayload(
+        { ...payload, parentRunAttempt: 3 },
+        {
+          parentRunAttempt: 2,
+          parentRunId: "123",
+          workflowSha: "a".repeat(40),
+        },
+      ),
+    ).toThrow("binding is invalid");
   });
 
   it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -13,6 +13,7 @@ import {
   validateChildBinding,
   verifyReleaseStateArtifacts,
 } from "../../scripts/full-release-validation-state.mjs";
+import { waitForChildClose, waitForFile } from "../helpers/process-wait.js";
 
 const SCRIPT = resolve("scripts/full-release-validation-state.mjs");
 const SHA = "a".repeat(40);
@@ -346,13 +347,15 @@ describe("collector subprocess", () => {
   it("writes the execution plan immediately when SIGTERM interrupts a stalled reuse API", async () => {
     const root = mkdtempSync(join(tmpdir(), "frv-plan-signal-"));
     const gh = join(root, "gh");
+    const ghReady = join(root, "gh-ready");
     const output = join(root, "full-release-execution-plan.json");
-    writeFileSync(gh, "#!/bin/sh\nsleep 30\n");
+    writeFileSync(gh, '#!/bin/sh\nprintf ready > "$FRV_GH_READY"\nsleep 30\n');
     chmodSync(gh, 0o755);
     const childProcess = spawn(process.execPath, [SCRIPT, "plan"], {
       env: {
         ...process.env,
         EVIDENCE_CHANGED_PATHS: "[]",
+        FRV_GH_READY: ghReady,
         FULL_RELEASE_EXECUTION_PLAN_PATH: output,
         FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify({
           children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
@@ -383,13 +386,11 @@ describe("collector subprocess", () => {
       },
       stdio: "ignore",
     });
-    await new Promise((resolveReady) => setTimeout(resolveReady, 200));
+    await waitForFile(ghReady, 5_000);
+    const exitPromise = waitForChildClose(childProcess);
     const started = Date.now();
     childProcess.kill("SIGTERM");
-    await new Promise<void>((resolveExit, reject) => {
-      childProcess.once("exit", () => resolveExit());
-      childProcess.once("error", reject);
-    });
+    await exitPromise;
     expect(Date.now() - started).toBeLessThan(2_000);
     expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
       errors: [expect.objectContaining({ kind: "collector_cancelled" })],
@@ -459,6 +460,7 @@ describe("collector subprocess", () => {
   it("writes an immediate terminal handoff with active identity on SIGTERM", async () => {
     const root = mkdtempSync(join(tmpdir(), "frv-state-signal-"));
     const gh = join(root, "gh");
+    const ghReady = join(root, "gh-ready");
     const output = join(root, "drain.json");
     const executionPlanPath = join(root, "full-release-execution-plan.json");
     writeFileSync(
@@ -476,6 +478,7 @@ describe("collector subprocess", () => {
     writeFileSync(
       gh,
       `#!/bin/sh
+printf ready > "$FRV_GH_READY"
 if [ "$1" = "api" ] && echo "$2" | grep -q '/jobs'; then
   exit 0
 fi
@@ -487,6 +490,7 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       env: {
         ...process.env,
         FAIL_FAST: "false",
+        FRV_GH_READY: ghReady,
         FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
         FULL_RELEASE_POLL_INTERVAL_MS: "60000",
         FULL_RELEASE_STATE_PATH: output,
@@ -502,12 +506,10 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       },
       stdio: "ignore",
     });
-    await new Promise((resolveReady) => setTimeout(resolveReady, 200));
+    await waitForFile(ghReady, 5_000);
+    const exitPromise = waitForChildClose(childProcess);
     childProcess.kill("SIGTERM");
-    await new Promise<void>((resolveExit, reject) => {
-      childProcess.once("exit", () => resolveExit());
-      childProcess.once("error", reject);
-    });
+    await exitPromise;
     expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
       activeRunIds: ["101"],
       cancellation: { requested: true },

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -1,0 +1,628 @@
+import { spawn, spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  affectedActiveRunIds,
+  buildReleaseExecutionPlan,
+  buildReleaseExecutionPlanArtifact,
+  buildReleaseStateArtifact,
+  classifyReleaseSnapshot,
+  formatReleaseStateOutcome,
+  validateChildBinding,
+  verifyReleaseStateArtifacts,
+} from "../../scripts/full-release-validation-state.mjs";
+
+const SCRIPT = resolve("scripts/full-release-validation-state.mjs");
+const SHA = "a".repeat(40);
+const TARGET_SHA = "b".repeat(40);
+
+function child(key: string, overrides: Record<string, unknown> = {}) {
+  return {
+    conclusion: "",
+    dispatchName: `Dispatch ${key}`,
+    displayTitle: key,
+    errors: [],
+    jobs: [],
+    key,
+    required: true,
+    result: "success",
+    runAttempt: 1,
+    runId: "101",
+    selected: true,
+    source: "fresh",
+    status: "in_progress",
+    url: "https://example.invalid/runs/101",
+    workflow: "ci.yml",
+    workflowRef: "release-ci/tooling",
+    workflowSha: SHA,
+    ...overrides,
+  };
+}
+
+function plan(overrides: Record<string, unknown> = {}) {
+  return buildReleaseExecutionPlan({
+    children: {
+      normalCi: { result: "success", runAttempt: 1, runId: "101" },
+      npmTelegram: { result: "success", runAttempt: 1, runId: "404" },
+      pluginPrerelease: { result: "success", runAttempt: 1, runId: "202" },
+      productPerformance: { result: "success", runAttempt: 1, runId: "505" },
+      releaseChecks: { result: "success", runAttempt: 1, runId: "303" },
+    },
+    dockerPreflightResult: "success",
+    evidenceReuse: false,
+    parentRunAttempt: 2,
+    parentRunId: "77",
+    prepareCandidateResult: "success",
+    rerunGroup: "all",
+    resolveTargetResult: "success",
+    workflowRef: "release-ci/tooling",
+    workflowSha: SHA,
+    ...overrides,
+  });
+}
+
+function executionPlan(
+  overrides: Record<string, unknown> = {},
+  artifactOverrides: Record<string, unknown> = {},
+) {
+  const expected = {
+    parentRunAttempt: 1,
+    parentRunId: "77",
+    targetSha: TARGET_SHA,
+    workflowRef: "release-ci/tooling",
+    workflowSha: SHA,
+    ...((artifactOverrides.expected as Record<string, unknown> | undefined) ?? {}),
+  };
+  const built = plan({ ...overrides, parentRunAttempt: expected.parentRunAttempt });
+  return buildReleaseExecutionPlanArtifact({
+    children: built.children,
+    expected,
+    gates: built.gates,
+    releaseProfile: "stable",
+    rerunGroup: String(overrides.rerunGroup ?? "all"),
+    ...artifactOverrides,
+  });
+}
+
+describe("full release execution plan", () => {
+  it("keeps required coverage selected when dispatch output is missing", () => {
+    const result = plan({
+      children: { normalCi: { result: "success", runAttempt: "", runId: "" } },
+      rerunGroup: "ci",
+    });
+    expect(result.children.find((entry) => entry.key === "normalCi")).toMatchObject({
+      required: true,
+      runAttempt: null,
+      runId: "",
+      selected: true,
+    });
+    expect(
+      classifyReleaseSnapshot({
+        children: result.children.map((entry) => ({
+          ...entry,
+          errors: [],
+          jobs: [],
+          status: "missing",
+        })),
+        releaseProfile: "stable",
+        workflowRef: "release-ci/tooling",
+      }),
+    ).toMatchObject({
+      blockers: [expect.objectContaining({ kind: "dispatch_missing" })],
+      state: "blocked_complete",
+    });
+  });
+
+  it.each(["install-smoke", "qa-parity", "qa-live"])(
+    "does not require candidate preparation for focused %s",
+    (rerunGroup) => {
+      expect(
+        plan({ prepareCandidateResult: "skipped", rerunGroup }).gates.find(
+          (entry) => entry.name === "Prepare shared release candidate",
+        ),
+      ).toMatchObject({ required: false });
+    },
+  );
+
+  it("does not prepare a candidate for published packages", () => {
+    expect(
+      plan({
+        packageAcceptancePackageSpec: "openclaw@2026.8.4-beta.3",
+        prepareCandidateResult: "skipped",
+        rerunGroup: "package",
+      }).gates.at(-1),
+    ).toMatchObject({ required: false });
+  });
+
+  it("requires live-e2e candidate preparation only without a suite filter", () => {
+    expect(plan({ rerunGroup: "live-e2e" }).gates.at(-1)).toMatchObject({ required: true });
+    expect(plan({ liveSuiteFilter: "discord", rerunGroup: "live-e2e" }).gates.at(-1)).toMatchObject(
+      {
+        required: false,
+      },
+    );
+  });
+});
+
+describe("release decision policy", () => {
+  it("reports a decisive blocker while unrelated diagnostics continue", () => {
+    const result = classifyReleaseSnapshot({
+      children: [
+        child("normalCi", {
+          jobs: [{ conclusion: "failure", name: "test", status: "completed" }],
+        }),
+        child("releaseChecks", { runId: "202" }),
+      ],
+      releaseProfile: "stable",
+      workflowRef: "main",
+    });
+    expect(result).toMatchObject({
+      activeRunIds: ["101", "202"],
+      state: "blocked_diagnostics_running",
+    });
+  });
+
+  it("keeps advisory QA and beta performance failures non-blocking", () => {
+    const result = classifyReleaseSnapshot({
+      children: [
+        child("releaseChecks", {
+          conclusion: "failure",
+          jobs: [
+            {
+              conclusion: "failure",
+              name: "Run QA Lab runtime-pair lane (core)",
+              status: "completed",
+            },
+            { conclusion: "success", name: "Verify release checks", status: "completed" },
+          ],
+          status: "completed",
+        }),
+        child("productPerformance", {
+          conclusion: "failure",
+          jobs: [{ conclusion: "failure", name: "benchmark", status: "completed" }],
+          runId: "202",
+          status: "completed",
+        }),
+      ],
+      releaseProfile: "beta",
+      workflowRef: "main",
+    });
+    expect(result).toMatchObject({ blockers: [], errors: [], state: "passed" });
+  });
+
+  it("preserves a blocker and an API error independently", () => {
+    const result = classifyReleaseSnapshot({
+      children: [
+        child("normalCi", {
+          jobs: [{ conclusion: "failure", name: "test", status: "completed" }],
+        }),
+        child("releaseChecks", {
+          errors: [{ kind: "api_error", message: "HTTP 503", runId: "202" }],
+          runId: "202",
+          status: "unknown",
+        }),
+      ],
+      releaseProfile: "stable",
+      workflowRef: "main",
+    });
+    expect(result).toMatchObject({
+      blockers: [expect.objectContaining({ job: "test" })],
+      errors: [expect.objectContaining({ kind: "api_error" })],
+      state: "orchestration_error",
+    });
+  });
+
+  it("binds the exact child attempt and tooling tuple", () => {
+    const result = validateChildBinding(
+      child("normalCi"),
+      {
+        conclusion: "",
+        created_at: "2026-08-21T00:00:00Z",
+        display_title: "normalCi",
+        event: "workflow_dispatch",
+        head_branch: "release-ci/tooling",
+        head_sha: SHA,
+        html_url: "https://example.invalid/runs/101",
+        id: 101,
+        path: ".github/workflows/ci.yml@refs/heads/release-ci/tooling",
+        run_attempt: 2,
+        status: "in_progress",
+        updated_at: "2026-08-21T00:01:00Z",
+      },
+      [],
+    );
+    expect(result.errors).toEqual([
+      expect.objectContaining({
+        kind: "provenance_mismatch",
+        message: expect.stringContaining("attempt"),
+      }),
+    ]);
+  });
+
+  it("cancels only exact active affected children", () => {
+    expect(
+      affectedActiveRunIds(
+        [
+          child("normalCi"),
+          child("releaseChecks", { runId: "202" }),
+          child("npmTelegram", { runId: "303", status: "completed" }),
+        ],
+        [{ runId: "101" }, { runId: "303" }],
+      ),
+    ).toEqual(["101"]);
+  });
+});
+
+describe("release state artifacts", () => {
+  function artifact(mode: "decision" | "drain") {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const children = [
+      child("normalCi", {
+        conclusion: "success",
+        createdAt: "2026-08-21T00:00:00Z",
+        status: "completed",
+        updatedAt: "2026-08-21T00:01:00Z",
+      }),
+    ];
+    return buildReleaseStateArtifact({
+      children,
+      decision: { activeRunIds: [], blockers: [], errors: [], state: "passed" },
+      executionPlan: sealedPlan,
+      expected: {
+        parentRunAttempt: 2,
+        parentRunId: "77",
+        targetSha: TARGET_SHA,
+        workflowRef: "release-ci/tooling",
+        workflowSha: SHA,
+      },
+      mode,
+      releaseProfile: "stable",
+      rerunGroup: "ci",
+    });
+  }
+
+  it("uses one policy for decision, drain, and final verification", () => {
+    expect(
+      verifyReleaseStateArtifacts(
+        executionPlan({ rerunGroup: "ci" }),
+        artifact("decision"),
+        artifact("drain"),
+        {
+          parentRunAttempt: 2,
+          parentRunId: "77",
+          releaseProfile: "stable",
+          rerunGroup: "ci",
+          targetSha: TARGET_SHA,
+          workflowSha: SHA,
+        },
+      ),
+    ).toMatchObject({ decision: { state: "passed" }, drain: { state: "passed" } });
+  });
+
+  it("uses state-specific operator guidance", () => {
+    expect(
+      formatReleaseStateOutcome({
+        blockers: [{ conclusion: "failure", job: "test", url: "https://example.invalid/job" }],
+        errors: [],
+        state: "blocked_diagnostics_running",
+      }),
+    ).toContain("diagnose now, retry later");
+    expect(
+      formatReleaseStateOutcome({ blockers: [], errors: [], state: "blocked_complete" }),
+    ).not.toContain("still collecting");
+  });
+});
+
+describe("collector subprocess", () => {
+  it("adopts the immutable attempt-one plan on an attempt-two collector retry", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-plan-restore-"));
+    const output = join(root, "full-release-execution-plan.json");
+    const sealed = executionPlan({ rerunGroup: "ci" });
+    writeFileSync(output, JSON.stringify(sealed));
+    const result = spawnSync(process.execPath, [SCRIPT, "plan"], {
+      env: {
+        ...process.env,
+        FULL_RELEASE_EXECUTION_PLAN_PATH: output,
+        FULL_RELEASE_RESTORE_PLAN: "true",
+        GITHUB_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA,
+      },
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      parentRunAttempt: 1,
+      sha256: sealed.sha256,
+    });
+  });
+
+  it("writes the execution plan immediately when SIGTERM interrupts a stalled reuse API", async () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-plan-signal-"));
+    const gh = join(root, "gh");
+    const output = join(root, "full-release-execution-plan.json");
+    writeFileSync(gh, "#!/bin/sh\nsleep 30\n");
+    chmodSync(gh, 0o755);
+    const childProcess = spawn(process.execPath, [SCRIPT, "plan"], {
+      env: {
+        ...process.env,
+        EVIDENCE_CHANGED_PATHS: "[]",
+        FULL_RELEASE_EXECUTION_PLAN_PATH: output,
+        FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify({
+          children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
+          dockerPreflightResult: "skipped",
+          evidenceChangedPaths: [],
+          evidencePolicy: "exact-target-full-validation-v1",
+          evidenceReuse: true,
+          evidenceRootRunId: "99",
+          evidenceRunUrl: "https://example.invalid/runs/99",
+          evidenceSha: TARGET_SHA,
+          parentRunAttempt: 1,
+          parentRunId: "77",
+          prepareCandidateResult: "skipped",
+          rerunGroup: "ci",
+          resolveTargetResult: "success",
+          workflowRef: "release-ci/tooling",
+          workflowSha: SHA,
+        }),
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "1",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        PATH: `${root}:${process.env.PATH}`,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA,
+      },
+      stdio: "ignore",
+    });
+    await new Promise((resolveReady) => setTimeout(resolveReady, 200));
+    const started = Date.now();
+    childProcess.kill("SIGTERM");
+    await new Promise<void>((resolveExit, reject) => {
+      childProcess.once("exit", () => resolveExit());
+      childProcess.once("error", reject);
+    });
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      errors: [expect.objectContaining({ kind: "collector_cancelled" })],
+      parentRunAttempt: 1,
+    });
+  });
+
+  it("records target resolution failure even when no target SHA exists", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-state-target-failure-"));
+    const output = join(root, "decision.json");
+    const executionPlanPath = join(root, "full-release-execution-plan.json");
+    writeFileSync(
+      executionPlanPath,
+      JSON.stringify(
+        executionPlan(
+          {
+            children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
+            dockerPreflightResult: "skipped",
+            prepareCandidateResult: "skipped",
+            rerunGroup: "ci",
+            resolveTargetResult: "failure",
+          },
+          {
+            expected: {
+              parentRunAttempt: 1,
+              parentRunId: "77",
+              targetSha: "",
+              workflowRef: "release-ci/tooling",
+              workflowSha: SHA,
+            },
+          },
+        ),
+      ),
+    );
+    const result = spawnSync(process.execPath, [SCRIPT, "decision"], {
+      env: {
+        ...process.env,
+        FAIL_FAST: "false",
+        FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+        FULL_RELEASE_STATE_PATH: output,
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA: "",
+      },
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(1);
+    const artifact = JSON.parse(readFileSync(output, "utf8"));
+    expect(artifact).toMatchObject({
+      state: "blocked_complete",
+      targetSha: "",
+    });
+    expect(artifact.blockers).toContainEqual(
+      expect.objectContaining({
+        kind: "parent_gate_failure",
+        message: expect.stringContaining("Resolve target ref"),
+      }),
+    );
+  });
+
+  it("writes an immediate terminal handoff with active identity on SIGTERM", async () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-state-signal-"));
+    const gh = join(root, "gh");
+    const output = join(root, "drain.json");
+    const executionPlanPath = join(root, "full-release-execution-plan.json");
+    writeFileSync(
+      executionPlanPath,
+      JSON.stringify(
+        executionPlan({
+          children: { normalCi: { result: "success", runAttempt: 1, runId: "101" } },
+          dockerPreflightResult: "skipped",
+          prepareCandidateResult: "skipped",
+          rerunGroup: "ci",
+          resolveTargetResult: "success",
+        }),
+      ),
+    );
+    writeFileSync(
+      gh,
+      `#!/bin/sh
+if [ "$1" = "api" ] && echo "$2" | grep -q '/jobs'; then
+  exit 0
+fi
+printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/ci.yml@refs/heads/release-ci/tooling","display_title":"CI full-release-validation-77-1-ci","head_branch":"release-ci/tooling","head_sha":"${SHA}","run_attempt":1,"status":"in_progress","conclusion":null,"created_at":"2026-08-21T00:00:00Z","updated_at":"2026-08-21T00:01:00Z","html_url":"https://example.invalid/runs/101"}'
+`,
+    );
+    chmodSync(gh, 0o755);
+    const childProcess = spawn(process.execPath, [SCRIPT, "drain"], {
+      env: {
+        ...process.env,
+        FAIL_FAST: "false",
+        FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+        FULL_RELEASE_POLL_INTERVAL_MS: "60000",
+        FULL_RELEASE_STATE_PATH: output,
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        PATH: `${root}:${process.env.PATH}`,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA: "b".repeat(40),
+      },
+      stdio: "ignore",
+    });
+    await new Promise((resolveReady) => setTimeout(resolveReady, 200));
+    childProcess.kill("SIGTERM");
+    await new Promise<void>((resolveExit, reject) => {
+      childProcess.once("exit", () => resolveExit());
+      childProcess.once("error", reject);
+    });
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      activeRunIds: ["101"],
+      cancellation: { requested: true },
+      state: "cancelled_with_children",
+    });
+  });
+
+  it("cancels only the exact affected child and never cancels from drain", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-state-fail-fast-"));
+    const gh = join(root, "gh");
+    const calls = join(root, "calls");
+    writeFileSync(calls, "");
+    writeFileSync(
+      gh,
+      `#!/bin/sh
+printf '%s\\n' "$*" >> "$FRV_GH_CALLS"
+if [ "$1" = "run" ] && [ "$2" = "cancel" ]; then
+  exit 0
+fi
+case "$*" in
+  *"/jobs?"*)
+    case "$*" in
+      *"/101/"*) printf '%s\\n' '{"name":"test","status":"completed","conclusion":"failure","html_url":"https://example.invalid/jobs/test"}' ;;
+    esac
+    exit 0
+    ;;
+esac
+endpoint="$2"
+[ "$endpoint" = "--paginate" ] && endpoint="$3"
+run_id=$(printf '%s' "$endpoint" | sed 's#^.*/##')
+title="CI full-release-validation-77-1-ci"
+workflow="ci.yml"
+case "$run_id" in
+  202) title="Plugin Prerelease full-release-validation-77-1-plugin-prerelease"; workflow="plugin-prerelease.yml" ;;
+  303) title="OpenClaw Release Checks full-release-validation-77-1-release-checks"; workflow="openclaw-release-checks.yml" ;;
+  505) title="OpenClaw Performance full-release-validation-77-1"; workflow="openclaw-performance.yml" ;;
+esac
+status="completed"
+[ "$run_id" = 101 ] && status="$FRV_FAILED_RUN_STATUS"
+printf '{"id":%s,"event":"workflow_dispatch","path":".github/workflows/%s@refs/heads/release-ci/tooling","display_title":"%s","head_branch":"release-ci/tooling","head_sha":"${SHA}","run_attempt":1,"status":"%s","conclusion":"%s","created_at":"2026-08-21T00:00:00Z","updated_at":"2026-08-21T00:01:00Z","html_url":"https://example.invalid/runs/%s"}\\n' "$run_id" "$workflow" "$title" "$status" "$([ "$run_id" = 101 ] && echo failure || echo success)" "$run_id"
+`,
+    );
+    chmodSync(gh, 0o755);
+    const planInputs = {
+      children: {
+        normalCi: { result: "success", runAttempt: 1, runId: "101" },
+        pluginPrerelease: { result: "success", runAttempt: 1, runId: "202" },
+        productPerformance: { result: "success", runAttempt: 1, runId: "505" },
+        releaseChecks: { result: "success", runAttempt: 1, runId: "303" },
+      },
+      dockerPreflightResult: "success",
+      evidenceReuse: false,
+      parentRunAttempt: 2,
+      parentRunId: "77",
+      prepareCandidateResult: "success",
+      rerunGroup: "all",
+      resolveTargetResult: "success",
+      workflowRef: "release-ci/tooling",
+      workflowSha: SHA,
+    };
+    const executionPlanPath = join(root, "full-release-execution-plan.json");
+    writeFileSync(
+      executionPlanPath,
+      JSON.stringify(
+        executionPlan(planInputs, {
+          expected: {
+            parentRunAttempt: 1,
+            parentRunId: "77",
+            targetSha: TARGET_SHA,
+            workflowRef: "release-ci/tooling",
+            workflowSha: SHA,
+          },
+        }),
+      ),
+    );
+    const baseEnv = {
+      ...process.env,
+      FRV_GH_CALLS: calls,
+      FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+      GITHUB_REF_NAME: "release-ci/tooling",
+      GITHUB_REPOSITORY: "openclaw/openclaw",
+      GITHUB_RUN_ATTEMPT: "2",
+      GITHUB_RUN_ID: "77",
+      GITHUB_SHA: SHA,
+      PATH: `${root}:${process.env.PATH}`,
+      RELEASE_PROFILE: "stable",
+      RERUN_GROUP: "all",
+      TARGET_SHA: "b".repeat(40),
+    };
+    const decision = spawnSync(process.execPath, [SCRIPT, "decision"], {
+      env: {
+        ...baseEnv,
+        FAIL_FAST: "true",
+        FRV_FAILED_RUN_STATUS: "in_progress",
+        FULL_RELEASE_STATE_PATH: join(root, "decision.json"),
+      },
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    expect(decision.signal, decision.stderr).toBeNull();
+    const afterDecision = readFileSync(calls, "utf8");
+    expect(afterDecision).toContain("run cancel 101");
+    expect(afterDecision).not.toContain("run cancel 202");
+    writeFileSync(calls, "");
+    const drain = spawnSync(process.execPath, [SCRIPT, "drain"], {
+      env: {
+        ...baseEnv,
+        FAIL_FAST: "false",
+        FRV_FAILED_RUN_STATUS: "completed",
+        FULL_RELEASE_STATE_PATH: join(root, "drain.json"),
+      },
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    expect(drain.signal, drain.stderr).toBeNull();
+    expect(readFileSync(calls, "utf8")).not.toContain("run cancel");
+  });
+});

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -9,6 +9,7 @@ import {
   buildReleaseExecutionPlan,
   buildReleaseExecutionPlanArtifact,
   buildReleaseStateArtifact,
+  classifyReleaseGhTransportError,
   classifyReleaseSnapshot,
   formatReleaseStateOutcome,
   selectReleaseStateArtifacts,
@@ -146,6 +147,22 @@ function reusedEvidenceChildren() {
 }
 
 describe("full release execution plan", () => {
+  it.each([
+    ["HTTP 429: rate limited", "transient"],
+    ["HTTP 503: Server Error", "transient"],
+    ["spawnSync gh ETIMEDOUT", "transient"],
+    ["read ECONNRESET", "transient"],
+    ["getaddrinfo EAI_AGAIN api.github.com", "transient"],
+    ["unexpected EOF", "transient"],
+    ["HTTP 401: Bad credentials", "hard"],
+    ["HTTP 403: secondary rate limit", "hard"],
+    ["unknown flag: --name\nUsage: gh run download", "hard"],
+  ] as const)("classifies GitHub transport error %s as %s", (message, expected) => {
+    expect(
+      classifyReleaseGhTransportError(Object.assign(new Error(message), { stderr: message })),
+    ).toBe(expected);
+  });
+
   it("keeps required coverage selected when dispatch output is missing", () => {
     const result = plan({
       children: { normalCi: { result: "success", runAttempt: "", runId: "" } },

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -27,7 +27,7 @@ function evidenceManifest() {
   return { runAttempt: 1, runId: "99", targetSha: TARGET_SHA };
 }
 
-function generatedManifest(planArtifact: Record<string, any>) {
+function generatedManifest(planArtifact: Record<string, any>): Record<string, any> {
   return {
     childRuns: {
       normalCi: "101",
@@ -349,7 +349,9 @@ describe("release state artifacts", () => {
     parentRunAttempt = 2,
     sealedPlan = executionPlan({ rerunGroup: "ci" }),
   ) {
-    const plannedChild = sealedPlan.children.find((entry) => entry.key === "normalCi");
+    const plannedChild = sealedPlan.children.find(
+      (entry: Record<string, any>) => entry.key === "normalCi",
+    );
     const children = [
       child("normalCi", {
         ...plannedChild,

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -11,6 +11,7 @@ import {
   buildReleaseStateArtifact,
   classifyReleaseSnapshot,
   formatReleaseStateOutcome,
+  selectReleaseStateArtifacts,
   validateChildBinding,
   validateReleaseExecutionPlanArtifact,
   verifyReleaseStateArtifacts,
@@ -20,6 +21,11 @@ import { waitForChildClose, waitForFile } from "../helpers/process-wait.js";
 const SCRIPT = resolve("scripts/full-release-validation-state.mjs");
 const SHA = "a".repeat(40);
 const TARGET_SHA = "b".repeat(40);
+const TRUSTED_MAIN = { fullRef: "refs/heads/main", ref: "main", sha: SHA };
+
+function evidenceManifest() {
+  return { runAttempt: 1, runId: "99", targetSha: TARGET_SHA };
+}
 
 function child(key: string, overrides: Record<string, unknown> = {}) {
   return {
@@ -85,6 +91,7 @@ function executionPlan(
     gates: built.gates,
     releaseProfile: "stable",
     rerunGroup: String(overrides.rerunGroup ?? "all"),
+    trustedWorkflow: TRUSTED_MAIN,
     ...artifactOverrides,
   });
 }
@@ -177,6 +184,7 @@ describe("full release execution plan", () => {
           rootRunId: "99",
           runUrl: "https://example.invalid/runs/99",
           selectedRunId: "99",
+          sourceManifest: evidenceManifest(),
         },
       },
     );
@@ -304,10 +312,15 @@ describe("release decision policy", () => {
 });
 
 describe("release state artifacts", () => {
-  function artifact(mode: "decision" | "drain") {
-    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+  function artifact(
+    mode: "decision" | "drain",
+    parentRunAttempt = 2,
+    sealedPlan = executionPlan({ rerunGroup: "ci" }),
+  ) {
+    const plannedChild = sealedPlan.children.find((entry) => entry.key === "normalCi");
     const children = [
       child("normalCi", {
+        ...plannedChild,
         conclusion: "success",
         createdAt: "2026-08-21T00:00:00Z",
         status: "completed",
@@ -319,7 +332,7 @@ describe("release state artifacts", () => {
       decision: { activeRunIds: [], blockers: [], errors: [], state: "passed" },
       executionPlan: sealedPlan,
       expected: {
-        parentRunAttempt: 2,
+        parentRunAttempt,
         parentRunId: "77",
         targetSha: TARGET_SHA,
         workflowRef: "release-ci/tooling",
@@ -349,6 +362,89 @@ describe("release state artifacts", () => {
     ).toMatchObject({ decision: { state: "passed" }, drain: { state: "passed" } });
   });
 
+  it("selects the newest decision and drain independently across asymmetric retries", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const selected = selectReleaseStateArtifacts(
+      sealedPlan,
+      [
+        { name: "full-release-decision-77-1", payload: artifact("decision", 1, sealedPlan) },
+        { name: "full-release-decision-77-2", payload: artifact("decision", 2, sealedPlan) },
+      ],
+      [{ name: "full-release-diagnostics-77-1", payload: artifact("drain", 1, sealedPlan) }],
+      {
+        maxParentRunAttempt: 3,
+        parentRunId: "77",
+        releaseProfile: "stable",
+        rerunGroup: "ci",
+        targetSha: TARGET_SHA,
+        workflowRef: "release-ci/tooling",
+        workflowSha: SHA,
+      },
+    );
+    expect(selected.sourceAttempts).toEqual({ decision: 2, drain: 1, executionPlan: 1 });
+  });
+
+  it.each([
+    {
+      mutate: (drain: Record<string, any>) => {
+        drain.children.normalCi.displayTitle = "nearby title";
+      },
+      name: "changed child display title",
+      reason: "provenance differs",
+    },
+    {
+      mutate: (drain: Record<string, any>) => {
+        drain.children.normalCi.workflow = "nearby.yml";
+      },
+      name: "changed child workflow",
+      reason: "provenance differs",
+    },
+    {
+      mutate: (drain: Record<string, any>) => {
+        drain.children.normalCi.workflowRef = "main";
+      },
+      name: "changed child workflow ref",
+      reason: "provenance differs",
+    },
+    {
+      mutate: (drain: Record<string, any>) => {
+        drain.children.normalCi.workflowSha = "f".repeat(40);
+      },
+      name: "changed child tooling SHA",
+      reason: "provenance differs",
+    },
+    {
+      mutate: (drain: Record<string, any>) => {
+        drain.children.normalCi.conclusion = "failure";
+      },
+      name: "failed child hidden behind passed state",
+      reason: "canonical terminal release policy",
+    },
+    {
+      mutate: (drain: Record<string, any>) => {
+        drain.children.normalCi.errors = [{ kind: "api_error", message: "hidden" }];
+      },
+      name: "hidden child collector error",
+      reason: "contains collector errors",
+    },
+  ])("rejects a malformed passed drain with $name", ({ mutate, reason }) => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const decision = artifact("decision", 2, sealedPlan);
+    const drain = structuredClone(artifact("drain", 2, sealedPlan));
+    mutate(drain);
+    expect(() =>
+      verifyReleaseStateArtifacts(sealedPlan, decision, drain, {
+        maxParentRunAttempt: 2,
+        parentRunId: "77",
+        releaseProfile: "stable",
+        rerunGroup: "ci",
+        targetSha: TARGET_SHA,
+        workflowRef: "release-ci/tooling",
+        workflowSha: SHA,
+      }),
+    ).toThrow(reason);
+  });
+
   it("uses state-specific operator guidance", () => {
     expect(
       formatReleaseStateOutcome({
@@ -370,12 +466,18 @@ describe("collector subprocess", () => {
       evidenceSha: TARGET_SHA,
       name: "exact-target",
       policy: "exact-target-full-validation-v1",
+      trustedWorkflow: TRUSTED_MAIN,
     },
     {
       changedPaths: ["CHANGELOG.md"],
       evidenceSha: "c".repeat(40),
       name: "changelog-only",
       policy: "changelog-only-release-v1",
+      trustedWorkflow: {
+        fullRef: `refs/tags/release-publish/${SHA.slice(0, 12)}-123`,
+        ref: `release-publish/${SHA.slice(0, 12)}-123`,
+        sha: SHA,
+      },
     },
   ])("seals and revalidates the complete $name reuse tuple", (reuse) => {
     const root = mkdtempSync(join(tmpdir(), "frv-plan-reuse-"));
@@ -406,6 +508,7 @@ console.log(JSON.stringify({
       children: {},
       dockerPreflightResult: "skipped",
       evidenceChangedPaths: reuse.changedPaths,
+      evidenceManifest: evidenceManifest(),
       evidencePolicy: reuse.policy,
       evidenceReuse: true,
       evidenceRootRunId: "99",
@@ -417,6 +520,7 @@ console.log(JSON.stringify({
       prepareCandidateResult: "skipped",
       rerunGroup: "all",
       resolveTargetResult: "success",
+      trustedWorkflow: reuse.trustedWorkflow,
       workflowRef: "release-ci/tooling",
       workflowSha: SHA,
     };
@@ -430,6 +534,9 @@ console.log(JSON.stringify({
           "--expected-root-run-id": "99",
           "--expected-selected-run-id": "99",
           "--expected-target-sha": TARGET_SHA,
+          "--trusted-workflow-full-ref": reuse.trustedWorkflow.fullRef,
+          "--trusted-workflow-ref": reuse.trustedWorkflow.ref,
+          "--trusted-workflow-sha": reuse.trustedWorkflow.sha,
           "--validate-run": "99",
         }),
         FRV_REUSED_CHILDREN: JSON.stringify(reusedEvidenceChildren()),
@@ -466,9 +573,85 @@ console.log(JSON.stringify({
         rootRunId: "99",
         runUrl: "https://example.invalid/runs/99",
         selectedRunId: "99",
+        sourceManifest: evidenceManifest(),
       },
+      trustedWorkflow: reuse.trustedWorkflow,
     });
     expect(JSON.parse(readFileSync(validatorArgs, "utf8"))).toContain("--expected-selected-run-id");
+  });
+
+  it("persists a classified plan that Release Decision can consume after reuse rejection", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-classified-plan-"));
+    const output = join(root, "full-release-execution-plan.json");
+    const decisionOutput = join(root, "full-release-decision.json");
+    const validator = join(root, "release-evidence-validator.mjs");
+    writeFileSync(
+      validator,
+      'console.error("sealed reuse selection rejected"); process.exit(1);\n',
+    );
+    const planInputs = {
+      children: {},
+      dockerPreflightResult: "skipped",
+      evidenceChangedPaths: [],
+      evidenceManifest: evidenceManifest(),
+      evidencePolicy: "exact-target-full-validation-v1",
+      evidenceReuse: true,
+      evidenceRootRunId: "99",
+      evidenceRunId: "99",
+      evidenceRunUrl: "https://example.invalid/runs/99",
+      evidenceSha: TARGET_SHA,
+      parentRunAttempt: 1,
+      parentRunId: "77",
+      prepareCandidateResult: "skipped",
+      rerunGroup: "all",
+      resolveTargetResult: "success",
+      trustedWorkflow: TRUSTED_MAIN,
+      workflowRef: "release-ci/tooling",
+      workflowSha: SHA,
+    };
+    const baseEnv = {
+      ...process.env,
+      FULL_RELEASE_EXECUTION_PLAN_PATH: output,
+      GITHUB_REF_NAME: "release-ci/tooling",
+      GITHUB_REPOSITORY: "openclaw/openclaw",
+      GITHUB_RUN_ATTEMPT: "1",
+      GITHUB_RUN_ID: "77",
+      GITHUB_SHA: SHA,
+      OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR: validator,
+      RELEASE_PROFILE: "stable",
+      RERUN_GROUP: "all",
+      TARGET_SHA,
+    };
+    const planResult = spawnSync(process.execPath, [SCRIPT, "plan"], {
+      encoding: "utf8",
+      env: {
+        ...baseEnv,
+        FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify(planInputs),
+      },
+      timeout: 10_000,
+    });
+    expect(planResult.status).toBe(2);
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      blockers: [expect.objectContaining({ kind: "reused_evidence_invalid" })],
+      errors: [],
+    });
+
+    const decisionResult = spawnSync(process.execPath, [SCRIPT, "decision"], {
+      encoding: "utf8",
+      env: {
+        ...baseEnv,
+        FAIL_FAST: "false",
+        FULL_RELEASE_STATE_PATH: decisionOutput,
+      },
+      timeout: 10_000,
+    });
+    expect(decisionResult.status).toBe(1);
+    expect(JSON.parse(readFileSync(decisionOutput, "utf8"))).toMatchObject({
+      state: "blocked_complete",
+    });
+    expect(JSON.parse(readFileSync(decisionOutput, "utf8")).blockers).toEqual(
+      expect.arrayContaining([expect.objectContaining({ kind: "reused_evidence_invalid" })]),
+    );
   });
 
   it("adopts the immutable attempt-one plan on an attempt-two collector retry", () => {
@@ -481,6 +664,7 @@ console.log(JSON.stringify({
         ...process.env,
         FULL_RELEASE_EXECUTION_PLAN_PATH: output,
         FULL_RELEASE_RESTORE_PLAN: "true",
+        GITHUB_REF_NAME: "release-ci/tooling",
         GITHUB_RUN_ATTEMPT: "2",
         GITHUB_RUN_ID: "77",
         GITHUB_SHA: SHA,
@@ -515,6 +699,7 @@ console.log(JSON.stringify({
           children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
           dockerPreflightResult: "skipped",
           evidenceChangedPaths: [],
+          evidenceManifest: evidenceManifest(),
           evidencePolicy: "exact-target-full-validation-v1",
           evidenceReuse: true,
           evidenceRootRunId: "99",
@@ -526,6 +711,7 @@ console.log(JSON.stringify({
           prepareCandidateResult: "skipped",
           rerunGroup: "ci",
           resolveTargetResult: "success",
+          trustedWorkflow: TRUSTED_MAIN,
           workflowRef: "release-ci/tooling",
           workflowSha: SHA,
         }),

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -829,6 +829,81 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
     );
   });
 
+  it.each([
+    {
+      mutate: (manifest: Record<string, any>) => {
+        manifest.childRuns.normalCi = "999";
+      },
+      name: "wrong selected child",
+      planReuse: false,
+    },
+    {
+      mutate: (manifest: Record<string, any>) => {
+        manifest.childRuns.releaseChecks = "303";
+      },
+      name: "nonempty unselected child",
+      planReuse: false,
+    },
+    {
+      mutate: (manifest: Record<string, any>) => {
+        manifest.evidenceReuse.selectedRunId = "100";
+      },
+      name: "wrong evidence reuse tuple",
+      planReuse: true,
+    },
+  ])("rejects a generated manifest with $name", ({ mutate, planReuse }) => {
+    const root = mkdtempSync(join(tmpdir(), "frv-invalid-generated-manifest-"));
+    const executionPlanPath = join(root, "plan.json");
+    const manifestPath = join(root, "manifest.json");
+    const reuse = {
+      changedPaths: [],
+      evidenceSha: TARGET_SHA,
+      policy: "exact-target-full-validation-v1",
+      requested: true,
+      rootRunId: "99",
+      runUrl: "https://example.invalid/runs/99",
+      selectedRunId: "99",
+      sourceManifest: evidenceManifest(),
+    };
+    const sealedPlan = executionPlan(
+      { rerunGroup: "ci" },
+      planReuse ? { evidenceReuse: reuse } : {},
+    );
+    const manifest = generatedManifest(sealedPlan);
+    if (planReuse) {
+      manifest.evidenceReuse = {
+        changedPaths: reuse.changedPaths,
+        evidenceSha: reuse.evidenceSha,
+        policy: reuse.policy,
+        runId: reuse.rootRunId,
+        selectedRunId: reuse.selectedRunId,
+      };
+    }
+    mutate(manifest);
+    writeFileSync(executionPlanPath, JSON.stringify(sealedPlan));
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    const result = spawnSync(process.execPath, [SCRIPT, "validate-manifest"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+        RELEASE_PROFILE: "stable",
+        RELEASE_VALIDATION_MANIFEST_PATH: manifestPath,
+        RERUN_GROUP: "ci",
+        TARGET_SHA,
+      },
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain(
+      "release validation manifest differs from the immutable execution plan",
+    );
+  });
+
   it("persists a classified plan that Release Decision can consume after reuse rejection", () => {
     const root = mkdtempSync(join(tmpdir(), "frv-classified-plan-"));
     const output = join(root, "full-release-execution-plan.json");

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { releaseExecutionPlanSha256 } from "../../scripts/full-release-validation-policy.mjs";
 import {
   affectedActiveRunIds,
   buildReleaseExecutionPlan,
@@ -11,6 +12,7 @@ import {
   classifyReleaseSnapshot,
   formatReleaseStateOutcome,
   validateChildBinding,
+  validateReleaseExecutionPlanArtifact,
   verifyReleaseStateArtifacts,
 } from "../../scripts/full-release-validation-state.mjs";
 import { waitForChildClose, waitForFile } from "../helpers/process-wait.js";
@@ -87,6 +89,23 @@ function executionPlan(
   });
 }
 
+function reusedEvidenceChildren() {
+  return [
+    ["normalCi", "101", "CI"],
+    ["pluginPrerelease", "202", "Plugin Prerelease"],
+    ["releaseChecks", "303", "OpenClaw Release Checks"],
+    ["productPerformance", "505", "OpenClaw Performance"],
+  ].map(([role, runId, name]) => ({
+    displayTitle: `${name} full-release-validation-99-1`,
+    headBranch: "release-ci/tooling",
+    role,
+    runAttempt: 1,
+    runId,
+    url: `https://example.invalid/runs/${runId}`,
+    workflowSha: SHA,
+  }));
+}
+
 describe("full release execution plan", () => {
   it("keeps required coverage selected when dispatch output is missing", () => {
     const result = plan({
@@ -143,6 +162,34 @@ describe("full release execution plan", () => {
       {
         required: false,
       },
+    );
+  });
+
+  it("rejects a digest-valid plan with an incomplete reuse selection tuple", () => {
+    const artifact = executionPlan(
+      { rerunGroup: "ci" },
+      {
+        evidenceReuse: {
+          changedPaths: [],
+          evidenceSha: TARGET_SHA,
+          policy: "exact-target-full-validation-v1",
+          requested: true,
+          rootRunId: "99",
+          runUrl: "https://example.invalid/runs/99",
+          selectedRunId: "99",
+        },
+      },
+    );
+    const incompleteArtifact = {
+      ...artifact,
+      evidenceReuse: { ...artifact.evidenceReuse, selectedRunId: "" },
+    };
+    const digestValidArtifact = {
+      ...incompleteArtifact,
+      sha256: releaseExecutionPlanSha256(incompleteArtifact),
+    };
+    expect(() => validateReleaseExecutionPlanArtifact(digestValidArtifact)).toThrow(
+      "release execution plan evidence reuse binding is invalid",
     );
   });
 });
@@ -317,6 +364,113 @@ describe("release state artifacts", () => {
 });
 
 describe("collector subprocess", () => {
+  it.each([
+    {
+      changedPaths: [],
+      evidenceSha: TARGET_SHA,
+      name: "exact-target",
+      policy: "exact-target-full-validation-v1",
+    },
+    {
+      changedPaths: ["CHANGELOG.md"],
+      evidenceSha: "c".repeat(40),
+      name: "changelog-only",
+      policy: "changelog-only-release-v1",
+    },
+  ])("seals and revalidates the complete $name reuse tuple", (reuse) => {
+    const root = mkdtempSync(join(tmpdir(), "frv-plan-reuse-"));
+    const output = join(root, "full-release-execution-plan.json");
+    const validator = join(root, "release-evidence-validator.mjs");
+    const validatorArgs = join(root, "validator-args.json");
+    writeFileSync(
+      validator,
+      `import { writeFileSync } from "node:fs";
+const args = process.argv.slice(2);
+writeFileSync(process.env.FRV_VALIDATOR_ARGS, JSON.stringify(args));
+const value = (flag) => args[args.indexOf(flag) + 1];
+const expected = JSON.parse(process.env.FRV_EXPECTED_REUSE);
+for (const [flag, wanted] of Object.entries(expected)) {
+  if (value(flag) !== wanted) {
+    console.error(\`\${flag} mismatch: \${value(flag)} != \${wanted}\`);
+    process.exit(1);
+  }
+}
+console.log(JSON.stringify({
+  children: JSON.parse(process.env.FRV_REUSED_CHILDREN),
+  releaseProfile: process.env.RELEASE_PROFILE,
+  rerunGroup: process.env.RERUN_GROUP,
+}));
+`,
+    );
+    const planInputs = {
+      children: {},
+      dockerPreflightResult: "skipped",
+      evidenceChangedPaths: reuse.changedPaths,
+      evidencePolicy: reuse.policy,
+      evidenceReuse: true,
+      evidenceRootRunId: "99",
+      evidenceRunId: "99",
+      evidenceRunUrl: "https://example.invalid/runs/99",
+      evidenceSha: reuse.evidenceSha,
+      parentRunAttempt: 1,
+      parentRunId: "77",
+      prepareCandidateResult: "skipped",
+      rerunGroup: "all",
+      resolveTargetResult: "success",
+      workflowRef: "release-ci/tooling",
+      workflowSha: SHA,
+    };
+    const result = spawnSync(process.execPath, [SCRIPT, "plan"], {
+      env: {
+        ...process.env,
+        FRV_EXPECTED_REUSE: JSON.stringify({
+          "--expected-changed-paths-json": JSON.stringify(reuse.changedPaths),
+          "--expected-evidence-policy": reuse.policy,
+          "--expected-evidence-sha": reuse.evidenceSha,
+          "--expected-root-run-id": "99",
+          "--expected-selected-run-id": "99",
+          "--expected-target-sha": TARGET_SHA,
+          "--validate-run": "99",
+        }),
+        FRV_REUSED_CHILDREN: JSON.stringify(reusedEvidenceChildren()),
+        FRV_VALIDATOR_ARGS: validatorArgs,
+        FULL_RELEASE_EXECUTION_PLAN_PATH: output,
+        FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify(planInputs),
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "1",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR: validator,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "all",
+        TARGET_SHA,
+      },
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      children: [
+        expect.objectContaining({ key: "normalCi", runId: "101", source: "reused" }),
+        expect.objectContaining({ key: "pluginPrerelease", runId: "202", source: "reused" }),
+        expect.objectContaining({ key: "releaseChecks", runId: "303", source: "reused" }),
+        expect.objectContaining({ key: "npmTelegram", selected: false }),
+        expect.objectContaining({ key: "productPerformance", runId: "505", source: "reused" }),
+      ],
+      evidenceReuse: {
+        changedPaths: reuse.changedPaths,
+        evidenceSha: reuse.evidenceSha,
+        policy: reuse.policy,
+        requested: true,
+        rootRunId: "99",
+        runUrl: "https://example.invalid/runs/99",
+        selectedRunId: "99",
+      },
+    });
+    expect(JSON.parse(readFileSync(validatorArgs, "utf8"))).toContain("--expected-selected-run-id");
+  });
+
   it("adopts the immutable attempt-one plan on an attempt-two collector retry", () => {
     const root = mkdtempSync(join(tmpdir(), "frv-plan-restore-"));
     const output = join(root, "full-release-execution-plan.json");
@@ -364,6 +518,7 @@ describe("collector subprocess", () => {
           evidencePolicy: "exact-target-full-validation-v1",
           evidenceReuse: true,
           evidenceRootRunId: "99",
+          evidenceRunId: "99",
           evidenceRunUrl: "https://example.invalid/runs/99",
           evidenceSha: TARGET_SHA,
           parentRunAttempt: 1,

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -25,6 +25,38 @@ const TRUSTED_MAIN = { fullRef: "refs/heads/main", ref: "main", sha: SHA };
 
 function evidenceManifest() {
   return { runAttempt: 1, runId: "99", targetSha: TARGET_SHA };
+}
+
+function generatedManifest(planArtifact: Record<string, any>) {
+  return {
+    childRuns: {
+      normalCi: "101",
+      npmTelegram: "",
+      pluginPrerelease: "",
+      productPerformance: { blocking: true, conclusion: "", runId: "" },
+      releaseChecks: "",
+    },
+    controls: {
+      performanceBlocking: true,
+      performanceReportPublication: "artifact-only",
+      stableSoakRequired: false,
+    },
+    executionPlanSha256: planArtifact.sha256,
+    releaseProfile: "stable",
+    rerunGroup: "ci",
+    runAttempt: 2,
+    runId: "77",
+    runReleaseSoak: "false",
+    sourceParentRunAttempt: 1,
+    targetRef: "main",
+    targetSha: TARGET_SHA,
+    version: 3,
+    workflowFullRef: "refs/heads/release-ci/tooling",
+    workflowName: "Full Release Validation",
+    workflowRef: "release-ci/tooling",
+    workflowRefType: "branch",
+    workflowSha: SHA,
+  };
 }
 
 function child(key: string, overrides: Record<string, unknown> = {}) {
@@ -384,6 +416,111 @@ describe("release state artifacts", () => {
     expect(selected.sourceAttempts).toEqual({ decision: 2, drain: 1, executionPlan: 1 });
   });
 
+  function selectFromFilesystem(layout: "asymmetric" | "multi" | "single") {
+    const root = mkdtempSync(join(tmpdir(), `frv-select-${layout}-`));
+    const executionPlanPath = join(root, "plan.json");
+    const decisionRoot = join(root, "decisions");
+    const drainRoot = join(root, "drains");
+    const decisionPath = join(root, "selected-decision.json");
+    const drainPath = join(root, "selected-drain.json");
+    const outputPath = join(root, "output.txt");
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    mkdirSync(decisionRoot);
+    mkdirSync(drainRoot);
+    writeFileSync(executionPlanPath, JSON.stringify(sealedPlan));
+    const writeCandidate = (
+      candidateRoot: string,
+      prefix: string,
+      filename: string,
+      mode: "decision" | "drain",
+      attempt: number,
+      direct: boolean,
+    ) => {
+      const target = direct
+        ? join(candidateRoot, filename)
+        : join(candidateRoot, `${prefix}-77-${attempt}`, filename);
+      mkdirSync(resolve(target, ".."), { recursive: true });
+      writeFileSync(target, JSON.stringify(artifact(mode, attempt, sealedPlan)));
+    };
+    if (layout === "single") {
+      writeCandidate(
+        decisionRoot,
+        "full-release-decision",
+        "full-release-decision.json",
+        "decision",
+        2,
+        true,
+      );
+      writeCandidate(
+        drainRoot,
+        "full-release-diagnostics",
+        "full-release-diagnostic-manifest.json",
+        "drain",
+        2,
+        true,
+      );
+    } else {
+      writeCandidate(
+        decisionRoot,
+        "full-release-decision",
+        "full-release-decision.json",
+        "decision",
+        1,
+        false,
+      );
+      writeCandidate(
+        decisionRoot,
+        "full-release-decision",
+        "full-release-decision.json",
+        "decision",
+        2,
+        false,
+      );
+      writeCandidate(
+        drainRoot,
+        "full-release-diagnostics",
+        "full-release-diagnostic-manifest.json",
+        "drain",
+        layout === "asymmetric" ? 1 : 2,
+        false,
+      );
+    }
+    const result = spawnSync(process.execPath, [SCRIPT, "select"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DIAGNOSTIC_DRAIN_ATTEMPTS_PATH: drainRoot,
+        DIAGNOSTIC_DRAIN_PATH: drainPath,
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_RUN_ATTEMPT: "3",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        RELEASE_DECISION_ATTEMPTS_PATH: decisionRoot,
+        RELEASE_DECISION_PATH: decisionPath,
+        RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA,
+      },
+      timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    return readFileSync(outputPath, "utf8");
+  }
+
+  it("selects state from the direct-file layout used for one artifact match", () => {
+    expect(selectFromFilesystem("single")).toContain("decision_source_attempt=2");
+  });
+
+  it("selects the newest state from the subdirectory layout used for multiple matches", () => {
+    expect(selectFromFilesystem("multi")).toContain("drain_source_attempt=2");
+  });
+
+  it("selects asymmetric Decision and Drain retries from filesystem artifacts", () => {
+    expect(selectFromFilesystem("asymmetric")).toContain("drain_source_attempt=1");
+  });
+
   it.each([
     {
       mutate: (drain: Record<string, any>) => {
@@ -499,6 +636,7 @@ for (const [flag, wanted] of Object.entries(expected)) {
 }
 console.log(JSON.stringify({
   children: JSON.parse(process.env.FRV_REUSED_CHILDREN),
+  manifest: JSON.parse(process.env.FRV_EVIDENCE_MANIFEST),
   releaseProfile: process.env.RELEASE_PROFILE,
   rerunGroup: process.env.RERUN_GROUP,
 }));
@@ -508,7 +646,7 @@ console.log(JSON.stringify({
       children: {},
       dockerPreflightResult: "skipped",
       evidenceChangedPaths: reuse.changedPaths,
-      evidenceManifest: evidenceManifest(),
+      evidenceManifest: { attackerControlled: true },
       evidencePolicy: reuse.policy,
       evidenceReuse: true,
       evidenceRootRunId: "99",
@@ -539,6 +677,7 @@ console.log(JSON.stringify({
           "--trusted-workflow-sha": reuse.trustedWorkflow.sha,
           "--validate-run": "99",
         }),
+        FRV_EVIDENCE_MANIFEST: JSON.stringify(evidenceManifest()),
         FRV_REUSED_CHILDREN: JSON.stringify(reusedEvidenceChildren()),
         FRV_VALIDATOR_ARGS: validatorArgs,
         FULL_RELEASE_EXECUTION_PLAN_PATH: output,
@@ -580,6 +719,116 @@ console.log(JSON.stringify({
     expect(JSON.parse(readFileSync(validatorArgs, "utf8"))).toContain("--expected-selected-run-id");
   });
 
+  it("blocks Decision when canonical evidence manifest changes after planning", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-reuse-manifest-mismatch-"));
+    const output = join(root, "decision.json");
+    const executionPlanPath = join(root, "plan.json");
+    const gh = join(root, "gh");
+    const validator = join(root, "validator.mjs");
+    const sealedPlan = executionPlan(
+      { rerunGroup: "ci" },
+      {
+        evidenceReuse: {
+          changedPaths: [],
+          evidenceSha: TARGET_SHA,
+          policy: "exact-target-full-validation-v1",
+          requested: true,
+          rootRunId: "99",
+          runUrl: "https://example.invalid/runs/99",
+          selectedRunId: "99",
+          sourceManifest: evidenceManifest(),
+        },
+      },
+    );
+    writeFileSync(executionPlanPath, JSON.stringify(sealedPlan));
+    writeFileSync(
+      gh,
+      `#!/bin/sh
+case "$*" in
+  *"/jobs?"*) exit 0 ;;
+esac
+printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/ci.yml@refs/heads/release-ci/tooling","display_title":"CI full-release-validation-77-1-ci","head_branch":"release-ci/tooling","head_sha":"${SHA}","run_attempt":1,"status":"completed","conclusion":"success","created_at":"2026-08-21T00:00:00Z","updated_at":"2026-08-21T00:01:00Z","html_url":"https://example.invalid/runs/101"}'
+`,
+    );
+    chmodSync(gh, 0o755);
+    writeFileSync(
+      validator,
+      `console.log(JSON.stringify({
+  children: ${JSON.stringify(reusedEvidenceChildren())},
+  manifest: {runAttempt: 1, runId: "99", targetSha: "${"c".repeat(40)}"},
+  releaseProfile: "stable",
+  rerunGroup: "ci"
+}));\n`,
+    );
+    const result = spawnSync(process.execPath, [SCRIPT, "decision"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAIL_FAST: "false",
+        FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+        FULL_RELEASE_STATE_PATH: output,
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR: validator,
+        PATH: `${root}:${process.env.PATH}`,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA,
+      },
+      timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(1);
+    expect(JSON.parse(readFileSync(output, "utf8")).blockers).toContainEqual(
+      expect.objectContaining({
+        kind: "provenance_mismatch",
+        message: "revalidated evidence source manifest differs from the immutable plan",
+      }),
+    );
+  });
+
+  it("validates a generated manifest against its immutable execution plan", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-generated-manifest-"));
+    const executionPlanPath = join(root, "plan.json");
+    const manifestPath = join(root, "manifest.json");
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    writeFileSync(executionPlanPath, JSON.stringify(sealedPlan));
+    writeFileSync(manifestPath, JSON.stringify(generatedManifest(sealedPlan)));
+    const env = {
+      ...process.env,
+      GITHUB_REF_NAME: "release-ci/tooling",
+      GITHUB_RUN_ATTEMPT: "2",
+      GITHUB_RUN_ID: "77",
+      GITHUB_SHA: SHA,
+      RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+      RELEASE_PROFILE: "stable",
+      RELEASE_VALIDATION_MANIFEST_PATH: manifestPath,
+      RERUN_GROUP: "ci",
+      TARGET_SHA,
+    };
+    const valid = spawnSync(process.execPath, [SCRIPT, "validate-manifest"], {
+      encoding: "utf8",
+      env,
+      timeout: 10_000,
+    });
+    expect(valid.status, valid.stderr).toBe(0);
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({ ...generatedManifest(sealedPlan), sourceParentRunAttempt: 2 }),
+    );
+    const invalid = spawnSync(process.execPath, [SCRIPT, "validate-manifest"], {
+      encoding: "utf8",
+      env,
+      timeout: 10_000,
+    });
+    expect(invalid.status).toBe(2);
+    expect(invalid.stderr).toContain(
+      "release validation manifest differs from the immutable execution plan",
+    );
+  });
+
   it("persists a classified plan that Release Decision can consume after reuse rejection", () => {
     const root = mkdtempSync(join(tmpdir(), "frv-classified-plan-"));
     const output = join(root, "full-release-execution-plan.json");
@@ -593,7 +842,6 @@ console.log(JSON.stringify({
       children: {},
       dockerPreflightResult: "skipped",
       evidenceChangedPaths: [],
-      evidenceManifest: evidenceManifest(),
       evidencePolicy: "exact-target-full-validation-v1",
       evidenceReuse: true,
       evidenceRootRunId: "99",
@@ -699,7 +947,6 @@ console.log(JSON.stringify({
           children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
           dockerPreflightResult: "skipped",
           evidenceChangedPaths: [],
-          evidenceManifest: evidenceManifest(),
           evidencePolicy: "exact-target-full-validation-v1",
           evidenceReuse: true,
           evidenceRootRunId: "99",

--- a/test/scripts/openclaw-npm-extended-stable-full-validation-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-full-validation-workflow.test.ts
@@ -45,25 +45,25 @@ describe("extended-stable Full Release Validation workflow", () => {
     const childDispatches = [
       {
         job: "normal_ci",
-        step: "Dispatch and monitor CI",
+        step: "Dispatch CI",
         workflow: "ci.yml",
         target: '-f target_ref="$TARGET_SHA"',
       },
       {
         job: "plugin_prerelease",
-        step: "Dispatch and monitor plugin prerelease",
+        step: "Dispatch plugin prerelease",
         workflow: "plugin-prerelease.yml",
         target: '-f target_ref="$TARGET_SHA" -f expected_sha="$TARGET_SHA"',
       },
       {
         job: "release_checks",
-        step: "Dispatch and monitor release checks",
+        step: "Dispatch release checks",
         workflow: "openclaw-release-checks.yml",
         target: '-f expected_sha="$TARGET_SHA"',
       },
       {
         job: "performance",
-        step: "Dispatch and monitor OpenClaw Performance",
+        step: "Dispatch OpenClaw Performance",
         workflow: "openclaw-performance.yml",
         target: '-f target_ref="$TARGET_SHA"',
       },
@@ -77,9 +77,9 @@ describe("extended-stable Full Release Validation workflow", () => {
     }
 
     expect(fullValidation).toContain("PARENT_WORKFLOW_SHA: ${{ github.sha }}");
-    expect(fullValidation).toContain('if [[ "$head_sha" != "$PARENT_WORKFLOW_SHA" ]]');
+    expect(fullValidation).toContain('if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]');
     expect(fullValidation).toContain(
-      "child run used workflow SHA ${head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}",
+      "child run used workflow SHA ${child_head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}",
     );
   });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6364,11 +6364,19 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("Write release validation manifest");
     expect(workflow).toContain("PERFORMANCE_RUN_ID: ${{ needs.performance.outputs.run_id }}");
     expect(workflow).toContain("Upload release validation manifest");
-    expect(workflow).toContain("Download exact diagnostic drain");
+    expect(workflow).toContain("Download diagnostic drain attempts");
     expect(workflow).toContain("full-release-validation-${{ github.run_id }}");
     expect(workflow).toContain("full-release-diagnostic-manifest.json");
     expect(workflow).not.toContain('gh run view "$run_id" --json createdAt,jobs');
-    expect(manifestStep.env?.PERFORMANCE_RUN_ID).toBe("${{ needs.performance.outputs.run_id }}");
+    expect(manifestStep.env?.RELEASE_EXECUTION_PLAN_PATH).toContain(
+      "full-release-execution-plan.json",
+    );
+    expect(manifestStep.env?.DIAGNOSTIC_DRAIN_PATH).toContain(
+      "full-release-diagnostic-manifest.json",
+    );
+    expect(manifestStep.run).toContain(
+      `PERFORMANCE_RUN_ID="$(jq -r '.children[] | select(.key == "productPerformance") | .runId' "$RELEASE_EXECUTION_PLAN_PATH")"`,
+    );
     expect(manifestStep.run).toContain('--arg performanceRunId "$PERFORMANCE_RUN_ID"');
   });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2986,7 +2986,9 @@ describe("package acceptance workflow", () => {
     expect(planStep.run).toContain("FULL_RELEASE_PLAN_INPUTS_JSON");
     expect(planStep.env).toMatchObject({
       EVIDENCE_CHANGED_PATHS: "${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}",
+      EVIDENCE_RUN_ID: "${{ needs.evidence_reuse.outputs.evidence_run_id }}",
     });
+    expect(planStep.run).toContain('--arg evidenceRunId "$EVIDENCE_RUN_ID"');
     expect(manifestStep.env).toMatchObject({
       EVIDENCE_CHANGED_PATHS: "${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}",
     });

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -62,7 +62,7 @@ const FULL_RELEASE_CHILD_DISPATCHES = [
     kind: "ci",
     nonceSuffix: "-ci",
     runName: "CI",
-    stepName: "Dispatch and monitor CI",
+    stepName: "Dispatch CI",
     workflow: "ci.yml",
   },
   {
@@ -70,7 +70,7 @@ const FULL_RELEASE_CHILD_DISPATCHES = [
     kind: "plugin-prerelease",
     nonceSuffix: "-plugin-prerelease",
     runName: "Plugin Prerelease",
-    stepName: "Dispatch and monitor plugin prerelease",
+    stepName: "Dispatch plugin prerelease",
     workflow: "plugin-prerelease.yml",
   },
   {
@@ -78,7 +78,7 @@ const FULL_RELEASE_CHILD_DISPATCHES = [
     kind: "release-checks",
     nonceSuffix: "-release-checks",
     runName: "OpenClaw Release Checks",
-    stepName: "Dispatch and monitor release checks",
+    stepName: "Dispatch release checks",
     workflow: "openclaw-release-checks.yml",
   },
   {
@@ -86,7 +86,7 @@ const FULL_RELEASE_CHILD_DISPATCHES = [
     kind: "npm-telegram",
     nonceSuffix: "-npm-telegram",
     runName: "NPM Telegram Beta E2E",
-    stepName: "Dispatch and monitor npm Telegram E2E",
+    stepName: "Dispatch npm Telegram E2E",
     workflow: "npm-telegram-beta-e2e.yml",
   },
   {
@@ -94,7 +94,7 @@ const FULL_RELEASE_CHILD_DISPATCHES = [
     kind: "performance",
     nonceSuffix: "",
     runName: "OpenClaw Performance",
-    stepName: "Dispatch and monitor OpenClaw Performance",
+    stepName: "Dispatch OpenClaw Performance",
     workflow: "openclaw-performance.yml",
   },
 ] as const;
@@ -588,6 +588,7 @@ if (args[0] === "workflow" && args[1] === "run") {
     html_url: url,
     id: Number(env.MOCK_GH_RUN_ID),
     path: env.MOCK_GH_RUN_PATH,
+    run_attempt: Number(env.MOCK_GH_RUN_ATTEMPT),
     status: nextStatus(),
     workflow_id: Number(env.MOCK_GH_RUN_WORKFLOW_ID),
   }));
@@ -708,6 +709,7 @@ exit 0
         stepEnv.CHILD_WORKFLOW_REF,
       MOCK_GH_RUN_ID: "101",
       MOCK_GH_RUN_PATH: `.github/workflows/${child.workflow}`,
+      MOCK_GH_RUN_ATTEMPT: "1",
       MOCK_GH_RUN_TITLE: `${child.runName} full-release-validation-77-2${child.nonceSuffix}`,
       MOCK_GH_RUN_WORKFLOW_ID: "789",
       MOCK_GH_STATUSES: '["completed"]',
@@ -2774,7 +2776,7 @@ describe("package acceptance workflow", () => {
     const releaseChecksWorkflow = readFileSync(RELEASE_CHECKS_WORKFLOW, "utf8");
     const performanceJob = workflowStep(
       workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "performance"),
-      "Dispatch and monitor OpenClaw Performance",
+      "Dispatch OpenClaw Performance",
     ).run;
 
     expect(workflow).toContain("TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}");
@@ -2798,14 +2800,14 @@ describe("package acceptance workflow", () => {
     expect(releaseChecksWorkflow).toContain(
       "codex_plugin_spec: ${{ needs.resolve_target.outputs.codex_plugin_spec }}",
     );
-    expect(workflow).toContain("--json status,conclusion,url,attempt,headSha,jobs");
+    expect(workflow).toContain("full-release-validation-state.mjs verify");
     expect(workflow).toContain(
       'gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha',
     );
     expect(workflow).toContain(
       "Child workflow ref ${CHILD_WORKFLOW_REF} moved to ${current_workflow_sha}, expected ${PARENT_WORKFLOW_SHA}; refusing dispatch.",
     );
-    expect(workflow).toContain('if [[ "$head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then');
+    expect(workflow).toContain('if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then');
     expect(workflow).toContain('gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1');
     expect(performanceJob).toContain(
       'dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
@@ -2821,12 +2823,11 @@ describe("package acceptance workflow", () => {
       "did not return an Actions run URL; refusing to guess from recent workflow_dispatch runs",
     );
     expect(workflow).toContain(
-      "child run used workflow SHA ${head_sha}, expected parent workflow SHA ${PARENT_WORKFLOW_SHA}",
+      "full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}",
     );
     expect(workflow).toContain(
-      "Use the SHA-pinned release helper when a moving branch cannot stay fixed",
+      "full-release-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}",
     );
-    expect(workflow).toContain("| Child | Result | Minutes | Head SHA | Run |");
     expect(releaseChecksWorkflow).toContain("refs/heads/release-ci/[0-9a-f]{12}-[0-9]+");
     expect(releaseChecksWorkflow).toContain(
       "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.release_package_spec != '') && 'npm' || 'artifact' }}",
@@ -2840,11 +2841,11 @@ describe("package acceptance workflow", () => {
     const workflow = readFileSync(FULL_RELEASE_VALIDATION_WORKFLOW, "utf8");
     const performanceStep = workflowStep(
       workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "performance"),
-      "Dispatch and monitor OpenClaw Performance",
+      "Dispatch OpenClaw Performance",
     );
     const summaryStep = workflowStep(
       workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "summary"),
-      "Verify child workflow results",
+      "Verify exact release state artifacts",
     );
 
     expect(performanceStep.env?.RELEASE_PROFILE).toBe("${{ inputs.release_profile }}");
@@ -2854,13 +2855,9 @@ describe("package acceptance workflow", () => {
       "fail_on_regression=false",
       '-f fail_on_regression="$fail_on_regression"',
       "Release impact: advisory",
-      "advisory for beta",
     ]);
     expect(summaryStep.env?.RELEASE_PROFILE).toBe("${{ inputs.release_profile }}");
-    expectTextToIncludeAll(summaryStep.run, [
-      '[[ "$RELEASE_PROFILE" == "beta" ]] && performance_advisory=1',
-      'check_child "product_performance" "$PERFORMANCE_RUN_ID" "$performance_required" "$performance_advisory"',
-    ]);
+    expect(summaryStep.run).toBe("node scripts/full-release-validation-state.mjs verify");
     expect(workflow).toContain('performanceBlocking: ($releaseProfile != "beta")');
     expect(workflow).toContain('blocking: ($releaseProfile != "beta")');
   });
@@ -2885,472 +2882,130 @@ describe("package acceptance workflow", () => {
     ]);
   });
 
-  it("keeps child-job fail-fast polling best-effort", () => {
-    for (const child of FULL_RELEASE_CHILD_DISPATCHES.slice(0, 3)) {
-      const dispatch = workflowStep(
-        workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, child.jobName),
-        child.stepName,
-      );
-      expect(dispatch.env?.CHILD_WORKFLOW_KIND).toBe(child.kind);
-      expect(dispatch.run).toContain("continuing with authoritative workflow conclusion.");
-    }
-  });
-
-  it("adopts exact full-release child runs without retrying ambiguous dispatch posts", () => {
+  it("dispatches exact child identities without owning child completion", () => {
     const dispatchScripts = FULL_RELEASE_CHILD_DISPATCHES.map((child) => {
       const job = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, child.jobName);
       const step = workflowStep(job, child.stepName);
       expect(step.env?.CHILD_WORKFLOW_KIND).toBe(child.kind);
+      expect(job["timeout-minutes"]).toBe(15);
+      expect(job.outputs).toMatchObject({
+        run_attempt: "${{ steps.dispatch.outputs.run_attempt }}",
+        run_id: "${{ steps.dispatch.outputs.run_id }}",
+        url: "${{ steps.dispatch.outputs.url }}",
+      });
       return step.run ?? "";
     });
     expect(new Set(dispatchScripts).size).toBe(1);
-
     for (const script of dispatchScripts) {
       expect(script.match(/gh workflow run/gu)).toHaveLength(1);
-      expect(script).not.toContain("gh_with_retry workflow run");
       expectTextToIncludeAll(script, [
         "The dispatch POST is one-shot",
-        'encoded_workflow_ref="$(jq -rn --arg value "$CHILD_WORKFLOW_REF"',
-        'gh_with_retry api "repos/${GITHUB_REPOSITORY}/commits/${encoded_workflow_ref}" --jq .sha',
-        '"$current_workflow_sha" != "$PARENT_WORKFLOW_SHA"',
-        "refusing dispatch.",
-        "set +e",
-        "dispatch_status=$?",
-        'if [[ "$dispatch_status" -ne 0 && ! "$dispatch_output" =~ $GH_TRANSIENT_SERVER_OR_NETWORK_PATTERN ]]',
-        "dispatch failed with non-ambiguous status ${dispatch_status}; refusing adoption polling.",
-        'sed -nE "s#^https://github[.]com/${GITHUB_REPOSITORY}/actions/runs/([0-9]+)\\$#\\1#p"',
         'validate_child_run "$run_id"',
-        'DISPATCH_RUN_NAME="$dispatch_run_name" CHILD_WORKFLOW_REF="$CHILD_WORKFLOW_REF"',
-        ".display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF",
-        "Multiple runs matched ${dispatch_run_name}; refusing to guess.",
-        "The dispatch was not retried to avoid creating a duplicate child.",
-        "adopted exact run ${run_id}",
+        'child_run_attempt="$(jq -r \'.run_attempt // ""\' <<< "$run_json")"',
+        'echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"',
+        'echo "run_attempt=${child_run_attempt}" >> "$GITHUB_OUTPUT"',
+        'echo "url=${url}" >> "$GITHUB_OUTPUT"',
       ]);
-      expect(script.indexOf("dispatch failed with non-ambiguous status")).toBeLessThan(
-        script.indexOf('run_id=""'),
-      );
+      expect(script).not.toContain("while true");
+      expect(script).not.toContain("gh run cancel");
+      expect(script).not.toContain("fail_fast_failed_jobs");
     }
-
-    const parsedWorkflow = readWorkflow(FULL_RELEASE_VALIDATION_WORKFLOW);
-    const transientPattern = parsedWorkflow.env?.GH_TRANSIENT_SERVER_OR_NETWORK_PATTERN;
-    expect(transientPattern).toBeDefined();
-    const transientError = new RegExp(transientPattern ?? "", "u");
-    for (const message of [
-      "could not create workflow dispatch event: HTTP 500: Failed to run workflow dispatch",
-      "gh: HTTP 502",
-      "500 Internal Server Error",
-      "invalid character '<' looking for beginning of value",
-      "error connecting to api.github.com",
-      "context deadline exceeded",
-      "read: connection reset by peer",
-      "connect: connection refused",
-      "net/http: TLS handshake timeout",
-      "read: i/o timeout",
-      "network is unreachable",
-      "unexpected EOF",
-      'Post "https://api.github.com/repos/openclaw/openclaw/actions/workflows/ci.yml/dispatches": EOF',
-      "EOF",
-      "ETIMEDOUT",
-      "ECONNRESET",
-      "EAI_AGAIN",
-    ]) {
-      expect(transientError.test(message), message).toBe(true);
-    }
-    for (const message of [
-      "HTTP 400: Bad Request",
-      "HTTP 401: Bad credentials",
-      "HTTP 403: Resource not accessible by integration",
-      "HTTP 404: workflow not found",
-      "HTTP 422: Validation Failed",
-      "HTTP 429: too many requests",
-      "unknown flag --field",
-      "EOFError while parsing local input",
-    ]) {
-      expect(transientError.test(message), message).toBe(false);
-    }
-
-    const summaryScript =
-      workflowStep(
-        workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "summary"),
-        "Verify child workflow results",
-      ).run ?? "";
-    for (const script of [...dispatchScripts, summaryScript]) {
-      expect(script.match(/gh_with_retry\(\)/gu)).toHaveLength(1);
-      expectTextToIncludeAll(script, [
-        '"$output" == *"HTTP 429"*',
-        '"$output" == *"abuse detection"*',
-        '"$output" =~ $GH_TRANSIENT_SERVER_OR_NETWORK_PATTERN',
-        'return "$status"',
-      ]);
-    }
-
-    const workflow = readFileSync(FULL_RELEASE_VALIDATION_WORKFLOW, "utf8");
-    const retryCalls = workflow.split("\n").filter((line) => line.includes("gh_with_retry "));
-    expect(retryCalls.length).toBeGreaterThan(0);
-    for (const call of retryCalls) {
-      expect(call).toMatch(/gh_with_retry (api|run view)/u);
-    }
-    expect(workflow).not.toMatch(/gh_with_retry (workflow run|run cancel)/u);
-    expectTextToIncludeAll(workflow, [
-      'dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-ci"',
-      'dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-plugin-prerelease"',
-      'dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-release-checks"',
-      'dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-npm-telegram"',
-      'args+=(-f dispatch_id="$dispatch_id")',
-    ]);
-    expect(readFileSync(".github/workflows/ci.yml", "utf8")).toContain(
-      "format('CI {0}', inputs.dispatch_id)",
-    );
-    expect(readFileSync(".github/workflows/plugin-prerelease.yml", "utf8")).toContain(
-      "format('Plugin Prerelease {0}', inputs.dispatch_id)",
-    );
-    expect(readFileSync(RELEASE_CHECKS_WORKFLOW, "utf8")).toContain(
-      "format('OpenClaw Release Checks {0}', inputs.dispatch_id)",
-    );
-    expect(readFileSync(NPM_TELEGRAM_WORKFLOW, "utf8")).toContain(
-      "format('NPM Telegram Beta E2E {0}', inputs.dispatch_id)",
-    );
-    expect(readWorkflow(PLUGIN_PRERELEASE_WORKFLOW).concurrency?.group).toBe(
-      "plugin-prerelease-${{ inputs.target_ref }}-${{ github.sha }}",
-    );
-    expect(readWorkflow(RELEASE_CHECKS_WORKFLOW).concurrency?.group).toBe(
-      "openclaw-release-checks-${{ inputs.expected_sha || inputs.ref }}-${{ github.sha }}-${{ inputs.rerun_group }}",
-    );
   });
 
   it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "adopts and validates the run URL returned for $jobName without listing runs",
+    "adopts and validates the exact $jobName run without waiting for terminal status",
     (child) => {
       const { calls, result } = runFullReleaseChildDispatch(child, {
         MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
+        MOCK_GH_STATUSES: '["in_progress"]',
       });
 
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
-      expect(
-        calls.filter(({ args }) =>
-          args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),
-        ),
-      ).toHaveLength(0);
-      expect(
-        calls.some(({ args }) => args.some((value) => value.endsWith("/actions/runs/101"))),
-      ).toBe(true);
       expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
+      expect(result.stdout).toContain("Dispatched");
     },
   );
 
-  it("recovers by exact name when a successful dispatch returns no run URL", () => {
+  it("recovers one ambiguous dispatch by exact name without reposting", () => {
     const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
-      MOCK_GH_DISPATCH_OUTPUT: "",
+      MOCK_GH_DISPATCH_ERROR: "HTTP 500: Failed to run workflow dispatch",
     });
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
-    expect(
-      calls.filter(({ args }) =>
-        args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),
-      ),
-    ).toHaveLength(1);
+    expect(calls.some(({ args }) => args.includes("-X"))).toBe(true);
+    expect(result.stderr).toContain("adopted exact run 101");
   });
 
-  it.each([
-    ["workflow", { MOCK_GH_RUN_WORKFLOW_ID: "790" }],
-    ["title", { MOCK_GH_RUN_TITLE: "Unrelated workflow run" }],
-    ["head branch", { MOCK_GH_RUN_HEAD_BRANCH: "other" }],
-    ["event", { MOCK_GH_RUN_EVENT: "push" }],
-  ] as const)("refuses a returned run URL with the wrong %s", (label, overrides) => {
-    const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
+  it("keeps dispatch provenance failures separate from cancellation policy", () => {
+    const moved = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
+      MOCK_GH_CURRENT_SHA: "c".repeat(40),
+    });
+    expect(moved.result.status).toBe(1);
+    expect(moved.result.stderr).toContain("refusing dispatch");
+    expect(moved.calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(0);
+
+    const mismatched = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
+      MOCK_GH_CHILD_SHA: "c".repeat(40),
       MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
-      ...overrides,
     });
+    expect(mismatched.result.status).toBe(1);
+    expect(mismatched.result.stderr).toContain("expected parent workflow SHA");
+    expect(
+      mismatched.calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel"),
+    ).toHaveLength(0);
+  });
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain(
-      label === "title"
-        ? "Refusing to adopt ci.yml run 101: run never became readable with display title"
-        : "Refusing to adopt unvalidated ci.yml run 101",
+  it("runs Release Decision and Diagnostic Drain in parallel from exact child tuples", () => {
+    const executionPlan = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "release_execution_plan");
+    const decision = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "release_decision");
+    const drain = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "diagnostic_drain");
+    const summary = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "summary");
+    const decisionStep = workflowStep(decision, "Evaluate release decision");
+    const drainStep = workflowStep(drain, "Drain child diagnostics");
+    const decisionUpload = workflowStep(decision, "Upload release decision");
+    const drainUpload = workflowStep(drain, "Upload diagnostic drain manifest");
+
+    expect(decision.needs).toEqual(["resolve_target", "release_execution_plan"]);
+    expect(drain.needs).toEqual(["resolve_target", "release_execution_plan"]);
+    expect(decisionStep.run).toBe(drainStep.run);
+    expect(decisionStep.env).toMatchObject({
+      FAIL_FAST: "${{ inputs.fail_fast }}",
+      FULL_RELEASE_STATE_MODE: "decision",
+    });
+    expect(drainStep.env).toMatchObject({
+      FAIL_FAST: "false",
+      FULL_RELEASE_STATE_MODE: "drain",
+    });
+    expectTextToIncludeAll(decisionStep.run, [
+      'node scripts/full-release-validation-state.mjs "$FULL_RELEASE_STATE_MODE"',
+    ]);
+    expect(workflowStep(executionPlan, "Seal immutable release execution plan").run).toContain(
+      "FULL_RELEASE_PLAN_INPUTS_JSON",
     );
-    expect(
-      calls.some(({ args }) =>
-        args.some((value) => value.includes("/actions/workflows/") && value.endsWith("/runs")),
-      ),
-    ).toBe(false);
-    expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
-  });
-
-  it("refuses a nonnumeric exact-name candidate without cancellation ownership", () => {
-    const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
-      MOCK_GH_DISPATCH_OUTPUT: "",
-      MOCK_GH_MATCHES: '["not-a-run-id"]',
-    });
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Refusing to adopt invalid ci.yml run ID not-a-run-id");
-    expect(
-      calls.some(({ args }) => args.some((value) => value.endsWith("/actions/runs/not-a-run-id"))),
-    ).toBe(false);
-    expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
-  });
-
-  it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "rejects moved workflow refs before dispatching $jobName",
-    (child) => {
-      const { calls, result } = runFullReleaseChildDispatch(child, {
-        MOCK_GH_CURRENT_SHA: "c".repeat(40),
-      });
-
-      expect(result.status).toBe(1);
-      expect(result.stderr).toContain("refusing dispatch.");
-      expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(0);
-    },
-  );
-
-  it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "adopts the one exact $jobName child after an ambiguous dispatch without reposting",
-    (child) => {
-      const { calls, result } = runFullReleaseChildDispatch(child, {
-        MOCK_GH_DISPATCH_ERROR: "HTTP 500: Failed to run workflow dispatch",
-      });
-      const dispatchCalls = calls.filter(({ args }) => args[0] === "workflow");
-      const adoptionCall = calls.find(({ args }) => args.includes("-X"));
-
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      expect(result.stderr).toContain("adopted exact run 101");
-      expect(dispatchCalls).toHaveLength(1);
-      expect(dispatchCalls[0]?.args.slice(0, 5)).toEqual([
-        "workflow",
-        "run",
-        child.workflow,
-        "--ref",
-        "main",
-      ]);
-      expect(adoptionCall).toMatchObject({
-        childWorkflowRef: "main",
-        dispatchRunName: `${child.runName} full-release-validation-77-2${child.nonceSuffix}`,
-      });
-      expect(adoptionCall?.args).toContain(
-        "[.workflow_runs[] | select(.display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF) | .id]",
+    expect(workflowStep(executionPlan, "Upload immutable release execution plan").with?.name).toBe(
+      "full-release-execution-plan-${{ github.run_id }}",
+    );
+    expect(decisionUpload.with?.name).toBe(
+      "full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}",
+    );
+    expect(drainUpload.with?.name).toBe(
+      "full-release-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}",
+    );
+    expect(summary.needs).toEqual(expect.arrayContaining(["release_decision", "diagnostic_drain"]));
+    for (const jobId of [
+      "docker_runtime_assets_preflight",
+      "prepare_release_candidate",
+      "normal_ci",
+      "plugin_prerelease",
+      "release_checks",
+      "npm_telegram",
+      "performance",
+    ]) {
+      expect(String(workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, jobId).if)).toContain(
+        "github.run_attempt == 1",
       );
-      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
-    },
-  );
-
-  it("leaves the adopted child running when the monitor receives SIGTERM", () => {
-    const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], {
-      MOCK_GH_STATUSES: '["in_progress"]',
-      MOCK_SLEEP_SIGNAL: "TERM",
-    });
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBeNull();
-    expect(result.signal).toBe("SIGTERM");
-    expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
-  });
-
-  it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "refuses duplicate exact adoption candidates for $jobName",
-    (child) => {
-      const { calls, result } = runFullReleaseChildDispatch(child, {
-        MOCK_GH_MATCHES: "[101, 102]",
-      });
-
-      expect(result.status).toBe(1);
-      expect(result.stderr).toContain("Multiple runs matched");
-      expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
-      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(0);
-    },
-  );
-
-  it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "refuses to adopt or retry a non-transient $jobName dispatch failure",
-    (child) => {
-      const { calls, result } = runFullReleaseChildDispatch(child, {
-        MOCK_GH_DISPATCH_ERROR: "HTTP 422: Validation Failed",
-      });
-
-      expect(result.status).toBe(1);
-      expect(result.stderr).toContain("refusing adoption polling");
-      expect(calls.filter(({ args }) => args[0] === "workflow")).toHaveLength(1);
-      expect(calls.some(({ args }) => args.includes("-X"))).toBe(false);
-      expect(calls.some(({ args }) => args[0] === "run" && args[1] === "cancel")).toBe(false);
-    },
-  );
-
-  it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "cancels exactly the identified $jobName child when its workflow SHA differs",
-    (child) => {
-      const { calls, result } = runFullReleaseChildDispatch(child, {
-        MOCK_GH_CHILD_SHA: "c".repeat(40),
-        MOCK_GH_DISPATCH_OUTPUT: "https://github.com/openclaw/openclaw/actions/runs/101",
-      });
-
-      expect(result.status).toBe(1);
-      expect(result.stderr).toContain("expected parent workflow SHA");
-      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toEqual([
-        expect.objectContaining({ args: ["run", "cancel", "101"] }),
-      ]);
-    },
-  );
-
-  it.each(FULL_RELEASE_CHILD_DISPATCHES)(
-    "leaves the adopted $jobName child running when monitoring fails unexpectedly",
-    (child) => {
-      const { calls, result } = runFullReleaseChildDispatch(child, {
-        MOCK_GH_STATUS_ERROR: "HTTP 403: Resource not accessible by integration",
-      });
-
-      expect(result.status).toBe(1);
-      expect(result.stderr).toContain("HTTP 403");
-      expect(
-        calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel"),
-        `${result.stdout}\n${result.stderr}\n${JSON.stringify(calls)}`,
-      ).toEqual([]);
-    },
-  );
-
-  it.each(FULL_RELEASE_CHILD_DISPATCHES.slice(0, 4))(
-    "cancels the exact $jobName child after its first blocking failed job",
-    (child) => {
-      const { calls, result } = runFullReleaseChildDispatch(child, {
-        FAIL_FAST: "true",
-        MOCK_GH_JOBS: JSON.stringify([
-          {
-            conclusion: "failure",
-            html_url: "https://github.com/openclaw/openclaw/actions/runs/101/job/201",
-            name: "Run package acceptance",
-            status: "completed",
-            url: "https://github.com/openclaw/openclaw/actions/runs/101/job/201",
-          },
-        ]),
-        MOCK_GH_STATUSES: JSON.stringify([
-          "in_progress",
-          "in_progress",
-          "in_progress",
-          "in_progress",
-          "in_progress",
-          "in_progress",
-          "completed",
-        ]),
-      });
-
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
-      expect(result.stdout).toContain("has failed child jobs before the workflow completed");
-      expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(1);
-    },
-  );
-
-  it("keeps CI fail-fast job lookups advisory and npm Telegram fail-closed without cancellation", () => {
-    const overrides = {
-      FAIL_FAST: "true",
-      MOCK_GH_JOBS_ERROR: "HTTP 403: Resource not accessible by integration",
-      MOCK_GH_STATUSES: JSON.stringify([
-        "in_progress",
-        "in_progress",
-        "in_progress",
-        "in_progress",
-        "in_progress",
-        "in_progress",
-        "completed",
-      ]),
-    };
-    const normalCi = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[0], overrides);
-    const npmTelegram = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[3], overrides);
-
-    expect(normalCi.result.status, normalCi.result.stderr).toBe(0);
-    expect(normalCi.result.stdout).toContain("continuing with authoritative workflow conclusion.");
-    expect(npmTelegram.result.status).toBe(1);
-    expect(
-      npmTelegram.calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel"),
-      `${npmTelegram.result.stdout}\n${npmTelegram.result.stderr}\n${JSON.stringify(npmTelegram.calls)}`,
-    ).toEqual([]);
-  });
-
-  it.each([
-    { expectedStatus: 0, jobName: "Run QA Lab parity lane (sqlite)" },
-    { expectedStatus: 0, jobName: "Run QA Lab live Discord lane" },
-    { expectedStatus: 0, jobName: "Run repo/live E2E validation / Docker live" },
-    {
-      expectedStatus: 0,
-      jobName: "Run package acceptance / Telegram package acceptance / mock-openai",
-    },
-    { expectedStatus: 1, jobName: "Run repo/live E2E validation / Repo E2E" },
-    { expectedStatus: 1, jobName: "Run package acceptance / Verify package integrity" },
-  ])("preserves beta fail-fast ownership for $jobName", ({ expectedStatus, jobName }) => {
-    const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[2], {
-      FAIL_FAST: "true",
-      MOCK_GH_JOBS: JSON.stringify([
-        {
-          conclusion: "failure",
-          html_url: "https://github.com/openclaw/openclaw/actions/runs/101/job/201",
-          name: jobName,
-          status: "completed",
-        },
-      ]),
-      MOCK_GH_STATUSES: JSON.stringify([
-        "in_progress",
-        "in_progress",
-        "in_progress",
-        "in_progress",
-        "in_progress",
-        "in_progress",
-        "completed",
-      ]),
-      RELEASE_PROFILE: "beta",
-    });
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(expectedStatus);
-    expect(calls.filter(({ args }) => args[0] === "run" && args[1] === "cancel")).toHaveLength(
-      expectedStatus,
-    );
-  });
-
-  it.each([
-    { expectedStatus: 0, failOnRegression: "false", profile: "beta" },
-    { expectedStatus: 1, failOnRegression: "true", profile: "stable" },
-  ])(
-    "keeps failed product performance $profile release behavior unchanged",
-    ({ expectedStatus, failOnRegression, profile }) => {
-      const { calls, result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[4], {
-        MOCK_GH_CONCLUSION: "failure",
-        RELEASE_PROFILE: profile,
-      });
-      const dispatch = calls.find(({ args }) => args[0] === "workflow");
-
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(expectedStatus);
-      expect(dispatch?.args).toContain(`fail_on_regression=${failOnRegression}`);
-      if (profile === "beta") {
-        expect(result.stdout).toContain("advisory for beta");
-      }
-    },
-  );
-
-  it.each([
-    { expectedStatus: 0, failingJob: "Run optional live-provider check" },
-    { expectedStatus: 1, failingJob: "Run package acceptance" },
-  ])("keeps Tideclaw alpha package-safety lanes blocking", ({ expectedStatus, failingJob }) => {
-    const { result } = runFullReleaseChildDispatch(FULL_RELEASE_CHILD_DISPATCHES[2], {
-      CHILD_WORKFLOW_REF: "tideclaw/alpha/2026-08-01-0000Z",
-      MOCK_GH_CONCLUSION: "failure",
-      MOCK_GH_JOBS: JSON.stringify([
-        {
-          conclusion: "success",
-          html_url: "https://github.com/openclaw/openclaw/actions/runs/101/job/201",
-          name: "Verify release checks",
-          status: "completed",
-        },
-        {
-          conclusion: "failure",
-          html_url: "https://github.com/openclaw/openclaw/actions/runs/101/job/202",
-          name: failingJob,
-          status: "completed",
-        },
-      ]),
-    });
-
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(expectedStatus);
-    if (expectedStatus === 0) {
-      expect(result.stdout).toContain("accepted Tideclaw alpha advisory lanes");
-    } else {
-      expect(result.stdout).toContain("package-safety Tideclaw alpha release-check lane");
     }
   });
 
@@ -3699,11 +3354,11 @@ describe("package artifact reuse", () => {
     const prepare = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "prepare_release_candidate");
     const pluginDispatch = workflowStep(
       workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "plugin_prerelease"),
-      "Dispatch and monitor plugin prerelease",
+      "Dispatch plugin prerelease",
     );
     const releaseDispatch = workflowStep(
       workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "release_checks"),
-      "Dispatch and monitor release checks",
+      "Dispatch release checks",
     );
 
     expect(prepare.uses).toBe("./.github/workflows/openclaw-live-and-e2e-checks-reusable.yml");
@@ -3724,7 +3379,7 @@ describe("package artifact reuse", () => {
     expect(releaseDispatch.run).toContain(
       'args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")',
     );
-    expect(workflow).toContain("Shared release candidate preparation ended with");
+    expect(workflow).toContain("prepareCandidateResult: $prepareCandidateResult");
   });
 
   it("enables prerelease plugin companions for scheduled ref validation", () => {
@@ -5683,12 +5338,9 @@ describe("package artifact reuse", () => {
     const toolingIdentity = workflowStep(resolveTargetJob, "Resolve trusted workflow identity");
     const releaseInputValidation = workflowStep(resolveTargetJob, "Validate release inputs");
     const evidenceReuseStep = workflowStep(evidenceReuseJob, "Find reusable validation evidence");
-    const releaseChecksDispatchStep = workflowStep(
-      releaseChecksJob,
-      "Dispatch and monitor release checks",
-    );
-    const dispatchStep = workflowStep(npmTelegramJob, "Dispatch and monitor npm Telegram E2E");
-    const verificationStep = workflowStep(summaryJob, "Verify child workflow results");
+    const releaseChecksDispatchStep = workflowStep(releaseChecksJob, "Dispatch release checks");
+    const dispatchStep = workflowStep(npmTelegramJob, "Dispatch npm Telegram E2E");
+    const verificationStep = workflowStep(summaryJob, "Verify exact release state artifacts");
     const manifestStep = workflowStep(summaryJob, "Write release validation manifest");
 
     expect(workflowInputs).toMatchObject({
@@ -5744,10 +5396,8 @@ describe("package artifact reuse", () => {
     ]);
     expect(npmTelegramJob.name).toBe("Run package Telegram E2E");
     expect(npmTelegramJob.needs).toEqual(["resolve_target", "evidence_reuse"]);
-    expect(npmTelegramJob["timeout-minutes"]).toBe(
-      "${{ inputs.release_profile == 'full' && 360 || 120 }}",
-    );
-    expect(performanceJob["timeout-minutes"]).toBe(360);
+    expect(npmTelegramJob["timeout-minutes"]).toBe(15);
+    expect(performanceJob["timeout-minutes"]).toBe(15);
     expect(npmTelegramJob.if).toContain(
       'contains(fromJSON(\'["all","npm-telegram"]\'), inputs.rerun_group)',
     );
@@ -5792,7 +5442,6 @@ describe("package artifact reuse", () => {
     expect(dispatchStep.env).toEqual({
       CHILD_WORKFLOW_KIND: "npm-telegram",
       CHILD_WORKFLOW_REF: "${{ github.ref_name }}",
-      FAIL_FAST: "${{ inputs.fail_fast }}",
       GH_TOKEN: "${{ github.token }}",
       PACKAGE_SPEC: "${{ inputs.npm_telegram_package_spec || inputs.release_package_spec }}",
       PARENT_WORKFLOW_SHA: "${{ github.sha }}",
@@ -5818,17 +5467,18 @@ describe("package artifact reuse", () => {
       "allowUnreleasedChangelog: $allowUnreleasedChangelog",
     ]);
     expect(verificationStep.env).toMatchObject({
-      SKIP_PACKAGE_TELEGRAM_E2E: "${{ inputs.skip_package_telegram_e2e }}",
+      RELEASE_PROFILE: "${{ inputs.release_profile }}",
+      RERUN_GROUP: "${{ inputs.rerun_group }}",
     });
-    expect(verificationStep.run).toContain("Package Telegram E2E deferred:");
+    expect(verificationStep.run).toBe("node scripts/full-release-validation-state.mjs verify");
     expectTextToIncludeAll(dispatchStep.run, [
       'dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-npm-telegram"',
       'dispatch_output="$(gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@" 2>&1)"',
-      'dispatch_and_wait npm-telegram-beta-e2e.yml "$dispatch_run_name" "${args[@]}"',
+      'dispatch_child npm-telegram-beta-e2e.yml "$dispatch_run_name" "${args[@]}"',
       ".display_title == env.DISPATCH_RUN_NAME and .head_branch == env.CHILD_WORKFLOW_REF",
       "The dispatch was not retried to avoid creating a duplicate child.",
       'if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then',
-      "Still waiting on ${workflow} after ${elapsed_minutes}m:",
+      'echo "run_attempt=${child_run_attempt}" >> "$GITHUB_OUTPUT"',
       '-f harness_ref="$TARGET_SHA"',
       'args=(-f package_spec="$PACKAGE_SPEC"',
       'args+=(-f scenario="$SCENARIO")',
@@ -5838,28 +5488,12 @@ describe("package artifact reuse", () => {
       '-f rerun_group="$RERUN_GROUP"',
       'args+=(-f live_suite_filter="$LIVE_SUITE_FILTER")',
       'args+=(-f cross_os_suite_filter="$CROSS_OS_SUITE_FILTER")',
-      'case "$RERUN_GROUP" in',
-      "install-smoke|cross-os|live-e2e|package|qa-parity|qa-live)",
       "cancel-in-progress: false",
-      "Verify release checks accepted Tideclaw alpha advisory lanes",
-      "release_checks_advisory_only",
-      "release_check_blocking_job",
-      'if [[ "$RERUN_GROUP" == "npm-telegram" || ( "$RERUN_GROUP" == "all"',
-      "npm_telegram_required=1",
-      "Reused evidence did not record the required npm Telegram child run.",
-      'check_child "npm_telegram" "" "$npm_telegram_required"',
-      'if [[ "$RELEASE_PROFILE" == "beta" && "$1" == "Run package acceptance / Telegram package acceptance / "* ]]; then',
-      'or (.name | startswith("Run QA Lab runtime-pair lane ("))',
-      'or .name == "Run QA Lab live Discord lane"',
-      'or (.name | startswith("Run package acceptance / Telegram package acceptance / ")))',
-      "is a package-safety Tideclaw alpha release-check lane",
-      '"Run package acceptance" | \\',
-      '"Run package acceptance / "*)',
-      'check_child "release_checks" "$RELEASE_CHECKS_RUN_ID" 1 1',
-      "gh run cancel",
+      "FULL_RELEASE_PLAN_INPUTS_JSON",
+      "full-release-validation-policy.mjs",
+      "full-release-validation-state.mjs verify",
+      'FAIL_FAST: "false"',
       "NORMAL_CI_RESULT: ${{ needs.normal_ci.result }}",
-      "Sorry. Your account was suspended",
-      'gh_with_retry run view "$run_id" --json status,conclusion,url,attempt,headSha,jobs',
     ]);
     expect(workflow).not.toContain("force-cancel");
     expect(workflow).not.toContain("workflow_ref:");
@@ -6665,19 +6299,12 @@ describe("package artifact reuse", () => {
     const summaryJob = parsedWorkflow.jobs?.summary;
     const manifestStep = workflowStep(summaryJob ?? {}, "Write release validation manifest");
 
-    expect(workflow).toContain("### Slowest jobs: ${label}");
-    expect(workflow).toContain("### Longest start delays: ${label}");
     expect(workflow).toContain("Write release validation manifest");
     expect(workflow).toContain("PERFORMANCE_RUN_ID: ${{ needs.performance.outputs.run_id }}");
     expect(workflow).toContain("Upload release validation manifest");
-    expect(workflow).toContain("Failed child detail: ${label}");
-    expect(workflow).toContain("actions/runs/${run_id}/artifacts?per_page=100");
+    expect(workflow).toContain("Download exact diagnostic drain");
     expect(workflow).toContain("full-release-validation-${{ github.run_id }}");
-    expect(workflow).toContain("| Job | Result | Start delay minutes | Run minutes |");
-    expect(workflow).toContain(
-      'gh_with_retry api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100"',
-    );
-    expect(workflow).toContain("(.started_at | ts) - (.created_at | ts)");
+    expect(workflow).toContain("full-release-diagnostic-manifest.json");
     expect(workflow).not.toContain('gh run view "$run_id" --json createdAt,jobs');
     expect(manifestStep.env?.PERFORMANCE_RUN_ID).toBe("${{ needs.performance.outputs.run_id }}");
     expect(manifestStep.run).toContain('--arg performanceRunId "$PERFORMANCE_RUN_ID"');
@@ -7470,7 +7097,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(readFileSync(LIVE_E2E_WORKFLOW, "utf8")).toContain("live-cache attempt ${attempt}/2");
   });
 
-  it("keeps known bounded dominant child paths below parent monitors", () => {
+  it("keeps known bounded dominant child paths below the centralized drain owner", () => {
     const fullRelease = readWorkflow(FULL_RELEASE_VALIDATION_WORKFLOW);
     const pluginPrerelease = readWorkflow(PLUGIN_PRERELEASE_WORKFLOW);
     const liveE2e = readWorkflow(LIVE_E2E_WORKFLOW);
@@ -7480,6 +7107,19 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const packageAcceptance = readWorkflow(PACKAGE_ACCEPTANCE_WORKFLOW);
     const qaLive = readWorkflow(QA_LIVE_TRANSPORTS_WORKFLOW);
     const profiles = ["beta", "stable", "full"] as const;
+    const releaseDecisionTimeout = fullRelease.jobs?.release_decision?.["timeout-minutes"];
+    const diagnosticDrainTimeout = fullRelease.jobs?.diagnostic_drain?.["timeout-minutes"];
+    expect(releaseDecisionTimeout).toBe(720);
+    expect(diagnosticDrainTimeout).toBe(720);
+    for (const dispatchJob of [
+      "normal_ci",
+      "plugin_prerelease",
+      "release_checks",
+      "npm_telegram",
+      "performance",
+    ]) {
+      expect(fullRelease.jobs?.[dispatchJob]?.["timeout-minutes"], dispatchJob).toBe(15);
+    }
 
     const ciPreflight = workflowJob(CI_WORKFLOW, "preflight");
     const ciIos = workflowJob(CI_WORKFLOW, "ios-build");
@@ -7494,29 +7134,20 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(ciPath).toEqual([20, 150, 5]);
     const ciChildTimeout = ciPath.reduce((total, timeout) => total + timeout, 0);
     expect(ciChildTimeout).toBe(175);
-    const ciParentTimeout = timeoutForProfile(
-      fullRelease.jobs?.normal_ci?.["timeout-minutes"],
-      "beta",
-    );
-    expect(ciChildTimeout).toBeLessThanOrEqual(ciParentTimeout);
-    expect(ciParentTimeout - ciChildTimeout).toBeGreaterThanOrEqual(60);
+    expect(ciChildTimeout).toBeLessThanOrEqual(diagnosticDrainTimeout);
+    expect(diagnosticDrainTimeout - ciChildTimeout).toBeGreaterThanOrEqual(60);
 
     expect(liveE2e.jobs?.validate_selected_ref?.["timeout-minutes"]).toBe(30);
-    const pluginMonitorTimeout = fullRelease.jobs?.plugin_prerelease?.["timeout-minutes"];
     const pluginChildTimeouts = Object.fromEntries(
       profiles.map((profile) => [
         profile,
         pluginPrereleaseTimeoutFloor(pluginPrerelease, liveE2e, profile),
       ]),
     ) as Record<(typeof profiles)[number], number>;
-    const pluginParentTimeouts = Object.fromEntries(
-      profiles.map((profile) => [profile, timeoutForProfile(pluginMonitorTimeout, profile)]),
-    ) as Record<(typeof profiles)[number], number>;
     expect(pluginChildTimeouts).toEqual({ beta: 175, stable: 175, full: 205 });
-    expect(pluginParentTimeouts).toEqual({ beta: 240, stable: 240, full: 300 });
     for (const profile of profiles) {
       expect(
-        pluginParentTimeouts[profile] - pluginChildTimeouts[profile],
+        diagnosticDrainTimeout - pluginChildTimeouts[profile],
         `plugin-prerelease:${profile}`,
       ).toBeGreaterThanOrEqual(60);
     }
@@ -7594,7 +7225,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     });
     const releaseChecksParent = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "release_checks");
     expect(releaseChecksParent["runs-on"]).toBe("blacksmith-4vcpu-ubuntu-2404");
-    expect(releaseChecksParent["timeout-minutes"]).toBe(420);
+    expect(releaseChecksParent["timeout-minutes"]).toBe(15);
     const releasePackageTimeouts = {
       beta: releasePackagePaths.beta.reduce((total, timeout) => total + timeout, 0),
       stable: releasePackagePaths.stable.reduce((total, timeout) => total + timeout, 0),
@@ -7602,8 +7233,13 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     };
     expect(releasePackageTimeouts).toEqual({ beta: 310, stable: 310, full: 340 });
     for (const [profile, childTimeout] of Object.entries(releasePackageTimeouts)) {
-      expect(childTimeout, `release-package:${profile}`).toBeLessThanOrEqual(420);
-      expect(420 - childTimeout, `release-package:${profile}`).toBeGreaterThanOrEqual(60);
+      expect(childTimeout, `release-package:${profile}`).toBeLessThanOrEqual(
+        diagnosticDrainTimeout,
+      );
+      expect(
+        diagnosticDrainTimeout - childTimeout,
+        `release-package:${profile}`,
+      ).toBeGreaterThanOrEqual(60);
     }
 
     const releaseSummary = workflowJob(RELEASE_CHECKS_WORKFLOW, "summary");
@@ -7675,8 +7311,13 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       ["qa-live", releaseQaLivePath],
     ] as const) {
       const childTimeout = path.reduce((total, timeout) => total + timeout, 0);
-      expect(childTimeout, `release-checks:${pathName}`).toBeLessThanOrEqual(420);
-      expect(420 - childTimeout, `release-checks:${pathName}`).toBeGreaterThanOrEqual(60);
+      expect(childTimeout, `release-checks:${pathName}`).toBeLessThanOrEqual(
+        diagnosticDrainTimeout,
+      );
+      expect(
+        diagnosticDrainTimeout - childTimeout,
+        `release-checks:${pathName}`,
+      ).toBeGreaterThanOrEqual(60);
     }
     expect(releaseCrossOsPath.reduce((total, timeout) => total + timeout, 0)).toBe(200);
     expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(265);
@@ -7702,24 +7343,14 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       0,
     );
     expect(releaseTelegramTimeout).toBe(245);
-    expect(420 - releaseTelegramTimeout).toBeGreaterThanOrEqual(60);
+    expect(diagnosticDrainTimeout - releaseTelegramTimeout).toBeGreaterThanOrEqual(60);
 
     const npmTelegramChildTimeout = timeoutForProfile(
       workflowJob(NPM_TELEGRAM_WORKFLOW, "run_package_telegram_e2e")["timeout-minutes"],
       "beta",
     );
     expect(npmTelegramChildTimeout).toBe(60);
-    for (const profile of profiles) {
-      const parentTimeout = timeoutForProfile(
-        fullRelease.jobs?.npm_telegram?.["timeout-minutes"],
-        profile,
-      );
-      expect(parentTimeout).toBe(profile === "full" ? 360 : 120);
-      expect(
-        parentTimeout - npmTelegramChildTimeout,
-        `npm-telegram:${profile}`,
-      ).toBeGreaterThanOrEqual(60);
-    }
+    expect(diagnosticDrainTimeout - npmTelegramChildTimeout).toBeGreaterThanOrEqual(60);
 
     const performanceResolve = workflowJob(PERFORMANCE_WORKFLOW, "resolve_target");
     const performanceKova = workflowJob(PERFORMANCE_WORKFLOW, "kova");
@@ -7750,17 +7381,20 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(performanceArtifactPath.reduce((total, timeout) => total + timeout, 0)).toBe(255);
     expect(performancePublishPath.reduce((total, timeout) => total + timeout, 0)).toBe(280);
     const performanceParent = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "performance");
-    expect(performanceParent["timeout-minutes"]).toBe(360);
-    expect(
-      workflowStep(performanceParent, "Dispatch and monitor OpenClaw Performance").run,
-    ).toContain("-f publish_reports=false");
+    expect(performanceParent["timeout-minutes"]).toBe(15);
+    expect(workflowStep(performanceParent, "Dispatch OpenClaw Performance").run).toContain(
+      "-f publish_reports=false",
+    );
     for (const [pathName, path] of [
       ["artifact-only", performanceArtifactPath],
       ["publish", performancePublishPath],
     ] as const) {
       const childTimeout = path.reduce((total, timeout) => total + timeout, 0);
-      expect(childTimeout, `performance:${pathName}`).toBeLessThanOrEqual(360);
-      expect(360 - childTimeout, `performance:${pathName}`).toBeGreaterThanOrEqual(60);
+      expect(childTimeout, `performance:${pathName}`).toBeLessThanOrEqual(diagnosticDrainTimeout);
+      expect(
+        diagnosticDrainTimeout - childTimeout,
+        `performance:${pathName}`,
+      ).toBeGreaterThanOrEqual(60);
     }
 
     const prepareReleaseCandidate = workflowJob(
@@ -7787,12 +7421,11 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       timeoutForProfile(liveE2e.jobs?.prepare_docker_e2e_image?.["timeout-minutes"], "full"),
       timeoutForProfile(liveE2e.jobs?.docker_e2e_image_ready?.["timeout-minutes"], "full"),
       timeoutForProfile(releaseChecksParent["timeout-minutes"], "full"),
-      timeoutForProfile(fullRelease.jobs?.summary?.["timeout-minutes"], "full"),
     ];
-    expect(fullParentPath).toEqual([10, 10, 30, 90, 5, 420, 5]);
+    expect(fullParentPath).toEqual([10, 10, 30, 90, 5, 15]);
     const fullParentTimeoutFloor = fullParentPath.reduce((total, timeout) => total + timeout, 0);
-    expect(fullParentTimeoutFloor).toBe(570);
-    expect(FULL_RELEASE_WAIT_TIMEOUT_MINUTES - fullParentTimeoutFloor).toBeGreaterThanOrEqual(60);
+    expect(fullParentTimeoutFloor).toBe(160);
+    expect(FULL_RELEASE_WAIT_TIMEOUT_MINUTES).toBe(diagnosticDrainTimeout);
   });
 
   it("bounds every direct job in nested release workflows", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2966,6 +2966,8 @@ describe("package acceptance workflow", () => {
     const drainStep = workflowStep(drain, "Drain child diagnostics");
     const decisionUpload = workflowStep(decision, "Upload release decision");
     const drainUpload = workflowStep(drain, "Upload diagnostic drain manifest");
+    const planStep = workflowStep(executionPlan, "Seal immutable release execution plan");
+    const manifestStep = workflowStep(summary, "Write release validation manifest");
 
     expect(decision.needs).toEqual(["resolve_target", "release_execution_plan"]);
     expect(drain.needs).toEqual(["resolve_target", "release_execution_plan"]);
@@ -2981,9 +2983,13 @@ describe("package acceptance workflow", () => {
     expectTextToIncludeAll(decisionStep.run, [
       'node scripts/full-release-validation-state.mjs "$FULL_RELEASE_STATE_MODE"',
     ]);
-    expect(workflowStep(executionPlan, "Seal immutable release execution plan").run).toContain(
-      "FULL_RELEASE_PLAN_INPUTS_JSON",
-    );
+    expect(planStep.run).toContain("FULL_RELEASE_PLAN_INPUTS_JSON");
+    expect(planStep.env).toMatchObject({
+      EVIDENCE_CHANGED_PATHS: "${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}",
+    });
+    expect(manifestStep.env).toMatchObject({
+      EVIDENCE_CHANGED_PATHS: "${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}",
+    });
     expect(workflowStep(executionPlan, "Upload immutable release execution plan").with?.name).toBe(
       "full-release-execution-plan-${{ github.run_id }}",
     );

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2967,10 +2967,16 @@ describe("package acceptance workflow", () => {
     const decisionUpload = workflowStep(decision, "Upload release decision");
     const drainUpload = workflowStep(drain, "Upload diagnostic drain manifest");
     const planStep = workflowStep(executionPlan, "Seal immutable release execution plan");
+    const planUpload = workflowStep(executionPlan, "Upload immutable release execution plan");
     const manifestStep = workflowStep(summary, "Write release validation manifest");
+    const selectState = workflowStep(summary, "Select newest compatible release state artifacts");
+    const decisionDownloads = workflowStep(summary, "Download release decision attempts");
+    const drainDownloads = workflowStep(summary, "Download diagnostic drain attempts");
 
     expect(decision.needs).toEqual(["resolve_target", "release_execution_plan"]);
     expect(drain.needs).toEqual(["resolve_target", "release_execution_plan"]);
+    expect(decision.if).toBe("always()");
+    expect(drain.if).toBe("always()");
     expect(decisionStep.run).toBe(drainStep.run);
     expect(decisionStep.env).toMatchObject({
       FAIL_FAST: "${{ inputs.fail_fast }}",
@@ -2986,21 +2992,34 @@ describe("package acceptance workflow", () => {
     expect(planStep.run).toContain("FULL_RELEASE_PLAN_INPUTS_JSON");
     expect(planStep.env).toMatchObject({
       EVIDENCE_CHANGED_PATHS: "${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}",
+      EVIDENCE_MANIFEST: "${{ needs.evidence_reuse.outputs.evidence_manifest }}",
       EVIDENCE_RUN_ID: "${{ needs.evidence_reuse.outputs.evidence_run_id }}",
+      TRUSTED_WORKFLOW_JSON: "${{ needs.resolve_target.outputs.trusted_workflow_json }}",
     });
     expect(planStep.run).toContain('--arg evidenceRunId "$EVIDENCE_RUN_ID"');
-    expect(manifestStep.env).toMatchObject({
-      EVIDENCE_CHANGED_PATHS: "${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}",
-    });
-    expect(workflowStep(executionPlan, "Upload immutable release execution plan").with?.name).toBe(
-      "full-release-execution-plan-${{ github.run_id }}",
+    expect(planStep.run).toContain('--argjson trustedWorkflow "$TRUSTED_WORKFLOW_JSON"');
+    expect(planUpload.if).toBe("${{ always() && github.run_attempt == 1 }}");
+    expect(planUpload.with?.name).toBe("full-release-execution-plan-${{ github.run_id }}");
+    expect(manifestStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");
+    expect(manifestStep.run).toContain(
+      'EVIDENCE_MANIFEST="$(jq -c \'.evidenceReuse.sourceManifest // empty\' "$RELEASE_EXECUTION_PLAN_PATH")"',
     );
+    expect(manifestStep.run).not.toContain("needs.evidence_reuse.outputs");
     expect(decisionUpload.with?.name).toBe(
       "full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}",
     );
     expect(drainUpload.with?.name).toBe(
       "full-release-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}",
     );
+    expect(decisionDownloads.with).toMatchObject({
+      path: "${{ runner.temp }}/full-release-decision-attempts",
+      pattern: "full-release-decision-${{ github.run_id }}-*",
+    });
+    expect(drainDownloads.with).toMatchObject({
+      path: "${{ runner.temp }}/full-release-diagnostic-attempts",
+      pattern: "full-release-diagnostics-${{ github.run_id }}-*",
+    });
+    expect(selectState.run).toBe("node scripts/full-release-validation-state.mjs select");
     expect(summary.needs).toEqual(expect.arrayContaining(["release_decision", "diagnostic_drain"]));
     for (const jobId of [
       "docker_runtime_assets_preflight",
@@ -3015,6 +3034,28 @@ describe("package acceptance workflow", () => {
         "github.run_attempt == 1",
       );
     }
+  });
+
+  it("builds a rerun-all manifest from sealed plan A instead of retry-B job outputs", () => {
+    const summary = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "summary");
+    const manifest = workflowStep(summary, "Write release validation manifest");
+    const evidenceDispatch = workflowStep(summary, "Request release evidence update");
+
+    expect(manifest.env).not.toHaveProperty("TARGET_SHA");
+    expect(manifest.env).not.toHaveProperty("NORMAL_CI_RUN_ID");
+    expect(manifest.env).not.toHaveProperty("EVIDENCE_REUSE");
+    expectTextToIncludeAll(manifest.run, [
+      'TARGET_SHA="$(jq -r \'.targetSha\' "$RELEASE_EXECUTION_PLAN_PATH")"',
+      'NORMAL_CI_RUN_ID="$(jq -r \'.children[] | select(.key == "normalCi") | .runId\' "$RELEASE_EXECUTION_PLAN_PATH")"',
+      'EVIDENCE_RUN_ID="$(jq -r \'.evidenceReuse.selectedRunId // ""\' "$RELEASE_EXECUTION_PLAN_PATH")"',
+      'EVIDENCE_MANIFEST="$(jq -c \'.evidenceReuse.sourceManifest // empty\' "$RELEASE_EXECUTION_PLAN_PATH")"',
+      'PERFORMANCE_CONCLUSION="$(jq -r \'.children.productPerformance.conclusion // ""\' "$DIAGNOSTIC_DRAIN_PATH")"',
+    ]);
+    expect(manifest.run).not.toContain("needs.evidence_reuse.outputs");
+    expect(evidenceDispatch.run).toContain(
+      'EVIDENCE_REUSE="$(jq -r \'.evidenceReuse.requested\' "$RELEASE_EXECUTION_PLAN_PATH")"',
+    );
+    expect(evidenceDispatch.env).not.toHaveProperty("EVIDENCE_REUSE");
   });
 
   it("pins every Full Release Validation artifact download to the canonical action", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3009,6 +3009,18 @@ describe("package acceptance workflow", () => {
     }
   });
 
+  it("pins every Full Release Validation artifact download to the canonical action", () => {
+    const workflow = readWorkflow(FULL_RELEASE_VALIDATION_WORKFLOW);
+    const downloadSteps = Object.values(workflow.jobs ?? {}).flatMap((job) =>
+      (job.steps ?? []).filter((step) => step.uses?.startsWith("actions/download-artifact@")),
+    );
+
+    expect(downloadSteps).toHaveLength(6);
+    for (const step of downloadSteps) {
+      expect(step.uses).toBe(DOWNLOAD_ARTIFACT_V8);
+    }
+  });
+
   it("keeps exhaustive update migration as a separate manual package gate", () => {
     const workflow = readFileSync(UPDATE_MIGRATION_WORKFLOW, "utf8");
     const packageWorkflow = readFileSync(PACKAGE_ACCEPTANCE_WORKFLOW, "utf8");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7107,8 +7107,14 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const packageAcceptance = readWorkflow(PACKAGE_ACCEPTANCE_WORKFLOW);
     const qaLive = readWorkflow(QA_LIVE_TRANSPORTS_WORKFLOW);
     const profiles = ["beta", "stable", "full"] as const;
-    const releaseDecisionTimeout = fullRelease.jobs?.release_decision?.["timeout-minutes"];
-    const diagnosticDrainTimeout = fullRelease.jobs?.diagnostic_drain?.["timeout-minutes"];
+    const releaseDecisionTimeout = timeoutForProfile(
+      fullRelease.jobs?.release_decision?.["timeout-minutes"],
+      "beta",
+    );
+    const diagnosticDrainTimeout = timeoutForProfile(
+      fullRelease.jobs?.diagnostic_drain?.["timeout-minutes"],
+      "beta",
+    );
     expect(releaseDecisionTimeout).toBe(720);
     expect(diagnosticDrainTimeout).toBe(720);
     for (const dispatchJob of [

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2992,10 +2992,11 @@ describe("package acceptance workflow", () => {
     expect(planStep.run).toContain("FULL_RELEASE_PLAN_INPUTS_JSON");
     expect(planStep.env).toMatchObject({
       EVIDENCE_CHANGED_PATHS: "${{ needs.evidence_reuse.outputs.changed_paths || '[]' }}",
-      EVIDENCE_MANIFEST: "${{ needs.evidence_reuse.outputs.evidence_manifest }}",
       EVIDENCE_RUN_ID: "${{ needs.evidence_reuse.outputs.evidence_run_id }}",
       TRUSTED_WORKFLOW_JSON: "${{ needs.resolve_target.outputs.trusted_workflow_json }}",
     });
+    expect(planStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");
+    expect(planStep.run).not.toContain("EVIDENCE_MANIFEST");
     expect(planStep.run).toContain('--arg evidenceRunId "$EVIDENCE_RUN_ID"');
     expect(planStep.run).toContain('--argjson trustedWorkflow "$TRUSTED_WORKFLOW_JSON"');
     expect(planUpload.if).toBe("${{ always() && github.run_attempt == 1 }}");

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -11,10 +11,6 @@ import {
   assertPluginPrereleaseTestPlanComplete,
   createPluginPrereleaseTestPlan,
 } from "../../scripts/lib/plugin-prerelease-test-plan.mts";
-import {
-  pluginPrereleaseTimeoutComponents,
-  releaseTimeoutForProfile,
-} from "../helpers/release-workflow-timeouts.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const CHECKOUT_V6 = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10";
@@ -43,19 +39,6 @@ function readFullReleaseValidationWorkflow() {
 
 function readPluginPrereleaseWorkflow() {
   return parse(readFileSync(".github/workflows/plugin-prerelease.yml", "utf8"));
-}
-
-function readLiveE2eWorkflow() {
-  return parse(readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"));
-}
-
-function pluginPrereleaseTimeoutFloor(profile: "beta" | "stable" | "full"): number {
-  const components = pluginPrereleaseTimeoutComponents({
-    pluginPrerelease: readPluginPrereleaseWorkflow(),
-    liveE2e: readLiveE2eWorkflow(),
-    profile,
-  });
-  return Object.values(components).reduce((total, value) => total + value, 0);
 }
 
 function getDockerLane(name: string) {
@@ -387,7 +370,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       (step: WorkflowStep) => step.name === "Summarize target",
     );
     const pluginDispatch = releaseWorkflow.jobs.plugin_prerelease.steps.find(
-      (step: WorkflowStep) => step.name === "Dispatch and monitor plugin prerelease",
+      (step: WorkflowStep) => step.name === "Dispatch plugin prerelease",
     );
     const evidenceReuse = releaseWorkflow.jobs.evidence_reuse.steps.find(
       (step: WorkflowStep) => step.name === "Find reusable validation evidence",
@@ -497,13 +480,13 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       (step: WorkflowStep) => step.name === "Build plugin prerelease manifest",
     ).env;
     const normalCiScript = releaseWorkflow.jobs.normal_ci.steps.find(
-      (step: WorkflowStep) => step.name === "Dispatch and monitor CI",
+      (step: WorkflowStep) => step.name === "Dispatch CI",
     ).run;
     const pluginPrereleaseScript = releaseWorkflow.jobs.plugin_prerelease.steps.find(
-      (step: WorkflowStep) => step.name === "Dispatch and monitor plugin prerelease",
+      (step: WorkflowStep) => step.name === "Dispatch plugin prerelease",
     ).run;
     const releaseChecksStep = releaseWorkflow.jobs.release_checks.steps.find(
-      (step: WorkflowStep) => step.name === "Dispatch and monitor release checks",
+      (step: WorkflowStep) => step.name === "Dispatch release checks",
     );
     const releaseChecksScript = releaseChecksStep.run;
     const buildDistStep = workflow.jobs["build-artifacts"].steps.find(
@@ -665,9 +648,9 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(releaseChecksScript).toContain("args+=(-f allow_frozen_target_scenario_omissions=true)");
     expect(releaseWorkflowSource).toContain('--arg targetContextRef "$TARGET_CONTEXT_REF"');
     expect(releaseWorkflowSource).toContain("targetContextRef: $targetContextRef");
-    expect(normalCiScript).toContain('dispatch_and_wait ci.yml "$dispatch_run_name" "${args[@]}"');
+    expect(normalCiScript).toContain('dispatch_child ci.yml "$dispatch_run_name" "${args[@]}"');
     const normalCiDispatchCase = normalCiScript.match(/^\s*ci\)\n([\s\S]*?)^\s*;;$/mu)?.[1];
-    expect(normalCiDispatchCase).toContain('dispatch_and_wait ci.yml "$dispatch_run_name"');
+    expect(normalCiDispatchCase).toContain('dispatch_child ci.yml "$dispatch_run_name"');
     expect(normalCiDispatchCase).not.toContain("full_release_validation=true");
     expect(pluginPrereleaseScript).toContain(
       'args=(-f target_ref="$TARGET_SHA" -f expected_sha="$TARGET_SHA" -f full_release_validation=true -f dispatch_id="$dispatch_id" -f node_test_exclude_patterns_json="$PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON")',
@@ -676,7 +659,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       'args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")',
     );
     expect(pluginPrereleaseScript).toContain(
-      'dispatch_and_wait plugin-prerelease.yml "$dispatch_run_name" "${args[@]}"',
+      'dispatch_child plugin-prerelease.yml "$dispatch_run_name" "${args[@]}"',
     );
     expect(pluginManifestScript).toContain("await import(");
     expect(pluginManifestScript).toContain('"./scripts/lib/plugin-prerelease-test-plan.mts"');
@@ -885,7 +868,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     }
     expect(fullReleaseWorkflow.jobs.release_checks["runs-on"]).toBe("blacksmith-4vcpu-ubuntu-2404");
     expect(fullReleaseWorkflow.jobs.performance["runs-on"]).toBe("blacksmith-4vcpu-ubuntu-2404");
-    expect(fullReleaseWorkflow.jobs.normal_ci["timeout-minutes"]).toBe(240);
+    expect(fullReleaseWorkflow.jobs.normal_ci["timeout-minutes"]).toBe(15);
     expect(fullReleaseWorkflow.jobs.normal_ci.needs).toEqual(["resolve_target", "evidence_reuse"]);
     expect(fullReleaseWorkflow.jobs.normal_ci.if).toContain(
       "needs.resolve_target.result == 'success'",
@@ -894,7 +877,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       "needs.evidence_reuse.outputs.reuse != 'true'",
     );
     expect(fullReleaseWorkflow.jobs.docker_runtime_assets_preflight.if).toBe(
-      "${{ always() && needs.resolve_target.result == 'success' && inputs.rerun_group == 'all' && needs.evidence_reuse.outputs.reuse != 'true' }}",
+      "${{ always() && github.run_attempt == 1 && needs.resolve_target.result == 'success' && inputs.rerun_group == 'all' && needs.evidence_reuse.outputs.reuse != 'true' }}",
     );
     expect(fullReleaseWorkflow.jobs.docker_runtime_assets_preflight["timeout-minutes"]).toBe(20);
     const dockerPreflightStep = fullReleaseWorkflow.jobs.docker_runtime_assets_preflight.steps.find(
@@ -912,33 +895,13 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
         (step: WorkflowStep) => step.name === "Build and smoke test final Docker runtime image",
       ),
     ).toBe(false);
-    const pluginMonitorTimeout = fullReleaseWorkflow.jobs.plugin_prerelease["timeout-minutes"];
-    const childTimeoutFloors = {
-      beta: pluginPrereleaseTimeoutFloor("beta"),
-      stable: pluginPrereleaseTimeoutFloor("stable"),
-      full: pluginPrereleaseTimeoutFloor("full"),
-    };
-    const parentTimeouts = {
-      beta: releaseTimeoutForProfile(pluginMonitorTimeout, "beta"),
-      stable: releaseTimeoutForProfile(pluginMonitorTimeout, "stable"),
-      full: releaseTimeoutForProfile(pluginMonitorTimeout, "full"),
-    };
-    expect(childTimeoutFloors).toEqual({ beta: 175, stable: 175, full: 205 });
-    expect(parentTimeouts).toEqual({ beta: 240, stable: 240, full: 300 });
-    for (const profile of ["beta", "stable", "full"] as const) {
-      expect(parentTimeouts[profile] - childTimeoutFloors[profile], profile).toBeGreaterThanOrEqual(
-        60,
-      );
+    for (const jobName of ["plugin_prerelease", "release_checks", "npm_telegram", "performance"]) {
+      expect(fullReleaseWorkflow.jobs[jobName]["timeout-minutes"], jobName).toBe(15);
     }
-    expect(fullReleaseWorkflow.jobs.release_checks["timeout-minutes"]).toBe(420);
-    expect(fullReleaseWorkflow.jobs.npm_telegram["timeout-minutes"]).toBe(
-      "${{ inputs.release_profile == 'full' && 360 || 120 }}",
-    );
-    expect(fullReleaseWorkflow.jobs.performance["timeout-minutes"]).toBe(360);
     const fullReleaseSource = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
     expect(fullReleaseWorkflow.on.workflow_dispatch.inputs.fail_fast).toEqual({
       description:
-        "Cancel each child workflow after its first failed job; false collects independent failures to completion",
+        "Cancel only an exact active child after its first blocking job; false drains all children to completion",
       required: false,
       default: false,
       type: "boolean",
@@ -951,26 +914,26 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     ] as const) {
       const dispatch: WorkflowStep = fullReleaseWorkflow.jobs[jobName].steps[0];
       expect(dispatch.env?.CHILD_WORKFLOW_KIND).toBe(kind);
-      expect(dispatch.env?.FAIL_FAST).toBe("${{ inputs.fail_fast }}");
-      expect(dispatch.run).toContain('if [[ "$FAIL_FAST" != "true" ]]; then');
-      expect(dispatch.run).toContain("has failed child jobs before the workflow completed");
+      if (jobName === "release_checks") {
+        expect(dispatch.env?.FAIL_FAST).toBe("${{ inputs.fail_fast }}");
+        expect(dispatch.run).toContain('-f fail_fast="$FAIL_FAST"');
+      } else {
+        expect(dispatch.env).not.toHaveProperty("FAIL_FAST");
+      }
     }
     expect(fullReleaseWorkflow.jobs.performance.steps[0].env).not.toHaveProperty("FAIL_FAST");
     expect(fullReleaseSource).toContain('-f fail_fast="$FAIL_FAST"');
-    expect(fullReleaseSource).toContain(
-      "npm-telegram-beta-e2e.yml has failed child jobs before the workflow completed; cancelling the remaining run.",
+    expect(fullReleaseSource).not.toContain(
+      "has failed child jobs before the workflow completed; cancelling the remaining run.",
     );
     expect(fullReleaseSource).not.toContain("trap cancel_child");
     expect(fullReleaseSource).not.toContain("cancel_child_on_failure");
     expect(fullReleaseSource).not.toContain("exit_on_parent_signal");
     expect(fullReleaseSource).not.toContain("disable_child_cleanup");
-    expect(fullReleaseSource).toContain(
-      "Parent cancellation leaves this child running; cancel it explicitly if no longer needed.",
-    );
+    expect(fullReleaseSource).not.toContain("cancel_child");
     expect(fullReleaseSource).toContain(
       'if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]; then',
     );
-    expect(fullReleaseSource).toContain("cancel_child\n              exit 1");
     expect(releaseChecksWorkflow.on.workflow_dispatch.inputs.fail_fast).toEqual({
       description: "Stop the Matrix QA lane after its first failed check or scenario",
       required: false,
@@ -1032,7 +995,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       (step: WorkflowStep) => step.name === "Summarize target",
     );
     const releaseChecksDispatch = fullReleaseWorkflow.jobs.release_checks.steps.find(
-      (step: WorkflowStep) => step.name === "Dispatch and monitor release checks",
+      (step: WorkflowStep) => step.name === "Dispatch release checks",
     );
     expect(summarizeTarget?.env?.ALLOW_UNRELEASED_CHANGELOG).toBe(fullReleaseAllowance);
     expect(releaseChecksDispatch?.env?.ALLOW_UNRELEASED_CHANGELOG).toBe(fullReleaseAllowance);

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -1101,16 +1101,24 @@ describe("release CI summary child correlation", () => {
       requestedRunId === String(fixture.childRun.id)
         ? [
             {
+              completed_at: "2026-07-10T01:10:00Z",
               conclusion: "failure",
+              id: 86293408711,
               name: "Run QA Lab parity lane (core)",
               run_attempt: 1,
+              started_at: "2026-07-10T01:00:00Z",
               status: "completed",
+              steps: [],
             },
             {
+              completed_at: "2026-07-10T01:10:00Z",
               conclusion: "success",
+              id: 86293408712,
               name: "Verify release checks",
               run_attempt: 1,
+              started_at: "2026-07-10T01:00:00Z",
               status: "completed",
+              steps: [],
             },
           ]
         : getParentJobs(requestedRunId);

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -1435,7 +1435,10 @@ describe("release CI summary child correlation", () => {
       verifierSourceSha: "c".repeat(40),
     };
 
-    fixture.client.getRef = () => ({ object: { sha: "6".repeat(40) } });
+    fixture.client.getRef = (fullRef: string) => ({
+      object: { sha: "6".repeat(40) },
+      ref: fullRef,
+    });
     expect(() => validateReleaseRunEvidence(options, fixture.client)).toThrow(
       "protected tooling tag moved",
     );

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -21,6 +21,7 @@ import {
   selectManifestArtifact,
   selectManifestParentJob,
   selectedChildKeys,
+  tryReadReleaseDecisionArtifact,
   validateEvidenceReuseChain,
   validateManifestArtifactCompatibility,
   validateManifestArtifactIdentity,
@@ -312,6 +313,42 @@ describe("runReleaseCiGh", () => {
         },
       }),
     ).toThrow(timeoutError);
+  });
+});
+
+describe("Release Decision artifact polling", () => {
+  const parent = { attempt: 1, headSha: "a".repeat(40) };
+
+  it("treats transient download transport failures as unavailable this poll", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        tryReadReleaseDecisionArtifact(parent, "123", "openclaw/openclaw", () => {
+          throw Object.assign(new Error("HTTP 503: Server Error"), {
+            stderr: "HTTP 503: Server Error",
+          });
+        }),
+      ).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("release decision artifact unavailable this poll"),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("keeps authentication and invocation failures hard", () => {
+    for (const message of [
+      "HTTP 401: Bad credentials",
+      "HTTP 403: secondary rate limit",
+      "unknown flag: --name\nUsage: gh run download",
+    ]) {
+      expect(() =>
+        tryReadReleaseDecisionArtifact(parent, "123", "openclaw/openclaw", () => {
+          throw Object.assign(new Error(message), { stderr: message });
+        }),
+      ).toThrow("release decision artifact read failed");
+    }
   });
 });
 

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -29,6 +29,7 @@ import {
   validateParentRunBinding,
   validatePerformanceArtifactOnlyJobs,
   validateReleaseRunEvidence,
+  validateRequestedEvidenceReuse,
   validateTrustedProducerIdentity,
 } from "../../scripts/release-ci-summary.mjs";
 
@@ -75,7 +76,7 @@ describe("GitHub API commands", () => {
         artifact: fixture.artifact,
         artifactList: { artifacts: [fixture.artifact] },
         child: fixture.childRun,
-        jobLog: `TARGET_SHA: ${targetSha}\nDispatched: https://github.com/openclaw/openclaw/actions/runs/${childRunId}`,
+        jobLog: `TARGET_SHA: ${targetSha}\nDispatched: https://github.com/openclaw/openclaw/actions/runs/${childRunId} (attempt 1)`,
         jobs: { jobs: [fixture.parentJob] },
         lineage: { merge_base_commit: { sha: workflowSha }, status: "ahead" },
         parent: fixture.parentRun,
@@ -609,7 +610,7 @@ function trustedMainPackageFixture({
       expect(jobId).toBe(parentJob.id);
       return [
         `TARGET_SHA: ${targetSha}`,
-        `Dispatched openclaw-release-checks.yml: ${childRun.html_url}`,
+        `Dispatched openclaw-release-checks.yml: ${childRun.html_url} (attempt ${childRun.run_attempt})`,
       ].join("\n");
     },
     getParentJobs(requestedRunId: string) {
@@ -673,18 +674,43 @@ function createReleaseCiWatchFixture(states: ReleaseCiWatchState[]) {
   writeFileSync(
     ghPath,
     `#!${process.execPath}
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 const args = process.argv.slice(2);
 appendFileSync(process.env.RELEASE_CI_WATCH_CALLS, JSON.stringify(args) + "\\n");
 const endpoint = args[1] ?? "";
 const states = ${JSON.stringify(states)};
 let output;
 if (args[0] === "run" && args[1] === "view") {
-  if (args[args.indexOf("--json") + 1] === "status,conclusion,attempt,jobs") {
+  if (args[args.indexOf("--json") + 1] === "status,conclusion,attempt,headSha,jobs") {
     const index = Number(readFileSync(process.env.RELEASE_CI_WATCH_INDEX, "utf8"));
-    output = states[Math.min(index, states.length - 1)];
+    output = { headSha: ${JSON.stringify(fixture.workflowSha)}, ...states[Math.min(index, states.length - 1)] };
     writeFileSync(process.env.RELEASE_CI_WATCH_INDEX, String(index + 1));
   } else output = ${JSON.stringify(parentView)};
+} else if (args[0] === "run" && args[1] === "download") {
+  const dir = args[args.indexOf("--dir") + 1];
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(dir + "/full-release-decision.json", JSON.stringify({
+    version: 2,
+    kind: "openclaw.full-release-decision",
+    mode: "decision",
+    parentRunId: ${JSON.stringify(runId)},
+    parentRunAttempt: 1,
+    sourceParentRunAttempt: 1,
+    workflowRef: "main",
+    workflowSha: ${JSON.stringify(fixture.workflowSha)},
+    targetSha: ${JSON.stringify(fixture.targetSha)},
+    releaseProfile: "stable",
+    rerunGroup: "all",
+    executionPlanSha256: "${"d".repeat(64)}",
+    state: "blocked_diagnostics_running",
+    activeRunIds: ["101"],
+    blockers: [{ child: "normalCi", job: "test", conclusion: "failure", runId: "101", url: "https://example.invalid/job" }],
+    errors: [],
+    cancellation: { requested: false, cancelledRunIds: [] },
+    plan: [{ key: "normalCi", workflow: "ci.yml", displayTitle: "CI", dispatchName: "Dispatch CI", required: true, selected: true, source: "fresh", result: "success", runId: "101", runAttempt: 1, url: "https://example.invalid/run", workflowRef: "main", workflowSha: ${JSON.stringify(fixture.workflowSha)} }],
+    children: {}
+  }));
+  process.exit(0);
 } else if (endpoint === "rate_limit") output = { resources: { core: { limit: 5000, remaining: 4999, reset: 2_000_000_000 } } };
 else if (endpoint === "repos/openclaw/openclaw/actions/runs/${runId}") output = ${JSON.stringify(parent)};
 else if (endpoint.startsWith("repos/openclaw/openclaw/actions/runs/${runId}/artifacts?")) output = { artifacts: [] };
@@ -775,7 +801,7 @@ describe("release CI summary child correlation", () => {
       const watchPolls = calls.filter(
         (args) =>
           args[0] === "run" &&
-          args[args.indexOf("--json") + 1] === "status,conclusion,attempt,jobs",
+          args[args.indexOf("--json") + 1] === "status,conclusion,attempt,headSha,jobs",
       );
       expect(result.status, result.stderr).toBe(0);
       expect(watchPolls).toHaveLength(4);
@@ -807,6 +833,37 @@ describe("release CI summary child correlation", () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(failedJob);
       expect(calls.filter((args) => args[0] === "run" && args[1] === "view")).toHaveLength(2);
+      expect(calls.filter((args) => args[0] === "api" && args[1] === "rate_limit")).toHaveLength(1);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("reports an early release blocker once while the diagnostic drain continues", () => {
+    const fixture = createReleaseCiWatchFixture([
+      {
+        attempt: 1,
+        conclusion: "",
+        jobs: [
+          { conclusion: "failure", name: "Release Decision", status: "completed" },
+          { conclusion: "", name: "Diagnostic Drain", status: "in_progress" },
+        ],
+        status: "in_progress",
+      },
+    ]);
+    try {
+      const result = fixture.run();
+      const calls = fixture.readCalls();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Full Release Validation state: blocked_diagnostics_running");
+      expect(result.stderr).toContain("Diagnostic Drain is still collecting terminal evidence");
+      expect(
+        calls.filter(
+          (args) =>
+            args[0] === "run" &&
+            args[args.indexOf("--json") + 1] === "status,conclusion,attempt,headSha,jobs",
+        ),
+      ).toHaveLength(1);
       expect(calls.filter((args) => args[0] === "api" && args[1] === "rate_limit")).toHaveLength(1);
     } finally {
       fixture.cleanup();
@@ -878,8 +935,7 @@ describe("release CI summary child correlation", () => {
 
     const source = readFileSync(SCRIPT, "utf8");
     expect(source).toContain("actions/artifacts/${artifactId}/zip");
-    expect(source).not.toContain('"--name",');
-    expect(source).not.toContain("gh run download");
+    expect(source).toContain('"--name",');
     expect(source).toContain(
       "downloadParentManifestEvidence(runId, runAttempt, normalizedRepository, manifestPath)",
     );
@@ -1033,6 +1089,44 @@ describe("release CI summary child correlation", () => {
       name: fixture.artifact.name,
       runAttempt: 1,
       sizeInBytes: fixture.artifact.size_in_bytes,
+    });
+  });
+
+  it("accepts beta advisory release-check failures through canonical policy", () => {
+    const fixture = trustedMainPackageFixture();
+    fixture.manifest.releaseProfile = "beta";
+    fixture.childRun.conclusion = "failure";
+    const getParentJobs = fixture.client.getParentJobs;
+    fixture.client.getParentJobs = (requestedRunId: string) =>
+      requestedRunId === String(fixture.childRun.id)
+        ? [
+            {
+              conclusion: "failure",
+              name: "Run QA Lab parity lane (core)",
+              run_attempt: 1,
+              status: "completed",
+            },
+            {
+              conclusion: "success",
+              name: "Verify release checks",
+              run_attempt: 1,
+              status: "completed",
+            },
+          ]
+        : getParentJobs(requestedRunId);
+
+    const evidence = validateReleaseRunEvidence(
+      {
+        repository: "openclaw/openclaw",
+        runId: fixture.runId,
+        verifierSourceContent: readFileSync(SCRIPT),
+        verifierSourceSha: "c".repeat(40),
+      },
+      fixture.client,
+    );
+    expect(evidence.conclusions).toMatchObject({
+      allRequiredSucceeded: true,
+      children: { releaseChecks: "failure" },
     });
   });
 
@@ -2067,7 +2161,7 @@ describe("release CI summary child correlation", () => {
     ];
     const parentLog = [
       `TARGET_SHA: ${parentManifest.targetSha}`,
-      "Dispatched ci.yml: https://github.com/openclaw/openclaw/actions/runs/101",
+      "Dispatched ci.yml: https://github.com/openclaw/openclaw/actions/runs/101 (attempt 1)",
     ].join("\n");
     const run = {
       actor: { login: "github-actions[bot]" },
@@ -2178,13 +2272,23 @@ describe("release CI summary child correlation", () => {
       const parentLog = [
         `TARGET_SHA: ${parentManifest.targetSha}`,
         ...(child.manifestKey === "productPerformance" ? ["-f publish_reports=false"] : []),
-        `Dispatched ${child.workflow}: https://github.com/openclaw/openclaw/actions/runs/${runId}`,
+        `Dispatched ${child.workflow}: https://github.com/openclaw/openclaw/actions/runs/${runId} (attempt ${run.run_attempt})`,
       ].join("\n");
       expect(resolveManifestChildOriginAttempt(run, child, parentManifest, parentJobs)).toBe(
         originAttempt,
       );
       expect(
         validateManifestChildRun(run, child, String(runId), parentManifest, parentJobs, parentLog),
+      ).toBe(run);
+      expect(
+        validateManifestChildRun(
+          run,
+          child,
+          String(runId),
+          parentManifest,
+          parentJobs,
+          parentLog.replace(` (attempt ${run.run_attempt})`, ""),
+        ),
       ).toBe(run);
       if (child.manifestKey === "productPerformance") {
         expect(() =>
@@ -2221,7 +2325,7 @@ describe("release CI summary child correlation", () => {
     ];
     const ciLog = [
       `TARGET_SHA: ${parentManifest.targetSha}`,
-      "Dispatched ci.yml: https://github.com/openclaw/openclaw/actions/runs/101",
+      "Dispatched ci.yml: https://github.com/openclaw/openclaw/actions/runs/101 (attempt 1)",
     ].join("\n");
     expect(() =>
       validateManifestChildRun(wrongParent, ci, "101", parentManifest, ciJobs, ciLog),
@@ -2242,6 +2346,49 @@ describe("release CI summary child correlation", () => {
     expect(
       resolveManifestChildOriginAttempt({ display_title: "CI nearby" }, ci, parentManifest, ciJobs),
     ).toBeUndefined();
+  });
+
+  it("keeps requested changelog reuse target and evidence SHAs separate", () => {
+    const evidenceSha = "a".repeat(40);
+    const targetSha = "b".repeat(40);
+    expect(() =>
+      validateRequestedEvidenceReuse(
+        {
+          evidenceReuse: {
+            changedPaths: ["CHANGELOG.md"],
+            evidenceSha,
+            policy: "changelog-only-release-v1",
+          },
+          targetSha,
+        },
+        { targetSha: evidenceSha },
+        {
+          expectedChangedPaths: ["CHANGELOG.md"],
+          expectedEvidencePolicy: "changelog-only-release-v1",
+          expectedEvidenceSha: evidenceSha,
+          expectedTargetSha: targetSha,
+        },
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateRequestedEvidenceReuse(
+        {
+          evidenceReuse: {
+            changedPaths: ["CHANGELOG.md"],
+            evidenceSha,
+            policy: "changelog-only-release-v1",
+          },
+          targetSha,
+        },
+        { targetSha },
+        {
+          expectedChangedPaths: ["CHANGELOG.md"],
+          expectedEvidencePolicy: "changelog-only-release-v1",
+          expectedEvidenceSha: evidenceSha,
+          expectedTargetSha: targetSha,
+        },
+      ),
+    ).toThrow("no longer matches");
   });
 
   it("rejects carried parent jobs whose selected-attempt execution fingerprint changed", () => {

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -617,6 +617,9 @@ function trustedMainPackageFixture({
       expect(requestedRunId).toBe(runId);
       return [parentJob];
     },
+    getRef(fullRef: string) {
+      return { object: { sha: workflowSha }, ref: fullRef };
+    },
     getRun(requestedRunId: string) {
       if (requestedRunId === runId) {
         return parentRun;
@@ -1369,6 +1372,10 @@ describe("release CI summary child correlation", () => {
       workflowSha: olderWorkflowSha,
     });
     olderFixture.manifest.targetRef = olderFixture.targetSha;
+    olderFixture.client.getRef = (fullRef: string) => ({
+      object: { sha: trustedWorkflowSha },
+      ref: fullRef,
+    });
     expect(() =>
       validateReleaseRunEvidence(
         {
@@ -1404,6 +1411,41 @@ describe("release CI summary child correlation", () => {
         sameNameFixture.client,
       ),
     ).toThrow("canonical release-ci branch");
+  });
+
+  it("rejects a protected tooling tag that moved or disappeared after sealing", () => {
+    const workflowSha = "7".repeat(40);
+    const workflowRef = `release-ci/${workflowSha.slice(0, 12)}-1783705000000`;
+    const trustedWorkflowRef = `release-publish/${workflowSha.slice(0, 12)}-123`;
+    const fixture = trustedMainPackageFixture({
+      manifestVersion: 3,
+      targetSha: "8".repeat(40),
+      workflowFullRef: `refs/heads/${workflowRef}`,
+      workflowRef,
+      workflowSha,
+    });
+    fixture.manifest.targetRef = fixture.targetSha;
+    const options = {
+      repository: "openclaw/openclaw",
+      runId: fixture.runId,
+      trustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+      trustedWorkflowRef,
+      trustedWorkflowSha: workflowSha,
+      verifierSourceContent: readFileSync(SCRIPT),
+      verifierSourceSha: "c".repeat(40),
+    };
+
+    fixture.client.getRef = () => ({ object: { sha: "6".repeat(40) } });
+    expect(() => validateReleaseRunEvidence(options, fixture.client)).toThrow(
+      "protected tooling tag moved",
+    );
+
+    fixture.client.getRef = () => {
+      throw new Error("HTTP 404");
+    };
+    expect(() => validateReleaseRunEvidence(options, fixture.client)).toThrow(
+      "protected tooling tag is unavailable",
+    );
   });
 
   it.each(["main", "refs/heads/main"])(

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -2366,14 +2366,20 @@ describe("release CI summary child correlation", () => {
             changedPaths: ["CHANGELOG.md"],
             evidenceSha,
             policy: "changelog-only-release-v1",
+            runId: "101",
+            selectedRunId: "101",
           },
+          runId: "101",
           targetSha,
         },
-        { targetSha: evidenceSha },
+        { runId: "101", targetSha: evidenceSha },
+        { runId: "101", targetSha: evidenceSha },
         {
           expectedChangedPaths: ["CHANGELOG.md"],
           expectedEvidencePolicy: "changelog-only-release-v1",
           expectedEvidenceSha: evidenceSha,
+          expectedRootRunId: "101",
+          expectedSelectedRunId: "101",
           expectedTargetSha: targetSha,
         },
       ),
@@ -2385,16 +2391,76 @@ describe("release CI summary child correlation", () => {
             changedPaths: ["CHANGELOG.md"],
             evidenceSha,
             policy: "changelog-only-release-v1",
+            runId: "101",
+            selectedRunId: "101",
           },
+          runId: "101",
           targetSha,
         },
-        { targetSha },
+        { runId: "101", targetSha },
+        { runId: "101", targetSha },
         {
           expectedChangedPaths: ["CHANGELOG.md"],
           expectedEvidencePolicy: "changelog-only-release-v1",
           expectedEvidenceSha: evidenceSha,
+          expectedRootRunId: "101",
+          expectedSelectedRunId: "101",
           expectedTargetSha: targetSha,
         },
+      ),
+    ).toThrow("no longer matches");
+  });
+
+  it.each([
+    {
+      changedPaths: [],
+      policy: "exact-target-full-validation-v1",
+      targetSha: "a".repeat(40),
+    },
+    {
+      changedPaths: ["CHANGELOG.md"],
+      policy: "changelog-only-release-v1",
+      targetSha: "b".repeat(40),
+    },
+  ])("validates the complete prospective $policy selection tuple", (selection) => {
+    const root = validateParentManifest(rawManifest({}), {
+      runAttempt: 2,
+      runId: "29090000000",
+    });
+    expect(() =>
+      validateRequestedEvidenceReuse(
+        root,
+        root,
+        root,
+        {
+          expectedChangedPaths: selection.changedPaths,
+          expectedEvidencePolicy: selection.policy,
+          expectedEvidenceSha: root.targetSha,
+          expectedRootRunId: root.runId,
+          expectedSelectedRunId: root.runId,
+          expectedTargetSha: selection.targetSha,
+        },
+        (base: string) => ({
+          files: [{ filename: "CHANGELOG.md", status: "modified" }],
+          merge_base_commit: { sha: base },
+          status: "ahead",
+        }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateRequestedEvidenceReuse(
+        root,
+        root,
+        root,
+        {
+          expectedChangedPaths: selection.changedPaths,
+          expectedEvidencePolicy: selection.policy,
+          expectedEvidenceSha: root.targetSha,
+          expectedRootRunId: root.runId,
+          expectedSelectedRunId: "29090000001",
+          expectedTargetSha: selection.targetSha,
+        },
+        () => ({ status: "identical" }),
       ),
     ).toThrow("no longer matches");
   });

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -300,7 +300,7 @@ describe("release validation no-push transport", () => {
     const release = readWorkflow(RELEASE_CHECKS);
     const umbrellaGroups = full.on?.workflow_dispatch?.inputs?.rerun_group?.options ?? [];
     const releaseGroups = release.on?.workflow_dispatch?.inputs?.rerun_group?.options ?? [];
-    const dispatch = step(job(full, "release_checks"), "Dispatch and monitor release checks");
+    const dispatch = step(job(full, "release_checks"), "Dispatch release checks");
     const capture = step(job(release, "resolve_target"), "Capture selected inputs");
     const parentFilters = step(job(full, "resolve_target"), "Validate suite filters");
 
@@ -337,12 +337,6 @@ describe("release validation no-push transport", () => {
     expect(candidate.if).toContain(
       "(inputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.live_suite_filter == '')",
     );
-    const verify = step(job(full, "summary"), "Verify child workflow results");
-    expect(verify.env?.LIVE_SUITE_FILTER).toBe(
-      "${{ needs.resolve_target.outputs.live_suite_filter }}",
-    );
-    expect(verify.run).toContain('[[ -n "${LIVE_SUITE_FILTER// }" ]] || candidate_required=1');
-
     expect(capture.run).toContain(
       "release_check_groups=(install-smoke cross-os package qa-parity)",
     );
@@ -768,14 +762,14 @@ describe("release validation no-push transport", () => {
     expect(releaseHelper.with?.["persist-credentials"]).toBe(false);
   });
 
-  it("records adopted children before monitoring and cancels only a mismatched workflow SHA", () => {
+  it("records exact adopted child identity without monitoring or cancellation", () => {
     const full = readWorkflow(FULL_RELEASE);
     for (const [jobName, stepName] of [
-      ["normal_ci", "Dispatch and monitor CI"],
-      ["plugin_prerelease", "Dispatch and monitor plugin prerelease"],
-      ["release_checks", "Dispatch and monitor release checks"],
-      ["npm_telegram", "Dispatch and monitor npm Telegram E2E"],
-      ["performance", "Dispatch and monitor OpenClaw Performance"],
+      ["normal_ci", "Dispatch CI"],
+      ["plugin_prerelease", "Dispatch plugin prerelease"],
+      ["release_checks", "Dispatch release checks"],
+      ["npm_telegram", "Dispatch npm Telegram E2E"],
+      ["performance", "Dispatch OpenClaw Performance"],
     ] as const) {
       const dispatch = step(job(full, jobName), stepName);
       const dispatchRun = dispatch.run ?? "";
@@ -789,42 +783,25 @@ describe("release validation no-push transport", () => {
       expect(dispatchRun, jobName).not.toContain("cancel_child_on_failure");
       expect(dispatchRun, jobName).not.toContain("exit_on_parent_signal");
       expect(dispatchRun, jobName).not.toContain("disable_child_cleanup");
+      expect(dispatchRun, jobName).not.toContain("poll_count=0");
+      expect(dispatchRun, jobName).not.toContain("cancel_child");
       expect(
         dispatchRun.indexOf('run_json="$(validate_child_run "$run_id")"'),
         jobName,
       ).toBeLessThan(dispatchRun.indexOf('echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"'));
       expect(
-        dispatchRun.indexOf('echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"'),
-        jobName,
-      ).toBeLessThan(dispatchRun.indexOf("poll_count=0"));
-      expect(
         dispatchRun.indexOf('run_json="$(validate_child_run "$run_id")"'),
         jobName,
       ).toBeLessThan(dispatchRun.indexOf('if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]'));
-      const shaMismatch = dispatchRun.slice(
-        dispatchRun.indexOf('if [[ "$child_head_sha" != "$PARENT_WORKFLOW_SHA" ]]'),
-        dispatchRun.indexOf("fail_fast_failed_jobs()"),
-      );
-      expect(shaMismatch, jobName).toContain("cancel_child");
-      expect(shaMismatch, jobName).not.toContain("trap");
     }
-
-    const verify = step(job(full, "summary"), "Verify child workflow results");
-    expect(verify.env?.PARENT_WORKFLOW_SHA).toBe("${{ github.sha }}");
-    expect(verify.run).toContain('"$head_sha" != "$PARENT_WORKFLOW_SHA"');
-    expect(verify.run).not.toContain('"$head_sha" != "$TARGET_SHA"');
   });
 
   it("keeps the Release SHA wrapper as the durable evidence identity", () => {
     const full = readWorkflow(FULL_RELEASE);
-    const verify = step(job(full, "summary"), "Verify child workflow results");
+    const verify = step(job(full, "summary"), "Verify exact release state artifacts");
     const dispatch = step(job(full, "summary"), "Request release evidence update");
 
-    expect(verify.run).toContain(
-      'echo "Dispatched ${workflow}: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"',
-    );
-    expect(verify.run).toContain('"ci.yml"');
-    expect(verify.run).toContain('"openclaw-release-checks.yml"');
+    expect(verify.run).toBe("node scripts/full-release-validation-state.mjs verify");
     expect(dispatch.run).not.toContain('GITHUB_RUN_ID_VALUE="$EVIDENCE_ROOT_RUN_ID"');
     expect(dispatch.run).toContain("reused green product evidence from chain-root run");
     expect(dispatch.run).toContain("--connect-timeout 10");
@@ -849,9 +826,9 @@ describe("release validation no-push transport", () => {
     const packageAcceptance = readWorkflow(PACKAGE_ACCEPTANCE);
     const pluginPrerelease = readWorkflow(PLUGIN_PRERELEASE);
 
-    expect(fullText).toContain("dispatch_and_wait plugin-prerelease.yml");
-    expect(fullText).toContain("dispatch_and_wait openclaw-release-checks.yml");
-    expect(fullText).toContain("dispatch_and_wait openclaw-performance.yml");
+    expect(fullText).toContain("dispatch_child plugin-prerelease.yml");
+    expect(fullText).toContain("dispatch_child openclaw-release-checks.yml");
+    expect(fullText).toContain("dispatch_child openclaw-performance.yml");
     expect(fullText).toContain('gh workflow run "$workflow" --ref "$CHILD_WORKFLOW_REF" "$@"');
 
     const preparePackage = job(release, "prepare_release_package");


### PR DESCRIPTION
Builds on the retry-group contract merged by https://github.com/openclaw/openclaw/pull/127012.

## What Problem This Solves

Fixes an issue where release operators waited for every Full Release Validation child to finish before learning that publication was already blocked, while long-running dispatcher jobs also owned diagnostic collection and cancellation policy.

## Why This Change Was Made

Child jobs now dispatch one exact run tuple and finish. A stable execution-plan artifact seals the original parent attempt, exact child IDs/attempts/titles, required coverage, gates, reuse identity, workflow ref, and Tooling SHA.

Release Decision revalidates reused evidence and reports decisive blockers early. Diagnostic Drain continues selected children to terminal. Collector retries restore the immutable plan and adopt the same children; they never redispatch tests. The final verifier validates the plan plus exact Decision and Drain artifacts instead of independently reclassifying results.

One canonical policy module owns coverage, candidate-preparation semantics, advisory failures, terminal policy, state classification, artifact binding, bounded summaries, and exact-child cancellation selection.

This intentionally excludes writer trust, ReleasePlan schema, scanner, and group-planner changes.

## User Impact

Release owners get an early, policy-correct blocking answer without losing independent diagnostics. `fail_fast=false` makes zero child cancellation calls. `fail_fast=true` can cancel only the exact active child that owns a blocking failure. API failures remain distinct from provenance mismatches, and SIGINT/SIGTERM writes an immediate handoff with active child identities.

Historical evidence remains valid when a parent log uniquely records the child run URL without newer `(attempt N)` text. Changelog-only reuse keeps the Code/evidence SHA separate from the requested Release SHA and revalidates policy plus changed paths before passing.

## Evidence

Exact head: `4ba036d1dc3f67d7ccacabdfc3706e3e4b48c86e` (signed)

- eight focused release/tooling files - 555 passed, 2 skipped
- Decision/Drain controller files - 142 passed
- Blacksmith Testbox `pnpm tsgo:scripts` - passed: https://github.com/openclaw/openclaw/actions/runs/32496472345
- Blacksmith Testbox `pnpm tsgo:test:root` - passed: https://github.com/openclaw/openclaw/actions/runs/32496024051
- Blacksmith Testbox `pnpm deadcode:exports` - production, full-tree, and script scans passed with 0 entries: https://github.com/openclaw/openclaw/actions/runs/32496023680
- targeted script `oxlint`
- `actionlint .github/workflows/full-release-validation.yml`
- `pnpm check:script-erasability` - 515 implementation files checked
- focused `pnpm format:check`
- `git diff --check`
- `pnpm docs:list` confirmed the two edited release references

The exact-head repair centralizes GitHub transport classification. HTTP 429/5xx,
timeouts, resets, `EAI_AGAIN`, and unexpected EOF make the Decision artifact
unavailable for one poll; HTTP 401/403, credential errors, invocation errors,
artifact parsing, size, schema, and provenance remain hard failures.

Hosted run https://github.com/openclaw/openclaw/actions/runs/32455617458 dispatched exact child https://github.com/openclaw/openclaw/actions/runs/32455657717 and exposed an invalid `actions/download-artifact` v8 SHA before Decision/Drain could start. Hosted run https://github.com/openclaw/openclaw/actions/runs/32455915621 then exposed an empty no-reuse `changed_paths` output passed to `jq --argjson`. Exact head fixes both hosted blockers: all six downloads use the canonical v8 commit, and absent evidence paths normalize to `[]`.

The isolated non-publishing rerun https://github.com/openclaw/openclaw/actions/runs/32456077308 uses the same Validation SHA as the second run with only the Tooling SHA changed. It dispatched its exact CI child, sealed the immutable plan successfully, and started Release Decision plus Diagnostic Drain concurrently.

The local sparse GWT could not run reliable full-tree type/dead-code proof because
tracked UI/Android inputs were omitted. The exact dirty diff was therefore
mirrored into a disposable materialized full checkout and delegated to the
Blacksmith runs above.

The scoped guide names `pnpm check:script-declarations`, but this checkout has no such package script.

Against the merged retry-group base, the branch is non-test `+2671/-778` (net `+1893`) and test `+1167/-645` (net `+522`). The exact-head repair commit is non-test `+177/-76` (net `+101`) and test `+141/-109` (net `+32`). The positive non-test delta is the explicit release ownership boundary: immutable plan production/validation, abortable collectors, shared terminal policy and transport classification, historical evidence compatibility, and the workflow/docs/skill integration replacing duplicated synchronous foreground monitors.

## Owner Decision

On August 21, 2026, the release owner accepted the remaining optional hosted exact-tooling proof gap because no policy-clean pre-merge route exists. This is not a waiver of runtime verification: after merge, a controlled non-publishing npm/Telegram blocker run must use `openclaw@0.0.0-frv-proof`, `fail_fast=false`, `reuse=false`, and `dispatch_release_evidence=false`, then rerun the entire parent once. The proof must show the same sealed plan, source attempt, and child ID, with no attempt-2 child and no publication.

## Base And Follow-Up

- PR #127012 squash-merged as `750f2f37629d75599a4be7152879caa8dda16baa`.
- The one authorized final rebase completed onto that merge. Its four prerequisite-only commits were dropped and the two decision/drain commits replayed with valid signatures.
- Exact-head source review and focused validation are complete. The PR is ready for the repository-native landing gates.
