### PR TITLE
fix(agents): record when a memory flush has no write tool

### DIFF
--- a/src/agents/agent-tools.memory-flush-writer.test.ts
+++ b/src/agents/agent-tools.memory-flush-writer.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The memory flush warning must reflect the final authorized tool list.
+ * tools.deny and the rest of the policy pipeline run after the flush surface is
+ * assembled, so a run can hold `write` there and still lose it before dispatch.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const warnings = vi.hoisted(() => [] as string[]);
+
+vi.mock("../logger.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logger.js")>();
+  return {
+    ...actual,
+    logWarn: (message: unknown, ...rest: unknown[]) => {
+      warnings.push(String(message));
+      return actual.logWarn(message as never, ...(rest as never[]));
+    },
+  };
+});
+
+import "./test-helpers/fast-bash-tools.js";
+import "./test-helpers/fast-coding-tools.js";
+import "./test-helpers/fast-openclaw-tools.js";
+import { createOpenClawCodingTools } from "./agent-tools.js";
+
+const MEMORY_PATH = "memory/2026-08-22.md";
+
+describe("memory flush writer availability", () => {
+  afterEach(() => {
+    warnings.length = 0;
+  });
+
+  it("warns when tools.deny removes write after the flush surface is built", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-flush-deny-"));
+    try {
+      const tools = createOpenClawCodingTools({
+        workspaceDir,
+        config: { tools: { deny: ["write"] } },
+        trigger: "memory",
+        memoryFlushWritePath: MEMORY_PATH,
+        senderIsOwner: true,
+      });
+
+      expect(tools.some((tool) => tool.name === "write")).toBe(false);
+      expect(
+        warnings.some((line) => line.includes(`memory flush cannot persist ${MEMORY_PATH}`)),
+      ).toBe(true);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("stays quiet when the flush run keeps its writer", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-flush-ok-"));
+    try {
+      const tools = createOpenClawCodingTools({
+        workspaceDir,
+        trigger: "memory",
+        memoryFlushWritePath: MEMORY_PATH,
+        senderIsOwner: true,
+      });
+
+      expect(tools.some((tool) => tool.name === "write")).toBe(true);
+      expect(warnings.some((line) => line.includes("memory flush cannot persist"))).toBe(false);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/agent-tools.memory-flush-writer.test.ts
+++ b/src/agents/agent-tools.memory-flush-writer.test.ts
@@ -53,6 +53,29 @@ describe("memory flush writer availability", () => {
     }
   });
 
+  it("warns when the message-provider allowlist is what drops write", async () => {
+    // TOOL_ALLOW_BY_MESSAGE_PROVIDER.node omits write, so this path loses the writer
+    // without tools.deny being involved. The warning must not blame a config key here.
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-flush-node-"));
+    try {
+      const tools = createOpenClawCodingTools({
+        workspaceDir,
+        trigger: "memory",
+        memoryFlushWritePath: MEMORY_PATH,
+        messageProvider: "node",
+        senderIsOwner: true,
+      });
+
+      expect(tools.some((tool) => tool.name === "write")).toBe(false);
+      const warned = warnings.find((line) => line.includes("memory flush cannot persist"));
+      expect(warned).toBeDefined();
+      expect(warned).not.toContain("tools.deny");
+      expect(warned).not.toContain("tools.allow");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("stays quiet when the flush run keeps its writer", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-flush-ok-"));
     try {

--- a/src/agents/agent-tools.memory-flush-writer.test.ts
+++ b/src/agents/agent-tools.memory-flush-writer.test.ts
@@ -53,9 +53,10 @@ describe("memory flush writer availability", () => {
     }
   });
 
-  it("warns when the message-provider allowlist is what drops write", async () => {
-    // TOOL_ALLOW_BY_MESSAGE_PROVIDER.node omits write, so this path loses the writer
-    // without tools.deny being involved. The warning must not blame a config key here.
+  it("stays quiet when the transport was never meant to carry write", async () => {
+    // TOOL_ALLOW_BY_MESSAGE_PROVIDER.node lists only canvas, pdf, tts, view_image,
+    // web_fetch and web_search, so every node-originated flush loses the writer by
+    // design. Warning here would fire on an intended configuration on every flush.
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-flush-node-"));
     try {
       const tools = createOpenClawCodingTools({
@@ -67,10 +68,7 @@ describe("memory flush writer availability", () => {
       });
 
       expect(tools.some((tool) => tool.name === "write")).toBe(false);
-      const warned = warnings.find((line) => line.includes("memory flush cannot persist"));
-      expect(warned).toBeDefined();
-      expect(warned).not.toContain("tools.deny");
-      expect(warned).not.toContain("tools.allow");
+      expect(warnings.some((line) => line.includes("memory flush cannot persist"))).toBe(false);
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }

--- a/src/agents/agent-tools.message-provider-policy.ts
+++ b/src/agents/agent-tools.message-provider-policy.ts
@@ -14,6 +14,23 @@ const TOOL_ALLOW_BY_MESSAGE_PROVIDER: Readonly<Record<string, readonly string[]>
   node: ["canvas", "pdf", "tts", "view_image", "web_fetch", "web_search"],
 };
 
+/**
+ * True when a provider's allowlist removes the tool by design rather than by an
+ * operator's policy. Callers that diagnose a missing tool use this to stay quiet about
+ * transports that were never meant to carry it.
+ */
+export function messageProviderExcludesTool(
+  messageProvider: string | undefined,
+  toolName: string,
+): boolean {
+  const normalizedProvider = normalizeOptionalLowercaseString(messageProvider);
+  if (!normalizedProvider) {
+    return false;
+  }
+  const allowedTools = TOOL_ALLOW_BY_MESSAGE_PROVIDER[normalizedProvider];
+  return allowedTools !== undefined && allowedTools.length > 0 && !allowedTools.includes(toolName);
+}
+
 /** Applies message-provider filtering while preserving duplicate tool entries. */
 export function filterToolsByMessageProvider<TTool extends { name: string }>(
   tools: readonly TTool[],

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -41,7 +41,10 @@ import {
 } from "./agent-tool-metadata.js";
 import type { ToolOutcomeObserver } from "./agent-tools.before-tool-call.js";
 import { finalizeAgentTools } from "./agent-tools.finalize.js";
-import { filterToolsByMessageProvider } from "./agent-tools.message-provider-policy.js";
+import {
+  filterToolsByMessageProvider,
+  messageProviderExcludesTool,
+} from "./agent-tools.message-provider-policy.js";
 import {
   type SkillInstructionDeliveryCache,
   wrapToolMemoryFlushAppendOnlyWrite,
@@ -1080,11 +1083,17 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   if (
     isMemoryFlushRun &&
     memoryFlushWritePath &&
-    !authorizedTools.some((tool) => tool.name === "write")
+    !authorizedTools.some((tool) => tool.name === "write") &&
+    // A transport whose allowlist never carries `write`, such as node, is an intended
+    // configuration, not a lost writer, so it stays quiet instead of warning per flush.
+    !messageProviderExcludesTool(
+      options?.toolPolicyMessageProvider ?? options?.messageProvider,
+      "write",
+    )
   ) {
     // Checked on the final authorized list, not the earlier flush surface: tools.deny,
-    // the message-provider allowlist and the rest of the policy pipeline all run after
-    // that surface is built, so a flush can hold `write` there and lose it here.
+    // the model-provider policy and the rest of the pipeline all run after that surface
+    // is built, so a flush can hold `write` there and lose it here.
     // Otherwise the run completes normally, the model reports the save as done, and the
     // memory is lost with no record that it was never persisted. The text names no
     // single config key because any of those filters can be the one that removed it.

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -1000,15 +1000,6 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       }
       toolsForMemoryFlush.push(tool);
     }
-    if (!toolsForMemoryFlush.some((tool) => tool.name === "write")) {
-      // The flush run reaches here with nothing that can write, which happens when
-      // policy already removed `write` upstream. Without this the run completes
-      // normally and the model reports the save as done, so the memory is lost with
-      // no record anywhere that it was never persisted.
-      logWarn(
-        `memory flush cannot persist ${memoryFlushWritePath}: the write tool is unavailable for this agent, so this run will not save anything. Check tools.deny and tools.allow.`,
-      );
-    }
   }
   const unavailableCoreToolReason =
     isMemoryFlushRun && memoryFlushWritePath
@@ -1086,6 +1077,20 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   replaceWithEffectiveCronCreatorToolAllowlist(cronCreatorToolAllowlist, authorizedTools, (tool) =>
     getPluginToolMeta(tool),
   );
+  if (
+    isMemoryFlushRun &&
+    memoryFlushWritePath &&
+    !authorizedTools.some((tool) => tool.name === "write")
+  ) {
+    // Checked on the final authorized list, not the earlier flush surface: tools.deny
+    // and the rest of the policy pipeline run after that surface is built, so a flush
+    // can hold `write` there and lose it here. Otherwise the run completes normally,
+    // the model reports the save as done, and the memory is lost with no record that
+    // it was never persisted.
+    logWarn(
+      `memory flush cannot persist ${memoryFlushWritePath}: the write tool is unavailable for this agent, so this run will not save anything. Check tools.deny and tools.allow.`,
+    );
+  }
   options?.recordToolPrepStage?.("authorization-policy");
   const turnSourceChannel = options?.messageChannel ?? options?.messageProvider;
   const turnSourceTo = options?.currentMessagingTarget ?? options?.currentChannelId;

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -1082,13 +1082,14 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     memoryFlushWritePath &&
     !authorizedTools.some((tool) => tool.name === "write")
   ) {
-    // Checked on the final authorized list, not the earlier flush surface: tools.deny
-    // and the rest of the policy pipeline run after that surface is built, so a flush
-    // can hold `write` there and lose it here. Otherwise the run completes normally,
-    // the model reports the save as done, and the memory is lost with no record that
-    // it was never persisted.
+    // Checked on the final authorized list, not the earlier flush surface: tools.deny,
+    // the message-provider allowlist and the rest of the policy pipeline all run after
+    // that surface is built, so a flush can hold `write` there and lose it here.
+    // Otherwise the run completes normally, the model reports the save as done, and the
+    // memory is lost with no record that it was never persisted. The text names no
+    // single config key because any of those filters can be the one that removed it.
     logWarn(
-      `memory flush cannot persist ${memoryFlushWritePath}: the write tool is unavailable for this agent, so this run will not save anything. Check tools.deny and tools.allow.`,
+      `memory flush cannot persist ${memoryFlushWritePath}: no write tool survived this agent's tool policy, so this run will not save anything.`,
     );
   }
   options?.recordToolPrepStage?.("authorization-policy");

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -1000,6 +1000,15 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       }
       toolsForMemoryFlush.push(tool);
     }
+    if (!toolsForMemoryFlush.some((tool) => tool.name === "write")) {
+      // The flush run reaches here with nothing that can write, which happens when
+      // policy already removed `write` upstream. Without this the run completes
+      // normally and the model reports the save as done, so the memory is lost with
+      // no record anywhere that it was never persisted.
+      logWarn(
+        `memory flush cannot persist ${memoryFlushWritePath}: the write tool is unavailable for this agent, so this run will not save anything. Check tools.deny and tools.allow.`,
+      );
+    }
   }
   const unavailableCoreToolReason =
     isMemoryFlushRun && memoryFlushWritePath


### PR DESCRIPTION
## What Problem This Solves

Partially addresses #126906.

A memory-triggered flush run rebuilds its tool list from the already policy-filtered set, keeping only `read` and a `write` that gets wrapped into the append-only memory writer:

`src/agents/agent-tools.ts:139` and `:984`

```ts
const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
...
for (const tool of tools) {
  if (!MEMORY_FLUSH_ALLOWED_TOOL_NAMES.has(tool.name)) continue;
  if (tool.name === "write") {
    toolsForMemoryFlush.push(wrapToolMemoryFlushAppendOnlyWrite(tool, { ... }));
```

`write` is not used generically there. It is the specific tool that becomes the memory writer. When a policy removes `write`, the loop never finds it, the flush surface ends up with no writer, and the run proceeds anyway. No branch notices.

The model is not told either, because a removed tool is absent from the schema it sees, so it answers as though the save happened. The reporter's transcript shows the agent confirming a save that wrote nothing, and the daily session reset then discards the conversation. The loss is silent and permanent.

## Why This Change Was Made

This records the non-outcome at the one place that knows about it. Two things about *where* matter, and both came out of review.

**The check reads the final authorized list, not the flush surface.** `toolsForMemoryFlush` is built at `:983`, but `tools.deny`, the message-provider allowlist, the model-provider policy and the rest of the pipeline all run after that, and `authorizedTools` is not finalized until `:1058`. Checking early would have missed every removal that happens in between. The guard sits at `:1084`, on the list the run actually dispatches with.

**It stays quiet when the transport was never meant to carry a writer.** `TOOL_ALLOW_BY_MESSAGE_PROVIDER.node` is

```ts
node: ["canvas", "pdf", "tts", "view_image", "web_fetch", "web_search"],
```

so a node-originated flush loses `write` by design, on every flush, on a healthy install. Warning there would be noise on an intended configuration, which is worse than not warning at all. The exemption is read from that existing table rather than hardcoding a channel name:

```ts
export function messageProviderExcludesTool(
  messageProvider: string | undefined,
  toolName: string,
): boolean {
  const normalizedProvider = normalizeOptionalLowercaseString(messageProvider);
  if (!normalizedProvider) {
    return false;
  }
  const allowedTools = TOOL_ALLOW_BY_MESSAGE_PROVIDER[normalizedProvider];
  return allowedTools !== undefined && allowedTools.length > 0 && !allowedTools.includes(toolName);
}
```

What is left is exactly the reported case: a writer removed by operator policy, where the flush silently persists nothing.

The message names no single config key, because by the time the guard runs any one of several filters could have been the cause, and naming one would send an operator to the wrong place.

This is deliberately the smallest of the three options in the issue and does not close it:

- It does **not** add the `doctor` check (option 1), which catches the config ahead of time but not the silent no-op, and needs a decision about which agent scopes to inspect.
- It does **not** tell the model (option 3). That is the one that generalises, but injecting a note about removed capabilities is model-visible prompt text on a shared path, which is a product call.
- It does **not** change flush completion semantics. Review's recommendation is to persist a skipped or degraded outcome through the established user-notice path, which I am willing to build; it changes what a flush reports to the operator, so it belongs to the linked issue rather than to a bounded diagnostic.

## User Impact

An operator whose policy removes `write` now gets a log line saying memory cannot be persisted for that run, naming the target path, instead of an ordinary policy-removal line that reads like intended configuration. Node-originated flushes are unchanged and silent. No behavior change otherwise: the run still proceeds exactly as before, and nothing new is surfaced to the model or to users.

## Evidence

Production change is +42/-1 across two files.

Both branches of the guard fail on unfixed code for the right reason.

Removing the guard entirely:

```
× warns when tools.deny removes write after the flush surface is built
  expected false to be true
```

Removing only the transport exemption:

```
× stays quiet when the transport was never meant to carry write
  AssertionError: expected true to be false
  Tests  1 failed | 2 passed (3)
```

The three tests drive the real `createOpenClawCodingTools` through a temporary workspace: `tools.deny` removing the writer warns, a node-originated run stays quiet, and a healthy flush stays quiet.

At the rebased head `aaff0ba`:

```
node scripts/run-vitest.mjs <memory-flush + tool-policy-pipeline + create-openclaw-coding-tools>  183 passed
node scripts/run-tsgo.mjs -p tsconfig.core.json                                                   clean
node scripts/run-oxlint.mjs <all three touched files>                                             clean
./node_modules/.bin/oxfmt --check <all three touched files>                                       clean
```

Fourteen failures in `src/agents/worktrees/*` reproduce identically on a clean detached `upstream/main` with an empty working tree, so they are not from this branch.

Proof gap worth stating: not reproduced end to end against a live agent with `write` denied. The tests exercise the real tool-assembly owner and show the warning appearing and not appearing at the boundary this change owns; the reporter supplied the runtime transcript for the symptom itself.

AI-assisted: yes. I traced the source path by hand and ran every command above myself.

## Maintainer Validation

Validated `aaff0ba6de883f95c9ee56cd1782d5cd0b56061a` in isolated, unhydrated AWS:

- 15 focused writer, append-only and forwarding tests passed.
- The real tool factory failed the two missing-warning assertions on the original production owner; all six head cases passed. Authorized toolsets were identical across base and head. Healthy/non-memory/intentional transport exclusions stayed quiet, and effective provider precedence was covered in both directions.
- 28 selected checks passed, including core/core-test types and scoped lint. Final pinned-base review found no actionable scoped findings.
- The original hosted cold-facade timeout was investigated, not waived. The unchanged exact-head test passed in isolation, and the single hosted retry passed without timeout or test changes: https://github.com/openclaw/openclaw/actions/runs/34269270093/job/102413870293. The required CI gate subsequently passed: https://github.com/openclaw/openclaw/actions/runs/34269270093/job/102417264180.

Limits: the factory fixture uses existing tool stubs; append-only tests are separate, not a full live memory session. The full local changed-gate aggregate is not claimed green: a dated compatibility-registry entry fails on both the base and head and was independently removed on main by `c7cb45dfd5dbcf2098d7dd10efd4a64054a2662d` in three nonoverlapping files. No unrelated fix was copied and no gate was weakened.

This remains a diagnostic-only partial mitigation for https://github.com/openclaw/openclaw/issues/126906. It does not restore denied tools, change prompts or completion semantics, or close that issue.
