### PR TITLE
fix(sessions): cleanup large backlogs without OOM

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -98,6 +98,86 @@ describe("SQLite transcript archive worker", () => {
     );
   });
 
+  it("processes maintenance across the archive byte limit", async () => {
+    const largeContent = "x".repeat(33 * 1024 * 1024);
+    const archivedSessions = [0, 1].map((index) => ({
+      event: createTranscriptEvent(`worker-byte-session-${index}`, `${index}:${largeContent}`),
+      sessionId: `worker-byte-session-${index}`,
+      sessionKey: `agent:main:worker-byte-${index}`,
+    }));
+    for (const [index, session] of archivedSessions.entries()) {
+      await replaceSessionEntry(
+        { sessionKey: session.sessionKey, storePath },
+        { sessionId: session.sessionId, updatedAt: Date.now() + index },
+      );
+      await replaceTranscriptEvents(
+        { sessionKey: session.sessionKey, sessionId: session.sessionId, storePath },
+        [session.event],
+      );
+    }
+    const retainedSession = {
+      sessionId: "worker-byte-session-retained",
+      sessionKey: "agent:main:worker-byte-retained",
+    };
+    await replaceSessionEntry(
+      { sessionKey: retainedSession.sessionKey, storePath },
+      { sessionId: retainedSession.sessionId, updatedAt: Date.now() + archivedSessions.length },
+    );
+
+    const result = await applySessionEntryLifecycleMutation({
+      storePath,
+      maintenanceOverride: {
+        maxEntries: 1,
+        mode: "enforce",
+        pruneAfterMs: Number.MAX_SAFE_INTEGER,
+      },
+    });
+
+    expect(result).toMatchObject({
+      afterCount: 1,
+      beforeCount: archivedSessions.length + 1,
+      capped: archivedSessions.length,
+      modelRunPruned: 0,
+      pruned: 0,
+    });
+    expect(result.archivedTranscriptDirectories).toEqual([path.dirname(storePath)]);
+    expect(loadSessionEntry({ sessionKey: retainedSession.sessionKey, storePath })).toBeDefined();
+    const archiveRows = openLifecycleTestDatabase(storePath)
+      .db.prepare(
+        `SELECT archive_name, archive_sha256, published_at, session_id
+           FROM session_transcript_archives
+          ORDER BY session_id`,
+      )
+      .all() as Array<{
+      archive_name: string;
+      archive_sha256: string;
+      published_at: number | null;
+      session_id: string;
+    }>;
+    expect(archiveRows).toHaveLength(archivedSessions.length);
+    for (const session of archivedSessions) {
+      expect(loadSessionEntry({ sessionKey: session.sessionKey, storePath })).toBeUndefined();
+      await expect(
+        loadTranscriptEvents({
+          sessionKey: session.sessionKey,
+          sessionId: session.sessionId,
+          storePath,
+        }),
+      ).resolves.toEqual([]);
+      const archive = archiveRows.find((row) => row.session_id === session.sessionId);
+      expect(archive).toMatchObject({
+        archive_sha256: expect.any(String),
+        published_at: expect.any(Number),
+      });
+      const archivePath = path.join(path.dirname(storePath), archive?.archive_name ?? "");
+      expect(sha256(fs.readFileSync(archivePath))).toBe(archive?.archive_sha256);
+      const archivedContent = readSessionArchiveContentSync(archivePath);
+      const expectedContent = `${JSON.stringify(session.event)}\n`;
+      expect(Buffer.byteLength(archivedContent)).toBe(Buffer.byteLength(expectedContent));
+      expect(sha256(archivedContent)).toBe(sha256(expectedContent));
+    }
+  });
+
   it("commits a canonical archive before publishing its derived file", async () => {
     const sessionId = "durable-delete-session";
     const sessionKey = "agent:main:durable-delete";
@@ -682,7 +762,7 @@ function readArchiveLines(archivePath: string | undefined): string[] {
     .split("\n");
 }
 
-function sha256(content: string): string {
+function sha256(content: string | Uint8Array): string {
   return createHash("sha256").update(content).digest("hex");
 }
 

--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -18,11 +18,13 @@ import {
 import { planSessionLifecycleArtifactCleanup } from "./session-accessor.sqlite-lifecycle-state.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { runByteLimitedArchiveCleanupFixture } from "./test-helpers.js";
 import type { SessionEntry } from "./types.js";
 
 const archiveMaterializationHook = vi.hoisted(() => ({
   beforeMaterialize: undefined as (() => Promise<void>) | undefined,
   afterMaterialize: undefined as (() => void) | undefined,
+  onMaterialize: undefined as ((sessionIds: string[]) => void) | undefined,
 }));
 const archivePublicationHook = vi.hoisted(() => ({
   failNext: undefined as Error | undefined,
@@ -38,6 +40,7 @@ vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
       ...args: Parameters<typeof actual.materializeSessionStateDeletePlans>
     ) => {
       await archiveMaterializationHook.beforeMaterialize?.();
+      archiveMaterializationHook.onMaterialize?.(args[0].map((plan) => plan.sessionId));
       const result = await actual.materializeSessionStateDeletePlans(...args);
       archiveMaterializationHook.afterMaterialize?.();
       return result;
@@ -77,6 +80,7 @@ describe("SQLite lifecycle cleanup races", () => {
   afterEach(() => {
     archiveMaterializationHook.beforeMaterialize = undefined;
     archiveMaterializationHook.afterMaterialize = undefined;
+    archiveMaterializationHook.onMaterialize = undefined;
     archivePublicationHook.failNext = undefined;
     closeOpenClawAgentDatabasesForTest();
   });
@@ -848,6 +852,108 @@ describe("SQLite lifecycle cleanup races", () => {
       capped: 0,
     });
     expect(loadSessionEntry({ sessionKey, storePath })).toBeUndefined();
+  });
+
+  it("splits byte-limited cleanup into real worker batches", async () => {
+    const batches: string[][] = [];
+    archiveMaterializationHook.onMaterialize = (ids) => void batches.push(ids);
+    const ids = await runByteLimitedArchiveCleanupFixture(storePath);
+    expect(batches.toSorted((left, right) => left[0]!.localeCompare(right[0]!))).toEqual(
+      ids.toSorted((left, right) => left.localeCompare(right)).map((id) => [id]),
+    );
+  });
+  it("commits large maintenance cleanup in bounded retry-safe batches", async () => {
+    const entryCount = 66;
+    const historicalSessionId = "maintenance-batch-historical-session";
+    const sessionKeyById = new Map<string, string>();
+    const sessionKeys = Array.from(
+      { length: entryCount },
+      (_, index) => `agent:main:maintenance-batch-${String(index).padStart(2, "0")}`,
+    );
+    for (const [index, sessionKey] of sessionKeys.entries()) {
+      const sessionId = `maintenance-batch-session-${String(index).padStart(2, "0")}`;
+      sessionKeyById.set(sessionId, sessionKey);
+      await replaceSessionEntry(
+        { sessionKey, storePath },
+        { sessionId, updatedAt: Date.now() + index },
+      );
+      await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, [
+        { type: "session", id: sessionId, content: `batch transcript ${index}` },
+      ]);
+    }
+    const historicalOwnerKey = sessionKeys[entryCount - 2] ?? "";
+    await replaceTranscriptEvents(
+      { sessionKey: historicalOwnerKey, sessionId: historicalSessionId, storePath },
+      [{ type: "session", id: historicalSessionId, content: "historical batch transcript" }],
+    );
+
+    const batchSizes: number[] = [];
+    let currentBatchSessionIds: string[] = [];
+    let materializations = 0;
+    archiveMaterializationHook.onMaterialize = (sessionIds) => {
+      currentBatchSessionIds = sessionIds;
+      batchSizes.push(sessionIds.length);
+    };
+    let racedKey: string | undefined;
+    archiveMaterializationHook.afterMaterialize = () => {
+      materializations += 1;
+      if (materializations !== 2) {
+        return;
+      }
+      racedKey = sessionKeyById.get(currentBatchSessionIds[0] ?? "");
+      if (!racedKey) {
+        throw new Error("expected a maintenance entry in the second batch");
+      }
+      const current = loadSessionEntry({ sessionKey: racedKey, storePath });
+      if (!current) {
+        throw new Error("expected the raced maintenance entry to remain");
+      }
+      replaceSessionEntrySync(
+        { sessionKey: racedKey, storePath },
+        { ...current, label: "changed during batch materialization" },
+      );
+    };
+
+    const result = await applySessionEntryLifecycleMutation({
+      storePath,
+      maintenanceOverride: {
+        mode: "enforce",
+        maxEntries: 1,
+        pruneAfterMs: Number.MAX_SAFE_INTEGER,
+      },
+    });
+
+    expect(batchSizes).toEqual([64, 2]);
+    expect(result).toMatchObject({
+      beforeCount: entryCount,
+      afterCount: 3,
+      modelRunPruned: 0,
+      pruned: 0,
+      capped: 63,
+    });
+    expect(loadSessionEntry({ sessionKey: racedKey ?? "", storePath })).toMatchObject({
+      label: "changed during batch materialization",
+    });
+    expect(loadSessionEntry({ sessionKey: sessionKeys.at(-1) ?? "", storePath })).toBeDefined();
+    await expect(
+      loadTranscriptEvents({
+        sessionKey: historicalOwnerKey,
+        sessionId: historicalSessionId,
+        storePath,
+      }),
+    ).resolves.toEqual([]);
+    const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: "main",
+    }).path;
+    if (!databasePath) {
+      throw new Error("expected maintenance batch database path");
+    }
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    expect(
+      database.db
+        .prepare("SELECT 1 AS present FROM session_nodes WHERE session_key = ?")
+        .get(historicalOwnerKey),
+    ).toBeUndefined();
   });
 
   it("retains unplanned historical windows behind a placeholder node", async () => {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
@@ -9,6 +9,7 @@ import type { SessionEntry } from "./types.js";
 
 export type SessionEntryRemovalPlan = {
   expectedEntry: SessionEntry | undefined;
+  maintenanceReason?: "capped" | "model-run-pruned" | "pruned";
   sessionKey: string;
 };
 type SessionEntryMaintenanceCounts = {

--- a/src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts
@@ -1,0 +1,92 @@
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import {
+  applySessionEntryLifecycleMutation,
+  loadSessionEntry,
+  replaceSessionEntrySync,
+  replaceTranscriptEventsSync,
+} from "./session-accessor.js";
+
+const archiveMaterializationHook = vi.hoisted(() => ({
+  beforeMaterialize: undefined as (() => void) | undefined,
+}));
+
+vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
+  return {
+    ...actual,
+    materializeSessionStateDeletePlans: async (
+      ...args: Parameters<typeof actual.materializeSessionStateDeletePlans>
+    ) => {
+      archiveMaterializationHook.beforeMaterialize?.();
+      return await actual.materializeSessionStateDeletePlans(...args);
+    },
+  };
+});
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  archiveMaterializationHook.beforeMaterialize = undefined;
+  closeOpenClawAgentDatabasesForTest();
+});
+
+it("releases the store writer before maintenance archive sizing completes", async () => {
+  const tempDir = tempDirs.make("openclaw-session-maintenance-writer-");
+  const storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
+  const removedKey = "agent:main:maintenance-sizing-removed";
+  const writerKey = "agent:main:maintenance-sizing-writer";
+  replaceSessionEntrySync(
+    { sessionKey: removedKey, storePath },
+    { sessionId: "maintenance-sizing-removed", updatedAt: 1 },
+  );
+  replaceTranscriptEventsSync(
+    { sessionKey: removedKey, sessionId: "maintenance-sizing-removed", storePath },
+    [{ type: "session", id: "maintenance-sizing-removed", content: "archive me" }],
+  );
+  replaceSessionEntrySync(
+    { sessionKey: writerKey, storePath },
+    { sessionId: "maintenance-sizing-writer", updatedAt: Date.now() },
+  );
+
+  let writerCompleted = false;
+  let writerCompletedBeforeMaterialization = false;
+  archiveMaterializationHook.beforeMaterialize = () => {
+    writerCompletedBeforeMaterialization = writerCompleted;
+  };
+
+  const cleanup = applySessionEntryLifecycleMutation({
+    storePath,
+    maintenanceOverride: {
+      maxEntries: 1,
+      mode: "enforce",
+      pruneAfterMs: Number.MAX_SAFE_INTEGER,
+    },
+  });
+  const writer = applySessionEntryLifecycleMutation({
+    storePath,
+    skipMaintenance: true,
+    upserts: [
+      {
+        sessionKey: writerKey,
+        entry: {
+          sessionId: "maintenance-sizing-writer",
+          label: "progressed",
+          updatedAt: Date.now(),
+        },
+      },
+    ],
+  }).then((result) => {
+    writerCompleted = true;
+    return result;
+  });
+
+  await expect(cleanup).resolves.toMatchObject({ capped: 1 });
+  await writer;
+  expect(loadSessionEntry({ sessionKey: writerKey, storePath })).toMatchObject({
+    label: "progressed",
+  });
+  expect(writerCompletedBeforeMaterialization).toBe(true);
+});

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -1,6 +1,8 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { sql } from "kysely";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { getChildLogger } from "../../logging/logger.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
@@ -59,6 +61,162 @@ import type { SessionEntry } from "./types.js";
 
 // Live-entry pruning owner. Produces plans inside writes; finalizes archives afterward.
 
+const MAX_SESSION_MAINTENANCE_BATCH_ENTRIES = 64;
+const MAX_SESSION_MAINTENANCE_BATCH_ARCHIVE_BYTES = 64 * 1024 * 1024;
+const SESSION_TRANSCRIPT_BYTE_QUERY_BATCH = MAX_SESSION_MAINTENANCE_BATCH_ENTRIES;
+
+type SessionMaintenanceBatch = {
+  archiveBytes: number;
+  entryRemovals: SessionEntryMaintenancePlan["entryRemovals"];
+  stateDeletePlans: SessionStateDeletePlan[];
+  workItems: number;
+};
+
+function buildSessionMaintenanceBatches(params: {
+  archiveBytesBySessionId: ReadonlyMap<string, number>;
+  entryRemovals: SessionEntryMaintenancePlan["entryRemovals"];
+  stateDeletePlans: readonly SessionStateDeletePlan[];
+}): SessionMaintenanceBatch[] {
+  const parent = params.entryRemovals.map((_, index) => index);
+  const find = (index: number): number => {
+    let root = index;
+    while (parent[root] !== root) {
+      root = parent[root] ?? root;
+    }
+    let current = index;
+    while (parent[current] !== current) {
+      const next = parent[current] ?? root;
+      parent[current] = root;
+      current = next;
+    }
+    return root;
+  };
+  const union = (left: number, right: number): void => {
+    const leftRoot = find(left);
+    const rightRoot = find(right);
+    if (leftRoot !== rightRoot) {
+      parent[rightRoot] = leftRoot;
+    }
+  };
+
+  const removalIndexesBySessionId = new Map<string, number[]>();
+  const removalIndexBySessionKey = new Map<string, number>();
+  const addRemovalIndex = (sessionId: string, index: number): void => {
+    const indexes = removalIndexesBySessionId.get(sessionId) ?? [];
+    if (indexes.includes(index)) {
+      return;
+    }
+    if (indexes.length > 0) {
+      union(indexes[0] ?? index, index);
+    }
+    indexes.push(index);
+    removalIndexesBySessionId.set(sessionId, indexes);
+  };
+  for (const [index, removal] of params.entryRemovals.entries()) {
+    if (!removal.expectedEntry) {
+      continue;
+    }
+    removalIndexBySessionKey.set(removal.sessionKey, index);
+    for (const sessionId of collectSessionStateIdsForEntry(removal.expectedEntry)) {
+      addRemovalIndex(sessionId, index);
+    }
+  }
+  for (const plan of params.stateDeletePlans) {
+    const ownerIndex = plan.snapshot.sessionKey
+      ? removalIndexBySessionKey.get(plan.snapshot.sessionKey)
+      : undefined;
+    if (ownerIndex !== undefined) {
+      addRemovalIndex(plan.sessionId, ownerIndex);
+    }
+  }
+
+  const groupsByRoot = new Map<number, SessionMaintenanceBatch & { order: number }>();
+  for (const [index, removal] of params.entryRemovals.entries()) {
+    const root = find(index);
+    const group = groupsByRoot.get(root) ?? {
+      archiveBytes: 0,
+      entryRemovals: [],
+      order: index,
+      stateDeletePlans: [],
+      workItems: 0,
+    };
+    group.entryRemovals.push(removal);
+    group.order = Math.min(group.order, index);
+    groupsByRoot.set(root, group);
+  }
+
+  const plansBySessionId = new Map<string, SessionStateDeletePlan[]>();
+  for (const plan of params.stateDeletePlans) {
+    const plans = plansBySessionId.get(plan.sessionId) ?? [];
+    plans.push(plan);
+    plansBySessionId.set(plan.sessionId, plans);
+  }
+  const standaloneGroups: Array<SessionMaintenanceBatch & { order: number }> = [];
+  let standaloneOrder = params.entryRemovals.length;
+  for (const [sessionId, plans] of plansBySessionId) {
+    const removalIndex = removalIndexesBySessionId.get(sessionId)?.[0];
+    const removalGroup =
+      removalIndex === undefined ? undefined : groupsByRoot.get(find(removalIndex));
+    const group = removalGroup ?? {
+      archiveBytes: 0,
+      entryRemovals: [],
+      order: standaloneOrder++,
+      stateDeletePlans: [],
+      workItems: 0,
+    };
+    group.stateDeletePlans.push(...plans);
+    if (plans.some((plan) => plan.archiveTranscript)) {
+      group.archiveBytes += params.archiveBytesBySessionId.get(sessionId) ?? 0;
+    }
+    if (!removalGroup) {
+      standaloneGroups.push(group);
+    }
+  }
+
+  const groups = [...groupsByRoot.values(), ...standaloneGroups]
+    .map((group) => {
+      group.workItems = Math.max(
+        group.entryRemovals.length,
+        new Set(group.stateDeletePlans.map((plan) => plan.sessionId)).size,
+      );
+      return group;
+    })
+    .toSorted((left, right) => left.order - right.order);
+  const batches: SessionMaintenanceBatch[] = [];
+  let batch: SessionMaintenanceBatch = {
+    archiveBytes: 0,
+    entryRemovals: [],
+    stateDeletePlans: [],
+    workItems: 0,
+  };
+  const flush = (): void => {
+    if (batch.workItems === 0) {
+      return;
+    }
+    batches.push(batch);
+    batch = { archiveBytes: 0, entryRemovals: [], stateDeletePlans: [], workItems: 0 };
+  };
+  // Limits apply between ownership groups. One inseparable group may exceed them so shared or
+  // historical session state is never deleted in a different transaction from its last owner.
+  for (const group of groups) {
+    const exceedsEntryLimit =
+      batch.workItems > 0 &&
+      batch.workItems + group.workItems > MAX_SESSION_MAINTENANCE_BATCH_ENTRIES;
+    const exceedsByteLimit =
+      batch.workItems > 0 &&
+      batch.archiveBytes + group.archiveBytes > MAX_SESSION_MAINTENANCE_BATCH_ARCHIVE_BYTES;
+    if (exceedsEntryLimit || exceedsByteLimit) {
+      flush();
+    }
+    batch.archiveBytes += group.archiveBytes;
+    batch.entryRemovals.push(...group.entryRemovals);
+    batch.stateDeletePlans.push(...group.stateDeletePlans);
+    batch.workItems += group.workItems;
+  }
+  flush();
+  return batches;
+}
+
 function collectSqliteSessionMaintenanceBaseKeys(
   store: Record<string, SessionEntry>,
   activeSessionKey: string,
@@ -100,6 +258,44 @@ function hasStaleSqliteSessionEntryCandidate(
     }
     return isCandidate(normalizeStoreSessionKey(row.session_key), entry);
   });
+}
+
+async function readSessionTranscriptJsonlBytes(
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
+  sessionIds: readonly string[],
+): Promise<Map<string, number>> {
+  const bytesBySessionId = new Map<string, number>();
+  for (let offset = 0; offset < sessionIds.length; offset += SESSION_TRANSCRIPT_BYTE_QUERY_BATCH) {
+    const batch = sessionIds.slice(offset, offset + SESSION_TRANSCRIPT_BYTE_QUERY_BATCH);
+    // Give queued writers a turn between bounded read-only sizing batches.
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const opened = withOpenClawAgentDatabaseReadOnly((database) => {
+      const db = getSessionKysely(database.db);
+      return executeSqliteQuerySync(
+        database.db,
+        db
+          .selectFrom("transcript_events")
+          .select([
+            "session_id",
+            /* kysely-allow-raw: exact JSONL bytes bound maintenance worker batches. */
+            sql<number | bigint>`SUM(LENGTH(CAST(event_json AS BLOB)) + 1)`.as("jsonl_bytes"),
+          ])
+          .where("session_id", "in", batch)
+          .groupBy("session_id"),
+      ).rows;
+    }, toDatabaseOptions(scope));
+    if (!opened.found) {
+      throw new Error(
+        `Cannot size SQLite session transcripts: ${opened.reason.replaceAll("-", " ")}`,
+      );
+    }
+    for (const row of opened.value) {
+      bytesBySessionId.set(row.session_id, Number(row.jsonl_bytes));
+    }
+  }
+  return bytesBySessionId;
 }
 
 export function applySessionEntryMaintenance(
@@ -198,14 +394,25 @@ export function applySessionEntryMaintenance(
     }) ?? new Set<string>();
   const removedKeys = new Set<string>();
   const removedEntriesByKey = new Map<string, SessionEntry>();
+  const removalReasonsByKey = new Map<
+    string,
+    NonNullable<SessionEntryMaintenancePlan["entryRemovals"][number]["maintenanceReason"]>
+  >();
   const removedSessionIds = new Set<string>();
-  const rememberRemovedEntry = (removed: { key: string; entry: SessionEntry }) => {
-    removedKeys.add(removed.key);
-    removedEntriesByKey.set(removed.key, cloneSessionEntry(removed.entry));
-    for (const sessionId of collectSessionStateIdsForEntry(removed.entry)) {
-      removedSessionIds.add(sessionId);
-    }
-  };
+  const rememberRemovedEntry =
+    (
+      maintenanceReason: NonNullable<
+        SessionEntryMaintenancePlan["entryRemovals"][number]["maintenanceReason"]
+      >,
+    ) =>
+    (removed: { key: string; entry: SessionEntry }) => {
+      removedKeys.add(removed.key);
+      removedEntriesByKey.set(removed.key, cloneSessionEntry(removed.entry));
+      removalReasonsByKey.set(removed.key, maintenanceReason);
+      for (const sessionId of collectSessionStateIdsForEntry(removed.entry)) {
+        removedSessionIds.add(sessionId);
+      }
+    };
   let remainingEntryCount = entryCount;
   let modelRunPruned = 0;
   if (
@@ -217,7 +424,7 @@ export function applySessionEntryMaintenance(
   ) {
     modelRunPruned = pruneStaleModelRunEntries(store, maintenance.modelRunPruneAfterMs, {
       log: false,
-      onPruned: rememberRemovedEntry,
+      onPruned: rememberRemovedEntry("model-run-pruned"),
       preserveKeys,
       preserveRecentMs: maintenance.preserveRecentMs,
     });
@@ -238,7 +445,7 @@ export function applySessionEntryMaintenance(
   ) {
     pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
       log: false,
-      onPruned: rememberRemovedEntry,
+      onPruned: rememberRemovedEntry("pruned"),
       preserveKeys,
       preserveRecentMs: maintenance.preserveRecentMs,
     });
@@ -254,7 +461,7 @@ export function applySessionEntryMaintenance(
   ) {
     capped = capEntryCount(store, maintenance.maxEntries, {
       log: false,
-      onCapped: rememberRemovedEntry,
+      onCapped: rememberRemovedEntry("capped"),
       preserveKeys,
       preserveRecentMs: maintenance.preserveRecentMs,
     });
@@ -283,6 +490,7 @@ export function applySessionEntryMaintenance(
   return {
     entryRemovals: [...removedEntriesByKey].map(([sessionKey, entry]) => ({
       expectedEntry: entry,
+      maintenanceReason: removalReasonsByKey.get(sessionKey),
       sessionKey,
     })),
     stateDeletePlans: deletePlans,
@@ -323,62 +531,79 @@ async function finalizeSqliteSessionEntryMaintenancePlansWithCommit(
 ): Promise<SessionEntryMaintenanceResult> {
   const entryRemovals = plans.flatMap((plan) => plan.entryRemovals);
   const stateDeletePlans = plans.flatMap((plan) => plan.stateDeletePlans);
-  const warn = (message: string, error: unknown) => {
+  const warn = (
+    message: string,
+    error: unknown,
+    warnedStateDeletePlans: readonly SessionStateDeletePlan[],
+  ) => {
     getChildLogger({ subsystem: "session-sqlite" }).warn(message, {
       agentId: scope.agentId,
       error,
       path: scope.path,
-      sessionIds: uniqueStrings(stateDeletePlans.map((plan) => plan.sessionId)),
+      sessionIds: uniqueStrings(warnedStateDeletePlans.map((plan) => plan.sessionId)),
     });
   };
-  const committedCounts = plans.reduce(
-    (counts, plan) => ({
-      archived: counts.archived + plan.archived,
-      modelRunPruned: counts.modelRunPruned + plan.modelRunPruned,
-      pruned: counts.pruned + plan.pruned,
-      capped: counts.capped + plan.capped,
-    }),
-    { archived: 0, modelRunPruned: 0, pruned: 0, capped: 0 },
-  );
-  const emptyResult: SessionEntryMaintenanceResult = {
-    archivedTranscripts: [],
-    archived: committedCounts.archived,
+  const committedCounts = {
+    archived: plans.reduce((count, plan) => count + plan.archived, 0),
     modelRunPruned: 0,
     pruned: 0,
     capped: 0,
   };
   if (entryRemovals.length === 0 && stateDeletePlans.length === 0) {
-    return emptyResult;
-  }
-  let archivedTranscripts: SessionLifecycleArchivedTranscript[];
-  try {
-    const materializedPlans = await materializeSessionStateDeletePlans(stateDeletePlans);
-    archivedTranscripts = await commit(() => {
-      let committed: SessionLifecycleArchivedTranscript[] = [];
-      runOpenClawAgentWriteTransaction((database) => {
-        assertPlannedLifecycleArtifactEntriesUnchanged(database, entryRemovals);
-        committed = deleteMaterializedSessionStatePlans(
-          database,
-          materializedPlans,
-          undefined,
-          new Set(entryRemovals.map((removal) => removal.sessionKey)),
-        );
-        deletePlannedLifecycleArtifactEntries(database, entryRemovals);
-      }, toDatabaseOptions(scope));
-      return committed;
-    });
-  } catch (error) {
-    warn("SQLite session maintenance cleanup failed", error);
-    return emptyResult;
-  }
-  emitCommittedSessionEntryRemovals(entryRemovals);
-  try {
-    return {
-      archivedTranscripts: await publishSessionStateArchives(scope, archivedTranscripts),
-      ...committedCounts,
-    };
-  } catch (error) {
-    warn("SQLite session maintenance archive publication failed", error);
     return { archivedTranscripts: [], ...committedCounts };
   }
+  let archiveBytesBySessionId: Map<string, number>;
+  try {
+    archiveBytesBySessionId = await readSessionTranscriptJsonlBytes(
+      scope,
+      stateDeletePlans.filter((plan) => plan.archiveTranscript).map((plan) => plan.sessionId),
+    );
+  } catch (error) {
+    warn("SQLite session maintenance archive sizing failed", error, stateDeletePlans);
+    return { archivedTranscripts: [], ...committedCounts };
+  }
+  const publishedTranscripts: SessionLifecycleArchivedTranscript[] = [];
+  for (const batch of buildSessionMaintenanceBatches({
+    archiveBytesBySessionId,
+    entryRemovals,
+    stateDeletePlans,
+  })) {
+    let archivedTranscripts: SessionLifecycleArchivedTranscript[];
+    try {
+      const materializedPlans = await materializeSessionStateDeletePlans(batch.stateDeletePlans);
+      archivedTranscripts = await commit(() => {
+        let committed: SessionLifecycleArchivedTranscript[] = [];
+        runOpenClawAgentWriteTransaction((database) => {
+          assertPlannedLifecycleArtifactEntriesUnchanged(database, batch.entryRemovals);
+          committed = deleteMaterializedSessionStatePlans(
+            database,
+            materializedPlans,
+            undefined,
+            new Set(batch.entryRemovals.map((removal) => removal.sessionKey)),
+          );
+          deletePlannedLifecycleArtifactEntries(database, batch.entryRemovals);
+        }, toDatabaseOptions(scope));
+        return committed;
+      });
+    } catch (error) {
+      warn("SQLite session maintenance cleanup failed", error, batch.stateDeletePlans);
+      break;
+    }
+    emitCommittedSessionEntryRemovals(batch.entryRemovals);
+    for (const removal of batch.entryRemovals) {
+      if (removal.maintenanceReason === "model-run-pruned") {
+        committedCounts.modelRunPruned += 1;
+      } else if (removal.maintenanceReason === "pruned") {
+        committedCounts.pruned += 1;
+      } else if (removal.maintenanceReason === "capped") {
+        committedCounts.capped += 1;
+      }
+    }
+    try {
+      publishedTranscripts.push(...(await publishSessionStateArchives(scope, archivedTranscripts)));
+    } catch (error) {
+      warn("SQLite session maintenance archive publication failed", error, batch.stateDeletePlans);
+    }
+  }
+  return { archivedTranscripts: publishedTranscripts, ...committedCounts };
 }

--- a/src/config/sessions/test-helpers.ts
+++ b/src/config/sessions/test-helpers.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach } from "vitest";
+import { applySessionEntryLifecycleMutation, replaceSessionEntry } from "./session-accessor.js";
+import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 
 /** Creates and cleans a temporary session store fixture around each test. */
 export function useTempSessionsFixture(prefix: string) {
@@ -25,4 +27,29 @@ export function useTempSessionsFixture(prefix: string) {
     storePath: () => storePath,
     sessionsDir: () => sessionsDir,
   };
+}
+
+export async function runByteLimitedArchiveCleanupFixture(storePath: string): Promise<string[]> {
+  const sessionIds = ["worker-byte-session-0", "worker-byte-session-1"];
+  const largeContent = "x".repeat(33 * 1024 * 1024);
+  for (const [index, sessionId] of sessionIds.entries()) {
+    const sessionKey = `agent:main:worker-byte-${index}`;
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: index });
+    await replaceTranscriptEvents({ sessionId, sessionKey, storePath }, [
+      { content: `${index}:${largeContent}`, id: sessionId, type: "session" },
+    ]);
+  }
+  await replaceSessionEntry(
+    { sessionKey: "agent:main:worker-byte-retained", storePath },
+    { sessionId: "worker-byte-session-retained", updatedAt: sessionIds.length },
+  );
+  await applySessionEntryLifecycleMutation({
+    storePath,
+    maintenanceOverride: {
+      maxEntries: 1,
+      mode: "enforce",
+      pruneAfterMs: Number.MAX_SAFE_INTEGER,
+    },
+  });
+  return sessionIds;
 }


### PR DESCRIPTION
Closes #126647

## What Problem This Solves

Operators running `openclaw sessions cleanup --enforce` on a large retained-session backlog could wait indefinitely or exhaust the Node heap because every transcript archive was sent through one worker invocation.

## Why This Change Was Made

The SQLite maintenance owner now processes removal and archive plans in bounded batches: at most 64 unique work items and 64 MiB of raw JSONL per separable batch. Each batch materializes, revalidates, commits its canonical archives and deletions, publishes derived files, and releases its buffers before the next batch.

Shared and historical transcript generations remain in one atomic ownership group, using the existing snapshot's `session_key`, so batching cannot delete state separately from its last owner. A failed later batch reports only previously committed removals and leaves the rest retryable. There are no configuration, schema, provider, or public CLI contract changes.

The branch is based on upstream `main` at `998128abd85b76ee2ac57211a87df1ae3ff592f6`, including its owner-complete session-store reader. The reviewed six-file change is one DCO-signed commit.

## User Impact

Large cleanup runs can make durable incremental progress without building one backlog-sized structured-clone payload. Small cleanup behavior is unchanged, and archive publication remains best-effort after the canonical SQLite archive is committed.

## Evidence

Current exact head: `5e4d36117c173abe8bac83098e6ea8801ee24bc0`.

- A failing-before regression on the old writer-bound sizing path showed the queued writer had not completed when archive materialization began (`expected true`, received `false`). The same regression passes after sizing is moved to bounded read-only work following writer release.
- A failing-before regression on pre-fix code showed the real maintenance path sent one 65-plan worker batch (`expected [64, 1]`, received `[65]`).
- The 66-entry retry/race regression observes bounded `64 + 2` materialization, commits completed work, injects a second-batch compare-and-delete race, preserves raced state, and verifies historical cleanup.
- The byte-limit regression creates two real approximately 33 MiB transcripts and observes two singleton materializer calls. Removing the 64 MiB split makes this test fail.
- A separate no-mock worker regression retains byte-for-byte canonical archive, publication, compressed SHA-256, decoded-length/hash, deletion, and retained-state checks.
- Exact-head fork CI [run 32774353474](https://github.com/openclaw/openclaw/actions/runs/32774353474) completed successfully: 186 jobs passed, 14 manifest-disabled jobs skipped, with zero failures or cancellations.
- The green run includes production and test type checks, all core lint shards, session accessor/transcript/schema boundary checks, the dedicated built-CLI SQLite session lifecycle job, and the aggregate `openclaw/ci-gate`.
- `oxfmt --check` and `git diff --check` pass on the exact head.
- The cumulative PR diff contains six session implementation and test-support files only.

### Real CLI proof

I created a disposable local SQLite store through OpenClaw's production session APIs with two approximately 33 MiB transcripts and one newer retained session. I used an isolated config/state directory and the real source CLI; no personal store, credentials, or external service was used. The generated store was deleted afterward.

```text
$ openclaw sessions cleanup --dry-run --store <temp>/openclaw-agent.sqlite --json
beforeCount=3 afterCount=1 capped=2 wouldMutate=true

$ openclaw sessions cleanup --enforce --store <temp>/openclaw-agent.sqlite --json
beforeCount=3 afterCount=1 capped=2 applied=true exit=0 elapsed=63.12s

$ verify-disposable-store
archiveRows=2 publishedRows=2 removedEntries=2 removedTranscripts=2 retained=true verifiedHashes=2
```

The post-run verifier independently queried the canonical archive rows, checked both publication timestamps, confirmed both entry/transcript deletions, confirmed the retained session, and matched both compressed archive files to their stored SHA-256 values.

## Deliberate Boundary

One inseparable ownership group may exceed a batch limit. This is intentional: splitting one transcript or shared ownership component would require a new chunked archive format and transaction protocol, and doing it here would weaken the existing archive-before-delete guarantee. This PR bounds ordinary multi-session backlogs while preserving that atomic safety invariant.

## Local Validation Limits

Linux exact-head CI is authoritative. Five plugin-SDK owner regressions on Windows reached their shared temporary-directory cleanup and then failed with `EPERM`; no behavioral assertion failed.

AI-assisted: Codex helped trace the owner path, implement the change, and build the regressions. I reviewed the batching, transaction, snapshot, archive, retry, merge-resolution, and test behavior and understand the submitted code.
