### PR TITLE
fix(clawhub): prevent failed archive staging from leaking temporary files

### DIFF
--- a/src/infra/clawhub-artifacts.test.ts
+++ b/src/infra/clawhub-artifacts.test.ts
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
+  type ClawHubDownloadResult,
   downloadClawHubGitHubSkillArchive,
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
@@ -11,6 +13,61 @@ import {
   normalizeClawHubSha256Integrity,
   normalizeClawHubSha256Hex,
 } from "./clawhub-artifacts.js";
+import * as privateTempWorkspace from "./private-temp-workspace.js";
+
+const tempDirs = createTrackedTempDirs();
+
+type FsSafeTempWorkspace = Awaited<ReturnType<typeof privateTempWorkspace.tempWorkspace>>;
+type TempWorkspace = Omit<FsSafeTempWorkspace, "cleanup"> & {
+  cleanup: () => ReturnType<FsSafeTempWorkspace["cleanup"]>;
+};
+
+async function observeTempWorkspace(params: { cleanupFailure?: Error } = {}) {
+  const root = await tempDirs.make("openclaw-clawhub-archive-");
+  const createWorkspace = privateTempWorkspace.tempWorkspace;
+  let workspace: TempWorkspace | undefined;
+  vi.spyOn(privateTempWorkspace, "tempWorkspace").mockImplementation(async (options) => {
+    const ownedWorkspace = await createWorkspace({ ...options, rootDir: root });
+    workspace = {
+      ...ownedWorkspace,
+      cleanup: vi.fn(async () => {
+        const result = await ownedWorkspace.cleanup();
+        if (params.cleanupFailure) {
+          throw params.cleanupFailure;
+        }
+        return result;
+      }),
+    };
+    return workspace;
+  });
+
+  return {
+    root,
+    workspace(): TempWorkspace {
+      if (!workspace) {
+        throw new Error("archive acquisition did not create a temporary workspace");
+      }
+      return workspace;
+    },
+  };
+}
+
+function createArchiveResponse(bytes: Uint8Array, headers?: HeadersInit): Response {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("content-type", responseHeaders.get("content-type") ?? "application/zip");
+  responseHeaders.set(
+    "X-ClawHub-Artifact-Sha256",
+    createHash("sha256").update(bytes).digest("hex"),
+  );
+  responseHeaders.set(
+    "X-ClawHub-Npm-Integrity",
+    `sha512-${createHash("sha512").update(bytes).digest("base64")}`,
+  );
+  responseHeaders.set("X-ClawHub-Npm-Shasum", createHash("sha1").update(bytes).digest("hex"));
+  responseHeaders.set("X-ClawHub-Npm-Tarball-Name", "registry-selected.tgz");
+  responseHeaders.set("X-ClawHub-ClawPack-Spec-Version", "3");
+  return new Response(new Uint8Array(bytes), { status: 200, headers: responseHeaders });
+}
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   let statError: unknown;
@@ -79,11 +136,13 @@ function createOversizedArchiveResponse(
   };
 }
 
