### PR TITLE
fix(ui): recover when first-run setup detection fails

### DIFF
--- a/ui/src/e2e/inference-setup-gate.e2e.test.ts
+++ b/ui/src/e2e/inference-setup-gate.e2e.test.ts
@@ -49,6 +49,51 @@ suite.define(() => {
     }
   });
 
+  it("shows retryable model setup when first-run detection stays unavailable", async () => {
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      agentModel: null,
+      deferredMethods: ["openclaw.setup.detect"],
+      featureMethods: ["openclaw.setup.detect"],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("openclaw.setup.detect");
+      await gateway.deferNext("openclaw.setup.detect");
+      await gateway.rejectDeferred("openclaw.setup.detect", {
+        code: "UNAVAILABLE",
+        message: "temporary setup detection failure",
+      });
+
+      await gateway.waitForRequest("openclaw.setup.detect", { after: 1 });
+      await gateway.deferNext("openclaw.setup.detect");
+      await gateway.rejectDeferred("openclaw.setup.detect", {
+        code: "UNAVAILABLE",
+        message: "setup detection still unavailable",
+      });
+
+      await gateway.waitForRequest("openclaw.setup.detect", { after: 2 });
+      await gateway.rejectDeferred("openclaw.setup.detect", {
+        code: "UNAVAILABLE",
+        message: "setup detection unavailable on recovery page",
+      });
+
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");
+      await page.getByRole("alert").waitFor();
+      await expect.poll(() => page.getByRole("button", { name: "Retry" }).count()).toBe(1);
+      await captureProof(page, "first-run-detection-recovery.png");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("blocks the new-session composer until a model is connected", async () => {
     const context = await suite.browser.newContext({
       colorScheme: "dark",

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -221,7 +221,7 @@ describe("model setup first-run redirect", () => {
     expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
   });
 
-  it("stops after the same connection rejects detection twice", async () => {
+  it("opens visible recovery after the same connection rejects detection twice", async () => {
     const request = vi.fn().mockRejectedValue(new Error("gateway unavailable"));
     const client = { request } as unknown as GatewayBrowserClient;
     type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
@@ -234,6 +234,7 @@ describe("model setup first-run redirect", () => {
         features: { methods: ["openclaw.setup.detect"] },
       },
     };
+    const replace = vi.fn();
     const context = {
       gateway: {
         snapshot,
@@ -246,15 +247,16 @@ describe("model setup first-run redirect", () => {
         state: { selectedId: "main" },
         subscribe: () => () => undefined,
       },
-      replace: vi.fn(),
+      replace,
     } as unknown as ApplicationContext<RouteId>;
 
     await startRedirect(context);
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
     listener!(snapshot as Parameters<GatewayListener>[0]);
-    await Promise.resolve();
+    await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
 
     expect(request).toHaveBeenCalledTimes(2);
+    expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
   });
 
   it("does not redirect after the operator leaves the default landing", async () => {

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -152,11 +152,16 @@ function startModelSetupFirstRunRedirect(params: {
           return;
         }
         // One same-generation retry absorbs a transient startup race without
-        // turning first-run guidance into a background retry loop.
+        // turning first-run guidance into a background retry loop. Route an
+        // exhausted first-run check to the page that owns visible retry UI.
         detection = { ...attempt, phase: attempt.attempts < 2 ? "retry-ready" : "settled" };
         if (detection.phase === "retry-ready" && params.isStillDefaultLanding()) {
           handleSnapshot(params.context.gateway.snapshot);
         } else {
+          if (detection.phase === "settled" && params.isStillDefaultLanding()) {
+            redirected = true;
+            params.redirect();
+          }
           settleInitialDecision();
         }
       });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where first-time Control UI users could remain on an unusable chat landing page when model-setup detection repeatedly failed during startup.

## Why This Change Was Made

After the bounded startup retry is exhausted, the first-run gate now routes users to the existing model setup recovery page, which owns the visible error and retry action. The change retains the one-retry startup policy and does not add a background retry loop.

## User Impact

Users encountering a temporary or persistent setup-detection failure now see a clear error and an accessible **Retry** action instead of being stranded on chat.

## Evidence

- `ui/src/pages/model-setup/first-run.test.ts`: 8/8 passing, including exhausted-detection recovery.
- `ui/src/e2e/inference-setup-gate.e2e.test.ts`: 5/5 Playwright cases passing.
- Recovery E2E asserts the `alert` role and exactly one button named `Retry` after three mocked detection failures.
- Visual inspection at 1440×900 confirms the alert text and full-width Retry button are fully visible with no clipping.
- `pnpm check:changed`: passed (conflict/max-lines/assertion/dependency guards, formatting, dead-code scan, UI i18n verification, core/UI typechecks, and changed-file lint).
- TruffleHog 3.95.9 focused scan: 0 verified or unknown secrets.

The generated screenshot was inspected locally and remains uncommitted. GitHub’s REST API exposed no supported issue/PR attachment endpoint for upload, so the role-based DOM assertions and visual inspection result are recorded above.
