### PR TITLE
fix(macos): fingerprint persisted gateway routes

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 enum GatewayDiscoveryPreferences {
@@ -27,7 +28,7 @@ enum GatewayDiscoveryPreferences {
         }
     }
 
-    static func preferredRouteBinding() -> String? {
+    static func preferredRouteBindingDigest() -> String? {
         let raw = AppDefaults.standard.string(forKey: self.preferredRouteBindingKey)
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
@@ -36,16 +37,16 @@ enum GatewayDiscoveryPreferences {
     static func setPreferredStableID(_ stableID: String?, routeBinding: String?) {
         self.setPreferredStableID(stableID)
         guard self.preferredStableID() != nil,
-              let routeBinding = self.normalized(routeBinding)
+              let routeBindingDigest = self.routeBindingDigest(routeBinding)
         else {
             AppDefaults.standard.removeObject(forKey: self.preferredRouteBindingKey)
             return
         }
-        AppDefaults.standard.set(routeBinding, forKey: self.preferredRouteBindingKey)
+        AppDefaults.standard.set(routeBindingDigest, forKey: self.preferredRouteBindingKey)
     }
 
     /// Discovery ids name one concrete Gateway. Persist the non-secret fallback
-    /// route beside the id so an app-off config edit cannot reuse its receipts.
+    /// route fingerprint beside the id so an app-off config edit cannot reuse its receipts.
     static func routeBinding(
         connectionMode: AppState.ConnectionMode,
         remoteTransport: AppState.RemoteTransport,
@@ -100,8 +101,8 @@ enum GatewayDiscoveryPreferences {
             AppDefaults.standard.removeObject(forKey: self.preferredRouteBindingKey)
             return false
         }
-        guard let stored = self.preferredRouteBinding(),
-              let current = self.normalized(currentRouteBinding),
+        guard let stored = self.preferredRouteBindingDigest(),
+              let current = self.routeBindingDigest(currentRouteBinding),
               stored == current
         else {
             self.setPreferredStableID(nil, routeBinding: nil)
@@ -113,5 +114,12 @@ enum GatewayDiscoveryPreferences {
     private static func normalized(_ value: String?) -> String? {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private static func routeBindingDigest(_ value: String?) -> String? {
+        guard let value = self.normalized(value) else { return nil }
+        return SHA256.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -4,19 +4,22 @@ import Testing
 
 private struct StoredGatewayPreference {
     let stableID: String?
-    let routeBinding: String?
+    let storedRouteBinding: Any?
 }
+
+private let preferredRouteBindingKey = "gateway.preferredStableIDRouteBinding.v1"
 
 private func captureGatewayPreference() -> StoredGatewayPreference {
     StoredGatewayPreference(
         stableID: GatewayDiscoveryPreferences.preferredStableID(),
-        routeBinding: GatewayDiscoveryPreferences.preferredRouteBinding())
+        storedRouteBinding: AppDefaults.standard.object(forKey: preferredRouteBindingKey))
 }
 
 private func restoreGatewayPreference(_ preference: StoredGatewayPreference) {
-    GatewayDiscoveryPreferences.setPreferredStableID(
-        preference.stableID,
-        routeBinding: preference.routeBinding)
+    GatewayDiscoveryPreferences.setPreferredStableID(preference.stableID)
+    if let storedRouteBinding = preference.storedRouteBinding {
+        AppDefaults.standard.set(storedRouteBinding, forKey: preferredRouteBindingKey)
+    }
 }
 
 private actor GatewayConfigReadGate {
@@ -125,7 +128,21 @@ struct AppStateRemoteConfigTests {
         GatewayDiscoveryPreferences.setPreferredStableID("gateway-b")
 
         #expect(GatewayDiscoveryPreferences.preferredStableID() == "gateway-b")
-        #expect(GatewayDiscoveryPreferences.preferredRouteBinding() == nil)
+        #expect(GatewayDiscoveryPreferences.preferredRouteBindingDigest() == nil)
+    }
+
+    @Test
+    func `route binding persists only a matching fingerprint`() throws {
+        let previousGatewayPreference = captureGatewayPreference()
+        defer { restoreGatewayPreference(previousGatewayPreference) }
+        let routeBinding = "remote:direct:wss://gateway-a.example.test:443"
+
+        GatewayDiscoveryPreferences.setPreferredStableID("gateway-a", routeBinding: routeBinding)
+
+        let stored = try #require(GatewayDiscoveryPreferences.preferredRouteBindingDigest())
+        #expect(stored != routeBinding)
+        #expect(stored.count == 64)
+        #expect(!GatewayDiscoveryPreferences.clearPreferredStableIDIfRouteBindingMismatch(routeBinding))
     }
 
     @Test
@@ -666,7 +683,7 @@ struct AppStateRemoteConfigTests {
             #expect(state.remoteUrl == "wss://gateway-b.example.test")
             #expect(state._testReconcilePreferredGatewayRouteBinding())
             #expect(GatewayDiscoveryPreferences.preferredStableID() == nil)
-            #expect(GatewayDiscoveryPreferences.preferredRouteBinding() == nil)
+            #expect(GatewayDiscoveryPreferences.preferredRouteBindingDigest() == nil)
         }
     }
 
@@ -712,7 +729,7 @@ struct AppStateRemoteConfigTests {
                 #expect(settings.identity == "/tmp/gateway-b-id")
                 #expect(state._testReconcilePreferredGatewayRouteBinding())
                 #expect(GatewayDiscoveryPreferences.preferredStableID() == nil)
-                #expect(GatewayDiscoveryPreferences.preferredRouteBinding() == nil)
+                #expect(GatewayDiscoveryPreferences.preferredRouteBindingDigest() == nil)
             }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -8,19 +8,22 @@ import Testing
 
 private struct OnboardingStoredGatewayPreference {
     let stableID: String?
-    let routeBinding: String?
+    let storedRouteBinding: Any?
 }
+
+private let onboardingPreferredRouteBindingKey = "gateway.preferredStableIDRouteBinding.v1"
 
 private func captureOnboardingGatewayPreference() -> OnboardingStoredGatewayPreference {
     OnboardingStoredGatewayPreference(
         stableID: GatewayDiscoveryPreferences.preferredStableID(),
-        routeBinding: GatewayDiscoveryPreferences.preferredRouteBinding())
+        storedRouteBinding: AppDefaults.standard.object(forKey: onboardingPreferredRouteBindingKey))
 }
 
 private func restoreOnboardingGatewayPreference(_ preference: OnboardingStoredGatewayPreference) {
-    GatewayDiscoveryPreferences.setPreferredStableID(
-        preference.stableID,
-        routeBinding: preference.routeBinding)
+    GatewayDiscoveryPreferences.setPreferredStableID(preference.stableID)
+    if let storedRouteBinding = preference.storedRouteBinding {
+        AppDefaults.standard.set(storedRouteBinding, forKey: onboardingPreferredRouteBindingKey)
+    }
 }
 
 private func makeOnboardingResumeDefaults() throws -> (UserDefaults, String) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS app persisted a remote Gateway route identity, including its host or SSH target, in cleartext preferences.

## Why This Change Was Made

The discovery preference now persists a SHA-256 route fingerprint and compares it with the fingerprint of the current route. The raw route remains available only in memory where it owns device credentials and routing decisions.

Existing cleartext route bindings are transient cache state. On the next normal route reconciliation they cannot match the fingerprinted current route, so the stale preferred discovery ID and raw binding are removed and rebuilt from the next selected route. No dual-read or fallback path remains.

Architectural owner: `apps/macos/Sources/OpenClaw/GatewayDiscoveryPreferences.swift`.

Production LOC: 14 added, 6 removed, net +8 for the privacy invariant. Test LOC: 33 added, 13 removed, net +20.

## User Impact

Gateway host and SSH target details are no longer retained in macOS preferences. An existing preferred discovery selection may be cleared once after upgrade and rediscovered; configured connection details and device credentials are unchanged.

## Evidence

- added coverage that the persisted value differs from the route, is a 64-character fingerprint, and still matches the original route
- existing route-mismatch and cold-config replacement coverage remains in place
- `git diff --check`
- project `autoreview --mode local`: clean, no accepted/actionable findings
- TruffleHog scan of the exact diff: clean
- exact reviewed commit: `661134df0ed0a0820728d27f5c8ee1cb805cb178`
- focused macOS CI and exact-head CodeQL proof pending on this draft
