### PR TITLE
fix(macos): unblock remote onboarding after local Gateway failure

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -52,11 +52,16 @@ extension OnboardingView {
     }
 
     func startExistingCLIActivationIfNeeded() {
-        guard Self.shouldStartExistingCLIActivation(
-            isLocal: state.connectionMode == .local,
+        guard let setupMode = Self.existingCLISetupMode(
+            connectionMode: state.connectionMode,
             executableReady: cliExecutableReady,
             installing: installingCLI)
         else { return }
+        if setupMode == .remote {
+            cliInstalled = true
+            cliStatus = nil
+            return
+        }
         // Keep the CLI setup gate in the page order until its Gateway is reachable.
         cliInstalled = false
         installingCLI = true
@@ -67,12 +72,13 @@ extension OnboardingView {
         Task { @MainActor in await self.finishExistingCLIActivation() }
     }
 
-    static func shouldStartExistingCLIActivation(
-        isLocal: Bool,
+    static func existingCLISetupMode(
+        connectionMode: AppState.ConnectionMode,
         executableReady: Bool,
-        installing: Bool) -> Bool
+        installing: Bool) -> AppState.ConnectionMode?
     {
-        isLocal && executableReady && !installing
+        guard connectionMode != .unconfigured, executableReady, !installing else { return nil }
+        return connectionMode
     }
 
     static func shouldReviseCLIActivationFailure(

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -213,19 +213,28 @@ struct OnboardingViewSmokeTests {
             installing: false))
     }
 
-    @Test func `detected CLI starts its gateway after this Mac is selected`() {
-        #expect(!OnboardingView.shouldStartExistingCLIActivation(
-            isLocal: false,
+    @Test func `detected CLI follows the selected onboarding connection mode`() {
+        #expect(OnboardingView.existingCLISetupMode(
+            connectionMode: .remote,
             executableReady: true,
-            installing: false))
-        #expect(OnboardingView.shouldStartExistingCLIActivation(
-            isLocal: true,
+            installing: false) == .remote)
+        #expect(OnboardingView.existingCLISetupMode(
+            connectionMode: .local,
             executableReady: true,
-            installing: false))
-        #expect(!OnboardingView.shouldStartExistingCLIActivation(
-            isLocal: true,
+            installing: false) == .local)
+        #expect(OnboardingView.existingCLISetupMode(
+            connectionMode: .unconfigured,
             executableReady: true,
-            installing: true))
+            installing: false) == nil)
+        #expect(OnboardingView.existingCLISetupMode(
+            connectionMode: .local,
+            executableReady: true,
+            installing: true) == nil)
+        #expect(OnboardingView.existingCLISetupMode(
+            connectionMode: .remote,
+            executableReady: false,
+            installing: false) == nil)
+        #expect(!OnboardingView.shouldActivateLocalGateway(afterCLIInstallFor: .remote))
     }
 
     @Test func `later gateway readiness revises a pinned CLI activation failure`() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mac app users who switch to a remote Gateway after a local Gateway startup fails remain stuck on the CLI setup page even though the required CLI is already installed. The stale local Gateway failure remains visible and retrying cannot advance remote onboarding.

## Why This Change Was Made

Resolve an existing CLI at the onboarding lifecycle owner according to the currently selected connection mode. Remote mode immediately marks the CLI ready and clears the stale local failure; local mode retains its existing Gateway activation flow, while unconfigured mode, missing executables, and in-flight installation remain blocked.

## User Impact

Users can recover from a failed local Gateway by selecting a remote Gateway without reinstalling the CLI or starting an unrelated local Gateway.

## Evidence

- Pre-fix macOS regression failed because remote existing-CLI resolution returned no setup action instead of the selected remote mode; the other 26 onboarding tests passed.
- Post-fix owner, CLI installer, updater, and profile-isolation suites: **83 tests across 4 suites passed**.
- SwiftFormat and SwiftLint passed for the changed files.
- Independent Codex review and secret scan passed with no actionable findings.
- A real visual wizard replay is infeasible without disrupting the operator: background-only launches never instantiate the onboarding view, while interactive onboarding forcibly activates its window and takes desktop focus; this lifecycle has no non-GUI control or diagnostic endpoint. The failing-to-passing production-owner regression covers the actual local/remote decision and confirms remote mode never activates a local Gateway.
- Production: +12/-6 (net +6), required to explicitly complete existing-CLI remote setup at its existing lifecycle owner; tests: +19/-10.
