### PR TITLE
fix(gateway): stop rescanning retired delivery queues

### DIFF
--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -23,6 +23,8 @@ type DrainPendingDeliveries =
   typeof import("../infra/outbound/delivery-queue-recovery.js").drainPendingDeliveriesCore;
 type RecoverPendingDeliveries =
   typeof import("../infra/outbound/delivery-queue-recovery.js").recoverPendingDeliveries;
+type MigrateLegacyPendingOutboundDeliveries =
+  typeof import("../infra/outbound/delivery-queue-migration.js").migrateLegacyPendingOutboundDeliveries;
 
 const hoisted = vi.hoisted(() => {
   const heartbeatRunner = {
@@ -53,6 +55,9 @@ const hoisted = vi.hoisted(() => {
       skippedMaxRetries: 0,
       deferredBackoff: 0,
     })),
+    migrateLegacyPendingOutboundDeliveries: vi.fn<MigrateLegacyPendingOutboundDeliveries>(
+      async () => ({ moved: 0, skipped: 0, remaining: 0 }),
+    ),
     drainPendingDeliveries: vi.fn<DrainPendingDeliveries>(async () => undefined),
     recoverPendingRestartContinuationDeliveries: vi.fn(async () => undefined),
     deliverQueuedSessionDelivery: vi.fn(async () => undefined),
@@ -81,6 +86,10 @@ vi.mock("../infra/outbound/deliver.js", () => ({
 vi.mock("../infra/outbound/delivery-queue-recovery.js", () => ({
   recoverPendingDeliveries: hoisted.recoverPendingDeliveries,
   drainPendingDeliveriesCore: hoisted.drainPendingDeliveries,
+}));
+
+vi.mock("../infra/outbound/delivery-queue-migration.js", () => ({
+  migrateLegacyPendingOutboundDeliveries: hoisted.migrateLegacyPendingOutboundDeliveries,
 }));
 
 vi.mock("../infra/session-delivery-queue-runtime.js", () => ({
@@ -137,6 +146,12 @@ describe("server-runtime-services", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+    });
+    hoisted.migrateLegacyPendingOutboundDeliveries.mockReset();
+    hoisted.migrateLegacyPendingOutboundDeliveries.mockResolvedValue({
+      moved: 0,
+      skipped: 0,
+      remaining: 0,
     });
     hoisted.drainPendingDeliveries.mockReset();
     hoisted.drainPendingDeliveries.mockResolvedValue(undefined);
@@ -558,6 +573,66 @@ describe("server-runtime-services", () => {
     await vi.advanceTimersByTimeAsync(1_250);
     await vi.dynamicImportSettled();
     expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs legacy migration once while clean periodic ticks keep draining canonical work", async () => {
+    vi.useFakeTimers();
+    const { services } = activateScheduledServicesForTest({ startCron: false });
+
+    await vi.dynamicImportSettled();
+    expect(hoisted.migrateLegacyPendingOutboundDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(hoisted.migrateLegacyPendingOutboundDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledTimes(3);
+    services.heartbeatRunner.stop();
+  });
+
+  it.each([
+    {
+      name: "the pass skipped work",
+      firstPass: { moved: 0, skipped: 1, remaining: 0 },
+    },
+    {
+      name: "retired work remains",
+      firstPass: { moved: 0, skipped: 0, remaining: 1 },
+    },
+  ])("retries legacy migration when $name until a clean pass completes", async ({ firstPass }) => {
+    vi.useFakeTimers();
+    hoisted.migrateLegacyPendingOutboundDeliveries
+      .mockResolvedValueOnce(firstPass)
+      .mockResolvedValueOnce({ moved: 1, skipped: 0, remaining: 0 });
+    const { services } = activateScheduledServicesForTest({ startCron: false });
+
+    await vi.dynamicImportSettled();
+    expect(hoisted.migrateLegacyPendingOutboundDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(hoisted.migrateLegacyPendingOutboundDeliveries).toHaveBeenCalledTimes(2);
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledTimes(2);
+    expect(hoisted.drainPendingDeliveries).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(hoisted.migrateLegacyPendingOutboundDeliveries).toHaveBeenCalledTimes(2);
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+    services.heartbeatRunner.stop();
+  });
+
+  it("resets legacy migration completion with the scheduled-service lifecycle", async () => {
+    vi.useFakeTimers();
+    const first = activateScheduledServicesForTest({ startCron: false });
+    await vi.dynamicImportSettled();
+    expect(hoisted.migrateLegacyPendingOutboundDeliveries).toHaveBeenCalledOnce();
+    await first.services.stopOutboundDeliveryRecovery();
+
+    const second = activateScheduledServicesForTest({ startCron: false });
+    await vi.dynamicImportSettled();
+    expect(hoisted.migrateLegacyPendingOutboundDeliveries).toHaveBeenCalledTimes(2);
+    second.services.heartbeatRunner.stop();
   });
 
   it.each([

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -195,11 +195,13 @@ function startPendingOutboundDeliveryRecovery(params: {
   log: GatewayRuntimeServiceLogger;
 }): () => Promise<void> {
   let stopped = false;
+  let migrationPending = true;
+  let initialPass = true;
   let inFlight: Promise<void> | null = null;
   let stopPromise: Promise<void> | null = null;
   let logRecovery: ReturnType<GatewayRuntimeServiceLogger["child"]> | undefined;
 
-  const recover = (startup: boolean): void => {
+  const recover = (): void => {
     if (stopped || inFlight || isGatewayWorkAdmissionClosed()) {
       return;
     }
@@ -214,16 +216,27 @@ function startPendingOutboundDeliveryRecovery(params: {
         return;
       }
       logRecovery ??= params.log.child("delivery-recovery");
-      if (startup) {
+      if (migrationPending) {
+        const cfg = initialPass ? params.cfg : getRuntimeConfig();
+        initialPass = false;
+        const { migrateLegacyPendingOutboundDeliveries } =
+          await import("../infra/outbound/delivery-queue-migration.js");
+        const migration = await migrateLegacyPendingOutboundDeliveries({
+          cfg,
+          log: logRecovery,
+        });
+        // A new scheduled-service lifecycle starts unchecked. Latch only after
+        // one pass neither skipped ownership nor left retired rows behind.
+        migrationPending = migration.skipped > 0 || migration.remaining > 0;
         await recoverPendingDeliveries({
           deliver: deliverOutboundPayloadsInternal,
           log: logRecovery,
-          cfg: params.cfg,
+          cfg,
         });
         return;
       }
-      // Startup migration runs once. Normal retries use fresh config so revoked
-      // accounts cannot inherit the authority captured at gateway startup.
+      // Normal retries use fresh config so revoked accounts cannot inherit the
+      // authority captured at gateway startup.
       await drainPendingDeliveriesCore({
         drainKey: "gateway:outbound",
         logLabel: "Outbound delivery retry",
@@ -243,9 +256,9 @@ function startPendingOutboundDeliveryRecovery(params: {
 
   // Match the queue's first backoff window without holding admission between
   // ticks; otherwise suspended/restarting gateways retain invisible work.
-  const retryTimer = setInterval(() => recover(false), computeBackoffMs(1));
+  const retryTimer = setInterval(recover, computeBackoffMs(1));
   retryTimer.unref?.();
-  recover(true);
+  recover();
   return () => {
     stopped = true;
     clearInterval(retryTimer);

--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -12,6 +12,7 @@ import { commitStagedDeliveryQueueEntryOnceAcrossNamespaces } from "./delivery-q
 import {
   completeDeliveryQueueEntry,
   countFailedDeliveryQueueEntries,
+  countPendingDeliveryQueueEntries,
   deleteDeliveryQueueEntry,
   getDeliveryQueueEntryStatus,
   loadDeliveryQueueEntries,
@@ -108,6 +109,24 @@ describe("delivery-queue-sqlite corrupt JSON resilience", () => {
 
       expect(loadDeliveryQueueEntries(QUEUE, stateDir)).toHaveLength(3);
     });
+  });
+
+  it("counts pending rows across only the selected namespaces", () => {
+    enqueueValid("pending");
+    upsertDeliveryQueueEntry({
+      queueName: "other-q",
+      entry: { id: "other", enqueuedAt: Date.now(), retryCount: 0 },
+      stateDir,
+    });
+    upsertDeliveryQueueEntry({
+      queueName: "ignored-q",
+      entry: { id: "ignored", enqueuedAt: Date.now(), retryCount: 0 },
+      stateDir,
+    });
+    completeDeliveryQueueEntry(QUEUE, "pending", stateDir);
+
+    expect(countPendingDeliveryQueueEntries([QUEUE, "other-q"], stateDir)).toBe(1);
+    expect(countPendingDeliveryQueueEntries([], stateDir)).toBe(0);
   });
 
   describe("updateDeliveryQueueEntry with corrupt row", () => {

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -364,6 +364,27 @@ export function countFailedDeliveryQueueEntries(stateDir?: string): Array<{
   );
 }
 
+/** Count pending entries across an exact set of queue namespaces. */
+export function countPendingDeliveryQueueEntries(
+  queueNames: readonly string[],
+  stateDir?: string,
+): number {
+  if (queueNames.length === 0) {
+    return 0;
+  }
+  const database = openStateDatabase(stateDir);
+  const queueDb = getNodeSqliteKysely<DeliveryQueueDatabase>(database.db);
+  const [row] = executeSqliteQuerySync(
+    database.db,
+    queueDb
+      .selectFrom("delivery_queue_entries")
+      .select((eb) => eb.fn.countAll<number>().as("count"))
+      .where("queue_name", "in", queueNames)
+      .where("status", "=", "pending"),
+  ).rows;
+  return row?.count ?? 0;
+}
+
 /** Physically expire age-bounded delivery queue tombstones. */
 export function pruneExpiredDeliveryQueueTombstones(stateDir?: string): void {
   const database = openStateDatabase(stateDir);

--- a/src/infra/outbound/delivery-queue-migration.test.ts
+++ b/src/infra/outbound/delivery-queue-migration.test.ts
@@ -253,7 +253,7 @@ describe("outbound prepared queue migration", () => {
         log: createRecoveryLog(),
         stateDir: tmpDir(),
       }),
-    ).resolves.toEqual({ moved: 1, skipped: 0 });
+    ).resolves.toEqual({ moved: 1, skipped: 0, remaining: 0 });
     expect(hookMocks.runMessageSending).toHaveBeenCalledTimes(1);
     expect(getDeliveryQueueEntryStatus(LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME, id, tmpDir())).toBe(
       "completed",
@@ -346,8 +346,12 @@ describe("outbound prepared queue migration", () => {
     });
     releaseHook?.({ content: "first-prepared" });
 
-    await expect(migration).resolves.toEqual({ moved: 1, skipped: 0 });
-    await expect(overlappingMigration).resolves.toEqual({ moved: 1, skipped: 0 });
+    await expect(migration).resolves.toEqual({ moved: 1, skipped: 0, remaining: 0 });
+    await expect(overlappingMigration).resolves.toEqual({
+      moved: 1,
+      skipped: 0,
+      remaining: 0,
+    });
     expect(hookMocks.runMessageSending).toHaveBeenCalledOnce();
     expect(loadDeliveryQueueEntry(OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME, id, tmpDir())).toBeNull();
     expect(loadDeliveryQueueEntry(OUTBOUND_DELIVERY_QUEUE_NAME, id, tmpDir())).toMatchObject({
@@ -385,7 +389,7 @@ describe("outbound prepared queue migration", () => {
       await vi.advanceTimersByTimeAsync(30_000);
       releaseHook?.({ content: "must not replay-prepared" });
 
-      await expect(migration).resolves.toEqual({ moved: 0, skipped: 1 });
+      await expect(migration).resolves.toEqual({ moved: 0, skipped: 1, remaining: 0 });
       expect(
         getDeliveryQueueEntryStatus(OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME, id, tmpDir()),
       ).toBe("failed");
@@ -421,7 +425,7 @@ describe("outbound prepared queue migration", () => {
         log: createRecoveryLog(),
         stateDir: tmpDir(),
       }),
-    ).resolves.toEqual({ moved: 0, skipped: 1 });
+    ).resolves.toEqual({ moved: 0, skipped: 1, remaining: 0 });
 
     expect(hookMocks.runMessageSending).not.toHaveBeenCalled();
     expect(completionMocks.failDurableDelivery).toHaveBeenCalledWith(
@@ -472,7 +476,7 @@ describe("outbound prepared queue migration", () => {
         log: createRecoveryLog(),
         stateDir: tmpDir(),
       }),
-    ).resolves.toEqual({ moved: 0, skipped: 1 });
+    ).resolves.toEqual({ moved: 0, skipped: 1, remaining: 1 });
 
     expect(hookMocks.runMessageSending).not.toHaveBeenCalled();
     expect(completionMocks.failDurableDelivery).not.toHaveBeenCalled();
@@ -501,7 +505,7 @@ describe("outbound prepared queue migration", () => {
         log: createRecoveryLog(),
         stateDir: tmpDir(),
       }),
-    ).resolves.toEqual({ moved: 0, skipped: 1 });
+    ).resolves.toEqual({ moved: 0, skipped: 1, remaining: 1 });
     expect(hookMocks.runMessageSending).not.toHaveBeenCalled();
     expect(
       loadDeliveryQueueEntry(OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME, id, tmpDir()),
@@ -516,7 +520,7 @@ describe("outbound prepared queue migration", () => {
         log: createRecoveryLog(),
         stateDir: tmpDir(),
       }),
-    ).resolves.toEqual({ moved: 1, skipped: 0 });
+    ).resolves.toEqual({ moved: 1, skipped: 0, remaining: 0 });
     expect(hookMocks.runMessageSending).toHaveBeenCalledOnce();
     expect(loadDeliveryQueueEntry(OUTBOUND_DELIVERY_QUEUE_NAME, id, tmpDir())).toMatchObject({
       preparedBatch: {
@@ -554,7 +558,7 @@ describe("outbound prepared queue migration", () => {
         log,
         stateDir: tmpDir(),
       }),
-    ).resolves.toEqual({ moved: 0, skipped: 1 });
+    ).resolves.toEqual({ moved: 0, skipped: 1, remaining: 1 });
     expect(hookMocks.runMessageSending).toHaveBeenCalledOnce();
     expect(loadDeliveryQueueEntry(LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME, id, tmpDir())).toBeNull();
     expect(
@@ -585,7 +589,7 @@ describe("outbound prepared queue migration", () => {
       stateDir: tmpDir(),
     });
     expect({ secondMigration, warnings }).toEqual({
-      secondMigration: { moved: 1, skipped: 0 },
+      secondMigration: { moved: 1, skipped: 0, remaining: 0 },
       warnings: [],
     });
     expect(hookMocks.runMessageSending).toHaveBeenCalledOnce();
@@ -640,7 +644,7 @@ describe("outbound prepared queue migration", () => {
     expect(hookMocks.runMessageSending).not.toHaveBeenCalled();
     settleReconciliation?.({ status: "not_sent" });
 
-    await expect(migration).resolves.toEqual({ moved: 1, skipped: 0 });
+    await expect(migration).resolves.toEqual({ moved: 1, skipped: 0, remaining: 0 });
     expect(hookMocks.runMessageSending).toHaveBeenCalledOnce();
     const queued = loadDeliveryQueueEntry(
       OUTBOUND_DELIVERY_QUEUE_NAME,
@@ -700,7 +704,7 @@ describe("outbound prepared queue migration", () => {
         log: createRecoveryLog(),
         stateDir: tmpDir(),
       }),
-    ).resolves.toEqual({ moved: 1, skipped: 0 });
+    ).resolves.toEqual({ moved: 1, skipped: 0, remaining: 0 });
     const migrated = loadDeliveryQueueEntry(
       OUTBOUND_DELIVERY_QUEUE_NAME,
       id,
@@ -903,6 +907,13 @@ describe("outbound prepared queue migration", () => {
     });
     const sendMatrix = vi.fn();
 
+    await expect(
+      migrateLegacyPendingOutboundDeliveries({
+        cfg: {},
+        log: createRecoveryLog(),
+        stateDir: tmpDir(),
+      }),
+    ).resolves.toEqual({ moved: 1, skipped: 0, remaining: 0 });
     await recoverPendingDeliveries({
       cfg: {},
       log: createRecoveryLog(),
@@ -952,7 +963,7 @@ describe("outbound prepared queue migration", () => {
         log: createRecoveryLog(),
         stateDir: tmpDir(),
       }),
-    ).resolves.toEqual({ moved: 0, skipped: 1 });
+    ).resolves.toEqual({ moved: 0, skipped: 1, remaining: 0 });
     expect(hookMocks.runMessageSending).not.toHaveBeenCalled();
     expect(loadDeliveryQueueEntry(OUTBOUND_DELIVERY_QUEUE_NAME, id, tmpDir())).toBeNull();
     expect(loadDeliveryQueueEntry(LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME, id, tmpDir())).toBeNull();

--- a/src/infra/outbound/delivery-queue-migration.ts
+++ b/src/infra/outbound/delivery-queue-migration.ts
@@ -9,6 +9,7 @@ import {
   replacePendingDeliveryQueueEntry,
 } from "../delivery-queue-sqlite-namespace.js";
 import {
+  countPendingDeliveryQueueEntries,
   loadDeliveryQueueEntries,
   loadDeliveryQueueEntry,
   terminalizePendingDeliveryQueueEntry,
@@ -508,14 +509,20 @@ async function finalizePreparedMigration(params: {
   }
 }
 
-const activeLegacyMigrations = new Map<string, Promise<{ moved: number; skipped: number }>>();
+type LegacyOutboundDeliveryMigrationResult = {
+  moved: number;
+  skipped: number;
+  remaining: number;
+};
+
+const activeLegacyMigrations = new Map<string, Promise<LegacyOutboundDeliveryMigrationResult>>();
 
 /** Migrates every unchanged pre-D4 pending row before canonical recovery scans. */
 export async function migrateLegacyPendingOutboundDeliveries(params: {
   cfg: OpenClawConfig;
   log: RecoveryLogger;
   stateDir?: string;
-}): Promise<{ moved: number; skipped: number }> {
+}): Promise<LegacyOutboundDeliveryMigrationResult> {
   const migrationKey = params.stateDir ?? "<default-state>";
   return await getOrCreatePromise(
     activeLegacyMigrations,
@@ -529,7 +536,7 @@ async function migrateLegacyPendingOutboundDeliveriesOwned(params: {
   cfg: OpenClawConfig;
   log: RecoveryLogger;
   stateDir?: string;
-}): Promise<{ moved: number; skipped: number }> {
+}): Promise<LegacyOutboundDeliveryMigrationResult> {
   // Beta rows can exist in either prepared namespace. Canonicalize them before
   // any recovery owner sees the row; interrupted migrations then resume normally.
   migratePreparedReplyFields(OUTBOUND_DELIVERY_QUEUE_NAME, params.stateDir);
@@ -598,5 +605,13 @@ async function migrateLegacyPendingOutboundDeliveriesOwned(params: {
   if (moved > 0 || skipped > 0) {
     params.log.info(`Legacy delivery migration settled moved=${moved} skipped=${skipped}`);
   }
-  return { moved, skipped };
+  const remaining = countPendingDeliveryQueueEntries(
+    [
+      OUTBOUND_LEGACY_PREPARATION_QUEUE_NAME,
+      LEGACY_OUTBOUND_DELIVERY_QUEUE_NAME,
+      OUTBOUND_DELIVERY_MIGRATION_QUEUE_NAME,
+    ],
+    params.stateDir,
+  );
+  return { moved, skipped, remaining };
 }

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -1230,12 +1230,6 @@ export async function drainPendingDeliveriesCore(opts: {
   deliver: DeliverFn;
   selectEntry: (entry: QueuedDelivery, now: number) => DeliveryRecoveryDrainDecision;
 }): Promise<void> {
-  const { migrateLegacyPendingOutboundDeliveries } = await import("./delivery-queue-migration.js");
-  await migrateLegacyPendingOutboundDeliveries({
-    cfg: opts.cfg,
-    log: opts.log,
-    stateDir: opts.stateDir,
-  });
   const drained = await recoveryCoordinator.withDrain(opts.drainKey, async () => {
     const now = Date.now();
     const matchingEntries = (await loadPendingDeliveries(opts.stateDir)).filter(
@@ -1344,7 +1338,8 @@ export async function drainPendingDeliveriesCore(opts: {
 }
 
 /**
- * On gateway startup, scan the delivery queue and retry any pending entries.
+ * Scan the canonical delivery queue and retry any pending entries.
+ * The gateway startup owner runs legacy migration before invoking this recovery pass.
  * Uses exponential backoff and moves entries that exhaust their retry budget to failed/.
  */
 export async function recoverPendingDeliveries(opts: {
@@ -1355,12 +1350,6 @@ export async function recoverPendingDeliveries(opts: {
   /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next startup. Default: 60 000. */
   maxRecoveryMs?: number;
 }): Promise<DeliveryRecoverySummary> {
-  const { migrateLegacyPendingOutboundDeliveries } = await import("./delivery-queue-migration.js");
-  await migrateLegacyPendingOutboundDeliveries({
-    cfg: opts.cfg,
-    log: opts.log,
-    stateDir: opts.stateDir,
-  });
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
     return createEmptyDeliveryRecoverySummary();

--- a/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
+++ b/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
@@ -34,10 +34,16 @@ const stubCfg = {} as OpenClawConfig;
 const NO_LISTENER_ERROR = "No active DirectChat listener";
 const sleepMock = vi.hoisted(() => vi.fn<(ms: number) => Promise<void>>());
 const resolveOutboundChannelMessageAdapterMock = vi.hoisted(() => vi.fn());
+const migrateLegacyPendingOutboundDeliveriesMock = vi.hoisted(() =>
+  vi.fn(async () => ({ moved: 0, skipped: 0, remaining: 0 })),
+);
 
 vi.mock("../../utils/sleep.js", () => ({ sleep: sleepMock }));
 vi.mock("./channel-resolution.js", () => ({
   resolveOutboundChannelMessageAdapter: resolveOutboundChannelMessageAdapterMock,
+}));
+vi.mock("./delivery-queue-migration.js", () => ({
+  migrateLegacyPendingOutboundDeliveries: migrateLegacyPendingOutboundDeliveriesMock,
 }));
 
 function normalizeReconnectAccountIdForTest(accountId?: string | null): string {
@@ -152,6 +158,26 @@ describe("drainPendingDeliveriesCore for reconnect", () => {
     sleepMock.mockReset();
     sleepMock.mockResolvedValue(undefined);
     resolveOutboundChannelMessageAdapterMock.mockReset();
+    migrateLegacyPendingOutboundDeliveriesMock.mockClear();
+  });
+
+  it("keeps one-time migration out of repeated canonical drains", async () => {
+    const drain = () =>
+      drainPendingDeliveriesCore({
+        drainKey: "gateway:outbound",
+        logLabel: "Outbound delivery retry",
+        cfg: stubCfg,
+        log: createRecoveryLog(),
+        stateDir: tmpDir,
+        deliver: vi.fn<DeliverFn>(),
+        selectEntry: () => ({ match: true }),
+      });
+
+    await drain();
+    await drain();
+    await drain();
+
+    expect(migrateLegacyPendingOutboundDeliveriesMock).not.toHaveBeenCalled();
   });
 
   it("drains entries that failed with 'no listener' error", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a running Gateway rescanned retired outbound-delivery queue namespaces on every scheduled retry tick, even after startup migration had completed cleanly.

## Why This Change Was Made

The scheduled-service lifecycle now owns legacy migration, retries it while work was skipped or retired rows remain, and latches after a clean pass. Ordinary retry ticks scan only the canonical queue; migration semantics, persistence, backoff, and delivery policy are unchanged.

## User Impact

Gateways with durable outbound delivery enabled avoid repeated legacy namespace scans and associated SQLite/queue traversal work every five seconds. Interrupted or concurrently owned migration work is still retried until clean.

## Evidence

- Exact regression: three canonical drains make zero migration calls (failed before the fix with three calls).
- Gateway lifecycle: 66/66 tests passed.
- Delivery migration/recovery/SQLite/backoff siblings: 131/131 tests passed.
- `node scripts/check-changed.mjs -- <8 changed paths>` passed all routed format, dead-export, core/core-test typecheck, lint, import-cycle, database/schema, and architecture guards.
- Branch autoreview: clean; patch correct at 0.95 confidence.
