### PR TITLE
fix(cli): render task flow JSON failures

### DIFF
--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -318,6 +318,28 @@ describe("flows commands", () => {
     });
   });
 
+  it("keeps terminal reset bytes off stdout for JSON lookup failures", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const runtime = createRuntime();
+
+      await flowsShowCommand({ lookup: "missing-flow", json: true }, runtime);
+
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        {
+          ok: false,
+          error: {
+            type: "cli_error",
+            message:
+              "TaskFlow not found: missing-flow. Run openclaw tasks flow list to see recent flow ids.",
+          },
+        },
+        2,
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1, { resetStream: process.stderr });
+    });
+  });
+
   it("shows one TaskFlow with linked task details in text mode", async () => {
     await withTaskFlowCommandStateDir(async () => {
       const flow = createManagedTaskFlow({

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -217,7 +217,7 @@ export async function flowsShowCommand(
     } else {
       runtime.error(message);
     }
-    runtime.exit(1);
+    runtime.exit(1, opts.json ? { resetStream: process.stderr } : undefined);
     return;
   }
   const tasks = listTasksForFlowId(flow.flowId);

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -7,10 +7,10 @@ import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { parseCliEnumFilter } from "../cli/enum-filter.js";
+import { formatCliJsonFailure } from "../cli/failure-output.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { info } from "../globals.js";
-import type { RuntimeEnv } from "../runtime.js";
-import { writeRuntimeJson } from "../runtime.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { cancelFlowById, getFlowTaskSummary } from "../tasks/task-executor.js";
 import {
@@ -211,7 +211,12 @@ export async function flowsShowCommand(
 ) {
   const flow = resolveTaskFlowForLookupToken(opts.lookup);
   if (!flow) {
-    runtime.error(formatFlowLookupMiss(opts.lookup));
+    const message = formatFlowLookupMiss(opts.lookup);
+    if (opts.json) {
+      writeRuntimeJson(runtime, formatCliJsonFailure(message));
+    } else {
+      runtime.error(message);
+    }
     runtime.exit(1);
     return;
   }

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -811,6 +811,7 @@ describe("tasks commands", () => {
           message: expect.stringContaining("Task not found: missing"),
         },
       });
+      expect(jsonLookupRuntime.exit).toHaveBeenCalledWith(1, { resetStream: process.stderr });
     });
   });
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -330,7 +330,7 @@ export async function tasksShowCommand(
     } else {
       runtime.error(message);
     }
-    runtime.exit(1);
+    runtime.exit(1, opts.json ? { resetStream: process.stderr } : undefined);
     return;
   }
 

--- a/src/entry.run-main.test.ts
+++ b/src/entry.run-main.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { ExpectedCliError } from "./cli/failure-output.js";
 import { runMainOrRootHelp } from "./entry.js";
+import { enableConsoleCapture } from "./logging.js";
 
 describe("entry run-main boundary", () => {
   it("retains JSON console routing through process finalization", async () => {
@@ -25,6 +26,7 @@ describe("entry run-main boundary", () => {
       humanOutput: message,
       machineOutput: message,
     });
+    enableConsoleCapture();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     process.exitCode = undefined;
 

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -295,6 +295,27 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it("renders a missing TaskFlow as one canonical JSON document without stderr", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const result = runBuiltCli(tempHome, ["tasks", "flow", "show", "missing-flow", "--json"]);
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stdout, result.stderr).not.toBe("");
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message:
+              "TaskFlow not found: missing-flow. Run openclaw tasks flow list to see recent flow ids.",
+          },
+        });
+        expect(result.stderr).toBe("");
+      },
+      { prefix: "openclaw-task-flow-json-failure-e2e-" },
+    );
+  });
+
   it.each([
     { name: "qr", command: ["qr"] },
     { name: "clawbot qr", command: ["clawbot", "qr"] },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw tasks flow show <missing> --json` exited with empty stdout and a human-only stderr message, leaving automation without a parseable failure document.

## Why This Change Was Made

The TaskFlow lookup owner now follows the existing sibling `tasks show` contract: JSON mode writes the shared canonical CLI failure envelope before exiting, while human mode retains the same stderr text and exit status.

## User Impact

Scripts and agents can reliably parse missing TaskFlow lookups as one JSON document instead of receiving no machine-readable output.

## Evidence

- Pre-fix real-process regression: exit 1, empty stdout, human stderr.
- Post-fix real-process regression: exit 1, empty stderr, and exactly one `{ "ok": false, "error": { "type": "cli_error", ... } }` document.
- `node scripts/run-vitest.mjs test/cli-json-stdout.e2e.test.ts -t 'renders a missing TaskFlow as one canonical JSON document without stderr'` — passed on the final rebased head.
- `node scripts/run-vitest.mjs src/commands/flows.test.ts src/cli/program/register.tasks.test.ts` — 70 passed.
- Proportional changed-file gates passed, including formatting, production/root-test typechecks, core/tooling lint, architecture guards, and import-cycle checks.
- Fresh final-branch structured autoreview reported no accepted P0/P1 findings.
- The first exact-head CI run exposed an unrelated shared-shard test-isolation defect: `entry.run-main.test.ts` installed its `console.error` spy before the production path could install console capture. The test now establishes that precondition first without weakening its assertions; the refreshed compact shard is green.
- ClawSweeper found a TTY-only JSON corruption risk: terminal reset bytes could be appended to stdout after the document. Both TaskFlow and direct-task JSON lookup failures now route cleanup to `process.stderr`, with focused owner-boundary coverage.
- Production delta: +10/-5, net +5, required to preserve distinct JSON/human output and TTY cleanup contracts. Tests: +46/-0.

AI-assisted: yes. I reviewed the implementation and validation results.
