### PR TITLE
test(release): honor Codex ultra request mapping

### DIFF
--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -276,11 +276,11 @@ function resolveCodexHarnessThinkingLevel(raw: string | undefined): CodexHarness
   return normalized as CodexHarnessThinkingLevel;
 }
 
-function resolveCodexHarnessExpectedEffort(modelId: string): string | null {
+function resolveCodexHarnessExpectedRequestEffort(modelId: string): string | null {
   const configured = process.env.OPENCLAW_LIVE_CODEX_HARNESS_EXPECTED_EFFORT;
   if (configured?.trim()) {
     const expected = resolveCodexHarnessThinkingLevel(configured);
-    return expected === "off" ? null : expected;
+    return expected === "off" ? null : expected === "ultra" ? "max" : expected;
   }
   const supported = CODEX_HARNESS_SUPPORTED_EFFORTS.get(modelId);
   if (!supported) {
@@ -289,14 +289,14 @@ function resolveCodexHarnessExpectedEffort(modelId: string): string | null {
   if (CODEX_HARNESS_THINKING === "off") {
     return null;
   }
-  // Independent oracle for the pinned Codex model catalog. Lower requested
-  // levels choose the nearest advertised effort; Ultra remains explicit.
+  // Codex preserves Ultra in config but intentionally sends Max to the model.
+  // Compare the request-facing lifecycle event to that wire contract.
   const candidates =
     CODEX_HARNESS_THINKING === "ultra"
       ? supported
       : supported.filter((effort) => effort !== "ultra");
   const requestedRank = CODEX_HARNESS_REASONING_EFFORTS.indexOf(CODEX_HARNESS_THINKING);
-  return (
+  const configuredEffort =
     candidates.find(
       (effort) =>
         CODEX_HARNESS_REASONING_EFFORTS.indexOf(
@@ -304,8 +304,8 @@ function resolveCodexHarnessExpectedEffort(modelId: string): string | null {
         ) >= requestedRank,
     ) ??
     candidates.at(-1) ??
-    null
-  );
+    null;
+  return configuredEffort === "ultra" ? "max" : configuredEffort;
 }
 
 function logCodexLiveStep(step: string, details?: Record<string, unknown>): void {
@@ -846,7 +846,7 @@ function recordCodexAttemptIdentity(params: {
   expect(turnStarting?.data).toMatchObject({ model: expectedModel });
   const actualEffort = turnStarting?.data?.effort;
   const actualCollaborationEffort = turnStarting?.data?.collaborationEffort;
-  const expectedEffort = resolveCodexHarnessExpectedEffort(expectedModel);
+  const expectedEffort = resolveCodexHarnessExpectedRequestEffort(expectedModel);
   expect(actualEffort ?? null).toBe(expectedEffort);
   expect(actualCollaborationEffort ?? null).toBe(actualEffort ?? null);
   if (CODEX_HARNESS_FULL_CONTEXT) {


### PR DESCRIPTION
## Summary

- keep `ultra` as the configured OpenClaw/Codex effort
- expect Codex request-facing lifecycle evidence to report `max`, matching Codex's intentional wire mapping
- preserve explicit expected-effort overrides under the same request contract

## Root cause

Main full validation configured Codex Sol and Terra with `ultra`, then asserted that the app-server request-facing lifecycle event also contained `ultra`. Codex intentionally preserves Ultra in its model/config enum but maps Ultra to Max when building the provider request. The harness therefore rejected correct Codex behavior.

Codex source contract checked directly:

- `../codex/codex-rs/protocol/src/openai_models.rs:50-76` preserves Ultra in the public/config enum
- `../codex/codex-rs/core/src/client.rs:178-183` maps Ultra to Max at request construction
- `../codex/codex-rs/core/src/client_tests.rs:297-307` locks that behavior with `ultra_reasoning_uses_max_for_requests`

## Evidence

- main full validation child: https://github.com/openclaw/openclaw/actions/runs/32447357591
- Sol Ultra failure: https://github.com/openclaw/openclaw/actions/runs/32447357591/job/96672116730
- Terra Ultra failure: https://github.com/openclaw/openclaw/actions/runs/32447357591/job/96672116787
- both received `max` while the harness expected `ultra`

## Validation

- `git diff --check`
- remote exact-head CI and the next main live validation own the authenticated Codex proof
- no local provider call was made

## LOC

- production: +0/-0
- live release harness: +8/-8

## Test audit

This changes the existing authenticated boundary assertion rather than adding a duplicate test or production seam. The pre-fix assertion fails both exact live lanes; the repaired expectation follows Codex's explicit request contract while still checking configured model and collaboration effort.