### PR TITLE
improve(plugins): reduce installed index import fanout

### DIFF
--- a/src/plugins/installed-plugin-index-hash.ts
+++ b/src/plugins/installed-plugin-index-hash.ts
@@ -1,7 +1,7 @@
 // Hashes installed plugin index records for change detection.
 import crypto from "node:crypto";
 import fs from "node:fs";
-import { stableStringify } from "@openclaw/normalization-core";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import type { PluginDiagnostic } from "./manifest-types.js";
 
 /** File metadata signature used to skip unchanged installed plugin files. */

--- a/src/plugins/installed-plugin-index-record-state.ts
+++ b/src/plugins/installed-plugin-index-record-state.ts
@@ -1,4 +1,4 @@
-import { safeParseJson } from "@openclaw/normalization-core";
+import { safeParseJson } from "@openclaw/normalization-core/json-coercion";
 import {
   inspectPluginInstallRecordMap,
   type PluginInstallRecordMapState,

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -1,7 +1,7 @@
 /** Persists, inspects, and refreshes the installed plugin index in the state database. */
 import { existsSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
-import { safeParseJson } from "@openclaw/normalization-core";
+import { safeParseJson } from "@openclaw/normalization-core/json-coercion";
 import { z } from "zod";
 import {
   createPluginInstallRecordMap,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -191,6 +191,9 @@
       "@openclaw/normalization-core/stable-node-path": [
         "./packages/normalization-core/src/stable-node-path.ts"
       ],
+      "@openclaw/normalization-core/stable-stringify": [
+        "./packages/normalization-core/src/stable-stringify.ts"
+      ],
       "@openclaw/normalization-core/string-coerce": [
         "./packages/normalization-core/src/string-coerce.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves

Installed plugin-index hashing and persistence loaded the 109-export normalization barrel even though those paths need only stable stringification or JSON parsing. This adds avoidable cold import work to plugin-index startup and maintenance paths.

## Why This Change Was Made

Use the package's existing focused `stable-stringify` and `json-coercion` exports at the three installed-index owners. Add the matching TypeScript source path for `stable-stringify`, preserving the package's NodeNext resolution contract without adding a wrapper or changing behavior.

## User Impact

Plugin-index code loads a smaller normalization graph. There is no API, configuration, storage, or runtime behavior change.

## Evidence

- Current-main cold imports, 25 fresh Node 24.15.0 processes: normalization root 109 exports / 7.539 ms median; `stable-stringify` 1 export / 2.123 ms (71.8% lower); `json-coercion` 2 exports / 2.629 ms (65.1% lower).
- Root and focused subpaths expose identical function objects and matching results.
- Focused installed-index and normalization contracts: 8 files, 120/120 tests passed after rebase.
- `pnpm --filter @openclaw/normalization-core build`: passed.
- `node scripts/check-changed.mjs --base HEAD --head HEAD -- <four changed files>`: passed, including core/core-test typecheck, formatting, lint, dead exports, cycles, and architecture guards.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm build`: passed.
- Fresh branch autoreview against `origin/main`: TruffleHog clean, no accepted/actionable findings, patch correct at 0.99 confidence.
