### PR TITLE
improve(gateway): skip unconfigured model catalog startup work

### DIFF
--- a/src/commands/models/list.manifest-catalog.test.ts
+++ b/src/commands/models/list.manifest-catalog.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   resolvePluginContributionOwners: vi.fn(),
   getPluginRecord: vi.fn(),
   isPluginEnabled: vi.fn(),
-  getRemoteModelCatalogOverlay: vi.fn(),
+  getRemoteModelCatalogProviderOverlay: vi.fn(),
 }));
 
 vi.mock("../../plugins/plugin-registry-contributions.js", () => ({
@@ -24,7 +24,7 @@ vi.mock("../../plugins/plugin-metadata-snapshot.js", () => ({
 }));
 
 vi.mock("../../model-catalog/remote-overlay.js", () => ({
-  getRemoteModelCatalogOverlay: mocks.getRemoteModelCatalogOverlay,
+  getRemoteModelCatalogProviderOverlay: mocks.getRemoteModelCatalogProviderOverlay,
 }));
 
 const moonshotPlugin = {
@@ -95,7 +95,7 @@ const anthropicRuntimeAugmentPlugin = {
 describe("loadStaticManifestCatalogRowsForList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getRemoteModelCatalogOverlay.mockReturnValue(undefined);
+    mocks.getRemoteModelCatalogProviderOverlay.mockReturnValue(undefined);
   });
 
   it("loads only static manifest catalog rows without a provider filter", async () => {
@@ -175,10 +175,8 @@ describe("loadStaticManifestCatalogRowsForList", () => {
       manifestRegistry,
       plugins: manifestRegistry.plugins,
     };
-    mocks.getRemoteModelCatalogOverlay.mockReturnValue({
-      openai: {
-        models: [{ id: "gpt-refreshed", name: "Refreshed GPT" }],
-      },
+    mocks.getRemoteModelCatalogProviderOverlay.mockReturnValue({
+      models: [{ id: "gpt-refreshed", name: "Refreshed GPT" }],
     });
     mocks.getPluginRecord.mockReturnValue({ pluginId: "openai" });
     mocks.isPluginEnabled.mockReturnValue(true);

--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -100,6 +100,22 @@ function readServerImplementation(): string {
 }
 
 describe("gateway startup import boundaries", () => {
+  it("keeps remote catalog refresh networking behind the overlay boundary", () => {
+    const startupGraph = collectStaticValueImportGraph(
+      "src/plugins/gateway-startup-plugin-providers.ts",
+    );
+    const startupPaths = [...startupGraph.keys()].map((filePath) =>
+      path.relative(repoRoot, filePath),
+    );
+    const overlayGraph = collectStaticValueImportGraph("src/model-catalog/remote-overlay.ts");
+    const overlayPaths = [...overlayGraph.keys()].map((filePath) =>
+      path.relative(repoRoot, filePath),
+    );
+
+    expect(startupPaths).not.toContain("src/model-catalog/remote-refresh.ts");
+    expect(overlayPaths).not.toContain("src/infra/net/fetch-guard.ts");
+  });
+
   it("keeps ordinary session lifecycle code out of the prepared shutdown graph", () => {
     const graph = collectStaticValueImportGraph("src/gateway/server-close.runtime.ts");
 

--- a/src/model-catalog/index.ts
+++ b/src/model-catalog/index.ts
@@ -1,12 +1,11 @@
 // Public model-catalog facade. Keep exports here curated so callers use the
 // normalized planning APIs instead of reaching into provider-index internals.
-import type { ModelCatalogProvider } from "@openclaw/model-catalog-core/model-catalog-types";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   planManifestModelCatalogRows,
   type ManifestModelCatalogRowSelection,
 } from "./manifest-planner.js";
-import { getRemoteModelCatalogOverlay } from "./remote-overlay.js";
+import { getRemoteModelCatalogProviderOverlay } from "./remote-overlay.js";
 export { loadOpenClawProviderIndex } from "./provider-index/index.js";
 export { planManifestModelCatalogSuppressions } from "./manifest-planner.js";
 
@@ -14,14 +13,17 @@ export function planEffectiveModelCatalogRows(params: {
   registry: Parameters<typeof planManifestModelCatalogRows>[0]["registry"];
   config: OpenClawConfig;
   providerFilter?: string;
+  providerFilters?: readonly string[];
+  mergeKeyFilter?: ReadonlySet<string>;
   selection?: ManifestModelCatalogRowSelection;
 }) {
-  const remoteOverlay: Readonly<Record<string, ModelCatalogProvider>> | undefined =
-    getRemoteModelCatalogOverlay(params.config);
   return planManifestModelCatalogRows({
     registry: params.registry,
     ...(params.providerFilter ? { providerFilter: params.providerFilter } : {}),
-    ...(remoteOverlay ? { remoteOverlay } : {}),
+    ...(params.providerFilters ? { providerFilters: params.providerFilters } : {}),
+    ...(params.mergeKeyFilter ? { mergeKeyFilter: params.mergeKeyFilter } : {}),
+    resolveRemoteProvider: (provider) =>
+      getRemoteModelCatalogProviderOverlay(params.config, provider),
     ...(params.selection ? { selection: params.selection } : {}),
   });
 }

--- a/src/model-catalog/manifest-planner.test.ts
+++ b/src/model-catalog/manifest-planner.test.ts
@@ -1,5 +1,5 @@
 // Manifest model-catalog planner tests cover plugin-owned row planning, filters, conflicts, and suppressions.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   planManifestModelCatalogRows,
   planManifestModelCatalogSuppressions,
@@ -75,6 +75,66 @@ describe("manifest model catalog planner", () => {
     });
     expect(aliasPlan.rows).toMatchObject([
       { provider: "anthropic-alias", id: "old", name: "Remote alias", source: "runtime-refresh" },
+    ]);
+  });
+
+  it("scopes requested merge keys while preserving alias overlays", () => {
+    const resolveRemoteProvider = vi.fn((provider: string) =>
+      provider === "anthropic"
+        ? {
+            models: [
+              { id: "requested", name: "Remote" },
+              { id: "unrelated", name: "Remote unrelated" },
+            ],
+          }
+        : undefined,
+    );
+    const plan = planManifestModelCatalogRows({
+      registry: {
+        plugins: [
+          {
+            id: "anthropic",
+            providers: ["anthropic"],
+            modelCatalog: {
+              aliases: {
+                "anthropic-alias": {
+                  provider: "anthropic",
+                  api: "anthropic-messages",
+                  baseUrl: "https://alias.anthropic.test",
+                },
+              },
+              providers: {
+                anthropic: {
+                  models: [{ id: "requested", name: "Bundled" }, { id: "unrelated" }],
+                },
+              },
+            },
+          },
+          {
+            id: "unrelated",
+            providers: ["unrelated"],
+            modelCatalog: {
+              providers: { unrelated: { models: [{ id: "unrelated" }] } },
+            },
+          },
+        ],
+      },
+      providerFilters: ["anthropic-alias"],
+      mergeKeyFilter: new Set(["anthropic-alias::requested"]),
+      resolveRemoteProvider,
+    });
+
+    expect(resolveRemoteProvider.mock.calls).toEqual([["anthropic"]]);
+    expect(plan.entries).toHaveLength(1);
+    expect(plan.rows).toMatchObject([
+      {
+        provider: "anthropic-alias",
+        id: "requested",
+        name: "Remote",
+        api: "anthropic-messages",
+        baseUrl: "https://alias.anthropic.test",
+        source: "runtime-refresh",
+      },
     ]);
   });
 

--- a/src/model-catalog/manifest-planner.ts
+++ b/src/model-catalog/manifest-planner.ts
@@ -83,19 +83,32 @@ function mergeRemoteModelWithTrustedTransport(
 export function planManifestModelCatalogRows(params: {
   registry: ManifestModelCatalogRegistry;
   providerFilter?: string;
+  providerFilters?: readonly string[];
+  mergeKeyFilter?: ReadonlySet<string>;
   remoteOverlay?: Readonly<Record<string, ModelCatalogProvider>>;
+  resolveRemoteProvider?: (provider: string) => ModelCatalogProvider | undefined;
   selection?: ManifestModelCatalogRowSelection;
 }): ManifestModelCatalogPlan {
-  const providerFilter = params.providerFilter
-    ? normalizeModelCatalogProviderId(params.providerFilter)
+  const hasProviderFilter = Boolean(params.providerFilter) || params.providerFilters !== undefined;
+  const providerFilters = hasProviderFilter
+    ? new Set(
+        normalizeUniqueStringEntries(
+          [
+            ...(params.providerFilter !== undefined ? [params.providerFilter] : []),
+            ...(params.providerFilters ?? []),
+          ].map(normalizeModelCatalogProviderId),
+        ),
+      )
     : undefined;
   const entries: ManifestModelCatalogPlanEntry[] = [];
 
   for (const plugin of params.registry.plugins) {
     for (const entry of planManifestModelCatalogPluginEntries({
       plugin,
-      providerFilter,
+      providerFilters,
+      mergeKeyFilter: params.mergeKeyFilter,
       remoteOverlay: params.remoteOverlay,
+      resolveRemoteProvider: params.resolveRemoteProvider,
     })) {
       entries.push(entry);
     }
@@ -166,8 +179,10 @@ export function planManifestModelCatalogRows(params: {
 
 function planManifestModelCatalogPluginEntries(params: {
   plugin: ManifestModelCatalogPlugin;
-  providerFilter: string | undefined;
+  providerFilters: ReadonlySet<string> | undefined;
+  mergeKeyFilter: ReadonlySet<string> | undefined;
   remoteOverlay: Readonly<Record<string, ModelCatalogProvider>> | undefined;
+  resolveRemoteProvider: ((provider: string) => ModelCatalogProvider | undefined) | undefined;
 }): ManifestModelCatalogPlanEntry[] {
   const providers = params.plugin.modelCatalog?.providers;
   if (!providers) {
@@ -182,19 +197,25 @@ function planManifestModelCatalogPluginEntries(params: {
       return [];
     }
     const providerAliases = aliasesByTargetProvider.get(normalizedProvider) ?? [];
-    const plannedProviders = params.providerFilter
-      ? providerAliases.includes(params.providerFilter) ||
-        normalizedProvider === params.providerFilter
-        ? [params.providerFilter]
-        : []
+    const plannedProviders = params.providerFilters
+      ? normalizeUniqueStringEntries([normalizedProvider, ...providerAliases]).filter(
+          (candidateProvider) => params.providerFilters?.has(candidateProvider),
+        )
       : [normalizedProvider];
     if (plannedProviders.length === 0) {
       return [];
     }
+    const remoteProvider = params.resolveRemoteProvider
+      ? params.resolveRemoteProvider(normalizedProvider)
+      : params.remoteOverlay?.[normalizedProvider];
     return plannedProviders.flatMap((plannedProvider) => {
-      const remoteProvider = params.remoteOverlay?.[normalizedProvider];
-      const remoteModelIds = new Set(remoteProvider?.models.map((model) => model.id) ?? []);
-      const manifestModelsById = new Map(providerCatalog.models.map((model) => [model.id, model]));
+      const includesModel = (model: ModelCatalogModel) =>
+        !params.mergeKeyFilter ||
+        params.mergeKeyFilter.has(buildModelCatalogMergeKey(plannedProvider, model.id));
+      const manifestModels = providerCatalog.models.filter(includesModel);
+      const remoteModels = remoteProvider?.models.filter(includesModel) ?? [];
+      const remoteModelIds = new Set(remoteModels.map((model) => model.id));
+      const manifestModelsById = new Map(manifestModels.map((model) => [model.id, model]));
       const providerDefaults = remoteProvider
         ? {
             ...providerCatalog,
@@ -207,7 +228,7 @@ function planManifestModelCatalogPluginEntries(params: {
         provider: plannedProvider,
         providerCatalog: {
           ...providerDefaults,
-          models: providerCatalog.models.filter((model) => !remoteModelIds.has(model.id)),
+          models: manifestModels.filter((model) => !remoteModelIds.has(model.id)),
         },
         source: "manifest",
       });
@@ -216,7 +237,7 @@ function planManifestModelCatalogPluginEntries(params: {
             provider: plannedProvider,
             providerCatalog: {
               ...providerDefaults,
-              models: remoteProvider.models.map((model) =>
+              models: remoteModels.map((model) =>
                 mergeRemoteModelWithTrustedTransport(model, manifestModelsById.get(model.id)),
               ),
             },

--- a/src/model-catalog/remote-config.ts
+++ b/src/model-catalog/remote-config.ts
@@ -1,0 +1,11 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const DEFAULT_REMOTE_MODEL_CATALOG_URL = "https://catalog.openclaw.ai/models/v1/catalog.json";
+
+export function isRemoteModelCatalogRefreshEnabled(config: OpenClawConfig): boolean {
+  return config.models?.catalogRefresh?.enabled !== false;
+}
+
+export function resolveRemoteCatalogUrl(config: OpenClawConfig): string {
+  return config.models?.catalogRefresh?.url?.trim() || DEFAULT_REMOTE_MODEL_CATALOG_URL;
+}

--- a/src/model-catalog/remote-overlay.test.ts
+++ b/src/model-catalog/remote-overlay.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getRemoteModelCatalogOverlay, getRemoteModelCatalogPricing } from "./remote-overlay.js";
+import {
+  getRemoteModelCatalogPricing,
+  getRemoteModelCatalogProviderOverlay,
+} from "./remote-overlay.js";
 import {
   resetRemoteModelCatalogOverlayForTest,
   setRemoteModelCatalogOverlaySourcesForTest,
@@ -39,8 +42,8 @@ afterEach(() => {
 
 describe("remote model catalog overlay", () => {
   it("loads a newer compatible bundle once", () => {
-    expect(getRemoteModelCatalogOverlay({})).toHaveProperty("anthropic");
-    expect(getRemoteModelCatalogOverlay({})).toHaveProperty("anthropic");
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toHaveProperty("models");
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toHaveProperty("models");
     expect(getRemoteModelCatalogPricing({})?.["openai/gpt-external"]).toEqual({
       input: 2.5,
       output: 10,
@@ -50,26 +53,35 @@ describe("remote model catalog overlay", () => {
 
   it("fails closed when disabled, stale, or missing a build stamp", () => {
     expect(
-      getRemoteModelCatalogOverlay({ models: { catalogRefresh: { enabled: false } } }),
+      getRemoteModelCatalogProviderOverlay(
+        { models: { catalogRefresh: { enabled: false } } },
+        "anthropic",
+      ),
     ).toBeUndefined();
     expect(mocks.read).not.toHaveBeenCalled();
     resetRemoteModelCatalogOverlayForTest();
     mocks.builtAt.mockReturnValue(200);
-    expect(getRemoteModelCatalogOverlay({})).toBeUndefined();
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toBeUndefined();
     resetRemoteModelCatalogOverlayForTest();
     mocks.builtAt.mockReturnValue(undefined);
-    expect(getRemoteModelCatalogOverlay({})).toBeUndefined();
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toBeUndefined();
   });
 
   it("does not reuse a cached overlay after disablement or a URL change", () => {
-    expect(getRemoteModelCatalogOverlay({})).toHaveProperty("anthropic");
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toHaveProperty("models");
     expect(
-      getRemoteModelCatalogOverlay({ models: { catalogRefresh: { enabled: false } } }),
+      getRemoteModelCatalogProviderOverlay(
+        { models: { catalogRefresh: { enabled: false } } },
+        "anthropic",
+      ),
     ).toBeUndefined();
     expect(
-      getRemoteModelCatalogOverlay({
-        models: { catalogRefresh: { url: "https://mirror.example.test/catalog.json" } },
-      }),
+      getRemoteModelCatalogProviderOverlay(
+        {
+          models: { catalogRefresh: { url: "https://mirror.example.test/catalog.json" } },
+        },
+        "anthropic",
+      ),
     ).toBeUndefined();
     expect(mocks.read).toHaveBeenCalledTimes(2);
   });

--- a/src/model-catalog/remote-overlay.ts
+++ b/src/model-catalog/remote-overlay.ts
@@ -4,11 +4,12 @@ import {
   type RemoteModelCatalogPricing,
 } from "@openclaw/model-catalog-core";
 import type { ModelCatalogProvider } from "@openclaw/model-catalog-core/model-catalog-types";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { compareOpenClawVersions } from "../config/version.js";
 import { VERSION } from "../version.js";
 import { bundledCatalogGeneratedAt } from "./bundled-catalog-stamp.js";
-import { isRemoteModelCatalogRefreshEnabled, resolveRemoteCatalogUrl } from "./remote-refresh.js";
+import { isRemoteModelCatalogRefreshEnabled, resolveRemoteCatalogUrl } from "./remote-config.js";
 import { readRemoteModelCatalog } from "./remote-store.js";
 
 type RemoteModelCatalogOverlay = Readonly<Record<string, ModelCatalogProvider>>;
@@ -65,10 +66,12 @@ function getActiveRemoteModelCatalog(config: OpenClawConfig): ActiveRemoteModelC
   }
 }
 
-export function getRemoteModelCatalogOverlay(
+export function getRemoteModelCatalogProviderOverlay(
   config: OpenClawConfig,
-): RemoteModelCatalogOverlay | undefined {
-  return getActiveRemoteModelCatalog(config)?.providers;
+  provider: string,
+): ModelCatalogProvider | undefined {
+  const providerId = normalizeProviderId(provider);
+  return providerId ? getActiveRemoteModelCatalog(config)?.providers[providerId] : undefined;
 }
 
 export function getRemoteModelCatalogPricing(

--- a/src/model-catalog/remote-refresh.test.ts
+++ b/src/model-catalog/remote-refresh.test.ts
@@ -3,11 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import {
-  refreshRemoteModelCatalog,
-  REMOTE_MODEL_CATALOG_TTL_MS,
-  resolveRemoteCatalogUrl,
-} from "./remote-refresh.js";
+import { resolveRemoteCatalogUrl } from "./remote-config.js";
+import { refreshRemoteModelCatalog, REMOTE_MODEL_CATALOG_TTL_MS } from "./remote-refresh.js";
 import { readRemoteModelCatalog, writeRemoteModelCatalog } from "./remote-store.js";
 
 const roots: string[] = [];

--- a/src/model-catalog/remote-refresh.ts
+++ b/src/model-catalog/remote-refresh.ts
@@ -12,13 +12,13 @@ import {
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { VERSION } from "../version.js";
 import { bundledCatalogGeneratedAt } from "./bundled-catalog-stamp.js";
+import { isRemoteModelCatalogRefreshEnabled, resolveRemoteCatalogUrl } from "./remote-config.js";
 import {
   markRemoteModelCatalogChecked,
   readRemoteModelCatalog,
   writeRemoteModelCatalog,
 } from "./remote-store.js";
 
-const DEFAULT_REMOTE_MODEL_CATALOG_URL = "https://catalog.openclaw.ai/models/v1/catalog.json";
 export const REMOTE_MODEL_CATALOG_TTL_MS = 6 * 60 * 60_000;
 const REMOTE_MODEL_CATALOG_TIMEOUT_MS = 15_000;
 const REMOTE_MODEL_CATALOG_MAX_BYTES = 4 * 1024 * 1024;
@@ -29,14 +29,6 @@ type RemoteModelCatalogRefreshResult =
   | ({ status: "fresh"; generatedAt: number; nextCheckInMs: number } & RefreshCounts)
   | { status: "disabled"; providers: 0; models: 0 }
   | { status: "error"; error: string; providers: 0; models: 0 };
-
-export function isRemoteModelCatalogRefreshEnabled(config: OpenClawConfig): boolean {
-  return config.models?.catalogRefresh?.enabled !== false;
-}
-
-export function resolveRemoteCatalogUrl(config: OpenClawConfig): string {
-  return config.models?.catalogRefresh?.url?.trim() || DEFAULT_REMOTE_MODEL_CATALOG_URL;
-}
 
 function bundleCounts(bundle: RemoteModelCatalogBundle): RefreshCounts {
   const providers = Object.values(bundle.providers);

--- a/src/plugins/gateway-startup-plugin-providers.test.ts
+++ b/src/plugins/gateway-startup-plugin-providers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { collectConfiguredAgentModelProviderIds } from "./gateway-startup-plugin-providers.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+
+function createManifestRecord(
+  plugin: Pick<PluginManifestRecord, "id"> & Partial<PluginManifestRecord>,
+): PluginManifestRecord {
+  return {
+    channels: [],
+    providers: [],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    origin: "bundled",
+    rootDir: `/tmp/plugins/${plugin.id}`,
+    source: `/tmp/plugins/${plugin.id}/index.ts`,
+    manifestPath: `/tmp/plugins/${plugin.id}/openclaw.plugin.json`,
+    ...plugin,
+  };
+}
+
+function createManifestRegistry(
+  plugins: Array<Pick<PluginManifestRecord, "id"> & Partial<PluginManifestRecord>>,
+): PluginManifestRegistry {
+  return { plugins: plugins.map(createManifestRecord), diagnostics: [] };
+}
+
+describe("configured Gateway model provider ownership", () => {
+  it("does not inspect model catalogs when no agent model refs are configured", () => {
+    const registry = createManifestRegistry([
+      {
+        id: "unused",
+        providers: ["unused"],
+        modelCatalog: {
+          providers: {
+            unused: {
+              get models(): never {
+                throw new Error("unconfigured catalog was inspected");
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(collectConfiguredAgentModelProviderIds({}, registry)).toEqual(new Set());
+  });
+
+  it("does not normalize unrelated rows in a large catalog", () => {
+    let unrelatedNormalizationReads = 0;
+    const unrelatedModels = Array.from({ length: 10_000 }, (_, index) => ({
+      id: `unrelated-${index}`,
+      get name() {
+        unrelatedNormalizationReads += 1;
+        return `Unrelated ${index}`;
+      },
+    }));
+    const registry = createManifestRegistry([
+      {
+        id: "selected",
+        providers: ["selected"],
+        modelCatalog: {
+          providers: {
+            selected: {
+              api: "bedrock-converse-stream",
+              models: [{ id: "requested" }, ...unrelatedModels],
+            },
+          },
+        },
+      },
+      {
+        id: "unrelated",
+        providers: ["unrelated"],
+        modelCatalog: {
+          providers: {
+            unrelated: { models: unrelatedModels },
+          },
+        },
+      },
+    ]);
+    const config = {
+      agents: { defaults: { model: "selected/requested" } },
+    } as OpenClawConfig;
+
+    expect(collectConfiguredAgentModelProviderIds(config, registry)).toEqual(new Set(["selected"]));
+    expect(unrelatedNormalizationReads).toBe(0);
+  });
+});

--- a/src/plugins/gateway-startup-plugin-providers.ts
+++ b/src/plugins/gateway-startup-plugin-providers.ts
@@ -85,11 +85,21 @@ type ManifestModelProviderLookup = {
 function buildManifestModelProviderLookup(
   manifestRegistry: PluginManifestRegistry,
   config: OpenClawConfig,
+  modelIdsByProvider: ReadonlyMap<string, ReadonlySet<string>>,
 ): ManifestModelProviderLookup {
-  const modelApis = new Map(
-    planEffectiveModelCatalogRows({ registry: manifestRegistry, config }).rows.flatMap((row) =>
-      row.api ? [[row.mergeKey, row.api] as const] : [],
+  const providerFilters = [...modelIdsByProvider.keys()];
+  const mergeKeyFilter = new Set(
+    [...modelIdsByProvider].flatMap(([providerId, modelIds]) =>
+      [...modelIds].map((modelId) => buildModelCatalogMergeKey(providerId, modelId)),
     ),
+  );
+  const modelApis = new Map(
+    planEffectiveModelCatalogRows({
+      registry: manifestRegistry,
+      config,
+      providerFilters,
+      mergeKeyFilter,
+    }).rows.flatMap((row) => (row.api ? [[row.mergeKey, row.api] as const] : [])),
   );
   return {
     modelApis,
@@ -104,7 +114,6 @@ export function collectConfiguredAgentModelProviderIds(
   manifestRegistry: PluginManifestRegistry,
 ): ReadonlySet<string> {
   const modelIdsByProvider = new Map<string, Set<string>>();
-  const manifestModelProviders = buildManifestModelProviderLookup(manifestRegistry, config);
   const addModelProviderRefs = (value: unknown) => {
     for (const { providerId, modelId } of listModelProviderRefParts(value)) {
       const modelIds = modelIdsByProvider.get(providerId) ?? new Set<string>();
@@ -134,6 +143,15 @@ export function collectConfiguredAgentModelProviderIds(
     addModelProviderRefs(agent.utilityModel);
     addModelMapProviderIds(agent.models);
   }
+
+  if (modelIdsByProvider.size === 0) {
+    return new Set();
+  }
+  const manifestModelProviders = buildManifestModelProviderLookup(
+    manifestRegistry,
+    config,
+    modelIdsByProvider,
+  );
 
   return new Set(
     [...modelIdsByProvider.entries()]


### PR DESCRIPTION
## What Problem This Solves

Gateway startup planned and normalized the complete plugin-owned model catalog before checking whether any agent model was configured. An empty configuration therefore traversed every manifest model and pulled remote-refresh networking into the startup import graph without using those results.

## Why This Change Was Made

The startup collector now gathers configured default and per-agent model references first, returns immediately when none exist, and scopes the canonical catalog planner by normalized provider and merge key. Provider and model filtering happens before normalization, and remote overlay access is provider-scoped. Pure refresh enablement/URL configuration moved to a network-free module so startup planning no longer imports remote refresh machinery.

Aliases and overrides, trusted transport fields, remote overlay identity, pricing, and full unscoped catalog behavior remain unchanged. No provider-specific branch, cache, configuration option, protocol, or public API was added.

## User Impact

Gateways with few or no configured agent models avoid unrelated plugin catalog normalization during startup. In the synthetic current-main workload, 2,000 empty-config calls improved from 2,042.56 ms total to a 2.82 ms median total (723×, 99.86%). The broad startup suite also reduced max RSS from 536,256 KB to 390,300 KB, though the focused benchmark is the primary evidence.

## Evidence

- Current-main regression first failed 0/2: empty config inspected a throwing unconfigured catalog, and one selected model read 20,000 unrelated normalization properties. It passes 2/2 after the owner-boundary fix.
- Three post-fix 2,000-call runs: 3.784 / 2.724 / 2.824 ms total; unscoped planning still returns exactly 40 entries, 254 rows, and zero conflicts.
- Startup collector import graph excludes `remote-refresh.ts`; overlay graph shrank from 185 to 156 modules and excludes both `remote-refresh.ts` and `fetch-guard.ts`.
- Focused startup/planner/alias/overlay/pricing/import-boundary coverage: 56/56 passed locally on the published commit.
- Broad startup coverage: 171/171 passed.
- `node scripts/check-changed.mjs -- <12 changed paths>` passed all routed checks, typechecks, lint, import-cycle and architecture guards.
- Full `pnpm build` passed, including postbuild and SDK/UI checks.
- `git diff --check` passed.
- Fresh autoreview and TruffleHog were clean; no actionable findings, correctness confidence 0.99.

AI-assisted implementation and verification. The change and its owner boundaries were reviewed; no agent transcript is attached because transcript publication was not authorized.
