### PR TITLE
docs: add a Docker Sandboxes page

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -330,6 +330,7 @@
           - "docs/cli/sandbox.md"
           - "docs/gateway/sandbox*.md"
           - "docs/install/docker.md"
+          - "docs/install/docker-sandboxes.md"
           - "docs/tools/multi-agent-sandbox-tools.md"
 
 "deploy: cloudflare":

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -365,6 +365,7 @@
           - "docs/cli/sandbox.md"
           - "docs/gateway/sandbox*.md"
           - "docs/gateway/sandboxing/**"
+          - "docs/install/docker-sandboxes.md"
           - "docs/install/docker.md"
           - "docs/install/docker/**"
           - "docs/tools/multi-agent-sandbox-tools.md"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1123,6 +1123,7 @@
                   "install/cloudflare",
                   "install/daytona",
                   "install/digitalocean",
+                  "install/docker-sandboxes",
                   "install/docker-vm-runtime",
                   "install/exe-dev",
                   "install/fly",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1471,6 +1471,7 @@
                   {
                     "group": "Self-hosted and local",
                     "pages": [
+                      "install/docker-sandboxes",
                       "install/docker-vm-runtime",
                       "install/kubernetes",
                       "install/macos-vm",

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -571,6 +571,7 @@ Each agent can override sandbox + tools: `agents.entries.*.sandbox` and `agents.
 
 ## Related
 
+- [Docker Sandboxes](/install/docker-sandboxes) -- hosting OpenClaw on Docker Sandboxes, a separate axis from sandboxing tool calls
 - [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) -- per-agent overrides and precedence
 - [OpenShell](/gateway/openshell) -- managed sandbox backend setup, workspace modes, and config reference
 - [Sandbox configuration](/gateway/config-agents#agentsdefaultssandbox)

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -92,6 +92,7 @@ Each agent can override sandbox + tools: `agents.entries.*.sandbox` and `agents.
 
 ## Related
 
+- [Docker Sandboxes](/install/docker-sandboxes) -- hosting OpenClaw on Docker Sandboxes, a separate axis from sandboxing tool calls
 - [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) -- per-agent overrides and precedence
 - [OpenShell](/gateway/openshell) -- managed sandbox backend setup, workspace modes, and config reference
 - [Sandbox configuration](/gateway/config-agents/sandbox#agentsdefaultssandbox)

--- a/docs/install/docker-sandboxes.md
+++ b/docs/install/docker-sandboxes.md
@@ -83,7 +83,7 @@ before anyone attaches. It generates its own token on first boot, because it
 binds to the container's external interface for port publishing and refuses a
 non-loopback bind without one. And it enables
 [Docker-backed sandboxing](/gateway/sandboxing#docker-backend) for tool
-execution, building that sandbox image on first boot, so the agent's shell never
+execution, pulling the image it needs on first boot, so the agent's shell never
 shares a filesystem with the Gateway's credential state:
 
 ```bash

--- a/docs/install/docker-sandboxes.md
+++ b/docs/install/docker-sandboxes.md
@@ -1,0 +1,156 @@
+---
+summary: "Run OpenClaw in a Docker Sandbox with proxy-managed credentials and sandboxed tool calls"
+read_when:
+  - You want to run OpenClaw somewhere isolated without managing a VPS
+  - You want provider credentials to stay off the machine that runs the agent
+title: "Docker Sandboxes"
+---
+
+Run OpenClaw in a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/): an
+isolated environment on your own machine. Provider credentials stay outside it:
+the sandbox gets a placeholder, and the proxy swaps in the real value on the way
+out. Egress is limited to a declared allowlist, and the agent's own tool calls
+run in a second sandbox inside the first.
+
+The environment ships as a kit, so this is two commands: store a credential,
+then start.
+
+<Note>
+The `openclaw` kit is community maintained in
+[docker/sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib/tree/main/openclaw).
+Report kit issues and contribute there.
+</Note>
+
+## What you need
+
+- The `sbx` CLI. It ships its own `sandboxd` daemon and does not need Docker
+  Desktop. See the [Docker Sandboxes docs](https://docs.docker.com/ai/sandboxes/)
+  for install steps.
+- A Docker login, so kit and template images can be pulled: `sbx login`.
+- An Anthropic API key, or a token from `claude setup-token` on a machine with
+  Claude Code.
+
+## Store the credential first
+
+Credentials are wired when a sandbox is created, so store yours before starting
+one. Both commands prompt with `Enter secret:` and read the value from stdin, so
+it never becomes a shell argument.
+
+An API key goes in as a service secret:
+
+```bash
+sbx secret set anthropic
+```
+
+A Claude subscription token goes in as a custom secret, with a placeholder
+shaped like an OAuth token:
+
+```bash
+sbx secret set-custom \
+  --host api.anthropic.com \
+  --env ANTHROPIC_OAUTH_TOKEN \
+  --placeholder 'sk-ant-oat01-{rand}'
+```
+
+`{rand}` is expanded when the secret is stored, so the sandbox receives an
+OAuth-shaped value. The shape decides the request: OpenClaw sends a token
+containing `sk-ant-oat` as a bearer token and anything else as `x-api-key`, and
+Anthropic rejects either one sent in the wrong header. A subscription token
+stored as a service secret fails for exactly that reason.
+
+Bind one credential, not both. A service secret makes the proxy set `x-api-key`
+on every request to `api.anthropic.com`, so a bearer credential alongside it
+sends two auth headers and Anthropic rejects the request.
+
+<Warning>
+Do not authenticate from inside the sandbox. OpenClaw's own auth commands write
+a real credential to the agent's auth store in the container, where the agent
+and anything it runs can read it, which defeats the whole proxy-managed model.
+</Warning>
+
+## Start OpenClaw
+
+```bash
+sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
+```
+
+This lands you in `openclaw chat`. Say hello: a reply means the Gateway, its
+token, and your provider credential are all wired correctly.
+
+The kit has already done the parts that are easy to get wrong. The Gateway
+starts with the container rather than on attach, so its published port answers
+before anyone attaches. It generates its own token on first boot, because it
+binds to the container's external interface for port publishing and refuses a
+non-loopback bind without one. And it enables
+[Docker-backed sandboxing](/gateway/sandboxing#docker-backend) for tool
+execution, building that sandbox image on first boot, so the agent's shell never
+shares a filesystem with the Gateway's credential state:
+
+```bash
+sbx exec <sandbox-name> -- openclaw sandbox list
+```
+
+Tool calls land in a container named `openclaw-sbx-<session>` as an unprivileged
+user, with the agent workspace at `/workspace`. That inner Docker daemon is the
+sandbox's own, separate from the one on your machine, so the
+[Docker-out-of-Docker constraints](/gateway/sandboxing#docker-backend) do not
+apply.
+
+## Open the Control UI
+
+The dashboard is on the published port:
+
+```bash
+sbx ports <sandbox-name>
+```
+
+Open `http://127.0.0.1:<published-port>/` and paste the Gateway token when
+asked. Read it from the config file, since `openclaw config get
+gateway.auth.token` returns a redaction placeholder rather than the value:
+
+```bash
+sbx exec <sandbox-name> -- sh -lc 'jq -r .gateway.auth.token ~/.openclaw/openclaw.json'
+```
+
+## Drive it from scripts
+
+`sbx exec` reaches the same Gateway without attaching:
+
+```bash
+sbx exec <sandbox-name> -- openclaw agent --agent main --message "what version are you running"
+```
+
+Wait for `~/.openclaw/gateway-ready` first if you run this right after starting a
+sandbox. Startup commands do not block `sbx exec`, and that sentinel is what the
+kit writes once the Gateway is serving.
+
+## Change the credential or the kit
+
+Both are applied at create time, so neither takes effect in a running sandbox.
+Store the new secret or pull the new kit, then start a fresh one:
+
+```bash
+sbx rm -f <sandbox-name>
+sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
+```
+
+The OpenClaw version is pinned by the kit image, so a newer OpenClaw arrives
+with a newer kit rather than through an in-place update.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| ------- | ----- |
+| `No API key found for provider "anthropic"` | No credential bound on the host. Store one, then start a fresh sandbox. |
+| `authentication_error: API key is invalid` | The credential reached Anthropic in the wrong shape, usually a subscription token bound as a service secret, or a stale service secret still setting `x-api-key`. |
+| `authentication_error: OAuth access token is invalid` | The bearer placeholder went out unswapped, so no matching credential is bound for that host. |
+| `auth flow failed (exit 1)` after `/auth` | Interactive login needs a TTY the TUI's subprocess does not get. Credentials belong on the host. |
+| `Sandbox image not found: openclaw-sandbox:bookworm-slim` | The kit's first-boot image build did not finish. Check `~/.openclaw/sandbox-image-build.log`. |
+| A new secret changes nothing | Credentials are wired at create time. Start a fresh sandbox. |
+
+## Related
+
+- [Channels](/channels) -- connect Telegram, Discord, WhatsApp, or Slack
+- [Gateway configuration](/gateway/configuration)
+- [Sandboxing](/gateway/sandboxing) -- the tool-execution sandbox the kit turns on
+- [Security](/gateway/security)

--- a/docs/install/docker-sandboxes.md
+++ b/docs/install/docker-sandboxes.md
@@ -2,15 +2,21 @@
 summary: "Run OpenClaw in a Docker Sandbox with proxy-managed credentials and sandboxed tool calls"
 read_when:
   - You want to run OpenClaw somewhere isolated without managing a VPS
-  - You want provider credentials to stay off the machine that runs the agent
+  - You want the provider credential stored outside the sandbox the agent runs in
 title: "Docker Sandboxes"
 ---
 
 Run OpenClaw in a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/): an
-isolated environment on your own machine. Provider credentials stay outside it:
-the sandbox gets a placeholder, and the proxy swaps in the real value on the way
-out. Egress is limited to a declared allowlist, and the agent's own tool calls
-run in a second sandbox inside the first.
+isolated environment on your own machine. The credential you store never has to
+be written inside it: the sandbox receives a placeholder value, and the sandbox
+proxy substitutes the real one on requests leaving for the provider host. Egress
+is limited to a declared allowlist, and the agent's own tool calls run in a
+second sandbox inside the first.
+
+How far that substitution isolates the credential from code running in the
+sandbox is a property of Docker Sandboxes and the kit, not of OpenClaw. Treat it
+as the placeholder-substitution mechanism described above rather than a
+guarantee this page can make.
 
 The environment ships as a kit, so this is two commands: store a credential,
 then start.
@@ -18,7 +24,9 @@ then start.
 <Note>
 The `openclaw` kit is community maintained in
 [docker/sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib/tree/main/openclaw).
-Report kit issues and contribute there.
+Report kit issues and contribute there. This page describes the kit at
+[`cc502cd`](https://github.com/docker/sbx-kits-contrib/commit/cc502cd); the
+`:latest` artifact moves, so behavior can change ahead of this page.
 </Note>
 
 ## What you need
@@ -145,7 +153,7 @@ with a newer kit rather than through an in-place update.
 | `authentication_error: API key is invalid` | The credential reached Anthropic in the wrong shape, usually a subscription token bound as a service secret, or a stale service secret still setting `x-api-key`. |
 | `authentication_error: OAuth access token is invalid` | The bearer placeholder went out unswapped, so no matching credential is bound for that host. |
 | `auth flow failed (exit 1)` after `/auth` | Interactive login needs a TTY the TUI's subprocess does not get. Credentials belong on the host. |
-| `Sandbox image not found: openclaw-sandbox:bookworm-slim` | The kit's first-boot image build did not finish. Check `~/.openclaw/sandbox-image-build.log`. |
+| `Sandbox image not found: docker/sandbox-templates:shell-docker. Build or pull it first.` | The kit's first-boot image pull has not finished. Check `~/.openclaw/sandbox-image-pull.log` in the sandbox. |
 | A new secret changes nothing | Credentials are wired at create time. Start a fresh sandbox. |
 
 ## Related

--- a/docs/install/docker-sandboxes.md
+++ b/docs/install/docker-sandboxes.md
@@ -3,20 +3,25 @@ summary: "Run OpenClaw in a Docker Sandbox with proxy-managed credentials and sa
 read_when:
   - You want to run OpenClaw somewhere isolated without managing a VPS
   - You want the provider credential stored outside the sandbox the agent runs in
+  - You want the Gateway itself isolated from your host, not only tool execution
 title: "Docker Sandboxes"
 ---
 
-Run OpenClaw in a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/): an
-isolated environment on your own machine. The credential you store never has to
-be written inside it: the sandbox receives a placeholder value, and the sandbox
-proxy substitutes the real one on requests leaving for the provider host. Egress
-is limited to a declared allowlist, and the agent's own tool calls run in a
-second sandbox inside the first.
+Run OpenClaw in a [Docker Sandbox](https://docs.docker.com/ai/sandboxes/): a
+microVM on your own machine, with its own kernel and its own Docker engine. The
+credential you store never has to be written inside it, because the sandbox
+receives a placeholder value and the sandbox proxy substitutes the real one on
+requests leaving for the provider host. The agent's own tool calls then run in a
+second sandbox nested inside the first.
 
 How far that substitution isolates the credential from code running in the
 sandbox is a property of Docker Sandboxes and the kit, not of OpenClaw. Treat it
 as the placeholder-substitution mechanism described above rather than a
 guarantee this page can make.
+
+This page covers local sandboxes. Cloud sandboxes (`sbx --cloud`) cannot mount a
+host workspace and are deleted when their expiration lapses, so they do not suit
+a Gateway you mean to keep running.
 
 The environment ships as a kit, so this is two commands: store a credential,
 then start.
@@ -24,10 +29,28 @@ then start.
 <Note>
 The `openclaw` kit is community maintained in
 [docker/sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib/tree/main/openclaw).
-Report kit issues and contribute there. This page describes the kit at
-[`cc502cd`](https://github.com/docker/sbx-kits-contrib/commit/cc502cd); the
-`:latest` artifact moves, so behavior can change ahead of this page.
+Report kit issues and contribute there. That repository owns the kit's own
+behavior and reference; this page covers only the OpenClaw side of the setup.
 </Note>
+
+## How this fits with OpenClaw's own isolation
+
+OpenClaw has its own sandboxing, and this page is a different layer. They
+compose rather than duplicate:
+
+- Docker Sandboxes isolates your **host** from everything OpenClaw runs, the
+  Gateway included, and enforces network policy outside the VM.
+- OpenClaw [sandboxing](/gateway/sandboxing), which this kit turns on, isolates
+  **Gateway state** from agent tool execution. Config, the Gateway token,
+  channel credentials, and the session store stay outside the container the
+  agent's shell runs in.
+- The OpenClaw [secret egress proxy](/gateway/secrets#secret-egress-proxy) is a
+  third, unrelated mechanism, and this setup does not use it. It covers
+  Gateway-hosted exec rather than sandboxed tool calls, and here the provider
+  credential is handled by the sandbox proxy instead.
+
+So nothing extra has to be enabled in OpenClaw to get the credential handling
+described below.
 
 ## What you need
 
@@ -60,21 +83,33 @@ sbx secret set-custom \
   --placeholder 'sk-ant-oat01-{rand}'
 ```
 
-`{rand}` is expanded when the secret is stored, so the sandbox receives an
-OAuth-shaped value. The shape decides the request: OpenClaw sends a token
-containing `sk-ant-oat` as a bearer token and anything else as `x-api-key`, and
-Anthropic rejects either one sent in the wrong header. A subscription token
-stored as a service secret fails for exactly that reason.
-
-Bind one credential, not both. A service secret makes the proxy set `x-api-key`
-on every request to `api.anthropic.com`, so a bearer credential alongside it
-sends two auth headers and Anthropic rejects the request.
+Bind one credential, not both. The two are not interchangeable on the wire:
+OpenClaw picks the request shape from the token it holds, and Anthropic rejects
+the wrong shape or two auth headers at once. The kit's
+[How auth works](https://github.com/docker/sbx-kits-contrib/blob/main/openclaw/README.md#how-auth-works)
+owns which host credential produces which wire format, and how to switch
+between them.
 
 <Warning>
 Do not authenticate from inside the sandbox. OpenClaw's own auth commands write
 a real credential to the agent's auth store in the container, where the agent
 and anything it runs can read it, which defeats the whole proxy-managed model.
 </Warning>
+
+## Network policy
+
+The kit declares the hosts it needs, and those rules are added to your host's
+policy rather than replacing it. Denies win over allows, and the shipped presets
+include broad wildcards, so "only the kit's hosts are reachable" describes a host
+with a strict policy rather than the kit on its own. Check where yours stands:
+
+```bash
+sbx policy ls
+```
+
+Prefer a deny-all posture for this kit. Its own end-to-end tests run that way,
+so the declared list is known sufficient there, and anything the kit does not
+declare stays unreachable even when a credential names it.
 
 ## Start OpenClaw
 
@@ -88,8 +123,8 @@ token, and your provider credential are all wired correctly.
 The kit has already done the parts that are easy to get wrong. The Gateway
 starts with the container rather than on attach, so its published port answers
 before anyone attaches. It generates its own token on first boot, because it
-binds to the container's external interface for port publishing and refuses a
-non-loopback bind without one. And it enables
+binds to the container's external interface for port publishing and OpenClaw
+refuses a non-loopback bind without one. And it enables
 [Docker-backed sandboxing](/gateway/sandboxing#docker-backend) for tool
 execution, pulling the image it needs on first boot, so the agent's shell never
 shares a filesystem with the Gateway's credential state:
@@ -106,19 +141,30 @@ apply.
 
 ## Open the Control UI
 
-The dashboard is on the published port:
+Pin the host port to the Gateway's own port rather than taking the ephemeral one
+the runtime assigns:
 
 ```bash
-sbx ports <sandbox-name>
+sbx ports <sandbox-name> --publish 18789:18789/tcp
 ```
 
-Open `http://127.0.0.1:<published-port>/` and paste the Gateway token when
-asked. Read it from the config file, since `openclaw config get
-gateway.auth.token` returns a redaction placeholder rather than the value:
+Then open `http://127.0.0.1:18789/`. Both halves of that address matter. On a
+non-loopback bind the Gateway seeds its Control UI origin allowlist with its own
+port and nothing else, and a port-forwarded browser connection does not count as
+a local client, so a browser arriving on any other port is refused with
+`origin not allowed`. Use the loopback address rather than a LAN one, because
+the Control UI needs a secure context to present a device identity.
+
+Paste the Gateway token when asked. Read it from the config file, since
+`openclaw config get gateway.auth.token` returns a redaction placeholder rather
+than the value:
 
 ```bash
 sbx exec <sandbox-name> -- sh -lc 'jq -r .gateway.auth.token ~/.openclaw/openclaw.json'
 ```
+
+Wait for `~/.openclaw/gateway-ready` before reading it. Earlier, the key is
+absent and `jq -r` prints `null`.
 
 ## Drive it from scripts
 
@@ -142,23 +188,41 @@ sbx rm -f <sandbox-name>
 sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
 ```
 
-The OpenClaw version is pinned by the kit image, so a newer OpenClaw arrives
-with a newer kit rather than through an in-place update.
+Recreating discards everything living inside the sandbox, including the Gateway
+token minted on first boot and any channels configured from within the session.
+
+`:latest` follows the kit's `main`. Every kit build also publishes an immutable
+`<date>-<sha>` tag, so pass one of those instead to hold a sandbox on a known
+kit revision. That pins kit content rather than the whole environment, because
+the image the kit boots stays on a floating tag by design. See
+[Pinning a kit revision](https://github.com/docker/sbx-kits-contrib/blob/main/openclaw/README.md#pinning-a-kit-revision).
+
+<Warning>
+The OpenClaw version comes from the kit's image, not from an in-place update.
+`openclaw update` inside the sandbox can fail when the image's Node is older
+than the engine floor of the release it tries to install, so treat a newer
+OpenClaw as a kit bump and recreate from a newer kit. Check what a sandbox has
+with `sbx exec <sandbox-name> -- openclaw --version`.
+</Warning>
 
 ## Troubleshooting
 
-| Symptom | Cause |
-| ------- | ----- |
-| `No API key found for provider "anthropic"` | No credential bound on the host. Store one, then start a fresh sandbox. |
-| `authentication_error: API key is invalid` | The credential reached Anthropic in the wrong shape, usually a subscription token bound as a service secret, or a stale service secret still setting `x-api-key`. |
-| `authentication_error: OAuth access token is invalid` | The bearer placeholder went out unswapped, so no matching credential is bound for that host. |
-| `auth flow failed (exit 1)` after `/auth` | Interactive login needs a TTY the TUI's subprocess does not get. Credentials belong on the host. |
-| `Sandbox image not found: docker/sandbox-templates:shell-docker. Build or pull it first.` | The kit's first-boot image pull has not finished. Check `~/.openclaw/sandbox-image-pull.log` in the sandbox. |
-| A new secret changes nothing | Credentials are wired at create time. Start a fresh sandbox. |
+| Symptom                                                                                   | Cause                                                                                                                                                             |
+| ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `No API key found for provider "anthropic"`                                               | No credential bound on the host. Store one, then start a fresh sandbox.                                                                                           |
+| `authentication_error: API key is invalid`                                                | The credential reached Anthropic in the wrong shape, usually a subscription token bound as a service secret, or a stale service secret still setting `x-api-key`. |
+| `authentication_error: OAuth access token is invalid`                                     | The bearer placeholder went out unswapped, so no matching credential is bound for that host.                                                                      |
+| `auth flow failed (exit 1)` after `/auth`                                                 | Interactive login needs a TTY the TUI's subprocess does not get. Credentials belong on the host.                                                                  |
+| `origin not allowed` in the browser                                                       | The Control UI was opened on a host port other than the Gateway's. Republish with `--publish 18789:18789/tcp` and open `http://127.0.0.1:18789/`.                 |
+| `control ui requires device identity`                                                     | The Control UI needs a secure context. Open it on `127.0.0.1` rather than a LAN address.                                                                          |
+| `jq -r` prints `null` for the token                                                       | The Gateway has not finished its first boot. Wait for `~/.openclaw/gateway-ready`.                                                                                |
+| `Sandbox image not found: docker/sandbox-templates:shell-docker. Build or pull it first.` | The kit's first-boot image pull has not finished. Check `~/.openclaw/sandbox-image-pull.log` in the sandbox.                                                      |
+| A new secret changes nothing                                                              | Credentials are wired at create time. Start a fresh sandbox.                                                                                                      |
 
 ## Related
 
 - [Channels](/channels) -- connect Telegram, Discord, WhatsApp, or Slack
 - [Gateway configuration](/gateway/configuration)
 - [Sandboxing](/gateway/sandboxing) -- the tool-execution sandbox the kit turns on
+- [Secret egress proxy](/gateway/secrets#secret-egress-proxy) -- the unrelated OpenClaw mechanism this setup does not use
 - [Security](/gateway/security)


### PR DESCRIPTION
## What Problem This Solves

Docker Sandboxes has no page in the docs. The `openclaw` kit that runs OpenClaw
there exists, but nothing in the docs points to it, so it is only findable if
you already know it is there.

## Why This Change Was Made

Adds `install/docker-sandboxes` as a tutorial, in the Hosting group next to
Daytona.

It is not filed under Sandboxing, because that page is about OpenClaw
sandboxing its own tool execution and states that the Gateway stays on the host.
This page is about where OpenClaw runs. The two compose, so each links the
other.

The page records four things that are easy to get wrong and produce errors that
point elsewhere:

- Credentials are wired at sandbox create time, so one stored later has no
  effect until a new sandbox exists.
- OpenClaw picks the request shape from the token it holds: a value containing
  `sk-ant-oat` goes out as `Authorization: Bearer`, anything else as
  `x-api-key`. Anthropic rejects either shape in the wrong header, which is why
  a subscription token stored as a service secret fails.
- A service secret makes the proxy set `x-api-key` on that host, so a bearer
  credential alongside it sends two auth headers and the request is rejected.
- `openclaw config get gateway.auth.token` returns a redaction placeholder, so
  the Control UI token has to be read from the config file.

## User Impact

Readers can run OpenClaw in a Docker Sandbox from the docs, with credentials
staying on the host rather than in the container. The troubleshooting table maps
the auth errors this setup produces to their causes.

## How To Test This

Docs checks:

```bash
pnpm docs:check-links
pnpm docs:check-mdx
```

The page is its own test plan. To reproduce the result it documents, follow
[Docker Sandboxes](/install/docker-sandboxes) end to end; the short version:

```bash
# API-key path. For a Claude subscription token use the set-custom form on the
# page instead; the two are not interchangeable on the wire.
sbx secret set anthropic

sbx run --kit "docker.io/sbx/openclaw-kit:latest" openclaw
sbx exec <sandbox-name> -- openclaw agent --agent main --message "what version are you running"
```

A model answer from the last command is the success signal.

## Evidence

The kit change that enables Docker-backed tool sandboxing is **merged**: docker/sbx-kits-contrib#229, squashed as `cc502cd`. Merged `main` carries both the `agents.defaults.sandbox` config and the registry hosts its image pull needs, so the guide describes shipped behavior. The page says the kit *pulls* that image rather than builds one, matching what landed.

**Tool calls land in a nested container inside the sandbox.** Outer shell, the same commands run through the agent, then the container list from inside the sandbox:

```console
$ sbx exec <sandbox> -- sh -lc "id -un; hostname"
agent
tools

$ # same two commands via the agent exec tool, plus the workspace mount
agent
552d76ad60f2
/workspace

$ sbx exec <sandbox> -- docker ps --format "{{.Image}} {{.Names}}"
docker/sandbox-templates:shell-docker openclaw-sbx-agent-main-main-6d9217fe
```

That daemon is the sandbox's own: `dockerd` runs inside it, `docker info` reports `root=/var/lib/docker os=Ubuntu 26.04 LTS (containerized)`, and its image store starts empty while the host has 76 images.

**Credentials resolve to the documented wire format.**

```console
$ sbx exec <sandbox> -- printenv ANTHROPIC_OAUTH_TOKEN
sk-ant-oat01-<redacted>
$ sbx exec <sandbox> -- printenv ANTHROPIC_API_KEY
(unset)

$ sbx exec <sandbox> -- openclaw agent --agent main --message "Reply with exactly: PONG"
PONG
$ sbx exec <sandbox> -- openclaw agent --local --agent main --message "Reply with exactly: PONG"
PONG
```

Both paths matter: `--local` is the in-process runtime the TUI uses. No `authentication_error` or `rate_limit_error` in the gateway logs.

**The token-retrieval instruction is exercised**, including why `config get` is not the route:

```console
$ sbx exec <sandbox> -- openclaw config get gateway.auth.token
__OPENCLAW_RED...
$ sbx exec <sandbox> -- sh -lc "jq -r .gateway.auth.token ~/.openclaw/openclaw.json"
<64 hex characters>
```

**Docs checks.** `pnpm docs:list` lists the page, line 546:

```text
install/docker-sandboxes.md - Run OpenClaw in a Docker Sandbox with proxy-managed credentials and sandboxed tool calls
```

`docs:check-links` and `docs:check-mdx` could not run here: both need `tsx`, and `node_modules` was unavailable in my checkout. Verified by hand instead that `docs.json` parses, every internal link target resolves, headings carry no em dashes or apostrophes, every fence has a language, and `git diff --check` is clean.
