### PR TITLE
perf(test): speed up lazy UI lifecycle polling

### DIFF
--- a/ui/src/app/app-host-onboarding-memory-import.test.ts
+++ b/ui/src/app/app-host-onboarding-memory-import.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../test-helpers/wait-for.ts";
 import {
   createLazyElementSpec,
   resetAppHostTestGlobals,
@@ -29,10 +30,10 @@ describe("OpenClaw shell onboarding memory import", () => {
 
     shell.lazyCustomElements.requestWhileActive(element, true);
 
-    await vi.waitFor(() => expect(shell.lazyCustomElements.visibleState?.status).toBe("error"));
+    await waitForFast(() => expect(shell.lazyCustomElements.visibleState?.status).toBe("error"));
     expect(shell.lazyCustomElements.visibleState?.element).toBe(element);
     shell.lazyCustomElements.retry();
-    await vi.waitFor(() => expect(customElements.get(element.tagName)).toBeDefined());
+    await waitForFast(() => expect(customElements.get(element.tagName)).toBeDefined());
     expect(shell.lazyCustomElements.visibleState).toBeUndefined();
   });
 
@@ -53,7 +54,7 @@ describe("OpenClaw shell onboarding memory import", () => {
     shell.onboardingMemoryImportElement = element;
 
     shell.lazyCustomElements.requestWhileActive(element, true);
-    await vi.waitFor(() => expect(element.loadModule).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(element.loadModule).toHaveBeenCalledOnce());
     expect(shell.lazyCustomElements.visibleState?.status).toBe("loading");
     shell.lazyCustomElements.requestWhileActive(element, false);
     const error = new Error("late memory import chunk failure");

--- a/ui/src/app/lazy-custom-element.test.ts
+++ b/ui/src/app/lazy-custom-element.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../test-helpers/wait-for.ts";
 import {
   ensureCustomElementDefined,
   LazyCustomElementRequestController,
@@ -82,7 +83,7 @@ describe("optional custom element requests", () => {
     requests.request(element, continuation);
 
     expect(requests.visibleState).toMatchObject({ status: "loading", element });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(requests.visibleState).toMatchObject({
         status: "error",
         element,
@@ -95,7 +96,7 @@ describe("optional custom element requests", () => {
     requests.retry();
 
     expect(requests.visibleState).toMatchObject({ status: "loading", element });
-    await vi.waitFor(() => expect(continuation).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(continuation).toHaveBeenCalledOnce());
     expect(element.loadModule).toHaveBeenCalledTimes(2);
     expect(requests.visibleState).toBeUndefined();
   });
@@ -129,15 +130,15 @@ describe("optional custom element requests", () => {
     };
 
     requests.requestWhileActive(activeElement, true);
-    await vi.waitFor(() => expect(activeElement.loadModule).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(activeElement.loadModule).toHaveBeenCalledOnce());
     requests.request(foregroundElement);
-    await vi.waitFor(() => expect(foregroundElement.loadModule).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(foregroundElement.loadModule).toHaveBeenCalledOnce());
     resolveForeground?.();
-    await vi.waitFor(() => expect(requests.visibleState?.element).toBe(activeElement));
+    await waitForFast(() => expect(requests.visibleState?.element).toBe(activeElement));
 
     const error = new Error("active chunk unavailable");
     rejectActive?.(error);
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(requests.visibleState).toMatchObject({
         element: activeElement,
         error,
@@ -162,7 +163,7 @@ describe("optional custom element requests", () => {
     };
 
     requests.requestWhileActive(element, true);
-    await vi.waitFor(() => expect(requests.visibleState?.status).toBe("error"));
+    await waitForFast(() => expect(requests.visibleState?.status).toBe("error"));
     requests.close();
     requests.requestWhileActive(element, true);
 
@@ -171,7 +172,7 @@ describe("optional custom element requests", () => {
 
     requests.requestWhileActive(element, false);
     requests.requestWhileActive(element, true);
-    await vi.waitFor(() => expect(element.loadModule).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(element.loadModule).toHaveBeenCalledTimes(2));
   });
 
   it("delegates stale recovery before falling back to the same in-place load", async () => {
@@ -191,12 +192,12 @@ describe("optional custom element requests", () => {
     };
 
     requests.request(element, continuation);
-    await vi.waitFor(() => expect(requests.visibleState?.status).toBe("error"));
+    await waitForFast(() => expect(requests.visibleState?.status).toBe("error"));
     expect(requests.visibleState).toMatchObject({ stale: true });
 
     requests.retry();
 
-    await vi.waitFor(() => expect(continuation).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(continuation).toHaveBeenCalledOnce());
     expect(retryStale).toHaveBeenCalledOnce();
     expect(element.loadModule).toHaveBeenCalledTimes(2);
   });
@@ -222,12 +223,12 @@ describe("optional custom element requests", () => {
 
     requests.request(element, continuation);
     expect(requests.visibleState?.status).toBe("loading");
-    await vi.waitFor(() => expect(element.loadModule).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(element.loadModule).toHaveBeenCalledOnce());
 
     requests.close();
     resolveLoad?.();
 
-    await vi.waitFor(() => expect(customElements.get(element.tagName)).toBeDefined());
+    await waitForFast(() => expect(customElements.get(element.tagName)).toBeDefined());
     expect(requests.visibleState).toBeUndefined();
     expect(continuation).not.toHaveBeenCalled();
   });
@@ -246,11 +247,11 @@ describe("optional custom element requests", () => {
     requests.preload(element);
     requests.preload(element);
 
-    await vi.waitFor(() => expect(element.loadModule).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(element.loadModule).toHaveBeenCalledOnce());
     expect(requests.visibleState).toBeUndefined();
 
     requests.request(element);
-    await vi.waitFor(() => expect(requests.visibleState?.status).toBe("error"));
+    await waitForFast(() => expect(requests.visibleState?.status).toBe("error"));
     expect(element.loadModule).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The Control UI lazy-element and onboarding-memory-import regression suites spent about 0.8 seconds waiting for default 50 ms polling intervals even though their observed state transitions settle immediately through Promises. Recent onboarding coverage introduced additional waits on this same owner boundary.

## Why This Change Was Made

Use the existing Control UI `waitForFast` helper for the 17 asynchronous assertions across the two affected suites. It retains the original assertions, one-second failure deadline, actual lazy-element controller, application shell, and lifecycle ordering while reducing the polling interval to 1 ms. No production code, timeout, mock, fixture, or browser boundary changes.

## User Impact

No user-visible behavior changes. Developers and CI retain all existing lazy-load, failure, retry, dismissal, foreground takeover, and onboarding cleanup coverage while running these focused tests approximately 16% faster end to end.

## Evidence

- Same Blacksmith Testbox, one worker, distinct filesystem module caches, import diagnostics, GNU `/usr/bin/time -v`, and excluded warmups.
- Before retained runs: **2.94 s / 3.09 s wall**, **2.38 s / 2.57 s Vitest**, **820 ms / 821 ms test bodies**, **685440 KB / 677964 KB max RSS**, **2.55+0.31 s / 2.72+0.30 s user+system CPU**; 11 tests passed in both runs.
- After retained runs: **2.59 s / 2.45 s wall**, **1.97 s / 1.82 s Vitest**, **33 ms / 32 ms test bodies**, **683404 KB / 679792 KB max RSS**, **2.87+0.44 s / 2.82+0.38 s user+system CPU**; the same 11 tests passed in both runs.
- Mean wall time: **3.015 s → 2.520 s, 16.4% faster**; mean test-body time: **820.5 ms → 32.5 ms, 96.0% faster**. Import counts stayed unchanged at 20.
- Intended-fault proof: temporarily removing the production lazy controller's authoritative current-request assignment makes the preserved regression fail with `expected undefined to match object { status: "loading", ... }`; production source was restored completely.
- Focused owner and canonical-helper sibling coverage: **60 tests passed**. Real isolated Chromium stale-chunk recovery: **4 tests passed** across terminal, desktop, dashboard, and command-palette recovery.
- `OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test ui/src/app/lazy-custom-element.test.ts ui/src/app/app-host-onboarding-memory-import.test.ts ui/src/app/question-prompt.test.ts ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts --maxWorkers=1 --reporter=verbose`
- `pnpm check:changed`
- `node_modules/.bin/oxfmt --check ui/src/app/lazy-custom-element.test.ts ui/src/app/app-host-onboarding-memory-import.test.ts`
- Independent structured autoreview: clean, no actionable findings.
- Production LOC: **+0/-0**. Tests: **+19/-17** across two files; 17 existing waits replaced and two existing-helper imports added. No tests or assertions removed.
- Blacksmith proof run: https://github.com/openclaw/openclaw/actions/runs/32447826685
