### PR TITLE
docs: update himalaya skill commands for the v2 CLI

### DIFF
--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -35,7 +35,7 @@ Use `himalaya` for IMAP/SMTP email from shell.
 
 ```bash
 himalaya --version
-himalaya account configure
+himalaya configure
 ```
 
 Config path: `~/.config/himalaya/config.toml`.
@@ -45,18 +45,21 @@ Prefer password managers/keyrings for credentials; do not paste secrets into cha
 ## Read/search
 
 ```bash
-himalaya folder list
+himalaya mailbox list
 himalaya envelope list
 himalaya message read <id>
-himalaya envelope list from alice@example.com subject invoice
+himalaya envelope search "from alice and subject invoice"
 ```
+
+`envelope list` takes no query; all filtering goes through `envelope search`
+(pass the whole query as one argument). `--json` is the global flag for
+machine-readable output.
 
 ## Write
 
 ```bash
 himalaya message write
-himalaya template write
-himalaya template send < /tmp/message.txt
+himalaya message send < /tmp/message.eml
 himalaya message reply <id>
 himalaya message forward <id>
 ```
@@ -66,12 +69,16 @@ Use MML for attachments and rich messages; read `references/message-composition.
 ## Organize
 
 ```bash
-himalaya message copy <id> <folder>
-himalaya message move <id> <folder>
+himalaya message copy --to <folder> <id>
+himalaya message move --to <folder> <id>
 himalaya message delete <id>
 himalaya flag add <id> --flag seen
 himalaya flag remove <id> --flag seen
 ```
+
+`--to` is mandatory on copy/move; `--from` is optional and defaults to the
+inbox alias. To dump a message's raw RFC 5322 bytes (full headers), use
+`himalaya message read --raw <id>`.
 
 ## Safety
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where agents following the himalaya skill hit hard CLI errors on its documented commands: himalaya v2.1.0 — which is what `brew install himalaya`, the skill's own install path, serves today — removed the `folder` and `template` subcommands, made `--to` a mandatory flag on `message copy`/`message move`, and takes no query arguments on `envelope list`. An agent follows the skill verbatim, gets `unrecognized subcommand` / usage errors, and has to burn turns rediscovering the real syntax with `--help`.

## Why This Change Was Made

Updates the stale command shapes to the v2 CLI and adds two short notes so agents do not have to probe `--help`: the `envelope list` vs `envelope search` split (all filtering lives on `search`, query passed as one argument), and `--to`/`--from` semantics on copy/move plus `message read --raw` for raw RFC 5322 output. Docs-only; no runtime change.

## User Impact

Agents using the bundled himalaya skill run working mail commands on the first attempt against a current himalaya install, instead of erroring on the skill's own examples.

## Evidence

Every changed command was verified against the himalaya v2.1.0 release binary (linux musl x86_64, published 2026-08-16) on a live IMAP account.

Old documented forms fail:

```
$ himalaya folder list
error: unrecognized subcommand 'folder'

$ himalaya envelope list --output json
error: unexpected argument '--output' found
```

`himalaya message move --help` shows `--to <NAME>` is required with message ids positional (`Usage: himalaya message move [OPTIONS] --to <NAME> [MESSAGE-IDS]...`), and `message export` / `template` no longer exist as subcommands.

Replacement forms all executed successfully against the live account: `mailbox list`, `envelope search "from ... and subject ..."`, `message move --to <folder> <id>`, `message read --raw <id>`, and the global `--json` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
