### PR TITLE
fix(secrets): compare proxy bearer tokens directly

### DIFF
--- a/src/secrets/egress-proxy/proxy-server.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.test.ts
@@ -297,8 +297,13 @@ describe("secret egress proxy", () => {
   it.each([
     { label: "missing", auth: undefined, expectedReason: "missing-proxy-auth" },
     {
-      label: "wrong",
+      label: "malformed",
       auth: basicProxyAuth("wrong-token"),
+      expectedReason: "invalid-proxy-auth",
+    },
+    {
+      label: "wrong",
+      auth: basicProxyAuth("A".repeat(43)),
       expectedReason: "invalid-proxy-auth",
     },
   ])("refuses $label authentication on CONNECT and forwarded requests", async (testCase) => {

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import {
   createServer as createHttpServer,
@@ -61,10 +61,9 @@ export type SecretEgressProxyHandle = {
 
 type ConnectTarget = { hostname: string; port: number };
 type RegisteredRun = {
-  digest: Buffer;
   key: string;
   sentinelBindings: Map<string, { allowedHosts: Set<string>; name: string }>;
-  token: string;
+  token: Buffer;
 };
 
 function normalizeHostname(raw: string): string {
@@ -120,15 +119,12 @@ function runKey(run: Readonly<{ instanceId: string; runId: string }>): string {
   return `${run.runId}\0${run.instanceId}`;
 }
 
-// Proxy tokens are 256-bit random bearer credentials, not user-chosen passwords, so a
-// slow KDF would add per-request latency on the proxy hot path without making brute force
-// any more infeasible. A process-keyed MAC is the right primitive: it normalizes attacker-
-// controlled input to a fixed length for constant-time compare, and a leaked digest cannot
-// be correlated back to a token without the in-memory key.
-const tokenMacKey = randomBytes(32);
-
-function tokenDigest(token: string): Buffer {
-  return createHmac("sha256", tokenMacKey).update(token).digest();
+function parseProxyToken(token: string): Buffer | undefined {
+  if (!/^[A-Za-z0-9_-]{43}$/u.test(token)) {
+    return undefined;
+  }
+  const bytes = Buffer.from(token, "base64url");
+  return bytes.length === 32 && bytes.toString("base64url") === token ? bytes : undefined;
 }
 
 function parseBasicProxyPassword(header: string | string[] | undefined): string | undefined {
@@ -329,9 +325,12 @@ export async function startSecretEgressProxyServer(params: {
     if (!password) {
       return "invalid-proxy-auth";
     }
-    const candidate = tokenDigest(password);
+    const candidate = parseProxyToken(password);
+    if (!candidate) {
+      return "invalid-proxy-auth";
+    }
     for (const registered of tokens.values()) {
-      if (timingSafeEqual(candidate, registered.digest)) {
+      if (timingSafeEqual(candidate, registered.token)) {
         return registered;
       }
     }
@@ -611,12 +610,10 @@ export async function startSecretEgressProxyServer(params: {
       const key = runKey(run);
       let registered = tokens.get(key);
       if (!registered) {
-        const token = randomBytes(32).toString("base64url");
         registered = {
-          digest: tokenDigest(token),
           key,
           sentinelBindings: new Map(),
-          token,
+          token: randomBytes(32),
         };
         tokens.set(key, registered);
       }
@@ -633,7 +630,8 @@ export async function startSecretEgressProxyServer(params: {
       // proxy-URL credentials. Base64 is acceptable here: loopback is the only
       // listener, the token is run-scoped, and a process that can read it from
       // this env can already read the sentinels that authorize substitution.
-      const proxyUrl = `http://${PROXY_AUTH_USERNAME}:${registered.token}@127.0.0.1:${address.port}`;
+      const token = registered.token.toString("base64url");
+      const proxyUrl = `http://${PROXY_AUTH_USERNAME}:${token}@127.0.0.1:${address.port}`;
       return {
         HTTPS_PROXY: proxyUrl,
         HTTP_PROXY: proxyUrl,

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import {
   createServer as createHttpServer,
@@ -61,10 +61,9 @@ export type SecretEgressProxyHandle = {
 
 type ConnectTarget = { hostname: string; port: number };
 type RegisteredRun = {
-  digest: Buffer;
   key: string;
   sentinelBindings: Map<string, { allowedHosts: Set<string>; name: string }>;
-  token: string;
+  token: Buffer;
 };
 
 function normalizeHostname(raw: string): string {
@@ -120,15 +119,12 @@ function runKey(run: Readonly<{ instanceId: string; runId: string }>): string {
   return `${run.runId}\0${run.instanceId}`;
 }
 
-// Proxy tokens are 256-bit random bearer credentials, not user-chosen passwords, so a
-// slow KDF would add per-request latency on the proxy hot path without making brute force
-// any more infeasible. A process-keyed MAC is the right primitive: it normalizes attacker-
-// controlled input to a fixed length for constant-time compare, and a leaked digest cannot
-// be correlated back to a token without the in-memory key.
-const tokenMacKey = randomBytes(32);
-
-function tokenDigest(token: string): Buffer {
-  return createHmac("sha256", tokenMacKey).update(token).digest();
+function parseProxyToken(token: string): Buffer | undefined {
+  if (!/^[A-Za-z0-9_-]{43}$/u.test(token)) {
+    return undefined;
+  }
+  const bytes = Buffer.from(token, "base64url");
+  return bytes.length === 32 && bytes.toString("base64url") === token ? bytes : undefined;
 }
 
 function parseBasicProxyPassword(header: string | string[] | undefined): string | undefined {
@@ -311,9 +307,12 @@ export async function startSecretEgressProxyServer(params: {
     if (!password) {
       return "invalid-proxy-auth";
     }
-    const candidate = tokenDigest(password);
+    const candidate = parseProxyToken(password);
+    if (!candidate) {
+      return "invalid-proxy-auth";
+    }
     for (const registered of tokens.values()) {
-      if (timingSafeEqual(candidate, registered.digest)) {
+      if (timingSafeEqual(candidate, registered.token)) {
         return registered;
       }
     }
@@ -574,12 +573,10 @@ export async function startSecretEgressProxyServer(params: {
       const key = runKey(run);
       let registered = tokens.get(key);
       if (!registered) {
-        const token = randomBytes(32).toString("base64url");
         registered = {
-          digest: tokenDigest(token),
           key,
           sentinelBindings: new Map(),
-          token,
+          token: randomBytes(32),
         };
         tokens.set(key, registered);
       }
@@ -596,7 +593,8 @@ export async function startSecretEgressProxyServer(params: {
       // proxy-URL credentials. Base64 is acceptable here: loopback is the only
       // listener, the token is run-scoped, and a process that can read it from
       // this env can already read the sentinels that authorize substitution.
-      const proxyUrl = `http://${PROXY_AUTH_USERNAME}:${registered.token}@127.0.0.1:${address.port}`;
+      const token = registered.token.toString("base64url");
+      const proxyUrl = `http://${PROXY_AUTH_USERNAME}:${token}@127.0.0.1:${address.port}`;
       return {
         HTTPS_PROXY: proxyUrl,
         HTTP_PROXY: proxyUrl,


### PR DESCRIPTION
## What Problem This Solves

Resolves CodeQL alert [#783](https://github.com/openclaw/openclaw/security/code-scanning/783), where the secret egress proxy normalized its per-run bearer credentials with a fast HMAC before authorization, making random fixed-length tokens look like password hashes.

## Why This Change Was Made

The proxy now stores the generated 256-bit token as bytes, accepts only its canonical 43-character base64url representation, and compares the fixed-length bytes directly with `timingSafeEqual`. This removes the digest detour while preserving constant-time comparison, token generation, run scope, revocation, and loopback-only exposure.

Architectural owner: `src/secrets/egress-proxy/proxy-server.ts`.

Production LOC: 16 added, 18 removed, net -2. Test LOC: 6 added, 1 removed, net +5. No compatibility path or public contract changed.

## User Impact

No user-visible behavior changes. Proxy bearer credentials remain random, run-scoped, revocable, and valid only for the owning in-process registration. Malformed and canonical-but-incorrect credentials are rejected before forwarding.

## Evidence

- exact signed head: `837b88eddd913e944ae1f9df68fa07a92313ea70`
- synchronized parent: `110eb787a14e7a43bdcb91c5aa0fd8794d3d5478`
- pre-fix reproduction: CodeQL alert #783 remains open on the latest analyzed default-branch instance
- `git diff --check`: passed
- `node scripts/run-vitest.mjs src/secrets/egress-proxy/proxy-server.test.ts`: 18 passed
- changed-scope checks: all completed stages passed; the linked-worktree core-test type shard initially missed `ui`'s workspace-local `pako` types, then passed on exact retry after linking the canonical nested workspace install
- remaining oxlint, schema, database-first, media, runtime-sidecar, import-cycle, webhook-order, and auth-pairing guards: passed
- exact-head Codex autoreview using `gpt-5.6-sol` with high reasoning: clean, no P0 findings, 0.99 confidence
- hosted CI, exact-head CodeQL, ClawSweeper, and Testbox proof pending
