### PR TITLE
test(xai): bound live tool probe requests

### DIFF
--- a/src/agents/xai.live.test.ts
+++ b/src/agents/xai.live.test.ts
@@ -16,7 +16,7 @@ import { createWebSearchTool } from "./tools/web-search.js";
 const XAI_KEY = process.env.XAI_API_KEY ?? "";
 const LIVE = isLiveTestEnabled(["XAI_LIVE_TEST"]);
 const XAI_COMPLETE_LIVE_TIMEOUT_MS = 90_000;
-const XAI_TOOL_REQUEST_TIMEOUT_MS = 80_000;
+const XAI_TOOL_REQUEST_TIMEOUT_MS = 60_000;
 const XAI_WEB_SEARCH_LIVE_TIMEOUT_SECONDS = 60;
 const XAI_LIVE_COMPLETION_CASES = [
   { modelId: "grok-4.3", completionReasoning: undefined },
@@ -177,14 +177,16 @@ describeLive("xai live", () => {
         let capturedPayload: Record<string, unknown> | undefined;
         const streamOptions = {
           apiKey: XAI_KEY,
+          firstEventTimeoutMs: XAI_TOOL_REQUEST_TIMEOUT_MS,
           maxTokens: 128,
           reasoning: "low",
-          signal: AbortSignal.timeout(XAI_TOOL_REQUEST_TIMEOUT_MS),
+          timeoutMs: XAI_TOOL_REQUEST_TIMEOUT_MS,
           toolChoice: { type: "function", name: "noop" },
           onPayload: (payload: unknown) => {
             capturedPayload = payload as Record<string, unknown>;
           },
         } satisfies Parameters<typeof agent.streamFn>[2] & {
+          firstEventTimeoutMs: number;
           reasoning: "low";
           toolChoice: { type: "function"; name: string };
         };
@@ -199,24 +201,19 @@ describeLive("xai live", () => {
           streamOptions,
         );
 
-        let doneMessage: AssistantLikeMessage;
-        try {
-          doneMessage = await collectDoneMessage(
-            stream as AsyncIterable<{
-              type: string;
-              message?: AssistantLikeMessage;
-              error?: { errorMessage?: string };
-            }>,
+        const doneMessage = await collectDoneMessage(
+          stream as AsyncIterable<{
+            type: string;
+            message?: AssistantLikeMessage;
+            error?: { errorMessage?: string };
+          }>,
+        ).catch((error: unknown) => {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `xAI ${modelId} tool stream failed (payloadCaptured=${capturedPayload !== undefined}): ${message}`,
+            { cause: error },
           );
-        } catch (error) {
-          if (streamOptions.signal.aborted) {
-            throw new Error(
-              `xAI ${modelId} tool stream produced no terminal event within ${XAI_TOOL_REQUEST_TIMEOUT_MS}ms (payloadCaptured=${capturedPayload !== undefined})`,
-              { cause: error },
-            );
-          }
-          throw error;
-        }
+        });
         const content = requireLiveValue(doneMessage.content, "done message content");
         expect(Array.isArray(content)).toBe(true);
         expect(content.some((block) => block.type === "toolCall" && block.name === "noop")).toBe(

--- a/src/agents/xai.live.test.ts
+++ b/src/agents/xai.live.test.ts
@@ -16,6 +16,7 @@ import { createWebSearchTool } from "./tools/web-search.js";
 const XAI_KEY = process.env.XAI_API_KEY ?? "";
 const LIVE = isLiveTestEnabled(["XAI_LIVE_TEST"]);
 const XAI_COMPLETE_LIVE_TIMEOUT_MS = 90_000;
+const XAI_TOOL_REQUEST_TIMEOUT_MS = 80_000;
 const XAI_WEB_SEARCH_LIVE_TIMEOUT_SECONDS = 60;
 const XAI_LIVE_COMPLETION_CASES = [
   { modelId: "grok-4.3", completionReasoning: undefined },
@@ -178,6 +179,7 @@ describeLive("xai live", () => {
           apiKey: XAI_KEY,
           maxTokens: 128,
           reasoning: "low",
+          signal: AbortSignal.timeout(XAI_TOOL_REQUEST_TIMEOUT_MS),
           toolChoice: { type: "function", name: "noop" },
           onPayload: (payload: unknown) => {
             capturedPayload = payload as Record<string, unknown>;
@@ -197,13 +199,24 @@ describeLive("xai live", () => {
           streamOptions,
         );
 
-        const doneMessage = await collectDoneMessage(
-          stream as AsyncIterable<{
-            type: string;
-            message?: AssistantLikeMessage;
-            error?: { errorMessage?: string };
-          }>,
-        );
+        let doneMessage: AssistantLikeMessage;
+        try {
+          doneMessage = await collectDoneMessage(
+            stream as AsyncIterable<{
+              type: string;
+              message?: AssistantLikeMessage;
+              error?: { errorMessage?: string };
+            }>,
+          );
+        } catch (error) {
+          if (streamOptions.signal.aborted) {
+            throw new Error(
+              `xAI ${modelId} tool stream produced no terminal event within ${XAI_TOOL_REQUEST_TIMEOUT_MS}ms (payloadCaptured=${capturedPayload !== undefined})`,
+              { cause: error },
+            );
+          }
+          throw error;
+        }
         const content = requireLiveValue(doneMessage.content, "done message content");
         expect(Array.isArray(content)).toBe(true);
         expect(content.some((block) => block.type === "toolCall" && block.name === "noop")).toBe(


### PR DESCRIPTION
## Summary

- abort xAI live tool-call requests before the outer Vitest deadline
- report the affected model, elapsed request bound, and whether payload construction completed
- keep provider tool-call failures release-blocking; no skip, retry, or weaker assertion

## Root cause

The Grok 4.3 live tool probe repeatedly produced no response or terminal stream event. Vitest's 90-second timeout rejected the test but did not cancel the underlying provider stream, so requests continued for another minute and the release log only reported a generic test timeout.

The stream transport already accepts an `AbortSignal`; the live harness failed to bind request lifetime to test lifetime.

## Validation

- Four provider-backed reproductions on main: the original full-validation run and focused exact-main run each attempted the probe twice; all four stalled while Grok 4.3 text and Grok 4.5 tool calls succeeded.
- `pnpm dlx oxfmt@0.60.0 --check src/agents/xai.live.test.ts`
- `git diff --check`
- Full authenticated proof is delegated to PR CI because this host has no provider secrets or installed workspace dependencies.

## Test audit

This preserves an external observable contract: a supported xAI model must return a function call. A provider request that never terminates now fails before Vitest's deadline with bounded evidence. No production code or test-only production seam changes.

## LOC

- Production: +0/-0
- Tests: +20/-7

## Provenance

- Regression: clear harness lifecycle defect exposed by current xAI provider stall.
- Provider capability remains release-blocking; this PR only repairs request ownership and diagnostics.
