### PR TITLE
perf(test): speed up Tasks page state observations

### DIFF
--- a/ui/src/pages/tasks/tasks-page.test.ts
+++ b/ui/src/pages/tasks/tasks-page.test.ts
@@ -3,6 +3,7 @@ import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.
 import { sessionRefFromPath } from "../../app-session-route-paths.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { TaskStatus, TaskSummary } from "../../lib/tasks/task-summary.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import "./tasks-page.ts";
 
 type TasksPageTestElement = HTMLElement & {
@@ -102,7 +103,7 @@ async function createDeferredTaskRefresh(initialTasks: TaskSummary[]) {
   const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
   page.context = createContext(source.gateway);
   document.body.append(page);
-  await vi.waitFor(() => expect(page.tasks).toHaveLength(initialTasks.length));
+  await waitForFast(() => expect(page.tasks).toHaveLength(initialTasks.length));
 
   return {
     active,
@@ -314,7 +315,7 @@ describe("TasksPage active pagination", () => {
     page.context = createContext(source.gateway);
     document.body.append(page);
 
-    await vi.waitFor(() => expect(page.error).toBe("OPENAI_API_KEY=sk-123...cdef"));
+    await waitForFast(() => expect(page.error).toBe("OPENAI_API_KEY=sk-123...cdef"));
   });
 
   it("drains active pages with the selected scope and merges each task once", async () => {
@@ -356,7 +357,7 @@ describe("TasksPage active pagination", () => {
     page.context = createContext(source.gateway, "writer");
     document.body.append(page);
 
-    await vi.waitFor(() => expect(page.tasks).toHaveLength(4));
+    await waitForFast(() => expect(page.tasks).toHaveLength(4));
 
     expect(request).toHaveBeenCalledWith(
       "tasks.list",
@@ -402,7 +403,7 @@ describe("TasksPage active pagination", () => {
     page.context = createContext(source.gateway);
     document.body.append(page);
 
-    await vi.waitFor(() => expect(page.error).toBe("The gateway returned an invalid task list."));
+    await waitForFast(() => expect(page.error).toBe("The gateway returned an invalid task list."));
 
     expect(activeCalls).toBe(2);
     expect(request).toHaveBeenCalledTimes(3);
@@ -439,7 +440,7 @@ describe("TasksPage active pagination", () => {
       task: { ...stale, status: "completed", updatedAt: 200 },
     });
     finalPage.resolve({ tasks: [stale] });
-    await vi.waitFor(() => expect(page.tasks[0]?.status).toBe("completed"));
+    await waitForFast(() => expect(page.tasks[0]?.status).toBe("completed"));
 
     expect(page.tasks).toHaveLength(1);
   });
@@ -476,7 +477,7 @@ describe("TasksPage cancellation lifecycle", () => {
     });
     try {
       document.body.append(page);
-      await vi.waitFor(() => expect(page.tasks).toHaveLength(1));
+      await waitForFast(() => expect(page.tasks).toHaveLength(1));
 
       const copyButton = [...page.querySelectorAll("button")].find(
         (button) => button.textContent?.trim() === "Copy result",
@@ -515,7 +516,7 @@ describe("TasksPage cancellation lifecycle", () => {
     page.context = createContext(source.gateway, "research");
     document.body.append(page);
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.querySelector<HTMLAnchorElement>(".session-link")?.getAttribute("href")).toBe(
         "/chat/research/telegram/12345",
       ),
@@ -613,7 +614,7 @@ describe("TasksPage cancellation lifecycle", () => {
     const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
     page.context = createContext(source.gateway);
     document.body.append(page);
-    await vi.waitFor(() => expect(page.tasks).toHaveLength(1));
+    await waitForFast(() => expect(page.tasks).toHaveLength(1));
 
     await page.recoverTask(blocked.taskId, "retry");
 
@@ -642,7 +643,7 @@ describe("TasksPage cancellation lifecycle", () => {
     const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
     page.context = createContext(source.gateway);
     document.body.append(page);
-    await vi.waitFor(() => expect(page.tasks).toHaveLength(1));
+    await waitForFast(() => expect(page.tasks).toHaveLength(1));
 
     const recovery = page.recoverTask(blocked.taskId, "retry");
     await vi.waitFor(() => expect(page.cancellingTaskIds.has(blocked.taskId)).toBe(true));
@@ -677,7 +678,7 @@ describe("TasksPage cancellation lifecycle", () => {
     const page = document.createElement("openclaw-tasks-page") as TasksPageTestElement;
     page.context = createContext(source.gateway);
     document.body.append(page);
-    await vi.waitFor(() => expect(page.tasks).toHaveLength(1));
+    await waitForFast(() => expect(page.tasks).toHaveLength(1));
 
     const text = page.textContent ?? "";
     expect(text).toContain("Completed; result delivery was dismissed.");


### PR DESCRIPTION
## What Problem This Solves

The Tasks page unit suite repeatedly waited for Vitest's default 50 ms polling interval after task snapshots, rendered links, and error state had already settled. Its shared setup helper repeated the same incidental delay throughout the concurrent-refresh coverage.

## Why This Change Was Made

Reuse the existing Control UI `waitForFast` helper for ten incidental state observations while retaining all seven synchronization barriers that protect reconnect ordering, pagination request order, clipboard completion, request counts, and in-flight cancellation/recovery. No production code, assertions, timeouts, timers, request semantics, or dependencies change.

## User Impact

No user-visible behavior changes. The existing Tasks page coverage runs faster while preserving refresh, cancellation, completion, errors, scope, read-only access, and stale-response protection.

## Evidence

- Same Blacksmith Testbox (`tbx_01m0hpx735wspjcpdddhge529a`), single worker, separate baseline/candidate module caches, excluded warmups, and eight retained interleaved samples per variant.
- Median wall: **2.100s -> 1.555s (-0.545s, -25.95%)**; Vitest: **1.720s -> 1.170s**; test body: **1.020s -> 0.470s (-53.9%)**; imports: **0.269s -> 0.265s**; max RSS: **519592 KiB -> 520238 KiB**; user CPU: **1.845s -> 1.805s**; system CPU: **0.195s -> 0.200s**. Every retained sample ran **18 tests and 10 measured imports**.
- Focused owner and sibling proof: `node scripts/run-vitest.mjs ui/src/pages/tasks/tasks-page.test.ts ui/src/lib/tasks/data.test.ts ui/src/lit/gateway-page-controller.test.ts ui/src/pages/chat/components/chat-background-tasks.test.ts ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts --reporter=verbose` -> **97 passed**.
- Real Chromium proof: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/tasks/tasks.e2e.test.ts ui/src/pages/chat/background-tasks.e2e.test.ts --reporter=verbose` -> **7 passed**, covering stale refresh/reconnect, 500-row active pagination, cancellation, and read-only result copying.
- Owner fault injection proved the optimized tests still fail when buffered task completions are dropped or when the Recent request loses its terminal-status filter; both temporary production faults were removed.
- Full changed gate, formatting/diff checks, test-audit/deslop review, and independent Codex autoreview passed. Production LOC: **+0/-0**; tests: **+11/-10**.
