### PR TITLE
fix(channels): retry timed-out ingress messages

### DIFF
--- a/extensions/telegram/AGENTS.md
+++ b/extensions/telegram/AGENTS.md
@@ -17,7 +17,7 @@ Proof: `src/channels/message/ingress-drain.test.ts`,
 
 - Completed rows tombstone via `complete()`, never `delete`.
 - Complete at turn adoption, not settle. Deferred holds the claim; watchdog
-  stays armed through deferral; dead-letter reason `handler-timeout`.
+  stays armed through deferral; watchdog timeouts use the shared retry disposition.
 - One retry policy: attempt floor **and** age gate (defaults 8 / 24h).
 - Claim refresh heartbeat while dispatching/deferred (`claimLeaseMs / 3`).
 - Never silently complete on transient failure — release/fail via disposition.

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -246,6 +246,13 @@ export function createTelegramInboundProcessing({
         maxBytes: mediaMaxBytes,
         ...mediaRuntime,
       });
+      if (mediaRuntime.abortSignal?.aborted) {
+        const abortError =
+          mediaRuntime.abortSignal.reason ?? new Error("telegram media hydration owner aborted");
+        recordTelegramMessageProcessingResult({ kind: "failed-retryable", error: abortError });
+        releaseDispatchDedupeClaims(dispatchDedupeClaims, abortError);
+        return { kind: "ignored" };
+      }
       if (media) {
         await recordMessageResolvedMedia({ msg, media, botUserId: ctx.me?.id });
       }

