### PR TITLE
fix: dismiss sidebar session tooltip when menu opens

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -41,6 +41,7 @@ import {
 } from "./session-row-subtitle.ts";
 import type { SidebarMenusController } from "./sidebar-menus-controller.ts";
 import "./elapsed-time.ts";
+import "./tooltip.ts";
 
 const SIDEBAR_VISIBLE_CHILD_SESSION_LIMIT = 4;
 
@@ -231,7 +232,9 @@ export function renderRecentSession(params: {
       (trigger, x, y) => host.sidebarMenus.openSessionMenu(session, x, y, trigger),
     );
   const pinLabel = `${t(session.pinned ? "sessionsView.unpinSession" : "sessionsView.pinSession")}: ${label}`;
-  const menuLabel = `${t("chat.sidebar.openSessionMenu")}: ${label}`;
+  const menuTooltip = t("chat.sidebar.openSessionMenu");
+  const menuLabel = `${menuTooltip}: ${label}`;
+  const menuOpen = host.sidebarMenus.sessionMenu?.session.key === session.key;
   const rowClass = [
     "sidebar-recent-session",
     "session-row-host",
@@ -426,22 +429,23 @@ export function renderRecentSession(params: {
               >
                 ${icons.pin}
               </button>`}
-          <button
-            class="session-action"
-            data-session-menu="true"
-            type="button"
-            title=${menuLabel}
-            aria-label=${menuLabel}
-            aria-haspopup="menu"
-            aria-expanded=${String(host.sidebarMenus.sessionMenu?.session.key === session.key)}
-            @click=${(event: MouseEvent) => {
-              event.stopPropagation();
-              const trigger = event.currentTarget as HTMLElement;
-              host.toggleSessionMenu(session, trigger);
-            }}
-          >
-            ${icons.moreHorizontal}
-          </button>
+          <openclaw-tooltip .content=${menuTooltip} .describe=${false} .disabled=${menuOpen}>
+            <button
+              class="session-action"
+              data-session-menu="true"
+              type="button"
+              aria-label=${menuLabel}
+              aria-haspopup="menu"
+              aria-expanded=${String(menuOpen)}
+              @click=${(event: MouseEvent) => {
+                event.stopPropagation();
+                const trigger = event.currentTarget as HTMLElement;
+                host.toggleSessionMenu(session, trigger);
+              }}
+            >
+              ${icons.moreHorizontal}
+            </button>
+          </openclaw-tooltip>
         </span>
       </span>
     </div>

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -211,6 +211,10 @@ class TooltipProvider extends OpenClawLitElement {
 class Tooltip extends OpenClawLitElement {
   @property() content = "";
 
+  @property({ type: Boolean }) describe = true;
+
+  @property({ type: Boolean }) disabled = false;
+
   /** Let a reveal-only trigger open on click instead of dismissing. */
   @property({ type: Boolean, attribute: "open-on-click" }) openOnClick = false;
 
@@ -289,6 +293,9 @@ class Tooltip extends OpenClawLitElement {
     this.attachTrigger();
     this.syncDescription();
     this.syncWebAwesomeTooltip();
+    if (this.disabled) {
+      this.close();
+    }
   }
 
   override disconnectedCallback() {
@@ -478,7 +485,7 @@ class Tooltip extends OpenClawLitElement {
   };
 
   private scheduleOpen() {
-    if (this.webAwesomeTooltip?.open || this.openTimer !== null) {
+    if (this.disabled || this.webAwesomeTooltip?.open || this.openTimer !== null) {
       return;
     }
     const provider = this.tooltipProvider;
@@ -491,7 +498,13 @@ class Tooltip extends OpenClawLitElement {
 
   private show() {
     const tooltip = this.webAwesomeTooltip;
-    if (!tooltip || !this.triggerElement || !this.tooltipText || this.isRedundant()) {
+    if (
+      this.disabled ||
+      !tooltip ||
+      !this.triggerElement ||
+      !this.tooltipText ||
+      this.isRedundant()
+    ) {
       return;
     }
     this.clearTimers(false);
@@ -540,6 +553,10 @@ class Tooltip extends OpenClawLitElement {
   }
 
   private syncDescription() {
+    if (!this.describe) {
+      this.restoreDescription();
+      return;
+    }
     const trigger = this.resolveDescribedElement();
     if (!trigger) {
       return;

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -57,31 +57,53 @@ describe("AppSidebar context menu boundary", () => {
 });
 
 describe("AppSidebar multi-select", () => {
-  it("names each session's pin and menu buttons after their owning session", async () => {
+  it("names session actions and routes menu hints through the shared tooltip", async () => {
     const { sidebar } = await mountMultiSelect();
 
     for (const key of ["agent:main:a", "agent:main:b"]) {
       const row = sidebar.querySelector<HTMLElement>(`[data-session-key="${key}"]`);
       const label = row?.querySelector(".sidebar-recent-session__name")?.textContent?.trim();
+      const menu = row?.querySelector<HTMLElement>("[data-session-menu]");
+      const tooltip = menu?.closest("openclaw-tooltip") as
+        | (HTMLElement & { content: string; describe: boolean })
+        | null;
       expect(label).toBeTruthy();
       expect(row?.querySelector("[data-sidebar-session-pin]")?.getAttribute("aria-label")).toBe(
         `Pin session: ${label}`,
       );
-      expect(row?.querySelector("[data-session-menu]")?.getAttribute("aria-label")).toBe(
-        `Open session menu: ${label}`,
-      );
+      expect(menu?.getAttribute("aria-label")).toBe(`Open session menu: ${label}`);
+      expect(menu?.hasAttribute("title")).toBe(false);
+      expect(tooltip?.content).toBe("Open session menu");
+      expect(tooltip?.describe).toBe(false);
     }
   });
 
   it("restores the thread action anchor when Tab exits its keyboard context menu", async () => {
     const { sidebar } = await mountMultiSelect();
-    const link = rowLink(sidebar, "agent:main:a");
     const trigger = sidebar.querySelector<HTMLElement>(
       '[data-session-key="agent:main:a"] [data-session-menu]',
     );
-    link.focus();
-    link.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    const tooltip = trigger?.closest("openclaw-tooltip") as
+      | (HTMLElement & {
+          disabled: boolean;
+          renderRoot: ShadowRoot;
+          updateComplete: Promise<unknown>;
+        })
+      | null;
+    if (!trigger || !tooltip) {
+      throw new Error("expected session menu tooltip");
+    }
+    const popup = tooltip.renderRoot.querySelector("wa-tooltip") as
+      | (HTMLElement & { open: boolean })
+      | null;
+    trigger.focus();
+    expect(popup?.open).toBe(true);
+
+    trigger.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     await sidebar.updateComplete;
+    await tooltip.updateComplete;
+    expect(tooltip.disabled).toBe(true);
+    expect(popup?.open).toBe(false);
 
     const menu = await sessionMenu(sidebar);
     const item = menu.querySelector<HTMLElement>("wa-dropdown-item:not([disabled])");


### PR DESCRIPTION
Closes #127039

## What Problem This Solves

Fixes an issue where users opening a session's overflow menu could have its hover tooltip remain visible and obscure the menu's upper actions.

## Why This Change Was Made

The session overflow hint now uses OpenClaw's shared tooltip and is disabled from the authoritative session-menu state while that menu is open. This closes the tooltip for click, keyboard, and context-menu opening paths and prevents it from reopening until the menu closes.

## User Impact

Session overflow menus now open unobstructed, while the normal hover hint remains available when the menu is closed.

## Evidence

- Original macOS reproduction and screenshot: #127039
- Focused sidebar interaction test and complete changed-file gate: https://github.com/openclaw/openclaw/actions/runs/32450980430
- Mocked-Gateway Chromium before/after visual proof: https://github.com/openclaw/openclaw/actions/runs/32451843985
- Final branch autoreview: clean, with no accepted/actionable findings
