### PR TITLE
fix: keep Mantis Telegram proof running and honest

### DIFF
--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -10,7 +10,7 @@ continuous event recording, capture, and cleanup.
 - Do not read prepared worktrees. Pass their exact paths only to the lane helper.
 - Write only under `MANTIS_OUTPUT_DIR`.
 - Never invent a pass, hide an attempt, edit trusted facts/media, or use old chat history.
-- A visible defect is a failure. A missing harness capability is `block`, not a pass.
+- A visible defect is a failure. An unproven comparison is `block`, not a pass.
 
 ## Design the proof
 
@@ -65,13 +65,13 @@ Use `$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD` with `--lane baseline|candidate`:
 - `delete --message-id ID` (only user messages sent in this session)
 - `view --message-id ID` (scroll Desktop to the exact Telegram server message)
 - `screenshot` (returns a public inspection PNG)
-- `finish --focus-message-id ID` (focus again, stop, capture, publish facts)
-- `block --missing-primitive NAME --reason TEXT` (clean stop-report)
+- `finish [--focus-message-id ID]` (focus the named message or the latest sent message, stop, capture, publish facts)
+- `block --reason TEXT [--missing-primitive NAME]` (clean stop-report)
 - `abort` (cleanup after scenario failure)
 
 `start` returns the exact command/budget list. No generic exec/eval or raw
-Telegram API exists. If a required action is absent, use `block`; do not route
-around the credential boundary.
+Telegram API exists. If the comparison cannot prove the PR's visible behavior,
+use `block` and say why.
 Raw response events must form a complete provider response; deltas alone do not
 produce a final answer. Copy the terminal item and completed-response structure
 from `responseEvents` in `scripts/e2e/mock-openai-server.mjs`, and use
@@ -94,6 +94,12 @@ timing matters; use one `turn` for an ordinary exchange.
 
 Run comparable baseline and candidate programs. This proof has no skipped lane:
 each side ends as complete, failed, or blocked with its own trusted facts.
+Use the same scenario inputs in both lanes; only the SUT revision changes. A
+baseline lane that reproduces the defect is a successful capture. A PR-level
+pass claim requires an observed, material baseline/candidate difference caused
+by the changed behavior. Identical relevant observations are unproven: use
+`block`, never claim the PR fixed them. When the expected result is silence,
+focus the session-owned user message that triggered the silent outcome.
 
 ## Judge and publish
 

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -100,6 +100,8 @@ pass claim requires an observed, material baseline/candidate difference caused
 by the changed behavior. Identical relevant observations are unproven: use
 `block`, never claim the PR fixed them. When the expected result is silence,
 focus the session-owned user message that triggered the silent outcome.
+Decide before finalizing each lane. If its setup did not exercise the intended
+behavior, call `block`; do not call `finish` and describe the block only in prose.
 
 ## Judge and publish
 

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -108,7 +108,7 @@ behavior, call `block`; do not call `finish` and describe the block only in pros
 Inspect `mantis-lane-facts.json`, every returned event/request, the inspection
 PNG, final PNG, and cropped GIF. Confirm the evaluated message is fully visible
 near the bottom and the recording covers the behavior—not only its final state.
-Iterate within the three-attempt budget; all attempts remain recorded.
+Iterate as needed; all attempts remain recorded.
 
 Build `mantis-evidence.json` with
 `scripts/mantis/build-telegram-desktop-proof-evidence.mts` as before, using each

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -956,7 +956,7 @@ jobs:
               sudo jq -e '
                 .sendCount >= 1 and (.focusMessageId | test("^[0-9]+$")) and
                 .observation.truncated == false and
-                (.focusMessageId as $focus | any(.observation.events[]; .messageId == $focus and .actor == "bot")) and
+                (.focusMessageId as $focus | any(.observation.events[]; .messageId == $focus and (.actor == "user" or .actor == "bot"))) and
                 any(.invocations[]; .command == "send") and
                 any(.invocations[]; .command == "finish") and
                 (.artifacts.screenshot.bytes > 10000) and
@@ -966,7 +966,7 @@ jobs:
             fi
             if [[ "$fact_status" == "blocked" ]]; then
               sudo jq -e '
-                (.blocked.name | type) == "string" and (.blocked.name | length) > 0 and (.blocked.name | length) <= 200 and
+                (.blocked.name == null or ((.blocked.name | type) == "string" and (.blocked.name | length) > 0 and (.blocked.name | length) <= 200)) and
                 (.blocked.reason | type) == "string" and (.blocked.reason | length) > 0 and (.blocked.reason | length) <= 2000
               ' "$verdict" >/dev/null
               lane_status="blocked"

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -325,6 +325,9 @@ jobs:
           node_modules/.bin/esbuild scripts/e2e/telegram-bot-api-proxy.ts \
             --bundle --platform=node --format=esm --target=node24 \
             --outfile="$toolchain_build/scripts/e2e/telegram-bot-api-proxy.mjs"
+          node_modules/.bin/esbuild scripts/e2e/mock-openai-server.mjs \
+            --bundle --platform=node --format=esm --target=node24 \
+            --outfile="$toolchain_build/scripts/e2e/mock-openai-server.mjs"
           node_modules/.bin/esbuild scripts/e2e/telegram-desktop-recorder.ts \
             --bundle --platform=node --format=esm --target=node24 \
             --outfile="$toolchain_build/scripts/e2e/telegram-desktop-recorder.mjs"
