### PR TITLE
fix(release): preserve frozen ClawHub request contracts

### DIFF
--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -9,7 +9,7 @@ export function legacyPackageAcceptanceCompat(version) {
   );
 }
 
-export function clawhubReleaseSecurityMode(version) {
+function clawhubReleaseSecurityMode(version) {
   // The frozen 2026.6.35 candidate predates the ClawHub release-security endpoint.
   return version === "2026.6.35" ? "absent" : "required";
 }

--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -29,9 +29,9 @@ if (isDirectRunUrl(process.argv[1], import.meta.url)) {
     process.argv[2] === "--clawhub-release-security-mode"
       ? clawhubReleaseSecurityMode(process.argv[3])
       : process.argv[2] === "fixture-consent"
-      ? fixtureCapabilityConsentArgs(readFileSync(0, "utf8")).join("\n")
-      : legacyPackageAcceptanceCompat(process.argv[2])
-        ? "1"
-        : "0",
+        ? fixtureCapabilityConsentArgs(readFileSync(0, "utf8")).join("\n")
+        : legacyPackageAcceptanceCompat(process.argv[2])
+          ? "1"
+          : "0",
   );
 }

--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -20,7 +20,7 @@ export function fixtureCapabilityConsentArgs(help) {
 }
 
 function clawhubReleaseSecurityMode(version) {
-  // 2026.6.35 shipped before the ClawHub release-security endpoint existed.
+  // The frozen 2026.6.35 candidate predates the ClawHub release-security endpoint.
   return version === "2026.6.35" ? "absent" : "required";
 }
 

--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -9,6 +9,15 @@ export function legacyPackageAcceptanceCompat(version) {
   );
 }
 
+export function clawhubReleaseSecurityMode(version) {
+  // 2026.6.35 shipped before the ClawHub release-security endpoint existed.
+  return version === "2026.6.35" ? "absent" : "required";
+}
+
 if (isDirectRunUrl(process.argv[1], import.meta.url)) {
-  console.log(legacyPackageAcceptanceCompat(process.argv[2]) ? "1" : "0");
+  if (process.argv[2] === "--clawhub-release-security-mode") {
+    console.log(clawhubReleaseSecurityMode(process.argv[3]));
+  } else {
+    console.log(legacyPackageAcceptanceCompat(process.argv[2]) ? "1" : "0");
+  }
 }

--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -10,7 +10,7 @@ export function legacyPackageAcceptanceCompat(version) {
 }
 
 export function clawhubReleaseSecurityMode(version) {
-  // 2026.6.35 shipped before the ClawHub release-security endpoint existed.
+  // The frozen 2026.6.35 candidate predates the ClawHub release-security endpoint.
   return version === "2026.6.35" ? "absent" : "required";
 }
 

--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -19,9 +19,16 @@ export function fixtureCapabilityConsentArgs(help) {
     : [];
 }
 
+function clawhubReleaseSecurityMode(version) {
+  // 2026.6.35 shipped before the ClawHub release-security endpoint existed.
+  return version === "2026.6.35" ? "absent" : "required";
+}
+
 if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   console.log(
-    process.argv[2] === "fixture-consent"
+    process.argv[2] === "--clawhub-release-security-mode"
+      ? clawhubReleaseSecurityMode(process.argv[3])
+      : process.argv[2] === "fixture-consent"
       ? fixtureCapabilityConsentArgs(readFileSync(0, "utf8")).join("\n")
       : legacyPackageAcceptanceCompat(process.argv[2])
         ? "1"

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1625,15 +1625,12 @@ phase prepare-update-restart-probe prepare_update_restart_probe
 phase configure-plugin-registry configure_plugin_registry
 phase update-candidate update_candidate
 if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
-  clawhub_security_mode="required"
+  clawhub_security_mode="$(
+    node scripts/e2e/lib/package-compat.mjs --clawhub-release-security-mode "$candidate_version"
+  )"
   prepublish_package="@openclaw/whatsapp"
   if configured_plugin_installs_enabled; then
     prepublish_package="@openclaw/matrix"
