### PR TITLE
fix(twitch): prevent retired chat managers from reconnecting during shutdown

### DIFF
--- a/extensions/twitch/src/client-manager-registry.test.ts
+++ b/extensions/twitch/src/client-manager-registry.test.ts
@@ -1,11 +1,14 @@
 // Twitch tests cover client manager registry plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getClientManager,
   getOrCreateClientManager,
   removeClientManager,
 } from "./client-manager-registry.js";
-import type { ChannelLogSink } from "./types.js";
+import { sendMessageTwitchInternal } from "./send.js";
+import { BASE_TWITCH_TEST_ACCOUNT, makeTwitchTestConfig } from "./test-fixtures.js";
+import type { ChannelLogSink, TwitchAccountConfig } from "./types.js";
 
 function makeLogger(): ChannelLogSink {
   return {
@@ -16,22 +19,130 @@ function makeLogger(): ChannelLogSink {
   };
 }
 
+const account = {
+  ...BASE_TWITCH_TEST_ACCOUNT,
+  accessToken: "oauth:test-token",
+  enabled: true,
+} satisfies TwitchAccountConfig;
+
+function attachFakeTransport(manager: ReturnType<typeof getOrCreateClientManager>) {
+  const transport = {
+    quit: vi.fn(),
+    say: vi.fn((_channel: string, _message: string) => Promise.resolve()),
+  };
+  const state = manager as unknown as {
+    clients: Map<string, typeof transport>;
+    messageHandlers: Map<string, unknown>;
+  };
+  state.clients.set(manager.getAccountKey(account), transport);
+  manager.onMessage(account, vi.fn());
+  return { state, transport };
+}
+
 describe("client manager registry", () => {
   afterEach(async () => {
     await removeClientManager("default");
   });
 
-  it("removes cached managers even when disconnectAll rejects", async () => {
-    const firstManager = getOrCreateClientManager("default", makeLogger());
-    const disconnectError = new Error("disconnect failed");
-    const disconnectAll = vi
-      .spyOn(firstManager, "disconnectAll")
-      .mockRejectedValueOnce(disconnectError);
+  it.each(["resolves", "rejects"] as const)(
+    "retires managers immediately and preserves replacements when cleanup %s",
+    async (outcome) => {
+      const logger = makeLogger();
+      const firstManager = getOrCreateClientManager("default", logger);
+      const { state, transport } = attachFakeTransport(firstManager);
+      const cleanup = createDeferred<void>();
+      const disconnect = firstManager.disconnectAll.bind(firstManager);
+      const disconnectAll = vi.spyOn(firstManager, "disconnectAll").mockImplementation(async () => {
+        await disconnect();
+        await cleanup.promise;
+      });
+      const unregisterMessage = "Unregistered client manager for account: default";
+      const removal = removeClientManager("default");
 
-    await expect(removeClientManager("default")).rejects.toBe(disconnectError);
+      try {
+        expect(disconnectAll).toHaveBeenCalledOnce();
+        expect(transport.quit).toHaveBeenCalledOnce();
+        expect(state.clients.size).toBe(0);
+        expect(state.messageHandlers.size).toBe(0);
+        expect(getClientManager("default")).toBeUndefined();
+        expect(logger.info).not.toHaveBeenCalledWith(unregisterMessage);
 
-    expect(disconnectAll).toHaveBeenCalledOnce();
-    expect(getClientManager("default")).toBeUndefined();
-    expect(getOrCreateClientManager("default", makeLogger())).not.toBe(firstManager);
+        const replacement = getOrCreateClientManager("default", makeLogger());
+        expect(replacement).not.toBe(firstManager);
+
+        if (outcome === "rejects") {
+          const disconnectError = new Error("disconnect failed");
+          const rejected = expect(removal).rejects.toBe(disconnectError);
+          cleanup.reject(disconnectError);
+          await rejected;
+        } else {
+          cleanup.resolve();
+          await expect(removal).resolves.toBeUndefined();
+        }
+
+        expect(getClientManager("default")).toBe(replacement);
+        expect(logger.info).toHaveBeenCalledWith(unregisterMessage);
+      } finally {
+        cleanup.resolve();
+        await removal.catch(() => undefined);
+      }
+    },
+  );
+
+  it("keeps outbound delivery off a retired manager and sends through its replacement", async () => {
+    const logger = makeLogger();
+    const firstManager = getOrCreateClientManager("default", logger);
+    const first = attachFakeTransport(firstManager);
+    const cleanup = createDeferred<void>();
+    const disconnect = firstManager.disconnectAll.bind(firstManager);
+    vi.spyOn(firstManager, "disconnectAll").mockImplementation(async () => {
+      await disconnect();
+      await cleanup.promise;
+    });
+    const getClient = firstManager.getClient.bind(firstManager);
+    const reconnect = vi.spyOn(firstManager, "getClient").mockImplementation(async (...args) => {
+      first.state.clients.set(firstManager.getAccountKey(account), first.transport);
+      return await getClient(...args);
+    });
+    const config = makeTwitchTestConfig(account);
+    const removal = removeClientManager("default");
+
+    try {
+      const whileRetiring = await sendMessageTwitchInternal(
+        "#testchannel",
+        "while retiring",
+        config,
+        "default",
+        false,
+      );
+
+      expect(whileRetiring).toMatchObject({
+        ok: false,
+        error:
+          "Client manager not found for account: default. Please start the Twitch gateway first.",
+      });
+      expect(reconnect).not.toHaveBeenCalled();
+      expect(first.transport.say).not.toHaveBeenCalled();
+
+      const replacement = getOrCreateClientManager("default", makeLogger());
+      const { transport } = attachFakeTransport(replacement);
+      const afterRestart = await sendMessageTwitchInternal(
+        "#testchannel",
+        "after restart",
+        config,
+        "default",
+        false,
+      );
+
+      expect(afterRestart.ok).toBe(true);
+      expect(transport.say).toHaveBeenCalledWith("testchannel", "after restart");
+
+      cleanup.resolve();
+      await expect(removal).resolves.toBeUndefined();
+      expect(getClientManager("default")).toBe(replacement);
+    } finally {
+      cleanup.resolve();
+      await removal.catch(() => undefined);
+    }
   });
 });

--- a/extensions/twitch/src/client-manager-registry.ts
+++ b/extensions/twitch/src/client-manager-registry.ts
@@ -80,10 +80,10 @@ export async function removeClientManager(accountId: string): Promise<void> {
     return;
   }
 
+  registry.delete(accountId);
   try {
     await entry.manager.disconnectAll();
   } finally {
-    registry.delete(accountId);
     entry.logger.info(`Unregistered client manager for account: ${accountId}`);
   }
 }


### PR DESCRIPTION
Closes #127100

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Twitch users stopping or restarting an account could reconnect an already-retired chat manager through outbound delivery, or lose a newly started replacement manager when the previous asynchronous shutdown finished.

## Why This Change Was Made

The Twitch registry is the owner of manager publication, so it must unpublish the exact current manager synchronously before awaiting its existing disconnect. Keeping unregister logging in `finally` preserves completion timing and the original cleanup rejection, while eliminating stale-finally deletion of a replacement. This matches the existing Nostr, Buzz, and Voice Call lifecycle invariant without adding production lines, compatibility paths, configuration, or SDK surface.

## User Impact

Twitch outbound delivery no longer resurrects a shutting-down connection, and a restarted account remains registered even if the previous manager finishes or fails late. During the brief gap before a replacement starts, users receive the existing actionable instruction to start the Twitch gateway first.

## Evidence

- Before the production change, all three new owner-boundary regressions failed: deferred cleanup remained visible for both resolve/reject, and the real outbound sender reconnected the retired fake transport.
- After the change, the complete Twitch plugin plus Nostr lifecycle coverage passed: **19 files, 227 tests**.
- Buzz lifecycle coverage passed: **12 tests**; Voice Call lifecycle coverage passed: **9 tests**.
- The actual changed gate passed, including production and test typechecks, formatting, extension lint, plugin-boundary/dead-export checks, database/storage guards, and import-cycle verification.
- Production LOC: **+1/-1 (net 0)**. Tests: **+122/-11**.
- Validation used the real Twitch registry, real sender, real manager cleanup, and in-memory fake transports only. **No real Twitch calls or credentials were used**, as required; live Twitch proof is intentionally unavailable under that explicit constraint.
- AI-assisted; independently reviewed before landing.

```text
env OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-twitch-retirement-vitest-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts --configLoader runner extensions/twitch extensions/nostr/src/channel.lifecycle.test.ts
env OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-twitch-retirement-vitest-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts --configLoader runner extensions/buzz/src/gateway.lifecycle.test.ts
env OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-twitch-retirement-vitest-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-voice-call.config.ts --configLoader runner extensions/voice-call/index.lifecycle.test.ts
node scripts/check-changed.mjs -- extensions/twitch/src/client-manager-registry.ts extensions/twitch/src/client-manager-registry.test.ts
git diff --check
git diff --numstat
```
