### PR TITLE
fix(codex): refresh Computer Use runtimes without Gateway restart

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -155,10 +155,15 @@ OpenClaw serializes native Codex config reads and Computer Use installation
 inside one running Gateway. A separate Codex process or another Gateway is not
 part of that fence. After changing native Codex plugin config outside the
 Gateway, restart the Gateway and start a new chat before relying on the new
-selection. Restart the Gateway after updating the selected ChatGPT or Codex
-desktop app as well; cold app-server startup then verifies and, when needed,
-refreshes each isolated home's signed Computer Use service before launching it.
-Warm clients are intentionally not polled for desktop bundle changes.
+selection. For an OpenClaw-managed isolated home, each Computer Use request
+checks the selected ChatGPT or Codex desktop bundle generation. After a desktop
+update, OpenClaw verifies and refreshes that isolated home's signed service,
+retires only the affected warm app-server, and retries startup once against the
+current desktop generation; the Gateway itself does not need to restart.
+Explicit `CODEX_HOME` overrides and user-scoped homes remain operator-owned and
+retain their configured repair behavior. Warm clients are not continuously
+polled solely for desktop bundle changes; request-time checks and explicitly
+enabled periodic health checks use the same managed-runtime reconciliation.
 
 ## Commands
 

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -309,6 +309,9 @@ export async function startCodexAttemptThread(params: {
                 signal: startupAbandonController.signal,
               });
             } catch (error) {
+              if (isCodexAppServerStartSelectionChangedError(error)) {
+                throw error;
+              }
               if (startupAbandonController.signal.aborted) {
                 throw error;
               }

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -30,12 +30,14 @@ import {
 } from "./auth-start-options.js";
 import type { CodexAppServerClient } from "./client.js";
 import { ensureCodexComputerUseSharedPluginCache } from "./computer-use-cache.js";
+import { ensureCodexComputerUseBundledMarketplace } from "./computer-use-marketplace.js";
 import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
   resolveCodexComputerUseConfig,
   type CodexAppServerHomeScope,
   type CodexAppServerStartOptions,
 } from "./config.js";
+import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import {
   isJsonObject,
   type CodexChatgptAuthTokensRefreshResponse,
@@ -523,12 +525,24 @@ async function withCodexHomeEnvironment(
     : undefined;
   await fs.mkdir(codexHome, { recursive: true });
   const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig });
-  await ensureCodexComputerUseSharedPluginCache({
-    codexHome,
-    config: computerUseConfig,
-  });
   const ownsIsolatedCodexHome =
     startOptions.homeScope !== "user" && !startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim();
