### PR TITLE
fix(media): clean failed temporary staging

### DIFF
--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -1,9 +1,18 @@
 // Discord tests cover audio plugin behavior.
 import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { PassThrough, Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const spawnMock = vi.hoisted(() => vi.fn());
+const { spawnMock, voiceWorkspaceFixture } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  voiceWorkspaceFixture: {
+    rootDir: "",
+    writeError: undefined as Error | undefined,
+  },
+}));
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
   spawn: spawnMock,
@@ -12,12 +21,36 @@ vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>()),
   resolveFfmpegBin: () => "ffmpeg",
 }));
+vi.mock("openclaw/plugin-sdk/temp-path", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/temp-path")>();
+  return {
+    ...actual,
+    resolvePreferredOpenClawTmpDir: () => voiceWorkspaceFixture.rootDir,
+    tempWorkspace: async (options: Parameters<typeof actual.tempWorkspace>[0]) => {
+      const workspace = await actual.tempWorkspace({
+        ...options,
+        rootDir: voiceWorkspaceFixture.rootDir,
+      });
+      return {
+        ...workspace,
+        write: async (fileName: string, data: string | Uint8Array) => {
+          if (voiceWorkspaceFixture.writeError) {
+            await workspace.write(fileName, Buffer.from(data).subarray(0, 8));
+            throw voiceWorkspaceFixture.writeError;
+          }
+          return await workspace.write(fileName, data);
+        },
+      };
+    },
+  };
+});
 
 import {
   createDiscordOpusEncodeStream,
   createDiscordOpusPlaybackStream,
   decodeOpusStream,
   decodeOpusStreamChunks,
+  writeVoiceWavFile,
 } from "./audio.js";
 
 function createFakeFfmpeg() {
@@ -152,5 +185,73 @@ describe("createDiscordOpusPlaybackStream child stream errors", () => {
     expect(stderrText).toBe("é".repeat(4095));
     expect(Buffer.byteLength(stderrText)).toBeLessThanOrEqual(8192);
     expect(stderrText).not.toContain("\uFFFD");
+  });
+});
+
+describe("Discord voice WAV workspace ownership", () => {
+  async function withVoiceWorkspace(
+    run: (params: { rootDir: string; timeoutSpy: ReturnType<typeof vi.spyOn> }) => Promise<void>,
+  ): Promise<void> {
+    const rootDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-voice-workspace-")),
+    );
+    voiceWorkspaceFixture.rootDir = rootDir;
+    voiceWorkspaceFixture.writeError = undefined;
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      await run({ rootDir, timeoutSpy });
+    } finally {
+      for (const result of timeoutSpy.mock.results) {
+        if (result.type === "return") {
+          clearTimeout(result.value as ReturnType<typeof setTimeout>);
+        }
+      }
+      timeoutSpy.mockRestore();
+      voiceWorkspaceFixture.rootDir = "";
+      voiceWorkspaceFixture.writeError = undefined;
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  }
+
+  it("owns partial WAV writes before surfacing their original failure", async () => {
+    await withVoiceWorkspace(async ({ rootDir, timeoutSpy }) => {
+      const writeError = Object.assign(new Error("disk full"), { code: "ENOSPC" });
+      voiceWorkspaceFixture.writeError = writeError;
+
+      await expect(writeVoiceWavFile(Buffer.alloc(960))).rejects.toBe(writeError);
+
+      const workspaces = await fs.readdir(rootDir);
+      expect(workspaces).toHaveLength(1);
+      expect(await fs.readFile(path.join(rootDir, workspaces[0]!, "segment.wav"))).toHaveLength(8);
+      const scheduledCleanup = timeoutSpy.mock.calls.find(
+        (call: Parameters<typeof setTimeout>) => call[1] === 30 * 60 * 1_000,
+      );
+      expect(scheduledCleanup).toBeDefined();
+
+      (scheduledCleanup![0] as () => void)();
+
+      await vi.waitFor(async () => expect(await fs.readdir(rootDir)).toEqual([]));
+    });
+  });
+
+  it("retains successful WAV files until the existing scheduled cleanup runs", async () => {
+    await withVoiceWorkspace(async ({ rootDir, timeoutSpy }) => {
+      const pcm = Buffer.alloc(960);
+
+      const result = await writeVoiceWavFile(pcm);
+
+      expect(path.basename(result.path)).toBe("segment.wav");
+      expect((await fs.readFile(result.path)).subarray(0, 4).toString()).toBe("RIFF");
+      expect(result.durationSeconds).toBe(960 / (4 * 48_000));
+      const scheduledCleanup = timeoutSpy.mock.calls.find(
+        (call: Parameters<typeof setTimeout>) => call[1] === 30 * 60 * 1_000,
+      );
+      expect(scheduledCleanup).toBeDefined();
+      expect(await fs.readdir(rootDir)).toHaveLength(1);
+
+      (scheduledCleanup![0] as () => void)();
+
+      await vi.waitFor(async () => expect(await fs.readdir(rootDir)).toEqual([]));
+    });
   });
 });

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -374,9 +374,9 @@ export async function writeVoiceWavFile(
     rootDir: resolvePreferredOpenClawTmpDir(),
     prefix: "discord-voice-",
   });
