### PR TITLE
fix(slack): preserve accepted reply parts after later delivery failures

### DIFF
--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -1,4 +1,7 @@
 // Slack tests cover replies plugin behavior.
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { createReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMock = vi.fn();
@@ -70,6 +73,17 @@ function requireSendCall(index = 0) {
     throw new Error(`sendMessageSlack call ${index} missing`);
   }
   return call;
+}
+
+function acceptedSlackSendResult(messageId: string, kind: "media" | "text" = "media") {
+  return {
+    messageId,
+    channelId: "C123",
+    receipt: createMessageReceiptFromOutboundResults({
+      results: [{ channel: "slack", messageId, channelId: "C123" }],
+      kind,
+    }),
+  };
 }
 
 type SlashTestMessage = {
@@ -228,6 +242,7 @@ describe("deliverReplies identity passthrough", () => {
       mediaUrl: "https://example.com/report.png",
       threadTs: "thread-ts",
       accountId: "work",
+      onDeliveryResult: expect.any(Function),
       eventScope,
       textLimit: 4000,
       mediaMaxBytes: 1024,
@@ -239,6 +254,7 @@ describe("deliverReplies identity passthrough", () => {
       token: "xoxb-test",
       threadTs: "thread-ts",
       accountId: "work",
+      onDeliveryResult: expect.any(Function),
       eventScope,
       textLimit: 4000,
       mediaMaxBytes: 1024,
@@ -1211,11 +1227,19 @@ describe("deliverReplies message_sent hook", () => {
 
   it("emits one message_sent event after a multi-media reply succeeds", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const first = acceptedSlackSendResult("media-1");
+    const second = acceptedSlackSendResult("media-2");
     sendMock
-      .mockResolvedValueOnce({ messageId: "media-1", channelId: "C123" })
-      .mockResolvedValueOnce({ messageId: "media-2", channelId: "C123" });
+      .mockImplementationOnce(async (_target, _text, options) => {
+        await options.onDeliveryResult?.(first);
+        return first;
+      })
+      .mockImplementationOnce(async (_target, _text, options) => {
+        await options.onDeliveryResult?.(second);
+        return second;
+      });
 
-    await deliverReplies(
+    const result = await deliverReplies(
       baseParams({
         replies: [
           {
@@ -1226,6 +1250,7 @@ describe("deliverReplies message_sent hook", () => {
       }),
     );
 
+    expect(result).toBe(second);
     expect(sendMock).toHaveBeenCalledTimes(2);
     expect(messageHookRunner.runMessageSent).toHaveBeenCalledTimes(1);
     const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
@@ -1312,22 +1337,44 @@ describe("deliverReplies message_sent hook", () => {
 
   it("emits only failure when a later attachment in the payload fails", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const accepted = acceptedSlackSendResult("media-1");
+    const failure = new PlatformMessageNotDispatchedError("second_upload_failed", {
+      cause: new Error("upload connection refused"),
+    });
     sendMock
-      .mockResolvedValueOnce({ messageId: "media-1", channelId: "C123" })
-      .mockRejectedValueOnce(new Error("second_upload_failed"));
+      .mockImplementationOnce(async (_target, _text, options) => {
+        await options.onDeliveryResult?.(accepted);
+        return accepted;
+      })
+      .mockRejectedValueOnce(failure);
 
-    await expect(
-      deliverReplies(
-        baseParams({
-          replies: [
-            {
-              text: "two attachments",
-              mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
-            },
-          ],
-        }),
-      ),
-    ).rejects.toThrow(/second_upload_failed/);
+    const error = await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "two attachments",
+            mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+          },
+        ],
+      }),
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      sentBeforeError: true,
+      visibleReplySent: true,
+      deliveryResult: {
+        messageIds: ["media-1"],
+        visibleReplySent: true,
+        receipt: {
+          primaryPlatformMessageId: "media-1",
+          platformMessageIds: ["media-1"],
+          parts: [{ platformMessageId: "media-1", kind: "media", index: 0 }],
+        },
+      },
+    });
+    expect((error as Error).cause).toBe(failure);
+    expect(sendMock).toHaveBeenCalledTimes(2);
 
     expect(messageHookRunner.runMessageSent).toHaveBeenCalledTimes(1);
     const event = messageHookRunner.runMessageSent.mock.calls[0]?.[0] as Record<string, unknown>;
@@ -1335,6 +1382,121 @@ describe("deliverReplies message_sent hook", () => {
       content: "two attachments",
       success: false,
     });
+  });
+
+  it("preserves an accepted internal chunk when the same Slack send later fails", async () => {
+    const accepted = acceptedSlackSendResult("chunk-1", "text");
+    const failure = new PlatformMessageNotDispatchedError("second_chunk_failed", {
+      cause: new Error("upload connection refused"),
+    });
+    sendMock.mockImplementationOnce(async (_target, _text, options) => {
+      await options.onDeliveryResult?.(accepted);
+      throw failure;
+    });
+
+    const error = await deliverReplies(baseParams({ replies: [{ text: "chunked reply" }] })).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["chunk-1"],
+        receipt: { platformMessageIds: ["chunk-1"] },
+        visibleReplySent: true,
+      },
+    });
+    expect((error as Error).cause).toBe(failure);
+    expect(sendMock).toHaveBeenCalledOnce();
+  });
+
+  it("preserves an undispatched first-send failure without a partial wrapper", async () => {
+    const failure = new PlatformMessageNotDispatchedError("first_upload_failed", {
+      cause: new Error("upload connection refused"),
+    });
+    sendMock.mockRejectedValueOnce(failure);
+
+    await expect(
+      deliverReplies(
+        baseParams({
+          replies: [{ text: "one attachment", mediaUrls: ["https://example.com/one.png"] }],
+        }),
+      ),
+    ).rejects.toBe(failure);
+    expect(sendMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not carry accepted receipts into the next logical reply", async () => {
+    const accepted = acceptedSlackSendResult("reply-1", "text");
+    const failure = new PlatformMessageNotDispatchedError("next_reply_failed", {
+      cause: new Error("upload connection refused"),
+    });
+    sendMock
+      .mockImplementationOnce(async (_target, _text, options) => {
+        await options.onDeliveryResult?.(accepted);
+        return accepted;
+      })
+      .mockRejectedValueOnce(failure);
+
+    await expect(
+      deliverReplies(baseParams({ replies: [{ text: "accepted" }, { text: "never sent" }] })),
+    ).rejects.toBe(failure);
+    expect(sendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("settles real Slack transport chunks as visible failure without replaying the turn", async () => {
+    const failure = new PlatformMessageNotDispatchedError("third_chunk_failed", {
+      cause: new Error("upload connection refused"),
+    });
+    const postMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, ts: "chunk-1", channel: "C123" })
+      .mockResolvedValueOnce({ ok: true, ts: "chunk-2", channel: "C123" })
+      .mockRejectedValueOnce(failure);
+    const { sendMessageSlack } = await vi.importActual<typeof import("../send.js")>("../send.js");
+    sendMock.mockImplementationOnce(async (target, text, options) => {
+      return await sendMessageSlack(target, text, options);
+    });
+    const onError = vi.fn();
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) =>
+        await deliverReplies(
+          baseParams({
+            replies: [payload],
+            eventScope: { teamId: "T123", client: { chat: { postMessage } } },
+          }),
+        ),
+      onError,
+      propagateRetryableNoSendFailure: true,
+    });
+
+    expect(dispatcher.sendFinalReply({ text: "a".repeat(9_000) })).toBe(true);
+    dispatcher.markComplete();
+    const receipt = await dispatcher.waitForIdle();
+
+    expect(receipt).toMatchObject({
+      counts: { final: { failedBeforeSend: 0, failedAfterSend: 1 } },
+      anyVisibleDelivered: true,
+    });
+    expect(onError).toHaveBeenCalledOnce();
+    const deliveryError = onError.mock.calls[0]?.[0] as Error;
+    expect(deliveryError).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["chunk-1", "chunk-2"],
+        receipt: {
+          primaryPlatformMessageId: "chunk-1",
+          platformMessageIds: ["chunk-1", "chunk-2"],
+          parts: [
+            { platformMessageId: "chunk-1", kind: "text" },
+            { platformMessageId: "chunk-2", kind: "text" },
+          ],
+        },
+      },
+    });
+    expect(deliveryError.cause).toBe(failure);
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(postMessage).toHaveBeenCalledTimes(3);
   });
 
   it("does not emit the plugin hook when no listener observes message_sent", async () => {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -2,6 +2,7 @@
 import type { MessageMetadata } from "@slack/types";
 import type { Block, KnownBlock } from "@slack/web-api";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -146,42 +147,6 @@ export async function deliverReplies(params: {
   eventScope?: SlackEventScope;
 }) {
   let latestResult: SlackSendResult | undefined;
-  const sendReply = async (input: {
-    text: string;
-    threadTs?: string | undefined;
-    mediaUrl?: string | undefined;
-    blocks?: (Block | KnownBlock)[] | undefined;
-    authoredTextPlacement?: "none" | "blocks" | "outside-blocks";
-    nativeDataFallbackBaseText?: string;
-    textIsSlackMrkdwn?: boolean;
-    textIsSlackPlainText?: boolean;
-  }): Promise<SlackSendResult> => {
-    return await sendMessageSlack(params.target, input.text, {
-      cfg: params.cfg,
-      token: params.token,
-      threadTs: input.threadTs,
-      accountId: params.accountId,
-      ...(input.mediaUrl ? { mediaUrl: input.mediaUrl } : {}),
-      ...(input.blocks ? { blocks: input.blocks } : {}),
-      ...(input.authoredTextPlacement
-        ? { authoredTextPlacement: input.authoredTextPlacement }
-        : {}),
-      ...(Object.hasOwn(input, "nativeDataFallbackBaseText")
-        ? { nativeDataFallbackBaseText: input.nativeDataFallbackBaseText }
-        : {}),
-      ...(input.textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
-      ...(input.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
-      ...(params.eventScope
-        ? {
-            eventScope: params.eventScope,
-            textLimit: params.textLimit,
-            ...(params.mediaMaxBytes !== undefined ? { mediaMaxBytes: params.mediaMaxBytes } : {}),
-          }
-        : {}),
-      ...(params.identity ? { identity: params.identity } : {}),
-      ...(params.metadata ? { metadata: params.metadata } : {}),
-    });
-  };
   for (const payload of params.replies) {
     if (payload.isReasoning === true) {
       continue;
@@ -203,6 +168,49 @@ export async function deliverReplies(params: {
     if (!textRaw && !reply.hasMedia && segments.length === 0) {
       continue;
     }
+
+    const acceptedResults: SlackSendResult[] = [];
+    const sendReply = async (input: {
+      text: string;
+      threadTs?: string | undefined;
+      mediaUrl?: string | undefined;
+      blocks?: (Block | KnownBlock)[] | undefined;
+      authoredTextPlacement?: "none" | "blocks" | "outside-blocks";
+      nativeDataFallbackBaseText?: string;
+      textIsSlackMrkdwn?: boolean;
+      textIsSlackPlainText?: boolean;
+    }): Promise<SlackSendResult> => {
+      return await sendMessageSlack(params.target, input.text, {
+        cfg: params.cfg,
+        token: params.token,
+        threadTs: input.threadTs,
+        accountId: params.accountId,
+        onDeliveryResult: (result) => {
+          acceptedResults.push(result);
+        },
+        ...(input.mediaUrl ? { mediaUrl: input.mediaUrl } : {}),
+        ...(input.blocks ? { blocks: input.blocks } : {}),
+        ...(input.authoredTextPlacement
+          ? { authoredTextPlacement: input.authoredTextPlacement }
+          : {}),
+        ...(Object.hasOwn(input, "nativeDataFallbackBaseText")
+          ? { nativeDataFallbackBaseText: input.nativeDataFallbackBaseText }
+          : {}),
+        ...(input.textIsSlackMrkdwn ? { textIsSlackMrkdwn: true } : {}),
+        ...(input.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+        ...(params.eventScope
+          ? {
+              eventScope: params.eventScope,
+              textLimit: params.textLimit,
+              ...(params.mediaMaxBytes !== undefined
+                ? { mediaMaxBytes: params.mediaMaxBytes }
+                : {}),
+            }
+          : {}),
+        ...(params.identity ? { identity: params.identity } : {}),
+        ...(params.metadata ? { metadata: params.metadata } : {}),
+      });
+    };
 
     // Fire the `message_sent` hook(s) after delivery, mirroring Telegram's
     // `emitMessageSentHooks` in `extensions/telegram/src/bot/delivery.replies.ts`.
@@ -309,7 +317,15 @@ export async function deliverReplies(params: {
     } catch (error) {
       const hookContent = hookParts.join("\n\n") || textRaw || spokenText || "";
       emitFailed(hookContent, error);
-      throw error;
+      if (acceptedResults.length === 0) {
+        throw error;
+      }
+      const receipt = createMessageReceiptFromOutboundResults({ results: acceptedResults });
+      throw createChannelPartialDeliveryError(error, {
+        messageIds: receipt.platformMessageIds,
+        receipt,
+        visibleReplySent: true,
+      });
     }
     if (delivered) {
       const hookContent = hookParts.join("\n\n") || textRaw || spokenText || "";


### PR DESCRIPTION
Closes #127120

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Slack users could receive duplicate replies or attachments when an ordinary multipart reply successfully delivered an earlier attachment or text chunk but a later part failed before its own dispatch. The later operation's no-dispatch error previously made the entire logical reply look safely replayable even though Slack had already accepted visible content.

## Why This Change Was Made

The existing Slack transport already reports every accepted physical upload, chunk, or Block Kit fallback part through its delivery callback. The ordinary Slack reply owner now collects those accepted results separately for each logical reply and, only when a later operation fails, wraps the original error in the existing channel partial-delivery contract with an ordered aggregate receipt. Existing successful results, first-send failures, terminal hook ownership, dispatcher behavior, retry policy, plugin boundaries, and public SDK contracts remain unchanged.

Production delta is +53/-37 (net +16): most changed lines simply move the existing sender into its logical-reply scope. The remaining growth is the unavoidable ownership boundary for retaining accepted physical-send receipts before the overall send settles; replacing the successful aggregate result with the final callback result would silently discard earlier successful receipt parts.

## User Impact

Slack replies and attachments already accepted by the provider are no longer misclassified as wholly undelivered after a later multipart failure, preventing duplicate fallback/replay. Genuinely undispatched first attempts retain their original error and remain eligible for the existing recovery behavior.

## Evidence

Before the fix, the focused regression failed in all three relevant places: an accepted attachment lost its receipt, an accepted internal chunk lost its receipt, and the real reply dispatcher propagated the later no-dispatch error as safely replayable.

After the fix:

- `node scripts/run-vitest.mjs extensions/slack/src/monitor/replies.test.ts`: 51 passed, including first-attachment success followed by a real provider-shaped no-dispatch failure, original-cause identity, ordered receipts, single failure hook, internal chunk acceptance, unchanged successful multipart result/hook, unchanged first-send failure, and strict per-logical-reply isolation.
- The boundary regression drives the actual Slack send transport through a fake Slack Web API: two ordered chunks are accepted, the third fails, the aggregate receipt retains both provider IDs, the real public-SDK reply dispatcher records `failedAfterSend: 1`, `failedBeforeSend: 0`, and `anyVisibleDelivered: true`, the error callback fires once, and retry propagation does not occur.
- `node scripts/run-vitest.mjs extensions/slack`: 135 files / 2,428 tests passed across the complete Slack plugin lane.
- `node scripts/run-vitest.mjs src/auto-reply/reply/before-deliver.test.ts src/channels/turn/delivery-result.test.ts extensions/matrix/src/matrix/monitor/replies.test.ts extensions/discord/src/monitor/reply-delivery.test.ts extensions/mattermost/src/mattermost/reply-delivery.test.ts extensions/msteams/src/reply-dispatcher.test.ts extensions/telegram/src/chunk-delivery.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts`: eight focused dispatcher, receipt, and sibling-channel shards passed. The unchanged dispatcher fallback regression proves that attached fallback runs only after a proven invisible failure and does not run after a visible post-send failure.
- `node scripts/check-changed.mjs -- extensions/slack/src/monitor/replies.ts extensions/slack/src/monitor/replies.test.ts`: passed formatting, production/test TypeScript, strict lint, plugin-boundary checks, import-cycle checks, and all changed-file guards.
- `git diff --check`: clean. Independent structured autoreview: clean, no actionable findings.

Live Slack proof is intentionally unavailable because this repair must not use Slack credentials, services, real API calls, or operator state. The existing mock-Gateway harness exercises `qa-channel`, not the Slack owner; the existing Slack QA adapter requires two live Slack credential leases and real identity calls. The actual owner + actual Slack transport + fake provider API + actual dispatcher boundary above is therefore the strongest authorized changed-path proof.

AI-assisted; no changelog, dependency, core, SDK, configuration, persistence, security, authentication, product, retry-policy, protocol, or public-contract changes.
