### PR TITLE
fix(setup): reject message with onboarding options

### DIFF
--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -17,11 +17,13 @@ falls through to guided onboarding. Use `-m`/`--message` for one request or
 
 Routing order:
 
-1. Any onboarding option (`--wizard`, `--baseline`, workspace, reset,
+1. Mixing `-m`/`--message` or `--yes` with an onboarding option is rejected;
+   choose either a system-agent request or onboarding.
+2. Any onboarding option (`--wizard`, `--baseline`, workspace, reset,
    non-interactive, flow, mode, Gateway, daemon, skip, import, remote, or auth
    options) runs onboarding exactly as `openclaw onboard` does.
-2. `-m`/`--message` or `--yes` runs the system agent.
-3. With no routing option, a configured interactive system opens OpenClaw. A
+3. `-m`/`--message` or `--yes` runs the system agent.
+4. With no routing option, a configured interactive system opens OpenClaw. A
    fresh system runs onboarding. On a configured system, `--json` prints the
    system overview even without a TTY; an onboarding option keeps onboarding's
    JSON summary.

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -198,7 +198,7 @@ describe("registerSetupCommand", () => {
     await runCli(["setup", ...args]);
 
     expect(runtime.error).toHaveBeenCalledWith(
-      `${flag} cannot be combined with onboarding options.`,
+      `${flag} cannot be combined with onboarding options. Rerun with either --message/--yes or onboarding options, not both.`,
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -206,6 +206,19 @@ describe("registerSetupCommand", () => {
     expect(runSystemAgentMock).not.toHaveBeenCalled();
   });
 
+  it.each(["--tailscale-reset-on-exit", "--no-tailscale-reset-on-exit"])(
+    "keeps retired no-op %s neutral to system-agent routing",
+    async (flag) => {
+      await runCli(["setup", "--message", "status", flag]);
+
+      expect(runSystemAgentMock).toHaveBeenCalledWith(
+        { message: "status", yes: false, json: false },
+        runtime,
+      );
+      expect(runtime.error).not.toHaveBeenCalled();
+    },
+  );
+
   it("resumes pending local onboarding instead of opening chat after inference commits", async () => {
     const sourceConfig = {
       agents: { defaults: { model: "acme/verified" } },

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -191,6 +191,21 @@ describe("registerSetupCommand", () => {
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { args: ["-m", "status", "--non-interactive", "--accept-risk"], flag: "--message" },
+    { args: ["--yes", "--wizard"], flag: "--yes" },
+  ])("rejects system-agent $flag when onboarding options are explicit", async ({ args, flag }) => {
+    await runCli(["setup", ...args]);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      `${flag} cannot be combined with onboarding options.`,
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+    expect(runSystemAgentMock).not.toHaveBeenCalled();
+  });
+
   it("resumes pending local onboarding instead of opening chat after inference commits", async () => {
     const sourceConfig = {
       agents: { defaults: { model: "acme/verified" } },

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -150,6 +150,21 @@ describe("registerSetupCommand", () => {
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { args: ["-m", "status", "--non-interactive", "--accept-risk"], flag: "--message" },
+    { args: ["--yes", "--wizard"], flag: "--yes" },
+  ])("rejects system-agent $flag when onboarding options are explicit", async ({ args, flag }) => {
+    await runCli(["setup", ...args]);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      `${flag} cannot be combined with onboarding options.`,
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+    expect(runSystemAgentMock).not.toHaveBeenCalled();
+  });
+
   it("resumes pending local onboarding instead of opening chat after inference commits", async () => {
     const sourceConfig = {
       agents: { defaults: { model: "acme/verified" } },

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -157,7 +157,7 @@ describe("registerSetupCommand", () => {
     await runCli(["setup", ...args]);
 
     expect(runtime.error).toHaveBeenCalledWith(
-      `${flag} cannot be combined with onboarding options.`,
+      `${flag} cannot be combined with onboarding options. Rerun with either --message/--yes or onboarding options, not both.`,
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -183,7 +183,7 @@ export function registerSetupCommand(program: Command): void {
           .map((option) => option.long ?? option.short ?? option.flags)
           .toSorted();
         defaultRuntime.error(
-          `${systemAgentFlags.join(", ")} cannot be combined with onboarding options.`,
+          `${systemAgentFlags.join(", ")} cannot be combined with onboarding options. Rerun with either --message/--yes or onboarding options, not both.`,
         );
         defaultRuntime.exit(1);
         return;

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -173,6 +173,21 @@ export function registerSetupCommand(program: Command): void {
       const options = rawOptions as Record<string, unknown>;
       const hasOnboardingFlag = hasExplicitOnboardingOption(commandRuntime);
       const hasSystemAgentRequest = hasExplicitOptions(commandRuntime, ["message", "yes"]);
+      if (hasOnboardingFlag && hasSystemAgentRequest) {
+        const systemAgentFlags = commandRuntime.options
+          .filter(
+            (option) =>
+              ["message", "yes"].includes(option.attributeName()) &&
+              commandRuntime.getOptionValueSource(option.attributeName()) === "cli",
+          )
+          .map((option) => option.long ?? option.short ?? option.flags)
+          .toSorted();
+        defaultRuntime.error(
+          `${systemAgentFlags.join(", ")} cannot be combined with onboarding options.`,
+        );
+        defaultRuntime.exit(1);
+        return;
+      }
       const configured =
         hasOnboardingFlag || hasSystemAgentRequest ? false : await isConfiguredInstance();
       const route = resolveSetupCommandRoute({

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -16,7 +16,7 @@ import {
   resolveOnboardCommandOptions,
 } from "./register.onboard.js";
 
-const SYSTEM_AGENT_OPTION_NAMES = new Set(["message", "yes", "json"]);
+const NON_ONBOARDING_OPTION_NAMES = new Set(["message", "yes", "json", "tailscaleResetOnExit"]);
 const BASELINE_OPTION_NAMES = new Set(["baseline", "workspace", "json"]);
 
 type SetupRoute = "onboarding" | "system-agent";
@@ -43,7 +43,7 @@ export function resolveSetupCommandRoute(input: {
 function hasExplicitOnboardingOption(command: Command): boolean {
   return command.options.some((option) => {
     const name = option.attributeName();
-    return !SYSTEM_AGENT_OPTION_NAMES.has(name) && command.getOptionValueSource(name) === "cli";
+    return !NON_ONBOARDING_OPTION_NAMES.has(name) && command.getOptionValueSource(name) === "cli";
   });
 }
 

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -261,7 +261,7 @@ export function registerSetupCommand(program: Command): void {
           .map((option) => option.long ?? option.short ?? option.flags)
           .toSorted();
         defaultRuntime.error(
-          `${systemAgentFlags.join(", ")} cannot be combined with onboarding options.`,
+          `${systemAgentFlags.join(", ")} cannot be combined with onboarding options. Rerun with either --message/--yes or onboarding options, not both.`,
         );
         defaultRuntime.exit(1);
         return;

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -251,6 +251,21 @@ export function registerSetupCommand(program: Command): void {
       const options = rawOptions as Record<string, unknown>;
       const hasOnboardingFlag = hasExplicitOnboardingOption(commandRuntime);
       const hasSystemAgentRequest = hasExplicitOptions(commandRuntime, ["message", "yes"]);
+      if (hasOnboardingFlag && hasSystemAgentRequest) {
+        const systemAgentFlags = commandRuntime.options
+          .filter(
+            (option) =>
+              ["message", "yes"].includes(option.attributeName()) &&
+              commandRuntime.getOptionValueSource(option.attributeName()) === "cli",
+          )
+          .map((option) => option.long ?? option.short ?? option.flags)
+          .toSorted();
+        defaultRuntime.error(
+          `${systemAgentFlags.join(", ")} cannot be combined with onboarding options.`,
+        );
+        defaultRuntime.exit(1);
+        return;
+      }
       const configured =
         hasOnboardingFlag || hasSystemAgentRequest ? false : await isConfiguredInstance();
       const route = resolveSetupCommandRoute({


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users invoking `openclaw setup --message ...` could also pass onboarding-only options, leaving the CLI to silently choose one incompatible setup path.

## Why This Change Was Made

The setup command now rejects explicit system-agent options combined with explicit onboarding options before reading configuration or entering either flow. Retired `--tailscale-reset-on-exit` and `--no-tailscale-reset-on-exit` compatibility no-ops remain routing-neutral rather than being misclassified as onboarding options. The public setup routing reference documents the compatibility change, and focused regression coverage verifies conflicts and both retired flags.

## User Impact

Conflicting setup invocations now fail immediately with an actionable recovery command instead of ambiguously selecting a setup mode. Valid system-agent-only and onboarding-only invocations, including the retired no-op flags, are unchanged.

## Evidence

Exact head `da2047950a675e9125e552a38cbd22249bf7717b` after rebasing current `origin/main`:

- `node scripts/run-vitest.mjs src/cli/program/register.setup.test.ts`: 46 tests passed.
- `pnpm docs:check-mdx`: 780 files passed.
- Fresh branch autoreview: clean, patch correct at 0.99 confidence.
- TruffleHog 3.97.0 scan: clean.
- The complete `pnpm check:changed` gate passed before the conflict-free rebase; exact-head CI is running.
- Isolated real CLI proof with temporary `HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`: exit 1, zero stdout bytes, zero state files, and actionable conflict stderr.

Owner review remains required because this changes public CLI compatibility behavior.
