### PR TITLE
fix(onboard): redact secrets from gateway health failures

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -62,8 +62,11 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     envSnapshot.restore();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     gatewayReachableState.mock = undefined;
+    const { resetSecretRedactionRegistryForTest } =
+      await import("../logging/secret-redaction-registry.test-support.js");
+    resetSecretRedactionRegistryForTest();
     testConfigStore.clear();
     capturedReplaceConfigFileCalls.length = 0;
     configWritePluginLeaseDepths.length = 0;
@@ -609,10 +612,17 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
   it("emits structured JSON diagnostics when daemon health fails", async () => {
     await withStateDir("state-local-daemon-health-json-fail-", async (stateDir) => {
+      const registeredSecret = "qa-onboarding-health-secret";
+      const { registerSecretValueForRedaction } =
+        await import("../logging/secret-redaction-registry.js");
+      registerSecretValueForRedaction(registeredSecret);
       gatewayReachableState.mock = vi.fn(async () => ({
         ok: false,
-        detail: "gateway closed (1006 abnormal closure (no close frame)): no close reason",
+        detail: `gateway closed (1006 abnormal closure (no close frame)): ${registeredSecret}`,
       }));
+      readLastGatewayErrorLineMock.mockResolvedValueOnce(
+        `Gateway failed to start: required secrets are unavailable: ${registeredSecret}`,
+      );
 
       const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
       await expectOnboardLocalJsonSetupFailure({
@@ -651,6 +661,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       expect(parsed.diagnostics?.service?.runtimeStatus).toBe("running");
       expect(parsed.diagnostics?.service?.pid).toBe(4242);
       expect(parsed.diagnostics?.lastGatewayError).toContain("required secrets are unavailable");
+      expect(readCapturedJson()).not.toContain(registeredSecret);
     });
   }, 60_000);
 
@@ -694,12 +705,22 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
   it("routes thrown health-check errors through the onboarding failure owner", async () => {
     await withStateDir("state-local-health-failure-text-", async (stateDir) => {
+      const registeredSecret = "qa-onboarding-health-secret";
+      const { registerSecretValueForRedaction } =
+        await import("../logging/secret-redaction-registry.js");
+      registerSecretValueForRedaction(registeredSecret);
       gatewayReachableState.mock = vi.fn(async () => ({ ok: true }));
-      healthCommandMock.mockRejectedValueOnce(new Error("health request timed out"));
+      healthCommandMock.mockRejectedValueOnce(
+        new Error(`health request timed out: ${registeredSecret}`),
+      );
 
-      await expect(
-        runNonInteractiveSetup(createOnboardLocalDaemonOptions(stateDir), runtime),
-      ).rejects.toThrow(/health check failed[\s\S]*health request timed out/);
+      const failure = await runNonInteractiveSetup(
+        createOnboardLocalDaemonOptions(stateDir),
+        runtime,
+      ).catch((error: unknown) => error);
+      expect(failure).toBeInstanceOf(Error);
+      expect(String(failure)).toMatch(/health check failed[\s\S]*health request timed out/);
+      expect(String(failure)).not.toContain(registeredSecret);
     });
   }, 60_000);
 

--- a/src/commands/onboard-non-interactive/local/output.ts
+++ b/src/commands/onboard-non-interactive/local/output.ts
@@ -5,6 +5,7 @@
  * are kept here so local and remote setup report failures consistently.
  */
 import type { GatewayServiceLoadState } from "../../../daemon/service-types.js";
+import { redactSecrets } from "../../../logging/redact.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../../runtime.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 
@@ -197,8 +198,17 @@ export function logNonInteractiveOnboardingFailure(params: {
   });
   const recoveryHint = recoveryHintForGatewayHealthFailure(classification);
   const hints = [...(recoveryHint ? [recoveryHint] : []), ...(params.hints?.filter(Boolean) ?? [])];
-  const gatewayRuntime = formatGatewayRuntimeSummary(params.diagnostics);
-  const service = params.diagnostics?.service;
+  const output = redactSecrets({
+    message: params.message,
+    detail: params.detail,
+    hints,
+    gateway: params.gateway,
+    daemonInstall: params.daemonInstall,
+    daemonRuntime: params.daemonRuntime,
+    diagnostics: params.diagnostics,
+  });
+  const gatewayRuntime = formatGatewayRuntimeSummary(output.diagnostics);
+  const service = output.diagnostics?.service;
   const serviceLoadText = service
     ? service.loadState.status === "loaded"
       ? service.loadedText
@@ -210,32 +220,32 @@ export function logNonInteractiveOnboardingFailure(params: {
       ok: false,
       mode: params.mode,
       phase: params.phase,
-      message: params.message,
+      message: output.message,
       classification,
-      detail: params.detail,
-      gateway: params.gateway,
+      detail: output.detail,
+      gateway: output.gateway,
       installDaemon: Boolean(params.installDaemon),
-      daemonInstall: params.daemonInstall,
-      daemonRuntime: params.daemonRuntime,
-      diagnostics: params.diagnostics,
-      hints: hints.length > 0 ? hints : undefined,
+      daemonInstall: output.daemonInstall,
+      daemonRuntime: output.daemonRuntime,
+      diagnostics: output.diagnostics,
+      hints: output.hints.length > 0 ? output.hints : undefined,
     });
     return;
   }
 
   const lines = [
-    params.message,
+    output.message,
     classification ? `Classification: ${classification}` : undefined,
-    params.detail ? `Last probe: ${params.detail}` : undefined,
+    output.detail ? `Last probe: ${output.detail}` : undefined,
     service ? `Service: ${service.label} (${serviceLoadText})` : undefined,
     gatewayRuntime ? `Runtime: ${gatewayRuntime}` : undefined,
-    params.diagnostics?.lastGatewayError
-      ? `Last gateway error: ${params.diagnostics.lastGatewayError}`
+    output.diagnostics?.lastGatewayError
+      ? `Last gateway error: ${output.diagnostics.lastGatewayError}`
       : undefined,
-    params.diagnostics?.inspectError
-      ? `Diagnostics warning: ${params.diagnostics.inspectError}`
+    output.diagnostics?.inspectError
+      ? `Diagnostics warning: ${output.diagnostics.inspectError}`
       : undefined,
-    hints.length > 0 ? hints.join("\n") : undefined,
+    output.hints.length > 0 ? output.hints.join("\n") : undefined,
   ]
     .filter(Boolean)
     .join("\n");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running non-interactive onboarding could have registered secret values exposed in gateway health failure output when probe errors, daemon diagnostics, or recovery details included those values.

## Why This Change Was Made

The onboarding failure output owner now redacts the complete output payload before rendering either JSON or human-readable diagnostics. Classification still uses the original diagnostic values so redaction does not alter recovery guidance.

## User Impact

Non-interactive onboarding health failures retain actionable diagnostics while registered secrets are omitted from JSON output, text output, and propagated failure messages.

## Evidence

- `node scripts/run-vitest.mjs src/commands/onboard-non-interactive.gateway.test.ts` — 21/21 passed on Node 24.15.0.
- Direct fake-sentinel output probe — `{"leaked":false,"redacted":false}` (the sentinel was absent; output contained no literal replacement marker because the registry redactor masks with its configured representation).
- `trufflehog filesystem <exact branch patch> --results=verified,unknown --fail --no-update` — 0 verified, 0 unverified secrets.
- `node scripts/check-changed.mjs` — formatting, guards, dead-code scan, and core production typecheck passed; the core-test typecheck runner did not terminate in this linked-worktree setup and was stopped after producing no child process or further output. Exact-head CI remains the authoritative completion gate.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin /tmp/openclaw-autoreview-codex/node_modules/.bin/codex --stream-engine-output` — clean, no accepted/actionable findings (confidence 0.98).
