### PR TITLE
fix(ai): retain compaction-only replay checkpoints

### DIFF
--- a/packages/ai/src/transports/provider-compaction-replay.test.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.test.ts
@@ -110,6 +110,13 @@ describe("compaction replay owner rewrites", () => {
     expect(JSON.stringify(input)).toContain("full history prefix");
   });
 
+  it("keeps a compaction-only checkpoint through an unchanged empty-content projection", () => {
+    const owner = createAssistant([], 0);
+    const projected = replaceCompactionReplayOwnerContent(owner, []);
+
+    expect(projected.providerReplay).toBe(owner.providerReplay);
+  });
+
   it("keeps retained-user checkpoints independent of owner content indexes", () => {
     const retained = createAssistant([{ type: "text", text: "removed owner output" }], 0);
     const providerReplay = retained.providerReplay;

--- a/packages/ai/src/transports/provider-compaction-replay.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.ts
@@ -44,6 +44,12 @@ export function replaceCompactionReplayOwnerContent(
     // This checkpoint is anchored to retained user turns, not assistant content indexes.
     return next;
   }
+  if (
+    content.length === message.content.length &&
+    content.every((block, index) => block === message.content[index])
+  ) {
+    return next;
+  }
   const replayIndex = replay.replayIndex ?? 0;
   if (content.length === 0 || replayIndex > message.content.length) {
     return stripCompactionReplayCheckpoint(next);

--- a/packages/ai/src/transports/provider-compaction-replay.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.ts
@@ -44,14 +44,11 @@ export function replaceCompactionReplayOwnerContent(
     // This checkpoint is anchored to retained user turns, not assistant content indexes.
     return next;
   }
-  if (
-    content.length === message.content.length &&
-    content.every((block, index) => block === message.content[index])
-  ) {
-    return next;
-  }
   const replayIndex = replay.replayIndex ?? 0;
-  if (content.length === 0 || replayIndex > message.content.length) {
+  if (
+    (content.length === 0 && message.content.length > 0) ||
+    replayIndex > message.content.length
+  ) {
     return stripCompactionReplayCheckpoint(next);
   }
   let sourceIndex = 0;

--- a/test/embedded-transcript-cursor.e2e.test.ts
+++ b/test/embedded-transcript-cursor.e2e.test.ts
@@ -43,7 +43,10 @@ describe("embedded transcript cursor settlement", () => {
       const instance = await createOpenClawTestInstance({
         name: "embedded-transcript-cursor",
         config: createTestConfig(modelServer.baseUrl),
-        env: { OPENCLAW_SKIP_PROVIDERS: undefined },
+        env: {
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
       });
       instances.push(instance);
       await instance.startGateway();

--- a/test/gateway-openai-compaction-replay.e2e.test.ts
+++ b/test/gateway-openai-compaction-replay.e2e.test.ts
@@ -50,6 +50,7 @@ describe("Gateway OpenAI Responses compaction replay", () => {
         env: {
           OPENCLAW_DEBUG_MODEL_TRANSPORT: "1",
           OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
         },
       });
       instances.push(instance);

--- a/test/gateway-openai-compaction-replay.e2e.test.ts
+++ b/test/gateway-openai-compaction-replay.e2e.test.ts
@@ -50,7 +50,6 @@ describe("Gateway OpenAI Responses compaction replay", () => {
         env: {
           OPENCLAW_DEBUG_MODEL_TRANSPORT: "1",
           OPENCLAW_SKIP_PROVIDERS: undefined,
-          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
         },
       });
       instances.push(instance);


### PR DESCRIPTION
## Summary

- preserve an OpenAI Responses compaction checkpoint when a sanitizer projects an unchanged empty assistant body
- keep stripping the checkpoint when previously present owner content is actually removed
- run the compaction replay Gateway E2E with the full prepared runtime lifecycle

## Root cause

OpenAI Responses can finish a turn with only a provider compaction item, so the durable assistant owner legitimately has `content: []` plus `providerReplay`. The shared image/history sanitizer projects assistant content into a fresh array before the next request. `replaceCompactionReplayOwnerContent` treated every empty projected array as destructive content removal and stripped the checkpoint, even when both the source and projection were unchanged empty arrays.

The transport then received the original user history and continuation prompt without the compaction item. The fix belongs in the shared replay-owner rewrite helper: unchanged projections retain provider state, while actual removals still invalidate prefix-bound state.

This PR is stacked on #127094 so that the E2E reaches the model transport. #127094 now remains focused on the independent prepared-runtime publication failure in the embedded cursor E2E; this PR owns the compaction test's full-startup opt-in and replay repair.

## Proof

Pre-fix, in the original run order after enabling full startup:

```text
OPENCLAW_E2E_WORKERS=1 node scripts/run-vitest.mjs \
  test/gateway-openai-compaction-replay.e2e.test.ts \
  test/embedded-transcript-cursor.e2e.test.ts

gateway-openai-compaction-replay: expected request 2 to contain
{ type: "compaction", id: "cmp_gateway_replay", encrypted_content: "opaque-gateway-compaction" }
```

Post-fix:

```text
OPENCLAW_E2E_SKIP_BUILD=1 OPENCLAW_E2E_WORKERS=1 node scripts/run-vitest.mjs test/gateway-openai-compaction-replay.e2e.test.ts
Test Files  1 passed (1)
Tests       1 passed (1)
```

Additional verification:

```text
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts \
  packages/ai/src/transports/provider-compaction-replay.test.ts
Test Files  2 passed (2)
Tests       27 passed (27)

node scripts/check-changed.mjs -- \
  packages/ai/src/transports/provider-compaction-replay.ts \
  packages/ai/src/transports/provider-compaction-replay.test.ts
passed

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/fix/prepared-runtime-e2e
autoreview clean: no accepted/actionable findings reported (0.99)
```

Original release-validation failure: https://github.com/openclaw/openclaw/actions/runs/32457175968/job/96697080014

## Scope

- Architectural owner: shared provider compaction replay rewrite helper
- Siblings covered: generic replay owner rewrite tests plus the image/history sanitizer lane
- Production delta: +6/-0; tests/config: +8/-0
- No schema, protocol, config contract, or extended-stable changes
