### PR TITLE
fix(auto-reply): surface missing final replies after progress updates

### DIFF
--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -454,6 +454,9 @@ describe("resolveFollowupDeliveryDecision", () => {
     to: "channel:C1",
     text: "Still working",
   };
+  const progressTarget = { ...sourceReplyTarget, sourceReplyFinal: false };
+  const finalTarget = { ...sourceReplyTarget, sourceReplyFinal: true };
+  const progressPayload = { text: "Still working", sourceReplyFinal: false };
 
   it("delivers a yield acknowledgment after accepting a child spawn", () => {
     const execution = createSettledExecution();
@@ -503,28 +506,6 @@ describe("resolveFollowupDeliveryDecision", () => {
       kind: "deliver",
       payloads: [{ text: "Research started; results will follow." }],
     });
-  });
-
-  it("does not repeat a yield acknowledgment after visible progress delivery", () => {
-    const execution = createSettledExecution();
-    if (execution.outcome.kind === "settled") {
-      execution.outcome.result.meta = {
-        durationMs: 0,
-        yielded: true,
-        yieldAcknowledgment: "Research started; results will follow.",
-      };
-      execution.outcome.result.messagingToolSentTargets = [
-        { ...sourceReplyTarget, sourceReplyFinal: false },
-      ];
-    }
-
-    expect(
-      resolveFollowupDeliveryDecision({
-        turn: createTurn(),
-        execution,
-        accounting: createAccounting(),
-      }),
-    ).toEqual({ kind: "suppress", reason: "silent" });
   });
 
   it("keeps ambient room-event finals silent", () => {
@@ -795,74 +776,47 @@ describe("resolveFollowupDeliveryDecision", () => {
   });
 
   it.each([
-    {
-      label: "progress-only target",
-      evidence: {
-        didDeliverSourceReplyViaMessageTool: true,
-        messagingToolSentTargets: [{ ...sourceReplyTarget, sourceReplyFinal: false }],
+    ["progress-only target", { messagingToolSentTargets: [progressTarget] }, true],
+    ["progress-only source payload", { messagingToolSourceReplyPayloads: [progressPayload] }, true],
+    ["final source reply", { messagingToolSentTargets: [finalTarget] }, false],
+    ["legacy target", { messagingToolSentTargets: [sourceReplyTarget] }, false],
+    ["legacy source reply", { didDeliverSourceReplyViaMessageTool: true }, false],
+    ["legacy outbound send", { didSendViaMessagingTool: true }, false],
+    ["deterministic approval prompt", { didSendDeterministicApprovalPrompt: true }, false],
+    [
+      "visible progress with yield acknowledgment",
+      {
+        meta: { durationMs: 0, yielded: true, yieldAcknowledgment: "Still working" },
+        messagingToolSentTargets: [progressTarget],
       },
-      completed: false,
-    },
-    {
-      label: "progress-only source payload",
-      evidence: {
-        didDeliverSourceReplyViaMessageTool: true,
-        messagingToolSourceReplyPayloads: [{ text: "Still working", sourceReplyFinal: false }],
-      },
-      completed: false,
-    },
-    {
-      label: "final source reply",
-      evidence: {
-        didDeliverSourceReplyViaMessageTool: true,
-        messagingToolSentTargets: [
-          { ...sourceReplyTarget, text: "Finished", sourceReplyFinal: true },
-        ],
-      },
-      completed: true,
-    },
-    {
-      label: "legacy source reply",
-      evidence: { didDeliverSourceReplyViaMessageTool: true },
-      completed: true,
-    },
-    {
-      label: "legacy outbound send",
-      evidence: { didSendViaMessagingTool: true },
-      completed: true,
-    },
-    {
-      label: "deterministic approval prompt",
-      evidence: { didSendDeterministicApprovalPrompt: true },
-      completed: true,
-    },
-  ])("accounts for a $label before suppressing an empty follow-up", ({ evidence, completed }) => {
-    const execution = createSettledExecution();
-    if (execution.outcome.kind === "settled") {
-      Object.assign(execution.outcome.result, evidence);
-    }
+      false,
+    ],
+  ])(
+    "accounts for %s before suppressing an empty follow-up",
+    (_label, evidence, expectFallback) => {
+      const execution = createSettledExecution();
+      if (execution.outcome.kind === "settled") {
+        Object.assign(execution.outcome.result, evidence);
+      }
 
-    const decision = resolveFollowupDeliveryDecision({
-      turn: createTurn(),
-      execution,
-      accounting: createAccounting(),
-    });
+      const decision = resolveFollowupDeliveryDecision({
+        turn: createTurn(),
+        execution,
+        accounting: createAccounting(),
+      });
 
-    if (completed) {
-      expect(decision).toEqual({ kind: "suppress", reason: "silent" });
-      return;
-    }
-
-    expect(decision).toMatchObject({
-      kind: "deliver",
-      payloads: [
-        {
-          text: expect.stringContaining("did not produce a visible reply"),
-          isError: true,
-        },
-      ],
-    });
-  });
+      expect(decision).toMatchObject(
+        expectFallback
+          ? {
+              kind: "deliver",
+              payloads: [
+                { text: expect.stringContaining("did not produce a visible reply"), isError: true },
+              ],
+            }
+          : { kind: "suppress", reason: "silent" },
+      );
+    },
+  );
 
   it.each([
     { label: "accidental", intentionalTerminalCompletion: undefined },

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -448,6 +448,13 @@ function createAccounting(
 }
 
 describe("resolveFollowupDeliveryDecision", () => {
+  const sourceReplyTarget = {
+    tool: "message",
+    provider: "discord",
+    to: "channel:C1",
+    text: "Still working",
+  };
+
   it("delivers a yield acknowledgment after accepting a child spawn", () => {
     const execution = createSettledExecution();
     if (execution.outcome.kind === "settled") {
@@ -496,6 +503,28 @@ describe("resolveFollowupDeliveryDecision", () => {
       kind: "deliver",
       payloads: [{ text: "Research started; results will follow." }],
     });
+  });
+
+  it("does not repeat a yield acknowledgment after visible progress delivery", () => {
+    const execution = createSettledExecution();
+    if (execution.outcome.kind === "settled") {
+      execution.outcome.result.meta = {
+        durationMs: 0,
+        yielded: true,
+        yieldAcknowledgment: "Research started; results will follow.",
+      };
+      execution.outcome.result.messagingToolSentTargets = [
+        { ...sourceReplyTarget, sourceReplyFinal: false },
+      ];
+    }
+
+    expect(
+      resolveFollowupDeliveryDecision({
+        turn: createTurn(),
+        execution,
+        accounting: createAccounting(),
+      }),
+    ).toEqual({ kind: "suppress", reason: "silent" });
   });
 
   it("keeps ambient room-event finals silent", () => {
@@ -762,6 +791,76 @@ describe("resolveFollowupDeliveryDecision", () => {
     expect(decision).toMatchObject({
       kind: "deliver",
       payloads: [{ text: "terminal failure", isError: true }],
+    });
+  });
+
+  it.each([
+    {
+      label: "progress-only target",
+      evidence: {
+        didDeliverSourceReplyViaMessageTool: true,
+        messagingToolSentTargets: [{ ...sourceReplyTarget, sourceReplyFinal: false }],
+      },
+      completed: false,
+    },
+    {
+      label: "progress-only source payload",
+      evidence: {
+        didDeliverSourceReplyViaMessageTool: true,
+        messagingToolSourceReplyPayloads: [{ text: "Still working", sourceReplyFinal: false }],
+      },
+      completed: false,
+    },
+    {
+      label: "final source reply",
+      evidence: {
+        didDeliverSourceReplyViaMessageTool: true,
+        messagingToolSentTargets: [
+          { ...sourceReplyTarget, text: "Finished", sourceReplyFinal: true },
+        ],
+      },
+      completed: true,
+    },
+    {
+      label: "legacy source reply",
+      evidence: { didDeliverSourceReplyViaMessageTool: true },
+      completed: true,
+    },
+    {
+      label: "legacy outbound send",
+      evidence: { didSendViaMessagingTool: true },
+      completed: true,
+    },
+    {
+      label: "deterministic approval prompt",
+      evidence: { didSendDeterministicApprovalPrompt: true },
+      completed: true,
+    },
+  ])("accounts for a $label before suppressing an empty follow-up", ({ evidence, completed }) => {
+    const execution = createSettledExecution();
+    if (execution.outcome.kind === "settled") {
+      Object.assign(execution.outcome.result, evidence);
+    }
+
+    const decision = resolveFollowupDeliveryDecision({
+      turn: createTurn(),
+      execution,
+      accounting: createAccounting(),
+    });
+
+    if (completed) {
+      expect(decision).toEqual({ kind: "suppress", reason: "silent" });
+      return;
+    }
+
+    expect(decision).toMatchObject({
+      kind: "deliver",
+      payloads: [
+        {
+          text: expect.stringContaining("did not produce a visible reply"),
+          isError: true,
+        },
+      ],
     });
   });
 

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -5,7 +5,6 @@ import {
   hasCompletedSourceReplyDeliveryEvidence,
   hasCompletedTerminalDeliveryEvidence,
   hasVisibleCommittedMessagingToolDeliveryEvidence,
-  hasVisibleOutboundDeliveryEvidence,
 } from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import {
   hasDeliberateSilentTerminalReply,
@@ -203,10 +202,6 @@ export function resolveFollowupDeliveryDecision(params: {
       resolved: runtimeResolved,
     };
   }
-  const hasCommittedDelivery =
-    hasVisibleOutboundDeliveryEvidence(result) ||
-    hasCommittedSourceReplyDeliveryEvidence(result) ||
-    result.didSendDeterministicApprovalPrompt === true;
   const fallbackPayload = accounting.terminalFailurePayload
     ? isInteractive && !hasCompletedTerminalDeliveryEvidence(result)
       ? sourcePolicy.sourceReplyDeliveryMode === "message_tool_only"
@@ -237,7 +232,7 @@ export function resolveFollowupDeliveryDecision(params: {
         hasPendingContinuation:
           result.meta?.yielded === true || (result.meta?.pendingToolCalls?.length ?? 0) > 0,
         hasExplicitSilentReply: hasDeliberateSilentTerminalReply(result),
-        hasCommittedDelivery,
+        hasCommittedDelivery: hasCompletedTerminalDeliveryEvidence(result),
         hasIntentionalTerminalCompletion: hasIntentionalTerminalCompletion(result),
         sessionCtx: {
           ChatType: turn.queued.originatingChatType,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users waiting for a queued follow-up reply would see an in-progress message and then no final answer or explanation when the agent completed without producing terminal content. A progress update explicitly marked `sourceReplyFinal: false` was incorrectly treated as proof that the follow-up had already completed.

## Why This Change Was Made

The queued follow-up delivery owner independently inferred terminal completion from any visible outbound/source delivery, diverging from the canonical delivery-evidence contract already used by normal reply finalization and queued terminal failures. Delete that duplicate inference and pass `hasCompletedTerminalDeliveryEvidence(result)` directly to the empty-interactive-reply diagnostic, preserving the existing distinction between progress and a completed final reply.

Explicit final replies, legacy unmarked target/source/outbound evidence, deterministic approval prompts, intentional terminal completions, and yield acknowledgments retain their existing behavior. Production changes are **+1/-6 (net -5)**; regression tests are **+53/-0**.

## User Impact

Queued follow-up turns that emit only progress now end with an actionable visible explanation instead of silently disappearing when there is no final answer. Successfully delivered final replies and intentionally waiting/silent turns remain unchanged.

Release-note context: **Auto-reply: show the missing-reply diagnostic when a queued follow-up emits progress but never delivers a final answer.**

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/followup-delivery.test.ts` — **PASS: 1 file, 58 tests**.
- Pre-fix owner-boundary reproduction using that same suite — **expected FAIL: exactly two cases**, `progress-only target` and `progress-only source payload`; both returned silent suppression instead of the visible missing-reply diagnostic. The other 56 cases passed. Restoring the fix makes all 58 pass.
- `node scripts/check-changed.mjs` — **PASS: core and coreTests**, including formatting, production/test typechecks, changed-file lint, dead exports, architecture, security, and storage guards.
- `git diff --check` and `git diff --check origin/main...HEAD` — **PASS**.
- `git diff --numstat origin/main...HEAD` — `src/auto-reply/reply/followup-delivery.ts` **+1/-6**; `src/auto-reply/reply/followup-delivery.test.ts` **+53/-0**.
- Table-driven behavior proof covers progress-only target and payload evidence, explicit final delivery, legacy target/source/outbound evidence, deterministic approvals, and visible progress with a pending yield acknowledgment.
- Independent exact-head terminal smoke: `pnpm openclaw --help` — **PASS**, including the expected `Usage:` output.
- ClawSweeper exact-head review completed with **zero correctness findings** and rated the patch **A**; its public review publication is queued.
- Rank-up disposition: the optional mock-gateway/live queued-follow-up recording was not captured because this approved landing has no configured isolated channel/gateway capture fixture and the exact head must remain unchanged. The pre-fix two-case failure, post-fix 58-case owner-boundary pass, green exact-head CI, and independent CLI smoke are recorded instead.
- Proof boundary: deterministic queued-follow-up delivery decisions and the emitted user-facing diagnostic; no authenticated live-channel run or UI capture was performed.