-  fi
-  # 2026.6.35 predates the release-security endpoint. The trusted fixture still
-  # asserts its exact older request contract instead of accepting arbitrary IO.
-  if [ "$candidate_version" = "2026.6.35" ]; then
-    clawhub_security_mode="absent"
   fi
   phase assert-prepublish-requests node \
     "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1669,15 +1669,12 @@ phase prepare-update-restart-probe prepare_update_restart_probe
 phase configure-plugin-registry configure_plugin_registry
 phase update-candidate update_candidate
 if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
-  clawhub_security_mode="required"
+  clawhub_security_mode="$(
+    node scripts/e2e/lib/package-compat.mjs --clawhub-release-security-mode "$candidate_version"
+  )"
   prepublish_package="@openclaw/whatsapp"
   if configured_plugin_installs_enabled; then
     prepublish_package="@openclaw/matrix"
-  fi
-  # 2026.6.35 predates the release-security endpoint. The trusted fixture still
-  # asserts its exact older request contract instead of accepting arbitrary IO.
-  if [ "$candidate_version" = "2026.6.35" ]; then
-    clawhub_security_mode="absent"
   fi
   phase assert-prepublish-requests node \
     "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -503,6 +503,10 @@ node scripts/e2e/lib/upgrade-survivor/assertions.mjs seed
 openclaw_e2e_install_package "$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/install.log" "upgrade survivor package" "$npm_config_prefix"
 command -v openclaw >/dev/null
 package_version="$(node -p "JSON.parse(require(\"node:fs\").readFileSync(process.argv[1] + \"/lib/node_modules/openclaw/package.json\", \"utf8\")).version" "$npm_config_prefix")"
+candidate_version="$(
+  tar -xOf "${OPENCLAW_CURRENT_PACKAGE_TGZ:?missing OPENCLAW_CURRENT_PACKAGE_TGZ}" package/package.json |
+    node -e "let raw=[]; process.stdin.on(\"data\", (chunk) => raw.push(chunk)); process.stdin.on(\"end\", () => process.stdout.write(JSON.parse(Buffer.concat(raw)).version));"
+)"
 OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT="$(
   node scripts/e2e/lib/package-compat.mjs "$package_version"
 )"
@@ -540,8 +544,11 @@ if [ "$update_status" -ne 0 ]; then
   exit "$update_status"
 fi
 if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
+  clawhub_security_mode="$(
+    node scripts/e2e/lib/package-compat.mjs --clawhub-release-security-mode "$candidate_version"
+  )"
   node "$OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER" \
-    assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$package_version"
+    assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$candidate_version" "$clawhub_security_mode"
 fi
 
 if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then