+  scheduleTempCleanup(workspace.dir);
   const wav = buildWavBuffer(pcm);
   const filePath = await workspace.write("segment.wav", wav);
-  scheduleTempCleanup(workspace.dir);
   return { path: filePath, durationSeconds: estimateDurationSeconds(pcm) };
 }
 

--- a/src/media-understanding/attachments.cache.test.ts
+++ b/src/media-understanding/attachments.cache.test.ts
@@ -6,13 +6,26 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { MediaAttachmentCache } from "./attachments.js";
 
-const readRemoteMediaBufferMock = vi.hoisted(() => vi.fn());
+const { buildRandomTempFilePathMock, readRemoteMediaBufferMock } = vi.hoisted(() => ({
+  buildRandomTempFilePathMock: vi.fn(),
+  readRemoteMediaBufferMock: vi.fn(),
+}));
 
 vi.mock("../media/fetch.js", async () => {
   const actual = await vi.importActual<typeof import("../media/fetch.js")>("../media/fetch.js");
   return {
     ...actual,
     readRemoteMediaBuffer: readRemoteMediaBufferMock,
+  };
+});
+
+vi.mock("../plugin-sdk/temp-path.js", async () => {
+  const actual = await vi.importActual<typeof import("../plugin-sdk/temp-path.js")>(
+    "../plugin-sdk/temp-path.js",
+  );
+  return {
+    ...actual,
+    buildRandomTempFilePath: buildRandomTempFilePathMock,
   };
 });
 
@@ -24,6 +37,8 @@ const AMBIGUOUS_WEBM = Buffer.from("1a45dfa3874282847765626d", "hex");
 
 describe("media understanding attachment MIME detection", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
+    buildRandomTempFilePathMock.mockReset();
     readRemoteMediaBufferMock.mockReset();
   });
 
@@ -102,5 +117,59 @@ describe("media understanding attachment MIME detection", () => {
     });
 
     expect(result.mime).toBe(docxMime);
+  });
+
+  it("removes a partially staged attachment and preserves its write failure", async () => {
+    await withTestDir({ prefix: "openclaw-media-cache-write-failure-" }, async (base) => {
+      const stagedPath = path.join(base, "failed.png");
+      const writeError = Object.assign(new Error("disk full"), { code: "ENOSPC" });
+      const writeFile = fs.writeFile.bind(fs);
+      buildRandomTempFilePathMock.mockReturnValueOnce(stagedPath);
+      readRemoteMediaBufferMock.mockResolvedValue({ buffer: PNG_1X1, fileName: "photo.png" });
+      vi.spyOn(fs, "writeFile").mockImplementationOnce(async (file) => {
+        await writeFile(file, PNG_1X1.subarray(0, 4));
+        throw writeError;
+      });
+      const cache = new MediaAttachmentCache([{ index: 0, url: "https://example.com/photo.png" }]);
+
+      await expect(cache.getPath({ attachmentIndex: 0, timeoutMs: 1_000 })).rejects.toBe(
+        writeError,
+      );
+      await cache.cleanup();
+
+      expect(await fs.readdir(base)).toEqual([]);
+    });
+  });
+
+  it("retries failed cleanup without losing earlier staging when a later attempt succeeds", async () => {
+    await withTestDir({ prefix: "openclaw-media-cache-cleanup-retry-" }, async (base) => {
+      const firstPath = path.join(base, "failed.png");
+      const secondPath = path.join(base, "success.png");
+      const writeError = Object.assign(new Error("disk full"), { code: "ENOSPC" });
+      const cleanupError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+      const writeFile = fs.writeFile.bind(fs);
+      buildRandomTempFilePathMock.mockReturnValueOnce(firstPath).mockReturnValueOnce(secondPath);
+      readRemoteMediaBufferMock.mockResolvedValue({ buffer: PNG_1X1, fileName: "photo.png" });
+      const writeFileSpy = vi.spyOn(fs, "writeFile").mockImplementationOnce(async (file) => {
+        await writeFile(file, PNG_1X1.subarray(0, 4));
+        throw writeError;
+      });
+      vi.spyOn(fs, "unlink").mockRejectedValueOnce(cleanupError);
+      const cache = new MediaAttachmentCache([{ index: 0, url: "https://example.com/photo.png" }]);
+      const request = { attachmentIndex: 0, timeoutMs: 1_000 };
+
+      await expect(cache.getPath(request)).rejects.toBe(writeError);
+      expect(await fs.readdir(base)).toEqual(["failed.png"]);
+
+      const staged = await cache.getPath(request);
+      expect(staged.path).toBe(secondPath);
+      expect((await cache.getPath(request)).path).toBe(secondPath);
+      expect(writeFileSpy).toHaveBeenCalledTimes(2);
+      expect((await fs.readdir(base)).toSorted()).toEqual(["failed.png", "success.png"]);
+
+      await cache.cleanup();
+
+      expect(await fs.readdir(base)).toEqual([]);
+    });
   });
 });

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -391,11 +391,17 @@ export class MediaAttachmentCache {
       prefix: "openclaw-media",
       extension,
     });
