### PR TITLE
fix: preserve auth ownership when onboarding config write fails

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -45,7 +45,10 @@ export {
   upsertAuthProfileWithLock,
   upsertAuthProfileWithLockOrThrow,
 } from "./auth-profiles/profiles.js";
-export { persistAuthProfileBatch } from "./auth-profiles/upsert-with-lock.js";
+export {
+  persistAuthProfileBatch,
+  type AuthProfilePersistenceReceipt,
+} from "./auth-profiles/upsert-with-lock.js";
 export {
   repairOAuthProfileIdMismatch,
   suggestOAuthProfileIdForLegacyDefault,

--- a/src/agents/auth-profiles/upsert-with-lock.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.ts
@@ -25,10 +25,14 @@ type PersistAuthProfileBatchParams = {
   stateDir?: string;
 };
 
+export type AuthProfilePersistenceReceipt = {
+  rollback: () => void;
+};
+
 /** Atomically persists a batch and returns conditional attempt-scoped compensation. */
 export async function persistAuthProfileBatch(
   params: PersistAuthProfileBatchParams,
-): Promise<{ rollback: () => void }> {
+): Promise<AuthProfilePersistenceReceipt> {
   const profiles = new Map(
     params.profiles.map(({ profileId, credential, replaceExisting }) => [
       profileId,

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -321,7 +321,7 @@ describe("agents add command", () => {
         auth: { profiles: { "openai:primary": { provider: "openai", mode: "api_key" } } },
       },
       authProfiles: profiles,
-      persistAuthProfiles: async () => {},
+      persistAuthProfiles: async () => ({ rollback() {} }),
     }));
   }
 

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -43,7 +43,7 @@ vi.mock("../plugins/provider-auth-choices.js", () => ({
   resolveManifestProviderAuthChoice,
 }));
 
-const persistAuthProfileBatch = vi.hoisted(() => vi.fn(async () => {}));
+const persistAuthProfileBatch = vi.hoisted(() => vi.fn(async () => ({ rollback() {} })));
 vi.mock("../agents/auth-profiles.js", () => ({
   persistAuthProfileBatch,
 }));

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -126,7 +126,7 @@ export async function prepareAuthChoice(
   return {
     config: normalizedParams.config,
     authProfiles: [],
-    persistAuthProfiles: async () => {},
+    persistAuthProfiles: async () => ({ rollback() {} }),
   };
 }
 

--- a/src/commands/auth-choice.apply.types.ts
+++ b/src/commands/auth-choice.apply.types.ts
@@ -1,4 +1,5 @@
 // Shared types for applying auth-choice selections during onboarding and agent setup.
+import type { AuthProfilePersistenceReceipt } from "../agents/auth-profiles.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -26,5 +27,7 @@ export type ApplyAuthChoiceResult = {
 
 export type PreparedAuthChoiceResult = ApplyAuthChoiceResult & {
   authProfiles: ProviderAuthResult["profiles"];
-  persistAuthProfiles: (profiles?: ProviderAuthResult["profiles"]) => Promise<void>;
+  persistAuthProfiles: (
+    profiles?: ProviderAuthResult["profiles"],
+  ) => Promise<AuthProfilePersistenceReceipt>;
 };

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -5,7 +5,10 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
-import { persistAuthProfileBatch } from "../agents/auth-profiles.js";
+import {
+  persistAuthProfileBatch,
+  type AuthProfilePersistenceReceipt,
+} from "../agents/auth-profiles.js";
 import { formatLiteralProviderPrefixedModelRef } from "../agents/model-ref-shared.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import { normalizeAgentModelRefForConfig } from "../config/model-input.js";
@@ -56,7 +59,9 @@ type ApplyProviderAuthChoiceResult = {
 
 type PreparedApplyProviderAuthChoiceResult = ApplyProviderAuthChoiceResult & {
   authProfiles: ProviderAuthResult["profiles"];
-  persistAuthProfiles: (profiles?: ProviderAuthResult["profiles"]) => Promise<void>;
+  persistAuthProfiles: (
+    profiles?: ProviderAuthResult["profiles"],
+  ) => Promise<AuthProfilePersistenceReceipt>;
 };
 
 function preparedWithoutAuthProfiles(
@@ -65,7 +70,7 @@ function preparedWithoutAuthProfiles(
   return {
     ...result,
     authProfiles: [],
-    persistAuthProfiles: async () => {},
+    persistAuthProfiles: async () => ({ rollback() {} }),
   };
 }
 
@@ -345,7 +350,9 @@ async function prepareProviderPluginAuthMethod(
   config: OpenClawConfig;
   defaultModel?: string;
   authProfiles: ProviderAuthResult["profiles"];
-  persistAuthProfiles: (profiles?: ProviderAuthResult["profiles"]) => Promise<void>;
+  persistAuthProfiles: (
+    profiles?: ProviderAuthResult["profiles"],
+  ) => Promise<AuthProfilePersistenceReceipt>;
 }> {
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
   const agentDir = params.agentDir ?? resolveAgentDir(params.config, agentId);
@@ -380,18 +387,18 @@ async function prepareProviderPluginAuthMethod(
     ? normalizeAgentModelRefForConfig(result.defaultModel)
     : undefined;
 
-  let profilesPersisted = false;
+  let persistenceReceipt: AuthProfilePersistenceReceipt | undefined;
   const persistAuthProfiles = async (profiles = result.profiles) => {
-    if (profilesPersisted) {
-      return;
+    if (persistenceReceipt) {
+      return persistenceReceipt;
     }
     await params.beforePersistentEffect?.();
-    await persistAuthProfileBatch({
+    persistenceReceipt = await persistAuthProfileBatch({
       profiles,
       agentDir,
       stateDir: params.env?.OPENCLAW_STATE_DIR,
     });
-    profilesPersisted = true;
+    return persistenceReceipt;
   };
 
   return {

--- a/src/wizard/setup.default-agent.test.ts
+++ b/src/wizard/setup.default-agent.test.ts
@@ -50,7 +50,7 @@ vi.mock("./setup.model-auth.js", () => ({
   runSetupModelAuthStep: async ({ config }: { config: OpenClawConfig }) => ({
     config,
     authProfiles: [],
-    persistAuthProfiles: async () => {},
+    persistAuthProfiles: async () => ({ rollback() {} }),
   }),
 }));
 

--- a/src/wizard/setup.inference-verification.test.ts
+++ b/src/wizard/setup.inference-verification.test.ts
@@ -105,7 +105,7 @@ describe("offerLiveModelVerification", () => {
         },
       },
     };
-    const persistAuthProfiles = vi.fn(async () => {});
+    const persistAuthProfiles = vi.fn(async () => ({ rollback() {} }));
     const writeConfig = vi.fn(async () => repairedConfig);
     mocks.verify
       .mockResolvedValueOnce({ ok: false, status: "auth", error: "credential expired" })
@@ -144,5 +144,47 @@ describe("offerLiveModelVerification", () => {
     });
     expect(persistAuthProfiles).toHaveBeenCalledOnce();
     expect(writeConfig).toHaveBeenCalledOnce();
+  });
+
+  it("rolls verified auth persistence back when config publication fails", async () => {
+    const publicationError = new Error("injected config publication failure");
+    const rollback = vi.fn();
+    const persistAuthProfiles = vi.fn(async () => ({ rollback }));
+    mocks.verify.mockResolvedValue({
+      ok: true,
+      modelRef: "openai/gpt-5.6",
+      latencyMs: 10,
+    });
+    const prompter = {
+      intro: vi.fn(),
+      outro: vi.fn(),
+      note: vi.fn(),
+      confirm: vi.fn(async () => true),
+      select: vi.fn(),
+      multiselect: vi.fn(),
+      text: vi.fn(),
+      progress: vi.fn(() => ({ stop: vi.fn(), update: vi.fn() })),
+    } as unknown as WizardPrompter;
+
+    await expect(
+      offerLiveModelVerification({
+        config: { agents: { entries: { main: { default: true } } } },
+        initialCandidate: {
+          config: { agents: { entries: { main: { default: true } } } },
+          authProfiles: [],
+          persistAuthProfiles,
+        },
+        opts: {},
+        prompter,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as never,
+        workspaceDir: "/tmp/openclaw-test-workspace",
+        writeConfig: vi.fn(async () => {
+          throw publicationError;
+        }),
+      }),
+    ).rejects.toBe(publicationError);
+
+    expect(persistAuthProfiles).toHaveBeenCalledOnce();
+    expect(rollback).toHaveBeenCalledOnce();
   });
 });

--- a/src/wizard/setup.inference-verification.ts
+++ b/src/wizard/setup.inference-verification.ts
@@ -92,7 +92,7 @@ export async function offerLiveModelVerification(params: {
     ({
       config: params.config,
       authProfiles: [],
-      persistAuthProfiles: async () => {},
+      persistAuthProfiles: async () => ({ rollback() {} }),
     } satisfies SetupModelAuthCandidate);
   let shouldPersistCandidate = params.initialCandidate !== undefined;
   while (true) {
@@ -107,8 +107,14 @@ export async function offerLiveModelVerification(params: {
           modelRef: result.modelRef,
         };
       }
-      await candidate.persistAuthProfiles(result.authProfiles);
-      const config = await params.writeConfig(candidate.config);
+      const authPersistence = await candidate.persistAuthProfiles(result.authProfiles);
+      let config: OpenClawConfig;
+      try {
+        config = await params.writeConfig(candidate.config);
+      } catch (error) {
+        authPersistence.rollback();
+        throw error;
+      }
       return {
         config,
         attempted: true,

--- a/src/wizard/setup.inference-verification.ts
+++ b/src/wizard/setup.inference-verification.ts
@@ -7,6 +7,21 @@ import { t } from "./i18n/index.js";
 import type { WizardPrompter } from "./prompts.js";
 import { runSetupModelAuthStep, type SetupModelAuthCandidate } from "./setup.model-auth.js";
 
+export async function publishSetupModelAuthCandidate(
+  candidate: SetupModelAuthCandidate,
+  config: OpenClawConfig,
+  writeConfig: (config: OpenClawConfig) => Promise<OpenClawConfig>,
+  authProfiles?: SetupModelAuthCandidate["authProfiles"],
+): Promise<OpenClawConfig> {
+  const persistence = await candidate.persistAuthProfiles(authProfiles);
+  try {
+    return await writeConfig(config);
+  } catch (error) {
+    persistence.rollback();
+    throw error;
+  }
+}
+
 export async function offerLiveModelVerification(params: {
   config: OpenClawConfig;
   initialCandidate?: SetupModelAuthCandidate;
@@ -107,14 +122,12 @@ export async function offerLiveModelVerification(params: {
           modelRef: result.modelRef,
         };
       }
-      const authPersistence = await candidate.persistAuthProfiles(result.authProfiles);
-      let config: OpenClawConfig;
-      try {
-        config = await params.writeConfig(candidate.config);
-      } catch (error) {
-        authPersistence.rollback();
-        throw error;
-      }
+      const config = await publishSetupModelAuthCandidate(
+        candidate,
+        candidate.config,
+        params.writeConfig,
+        result.authProfiles,
+      );
       return {
         config,
         attempted: true,

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -111,7 +111,7 @@ describe("runSetupModelAuthStep", () => {
     applyAuthChoice.mockResolvedValueOnce({
       config,
       authProfiles: [],
-      persistAuthProfiles: async () => {},
+      persistAuthProfiles: async () => ({ rollback() {} }),
     });
 
     await runSetupModelAuthStep({
@@ -167,7 +167,7 @@ describe("runSetupModelAuthStep", () => {
     applyAuthChoice.mockResolvedValueOnce({
       config,
       authProfiles: [],
-      persistAuthProfiles: async () => {},
+      persistAuthProfiles: async () => ({ rollback() {} }),
     });
 
     await runSetupModelAuthStep({
@@ -227,7 +227,7 @@ describe("runSetupModelAuthStep", () => {
         },
       },
     ];
-    const persistAuthProfiles = vi.fn(async () => {});
+    const persistAuthProfiles = vi.fn(async () => ({ rollback() {} }));
     promptAuthChoiceGrouped.mockResolvedValueOnce("anthropic-cli");
     applyAuthChoice.mockResolvedValueOnce({
       config,

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -135,7 +135,7 @@ export async function runSetupModelAuthStep(params: {
   let authProfiles: PreparedAuthChoiceResult["authProfiles"] =
     params.stagedCandidate?.authProfiles ?? [];
   let persistAuthProfiles: PreparedAuthChoiceResult["persistAuthProfiles"] =
-    params.stagedCandidate?.persistAuthProfiles ?? (async () => {});
+    params.stagedCandidate?.persistAuthProfiles ?? (async () => ({ rollback() {} }));
   const authChoiceFromPrompt = opts.authChoice === undefined;
   let authChoice: AuthChoice | undefined = opts.authChoice;
   let authStore:
@@ -194,7 +194,7 @@ export async function runSetupModelAuthStep(params: {
     // A new auth choice replaces the rejected candidate instead of layering onto it.
     nextConfig = replacementBaseConfig;
     authProfiles = [];
-    persistAuthProfiles = async () => {};
+    persistAuthProfiles = async () => ({ rollback() {} });
 
     if (authChoice === "custom-api-key") {
       const { promptCustomApiConfig } = await import("../commands/onboard-custom.js");

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -11,6 +11,7 @@ import {
   removeOAuthTestTempRoot,
 } from "../agents/auth-profiles/oauth-test-utils.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
+import { persistAuthProfileBatch } from "../agents/auth-profiles/upsert-with-lock.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import { ConfigMutationConflictError } from "../config/config.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
@@ -54,7 +55,7 @@ const prepareAuthChoice = vi.hoisted(() =>
   vi.fn<PrepareAuthChoice>(async (args) => ({
     ...(await applyAuthChoice(args)),
     authProfiles: [],
-    persistAuthProfiles: async () => {},
+    persistAuthProfiles: async () => ({ rollback() {} }),
   })),
 );
 const resolvePreferredProviderForAuthChoice = vi.hoisted(() => vi.fn(async () => "demo-provider"));
@@ -281,7 +282,7 @@ function prepareMockAuthProfilesIn(
       return {
         ...result,
         authProfiles: [],
-        persistAuthProfiles: async () => {},
+        persistAuthProfiles: async () => ({ rollback() {} }),
       };
     }
     const profile = stagedOpenAiProfile(apiKey);
@@ -290,12 +291,7 @@ function prepareMockAuthProfilesIn(
       authProfiles: [profile],
       persistAuthProfiles: async (profiles) => {
         persistCalls.push(profiles);
-        for (const candidate of profiles ?? [profile]) {
-          const updated = await upsertAuthProfileWithLock({ ...candidate, agentDir });
-          if (!updated) {
-            throw new Error("test auth profile write failed");
-          }
-        }
+        return await persistAuthProfileBatch({ profiles: profiles ?? [profile], agentDir });
       },
     };
   });
@@ -632,7 +628,7 @@ describe("runSetupWizard", () => {
     prepareAuthChoice.mockImplementation(async (args) => ({
       ...(await applyAuthChoice(args)),
       authProfiles: [],
-      persistAuthProfiles: async () => {},
+      persistAuthProfiles: async () => ({ rollback() {} }),
     }));
     setupChannels.mockReset();
     setupChannels.mockImplementation(async (cfg) => cfg);
@@ -3501,6 +3497,80 @@ describe("runSetupWizard", () => {
     expect(replaceConfigFile).not.toHaveBeenCalled();
     expect(persistCalls).toEqual([]);
     await expect(fs.access(agentDir)).rejects.toThrow();
+  });
+
+  it("rolls noninteractive auth persistence back when the first config write fails", async () => {
+    const stateDir = await makeCaseDir("auth-config-write-rollback-");
+    const agentDir = path.join(stateDir, "agent");
+    prepareMockAuthProfilesIn(agentDir);
+    applyAuthChoice.mockResolvedValueOnce({
+      config: modelConfigWithApiKey("test-rollback-key"),
+    });
+    replaceConfigFile.mockRejectedValueOnce(new Error("injected config publication failure"));
+
+    try {
+      await expect(
+        runSetupWizard(
+          {
+            acceptRisk: true,
+            flow: "quickstart",
+            authChoice: "demo-provider",
+            nonInteractive: true,
+            installDaemon: false,
+            skipChannels: true,
+            skipSkills: true,
+            skipSearch: true,
+            skipHealth: true,
+            skipUi: true,
+          },
+          createRuntime(),
+          buildWizardPrompter({}),
+        ),
+      ).rejects.toThrow("injected config publication failure");
+
+      expect(readAuthProfileStoreForTest(agentDir).profiles["openai:default"]).toBeUndefined();
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
+  });
+
+  it("retains noninteractive auth persistence when a later config write fails", async () => {
+    const stateDir = await makeCaseDir("auth-later-config-write-failure-");
+    const agentDir = path.join(stateDir, "agent");
+    prepareMockAuthProfilesIn(agentDir);
+    applyAuthChoice.mockResolvedValueOnce({
+      config: modelConfigWithApiKey("test-retained-key"),
+    });
+    replaceConfigFile
+      .mockResolvedValueOnce({ config: modelConfigWithApiKey("test-retained-key") })
+      .mockRejectedValueOnce(new Error("injected later config publication failure"));
+
+    try {
+      await expect(
+        runSetupWizard(
+          {
+            acceptRisk: true,
+            flow: "quickstart",
+            authChoice: "demo-provider",
+            nonInteractive: true,
+            installDaemon: false,
+            skipChannels: true,
+            skipSkills: true,
+            skipSearch: true,
+            skipHealth: true,
+            skipUi: true,
+          },
+          createRuntime(),
+          buildWizardPrompter({}),
+        ),
+      ).rejects.toThrow("injected later config publication failure");
+
+      expect(readAuthProfileStoreForTest(agentDir).profiles["openai:default"]).toEqual(
+        stagedOpenAiProfile("test-retained-key").credential,
+      );
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
   });
 
   it("keeps failed model/auth fixes in the verification loop without persisting them", async () => {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -1,6 +1,7 @@
 import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
+import type { AuthProfilePersistenceReceipt } from "../agents/auth-profiles.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveOnboardingSetupTarget } from "../commands/onboard-agent-target.js";
 import * as firstAgentOnboarding from "../commands/onboard-first-agent.js";
@@ -564,6 +565,7 @@ async function runSetupWizardOnce(
 
   let liveModelVerified = false;
   let setupConfigPersisted = false;
+  let unpublishedAuthPersistence: AuthProfilePersistenceReceipt | undefined;
   // keepExistingModelConfig is latched before auth setup, so this distinguishes
   // a route supplied by the import from one configured normally after the import.
   if (
@@ -604,18 +606,23 @@ async function runSetupWizardOnce(
     } else if (!verification.verified && stagedModelAuth) {
       // Declining an optional probe is not a failed verification; keep the
       // provider/model choice the user just made and persist it once here.
-      await stagedModelAuth.persistAuthProfiles();
+      unpublishedAuthPersistence = await stagedModelAuth.persistAuthProfiles();
     }
   } else if (stagedModelAuth) {
     // Non-interactive setup has no live-verification step by contract.
-    await stagedModelAuth.persistAuthProfiles();
+    unpublishedAuthPersistence = await stagedModelAuth.persistAuthProfiles();
   }
 
   if (!setupConfigPersisted) {
     // Persist gateway/roster decisions only after the interactive verification boundary.
-    nextConfig = await writeSetupConfigFile(nextConfig, {
-      allowConfigSizeDrop: false,
-    });
+    try {
+      nextConfig = await writeSetupConfigFile(nextConfig, {
+        allowConfigSizeDrop: false,
+      });
+    } catch (error) {
+      unpublishedAuthPersistence?.rollback();
+      throw error;
+    }
   }
 
   prompter.disableBackNavigation?.();

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -1,14 +1,13 @@
 import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
-import type { AuthProfilePersistenceReceipt } from "../agents/auth-profiles.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveOnboardingSetupTarget } from "../commands/onboard-agent-target.js";
 import * as firstAgentOnboarding from "../commands/onboard-first-agent.js";
 import type { OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { ConfigMutationConflictError } from "../config/config.js";
-import { createMergePatch, applyMergePatch } from "../config/merge-patch.js";
+import { applyMergePatch, createMergePatch } from "../config/merge-patch.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../gateway/probe-auth.js";
@@ -24,7 +23,10 @@ import { resolveUserPath } from "../utils.js";
 import { t } from "./i18n/index.js";
 import { runWizardWithPromptNavigation } from "./navigation-prompter.js";
 import type { WizardPrompter } from "./prompts.js";
-import { offerLiveModelVerification } from "./setup.inference-verification.js";
+import {
+  offerLiveModelVerification,
+  publishSetupModelAuthCandidate,
+} from "./setup.inference-verification.js";
 import {
   detectSetupMigrationSources,
   listSetupMigrationOptions,
@@ -565,7 +567,7 @@ async function runSetupWizardOnce(
 
   let liveModelVerified = false;
   let setupConfigPersisted = false;
-  let unpublishedAuthPersistence: AuthProfilePersistenceReceipt | undefined;
+  let authCandidateToPublish: SetupModelAuthCandidate | undefined;
   // keepExistingModelConfig is latched before auth setup, so this distinguishes
   // a route supplied by the import from one configured normally after the import.
   if (
@@ -577,14 +579,7 @@ async function runSetupWizardOnce(
     const verificationTarget = resolveOnboardingSetupTarget(nextConfig);
     const verification = await offerLiveModelVerification({
       config: nextConfig,
-      ...(stagedModelAuth
-        ? {
-            initialCandidate: {
-              ...stagedModelAuth,
-              config: nextConfig,
-            },
-          }
-        : {}),
+      ...(stagedModelAuth ? { initialCandidate: { ...stagedModelAuth, config: nextConfig } } : {}),
       opts,
       prompter,
       runtime,
@@ -603,26 +598,20 @@ async function runSetupWizardOnce(
         nextConfig,
         createMergePatch(stagedModelAuth.config, preModelAuthConfig),
       ) as OpenClawConfig;
-    } else if (!verification.verified && stagedModelAuth) {
-      // Declining an optional probe is not a failed verification; keep the
-      // provider/model choice the user just made and persist it once here.
-      unpublishedAuthPersistence = await stagedModelAuth.persistAuthProfiles();
+    } else if (!verification.verified) {
+      authCandidateToPublish = stagedModelAuth;
     }
-  } else if (stagedModelAuth) {
-    // Non-interactive setup has no live-verification step by contract.
-    unpublishedAuthPersistence = await stagedModelAuth.persistAuthProfiles();
+  } else {
+    authCandidateToPublish = stagedModelAuth;
   }
 
   if (!setupConfigPersisted) {
-    // Persist gateway/roster decisions only after the interactive verification boundary.
-    try {
-      nextConfig = await writeSetupConfigFile(nextConfig, {
-        allowConfigSizeDrop: false,
-      });
-    } catch (error) {
-      unpublishedAuthPersistence?.rollback();
-      throw error;
-    }
+    // This is the first publication boundary for both staged auth and setup config.
+    const writeConfig = async (config: OpenClawConfig) =>
+      await writeSetupConfigFile(config, { allowConfigSizeDrop: false });
+    nextConfig = authCandidateToPublish
+      ? await publishSetupModelAuthCandidate(authCandidateToPublish, nextConfig, writeConfig)
+      : await writeConfig(nextConfig);
   }
 
   prompter.disableBackNavigation?.();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where onboarding could leave orphaned credentials, or fail to restore overwritten credentials, when the first configuration publication failed after provider authentication was staged.

## Why This Change Was Made

Auth persistence now returns an attempt-scoped receipt whose rollback compensates only profile values still owned by that persistence attempt. Classic, inference-verification, and noninteractive setup share one auth/config publication primitive and roll back only if the first config publication containing the auth selection fails. Once publication succeeds, later setup failures retain the published auth.

## User Impact

Failed initial onboarding config writes no longer leave unreferenced or incorrectly overwritten auth profiles. Concurrent or newer profile updates remain untouched, and credentials remain available after failures that occur after config publication.

## Evidence

- Pre-fix focused regression run failed the two intended first-publication rollback cases.
- `node scripts/run-vitest.mjs src/wizard/setup.test.ts src/wizard/setup.inference-verification.test.ts src/wizard/setup.model-auth.test.ts src/wizard/setup.default-agent.test.ts src/commands/agents.add.test.ts src/commands/auth-choice.apply.plugin-provider.test.ts` — 129/129 passed.
- Coverage includes classic and verified-auth first-write rollback, ownership-safe concurrent rollback, and post-publication auth retention when a later config write fails.
- `pnpm check:changed` — passed the complete `core, coreTests` plan: max-lines ratchet, formatting, core and core-test typechecks, lint, dead exports, import cycles, and storage/security boundary guards. The linked dependency tree was refreshed first so the declared `ui/pako@3.0.1` types resolved correctly.
- `git diff --check` — passed.
- Fresh uncommitted autoreview — clean, no accepted/actionable findings; correctness 0.98.
- Autoreview TruffleHog scan — 0 verified and 0 unknown secrets.