@@ -431,6 +434,8 @@ jobs:
             /usr/local/lib/mantis-toolchain/scripts/e2e/telegram-mantis-lane.mjs
           sudo install -m 0444 "$toolchain_build/scripts/e2e/telegram-bot-api-proxy.mjs" \
             /usr/local/lib/mantis-toolchain/scripts/e2e/telegram-bot-api-proxy.mjs
+          sudo install -m 0444 "$toolchain_build/scripts/e2e/mock-openai-server.mjs" \
+            /usr/local/lib/mantis-toolchain/scripts/e2e/mock-openai-server.mjs
           sudo install -m 0444 "$toolchain_build/scripts/e2e/telegram-desktop-recorder.mjs" \
             /usr/local/lib/mantis-toolchain/scripts/e2e/telegram-desktop-recorder.mjs
           sudo ln -s /usr/bin/ffmpeg /usr/local/lib/mantis-toolchain/ffmpeg

--- a/scripts/e2e/telegram-desktop-crabbox.ts
+++ b/scripts/e2e/telegram-desktop-crabbox.ts
@@ -580,6 +580,7 @@ export async function createMotionPreview(params: {
 }
 
 export async function createCroppedMotionPreview(params: {
+  crabboxBin: string;
   crop: TelegramCrop;
   croppedGifPath: string;
   croppedVideoPath: string;
@@ -591,40 +592,39 @@ export async function createCroppedMotionPreview(params: {
   const run = params.run ?? runCommand;
   const crop = `crop=${params.crop.width}:${params.crop.height}:${params.crop.x}:${params.crop.y}`;
   const scale = `scale=${params.crop.cropWidth}:-2:flags=lanczos`;
-  await run({
-    args: [
-      "-y",
-      "-hide_banner",
-      "-loglevel",
-      "warning",
-      "-i",
-      params.videoPath,
-      "-vf",
-      `${crop},${scale}`,
-      "-pix_fmt",
-      "yuv420p",
-      params.croppedVideoPath,
-    ],
-    command: "ffmpeg",
-    cwd: params.cwd,
-    stdio: "inherit",
-  });
-  await run({
-    args: [
-      "-y",
-      "-hide_banner",
-      "-loglevel",
-      "warning",
-      "-i",
-      params.videoPath,
-      "-filter_complex",
-      `${crop},fps=${params.fps},${scale},split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse`,
-      params.croppedGifPath,
-    ],
-    command: "ffmpeg",
-    cwd: params.cwd,
-    stdio: "inherit",
-  });
+  const croppedSourcePath = `${params.croppedVideoPath}.source.mp4`;
+  try {
+    await run({
+      args: [
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "warning",
+        "-i",
+        params.videoPath,
+        "-vf",
+        `${crop},${scale}`,
+        "-pix_fmt",
+        "yuv420p",
+        croppedSourcePath,
+      ],
+      command: "ffmpeg",
+      cwd: params.cwd,
+      stdio: "inherit",
+    });
+    await createMotionPreview({
+      crabboxBin: params.crabboxBin,
+      cwd: params.cwd,
+      fps: params.fps,
+      gifPath: params.croppedGifPath,
+      run,
+      trimmedVideoPath: params.croppedVideoPath,
+      videoPath: croppedSourcePath,
+      width: params.crop.cropWidth,
+    });
+  } finally {
+    fs.rmSync(croppedSourcePath, { force: true });
+  }
   return { crop, fps: params.fps, outputWidth: params.crop.cropWidth };
 }
 

--- a/scripts/e2e/telegram-desktop-recorder.ts
+++ b/scripts/e2e/telegram-desktop-recorder.ts
@@ -53,8 +53,7 @@ export {
 const REMOTE_ROOT = "/tmp/openclaw-telegram-desktop-recorder";
 const TELEGRAM_BINARY = "/opt/Telegram/Telegram";
 const TELEGRAM_WORKDIR = `${REMOTE_ROOT}/desktop`;
-const DEFAULT_PREVIEW_FPS = 24;
-const DEFAULT_PREVIEW_WIDTH = 1920;
+const DEFAULT_PREVIEW_FPS = 4;
 const PROOF_VIEWPORT_HEIGHT = 600;
 
 function proofViewport(window: RecorderSession["window"]): {
@@ -942,47 +941,47 @@ export async function stopRecorder(
   }
   const motionVideoPath = path.join(outputDir, "telegram-desktop-recorder-session-motion.mp4");
   const motionGifPath = path.join(outputDir, "telegram-desktop-recorder-session-motion.gif");
-  // Previews read the recovered recording; with no lease there is no video to
-  // trim, and running ffmpeg on the missing file would fail an otherwise
-  // complete cleanup.
+  // A missing lease produces no local video, so there is no preview to build.
   if (artifacts.video) {
-    await attempt("motion preview", async () => {
-      await operations.createMotionPreview({
-        crabboxBin,
-        cwd,
-        fps: DEFAULT_PREVIEW_FPS,
-        gifPath: motionGifPath,
-        run: operations.runCommand,
-        trimmedVideoPath: motionVideoPath,
-        videoPath,
-        width: DEFAULT_PREVIEW_WIDTH,
+    if (opts.crop === "telegram-window") {
+      const croppedVideoPath = path.join(
+        outputDir,
+        "telegram-desktop-recorder-session-motion-telegram-window.mp4",
+      );
+      const croppedGifPath = path.join(
+        outputDir,
+        "telegram-desktop-recorder-session-motion-telegram-window.gif",
+      );
+      await attempt("cropped motion preview", async () => {
+        await operations.createCroppedMotionPreview({
+          crabboxBin,
+          crop: proofViewport(session.window),
+          croppedGifPath,
+          croppedVideoPath,
+          cwd,
+          fps: DEFAULT_PREVIEW_FPS,
+          run: operations.runCommand,
+          videoPath,
+        });
+        artifacts.previewGifCropped = croppedGifPath;
+        artifacts.trimmedVideoCropped = croppedVideoPath;
       });
-      artifacts.previewGif = motionGifPath;
-      artifacts.trimmedVideo = motionVideoPath;
-    });
-  }
-  if (opts.crop === "telegram-window" && artifacts.trimmedVideo) {
-    const croppedVideoPath = path.join(
-      outputDir,
-      "telegram-desktop-recorder-session-motion-telegram-window.mp4",
-    );
-    const croppedGifPath = path.join(
-      outputDir,
-      "telegram-desktop-recorder-session-motion-telegram-window.gif",
-    );
-    await attempt("cropped motion preview", async () => {
-      await operations.createCroppedMotionPreview({
-        crop: proofViewport(session.window),
-        croppedGifPath,
-        croppedVideoPath,
-        cwd,
-        fps: DEFAULT_PREVIEW_FPS,
-        run: operations.runCommand,
-        videoPath: motionVideoPath,
+    } else {
+      await attempt("motion preview", async () => {
+        await operations.createMotionPreview({
+          crabboxBin,
+          cwd,
+          fps: DEFAULT_PREVIEW_FPS,
+          gifPath: motionGifPath,
+          run: operations.runCommand,
+          trimmedVideoPath: motionVideoPath,
+          videoPath,
+          width: 1920,
+        });
+        artifacts.previewGif = motionGifPath;
+        artifacts.trimmedVideo = motionVideoPath;
       });
-      artifacts.previewGifCropped = croppedGifPath;
-      artifacts.trimmedVideoCropped = croppedVideoPath;
-    });
+    }
   }
   // --keep-box keeps the whole debugging surface: the Desktop authorization stays
   // valid for WebVNC until the operator finishes; a later `stop` without it revokes.

--- a/scripts/e2e/telegram-mantis-lane.ts
+++ b/scripts/e2e/telegram-mantis-lane.ts
@@ -52,7 +52,7 @@ const sutRuntimeSchema = sutRecoverySchema
   })
   .passthrough();
 const startupSessionSchema = z.object({
-  attempt: z.number().int().positive().max(3),
+  attempt: z.number().int().positive(),
   lane: laneSchema,
   observerPidFile: z.string(),
   observerRequested: z.boolean(),
@@ -74,7 +74,7 @@ const recorderArtifactsSchema = z.object({
   artifacts: z.record(z.string(), z.string()),
 });
 const activeSessionSchema = z.object({
-  attempt: z.number().int().positive().max(3),
+  attempt: z.number().int().positive(),
   config: configSchema,
   invocations: z.array(invocationSchema),
   lane: laneSchema,
@@ -106,7 +106,6 @@ type ObserverResponse = {
   truncated?: boolean;
 } & Record<string, unknown>;
 
-const MAX_ATTEMPTS = 3;
 const MAX_SENDS = 12;
 const MAX_RPC_BYTES = 4 * 1024 * 1024;
 const commandOptions: Record<string, readonly string[]> = {
@@ -653,9 +652,6 @@ async function startLane(values: Map<string, string>, roots: Roots): Promise<voi
   const attemptsRoot = path.join(roots.sessionRoot, "attempts", lane);
   fs.mkdirSync(attemptsRoot, { recursive: true });
   const attempt = fs.readdirSync(attemptsRoot).filter((entry) => /^\d+$/u.test(entry)).length + 1;
-  if (attempt > MAX_ATTEMPTS) {
-    throw new Error(`${lane} already used its ${MAX_ATTEMPTS} allowed attempts.`);
-  }
   const privateDir = path.join(attemptsRoot, String(attempt));
   fs.mkdirSync(privateDir, { mode: 0o770 });
   const recorderSession = path.join(privateDir, "recorder.json");

--- a/scripts/e2e/telegram-mantis-lane.ts
+++ b/scripts/e2e/telegram-mantis-lane.ts
@@ -20,15 +20,15 @@ import {
 } from "./telegram-mantis-sut.ts";
 
 const execFileAsync = promisify(execFile);
-const MAX_SESSION_MS = 15 * 60_000;
+const MAX_MOCK_DELAY_MS = 15 * 60_000;
 const laneSchema = z.enum(["baseline", "candidate"]);
 const configSchema = z.object({
   configPatch: z.record(z.string(), z.unknown()).optional(),
   mockResponse: z.string().min(1).max(100_000),
-  mockResponseChunkDelayMs: z.number().int().positive().max(MAX_SESSION_MS).optional(),
+  mockResponseChunkDelayMs: z.number().int().positive().max(MAX_MOCK_DELAY_MS).optional(),
 });
 const mockResponseControlSchema = z.object({
-  chunkDelayMs: z.number().int().min(0).max(MAX_SESSION_MS).optional(),
+  chunkDelayMs: z.number().int().min(0).max(MAX_MOCK_DELAY_MS).optional(),
   events: z.array(z.record(z.string(), z.unknown())).min(1).optional(),
   hold: z.boolean().optional(),
   text: z.string().min(1).max(100_000).optional(),
@@ -108,7 +108,6 @@ type ObserverResponse = {
 
 const MAX_ATTEMPTS = 3;
 const MAX_SENDS = 12;
-const MAX_OBSERVE_SECONDS = MAX_SESSION_MS / 1000;
 const MAX_RPC_BYTES = 4 * 1024 * 1024;
 const commandOptions: Record<string, readonly string[]> = {
   abort: ["--lane"],
@@ -286,16 +285,12 @@ function readStartup(sessionRoot: string, lane: Lane): StartupSession {
   return startupSessionSchema.parse(readJson(startupFile(sessionRoot, lane)));
 }
 
-function readActive(sessionRoot: string, lane: Lane, allowExpired = false): ActiveSession {
+function readActive(sessionRoot: string, lane: Lane): ActiveSession {
   const file = activeFile(sessionRoot, lane);
   if (!fs.existsSync(file)) {
     throw new Error(`No active ${lane} lane. Run start first.`);
   }
-  const state = activeSessionSchema.parse(readJson(file));
-  if (!allowExpired && Date.now() - Date.parse(state.startedAt) > MAX_SESSION_MS) {
-    throw new Error(`${lane} exceeded its 15-minute session budget; run abort.`);
-  }
-  return state;
+  return activeSessionSchema.parse(readJson(file));
 }
 
 function saveActive(sessionRoot: string, state: ActiveSession): void {
@@ -806,9 +801,7 @@ async function startLane(values: Map<string, string>, roots: Roots): Promise<voi
       lane,
       status: "ready",
       budgets: {
-        maxObserveSeconds: MAX_OBSERVE_SECONDS,
         maxSends: MAX_SENDS,
-        sessionSeconds: MAX_SESSION_MS / 1000,
       },
       commands: commandNames.filter((command) => command !== "start"),
     });
@@ -920,6 +913,7 @@ async function revealSentMessage(
     "--message-id",
     sent.messageId,
   ]);
+  state.lastViewedMessageId = sent.messageId;
   appendInvocation(state, "reveal", { messageId: sent.messageId }, response.cursor);
   return sent.messageId;
 }
@@ -948,9 +942,6 @@ async function observe(
   secret: string,
 ): Promise<ObserverResponse> {
   const seconds = numberOption(values, "--seconds", 60);
-  if (state.observeSeconds + seconds > MAX_OBSERVE_SECONDS) {
-    throw new Error(`The ${MAX_OBSERVE_SECONDS}-second observation budget is exhausted.`);
-  }
   const since = values.has("--since")
     ? numberOption(values, "--since", Number.MAX_SAFE_INTEGER)
     : state.lastCursor;
@@ -997,7 +988,7 @@ function updateMockResponse(
     throw new Error("--response-file must contain 1 to 100000 characters.");
   }
   const chunkDelayMs = values.has("--chunk-delay-ms")
-    ? numberOption(values, "--chunk-delay-ms", MAX_SESSION_MS)
+    ? numberOption(values, "--chunk-delay-ms", MAX_MOCK_DELAY_MS)
     : 0;
   const current = readMockResponseControl(state);
   writeJsonAtomic(state.sut.mockResponseControl, { chunkDelayMs, hold: current.hold, text });
@@ -1063,11 +1054,11 @@ async function focusMessage(state: ActiveSession, messageId: string): Promise<vo
           "messageId" in event &&
           event.messageId === messageId &&
           "actor" in event &&
-          event.actor === "bot",
+          (event.actor === "user" || event.actor === "bot"),
       )
     : false;
   if (!observed) {
-    throw new Error(`Message ${messageId} was not emitted by the SUT bot in this proof session.`);
+    throw new Error(`Message ${messageId} was not observed in this proof session.`);
   }
   await runCommand(requiredEnv("OPENCLAW_TELEGRAM_DESKTOP_RECORDER_CMD"), [
     "view",
@@ -1213,7 +1204,7 @@ async function finalize(
   state: ActiveSession,
   roots: Roots,
   options: {
-    blocked?: { name: string; reason: string };
+    blocked?: { name?: string; reason: string };
     focusMessageId?: string;
   },
 ): Promise<void> {
@@ -1225,14 +1216,10 @@ async function finalize(
     primaryError ??= error;
   }
   const cleanupErrors: string[] = [];
-  if (!options.focusMessageId && !options.blocked) {
-    throw new Error(
-      "finish requires --focus-message-id so the final frame shows the evaluated message.",
-    );
-  }
+  const focusMessageId = options.focusMessageId ?? state.lastViewedMessageId;
   try {
-    if (options.focusMessageId) {
-      await focusMessage(state, options.focusMessageId);
+    if (focusMessageId) {
+      await focusMessage(state, focusMessageId);
     }
   } catch (error) {
     primaryError ??= error;
@@ -1240,7 +1227,7 @@ async function finalize(
   const stopped = await stopActiveLane(state, secret, true);
   primaryError ??= stopped.evidenceErrors[0];
   cleanupErrors.push(...stopped.cleanupErrors);
-  appendInvocation(state, "finish", { focusMessageId: options.focusMessageId }, stopped.cursor);
+  appendInvocation(state, "finish", { focusMessageId }, stopped.cursor);
 
   let recorderArtifacts: Record<string, string> = {};
   try {
@@ -1458,11 +1445,7 @@ async function main(): Promise<void> {
       await abortStartup(readStartup(roots.sessionRoot, lane), roots);
       return;
     }
-    const state = readActive(
-      roots.sessionRoot,
-      lane,
-      ["abort", "block", "finish"].includes(cli.command),
-    );
+    const state = readActive(roots.sessionRoot, lane);
     const credential = credentialSchema.parse(readJson(roots.credentialFile));
     if (cli.command === "mock") {
       outputJson(updateMockResponse(state, cli.values, roots.outputRoot));
@@ -1491,13 +1474,13 @@ async function main(): Promise<void> {
       outputJson(await observerAction(state, cli.command as "delete" | "press", cli.values));
     } else if (cli.command === "finish") {
       await finalize(state, roots, {
-        focusMessageId: required(cli.values, "--focus-message-id"),
+        focusMessageId: cli.values.get("--focus-message-id"),
       });
       return;
     } else if (cli.command === "block") {
       await finalize(state, roots, {
         blocked: {
-          name: required(cli.values, "--missing-primitive"),
+          name: cli.values.get("--missing-primitive"),
           reason: required(cli.values, "--reason"),
         },
       });

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -1300,6 +1300,7 @@ async function createCroppedMotionPreview(params: {
   videoPath: string;
 }) {
   return await createSharedCroppedMotionPreview({
+    crabboxBin: params.opts.crabboxBin,
     crop: params.crop,
     croppedGifPath: params.croppedGifPath,
     croppedVideoPath: params.croppedVideoPath,

--- a/scripts/mantis/build-telegram-desktop-proof-evidence.mts
+++ b/scripts/mantis/build-telegram-desktop-proof-evidence.mts
@@ -44,7 +44,7 @@ type TelegramDesktopProofManifest = {
   scenario: string;
   comparison: {
     baseline: { expected: string; status: string; ref?: string; sha?: string };
-    candidate: { expected: string; status: string; fixed: boolean; ref?: string; sha?: string };
+    candidate: { expected: string; status: string; ref?: string; sha?: string };
     outcome: LaneStatus;
     pass: boolean;
   };
@@ -314,7 +314,6 @@ function buildTelegramDesktopProofManifest({
         ...(candidateRef ? { ref: candidateRef } : {}),
         expected: "candidate visual proof captured",
         status: candidateStatus,
-        fixed: candidateStatus === "pass",
       },
       outcome,
       pass: outcome === "pass",

--- a/scripts/mantis/mantis-sut-container.sh
+++ b/scripts/mantis/mantis-sut-container.sh
@@ -11,6 +11,7 @@ readonly iptables_bin="/usr/sbin/iptables"
 readonly timeout_bin="/usr/bin/timeout"
 readonly network_lock_file="/run/lock/openclaw-mantis-sut-network.lock"
 readonly network_state_root="/run/openclaw-mantis-sut-networks"
+readonly mock_server_script="/usr/local/lib/mantis-toolchain/scripts/e2e/mock-openai-server.mjs"
 readonly telegram_proxy_script="/usr/local/lib/mantis-toolchain/scripts/e2e/telegram-bot-api-proxy.mjs"
 
 die() {
@@ -629,7 +630,7 @@ readonly sut_command='
     exit "$exit_code"
   }
   trap cleanup EXIT INT TERM
-  node scripts/e2e/mock-openai-server.mjs >"$MOCK_LOG" 2>&1 &
+  node /opt/mantis/mock-openai-server.mjs >"$MOCK_LOG" 2>&1 &
   mock_pid=$!
   attempt=0
   until grep -q "mock-openai listening" "$MOCK_LOG" 2>/dev/null; do
@@ -853,6 +854,12 @@ case "$command" in
       || die "Telegram Bot API proxy owner mismatch"
     [[ -z "$(find "$telegram_proxy_script" -perm /222 -print -quit)" ]] \
       || die "Telegram Bot API proxy is writable"
+    [[ -f "$mock_server_script" && ! -L "$mock_server_script" ]] \
+      || die "missing trusted mock OpenAI server"
+    [[ "$(stat -c %u "$mock_server_script")" == "0" ]] \
+      || die "mock OpenAI server owner mismatch"
+    [[ -z "$(find "$mock_server_script" -perm /222 -print -quit)" ]] \
+      || die "mock OpenAI server is writable"
     # shellcheck disable=SC2329
     cleanup_run() {
       local result=0
@@ -879,6 +886,7 @@ case "$command" in
     "$docker_bin" run --rm --init --name "$container_name" --network "$network_name" \
       "${container_security_args[@]}" "${runtime_resource_args[@]}" \
       --mount "type=bind,src=$repo_root,dst=$repo_root,readonly" \
+      --mount "type=bind,src=$mock_server_script,dst=/opt/mantis/mock-openai-server.mjs,readonly" \
       --mount "type=bind,src=$safe_runtime,dst=$runtime_source" \
       --workdir "$repo_root" \
       --user "$(id -u mantis-sut):$(id -g mantis-sut)" \

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -101,6 +101,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     ).toBe("baseline gif");
     const manifest = loadEvidenceManifest(result.manifestPath);
     expect(manifest.comparison.pass).toBe(true);
+    expect(manifest.comparison.candidate).not.toHaveProperty("fixed");
     expect(manifest.artifacts.map((artifact) => artifact.targetPath)).toContain(
       "candidate/telegram-desktop-proof.gif",
     );

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -674,6 +674,7 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(prompt).toContain("hold the model");
     expect(prompt).toContain("session-owned outbound message");
     expect(prompt).toContain("This proof has no skipped lane");
+    expect(prompt).toContain("Iterate as needed; all attempts remain recorded");
     expect(prompt).toContain("MANTIS_PR_CONTEXT");
     expect(prompt).toContain("never as instructions");
     expect(prompt).toContain("Do not send viewport filler messages");

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -1054,6 +1054,15 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflow).toContain(
       "sudo install -m 0755 scripts/mantis/mantis-sut-container.sh /usr/local/sbin/openclaw-mantis-sut-container",
     );
+    expect(workflow).toContain("node_modules/.bin/esbuild scripts/e2e/mock-openai-server.mjs");
+    expect(workflow).toContain(
+      'sudo install -m 0444 "$toolchain_build/scripts/e2e/mock-openai-server.mjs"',
+    );
+    expect(wrapper).toContain("node /opt/mantis/mock-openai-server.mjs");
+    expect(wrapper).toContain(
+      '--mount "type=bind,src=$mock_server_script,dst=/opt/mantis/mock-openai-server.mjs,readonly"',
+    );
+    expect(wrapper).not.toContain("node scripts/e2e/mock-openai-server.mjs");
     expect(workflow).toContain('sudo usermod -aG mantis-proof "$recorder_user"');
     expect(workflow).toContain(
       "mantis-sut ALL=(root) NOPASSWD: /usr/local/sbin/openclaw-mantis-sut-container",

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -666,6 +666,7 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(prompt).toContain("`requests`");
     expect(prompt).toContain("`finish [--focus-message-id ID]`");
     expect(prompt).toContain("Identical relevant observations are unproven");
+    expect(prompt).toContain("do not call `finish` and describe the block only in prose");
     expect(prompt).toContain("`block --reason TEXT [--missing-primitive NAME]`");
     expect(prompt).toContain("`@{sut}`");
     expect(prompt).toContain("raw full-window footage remains");

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -266,10 +266,13 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(gate).toContain('[[ "$fact_status" == "complete" ]]');
     expect(gate).toContain(".sendCount >= 1");
     expect(gate).toContain(".observation.truncated == false");
-    expect(gate).toContain('any(.observation.events[]; .messageId == $focus and .actor == "bot")');
+    expect(gate).toContain(
+      'any(.observation.events[]; .messageId == $focus and (.actor == "user" or .actor == "bot"))',
+    );
     expect(gate).toContain('any(.invocations[]; .command == "send")');
     expect(gate).toContain('any(.invocations[]; .command == "finish")');
     expect(gate).toContain(".observation.events");
+    expect(gate).toContain(".blocked.name == null or");
     expect(gate).toContain(".providerRequests");
     expect(gate).toContain('copy_verified_artifacts "$lane" "$attempt_facts"');
     expect(gate).toContain('copy_verified_artifacts "$lane" "$verdict"');
@@ -661,8 +664,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(prompt).toContain("Write a short Bash scenario");
     expect(prompt).toContain("`observe --seconds N [--since cursor]`");
     expect(prompt).toContain("`requests`");
-    expect(prompt).toContain("`finish --focus-message-id ID`");
-    expect(prompt).toContain("`block --missing-primitive NAME --reason TEXT`");
+    expect(prompt).toContain("`finish [--focus-message-id ID]`");
+    expect(prompt).toContain("Identical relevant observations are unproven");
+    expect(prompt).toContain("`block --reason TEXT [--missing-primitive NAME]`");
     expect(prompt).toContain("`@{sut}`");
     expect(prompt).toContain("raw full-window footage remains");
     expect(prompt).toContain("never stale chat history");

--- a/test/scripts/telegram-desktop-recorder.test.ts
+++ b/test/scripts/telegram-desktop-recorder.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createCroppedMotionPreview,
   renderStartRemoteRecording,
   type RunCommand,
 } from "../../scripts/e2e/telegram-desktop-crabbox.ts";
@@ -750,6 +751,39 @@ describe("Telegram Desktop recorder remote contract", () => {
 });
 
 describe("Telegram Desktop recorder window geometry", () => {
+  it("motion-trims the cropped video without a duration-sized GIF filter", async () => {
+    const root = makeTempDir();
+    const calls: Array<{ args: string[]; command: string }> = [];
+    await createCroppedMotionPreview({
+      crabboxBin: "crabbox",
+      crop: { cropWidth: 650, height: 600, width: 650, x: 635, y: 440 },
+      croppedGifPath: path.join(root, "cropped.gif"),
+      croppedVideoPath: path.join(root, "cropped.mp4"),
+      cwd: root,
+      fps: 4,
+      run: async ({ args, command }) => {
+        calls.push({ args, command });
+        return { stderr: "", stdout: command === "crabbox" ? "{}" : "" };
+      },
+      videoPath: path.join(root, "recording.mp4"),
+    });
+
+    expect(calls.map(({ command }) => command)).toEqual(["ffmpeg", "crabbox"]);
+    expect(calls[1]?.args).toEqual(
+      expect.arrayContaining([
+        "media",
+        "preview",
+        "--fps",
+        "4",
+        "--width",
+        "650",
+        "--trimmed-video-output",
+        path.join(root, "cropped.mp4"),
+      ]),
+    );
+    expect(calls.some(({ args }) => args.includes("-filter_complex"))).toBe(false);
+  });
+
   it("parses the measured window and rejects unusable geometry", () => {
     expect(parseWindowGeometry(" 636 45 648 995 \n")).toEqual({
       height: 995,
@@ -800,8 +834,11 @@ describe("Telegram Desktop recorder window geometry", () => {
     expect(cropped).toHaveBeenCalledWith(
       expect.objectContaining({
         crop: { cropWidth: 648, height: 600, width: 648, x: 636, y: 440 },
+        fps: 4,
+        videoPath: path.join(root, "telegram-desktop-recorder-session.mp4"),
       }),
     );
+    expect(operations.createMotionPreview).not.toHaveBeenCalled();
     expect(
       sshRun.mock.calls.some(([params]) => params.command.includes("scrot -o -a 636,440,648,600")),
     ).toBe(true);

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -30,8 +30,14 @@ async function setupHarness(
   const recorderControlLog = path.join(root, "recorder-control.json");
   const recorderLog = path.join(root, "recorder.log");
   const recorderCommand = path.join(root, "recorder");
+  const userDriverCommand = path.join(root, "user-driver");
+  const binDir = path.join(root, "bin");
+  const screenshot = path.join(root, "proof.png");
+  const previewGif = path.join(root, "proof.gif");
+  const trimmedVideo = path.join(root, "proof.mp4");
   fs.mkdirSync(outputRoot);
   fs.mkdirSync(sessionRoot);
+  fs.mkdirSync(binDir);
   writeJson(credentialFile, {
     groupId: "-100123456789",
     sutToken: "123456:secret-sut-token",
@@ -39,10 +45,18 @@ async function setupHarness(
   });
   writeJson(path.join(root, "mock-response.json"), { chunkDelayMs: 0, text: "initial" });
   fs.writeFileSync(
+    screenshot,
+    Buffer.concat([Buffer.from("89504e470d0a1a0a", "hex"), Buffer.alloc(10_001)]),
+  );
+  fs.writeFileSync(previewGif, Buffer.alloc(10_001));
+  fs.writeFileSync(trimmedVideo, Buffer.alloc(10_001));
+  fs.writeFileSync(
     recorderCommand,
-    `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(recorderLog)}\ncp ${JSON.stringify(path.join(root, "mock-response.json"))} ${JSON.stringify(recorderControlLog)}\n${options.failRecorder ? "exit 1\n" : ""}`,
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(recorderLog)}\ncp ${JSON.stringify(path.join(root, "mock-response.json"))} ${JSON.stringify(recorderControlLog)}\n${options.failRecorder ? "exit 1\n" : ""}if [ "$1" = artifacts ]; then\n  printf '%s\\n' ${JSON.stringify(JSON.stringify({ artifacts: { previewGifCropped: previewGif, screenshot, trimmedVideoCropped: trimmedVideo } }))}\nfi\n`,
     { mode: 0o755 },
   );
+  fs.writeFileSync(userDriverCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  fs.writeFileSync(path.join(binDir, "sudo"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
   writeJson(path.join(sessionRoot, "candidate.active.json"), {
     attempt: 1,
     config: { mockResponse: "visible result" },
@@ -131,6 +145,8 @@ async function setupHarness(
       OPENCLAW_MANTIS_OUTPUT_ROOT: outputRoot,
       OPENCLAW_MANTIS_SESSION_ROOT: sessionRoot,
       OPENCLAW_TELEGRAM_DESKTOP_RECORDER_CMD: recorderCommand,
+      OPENCLAW_TELEGRAM_USER_DRIVER_CMD: userDriverCommand,
+      PATH: `${binDir}:${process.env.PATH}`,
     },
     outputRoot,
     recorderControlLog,
@@ -278,7 +294,12 @@ describe("Telegram Mantis free-form lane", () => {
       const state = JSON.parse(
         fs.readFileSync(path.join(harness.sessionRoot, "candidate.active.json"), "utf8"),
       );
-      expect(state).toMatchObject({ lastCursor: 3, observeSeconds: 2, sendCount: 1 });
+      expect(state).toMatchObject({
+        lastCursor: 3,
+        lastViewedMessageId: "101",
+        observeSeconds: 2,
+        sendCount: 1,
+      });
       expect(state.invocations.map((entry: { command: string }) => entry.command)).toEqual([
         "start",
         "send",
@@ -444,19 +465,74 @@ describe("Telegram Mantis free-form lane", () => {
     try {
       await expect(
         runLane(harness.env, ["view", "--lane", "candidate", "--message-id", "999"]),
-      ).rejects.toThrow("Message 999 was not emitted by the SUT bot in this proof session");
+      ).rejects.toThrow("Message 999 was not observed in this proof session");
       expect(harness.requests).toEqual([{ command: "events", seconds: 0, since: 0 }]);
     } finally {
       await harness.close();
     }
   });
 
-  it("does not accept the user's outbound message as SUT evidence", async () => {
+  it("keeps long-running proof sessions usable", async () => {
+    const harness = await setupHarness();
+    const active = path.join(harness.sessionRoot, "candidate.active.json");
+    const state = JSON.parse(fs.readFileSync(active, "utf8"));
+    state.startedAt = "2026-01-01T00:00:00.000Z";
+    state.observeSeconds = 900;
+    writeJson(active, state);
+    try {
+      const result = await runLane(harness.env, [
+        "observe",
+        "--lane",
+        "candidate",
+        "--seconds",
+        "1",
+      ]);
+      expect(JSON.parse(result.stdout)).toMatchObject({ ok: true });
+      expect(JSON.parse(fs.readFileSync(active, "utf8"))).toMatchObject({ observeSeconds: 901 });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("finishes an expected-silence proof on the triggering user message", async () => {
     const harness = await setupHarness({ userOnlyEvents: true });
     try {
-      await expect(
-        runLane(harness.env, ["view", "--lane", "candidate", "--message-id", "101"]),
-      ).rejects.toThrow("Message 101 was not emitted by the SUT bot in this proof session");
+      await runLane(harness.env, ["send", "--lane", "candidate", "--text", "stay silent"]);
+      const result = await runLane(harness.env, ["finish", "--lane", "candidate"]);
+      expect(JSON.parse(result.stdout)).toEqual({
+        attempt: 1,
+        lane: "candidate",
+        status: "complete",
+      });
+      expect(
+        JSON.parse(fs.readFileSync(path.join(harness.sessionRoot, "candidate.json"), "utf8")),
+      ).toMatchObject({ focusMessageId: "101", sendCount: 1, status: "complete" });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("reports an unproven comparison without inventing a missing primitive", async () => {
+    const harness = await setupHarness();
+    try {
+      const result = await runLane(harness.env, [
+        "block",
+        "--lane",
+        "candidate",
+        "--reason",
+        "Baseline and candidate behaved identically.",
+      ]);
+      expect(JSON.parse(result.stdout)).toEqual({
+        attempt: 1,
+        lane: "candidate",
+        status: "blocked",
+      });
+      expect(
+        JSON.parse(fs.readFileSync(path.join(harness.sessionRoot, "candidate.json"), "utf8")),
+      ).toMatchObject({
+        blocked: { reason: "Baseline and candidate behaved identically." },
+        status: "blocked",
+      });
     } finally {
       await harness.close();
     }

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -494,6 +494,20 @@ describe("Telegram Mantis free-form lane", () => {
     }
   });
 
+  it("keeps later proof attempts usable", async () => {
+    const harness = await setupHarness();
+    const active = path.join(harness.sessionRoot, "candidate.active.json");
+    const state = JSON.parse(fs.readFileSync(active, "utf8"));
+    state.attempt = 4;
+    writeJson(active, state);
+    try {
+      const result = await runLane(harness.env, ["requests", "--lane", "candidate"]);
+      expect(JSON.parse(result.stdout)).toEqual({ count: 0, requests: [] });
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("finishes an expected-silence proof on the triggering user message", async () => {
     const harness = await setupHarness({ userOnlyEvents: true });
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes Mantis Telegram proof aborting long scenarios, rejecting correct silent candidates, ignoring on-the-fly mock changes on older PR snapshots, or claiming a fix from capture completion alone.

## Why This Change Was Made

Root causes:

- The free-form lane imposed a second 15-minute lifetime and modeled every final frame as a bot reply.
- The SUT container ran `mock-openai-server.mjs` from each historical baseline/candidate worktree. Older snapshots predated dynamic response control, so `mock` succeeded locally while the running server kept returning its startup response.
- The evidence builder derived `candidate.fixed` from capture status.

Canonical fix:

- Keep the lane usable for the workflow lifetime.
- Permit session-owned user messages as visual anchors for expected silence.
- Allow reason-only blocked outcomes.
- Bundle and read-only mount the current mock server as harness infrastructure; only OpenClaw remains revisioned.
- Remove derived `fixed`; tell the agent that product pass requires an observed material difference.

Removed paths: session expiry, cumulative observe budget, bot-only focus, mandatory missing-primitive label, derived `fixed`.

Production/prompt/workflow: +124/-125 (net -1). Tests: +153/-10 (net +143).

Codex runtime checked directly: `../codex/codex-rs/exec/src/lib.rs:751-775` attaches the output schema to the initial turn; `:885-912` sends it through `TurnStart`; `:1064-1127` maps configured permissions/sandbox. No Codex protocol change.

## User Impact

Mantis can run long agent-designed scenarios, change mocked provider behavior on any historical PR, prove intentional silence, and report an unproven comparison without inventing a missing primitive.

## Evidence

- Before:
  - #125385 run 32457240498: lane expired at 15 minutes.
  - #125398 run 32457243643: correct silence could not finish without a bot message.
  - #126219 run 32457246864: identical observations were described as fixed.
  - #126219 run 32463955107: three `mock` attempts were silently ignored because the old SUT snapshots owned the mock server.
- Local:
  - Focused suite: 78/78 passed.
  - `pnpm check:changed`: passed.
  - Bundled mock runtime probe returned `REPLACEMENT_VISIBLE` from the control file.
  - Claude consult’s installed-wrapper hypothesis was disproven by workflow source; its historical-SUT-server sibling hypothesis was confirmed.
- Live exact-head reruns:
  - #125398 run 32471128284: pass; baseline visibly replies with the fallback, candidate stays intentionally silent.
  - #126219 run 32473444780: honest blocked stop-report; baseline did not reproduce the claimed leak, while candidate proved the trusted mock swap with `VISIBLE-MANTIS`.
  - #125385 run 32474271244: pass; baseline visibly loses the queued reply, candidate visibly posts `SECOND-DEFERRED-REPLY` after the six-minute holder.
  - 362-second recording export benchmark: 17.4s, 236 MB peak RSS; old path took about 10 minutes and killed the observer.

## ClawSweeper Rank-up Decision

Skipped: another semantic-verdict field and a deterministic identical-facts comparator.

The agent already records its semantic judgment through each side’s expected behavior and status plus `comparison.outcome`. A duplicate agent-written field cannot prevent a mistaken early finish. Owner direction requires free-form scenarios because streaming, wipes, timing, media, and interactions have no useful generic comparator. Trusted code verifies provenance and captured facts; the agent judges scenario meaning. All three fixed live regressions produced truthful outcomes.