--- a/test/scripts/direct-run-entrypoints.test.ts
+++ b/test/scripts/direct-run-entrypoints.test.ts
@@ -39,6 +39,18 @@ const EXECUTABLE_ENTRYPOINTS = [
     status: 0,
   },
   {
+    args: ["--clawhub-release-security-mode", "2026.6.35"],
+    output: "absent",
+    script: "scripts/e2e/lib/package-compat.mjs",
+    status: 0,
+  },
+  {
+    args: ["--clawhub-release-security-mode", "2026.8.1"],
+    output: "required",
+    script: "scripts/e2e/lib/package-compat.mjs",
+    status: 0,
+  },
+  {
     args: [],
     output: "docker_e2e_count=",
     script: "scripts/plan-release-workflow-matrix.mjs",

--- a/test/scripts/direct-run-entrypoints.test.ts
+++ b/test/scripts/direct-run-entrypoints.test.ts
@@ -43,6 +43,18 @@ const EXECUTABLE_ENTRYPOINTS = [
     status: 0,
   },
   {
+    args: ["--clawhub-release-security-mode", "2026.6.35"],
+    output: "absent",
+    script: "scripts/e2e/lib/package-compat.mjs",
+    status: 0,
+  },
+  {
+    args: ["--clawhub-release-security-mode", "2026.8.1"],
+    output: "required",
+    script: "scripts/e2e/lib/package-compat.mjs",
+    status: 0,
+  },
+  {
     args: [],
     output: "docker_e2e_count=",
     script: "scripts/plan-release-workflow-matrix.mjs",

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2586,7 +2586,11 @@ docker_e2e_docker_run_cmd run demo
     expect(publishedRunner.indexOf("phase update-candidate update_candidate")).toBeLessThan(
       publishedRunner.indexOf("phase assert-prepublish-requests node"),
     );
-    expect(publishedRunner).toContain('if [ "$candidate_version" = "2026.6.35" ]; then');
+    expectTextToIncludeAll(publishedRunner, [
+      'package-compat.mjs --clawhub-release-security-mode "$candidate_version"',
+      'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "$prepublish_package" "$candidate_version" "$clawhub_security_mode"',
+    ]);
+    expect(publishedRunner).not.toContain('if [ "$candidate_version" = "2026.6.35" ]; then');
     expect(publishedRunner).toContain('prepublish_package="@openclaw/whatsapp"');
     expect(publishedRunner).toContain("if configured_plugin_installs_enabled; then");
     expect(publishedRunner).toContain('prepublish_package="@openclaw/matrix"');

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2536,7 +2536,15 @@ docker_e2e_docker_run_cmd run demo
     expect(publishedRunner.indexOf("phase update-candidate update_candidate")).toBeLessThan(
       publishedRunner.indexOf("phase assert-prepublish-requests node"),
     );
-    expect(publishedRunner).toContain('if [ "$candidate_version" = "2026.6.35" ]; then');
+    expectTextToIncludeAll(runner, [
+      'tar -xOf "${OPENCLAW_CURRENT_PACKAGE_TGZ:?missing OPENCLAW_CURRENT_PACKAGE_TGZ}" package/package.json',
+      '"${OPENCLAW_CURRENT_PACKAGE_TGZ:?missing OPENCLAW_CURRENT_PACKAGE_TGZ}"',
+      'package-compat.mjs --clawhub-release-security-mode "$candidate_version"',
+      'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$candidate_version" "$clawhub_security_mode"',
+    ]);
+    expect(publishedRunner).toContain(
+      'package-compat.mjs --clawhub-release-security-mode "$candidate_version"',
+    );
     expect(publishedRunner).toContain('prepublish_package="@openclaw/whatsapp"');
     expect(publishedRunner).toContain("if configured_plugin_installs_enabled; then");
     expect(publishedRunner).toContain('prepublish_package="@openclaw/matrix"');
@@ -2557,12 +2565,12 @@ docker_e2e_docker_run_cmd run demo
     );
     expect(runner.indexOf('openclaw "${update_args[@]}"')).toBeLessThan(
       runner.indexOf(
-        'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$package_version"',
+        'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$candidate_version" "$clawhub_security_mode"',
       ),
     );
     expect(
       runner.indexOf(
-        'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$package_version"',
+        'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$candidate_version" "$clawhub_security_mode"',
       ),
     ).toBeLessThan(runner.indexOf("openclaw doctor --fix --non-interactive"));
     expect(runner).toContain(


### PR DESCRIPTION
## Summary

Fixes the non-published upgrade-survivor Docker path when validating the frozen `2026.6.35` candidate. That path used the pre-update image version when asserting the ClawHub request ledger; it therefore expected current release-security traffic while the candidate correctly made its older three-request flow.

The candidate version is now read from the mounted package tarball, and both survivor runners use one version-compatibility helper to select the exact request contract. No candidate source/package changes.

## Root cause and scope

Full Validation [32442753023](https://github.com/openclaw/openclaw/actions/runs/32442753023), Docker core [job 96658698328](https://github.com/openclaw/openclaw/actions/runs/32443171582/job/96658698328): the failing non-published survivor image had `2026.8.1`, while the mounted candidate tarball was `2026.6.35`. The assertion used the former and rejected the candidate's valid request sequence. Published survivor paths already computed request expectations from the candidate.

Architectural owner: trusted release harness. The repair keeps strict exact request assertions; it does not relax or retry them.

## Validation

- `bash -n scripts/e2e/upgrade-survivor-docker.sh`
- `bash -n scripts/e2e/lib/upgrade-survivor/run.sh`
- `node scripts/run-vitest.mjs test/scripts/direct-run-entrypoints.test.ts test/scripts/docker-build-helper.test.ts test/scripts/clawhub-fixture-server.test.ts` — 238 passed
- `CI=1 node scripts/check-changed.mjs`
- focused `oxfmt --check`, `git diff --check`
- `autoreview --mode local --base origin/main` — clean (0.99)

Production/harness delta: +21/-8; test delta: +23/-3. The small net harness growth adds a single candidate-version extraction and centralizes the pre-existing `2026.6.35` endpoint contract; it removes duplicated mode policy from the published runner.