### PR TITLE
fix(onboard): --auth-choice help lists a value that fails and hides one that works

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -63,10 +63,7 @@ function validateRecommendationParentOptions(
   return false;
 }
 
-const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({
-  includeLegacyAliases: true,
-  includeSkip: true,
-});
+const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({ includeSkip: true });
 const RECOMMENDATION_READ_PARENT_OPTIONS = new Set(["json"]);
 const NO_RECOMMENDATION_PARENT_OPTIONS = new Set<string>();
 

--- a/src/commands/auth-choice-cli-agreement.test.ts
+++ b/src/commands/auth-choice-cli-agreement.test.ts
@@ -1,0 +1,121 @@
+// Pins the contract that onboard help advertises exactly the auth choices the
+// non-interactive dispatcher accepts, so the two lists cannot drift apart.
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const PROVIDER_SETUP_CONTRIBUTIONS = [
+  { providerId: "demo", option: { value: "demo-api-key", label: "Demo API key" } },
+  { providerId: "demo", option: { value: "demo-cli", label: "Demo CLI" } },
+];
+
+vi.mock("../flows/provider-flow.js", () => ({
+  resolveProviderSetupFlowContributions: () => PROVIDER_SETUP_CONTRIBUTIONS,
+}));
+
+// "claude-cli" is the one deprecated alias `auth-choice-legacy.ts` recognizes,
+// so reproducing the advertised-but-rejected case needs that exact id. It is
+// normalized to its replacement before any CLI list is consulted, which is why
+// neither list may contain it.
+const DEPRECATED_ALIAS = "claude-cli";
+
+vi.mock("../plugins/provider-auth-choices.js", () => ({
+  resolveProviderOnboardAuthFlags: () => [],
+  resolveManifestProviderAuthChoices: () => [
+    {
+      pluginId: "demo",
+      providerId: "demo",
+      methodId: "cli",
+      choiceId: "demo-cli",
+      choiceLabel: "Demo CLI",
+      deprecatedChoiceIds: [DEPRECATED_ALIAS],
+    },
+  ],
+  resolveManifestDeprecatedProviderAuthChoice: (choiceId: string) =>
+    choiceId === DEPRECATED_ALIAS
+      ? { choiceId: "demo-cli", choiceLabel: "Demo CLI", providerId: "demo" }
+      : undefined,
+}));
+
+vi.mock("../plugins/provider-install-catalog.js", () => ({
+  resolveDeprecatedProviderInstallCatalogEntry: () => undefined,
+}));
+
+vi.mock("./onboard-non-interactive/local/auth-choice.plugin-providers.js", () => ({
+  applyNonInteractivePluginProviderChoice: async () => undefined,
+}));
+
+vi.mock("./onboard-recommendations.js", () => ({
+  acknowledgeOnboardRecommendationsCommand: vi.fn(),
+  onboardRecommendationsCommand: vi.fn(),
+  refreshOnboardRecommendationsCommand: vi.fn(),
+}));
+
+async function readHelpAuthChoices(): Promise<string[]> {
+  const { registerOnboardCommand } = await import("../cli/program/register.onboard.js");
+  const program = new Command();
+  registerOnboardCommand(program);
+  const onboard = program.commands.find((command) => command.name() === "onboard");
+  const description = onboard?.options.find(
+    (option) => option.long === "--auth-choice",
+  )?.description;
+  if (!description?.startsWith("Auth: ")) {
+    throw new Error(`unexpected --auth-choice help text: ${String(description)}`);
+  }
+  return description.slice("Auth: ".length).split("|");
+}
+
+async function readAcceptedAuthChoices(rejectedChoice: string): Promise<string[]> {
+  const { applyNonInteractiveAuthChoice } =
+    await import("./onboard-non-interactive/local/auth-choice.js");
+  const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+  const result = await applyNonInteractiveAuthChoice({
+    nextConfig: {} as OpenClawConfig,
+    authChoice: rejectedChoice,
+    opts: {},
+    runtime: runtime as never,
+    baseConfig: {} as OpenClawConfig,
+    target: { agentId: "main", agentDir: "/tmp/agent", workspaceDir: "/tmp/workspace" },
+  });
+  expect(result).toBeNull();
+  expect(runtime.exit).toHaveBeenCalledWith(1);
+  const message = runtime.error.mock.calls.at(0)?.at(0);
+  const listed = /Valid choices: (.*)\.$/.exec(String(message))?.[1];
+  if (!listed) {
+    throw new Error(`unexpected rejection message: ${String(message)}`);
+  }
+  return listed.split(", ");
+}
+
+describe("onboard --auth-choice help and validation agreement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("advertises exactly the choices the non-interactive dispatcher accepts", async () => {
+    const help = await readHelpAuthChoices();
+    const accepted = await readAcceptedAuthChoices("definitely-not-an-auth-choice");
+
+    expect([...help].toSorted()).toEqual([...accepted].toSorted());
+    // Guard against both lists collapsing to an empty set and passing vacuously.
+    expect(help).toContain("demo-api-key");
+    expect(help).toContain("custom-api-key");
+    expect(help).toContain("skip");
+  });
+
+  it("advertises the generic token-provider choices the dispatcher accepts", async () => {
+    const help = await readHelpAuthChoices();
+
+    // `--auth-choice token --token-provider anthropic` is a working, documented
+    // combination; help must not hide it behind provider-specific choice ids.
+    expect(help).toEqual(expect.arrayContaining(["setup-token", "token", "apiKey"]));
+  });
+
+  it("keeps deprecated aliases out of help and out of the accepted set", async () => {
+    const help = await readHelpAuthChoices();
+    const accepted = await readAcceptedAuthChoices("definitely-not-an-auth-choice");
+
+    expect(help).not.toContain(DEPRECATED_ALIAS);
+    expect(accepted).not.toContain(DEPRECATED_ALIAS);
+  });
+});