-const oversizedArchiveCases: Array<{
+const archiveDownloadCases: Array<{
   name: string;
   headers?: HeadersInit;
-  download: (response: Response) => Promise<unknown>;
+  download: (response: Response) => Promise<ClawHubDownloadResult>;
   expectedResource: string;
+  expectedFileName: string;
+  expectedArtifact?: "clawpack";
 }> = [
   {
     name: "package archive",
@@ -91,9 +150,11 @@ const oversizedArchiveCases: Array<{
       downloadClawHubPackageArchive({
         name: "@hyf/zai-external-alpha",
         version: "0.0.1",
+        token: "test-token",
         fetchImpl: async () => response,
       }),
     expectedResource: "package archive download for @hyf/zai-external-alpha",
+    expectedFileName: "zai-external-alpha.zip",
   },
   {
     name: "ClawPack artifact",
@@ -103,9 +164,12 @@ const oversizedArchiveCases: Array<{
         name: "demo",
         version: "1.2.3",
         artifact: "clawpack",
+        token: "test-token",
         fetchImpl: async () => response,
       }),
     expectedResource: "ClawPack download for demo@1.2.3",
+    expectedFileName: "registry-selected.tgz",
+    expectedArtifact: "clawpack",
   },
   {
     name: "skill archive",
@@ -113,9 +177,11 @@ const oversizedArchiveCases: Array<{
       downloadClawHubSkillArchive({
         slug: "agentreceipt",
         version: "1.0.0",
+        token: "test-token",
         fetchImpl: async () => response,
       }),
     expectedResource: "skill archive download for agentreceipt",
+    expectedFileName: "agentreceipt.zip",
   },
   {
     name: "resolver URL archive",
@@ -126,6 +192,7 @@ const oversizedArchiveCases: Array<{
         fetchImpl: async () => response,
       }),
     expectedResource: "skill archive download at /skill.zip",
+    expectedFileName: "skill.zip",
   },
   {
     name: "GitHub source archive",
@@ -136,12 +203,15 @@ const oversizedArchiveCases: Array<{
         fetchImpl: async () => response,
       }),
     expectedResource: "GitHub source archive for owner/repo@abc123",
+    expectedFileName: "abc123.zip",
   },
 ];
 
 describe("clawhub artifacts", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
     delete process.env.CLAWHUB_TOKEN;
+    await tempDirs.cleanup();
   });
 
   it("normalizes raw ClawHub SHA-256 hashes into integrity strings", () => {
@@ -241,7 +311,7 @@ describe("clawhub artifacts", () => {
     ).rejects.toThrow(/declared sha256/);
   });
 
-  it.each(oversizedArchiveCases)(
+  it.each(archiveDownloadCases)(
     "rejects and cancels oversized $name downloads",
     async ({ headers, download, expectedResource }) => {
       const oversized = createOversizedArchiveResponse({ headers });
@@ -250,6 +320,134 @@ describe("clawhub artifacts", () => {
         `ClawHub ${expectedResource} exceeded 268435456 bytes (268959744 bytes declared)`,
       );
       expect(oversized.cancel).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(archiveDownloadCases)(
+    "removes the owned workspace when writing a $name partially fails",
+    async ({ headers, download }) => {
+      const observed = await observeTempWorkspace();
+      const unrelatedFile = path.join(observed.root, "preexisting.txt");
+      await fs.writeFile(unrelatedFile, "preserved");
+
+      const writeError = Object.assign(new Error("disk full after partial archive write"), {
+        code: "ENOSPC",
+      });
+      const writeFile = fs.writeFile;
+      vi.spyOn(fs, "writeFile").mockImplementation(async (file) => {
+        await writeFile(file, new Uint8Array([1]));
+        throw writeError;
+      });
+
+      const bytes = new Uint8Array([7, 8, 9]);
+
+      await expect(download(createArchiveResponse(bytes, headers))).rejects.toBe(writeError);
+      const workspace = observed.workspace();
+      expect(workspace.cleanup).toHaveBeenCalledOnce();
+      await expectPathMissing(workspace.dir);
+      await expect(fs.readFile(unrelatedFile, "utf8")).resolves.toBe("preserved");
+      await expect(fs.readdir(observed.root)).resolves.toEqual(["preexisting.txt"]);
+    },
+  );
+
+  it.each(archiveDownloadCases)(
+    "preserves $name bytes, integrity, metadata, and caller-owned cleanup",
+    async ({ headers, download, expectedFileName, expectedArtifact }) => {
+      const observed = await observeTempWorkspace();
+      const bytes = new Uint8Array([7, 8, 9]);
+      const sha256Digest = createHash("sha256").update(bytes).digest("hex");
+      const archive = await download(createArchiveResponse(bytes, headers));
+      const workspace = observed.workspace();
+
+      expect(path.basename(archive.archivePath)).toBe(expectedFileName);
+      expect(archive.artifact).toBe(expectedArtifact ?? "archive");
+      expect(archive.sha256Hex).toBe(sha256Digest);
+      expect(archive.integrity).toBe(
+        `sha256-${createHash("sha256").update(bytes).digest("base64")}`,
+      );
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(Buffer.from(bytes));
+      expect(workspace.cleanup).not.toHaveBeenCalled();
+
+      if (expectedArtifact === "clawpack") {
+        expect(archive.clawpackHeaderSha256).toBe(sha256Digest);
+        expect(archive.clawpackHeaderSpecVersion).toBe(3);
+        expect(archive.npmIntegrity).toBe(
+          `sha512-${createHash("sha512").update(bytes).digest("base64")}`,
+        );
+        expect(archive.npmShasum).toBe(createHash("sha1").update(bytes).digest("hex"));
+        expect(archive.npmTarballName).toBe("registry-selected.tgz");
+      }
+
+      await archive.cleanup();
+      expect(workspace.cleanup).toHaveBeenCalledOnce();
+      await expectPathMissing(workspace.dir);
+    },
+  );
+
+  it("does not delete a replacement workspace after an archive write failure", async () => {
+    const observed = await observeTempWorkspace();
+    const writeError = Object.assign(new Error("disk full after workspace replacement"), {
+      code: "ENOSPC",
+    });
+    const writeFile = fs.writeFile;
+    vi.spyOn(fs, "writeFile").mockImplementation(async (file) => {
+      await writeFile(file, new Uint8Array([1]));
+      const workspace = observed.workspace();
+      await fs.rename(workspace.dir, `${workspace.dir}-original`);
+      await fs.mkdir(workspace.dir);
+      await writeFile(path.join(workspace.dir, "replacement-marker"), "preserved");
+      throw writeError;
+    });
+
+    await expect(
+      downloadClawHubSkillArchive({
+        slug: "replacement-skill",
+        token: "test-token",
+        fetchImpl: async () => createArchiveResponse(new Uint8Array([4, 5, 6])),
+      }),
+    ).rejects.toBe(writeError);
+
+    const workspace = observed.workspace();
+    expect(workspace.cleanup).toHaveBeenCalledOnce();
+    await expect(vi.mocked(workspace.cleanup).mock.results[0]?.value).resolves.toBe(
+      "identity-mismatch",
+    );
+    await expect(fs.readFile(path.join(workspace.dir, "replacement-marker"), "utf8")).resolves.toBe(
+      "preserved",
+    );
+    await expect(
+      fs.readFile(path.join(`${workspace.dir}-original`, "replacement-skill.zip")),
+    ).resolves.toEqual(Buffer.from([1]));
+  });
+
+  it.each(["cleanup", "cleanup logging"])(
+    "keeps the original archive write failure when %s fails",
+    async (failureStage) => {
+      const cleanupError = new Error("temporary workspace cleanup failed");
+      if (failureStage === "cleanup logging") {
+        cleanupError.toString = () => {
+          throw new Error("temporary workspace cleanup logger failed");
+        };
+      }
+      const observed = await observeTempWorkspace({ cleanupFailure: cleanupError });
+      const writeError = Object.assign(new Error("disk full after partial archive write"), {
+        code: "ENOSPC",
+      });
+      const writeFile = fs.writeFile;
+      vi.spyOn(fs, "writeFile").mockImplementation(async (file) => {
+        await writeFile(file, new Uint8Array([1]));
+        throw writeError;
+      });
+
+      await expect(
+        downloadClawHubSkillArchive({
+          slug: "cleanup-failure-skill",
+          token: "test-token",
+          fetchImpl: async () => createArchiveResponse(new Uint8Array([4, 5, 6])),
+        }),
+      ).rejects.toBe(writeError);
+      expect(observed.workspace().cleanup).toHaveBeenCalledOnce();
+      await expectPathMissing(observed.workspace().dir);
     },
   );
 

--- a/src/infra/clawhub-artifacts.ts
+++ b/src/infra/clawhub-artifacts.ts
@@ -49,10 +49,6 @@ function buildGitHubZipUrl(repo: string, commit: string): string {
   return url.toString();
 }
 
-function formatSha256Integrity(bytes: Uint8Array): string {
-  return `sha256-${sha256Base64(bytes)}`;
-}
-
 function formatSha512Integrity(bytes: Uint8Array): string {
   const digest = createHash("sha512").update(bytes).digest("base64");
   return `sha512-${digest}`;
@@ -68,6 +64,32 @@ function safePackageTarballName(name: string, version: string): string {
     .replace(/[\\/]+/g, "-")
     .replace(/[^A-Za-z0-9._-]/g, "-");
   return `${base || "package"}-${version}.tgz`;
+}
+
+async function stageClawHubArchive(params: {
+  prefix: string;
+  fileName: string;
+  bytes: Uint8Array;
+  sha256Hex?: string;
+  result?: Omit<ClawHubDownloadResult, "archivePath" | "integrity" | "sha256Hex" | "cleanup">;
+}): Promise<ClawHubDownloadResult> {
+  const sha256Digest =
+    params.sha256Hex ?? Buffer.from(sha256Base64(params.bytes), "base64").toString("hex");
+  const target = await createTempDownloadTarget(params);
+  try {
+    await fs.writeFile(target.path, params.bytes);
+    return {
+      archivePath: target.path,
+      integrity: `sha256-${Buffer.from(sha256Digest, "hex").toString("base64")}`,
+      sha256Hex: sha256Digest,
+      artifact: "archive",
+      ...params.result,
+      cleanup: target.cleanup,
+    };
+  } catch (error) {
+    await target.cleanup().catch(() => undefined);
+    throw error;
+  }
 }
 
 /** Normalizes ClawHub SHA-256 metadata into Subresource Integrity format. */
@@ -175,25 +197,22 @@ export async function downloadClawHubPackageArchive(params: {
       safePackageTarballName(params.name, params.version);
     const rawSpecVersion = response.headers.get("X-ClawHub-ClawPack-Spec-Version");
     const specVersion = parseStrictPositiveInteger(rawSpecVersion);
-    const target = await createTempDownloadTarget({
+    return stageClawHubArchive({
       prefix: "openclaw-clawhub-clawpack",
       fileName: npmTarballName,
-    });
-    await fs.writeFile(target.path, bytes);
-    return {
-      archivePath: target.path,
-      integrity: normalizeClawHubSha256Integrity(sha256Digest) ?? formatSha256Integrity(bytes),
+      bytes,
       sha256Hex: sha256Digest,
-      artifact: "clawpack",
-      clawpackHeaderSha256: headerSha256,
-      ...(typeof specVersion === "number" && Number.isSafeInteger(specVersion) && specVersion >= 0
-        ? { clawpackHeaderSpecVersion: specVersion }
-        : {}),
-      npmIntegrity,
-      npmShasum,
-      npmTarballName,
-      cleanup: target.cleanup,
-    };
+      result: {
+        artifact: "clawpack",
+        clawpackHeaderSha256: headerSha256,
+        ...(typeof specVersion === "number" && Number.isSafeInteger(specVersion) && specVersion >= 0
+          ? { clawpackHeaderSpecVersion: specVersion }
+          : {}),
+        npmIntegrity,
+        npmShasum,
+        npmTarballName,
+      },
+    });
   }
   const search = params.version
     ? { version: params.version }
@@ -216,19 +235,11 @@ export async function downloadClawHubPackageArchive(params: {
     timeoutMs: params.timeoutMs,
     resourceLabel: `package archive download for ${params.name}`,
   });
-  const sha256Digest = sha256Hex(bytes);
-  const target = await createTempDownloadTarget({
+  return stageClawHubArchive({
     prefix: "openclaw-clawhub-package",
     fileName: `${params.name}.zip`,
+    bytes,
   });
-  await fs.writeFile(target.path, bytes);
-  return {
-    archivePath: target.path,
-    integrity: formatSha256Integrity(bytes),
-    sha256Hex: sha256Digest,
-    artifact: "archive",
-    cleanup: target.cleanup,
-  };
 }
 
 export async function downloadClawHubSkillArchive(params: {
@@ -262,19 +273,11 @@ export async function downloadClawHubSkillArchive(params: {
     timeoutMs: params.timeoutMs,
     resourceLabel: `skill archive download for ${params.slug}`,
   });
-  const sha256Digest = sha256Hex(bytes);
-  const target = await createTempDownloadTarget({
+  return stageClawHubArchive({
     prefix: "openclaw-clawhub-skill",
     fileName: `${params.slug}.zip`,
+    bytes,
   });
-  await fs.writeFile(target.path, bytes);
-  return {
-    archivePath: target.path,
-    integrity: formatSha256Integrity(bytes),
-    sha256Hex: sha256Digest,
-    artifact: "archive",
-    cleanup: target.cleanup,
-  };
 }
 
 export async function downloadClawHubSkillArchiveUrl(params: {
@@ -304,19 +307,11 @@ export async function downloadClawHubSkillArchiveUrl(params: {
     timeoutMs: params.timeoutMs,
     resourceLabel: `skill archive download at ${url.pathname}`,
   });
-  const sha256Digest = sha256Hex(bytes);
-  const target = await createTempDownloadTarget({
+  return stageClawHubArchive({
     prefix: "openclaw-clawhub-skill",
     fileName: "skill.zip",
+    bytes,
   });
-  await fs.writeFile(target.path, bytes);
-  return {
-    archivePath: target.path,
-    integrity: formatSha256Integrity(bytes),
-    sha256Hex: sha256Digest,
-    artifact: "archive",
-    cleanup: target.cleanup,
-  };
 }
 
 export async function downloadClawHubGitHubSkillArchive(params: {
@@ -340,17 +335,9 @@ export async function downloadClawHubGitHubSkillArchive(params: {
     timeoutMs: params.timeoutMs,
     resourceLabel: `GitHub source archive for ${params.repo}@${params.commit}`,
   });
-  const sha256Digest = sha256Hex(bytes);
-  const target = await createTempDownloadTarget({
+  return stageClawHubArchive({
     prefix: "openclaw-clawhub-github-skill",
     fileName: `${params.commit}.zip`,
+    bytes,
   });
-  await fs.writeFile(target.path, bytes);
-  return {
-    archivePath: target.path,
-    integrity: formatSha256Integrity(bytes),
-    sha256Hex: sha256Digest,
-    artifact: "archive",
-    cleanup: target.cleanup,
-  };
 }


### PR DESCRIPTION
Closes #127057

AI-assisted: Codex; the implementation and evidence were independently reviewed.

## What Problem This Solves

Fixes an issue where users installing ClawHub plugins or skills would retain a private temporary directory and partially written archive when staging failed with a filesystem error such as `ENOSPC` before the caller received a cleanup handle. ClawPack packages, legacy package archives, versioned skills, resolver-backed skills, and GitHub-backed skills were all affected. The defect is also present in stable `v2026.7.1` under the earlier `src/infra/clawhub.ts` owner.

## Why This Change Was Made

One private archive-staging owner now allocates the existing temporary target, writes and constructs the unchanged download result while it still owns cleanup, and performs best-effort identity-checked workspace cleanup before rethrowing the exact original failure. Successful downloads continue transferring the existing cleanup handle to their callers; their filenames, bytes, SHA-256 integrity values, and all ClawPack SHA-512/SHA-1/header metadata are unchanged. ClawPack reuses its already-validated SHA-256 digest, and ordinary archives hash their bytes once through the existing shared helper before deriving both integrity representations.

Rejected alternatives: caller-side cleanup cannot work because failed acquisition never returns a target; five independent `try`/`catch` blocks preserve the duplicate lifecycle bug surface; unlinking a pathname directly could delete a replacement path and would bypass the existing workspace identity contract.

## User Impact

Failed ClawHub plugin and skill downloads release their own partially staged archive and temporary directory immediately, keep unrelated files and replacement paths intact, and still report the original filesystem error. Successful installs, preflight behavior, verification metadata, public result shapes, and caller-owned cleanup remain unchanged.

## Evidence

- Exact reviewed head: `4b48c0b2786b0a17d28bdebb156c192462a7fd60`.
- Before the fix, the actual acquisition-owner suite passed its 17 existing cases and failed all five new real-filesystem partial-write regressions because workspace cleanup was called zero times.
- After the fix, the focused owner suite passes all 30 cases, including five exact-identity `ENOSPC` failures, five complete success/result/cleanup contracts, preservation of a renamed-workspace replacement, and cleanup/logger-failure error precedence.
- Owner, existing temporary-download boundary, ClawHub client/package/skill siblings, plugin install, and skill install/preflight: seven files, five Vitest shards, 286 tests passed.
- Direct inspection and disposable-files proof establish the locked and installed `@openclaw/fs-safe@0.5.5` cleanup outcomes: `removed`, `missing`, and `identity-mismatch`; a preexisting replacement marker and unrelated sibling survive. The identity check is not claimed to be atomic against a replacement during the cleanup call.
- `node scripts/check-changed.mjs -- src/infra/clawhub-artifacts.ts src/infra/clawhub-artifacts.test.ts`, targeted `oxfmt --check`, and `git diff --check` pass.
- Fresh uncommitted Codex autoreview: clean, no actionable findings; independent adversarial owner/dependency/caller review: clean.
- Production: `+47/-60` (net `-13`); tests: `+202/-4` (net `+198`). No new file, dependency, exported helper, Plugin SDK change, config surface, persistence change, install-flow change, or `CHANGELOG.md` edit.
- All requests use synthetic responses and real disposable files. No live ClawHub service, real install, external archive request, or operator state was accessed; live installation is intentionally out of scope.

```text
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-179-vitest-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts --configLoader runner src/infra/clawhub-artifacts.test.ts
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-179-vitest-cache node scripts/run-vitest.mjs src/infra/clawhub-artifacts.test.ts src/infra/clawhub-client.test.ts src/infra/clawhub-packages.test.ts src/infra/clawhub-skills.test.ts src/plugin-sdk/temp-path.test.ts src/plugins/clawhub.test.ts src/skills/lifecycle/clawhub.test.ts --configLoader runner
node scripts/check-changed.mjs -- src/infra/clawhub-artifacts.ts src/infra/clawhub-artifacts.test.ts
node_modules/.bin/oxfmt --check src/infra/clawhub-artifacts.ts src/infra/clawhub-artifacts.test.ts
git diff --check
```
