### PR TITLE
fix(byteplus): report token usage for streamed responses

### DIFF
--- a/extensions/byteplus/index.test.ts
+++ b/extensions/byteplus/index.test.ts
@@ -65,6 +65,21 @@ describe("byteplus plugin", () => {
     });
   });
 
+  it("declares OpenAI-compatible streaming usage support in the manifest", () => {
+    const pluginJson = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, "openclaw.plugin.json"), "utf-8"),
+    );
+
+    expect(pluginJson.providerRequest?.providers).toMatchObject({
+      byteplus: {
+        openAICompletions: { supportsStreamingUsage: true },
+      },
+      "byteplus-plan": {
+        openAICompletions: { supportsStreamingUsage: true },
+      },
+    });
+  });
+
   it("keeps Kimi catalog metadata aligned with provider capabilities", () => {
     const planKimi = BYTEPLUS_CODING_MODEL_CATALOG.find((entry) => entry.id === "kimi-k2.5");
 

--- a/extensions/byteplus/openclaw.plugin.json
+++ b/extensions/byteplus/openclaw.plugin.json
@@ -17,6 +17,20 @@
   "providerAuthAliases": {
     "byteplus-plan": "byteplus"
   },
+  "providerRequest": {
+    "providers": {
+      "byteplus": {
+        "openAICompletions": {
+          "supportsStreamingUsage": true
+        }
+      },
+      "byteplus-plan": {
+        "openAICompletions": {
+          "supportsStreamingUsage": true
+        }
+      }
+    }
+  },
   "modelCatalog": {
     "providers": {
       "byteplus": {


### PR DESCRIPTION
AI-assisted PR (written with Claude). I understand what the change does.

## What Problem This Solves

Fixes an issue where users on the `byteplus` and `byteplus-plan` providers get no token
usage for streamed responses. Because the usage block never arrives, per-turn cost,
token counters, and anything downstream that reads usage stay empty for the whole
session. The same models reached through `volcengine` / `volcengine-plan` — the same
Volcano Ark OpenAI-compatible endpoints — report usage normally.

## Why This Change Was Made

Neither `ark.ap-southeast.bytepluses.com` nor `ark.cn-beijing.volces.com` is mapped to a
known endpoint class, so both resolve to `endpointClass: "custom"`. In
`resolveOpenAICompletionsCompatDefaults`
(`packages/ai/src/transports/openai-completions-compat.ts:136-141`) a custom endpoint
defaults `supportsUsageInStreaming` to `false` unless the owning plugin manifest opts in
through `providerRequest.providers.<id>.openAICompletions.supportsStreamingUsage`
(read at `src/agents/provider-attribution.ts:683-684`). When that flag is false,
`stream_options: { include_usage: true }` is never added to the request
(`packages/ai/src/providers/openai-completions.ts:825-827`,
`packages/ai/src/transports/openai-completions-params.ts:319-321`).

`extensions/volcengine/openclaw.plugin.json` declares that flag for both of its ids.
`extensions/byteplus/openclaw.plugin.json` had no `providerRequest` block at all, so
BytePlus fell to the default. This adds the same declaration for both ids the BytePlus
manifest owns. It is manifest-only — the capability plumbing already exists and is
already exercised by Volcengine.

## User Impact

BytePlus users get streaming token usage back, so cost accounting, token counters, and
context-window tracking work the same way they already do on Volcengine. No config
change or migration needed; nothing else about the request changes.

## Evidence

**Before / after, using the repo's own resolver** (from the repo root):

```
node --import tsx -e "
import('./src/agents/provider-attribution.ts').then(({resolveProviderRequestCapabilities})=>{
  for (const [provider, baseUrl] of [
    ['byteplus','https://ark.ap-southeast.bytepluses.com/api/v3'],
    ['byteplus-plan','https://ark.ap-southeast.bytepluses.com/api/coding/v3'],
    ['volcengine','https://ark.cn-beijing.volces.com/api/v3'],
    ['volcengine-plan','https://ark.cn-beijing.volces.com/api/coding/v3'],
  ]) {
    const c = resolveProviderRequestCapabilities({provider, api:'openai-completions', baseUrl, modelId:'x'});
    console.log(provider, 'endpointClass='+c.endpointClass, 'streamingUsageCompat='+c.supportsOpenAICompletionsStreamingUsageCompat);
  }
});
"
```

Before this change:

```
byteplus       endpointClass=custom streamingUsageCompat=false
byteplus-plan  endpointClass=custom streamingUsageCompat=false
volcengine     endpointClass=custom streamingUsageCompat=true
volcengine-plan endpointClass=custom streamingUsageCompat=true
```

After this change all four report `streamingUsageCompat=true`.

Feeding those capabilities into `detectOpenAICompletionsCompat` shows the wire
consequence directly: with the manifest flag absent,
`defaults.supportsUsageInStreaming` is `false` for `byteplus` and `byteplus-plan`
(so no `stream_options`); with it present it is `true` for both.

**Tests:** added `declares OpenAI-compatible streaming usage support in the manifest`
to `extensions/byteplus/index.test.ts`, mirroring the Volcengine test that already
guards the same declaration (`extensions/volcengine/index.test.ts:72-85`).

Ran locally on Node 24.15.0, at `c6ecfd26e5f` plus this change:

- `pnpm test:extension byteplus` — 3 files, 25 passed / 1 skipped
- `pnpm tsgo:prod`, `pnpm tsgo:test:root` — clean
- `pnpm format:check` — clean
- type-aware `oxlint` over the changed extension, using the repo's own
  `config/tsconfig/oxlint.extensions.json` shard config — clean

`pnpm check` stops in its preflight stage on my machine, but it stops the same way on an
unmodified `c6ecfd26e5f`: `check:max-lines-ratchet` and `check:assertion-safety` fail
identically with and without this change, and every entry they name lives in `src/cli/**`
or `ui/src/**`, which this PR does not touch. Because that stage aborts before typecheck,
lint, and format run, I ran those three lanes directly — results above — rather than
chasing known `main` failures.

Locally I did not finish the full-repo `pnpm lint` shard run or `pnpm build` / `pnpm test`; this PR touches one bundled plugin's manifest and that plugin's own test file, no shared plugin or channel surface, so I ran the extension lane CONTRIBUTING names for extension changes. CI has since run the full lanes on this branch: `check-lint` and the `check-lint-core-*` shards pass, as do the typecheck, boundary, and test lanes.
