### PR TITLE
perf(test): speed up model provider page observation polling

### DIFF
--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelsProbeResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { DefaultModelSelection, ModelProviderLogoutTarget } from "./data.ts";
 import { EMPTY_MODEL_PROVIDERS_DATA, type ModelProvidersData } from "./load.ts";
 import type { ModelProvidersRouteData } from "./model-providers-page.ts";
@@ -191,7 +192,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("switches application ownership from the concrete agent picker", async () => {
     const { agentSelection, context } = createHarness("main");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.querySelector("openclaw-agent-select")).not.toBeNull());
+    await waitForFast(() => expect(page.querySelector("openclaw-agent-select")).not.toBeNull());
 
     page.querySelector<AgentSelectElement>("openclaw-agent-select")?.onSelect("writer");
 
@@ -212,7 +213,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("patches thinking and fast mode through the shared config draft", async () => {
     const { context, runtimeConfig } = createHarness("main");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.querySelector("#settings-model-behavior")).not.toBeNull());
+    await waitForFast(() => expect(page.querySelector("#settings-model-behavior")).not.toBeNull());
 
     const groups = page.querySelectorAll<HTMLElement & { value: string }>("wa-radio-group");
     expect(groups).toHaveLength(2);
@@ -236,7 +237,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("removes thinking and fast overrides through the shared config draft", async () => {
     const { context, runtimeConfig } = createHarness("main");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.querySelector("#settings-model-behavior")).not.toBeNull());
+    await waitForFast(() => expect(page.querySelector("#settings-model-behavior")).not.toBeNull());
 
     const groups = page.querySelectorAll<HTMLElement & { value: string }>(
       "#settings-model-behavior wa-radio-group",
@@ -265,7 +266,7 @@ describe("ModelProvidersPage agent scope", () => {
       agents: { defaults: { thinkingDefault: 42, fastModeDefault: "bogus" } },
     } as unknown as typeof runtimeConfig.state.configForm;
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.querySelector("#settings-model-behavior")).not.toBeNull());
+    await waitForFast(() => expect(page.querySelector("#settings-model-behavior")).not.toBeNull());
 
     const behavior = page.querySelector("#settings-model-behavior")!;
     const groups = behavior.querySelectorAll<HTMLElement & { value: string }>("wa-radio-group");
@@ -294,7 +295,7 @@ describe("ModelProvidersPage agent scope", () => {
       runtimeConfig.state.lastError = "config.get failed after provider-key commit";
     });
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     page.keyEditorProvider = "openai";
     page.keyDraft = "replacement";
 
@@ -315,7 +316,7 @@ describe("ModelProvidersPage agent scope", () => {
       runtimeConfig.state.lastError = "config.get failed after provider add";
     });
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     page.addProviderOpen = true;
     page.addProviderId = "anthropic";
     page.addProviderKey = "new-provider-key";
