### PR TITLE
perf(test): speed up model setup state observations

### DIFF
--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -10,6 +10,7 @@ import {
   createApplicationContextProvider,
   type ApplicationContextProvider,
 } from "../../test-helpers/application-context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { ModelSetupRouteData } from "./model-setup-page.ts";
 import "./model-setup-page.ts";
 
@@ -228,7 +229,7 @@ describe("ModelSetupPage catalog icons", () => {
       firstRun: false,
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(
         page
           .querySelector<HTMLImageElement>(".model-setup__recommendation img")
@@ -276,7 +277,7 @@ describe("ModelSetupPage catalog icons", () => {
       firstRun: false,
     });
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(
         page
           .querySelector<HTMLImageElement>(".model-setup__recommendation img")
@@ -317,7 +318,7 @@ describe("ModelSetupPage catalog icons", () => {
 
     page.querySelector<HTMLButtonElement>('[data-prepare-choice="llama-cpp"] button')?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(request).toHaveBeenCalledWith(
         "openclaw.setup.prepare.start",
         { sessionId: expect.any(String), agentId: "main", authChoice: "llama-cpp" },
@@ -403,7 +404,7 @@ describe("ModelSetupPage catalog icons", () => {
 
     page.querySelector<HTMLButtonElement>(`[data-prepare-choice="${choiceId}"] button`)?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(request).toHaveBeenCalledWith(
         "openclaw.setup.activate",
         {
@@ -450,7 +451,7 @@ describe("ModelSetupPage catalog icons", () => {
 
     page.querySelector<HTMLButtonElement>('[data-prepare-choice="llama-cpp"] button')?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(page.textContent).toContain(
         "llama.cpp did not expose a usable local model. Review the setup result, then retry.",
       );
@@ -590,7 +591,7 @@ describe("ModelSetupPage catalog icons", () => {
 
     page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(order).toEqual([
         "config.set",
         "openclaw.setup.auth.start",
@@ -644,7 +645,7 @@ describe("ModelSetupPage catalog icons", () => {
     snapshot.hello.auth.scopes = ["operator.read"];
     releaseConfigSet?.({ hash: "hash-2" });
 
-    await vi.waitFor(() => expect(page.textContent).toContain("Model setup request failed."));
+    await waitForFast(() => expect(page.textContent).toContain("Model setup request failed."));
     expect(request).not.toHaveBeenCalledWith(
       "openclaw.setup.auth.start",
       expect.anything(),
@@ -773,7 +774,7 @@ describe("ModelSetupPage catalog icons", () => {
 
     page.querySelector<HTMLButtonElement>('[data-candidate-kind="codex-cli"] button')?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(page.textContent).toContain("Connection changed before model activation started.");
     });
     expect(replacementRequest).not.toHaveBeenCalled();
@@ -815,7 +816,7 @@ describe("ModelSetupPage catalog icons", () => {
 
     page.querySelector<HTMLButtonElement>('[data-candidate-kind="codex-cli"] button')?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(page.textContent).toContain("Connection verified");
       expect(page.textContent).toContain("config.get failed after model commit");
     });
@@ -864,7 +865,7 @@ describe("ModelSetupPage catalog icons", () => {
 
     page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-auth"] button')?.click();
 
-    await vi.waitFor(() => {
+    await waitForFast(() => {
       expect(runExternalMutation).toHaveBeenCalledTimes(1);
       expect(page.textContent).toContain("config.get failed after wizard commit");
       expect(page.textContent).toContain("Paste token");


### PR DESCRIPTION
## What Problem This Solves

The Control UI model-setup test file repeatedly pays Vitest's default 50 ms polling interval while observing already-settling icon, wizard, activation, authorization-error, and refresh-warning state. Those incidental delays slow the developer and CI test loop without strengthening coverage.

## Why This Change Was Made

Reuse the existing `waitForFast` helper for ten observation-only waits. Preserve the original polling calls for the fake-timer config-write/activation/refresh ordering contract and both deferred configuration-write and gateway-progress handoff barriers. No assertions, timeouts, production code, dependencies, snapshots, baselines, or user-facing behavior change.

## User Impact

No user-visible product changes. The focused model-setup test file is 20.05% faster on the same Blacksmith Testbox, with every existing setup, provider, authorization, persistence, error, and ordering assertion intact.

## Evidence

- Controlled same-[Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/32466586437): two excluded warmups, eight counterbalanced/interleaved retained samples per variant, one Vitest worker, separate per-variant module caches, import diagnostics, and `/usr/bin/time -v`; baseline content verified against immutable Git blob `152294ca70aab9a7556f7ddfdbced8181d346029` on base `be2f7c6a3df29a423e9623dbde1d44ca3e90a078`.
- Median wall time: **1.945 s → 1.555 s**, **−0.390 s / −20.05%**; Vitest duration: **1.530 s → 1.125 s**; test-body duration: **802.5 ms → 397.0 ms**; imports: **260.0 ms → 259.5 ms**; peak RSS: **504,140 KiB → 494,414 KiB**; all samples retained **14 passing tests** and **10 measured imports**.
- Focused owner and sibling proof: **144 tests across 12 files passed**, covering model setup, reconnect, wizard ownership, first run, view/provider rendering, configuration write coordination, and configuration gateway operations.
- Real Chromium with mocked Gateway: **nine scenarios across five files passed**, including first-run persistence, device-code sign-in, Ollama/llama.cpp/LM Studio setup, provider switching, secret clearing, failure recovery, and reconnect. No live Gateway or provider credentials used.
- Two temporary owner-fault injections were proven on the disposable Testbox and restored: removing the pre-dispatch authorization check fails the queued-setup regression; breaking gateway-owned wizard progress fails both the page regression and wizard-owner regression.
- Full changed-file format/type/lint/guard gate passed on the same exact-base Testbox, including the complete core-test typecheck; `git diff --check` passed, and structured Codex autoreview returned no actionable findings.
- Diff: **production +0/−0; tests +11/−10** in one existing test file.
