### PR TITLE
fix: send max_tokens to Alibaba Model Studio instead of max_completion_tokens

### DIFF
--- a/packages/ai/src/transports/openai-completions-compat.ts
+++ b/packages/ai/src/transports/openai-completions-compat.ts
@@ -84,6 +84,16 @@ function resolveOpenAICompletionsCompatDefaults(
     knownProviderFamily === "modelstudio" ||
     endpointClass === "modelstudio-native" ||
     (isDefaultRoute && isDefaultRouteProvider(provider, "dashscope", "modelstudio", "qwen"));
+  // The `modelstudio-native` endpoint class covers six base URLs, and they are not
+  // one surface. Alibaba's OpenAI-compatibility reference documents `max_tokens`
+  // for the four `/compatible-mode/v1` endpoints (dashscope, dashscope-intl, and
+  // both token-plan regions). The two Coding Plan endpoints
+  // (coding[-intl].dashscope.aliyuncs.com) are plain `/v1` and are not covered by
+  // that reference, so they keep the existing field until someone with a Coding
+  // Plan key can check. Matching the path segment rather than a URL list so a new
+  // Alibaba region does not silently fall out of the documented surface.
+  const isModelStudioCompatibleMode =
+    isModelStudioLike && input.baseUrl?.includes("/compatible-mode/") === true;
   const isZai =
     endpointClass === "zai-native" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "zai"));
@@ -120,8 +130,9 @@ function resolveOpenAICompletionsCompatDefaults(
     knownProviderFamily === "mistral" ||
     isMoonshot ||
     // Model Studio's OpenAI-compatible reference documents `max_tokens` and does
-    // not list `max_completion_tokens`.
-    isModelStudioLike ||
+    // not list `max_completion_tokens` — but only for the `/compatible-mode/v1`
+    // surface, hence the narrower predicate.
+    isModelStudioCompatibleMode ||
     isCloudflareAiGateway ||
     isZai ||
     isTogether ||

--- a/packages/ai/src/transports/openai-completions-compat.ts
+++ b/packages/ai/src/transports/openai-completions-compat.ts
@@ -61,6 +61,35 @@ function isDefaultRouteProvider(provider: string | undefined, ...ids: string[]) 
   return provider !== undefined && ids.includes(provider);
 }
 
+/**
+ * True when `baseUrl` is an Alibaba-owned Model Studio endpoint on the
+ * `/compatible-mode` surface, which is the surface Alibaba's OpenAI-compatibility
+ * reference covers.
+ *
+ * The host shapes mirror `resolveDashscopeAigcApiBaseUrl` in
+ * `extensions/qwen/video-generation-provider.ts`: the
+ * `dashscope[-region].aliyuncs.com` family and the Token Plan
+ * `*.maas.aliyuncs.com` regions.
+ */
+function isAlibabaCompatibleModeBaseUrl(baseUrl: string | undefined): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return false;
+  }
+  const hostname = url.hostname.toLowerCase().replace(/\.+$/u, "");
+  const isAlibabaHost =
+    /(?:^|\.)dashscope(?:-[^.]+)?\.aliyuncs\.com$/u.test(hostname) ||
+    hostname.endsWith(".maas.aliyuncs.com");
+  // Trailing slash so `/compatible-mode` matches and `/compatible-mode-x` does not.
+  return isAlibabaHost && `${url.pathname}/`.startsWith("/compatible-mode/");
+}
+
 /** Resolves default request flags for an OpenAI-compatible completions endpoint. */
 function resolveOpenAICompletionsCompatDefaults(
   input: OpenAICompletionsCompatDefaultsInput,
@@ -90,10 +119,16 @@ function resolveOpenAICompletionsCompatDefaults(
   // both token-plan regions). The two Coding Plan endpoints
   // (coding[-intl].dashscope.aliyuncs.com) are plain `/v1` and are not covered by
   // that reference, so they keep the existing field until someone with a Coding
-  // Plan key can check. Matching the path segment rather than a URL list so a new
-  // Alibaba region does not silently fall out of the documented surface.
+  // Plan key can check.
+  //
+  // The gate is the host together with the path, not the path alone. A Qwen-family
+  // provider accepts an arbitrary custom `baseUrl`, so a bare path test would hand
+  // `max_tokens` to any proxy that happens to serve `/compatible-mode/` — a route
+  // Alibaba does not own and the reference does not describe. Matching the host
+  // shapes still lets a future Alibaba region into the documented surface, which a
+  // fixed URL list would not.
   const isModelStudioCompatibleMode =
-    isModelStudioLike && input.baseUrl?.includes("/compatible-mode/") === true;
+    isModelStudioLike && isAlibabaCompatibleModeBaseUrl(input.baseUrl);
   const isZai =
     endpointClass === "zai-native" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "zai"));