@@ -338,7 +339,7 @@ describe("ModelProvidersPage agent scope", () => {
       runtimeConfig.state.lastError = "config.get failed after saving default models";
     });
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     const selection: DefaultModelSelection = {
       primary: "openai/gpt-5",
       fallbacks: [],
@@ -362,7 +363,7 @@ describe("ModelProvidersPage agent scope", () => {
     const gate = deferred<void>();
     runtimeConfig.ensureLoaded.mockImplementationOnce(async () => gate.promise);
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     const selection: DefaultModelSelection = {
       primary: "openai/gpt-5",
       fallbacks: [],
@@ -389,7 +390,7 @@ describe("ModelProvidersPage agent scope", () => {
     const gate = deferred<void>();
     runtimeConfig.ensureLoaded.mockImplementationOnce(async () => gate.promise);
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     page.keyEditorProvider = "openai";
     page.keyDraft = "main-agent-key";
 
@@ -420,7 +421,7 @@ describe("ModelProvidersPage agent scope", () => {
     const gate = deferred<void>();
     runtimeConfig.ensureLoaded.mockImplementationOnce(async () => gate.promise);
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     page.addProviderOpen = true;
     page.addProviderId = "anthropic";
     page.addProviderKey = "shared-provider-key";
@@ -447,7 +448,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("stops queued agent-scoped logouts after the selected agent changes", async () => {
     const { agentSelection, context, notifySelection, request } = createHarness("main");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     request.mockClear();
     const firstLogout = deferred<unknown>();
     request.mockImplementationOnce(async () => firstLogout.promise);
@@ -480,7 +481,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("stops queued agent-scoped logouts when route data changes the selected agent", async () => {
     const { agentSelection, context, request, snapshot } = createHarness("main");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     request.mockClear();
     const firstLogout = deferred<unknown>();
     request.mockImplementationOnce(async () => firstLogout.promise);
@@ -532,7 +533,7 @@ describe("ModelProvidersPage agent scope", () => {
     agentSelection.state.scopeId = "writer";
     notifySelection();
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
         "models.authStatus",
         { agentId: "writer" },
@@ -549,7 +550,7 @@ describe("ModelProvidersPage agent scope", () => {
 
     const page = appendPage(context);
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
         "models.authStatus",
         { agentId: "writer" },
@@ -614,14 +615,14 @@ describe("ModelProvidersPage agent scope", () => {
     notifySelection();
     release();
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
         "models.authStatus",
         { agentId: "writer" },
         { signal: expect.any(AbortSignal) },
       ),
     );
-    await vi.waitFor(() => expect(page.data?.updatedAt).toEqual(expect.any(Number)));
+    await waitForFast(() => expect(page.data?.updatedAt).toEqual(expect.any(Number)));
   });
 
   it("discards stale route data when selection changes during preload", async () => {
@@ -634,7 +635,7 @@ describe("ModelProvidersPage agent scope", () => {
     page.routeData = { data: staleData, client: snapshot.client, agentId: "main" };
     document.body.append(page);
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
         "models.authStatus",
         { agentId: "writer" },
@@ -648,7 +649,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("probes credentials in the selected agent scope", async () => {
     const { context, request } = createHarness("writer");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     request.mockClear();
 
     await page.probe("openai", ["openai"]);
@@ -662,7 +663,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("stops queued provider probes after switching away from and back to the selected agent", async () => {
     const { agentSelection, context, notifySelection, request } = createHarness("main");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     request.mockClear();
     const firstProbe = deferred<ModelsProbeResult>();
     request.mockImplementationOnce(() => firstProbe.promise);
@@ -693,7 +694,7 @@ describe("ModelProvidersPage agent scope", () => {
   it("discards an in-flight probe result after the selected agent changes", async () => {
     const { agentSelection, context, notifySelection, request } = createHarness("main");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    await waitForFast(() => expect(page.data?.config).toEqual({}));
     const pending = deferred<ModelsProbeResult>();
     request.mockImplementationOnce(() => pending.promise);
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI model-provider page regression suite repeatedly pays Vitest's default 50 ms polling interval while observing render completion, loaded provider configuration, and final authentication state. Those incidental delays slow maintainer and CI feedback even though the page's actual request ordering and agent-ownership boundaries do not require a 50 ms wait.

## Why This Change Was Made

Use the existing Control UI `waitForFast` helper for 20 incidental observations, while deliberately preserving all 17 original waits that establish deferred request ordering, agent-selection transitions, logout/probe ownership, and ABA invalidation. The helper changes polling to 1 ms without altering Vitest's 1,000 ms failure deadline, assertions, mocks, test count, production code, or user-visible behavior.

## User Impact

No product behavior changes. Maintainers and CI receive the same model-provider regression coverage with materially faster scoped test execution.

## Evidence

- Blacksmith Testbox `tbx_01m0hja5jh12xendpgv4djvmxk`: one excluded warmup, eight retained interleaved baseline/candidate samples each, one worker, separate filesystem-module caches, import diagnostics, and GNU `/usr/bin/time -v`.
- Median scoped wall time: **3.625 s -> 3.125 s**, a **0.500 s / 13.8% improvement**; median Vitest test-body time: **1.440 s -> 0.9435 s**, a **34.5% improvement**.
- Median imports were effectively unchanged (**696 ms -> 703 ms**), and median peak RSS was **848,344 KiB -> 846,898 KiB**. Every benchmark retained all **22 passing tests**.
- Owner-boundary fault injection changed the disposable Testbox copy of the production agent epoch increment from `+= 1` to `+= 0`: existing logout and provider-probe regressions both failed because a second request escaped after switching away and back. Restoring production immediately returned both tests to passing.
- Focused page, loader, data, mutations, view, catalog cache, usage, connection lifecycle, and subscription-controller suites: **111 tests passing across nine files**.
- Real Chromium plus mocked Gateway: **nine passing browser scenarios across model-provider management, provider-usage outcomes, and explicit selected-agent request ownership**.
- Complete `pnpm check:changed` gate, targeted `oxfmt --check`, `git diff --check`, and independent structured review.
- Production LOC: **+0/-0**. Tests: **+21/-20**. AI-assisted maintainer-requested performance work.
