### PR TITLE
fix(plugins): bound allowlist warning history

### DIFF
--- a/src/plugins/loader-cache-state.test.ts
+++ b/src/plugins/loader-cache-state.test.ts
@@ -18,6 +18,18 @@ describe("PluginLoaderCacheState", () => {
     expect(cache.get("c")).toBe("charlie");
   });
 
+  it("bounds open-allowlist warning suppression by loader cache capacity", () => {
+    const cache = new PluginLoaderCacheState<string>(2);
+
+    cache.recordOpenAllowlistWarning("first");
+    cache.recordOpenAllowlistWarning("second");
+    cache.recordOpenAllowlistWarning("third");
+
+    expect(cache.hasOpenAllowlistWarning("first")).toBe(false);
+    expect(cache.hasOpenAllowlistWarning("second")).toBe(true);
+    expect(cache.hasOpenAllowlistWarning("third")).toBe(true);
+  });
+
   it("clears registry, in-flight, and warning state together", () => {
     const cache = new PluginLoaderCacheState<string>(2);
 

--- a/src/plugins/loader-cache-state.ts
+++ b/src/plugins/loader-cache-state.ts
@@ -16,10 +16,11 @@ class PluginLoadReentryError extends Error {
 export class PluginLoaderCacheState<T> {
   readonly #registryCache: PluginLruCache<T>;
   readonly #inFlightLoads = new Set<string>();
-  readonly #openAllowlistWarningCache = new Set<string>();
+  readonly #openAllowlistWarningCache: PluginLruCache<true>;
 
   constructor(defaultMaxEntries: number) {
     this.#registryCache = new PluginLruCache<T>(defaultMaxEntries);
+    this.#openAllowlistWarningCache = new PluginLruCache<true>(defaultMaxEntries);
   }
 
   clear(): void {
@@ -57,10 +58,10 @@ export class PluginLoaderCacheState<T> {
   }
 
   hasOpenAllowlistWarning(cacheKey: string): boolean {
-    return this.#openAllowlistWarningCache.has(cacheKey);
+    return this.#openAllowlistWarningCache.get(cacheKey) === true;
   }
 
   recordOpenAllowlistWarning(cacheKey: string): void {
-    this.#openAllowlistWarningCache.add(cacheKey);
+    this.#openAllowlistWarningCache.set(cacheKey, true);
   }
 }


### PR DESCRIPTION
Closes #127102

## What Problem This Solves

Long-lived Gateways that hot-reload non-bundled plugins without a matching explicit allowlist retained one warning-suppression key for every historical plugin configuration generation, growing process memory without a bound.

## Why This Change Was Made

Open-allowlist warning memory now uses the plugin loader's existing lifecycle-owned LRU primitive with the same capacity as the registry cache it annotates. Recent duplicate-warning suppression, LRU recency, and explicit clear behavior are preserved without a new lifecycle, configuration surface, persistent store, or migration.

Production change: 4 added / 3 removed lines. Regression coverage: 12 added lines. The one additional production line initializes the separately typed warning-marker cache using the existing loader capacity.

## User Impact

Valid plugin configuration churn no longer grows process-lifetime warning history beyond the loader's existing 128-entry bound. Plugin discovery, activation, authorization, and warning contents are unchanged.

## Evidence

- Current-main direct owner reproduction fails: a capacity-2 cache retains all three warning keys.
- `node scripts/run-vitest.mjs src/plugins/loader-cache-state.test.ts --reporter=verbose`: 4/4 passed, including the visible `bounds open-allowlist warning suppression by loader cache capacity` regression.
- `node scripts/run-vitest.mjs src/plugins/loader-cache-state.test.ts src/plugins/loader.test.ts src/plugins/loader-shared.test.ts`: 196/196 passed across the cache, shared-loader, and bundled-loader owners.
- Real direct-process owner stress inserted 10,000 distinct warning generations at capacity 128: old generations were evicted, the newest 128 remained accessible, and explicit lifecycle clearing removed warning history.
- Fresh independent Codex autoreview of the complete branch: clean, no actionable findings.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/32466560156; Workflow Sanity: https://github.com/openclaw/openclaw/actions/runs/32466537795.
- The automated persistent-schema concern is a false positive: this owner and regression exercise bounded, in-memory process state only; no database, storage schema, or migration is touched.

Implementation and tests were produced with AI assistance and manually inspected against the plugin loader cache ownership contract.