+  const configFenceKey = `codex-home:${path.resolve(codexHome)}`;
+  const releaseConfigFence = await acquireCodexNativeConfigFence(configFenceKey);
+  try {
+    if (ownsIsolatedCodexHome) {
+      await ensureCodexComputerUseBundledMarketplace({
+        codexHome,
+        config: computerUseConfig,
+      });
+    }
+    await ensureCodexComputerUseSharedPluginCache({
+      codexHome,
+      config: computerUseConfig,
+    });
+  } finally {
+    releaseConfigFence();
+  }
   if (computerUseConfig.enabled && computerUseConfig.autoInstall && ownsIsolatedCodexHome) {
     try {
       await ensureCodexComputerUseServiceApp({

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -31,6 +31,7 @@ import {
 import type { CodexAppServerClient } from "./client.js";
 import { ensureCodexComputerUseSharedPluginCache } from "./computer-use-cache.js";
 import { ensureCodexComputerUseBundledMarketplace } from "./computer-use-marketplace.js";
+import { ensureOwnedCodexHome } from "./computer-use-service-path.js";
 import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
   resolveCodexComputerUseConfig,
@@ -523,16 +524,21 @@ async function withCodexHomeEnvironment(
   const nativeHome = startOptions.env?.[HOME_ENV_VAR]?.trim()
     ? startOptions.env[HOME_ENV_VAR]
     : undefined;
-  await fs.mkdir(codexHome, { recursive: true });
   const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig });
   const ownsIsolatedCodexHome =
     startOptions.homeScope !== "user" && !startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim();
+  if (ownsIsolatedCodexHome) {
+    await ensureOwnedCodexHome(codexHome, agentDir);
+  } else {
+    await fs.mkdir(codexHome, { recursive: true });
+  }
   const configFenceKey = `codex-home:${path.resolve(codexHome)}`;
   const releaseConfigFence = await acquireCodexNativeConfigFence(configFenceKey);
   try {
     if (ownsIsolatedCodexHome) {
       await ensureCodexComputerUseBundledMarketplace({
         codexHome,
+        ownershipRoot: agentDir,
         config: computerUseConfig,
       });
     }

--- a/extensions/codex/src/app-server/computer-use-health.test.ts
+++ b/extensions/codex/src/app-server/computer-use-health.test.ts
@@ -69,6 +69,34 @@ describe("Codex Computer Use periodic health", () => {
     expect(repairComputerUseMcpChildren).toHaveBeenCalledTimes(1);
   });
 
+  it("repairs a failed live handshake even when optional auto-repair is off", async () => {
+    vi.useFakeTimers();
+    const client = createClient({ liveTestFailures: 1 });
+    const repairComputerUseRuntime = vi.fn(async () => ({
+      attempted: true,
+      killedPids: [5678],
+      warnings: [],
+      message: "Revalidated the signed service and replaced the incompatible native client.",
+    }));
+
+    startCodexComputerUseHealthMonitor({
+      client: client.client,
+      config: computerUseConfig({
+        autoRepair: false,
+        healthCheckEnabled: true,
+        healthCheckIntervalMinutes: 30,
+      }),
+      repairComputerUseRuntime,
+    });
+
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+
+    expect(
+      client.request.mock.calls.filter(([method]) => method === "mcpServer/tool/call"),
+    ).toHaveLength(2);
+    expect(repairComputerUseRuntime).toHaveBeenCalledTimes(1);
+  });
+
   it("stops an existing monitor when health checks are disabled", async () => {
     vi.useFakeTimers();
     const client = createClient();

--- a/extensions/codex/src/app-server/computer-use-health.ts
+++ b/extensions/codex/src/app-server/computer-use-health.ts
@@ -56,7 +56,7 @@ export function startCodexComputerUseHealthMonitor(params: {
     params.repairComputerUseRuntime ??
     (params.repairComputerUseMcpChildren
       ? undefined
-      : getCodexComputerUseRuntimeReconciler(params.client).repairAfterProbeFailure);
+      : getCodexComputerUseRuntimeReconciler(params.client)?.repairAfterProbeFailure);
   const fingerprint = buildComputerUseHealthMonitorFingerprint(params.config);
   const intervalMs = params.config.healthCheckIntervalMinutes * 60_000;
   if (

--- a/extensions/codex/src/app-server/computer-use-health.ts
+++ b/extensions/codex/src/app-server/computer-use-health.ts
@@ -5,6 +5,7 @@ import {
   killStaleComputerUseMcpChildren,
   type CodexComputerUseRepairStatus,
 } from "./computer-use-process-repair.js";
+import { getCodexComputerUseRuntimeReconciler } from "./computer-use-runtime-repair.js";
 import { runCodexComputerUseLiveTest } from "./computer-use.js";
 import type { ResolvedCodexComputerUseConfig } from "./config.js";
 
@@ -12,6 +13,7 @@ type ComputerUseHealthMonitor = {
   fingerprint: string;
   intervalMs: number;
   repairComputerUseMcpChildren?: () => Promise<CodexComputerUseRepairStatus>;
+  repairComputerUseRuntime?: () => Promise<CodexComputerUseRepairStatus>;
   timer: ReturnType<typeof setInterval>;
   disposeCloseHandler: () => void;
   running: boolean;
@@ -37,6 +39,7 @@ export function startCodexComputerUseHealthMonitor(params: {
   client: CodexAppServerClient;
   config: ResolvedCodexComputerUseConfig;
   repairComputerUseMcpChildren?: () => Promise<CodexComputerUseRepairStatus>;
+  repairComputerUseRuntime?: () => Promise<CodexComputerUseRepairStatus>;
 }): { started: boolean; intervalMs?: number; reason?: string } {
   const state = getComputerUseHealthMonitorState();
   const existing = state.monitors.get(params.client);
@@ -49,11 +52,17 @@ export function startCodexComputerUseHealthMonitor(params: {
       reason: params.config.enabled ? "health_disabled" : "disabled",
     };
   }
+  const repairComputerUseRuntime =
+    params.repairComputerUseRuntime ??
+    (params.repairComputerUseMcpChildren
+      ? undefined
+      : getCodexComputerUseRuntimeReconciler(params.client).repairAfterProbeFailure);
   const fingerprint = buildComputerUseHealthMonitorFingerprint(params.config);
   const intervalMs = params.config.healthCheckIntervalMinutes * 60_000;
   if (
     existing?.fingerprint === fingerprint &&
-    existing.repairComputerUseMcpChildren === params.repairComputerUseMcpChildren
+    existing.repairComputerUseMcpChildren === params.repairComputerUseMcpChildren &&
+    existing.repairComputerUseRuntime === repairComputerUseRuntime
   ) {
     return { started: false, intervalMs, reason: "already_started" };
   }
@@ -67,9 +76,11 @@ export function startCodexComputerUseHealthMonitor(params: {
     fingerprint,
     intervalMs,
     repairComputerUseMcpChildren: params.repairComputerUseMcpChildren,
+    repairComputerUseRuntime,
     timer: setInterval(() => {
       void runCodexComputerUseHealthProbe(params.client, params.config, monitor, {
         repairComputerUseMcpChildren,
+        repairComputerUseRuntime,
       });
     }, intervalMs),
     disposeCloseHandler: () => undefined,
@@ -102,6 +113,7 @@ async function runCodexComputerUseHealthProbe(
   monitor: ComputerUseHealthMonitor,
   options: {
     repairComputerUseMcpChildren?: () => Promise<CodexComputerUseRepairStatus>;
+    repairComputerUseRuntime?: () => Promise<CodexComputerUseRepairStatus>;
   },
 ): Promise<void> {
   if (monitor.running) {
@@ -112,6 +124,7 @@ async function runCodexComputerUseHealthProbe(
     const { liveTest, repair } = await runCodexComputerUseLiveTest({
       config,
       repairComputerUseMcpChildren: options.repairComputerUseMcpChildren,
+      repairComputerUseRuntime: options.repairComputerUseRuntime,
       request: async <T>(
         method: string,
         requestParams?: unknown,

--- a/extensions/codex/src/app-server/computer-use-marketplace.test.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { parse as parseToml } from "smol-toml";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ensureCodexComputerUseBundledMarketplace } from "./computer-use-marketplace.js";
@@ -170,7 +171,12 @@ describe("Codex Computer Use bundled marketplace", () => {
       let rebound = false;
       vi.spyOn(fs, "symlink").mockImplementation(async (target, linkPath, type) => {
         await originalSymlink(target, linkPath, type);
-        if (!rebound && path.basename(String(linkPath)).startsWith(".openai-bundled.staging-")) {
+        const linkPathString = resolvePathArgument(linkPath);
+        if (
+          !rebound &&
+          linkPathString &&
+          path.basename(linkPathString).startsWith(".openai-bundled.staging-")
+        ) {
           rebound = true;
           await fs.rename(marketplaceParent, parkedParent);
           await originalSymlink(externalParent, marketplaceParent, "dir");
@@ -221,7 +227,8 @@ describe("Codex Computer Use bundled marketplace", () => {
       let rebound = false;
       vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, options) => {
         await originalWriteFile(file, data, options);
-        if (!rebound && path.basename(String(file)).startsWith(".config.toml.staging-")) {
+        const filePath = resolvePathArgument(file);
+        if (!rebound && filePath && path.basename(filePath).startsWith(".config.toml.staging-")) {
           rebound = true;
           await fs.rename(codexHome, parkedHome);
           await originalSymlink(externalHome, codexHome, "dir");
@@ -246,3 +253,16 @@ describe("Codex Computer Use bundled marketplace", () => {
     },
   );
 });
+
+function resolvePathArgument(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString();
+  }
+  if (value instanceof URL) {
+    return fileURLToPath(value);
+  }
+  return undefined;
+}

--- a/extensions/codex/src/app-server/computer-use-marketplace.test.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.test.ts
@@ -170,7 +170,7 @@ describe("Codex Computer Use bundled marketplace", () => {
       let rebound = false;
       vi.spyOn(fs, "symlink").mockImplementation(async (target, linkPath, type) => {
         await originalSymlink(target, linkPath, type);
-        if (!rebound && path.basename(linkPath).startsWith(".openai-bundled.staging-")) {
+        if (!rebound && path.basename(String(linkPath)).startsWith(".openai-bundled.staging-")) {
           rebound = true;
           await fs.rename(marketplaceParent, parkedParent);
           await originalSymlink(externalParent, marketplaceParent, "dir");

--- a/extensions/codex/src/app-server/computer-use-marketplace.test.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parse as parseToml } from "smol-toml";
+import { afterEach, describe, expect, it } from "vitest";
+import { ensureCodexComputerUseBundledMarketplace } from "./computer-use-marketplace.js";
+import { resolveCodexComputerUseConfig } from "./config.js";
+import { useAutoCleanupTempDirTracker } from "./test-support.js";
+
+describe("Codex Computer Use bundled marketplace", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("moves the reserved marketplace behind the isolated CODEX_HOME path", async () => {
+    const root = tempDirs.make("openclaw-computer-use-marketplace-");
+    const codexHome = path.join(root, "codex-home");
+    const sourcePath = path.join(root, "ChatGPT.app", "openai-bundled");
+    await fs.mkdir(sourcePath, { recursive: true });
+    await fs.mkdir(codexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(codexHome, "config.toml"),
+      [
+        'notify = ["helper", "turn-ended"]',
+        "",
+        '[plugins."computer-use@openai-bundled"]',
+        "enabled = true",
+        "",
+        "[marketplaces.openai-bundled]",
+        'last_updated = "2026-07-30T23:34:57Z"',
+        'source_type = "local"',
+        'source = "/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled"',
+        "",
+      ].join("\n"),
+    );
+
+    const result = await ensureCodexComputerUseBundledMarketplace({
+      codexHome,
+      config: resolveCodexComputerUseConfig({ overrides: { enabled: true } }),
+      bundledMarketplacePath: sourcePath,
+    });
+
+    const marketplacePath = path.join(codexHome, ".tmp", "bundled-marketplaces", "openai-bundled");
+    expect(result).toMatchObject({ status: "ready", changed: true, marketplacePath });
+    expect(await fs.realpath(marketplacePath)).toBe(await fs.realpath(sourcePath));
+    const config = parseToml(await fs.readFile(path.join(codexHome, "config.toml"), "utf8")) as {
+      notify: string[];
+      marketplaces: Record<string, { source_type: string; source: string }>;
+    };
+    expect(config.notify).toEqual(["helper", "turn-ended"]);
+    expect(config.marketplaces["openai-bundled"]).toMatchObject({
+      source_type: "local",
+      source: marketplacePath,
+    });
+  });
+
+  it("refreshes a stale marketplace symlink and becomes idempotent", async () => {
+    const root = tempDirs.make("openclaw-computer-use-marketplace-refresh-");
+    const codexHome = path.join(root, "codex-home");
+    const oldSourcePath = path.join(root, "old", "openai-bundled");
+    const sourcePath = path.join(root, "new", "openai-bundled");
+    const marketplacePath = path.join(codexHome, ".tmp", "bundled-marketplaces", "openai-bundled");
+    await fs.mkdir(oldSourcePath, { recursive: true });
+    await fs.mkdir(sourcePath, { recursive: true });
+    await fs.mkdir(path.dirname(marketplacePath), { recursive: true });
+    await fs.symlink(oldSourcePath, marketplacePath, "dir");
+
+    const params = {
+      codexHome,
+      config: resolveCodexComputerUseConfig({ overrides: { enabled: true } }),
+      bundledMarketplacePath: sourcePath,
+    };
+    expect((await ensureCodexComputerUseBundledMarketplace(params)).changed).toBe(true);
+    expect(await fs.realpath(marketplacePath)).toBe(await fs.realpath(sourcePath));
+    expect((await ensureCodexComputerUseBundledMarketplace(params)).changed).toBe(false);
+  });
+
+  it("leaves an explicitly configured marketplace untouched", async () => {
+    const root = tempDirs.make("openclaw-computer-use-marketplace-explicit-");
+    const result = await ensureCodexComputerUseBundledMarketplace({
+      codexHome: path.join(root, "codex-home"),
+      config: resolveCodexComputerUseConfig({
+        overrides: { enabled: true, marketplacePath: "/custom/marketplace" },
+      }),
+      bundledMarketplacePath: path.join(root, "openai-bundled"),
+    });
+    expect(result).toEqual({ status: "explicit_marketplace", changed: false });
+  });
+});

--- a/extensions/codex/src/app-server/computer-use-marketplace.test.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.test.ts
@@ -1,13 +1,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { parse as parseToml } from "smol-toml";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ensureCodexComputerUseBundledMarketplace } from "./computer-use-marketplace.js";
 import { resolveCodexComputerUseConfig } from "./config.js";
 import { useAutoCleanupTempDirTracker } from "./test-support.js";
 
 describe("Codex Computer Use bundled marketplace", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  afterEach(() => vi.restoreAllMocks());
 
   it("moves the reserved marketplace behind the isolated CODEX_HOME path", async () => {
     const root = tempDirs.make("openclaw-computer-use-marketplace-");
@@ -33,6 +34,7 @@ describe("Codex Computer Use bundled marketplace", () => {
 
     const result = await ensureCodexComputerUseBundledMarketplace({
       codexHome,
+      ownershipRoot: root,
       config: resolveCodexComputerUseConfig({ overrides: { enabled: true } }),
       bundledMarketplacePath: sourcePath,
     });
@@ -64,6 +66,7 @@ describe("Codex Computer Use bundled marketplace", () => {
 
     const params = {
       codexHome,
+      ownershipRoot: root,
       config: resolveCodexComputerUseConfig({ overrides: { enabled: true } }),
       bundledMarketplacePath: sourcePath,
     };
@@ -76,6 +79,7 @@ describe("Codex Computer Use bundled marketplace", () => {
     const root = tempDirs.make("openclaw-computer-use-marketplace-explicit-");
     const result = await ensureCodexComputerUseBundledMarketplace({
       codexHome: path.join(root, "codex-home"),
+      ownershipRoot: root,
       config: resolveCodexComputerUseConfig({
         overrides: { enabled: true, marketplacePath: "/custom/marketplace" },
       }),
@@ -83,4 +87,162 @@ describe("Codex Computer Use bundled marketplace", () => {
     });
     expect(result).toEqual({ status: "explicit_marketplace", changed: false });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked isolated Codex home without touching its external target",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-marketplace-home-symlink-");
+      const ownershipRoot = path.join(root, "agent");
+      const codexHome = path.join(ownershipRoot, "codex-home");
+      const externalHome = path.join(root, "external-home");
+      const sourcePath = path.join(root, "source", "openai-bundled");
+      const sentinelPath = path.join(externalHome, "sentinel.txt");
+      await fs.mkdir(ownershipRoot, { recursive: true });
+      await fs.mkdir(externalHome, { recursive: true });
+      await fs.mkdir(sourcePath, { recursive: true });
+      await fs.writeFile(sentinelPath, "outside");
+      await fs.symlink(externalHome, codexHome, "dir");
+
+      await expect(
+        ensureCodexComputerUseBundledMarketplace({
+          codexHome,
+          ownershipRoot,
+          config: resolveCodexComputerUseConfig({ overrides: { enabled: true } }),
+          bundledMarketplacePath: sourcePath,
+        }),
+      ).rejects.toThrow(/symlinked directory|real directory|symbolic link/iu);
+
+      expect((await fs.lstat(codexHome)).isSymbolicLink()).toBe(true);
+      await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("outside");
+      await expect(fs.access(path.join(externalHome, ".tmp"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked Codex config without modifying its external target",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-marketplace-config-symlink-");
+      const ownershipRoot = path.join(root, "agent");
+      const codexHome = path.join(ownershipRoot, "codex-home");
+      const sourcePath = path.join(root, "source", "openai-bundled");
+      const externalConfig = path.join(root, "external-config.toml");
+      await fs.mkdir(codexHome, { recursive: true });
+      await fs.mkdir(sourcePath, { recursive: true });
+      await fs.writeFile(externalConfig, 'owner = "outside"\n');
+      await fs.symlink(externalConfig, path.join(codexHome, "config.toml"));
+
+      await expect(
+        ensureCodexComputerUseBundledMarketplace({
+          codexHome,
+          ownershipRoot,
+          config: resolveCodexComputerUseConfig({ overrides: { enabled: true } }),
+          bundledMarketplacePath: sourcePath,
+        }),
+      ).rejects.toThrow(/Codex config must not be a symbolic link/iu);
+
+      await expect(fs.readFile(externalConfig, "utf8")).resolves.toBe('owner = "outside"\n');
+      expect((await fs.lstat(path.join(codexHome, "config.toml"))).isSymbolicLink()).toBe(true);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "refuses to publish or clean up through a marketplace parent rebound during staging",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-marketplace-parent-rebind-");
+      const ownershipRoot = path.join(root, "agent");
+      const codexHome = path.join(ownershipRoot, "codex-home");
+      const marketplaceParent = path.join(codexHome, ".tmp", "bundled-marketplaces");
+      const parkedParent = path.join(codexHome, ".tmp", "bundled-marketplaces-owned");
+      const externalParent = path.join(root, "external-marketplace");
+      const sourcePath = path.join(root, "source", "openai-bundled");
+      const externalSource = path.join(root, "external-source", "openai-bundled");
+      const externalTarget = path.join(externalParent, "openai-bundled");
+      const sentinelPath = path.join(externalParent, "sentinel.txt");
+      await fs.mkdir(marketplaceParent, { recursive: true });
+      await fs.mkdir(externalParent, { recursive: true });
+      await fs.mkdir(sourcePath, { recursive: true });
+      await fs.mkdir(externalSource, { recursive: true });
+      await fs.symlink(externalSource, externalTarget, "dir");
+      await fs.writeFile(sentinelPath, "outside");
+      const originalSymlink = fs.symlink.bind(fs);
+      let rebound = false;
+      vi.spyOn(fs, "symlink").mockImplementation(async (target, linkPath, type) => {
+        await originalSymlink(target, linkPath, type);
+        if (!rebound && path.basename(linkPath).startsWith(".openai-bundled.staging-")) {
+          rebound = true;
+          await fs.rename(marketplaceParent, parkedParent);
+          await originalSymlink(externalParent, marketplaceParent, "dir");
+        }
+      });
+
+      await expect(
+        ensureCodexComputerUseBundledMarketplace({
+          codexHome,
+          ownershipRoot,
+          config: resolveCodexComputerUseConfig({ overrides: { enabled: true } }),
+          bundledMarketplacePath: sourcePath,
+        }),
+      ).rejects.toThrow(/marketplace parent changed during refresh/iu);
+
+      expect(rebound).toBe(true);
+      await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("outside");
+      await expect(fs.realpath(externalTarget)).resolves.toBe(await fs.realpath(externalSource));
+      await expect(fs.access(path.join(externalParent, "config.toml"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect(
+        (await fs.readdir(parkedParent)).some((entry) =>
+          entry.startsWith(".openai-bundled.staging-"),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "refuses to publish or clean up through a Codex home rebound during config staging",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-marketplace-home-rebind-");
+      const ownershipRoot = path.join(root, "agent");
+      const codexHome = path.join(ownershipRoot, "codex-home");
+      const parkedHome = path.join(ownershipRoot, "codex-home-owned");
+      const externalHome = path.join(root, "external-home");
+      const sourcePath = path.join(root, "source", "openai-bundled");
+      const externalConfig = path.join(externalHome, "config.toml");
+      const sentinelPath = path.join(externalHome, "sentinel.txt");
+      await fs.mkdir(codexHome, { recursive: true });
+      await fs.mkdir(externalHome, { recursive: true });
+      await fs.mkdir(sourcePath, { recursive: true });
+      await fs.writeFile(externalConfig, 'owner = "outside"\n');
+      await fs.writeFile(sentinelPath, "outside");
+      const originalWriteFile = fs.writeFile.bind(fs);
+      const originalSymlink = fs.symlink.bind(fs);
+      let rebound = false;
+      vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, options) => {
+        await originalWriteFile(file, data, options);
+        if (!rebound && path.basename(String(file)).startsWith(".config.toml.staging-")) {
+          rebound = true;
+          await fs.rename(codexHome, parkedHome);
+          await originalSymlink(externalHome, codexHome, "dir");
+        }
+      });
+
+      await expect(
+        ensureCodexComputerUseBundledMarketplace({
+          codexHome,
+          ownershipRoot,
+          config: resolveCodexComputerUseConfig({ overrides: { enabled: true } }),
+          bundledMarketplacePath: sourcePath,
+        }),
+      ).rejects.toThrow(/isolated Codex home changed during refresh/iu);
+
+      expect(rebound).toBe(true);
+      await expect(fs.readFile(externalConfig, "utf8")).resolves.toBe('owner = "outside"\n');
+      await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("outside");
+      expect(
+        (await fs.readdir(parkedHome)).some((entry) => entry.startsWith(".config.toml.staging-")),
+      ).toBe(true);
+    },
+  );
 });

--- a/extensions/codex/src/app-server/computer-use-marketplace.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.ts
@@ -1,0 +1,165 @@
+/** Prepares Codex's reserved bundled marketplace inside an isolated agent home. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
+import type { ResolvedCodexComputerUseConfig } from "./config.js";
+import { resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath } from "./desktop-app-paths.js";
+
+const BUNDLED_MARKETPLACE_NAME = "openai-bundled";
+const CONFIG_FILENAME = "config.toml";
+
+type CodexComputerUseBundledMarketplaceResult = {
+  status: "disabled" | "explicit_marketplace" | "source_missing" | "ready";
+  changed: boolean;
+  sourcePath?: string;
+  marketplacePath?: string;
+};
+
+/**
+ * Codex reserves `openai-bundled` for materializations below
+ * `$CODEX_HOME/.tmp/bundled-marketplaces`. OpenClaw-managed agent homes point
+ * that location at the currently installed desktop bundle before app-server
+ * startup, so a desktop update is visible without copying the whole catalog.
+ */
+export async function ensureCodexComputerUseBundledMarketplace(params: {
+  codexHome: string;
+  config: ResolvedCodexComputerUseConfig;
+  bundledMarketplacePath?: string;
+  bundledMarketplacePathCandidates?: readonly string[];
+}): Promise<CodexComputerUseBundledMarketplaceResult> {
+  if (!params.config.enabled) {
+    return { status: "disabled", changed: false };
+  }
+  if (
+    params.config.marketplaceSource ||
+    params.config.marketplacePath ||
+    params.config.marketplaceName
+  ) {
+    return { status: "explicit_marketplace", changed: false };
+  }
+
+  const sourcePath =
+    params.bundledMarketplacePath ??
+    resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath({
+      candidates: params.bundledMarketplacePathCandidates,
+    });
+  if (!sourcePath) {
+    return { status: "source_missing", changed: false };
+  }
+
+  const marketplacePath = path.join(
+    params.codexHome,
+    ".tmp",
+    "bundled-marketplaces",
+    BUNDLED_MARKETPLACE_NAME,
+  );
+  const linkChanged = await ensureMarketplaceSymlink(marketplacePath, sourcePath);
+  const configChanged = await ensureMarketplaceConfig(params.codexHome, marketplacePath);
+  return {
+    status: "ready",
+    changed: linkChanged || configChanged,
+    sourcePath,
+    marketplacePath,
+  };
+}
+
+async function ensureMarketplaceSymlink(targetPath: string, sourcePath: string): Promise<boolean> {
+  const parentPath = path.dirname(targetPath);
+  await fs.mkdir(parentPath, { recursive: true });
+  const current = await fs.lstat(targetPath).catch(() => undefined);
+  if (current?.isSymbolicLink()) {
+    const currentTarget = await fs.readlink(targetPath);
+    if (path.resolve(parentPath, currentTarget) === path.resolve(sourcePath)) {
+      return false;
+    }
+  }
+
+  const stagingPath = path.join(
+    parentPath,
+    `.${BUNDLED_MARKETPLACE_NAME}.staging-${process.pid}-${Date.now()}`,
+  );
+  const backupPath = path.join(
+    parentPath,
+    `.${BUNDLED_MARKETPLACE_NAME}.backup-${process.pid}-${Date.now()}`,
+  );
+  await fs.symlink(sourcePath, stagingPath, "dir");
+  let backupCreated = false;
+  try {
+    if (current) {
+      await fs.rename(targetPath, backupPath);
+      backupCreated = true;
+    }
+    try {
+      await fs.rename(stagingPath, targetPath);
+    } catch (error) {
+      if (backupCreated) {
+        await fs.rename(backupPath, targetPath);
+        backupCreated = false;
+      }
+      throw error;
+    }
+    if (backupCreated) {
+      await fs.rm(backupPath, { recursive: true, force: true });
+    }
+    return true;
+  } finally {
+    await fs.rm(stagingPath, { force: true });
+  }
+}
+
+async function ensureMarketplaceConfig(
+  codexHome: string,
+  marketplacePath: string,
+): Promise<boolean> {
+  const configPath = path.join(codexHome, CONFIG_FILENAME);
+  const existing = await fs.readFile(configPath, "utf8").catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  });
+  const parsedValue: unknown = existing.trim()
+    ? parseToml(existing, { integersAsBigInt: true })
+    : {};
+  if (!isRecord(parsedValue)) {
+    throw new Error("Codex config TOML root must be a table");
+  }
+  const parsed = parsedValue;
+  const marketplaces = readOrCreateTable(parsed, "marketplaces");
+  const bundled = readOrCreateTable(marketplaces, BUNDLED_MARKETPLACE_NAME);
+  if (bundled.source_type === "local" && bundled.source === marketplacePath) {
+    return false;
+  }
+  bundled.source_type = "local";
+  bundled.source = marketplacePath;
+
+  const serialized = stringifyToml(parsed);
+  const existingStat = await fs.stat(configPath).catch(() => undefined);
+  const stagingPath = path.join(
+    codexHome,
+    `.${CONFIG_FILENAME}.staging-${process.pid}-${Date.now()}`,
+  );
+  try {
+    await fs.writeFile(stagingPath, serialized, {
+      mode: existingStat ? existingStat.mode & 0o777 : 0o600,
+    });
+    await fs.rename(stagingPath, configPath);
+  } finally {
+    await fs.rm(stagingPath, { force: true });
+  }
+  return true;
+}
+
+function readOrCreateTable(parent: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = parent[key];
+  if (isRecord(value)) {
+    return value;
+  }
+  const table: Record<string, unknown> = {};
+  parent[key] = table;
+  return table;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/extensions/codex/src/app-server/computer-use-marketplace.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.ts
@@ -1,6 +1,7 @@
 /** Prepares Codex's reserved bundled marketplace inside an isolated agent home. */
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 import type { ResolvedCodexComputerUseConfig } from "./config.js";
 import { resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath } from "./desktop-app-paths.js";
@@ -158,8 +159,4 @@ function readOrCreateTable(parent: Record<string, unknown>, key: string): Record
   const table: Record<string, unknown> = {};
   parent[key] = table;
   return table;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/extensions/codex/src/app-server/computer-use-marketplace.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.ts
@@ -113,8 +113,8 @@ async function ensureMarketplaceConfig(
   marketplacePath: string,
 ): Promise<boolean> {
   const configPath = path.join(codexHome, CONFIG_FILENAME);
-  const existing = await fs.readFile(configPath, "utf8").catch((error: NodeJS.ErrnoException) => {
-    if (error.code === "ENOENT") {
+  const existing = await fs.readFile(configPath, "utf8").catch((error: unknown) => {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
       return "";
     }
     throw error;

--- a/extensions/codex/src/app-server/computer-use-marketplace.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.ts
@@ -3,6 +3,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
+import {
+  assertDirectoryIdentityStable,
+  assertNotSymlink,
+  directoryIdentityIsStable,
+  ensureOwnedCodexHome,
+  prepareOwnedServiceParent,
+  readRealDirectoryIdentity,
+} from "./computer-use-service-path.js";
 import type { ResolvedCodexComputerUseConfig } from "./config.js";
 import { resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath } from "./desktop-app-paths.js";
 
@@ -24,6 +32,7 @@ type CodexComputerUseBundledMarketplaceResult = {
  */
 export async function ensureCodexComputerUseBundledMarketplace(params: {
   codexHome: string;
+  ownershipRoot: string;
   config: ResolvedCodexComputerUseConfig;
   bundledMarketplacePath?: string;
   bundledMarketplacePathCandidates?: readonly string[];
@@ -48,14 +57,31 @@ export async function ensureCodexComputerUseBundledMarketplace(params: {
     return { status: "source_missing", changed: false };
   }
 
+  const codexHome = path.resolve(params.codexHome);
+  const ownershipRoot = path.resolve(params.ownershipRoot);
+  await ensureOwnedCodexHome(codexHome, ownershipRoot);
+  const marketplaceParent = path.join(codexHome, ".tmp", "bundled-marketplaces");
+  const ownedMarketplaceParent = await prepareOwnedServiceParent({
+    ownershipRoot,
+    codexHome,
+    targetParent: marketplaceParent,
+  });
+  const ownedCodexHome = await readRealDirectoryIdentity(codexHome, "isolated Codex home");
   const marketplacePath = path.join(
-    params.codexHome,
+    codexHome,
     ".tmp",
     "bundled-marketplaces",
     BUNDLED_MARKETPLACE_NAME,
   );
-  const linkChanged = await ensureMarketplaceSymlink(marketplacePath, sourcePath);
-  const configChanged = await ensureMarketplaceConfig(params.codexHome, marketplacePath);
+  const linkChanged = await ensureMarketplaceSymlink({
+    ownedParent: ownedMarketplaceParent,
+    targetPath: path.join(ownedMarketplaceParent.realPath, BUNDLED_MARKETPLACE_NAME),
+    sourcePath,
+  });
+  const configChanged = await ensureMarketplaceConfig({
+    ownedCodexHome,
+    marketplacePath,
+  });
   return {
     status: "ready",
     changed: linkChanged || configChanged,
@@ -64,61 +90,104 @@ export async function ensureCodexComputerUseBundledMarketplace(params: {
   };
 }
 
-async function ensureMarketplaceSymlink(targetPath: string, sourcePath: string): Promise<boolean> {
-  const parentPath = path.dirname(targetPath);
-  await fs.mkdir(parentPath, { recursive: true });
-  const current = await fs.lstat(targetPath).catch(() => undefined);
+type OwnedDirectoryIdentity = Awaited<ReturnType<typeof readRealDirectoryIdentity>>;
+
+async function ensureMarketplaceSymlink(params: {
+  ownedParent: OwnedDirectoryIdentity;
+  targetPath: string;
+  sourcePath: string;
+}): Promise<boolean> {
+  const { ownedParent, sourcePath, targetPath } = params;
+  await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
+  const current = await fs.lstat(targetPath).catch((error: unknown) => {
+    if (hasNodeErrorCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw error;
+  });
   if (current?.isSymbolicLink()) {
     const currentTarget = await fs.readlink(targetPath);
-    if (path.resolve(parentPath, currentTarget) === path.resolve(sourcePath)) {
+    await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
+    if (path.resolve(ownedParent.realPath, currentTarget) === path.resolve(sourcePath)) {
       return false;
     }
   }
 
   const stagingPath = path.join(
-    parentPath,
+    ownedParent.realPath,
     `.${BUNDLED_MARKETPLACE_NAME}.staging-${process.pid}-${Date.now()}`,
   );
   const backupPath = path.join(
-    parentPath,
+    ownedParent.realPath,
     `.${BUNDLED_MARKETPLACE_NAME}.backup-${process.pid}-${Date.now()}`,
   );
+  await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
   await fs.symlink(sourcePath, stagingPath, "dir");
   let backupCreated = false;
   try {
+    await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
     if (current) {
       await fs.rename(targetPath, backupPath);
+      await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
       backupCreated = true;
     }
     try {
+      await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
       await fs.rename(stagingPath, targetPath);
+      await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
     } catch (error) {
-      if (backupCreated) {
+      if (
+        backupCreated &&
+        (await directoryIdentityIsStable(ownedParent)) &&
+        !(await pathExists(targetPath))
+      ) {
+        await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
         await fs.rename(backupPath, targetPath);
+        await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
         backupCreated = false;
       }
       throw error;
     }
     if (backupCreated) {
-      await fs.rm(backupPath, { recursive: true, force: true });
+      await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
+      await removeMarketplaceEntry(backupPath);
+      await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
+      backupCreated = false;
     }
     return true;
+  } catch (error) {
+    if (
+      backupCreated &&
+      (await directoryIdentityIsStable(ownedParent)) &&
+      !(await pathExists(targetPath))
+    ) {
+      await assertDirectoryIdentityStable(ownedParent, "Computer Use marketplace parent");
+      await fs.rename(backupPath, targetPath);
+      backupCreated = false;
+    }
+    throw error;
   } finally {
-    await fs.rm(stagingPath, { force: true });
+    if (await directoryIdentityIsStable(ownedParent)) {
+      await fs.rm(stagingPath, { force: true });
+    }
   }
 }
 
-async function ensureMarketplaceConfig(
-  codexHome: string,
-  marketplacePath: string,
-): Promise<boolean> {
-  const configPath = path.join(codexHome, CONFIG_FILENAME);
+async function ensureMarketplaceConfig(params: {
+  ownedCodexHome: OwnedDirectoryIdentity;
+  marketplacePath: string;
+}): Promise<boolean> {
+  const { marketplacePath, ownedCodexHome } = params;
+  const configPath = path.join(ownedCodexHome.realPath, CONFIG_FILENAME);
+  await assertDirectoryIdentityStable(ownedCodexHome, "isolated Codex home");
+  await assertNotSymlink(configPath, "Codex config");
   const existing = await fs.readFile(configPath, "utf8").catch((error: unknown) => {
-    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+    if (hasNodeErrorCode(error, "ENOENT")) {
       return "";
     }
     throw error;
   });
+  await assertDirectoryIdentityStable(ownedCodexHome, "isolated Codex home");
   const parsedValue: unknown = existing.trim()
     ? parseToml(existing, { integersAsBigInt: true })
     : {};
@@ -135,20 +204,57 @@ async function ensureMarketplaceConfig(
   bundled.source = marketplacePath;
 
   const serialized = stringifyToml(parsed);
-  const existingStat = await fs.stat(configPath).catch(() => undefined);
+  await assertNotSymlink(configPath, "Codex config");
+  const existingStat = await fs.lstat(configPath).catch((error: unknown) => {
+    if (hasNodeErrorCode(error, "ENOENT")) {
+      return undefined;
+    }
+    throw error;
+  });
   const stagingPath = path.join(
-    codexHome,
+    ownedCodexHome.realPath,
     `.${CONFIG_FILENAME}.staging-${process.pid}-${Date.now()}`,
   );
   try {
+    await assertDirectoryIdentityStable(ownedCodexHome, "isolated Codex home");
     await fs.writeFile(stagingPath, serialized, {
       mode: existingStat ? existingStat.mode & 0o777 : 0o600,
     });
+    await assertDirectoryIdentityStable(ownedCodexHome, "isolated Codex home");
+    await assertNotSymlink(configPath, "Codex config");
     await fs.rename(stagingPath, configPath);
+    await assertDirectoryIdentityStable(ownedCodexHome, "isolated Codex home");
   } finally {
-    await fs.rm(stagingPath, { force: true });
+    if (await directoryIdentityIsStable(ownedCodexHome)) {
+      await fs.rm(stagingPath, { force: true });
+    }
   }
   return true;
+}
+
+async function removeMarketplaceEntry(entryPath: string): Promise<void> {
+  const entry = await fs.lstat(entryPath);
+  if (entry.isDirectory() && !entry.isSymbolicLink()) {
+    await fs.rm(entryPath, { recursive: true, force: true });
+    return;
+  }
+  await fs.unlink(entryPath);
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.lstat(filePath);
+    return true;
+  } catch (error) {
+    if (hasNodeErrorCode(error, "ENOENT")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function hasNodeErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
 }
 
 function readOrCreateTable(parent: Record<string, unknown>, key: string): Record<string, unknown> {

--- a/extensions/codex/src/app-server/computer-use-runtime-repair.test.ts
+++ b/extensions/codex/src/app-server/computer-use-runtime-repair.test.ts
@@ -1,0 +1,116 @@
+// Codex tests cover live, agent-local Computer Use runtime reconciliation.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CodexAppServerClient } from "./client.js";
+
+const runtimeMocks = vi.hoisted(() => ({
+  ensureService: vi.fn(),
+  killChildren: vi.fn(),
+  readContext: vi.fn(),
+}));
+
+vi.mock("./computer-use-service.js", () => ({
+  ensureCodexComputerUseServiceApp: runtimeMocks.ensureService,
+}));
+
+vi.mock("./computer-use-process-repair.js", () => ({
+  killStaleComputerUseMcpChildren: runtimeMocks.killChildren,
+}));
+
+vi.mock("./shared-client.js", () => ({
+  readCodexComputerUseRuntimeContext: runtimeMocks.readContext,
+}));
+
+import { getCodexComputerUseRuntimeReconciler } from "./computer-use-runtime-repair.js";
+
+describe("Codex Computer Use runtime reconciliation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runtimeMocks.ensureService.mockReset();
+    runtimeMocks.killChildren.mockReset();
+    runtimeMocks.readContext.mockReset();
+  });
+
+  it("replaces the warm native client immediately when the signed source changed", async () => {
+    const client = createClient(4101);
+    runtimeMocks.readContext.mockReturnValue(runtimeContext());
+    runtimeMocks.ensureService.mockResolvedValue({ status: "refreshed", changed: true });
+    runtimeMocks.killChildren.mockResolvedValue(repairStatus([4201]));
+
+    await getCodexComputerUseRuntimeReconciler(client).synchronizeBeforeRequest();
+
+    expect(runtimeMocks.ensureService).toHaveBeenCalledWith({
+      ...runtimeContext(),
+      forceRevalidate: false,
+    });
+    expect(runtimeMocks.killChildren).toHaveBeenCalledWith({ ancestorPid: 4101 });
+  });
+
+  it("keeps the warm fast path when the signed source generation is unchanged", async () => {
+    const client = createClient(4102);
+    runtimeMocks.readContext.mockReturnValue(runtimeContext());
+    runtimeMocks.ensureService.mockResolvedValue({ status: "already_current", changed: false });
+
+    await getCodexComputerUseRuntimeReconciler(client).synchronizeBeforeRequest();
+
+    expect(runtimeMocks.killChildren).not.toHaveBeenCalled();
+  });
+
+  it("force-revalidates the bundle and replaces the client after a failed handshake", async () => {
+    const client = createClient(4103);
+    runtimeMocks.readContext.mockReturnValue(runtimeContext());
+    runtimeMocks.ensureService.mockResolvedValue({ status: "already_current", changed: false });
+    runtimeMocks.killChildren.mockResolvedValue(repairStatus([4203]));
+
+    const result = await getCodexComputerUseRuntimeReconciler(client).repairAfterProbeFailure();
+
+    expect(runtimeMocks.ensureService).toHaveBeenCalledWith({
+      ...runtimeContext(),
+      forceRevalidate: true,
+    });
+    expect(runtimeMocks.killChildren).toHaveBeenCalledWith({ ancestorPid: 4103 });
+    expect(result.killedPids).toEqual([4203]);
+  });
+
+  it("coalesces simultaneous forced repairs for one physical app-server", async () => {
+    const client = createClient(4104);
+    const gate = createDeferred<void>();
+    runtimeMocks.readContext.mockReturnValue(runtimeContext());
+    runtimeMocks.ensureService.mockImplementation(async () => {
+      await gate.promise;
+      return { status: "already_current", changed: false };
+    });
+    runtimeMocks.killChildren.mockResolvedValue(repairStatus([4204]));
+    const reconciler = getCodexComputerUseRuntimeReconciler(client);
+
+    const first = reconciler.repairAfterProbeFailure();
+    const second = reconciler.repairAfterProbeFailure();
+    await vi.waitFor(() => expect(runtimeMocks.ensureService).toHaveBeenCalledTimes(1));
+    gate.resolve();
+    await Promise.all([first, second]);
+
+    expect(runtimeMocks.ensureService).toHaveBeenCalledTimes(1);
+    expect(runtimeMocks.killChildren).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createClient(pid: number): CodexAppServerClient {
+  return { getTransportPid: () => pid } as CodexAppServerClient;
+}
+
+function runtimeContext() {
+  return {
+    codexHome: "/owned/agent/codex-home",
+    ownershipRoot: "/owned/agent",
+    appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
+  };
+}
+
+function repairStatus(killedPids: number[]) {
+  return {
+    attempted: true,
+    killedPids,
+    warnings: [],
+    message: "Replaced the stale native client.",
+  };
+}

--- a/extensions/codex/src/app-server/computer-use-runtime-repair.test.ts
+++ b/extensions/codex/src/app-server/computer-use-runtime-repair.test.ts
@@ -7,6 +7,7 @@ const runtimeMocks = vi.hoisted(() => ({
   ensureService: vi.fn(),
   killChildren: vi.fn(),
   readContext: vi.fn(),
+  retireClient: vi.fn(),
 }));
 
 vi.mock("./computer-use-service.js", () => ({
@@ -18,7 +19,11 @@ vi.mock("./computer-use-process-repair.js", () => ({
 }));
 
 vi.mock("./shared-client.js", () => ({
+  CodexAppServerStartSelectionChangedError: class CodexAppServerStartSelectionChangedError extends Error {
+    readonly code = "CODEX_APP_SERVER_START_SELECTION_CHANGED";
+  },
   readCodexComputerUseRuntimeContext: runtimeMocks.readContext,
+  retireSharedCodexAppServerClientIfCurrent: runtimeMocks.retireClient,
 }));
 
 import { getCodexComputerUseRuntimeReconciler } from "./computer-use-runtime-repair.js";
@@ -29,31 +34,66 @@ describe("Codex Computer Use runtime reconciliation", () => {
     runtimeMocks.ensureService.mockReset();
     runtimeMocks.killChildren.mockReset();
     runtimeMocks.readContext.mockReset();
+    runtimeMocks.retireClient.mockReset();
   });
 
-  it("replaces the warm native client immediately when the signed source changed", async () => {
+  it("retires the warm app-server when the signed source changed", async () => {
     const client = createClient(4101);
     runtimeMocks.readContext.mockReturnValue(runtimeContext());
-    runtimeMocks.ensureService.mockResolvedValue({ status: "refreshed", changed: true });
+    runtimeMocks.ensureService.mockResolvedValue({
+      status: "refreshed",
+      changed: true,
+      sourceBuild: "1000816",
+    });
     runtimeMocks.killChildren.mockResolvedValue(repairStatus([4201]));
 
-    await getCodexComputerUseRuntimeReconciler(client).synchronizeBeforeRequest();
+    await expect(requireRuntimeReconciler(client).synchronizeBeforeRequest()).rejects.toMatchObject(
+      { code: "CODEX_APP_SERVER_START_SELECTION_CHANGED" },
+    );
 
-    expect(runtimeMocks.ensureService).toHaveBeenCalledWith({
-      ...runtimeContext(),
-      forceRevalidate: false,
-    });
+    expect(runtimeMocks.ensureService).toHaveBeenCalledWith(serviceParams(false));
     expect(runtimeMocks.killChildren).toHaveBeenCalledWith({ ancestorPid: 4101 });
+    expect(runtimeMocks.retireClient).toHaveBeenCalledWith(client);
   });
 
   it("keeps the warm fast path when the signed source generation is unchanged", async () => {
     const client = createClient(4102);
     runtimeMocks.readContext.mockReturnValue(runtimeContext());
-    runtimeMocks.ensureService.mockResolvedValue({ status: "already_current", changed: false });
+    runtimeMocks.ensureService.mockResolvedValue({
+      status: "already_current",
+      changed: false,
+      sourceBuild: "1000816",
+    });
 
-    await getCodexComputerUseRuntimeReconciler(client).synchronizeBeforeRequest();
+    await requireRuntimeReconciler(client).synchronizeBeforeRequest();
 
     expect(runtimeMocks.killChildren).not.toHaveBeenCalled();
+    expect(runtimeMocks.retireClient).not.toHaveBeenCalled();
+  });
+
+  it("retires the warm app-server when another reconciler already refreshed its target", async () => {
+    const client = createClient(4105);
+    runtimeMocks.readContext.mockReturnValue(runtimeContext());
+    runtimeMocks.ensureService
+      .mockResolvedValueOnce({
+        status: "already_current",
+        changed: false,
+        sourceBuild: "1000790",
+      })
+      .mockResolvedValueOnce({
+        status: "already_current",
+        changed: false,
+        sourceBuild: "1000816",
+      });
+    const reconciler = requireRuntimeReconciler(client);
+
+    await reconciler.synchronizeBeforeRequest();
+    await expect(reconciler.synchronizeBeforeRequest()).rejects.toMatchObject({
+      code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
+    });
+
+    expect(runtimeMocks.killChildren).not.toHaveBeenCalled();
+    expect(runtimeMocks.retireClient).toHaveBeenCalledWith(client);
   });
 
   it("force-revalidates the bundle and replaces the client after a failed handshake", async () => {
@@ -62,12 +102,9 @@ describe("Codex Computer Use runtime reconciliation", () => {
     runtimeMocks.ensureService.mockResolvedValue({ status: "already_current", changed: false });
     runtimeMocks.killChildren.mockResolvedValue(repairStatus([4203]));
 
-    const result = await getCodexComputerUseRuntimeReconciler(client).repairAfterProbeFailure();
+    const result = await requireRuntimeReconciler(client).repairAfterProbeFailure();
 
-    expect(runtimeMocks.ensureService).toHaveBeenCalledWith({
-      ...runtimeContext(),
-      forceRevalidate: true,
-    });
+    expect(runtimeMocks.ensureService).toHaveBeenCalledWith(serviceParams(true));
     expect(runtimeMocks.killChildren).toHaveBeenCalledWith({ ancestorPid: 4103 });
     expect(result.killedPids).toEqual([4203]);
   });
@@ -81,7 +118,7 @@ describe("Codex Computer Use runtime reconciliation", () => {
       return { status: "already_current", changed: false };
     });
     runtimeMocks.killChildren.mockResolvedValue(repairStatus([4204]));
-    const reconciler = getCodexComputerUseRuntimeReconciler(client);
+    const reconciler = requireRuntimeReconciler(client);
 
     const first = reconciler.repairAfterProbeFailure();
     const second = reconciler.repairAfterProbeFailure();
@@ -92,7 +129,25 @@ describe("Codex Computer Use runtime reconciliation", () => {
     expect(runtimeMocks.ensureService).toHaveBeenCalledTimes(1);
     expect(runtimeMocks.killChildren).toHaveBeenCalledTimes(1);
   });
+
+  it("does not attach automatic repair outside a managed isolated runtime", () => {
+    const client = createClient(4106);
+    runtimeMocks.readContext.mockReturnValue(undefined);
+
+    expect(getCodexComputerUseRuntimeReconciler(client)).toBeUndefined();
+    expect(runtimeMocks.ensureService).not.toHaveBeenCalled();
+    expect(runtimeMocks.killChildren).not.toHaveBeenCalled();
+    expect(runtimeMocks.retireClient).not.toHaveBeenCalled();
+  });
 });
+
+function requireRuntimeReconciler(client: CodexAppServerClient) {
+  const reconciler = getCodexComputerUseRuntimeReconciler(client);
+  if (!reconciler) {
+    throw new Error("expected a managed isolated Computer Use runtime reconciler");
+  }
+  return reconciler;
+}
 
 function createClient(pid: number): CodexAppServerClient {
   return { getTransportPid: () => pid } as CodexAppServerClient;
@@ -104,6 +159,10 @@ function runtimeContext() {
     ownershipRoot: "/owned/agent",
     appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
   };
+}
+
+function serviceParams(forceRevalidate: boolean) {
+  return { ...runtimeContext(), forceRevalidate };
 }
 
 function repairStatus(killedPids: number[]) {

--- a/extensions/codex/src/app-server/computer-use-runtime-repair.ts
+++ b/extensions/codex/src/app-server/computer-use-runtime-repair.ts
@@ -6,12 +6,15 @@ import {
 } from "./computer-use-process-repair.js";
 import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
+  CodexAppServerStartSelectionChangedError,
   readCodexComputerUseRuntimeContext,
+  retireSharedCodexAppServerClientIfCurrent,
   type CodexComputerUseRuntimeContext,
 } from "./shared-client.js";
 
 type ReconcileResult = {
   serviceChanged: boolean;
+  sourceBuild?: string;
   processRepair?: CodexComputerUseRepairStatus;
 };
 
@@ -39,9 +42,12 @@ function getRuntimeReconcilerState(): WeakMap<CodexAppServerClient, ReconcilerEn
 /** Returns stable, coalesced request-time repair functions for one physical app-server. */
 export function getCodexComputerUseRuntimeReconciler(
   client: CodexAppServerClient,
-): CodexComputerUseRuntimeReconciler {
+): CodexComputerUseRuntimeReconciler | undefined {
   const context = readCodexComputerUseRuntimeContext(client);
-  const fingerprint = JSON.stringify(context ?? null);
+  if (!context) {
+    return undefined;
+  }
+  const fingerprint = JSON.stringify(context);
   const state = getRuntimeReconcilerState();
   const existing = state.get(client);
   if (existing?.fingerprint === fingerprint) {
@@ -54,9 +60,10 @@ export function getCodexComputerUseRuntimeReconciler(
 
 function createRuntimeReconciler(
   client: CodexAppServerClient,
-  context: CodexComputerUseRuntimeContext | undefined,
+  context: CodexComputerUseRuntimeContext,
 ): CodexComputerUseRuntimeReconciler {
   let active: { forceRevalidate: boolean; promise: Promise<ReconcileResult> } | undefined;
+  let attachedSourceBuild: string | undefined;
 
   const reconcile = async (forceRevalidate: boolean): Promise<ReconcileResult> => {
     if (active) {
@@ -80,39 +87,66 @@ function createRuntimeReconciler(
 
   return {
     synchronizeBeforeRequest: async () => {
-      await reconcile(false);
+      const result = await reconcile(false);
+      requireCurrentAppServerGeneration(result);
     },
     repairAfterProbeFailure: async () => {
       const result = await reconcile(true);
+      requireCurrentAppServerGeneration(result);
       if (!result.processRepair) {
         throw new Error("Computer Use runtime repair did not replace the native client process");
       }
       return result.processRepair;
     },
   };
+
+  function requireCurrentAppServerGeneration(result: ReconcileResult): void {
+    const sourceBuild = result.sourceBuild?.trim() || undefined;
+    const sourceGenerationChanged =
+      attachedSourceBuild !== undefined &&
+      sourceBuild !== undefined &&
+      attachedSourceBuild !== sourceBuild;
+    if (sourceBuild) {
+      attachedSourceBuild = sourceBuild;
+    }
+    if (!result.serviceChanged && !sourceGenerationChanged) {
+      return;
+    }
+    // A Computer Use generation change also changes the native sender identity
+    // trusted by the service. Replacing only the MCP child leaves a warm app-server
+    // mapped to the previous signed desktop generation, which the refreshed service
+    // rejects as unauthenticated. Detach this one physical client so the bounded
+    // startup retry launches the current app-server without restarting the gateway.
+    retireSharedCodexAppServerClientIfCurrent(client);
+    throw new CodexAppServerStartSelectionChangedError(
+      "Codex Computer Use runtime generation changed during startup",
+    );
+  }
 }
 
 async function reconcileOnce(params: {
   client: CodexAppServerClient;
-  context?: CodexComputerUseRuntimeContext;
+  context: CodexComputerUseRuntimeContext;
   forceRevalidate: boolean;
 }): Promise<ReconcileResult> {
-  const service = params.context
-    ? await ensureCodexComputerUseServiceApp({
-        codexHome: params.context.codexHome,
-        ownershipRoot: params.context.ownershipRoot,
-        appServerCommand: params.context.appServerCommand,
-        forceRevalidate: params.forceRevalidate,
-      })
-    : undefined;
+  const service = await ensureCodexComputerUseServiceApp({
+    codexHome: params.context.codexHome,
+    ownershipRoot: params.context.ownershipRoot,
+    appServerCommand: params.context.appServerCommand,
+    forceRevalidate: params.forceRevalidate,
+  });
   if (!params.forceRevalidate && !service?.changed) {
-    return { serviceChanged: false };
+    return {
+      serviceChanged: false,
+      ...(service?.sourceBuild ? { sourceBuild: service.sourceBuild } : {}),
+    };
   }
   const processRepair = await killStaleComputerUseMcpChildren({
     ancestorPid: params.client.getTransportPid(),
   });
   return {
     serviceChanged: Boolean(service?.changed),
+    ...(service?.sourceBuild ? { sourceBuild: service.sourceBuild } : {}),
     processRepair: service?.changed
       ? {
           ...processRepair,

--- a/extensions/codex/src/app-server/computer-use-runtime-repair.ts
+++ b/extensions/codex/src/app-server/computer-use-runtime-repair.ts
@@ -145,7 +145,7 @@ async function reconcileOnce(params: {
     ancestorPid: params.client.getTransportPid(),
   });
   return {
-    serviceChanged: Boolean(service?.changed),
+    serviceChanged: service?.changed ?? false,
     ...(service?.sourceBuild ? { sourceBuild: service.sourceBuild } : {}),
     processRepair: service?.changed
       ? {

--- a/extensions/codex/src/app-server/computer-use-runtime-repair.ts
+++ b/extensions/codex/src/app-server/computer-use-runtime-repair.ts
@@ -1,0 +1,123 @@
+// Keeps a warm Codex app-server's native Computer Use client compatible in place.
+import type { CodexAppServerClient } from "./client.js";
+import {
+  killStaleComputerUseMcpChildren,
+  type CodexComputerUseRepairStatus,
+} from "./computer-use-process-repair.js";
+import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
+import {
+  readCodexComputerUseRuntimeContext,
+  type CodexComputerUseRuntimeContext,
+} from "./shared-client.js";
+
+type ReconcileResult = {
+  serviceChanged: boolean;
+  processRepair?: CodexComputerUseRepairStatus;
+};
+
+type CodexComputerUseRuntimeReconciler = {
+  synchronizeBeforeRequest: () => Promise<void>;
+  repairAfterProbeFailure: () => Promise<CodexComputerUseRepairStatus>;
+};
+
+type ReconcilerEntry = {
+  fingerprint: string;
+  reconciler: CodexComputerUseRuntimeReconciler;
+};
+
+const RUNTIME_RECONCILERS = Symbol.for("openclaw.codexComputerUseRuntimeReconcilers");
+
+function getRuntimeReconcilerState(): WeakMap<CodexAppServerClient, ReconcilerEntry> {
+  // SAFETY: this process-global Symbol is owned exclusively by this module and always stores this map shape.
+  const globalState = globalThis as typeof globalThis & {
+    [RUNTIME_RECONCILERS]?: WeakMap<CodexAppServerClient, ReconcilerEntry>;
+  };
+  globalState[RUNTIME_RECONCILERS] ??= new WeakMap();
+  return globalState[RUNTIME_RECONCILERS];
+}
+
+/** Returns stable, coalesced request-time repair functions for one physical app-server. */
+export function getCodexComputerUseRuntimeReconciler(
+  client: CodexAppServerClient,
+): CodexComputerUseRuntimeReconciler {
+  const context = readCodexComputerUseRuntimeContext(client);
+  const fingerprint = JSON.stringify(context ?? null);
+  const state = getRuntimeReconcilerState();
+  const existing = state.get(client);
+  if (existing?.fingerprint === fingerprint) {
+    return existing.reconciler;
+  }
+  const reconciler = createRuntimeReconciler(client, context);
+  state.set(client, { fingerprint, reconciler });
+  return reconciler;
+}
+
+function createRuntimeReconciler(
+  client: CodexAppServerClient,
+  context: CodexComputerUseRuntimeContext | undefined,
+): CodexComputerUseRuntimeReconciler {
+  let active: { forceRevalidate: boolean; promise: Promise<ReconcileResult> } | undefined;
+
+  const reconcile = async (forceRevalidate: boolean): Promise<ReconcileResult> => {
+    if (active) {
+      if (!forceRevalidate || active.forceRevalidate) {
+        return await active.promise;
+      }
+      await active.promise;
+      return await reconcile(true);
+    }
+    const promise = reconcileOnce({ client, context, forceRevalidate });
+    const current = { forceRevalidate, promise };
+    active = current;
+    try {
+      return await promise;
+    } finally {
+      if (active === current) {
+        active = undefined;
+      }
+    }
+  };
+
+  return {
+    synchronizeBeforeRequest: async () => {
+      await reconcile(false);
+    },
+    repairAfterProbeFailure: async () => {
+      const result = await reconcile(true);
+      if (!result.processRepair) {
+        throw new Error("Computer Use runtime repair did not replace the native client process");
+      }
+      return result.processRepair;
+    },
+  };
+}
+
+async function reconcileOnce(params: {
+  client: CodexAppServerClient;
+  context?: CodexComputerUseRuntimeContext;
+  forceRevalidate: boolean;
+}): Promise<ReconcileResult> {
+  const service = params.context
+    ? await ensureCodexComputerUseServiceApp({
+        codexHome: params.context.codexHome,
+        ownershipRoot: params.context.ownershipRoot,
+        appServerCommand: params.context.appServerCommand,
+        forceRevalidate: params.forceRevalidate,
+      })
+    : undefined;
+  if (!params.forceRevalidate && !service?.changed) {
+    return { serviceChanged: false };
+  }
+  const processRepair = await killStaleComputerUseMcpChildren({
+    ancestorPid: params.client.getTransportPid(),
+  });
+  return {
+    serviceChanged: Boolean(service?.changed),
+    processRepair: service?.changed
+      ? {
+          ...processRepair,
+          message: `Synchronized the signed Computer Use client. ${processRepair.message}`,
+        }
+      : processRepair,
+  };
+}

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -373,6 +373,77 @@ describe("Codex Computer Use native service", () => {
     await expect(inspectServiceFixture(targetPath)).resolves.toEqual(UNEXPECTED_IDENTITY);
   });
 
+  it("force-revalidates a cached target after a live compatibility failure", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    const copyServiceApp = vi.fn(copyServiceFixture);
+
+    await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp,
+      inspectServiceApp: inspectServiceFixture,
+    });
+    await writeFixtureIdentity(targetPath, STALE_IDENTITY);
+
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [sourcePath],
+        copyServiceApp,
+        inspectServiceApp: inspectServiceFixture,
+        forceRevalidate: true,
+      }),
+    ).resolves.toMatchObject({
+      status: "refreshed",
+      previousBuild: "1000502",
+      sourceBuild: "1000761",
+    });
+    expect(copyServiceApp).toHaveBeenCalledTimes(2);
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
+  });
+
+  it("force-revalidates after an overlapping ordinary synchronization completes", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    const copyStarted = createDeferred<void>();
+    const copyGate = createDeferred<void>();
+    const copyServiceApp = vi.fn(async (source: string, target: string) => {
+      copyStarted.resolve();
+      await copyGate.promise;
+      await copyServiceFixture(source, target);
+    });
+
+    const ordinary = ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp,
+      inspectServiceApp: inspectServiceFixture,
+    });
+    await copyStarted.promise;
+    const forced = ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp,
+      inspectServiceApp: inspectServiceFixture,
+      forceRevalidate: true,
+    });
+    copyGate.resolve();
+
+    await expect(ordinary).resolves.toMatchObject({ status: "installed", changed: true });
+    await expect(forced).resolves.toMatchObject({ status: "already_current", changed: false });
+    expect(copyServiceApp).toHaveBeenCalledTimes(1);
+  });
+
   it("bounds completed synchronization state and re-inspects an evicted home", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-cache-");
     const sourcePath = path.join(root, "source", "Codex Computer Use.app");

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -334,6 +334,45 @@ describe("Codex Computer Use native service", () => {
     expect(copyServiceApp).toHaveBeenCalledTimes(copyCount);
   });
 
+  it("refreshes a completed sync when its source changes in place", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    const copyServiceApp = vi.fn(copyServiceFixture);
+    const inspectServiceApp = vi.fn(inspectServiceFixture);
+
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [sourcePath],
+        copyServiceApp,
+        inspectServiceApp,
+      }),
+    ).resolves.toMatchObject({ status: "installed", sourceBuild: "1000761" });
+
+    await writeServiceFixture(sourcePath, UNEXPECTED_IDENTITY);
+    await fs.writeFile(path.join(sourcePath, CLIENT_RELATIVE_PATH), "updated-client");
+
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [sourcePath],
+        copyServiceApp,
+        inspectServiceApp,
+      }),
+    ).resolves.toMatchObject({
+      status: "refreshed",
+      previousBuild: "1000761",
+      sourceBuild: "1000900",
+    });
+    expect(copyServiceApp).toHaveBeenCalledTimes(2);
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(UNEXPECTED_IDENTITY);
+  });
+
   it("bounds completed synchronization state and re-inspects an evicted home", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-cache-");
     const sourcePath = path.join(root, "source", "Codex Computer Use.app");

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -95,7 +95,8 @@ export async function ensureCodexComputerUseServiceApp(params: {
   const candidates =
     params.sourceAppCandidates ??
     resolveMacOSDesktopCodexComputerUseServiceAppCandidates(platform, params.appServerCommand);
-  const syncKey = [targetPath, ...candidates].join("\0");
+  const sourceKeys = await Promise.all(candidates.map(readServiceAppFilesystemKey));
+  const syncKey = [targetPath, ...candidates, ...sourceKeys].join("\0");
   const completed = completedSyncs.get(targetPath);
   if (completed?.syncKey === syncKey) {
     // Keep frequently reused homes while bounding dynamic-agent history.

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -34,7 +34,11 @@ const INSPECT_TIMEOUT_MS = 30_000;
 const COMPLETED_SYNC_CACHE_MAX_ENTRIES = 64;
 const activeInstalls = new Map<
   string,
-  { syncKey: string; promise: Promise<CodexComputerUseServiceStatus> }
+  {
+    syncKey: string;
+    forceRevalidate: boolean;
+    promise: Promise<CodexComputerUseServiceStatus>;
+  }
 >();
 const completedSyncs = new Map<
   string,
@@ -81,6 +85,7 @@ export async function ensureCodexComputerUseServiceApp(params: {
   sourceAppCandidates?: readonly string[];
   copyServiceApp?: CopyServiceApp;
   inspectServiceApp?: InspectServiceApp;
+  forceRevalidate?: boolean;
 }): Promise<CodexComputerUseServiceStatus> {
   const platform = params.platform ?? process.platform;
   if (platform !== "darwin") {
@@ -98,7 +103,7 @@ export async function ensureCodexComputerUseServiceApp(params: {
   const sourceKeys = await Promise.all(candidates.map(readServiceAppFilesystemKey));
   const syncKey = [targetPath, ...candidates, ...sourceKeys].join("\0");
   const completed = completedSyncs.get(targetPath);
-  if (completed?.syncKey === syncKey) {
+  if (!params.forceRevalidate && completed?.syncKey === syncKey) {
     // Keep frequently reused homes while bounding dynamic-agent history.
     completedSyncs.delete(targetPath);
     completedSyncs.set(targetPath, completed);
@@ -112,7 +117,7 @@ export async function ensureCodexComputerUseServiceApp(params: {
   }
   const active = activeInstalls.get(targetPath);
   if (active) {
-    if (active.syncKey === syncKey) {
+    if (active.syncKey === syncKey && (!params.forceRevalidate || active.forceRevalidate)) {
       return await active.promise;
     }
     await active.promise.catch(() => undefined);
@@ -142,7 +147,11 @@ export async function ensureCodexComputerUseServiceApp(params: {
     }
     return result;
   });
-  const activeEntry = { syncKey, promise: install };
+  const activeEntry = {
+    syncKey,
+    forceRevalidate: Boolean(params.forceRevalidate),
+    promise: install,
+  };
   activeInstalls.set(targetPath, activeEntry);
   const clearActive = () => {
     if (activeInstalls.get(targetPath) === activeEntry) {

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -480,6 +480,27 @@ describe("Codex Computer Use setup", () => {
     ).toHaveLength(2);
   });
 
+  it("preserves the auto-repair opt-out outside managed isolated runtimes", async () => {
+    const request = createComputerUseRequest({ installed: true, liveTestFailures: 2 });
+    const client = { request } as never;
+    runtimeRepairMocks.getReconciler.mockReturnValueOnce(undefined);
+
+    const status = await ensureCodexComputerUse({
+      pluginConfig: { computerUse: { enabled: true, marketplaceName: "desktop-tools" } },
+      client,
+    });
+
+    expect(runtimeRepairMocks.getReconciler).toHaveBeenCalledWith(client);
+    expect(runtimeRepairMocks.synchronizeBeforeRequest).not.toHaveBeenCalled();
+    expect(runtimeRepairMocks.repairAfterProbeFailure).not.toHaveBeenCalled();
+    expect(status.liveTest).toMatchObject({
+      status: "failed",
+      attempts: 2,
+      retried: true,
+      repaired: false,
+    });
+  });
+
   it("fails fast when the named MCP server exposes no tools", async () => {
     const request = createComputerUseRequest({ installed: true, mcpToolsAvailable: false });
 

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -13,6 +13,20 @@ const sharedClientMocks = vi.hoisted(() => ({
   getLeasedSharedCodexAppServerClient: vi.fn(),
   releaseLeasedSharedCodexAppServerClient: vi.fn(),
 }));
+const runtimeRepairMocks = vi.hoisted(() => ({
+  synchronizeBeforeRequest: vi.fn(async () => undefined),
+  repairAfterProbeFailure: vi.fn(async () => ({
+    attempted: true,
+    killedPids: [4321],
+    warnings: [],
+    message: "Replaced the incompatible Computer Use client.",
+  })),
+  getReconciler: vi.fn(),
+}));
+runtimeRepairMocks.getReconciler.mockReturnValue({
+  synchronizeBeforeRequest: runtimeRepairMocks.synchronizeBeforeRequest,
+  repairAfterProbeFailure: runtimeRepairMocks.repairAfterProbeFailure,
+});
 
 vi.mock("./request.js", () => ({
   requestCodexAppServerJson: requestCodexAppServerJsonMock,
@@ -21,6 +35,10 @@ vi.mock("./request.js", () => ({
 vi.mock("./shared-client.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./shared-client.js")>()),
   ...sharedClientMocks,
+}));
+
+vi.mock("./computer-use-runtime-repair.js", () => ({
+  getCodexComputerUseRuntimeReconciler: runtimeRepairMocks.getReconciler,
 }));
 
 import {
@@ -81,6 +99,9 @@ describe("Codex Computer Use setup", () => {
     requestCodexAppServerJsonMock.mockReset();
     sharedClientMocks.getLeasedSharedCodexAppServerClient.mockReset();
     sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockReset();
+    runtimeRepairMocks.getReconciler.mockClear();
+    runtimeRepairMocks.synchronizeBeforeRequest.mockClear();
+    runtimeRepairMocks.repairAfterProbeFailure.mockClear();
   });
 
   it("stays disabled until configured", async () => {
@@ -431,6 +452,29 @@ describe("Codex Computer Use setup", () => {
       killedPids: [1234],
     });
     expect(repairComputerUseMcpChildren).toHaveBeenCalledTimes(1);
+    expect(
+      requestCalls(request).filter(([method]) => method === "mcpServer/tool/call"),
+    ).toHaveLength(2);
+  });
+
+  it("repairs a live client compatibility failure even when optional auto-repair is off", async () => {
+    const request = createComputerUseRequest({ installed: true, liveTestFailures: 1 });
+    const client = { request } as never;
+
+    const status = await ensureCodexComputerUse({
+      pluginConfig: { computerUse: { enabled: true, marketplaceName: "desktop-tools" } },
+      client,
+    });
+
+    expect(runtimeRepairMocks.getReconciler).toHaveBeenCalledWith(client);
+    expect(runtimeRepairMocks.synchronizeBeforeRequest).toHaveBeenCalledTimes(1);
+    expect(runtimeRepairMocks.repairAfterProbeFailure).toHaveBeenCalledTimes(1);
+    expect(status.liveTest).toMatchObject({
+      status: "passed",
+      attempts: 2,
+      retried: true,
+      repaired: true,
+    });
     expect(
       requestCalls(request).filter(([method]) => method === "mcpServer/tool/call"),
     ).toHaveLength(2);

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -15,6 +15,7 @@ import {
   scopedRepairUnavailableStatus,
   type CodexComputerUseRepairStatus,
 } from "./computer-use-process-repair.js";
+import { getCodexComputerUseRuntimeReconciler } from "./computer-use-runtime-repair.js";
 import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
@@ -138,6 +139,7 @@ export type CodexComputerUseSetupParams = {
   defaultBundledMarketplacePath?: string;
   defaultBundledMarketplacePathCandidates?: readonly string[];
   repairComputerUseMcpChildren?: () => Promise<CodexComputerUseRepairStatus>;
+  repairComputerUseRuntime?: () => Promise<CodexComputerUseRepairStatus>;
 };
 
 type CodexComputerUseInspectionParams = {
@@ -153,6 +155,7 @@ type CodexComputerUseInspectionParams = {
   defaultBundledMarketplacePath?: string;
   defaultBundledMarketplacePathCandidates?: readonly string[];
   repairComputerUseMcpChildren?: () => Promise<CodexComputerUseRepairStatus>;
+  repairComputerUseRuntime?: () => Promise<CodexComputerUseRepairStatus>;
   releaseNativeConfigFence?: () => void;
 };
 
@@ -229,8 +232,16 @@ export async function ensureCodexComputerUse(
   if (!config.enabled) {
     return disabledStatus(config);
   }
+  const runtimeReconciler = params.client
+    ? getCodexComputerUseRuntimeReconciler(params.client)
+    : undefined;
+  await runtimeReconciler?.synchronizeBeforeRequest();
+  const preparedParams =
+    runtimeReconciler && !params.repairComputerUseRuntime
+      ? { ...params, repairComputerUseRuntime: runtimeReconciler.repairAfterProbeFailure }
+      : params;
   const status = await inspectCodexComputerUse({
-    ...params,
+    ...preparedParams,
     computerUseConfig: config,
     installPlugin: false,
   });
@@ -246,7 +257,7 @@ export async function ensureCodexComputerUse(
       throw new CodexComputerUseSetupError(blockedAutoInstallStatus);
     }
     const installedStatus = await inspectCodexComputerUse({
-      ...params,
+      ...preparedParams,
       computerUseConfig: config,
       installPlugin: true,
     });
@@ -413,6 +424,7 @@ async function inspectCodexComputerUseWithoutFence(
     plugin: pluginInspection.plugin,
     installPlugin: params.installPlugin,
     repairComputerUseMcpChildren,
+    repairComputerUseRuntime: params.repairComputerUseRuntime,
     releaseNativeConfigFence: params.releaseNativeConfigFence,
   });
 }
@@ -473,6 +485,7 @@ async function readComputerUseTools(params: {
   plugin: CodexPluginDetail;
   installPlugin: boolean;
   repairComputerUseMcpChildren?: () => Promise<CodexComputerUseRepairStatus>;
+  repairComputerUseRuntime?: () => Promise<CodexComputerUseRepairStatus>;
   releaseNativeConfigFence?: () => void;
 }): Promise<CodexComputerUseStatus> {
   let server = await readMcpServerStatus(params.request, params.config.mcpServerName);
@@ -514,6 +527,7 @@ async function readComputerUseTools(params: {
     request: params.request,
     config: params.config,
     repairComputerUseMcpChildren: params.repairComputerUseMcpChildren,
+    repairComputerUseRuntime: params.repairComputerUseRuntime,
   });
   const compatibilityStartupAllowed = !liveTest.ok && !params.config.strictReadiness;
   return {
@@ -558,6 +572,7 @@ export async function runCodexComputerUseLiveTest(params: {
   request: CodexComputerUseRequest;
   config: ResolvedCodexComputerUseConfig;
   repairComputerUseMcpChildren?: () => Promise<CodexComputerUseRepairStatus>;
+  repairComputerUseRuntime?: () => Promise<CodexComputerUseRepairStatus>;
 }): Promise<{ liveTest: CodexComputerUseLiveTestStatus; repair?: CodexComputerUseRepairStatus }> {
   const startedAt = Date.now();
   let lastError: unknown;
@@ -610,7 +625,9 @@ export async function runCodexComputerUseLiveTest(params: {
       if (attempt >= COMPUTER_USE_LIVE_TEST_RETRY_COUNT) {
         break;
       }
-      if (params.config.autoRepair) {
+      if (params.repairComputerUseRuntime) {
+        repair = await params.repairComputerUseRuntime();
+      } else if (params.config.autoRepair) {
         repair = params.repairComputerUseMcpChildren
           ? await params.repairComputerUseMcpChildren()
           : scopedRepairUnavailableStatus();

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -83,6 +83,7 @@ import {
   assertCodexAppServerClientStartSelectionCurrent,
   getSharedCodexAppServerClient,
   readCodexAppServerClientProcessIdentity,
+  readCodexComputerUseRuntimeContext,
 } from "./shared-client.js";
 
 let listCodexAppServerModels: typeof import("./models.js").listCodexAppServerModels;
@@ -107,10 +108,11 @@ let withLeasedCodexAppServerClientStartSelectionRetry: typeof import("./shared-c
 async function sendInitializeResult(
   harness: ReturnType<typeof createClientHarness>,
   userAgent: string,
+  runtimeIdentity: Record<string, unknown> = {},
 ): Promise<void> {
   await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(1));
   const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
-  harness.send({ id: initialize.id, result: { userAgent } });
+  harness.send({ id: initialize.id, result: { userAgent, ...runtimeIdentity } });
 }
 
 async function sendEmptyModelList(harness: ReturnType<typeof createClientHarness>): Promise<void> {
@@ -699,7 +701,8 @@ describe("shared Codex app-server client", () => {
         startOptions,
         agentDir,
       });
-      await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)");
+      const codexHome = path.join(agentDir, "codex-home");
+      await sendInitializeResult(harness, "openclaw/0.147.0 (macOS; test)", { codexHome });
       const client = await clientPromise;
 
       expect(readCodexAppServerClientProcessIdentity(client)).toEqual({
@@ -710,6 +713,11 @@ describe("shared Codex app-server client", () => {
         nativeCommand: "/cache/openclaw/codex.native",
         serverVersion: "0.147.0",
         userAgent: "openclaw/0.147.0 (macOS; test)",
+      });
+      expect(readCodexComputerUseRuntimeContext(client)).toEqual({
+        codexHome,
+        ownershipRoot: agentDir,
+        appServerCommand: "/cache/openclaw/codex.native",
       });
 
       expect(() =>

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -210,11 +210,11 @@ export function resolveCodexAppServerSpawnIdentity(
   };
 }
 
-class CodexAppServerStartSelectionChangedError extends Error {
+export class CodexAppServerStartSelectionChangedError extends Error {
   readonly code = "CODEX_APP_SERVER_START_SELECTION_CHANGED";
 
-  constructor() {
-    super("Codex app-server managed executable selection changed during startup");
+  constructor(message = "Codex app-server managed executable selection changed during startup") {
+    super(message);
     this.name = "CodexAppServerStartSelectionChangedError";
   }
 }

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -87,6 +87,12 @@ type CodexAppServerClientStartMetadata = {
   nativeCommand?: string;
 };
 
+export type CodexComputerUseRuntimeContext = {
+  codexHome: string;
+  ownershipRoot: string;
+  appServerCommand: string;
+};
+
 /** Successful physical process identity, excluding environment and credentials. */
 type CodexAppServerClientProcessIdentity = {
   clientId: string;
@@ -154,6 +160,32 @@ export function readCodexAppServerClientProcessIdentity(
     ...resolveCodexAppServerSpawnIdentity(metadata.startOptions, metadata.nativeCommand),
     ...(runtimeIdentity?.serverVersion ? { serverVersion: runtimeIdentity.serverVersion } : {}),
     ...(runtimeIdentity?.userAgent ? { userAgent: runtimeIdentity.userAgent } : {}),
+  };
+}
+
+/** Reads the home-owned native Computer Use context for a running isolated client. */
+export function readCodexComputerUseRuntimeContext(
+  client: CodexAppServerClient,
+): CodexComputerUseRuntimeContext | undefined {
+  const metadata = getCodexAppServerClientStartMetadata().get(client);
+  const requested = metadata?.requestedStartOptions;
+  if (
+    !metadata ||
+    !requested ||
+    requested.transport !== "stdio" ||
+    requested.homeScope === "user" ||
+    requested.env?.CODEX_HOME?.trim()
+  ) {
+    return undefined;
+  }
+  const codexHome = client.getRuntimeIdentity()?.codexHome?.trim();
+  if (!codexHome) {
+    return undefined;
+  }
+  return {
+    codexHome,
+    ownershipRoot: metadata.agentDir,
+    appServerCommand: metadata.nativeCommand ?? metadata.startOptions.command,
   };
 }
 


### PR DESCRIPTION
## What problem this solves

A ChatGPT/Codex desktop update can replace several coupled Computer Use components at stable filesystem paths while OpenClaw's Gateway and a shared Codex app-server remain alive:

1. the signed Computer Use service,
2. the bundled `openai-bundled` marketplace and Computer Use plugin, and
3. the Codex app-server/native sender identity.

Before this change, stable paths could leave OpenClaw holding the previous process generation. Replacing only the scoped MCP child was insufficient when the warm app-server itself belonged to the previous signed generation. Trying to register the desktop marketplace directly also failed with Codex JSON-RPC error `-32600`, because `openai-bundled` is a reserved marketplace name. The practical result was a Computer Use failure that persisted until the Gateway was restarted.

This PR makes an admitted Computer Use request reconcile those generations and continue through the existing bounded app-server startup retry, without restarting the Gateway or replaying the user turn.

Related context: #126080.

## How it works

### 1. Materialize the reserved marketplace through Codex's supported managed path

For OpenClaw-managed isolated Codex homes only, app-server startup now runs under the existing native configuration fence and:

- materializes Codex's reserved bundled marketplace at `$CODEX_HOME/.tmp/bundled-marketplaces/openai-bundled` using an atomically replaced symlink to the current ChatGPT/Codex bundle;
- updates the isolated `config.toml` atomically, preserving its mode; and
- reconciles the shared plugin cache.

An explicit marketplace configuration remains untouched.

### 2. Enforce the existing managed-home ownership boundary

The marketplace/config writer reuses the signed-service provisioning boundary rather than trusting a supplied home path:

- `ensureOwnedCodexHome` establishes the real agent-owned Codex home;
- `prepareOwnedServiceParent` establishes the real owned marketplace parent;
- directory identity is checked before and after each staging, rename, rollback, and cleanup operation;
- a symlinked `config.toml` is rejected; and
- cleanup stops if the established directory identity is no longer stable.

Focused tests cover symlinked homes, symlinked config, marketplace-parent rebinding, and Codex-home rebinding. They verify that external targets and sentinels are not modified.

### 3. Reconcile the signed service generation at request time

The runtime reconciler records the selected source build for each physical shared app-server. Before Computer Use is admitted, it checks the current source/service generation.

If either the signed service was refreshed directly or another reconciler already moved the target to a newer source build, the reconciler:

- retires only the affected scoped Computer Use MCP child, when present;
- retires only that physical warm app-server;
- raises the existing app-server selection-changed signal; and
- lets the existing single bounded startup retry obtain the current app-server and continue the same admitted request.

When the source generation is unchanged, the warm app-server remains on the fast path. If the live compatibility probe fails without a source-generation change, OpenClaw performs one forced scoped revalidation/repair attempt. Concurrent repair attempts are coalesced.

### 4. Preserve ownership and opt-out boundaries

Automatic runtime reconciliation is created only when `readCodexComputerUseRuntimeContext(client)` proves that the client belongs to an OpenClaw-managed isolated runtime. User-scoped clients and explicit `CODEX_HOME` configurations remain operator-owned, and their existing `autoRepair` behavior is preserved.

This change does **not**:

- restart or broadly kill the Gateway;
- terminate unrelated Codex, ChatGPT, OpenClaw, or Computer Use processes;
- use error-message string matching as a control path;
- replay the user turn;
- create an alternate Computer Use execution path; or
- overwrite an explicit marketplace source.

## Direct Codex contract evidence

The implementation was checked against pinned upstream Codex commit [`d72d669ca727a26765315ffe03db3dd2594d9b91`](https://github.com/openai/codex/commit/d72d669ca727a26765315ffe03db3dd2594d9b91):

- [`marketplace_policy.rs:321-331`](https://github.com/openai/codex/blob/d72d669ca727a26765315ffe03db3dd2594d9b91/codex-rs/core-plugins/src/marketplace_policy.rs#L321-L331) rejects adding a reserved marketplace name from an arbitrary source.
- [`marketplace_policy.rs:478-488`](https://github.com/openai/codex/blob/d72d669ca727a26765315ffe03db3dd2594d9b91/codex-rs/core-plugins/src/marketplace_policy.rs#L478-L488) recognizes `openai-bundled` as bundled only beneath `$CODEX_HOME/.tmp/bundled-marketplaces/<marketplace_name>`.
- [`plugin_cmd.rs:833-844`](https://github.com/openai/codex/blob/d72d669ca727a26765315ffe03db3dd2594d9b91/codex-rs/cli/src/plugin_cmd.rs#L833-L844) applies the same bundled-marketplace-root contract in the CLI path.

That contract is why this PR atomically refreshes a managed-local marketplace path instead of attempting direct external registration.

## User impact

On the first Computer Use request after the desktop generation changes, OpenClaw can align the reserved marketplace, signed service, native client, and app-server generation automatically. The already admitted request then proceeds through the existing bounded startup retry. Other agents and clients are not restarted or replaced.

## Evidence

### Focused exact-head regression suite

Production/live-proof head: `19406684a878f353c07eeff8b89a40cdc7b9de31`

Current PR head: `69284c1654b14ea071536346dedb9534e48d3d26`. The only changes after the live-proof head are two test-only portability follow-ups that normalize mocked Node path arguments without relying on generic object-to-string coercion; the production tree is identical.

```text
node scripts/run-vitest.mjs \
  extensions/codex/src/app-server/computer-use-marketplace.test.ts \
  extensions/codex/src/app-server/computer-use-runtime-repair.test.ts \
  extensions/codex/src/app-server/computer-use.test.ts \
  extensions/codex/src/app-server/computer-use-health.test.ts \
  extensions/codex/src/app-server/computer-use-service.test.ts \
  extensions/codex/src/app-server/auth-bridge.test.ts \
  extensions/codex/src/app-server/attempt-startup.test.ts

7 test files passed
235 tests passed
```

The tests cover:

- reserved managed marketplace materialization, stale-link refresh, idempotence, and explicit-config preservation;
- managed-home containment, symlink rejection, and parent/home rebinding during mutation;
- direct service/source refresh and retirement of only the stale physical app-server;
- a sibling reconciler changing the source build;
- the unchanged-generation warm fast path;
- failed live-probe scoped repair;
- simultaneous repair coalescing;
- preservation of `autoRepair` opt-out outside managed isolated runtimes; and
- propagation of the selection-changed signal into the bounded startup retry.

Additional exact-head checks:

- `git diff --check`: passed.
- `oxlint` on changed files: passed.
- changed-file repository guards: passed.
- `pnpm build:docker`: passed completely, including all production bundles, external plugin assets, runtime postbuild, CLI bootstrap, plugin-SDK exports, and UI build.
- on current head `69284c1654b14ea071536346dedb9534e48d3d26`, the affected marketplace suite passes all 7 tests; targeted Oxlint and Oxfmt checks pass; and `git diff --check` passes.

The changed-file extension typecheck still reports two pre-existing errors in untouched `extensions/acpx` (`promptStarted` and `elicitationModes`). Those same baseline/toolchain errors are not introduced by this PR.

### Physical desktop replacement under one Gateway PID

The exact head was run against an isolated disposable state/config/workspace and candidate Gateway. Two real OpenAI-signed Computer Use service generations were placed in complete desktop bundles and the whole desktop bundle was atomically replaced at the stable path while the candidate Gateway remained alive.

```text
candidate Gateway PID / port:      94722 / 19027
serving Gateway PID / port:        13876 / 18789

generation A:                      build 1000740
identifier / team:                 com.openai.sky.CUAService / 2DC432GLL2
CDHash:                            688116b085bc9de38f341a6bfd3377dc4eb47d92
pre-swap run:                      f328cdf6-cde4-474d-8608-eb6ed47381fa
successful tool / reported build:  computer-use.get_app_state / 1000740

physical desktop replacement:      atomic rename at /Applications/Codex.app
Codex binary inode:                116537878 -> 116545088
candidate Gateway after swap:      PID 94722 (unchanged)

generation B:                      build 1000816
identifier / team:                 com.openai.sky.CUAService / 2DC432GLL2
CDHash:                            cbe2d09d96246ac3ee60b83214da5bec158f5351
first post-swap run:               a52ac29b-4a09-4f7a-9ce4-63b110e9604b
successful tool / reported build:  computer-use.get_app_state / 1000816
managed service after request:     1000816
candidate Gateway after request:   PID 94722 (unchanged)
serving Gateway after proof:       PID 13876 (unchanged)
```

The post-swap operation was one request and one run ID; no user turn was replayed. Process sampling also observed a generation-A app-server/MCP pair (`96444 -> 96486`) and a generation-B pair (`97302 -> 97426`), each parented beneath candidate Gateway `94722`.

The CLI proof route performs normal one-shot app-server cleanup at turn teardown, so this does not claim that one app-server PID persisted across both turns. It proves the requested boundary: a physical desktop replacement, one continuously running Gateway PID, and successful Computer Use recovery on the first post-replacement request.

After proof teardown, the disposable desktop fixture and Gateway were removed. The serving Gateway retained its PID and listeners, and the serving `/Applications/ChatGPT.app/Contents/Resources/codex` SHA-256 remained `10afbeddd6f951635d8fcfbb337034d37934bb3495c16d053b3560d75747619b`.

## Lifecycle decision

Whether managed isolated Codex homes should adopt request-time desktop polling and automatic app-server retirement, or retain an explicit restart/reload boundary, remains an owner/maintainer product-lifecycle decision. This PR now supplies the containment, direct upstream contract, tests, and live transition proof needed to evaluate the request-time design; it does not treat that policy choice as already approved.

## Review-size note

The cumulative PR diff is 15 files, `+1182/-23`: production code `+537/-17`, tests `+636/-2`, and documentation `+9/-4`. The additional delta since the previous review is the managed-home containment correction and its focused security tests; no unrelated feature work is included.

## AI assistance

AI assistance was used for implementation, focused test construction, source-contract inspection, and preparation of this PR update. The live behavior was reviewed against production head `19406684a878f353c07eeff8b89a40cdc7b9de31`; current head `69284c1654b14ea071536346dedb9534e48d3d26` differs only by the disclosed test-only path-argument portability fixes.
