### PR TITLE
fix(workboard): let proofId alone resolve an already-terminal proof [AI-assisted]

### DIFF
--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -990,33 +990,36 @@ function completionProofConflicts(existing: WorkboardProof, completion: Workboar
 
 export function appendCompletionProof(
   existing: readonly WorkboardProof[] | undefined,
-  proof: WorkboardProof,
+  proof: WorkboardProof | undefined,
   proofId?: string,
 ): WorkboardProof[] {
   const entries = [...(existing ?? [])];
   if (!proofId) {
-    return [...entries, proof].slice(-MAX_CARD_PROOF);
+    return proof ? [...entries, proof].slice(-MAX_CARD_PROOF) : entries;
   }
   const index = entries.findIndex((entry) => entry.id === proofId);
   const pending = index >= 0 ? entries[index] : undefined;
   if (!pending) {
     throw new Error(`proof not found: ${proofId}`);
   }
-  if (proof.status === "unknown") {
-    throw new Error("completion proof status must be passed, failed, or skipped.");
+  const completionProof = proof ?? pending;
+  if (completionProof.status === "unknown") {
+    throw new Error(
+      proof
+        ? "completion proof status must be passed, failed, or skipped."
+        : "proof is required to resolve a pending proof.",
+    );
   }
-  if (completionProofConflicts(pending, proof)) {
+  if (completionProofConflicts(pending, completionProof)) {
     throw new Error(`completion proof does not match pending proof: ${proofId}`);
   }
-  if (pending.status !== "unknown") {
-    if (pending.status !== proof.status) {
-      throw new Error(`completion proof status does not match existing proof: ${proofId}`);
-    }
-    return entries.slice(-MAX_CARD_PROOF);
+  if (pending.status !== "unknown" && pending.status !== completionProof.status) {
+    throw new Error(`completion proof status does not match existing proof: ${proofId}`);
   }
-  // A proof id is the durable correlation boundary between a separately recorded check and its
-  // completion. Preserve the original evidence identity and timestamp while resolving its status.
-  entries[index] = { ...pending, status: proof.status };
+  if (pending.status === "unknown") {
+    // Preserve the stored evidence identity and timestamp when resolving its status.
+    entries[index] = { ...pending, status: completionProof.status };
+  }
   return entries.slice(-MAX_CARD_PROOF);
 }
 

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -267,9 +267,6 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
     if (input.proofId !== undefined && !proofId) {
       throw new Error("proofId must be a non-empty string.");
     }
-    if (proofId && !proofInput) {
-      throw new Error("proof is required when proofId is provided.");
-    }
     const proof = proofInput ? normalizeProofInput(proofInput, now) : undefined;
     const artifacts = Array.isArray(input.artifacts)
       ? input.artifacts
@@ -315,7 +312,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
                 { id: randomUUID(), body: summary, createdAt: now },
               ].slice(-MAX_CARD_COMMENTS)
             : metadata.comments,
-          proof: proof ? appendCompletionProof(metadata.proof, proof, proofId) : metadata.proof,
+          proof: appendCompletionProof(metadata.proof, proof, proofId),
           artifacts: artifacts.length
             ? [...(metadata.artifacts ?? []), ...artifacts].slice(-MAX_CARD_ARTIFACTS)
             : metadata.artifacts,
@@ -326,7 +323,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
       },
       {
         enforceStatusHolds: true,
-        ...(proof ? { preserveProofId: proofId ?? proof.id } : {}),
+        preserveProofId: proofId ?? proof?.id,
       },
     );
   }

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1746,6 +1746,14 @@ describe("WorkboardStore", () => {
         token: "token-1",
       });
 
+      await expect(
+        store.complete(claimed.card.id, {
+          ownerId: "main",
+          token: "token-1",
+          proofId: pending.metadata?.proof?.[0]?.id,
+        }),
+      ).rejects.toThrow("proof is required to resolve a pending proof.");
+
       vi.setSystemTime(6_000);
       const completed = await store.complete(claimed.card.id, {
         ownerId: "main",

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -414,6 +414,7 @@ describe("workboard tools", () => {
       await tools.get("workboard_proof")?.execute("call-proof", {
         id: parent.id,
         token,
+        status: "passed",
         command: "pnpm test extensions/workboard",
       }),
     );
@@ -425,7 +426,6 @@ describe("workboard tools", () => {
         summary: "Done.",
         createdCardIds: [child.id],
         proofId: pendingProof.proofId,
-        proof: { status: "passed", command: "pnpm test extensions/workboard" },
       }),
     );
     expect(completed.card).toMatchObject({


### PR DESCRIPTION
Closes #127034

> Built with an AI coding agent (Claude and Codex). Marking as AI-assisted per CONTRIBUTING.md.

## What Problem This Solves

The documented `workboard_proof` to `workboard_complete({ proofId })` flow failed even when the stored proof already had a terminal status. Completion rejected the request before it looked up that proof, so cards stayed in `running` unless callers repeated the full proof payload.

## Root cause

`completeDirect` required a new proof object before `appendCompletionProof`, the proof-correlation owner, could inspect the stored record.

## Fix

`appendCompletionProof` now resolves the stored proof once. It reuses an already-terminal proof unchanged when completion supplies only its ID. It still rejects unresolved proofs without a terminal status, missing IDs, conflicting metadata, and terminal-status rewrites.

The production change is net zero. The workflow guard moved into the existing proof-correlation owner instead of adding a second lookup path.

## Evidence

- Exact main `2d642e8a40d44d593d82cb9318bbf1b796857f6f`: the public Workboard tool flow stored a `passed` proof, then rejected ID-only completion with `proof is required when proofId is provided.`
- Exact head `4bea2ad1fb1367e33581127c64875432ceb95ab2`: the same flow completed the card as `done` and retained the stored `passed` proof.
- Negative probes: an unresolved stored proof still requires an explicit terminal status, and an unknown proof ID returns `proof not found`.
- Focused tests: 184 passed across the Workboard store, public tools, and dispatcher.
- Format and scoped repository ratchets passed. Hosted CI owns the exact-head lint and type checks.
