### PR TITLE
test(agents): keep sandbox E2E module graph stable

### DIFF
--- a/src/agents/sandbox-agent-config.agent-specific-sandbox-config.e2e.test.ts
+++ b/src/agents/sandbox-agent-config.agent-specific-sandbox-config.e2e.test.ts
@@ -2,6 +2,9 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveSandboxConfigForAgent } from "./sandbox/config.js";
+import { resolveSandboxContext } from "./sandbox/context.js";
+import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { createRestrictedAgentSandboxConfig } from "./test-helpers/sandbox-agent-config-fixtures.js";
 
 type SpawnCall = {
@@ -37,10 +40,6 @@ vi.mock("../process/exec.js", async (importOriginal) => ({
 vi.mock("../skills/loading/workspace-skill-sync.runtime.js", () => ({
   syncWorkspaceSkills: vi.fn(async () => undefined),
 }));
-
-let resolveSandboxContext: typeof import("./sandbox/context.js").resolveSandboxContext;
-let resolveSandboxConfigForAgent: typeof import("./sandbox/config.js").resolveSandboxConfigForAgent;
-let resolveSandboxRuntimeStatus: typeof import("./sandbox/runtime-status.js").resolveSandboxRuntimeStatus;
 
 async function resolveContext(config: OpenClawConfig, sessionKey: string, workspaceDir: string) {
   // Convenience wrapper keeps session-key specific sandbox context assertions compact.
@@ -108,16 +107,7 @@ function createWorkSetupCommandConfig(scope: "agent" | "shared"): OpenClawConfig
 }
 
 describe("Agent-specific sandbox config", () => {
-  beforeEach(async () => {
-    vi.resetModules();
-    const [configModule, contextModule, runtimeModule] = await Promise.all([
-      import("./sandbox/config.js"),
-      import("./sandbox/context.js"),
-      import("./sandbox/runtime-status.js"),
-    ]);
-    ({ resolveSandboxConfigForAgent } = configModule);
-    ({ resolveSandboxContext } = contextModule);
-    ({ resolveSandboxRuntimeStatus } = runtimeModule);
+  beforeEach(() => {
     spawnCalls.length = 0;
   });
 


### PR DESCRIPTION
## Summary

- keep the sandbox configuration E2E file on one hoisted-mock module graph
- remove ten in-test `vi.resetModules()` calls from the shared `isolate:false` worker
- preserve all sandbox owner-boundary assertions with static imports

## Root cause

The full repo E2E worker collects tests into a shared module graph. This test reset that graph before every case and dynamically re-imported sandbox modules. In two consecutive full release runs, the tests immediately following this file retained pre-reset singleton references while Gateway startup and auth persistence used post-reset module instances. The result was:

- two Gateway tests could not see the published reply-dispatch runtime
- the Codex auth product proof could not see the SQLite-backed auth store written by doctor
- the worker later exited unexpectedly

The per-file non-isolated runner already owns module and mock cleanup. This file only needs to clear its observed Docker spawn calls between cases.

## Validation

- Pre-fix original-order reproduction: exact-main repo E2E runs 32447357591/job/96669828385 and 32454215356/job/96688889452 fail with the same downstream singleton symptoms immediately after this file.
- `pnpm dlx oxfmt@0.60.0 --check src/agents/sandbox-agent-config.agent-specific-sandbox-config.e2e.test.ts`
- `git diff --check`
- A remote full original-order repo E2E run will be linked after PR creation.

## Test audit

The existing tests protect sandbox config resolution, Docker setup, and runtime status at public owner boundaries. This change removes test-runner lifecycle coupling without changing assertions or adding production seams.

## LOC

- Production: +0/-0
- Tests: +4/-14

## Dependency contract

The Codex wire contract is unchanged. Direct sibling Codex inspection at bf2aee99 confirmed `codex-rs/app-server-protocol/src/protocol/v2/account.rs:88-102` and `codex-rs/app-server-protocol/src/protocol/common.rs:3352-3375`; the observed auth failure occurred earlier at OpenClaw's persisted-store read.
