### PR TITLE
fix(file-transfer): expose directory pagination tokens

### DIFF
--- a/extensions/file-transfer/src/tools/dir-list-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-list-tool.test.ts
@@ -24,6 +24,89 @@ afterEach(() => {
 });
 
 describe("dir_list tool", () => {
+  it("exposes the next page token to the model and forwards the current page token", async () => {
+    const entries = [
+      { name: "report.txt", isDir: false },
+      { name: "nested", isDir: true },
+    ];
+    vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1", displayName: "Node One" }]);
+    vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+    vi.mocked(callGatewayTool).mockResolvedValue({
+      payload: {
+        ok: true,
+        path: "/tmp/project",
+        entries,
+        nextPageToken: "3",
+        truncated: true,
+      },
+    });
+
+    const result = await createDirListTool().execute("tool-call-1", {
+      node: "node-1",
+      path: "/tmp/project",
+      pageToken: "+01",
+      maxEntries: 2,
+    });
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: 'Listed /tmp/project: 1 file, 1 subdir (more entries available). Call dir_list again with pageToken="3".',
+      },
+    ]);
+    expect(result.details).toEqual({
+      path: "/tmp/project",
+      entries,
+      nextPageToken: "3",
+      truncated: true,
+    });
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      expect.anything(),
+      expect.objectContaining({
+        nodeId: "node-1",
+        command: "dir.list",
+        params: {
+          path: "/tmp/project",
+          pageToken: "+01",
+          maxEntries: 2,
+        },
+      }),
+    );
+  });
+
+  it.each([undefined, ""])(
+    "reports truncation without inventing an unavailable page token (%s)",
+    async (nextPageToken) => {
+      vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1", displayName: "Node One" }]);
+      vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+      vi.mocked(callGatewayTool).mockResolvedValue({
+        payload: {
+          ok: true,
+          path: "/tmp/project",
+          entries: [],
+          nextPageToken,
+          truncated: true,
+        },
+      });
+
+      const result = await createDirListTool().execute("tool-call-1", {
+        node: "node-1",
+        path: "/tmp/project",
+      });
+
+      expect(result.content).toEqual([
+        { type: "text", text: "Listed /tmp/project: 0 files, 0 subdirs (more entries available)" },
+      ]);
+      expect(result.details).toEqual({
+        path: "/tmp/project",
+        entries: [],
+        nextPageToken,
+        truncated: true,
+      });
+    },
+  );
+
   it("reports missing paired nodes before retrying guessed local node names", async () => {
     vi.mocked(listNodes).mockResolvedValue([]);
 

--- a/extensions/file-transfer/src/tools/dir-list-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-list-tool.ts
@@ -52,8 +52,8 @@ export function createDirListTool(): AnyAgentTool {
 
       const fileCount = entries.filter((e) => !e.isDir).length;
       const dirCount = entries.filter((e) => e.isDir).length;
-      const truncatedNote = truncated ? " (more entries available — pass nextPageToken)" : "";
-      const summary = `Listed ${canonicalPath}: ${fileCount} file${fileCount !== 1 ? "s" : ""}, ${dirCount} subdir${dirCount !== 1 ? "s" : ""}${truncatedNote}`;
+      const truncatedNote = truncated ? " (more entries available)" : "";
+      const summary = `Listed ${canonicalPath}: ${fileCount} file${fileCount !== 1 ? "s" : ""}, ${dirCount} subdir${dirCount !== 1 ? "s" : ""}${truncatedNote}${truncated && nextPageToken ? `. Call dir_list again with pageToken=${JSON.stringify(nextPageToken)}.` : ""}`;
 
       await appendFileTransferAudit({
         op: "dir.list",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents listing a large paired-node directory could see that more entries existed but could not continue to the next page because the required pagination token was hidden from model-visible output.

## Why This Change Was Made

The node and Gateway protocol already return the correct `nextPageToken`; only the file-transfer plugin's result projection dropped it into UI/log-only details. The tool now includes the exact JSON-quoted token and parameter name in model-visible text while preserving structured details unchanged.

Truncated results without a usable token remain truthful and do not invent a continuation value.

## User Impact

Agents can continue paginated `dir_list` calls reliably instead of dead-ending after the first page of a large directory.

## Evidence

- Pre-fix regression: 3 focused cases failed because the output said to pass `nextPageToken` but omitted the actual token.
- `node scripts/run-vitest.mjs extensions/file-transfer/src/tools/dir-list-tool.test.ts` — 5 passed on the final rebased head.
- `node scripts/run-vitest.mjs extensions/file-transfer` — 191 passed across 20 files.
- Proportional changed-file gates passed, including format, production/test typechecks, lint, plugin boundaries, architecture guards, and import-cycle checks.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted P0/P1 findings on the final branch.
- Production delta: +2/-2, net zero. Tests: +83/-0.

AI-assisted: yes. I reviewed the implementation and validation results.
