### PR TITLE
fix(node-host): duplicate skill-bin refreshes on concurrent commands (#127095)

### DIFF
--- a/src/node-host/runtime.test.ts
+++ b/src/node-host/runtime.test.ts
@@ -4,7 +4,7 @@ import type { OpenClawPluginNodeHostCommandIo } from "../plugins/types.js";
 import { NODE_DESKTOP_STREAM_COMMAND } from "../shared/node-desktop-stream.js";
 import type { NodeHostClient } from "./client.js";
 import { listRegisteredNodeHostCapsAndCommands } from "./plugin-node-host.js";
-import { prepareNodeHostRuntime } from "./runtime.js";
+import { prepareNodeHostRuntime, SkillBinsCache } from "./runtime.js";
 
 const mocks = vi.hoisted(() => {
   const closeMcp = vi.fn(async () => undefined);
@@ -423,5 +423,64 @@ describe("installed application command advertisement", () => {
     expect(disabled.manifest.commands).not.toContain(NODE_DEVICE_APPS_COMMAND);
     expect(enabled.manifest.commands).toContain(NODE_DEVICE_APPS_COMMAND);
     expect(nonDarwin.manifest.commands).not.toContain(NODE_DEVICE_APPS_COMMAND);
+  });
+});
+
+describe("SkillBinsCache", () => {
+  it("deduplicates concurrent cold refresh requests into a single in-flight request", async () => {
+    let resolveRequest: ((value: { bins: string[] }) => void) | undefined;
+    const request = vi.fn(
+      () =>
+        new Promise<{ bins: string[] }>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+    const client = { request } as unknown as NodeHostClient;
+    const cache = new SkillBinsCache(client, "/bin:/usr/bin");
+
+    const [firstPromise, secondPromise, thirdPromise] = [
+      cache.current(),
+      cache.current(),
+      cache.current(),
+    ];
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith("skills.bins", {});
+
+    resolveRequest?.({ bins: ["echo"] });
+    const [first, second, third] = await Promise.all([firstPromise, secondPromise, thirdPromise]);
+
+    expect(first).toEqual([{ name: "echo", resolvedPath: "/bin/echo" }]);
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+
+    const warm = await cache.current();
+    expect(warm).toBe(first);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears in-flight tracking and preserves prior bins when a refresh fails", async () => {
+    let callCount = 0;
+    const request = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        return { bins: ["echo"] };
+      }
+      throw new Error("gateway network error");
+    });
+    const client = { request } as unknown as NodeHostClient;
+    const cache = new SkillBinsCache(client, "/bin:/usr/bin");
+
+    const initial = await cache.current();
+    expect(initial).toEqual([{ name: "echo", resolvedPath: "/bin/echo" }]);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    const forcedFailure = await cache.current(true);
+    expect(forcedFailure).toEqual([{ name: "echo", resolvedPath: "/bin/echo" }]);
+    expect(request).toHaveBeenCalledTimes(2);
+
+    // Can immediately retry again after failure
+    await cache.current(true);
+    expect(request).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -176,9 +176,10 @@ function resolveSkillBinTrustEntries(bins: string[], pathEnv: string): SkillBinT
   );
 }
 
-class SkillBinsCache implements SkillBinsProvider {
+export class SkillBinsCache implements SkillBinsProvider {
   private bins: SkillBinTrustEntry[] = [];
   private lastRefresh = 0;
+  private inFlight: Promise<SkillBinTrustEntry[]> | null = null;
   private readonly ttlMs = 90_000;
 
   constructor(
@@ -187,13 +188,24 @@ class SkillBinsCache implements SkillBinsProvider {
   ) {}
 
   async current(force = false): Promise<SkillBinTrustEntry[]> {
-    if (force || Date.now() - this.lastRefresh > this.ttlMs) {
-      await this.refresh();
+    if (!force && Date.now() - this.lastRefresh <= this.ttlMs) {
+      return this.bins;
     }
-    return this.bins;
+    if (this.inFlight) {
+      return this.inFlight;
+    }
+    const refreshPromise = this.refresh();
+    this.inFlight = refreshPromise;
+    try {
+      return await refreshPromise;
+    } finally {
+      if (this.inFlight === refreshPromise) {
+        this.inFlight = null;
+      }
+    }
   }
 
-  private async refresh() {
+  private async refresh(): Promise<SkillBinTrustEntry[]> {
     try {
       const res = await this.client.request<{ bins: Array<unknown> }>("skills.bins", {});
       const bins = Array.isArray(res?.bins) ? res.bins.map((bin) => String(bin)) : [];
@@ -204,6 +216,7 @@ class SkillBinsCache implements SkillBinsProvider {
         this.bins = [];
       }
     }
+    return this.bins;
   }
 }
 


### PR DESCRIPTION
Closes #127095

## What Problem This Solves

Fixes an issue where node-host deployments executing concurrent commands when the skill-bin cache is cold or expired would trigger multiple independent Gateway-wide `skills.bins` refreshes and create duplicate pending bridge timers.

## Why This Change Was Made

`SkillBinsCache` now retains an in-flight refresh promise across overlapping callers encountering the same cold or expired cache generation. Callers share the single active refresh wave, and in-flight tracking is cleared upon completion or failure so subsequent requests can retry cleanly without stale state.

## User Impact

Concurrent command bursts on node hosts (including delegated Claude CLI requests) share a single skill discovery cycle instead of repeating filesystem scans across all configured workspaces on the Gateway.

## Evidence

- Added focused unit tests in `src/node-host/runtime.test.ts`:
  1. `deduplicates concurrent cold refresh requests into a single in-flight request`: verifies 3 concurrent `current()` calls trigger exactly 1 `skills.bins` bridge request and all receive the identical resolved entry array.
  2. `clears in-flight tracking and preserves prior bins when a refresh fails`: verifies failed refreshes preserve prior bins and permit immediate subsequent retries.
- Verified test suite:
  ```bash
  pnpm test src/node-host/runtime.test.ts
  # Test Files  1 passed (1)
  # Tests       19 passed (19)
  ```