### PR TITLE
fix: session updates overwrite concurrent state or new owners

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-replacement-projection.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-replacement-projection.test.ts
@@ -1,45 +1,81 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 
-const { readExactSessionEntryJsonMock } = vi.hoisted(() => ({
-  readExactSessionEntryJsonMock: vi.fn(),
+const { readExactSessionEntryRowMock } = vi.hoisted(() => ({
+  readExactSessionEntryRowMock:
+    vi.fn<typeof import("./session-accessor.sqlite-entry-store.js").readExactSessionEntryRow>(),
 }));
 
 vi.mock("./session-accessor.sqlite-entry-store.js", async () => {
   const actual = await vi.importActual<typeof import("./session-accessor.sqlite-entry-store.js")>(
     "./session-accessor.sqlite-entry-store.js",
   );
-  readExactSessionEntryJsonMock.mockImplementation(actual.readExactSessionEntryJson);
-  return { ...actual, readExactSessionEntryJson: readExactSessionEntryJsonMock };
+  readExactSessionEntryRowMock.mockImplementation(actual.readExactSessionEntryRow);
+  return { ...actual, readExactSessionEntryRow: readExactSessionEntryRowMock };
 });
 
-const { applySessionEntryReplacements, loadSessionEntry, upsertSessionEntryCore } =
-  await import("./session-accessor.js");
+const actualSessionEntryStore = await vi.importActual<
+  typeof import("./session-accessor.sqlite-entry-store.js")
+>("./session-accessor.sqlite-entry-store.js");
+const {
+  applySessionEntryReplacements,
+  assignSessionOwner,
+  loadSessionEntry,
+  upsertSessionEntryCore,
+} = await import("./session-accessor.js");
 
 describe("session entry replacement compare-and-swap", () => {
   const tempDirs: string[] = [];
   let storePath: string;
+  let scope: { sessionKey: string; storePath: string };
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    readExactSessionEntryRowMock.mockImplementation(
+      actualSessionEntryStore.readExactSessionEntryRow,
+    );
     storePath = `${makeTempDir(tempDirs, "replacement-cas")}/openclaw-agent.sqlite`;
+    scope = { sessionKey: "agent:main:replacement-row", storePath };
+    await upsertSessionEntryCore(scope, {
+      model: "base",
+      sessionId: "replacement-row",
+      updatedAt: 10,
+    });
   });
 
   afterEach(() => {
-    readExactSessionEntryJsonMock.mockReset();
+    readExactSessionEntryRowMock.mockReset();
     cleanupTempDirs(tempDirs);
   });
 
-  it("refuses to replace a selected row whose bytes disappear before the snapshot completes", async () => {
-    const scope = { sessionKey: "agent:main:vanishing-row", storePath };
-    await upsertSessionEntryCore(scope, {
-      model: "base",
-      sessionId: "vanishing-row",
-      updatedAt: 10,
+  it.each([
+    { mutation: "deleted", expected: undefined },
+    {
+      mutation: "rewritten",
+      expected: expect.objectContaining({
+        label: "concurrent-owner-metadata",
+        model: "base",
+        sessionId: "replacement-row",
+      }),
+    },
+  ])("rejects a row $mutation during its detached snapshot", async ({ mutation, expected }) => {
+    readExactSessionEntryRowMock.mockImplementationOnce((database, sessionKey) => {
+      const row = actualSessionEntryStore.readExactSessionEntryRow(database, sessionKey);
+      if (!row) {
+        throw new Error("expected a persisted session row");
+      }
+      if (mutation === "deleted") {
+        database.db.prepare("DELETE FROM session_nodes WHERE session_key = ?").run(sessionKey);
+      } else {
+        const updatedEntryJson = JSON.stringify({
+          ...JSON.parse(row.row.entry_json),
+          label: "concurrent-owner-metadata",
+        });
+        database.db
+          .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+          .run(updatedEntryJson, sessionKey);
+      }
+      return row;
     });
-    // A concurrent writer can delete the row between hydrating the snapshot entry and reading
-    // its persisted bytes. Both the snapshot and the transaction then observe "no bytes", so a
-    // missing-vs-missing compare would agree and rewrite the stale entry into the deleted key.
-    readExactSessionEntryJsonMock.mockReturnValue(undefined);
 
     await expect(
       applySessionEntryReplacements({
@@ -47,7 +83,7 @@ describe("session entry replacement compare-and-swap", () => {
         storePath,
         update: (entries) => ({
           replacements: entries.map(({ entry, sessionKey }) => ({
-            entry: { ...entry, model: "resurrected" },
+            entry: { ...entry, model: "stale-replacement" },
             sessionKey,
           })),
           result: undefined,
@@ -55,6 +91,41 @@ describe("session entry replacement compare-and-swap", () => {
       }),
     ).rejects.toThrow("changed before replacement");
 
-    expect(loadSessionEntry(scope)).toMatchObject({ model: "base", sessionId: "vanishing-row" });
+    expect(loadSessionEntry({ ...scope, readConsistency: "latest" })).toEqual(expected);
+  });
+
+  it("rejects a replacement prepared under a session owner that changes before commit", async () => {
+    const assignedBy = { id: "assigner", type: "human" as const };
+    assignSessionOwner(scope, {
+      assignedBy,
+      owner: { id: "owner-a", type: "human" },
+    });
+
+    await expect(
+      applySessionEntryReplacements({
+        sessionKeys: [scope.sessionKey],
+        storePath,
+        update: (entries) => {
+          expect(entries[0]?.entry.owner?.actor.id).toBe("owner-a");
+          assignSessionOwner(scope, {
+            assignedBy,
+            owner: { id: "owner-b", type: "human" },
+          });
+          return {
+            replacements: entries.map(({ entry, sessionKey }) => ({
+              entry: { ...entry, model: "stale-owner-replacement" },
+              sessionKey,
+            })),
+            result: undefined,
+          };
+        },
+      }),
+    ).rejects.toThrow("changed before replacement");
+
+    expect(loadSessionEntry({ ...scope, readConsistency: "latest" })).toMatchObject({
+      model: "base",
+      owner: { actor: { id: "owner-b", type: "human" } },
+      sessionId: "replacement-row",
+    });
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-replacement-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-replacement-projection.ts
@@ -9,11 +9,12 @@ import type {
   SessionEntryReplacementUpdate,
   SessionEntryStatus,
 } from "./session-accessor.sqlite-contract.js";
+import { sqliteSessionEntriesEqual } from "./session-accessor.sqlite-entry-equality.js";
 import {
   deleteLegacySessionEntryRows,
-  readExactSessionEntryJson,
   readExactSessionEntryRow,
   readSessionEntryStore,
+  type ResolvedSessionEntryRow,
   writeSessionEntry,
 } from "./session-accessor.sqlite-entry-store.js";
 import { emitCommittedSessionIdentityDiff } from "./session-accessor.sqlite-identity.js";
@@ -72,36 +73,31 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const selectedKeys = params.sessionKeys ? new Set(params.sessionKeys) : undefined;
     const selectedStatuses = params.statuses ? new Set(params.statuses) : undefined;
-    const entries = selectedStatuses
+    const selected = selectedStatuses
       ? readSessionEntriesByStatus(database, [...selectedStatuses], params.sessionKeys)
       : selectedKeys
-        ? [...selectedKeys].flatMap((sessionKey) => {
-            const entry = readExactSessionEntryRow(database, sessionKey)?.entry;
-            return entry ? [{ entry: cloneSessionEntry(entry), sessionKey }] : [];
-          })
-        : Object.entries(readSessionEntryStore(database)).map(([sessionKey, entry]) => ({
-            entry: cloneSessionEntry(entry),
-            sessionKey,
-          }));
+        ? [...selectedKeys].map((sessionKey) => ({ sessionKey }))
+        : Object.keys(readSessionEntryStore(database)).map((sessionKey) => ({ sessionKey }));
+    const expectedRows = new Map<string, ResolvedSessionEntryRow>();
+    const entries = selected.flatMap(({ sessionKey }) => {
+      const row = readExactSessionEntryRow(database, sessionKey);
+      if (!row) {
+        if (!selectedKeys || selectedStatuses) {
+          throw new Error(`SQLite session entry changed before replacement for ${sessionKey}`);
+        }
+        return [];
+      }
+      if (selectedStatuses && (!row.entry.status || !selectedStatuses.has(row.entry.status))) {
+        return [];
+      }
+      // Pair the detached entry and CAS bytes from one row; separate reads can
+      // otherwise bless stale data with a newer writer's comparison token.
+      expectedRows.set(sessionKey, row);
+      return [{ entry: cloneSessionEntry(row.entry), sessionKey }];
+    });
     const replacementAuthorityKeys = selectedStatuses
       ? new Set(entries.map(({ sessionKey }) => sessionKey))
       : selectedKeys;
-    // Compare persisted row bytes, never a hydrated entry. Participants and owner live in
-    // their own table/columns, and each selection reader projects a different subset of them,
-    // so an entry-object compare can differ from the transaction re-read with no write at all
-    // and wedge the row's repairs forever.
-    const expectedEntryJson = new Map(
-      entries.map(({ sessionKey }) => {
-        const rawEntryJson = readExactSessionEntryJson(database, sessionKey);
-        if (rawEntryJson === undefined) {
-          // The row vanished between hydrating the snapshot and reading its bytes. Fail closed:
-          // a selected key must hold bytes, or a later missing-vs-missing compare would pass and
-          // rewrite the stale entry into a concurrently deleted key.
-          throw new Error(`SQLite session entry changed before replacement for ${sessionKey}`);
-        }
-        return [sessionKey, rawEntryJson];
-      }),
-    );
     const operation = await params.update(entries);
     const replacements = normalize(operation.replacements);
     const claimedCanonicalKeys = new Set<string>();
@@ -133,7 +129,7 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
       }
       if (canonical) {
         for (const previousSessionKey of previousSessionKeys) {
-          if (!expectedEntryJson.has(previousSessionKey)) {
+          if (!expectedRows.has(previousSessionKey)) {
             throw new Error(
               `Session entry canonical projection cannot replace missing alias ${previousSessionKey}`,
             );
@@ -143,8 +139,7 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
     }
 
     const applicable = replacements.filter(
-      (replacement) =>
-        replacement.previousSessionKeys || expectedEntryJson.has(replacement.sessionKey),
+      (replacement) => replacement.previousSessionKeys || expectedRows.has(replacement.sessionKey),
     );
     if (params.requireWriteSuccess && replacements.length > 0 && applicable.length === 0) {
       throw new Error("session entry replacements did not persist any rows");
@@ -167,7 +162,11 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
         const transactionEntries = new Map<string, SessionEntry>();
         for (const sessionKey of validationKeys) {
           const transactionRow = readExactSessionEntryRow(transactionDb, sessionKey);
-          if (transactionRow?.row.entry_json !== expectedEntryJson.get(sessionKey)) {
+          const expectedRow = expectedRows.get(sessionKey);
+          if (
+            transactionRow?.row.entry_json !== expectedRow?.row.entry_json ||
+            !sqliteSessionEntriesEqual(transactionRow?.entry, expectedRow?.entry)
+          ) {
             throw new Error(`SQLite session entry changed before replacement for ${sessionKey}`);
           }
           if (transactionRow) {


### PR DESCRIPTION
Related: #126507, #126751, #126925

## What Problem This Solves

Resolves a problem where concurrent session recovery or model-selection updates could silently overwrite newer session metadata. A replacement prepared for one session owner could also commit after another actor had taken ownership because owner assignments live outside the session JSON blob.

## Why This Change Was Made

Capture each authoritative SQLite session row and its hydrated session entry as one immutable replacement snapshot, then compare both the exact persisted JSON bytes and the existing participant-aware logical-session equality inside the synchronous write transaction. This preserves independently mutable participant history, revalidates status-selected rows, keeps missing-key and canonical-insertion behavior, and removes the separate keyed-session snapshot query.

## User Impact

Newer session state and owner assignments are no longer silently overwritten by stale recovery, model-selection, or bulk replacement work. Conflicting updates fail safely; ordinary session replacements, participant changes, canonical rekeys, and restart recovery continue unchanged.

## Evidence

- Before the fix, real SQLite owner-boundary regressions failed for both a concurrent session JSON update and a public `assignSessionOwner` transfer; the existing actual row-deletion race still passed.
- After the fix, all three real compare-and-swap race cases pass alongside session-owner persistence, complete session-accessor sibling coverage, and main-session restart/recovery coverage.
- Production type checking, focused type-aware lint, formatter, runtime import-cycle validation, maximum-file-length guard, and unsafe-assertion ratchet are verified.
- Production LOC: +29/-30 (net -1). Test LOC: +91/-20 (net +71), with the real deletion and rewrite races sharing one table-driven fixture. No SQLite schema version, migration, configuration, dependency, or public protocol change.

Known separate follow-ups discovered during the bounded audit: model fallback can mistake status/TTS-only output for a visible final; restart recovery can misread hidden reasoning as applied configuration; watchdog recovery can incorrectly clear queued-work diagnostics or abort active maintenance too early. Those have distinct owners and remain outside this persistence fix.
