### PR TITLE
fix: return final results for completed cron and CLI tasks

### DIFF
--- a/src/gateway/server-methods/task-summary.ts
+++ b/src/gateway/server-methods/task-summary.ts
@@ -55,9 +55,19 @@ export function mapTaskSummary(task: TaskRecord, opts?: { includePrompt?: boolea
   const prompt = opts?.includePrompt
     ? sanitizeTaskPromptText(task.task, TASK_PROMPT_MAX_CHARS) || undefined
     : undefined;
-  const result = opts?.includePrompt
-    ? sanitizeTaskStatusText(task.progressSummary, { maxChars: TASK_RESULT_MAX_CHARS }) || undefined
-    : undefined;
+  const progressResult = opts?.includePrompt
+    ? sanitizeTaskStatusText(task.progressSummary, { maxChars: TASK_RESULT_MAX_CHARS })
+    : "";
+  const terminalResult = opts?.includePrompt
+    ? sanitizeTaskStatusText(task.terminalSummary, {
+        errorContext: true,
+        maxChars: TASK_RESULT_MAX_CHARS,
+      })
+    : "";
+  const result =
+    (task.runtime === "subagent" || task.runtime === "acp"
+      ? progressResult
+      : terminalResult || progressResult) || undefined;
   const toolUseCount =
     typeof task.toolUseCount === "number" && Number.isInteger(task.toolUseCount)
       ? Math.max(0, task.toolUseCount)

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -621,6 +621,94 @@ describe("tasks gateway handlers", () => {
     expect(payload?.task?.prompt).toBe("Done task");
   });
 
+  it.each([
+    {
+      label: "subagent completion",
+      runtime: "subagent",
+      progressSummary: "Subagent canonical result",
+      terminalSummary: "Subagent terminal status",
+      expected: "Subagent canonical result",
+    },
+    {
+      label: "ACP completion",
+      runtime: "acp",
+      progressSummary: "ACP canonical result",
+      terminalSummary: "ACP terminal status",
+      expected: "ACP canonical result",
+    },
+    {
+      label: "cron completion",
+      runtime: "cron",
+      progressSummary: "Cron stale progress",
+      terminalSummary: "Cron canonical result",
+      expected: "Cron canonical result",
+    },
+    {
+      label: "CLI completion",
+      runtime: "cli",
+      progressSummary: "CLI stale progress",
+      terminalSummary: "CLI canonical result",
+      expected: "CLI canonical result",
+    },
+    {
+      label: "CLI sanitized terminal result",
+      runtime: "cli",
+      progressSummary: "CLI stale progress",
+      terminalSummary: "Exec denied (gateway id=req-1, approval-timeout): bash -lc ls",
+      expected: "Command did not run: approval timed out.",
+    },
+    {
+      label: "cron progress fallback",
+      runtime: "cron",
+      progressSummary: "Cron fallback result",
+      terminalSummary: undefined,
+      expected: "Cron fallback result",
+    },
+    {
+      label: "cron blank-terminal fallback",
+      runtime: "cron",
+      progressSummary: "Cron blank-terminal fallback result",
+      terminalSummary: "",
+      preserveTerminalSummary: true,
+      expected: "Cron blank-terminal fallback result",
+    },
+    {
+      label: "CLI progress fallback",
+      runtime: "cli",
+      progressSummary: "CLI fallback result",
+      terminalSummary: undefined,
+      expected: "CLI fallback result",
+    },
+  ] as const)("returns the runtime-owned result for $label", async (fixture) => {
+    const task = createTaskRecord({
+      runtime: fixture.runtime,
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      task: fixture.label,
+      status: "succeeded",
+      deliveryStatus: "not_applicable",
+      progressSummary: fixture.progressSummary,
+      terminalSummary: fixture.terminalSummary,
+    });
+    if ("preserveTerminalSummary" in fixture) {
+      expectDefined(
+        markTaskTerminalById({
+          taskId: task.taskId,
+          status: "succeeded",
+          endedAt: Date.now(),
+          terminalSummary: fixture.terminalSummary,
+          preserveTerminalSummary: fixture.preserveTerminalSummary,
+        }),
+        "expected preserved terminal summary task",
+      );
+    }
+
+    const { payload } = await getTaskPayload(task.taskId);
+
+    expect(payload?.task?.result).toBe(fixture.expected);
+  });
+
   it("keeps bounded prompts lookup-only", async () => {
     const task = createTaskRecord({
       runtime: "cli",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where SDK clients and the Control UI could receive stale in-progress text from `tasks.get` after a cron or CLI task had already persisted a newer final result.

## Why This Change Was Made

The Gateway now selects and sanitizes the canonical completion result from the runtime that owns it: subagent and ACP tasks retain completion text in `progressSummary`, while cron and CLI tasks use an error-context-sanitized `terminalSummary` with a progress fallback for legacy, missing, blank, or sanitizes-empty terminal records. The protocol and `tasks.list` behavior are unchanged.

## User Impact

Operators copying a completed cron or CLI task result, and SDK consumers reading `tasks.get.result`, now receive the final terminal result instead of obsolete progress text. Existing subagent and ACP blocked-result delivery behavior is preserved.

## Evidence

- Pre-fix handler regression: cron and CLI rows failed in both Gateway Vitest projects, returning stale progress; subagent, ACP, and fallback rows already passed.
- ClawSweeper's preserved-empty finding was reproduced against the initial fix: the exact cron state written with `preserveTerminalSummary: true` failed in both Gateway projects (2 failures, 56 passes) because an empty terminal summary bypassed the fallback.
- The amended selector treats blank or sanitizes-empty terminal text as unavailable and sanitizes cron/CLI terminal output with error context before selection. A focused CLI fixture proves internal Gateway approval details are not exposed through `result`.
- Final focused Gateway proof: `src/gateway/server-methods/tasks.test.ts` — 60/60 passed across both projects, including runtime ownership, missing-terminal fallback, persisted exact-empty fallback, and terminal error-context sanitation.
- Control UI consumer proof: `ui/src/pages/tasks/tasks-page.test.ts` — 18/18 passed, including Copy result consuming the Gateway-provided `result`.
- The exact changed-file gate passed on amended head `e677aab8b9d781468d2ca9b796b8d8978c836f8f`, including formatting, core and core-test typechecks, lint, dead-export scan, import cycles, and repository policy guards.
- A fresh independent final-diff review found no actionable issues, confirmed the persisted-empty setup exercises the durable write path used by cron finalization, and recommended shipping.
- Live Gateway/Control UI video is infeasible without a test-only registry seam: no supported UI flow can create a persisted cron/CLI record whose progress and terminal summaries intentionally diverge. The regression instead exercises the exported real Gateway handler with real task-registry records, and the existing UI test covers the `tasks.get.result` Copy result boundary.
