### PR TITLE
test(qa): align failed-tool recovery oracle

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -8484,7 +8484,7 @@ Update and merge these partial structured summaries.`,
       input: [
         makeUserInput(prompt),
         makeUserInput(
-          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If any tool failed, state that failure plainly and do not claim it succeeded.`,
+          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If a tool failed, say so; never claim completion or success.`,
         ),
         failedToolOutput,
       ],

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1374,7 +1374,7 @@ async function buildResponsesPayload(
   }
   if (isActiveFailedToolTerminalRecovery) {
     if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
-      if (!allInputText.includes("state that failure plainly and do not claim it succeeded")) {
+      if (!allInputText.includes("If a tool failed, say so; never claim completion or success.")) {
         return buildAssistantEvents("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
       }
       const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-FAILED-TOOL-FINALIZED-OK";

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -50,6 +50,16 @@ function indexSpansById(spans: CapturedSpan[]): Map<string, CapturedSpan> {
   return new Map(spans.flatMap((span) => (span.spanId ? ([[span.spanId, span]] as const) : [])));
 }
 
+function summarizeRuntimeEvidence(spans: CapturedSpan[]) {
+  const traces = new Map<string, Record<string, number>>();
+  for (const span of spans) {
+    const trace = traces.get(span.traceId ?? "missing") ?? {};
+    trace[span.name] = (trace[span.name] ?? 0) + 1;
+    traces.set(span.traceId ?? "missing", trace);
+  }
+  return [...traces].slice(-8).map(([traceId, names]) => ({ traceId, names }));
+}
+
 function expectResolvedParent(
   span: CapturedSpan,
   spansById: ReadonlyMap<string, CapturedSpan>,
@@ -250,15 +260,8 @@ describe("diagnostics-otel gateway runtime", () => {
         },
         45_000,
         () => ({
-          requests: activeReceiver.capturedRequests,
-          spans: activeReceiver.capturedSpans.map((span) => ({
-            attributes: span.attributes,
-            name: span.name,
-            parentSpanId: span.parentSpanId,
-            spanId: span.spanId,
-            statusCode: span.statusCode,
-            traceId: span.traceId,
-          })),
+          requests: activeReceiver.capturedRequests.slice(-8),
+          traces: summarizeRuntimeEvidence(activeReceiver.capturedSpans),
         }),
       );
 

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -28,7 +28,7 @@ async function settleCleanup(...cleanups: Array<() => Promise<void>>): Promise<v
 async function waitFor<T>(
   read: () => T | undefined,
   timeoutMs = 30_000,
-  timeoutContext?: () => unknown,
+  timeoutContext?: () => unknown | Promise<unknown>,
 ): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -38,7 +38,7 @@ async function waitFor<T>(
     }
     await sleep(100);
   }
-  const context = timeoutContext?.();
+  const context = await timeoutContext?.();
   throw new Error(
     `timed out waiting for QA runtime evidence${
       context === undefined ? "" : `: ${JSON.stringify(context)}`
@@ -150,6 +150,7 @@ describe("diagnostics-otel gateway runtime", () => {
         text: string,
         expectedText: string,
         targetConversation = conversation,
+        phase = "reply",
       ) => {
         const cursor = state.getSnapshot().messages.length;
         state.addInboundMessage({
@@ -158,22 +159,56 @@ describe("diagnostics-otel gateway runtime", () => {
           senderName: "QA User",
           text,
         });
-        return await waitFor(() =>
-          state
-            .getSnapshot()
-            .messages.slice(cursor)
-            .find(
-              (message) =>
-                message.direction === "outbound" &&
-                message.conversation.id === targetConversation.id &&
-                message.text.includes(expectedText),
-            ),
+        return await waitFor(
+          () =>
+            state
+              .getSnapshot()
+              .messages.slice(cursor)
+              .find(
+                (message) =>
+                  message.direction === "outbound" &&
+                  message.conversation.id === targetConversation.id &&
+                  message.text.includes(expectedText),
+              ),
+          30_000,
+          async () => ({
+            phase,
+            gatewayLogs: gateway?.logs().slice(-8_192),
+            messages: state
+              .getSnapshot()
+              .messages.slice(-8)
+              .map((message) => ({
+                conversationId: message.conversation.id,
+                direction: message.direction,
+                text: message.text.slice(0, 512),
+              })),
+            providerRequests: mock
+              ? await fetch(`${mock.baseUrl}/debug/requests`)
+                  .then(
+                    async (response) => (await response.json()) as Array<Record<string, unknown>>,
+                  )
+                  .then((requests) =>
+                    requests.slice(-8).map((request) => ({
+                      plannedToolName: request.plannedToolName,
+                      plannedWireToolName: request.plannedWireToolName,
+                      toolOutputCallId: request.toolOutputCallId,
+                    })),
+                  )
+                  .catch((error: unknown) => [
+                    { diagnosticError: error instanceof Error ? error.message : String(error) },
+                  ])
+              : [],
+            telemetryRequests: activeReceiver.capturedRequests.slice(-8),
+            traces: summarizeRuntimeEvidence(activeReceiver.capturedSpans),
+          }),
         );
       };
 
       const successful = await send(
         "Tool progress QA check: use the read tool exactly once on `QA_KICKOFF_TASK.md` before answering. After that read completes, reply with only this exact marker and no other text: `OTEL-GATEWAY-SUCCESS-OK`.",
         "OTEL-GATEWAY-SUCCESS-OK",
+        conversation,
+        "success-reply",
       );
       expect(successful.direction).toBe("outbound");
       expect(successful.text).toContain("OTEL-GATEWAY-SUCCESS-OK");
@@ -184,6 +219,8 @@ describe("diagnostics-otel gateway runtime", () => {
       const recovered = await send(
         "Failed tool terminal recovery QA check: read the missing workspace file, then respond with exact marker: `QA-FAILED-TOOL-FINALIZED-OK`.",
         "QA-FAILED-TOOL-FINALIZED-OK",
+        conversation,
+        "failed-tool-reply",
       );
       expect(recovered.direction).toBe("outbound");
       expect(recovered.text).toContain("The requested file could not be read: ENOENT.");

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -50,16 +50,6 @@ function indexSpansById(spans: CapturedSpan[]): Map<string, CapturedSpan> {
   return new Map(spans.flatMap((span) => (span.spanId ? ([[span.spanId, span]] as const) : [])));
 }
 
-function summarizeRuntimeEvidence(spans: CapturedSpan[]) {
-  const traces = new Map<string, Record<string, number>>();
-  for (const span of spans) {
-    const trace = traces.get(span.traceId ?? "missing") ?? {};
-    trace[span.name] = (trace[span.name] ?? 0) + 1;
-    traces.set(span.traceId ?? "missing", trace);
-  }
-  return [...traces].slice(-8).map(([traceId, names]) => ({ traceId, names }));
-}
-
 function expectResolvedParent(
   span: CapturedSpan,
   spansById: ReadonlyMap<string, CapturedSpan>,
@@ -261,7 +251,7 @@ describe("diagnostics-otel gateway runtime", () => {
         45_000,
         () => ({
           requests: activeReceiver.capturedRequests.slice(-8),
-          traces: summarizeRuntimeEvidence(activeReceiver.capturedSpans),
+          traces: activeReceiver.recentTraceSummary(),
         }),
       );
 

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -28,7 +28,7 @@ async function settleCleanup(...cleanups: Array<() => Promise<void>>): Promise<v
 async function waitFor<T>(
   read: () => T | undefined,
   timeoutMs = 30_000,
-  timeoutContext?: () => unknown | Promise<unknown>,
+  timeoutContext?: () => unknown,
 ): Promise<T> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -38,7 +38,7 @@ async function waitFor<T>(
     }
     await sleep(100);
   }
-  const context = await timeoutContext?.();
+  const context = timeoutContext?.();
   throw new Error(
     `timed out waiting for QA runtime evidence${
       context === undefined ? "" : `: ${JSON.stringify(context)}`
@@ -150,7 +150,6 @@ describe("diagnostics-otel gateway runtime", () => {
         text: string,
         expectedText: string,
         targetConversation = conversation,
-        phase = "reply",
       ) => {
         const cursor = state.getSnapshot().messages.length;
         state.addInboundMessage({
@@ -159,56 +158,22 @@ describe("diagnostics-otel gateway runtime", () => {
           senderName: "QA User",
           text,
         });
-        return await waitFor(
-          () =>
-            state
-              .getSnapshot()
-              .messages.slice(cursor)
-              .find(
-                (message) =>
-                  message.direction === "outbound" &&
-                  message.conversation.id === targetConversation.id &&
-                  message.text.includes(expectedText),
-              ),
-          30_000,
-          async () => ({
-            phase,
-            gatewayLogs: gateway?.logs().slice(-8_192),
-            messages: state
-              .getSnapshot()
-              .messages.slice(-8)
-              .map((message) => ({
-                conversationId: message.conversation.id,
-                direction: message.direction,
-                text: message.text.slice(0, 512),
-              })),
-            providerRequests: mock
-              ? await fetch(`${mock.baseUrl}/debug/requests`)
-                  .then(
-                    async (response) => (await response.json()) as Array<Record<string, unknown>>,
-                  )
-                  .then((requests) =>
-                    requests.slice(-8).map((request) => ({
-                      plannedToolName: request.plannedToolName,
-                      plannedWireToolName: request.plannedWireToolName,
-                      toolOutputCallId: request.toolOutputCallId,
-                    })),
-                  )
-                  .catch((error: unknown) => [
-                    { diagnosticError: error instanceof Error ? error.message : String(error) },
-                  ])
-              : [],
-            telemetryRequests: activeReceiver.capturedRequests.slice(-8),
-            traces: summarizeRuntimeEvidence(activeReceiver.capturedSpans),
-          }),
+        return await waitFor(() =>
+          state
+            .getSnapshot()
+            .messages.slice(cursor)
+            .find(
+              (message) =>
+                message.direction === "outbound" &&
+                message.conversation.id === targetConversation.id &&
+                message.text.includes(expectedText),
+            ),
         );
       };
 
       const successful = await send(
         "Tool progress QA check: use the read tool exactly once on `QA_KICKOFF_TASK.md` before answering. After that read completes, reply with only this exact marker and no other text: `OTEL-GATEWAY-SUCCESS-OK`.",
         "OTEL-GATEWAY-SUCCESS-OK",
-        conversation,
-        "success-reply",
       );
       expect(successful.direction).toBe("outbound");
       expect(successful.text).toContain("OTEL-GATEWAY-SUCCESS-OK");
@@ -219,8 +184,6 @@ describe("diagnostics-otel gateway runtime", () => {
       const recovered = await send(
         "Failed tool terminal recovery QA check: read the missing workspace file, then respond with exact marker: `QA-FAILED-TOOL-FINALIZED-OK`.",
         "QA-FAILED-TOOL-FINALIZED-OK",
-        conversation,
-        "failed-tool-reply",
       );
       expect(recovered.direction).toBe("outbound");
       expect(recovered.text).toContain("The requested file could not be read: ENOENT.");
@@ -246,7 +209,7 @@ describe("diagnostics-otel gateway runtime", () => {
       expect(finalizations).toHaveLength(1);
       expect(finalizations[0]?.body?.tools ?? []).toHaveLength(0);
       expect(finalizations[0]?.allInputText).toContain(
-        "state that failure plainly and do not claim it succeeded",
+        "If a tool failed, say so; never claim completion or success.",
       );
       const finalizationInput = finalizations[0]?.body?.input ?? [];
       const failedExecCalls = finalizationInput.filter(

--- a/test/e2e/qa-lab/runtime/otel-test-support.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-test-support.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { type CapturedSpan, createRecentTraceSummary } from "./otel-test-support.js";
+
+function span(traceId: string, name: string): CapturedSpan {
+  return { attributes: {}, name, parent: false, traceId };
+}
+
+describe("recent OTLP trace summaries", () => {
+  test("retains the eight most recently active traces", () => {
+    const summary = createRecentTraceSummary();
+    summary.add(Array.from({ length: 9 }, (_, index) => span(`trace-${index}`, "started")));
+    summary.add([span("trace-0", "finished")]);
+
+    expect(summary.read()).toEqual([
+      ...Array.from({ length: 7 }, (_, index) => ({
+        traceId: `trace-${index + 2}`,
+        names: { started: 1 },
+      })),
+      { traceId: "trace-0", names: { finished: 1 } },
+    ]);
+  });
+
+  test("bounds distinct span names retained for each trace", () => {
+    const summary = createRecentTraceSummary();
+    summary.add(Array.from({ length: 20 }, (_, index) => span("trace", `span-${index}`)));
+
+    const [trace] = summary.read();
+    expect(Object.keys(trace!.names)).toHaveLength(16);
+    expect(trace!.names.other).toBe(5);
+  });
+});

--- a/test/e2e/qa-lab/runtime/otel-test-support.ts
+++ b/test/e2e/qa-lab/runtime/otel-test-support.ts
@@ -73,7 +73,7 @@ export type CapturedLogRecord = {
   traceId: string;
 };
 
-export type CapturedTraceSummary = {
+type CapturedTraceSummary = {
   traceId: string;
   names: Record<string, number>;
 };

--- a/test/e2e/qa-lab/runtime/otel-test-support.ts
+++ b/test/e2e/qa-lab/runtime/otel-test-support.ts
@@ -73,6 +73,49 @@ export type CapturedLogRecord = {
   traceId: string;
 };
 
+export type CapturedTraceSummary = {
+  traceId: string;
+  names: Record<string, number>;
+};
+
+const MAX_RECENT_TRACE_SUMMARIES = 8;
+const MAX_SPAN_NAMES_PER_TRACE_SUMMARY = 16;
+const OTHER_SPAN_NAME = "other";
+
+export function createRecentTraceSummary() {
+  const traces = new Map<string, Map<string, number>>();
+
+  return {
+    add(spans: readonly CapturedSpan[]): void {
+      for (const span of spans) {
+        const traceId = span.traceId || "missing";
+        const names = traces.get(traceId) ?? new Map<string, number>();
+        const name =
+          names.has(span.name) || names.size < MAX_SPAN_NAMES_PER_TRACE_SUMMARY - 1
+            ? span.name
+            : OTHER_SPAN_NAME;
+        names.set(name, (names.get(name) ?? 0) + 1);
+
+        // Map insertion order owns recency; reinserting keeps the latest active trace last.
+        traces.delete(traceId);
+        traces.set(traceId, names);
+        if (traces.size > MAX_RECENT_TRACE_SUMMARIES) {
+          const oldestTraceId = traces.keys().next().value;
+          if (oldestTraceId !== undefined) {
+            traces.delete(oldestTraceId);
+          }
+        }
+      }
+    },
+    read(): CapturedTraceSummary[] {
+      return [...traces].map(([traceId, names]) => ({
+        traceId,
+        names: Object.fromEntries(names),
+      }));
+    },
+  };
+}
+
 export function runModelCallAndCaptureTraceparent(params: {
   trace: DiagnosticTraceContext;
   runId: string;
@@ -672,6 +715,7 @@ export function startLocalOtlpReceiver(disallowedBodyNeedles: string[] = []) {
   const capturedMetrics: CapturedMetric[] = [];
   const capturedLogRecords: CapturedLogRecord[] = [];
   const capturedBodyText: Partial<Record<OtlpSignal, string[]>> = {};
+  const recentTraceSummary = createRecentTraceSummary();
   const sockets = new Set<Socket>();
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     void (async () => {
@@ -736,6 +780,7 @@ export function startLocalOtlpReceiver(disallowedBodyNeedles: string[] = []) {
         return;
       }
       capturedSpans.push(...spans);
+      recentTraceSummary.add(spans);
       capturedMetrics.push(...metrics);
       capturedLogRecords.push(...logRecords);
       capturedRequests.push({
@@ -767,6 +812,7 @@ export function startLocalOtlpReceiver(disallowedBodyNeedles: string[] = []) {
     capturedMetrics,
     capturedLogRecords,
     capturedBodyText,
+    recentTraceSummary: recentTraceSummary.read,
     async listen(): Promise<number> {
       await new Promise<void>((resolve) => {
         server.listen(0, "127.0.0.1", resolve);


### PR DESCRIPTION
## Summary

- align the QA failed-tool continuation oracle with the canonical failure-honesty instruction introduced by #125209
- keep OTEL timeout evidence bounded to the last eight export requests and per-trace span counts
- preserve the strict reply and telemetry deadlines

## Root cause

Exact-head diagnosis [32463220685](https://github.com/openclaw/openclaw/actions/runs/32463220685) reached failed-tool finalization, but the QA mock returned `FAILED-TOOL-HONESTY-INSTRUCTION-MISSING`. Production correctly emitted the shared `TOOL_FAILURE_INSTRUCTION` (`If a tool failed, say so; never claim completion or success.`); the mock and E2E assertion still required the pre-#125209 wording.

The same run showed OTEL itself was healthy: four successful trace exports, and the failed-tool trace contained the terminal message span, two harness spans, two run spans, two model spans, and the failed tool span.

## Test audit

- observable contract: settled failed-tool recovery tells the model not to claim success and emits the honest final reply
- credible regression: shared recovery wording changes while the QA mock continues matching an obsolete literal
- existing mock and gateway E2E cover the real continuation boundary; this updates those existing assertions instead of adding duplicate coverage
- no production seam added

## Verification

- failing diagnosis: [32463220685 / job 96714979744](https://github.com/openclaw/openclaw/actions/runs/32463220685/job/96714979744)
- passing exact-head owner test: [32466386291 / job 96724249249](https://github.com/openclaw/openclaw/actions/runs/32466386291/job/96724249249) — OTEL gateway runtime passed in 13.4s; the overall repo-E2E job remained red on unrelated pre-existing singleton/order failures
- `pnpm dlx oxfmt@0.60.0 --check` on all changed files
- `git diff --check`
- autoreview clean (0.99)

Production LOC: 0. QA tooling: +1/-1. Tests: +14/-11 (net +3).
