### PR TITLE
fix(browser): stop routing detached extension child sessions

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -672,6 +672,62 @@ describe("ExtensionRelayBridge", () => {
     expect(response?.error).toBeTruthy();
   });
 
+  it("retires a detached child session without retiring its source session", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const { socket: extSocket, handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    const attached = client.frames().find((frame) => frame.method === "Target.attachedToTarget");
+    const rootSessionId = (attached?.params as { sessionId?: string } | undefined)?.sessionId;
+    expect(typeof rootSessionId).toBe("string");
+
+    handlers.onMessage(
+      JSON.stringify({
+        type: "cdpEvent",
+        tabId: 1,
+        sessionId: rootSessionId,
+        method: "Target.attachedToTarget",
+        params: { sessionId: "child-abc", targetInfo: { type: "worker" } },
+      }),
+    );
+    handlers.onMessage(
+      JSON.stringify({
+        type: "cdpEvent",
+        tabId: 1,
+        sessionId: rootSessionId,
+        method: "Target.detachedFromTarget",
+        params: { sessionId: "child-abc", targetId: "worker-abc" },
+      }),
+    );
+    await flush();
+
+    expect(client.frames()).toContainEqual({
+      sessionId: rootSessionId,
+      method: "Target.detachedFromTarget",
+      params: { sessionId: "child-abc", targetId: "worker-abc" },
+    });
+    cdp.onMessage(JSON.stringify({ id: 2, sessionId: "child-abc", method: "Runtime.enable" }));
+    cdp.onMessage(JSON.stringify({ id: 3, sessionId: rootSessionId, method: "Runtime.enable" }));
+    await flush();
+
+    expect(client.frames().find((frame) => frame.id === 2)).toMatchObject({
+      sessionId: "child-abc",
+      error: { code: -32001, message: "Session not found: child-abc" },
+    });
+    expect(client.frames().find((frame) => frame.id === 3)?.result).toMatchObject({ ok: true });
+    expect(
+      extSocket
+        .frames()
+        .filter((frame) => frame.type === "cdp" && frame.method === "Runtime.enable"),
+    ).toEqual([expect.objectContaining({ tabId: 1 })]);
+  });
+
   it("requires a hello frame before other extension messages", () => {
     const bridge = new ExtensionRelayBridge();
     const socket = new FakeSocket();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -567,6 +567,17 @@ export class ExtensionRelayBridge {
         client.socket.send(frame);
       }
     }
+    if (method === "Target.detachedFromTarget") {
+      const detachedSessionId =
+        params && typeof params === "object" && "sessionId" in params
+          ? params.sessionId
+          : undefined;
+      if (typeof detachedSessionId === "string" && this.childSessions.delete(detachedSessionId)) {
+        for (const client of this.clients) {
+          client.announcedSessions.delete(detachedSessionId);
+        }
+      }
+    }
     if (!childSessionId) {
       // Page-scoped CDP sessions multiplex the same chrome.debugger root.
       // Mirror root events so Runtime/Page/Network listeners observe the


### PR DESCRIPTION
Closes #127087

## What Problem This Solves

Fixes an issue where Browser extension relay users with pages that detach iframe or worker targets would retain stale child sessions and keep routing commands to them until broader tab/client teardown.

## Why This Change Was Made

After forwarding `Target.detachedFromTarget`, the relay now removes an exact known child ID from its routing map and every client's announcement set. The known-child guard keeps malformed detach payloads from retiring the source/root session, whose routing remains unchanged.

Production change: 11 added lines. Regression coverage: 56 added lines.

## User Impact

Detached iframe and worker sessions stop being routable immediately while the root tab remains usable. Normal child-target churn no longer accumulates stale relay routing entries.

## Evidence

- Before the fix, the focused regression failed because a command addressed to detached `child-abc` was forwarded to the extension and returned success.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/relay-bridge.test.ts`: 28/28 passed after the final rebase.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay`: 103/103 passed.
- `pnpm check:changed`: passed, including format, typecheck, lint, dead-export, database-first, and import-cycle checks.
- Mandatory autoreview preflight: TruffleHog passed; Codex failed before returning a review result. This PR should not merge until that review gate succeeds.

Implementation and tests were produced with AI assistance and manually inspected against the extension-relay lifecycle owner.
