### PR TITLE
improve: speed up first-run model detection

### DIFF
--- a/src/system-agent/setup-inference-core.ts
+++ b/src/system-agent/setup-inference-core.ts
@@ -1,41 +1,41 @@
-import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
-import {
+import type { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import type {
   loadAuthProfileStoreForRuntime,
   updateAuthProfileStoreWithLock,
 } from "../agents/auth-profiles/store.js";
-import { readCodexCliActiveApiKey } from "../agents/cli-credentials.js";
+import type { readCodexCliActiveApiKey } from "../agents/cli-credentials.js";
 import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
-import {
+import type {
   detectInferenceBackends,
-  type InferenceBackendKind,
+  InferenceBackendKind,
 } from "../commands/onboard-inference.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { enablePluginInConfig } from "../plugins/enable.js";
-import {
-  type ProviderAuthChoiceMetadata,
+import type { enablePluginInConfig } from "../plugins/enable.js";
+import type {
+  ProviderAuthChoiceMetadata,
   resolveManifestProviderAuthChoice,
   resolveManifestProviderAuthChoices,
 } from "../plugins/provider-auth-choices.js";
-import { resolvePluginProvidersCore } from "../plugins/providers.runtime.js";
+import type { resolvePluginProvidersCore } from "../plugins/providers.runtime.js";
 import type { SetupRecommendedInstall } from "../plugins/recommended-tool-installs.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { loadAuthoredSetupConfig } from "./onboarding-welcome.js";
-import { probeLocalCommand } from "./probes.js";
+import type { probeLocalCommand } from "./probes.js";
 import type {
   SetupInferenceAuthOption,
   SetupInferenceManualProvider,
   SetupInferencePrepareOption,
 } from "./setup-inference-auth-options.js";
 import { resolveSetupInferenceCandidateBrandId } from "./setup-inference-brand.js";
-import {
+import type {
   captureSystemAgentOwnerPluginArtifacts,
-  type createSystemAgentVerifiedInferenceBinding,
-  type SystemAgentVerifiedInferenceBinding,
-  type SystemAgentVerifiedInferenceDeps,
+  createSystemAgentVerifiedInferenceBinding,
+  SystemAgentVerifiedInferenceBinding,
+  SystemAgentVerifiedInferenceDeps,
 } from "./verified-inference.js";
 
 export const setupInferenceLog = createSubsystemLogger("system-agent/setup-inference");

--- a/src/system-agent/setup-inference-detection.worker.ts
+++ b/src/system-agent/setup-inference-detection.worker.ts
@@ -1,10 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { listRecommendedToolInstalls } from "../plugins/recommended-tool-installs.js";
-import {
-  detectSetupInference,
-  listManualSetupInferenceOptions,
-  type SetupInferenceDetection,
-} from "./setup-inference.js";
+import type { SetupInferenceDetection } from "./setup-inference-core.js";
+import { detectSetupInference, listManualSetupInferenceOptions } from "./setup-inference-detect.js";
 
 if (!parentPort) {
   throw new Error("setup inference detection worker requires a parent port");


### PR DESCRIPTION
## What Problem This Solves

First-run users opening Model Setup wait about 5.5 seconds while `openclaw.setup.detect` cold-starts an isolated worker. The worker was loading activation, auth, plugin, and verification modules that detection never executes, expanding its static runtime graph to 760 files / 10.44 MB before candidates could be returned.

## Why This Change Was Made

The worker now imports detection directly from its owning module instead of the broad setup barrel, and setup-core dependencies used only in `typeof` contracts are explicitly type-only. One-shot worker isolation, partial-result timeout semantics, and candidate behavior remain unchanged.

No new regression test was added because this is a behavior-neutral import-graph correction; the existing setup detection and activation suites cover the preserved runtime contract.

## User Impact

On the measured cold path, Model Setup starts receiving candidates about 395 ms sooner and completes detection about 126 ms sooner. Users see the same candidates and setup choices with less first-run waiting.

## Evidence

Measured from clean production builds on the same Linux host, three cold worker runs per revision:

| Metric | Exact-main baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Partial candidates | 3,152 ms | 2,757 ms | -395 ms (-12.5%) |
| Final detection | 5,012 ms | 4,886 ms | -126 ms (-2.5%) |
| Worker exit | 5,051 ms | 4,902 ms | -149 ms (-3.0%) |
| Wall time | 5.12 s | 4.97 s | -0.15 s (-2.9%) |
| Max RSS | 477,153 KiB | 480,395 KiB | effectively unchanged |
| Reachable static graph | 760 files / 10,444,837 B | 536 files / 7,626,244 B | -224 files / -27.0% bytes |
| Setup entry chunk | 117,799 B / 62 imports | 34,484 B / 33 imports | -70.7% bytes / -46.8% imports |

Real user-path proof after the final build:

- Restarted the task-owned real Gateway and opened the served Control UI in Chromium.
- Used **Model Setup → Check again**; the UI returned to its ready state in 5,580 ms and the Gateway logged successful `openclaw.setup.detect` completion in 5,388 ms.
- The candidate UI remained populated and Chromium reported no page errors.

Validation:

- `node scripts/run-vitest.mjs src/system-agent/setup-inference-detection.test.ts src/system-agent/setup-inference.test.ts` — 139 passed
- `pnpm build` — passed
- `pnpm check:changed` — passed
- Fresh Codex autoreview — clean, no accepted/actionable findings

AI-assisted change; implementation and measurements were reviewed against the built worker graph and real Gateway behavior.