--- a/src/commands/auth-choice-legacy.test.ts
+++ b/src/commands/auth-choice-legacy.test.ts
@@ -26,7 +26,6 @@ vi.mock("../plugins/provider-auth-choices.js", () => ({
 }));
 
 import {
-  resolveLegacyAuthChoiceAliasesForCli,
   formatDeprecatedNonInteractiveAuthChoiceError,
   normalizeLegacyOnboardAuthChoice,
   resolveDeprecatedAuthChoiceReplacement,
@@ -51,12 +50,6 @@ describe("auth choice legacy aliases", () => {
     expect(formatDeprecatedNonInteractiveAuthChoiceError("claude-cli", { env })).toBe(
       'Auth choice "claude-cli" is deprecated.\nUse "--auth-choice anthropic-cli".',
     );
-  });
-
-  it("sources deprecated cli aliases from plugin manifests", () => {
-    expect(resolveLegacyAuthChoiceAliasesForCli({ env: authChoiceManifestEnv() })).toEqual([
-      "claude-cli",
-    ]);
   });
 
   it("does not keep retired Codex setup choices alive outside doctor", () => {

--- a/src/commands/auth-choice-legacy.ts
+++ b/src/commands/auth-choice-legacy.ts
@@ -1,9 +1,6 @@
 // Legacy auth-choice alias handling for CLI/onboarding compatibility.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  resolveManifestDeprecatedProviderAuthChoice,
-  resolveManifestProviderAuthChoices,
-} from "../plugins/provider-auth-choices.js";
+import { resolveManifestDeprecatedProviderAuthChoice } from "../plugins/provider-auth-choices.js";
 import type { AuthChoice } from "./onboard-types.js";
 
 const LEGACY_REPLACEMENT_AUTH_CHOICES = new Set(["claude-cli"]);
@@ -26,19 +23,6 @@ function resolveReplacementLabel(choiceLabel: string): string {
   return choiceLabel.trim() || "the replacement auth choice";
 }
 
-/** List deprecated CLI auth-choice aliases that manifest providers still recognize. */
-export function resolveLegacyAuthChoiceAliasesForCli(params?: {
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): ReadonlyArray<AuthChoice> {
-  const manifestCliAliases = resolveManifestProviderAuthChoices(params)
-    .flatMap((choice) => choice.deprecatedChoiceIds ?? [])
-    .filter((choice): choice is AuthChoice => LEGACY_REPLACEMENT_AUTH_CHOICES.has(choice))
-    .toSorted((left, right) => left.localeCompare(right));
-  return Array.from(new Set(manifestCliAliases));
-}
-
 /** Map old onboard auth choices to their current provider-backed choices. */
 export function normalizeLegacyOnboardAuthChoice(
   authChoice: AuthChoice | undefined,
@@ -49,6 +33,9 @@ export function normalizeLegacyOnboardAuthChoice(
   },
 ): AuthChoice | undefined {
   if (authChoice === "oauth") {
+    // Pre-manifest spelling of Anthropic setup-token auth. Normalizing here is
+    // what keeps it out of the CLI choice lists: every onboard surface runs this
+    // first, so no downstream validator ever sees "oauth".
     return "setup-token";
   }
   if (typeof authChoice === "string") {

--- a/src/commands/auth-choice-options.static.ts
+++ b/src/commands/auth-choice-options.static.ts
@@ -1,5 +1,4 @@
 // Static auth-choice option definitions used before provider manifests are loaded.
-import { resolveLegacyAuthChoiceAliasesForCli } from "./auth-choice-legacy.js";
 import type { AuthChoice, AuthChoiceGroupId } from "./onboard-types.js";
 
 export type AuthChoiceOption = {
@@ -35,23 +34,28 @@ export const CORE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
   },
 ];
 
+/**
+ * Provider-agnostic auth choices that `--token-provider` binds to a concrete
+ * provider method. They stay out of `CORE_AUTH_CHOICE_OPTIONS` because the
+ * interactive picker only offers self-contained choices, but every CLI surface
+ * must advertise and accept them even when no manifest contributes the same id.
+ */
+export const GENERIC_PROVIDER_AUTH_CHOICES: ReadonlyArray<AuthChoice> = [
+  "setup-token",
+  "token",
+  "apiKey",
+];
+
 /** Format static auth-choice values for Commander help/validation text. */
-export function formatStaticAuthChoiceChoicesForCli(params?: {
-  includeSkip?: boolean;
-  includeLegacyAliases?: boolean;
-  config?: import("../config/config.js").OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): string {
+export function formatStaticAuthChoiceChoicesForCli(params?: { includeSkip?: boolean }): string {
   const includeSkip = params?.includeSkip ?? true;
-  const includeLegacyAliases = params?.includeLegacyAliases ?? false;
-  const values = CORE_AUTH_CHOICE_OPTIONS.map((opt) => opt.value);
+  const values = [
+    ...CORE_AUTH_CHOICE_OPTIONS.map((opt) => opt.value),
+    ...GENERIC_PROVIDER_AUTH_CHOICES,
+  ];
 
   if (includeSkip) {
     values.push("skip");
-  }
-  if (includeLegacyAliases) {
-    values.push(...resolveLegacyAuthChoiceAliasesForCli(params));
   }
 
   return values.join("|");

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -19,12 +19,6 @@ const resolveManifestProviderAuthChoices = vi.hoisted(() =>
 const resolveProviderWizardOptions = vi.hoisted(() =>
   vi.fn<() => ProviderWizardOption[]>(() => []),
 );
-const resolveLegacyAuthChoiceAliasesForCli = vi.hoisted(() => vi.fn<() => string[]>(() => []));
-
-vi.mock("./auth-choice-legacy.js", () => ({
-  resolveLegacyAuthChoiceAliasesForCli,
-}));
-
 function includesOnboardingScope(
   scopes: readonly ("text-inference" | "image-generation" | "music-generation")[] | undefined,
   scope: "text-inference" | "image-generation" | "music-generation" | "all",
@@ -116,7 +110,6 @@ describe("buildAuthChoiceOptions", () => {
   beforeEach(() => {
     resolveManifestProviderAuthChoices.mockReturnValue([]);
     resolveProviderWizardOptions.mockReturnValue([]);
-    resolveLegacyAuthChoiceAliasesForCli.mockReturnValue([]);
   });
 
   it("includes core and provider-specific auth choices", () => {
@@ -360,7 +353,6 @@ describe("buildAuthChoiceOptions", () => {
     ]);
     const options = getOptions(true);
     const cliChoices = formatAuthChoiceChoicesForCli({
-      includeLegacyAliases: false,
       includeSkip: true,
     }).split("|");
 
@@ -371,18 +363,6 @@ describe("buildAuthChoiceOptions", () => {
     expect(cliChoices).toContain("skip");
     expect(options.map((option) => option.value)).toContain("ollama");
     expect(cliChoices).toContain("ollama");
-  });
-
-  it("can include legacy aliases in cli help choices", () => {
-    resolveLegacyAuthChoiceAliasesForCli.mockReturnValue(["claude-cli", "codex-cli"]);
-
-    const cliChoices = formatAuthChoiceChoicesForCli({
-      includeLegacyAliases: true,
-      includeSkip: true,
-    }).split("|");
-
-    expect(cliChoices).toContain("claude-cli");
-    expect(cliChoices).toContain("codex-cli");
   });
 
   it("keeps static cli help choices off the plugin-backed catalog", () => {
@@ -405,10 +385,7 @@ describe("buildAuthChoiceOptions", () => {
       },
     ]);
 
-    const cliChoices = formatStaticAuthChoiceChoicesForCli({
-      includeLegacyAliases: false,
-      includeSkip: true,
-    }).split("|");
+    const cliChoices = formatStaticAuthChoiceChoicesForCli({ includeSkip: true }).split("|");
 
     expect(cliChoices).not.toContain("ollama");
     expect(cliChoices).not.toContain("openai-api-key");
@@ -785,7 +762,6 @@ describe("buildAuthChoiceOptions", () => {
     const options = getOptions();
     const optionValues = options.map((option) => option.value);
     const cliChoiceValues = formatAuthChoiceChoicesForCli({
-      includeLegacyAliases: false,
       includeSkip: true,
     }).split("|");
 

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -72,10 +72,16 @@ function resolveProviderChoiceOptions(params?: {
   );
 }
 
-/** Format all currently available auth-choice values for CLI help/validation. */
+/**
+ * Format every accepted `--auth-choice` value for CLI help and validation.
+ *
+ * This is the single owner of that set: help text, onboard preflight, and the
+ * non-interactive dispatcher all render it, so an advertised value is always an
+ * accepted one. Deprecated aliases stay out; `auth-choice-legacy.ts` normalizes
+ * them before any surface sees them.
+ */
 export function formatAuthChoiceChoicesForCli(params?: {
   includeSkip?: boolean;
-  includeLegacyAliases?: boolean;
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -79,7 +79,7 @@ describe("applyNonInteractiveAuthChoice", () => {
 
     expect(result).toBeNull();
     expect(runtime.error).toHaveBeenCalledWith(
-      'Unknown --auth-choice "definitely-not-a-provider". Valid choices: custom-api-key, skip, demo-provider-api-key, oauth, setup-token, token, apiKey.',
+      'Unknown --auth-choice "definitely-not-a-provider". Valid choices: custom-api-key, skip, demo-provider-api-key.',
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -36,8 +36,6 @@ type ResolvedNonInteractiveApiKey = NonNullable<
   Awaited<ReturnType<typeof resolveNonInteractiveApiKey>>
 >;
 
-const GENERIC_NON_INTERACTIVE_AUTH_CHOICES = ["oauth", "setup-token", "token", "apiKey"];
-
 /** Applies a local non-interactive auth choice to the pending OpenClaw config. */
 export async function applyNonInteractiveAuthChoice(params: {
   nextConfig: OpenClawConfig;
@@ -176,18 +174,12 @@ export async function applyNonInteractiveAuthChoice(params: {
     return null;
   }
 
-  const validAuthChoices = Array.from(
-    new Set([
-      ...formatAuthChoiceChoicesForCli({
-        includeLegacyAliases: false,
-        includeSkip: true,
-        config: nextConfig,
-        workspaceDir: params.target.workspaceDir,
-        env: process.env,
-      }).split("|"),
-      ...GENERIC_NON_INTERACTIVE_AUTH_CHOICES,
-    ]),
-  );
+  const validAuthChoices = formatAuthChoiceChoicesForCli({
+    includeSkip: true,
+    config: nextConfig,
+    workspaceDir: params.target.workspaceDir,
+    env: process.env,
+  }).split("|");
   if (!validAuthChoices.includes(authChoice) && !authChoice.startsWith("provider-plugin:")) {
     runtime.error(
       `Unknown --auth-choice ${JSON.stringify(authChoice)}. Valid choices: ${validAuthChoices.join(", ")}.`,
@@ -309,16 +301,11 @@ export async function applyNonInteractiveAuthChoice(params: {
   }
 
   if (
-    authChoice === "oauth" ||
     authChoice === "chutes" ||
     authChoice === "minimax-global-oauth" ||
     authChoice === "minimax-cn-oauth"
   ) {
-    runtime.error(
-      authChoice === "oauth"
-        ? 'Auth choice "oauth" is no longer supported directly. Use "--auth-choice setup-token --token-provider anthropic" for Anthropic legacy token auth, or a provider-specific OAuth choice.'
-        : "OAuth requires interactive mode.",
-    );
+    runtime.error("OAuth requires interactive mode.");
     runtime.exit(1);
     return null;
   }

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -32,6 +32,7 @@ import {
   resolveDeprecatedAuthChoiceReplacement,
 } from "./auth-choice-legacy.js";
 import { formatAuthChoiceChoicesForCli } from "./auth-choice-options.js";
+import { GENERIC_PROVIDER_AUTH_CHOICES } from "./auth-choice-options.static.js";
 import { isGatewayDaemonRuntime } from "./daemon-runtime.js";
 import {
   applyCustomApiConfig,
@@ -56,7 +57,6 @@ import {
 } from "./onboard-types.js";
 
 const VALID_RESET_SCOPES = new Set<ResetScope>(["config", "config+creds+sessions", "full"]);
-const BUILT_IN_AUTH_CHOICES = ["setup-token", "token", "apiKey", "custom-api-key", "skip"];
 
 function rejectOption(runtime: RuntimeEnv, message: string): false {
   runtime.error(message);
@@ -253,16 +253,14 @@ async function validateResetAuthChoice(params: {
   if (!authChoice) {
     return true;
   }
-  const availableChoices = new Set([
-    ...BUILT_IN_AUTH_CHOICES,
-    ...formatAuthChoiceChoicesForCli({
-      includeLegacyAliases: true,
+  const availableChoices = new Set(
+    formatAuthChoiceChoicesForCli({
       includeSkip: true,
       config: params.baseConfig,
       workspaceDir: params.workspaceDir,
       env: process.env,
     }).split("|"),
-  ]);
+  );
   if (!availableChoices.has(authChoice)) {
     return rejectOption(
       params.runtime,
@@ -283,8 +281,7 @@ async function validateResetAuthChoice(params: {
       includeUntrustedWorkspacePlugins: false,
     }),
   ];
-  const isGenericProviderChoice =
-    authChoice === "token" || authChoice === "setup-token" || authChoice === "apiKey";
+  const isGenericProviderChoice = GENERIC_PROVIDER_AUTH_CHOICES.includes(authChoice);
   const normalizedTokenProvider = normalizeTokenProviderInput(params.opts.tokenProvider);
   const inferredOptionKey = inferredAuthChoice?.matches[0]?.optionKey;
   const providerAuthChoice = isGenericProviderChoice


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reading `openclaw onboard --help` were pointed at an auth choice the command refuses, and could not discover one that works.

`--help` listed `claude-cli` in the `--auth-choice <choice>` enum with no deprecation marking, but the command rejects it:

```
$ openclaw onboard --non-interactive --accept-risk --auth-choice claude-cli
Auth choice "claude-cli" is deprecated.
Use "--auth-choice anthropic-cli".
```

In the other direction, `--auth-choice token` is accepted and is the value OpenClaw's own error text recommends (`--auth-choice token --token-provider anthropic`), yet `--help` never listed it. So the primary discovery surface advertised a refused value and hid a working one.

## Why This Change Was Made

The accepted set was rebuilt independently in three places, each with a different idea of what counts:

- Commander help asked `formatAuthChoiceChoicesForCli` for `includeLegacyAliases: true`
- the reset preflight in `onboard.ts` added a hardcoded `BUILT_IN_AUTH_CHOICES`
- the non-interactive dispatcher added a hardcoded `GENERIC_NON_INTERACTIVE_AUTH_CHOICES`

`formatAuthChoiceChoicesForCli` is now the single owner of that set. It emits the generic token-provider choices (`setup-token`, `token`, `apiKey`) that `AuthChoice` in `onboard-types.ts` has always declared built-in, and all three surfaces render or validate that one list. Both hardcoded arrays are deleted.

Deprecated aliases stay out of it, and the evidence says they never belonged:

- Before the help-text refactor in `eab9dc538a5`, the hardcoded help string listed `setup-token|token|chutes|…` and **no** legacy alias. `includeLegacyAliases: true` arrived with that mechanical "unify auth-choice catalog" commit, not with a product decision.
- The reset preflight's `includeLegacyAliases: true` was unreachable: `setupWizardCommand` runs `normalizeLegacyOnboardAuthChoice` first, so a legacy alias is already rewritten before that validator sees it.
- The deprecation error is already targeted and names the replacement, so listing the alias in help bought nothing and cost a wrong recommendation.

`oauth` is the same story from the other side. It is normalized to `setup-token` before any validator runs, so the dispatcher's `authChoice === "oauth"` arm and its slot in the accepted list were dead code that only made the error text advertise a value the dispatcher never receives. Both are removed; `--auth-choice oauth` keeps working exactly as before through the normalizer.

Interactive `--auth-choice claude-cli` is unchanged too: it still warns and normalizes. It is simply no longer advertised.

## User Impact

`openclaw onboard --help` now advertises exactly the values the command accepts — 95 on both sides, byte-identical. Operators can discover `--auth-choice token` from help instead of only from an error message, and are no longer sent to `claude-cli`, which fails.

No accepted value changed behavior. Production LOC: **-26**.

## Evidence

**Mechanical diff of the two surfaces**, captured from a real `pnpm build` dist by parsing the help enum and the accepted set out of the `--auth-choice bogus-value` error.

Before (on `main`):

```
help=95  accepted=96
--- in HELP but REJECTED ---
claude-cli
--- ACCEPTED but not in help ---
oauth
token
```

After:

```
help=95  accepted=95
--- in HELP but REJECTED ---
--- ACCEPTED but not in help ---
--- sets identical? ---
IDENTICAL
```

**Live behavior unchanged for every accepted value** (dist build, isolated `OPENCLAW_STATE_DIR`, exit codes real):

| Invocation | Result |
| --- | --- |
| `--auth-choice claude-cli` | exit 1, `Auth choice "claude-cli" is deprecated. Use "--auth-choice anthropic-cli".` |
| `--auth-choice oauth` | reaches Anthropic setup-token flow, asks for `--token` |
| `--auth-choice token` | `Auth choice "token" was not matched to a provider setup flow.` + the recommended combination |
| `--auth-choice token --token-provider anthropic` | reaches Anthropic setup-token flow, asks for `--token` |

**Regression coverage.** New `src/commands/auth-choice-cli-agreement.test.ts` builds the real Commander program, parses the `--auth-choice` enum out of its help text, drives `applyNonInteractiveAuthChoice` with an unknown value to read the accepted set out of its rejection message, and asserts set equality — plus that the generic choices are advertised and the deprecated alias is in neither list. Verified to fail on pre-fix code for the intended reason (all 3 cases fail; the equality case reports `apiKey, oauth, setup-token, token` accepted but unadvertised).

**Validation.**

- `node scripts/run-vitest.mjs onboard auth-choice register.setup provider-auth-choice` — 91 files, 979 tests, all pass
- `node scripts/check-changed.mjs` — exit 0 (typecheck core + core tests, lint, dead-export scan, import cycles, all guards)
- `$autoreview` (codex / gpt-5.6-sol / xhigh) — clean, no accepted or actionable findings

No docs change needed: no page enumerates the `--auth-choice` enum, and `docs/cli/onboard.md:348` already documented `--auth-choice token`, which help now finally matches.

---

### Unrelated CI note

The first CI run showed one red job, `checks-node-compact-large-3`, failing `src/entry.run-main.test.ts > keeps expected conditions at exit 1 without crash framing`. That is pre-existing red `main`, not this change: `main` at this PR's exact merge base `76bb7ff2b667dd71f06c6a5c12ea851807b2acee` fails the identical test in the identical shard (run [32449777576](https://github.com/openclaw/openclaw/actions/runs/32449777576)), while neighbouring `main` SHAs pass. It went green on rerun ([attempt 2](https://github.com/openclaw/openclaw/actions/runs/32449986313), 180 pass / 0 fail).

It is a shared-state flake in the logging console layer, unrelated to onboarding. The assertion sees `[]` only when `loggingState.forceConsoleToStderr` is `true` and `loggingState.consolePatched` is `false` as `runMainOrRootHelp`'s error path runs: the cleared guard lets `enableConsoleCapture()` (`src/entry.ts:315`) re-patch the console over the test's spy, and `src/logging/console.ts:209` then writes straight to `process.stderr` instead of the wrapped sink. Both fields live on the process-global `loggingState` singleton, which is shared across files inside a non-isolated worker (verified locally: file A sets `consoleTimestampPrefix`, file B observes it). `src/entry.run-main.test.ts` has no logging-state lifecycle, so it both depends on those defaults and leaks its own console patch onward.

I did not fold a fix into this PR because I could not reproduce it locally on macOS — the full 146-file shard passes in parallel, a 26-file serial slice passes, and injecting the leaked flags from a preceding file does not trigger it. Patching a test I cannot make fail first would mask rather than fix. Flagged as a follow-up for the logging/test-infra owner; the fix is likely to give that file the `captureConsoleSnapshot`/`restoreConsoleSnapshot` lifecycle already used by `src/logging/console-capture.test.ts`.
