### PR TITLE
fix(plugins): register static node-host commands without activation

### DIFF
--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -507,12 +507,16 @@ export function loadRuntimePluginCandidate(params: {
     }
     return;
   }
+  // Node-host commands register in every load mode: the node host resolves its
+  // registry without activation (loadPluginRegistryHandle), and each command is
+  // already availability-gated per invocation. Gating them on full activation
+  // silently strips static registrations like browser.proxy from headless nodes.
+  for (const nodeHostCommand of definition?.nodeHostCommands ?? []) {
+    params.registryBuilder.registerNodeHostCommand(record, nodeHostCommand);
+  }
   if (registrationPlan.runFullActivationOnlyRegistrations) {
     if (definition?.reload) {
       params.registryBuilder.registerReload(record, definition.reload);
-    }
-    for (const nodeHostCommand of definition?.nodeHostCommands ?? []) {
-      params.registryBuilder.registerNodeHostCommand(record, nodeHostCommand);
     }
     for (const collector of definition?.securityAuditCollectors ?? []) {
       params.registryBuilder.registerSecurityAuditCollector(record, collector);

--- a/src/plugins/loader.node-host-commands.test.ts
+++ b/src/plugins/loader.node-host-commands.test.ts
@@ -1,0 +1,49 @@
+/** Verifies static plugin nodeHostCommands survive non-activating registry loads (node-host path). */
+import { afterAll, afterEach, expect, it } from "vitest";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  loadOpenClawPlugins,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+
+afterEach(resetPluginLoaderTestStateForTest);
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+// The node host resolves its registry via loadPluginRegistryHandle (activate:false).
+// Static nodeHostCommands (e.g. the browser plugin's browser.proxy) must register
+// there too, or headless meeting/browser nodes silently lose their surface.
+it("registers static nodeHostCommands without activation", () => {
+  useNoBundledPlugins();
+  const plugin = writePlugin({
+    id: "node-surface",
+    body: `module.exports = {
+      id: "node-surface",
+      nodeHostCommands: [{
+        command: "nodesurface.proxy",
+        cap: "node-surface",
+        handle: async () => "ok",
+      }],
+      register() {},
+    };`,
+  });
+
+  const registry = loadOpenClawPlugins({
+    cache: false,
+    activate: false,
+    workspaceDir: plugin.dir,
+    config: {
+      plugins: {
+        load: { paths: [plugin.file] },
+        allow: [plugin.id],
+      },
+    },
+    onlyPluginIds: [plugin.id],
+  });
+
+  expect(registry.plugins.find((entry) => entry.id === plugin.id)?.status).toBe("loaded");
+  expect(registry.nodeHostCommands.map((entry) => entry.command.command)).toContain(
+    "nodesurface.proxy",
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Since #117587 (2026-08-01), every headless node host silently lost the plugin node commands that are declared statically on plugin entries — most visibly the browser plugin's `browser.proxy`/`browser.proxy.upload.v1` (and with them the `browser` and `file` caps). The node host resolves its plugin registry through `loadPluginRegistryHandle`, which loads with `activate: false`; static `definition.nodeHostCommands` only registered under `runFullActivationOnlyRegistrations`, so they never reached the node manifest.

Operator-visible symptom: `openclaw googlemeet create/join` (and the Teams/Zoom meeting plugins) fail with `No connected Google Meet-capable node with browser proxy` even though the Chrome node is paired, connected, and advertises the `google-meet` cap — `isMeetingBrowserNode` requires `browser.proxy`, which the node can no longer expose. Nodes built from tags ≤ 2026.7.x still advertise the full surface; any node updated past #117587 drops it. This is a silent default-path regression: nothing logs, the node looks healthy, and meeting joins are dead.

## Why This Change Was Made

Node-host commands are the node host's own surface; each registration already carries a per-invocation `isAvailable` gate (e.g. the browser plugin checks `browser.enabled` and `nodeHost.browserProxy.enabled`). Gating their *registration* on full activation conflated "registry loaded for a node host" with "gateway live activation". Plugins that register node commands imperatively inside `register()` (google-meet's `googlemeet.chrome`) kept working, which made the static-declaration path the silent odd one out. The fix registers `definition.nodeHostCommands` in every load mode and keeps `reload` and `securityAuditCollectors` activation-only.

## User Impact

Headless `openclaw node run` / the macOS app node worker again advertise `browser.proxy`, `browser`, `file`, and the meeting-bot chain (`googlemeet.chrome` + browser proxy) works end to end. No config change needed; no new surface.

## Evidence

- Regression test `src/plugins/loader.node-host-commands.test.ts`: loads a plugin with static `nodeHostCommands` via `loadOpenClawPlugins({ activate: false })` (the node-host path) and asserts the command registers. Fails on pre-fix code (verified by reverting the hunk), passes with the fix.
- `pnpm test src/plugins` and `pnpm test src/node-host` green locally.
- Live proof on a real gateway+node rig (clawstudio gateway, clawmac node): pre-fix `node worker` manifest had `caps` without `browser`/`file` and no `browser.proxy`; post-fix manifest includes `browser.proxy`, `browser`, `file`. `openclaw googlemeet join <url> --mode transcribe` then joined a real Meet (in-call yes, live captions on) and wrote the first row into `meeting_transcript_sessions` with caption utterances.
