### PR TITLE
fix(cron): prevent scoped callers from mutating replaced jobs [AI-assisted]

### DIFF
--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { AgentDeletionCommitUncertainError } from "../../agents/agent-lifecycle-registry.js";
 import {
   openOpenClawStateDatabase,
@@ -66,11 +67,32 @@ describe("scheduled tool policy provenance", () => {
       throw new TypeError("authority closed");
     });
 
-    await expect(writeScratch(state, job.id, { content: "notes", commitGuard })).rejects.toThrow(
-      "authority closed",
-    );
+    const scratchBlockerEntered = createDeferred();
+    const releaseScratchBlocker = createDeferred();
+    const scratchBlocker = updateWithPrecondition(state, job.id, {}, async () => {
+      scratchBlockerEntered.resolve();
+      await releaseScratchBlocker.promise;
+    });
+    await scratchBlockerEntered.promise;
+    const scratchWrite = writeScratch(state, job.id, { content: "notes", commitGuard });
+    expect(commitGuard).not.toHaveBeenCalled();
+    releaseScratchBlocker.resolve();
+    await scratchBlocker;
+    await expect(scratchWrite).rejects.toThrow("authority closed");
     expect(readCronJobScratchState(storePath, job.id)).toEqual({ currentRevision: 0 });
-    await expect(remove(state, job.id, { commitGuard })).rejects.toThrow("authority closed");
+
+    const removeBlockerEntered = createDeferred();
+    const releaseRemoveBlocker = createDeferred();
+    const removeBlocker = updateWithPrecondition(state, job.id, {}, async () => {
+      removeBlockerEntered.resolve();
+      await releaseRemoveBlocker.promise;
+    });
+    await removeBlockerEntered.promise;
+    const removal = remove(state, job.id, { commitGuard });
+    expect(commitGuard).toHaveBeenCalledOnce();
+    releaseRemoveBlocker.resolve();
+    await removeBlocker;
+    await expect(removal).rejects.toThrow("authority closed");
     expect(state.store?.jobs.some((entry) => entry.id === job.id)).toBe(true);
     expect(commitGuard).toHaveBeenCalledTimes(2);
     if (state.timer) {

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -99,13 +99,47 @@ function resolveCronCreatorAuthorityCapture(
   return () => consumeCronCreatorAuthorityGrant(grant);
 }
 
-function resolveAgentRuntimeAuthorityCommitGuard(
+function resolveCronMutationCommitGuard(
   client: GatewayClient | null,
   context: GatewayRequestContext,
+  jobScope?: {
+    callerScope: CronCallerScope | undefined;
+    jobId: string;
+    allowCurrentJob?: boolean;
+    expectedConfigRevision?: string;
+  },
 ): (() => void) | undefined {
-  return client?.internal?.agentRuntimeIdentity && context.validateAgentRuntimeApprovalAuthority
-    ? () => assertActiveAgentRuntimeAuthority(client, context)
-    : undefined;
+  const validatesAuthority =
+    client?.internal?.agentRuntimeIdentity && context.validateAgentRuntimeApprovalAuthority;
+  if (!validatesAuthority && !jobScope?.callerScope) {
+    return undefined;
+  }
+  return () => {
+    if (validatesAuthority) {
+      assertActiveAgentRuntimeAuthority(client, context);
+    }
+    if (!jobScope?.callerScope) {
+      return;
+    }
+    // The capability can expire, or the same id can acquire another owner while
+    // this request waits for the cron lock. Re-read both at the commit owner.
+    const callerScope = readCronCallerScope(client);
+    const job = context.cron.getJob(jobScope.jobId);
+    if (
+      !callerScope ||
+      !job ||
+      (jobScope.expectedConfigRevision !== undefined &&
+        resolveCronJobConfigRevision(job) !== jobScope.expectedConfigRevision) ||
+      !cronJobMatchesCallerScope({
+        job,
+        callerScope,
+        defaultAgentId: context.cron.getDefaultAgentId(),
+        allowCurrentJob: jobScope.allowCurrentJob,
+      })
+    ) {
+      throw new TypeError(`unknown cron job id: ${jobScope.jobId}`);
+    }
+  };
 }
 
 function ensureActiveAgentRuntimeAuthority(params: {
@@ -639,7 +673,10 @@ export const cronHandlers: GatewayRequestHandlers = {
       ) {
         return;
       }
-      const commitGuard = resolveAgentRuntimeAuthorityCommitGuard(client, context);
+      const commitGuard = resolveCronMutationCommitGuard(client, context, {
+        callerScope,
+        jobId,
+      });
       const result = await context.cron.writeScratch(jobId, {
         content: p.content,
         expectedRevision: p.expectedRevision,
@@ -721,7 +758,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       respondInvalidCronParams(respond, "cron.add", formatErrorMessage(err));
       return;
     }
-    const commitGuard = resolveAgentRuntimeAuthorityCommitGuard(client, context);
+    const commitGuard = resolveCronMutationCommitGuard(client, context);
     const jobCreate = applyCronCreateCallerScopeDefault(candidate as CronJobCreate, callerScope);
     const cfg = context.getRuntimeConfig();
     try {
@@ -881,7 +918,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       respondInvalidCronParams(respond, "cron.update", formatErrorMessage(err));
       return;
     }
-    const commitGuard = resolveAgentRuntimeAuthorityCommitGuard(client, context);
+    const commitGuard = resolveCronMutationCommitGuard(client, context);
     const jobId = resolveCronJobId(p);
     if (!jobId) {
       respond(
@@ -1068,9 +1105,23 @@ export const cronHandlers: GatewayRequestHandlers = {
     if (!ensureActiveAgentRuntimeAuthority({ client, context, method: "cron.remove", respond })) {
       return;
     }
+    const defaultAgentId = context.cron.getDefaultAgentId();
+    const usesCurrentJobCapability = !cronJobMatchesCallerScope({
+      job,
+      callerScope,
+      defaultAgentId,
+    });
+    const expectedConfigRevision = usesCurrentJobCapability
+      ? resolveCronJobConfigRevision(job)
+      : undefined;
     let result: Awaited<ReturnType<typeof context.cron.remove>>;
     try {
-      const commitGuard = resolveAgentRuntimeAuthorityCommitGuard(client, context);
+      const commitGuard = resolveCronMutationCommitGuard(client, context, {
+        callerScope,
+        jobId,
+        allowCurrentJob: usesCurrentJobCapability,
+        expectedConfigRevision,
+      });
       result = commitGuard
         ? await context.cron.remove(jobId, { commitGuard })
         : await context.cron.remove(jobId);
@@ -1126,7 +1177,10 @@ export const cronHandlers: GatewayRequestHandlers = {
     }
     let result: Awaited<ReturnType<typeof context.cron.enqueueRun>>;
     try {
-      const commitGuard = resolveAgentRuntimeAuthorityCommitGuard(client, context);
+      const commitGuard = resolveCronMutationCommitGuard(client, context, {
+        callerScope,
+        jobId,
+      });
       result = commitGuard
         ? await context.cron.enqueueRun(jobId, p.mode ?? "force", { commitGuard })
         : await context.cron.enqueueRun(jobId, p.mode ?? "force");

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -4,10 +4,13 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { createOperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronRuntimeAuthority } from "../../cron/runtime-authority.js";
+import { CronService, type CronEvent } from "../../cron/service.js";
+import { createCronStoreHarness, createNoopLogger } from "../../cron/service.test-harness.js";
 import type { CronDelivery, CronJob } from "../../cron/types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
@@ -22,6 +25,9 @@ import {
 } from "../cron-creator-authority-grant.js";
 import { getGatewayProcessInstanceId } from "../process-instance.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
+
+const cronLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness({ prefix: "cron-gateway-validation-" });
 
 const getRuntimeConfig = vi.hoisted(() =>
   vi.fn<() => OpenClawConfig>(() => ({}) as OpenClawConfig),
@@ -656,7 +662,9 @@ describe("cron method validation", () => {
       { context, client: callerClient("ops") },
     );
 
-    expect(context.cron.remove).toHaveBeenCalledWith("cron-1");
+    expect(context.cron.remove).toHaveBeenCalledWith("cron-1", {
+      commitGuard: expect.any(Function),
+    });
     expect(respond).toHaveBeenCalledWith(true, { ok: true, removed: true }, undefined);
   });
 
@@ -1522,6 +1530,244 @@ describe("cron method validation", () => {
     },
   );
 
+  it.each([
+    ["cron.scratch.set", { id: "cron-1", content: "notes" }, "writeScratch"],
+    ["cron.remove", { id: "cron-1" }, "remove"],
+    ["cron.run", { id: "cron-1", mode: "force" }, "enqueueRun"],
+  ] as const)("revalidates caller scope at the %s commit owner", async (method, params, owner) => {
+    const { storePath } = await makeStorePath();
+    const runFinished = createDeferred<CronEvent>();
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      defaultAgentId: "main",
+      log: cronLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+      onEvent: (event) => {
+        if (event.jobId === "cron-1" && event.action === "finished") {
+          runFinished.resolve(event);
+        }
+      },
+    });
+    await cron.start();
+    const releaseReplacement = createDeferred();
+    try {
+      const staleJob = await cron.add({
+        id: "cron-1",
+        name: "scoped job",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        agentId: "main",
+        payload: { kind: "systemEvent", text: "before replacement" },
+        delivery: { mode: "none" },
+      });
+      const replacementEntered = createDeferred();
+      const replacement = cron.updateWithPrecondition(
+        staleJob.id,
+        {
+          agentId: "worker",
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "replacement" },
+        },
+        async () => {
+          replacementEntered.resolve();
+          await releaseReplacement.promise;
+        },
+      );
+      await replacementEntered.promise;
+
+      const mutationQueued = createDeferred();
+      const context = createCronContext();
+      context.cron.readJob.mockResolvedValue(staleJob);
+      context.cron.getJob.mockImplementation((id) => cron.getJob(id));
+      context.cron.getDefaultAgentId.mockImplementation(() => "main");
+      if (owner === "writeScratch") {
+        context.cron.writeScratch.mockImplementationOnce(async (id, write) => {
+          mutationQueued.resolve();
+          const result = await cron.writeScratch(id, write);
+          if (!result.ok || !result.scratch) {
+            throw new Error("expected scratch write to succeed");
+          }
+          return {
+            ok: true,
+            scratch: {
+              content: result.scratch.content,
+              revision: result.scratch.revision,
+            },
+            currentRevision: result.currentRevision,
+          };
+        });
+      } else if (owner === "remove") {
+        context.cron.remove.mockImplementationOnce(async (id, options) => {
+          mutationQueued.resolve();
+          return await cron.remove(id, options);
+        });
+      } else {
+        context.cron.enqueueRun.mockImplementationOnce(async (id, mode, options) => {
+          mutationQueued.resolve();
+          const result = await cron.enqueueRun(
+            id,
+            mode as "due" | "force" | "if-enabled" | undefined,
+            options,
+          );
+          if (!result.ok || !("enqueued" in result) || !result.enqueued) {
+            throw new Error("expected cron run to enqueue");
+          }
+          return { ok: true, enqueued: true, runId: result.runId };
+        });
+      }
+
+      const invocation = invokeCron(method, params, {
+        context,
+        client: callerClient("main"),
+      });
+      await mutationQueued.promise;
+      expect(context.cron.getJob).not.toHaveBeenCalled();
+
+      releaseReplacement.resolve();
+      await replacement;
+      const { respond } = await invocation;
+      const finishedEvent = owner === "enqueueRun" ? await runFinished.promise : undefined;
+
+      expect(context.cron[owner]).toHaveBeenCalledOnce();
+      if (owner === "writeScratch") {
+        expect(await cron.readScratch(staleJob.id)).toMatchObject({ currentRevision: 0 });
+      } else if (owner === "remove") {
+        expect(await cron.readJob(staleJob.id)).toMatchObject({
+          agentId: "worker",
+          payload: { kind: "agentTurn", message: "replacement" },
+        });
+      } else {
+        expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+        expect(finishedEvent).toMatchObject({
+          status: "error",
+          error: "unknown cron job id: cron-1",
+        });
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          {
+            ok: true,
+            enqueued: true,
+            runId: expect.stringMatching(/^manual:cron-1:/),
+            processInstanceId: getGatewayProcessInstanceId(),
+          },
+          undefined,
+        );
+        return;
+      }
+      expectResponseError(respond, {
+        code: "INVALID_REQUEST",
+        messageIncludes: "unknown cron job id: cron-1",
+      });
+    } finally {
+      releaseReplacement.resolve();
+      cron.stop();
+    }
+  });
+
+  it("revalidates an expiring current-job capability at removal commit", async () => {
+    const ownerSessionKey = "agent:ops:discord:work:group:creator";
+    const job = createCronJob({
+      agentId: "ops",
+      owner: { agentId: "ops", sessionKey: ownerSessionKey, accountId: "work" },
+      scheduledToolPolicy: {
+        version: 1,
+        mode: "account",
+        ownerSessionKey,
+        ownerAccountId: "work",
+      },
+    });
+    const context = createCronContext(job);
+    const client = callerClient("ops", "work", `agent:ops:cron:${job.id}:run:run-1`, job.id);
+    context.cron.remove.mockImplementationOnce(async (_id, options) => {
+      client.internal!.agentRuntimeIdentity!.cronSelfManagementContext!.expiresAtMs =
+        Date.now() - 1;
+      options?.commitGuard?.();
+      return { ok: true, removed: true };
+    });
+
+    const { respond } = await invokeCron("cron.remove", { id: job.id }, { context, client });
+
+    expect(context.cron.remove).toHaveBeenCalledOnce();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: `unknown cron job id: ${job.id}`,
+    });
+  });
+
+  it("rejects a same-id replacement when removal depends on the current-job capability", async () => {
+    const ownerSessionKey = "agent:ops:discord:work:group:creator";
+    const job = createCronJob({
+      agentId: "ops",
+      owner: { agentId: "ops", sessionKey: ownerSessionKey, accountId: "work" },
+      scheduledToolPolicy: {
+        version: 1,
+        mode: "account",
+        ownerSessionKey,
+        ownerAccountId: "work",
+      },
+    });
+    const replacement = createCronJob({
+      agentId: "ops",
+      owner: { agentId: "ops", sessionKey: "agent:ops:main", accountId: "default" },
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+    });
+    const context = createCronContext(job);
+    const client = callerClient("ops", "work", `agent:ops:cron:${job.id}:run:run-1`, job.id);
+    context.cron.remove.mockImplementationOnce(async (_id, options) => {
+      context.cron.getJob.mockReturnValue(replacement);
+      options?.commitGuard?.();
+      return { ok: true, removed: true };
+    });
+
+    const { respond } = await invokeCron("cron.remove", { id: job.id }, { context, client });
+
+    expect(context.cron.remove).toHaveBeenCalledOnce();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: `unknown cron job id: ${job.id}`,
+    });
+  });
+
+  it("does not switch from owner scope to the current-job capability at removal commit", async () => {
+    const ownerSessionKey = "agent:ops:discord:work:group:creator";
+    const job = createCronJob({
+      agentId: "ops",
+      owner: { agentId: "ops", sessionKey: ownerSessionKey, accountId: "work" },
+      scheduledToolPolicy: {
+        version: 1,
+        mode: "account",
+        ownerSessionKey,
+        ownerAccountId: "work",
+      },
+    });
+    const replacement = createCronJob({
+      agentId: "ops",
+      owner: { agentId: "ops", sessionKey: "agent:ops:main", accountId: "default" },
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+    });
+    const context = createCronContext(job);
+    const client = callerClient("ops", "work", ownerSessionKey, job.id);
+    context.cron.remove.mockImplementationOnce(async (_id, options) => {
+      context.cron.getJob.mockReturnValue(replacement);
+      options?.commitGuard?.();
+      return { ok: true, removed: true };
+    });
+
+    const { respond } = await invokeCron("cron.remove", { id: job.id }, { context, client });
+
+    expect(context.cron.remove).toHaveBeenCalledOnce();
+    expectResponseError(respond, {
+      code: "INVALID_REQUEST",
+      messageIncludes: `unknown cron job id: ${job.id}`,
+    });
+  });
+
   it("keeps cron.update mutation at zero after resolution outlives its run", async () => {
     const scope = createCronCreatorAuthorityRunScope("run-update-revoked");
     const grant = mintCronCreatorAuthorityGrant(scope);
@@ -1817,7 +2063,9 @@ describe("cron method validation", () => {
       { context, client: runClient },
     );
     expect(remove.respond).toHaveBeenCalledWith(true, { ok: true, removed: true }, undefined);
-    expect(context.cron.remove).toHaveBeenCalledWith(accountJob.id);
+    expect(context.cron.remove).toHaveBeenCalledWith(accountJob.id, {
+      commitGuard: expect.any(Function),
+    });
 
     const update = await invokeCron(
       "cron.update",
@@ -3742,7 +3990,9 @@ describe("cron method validation", () => {
       { context, client: callerClient("ops") },
     );
 
-    expect(context.cron.enqueueRun).toHaveBeenCalledWith("cron-1", "due");
+    expect(context.cron.enqueueRun).toHaveBeenCalledWith("cron-1", "due", {
+      commitGuard: expect.any(Function),
+    });
     expect(respond).toHaveBeenCalledWith(
       true,
       {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Agent-scoped cron requests were authorized against a job before entering the cron service's mutation lock. If the same job ID was replaced while the request waited, `cron.scratch.set`, `cron.remove`, or a queued `cron.run` could mutate or execute the replacement even when it belonged to another caller. The old commit guard revalidated delegated runtime authority, but not the caller's live job scope.

The same race affected the narrow current-job self-removal capability: an expired capability or same-ID replacement could be acted on after the original preflight.

## Why This Change Was Made

The Gateway now uses one commit guard that preserves delegated-runtime-authority validation and, for scoped job operations, re-reads both authenticated caller scope and the live job at the existing locked mutation owner.

- `cron.scratch.set` and `cron.run` must still match the caller's live scope when their locked mutation/reservation begins.
- `cron.remove` preserves the authorization route chosen at preflight. Current-job self-removal is bound to the exact configuration revision, so replacement cannot switch between owner authority and current-job fallback.
- `cron.add` and `cron.update` retain their existing delegated-runtime-authority commit checks.
- Unscoped operator behavior and direct Gateway validation remain unchanged.

This intentionally fails closed as the existing non-disclosing `unknown cron job id` error. `cron.run` keeps its immediate enqueue response; if ownership changes before the background reservation reaches the lock, execution is rejected and a terminal error event is emitted instead of running the replacement.

## Contract Boundaries

This PR does not make the product-policy change discussed in #119455 and does not weaken direct Gateway validation. Merged #122052 only stopped advertising trigger-gated model inputs when triggers are disabled; it did not define recovery for blank nested delivery fields or impossible supplied triggers. #119455 remains open pending the explicit model-input recovery contract. This authorization repair is independent of that decision.

## User Impact

Scoped runtimes can no longer write scratch, remove, or manually run a same-ID replacement they do not own after waiting for the cron lock. Scheduled jobs retain self-removal only for their exact live revision. Normal unscoped cron operations and immediate enqueue semantics are preserved.

## Executable Evidence

Exact branch base/head used for local proof:

- Base: `e7e1c53250083bac9b09f3b34a20c66ee491b631`
- Head: `9e7d16659315bf73d17bba438ccc192a2ceabe5e`
- Node: `v24.19.0`

### Real Gateway + CronService lock contention

The regression harness uses the persistent `CronService`, holds the real `updateWithPrecondition` mutation lock, starts the real Gateway handler from stale preflight state, queues scratch/remove/run behind that lock, replaces the live job while blocked, and then releases contention.

- **Pre-fix base:** applying only the retained regression-test patch and running
  `node scripts/run-vitest.mjs src/gateway/server-methods/cron.validation.test.ts -- -t "revalidates caller scope"`
  produced the expected **6 failed / 402 skipped** across both Gateway projections. Unauthorized scratch advanced revision `0 → 1`, removal deleted the foreign replacement, and queued run invoked the replacement runner. Retained patch SHA-256: `1f5e790bcb27edbb6e42d2bea2f3bf4ddf8ed62251c85290622df86143f3c8a7`.
- **Exact head:** the same targeted command passed **6/6**. Scratch remains revision 0, the replacement remains present, and the foreign runner is never invoked; the queued run emits terminal error `unknown cron job id: cron-1`.
- **Exact head focused:**
  `node scripts/run-vitest.mjs src/gateway/server-methods/cron.validation.test.ts src/cron/service/ops.test.ts`
  passed **408 Gateway + 68 cron service tests**.

### Current-main merge-tree proof

Latest tested `origin/main` `dfce5f695871aa2230037fdfb024f4c75fd180ef` merged conflict-free with the exact head (`git merge-tree --write-tree`; tree `b81969c247fb899e007f40db13e1e9aa170348af`, synthetic commit `96bef403d31f91c314eac090e26a6b56b37459bc`). This refresh includes the adjacent cron watchdog change from #93914. In that detached synthetic merge:

- targeted contention regressions: **6 passed / 402 skipped**;
- full focused suites: **408 + 68 passed**.

### Adjacent audit coverage

- Gateway caller scope, creator authority, exit watchers, drain, and cron server paths: **266 passed / 2 intentionally excluded projections**. The exclusions are the same unrelated `keeps script failure detail transient while preserving structured error payloads` isolated-projection timeout; its normal projection passed. An earlier unfiltered run was **223 passed / 1 timed out** only on that test.
- Protocol/schema validators, parse/normalize, persisted on-exit/stream/trigger shapes, payload transitions, declarative jobs, scratch persistence, removal post-commit behavior, and cron/every/at/timezone scheduling including DST: **34 gateway-protocol + 261 cron tests passed**.
- `node scripts/check-changed.mjs -- src/gateway/server-methods/cron.ts src/gateway/server-methods/cron.validation.test.ts src/cron/service/ops.test.ts`: passed formatting, core/core-test typechecks, lint, dead exports, cycles, database and repository guards.

## Review Evidence

- Repo autoreview on exact head/base: **CLEAN**, no findings, confidence 0.96.
- Independent read-only Codex review on exact head: **CLEAN**. It specifically confirmed the prior `cron.run` gap is resolved: caller scope reaches the commit guard and the guard executes under the service mutation lock.
- Direct sibling Codex source inspection at `44e95c857f37f81a5731eab72c32a3d334d0e2c4` confirmed thread/session IDs are routing and correlation identifiers, not authorization claims (`codex-rs/protocol/src/thread_id.rs`, `codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs`, `codex-rs/app-server/src/request_processors/thread_processor.rs`, `codex-rs/core/src/responses_metadata.rs`, `codex-rs/core/src/client.rs`, and model-provider auth sources). OpenClaw authorization must therefore remain anchored to authenticated Gateway runtime identity and the live job under lock.

## Surface and Residual Risk

- Production: `+63/-9` (net `+54`) in the Gateway cron handler.
- Tests: `+279/-7` (net `+272`) in two directly owned suites.
- Total: `+342/-16` (net `+326`) across 3 files.

Residual behavior is intentional and pre-existing: `cron.run` can acknowledge enqueue before its background locked reservation. A later ownership change now produces a terminal rejection rather than executing the replacement. No persistence schema, protocol schema, schedule policy, or model-input normalization behavior changes.

AI-assisted implementation and review; all reported commands were executed against the stated SHAs.
