### PR TITLE
fix: preserve remote auth for equivalent gateway URLs

### DIFF
--- a/src/commands/onboard-non-interactive/remote.test.ts
+++ b/src/commands/onboard-non-interactive/remote.test.ts
@@ -201,6 +201,34 @@ describe("runNonInteractiveRemoteSetup", () => {
     expect(commit?.nextConfig.gateway?.remote).toEqual(remote);
   });
 
+  it("preserves endpoint-bound config when the remote URL has equivalent spelling", async () => {
+    const existingRemote = {
+      url: `${remoteUrl}/`,
+      token: { source: "env" as const, provider: "default", id: "EXISTING_REMOTE_TOKEN" },
+      tlsFingerprint: "sha256:test-fingerprint",
+      sshTarget: "operator@gateway.example.test",
+      edgeAuth: { "X-Edge-Auth": "existing-edge-secret" },
+    };
+
+    await runNonInteractiveRemoteSetup({
+      opts: {
+        nonInteractive: true,
+        mode: "remote",
+        remoteUrl,
+        secretInputMode: "ref",
+        skipHooks: true,
+      },
+      runtime,
+      baseConfig: { gateway: { mode: "remote", remote: existingRemote } },
+    });
+
+    const commit = commitNonInteractiveOnboardConfigMock.mock.calls[0]?.[0];
+    expect(commit?.nextConfig.gateway?.remote).toEqual({
+      ...existingRemote,
+      url: remoteUrl,
+    });
+  });
+
   it("preserves an existing remote password SecretRef when no replacement is provided", async () => {
     const remote = {
       url: remoteUrl,

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -13,6 +13,7 @@ import { createGatewayEnvSecretRef } from "../../secrets/ref-contract.js";
 import { applySkipBootstrapConfig } from "../onboard-config.js";
 import { applyWizardMetadata } from "../onboard-helpers.js";
 import { enableDefaultOnboardingInternalHooks } from "../onboard-hooks.js";
+import { remoteGatewayUrlChanged } from "../onboard-remote-url.js";
 import type { OnboardOptions } from "../onboard-types.js";
 import { commitNonInteractiveOnboardConfig } from "./config-write.js";
 
@@ -54,7 +55,7 @@ export async function runNonInteractiveRemoteSetup(params: {
     return;
   }
   const existingRemote = baseConfig.gateway?.remote;
-  const remoteUrlChanged = normalizeOptionalString(existingRemote?.url) !== remoteUrl;
+  const remoteUrlChanged = remoteGatewayUrlChanged(remoteUrl, existingRemote?.url);
   // A remote block belongs to one endpoint. Reusing it for a different URL can
   // send old credentials or keep routing through the old SSH target.
   const preservedRemote = remoteUrlChanged ? {} : { ...existingRemote };

--- a/src/commands/onboard-remote-url.ts
+++ b/src/commands/onboard-remote-url.ts
@@ -1,4 +1,4 @@
-import { gatewayOriginScope } from "../../packages/gateway-client/src/gateway-origin-scope.js";
+import { gatewayCredentialScope } from "../../packages/gateway-client/src/gateway-origin-scope.js";
 
 /** Returns whether an explicit remote Gateway URL selects a different endpoint. */
 export function remoteGatewayUrlChanged(
@@ -6,6 +6,7 @@ export function remoteGatewayUrlChanged(
   previousUrl: string | undefined,
 ): boolean {
   return (
-    nextUrl !== undefined && gatewayOriginScope(nextUrl) !== gatewayOriginScope(previousUrl ?? "")
+    nextUrl !== undefined &&
+    gatewayCredentialScope(nextUrl) !== gatewayCredentialScope(previousUrl ?? "")
   );
 }

--- a/src/commands/onboard-remote-url.ts
+++ b/src/commands/onboard-remote-url.ts
@@ -1,0 +1,11 @@
+import { gatewayOriginScope } from "../../packages/gateway-client/src/gateway-origin-scope.js";
+
+/** Returns whether an explicit remote Gateway URL selects a different endpoint. */
+export function remoteGatewayUrlChanged(
+  nextUrl: string | undefined,
+  previousUrl: string | undefined,
+): boolean {
+  return (
+    nextUrl !== undefined && gatewayOriginScope(nextUrl) !== gatewayOriginScope(previousUrl ?? "")
+  );
+}

--- a/src/commands/onboard-remote.test.ts
+++ b/src/commands/onboard-remote.test.ts
@@ -116,6 +116,84 @@ describe("promptRemoteGatewayConfig", () => {
     expect(next.gateway?.remote?.edgeAuth).toEqual(expected);
   });
 
+  it("preserves credentials and target settings for an equivalently spelled URL", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example/rpc/",
+          token: "stored-token",
+          transport: "ssh",
+          remotePort: 18790,
+          tlsFingerprint: "sha256:stored",
+          sshTarget: "user@gateway.example",
+          sshIdentity: "~/.ssh/id_gateway",
+          sshHostKeyPolicy: "strict",
+        },
+      },
+    };
+    const prompter = createPrompter({
+      confirm: vi.fn(async (params) => params.message.startsWith("Use existing gateway token")),
+      select: createSelectPrompter({
+        "Gateway auth": "token",
+        "How do you want to provide this gateway token?": "plaintext",
+      }),
+      text: vi.fn(async (params) =>
+        params.message === "Gateway WebSocket URL" ? "wss://gateway.example/rpc" : "",
+      ) as WizardPrompter["text"],
+    });
+
+    const next = await promptRemoteGatewayConfig(cfg, prompter);
+
+    expect(next.gateway?.remote).toEqual({
+      ...cfg.gateway?.remote,
+      url: "wss://gateway.example/rpc",
+    });
+  });
+
+  it("clears credentials and target settings when the URL query changes", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          url: "wss://gateway.example/rpc?account=personal",
+          token: "stored-token",
+          transport: "ssh",
+          remotePort: 18790,
+          tlsFingerprint: "sha256:stored",
+          sshTarget: "user@gateway.example",
+          sshIdentity: "~/.ssh/id_gateway",
+          sshHostKeyPolicy: "strict",
+        },
+      },
+    };
+    const text: WizardPrompter["text"] = vi.fn(async (params) => {
+      if (params.message === "Gateway WebSocket URL") {
+        return "wss://gateway.example/rpc?account=work";
+      }
+      if (params.message === "Gateway token") {
+        return "replacement-token";
+      }
+      return "";
+    }) as WizardPrompter["text"];
+    const prompter = createPrompter({
+      confirm: vi.fn(async () => false),
+      select: createSelectPrompter({
+        "Gateway auth": "token",
+        "How do you want to provide this gateway token?": "plaintext",
+      }),
+      text,
+    });
+
+    const next = await promptRemoteGatewayConfig(cfg, prompter);
+
+    expect(next.gateway?.remote).toEqual({
+      url: "wss://gateway.example/rpc?account=work",
+      token: "replacement-token",
+    });
+    expect(vi.mocked(text).mock.calls.map(([params]) => params.message)).toContain("Gateway token");
+  });
+
   it("defaults discovered direct remote URLs to wss://", async () => {
     detectBinary.mockResolvedValue(true);
     discoverGatewayBeacons.mockResolvedValue([createGatewayDiscoveryBeacon()]);
@@ -419,7 +497,12 @@ describe("promptRemoteGatewayConfig", () => {
     });
 
     const cfg = {
-      gateway: { remote: { token: "preexisting-remote-token" } },
+      gateway: {
+        remote: {
+          url: "wss://remote.example.com:18789",
+          token: "preexisting-remote-token",
+        },
+      },
     } as OpenClawConfig;
     const prompter = createPrompter({ confirm, select, text });
 
@@ -457,7 +540,12 @@ describe("promptRemoteGatewayConfig", () => {
     });
 
     const cfg = {
-      gateway: { remote: { password: "preexisting-remote-password" } },
+      gateway: {
+        remote: {
+          url: "wss://remote.example.com:18789",
+          password: "preexisting-remote-password",
+        },
+      },
     } as OpenClawConfig;
     const prompter = createPrompter({ confirm, select, text });
 

--- a/src/commands/onboard-remote.ts
+++ b/src/commands/onboard-remote.ts
@@ -1,5 +1,8 @@
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
-import { gatewayOriginScope } from "../../packages/gateway-client/src/gateway-origin-scope.js";
+import {
+  gatewayCredentialScope,
+  gatewayOriginScope,
+} from "../../packages/gateway-client/src/gateway-origin-scope.js";
 /**
  * Interactive remote gateway onboarding.
  *
@@ -175,6 +178,10 @@ export async function promptRemoteGatewayConfig(
     validate: (value) => validateGatewayWebSocketUrl(value),
   });
   const url = ensureWsUrl(urlInput);
+  const storedRemote = cfg.gateway?.remote;
+  const sameCredentialTarget =
+    storedRemote?.url !== undefined &&
+    gatewayCredentialScope(url) === gatewayCredentialScope(storedRemote.url);
   const pinnedDiscoveryFingerprint =
     discoveryTlsFingerprint && url === trustedDiscoveryUrl ? discoveryTlsFingerprint : undefined;
 
@@ -187,8 +194,8 @@ export async function promptRemoteGatewayConfig(
     ],
   });
 
-  let token: SecretInput | undefined = cfg.gateway?.remote?.token;
-  let password: SecretInput | undefined = cfg.gateway?.remote?.password;
+  let token: SecretInput | undefined = sameCredentialTarget ? storedRemote.token : undefined;
+  let password: SecretInput | undefined = sameCredentialTarget ? storedRemote.password : undefined;
   if (authChoice === "token") {
     const selectedMode = await resolveSecretInputModeForEnvSelection({
       prompter,
@@ -290,6 +297,15 @@ export async function promptRemoteGatewayConfig(
     edgeAuthOriginUrl && gatewayOriginScope(url) === gatewayOriginScope(edgeAuthOriginUrl)
       ? cfg.gateway?.remote?.edgeAuth
       : undefined;
+  const {
+    url: _storedUrl,
+    token: _storedToken,
+    password: _storedPassword,
+    edgeAuth: _storedEdgeAuth,
+    tlsFingerprint: storedTlsFingerprint,
+    ...storedTargetSettings
+  } = sameCredentialTarget && storedRemote ? storedRemote : {};
+  const tlsFingerprint = pinnedDiscoveryFingerprint ?? storedTlsFingerprint;
 
   return {
     ...cfg,
@@ -297,11 +313,12 @@ export async function promptRemoteGatewayConfig(
       ...cfg.gateway,
       mode: "remote",
       remote: {
+        ...storedTargetSettings,
         url,
         ...(edgeAuth !== undefined ? { edgeAuth } : {}),
         ...(token !== undefined ? { token } : {}),
         ...(password !== undefined ? { password } : {}),
-        ...(pinnedDiscoveryFingerprint ? { tlsFingerprint: pinnedDiscoveryFingerprint } : {}),
+        ...(tlsFingerprint ? { tlsFingerprint } : {}),
       },
     },
   };

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1287,6 +1287,45 @@ describe("runSetupWizard", () => {
     );
   });
 
+  it("reuses stored remote credentials for an equivalent URL spelling", async () => {
+    const storedRemote = {
+      url: "wss://stored.example.com:18789",
+      token: { source: "env" as const, provider: "default", id: "STORED_GATEWAY_TOKEN" },
+      tlsFingerprint: "sha256:test-fingerprint",
+      edgeAuth: { "X-Edge-Auth": "test-secret" },
+    };
+    readConfigFileSnapshot.mockResolvedValueOnce(
+      configSnapshot({ gateway: { mode: "remote", remote: storedRemote } }),
+    );
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "advanced",
+        mode: "remote",
+        remoteUrl: `${storedRemote.url}/`,
+      },
+      createRuntime(),
+      buildWizardPrompter({}),
+    );
+
+    expect(promptRemoteGatewayConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gateway: expect.objectContaining({
+          remote: {
+            ...storedRemote,
+            url: `${storedRemote.url}/`,
+          },
+        }),
+      }),
+      expect.any(Object),
+      {
+        secretInputMode: undefined,
+        edgeAuthOriginUrl: storedRemote.url,
+      },
+    );
+  });
+
   it("does not probe an invalid CLI remote URL with its token", async () => {
     const remoteToken = "REDACTED";
     validateGatewayWebSocketUrl.mockReturnValueOnce("Use wss:// for public gateways");

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -4,6 +4,7 @@ import { listAgentEntries } from "../agents/agent-scope-config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveOnboardingSetupTarget } from "../commands/onboard-agent-target.js";
 import * as firstAgentOnboarding from "../commands/onboard-first-agent.js";
+import { remoteGatewayUrlChanged } from "../commands/onboard-remote-url.js";
 import type { OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { ConfigMutationConflictError } from "../config/config.js";
@@ -16,8 +17,7 @@ import {
   buildPluginCompatibilitySnapshotNotices,
   formatPluginCompatibilityNotice,
 } from "../plugins/status.js";
-import type { RuntimeEnv } from "../runtime.js";
-import { defaultRuntime } from "../runtime.js";
+import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { t } from "./i18n/index.js";
@@ -366,7 +366,7 @@ async function runSetupWizardOnce(
   const optionRemoteUrl = normalizeOptionalString(opts.remoteUrl);
   const optionRemoteToken = normalizeOptionalString(opts.remoteToken);
   const optionRemotePassword = normalizeOptionalString(opts.remotePassword);
-  const remoteUrlChanged = opts.remoteUrl !== undefined && optionRemoteUrl !== storedRemoteUrl;
+  const remoteUrlChanged = remoteGatewayUrlChanged(opts.remoteUrl, storedRemoteUrl);
   const remoteSeedConfig: OpenClawConfig =
     opts.remoteUrl === undefined &&
     opts.remoteToken === undefined &&


### PR DESCRIPTION
## What Problem This Solves

Interactive and non-interactive remote onboarding treated equivalent Gateway URL spellings as different endpoints, deleting stored authentication and connection settings. The first repair also exposed a broader interactive defect: the real remote prompt rebuilt `gateway.remote` and dropped same-target TLS pin and SSH/transport settings before publication.

## Why This Change Was Made

Both onboarding paths now compare endpoint identity with the existing `gatewayCredentialScope` contract. It normalizes equivalent trailing-slash spellings while retaining URL search parameters, so query changes remain credential-distinct.

The real interactive prompt now carries same-target `transport`, `remotePort`, `tlsFingerprint`, `sshTarget`, `sshIdentity`, and `sshHostKeyPolicy` through its returned configuration. A newly trusted discovery fingerprint overrides the stored pin. A changed credential target clears credentials and target-bound settings. Edge-auth remains intentionally origin-scoped through its existing contract.

## User Impact

Repeating remote onboarding with an equivalent URL no longer deletes credentials, the TLS MITM pin, or SSH settings. Switching to a different path/query target still requires new target-bound credentials and transport trust.

## Evidence

- `node scripts/run-vitest.mjs src/commands/onboard-remote.test.ts src/wizard/setup.test.ts` — 86/86 passed.
- Real `promptRemoteGatewayConfig` regressions prove equivalent spelling preserves credentials/TLS/SSH settings and query changes clear them.
- Existing non-interactive and setup coverage proves both callers use the same credential-scope decision.
- `node scripts/check-changed.mjs -- <seven changed files>` — passed all selected core/coreTests gates.
- `git diff --check` — passed.
- TruffleHog exact uncommitted repair scan — 0 findings.
- Fresh autoreview of the ClawSweeper repair — clean, no accepted/actionable findings (0.99 confidence).

Authored by @steipete with Amp.
