### PR TITLE
fix(agents): clean exec approvals on offline delete, and stop deleting main from taking the wildcard with it

### DIFF
--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -42,6 +42,7 @@ import {
   isGatewayCredentialsRequiredError,
   isGatewayTransportError,
 } from "../gateway/call.js";
+import { withAgentExecApprovalsRemoved } from "../infra/exec-approvals.js";
 import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
@@ -276,19 +277,21 @@ export async function agentsDeleteCommand(
     existingJournal ?? { agentId, agentDir, workspaceDir, sessionsDir, deleteFiles },
   );
   try {
-    if (configured) {
-      await replaceConfigFile({
-        nextConfig: result.config,
-        ...(baseHash !== undefined ? { baseHash } : {}),
-        writeOptions: {
-          allowedAgentRosterRemovals: [agentId],
-          ...(opts.json ? { skipOutputLogs: true } : {}),
-        },
-      });
-      if (!opts.json) {
-        logConfigUpdated(runtime);
+    await withAgentExecApprovalsRemoved(agentId, async () => {
+      if (configured) {
+        await replaceConfigFile({
+          nextConfig: result.config,
+          ...(baseHash !== undefined ? { baseHash } : {}),
+          writeOptions: {
+            allowedAgentRosterRemovals: [agentId],
+            ...(opts.json ? { skipOutputLogs: true } : {}),
+          },
+        });
+        if (!opts.json) {
+          logConfigUpdated(runtime);
+        }
       }
-    }
+    });
     deletion.commit();
   } catch (error) {
     if (!existingJournal) {

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -19,7 +19,7 @@ import { pinSurvivorWorkspaceForRosterCollapse } from "../config/agent-workspace
 import { listRouteBindings } from "../config/bindings.js";
 import type { IdentityConfig } from "../config/types.base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 
 export type AgentSummary = {
   id: string;
@@ -207,6 +207,10 @@ export function pruneAgentConfig(
 } {
   const id = normalizeAgentId(agentId);
   const clearedOwnerRefs: string[] = [];
+  const targetsDeletedAgent = (candidate: string) => {
+    const normalized = normalizeAgentIdStrict(candidate);
+    return normalized.ok && normalized.value === id;
+  };
   const clearOwnerRef = <T extends { agentId?: string }>(value: T | undefined, path: string) => {
     const owner = normalizeOptionalString(value?.agentId);
     if (!value || !owner || normalizeAgentId(owner) !== id) {
@@ -220,7 +224,7 @@ export function pruneAgentConfig(
   const pruneAllowAgents = (allowAgents: string[] | undefined) =>
     allowAgents?.filter((entry) => {
       const trimmed = entry.trim();
-      return !trimmed || trimmed === "*" || normalizeAgentId(trimmed) !== id;
+      return !trimmed || !targetsDeletedAgent(trimmed);
     });
   const nextAgentsList = [];
   for (const entry of agents) {
@@ -277,6 +281,23 @@ export function pruneAgentConfig(
       }
     : undefined;
   const nextTalk = clearOwnerRef(cfg.talk, "talk.agentId");
+  const nextBroadcast = cfg.broadcast
+    ? Object.fromEntries(
+        Object.entries(cfg.broadcast).map(([peerId, value]) => [
+          peerId,
+          Array.isArray(value) ? value.filter((entry) => !targetsDeletedAgent(entry)) : value,
+        ]),
+      )
+    : undefined;
+  const nextHooks = cfg.hooks
+    ? {
+        ...cfg.hooks,
+        allowedAgentIds: cfg.hooks.allowedAgentIds?.filter((entry) => !targetsDeletedAgent(entry)),
+        mappings: cfg.hooks.mappings?.filter(
+          (mapping) => !mapping.agentId || !targetsDeletedAgent(mapping.agentId),
+        ),
+      }
+    : undefined;
   const { list: _legacyList, ownership: _ownership, ...agentsConfig } = cfg.agents ?? {};
   const nextAgentsConfig = cfg.agents
     ? {
@@ -305,6 +326,8 @@ export function pruneAgentConfig(
     ...cfg,
     agents: nextAgentsConfig,
     bindings: filteredBindings.length > 0 ? filteredBindings : undefined,
+    broadcast: nextBroadcast,
+    hooks: nextHooks,
     talk: nextTalk,
     tools: nextTools,
   };

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { GatewayTransportError } from "../gateway/transport-error.js";
+import { readExecApprovalsSnapshot, saveExecApprovals } from "../infra/exec-approvals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { readAgentProvenance, recordAgentProvenance } from "../state/agent-provenance.js";
@@ -319,6 +320,14 @@ describe("agents delete command", () => {
           "agent:main:main": { sessionId: "sess-main", updatedAt: Date.now() },
         },
       });
+      saveExecApprovals({
+        version: 1,
+        agents: {
+          "*": { security: "deny" },
+          main: { security: "allowlist", allowlist: [{ pattern: "/usr/bin/old" }] },
+          ops: { security: "allowlist", allowlist: [{ pattern: "/usr/bin/keep" }] },
+        },
+      });
 
       await agentsDeleteCommand({ id: "main", force: true, json: true }, runtime);
 
@@ -326,6 +335,13 @@ describe("agents delete command", () => {
       expect(runtime.exit).not.toHaveBeenCalledWith(1);
       expect(configMocks.replaceConfigFile).toHaveBeenCalledOnce();
       expectSessionStore(cfg, {}, "main");
+      expect(readExecApprovalsSnapshot().file.agents).toEqual({
+        "*": { security: "deny" },
+        ops: {
+          security: "allowlist",
+          allowlist: [expect.objectContaining({ pattern: "/usr/bin/keep" })],
+        },
+      });
     });
   });
 
@@ -570,6 +586,7 @@ describe("agents delete command", () => {
           "agent:main:main": { sessionId: "sess-main", updatedAt: now + 3 },
         },
       });
+      expect(readExecApprovalsSnapshot().exists).toBe(false);
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
@@ -591,6 +608,7 @@ describe("agents delete command", () => {
       expectSessionStore(cfg, {
         "agent:main:main": { sessionId: "sess-main", updatedAt: now + 3 },
       });
+      expect(readExecApprovalsSnapshot().exists).toBe(false);
     });
   });
 

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -451,6 +451,19 @@ describe("agents helpers", () => {
         { agentId: "work", match: { channel: "whatsapp" } },
         { agentId: "home", match: { channel: "telegram" } },
       ],
+      broadcast: {
+        strategy: "parallel",
+        "peer-1": ["work", "home"],
+        "peer-2": ["WORK"],
+      },
+      hooks: {
+        allowedAgentIds: ["*", "work", "home"],
+        mappings: [
+          { id: "work-hook", agentId: "WORK", action: "agent" },
+          { id: "home-hook", agentId: "home", action: "agent" },
+          { id: "default-hook", action: "agent" },
+        ],
+      },
       tools: {
         agentToAgent: { enabled: true, allow: ["work", "home"] },
       },
@@ -462,6 +475,16 @@ describe("agents helpers", () => {
     expect(result.config.agents?.entries).toHaveProperty("home");
     expect(result.config.bindings).toStrictEqual([
       { agentId: "home", match: { channel: "telegram" } },
+    ]);
+    expect(result.config.broadcast).toEqual({
+      strategy: "parallel",
+      "peer-1": ["home"],
+      "peer-2": [],
+    });
+    expect(result.config.hooks?.allowedAgentIds).toEqual(["*", "home"]);
+    expect(result.config.hooks?.mappings).toEqual([
+      { id: "home-hook", agentId: "home", action: "agent" },
+      { id: "default-hook", action: "agent" },
     ]);
     expect(result.config.tools?.agentToAgent?.allow).toEqual(["home"]);
     expect(result.config.agents?.defaults?.subagents?.allowAgents).toEqual(["home"]);

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -261,18 +261,20 @@ describe("exec approvals SQLite store", () => {
     expect(commit).not.toHaveBeenCalled();
   });
 
-  it("removes one agent and preserves unrelated policy", async () => {
+  it("removes one agent and preserves wildcard and unrelated policy", async () => {
     saveExecApprovals({
       version: 1,
       agents: {
-        removed: { security: "allowlist", allowlist: [{ pattern: "/usr/bin/old" }] },
+        "*": { security: "deny" },
+        main: { security: "allowlist", allowlist: [{ pattern: "/usr/bin/old" }] },
         kept: { security: "allowlist", allowlist: [{ pattern: "/usr/bin/keep" }] },
       },
     });
-    seedAgentDeletionJournal("removed");
+    seedAgentDeletionJournal("main");
 
-    await expect(withAgentExecApprovalsRemoved("removed", async () => "ok")).resolves.toBe("ok");
+    await expect(withAgentExecApprovalsRemoved("main", async () => "ok")).resolves.toBe("ok");
     expect(loadExecApprovals().agents).toEqual({
+      "*": { security: "deny" },
       kept: expect.objectContaining({
         allowlist: [expect.objectContaining({ pattern: "/usr/bin/keep" })],
       }),

--- a/src/infra/exec-approvals-store.ts
+++ b/src/infra/exec-approvals-store.ts
@@ -4,7 +4,7 @@ import {
   AgentDeletionCommitUncertainError,
 } from "../agents/agent-lifecycle-registry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
@@ -224,9 +224,10 @@ export async function withAgentExecApprovalsRemoved<T>(
   if (!operationId) {
     throw new ExecApprovalsMutationFencedError();
   }
-  const removedPolicyEntries = Object.entries(snapshot.file.agents ?? {}).filter(
-    ([policyKey]) => normalizeAgentId(policyKey) === key,
-  );
+  const removedPolicyEntries = Object.entries(snapshot.file.agents ?? {}).filter(([policyKey]) => {
+    const normalizedPolicyKey = normalizeAgentIdStrict(policyKey);
+    return normalizedPolicyKey.ok && normalizedPolicyKey.value === key;
+  });
   if (removedPolicyEntries.length > 0) {
     const updated = updateExecApprovalsInTransaction({
       baseHash: snapshot.hash,


### PR DESCRIPTION
## What Problem This Solves

Two defects in one lifecycle. The second is the more serious one and is shipped today.

### 1. Offline `agents delete` leaves exec approvals behind

`agents delete` tries the Gateway first and falls back to a local path when the Gateway is unreachable — its own header calls this "gateway delegation and local cleanup fallback". The Gateway handler wraps deletion in `withAgentExecApprovalsRemoved`; the local fallback did not.

Verified against a real build, gateway stopped so the fallback path runs:

```
$ openclaw agents delete probe-agent --force
Moved to Trash: <workspace>
Moved to Trash: <state>/agents/probe-agent/sessions
Deleted agent: probe-agent          <- no mention of approvals
```

`agent_deletion_journal` and `diagnostic_events` legitimately still reference the agent afterward; scanning every table in the shared state database, `exec_approvals_config` was the only **live policy** store left behind.

The residue is not inert. Approve a pattern for an agent, delete it offline, then recreate an agent with the same id, and `approvals get --json` shows the old allowlist live under the new agent. The operator never granted it.

For contrast, the same delete **with** a Gateway running clears the entry — which is what makes this a sibling inconsistency rather than a missing feature.

### 2. Deleting `main` also deleted the `"*"` wildcard allowlist

This one is in the shared helper, so it affects the Gateway path too. It matched policy keys with:

```ts
([policyKey]) => normalizeAgentId(policyKey) === key
```

`normalizeAgentId` falls back to `DEFAULT_AGENT_ID` for anything it cannot represent. `"*"` strips to the empty string, so it returns `"main"`:

```
"*"            loose= "main"   strict.ok= false
"main"         loose= "main"   strict.ok= true
"other-agent"  loose= "other-agent"
=> deleting "main" with the old loose match also matches "*": true
```

So any operator who deletes their `main` agent silently loses their wildcard exec approvals. A pre-fix test reproduced exactly that.

## Why This Change Was Made

The offline path now calls the same journal-fenced, rollback-capable helper the Gateway path uses, rather than growing a second removal implementation.

**Removal rather than a warning** was a deliberate choice. An exec approval is a latent authority grant; leaving one behind contradicts the deletion contract the Gateway already enforces, and it is the id-reuse case above that turns residue into unintended authority. `agents delete` already moves the workspace and agent dir to Trash, so removing a policy entry is not out of character for it.

For the wildcard bug, strict normalization skips unrepresentable keys, so valid aliases are still removed while `"*"` and unrelated agents survive.

The fix belongs at the deletion lifecycle owner, not at the approvals read path. Making readers filter by "is this agent still configured" would compensate downstream for an upstream ownership failure, and would also change behavior for approvals written before an agent's first run.

### Sibling sweep

`pruneAgentConfig` already handled bindings, subagent and agent-to-agent allowlists, heartbeat/system-agent ownership, and Talk ownership. Three more core-owned references also retained the deleted id and are fixed here: broadcast targets, hook mappings, and hook agent allowlists (preserving `"*"`).

### Follow-ups deliberately not taken

Each needs its own owner or a design decision, and folding them in would make this unreviewable:

- Offline deletion still lacks the Gateway's transactional **cron-job** cleanup. I reproduced this separately: an hourly job survives an offline delete, stays enabled, and fires forever. It is not silent — each run records `error: "cron job agent is unavailable: <id>"` and `cron list` shows `error` — but it never stops, and id reuse would point it at the new agent. Cron mutation is Gateway-owned, so this needs the local cron seam wired up rather than a one-line addition.
- Plugin-owned routing and thread bindings need an agent-deletion lifecycle hook.
- Remote node approvals need distributed cleanup or explicit warning semantics.
- Approval `agentFilter` cleanup needs a disabled-state design, since removing its last entry would widen policy rather than narrow it.

`agents.defaults.sessionStore.agentId` is intentionally retained as a fail-closed retired owner; auth-inheritance owners already block deletion.

## User Impact

Deleting an agent without a Gateway now clears its exec approvals, matching Gateway behavior. Deleting `main` no longer takes the wildcard allowlist with it.

Production LOC: +45/-18, net +27.

## Evidence

Live before/after on a fresh isolated `HOME` and `OPENCLAW_STATE_DIR`, unused port, seeded with target, wildcard, and other-agent policies. Inspected via `json_extract(raw_json,'$.agents')` directly rather than trusting CLI output (no socket token was queried or printed):

| stage | `agents` keys |
| --- | --- |
| before deletion | `nope-agent`, `*`, `other-agent` |
| after deletion | `*`, `other-agent` |
| after recreating `nope-agent` | `*`, `other-agent` |

Pre-fix, both regressions failed as intended: `agents.delete.test.ts` (deleted agent's policy remained) and `exec-approvals-store.test.ts` (deleting `main` also removed `"*"`).

Post-fix, re-run independently here after rebasing onto current `main`: `agents-mutate.test.ts` 204 passed, `exec-approvals-store.test.ts` 24 passed, `agents.delete.test.ts` + `agents.test.ts` 42 passed, `rc=0`.

`pnpm build` passed (4m33s). `node scripts/check-changed.mjs` passed on Testbox `tbx_01m0hc0zw22enc9bzhpvja6wcv` (run 32449996049). `oxfmt --check` and `git diff --check` pass. `$autoreview`: clean, no accepted or actionable findings.
