### PR TITLE
fix(browser): keep Playwright out of Windows CLI registration

### DIFF
--- a/extensions/browser/plugin-registration.node-host-laziness.test.ts
+++ b/extensions/browser/plugin-registration.node-host-laziness.test.ts
@@ -8,11 +8,24 @@ vi.mock("./register.runtime.js", () => {
   throw new Error("node-host availability must not load the broad browser runtime");
 });
 
+vi.mock("./src/browser/act-policy.js", () => {
+  throw new Error("plugin entry must not load browser action policy");
+});
+
+vi.mock("./src/browser/cdp.helpers.js", () => {
+  throw new Error("plugin entry must not load CDP runtime helpers");
+});
+
+vi.mock("./src/browser/playwright-core.runtime.js", () => {
+  throw new Error("plugin entry must not load Playwright runtime");
+});
+
 vi.mock("./src/browser-proxy-upload-cleanup.runtime.js", () => ({
   ensureBrowserProxyUploadCleanup: cleanupMocks.ensureBrowserProxyUploadCleanup,
 }));
 
-const { browserPluginNodeHostCommands } = await import("./plugin-registration.js");
+const { default: browserPlugin } = await import("./index.js");
+const browserPluginNodeHostCommands = browserPlugin.nodeHostCommands ?? [];
 
 it("starts node-host upload cleanup without loading the broad browser runtime", async () => {
   const uploadCommand = browserPluginNodeHostCommands.find(

--- a/extensions/browser/src/browser-tool.schema.test.ts
+++ b/extensions/browser/src/browser-tool.schema.test.ts
@@ -2,7 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { createBrowserToolSchema, resolveBrowserToolCapabilities } from "./browser-tool.schema.js";
-import { ACT_MAX_VIEWPORT_DIMENSION } from "./browser/act-policy.js";
+import { ACT_MAX_VIEWPORT_DIMENSION } from "./browser/constants.js";
 
 type SchemaRecord = Record<string, { maximum?: number; properties?: SchemaRecord }>;
 type SchemaProperty = {

--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -13,7 +13,7 @@ import {
 } from "openclaw/plugin-sdk/channel-actions";
 import { Type } from "typebox";
 import { BROWSER_TAB_BOUND_ACTIONS } from "./browser-tool-binding.js";
-import { ACT_MAX_VIEWPORT_DIMENSION } from "./browser/act-policy.js";
+import { ACT_MAX_VIEWPORT_DIMENSION } from "./browser/constants.js";
 import type { BrowserProfileCapabilities } from "./browser/profile-capabilities.js";
 
 const BROWSER_ACT_KINDS = [

--- a/extensions/browser/src/browser/act-policy.ts
+++ b/extensions/browser/src/browser/act-policy.ts
@@ -23,8 +23,6 @@ export const ACT_MAX_BATCH_DEPTH = 5;
 export const ACT_MAX_CLICK_DELAY_MS = 5_000;
 /** Maximum explicit wait duration accepted from model/tool input. */
 export const ACT_MAX_WAIT_TIME_MS = 30_000;
-/** Maximum viewport side length accepted by resize actions. */
-export const ACT_MAX_VIEWPORT_DIMENSION = 8192;
 
 const ACT_MIN_TIMEOUT_MS = 500;
 const ACT_MAX_INTERACTION_TIMEOUT_MS = 60_000;

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -6,6 +6,7 @@
  */
 import os from "node:os";
 import path from "node:path";
+import { parseBrowserHttpUrl, redactCdpUrl } from "openclaw/plugin-sdk/browser-config";
 import { mergeSsrFPolicies } from "openclaw/plugin-sdk/ssrf-policy";
 import {
   normalizeOptionalString,
@@ -18,10 +19,10 @@ import {
   deriveDefaultBrowserCdpPortRange,
   deriveDefaultBrowserControlPort,
 } from "../config/port-defaults.js";
+import { isLoopbackHost } from "../gateway/net.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { parseBooleanValue } from "../sdk-config.js";
 import { resolveUserPath } from "../utils.js";
-import { parseBrowserHttpUrl, redactCdpUrl, isLoopbackHost } from "./cdp.helpers.js";
 import {
   DEFAULT_AI_SNAPSHOT_MAX_CHARS,
   DEFAULT_BROWSER_ACTION_TIMEOUT_MS,

--- a/extensions/browser/src/browser/constants.ts
+++ b/extensions/browser/src/browser/constants.ts
@@ -26,6 +26,8 @@ export const DEFAULT_BROWSER_LOCAL_CDP_READY_TIMEOUT_MS = 8_000;
 export const DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS = 20_000;
 /** Default timeout for snapshot capture. */
 export const DEFAULT_BROWSER_SNAPSHOT_TIMEOUT_MS = 20_000;
+/** Maximum viewport side length accepted by browser actions. */
+export const ACT_MAX_VIEWPORT_DIMENSION = 8192;
 /** Default idle age before session tab cleanup can close tabs. */
 export const DEFAULT_BROWSER_TAB_CLEANUP_IDLE_MINUTES = 120;
 /** Default maximum tracked tabs kept per session. */

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -10,8 +10,9 @@ import {
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { Frame, Page } from "playwright-core";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
-import { ACT_MAX_VIEWPORT_DIMENSION, resolveBrowserNavigationTimeoutMs } from "./act-policy.js";
+import { resolveBrowserNavigationTimeoutMs } from "./act-policy.js";
 import { type AriaSnapshotNode, formatAriaSnapshot, type RawAXNode } from "./cdp.js";
+import { ACT_MAX_VIEWPORT_DIMENSION } from "./constants.js";
 import type { BrowserDownloadResult } from "./download-types.js";
 import {
   assertBrowserNavigationAllowed,

--- a/extensions/browser/src/browser/routes/agent.act.normalize.ts
+++ b/extensions/browser/src/browser/routes/agent.act.normalize.ts
@@ -8,11 +8,11 @@ import {
   ACT_MAX_BATCH_ACTIONS,
   ACT_MAX_BATCH_DEPTH,
   ACT_MAX_CLICK_DELAY_MS,
-  ACT_MAX_VIEWPORT_DIMENSION,
   ACT_MAX_WAIT_TIME_MS,
   normalizeActBoundedNonNegativeMs,
 } from "../act-policy.js";
 import type { BrowserActRequest, BrowserFormField } from "../client-actions.types.js";
+import { ACT_MAX_VIEWPORT_DIMENSION } from "../constants.js";
 import { normalizeBrowserFormField } from "../form-fields.js";
 import { resolveTargetIdFromTabs } from "../target-id.js";
 import {

--- a/extensions/browser/src/cli/browser-cli-resize.ts
+++ b/extensions/browser/src/cli/browser-cli-resize.ts
@@ -1,7 +1,7 @@
 /**
  * Shared Browser CLI resize runner used by resize and set viewport commands.
  */
-import { ACT_MAX_VIEWPORT_DIMENSION } from "../browser/act-policy.js";
+import { ACT_MAX_VIEWPORT_DIMENSION } from "../browser/constants.js";
 import {
   callBrowserResize,
   parseBrowserPositiveIntegerValue,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows users running built Browser CLI commands could load Playwright during plugin registration, causing even `openclaw browser --help` to fail when startup metadata was unavailable or its fast path was bypassed.

## Why This Change Was Made

Browser registration now imports viewport policy and URL/config helpers from dependency-light owners instead of the action and CDP runtime modules. A full Browser entry-point regression test fails if registration loads action policy, CDP helpers, Playwright runtime, or the deferred registration runtime.

This intentionally does not change plugin loading, Jiti, SDK exports, package metadata, configuration behavior, docs, or CI workflows.

## User Impact

Built Browser CLI help and plugin registration no longer require Playwright runtime initialization. Actual browser actions continue to load the runtime on demand.

## Evidence

Exact head: `b1b2608f8ca9a56d573487c7eae8ecbdfa3aa8cc`

Exact base: `46d09d1a2809b1d266f4000cfdfb0817795c22ae`

- Focused Browser tests: 4 files passed, 88 tests passed, 1 skipped.
- `node scripts/check-changed.mjs -- extensions/browser`: passed, including extension typecheck, test typecheck, lint, import-cycle, format, and boundary checks.
- `git diff --check`: passed.
- Production delta: net +2 lines. Test delta: net +13 lines.
- The pre-fix baseline reproduced the registration dependency leak when the full Browser entry point reached `act-policy`.

Native Windows exact-head proof is still pending and is not claimed here. The disposable Azure hydration attempt was blocked before checkout/build when an OpenSSH post-quantum warning on stderr contaminated Crabbox's workspace-owner protocol response. Both task-owned replacement leases were released, the redacted failure log was preserved outside Git, and the parser owner is being audited separately. This PR remains draft until the reviewed Windows build/help/registration/runtime-action proof is completed on this exact head.

AI-assisted: yes. I reviewed the implementation and validation results.