-    await fs.writeFile(tmpPath, bufferResult.buffer);
-    entry.tempPath = tmpPath;
+    // Keep failed staging owned when model fallback retries the same attachment.
+    const previousCleanup = entry.tempCleanup;
     entry.tempCleanup = async () => {
+      await previousCleanup?.();
       await fs.unlink(tmpPath).catch(() => {});
     };
+    await fs.writeFile(tmpPath, bufferResult.buffer).catch(async (error: unknown) => {
+      await entry.tempCleanup?.();
+      throw error;
+    });
+    entry.tempPath = tmpPath;
     return { path: tmpPath, cleanup: entry.tempCleanup };
   }
 


### PR DESCRIPTION
Closes #127082

AI-assisted.

## What Problem This Solves

Fixes an issue where media-understanding attachment staging and Discord voice capture leave temporary files or workspaces behind when a filesystem write fails after creating an artifact. Repeated failures can consume additional temporary disk space, including when media model fallback successfully stages a later candidate.

## Why This Change Was Made

Both existing lifecycle owners now establish cleanup ownership before their first fallible write. The media cache immediately attempts best-effort cleanup, preserves the original write error, retains failed disposers for the existing lifecycle cleanup, and chains prior disposers when the same attachment is retried; Discord schedules its unchanged 30-minute workspace cleanup immediately after workspace allocation.

The fix occurs after existing selection, admission, policy, and limits. It changes no attachment authority, SDK, dependency, protocol, config, persistence, authentication, successful caching, model fallback, WAV content/filename, or successful cleanup timing.

## User Impact

Partial media writes and failed Discord voice staging no longer leave unowned temporary artifacts. Successful attachment caching and Discord voice capture retain their existing behavior, including the 30-minute voice-file retention window and original filesystem error reporting.

## Evidence

- Before the fix, actual media-cache owner regressions failed with `expected [], received ["failed.png"]` after lifecycle cleanup and `expected [], received ["failed.png", "success.png"]` after failed cleanup plus a successful later candidate. The actual Discord voice owner created one real partially written workspace and scheduled zero cleanup callbacks.
- After the fix, the same regressions prove zero owned artifacts after cleanup, exact `ENOSPC` error identity, `EACCES` immediate-cleanup failure followed by lifecycle retry, same-attachment model fallback, successful cached-path reuse, real WAV `RIFF` content, unchanged `segment.wav` naming/duration, and unchanged 30-minute cleanup timing.
- Focused and sibling proof: `node scripts/run-vitest.mjs src/media-understanding extensions/discord/src/voice extensions/discord/src/send.voice.test.ts src/media/playback-transcode.test.ts src/media/audio-transcode.test.ts extensions/imessage/src/actions.runtime.test.ts` — 884 tests passed, five existing tests skipped across five Vitest shards.
- Required changed gate: `node scripts/check-changed.mjs -- src/media-understanding/attachments.cache.ts src/media-understanding/attachments.cache.test.ts extensions/discord/src/voice/audio.ts extensions/discord/src/voice/audio.test.ts`.
- Production LOC: +9/-3 (net +6); regression-test growth is reported separately in the PR diff.
- Authenticated live Discord voice proof is infeasible and unnecessary for this pre-transport filesystem invariant; the deterministic proof invokes the actual Discord voice owner with a fake capture boundary and real temporary paths. No live Discord/service calls were made.
- No changelog change: this is a normal bug-fix PR, and release notes derive from merged PR context.
