### PR TITLE
fix(gateway): run transcript cursor E2E with full startup

### DIFF
--- a/test/embedded-transcript-cursor.e2e.test.ts
+++ b/test/embedded-transcript-cursor.e2e.test.ts
@@ -43,7 +43,10 @@ describe("embedded transcript cursor settlement", () => {
       const instance = await createOpenClawTestInstance({
         name: "embedded-transcript-cursor",
         config: createTestConfig(modelServer.baseUrl),
-        env: { OPENCLAW_SKIP_PROVIDERS: undefined },
+        env: {
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
       });
       instances.push(instance);
       await instance.startGateway();

--- a/test/gateway-openai-compaction-replay.e2e.test.ts
+++ b/test/gateway-openai-compaction-replay.e2e.test.ts
@@ -50,6 +50,7 @@ describe("Gateway OpenAI Responses compaction replay", () => {
         env: {
           OPENCLAW_DEBUG_MODEL_TRANSPORT: "1",
           OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
         },
       });
       instances.push(instance);

--- a/test/gateway-openai-compaction-replay.e2e.test.ts
+++ b/test/gateway-openai-compaction-replay.e2e.test.ts
@@ -50,7 +50,6 @@ describe("Gateway OpenAI Responses compaction replay", () => {
         env: {
           OPENCLAW_DEBUG_MODEL_TRANSPORT: "1",
           OPENCLAW_SKIP_PROVIDERS: undefined,
-          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
         },
       });
       instances.push(instance);


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the embedded transcript-cursor E2E could not start an agent turn because its child Gateway never published a prepared reply-dispatch runtime.

## Why This Change Was Made

The shared process helper defaults child Gateways to the test-only minimal startup path. This E2E exercises embedded agent execution, which requires the configured model and plugin generation published by normal post-attach startup. It now uses the helper's existing per-test override to select that full lifecycle; production behavior and assertions are unchanged.

Root cause: `OPENCLAW_TEST_MINIMAL_GATEWAY=1` skips `publishConfiguredModelRuntimeSnapshots`, while agent execution requires `loadPublishedGatewayReplyDispatchRuntime`.

Provenance: the requirement became visible in #125596 (code author and merger @steipete, 2026-08-18); the affected test predates that lifecycle contract.

## User Impact

No user-visible runtime change. Main-branch release validation can reach the transcript-cursor behavior this E2E owns instead of failing during test-only startup.

## Evidence

- Pre-fix current-main reproduction: the test fails with `prepared reply dispatch runtime was not published for main`.
- Exact-head focused proof: `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/embedded-transcript-cursor.e2e.test.ts` (1 passed).
- Exact-head required CI: green.
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings.

Test audit: the existing test protects end-to-end persisted transcript behavior through a real child Gateway. The change restores the production lifecycle it requires and adds no mock, retry, timeout, production seam, or weakened expectation.

LOC: production +0/-0; tests +4/-1.
