### PR TITLE
fix(telegram): keep direct-topic self-history isolated

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -300,7 +300,7 @@ export function createTelegramBotCore(
       }
       recordTelegramGroupHistoryEntry({
         historyMap: groupHistories,
-        historyKey: buildTelegramGroupPeerId(record.chatId, record.messageThreadId),
+        historyKey: buildTelegramGroupPeerId(record.chatId, record.threadSpec),
         limit: historyLimit,
         entry: {
           sender: botHistorySender,
@@ -331,23 +331,21 @@ export function createTelegramBotCore(
       groupId: String(chatId),
     });
   const resolveGroupActivation = (params: {
-    chatId: string | number;
     agentId?: string;
-    messageThreadId?: number;
-    sessionKey?: string;
+    sessionKey: string;
     cfg: OpenClawConfig;
   }) => {
     const agentId = params.agentId ?? ownerAgentId;
-    const sessionKey =
-      params.sessionKey ??
-      `agent:${agentId}:telegram:group:${buildTelegramGroupPeerId(params.chatId, params.messageThreadId)}`;
     const storePath = telegramDeps.resolveStorePath(params.cfg.session?.store, { agentId });
     try {
       const getSessionEntry = telegramDeps.getSessionEntry;
       if (!getSessionEntry) {
         return undefined;
       }
-      const storedActivation = getSessionEntry({ storePath, sessionKey })?.groupActivation;
+      const storedActivation = getSessionEntry({
+        storePath,
+        sessionKey: params.sessionKey,
+      })?.groupActivation;
       const activation =
         storedActivation === "mention" || storedActivation === "always"
           ? normalizeGroupActivation(storedActivation)

--- a/extensions/telegram/src/bot-handlers.inbound-media.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media.ts
@@ -159,8 +159,6 @@ export function createTelegramInboundMedia({
       runtimeCfg: authorization.authorizationCfg,
     });
     const activationOverride = resolveGroupActivation({
-      chatId,
-      messageThreadId: resolvedThreadId,
       sessionKey: sessionState.sessionKey,
       agentId: sessionState.agentId,
       cfg: authorization.authorizationCfg,

--- a/extensions/telegram/src/bot-handlers.types.ts
+++ b/extensions/telegram/src/bot-handlers.types.ts
@@ -83,10 +83,8 @@ export type RegisterTelegramHandlerParams = {
   telegramDeps: TelegramBotDeps;
   resolveGroupPolicy: (chatId: string | number, cfg: OpenClawConfig) => ChannelGroupPolicy;
   resolveGroupActivation: (params: {
-    chatId: string | number;
     agentId?: string;
-    messageThreadId?: number;
-    sessionKey?: string;
+    sessionKey: string;
     cfg: OpenClawConfig;
   }) => boolean | undefined;
   resolveGroupRequireMention: (chatId: string | number, cfg: OpenClawConfig) => boolean;

--- a/extensions/telegram/src/bot-message-context.require-mention.test.ts
+++ b/extensions/telegram/src/bot-message-context.require-mention.test.ts
@@ -380,13 +380,11 @@ describe("buildTelegramMessageContext requireMention precedence", () => {
     if (!ctx?.ctxPayload) {
       throw new Error("expected Telegram context payload when topic disables requireMention");
     }
-    const activationCalls = resolveGroupActivation.mock.calls as unknown as Array<
-      [{ chatId: number; messageThreadId?: number; sessionKey: string }]
-    >;
-    const [activationOptions] = activationCalls[0] ?? [];
-    expect(activationOptions?.chatId).toBe(-1001234567890);
-    expect(activationOptions?.messageThreadId).toBe(99);
-    expect(activationOptions?.sessionKey).toBe("agent:main:telegram:group:-1001234567890:topic:99");
+    expect(resolveGroupActivation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:telegram:group:-1001234567890:topic:99",
+      }),
+    );
   });
 
   it("lets explicit topic requireMention=true override always activation", async () => {

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -434,8 +434,6 @@ export const buildTelegramMessageContext = async ({
     }),
   };
   const activationOverride = resolveGroupActivation({
-    chatId,
-    messageThreadId: resolvedThreadId,
     sessionKey,
     agentId: route.agentId,
     cfg,

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -72,10 +72,8 @@ type ResolveTelegramGroupConfig = (
 };
 
 type ResolveGroupActivation = (params: {
-  chatId: string | number;
   agentId?: string;
-  messageThreadId?: number;
-  sessionKey?: string;
+  sessionKey: string;
   cfg: OpenClawConfig;
 }) => boolean | undefined;
 

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -6,12 +6,17 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildTelegramGroupPeerId } from "./bot/helpers.js";
+import { recordTelegramGroupHistoryEntry } from "./group-history-window.js";
 import { resolveTelegramMessageCacheScope } from "./message-cache-persistence.js";
 import {
   createTelegramMessageCache,
   hasProviderObservedTelegramThreadBinding,
 } from "./message-cache.js";
-import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import {
+  recordOutboundMessageForPromptContext,
+  registerTelegramOutboundGroupHistoryRecorder,
+} from "./outbound-message-context.js";
 import { setTelegramRuntime } from "./runtime.js";
 import {
   clearTelegramRuntimeForTest as clearTelegramRuntime,
@@ -170,6 +175,59 @@ describe("recordOutboundMessageForPromptContext", () => {
 
     expect(cached?.threadId).toBe("77");
     expect(cached?.threadBinding?.threadSpec).toEqual({ scope: "direct-messages", id: 77 });
+  });
+
+  it("records forum and channel Direct Messages replies with the same topic ID in separate histories", async () => {
+    const chatId = -1001;
+    const history = new Map<string, Array<{ sender: string; body: string; messageId: string }>>();
+    const unregister = registerTelegramOutboundGroupHistoryRecorder({
+      accountId: "default",
+      recorder: (record) =>
+        recordTelegramGroupHistoryEntry({
+          historyMap: history,
+          historyKey: buildTelegramGroupPeerId(record.chatId, record.threadSpec),
+          limit: 10,
+          entry: {
+            sender: "Configured Agent (you)",
+            body: record.text ?? "<media>",
+            messageId: String(record.messageId),
+          },
+        }),
+    });
+
+    try {
+      for (const { scope, messageId, body } of [
+        { scope: "forum", messageId: 710, body: "Forum reply" },
+        { scope: "direct-messages", messageId: 711, body: "Direct-topic reply" },
+      ] as const) {
+        await recordOutboundMessageForPromptContext({
+          cfg,
+          account: { accountId: "default", name: "Configured Agent" },
+          chatId,
+          messageId,
+          messageThreadId: 77,
+          successfulSendThread: { scope, id: 77 },
+          message: {
+            chat: { id: chatId, type: "supergroup" },
+            date: 1_736_380_700,
+            message_id: messageId,
+            ...(scope === "forum"
+              ? { message_thread_id: 77 }
+              : { direct_messages_topic: { topic_id: 77 } }),
+            text: body,
+          },
+        });
+      }
+
+      expect(history.get("-1001:direct-topic:77")).toEqual([
+        expect.objectContaining({ body: "Direct-topic reply", messageId: "711" }),
+      ]);
+      expect(history.get("-1001:topic:77")).toEqual([
+        expect.objectContaining({ body: "Forum reply", messageId: "710" }),
+      ]);
+    } finally {
+      unregister();
+    }
   });
 
   it("binds a successful General-topic response from trusted send context", async () => {

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -43,7 +43,7 @@ type TelegramOutboundGroupHistoryRecord = {
   chatId: string | number;
   messageId: number;
   text?: string;
-  messageThreadId?: number;
+  threadSpec?: TelegramThreadSpec;
   timestamp?: number;
 };
 
@@ -179,11 +179,12 @@ export async function recordOutboundMessageForPromptContext(params: {
     });
     if (params.recordGroupHistory !== false) {
       const timestamp = resolveOutboundCacheMessageTimestamp(cacheMessage);
+      const threadSpec = providerObservedThread ?? params.successfulSendThread;
       outboundGroupHistoryRecorders.get(params.account.accountId)?.({
         chatId: params.chatId,
         messageId: params.messageId,
         text: params.text ?? cacheMessage.text ?? cacheMessage.caption,
-        ...(messageThreadId !== undefined ? { messageThreadId } : {}),
+        ...(threadSpec ? { threadSpec } : {}),
         ...(timestamp !== undefined ? { timestamp } : {}),
       });
     }


### PR DESCRIPTION
Related: #127010

## What Problem This Solves

Fixes an issue where Telegram channel Direct Messages replies could be recorded in the same rolling self-history bucket as a forum reply when both topics had the same numeric ID. A later turn could therefore read the wrong self-history watermark and lose or mix the context shown since the bot's last reply.

## Why This Change Was Made

Outbound history now carries the canonical Telegram thread specification through the recorder instead of reducing it to a numeric thread ID, preserving the distinction between forum and channel Direct Messages scopes. The same change removes the obsolete numeric session-key reconstruction fallback and requires callers to pass the canonical resolved session key they already own.

This change was AI-assisted and reviewed with the repository autoreview workflow.

## User Impact

Telegram forum topics and channel Direct Messages topics remain isolated even when Telegram assigns them the same numeric topic ID. Persisted group activation continues to resolve against the canonical routed session.

Production LOC: +11/-20 (net -9) | Tests: +64/-8 (net +56)

## Evidence

- Regression proof: the new outbound-history test fails against `origin/main` because `-1001:direct-topic:77` is absent while the forum and Direct Messages replies collapse together; it passes on this branch.
- `node scripts/run-vitest.mjs extensions/telegram/src/outbound-message-context.test.ts extensions/telegram/src/bot-message-context.require-mention.test.ts` — 23 passed.
- Isolated owner/sibling Telegram tests — 72 passed, including message session/context, topic binding, and dispatch reply-target coverage.
- `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts` — 246 passed.
- `node scripts/check-changed.mjs` — passed all selected extension production/test typecheck, lint, formatting, dependency, boundary, dead-code, database-first, and import-cycle gates.
- `git diff --check origin/main...HEAD` — passed.
- Fresh Codex autoreview — no accepted or actionable findings.
- A broader local `pnpm test:changed` run was not counted as proof: it expanded into a stale-dist build/E2E path and exceeded the local ten-minute cap after 36 passing tests.
- Real Telegram proof was attempted but could not start because this host lacks the local Convex broker environment file. The canonical broker credentials are intentionally stored in the interactive `OpenClaw` 1Password vault, outside the prompt-free service-account boundary, so no live-session evidence is claimed.
