### PR TITLE
fix(test): verify migrated Codex auth through shared owner

### DIFF
--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.test-support.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.test-support.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import { expect } from "vitest";
-import { loadPersistedAuthProfileStore } from "../../../../src/agents/auth-profiles/persisted.js";
+import { loadPersistedSharedAuthProfileStore } from "../../../../src/agents/auth-profiles/persisted.js";
 import type { OpenClawTestInstance } from "../../../helpers/openclaw-test-instance.js";
 
 const OAUTH_PROFILE_ID = "openai:qa-oauth";
@@ -50,7 +50,7 @@ export async function runCodexAuthDoctorMigrationProof(
   });
   expect(doctor.code, doctor.stderr).toBe(0);
 
-  const canonicalStore = loadPersistedAuthProfileStore(instance.state.agentDir());
+  const canonicalStore = loadPersistedSharedAuthProfileStore(instance.env);
   const expectedProfiles: Record<string, Record<string, unknown>> = {
     [OAUTH_PROFILE_ID]: {
       type: "oauth",


### PR DESCRIPTION
## What Problem This Solves

Fixes a main release-validation failure where the Codex auth product proofs reported a missing migrated profile after doctor successfully moved it into canonical shared SQLite ownership.

## Why This Change Was Made

The proof now reads through the shared-auth owner using the isolated test instance environment. This follows the same ownership contract as runtime and avoids pinning the assertion to the retired agent-local table.

## User Impact

No runtime behavior changes. Main release validation accurately verifies the existing doctor migration and Codex app-server auth flow.

## Evidence

- Before: both exact main-only repo-E2E runs failed with `expected null to match object` after doctor archived the legacy JSON; direct SQLite inspection showed the expected profiles in `state/openclaw.sqlite` and an empty agent-local auth table.
- After: `OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts test/e2e/qa-lab/runtime/codex-auth-doctor-migration-product-proof.e2e.test.ts` — 2 files, 3 tests passed.
- `node scripts/check-changed.mjs -- test/e2e/qa-lab/runtime/codex-auth-product-proof.test-support.ts` — passed.
- Autoreview: clean, no accepted/actionable findings.

Production LOC: 0. Test support LOC: +2/-2.