--- a/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
@@ -11,6 +11,25 @@ import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness
 import { telegramInboundEventDelivery } from "./inbound-event-delivery.js";
 
 describeTelegramDispatch("dispatchTelegramMessage pipeline-init", () => {
+  it("does not enter the reply pipeline after the durable owner aborts", async () => {
+    const abortController = new AbortController();
+    abortController.abort(new Error("handler-timeout"));
+
+    await expect(
+      dispatchWithContext({
+        context: createContext(),
+        turnAdoptionLifecycle: {
+          abortSignal: abortController.signal,
+          onAdopted: vi.fn(),
+          onDeferred: vi.fn(),
+          onAbandoned: vi.fn(),
+        },
+      }),
+    ).resolves.toEqual({ kind: "completed" });
+
+    expect(createChannelMessageReplyPipeline).not.toHaveBeenCalled();
+  });
+
   it("keeps Telegram typing below its client expiry without a per-message cutoff", async () => {
     await dispatchWithContext({ context: createContext() });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -384,6 +384,12 @@ export const dispatchTelegramMessage = async (
       }
     }
     loadFreshSessionEntry.clear();
+    // Media hydration and other pre-dispatch work can outlive the durable
+    // ingress watchdog. Never enter the reply pipeline after that owner has
+    // already fenced this attempt; the canonical spool row will retry it.
+    if (isDispatchSuperseded()) {
+      return { kind: "completed" };
+    }
     if (status.controller && !isRoomEvent) {
       void status.controller.setThinking();
     }

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -468,6 +468,37 @@ describe("telegram bot message processor", () => {
     expect(finalizeSpooledReplayResult).toHaveBeenCalledWith({ kind: "completed" }, "adopted");
   });
 
+  it("keeps a pre-adoption owner abort retryable when dispatch returns completed", async () => {
+    buildTelegramMessageContext.mockResolvedValue(createMessageContext());
+    const timeoutError = new Error("handler-timeout");
+    const abortController = new AbortController();
+    const finalizeSpooledReplayResult = vi.fn(
+      async (result: TelegramMessageProcessingResult): Promise<TelegramMessageProcessingResult> =>
+        result,
+    );
+    dispatchTelegramMessage.mockImplementationOnce(async () => {
+      abortController.abort(timeoutError);
+      return { kind: "completed" };
+    });
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+
+    await expect(
+      processSampleMessage(
+        processMessage,
+        {
+          finalizeSpooledReplayResult,
+          spooledReplayAbortSignal: abortController.signal,
+        },
+        {},
+        { spooledReplay: true, isolateSpooledReplaySettlement: true },
+      ),
+    ).resolves.toEqual({ kind: "failed-retryable", error: timeoutError });
+    expect(finalizeSpooledReplayResult).toHaveBeenCalledWith(
+      { kind: "failed-retryable", error: timeoutError },
+      "terminal",
+    );
+  });
+
   it("retries durable replay protection after an active steer already committed", async () => {
     buildTelegramMessageContext.mockResolvedValue(createMessageContext());
     const finalizerError = new Error("dedupe commit failed");

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -447,6 +447,18 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         if (settledResult) {
           return settledResult;
         }
+        if (turnAbortSignal.aborted) {
+          const abortResult: TelegramMessageProcessingResult =
+            turnAbortSignal.reason === "skipped"
+              ? { kind: "skipped" }
+              : {
+                  kind: "failed-retryable",
+                  error:
+                    turnAbortSignal.reason ??
+                    new Error("telegram spooled replay owner cancelled before adoption"),
+                };
+          return await settle(abortResult, "terminal");
+        }
         if (adoptionAttempted && !deferred && result.kind === "completed") {
           runtime.error?.(
             danger(

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4323,6 +4323,65 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
   });
 
+  it("durably retries when primary media hydration outlives its claim owner", async () => {
+    const claimOwner = new AbortController();
+    const timeoutError = new Error("claim adoption stalled");
+    const mediaFetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      claimOwner.abort(timeoutError);
+      expect(init?.signal?.aborted).toBe(true);
+      return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    });
+    const ssrfMock = mockPinnedHostnameResolution();
+
+    try {
+      createTelegramBot({
+        token: "tok",
+        telegramTransport: makeTelegramTransport(mediaFetch as typeof fetch),
+      });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const update = {
+        update_id: 98083,
+        message: {
+          chat: { id: 7, type: "private" },
+          message_id: 9002,
+          caption: "inspect this image",
+          date: 1_736_380_800,
+          from: { id: 42, first_name: "Ada" },
+          photo: [{ file_id: "primary-photo-1" }],
+        },
+      };
+
+      const { result } = await runWithTelegramUpdateProcessingFrame(() =>
+        runWithTelegramSpooledReplayUpdate(
+          update,
+          () =>
+            handler({
+              update,
+              message: update.message,
+              me: { username: "openclaw_bot" },
+              getFile: async () => ({ file_path: "media/primary-photo.jpg" }),
+            }),
+          {
+            abortSignal: claimOwner.signal,
+            onAdopted: vi.fn(),
+            onDeferred: vi.fn(),
+            onAdoptionFinalizing: vi.fn(),
+            onAbandoned: vi.fn(),
+          },
+        ),
+      );
+
+      expect(result).toEqual({ kind: "failed-retryable", error: timeoutError });
+      expect(mediaFetch).toHaveBeenCalledTimes(1);
+      expect(replySpy).not.toHaveBeenCalled();
+    } finally {
+      ssrfMock.mockRestore();
+    }
+  });
+
   it("reuses resolved media when hydrating cached Telegram reply chains", async () => {
     const mediaFetch = vi.fn(
       async () =>

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -2711,7 +2711,7 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("fails buffered spooled claims instead of requeueing when deferred processing times out", async () => {
+  it("requeues buffered spooled claims when deferred processing times out", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
       const log = vi.fn();
@@ -2731,15 +2731,15 @@ describe("TelegramPollingSession", () => {
 
       await waitForTelegramTestState(() => expect(participants).toHaveLength(1));
       await waitForTelegramTestState(async () =>
-        expect(await failedUpdateIds(tempDir)).toEqual([42]),
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]),
       );
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await failedUpdateIds(tempDir)).toEqual([]);
       expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
       // Core drain watchdog log (display-id stripped of zero padding).
       expectLogIncludes(log, "claim→adoption stalled for event");
       expectLogIncludes(log, "handler-timeout");
-      expectLogExcludes(log, "spooled update 42 failed; keeping for retry");
-      expect(await failedUpdateReasons(tempDir)).toEqual([{ id: 42, reason: "handler-timeout" }]);
+      expectLogIncludes(log, "spooled update 42 failed; keeping for retry");
+      expect(await failedUpdateReasons(tempDir)).toEqual([]);
       abort.abort();
       stopWorker();
       await runPromise;
@@ -3512,9 +3512,8 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("recovers a lone active spooled handler owned by a replaced session (#84158)", async () => {
-    // Core drain: a lone hanging claim is dead-lettered by the adoption-stall
-    // watchdog so a replacement session is not blocked forever on that lane.
+  it("retries a lone active spooled handler in a replacement session (#84158)", async () => {
+    // Core drain releases a hanging claim so a replacement session retries it.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const firstAbort = new AbortController();
     const secondAbort = new AbortController();
@@ -3524,7 +3523,9 @@ describe("TelegramPollingSession", () => {
       releaseTurn = resolve;
     });
     const handleUpdate = vi.fn(async () => {
-      await turnDone;
+      if (handleUpdate.mock.calls.length === 1) {
+        await turnDone;
+      }
     });
     createTelegramBotMock.mockImplementation(() => makeIsolatedBot({ handleUpdate }));
     await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "lone active topic turn")]);
@@ -3558,10 +3559,10 @@ describe("TelegramPollingSession", () => {
       });
       const firstRunPromise = firstSession.runUntilAbort();
       await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
-      // Watchdog dead-letters the hanging claim before the session is replaced.
+      // Watchdog releases the hanging claim before the session is replaced.
       await vi.advanceTimersByTimeAsync(1_000);
       await waitForTelegramTestState(async () =>
-        expect(await failedUpdateIds(tempDir)).toEqual([42]),
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]),
       );
       firstAbort.abort();
       await vi.advanceTimersByTimeAsync(16_000);
@@ -3578,10 +3579,12 @@ describe("TelegramPollingSession", () => {
         },
       });
       const secondRunPromise = secondSession.runUntilAbort();
-      await vi.advanceTimersByTimeAsync(1_000);
-      // Tombstoned/failed claim is not re-dispatched; replacement is unblocked.
-      expect(handleUpdate).toHaveBeenCalledTimes(1);
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(2));
+      await waitForTelegramTestState(async () =>
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+      );
+      expect(await failedUpdateIds(tempDir)).toEqual([]);
 
       secondAbort.abort();
       await vi.advanceTimersByTimeAsync(20_000);
@@ -4434,10 +4437,8 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("fails a timed-out spooled handler and drains later same-lane updates without restart", async () => {
-    // Core drain: adoption-stall dead-letters 42 and frees the lane for 43 on
-    // the same bot. Session restart on handler timeout is removed private-drain
-    // behavior; the user-visible outcome is 42 failed and 43 processed.
+  it("retries a timed-out spooled handler before later same-lane updates without restart", async () => {
+    // Core drain releases 42 for retry before 43 on the same bot.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
@@ -4451,11 +4452,13 @@ describe("TelegramPollingSession", () => {
       init: vi.fn(async () => undefined),
       handleUpdate: vi.fn(async (update: { update_id?: number }) => {
         events.push(`bot:${update.update_id}`);
-        if (update.update_id === 42) {
+        if (update.update_id === 42 && events.filter((event) => event === "bot:42").length === 1) {
           // Hang until the core watchdog aborts the drain lifecycle.
           await new Promise<void>(() => {});
         }
-        abort.abort();
+        if (update.update_id === 43) {
+          abort.abort();
+        }
       }),
       stop: vi.fn(async () => undefined),
     };
@@ -4482,11 +4485,8 @@ describe("TelegramPollingSession", () => {
       const runPromise = session.runUntilAbort();
       await waitForTelegramTestState(() => expect(events).toEqual(["bot:42"]));
 
-      await vi.advanceTimersByTimeAsync(1_000);
-      await waitForTelegramTestState(async () =>
-        expect(await failedUpdateIds(tempDir)).toEqual([42]),
-      );
-      await waitForTelegramTestState(() => expect(events).toEqual(["bot:42", "bot:43"]));
+      await vi.advanceTimersByTimeAsync(2_000);
+      await waitForTelegramTestState(() => expect(events).toEqual(["bot:42", "bot:42", "bot:43"]));
       await vi.advanceTimersByTimeAsync(15_000);
       await runPromise;
 
@@ -4494,6 +4494,7 @@ describe("TelegramPollingSession", () => {
       expect(worker.createWorker).toHaveBeenCalledTimes(1);
       expect(createTelegramBotMock).toHaveBeenCalledTimes(1);
       expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await failedUpdateIds(tempDir)).toEqual([]);
       expectLogIncludes(log, "handler-timeout");
     } finally {
       abort.abort();

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -1350,10 +1350,11 @@ describe("startTelegramWebhook", () => {
     }
   });
 
-  it("keeps a timed-out webhook lane guarded until replay settles", async () => {
+  it("retries a timed-out webhook update before later same-lane updates", async () => {
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     try {
       let finishFirstUpdate: (() => void) | undefined;
+      let finishRetry: (() => void) | undefined;
       const seenUpdateIds: number[] = [];
       const firstUpdate = telegramMessageUpdate(40, "slow");
       const secondUpdate = telegramMessageUpdate(41, "blocked");
@@ -1370,7 +1371,11 @@ describe("startTelegramWebhook", () => {
         seenUpdateIds.push(updateId);
         if (updateId === 40) {
           await new Promise<void>((resolve) => {
-            finishFirstUpdate = resolve;
+            if (seenUpdateIds.filter((id) => id === 40).length === 1) {
+              finishFirstUpdate = resolve;
+            } else {
+              finishRetry = resolve;
+            }
           });
         }
       });
@@ -1390,7 +1395,9 @@ describe("startTelegramWebhook", () => {
         expect(seenUpdateIds).toEqual([40]);
 
         finishFirstUpdate?.();
-        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40, 41]));
+        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40, 40]));
+        finishRetry?.();
+        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40, 40, 41]));
       } finally {
         await started.stop();
       }

--- a/extensions/zalouser/src/ingress.test.ts
+++ b/extensions/zalouser/src/ingress.test.ts
@@ -231,7 +231,7 @@ describe("Zalouser durable ingress", () => {
     });
   });
 
-  it("settles deferred bookkeeping when the adoption watchdog aborts a claim", async () => {
+  it("releases deferred bookkeeping for retry when the adoption watchdog aborts a claim", async () => {
     await withZalouserIngressTestQueue(async (queue) => {
       let deferredLifecycle: ZalouserIngressLifecycle | undefined;
       const dispatch = vi.fn(async (_message, lifecycle: ZalouserIngressLifecycle) => {
@@ -244,10 +244,21 @@ describe("Zalouser durable ingress", () => {
         runtime: runtime(),
         queue,
         dispatch,
+        pollIntervalMs: 60_000,
         adoptionStallTimeoutMs: 10,
       });
       await ingress.receive(createRawZalouserMessage({ msgId: "deferred-timeout" }));
-      await waitForZalouserIngressVerdict(queue, "deferred-timeout", "failed");
+      await vi.waitFor(async () => {
+        expect(await queue.listClaims()).toEqual([]);
+        expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+        expect(await queue.listPending({ limit: "all" })).toMatchObject([
+          {
+            id: "deferred-timeout",
+            attempts: 1,
+            lastError: expect.stringContaining("handler-timeout"),
+          },
+        ]);
+      });
       expect(deferredLifecycle?.abortSignal.aborted).toBe(true);
 
       await ingress.stop();

--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -1338,6 +1338,119 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).toHaveBeenCalledTimes(1);
   });
 
+  it("releases inbound dedupe when durable ingress aborts before adoption", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "before_dispatch") as () => boolean,
+    );
+    let markHookStarted!: () => void;
+    const hookStarted = new Promise<void>((resolve) => {
+      markHookStarted = resolve;
+    });
+    let releaseHook!: () => void;
+    const hookRelease = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    hookMocks.runner.runBeforeDispatch
+      .mockImplementationOnce(async () => {
+        markHookStarted();
+        await hookRelease;
+        return undefined;
+      })
+      .mockResolvedValue(undefined);
+
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "user:1",
+      SessionKey: "agent:main:telegram:direct:1",
+      MessageSid: "pre-adoption-retry",
+      BodyForAgent: "retry me",
+    });
+    const abortController = new AbortController();
+    const replyResolver = vi.fn(async () => ({ text: "retried" }) satisfies ReplyPayload);
+    const turnAdoptionLifecycle = {
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onSettled: vi.fn(),
+    };
+
+    const firstDispatch = dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher: createDispatcher(),
+      replyOptions: {
+        abortSignal: abortController.signal,
+        turnAdoptionLifecycle,
+      },
+      replyResolver,
+    });
+    await hookStarted;
+    abortController.abort(new Error("handler-timeout"));
+    releaseHook();
+    await expect(firstDispatch).resolves.toMatchObject({ queuedFinal: false });
+    expect(replyResolver).not.toHaveBeenCalled();
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher: createDispatcher(),
+      replyOptions: { turnAdoptionLifecycle },
+      replyResolver,
+    });
+    expect(replyResolver).toHaveBeenCalledOnce();
+  });
+
+  it("retains inbound dedupe when durable ingress aborts after adoption", async () => {
+    setNoAbort();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "user:1",
+      SessionKey: "agent:main:telegram:direct:1",
+      MessageSid: "post-adoption-abort",
+      BodyForAgent: "run once",
+    });
+    const turnAdoptionLifecycle = {
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onSettled: vi.fn(),
+    };
+    const firstReplyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions): Promise<ReplyPayload | undefined> => {
+        await opts?.turnAdoptionLifecycle?.onAdopted();
+        const operation = (
+          opts as { replyOperation?: { abortForRestart: () => boolean } } | undefined
+        )?.replyOperation;
+        expect(operation?.abortForRestart()).toBe(true);
+        return await new Promise<never>(() => {});
+      },
+    );
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher: createDispatcher(),
+      replyOptions: { turnAdoptionLifecycle },
+      replyResolver: firstReplyResolver,
+    });
+    expect(turnAdoptionLifecycle.onAdopted).toHaveBeenCalledOnce();
+
+    const duplicateReplyResolver = vi.fn(
+      async () => ({ text: "duplicate" }) satisfies ReplyPayload,
+    );
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher: createDispatcher(),
+      replyOptions: { turnAdoptionLifecycle },
+      replyResolver: duplicateReplyResolver,
+    });
+    expect(duplicateReplyResolver).not.toHaveBeenCalled();
+  });
+
   it("keeps message-tool-only delivery mode on duplicate inbound returns", async () => {
     setNoAbort();
     const cfg = {

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -64,15 +64,33 @@ export async function gatherDispatchRequest(
   const ctx = isFinalizedInboundContext(params.ctx)
     ? params.ctx
     : finalizeInboundContext(params.ctx);
+  const turnAdoptionLifecycle = params.replyOptions?.turnAdoptionLifecycle;
+  const turnAdoptionState = { adopted: false };
   const normalizedParams: DispatchFromConfigParams = {
     ...params,
     ctx,
-    replyOptions: { ...params.replyOptions },
+    replyOptions: {
+      ...params.replyOptions,
+      ...(turnAdoptionLifecycle
+        ? {
+            turnAdoptionLifecycle: {
+              ...turnAdoptionLifecycle,
+              onAdopted: async () => {
+                // The upstream owner is durable only after its callback commits.
+                // A rejected callback must leave replay dedupe releasable.
+                await turnAdoptionLifecycle.onAdopted();
+                turnAdoptionState.adopted = true;
+              },
+            },
+          }
+        : {}),
+    },
   };
   const state = {
     params: normalizedParams,
     messageAuditTerminal,
     inboundDedupeReplayUnsafe: false,
+    turnAdoptionState: turnAdoptionLifecycle ? turnAdoptionState : undefined,
   };
   const { cfg, dispatcher } = normalizedParams;
   const replyOperationRunState: ReplyOperationRunState =

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -474,7 +474,11 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
           isError: true,
         })
       : false;
-    commitInboundDedupeIfClaimed();
+    if (state.turnAdoptionState && !state.turnAdoptionState.adopted) {
+      releaseInboundDedupeIfClaimed();
+    } else {
+      commitInboundDedupeIfClaimed();
+    }
     recordProcessed("completed", { reason: "reply_operation_aborted" });
     markIdle("message_completed");
     state.completeDispatchReplyOperation();

--- a/src/channels/message/ingress-drain.debounce-failure.test.ts
+++ b/src/channels/message/ingress-drain.debounce-failure.test.ts
@@ -85,7 +85,7 @@ describe("channel ingress drain debounce failures", () => {
     });
   });
 
