### PR TITLE
fix: refresh active Agent Files content

### DIFF
--- a/ui/src/e2e/agent-file-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/agent-file-lifecycle.e2e.test.ts
@@ -212,6 +212,74 @@ suite.define(() => {
     );
   });
 
+  it("refreshes the active file while preserving a dirty draft", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "agents.files.get",
+            "agents.files.list",
+            "agents.files.set",
+            "agents.list",
+          ],
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+              agents: [{ id: "main", name: "Main" }],
+            },
+            "agents.files.get": fileGetResponses("server revision 1"),
+            "agents.files.list": fileListResponses,
+          },
+          operatorScopes: ["operator.admin", "operator.read", "operator.write"],
+        });
+
+        await page.goto(`${suite.server.baseUrl}settings/agents/main/files`);
+        const editor = page.locator(".agent-file-textarea");
+        const fileSection = page.locator(".settings-section").filter({
+          has: page.getByRole("heading", { name: "Core files" }),
+        });
+        const refresh = fileSection.getByRole("button", { name: "Refresh" });
+        const fileActions = page.locator(".agent-file-actions");
+        const reset = fileActions.getByRole("button", { name: "Reset" });
+        const save = fileActions.getByRole("button", { name: "Save" });
+        await expect.poll(() => editor.inputValue()).toBe("server revision 1");
+        expect(await gateway.getRequests("agents.files.get")).toHaveLength(1);
+
+        await gateway.setMethodResponse("agents.files.get", fileGetResponses("server revision 2"));
+        await refresh.click();
+        await expect
+          .poll(async () => (await gateway.getRequests("agents.files.get")).length)
+          .toBe(2);
+        await expect.poll(() => editor.inputValue()).toBe("server revision 2");
+        await expect.poll(() => editor.isEnabled()).toBe(true);
+        await capture(page, "04-refresh-adopts-authoritative-content.png");
+
+        await editor.fill("local dirty draft");
+        await gateway.setMethodResponse("agents.files.get", fileGetResponses("server revision 3"));
+        await refresh.click();
+        await expect
+          .poll(async () => (await gateway.getRequests("agents.files.get")).length)
+          .toBe(3);
+        await expect.poll(() => editor.inputValue()).toBe("local dirty draft");
+        await expect.poll(() => editor.isEnabled()).toBe(true);
+        await expect.poll(() => reset.isEnabled()).toBe(true);
+        await capture(page, "05-refresh-preserves-dirty-draft.png");
+        await reset.click();
+        await expect.poll(() => editor.inputValue()).toBe("server revision 3");
+        await expect.poll(() => reset.isDisabled()).toBe(true);
+        await expect.poll(() => save.isDisabled()).toBe(true);
+        await capture(page, "06-reset-uses-refreshed-authoritative-content.png");
+      },
+    );
+  });
+
   it("reads and saves the selected agent workspace through an isolated Gateway", async () => {
     const port = await getFreePort();
     const state = await createOpenClawTestState({
@@ -293,7 +361,7 @@ suite.define(() => {
           await expect
             .poll(() => readFile(path.join(mainWorkspace, "AGENTS.md"), "utf8"))
             .toBe("# Saved through real Gateway\n");
-          await capture(page, "04-real-gateway-main-save.png");
+          await capture(page, "07-real-gateway-main-save.png");
         },
       );
     } finally {

--- a/ui/src/pages/agents/agent-file-lifecycle.test.ts
+++ b/ui/src/pages/agents/agent-file-lifecycle.test.ts
@@ -18,6 +18,7 @@ type TestAgentsPage = HTMLElement & {
   agentFilesError: string | null;
   agentFileActive: string | null;
   agentFileContents: Record<string, string>;
+  agentFileDrafts: Record<string, string>;
   gateway: {
     applySnapshot: (
       snapshot: ApplicationGatewaySnapshot,
@@ -26,6 +27,7 @@ type TestAgentsPage = HTMLElement & {
   };
   selectDefaultAgentFile: (agentId: string) => Promise<void>;
   syncCurrentAgentFiles: (agents?: ApplicationContext["agents"]) => void;
+  loadAgentFiles: (agentId: string, force?: boolean) => Promise<void>;
   saveSelectedAgentFile: (agentId: string, name: string, content: string) => void;
 };
 
@@ -88,6 +90,41 @@ describe("agent file lifecycle", () => {
     await page.selectDefaultAgentFile("main");
 
     expect(page.agentFileContents["AGENTS.md"]).toBe("# Instructions");
+  });
+
+  it("refreshes the active file base without replacing a dirty draft", async () => {
+    const list = fileList();
+    let authoritativeContent = "server revision 1";
+    const request = vi.fn(async () => ({
+      file: {
+        ...list.files[0],
+        content: authoritativeContent,
+      },
+    }));
+    const refreshFiles = vi.fn(async () => list);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.context = {
+      gateway: gateway(snapshot(client)),
+      agents: {
+        files: () => ({ list: null, loading: false, error: null }),
+        ensureFiles: vi.fn(async () => list),
+        refreshFiles,
+      },
+    } as unknown as ApplicationContext;
+    setPageGateway(page, client);
+    page.agentsSelectedId = "main";
+
+    await page.loadAgentFiles("main");
+    page.agentFileDrafts = { "AGENTS.md": "local draft" };
+    authoritativeContent = "server revision 2";
+
+    await page.loadAgentFiles("main", true);
+
+    expect(refreshFiles).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(page.agentFileContents["AGENTS.md"]).toBe("server revision 2");
+    expect(page.agentFileDrafts["AGENTS.md"]).toBe("local draft");
   });
 
   it("keeps a rejected save visible without refreshing it away", async () => {

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -336,13 +336,15 @@ class AgentsPage
     void this.selectDefaultAgentFile(agentId);
   }
 
-  private async selectDefaultAgentFile(agentId: string) {
+  private async selectDefaultAgentFile(agentId: string, force = false) {
     const files = this.agentFilesList?.files ?? [];
     if (!this.agentFileActive || !files.some((file) => file.name === this.agentFileActive)) {
       this.agentFileActive = files.find((file) => file.name === "AGENTS.md")?.name ?? null;
     }
     if (this.agentFileActive) {
-      await loadAgentFileContent(this, agentId, this.agentFileActive);
+      await loadAgentFileContent(this, agentId, this.agentFileActive, {
+        force,
+      });
     }
   }
 
@@ -676,7 +678,7 @@ class AgentsPage
       }
     }
     if (this.isCurrentRequest(client, generation, agentId, { agents })) {
-      await this.selectDefaultAgentFile(agentId);
+      await this.selectDefaultAgentFile(agentId, force);
     }
   }
 

--- a/ui/src/pages/agents/files.ts
+++ b/ui/src/pages/agents/files.ts
@@ -39,7 +39,7 @@ export async function loadAgentFileContent(
   state: AgentFilesState,
   agentId: string,
   name: string,
-  opts?: { force?: boolean; preserveDraft?: boolean },
+  opts?: { force?: boolean },
 ): Promise<boolean> {
   const client = state.client;
   if (!client || !state.connected || state.agentFilesLoading) {
@@ -62,14 +62,9 @@ export async function loadAgentFileContent(
       const content = res.file.content ?? "";
       const previousBase = state.agentFileContents[name] ?? "";
       const currentDraft = state.agentFileDrafts[name];
-      const preserveDraft = opts?.preserveDraft ?? true;
       state.agentFilesList = mergeFileEntry(state.agentFilesList, res.file);
       state.agentFileContents = { ...state.agentFileContents, [name]: content };
-      if (
-        !preserveDraft ||
-        !Object.hasOwn(state.agentFileDrafts, name) ||
-        currentDraft === previousBase
-      ) {
+      if (!Object.hasOwn(state.agentFileDrafts, name) || currentDraft === previousBase) {
         state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
       }
       return true;


### PR DESCRIPTION
## What Problem This Solves

Fixes Agent Files Refresh leaving the selected editor on cached content even after the file list reloads from the Gateway.

## Why This Change Was Made

The page forwarded the refresh flag to `agents.files.list` but discarded it before loading the active file, so `loadAgentFileContent` returned from its content cache without issuing `agents.files.get`. Refresh now forwards the same force decision to the existing content-cache owner. A clean editor adopts the new authoritative content; a dirty editor keeps local text while rebasing its authoritative base so Reset uses the refreshed content.

The unused `preserveDraft` override was removed. Agent-file loads now have one canonical behavior: never discard a genuinely dirty draft.

## User Impact

Operators can trust Refresh to retrieve the current selected Agent file. Unsaved edits remain safe, and Reset returns to the newly refreshed server revision rather than stale cached text.

## Evidence

- Pre-fix owner regression failed exactly because only one `agents.files.get` occurred after initial load plus Refresh.
- Pre-fix source-mode Chromium regression failed waiting for the second `agents.files.get`; the editor remained on `server revision 1`.
- Post-fix owner/unit proof: 34/34 passed across Agent page, file-request, and file-lifecycle suites.
- Post-fix source-mode Control UI proof: full Agent file lifecycle 3/3 passed, including save failure/retry, stale cross-agent reads, authoritative refresh/draft rebase, and a real isolated Gateway workspace save. Post-rebase focused browser proof also passed.
- Exact changed-file gate passed: formatting, UI/core-test typechecks, Control UI i18n verification, lint, dead exports, and repository policy guards.
- Fresh independent final-diff review found no actionable findings and recommended shipping after the supported-Node proof above. The repository Codex autoreview helper remained unavailable because its configured authentication returned 401; the independent high-mode review is the disclosed substitute.
- Production delta: 7 additions / 10 deletions (net -3). No protocol, persistence, auth, config, or public API change.

### Inspected browser proof

Clean Refresh adopts authoritative revision 2:

![Agent Files editor after clean Refresh](https://ampcode.com/user-content/artifacts/4de1aa8851222c9b405619f4be003f663ca6b2df9d4b2888167ade0f33117126-file.png)

Dirty Refresh preserves the local draft and leaves Reset available:

![Agent Files editor preserving a dirty draft](https://ampcode.com/user-content/artifacts/ba65f79b9d52ee1087156c5dada1da8c533c06753a5143f4bba030331589e6d6-file.png)

Reset adopts refreshed authoritative revision 3:

![Agent Files editor after Reset](https://ampcode.com/user-content/artifacts/482d6875a2b844306c5e544a486114f145bcc00470289cadf0021a9e61ebb72c-file.png)

The screenshots were captured by the passing source-mode Chromium regression and individually inspected. GitHub's user-attachment upload endpoint returned 404 with the verified repository ID/admin identity, so permanent Amp artifact URLs are used as the documented fallback.
