### PR TITLE
fix(tui): clear stale session names after switching

### DIFF
--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -169,10 +169,13 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         const entryFastMode = isModeSource ? true : isModeTarget ? undefined : fastMode;
         const entryVerboseLevel = isModeSource ? "full" : isModeTarget ? undefined : verboseLevel;
         const entryTraceLevel = isModeSource ? "raw" : isModeTarget ? modeTargetTraceLevel : undefined;
-        const entryReasoningLevel = isModeSource ? "stream" : undefined;
         return {
           key,
-          displayName: key === pickerSessionKey ? pickerSessionDisplayName : "Main",
+          ...(isModeSource
+            ? { displayName: "Production incident" }
+            : isModeTarget
+              ? {}
+              : { displayName: key === pickerSessionKey ? pickerSessionDisplayName : "Main" }),
           model: currentModel,
           modelProvider: "fixture-provider",
           contextTokens: 128,
@@ -180,7 +183,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
           ...(currentThinkingLevel ? { thinkingLevel: currentThinkingLevel } : {}),
           ...(entryVerboseLevel ? { verboseLevel: entryVerboseLevel } : {}),
           ...(entryTraceLevel ? { traceLevel: entryTraceLevel } : {}),
-          ...(entryReasoningLevel ? { reasoningLevel: entryReasoningLevel } : {}),
+          ...(isModeSource ? { reasoningLevel: "stream" } : {}),
           thinkingLevels,
         };
       }

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1525,6 +1525,7 @@ describe("tui session actions", () => {
     const state = createBaseState({
       currentSessionKey: "agent:main:source",
       sessionInfo: {
+        displayName: "Production incident",
         fastMode: true,
         verboseLevel: "full",
         traceLevel: "raw",
@@ -1546,6 +1547,7 @@ describe("tui session actions", () => {
     await setSession("agent:main:target");
 
     expect(state.sessionInfo).toMatchObject({
+      displayName: undefined,
       fastMode: undefined,
       verboseLevel: undefined,
       traceLevel: undefined,

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -110,6 +110,7 @@ export function createSessionActions(context: SessionActionContext) {
     setActivityStatus("idle");
     if (selectionChanged) {
       state.currentSessionId = null;
+      state.sessionInfo.displayName = undefined;
       clearTuiSessionModeOverrides(state.sessionInfo);
     }
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness

--- a/src/tui/tui-session-identity-pty.e2e.test.ts
+++ b/src/tui/tui-session-identity-pty.e2e.test.ts
@@ -74,6 +74,37 @@ afterEach(async () => {
   await disposeActiveTuiFixtures();
 });
 
+it("clears the previous display name when the selected session is unnamed", async () => {
+  const fixture = await startTuiFixture();
+  try {
+    await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+    await fixture.run.write("/session agent:main:mode-source\r", { delay: false });
+    await fixture.waitForLogEntry(
+      (entry) =>
+        entry.method === "loadHistory" &&
+        objectFieldEquals(entry, "sessionKey", "agent:main:mode-source"),
+      STARTUP_TIMEOUT_MS,
+    );
+    await fixture.run.waitForOutput("Production incident", STARTUP_TIMEOUT_MS);
+
+    const targetOutputOffset = fixture.run.visibleOutput().length;
+    await fixture.run.write("/session agent:main:mode-target\r", { delay: false });
+    await fixture.waitForLogEntry(
+      (entry) =>
+        entry.method === "loadHistory" &&
+        objectFieldEquals(entry, "sessionKey", "agent:main:mode-target"),
+      STARTUP_TIMEOUT_MS,
+    );
+    await fixture.run.waitForOutput("session mode-target", STARTUP_TIMEOUT_MS);
+
+    expect(fixture.run.visibleOutput().slice(targetOutputOffset)).not.toContain(
+      "Production incident",
+    );
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
 it("hides a stale approval when startup restores the remembered session", async () => {
   const stateDir = tempDirs.make("openclaw-tui-identity-");
   await seedRememberedSession(stateDir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where TUI users switching from a named session to an unnamed session would continue seeing the previous session's display name.

## Why This Change Was Made

Session selection already clears session-scoped mode overrides when the selected key changes, but the display name remained cached in the same state object. This change clears the display name at that canonical transition boundary while preserving same-session partial updates.

The PTY fixture now models a named source session and an unnamed target session so the user-visible regression is exercised through the real TUI loop.

## User Impact

After switching to an unnamed session, the TUI immediately shows the target session identity instead of a stale name from the previous session.

## Evidence

- Pre-fix regression: the owner-level test retained `Production incident` after selecting an unnamed target.
- `node scripts/run-vitest.mjs src/tui/tui-session-actions.test.ts` — 78 passed after rebase.
- Focused real-PTY display-name regression passed.
- Full `src/tui/tui-session-identity-pty.e2e.test.ts` passed 8/8 before the final non-overlapping main rebase; post-rebase reruns passed the new regression and seven sibling cases, while host-wide build pressure interrupted the final sibling process without an assertion failure.
- Proportional changed-file gates passed before rebase; the post-rebase run completed formatting, typechecking, lint, architecture, database, import-cycle, webhook, and pairing guards before the 10-minute harness ceiling.
- Fresh structured autoreview reported no accepted P0/P1 findings on the final branch.

AI-assisted: yes. I reviewed the implementation and validation results.