-  it("keeps watchdog recovery after retry settlement fails", async () => {
+  it("keeps watchdog ownership when retry settlement keeps failing", async () => {
     vi.useFakeTimers();
     await withTempState(async (stateDir) => {
       let clock = 10_000;
@@ -98,6 +98,7 @@ describe("channel ingress drain debounce failures", () => {
       queue.release = async () => {
         throw new Error("persistent release failure");
       };
+      const log = vi.fn();
 
       const sessionError = new Error("Session changed while starting work. Retry.");
       const debouncer = createInboundDebouncer<{ lifecycle: ChannelIngressDispatchLifecycle }>({
@@ -116,6 +117,7 @@ describe("channel ingress drain debounce failures", () => {
         queue,
         now: () => clock,
         adoptionStallTimeoutMs: 200_000,
+        onLog: log,
         dispatchClaimedEvent: async (_event, lifecycle) => {
           await debouncer.enqueue({ lifecycle });
           return { kind: "deferred" };
@@ -134,11 +136,14 @@ describe("channel ingress drain debounce failures", () => {
 
       clock += 73_000;
       await vi.advanceTimersByTimeAsync(73_000);
-      expect(await queue.listClaims()).toEqual([]);
-      expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
-        { id: "debounced-settlement-failure", reason: "handler-timeout" },
+      expect((await queue.listClaims()).map((claim) => claim.id)).toEqual([
+        "debounced-settlement-failure",
       ]);
-      expect(drain.activeLaneKeys().has("shared")).toBe(false);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(drain.activeLaneKeys().has("shared")).toBe(true);
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining("applying retry policy (handler-timeout)"),
+      );
       drain.dispose();
     });
   });

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -300,9 +300,15 @@ describe("channel ingress drain", () => {
 
       clock += 1_000;
       await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(async () => expect(await queue.listFailed?.()).toHaveLength(1));
-      const failed = await queue.listFailed?.();
-      expect(failed?.[0]).toMatchObject({ id: "released-stall", reason: "handler-timeout" });
+      await vi.waitFor(async () => expect(await queue.listClaims()).toEqual([]));
+      expect(await queue.listFailed?.()).toEqual([]);
+      expect(await queue.listPending({ limit: "all" })).toMatchObject([
+        {
+          id: "released-stall",
+          attempts: 1,
+          lastError: expect.stringContaining("handler-timeout"),
+        },
+      ]);
       drain.dispose();
     });
   });

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -47,7 +47,7 @@ import {
 export { bindIngressLifecycleToReplyOptions } from "./ingress-drain-lifecycle.js";
 export { isIngressAdoptionLostError } from "./ingress-drain-state.js";
 
-/** Default claim→adoption stall before dead-lettering with handler-timeout. */
+/** Default claim→adoption stall before applying the shared retry disposition. */
 export const DEFAULT_INGRESS_ADOPTION_STALL_MS = 5 * 60 * 1000;
 
 /** Bounded tombstone write retries — wedged ownership beats silent double-dispatch. */
@@ -397,25 +397,26 @@ export function createChannelIngressDrain<
       }
       const ageMs = now() - state.startedAt;
       const displayId = state.eventId.replace(/^0+(?=\d)/, "") || state.eventId;
-      const message = `Channel ingress claim→adoption stalled for event ${displayId} on lane ${state.laneKey} after ${ageMs}ms; marking failed (handler-timeout).`;
+      const message = `Channel ingress claim→adoption stalled for event ${displayId} on lane ${state.laneKey} after ${ageMs}ms; applying retry policy (handler-timeout).`;
+      const timeoutError = new Error(message);
       // Closed guillotine flag — catch must not string-sniff errors.
       state.guillotined = true;
       clearStallTimer(state);
       log(message);
       try {
-        state.abortController.abort(new Error(message));
+        state.abortController.abort(timeoutError);
       } catch {
         // AbortController.abort is not fallible in practice.
       }
-      // Same bounded-retry/hold-ownership policy as tombstone: a fail write
+      // Route the timeout through the canonical retry owner. A release/fail write
       // error must not falsely settle (would stop heartbeat and wedge recovery).
       void state
         .settleOnce(async () => {
-          await failClaim(state.claim, "handler-timeout", message);
+          await applyFailureDisposition(state.claim, timeoutError);
         })
         .catch((err: unknown) => {
           log(
-            `ingress drain: failed to dead-letter stalled event ${displayId}; holding claim: ${formatError(err)}`,
+            `ingress drain: failed to settle stalled event ${displayId}; holding claim: ${formatError(err)}`,
           );
         });
     }, adoptionStallTimeoutMs);

--- a/src/channels/message/ingress-drain.watchdog.test.ts
+++ b/src/channels/message/ingress-drain.watchdog.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { createChannelIngressDrain } from "./ingress-drain.js";
+import type { ChannelIngressDispatchLifecycle } from "./ingress-drain-lifecycle.js";
+import { createChannelIngressDrain, isIngressAdoptionLostError } from "./ingress-drain.js";
 import {
   createTestIngressQueue,
   type IngressDrainTestPayload as Payload,
@@ -17,19 +18,27 @@ describe("channel ingress drain watchdog", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
-  it("guillotines pre-adoption stalls with handler-timeout", async () => {
+  it("retries pre-adoption stalls in lane order and fences late adoption", async () => {
     await withTempState(async (stateDir) => {
       let clock = 10_000;
       const queue = createTestIngressQueue(stateDir, { now: () => clock });
       await queue.enqueue("evt-stall", { text: "x" }, { laneKey: "l1" });
+      await queue.enqueue("evt-next", { text: "next" }, { laneKey: "l1", receivedAt: clock + 1 });
+      const dispatched: string[] = [];
+      let stalledLifecycle: ChannelIngressDispatchLifecycle | undefined;
 
       const drain = createChannelIngressDrain<Payload>({
         queue,
         now: () => clock,
         adoptionStallTimeoutMs: 5_000,
-        dispatchClaimedEvent: async () => {
-          // Never adopt, never return -- stall until watchdog.
-          await new Promise(() => {});
+        retryPolicy: { baseMs: 1_000, maxMs: 1_000 },
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatched.push(event.id);
+          if (!stalledLifecycle) {
+            stalledLifecycle = lifecycle;
+            await new Promise(() => {});
+          }
+          await lifecycle.onAdopted();
         },
       });
 
@@ -38,11 +47,20 @@ describe("channel ingress drain watchdog", () => {
       await vi.advanceTimersByTimeAsync(5_000);
       await drain.waitForIdle();
 
-      const reenqueue = await queue.enqueue("evt-stall", { text: "x" });
-      expect(reenqueue.kind).toBe("failed");
-      if (reenqueue.kind === "failed") {
-        expect(reenqueue.record.reason).toBe("handler-timeout");
-      }
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(await queue.listPending({ limit: "all", orderBy: "received" })).toMatchObject([
+        { id: "evt-stall", attempts: 1, lastError: expect.stringContaining("handler-timeout") },
+        { id: "evt-next", attempts: 0 },
+      ]);
+      await expect(stalledLifecycle?.onAdopted()).rejects.toSatisfy(isIngressAdoptionLostError);
+
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+      clock += 1_000;
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await drain.waitForIdle();
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await drain.waitForIdle();
+      expect(dispatched).toEqual(["evt-stall", "evt-stall", "evt-next"]);
       drain.dispose();
     });
   });
@@ -70,11 +88,14 @@ describe("channel ingress drain watchdog", () => {
       await vi.advanceTimersByTimeAsync(5_000);
       await drain.waitForIdle();
 
-      const reenqueue = await queue.enqueue("evt-def-stall", { text: "x" });
-      expect(reenqueue.kind).toBe("failed");
-      if (reenqueue.kind === "failed") {
-        expect(reenqueue.record.reason).toBe("handler-timeout");
-      }
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(await queue.listPending({ limit: "all" })).toMatchObject([
+        {
+          id: "evt-def-stall",
+          attempts: 1,
+          lastError: expect.stringContaining("handler-timeout"),
+        },
+      ]);
       drain.dispose();
     });
   });


### PR DESCRIPTION
Closes #126231

This is a narrower alternative to #126358. Thanks @PollyBot13 for surfacing the pre-adoption dedupe window and demonstrating the transport-level failure mode.

## What Problem This Solves

Fixes an issue where a durable channel message that exceeded the claim-to-adoption watchdog was immediately marked failed with `attempts=0`, so Telegram users could see their message delivered to the bot while OpenClaw silently lost it.

The retry also has to survive a late first attempt: if that attempt ignores cancellation and returns normally before durable adoption, it must not commit process-local dedupe or report the spool row as completed.

## Why This Change Was Made

The shared ingress drain now sends watchdog timeouts through its existing retry disposition instead of bypassing it with a direct dead-letter write. This preserves the existing guillotine, claim-token fence, settle-once owner, attempt/age policy, and claim-write failure behavior.

Reply dispatch tracks durable adoption only in its internal phase state. A pre-adoption abort releases inbound dedupe so the canonical spool row can replay; an abort after the durable adoption callback commits keeps dedupe. Telegram corrects an aborted, unadopted result only at the spooled participant ownership boundary.

The implementation intentionally adds no public `DispatchFromConfigParams` field, QA-only production stall hook, configuration, migration, or duplicate media/pipeline abort fences. The core drain remains the retry-policy owner and the Telegram participant remains the transport settlement owner.

## User Impact

Timed-out durable messages are retried in lane order instead of being silently discarded. Later messages on the same lane remain behind the retried message, and a late cancelled attempt cannot consume the retry as a false success. Terminal failure still follows the shared retry attempt and minimum-age policy.

No operator configuration or migration is required.

## Evidence

Before the repair, focused regressions demonstrated all three failure points on `origin/main@0e75204f0505b817a91443ee62c99a71ff950c53`:

- the watchdog produced a terminal `handler-timeout` row with `attempts=0`;
- replay after a pre-adoption abort was swallowed by inbound dedupe before the resolver ran;
- an aborted Telegram spool participant returned `{ kind: "completed" }`.

Final focused Vitest results:

- core ingress drain/watchdog/settlement: 32 passed;
- full reply-dispatch suite: 369 passed;
- full Telegram message processor suite: 26 passed;
- Telegram polling timeout, replacement-session replay, and same-lane ordering: 3 passed;
- Telegram webhook same-lane retry: 1 passed;
- Zalo deferred timeout retry: 1 passed;
- doctor contract coverage: 5 passed.

Final static proof:

- `node scripts/check-changed.mjs` — passed all selected guards, core and plugin production/test typechecks, lint, dependency, boundary, database-first, import-cycle, and webhook/pairing checks;
- targeted core `tsgo` — passed;
- `oxfmt --check` on all 13 changed files — passed;
- `git diff --check` — passed;
- fresh structured autoreview — no accepted/actionable findings (`patch is correct`, confidence 0.93).

The adoption boundary precedes agent execution in `src/auto-reply/reply/agent-runner-execute.ts`: the durable callback runs at line 294 and `executeAgentTurn` begins at line 373.

Diff shape: production `+43/-8`, tests `+249/-54`, scoped guide `+1/-1`. No live Telegram account or external credentials were used; channel proof is deterministic owner-boundary, polling/webhook replay, and replacement-session coverage.

### Exact-head hosted behavior proof

The exact reviewed head was checked out and verified in a clean Blacksmith Testbox, then built with the private QA profile and exercised through the reviewed Telegram, Zalo, and shared ingress suites. No external channel credentials were used.

- Head: `824320d19f2f5a88b0337c150e7ac6452556b8d7` (`git rev-parse HEAD` matched before build or tests).
- Testbox: `tbx_01m0jkw2zf85eafrtwbk2n3g5e` (`jade-shrimp-7454`).
- Hosted run: https://github.com/openclaw/openclaw/actions/runs/32505288824
- Build: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed, including bundled plugin assets, private QA/plugin SDK exports, CLI bootstrap import guard, runtime postbuild, UI build, and performance budget.
- Focused result: 411 passed across shared ingress drain/watchdog/debounce (32), Zalo ingress (14), and Telegram bot/message/pipeline-init/polling/webhook suites (365).
- Media-hydration fence: the Telegram regression makes media resolution ignore an already-aborted signal, then proves retryable settlement, dedupe release, and no reply from the stale attempt.
- Pre-pipeline fence: the dispatch regression proves an abort after pre-dispatch work cannot enter the reply pipeline.
- Runtime: `REMOTE_PROOF_RESULT=PASS`; Testbox command time 8m25s, total 8m29s.

This is deterministic exact-head owner-boundary and transport-suite proof, not a live Telegram-account run.

