### PR TITLE
fix(browser): retire cold tab activity after final owner

### DIFF
--- a/extensions/browser/src/browser/session-tab-cleanup-claim.ts
+++ b/extensions/browser/src/browser/session-tab-cleanup-claim.ts
@@ -5,13 +5,12 @@
  */
 import { randomUUID } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { clearDurableTabAliases } from "./session-tab-ephemeral-aliases.js";
-import { activeDurableStorageKeys } from "./session-tab-process-state.js";
 import {
   type BrowserSessionTabRecord,
   deleteBrowserSessionTabIf,
   getBrowserSessionTabStore,
   parseBrowserSessionTabRecord,
+  retireBrowserSessionTabProcessState,
   sameBrowserSessionTabRecord,
   updateBrowserSessionTab,
 } from "./session-tab-store.js";
@@ -87,8 +86,7 @@ export function deleteClaimedTab(tab: DurableTab, onWarn?: (message: string) => 
       return matchesCleanupAttempt(record, tab);
     });
     if (deleted) {
-      clearDurableTabAliases(tab.storageKey);
-      activeDurableStorageKeys().delete(tab.storageKey);
+      retireBrowserSessionTabProcessState(tab);
     }
   } catch (error) {
     onWarn?.(`failed to delete tracked browser tab ${tab.nativeTargetId}: ${String(error)}`);

--- a/extensions/browser/src/browser/session-tab-process-state.ts
+++ b/extensions/browser/src/browser/session-tab-process-state.ts
@@ -46,6 +46,11 @@ const coldNativeActivityStateSymbol = Symbol.for(
   "openclaw.browser.session-tabs.cold-native-activity",
 );
 
+type ColdNativeActivity = {
+  observedAt: number;
+  durableOwners: number;
+};
+
 export function activeDurableStorageKeys(): Set<string> {
   const state = globalThis as typeof globalThis & {
     [activeDurableStateSymbol]?: Set<string>;
@@ -81,16 +86,56 @@ export function deleteVolatileSessionTab(sessionKey: string, tabKey: string): vo
   }
 }
 
-function coldNativeActivity(): Map<string, number> {
+function coldNativeActivity(): Map<string, ColdNativeActivity> {
   const state = globalThis as typeof globalThis & {
-    [coldNativeActivityStateSymbol]?: Map<string, number>;
+    [coldNativeActivityStateSymbol]?: Map<string, ColdNativeActivity>;
   };
   state[coldNativeActivityStateSymbol] ??= new Map();
   return state[coldNativeActivityStateSymbol];
 }
 
-export function rememberColdNativeActivity(identity: string, now: number): void {
-  coldNativeActivity().set(identity, now);
+export function rememberColdNativeActivity(
+  identity: string,
+  now: number,
+  durableOwners: number,
+): void {
+  // One native target may have multiple durable generations. Keep the activity
+  // until the final owner retires so sibling cleanup cannot erase live evidence.
+  coldNativeActivity().set(identity, { observedAt: now, durableOwners });
+}
+
+function retainColdNativeActivityOwner(identity: string): void {
+  const activity = coldNativeActivity().get(identity);
+  if (activity) {
+    activity.durableOwners += 1;
+  }
+}
+
+export function releaseColdNativeActivityOwner(identity: string): void {
+  const activity = coldNativeActivity().get(identity);
+  if (!activity) {
+    return;
+  }
+  if (activity.durableOwners <= 1) {
+    forgetColdNativeActivity(identity);
+  } else {
+    activity.durableOwners -= 1;
+  }
+}
+
+export function replaceColdNativeActivityOwner(
+  previousIdentity: string | undefined,
+  nextIdentity: string | undefined,
+): void {
+  if (previousIdentity === nextIdentity) {
+    return;
+  }
+  if (previousIdentity) {
+    releaseColdNativeActivityOwner(previousIdentity);
+  }
+  if (nextIdentity) {
+    retainColdNativeActivityOwner(nextIdentity);
+  }
 }
 
 export function forgetColdNativeActivity(identity: string): void {
@@ -98,5 +143,5 @@ export function forgetColdNativeActivity(identity: string): void {
 }
 
 export function readColdNativeActivity(identity: string): number | undefined {
-  return coldNativeActivity().get(identity);
+  return coldNativeActivity().get(identity)?.observedAt;
 }

--- a/extensions/browser/src/browser/session-tab-registry.extension-cleanup.test.ts
+++ b/extensions/browser/src/browser/session-tab-registry.extension-cleanup.test.ts
@@ -21,11 +21,15 @@ import { useAutoCleanupTempDirTracker } from "../../test-support.js";
 import type { CloseTrackedCdpTargetResult } from "./cdp.helpers.js";
 import { resolveBrowserConfig, type ResolvedBrowserConfig } from "./config.js";
 import { BROWSER_TAB_UNREACHABLE_RETIRE_MS } from "./constants.js";
-import { durableOwnership } from "./session-tab-registry.sqlite.test-helpers.js";
+import {
+  durableOwnership,
+  type DurableRecord,
+} from "./session-tab-registry.sqlite.test-helpers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const cdpMocks = vi.hoisted(() => ({
-  closeTrackedCdpTarget: vi.fn<() => Promise<CloseTrackedCdpTargetResult>>(),
+  closeTrackedCdpTarget:
+    vi.fn<(params: { nativeTargetId: string }) => Promise<CloseTrackedCdpTargetResult>>(),
 }));
 
 vi.mock("./cdp.helpers.js", async (importOriginal) => ({
@@ -36,7 +40,9 @@ vi.mock("./cdp.helpers.js", async (importOriginal) => ({
 import {
   closeTrackedBrowserTabsForSessions,
   sweepTrackedBrowserTabs,
+  touchSessionBrowserTab,
   trackSessionBrowserTab,
+  untrackSessionBrowserTab,
 } from "./session-tab-registry.js";
 
 const config = {
@@ -66,6 +72,14 @@ function clearProcessLocalTabState(): void {
   ]) {
     delete state[Symbol.for(name)];
   }
+}
+
+function coldNativeActivityIdentities(): string[] {
+  const state = globalThis as Record<symbol, unknown>;
+  const activity = state[Symbol.for("openclaw.browser.session-tabs.cold-native-activity")] as
+    | Map<string, unknown>
+    | undefined;
+  return [...(activity?.keys() ?? [])];
 }
 
 function installRuntime(): void {
@@ -200,5 +214,89 @@ describe("durable extension session tab cleanup", () => {
       }),
     );
     expect(openStore().entries()).toEqual([]);
+  });
+
+  it("retires cold activity only with the final durable generation", () => {
+    const sessionKey = "agent:main:cold-retirement";
+    const nativeTargetId = "NATIVE-COLD-RETIREMENT";
+    const identity = `${sessionKey}\u0000chrome\u0000${nativeTargetId}`;
+    trackSessionBrowserTab({
+      sessionKey,
+      targetId: nativeTargetId,
+      profile: "chrome",
+      ownership: durableOwnership(nativeTargetId, "profile-a", "browser-a"),
+      now: 1_000,
+    });
+    clearProcessLocalTabState();
+    touchSessionBrowserTab({ sessionKey, targetId: nativeTargetId, profile: "chrome", now: 2_000 });
+    expect(coldNativeActivityIdentities()).toEqual([identity]);
+
+    trackSessionBrowserTab({
+      sessionKey,
+      targetId: nativeTargetId,
+      profile: "chrome",
+      ownership: durableOwnership(nativeTargetId, "profile-b", "browser-b"),
+      now: 3_000,
+    });
+    untrackSessionBrowserTab({
+      sessionKey,
+      targetId: nativeTargetId,
+      profile: "chrome",
+      ownership: durableOwnership(nativeTargetId, "profile-a", "browser-a"),
+    });
+    expect(openStore().entries()).toHaveLength(1);
+    expect(coldNativeActivityIdentities()).toEqual([identity]);
+
+    untrackSessionBrowserTab({
+      sessionKey,
+      targetId: nativeTargetId,
+      profile: "chrome",
+      ownership: durableOwnership(nativeTargetId, "profile-b", "browser-b"),
+    });
+    expect(openStore().entries()).toEqual([]);
+    expect(coldNativeActivityIdentities()).toEqual([]);
+  });
+
+  it("retires cold activity for terminal cleanup outcomes", async () => {
+    for (const outcome of ["closed", "unavailable"]) {
+      const nativeTargetId = `NATIVE-${outcome}`;
+      trackSessionBrowserTab({
+        sessionKey: `agent:main:${outcome}`,
+        targetId: nativeTargetId,
+        profile: "chrome",
+        ownership: durableOwnership(nativeTargetId),
+      });
+    }
+    clearProcessLocalTabState();
+    for (const outcome of ["closed", "unavailable"]) {
+      touchSessionBrowserTab({
+        sessionKey: `agent:main:${outcome}`,
+        targetId: `NATIVE-${outcome}`,
+        profile: "chrome",
+      });
+    }
+    cdpMocks.closeTrackedCdpTarget.mockImplementation(async ({ nativeTargetId }) =>
+      nativeTargetId === "NATIVE-closed"
+        ? { status: "closed" }
+        : { status: "unavailable", reason: "target-lookup-failed" },
+    );
+
+    await expect(
+      closeTrackedBrowserTabsForSessions({
+        sessionKeys: ["agent:main:closed", "agent:main:unavailable"],
+        getResolvedBrowserConfig: () => ({
+          ...resolved,
+          extensionRelayInternalTokens: { chrome: "terminal-outcome-test-credential" },
+        }),
+      }),
+    ).resolves.toBe(1);
+    expect(
+      openStore()
+        .entries()
+        .map((entry) => (entry.value as DurableRecord).nativeTargetId),
+    ).toEqual(["NATIVE-unavailable"]);
+    expect(coldNativeActivityIdentities()).toEqual([
+      "agent:main:unavailable\u0000chrome\u0000NATIVE-unavailable",
+    ]);
   });
 });

--- a/extensions/browser/src/browser/session-tab-registry.ts
+++ b/extensions/browser/src/browser/session-tab-registry.ts
@@ -37,8 +37,8 @@ import {
   deleteVolatileSessionTab,
   forgetColdNativeActivity,
   normalizeBrowserSessionKey,
-  readColdNativeActivity,
   rememberColdNativeActivity,
+  replaceColdNativeActivityOwner,
   sameVolatileSessionTab,
   type SessionTabInteractionIdentity as InteractionIdentity,
   type VolatileSessionTab as VolatileTab,
@@ -55,6 +55,7 @@ import {
   getBrowserSessionTabStore,
   getOptionalBrowserSessionTabStore,
   parseBrowserSessionTabRecord,
+  retireBrowserSessionTabProcessState,
   sameBrowserSessionTabRecord,
   updateBrowserSessionTab,
   withoutBrowserSessionTabCleanup,
@@ -258,8 +259,7 @@ function deleteDurableCandidate(tab: DurableTab): boolean {
     return Boolean(record && sameBrowserSessionTabRecord(record, tab));
   });
   if (deleted) {
-    clearDurableTabAliases(tab.storageKey);
-    activeDurableStorageKeys().delete(tab.storageKey);
+    retireBrowserSessionTabProcessState(tab);
   }
   return deleted;
 }
@@ -308,9 +308,14 @@ export function trackSessionBrowserTab(params: SessionTabParams & { now?: number
     profileFingerprint: ownership.profileFingerprint,
     browserInstanceFingerprint: ownership.browserInstanceFingerprint,
   });
+  const usesNativeTarget = identity.targetId === ownership.nativeTargetId;
   let persistedProfileAliases: string[] = [];
+  let previousNativeIdentity: string | undefined;
   updateBrowserSessionTab(storageKey, (current) => {
     const existing = parseBrowserSessionTabRecord(current);
+    if (existing?.interactionTargetKind === "native") {
+      previousNativeIdentity = browserSessionTabNativeIdentity(existing);
+    }
     persistedProfileAliases = normalizeProfileAliases([
       ...(existing?.profileAliases ?? []),
       existing?.profile,
@@ -324,11 +329,19 @@ export function trackSessionBrowserTab(params: SessionTabParams & { now?: number
       ...(persistedProfileAliases.length > 0 ? { profileAliases: persistedProfileAliases } : {}),
       profileFingerprint: ownership.profileFingerprint,
       browserInstanceFingerprint: ownership.browserInstanceFingerprint,
-      interactionTargetKind: identity.targetId === ownership.nativeTargetId ? "native" : "opaque",
+      interactionTargetKind: usesNativeTarget ? "native" : "opaque",
       trackedAt: existing?.trackedAt ?? now,
       lastUsedAt: now,
     };
   });
+  const nativeIdentity = usesNativeTarget
+    ? browserSessionTabNativeIdentity({
+        sessionKey: identity.sessionKey,
+        profile,
+        nativeTargetId: ownership.nativeTargetId,
+      })
+    : undefined;
+  replaceColdNativeActivityOwner(previousNativeIdentity, nativeIdentity);
   rememberDurableTabAliases(identity, params.aliases ?? [], storageKey, persistedProfileAliases);
   activeDurableStorageKeys().add(storageKey);
   deleteVolatileMatching(identity);
@@ -405,15 +418,13 @@ export function touchSessionBrowserTab(params: SessionTabParams & { now?: number
       profile: identity.profile,
       nativeTargetId,
     });
-    if (
-      readColdNativeActivity(coldIdentity) !== undefined ||
-      readDurableTabs().some(
-        (tab) =>
-          tab.interactionTargetKind === "native" &&
-          browserSessionTabNativeIdentity(tab) === coldIdentity,
-      )
-    ) {
-      rememberColdNativeActivity(coldIdentity, now);
+    const durableOwnerCount = readDurableTabs().filter(
+      (tab) =>
+        tab.interactionTargetKind === "native" &&
+        browserSessionTabNativeIdentity(tab) === coldIdentity,
+    ).length;
+    if (durableOwnerCount > 0) {
+      rememberColdNativeActivity(coldIdentity, now, durableOwnerCount);
     }
   }
 }

--- a/extensions/browser/src/browser/session-tab-store.ts
+++ b/extensions/browser/src/browser/session-tab-store.ts
@@ -7,9 +7,14 @@ import {
   setBrowserStateRuntime,
 } from "../browser-runtime-state.js";
 import {
+  clearDurableTabAliases,
   rememberDurableTabAliases,
   resetDurableTabAliases,
 } from "./session-tab-ephemeral-aliases.js";
+import {
+  activeDurableStorageKeys,
+  releaseColdNativeActivityOwner,
+} from "./session-tab-process-state.js";
 
 const BROWSER_SESSION_TABS_NAMESPACE = "browser.session-tabs";
 const BROWSER_SESSION_TABS_MAX_ENTRIES = 5_000;
@@ -123,6 +128,16 @@ export function browserSessionTabNativeIdentity(
   record: Pick<BrowserSessionTabRecord, "sessionKey" | "profile" | "nativeTargetId">,
 ): string {
   return `${record.sessionKey}\u0000${record.profile}\u0000${record.nativeTargetId}`;
+}
+
+export function retireBrowserSessionTabProcessState(
+  record: BrowserSessionTabRecord & { storageKey: string },
+): void {
+  clearDurableTabAliases(record.storageKey);
+  activeDurableStorageKeys().delete(record.storageKey);
+  if (record.interactionTargetKind === "native") {
+    releaseColdNativeActivityOwner(browserSessionTabNativeIdentity(record));
+  }
 }
 
 export function compareBrowserSessionTabProfileAliases(left: string, right: string): number {


### PR DESCRIPTION
Closes #127081

## What Problem This Solves

Fixes long-running Gateways retaining stale browser-tab activity after the last durable native owner is deleted or replaced.

## User Impact

Retired browser tabs release their process-local activity, while sibling generations, retryable cleanup, and retained stopping/stopped dashboards keep the observations they need. Existing browser ownership checks, stored data, cleanup ages, and retention policy remain unchanged.

## Why This Change Was Made

The existing store update/delete operations now retire process state only after a successful guarded mutation and a check for remaining canonical native owners. Direct untracking, cleanup claims, and stopped-dashboard deletion share that path. This avoids an additional process-local owner counter and removes duplicated caller cleanup.

## Evidence

Four regressions failed on the original source and passed after the repair. They create real SQLite sibling generations and ambiguous aliases, covering final deletion, replacement, terminal versus retryable cleanup, and stopped-dashboard removal without clearing process state to create the cold path. All 116 focused registry/cleanup/dashboard tests passed. The four regressions passed again after the final predicate-order optimization. Independent P2 review found no actionable issues.

At the existing 5,000-row namespace bound, five local samples per phase measured 10.1–21.8 ms for final cold-owner retirement. Cold retirement performs one inventory read; ordinary deletion with no cold observation performs none and measured 0.4–0.6 ms. These are local samples, not a new data-retention policy or latency guarantee. No real browser was needed for this internal ownership boundary. Selected changed checks passed against the pinned base, including extension production/test typechecking, lint, formatting, doctor contracts, and ownership/architecture guards. `git diff --check` passed.
