### PR TITLE
perf(test): speed up new-session model control observations

### DIFF
--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { DraftCloudProfile } from "./discovery.ts";
 import { contextWith, deferred, renderControl } from "./model-control.test-support.ts";
 import { NewSessionModelControl } from "./model-control.ts";
@@ -72,7 +73,7 @@ describe("new-session model runtime", () => {
     control.load(context, "main", true);
     control.loadCatalogTargets(context, "main", false);
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     expect(request).not.toHaveBeenCalledWith("sessions.catalog.list", expect.anything());
     expect(
       renderControl(control, context).querySelector("[data-chat-model-target-group]"),
@@ -117,14 +118,14 @@ describe("new-session model runtime", () => {
     control.load(context, "main", true);
     control.loadCatalogTargets(context, "main", true);
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(request).toHaveBeenCalledWith(
         "sessions.catalog.list",
         { agentId: "main", limitPerHost: 1 },
         { signal: expect.any(AbortSignal) },
       ),
     );
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const container = renderControl(control, context);
       expect(container.querySelector('[data-chat-model-target-group="cliAgents"]')).not.toBeNull();
       expect(container.querySelector('[data-chat-model-target="anthropic"]')).not.toBeNull();
@@ -149,7 +150,7 @@ describe("new-session model runtime", () => {
 
     control.load(context, "main", true);
     control.loadCatalogTargets(context, "main", true);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
 
     const container = renderControl(control, context);
     const picker = container.querySelector<HTMLDetailsElement>(".chat-controls__model-picker");
@@ -192,7 +193,7 @@ describe("new-session model runtime", () => {
     control.load(context, "main", true);
 
     expect(control.isRestoringPreference()).toBe(false);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
   });
 
   it("renders initial metadata loading without synthesizing the configured default", async () => {
@@ -203,7 +204,7 @@ describe("new-session model runtime", () => {
 
     control.load(context, "main", true);
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     const container = renderControl(control, context);
     expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
       "Loading models",
@@ -343,7 +344,7 @@ describe("new-session model runtime", () => {
     const control = new NewSessionModelControl(notify);
 
     control.load(context, "main", true);
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(request).toHaveBeenCalledOnce();
       expect(notify).toHaveBeenCalledTimes(2);
     });
@@ -396,7 +397,7 @@ describe("new-session model runtime", () => {
 
     control.load(context, "main", true);
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       const container = renderControl(control, context);
       expect(
         container
@@ -460,8 +461,8 @@ describe("new-session model runtime", () => {
 
     control.load(context, "main", true);
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    await vi.waitFor(() => {
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() => {
       const container = renderControl(control, context);
       expect(
         container


### PR DESCRIPTION
## What Problem This Solves

The new-session model-control test spends unnecessary wall-clock time waiting for Vitest's default 50 ms observation-polling interval after immediately resolved metadata and initial UI rendering.

## Why This Change Was Made

Use the existing 1 ms `waitForFast` helper for 10 initial-observation waits only. Preserve all 40 request-order, shared-ownership, catalog-freshness, reconnect, agent/model-selection, and preference-restoration waits, along with every existing assertion, deferred barrier, test case, timeout, and production file.

## User Impact

No user-facing or production behavior changes. Maintainers and CI get faster new-session model-control coverage without weakening its ownership, recovery, or persistence contracts.

## Evidence

- Same Blacksmith Testbox, one excluded warmup, eight retained interleaved samples per variant, one worker, separate filesystem-module caches, import diagnostics, and GNU `/usr/bin/time -v`.
- Median wall: **3.995 s -> 3.565 s (-0.430 s, -10.8%)**. Median Vitest: **3.020 s -> 2.725 s**. Median test body: **1.955 s -> 1.705 s (-12.8%)**.
- Median imports: **380 ms -> 374 ms**; peak RSS: **720,302 KiB -> 716,152 KiB**; CPU user/system: **3.020/0.350 s -> 2.820/0.280 s**. Every sample passed the same **37 tests**.
- Reversible production-owner fault proof: removing the CLI target capability filter correctly failed the history-only-target assertion; removing fresh-catalog auth gating correctly failed the pending-refresh auth assertion; both passed after restoring the exact production file.
- Focused owner/sibling validation: **122 passing tests across 10 files**, including metadata startup-retry/deadline, catalog targets, model selection, new-session ownership, preferences, and isolated draft persistence.
- Real Chromium plus isolated mocked Gateway: **29 passing scenarios across four files**, covering model-catalog retries, reconnect/request ordering, preference/model restoration, and durable draft handoff. No live Gateway was used.
- Complete Blacksmith `pnpm check:changed` passed in **11m04s**, including ratchets, dead-code scans, Control UI i18n, core-test typechecks, and changed-file lint with **0 warnings / 0 errors**. Structured independent review passed clean; production delta **+0/-0**, test delta **+11/-10**.
