### PR TITLE
test(agents): keep fallback E2E runtime coherent

### DIFF
--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -46,6 +46,7 @@ const installRunEmbeddedMocks = () => {
   // exercises fallback orchestration without live model/provider calls.
   vi.doMock("../plugins/runtime.js", () => ({
     getActivePluginRegistry: () => null,
+    getActivePluginRegistryWorkspaceDir: () => undefined,
     requireActivePluginRegistry: () => ({}),
   }));
   vi.doMock("./harness/runtime-plugin.js", () => ({
@@ -79,7 +80,6 @@ let runWithModelFallback: typeof import("./model-fallback-runner.js").runWithMod
 let runEmbeddedAgentEntry: typeof import("./embedded-agent-runner/run-entry.js").runEmbeddedAgentEntry;
 
 beforeAll(async () => {
-  vi.resetModules();
   installRunEmbeddedMocks();
   runEmbeddedAgent = wrapRunWithTestAdmission(
     (await import("./embedded-agent-runner/run.js")).runEmbeddedAgent,


### PR DESCRIPTION
## Summary

- complete the explicit plugin-runtime mock used by the embedded fallback E2E
- stop resetting the shared E2E worker's module graph inside the test file
- preserve the fallback behavior coverage without splitting process-lifecycle singletons for later files

## Root cause

`src/agents/model-fallback.run-embedded.e2e.test.ts` installed an explicit `../plugins/runtime.js` mock that omitted `getActivePluginRegistryWorkspaceDir`. The first direct-run cases passed, then fallback cases lazily loaded provider resolution and failed on the missing export.

The same setup also called `vi.resetModules()` inside an `isolate: false` E2E worker. Modules already captured by collected files could retain the old singleton graph while later imports published lifecycle state into the new graph, matching the later prepared-runtime/auth failures in the original full-suite order.

The test now declares the missing workspace fact and lets the repository's per-file non-isolated runner own module cleanup.

## Verification

- Exact-main reproduction: [repo E2E job](https://github.com/openclaw/openclaw/actions/runs/32454215356/job/96688889452) — 15 fallback failures on the missing export, followed by prepared-runtime/auth failures
- `git diff --check`
- `autoreview --mode local` — clean, no accepted/actionable findings
- Full original-order repo E2E and exact-head CI will provide remote proof (local worktree intentionally has no reconciled dependency install)

## Test audit

This retains the existing end-to-end fallback contract. No new test or production seam is introduced. The change removes a test-owned module-lifecycle mutation and completes the explicit mock at the dependency boundary it already owns.

Production LOC: `+0/-0`. Test LOC: `+1/-1`.
