### PR TITLE
refactor(cli): remove ineffective startup import edges

### DIFF
--- a/src/cli/run-main.import-boundary.test.ts
+++ b/src/cli/run-main.import-boundary.test.ts
@@ -1,0 +1,14 @@
+// Run-main owns these modules eagerly, so lazy imports only add ineffective bundle edges.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(new URL("./run-main.ts", import.meta.url), "utf8");
+
+describe("run-main import boundary", () => {
+  it("does not lazy-import its eager startup owners", () => {
+    for (const specifier of ["../config/paths.js", "./command-startup-policy.js"]) {
+      expect(source).toContain(`from "${specifier}"`);
+      expect(source).not.toContain(`import("${specifier}")`);
+    }
+  });
+});

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -6,7 +6,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Command as CommanderCommand, Option as CommanderOption } from "commander";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
-import { resolveStateDir } from "../config/paths.js";
+import { resolveGatewayPort, resolveStateDir } from "../config/paths.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { isLoopbackAddress, isSecureWebSocketUrl } from "../gateway/net.js";
 import { normalizeWebSocketProtocol } from "../gateway/websocket-protocol.js";
@@ -172,7 +172,6 @@ async function tryRunGatewayRunFastPath(
     { addGatewayRunCommand },
     { VERSION },
     { emitCliBanner },
-    { resolveCliStartupPolicy },
     { ensureCliExecutionBootstrap },
     { defaultRuntime },
   ] = await startupTrace.measure("gateway-run-imports", () =>
@@ -181,13 +180,12 @@ async function tryRunGatewayRunFastPath(
       import("./gateway-cli/run-command.js"),
       import("../version.js"),
       import("./banner.js"),
-      import("./command-startup-policy.js"),
       import("./command-execution-startup.js"),
       import("../runtime.js"),
     ]),
   );
   const commandPath = resolveGatewayCatalogCommandPath(argv) ?? ["gateway"];
-  const startupPolicy = resolveCliStartupPolicy({
+  const startupPolicy = resolveCliStartupPolicyForArgv({
     argv,
     commandPath,
     jsonOutputMode: hasJsonOutputFlag(argv),
@@ -633,12 +631,10 @@ async function resolveLocalGatewayProbeTargets(
   config: OpenClawConfig,
 ): Promise<{ targets: GatewayProbeTarget[]; auth: GatewayProbeAuth }> {
   const [
-    { resolveGatewayPort },
     { resolveControlUiLinks },
     { resolveGatewayClientBootstrap },
     { readActiveGatewayLockPort },
   ] = await Promise.all([
-    import("../config/paths.js"),
     import("../gateway/control-ui-links.js"),
     import("../gateway/client-bootstrap.js"),
     import("../infra/gateway-lock.js"),
@@ -1617,9 +1613,9 @@ async function runCliWithPreparedOutputMode(
       });
       if (!shouldSkipPluginRegistration) {
         const config = await startupTrace.measure("register-plugin-commands", async () => {
-          const [{ registerPluginCliCommandsFromValidatedConfig }, { resolveCliStartupPolicy }] =
-            await Promise.all([import("../plugins/cli.js"), import("./command-startup-policy.js")]);
-          const startupPolicy = resolveCliStartupPolicy({
+          const { registerPluginCliCommandsFromValidatedConfig } =
+            await import("../plugins/cli.js");
+          const startupPolicy = resolveCliStartupPolicyForArgv({
             argv: parseArgv,
             commandPath: invocation.commandPath,
             jsonOutputMode: suppressStartupProgress,


### PR DESCRIPTION
## What Problem This Solves

The CLI bootstrap contained three lazy import edges for modules that `run-main` already imported eagerly. Those edges could not defer module loading, but they still produced redundant facade chunks and import-graph advisory noise.

## Why This Change Was Made

Reuse the existing eager `config/paths` and startup-policy bindings at all three call sites, leaving genuinely lazy CLI/plugin modules unchanged. A CLI-owned import-boundary regression prevents either eager owner from being reintroduced as a dynamic import.

Production LOC: +5/-9 (net -4) | Tests: +14/-0.

## User Impact

No user-visible behavior or configuration changes. The emitted CLI graph is smaller and accurately represents which startup modules are eager; measured process-start timing remained noise-level flat, so this PR makes no runtime-latency claim.

## Evidence

- Independent source baseline: duplicate dynamic edges 3 → 0 (`command-startup-policy` 2 → 0, `config/paths` 1 → 0).
- Dynamic-import advisories: 121 → 118 in the integration baseline; all three relevant `run-main` advisories were removed. The current branch has 118 total advisories and no advisory for either owner.
- Full `pnpm build` passed on the rebased head. `dist/cli/run-main.js` contains 0 dynamic imports of either owner; the candidate build reduced that file by 208 bytes.
- Focused Vitest: 293/293 passed (`run-main.import-boundary`, `run-main`, profile-env, and exit suites).
- `node --import tsx scripts/check-cli-bootstrap-imports.mts`: passed.
- `node scripts/check-changed.mjs --base HEAD --head HEAD -- src/cli/run-main.ts src/cli/run-main.import-boundary.test.ts`: passed all core/core-test typecheck, format, lint, dead-export, cycle, and architecture gates before the clean rebase; focused tests, bootstrap guard, dynamic-import scan, and full build passed again after rebase.
- Fresh branch autoreview: TruffleHog clean; no accepted/actionable findings; correctness 0.99.
- Startup benchmark (`gateway status --json`, 5 measured + 1 warmup): wall 2403.28 → 2394.54 ms, first output 2319.07 → 2306.20 ms, RSS 202.73 → 202.97 MB. These deltas are noise-level and are not presented as a performance win.