--- a/packages/ai/src/transports/openai-completions-compat.ts
+++ b/packages/ai/src/transports/openai-completions-compat.ts
@@ -119,6 +119,9 @@ function resolveOpenAICompletionsCompatDefaults(
     endpointClass === "mistral-public" ||
     knownProviderFamily === "mistral" ||
     isMoonshot ||
+    // Model Studio's OpenAI-compatible reference documents `max_tokens` and does
+    // not list `max_completion_tokens`.
+    isModelStudioLike ||
     isCloudflareAiGateway ||
     isZai ||
     isTogether ||

--- a/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
@@ -64,7 +64,13 @@ describe("openai completions params", () => {
     ["qwen", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"],
     ["dashscope", "https://dashscope.aliyuncs.com/compatible-mode/v1"],
     ["modelstudio", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"],
-  ])("sends max_tokens on Model Studio provider %s", (provider, baseUrl) => {
+    // Token Plan regions are the other two documented /compatible-mode/v1 endpoints.
+    // Driven through provider "qwen" because the unit fixture's endpoint-class map
+    // only knows dashscope.aliyuncs.com; in production the plugin manifest lists all
+    // six URLs under modelstudio-native. Either way the path gate is what decides.
+    ["qwen", "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"],
+    ["qwen", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"],
+  ])("sends max_tokens on Model Studio compatible-mode provider %s", (provider, baseUrl) => {
     // Model Studio's OpenAI-compatibility reference documents `max_tokens` and
     // does not list `max_completion_tokens`.
     const params = buildOpenAICompletionsParams(
@@ -470,6 +476,24 @@ describe("openai completions params", () => {
     );
 
     expect(params.max_completion_tokens).toBe(65_536);
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
+  // The `modelstudio-native` endpoint class also covers the two Coding Plan base
+  // URLs, which are plain `/v1` and are NOT in Alibaba's OpenAI-compatibility
+  // reference. They keep `max_completion_tokens` until a Coding Plan key can
+  // confirm otherwise — the citation behind this change does not reach them.
+  it.each([
+    ["qwen", "https://coding.dashscope.aliyuncs.com/v1"],
+    ["qwen", "https://coding-intl.dashscope.aliyuncs.com/v1"],
+  ])("leaves Coding Plan %s on max_completion_tokens (undocumented surface)", (provider, baseUrl) => {
+    const params = buildOpenAICompletionsParams(
+      makeCompletionsModel({ id: "qwen3.5-plus", name: "Qwen 3.5 Plus", provider, baseUrl }),
+      { systemPrompt: "system", messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    expect(params.max_completion_tokens).toBeDefined();
     expect(params).not.toHaveProperty("max_tokens");
   });
 

--- a/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
@@ -486,16 +486,19 @@ describe("openai completions params", () => {
   it.each([
     ["qwen", "https://coding.dashscope.aliyuncs.com/v1"],
     ["qwen", "https://coding-intl.dashscope.aliyuncs.com/v1"],
-  ])("leaves Coding Plan %s on max_completion_tokens (undocumented surface)", (provider, baseUrl) => {
-    const params = buildOpenAICompletionsParams(
-      makeCompletionsModel({ id: "qwen3.5-plus", name: "Qwen 3.5 Plus", provider, baseUrl }),
-      { systemPrompt: "system", messages: [], tools: [] } as never,
-      undefined,
-    );
+  ])(
+    "leaves Coding Plan %s on max_completion_tokens (undocumented surface)",
+    (provider, baseUrl) => {
+      const params = buildOpenAICompletionsParams(
+        makeCompletionsModel({ id: "qwen3.5-plus", name: "Qwen 3.5 Plus", provider, baseUrl }),
+        { systemPrompt: "system", messages: [], tools: [] } as never,
+        undefined,
+      );
 
-    expect(params.max_completion_tokens).toBeDefined();
-    expect(params).not.toHaveProperty("max_tokens");
-  });
+      expect(params.max_completion_tokens).toBeDefined();
+      expect(params).not.toHaveProperty("max_tokens");
+    },
+  );
 
   it("omits output-token fields when the resolved model has no known cap", () => {
     const params = buildOpenAICompletionsParams(

--- a/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
@@ -70,6 +70,13 @@ describe("openai completions params", () => {
     // six URLs under modelstudio-native. Either way the path gate is what decides.
     ["qwen", "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"],
     ["qwen", "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"],
+    // Three more Alibaba compatible-mode regions the repository already names —
+    // extensions/alibaba, extensions/qwen and the external provider catalog —
+    // none of which appear in MODELSTUDIO_NATIVE_BASE_URLS. A fixed URL list
+    // would leave all three on the wrong field; matching the host does not.
+    ["qwen", "https://cn-hongkong.dashscope.aliyuncs.com/compatible-mode/v1"],
+    ["qwen", "https://dashscope-us.aliyuncs.com/compatible-mode/v1"],
+    ["qwen", "https://workspace.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"],
   ])("sends max_tokens on Model Studio compatible-mode provider %s", (provider, baseUrl) => {
     // Model Studio's OpenAI-compatibility reference documents `max_tokens` and
     // does not list `max_completion_tokens`.

--- a/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
@@ -83,6 +83,33 @@ describe("openai completions params", () => {
     expect(params).not.toHaveProperty("max_completion_tokens");
   });
 
+  it.each([
+    // A Qwen-family provider accepts an arbitrary custom `baseUrl`. A proxy that
+    // happens to serve the same path is not an Alibaba endpoint, and Alibaba's
+    // compatibility reference says nothing about what it accepts.
+    ["a custom proxy route", "https://proxy.example/compatible-mode/v1"],
+    // Suffix, not substring: this host sits under evil.example, not aliyuncs.com.
+    ["a look-alike host", "https://dashscope.aliyuncs.com.evil.example/compatible-mode/v1"],
+    // Ends with the string "aliyuncs.com" without being inside that domain.
+    ["a host merely ending in the domain text", "https://notaliyuncs.com/compatible-mode/v1"],
+    // The gate reads a path segment, not a prefix of one.
+    ["a look-alike path", "https://dashscope.aliyuncs.com/compatible-mode-preview/v1"],
+  ])("keeps max_completion_tokens on %s", (_label, baseUrl) => {
+    const params = buildOpenAICompletionsParams(
+      makeCompletionsModel({
+        id: "qwen3.5-plus",
+        name: "Qwen 3.5 Plus",
+        provider: "qwen",
+        baseUrl,
+      }),
+      emptyContext(),
+      undefined,
+    ) as Record<string, unknown>;
+
+    expect(params).toHaveProperty("max_completion_tokens");
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
   it("still sends max_completion_tokens on the OpenAI endpoint", () => {
     // Guards the change above from widening: OpenAI itself deprecated max_tokens.
     const params = buildOpenAICompletionsParams(

--- a/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.cache-and-compat.test.ts
@@ -60,6 +60,40 @@ describe("openai completions params", () => {
     expect(params.stream_options?.include_usage).toBe(true);
   });
 
+  it.each([
+    ["qwen", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"],
+    ["dashscope", "https://dashscope.aliyuncs.com/compatible-mode/v1"],
+    ["modelstudio", "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"],
+  ])("sends max_tokens on Model Studio provider %s", (provider, baseUrl) => {
+    // Model Studio's OpenAI-compatibility reference documents `max_tokens` and
+    // does not list `max_completion_tokens`.
+    const params = buildOpenAICompletionsParams(
+      makeCompletionsModel({ id: "qwen3.5-plus", name: "Qwen 3.5 Plus", provider, baseUrl }),
+      emptyContext(),
+      undefined,
+    ) as Record<string, unknown>;
+
+    expect(params).toHaveProperty("max_tokens");
+    expect(params).not.toHaveProperty("max_completion_tokens");
+  });
+
+  it("still sends max_completion_tokens on the OpenAI endpoint", () => {
+    // Guards the change above from widening: OpenAI itself deprecated max_tokens.
+    const params = buildOpenAICompletionsParams(
+      makeCompletionsModel({
+        id: "gpt-5",
+        name: "GPT-5",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+      }),
+      emptyContext(),
+      undefined,
+    ) as Record<string, unknown>;
+
+    expect(params).toHaveProperty("max_completion_tokens");
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
   it("enables streaming usage compat for generic providers on native DashScope endpoints", () => {
     const params = buildOpenAICompletionsParams(
       makeCompletionsModel({

--- a/packages/ai/src/transports/openai-completions-params.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.test.ts
@@ -29,8 +29,10 @@ describe("openai completions params", () => {
       undefined,
     );
 
-    expect(params.max_completion_tokens).toBe(64_000);
-    expect(params).not.toHaveProperty("max_tokens");
+    // dashscope is a Model Studio provider, so the cap ships as `max_tokens`;
+    // what this test pins is that the model-level params value wins.
+    expect(params.max_tokens).toBe(64_000);
+    expect(params).not.toHaveProperty("max_completion_tokens");
   });
 
   it("keeps runtime maxTokens ahead of model params max_completion_tokens for OpenAI completions", () => {
@@ -54,8 +56,8 @@ describe("openai completions params", () => {
       { maxTokens: 16_000 } as never,
     );
 
-    expect(params.max_completion_tokens).toBe(16_000);
-    expect(params).not.toHaveProperty("max_tokens");
+    expect(params.max_tokens).toBe(16_000);
+    expect(params).not.toHaveProperty("max_completion_tokens");
   });
 
   it("clamps runtime maxTokens to the OpenAI completions model output cap", () => {
@@ -96,8 +98,8 @@ describe("openai completions params", () => {
       { maxTokens: 0 } as never,
     );
 
-    expect(params.max_completion_tokens).toBe(64_000);
-    expect(params).not.toHaveProperty("max_tokens");
+    expect(params.max_tokens).toBe(64_000);
+    expect(params).not.toHaveProperty("max_completion_tokens");
   });
 
   it("uses model maxTokens with max_tokens completions compat when runtime maxTokens is omitted", () => {
@@ -169,7 +171,7 @@ describe("openai completions params", () => {
     );
 
     // 4,000 CJK chars count as 16,000 adjusted chars, then chars/4 * 1.25.
-    expect(params.max_completion_tokens).toBe(10_000 - 5_000 - 1);
+    expect(params.max_tokens).toBe(10_000 - 5_000 - 1);
   });
 
   it("rounds proxy-like completions input estimates after summing message content", () => {


### PR DESCRIPTION
Closes #127119

## What Problem This Solves

Fixes an issue where users on any Alibaba Cloud Model Studio provider (`qwen`, `dashscope`, `modelstudio`) would have their output-token cap sent under a field the vendor does not document. Model Studio's OpenAI-compatibility reference lists `max_tokens` and does not list `max_completion_tokens`, but every request OpenClaw sends to that family carried `max_completion_tokens`.

The endpoint is not obliged to honour an undocumented field, so the configured cap can be silently ignored on the vendor side.

## Why This Change Was Made

`resolveOpenAICompletionsCompatDefaults` builds `usesMaxTokens` from each vendor family it knows is not OpenAI-shaped — Chutes, Mistral, Moonshot, Cloudflare AI Gateway, Z.ai, Together — and the Model Studio family was the one omission, so it fell through to the `max_completion_tokens` default.

The same function already recognises this family for two other flags: `isModelStudioLike` gates `requiresNonEmptyUserOrAssistantMessage`, and `isMoonshotLike` (which includes it) gates `supportsDeveloperRole`. Adding `isModelStudioLike` to `usesMaxTokens` reuses the predicate that is already there rather than introducing a second notion of "is this Model Studio".

Scope is deliberately that one boolean. No manifest key, no model-catalog field, no new provider concept.

## User Impact

Requests to `qwen`, `dashscope` and `modelstudio` now carry the cap as `max_tokens`, the field Model Studio documents. A cap configured as `params.max_completion_tokens` in a model entry keeps working — the value is carried onto whichever field the provider uses, so no existing configuration needs editing. Nothing changes for OpenAI or any other provider.

## Evidence

Measured through `buildOpenAICompletionsParams`, so this is the field on the actual request body rather than the resolver's opinion. Moonshot and Together are non-OpenAI controls; OpenAI is the OpenAI-shaped control:

| provider | before | after |
| --- | --- | --- |
| `qwen` | `max_completion_tokens` | **`max_tokens`** |
| `dashscope` | `max_completion_tokens` | **`max_tokens`** |
| `modelstudio` | `max_completion_tokens` | **`max_tokens`** |
| `moonshotai` | `max_tokens` | `max_tokens` |
| `together` | `max_tokens` | `max_tokens` |
| `openai` | `max_completion_tokens` | `max_completion_tokens` |

**Tests.** Three new cases in `openai-completions-params.cache-and-compat.test.ts` for the three provider ids, plus a guard asserting OpenAI still gets `max_completion_tokens` so the change cannot widen.

**Four existing tests changed, and why.** `openai-completions-params.test.ts` has four tests that used `dashscope` as an incidental fixture while asserting on the field name:

- `uses model params max_completion_tokens ... before model maxTokens`
- `keeps runtime maxTokens ahead of model params max_completion_tokens ...`
- `keeps zero runtime maxTokens falling back to model params ...`
- `uses CJK-aware input estimates when clamping proxy-like completions output budgets`

Each is about *which value wins* or about CJK clamping, not about the spelling — their neighbours make the same assertions with `xiaomi-token-plan`, `chutes`, `stepfun-plan` and `vllm`. The assertions keep their values and move to `max_tokens`. I checked the value is not lost in the switch: with `params: { max_completion_tokens: 64_000 }` the request now carries `max_tokens: 64000`, and the same holds if it is configured as `max_tokens`.

If any of those four was in fact a deliberate statement that Model Studio wants `max_completion_tokens`, then the premise of #127119 is wrong and this PR should be closed — say so and I will. Nothing in the tests' titles, bodies or history suggests it, but they are the one piece of evidence pointing the other way and I would rather flag it than quietly rewrite it.

**Suite.** `packages/ai` on Node 24.19.0:

```
before   7 failed | 1813 passed   (the 3 new + the 4 updated)
after    1820 passed (104 files)  0 failed
```

`oxlint` and `oxfmt --check` clean on all three files. `tsc --noEmit` on `packages/ai` reports 41 pre-existing errors, none in the changed files — they are in `src/media/qr-runtime.ts` and `src/system-agent/chat-turn-router.ts` and stem from a missing `@types/qrcode` in my local install.

---

**Updated 2026-08-25 (`f79309c1`)** — narrowed to Alibaba's documented `/compatible-mode/v1` surface after the P1 endpoint-scope finding. The two Coding Plan endpoints (`coding[-intl].dashscope.aliyuncs.com/v1`) keep `max_completion_tokens`; nothing this PR changes now rests on inference rather than on the vendor reference. Every case in #127119's repro is on a `/compatible-mode/v1` URL, so the issue is still closed in full. See the comment thread for the endpoint table and test results.