### PR TITLE
fix(release): allow unreleased changelog in SHA preflight

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -510,6 +510,11 @@ jobs:
             fi
           fi
           PACK_OUTPUT="$RUNNER_TEMP/npm-pack-output.txt"
+          if [[ "${RELEASE_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            # Validation-only SHA runs package unreleased main; real release tags
+            # still require their exact versioned changelog section.
+            export OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG=1
+          fi
           pnpm pack --json 2>&1 | tee "$PACK_OUTPUT"
           PACK_NAME="$(node - "$PACK_OUTPUT" <<'NODE'
           const fs = require("node:fs");

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -273,8 +273,11 @@ describe("minimal npm extended-stable workflow", () => {
     const parsed = workflow();
     const preflight = parsed.jobs?.preflight_openclaw_npm;
     const metadata = step(preflight, "Validate release metadata");
+    const pack = step(preflight, "Pack prepared npm tarball");
     expect(metadata.run).toContain('RELEASE_BRANCH_REF="${RELEASE_SHA}"');
     expect(metadata.run).not.toContain("Validation-only SHA mode only supports");
+    expect(pack.run).toContain('if [[ "${RELEASE_REF}" =~ ^[0-9a-fA-F]{40}$ ]]');
+    expect(pack.run).toContain("export OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG=1");
 
     const plugins = step(preflight, "Exercise all extended-stable plugin npm packages");
     expect(step(preflight, "Verify release contents").env).toMatchObject({


### PR DESCRIPTION
## Summary

- allow `CHANGELOG.md`'s Unreleased section only while packing validation-only full-SHA npm preflights
- keep real release-tag packaging strict about an exact versioned changelog section
- extend the existing arbitrary-SHA workflow contract test

## Root cause

The npm workflow explicitly supports full commit SHAs for validation-only preflight. Its metadata stage synthesizes a release tag for that mode, but the final `pnpm pack` stage still required `CHANGELOG.md` to contain a release section matching the current package version. Main intentionally carries changes under `Unreleased`, so exact-main validation could never complete once it reached final packing.

The prepack owner already exposes `OPENCLAW_PREPACK_ALLOW_UNRELEASED_CHANGELOG` for this purpose. The workflow now sets it only after the input has passed the full-SHA validation path. Tagged beta/stable publication remains unchanged.

## Validation

- reproduced in main preflight https://github.com/openclaw/openclaw/actions/runs/32446665168, failed job https://github.com/openclaw/openclaw/actions/runs/32446665168/job/96667434736
- `git diff --check`
- Codex autoreview: clean, correctness 0.99
- `actionlint` unavailable locally; exact-head workflow CI owns syntax and focused test execution

## LOC

- production/workflow: +5/-0
- tests: +3/-0

## Test audit

The extended assertion protects an operator-visible workflow contract: arbitrary SHA preflight must package unreleased main without weakening tagged release packaging. It fails on the exact pre-fix workflow and requires no test-only production seam.
