### PR TITLE
fix(cli): render skills JSON failures

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -68,7 +68,7 @@ import type {
 } from "../skills/workshop/types.js";
 import { CONFIG_DIR } from "../utils.js";
 import { resolveClawHubRiskAcknowledgementCliOptions } from "./clawhub-risk-acknowledgement.js";
-import { resolveOptionFromCommand } from "./cli-utils.js";
+import { resolveOptionFromCommand, runCommandWithRuntime } from "./cli-utils.js";
 import { inheritOptionFromParent } from "./command-options.js";
 import { formatCliJsonFailure, rethrowExpectedCliError } from "./failure-output.js";
 import { resolveInstallPolicyWarningAcknowledgementCliOptions } from "./install-policy-warning-acknowledgement.js";
@@ -219,13 +219,10 @@ async function runSkillsAction(
   render: (report: SkillStatusReport) => string,
   options?: ResolveSkillsWorkspaceOptions,
 ): Promise<void> {
-  try {
+  await runCommandWithRuntime(defaultRuntime, async () => {
     const report = await loadSkillsStatusReport(options);
     defaultRuntime.writeStdout(render(report));
-  } catch (err) {
-    defaultRuntime.error(formatErrorMessage(err));
-    defaultRuntime.exit(1);
-  }
+  });
 }
 
 function resolveSkillsWorkspaceForCommand(
@@ -602,7 +599,7 @@ export function registerSkillsCli(program: Command) {
     .option("--limit <n>", "Max results", (value) => parseStrictPositiveIntOption(value, "--limit"))
     .option("--json", "Output as JSON", false)
     .action(async (queryParts: string[], opts: { limit?: number; json?: boolean }) => {
-      try {
+      await runCommandWithRuntime(defaultRuntime, async () => {
         const results = await searchSkillsFromClawHub({
           query: normalizeOptionalString(queryParts.join(" ")),
           limit: opts.limit,
@@ -627,10 +624,7 @@ export function registerSkillsCli(program: Command) {
           const trust = isExternalSource ? `  ${CLAWHUB_SKILLS_SH_TRUST_LABEL}` : "";
           defaultRuntime.log(`${skillRef}${version}  ${displayName}${summary}${trust}`);
         }
-      } catch (err) {
-        defaultRuntime.error(formatErrorMessage(err));
-        defaultRuntime.exit(1);
-      }
+      });
     });
 
   skills

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -358,6 +358,109 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it.each([
+    {
+      name: "search with a leaf JSON flag",
+      args: ["skills", "search", "fixture", "--json"],
+      message: "ClawHub /api/v1/search failed (400): offline fixture",
+    },
+    {
+      name: "search with a parent JSON flag",
+      args: ["skills", "--json", "search", "fixture"],
+      message: "ClawHub /api/v1/search failed (400): offline fixture",
+    },
+    {
+      name: "list with a leaf JSON flag",
+      args: ["skills", "list", "--agent", "", "--json"],
+      message: "--agent must not be blank",
+    },
+    {
+      name: "list with a parent JSON flag",
+      args: ["skills", "--json", "list", "--agent", ""],
+      message: "--agent must not be blank",
+    },
+    {
+      name: "info with a leaf JSON flag",
+      args: ["skills", "info", "fixture", "--agent", "", "--json"],
+      message: "--agent must not be blank",
+    },
+    {
+      name: "info with a parent JSON flag",
+      args: ["skills", "--json", "info", "fixture", "--agent", ""],
+      message: "--agent must not be blank",
+    },
+    {
+      name: "check with a leaf JSON flag",
+      args: ["skills", "check", "--agent", "", "--json"],
+      message: "--agent must not be blank",
+    },
+    {
+      name: "check with a parent JSON flag",
+      args: ["skills", "--json", "check", "--agent", ""],
+      message: "--agent must not be blank",
+    },
+    {
+      name: "the default report after its agent flag",
+      args: ["skills", "--agent", "", "--json"],
+      message: "--agent must not be blank",
+    },
+    {
+      name: "the default report before its agent flag",
+      args: ["skills", "--json", "--agent", ""],
+      message: "--agent must not be blank",
+    },
+  ])("returns one canonical JSON document when skills $name fails", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const preload = `data:text/javascript,${encodeURIComponent(
+          'globalThis.fetch = async () => new Response("offline fixture", { status: 400 });',
+        )}`;
+        const result = runBuiltCli(tempHome, testCase.args, {
+          NODE_OPTIONS: `--import=${preload}`,
+          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+          OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+        });
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: testCase.message,
+          },
+        });
+        expect(result.stderr).toContain(testCase.message);
+        expect(result.stderr.length).toBeLessThan(2_048);
+      },
+      { prefix: "openclaw-skills-json-failure-e2e-" },
+    );
+  });
+
+  it.each([
+    { name: "off", debug: "0", includesCause: false },
+    { name: "on", debug: "1", includesCause: true },
+  ])("keeps skills search nested causes behind debug mode ($name)", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const preload = `data:text/javascript,${encodeURIComponent(
+          'globalThis.fetch = async () => new Response("not-json", { status: 200 });',
+        )}`;
+        const result = runBuiltCli(tempHome, ["skills", "search", "fixture"], {
+          NODE_OPTIONS: `--import=${preload}`,
+          OPENCLAW_DEBUG: testCase.debug,
+          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+          OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+        });
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain("ClawHub /api/v1/search returned malformed JSON");
+        expect(result.stderr.includes("Unexpected token")).toBe(testCase.includesCause);
+      },
+      { prefix: "openclaw-skills-human-failure-e2e-" },
+    );
+  });
+
   it("returns one canonical document when docs search fails", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
Closes #126996

AI-assisted with Codex; changes and behavior were independently reviewed and verified.

## What Problem This Solves

Fixes an issue where users or agents running `openclaw skills search`, `skills list`, `skills info`, `skills check`, or the default `skills` report with `--json` would receive an empty stdout stream when the command failed. Both `skills search fixture --json` and `skills --json search fixture` violated the documented single-document JSON failure contract, preventing callers from inspecting the failure.

## Why This Change Was Made

The skills search action and shared read-only skills reporting action each caught their own exceptions, printed to stderr, and exited before the existing process-level CLI failure renderer could emit its canonical JSON document. Route only those two actions through the existing `runCommandWithRuntime` owner so JSON failures reach that renderer and human-readable failures inherit the established debug-gated cause policy.

Successful search/report output, agent and flag inheritance, Gateway/local report selection, Commander validation, and missing-skill enriched JSON remain unchanged. In particular, `skills info` still writes its domain-specific payload containing `skill` and exits once outside the reporting wrapper. Skill installation, updates, verification, curation, and workshop mutations are intentionally untouched.

## User Impact

Failed skills reporting and search commands now exit nonzero while writing exactly one parseable `cli_error` JSON document to stdout for either supported `--json` placement. Human-mode failures retain their primary diagnostic, with nested causes shown only when `OPENCLAW_DEBUG=1`. Existing successful output and enriched missing-skill responses are preserved.

## Evidence

Exact PR head: `e225abe8235329542dfdc21d34b1a7217f960c4e`. The repair was reproduced against exact audited base `514d148519106bd9f08bec1e0aabf7f911f2644a` and then refreshed onto current `main` after ClawSweeper review. An unrelated upstream max-lines CI failure was independently fixed in #127018 before landing; no unrelated CI or UI changes remain in this PR.

Regression-first proof against the exact clean base:

```text
OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs test/cli-json-stdout.e2e.test.ts --testNamePattern 'returns one canonical JSON document when skills|keeps skills search nested causes'
10 skills JSON cases failed with "Unexpected end of JSON input" (stdout was empty).
The debug-off human case failed because its nested cause leaked.
```

Repaired exact-head proof:

```text
node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/cli/skills-cli.test.ts src/cli/cli-utils.test.ts
3 files passed; 170 tests passed.

pnpm build
Complete production build passed, including CLI bootstrap import guard, plugin SDK exports, UI build/performance checks, and CLI startup metadata.

OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs test/cli-json-stdout.e2e.test.ts
1 file passed; 45 real-process tests passed.

pnpm check:changed
Changed-file formatting, typecheck, lint, architecture, and guard lanes passed.

node_modules/.bin/oxfmt --check src/cli/skills-cli.ts test/cli-json-stdout.e2e.test.ts
git diff --check
Both passed.
```

An independent source-blind real-entrypoint matrix passed 17/17 cases under Node permission restrictions with network and child-process access denied, isolated disposable home/state, and fake fetch responses. It covered both JSON flag positions across search/list/info/check/default, successful search output, enriched missing-skill JSON and exit status, human debug off/on, and unchanged Commander parse failures. A separate adversarial owner-boundary review and fresh Codex autoreview both reported no actionable findings.

Production LOC: `+5/-11` (net `-6`). Tests: `+103/-0`. Alternatives rejected: rendering JSON in local catch blocks would duplicate the canonical owner; wrapping the complete `skills info` action risks replacing or double-rendering its enriched missing-skill payload; changing curator/workshop behavior would broaden mutation and expected-error semantics outside this repair.

No changelog, configuration, persistence, security, protocol, product, dependency, release, or deployment changes.
