### PR TITLE
perf(ci): parallelize installer smoke validation

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -536,11 +536,95 @@ jobs:
             "
           '
 
-  installer_smoke:
-    needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready]
+  installer_smoke_image:
+    needs: [preflight]
     if: needs.preflight.outputs.run_full_install_smoke == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 150
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: update
+            artifact_key: install-smoke-update
+            dockerfile: ./scripts/docker/install-sh-smoke/Dockerfile
+            image_ref: openclaw-install-smoke:local
+          - group: nonroot
+            artifact_key: install-smoke-nonroot
+            dockerfile: ./scripts/docker/install-sh-nonroot/Dockerfile
+            image_ref: openclaw-install-nonroot:local
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
+    steps:
+      - name: Checkout trusted installer harness
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ needs.preflight.outputs.workflow_repository }}
+          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          persist-credentials: false
+
+      - name: Set up Blacksmith Docker Builder
+        uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1
+        with:
+          max-cache-size-mb: 800000
+
+      - name: Build installer smoke image
+        env:
+          DOCKERFILE: ${{ matrix.dockerfile }}
+          IMAGE_REF: ${{ matrix.image_ref }}
+        run: |
+          timeout --kill-after=30s 20m docker buildx build \
+            --progress=plain \
+            --load \
+            -t "$IMAGE_REF" \
+            -f "$DOCKERFILE" \
+            ./scripts/docker
+
+      - name: Pack installer smoke image artifact
+        id: image_artifact
+        env:
+          ARTIFACT_KEY: ${{ matrix.artifact_key }}
+          IMAGE_REF: ${{ matrix.image_ref }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/${ARTIFACT_KEY}-image"
+          artifact_name="${ARTIFACT_KEY}-image-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          bash scripts/docker/shared-image-artifact.sh \
+            pack "$artifact_dir" "$ARTIFACT_KEY" "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+          {
+            echo "artifact_name=$artifact_name"
+            echo "artifact_path=$artifact_dir"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload installer smoke image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.image_artifact.outputs.artifact_name }}
+          path: ${{ steps.image_artifact.outputs.artifact_path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  installer_smoke_group:
+    needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready, installer_smoke_image]
+    if: needs.preflight.outputs.run_full_install_smoke == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: update
+            artifact_key: install-smoke-update
+            image_ref: openclaw-install-smoke:local
+            timeout_minutes: 120
+          - group: nonroot
+            artifact_key: install-smoke-nonroot
+            image_ref: openclaw-install-nonroot:local
+            timeout_minutes: 60
     env:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
@@ -561,6 +645,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout trusted image artifact helper
+        if: matrix.group == 'update'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ needs.preflight.outputs.workflow_repository }}
@@ -569,6 +654,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate root Dockerfile image artifact binding
+        if: matrix.group == 'update'
         env:
           ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
           ARTIFACT_DIGEST: ${{ needs.root_dockerfile_image.outputs.artifact_digest }}
@@ -610,6 +696,7 @@ jobs:
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Download root Dockerfile image artifact
+        if: matrix.group == 'update'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
@@ -618,6 +705,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Verify and load root Dockerfile image artifact
+        if: matrix.group == 'update'
         env:
           IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
@@ -632,43 +720,45 @@ jobs:
             "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
 
       - name: Require local root Dockerfile image
+        if: matrix.group == 'update'
         env:
           IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
         run: docker image inspect "$IMAGE_REF" >/dev/null
 
-      - name: Set up Blacksmith Docker Builder
-        uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1
+      - name: Download installer smoke image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          max-cache-size-mb: 800000
+          name: ${{ format('{0}-image-{1}-{2}-{3}', matrix.artifact_key, needs.preflight.outputs.target_sha, github.run_id, github.run_attempt) }}
+          path: ${{ runner.temp }}/installer-smoke-image
 
-      - name: Build installer smoke image
+      - name: Verify and load installer smoke image artifact
+        env:
+          ARTIFACT_KEY: ${{ matrix.artifact_key }}
+          IMAGE_REF: ${{ matrix.image_ref }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
         run: |
-          timeout --kill-after=30s 20m docker buildx build \
-            --progress=plain \
-            --load \
-            -t openclaw-install-smoke:local \
-            -f ./scripts/docker/install-sh-smoke/Dockerfile \
-            ./scripts/docker
+          set -euo pipefail
+          bash scripts/docker/shared-image-artifact.sh \
+            load "${RUNNER_TEMP}/installer-smoke-image" "$ARTIFACT_KEY" \
+            "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
 
-      - name: Build installer non-root image
-        run: |
-          timeout --kill-after=30s 20m docker buildx build \
-            --progress=plain \
-            --load \
-            -t openclaw-install-nonroot:local \
-            -f ./scripts/docker/install-sh-nonroot/Dockerfile \
-            ./scripts/docker
+      - name: Require local installer smoke image
+        env:
+          IMAGE_REF: ${{ matrix.image_ref }}
+        run: docker image inspect "$IMAGE_REF" >/dev/null
 
       - name: Setup Node environment for installer smoke
         uses: ./.github/actions/setup-node-env
         with:
           cache-mode: restore
           install-bun: "false"
-          install-deps: "true"
+          install-deps: ${{ matrix.group == 'update' && 'true' || 'false' }}
 
       - name: Run installer docker tests
         env:
           OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
+          OPENCLAW_INSTALL_SMOKE_GROUP: ${{ matrix.group }}
           OPENCLAW_INSTALL_URL: file:///tmp/openclaw-install.sh
           OPENCLAW_INSTALL_CLI_URL: file:///tmp/openclaw-install-cli.sh
           OPENCLAW_NO_ONBOARD: "1"
@@ -685,6 +775,7 @@ jobs:
         run: bash scripts/test-install-sh-docker.sh
 
       - name: Run Rocky Linux installer smoke
+        if: matrix.group == 'update'
         run: |
           timeout --kill-after=30s 20m docker run --rm \
             --platform linux/amd64 \
@@ -695,6 +786,7 @@ jobs:
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install.sh --install-method npm --version latest --no-onboard --no-prompt --verify && openclaw --version'
 
       - name: Run Rocky Linux CLI installer smoke
+        if: matrix.group == 'update'
         run: |
           timeout --kill-after=30s 20m docker run --rm \
             --platform linux/amd64 \
@@ -703,6 +795,29 @@ jobs:
             -v "$PWD/candidate/scripts/install-cli.sh:/tmp/install-cli.sh:ro" \
             rockylinux:9@sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0 \
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install-cli.sh --prefix /tmp/openclaw-cli --version latest --no-onboard && /tmp/openclaw-cli/bin/openclaw --version'
+
+  installer_smoke:
+    needs: [preflight, installer_smoke_image, installer_smoke_group]
+    if: always() && needs.preflight.result == 'success' && needs.preflight.outputs.run_full_install_smoke == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Verify installer smoke groups
+        env:
+          CONSUMER_RESULT: ${{ needs.installer_smoke_group.result }}
+          PRODUCER_RESULT: ${{ needs.installer_smoke_image.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          if [[ "$PRODUCER_RESULT" != "success" ]]; then
+            echo "::error::Installer smoke image producers ended with ${PRODUCER_RESULT}."
+            failed=1
+          fi
+          if [[ "$CONSUMER_RESULT" != "success" ]]; then
+            echo "::error::Installer smoke consumers ended with ${CONSUMER_RESULT}."
+            failed=1
+          fi
+          exit "$failed"
 
   bun_global_install_smoke:
     needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready]

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -47,39 +47,28 @@ jobs:
       run_bun_global_install_smoke: ${{ steps.manifest.outputs.run_bun_global_install_smoke }}
       target_sha: ${{ steps.manifest.outputs.target_sha }}
       dockerfile_image: ${{ steps.manifest.outputs.dockerfile_image }}
-      workflow_repository: ${{ steps.workflow.outputs.workflow_repository }}
-      workflow_sha: ${{ steps.workflow.outputs.workflow_sha }}
     steps:
-      # github.workflow_sha identifies the caller during workflow_call. Resolve the called
-      # workflow SHA from job context so trusted harness checkouts cannot drift to candidate code.
-      - name: Resolve job workflow identity
-        id: workflow
+      # The caller workflow SHA can differ during workflow_call. The job context identifies
+      # this reusable workflow, so trusted harness checkouts cannot drift to candidate code.
+      - name: Assert trusted workflow identity
         env:
+          EXPECTED_WORKFLOW_REPOSITORY: ${{ github.repository }}
           JOB_CONTEXT: ${{ toJSON(job) }}
         shell: bash
         run: |
           set -euo pipefail
           node --input-type=module <<'NODE'
-          import fs from "node:fs";
-
           const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
-          if (
-            typeof job.workflow_repository !== "string" ||
-            !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(job.workflow_repository)
-          ) {
-            throw new Error("job.workflow_repository must be an owner/repository slug");
+          const repository = process.env.EXPECTED_WORKFLOW_REPOSITORY ?? "";
+          if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repository)) {
+            throw new Error("github.repository must be an owner/repository slug");
+          }
+          if (job.workflow_repository !== repository) {
+            throw new Error("job.workflow_repository must exactly match github.repository");
           }
           if (typeof job.workflow_sha !== "string" || !/^[0-9a-f]{40}$/u.test(job.workflow_sha)) {
             throw new Error("job.workflow_sha must be a full lowercase commit SHA");
           }
-          const outputPath = process.env.GITHUB_OUTPUT;
-          if (!outputPath) {
-            throw new Error("GITHUB_OUTPUT is required");
-          }
-          fs.appendFileSync(
-            outputPath,
-            `workflow_repository=${job.workflow_repository}\nworkflow_sha=${job.workflow_sha}\n`,
-          );
           NODE
 
       - name: Checkout
@@ -252,11 +241,31 @@ jobs:
           ref: ${{ needs.preflight.outputs.target_sha }}
           persist-credentials: false
 
+      - &trusted_workflow_identity_step
+        name: Resolve trusted workflow identity
+        id: workflow
+        env:
+          EXPECTED_WORKFLOW_REPOSITORY: ${{ github.repository }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
+          const repository = process.env.EXPECTED_WORKFLOW_REPOSITORY ?? "";
+          if (job.workflow_repository !== repository) {
+            throw new Error("job.workflow_repository must exactly match github.repository");
+          }
+          if (typeof job.workflow_sha !== "string" || !/^[0-9a-f]{40}$/u.test(job.workflow_sha)) {
+            throw new Error("job.workflow_sha must be a full lowercase commit SHA");
+          }
+          NODE
+
       - name: Checkout trusted image artifact helper
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: ${{ needs.preflight.outputs.workflow_repository }}
-          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
           path: .release-harness
           persist-credentials: false
 
@@ -282,7 +291,7 @@ jobs:
         env:
           IMAGE_REF: ${{ needs.preflight.outputs.dockerfile_image }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
         run: |
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/install-smoke-root-image"
@@ -380,11 +389,13 @@ jobs:
           ref: ${{ needs.preflight.outputs.target_sha }}
           persist-credentials: false
 
+      - *trusted_workflow_identity_step
+
       - name: Checkout trusted image artifact helper
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: ${{ needs.preflight.outputs.workflow_repository }}
-          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
           path: .release-harness
           persist-credentials: false
 
@@ -444,7 +455,7 @@ jobs:
           OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
           OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
         run: |
           set -euo pipefail
           bash .release-harness/scripts/docker/shared-image-artifact.sh \
@@ -536,6 +547,181 @@ jobs:
             "
           '
 
+  installer_smoke_candidate_payload:
+    needs: [preflight]
+    if: needs.preflight.outputs.run_full_install_smoke == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 75
+    outputs:
+      artifact_digest: ${{ steps.payload_upload.outputs.artifact-digest }}
+      artifact_id: ${{ steps.payload_upload.outputs.artifact-id }}
+      artifact_name: ${{ steps.payload.outputs.artifact_name }}
+      artifact_run_attempt: ${{ steps.payload.outputs.run_attempt }}
+      artifact_run_id: ${{ steps.payload.outputs.run_id }}
+      harness_repository: ${{ steps.payload.outputs.harness_repository }}
+      harness_sha: ${{ steps.payload.outputs.harness_sha }}
+      manifest_sha256: ${{ steps.payload.outputs.manifest_sha256 }}
+      package_version: ${{ steps.payload.outputs.package_version }}
+      repository: ${{ steps.payload.outputs.repository }}
+      source_archive_sha256: ${{ steps.payload.outputs.source_archive_sha256 }}
+      target_sha: ${{ steps.payload.outputs.target_sha }}
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
+    steps:
+      - *trusted_workflow_identity_step
+
+      - name: Checkout trusted installer harness
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          persist-credentials: false
+
+      - name: Require exact trusted installer harness
+        env:
+          EXPECTED_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          EXPECTED_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REPOSITORY" == "$EXPECTED_REPOSITORY" ]]
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]
+
+      - name: Download exact candidate source archive
+        env:
+          TARGET_REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$TARGET_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
+          curl --fail --location --silent --show-error \
+            --connect-timeout 15 \
+            --max-time 300 \
+            --retry 3 \
+            --output "${RUNNER_TEMP}/candidate.tar.gz" \
+            "https://codeload.github.com/${TARGET_REPOSITORY}/tar.gz/${TARGET_SHA}"
+          test -s "${RUNNER_TEMP}/candidate.tar.gz"
+
+      - name: Set up Blacksmith Docker Builder
+        uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1
+        with:
+          max-cache-size-mb: 800000
+
+      - name: Build pinned candidate packaging harness
+        run: |
+          timeout --kill-after=30s 20m docker buildx build \
+            --progress=plain \
+            --load \
+            -t openclaw-install-candidate-packager:local \
+            -f ./scripts/docker/install-sh-smoke/Dockerfile \
+            ./scripts/docker
+
+      - name: Package candidate only inside pinned harness
+        env:
+          ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
+        run: |
+          set -euo pipefail
+          package_dir="${RUNNER_TEMP}/candidate-package"
+          mkdir -p "$package_dir"
+          chmod 0777 "$package_dir"
+          timeout --kill-after=30s 50m docker run --rm \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --pids-limit 1024 \
+            --user node \
+            --entrypoint /bin/bash \
+            -e ALLOW_UNRELEASED_CHANGELOG \
+            -e CI=1 \
+            -v "${RUNNER_TEMP}/candidate.tar.gz:/input/candidate.tar.gz:ro" \
+            -v "${package_dir}:/output" \
+            openclaw-install-candidate-packager:local \
+            -lc '
+              set -euo pipefail
+              source_dir="$(mktemp -d)"
+              tar -xzf /input/candidate.tar.gz \
+                --strip-components=1 \
+                --no-same-owner \
+                --no-same-permissions \
+                -C "$source_dir"
+              cd "$source_dir"
+              mkdir -p /tmp/corepack
+              corepack enable --install-directory /tmp/corepack
+              export PATH="/tmp/corepack:$PATH"
+              pnpm install --frozen-lockfile
+              package_args=(
+                --source-dir "$source_dir"
+                --output-dir /output
+                --pack-json /output/pack.json
+              )
+              if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+                package_args+=(--allow-unreleased-changelog)
+              fi
+              node scripts/package-openclaw-for-docker.mjs "${package_args[@]}"
+            '
+
+      - name: Seal candidate payload in clean pinned harness
+        id: payload
+        env:
+          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          payload_dir="${RUNNER_TEMP}/install-smoke-candidate-payload"
+          install -d -m 0750 "$payload_dir"
+          docker run --rm \
+            --network none \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --user "$(id -u):$(id -g)" \
+            --entrypoint node \
+            -v "$PWD:/harness:ro" \
+            -v "${RUNNER_TEMP}/candidate.tar.gz:/input/candidate.tar.gz:ro" \
+            -v "${RUNNER_TEMP}/candidate-package:/package:ro" \
+            -v "${payload_dir}:/payload" \
+            openclaw-install-candidate-packager:local \
+            /harness/scripts/install-smoke-candidate-payload.mts seal \
+              --archive /input/candidate.tar.gz \
+              --package-dir /package \
+              --output-dir /payload \
+              --repository "$TARGET_REPOSITORY" \
+              --target-sha "$TARGET_SHA" \
+              --harness-repository "$HARNESS_REPOSITORY" \
+              --harness-sha "$HARNESS_SHA" \
+              --run-id "$GITHUB_RUN_ID" \
+              --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            >"${RUNNER_TEMP}/candidate-payload-result.json"
+          manifest="${payload_dir}/install-smoke-candidate-payload.json"
+          artifact_name="install-smoke-candidate-payload-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          manifest_sha256="$(sha256sum "$manifest" | cut -d ' ' -f 1)"
+          package_version="$(jq -er '.packageVersion' "$manifest")"
+          source_archive_sha256="$(jq -er '.sourceArchiveSha256' "$manifest")"
+          {
+            echo "artifact_name=$artifact_name"
+            echo "artifact_path=$payload_dir"
+            echo "harness_repository=$HARNESS_REPOSITORY"
+            echo "harness_sha=$HARNESS_SHA"
+            echo "manifest_sha256=$manifest_sha256"
+            echo "package_version=$package_version"
+            echo "repository=$TARGET_REPOSITORY"
+            echo "run_attempt=$GITHUB_RUN_ATTEMPT"
+            echo "run_id=$GITHUB_RUN_ID"
+            echo "source_archive_sha256=$source_archive_sha256"
+            echo "target_sha=$TARGET_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload candidate payload artifact
+        id: payload_upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.payload.outputs.artifact_name }}
+          path: ${{ steps.payload.outputs.artifact_path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
   installer_smoke_update_image:
     needs: [preflight]
     if: needs.preflight.outputs.run_full_install_smoke == 'true'
@@ -554,11 +740,13 @@ jobs:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
+      - *trusted_workflow_identity_step
+
       - name: Checkout trusted installer harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: ${{ needs.preflight.outputs.workflow_repository }}
-          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
           persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder
@@ -582,7 +770,7 @@ jobs:
         env:
           IMAGE_REF: openclaw-install-smoke:local
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
         run: |
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/install-smoke-update-image"
@@ -631,11 +819,13 @@ jobs:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
+      - *trusted_workflow_identity_step
+
       - name: Checkout trusted installer harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: ${{ needs.preflight.outputs.workflow_repository }}
-          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
           persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder
@@ -659,7 +849,7 @@ jobs:
         env:
           IMAGE_REF: openclaw-install-nonroot:local
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
         run: |
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/install-smoke-nonroot-image"
@@ -691,8 +881,7 @@ jobs:
           retention-days: 7
 
   installer_smoke_update:
-    needs:
-      [preflight, root_dockerfile_image, root_dockerfile_image_ready, installer_smoke_update_image]
+    needs: [preflight, installer_smoke_candidate_payload, installer_smoke_update_image]
     if: needs.preflight.outputs.run_full_install_smoke == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
@@ -701,95 +890,68 @@ jobs:
       DOCKER_BUILD_RECORD_UPLOAD: "false"
       OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
+      - *trusted_workflow_identity_step
+
       - name: Checkout trusted installer harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: ${{ needs.preflight.outputs.workflow_repository }}
-          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
           persist-credentials: false
 
-      - name: Checkout candidate CLI
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ needs.preflight.outputs.target_sha }}
-          path: candidate
-          persist-credentials: false
-
-      - name: Checkout trusted image artifact helper
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ needs.preflight.outputs.workflow_repository }}
-          ref: ${{ needs.preflight.outputs.workflow_sha }}
-          path: .release-harness
-          persist-credentials: false
-
-      - name: Validate root Dockerfile image artifact binding
+      - name: Validate candidate payload artifact binding
         env:
-          ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
-          ARTIFACT_DIGEST: ${{ needs.root_dockerfile_image.outputs.artifact_digest }}
-          ARTIFACT_ID: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
-          ARTIFACT_NAME: ${{ needs.root_dockerfile_image.outputs.artifact_name }}
-          ARTIFACT_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
-          ARTIFACT_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          ARTIFACT_DIGEST: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
+          ARTIFACT_HARNESS_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.harness_repository }}
+          ARTIFACT_HARNESS_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.harness_sha }}
+          ARTIFACT_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
+          ARTIFACT_TARGET_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.target_sha }}
+          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
         run: |
           set -euo pipefail
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact ID is missing or invalid." >&2
+            echo "Candidate payload artifact ID is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Root image artifact digest is missing or invalid." >&2
-            exit 1
-          }
-          [[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Root image archive SHA-256 is missing or invalid." >&2
+            echo "Candidate payload artifact digest is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact run ID is missing or invalid." >&2
+            echo "Candidate payload artifact run ID is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact run attempt is missing or invalid." >&2
+            echo "Candidate payload artifact run attempt is missing or invalid." >&2
             exit 1
           }
-          expected_artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_REPOSITORY" == "$GITHUB_REPOSITORY" ]]
+          [[ "$ARTIFACT_TARGET_SHA" == "$TARGET_SHA" ]]
+          [[ "$ARTIFACT_HARNESS_REPOSITORY" == "$HARNESS_REPOSITORY" ]]
+          [[ "$ARTIFACT_HARNESS_SHA" == "$HARNESS_SHA" ]]
+          expected_artifact_name="install-smoke-candidate-payload-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
           [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
-            echo "Root image artifact name does not match the target and producer run attempt." >&2
+            echo "Candidate payload artifact name does not match the producer tuple." >&2
             exit 1
           }
-          bash .release-harness/scripts/docker/shared-image-artifact.sh \
-            verify-upload "Root image" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+          bash scripts/docker/shared-image-artifact.sh \
+            verify-upload "Candidate payload" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
-      - name: Download root Dockerfile image artifact
+      - name: Download candidate payload artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          artifact-ids: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
-          path: ${{ runner.temp }}/install-smoke-root-image
-          run-id: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          artifact-ids: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-candidate-payload
+          run-id: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
           github-token: ${{ github.token }}
-
-      - name: Verify and load root Dockerfile image artifact
-        env:
-          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
-          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
-          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
-          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
-          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
-        run: |
-          set -euo pipefail
-          bash .release-harness/scripts/docker/shared-image-artifact.sh \
-            load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root \
-            "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
-
-      - name: Require local root Dockerfile image
-        env:
-          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
-        run: docker image inspect "$IMAGE_REF" >/dev/null
 
       - name: Validate installer update image artifact binding
         env:
@@ -803,7 +965,7 @@ jobs:
           ARTIFACT_WORKFLOW_SHA: ${{ needs.installer_smoke_update_image.outputs.workflow_sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
         run: |
           set -euo pipefail
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
@@ -868,16 +1030,40 @@ jobs:
       - name: Require local installer update image
         run: docker image inspect openclaw-install-smoke:local >/dev/null
 
-      - name: Setup Node environment for installer update smoke
-        uses: ./.github/actions/setup-node-env
-        with:
-          cache-mode: restore
-          install-bun: "false"
-          install-deps: "true"
+      - name: Verify candidate payload contents
+        env:
+          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          MANIFEST_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}
+          PACKAGE_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
+          SOURCE_ARCHIVE_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}
+          TARGET_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --network none \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --entrypoint node \
+            -v "$PWD:/harness:ro" \
+            -v "${RUNNER_TEMP}/install-smoke-candidate-payload:/payload:ro" \
+            openclaw-install-smoke:local \
+            /harness/scripts/install-smoke-candidate-payload.mts verify \
+              --payload-dir /payload \
+              --repository "$TARGET_REPOSITORY" \
+              --target-sha "$TARGET_SHA" \
+              --harness-repository "$HARNESS_REPOSITORY" \
+              --harness-sha "$HARNESS_SHA" \
+              --run-id "$GITHUB_RUN_ID" \
+              --run-attempt "$GITHUB_RUN_ATTEMPT" \
+              --package-version "$PACKAGE_VERSION" \
+              --manifest-sha256 "$MANIFEST_SHA256" \
+              --source-archive-sha256 "$SOURCE_ARCHIVE_SHA256"
 
       - name: Run installer update docker tests
         env:
-          OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
+          OPENCLAW_INSTALL_SMOKE_FROZEN_PAYLOAD_DIR: ${{ runner.temp }}/install-smoke-candidate-payload
           OPENCLAW_INSTALL_SMOKE_GROUP: update
           OPENCLAW_INSTALL_URL: file:///tmp/openclaw-install.sh
           OPENCLAW_INSTALL_CLI_URL: file:///tmp/openclaw-install-cli.sh
@@ -889,52 +1075,88 @@ jobs:
           OPENCLAW_INSTALL_SMOKE_SKIP_NPM_GLOBAL: "1"
           OPENCLAW_INSTALL_SMOKE_SKIP_PREVIOUS: "1"
           OPENCLAW_INSTALL_SMOKE_UPDATE_BASELINE: ${{ inputs.update_baseline_version || 'latest' }}
-          OPENCLAW_INSTALL_SMOKE_UPDATE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
-          OPENCLAW_INSTALL_SMOKE_UPDATE_SKIP_LOCAL_BUILD: "1"
-          OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: ${{ github.workspace }}/candidate
+          OPENCLAW_INSTALL_SMOKE_UPDATE_EXPECT_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
         run: bash scripts/test-install-sh-docker.sh
 
       - name: Run Rocky Linux installer smoke
+        env:
+          PAYLOAD_DIR: ${{ runner.temp }}/install-smoke-candidate-payload
         run: |
           timeout --kill-after=30s 20m docker run --rm \
             --platform linux/amd64 \
             -e OPENCLAW_NO_ONBOARD=1 \
             -e OPENCLAW_NO_PROMPT=1 \
-            -v "$PWD/candidate/scripts/install.sh:/tmp/install.sh:ro" \
+            -v "$PAYLOAD_DIR/install.sh:/tmp/install.sh:ro" \
             rockylinux:9@sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0 \
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install.sh --install-method npm --version latest --no-onboard --no-prompt --verify && openclaw --version'
 
       - name: Run Rocky Linux CLI installer smoke
+        env:
+          PAYLOAD_DIR: ${{ runner.temp }}/install-smoke-candidate-payload
         run: |
           timeout --kill-after=30s 20m docker run --rm \
             --platform linux/amd64 \
             -e OPENCLAW_NO_ONBOARD=1 \
             -e OPENCLAW_NO_PROMPT=1 \
-            -v "$PWD/candidate/scripts/install-cli.sh:/tmp/install-cli.sh:ro" \
+            -v "$PAYLOAD_DIR/install-cli.sh:/tmp/install-cli.sh:ro" \
             rockylinux:9@sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0 \
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install-cli.sh --prefix /tmp/openclaw-cli --version latest --no-onboard && /tmp/openclaw-cli/bin/openclaw --version'
 
   installer_smoke_nonroot:
-    needs: [preflight, installer_smoke_nonroot_image]
+    needs: [preflight, installer_smoke_candidate_payload, installer_smoke_nonroot_image]
     if: needs.preflight.outputs.run_full_install_smoke == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
       OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
+      - *trusted_workflow_identity_step
+
       - name: Checkout trusted installer harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: ${{ needs.preflight.outputs.workflow_repository }}
-          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
           persist-credentials: false
 
-      - name: Checkout candidate CLI
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Validate candidate payload artifact binding
+        env:
+          ARTIFACT_DIGEST: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
+          ARTIFACT_HARNESS_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.harness_repository }}
+          ARTIFACT_HARNESS_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.harness_sha }}
+          ARTIFACT_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
+          ARTIFACT_TARGET_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.target_sha }}
+          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]]
+          [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
+          [[ "$ARTIFACT_REPOSITORY" == "$GITHUB_REPOSITORY" ]]
+          [[ "$ARTIFACT_TARGET_SHA" == "$TARGET_SHA" ]]
+          [[ "$ARTIFACT_HARNESS_REPOSITORY" == "$HARNESS_REPOSITORY" ]]
+          [[ "$ARTIFACT_HARNESS_SHA" == "$HARNESS_SHA" ]]
+          expected_artifact_name="install-smoke-candidate-payload-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]]
+          bash scripts/docker/shared-image-artifact.sh \
+            verify-upload "Candidate payload" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download candidate payload artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          ref: ${{ needs.preflight.outputs.target_sha }}
-          path: candidate
-          persist-credentials: false
+          artifact-ids: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-candidate-payload
+          run-id: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Validate installer non-root image artifact binding
         env:
@@ -948,7 +1170,7 @@ jobs:
           ARTIFACT_WORKFLOW_SHA: ${{ needs.installer_smoke_nonroot_image.outputs.workflow_sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
         run: |
           set -euo pipefail
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
@@ -1013,15 +1235,40 @@ jobs:
       - name: Require local installer non-root image
         run: docker image inspect openclaw-install-nonroot:local >/dev/null
 
-      - name: Setup Node environment for installer non-root smoke
-        uses: ./.github/actions/setup-node-env
-        with:
-          cache-mode: off
-          install-bun: "false"
-          install-deps: "false"
+      - name: Verify candidate payload contents
+        env:
+          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          MANIFEST_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}
+          PACKAGE_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
+          SOURCE_ARCHIVE_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}
+          TARGET_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --network none \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --entrypoint node \
+            -v "$PWD:/harness:ro" \
+            -v "${RUNNER_TEMP}/install-smoke-candidate-payload:/payload:ro" \
+            openclaw-install-nonroot:local \
+            /harness/scripts/install-smoke-candidate-payload.mts verify \
+              --payload-dir /payload \
+              --repository "$TARGET_REPOSITORY" \
+              --target-sha "$TARGET_SHA" \
+              --harness-repository "$HARNESS_REPOSITORY" \
+              --harness-sha "$HARNESS_SHA" \
+              --run-id "$GITHUB_RUN_ID" \
+              --run-attempt "$GITHUB_RUN_ATTEMPT" \
+              --package-version "$PACKAGE_VERSION" \
+              --manifest-sha256 "$MANIFEST_SHA256" \
+              --source-archive-sha256 "$SOURCE_ARCHIVE_SHA256"
 
       - name: Run installer non-root docker tests
         env:
+          OPENCLAW_INSTALL_SMOKE_FROZEN_PAYLOAD_DIR: ${{ runner.temp }}/install-smoke-candidate-payload
           OPENCLAW_INSTALL_SMOKE_GROUP: nonroot
           OPENCLAW_INSTALL_URL: file:///tmp/openclaw-install.sh
           OPENCLAW_INSTALL_CLI_URL: file:///tmp/openclaw-install-cli.sh
@@ -1030,7 +1277,7 @@ jobs:
           OPENCLAW_INSTALL_SMOKE_SKIP_IMAGE_BUILD: "1"
           OPENCLAW_INSTALL_NONROOT_SKIP_IMAGE_BUILD: "1"
           OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT: "0"
-          OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: ${{ github.workspace }}/candidate
+          OPENCLAW_INSTALL_SMOKE_UPDATE_EXPECT_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
         run: bash scripts/test-install-sh-docker.sh
 
   installer_smoke:
@@ -1039,6 +1286,7 @@ jobs:
         preflight,
         root_dockerfile_image,
         root_dockerfile_image_ready,
+        installer_smoke_candidate_payload,
         installer_smoke_update_image,
         installer_smoke_update,
         installer_smoke_nonroot_image,
@@ -1050,6 +1298,7 @@ jobs:
     steps:
       - name: Verify installer smoke groups
         env:
+          CANDIDATE_PAYLOAD_RESULT: ${{ needs.installer_smoke_candidate_payload.result }}
           NONROOT_CONSUMER_RESULT: ${{ needs.installer_smoke_nonroot.result }}
           NONROOT_PRODUCER_RESULT: ${{ needs.installer_smoke_nonroot_image.result }}
           ROOT_IMAGE_READY_RESULT: ${{ needs.root_dockerfile_image_ready.result }}
@@ -1069,6 +1318,7 @@ jobs:
           }
           check_result "Root Dockerfile image producer" "$ROOT_IMAGE_RESULT"
           check_result "Root Dockerfile image gate" "$ROOT_IMAGE_READY_RESULT"
+          check_result "Installer candidate payload producer" "$CANDIDATE_PAYLOAD_RESULT"
           check_result "Installer update image producer" "$UPDATE_PRODUCER_RESULT"
           check_result "Installer update consumer" "$UPDATE_CONSUMER_RESULT"
           check_result "Installer non-root image producer" "$NONROOT_PRODUCER_RESULT"
@@ -1089,11 +1339,13 @@ jobs:
           ref: ${{ needs.preflight.outputs.target_sha }}
           persist-credentials: false
 
+      - *trusted_workflow_identity_step
+
       - name: Checkout trusted image artifact helper
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: ${{ needs.preflight.outputs.workflow_repository }}
-          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
+          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
           path: .release-harness
           persist-credentials: false
 
@@ -1153,7 +1405,7 @@ jobs:
           OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
           OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
         run: |
           set -euo pipefail
           bash .release-harness/scripts/docker/shared-image-artifact.sh \

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -536,23 +536,20 @@ jobs:
             "
           '
 
-  installer_smoke_image:
+  installer_smoke_update_image:
     needs: [preflight]
     if: needs.preflight.outputs.run_full_install_smoke == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - group: update
-            artifact_key: install-smoke-update
-            dockerfile: ./scripts/docker/install-sh-smoke/Dockerfile
-            image_ref: openclaw-install-smoke:local
-          - group: nonroot
-            artifact_key: install-smoke-nonroot
-            dockerfile: ./scripts/docker/install-sh-nonroot/Dockerfile
-            image_ref: openclaw-install-nonroot:local
+    outputs:
+      archive_sha256: ${{ steps.image_artifact.outputs.archive_sha256 }}
+      artifact_digest: ${{ steps.image_artifact_upload.outputs.artifact-digest }}
+      artifact_id: ${{ steps.image_artifact_upload.outputs.artifact-id }}
+      artifact_name: ${{ steps.image_artifact.outputs.artifact_name }}
+      artifact_run_attempt: ${{ steps.image_artifact.outputs.run_attempt }}
+      artifact_run_id: ${{ steps.image_artifact.outputs.run_id }}
+      target_sha: ${{ steps.image_artifact.outputs.target_sha }}
+      workflow_sha: ${{ steps.image_artifact.outputs.workflow_sha }}
     env:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
@@ -571,35 +568,43 @@ jobs:
 
       - name: Build installer smoke image
         env:
-          DOCKERFILE: ${{ matrix.dockerfile }}
-          IMAGE_REF: ${{ matrix.image_ref }}
+          IMAGE_REF: openclaw-install-smoke:local
         run: |
           timeout --kill-after=30s 20m docker buildx build \
             --progress=plain \
             --load \
             -t "$IMAGE_REF" \
-            -f "$DOCKERFILE" \
+            -f ./scripts/docker/install-sh-smoke/Dockerfile \
             ./scripts/docker
 
       - name: Pack installer smoke image artifact
         id: image_artifact
         env:
-          ARTIFACT_KEY: ${{ matrix.artifact_key }}
-          IMAGE_REF: ${{ matrix.image_ref }}
+          IMAGE_REF: openclaw-install-smoke:local
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
           WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
         run: |
           set -euo pipefail
-          artifact_dir="${RUNNER_TEMP}/${ARTIFACT_KEY}-image"
-          artifact_name="${ARTIFACT_KEY}-image-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_dir="${RUNNER_TEMP}/install-smoke-update-image"
+          artifact_name="install-smoke-update-image-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           bash scripts/docker/shared-image-artifact.sh \
-            pack "$artifact_dir" "$ARTIFACT_KEY" "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+            pack "$artifact_dir" install-smoke-update "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+          archive_sha256="$(
+            jq -er '.archive.sha256 | select(type == "string" and test("^[a-f0-9]{64}$"))' \
+              "$artifact_dir/shared-image-artifact.json"
+          )"
           {
+            echo "archive_sha256=$archive_sha256"
             echo "artifact_name=$artifact_name"
             echo "artifact_path=$artifact_dir"
+            echo "run_attempt=$GITHUB_RUN_ATTEMPT"
+            echo "run_id=$GITHUB_RUN_ID"
+            echo "target_sha=$TARGET_SHA"
+            echo "workflow_sha=$WORKFLOW_SHA"
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload installer smoke image artifact
+        id: image_artifact_upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.image_artifact.outputs.artifact_name }}
@@ -608,23 +613,89 @@ jobs:
           compression-level: 0
           retention-days: 7
 
-  installer_smoke_group:
-    needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready, installer_smoke_image]
+  installer_smoke_nonroot_image:
+    needs: [preflight]
     if: needs.preflight.outputs.run_full_install_smoke == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: ${{ matrix.timeout_minutes }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - group: update
-            artifact_key: install-smoke-update
-            image_ref: openclaw-install-smoke:local
-            timeout_minutes: 120
-          - group: nonroot
-            artifact_key: install-smoke-nonroot
-            image_ref: openclaw-install-nonroot:local
-            timeout_minutes: 60
+    timeout-minutes: 45
+    outputs:
+      archive_sha256: ${{ steps.image_artifact.outputs.archive_sha256 }}
+      artifact_digest: ${{ steps.image_artifact_upload.outputs.artifact-digest }}
+      artifact_id: ${{ steps.image_artifact_upload.outputs.artifact-id }}
+      artifact_name: ${{ steps.image_artifact.outputs.artifact_name }}
+      artifact_run_attempt: ${{ steps.image_artifact.outputs.run_attempt }}
+      artifact_run_id: ${{ steps.image_artifact.outputs.run_id }}
+      target_sha: ${{ steps.image_artifact.outputs.target_sha }}
+      workflow_sha: ${{ steps.image_artifact.outputs.workflow_sha }}
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
+      DOCKER_BUILD_RECORD_UPLOAD: "false"
+    steps:
+      - name: Checkout trusted installer harness
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ needs.preflight.outputs.workflow_repository }}
+          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          persist-credentials: false
+
+      - name: Set up Blacksmith Docker Builder
+        uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1
+        with:
+          max-cache-size-mb: 800000
+
+      - name: Build installer non-root image
+        env:
+          IMAGE_REF: openclaw-install-nonroot:local
+        run: |
+          timeout --kill-after=30s 20m docker buildx build \
+            --progress=plain \
+            --load \
+            -t "$IMAGE_REF" \
+            -f ./scripts/docker/install-sh-nonroot/Dockerfile \
+            ./scripts/docker
+
+      - name: Pack installer non-root image artifact
+        id: image_artifact
+        env:
+          IMAGE_REF: openclaw-install-nonroot:local
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/install-smoke-nonroot-image"
+          artifact_name="install-smoke-nonroot-image-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          bash scripts/docker/shared-image-artifact.sh \
+            pack "$artifact_dir" install-smoke-nonroot "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+          archive_sha256="$(
+            jq -er '.archive.sha256 | select(type == "string" and test("^[a-f0-9]{64}$"))' \
+              "$artifact_dir/shared-image-artifact.json"
+          )"
+          {
+            echo "archive_sha256=$archive_sha256"
+            echo "artifact_name=$artifact_name"
+            echo "artifact_path=$artifact_dir"
+            echo "run_attempt=$GITHUB_RUN_ATTEMPT"
+            echo "run_id=$GITHUB_RUN_ID"
+            echo "target_sha=$TARGET_SHA"
+            echo "workflow_sha=$WORKFLOW_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload installer non-root image artifact
+        id: image_artifact_upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.image_artifact.outputs.artifact_name }}
+          path: ${{ steps.image_artifact.outputs.artifact_path }}
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7
+
+  installer_smoke_update:
+    needs:
+      [preflight, root_dockerfile_image, root_dockerfile_image_ready, installer_smoke_update_image]
+    if: needs.preflight.outputs.run_full_install_smoke == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
     env:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
@@ -645,7 +716,6 @@ jobs:
           persist-credentials: false
 
       - name: Checkout trusted image artifact helper
-        if: matrix.group == 'update'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ needs.preflight.outputs.workflow_repository }}
@@ -654,7 +724,6 @@ jobs:
           persist-credentials: false
 
       - name: Validate root Dockerfile image artifact binding
-        if: matrix.group == 'update'
         env:
           ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
           ARTIFACT_DIGEST: ${{ needs.root_dockerfile_image.outputs.artifact_digest }}
@@ -696,7 +765,6 @@ jobs:
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Download root Dockerfile image artifact
-        if: matrix.group == 'update'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
@@ -705,7 +773,6 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Verify and load root Dockerfile image artifact
-        if: matrix.group == 'update'
         env:
           IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
@@ -720,45 +787,98 @@ jobs:
             "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
 
       - name: Require local root Dockerfile image
-        if: matrix.group == 'update'
         env:
           IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
         run: docker image inspect "$IMAGE_REF" >/dev/null
 
-      - name: Download installer smoke image artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ format('{0}-image-{1}-{2}-{3}', matrix.artifact_key, needs.preflight.outputs.target_sha, github.run_id, github.run_attempt) }}
-          path: ${{ runner.temp }}/installer-smoke-image
-
-      - name: Verify and load installer smoke image artifact
+      - name: Validate installer update image artifact binding
         env:
-          ARTIFACT_KEY: ${{ matrix.artifact_key }}
-          IMAGE_REF: ${{ matrix.image_ref }}
+          ARCHIVE_SHA256: ${{ needs.installer_smoke_update_image.outputs.archive_sha256 }}
+          ARTIFACT_DIGEST: ${{ needs.installer_smoke_update_image.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.installer_smoke_update_image.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.installer_smoke_update_image.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.installer_smoke_update_image.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.installer_smoke_update_image.outputs.artifact_run_id }}
+          ARTIFACT_TARGET_SHA: ${{ needs.installer_smoke_update_image.outputs.target_sha }}
+          ARTIFACT_WORKFLOW_SHA: ${{ needs.installer_smoke_update_image.outputs.workflow_sha }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
           WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
         run: |
           set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Installer update image artifact ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Installer update image artifact digest is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Installer update image archive SHA-256 is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Installer update image artifact run ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Installer update image artifact run attempt is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_TARGET_SHA" == "$TARGET_SHA" ]] || {
+            echo "Installer update image target SHA does not match the selected candidate." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_WORKFLOW_SHA" == "$WORKFLOW_SHA" ]] || {
+            echo "Installer update image workflow SHA does not match the trusted harness." >&2
+            exit 1
+          }
+          expected_artifact_name="install-smoke-update-image-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Installer update image artifact name does not match the producer tuple." >&2
+            exit 1
+          }
           bash scripts/docker/shared-image-artifact.sh \
-            load "${RUNNER_TEMP}/installer-smoke-image" "$ARTIFACT_KEY" \
+            verify-upload "Installer update image" "$ARTIFACT_ID" "$ARTIFACT_NAME" \
+            "$ARTIFACT_DIGEST" "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download installer update image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.installer_smoke_update_image.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-update-image
+          run-id: ${{ needs.installer_smoke_update_image.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load installer update image artifact
+        env:
+          IMAGE_REF: openclaw-install-smoke:local
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.installer_smoke_update_image.outputs.archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.installer_smoke_update_image.outputs.artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.installer_smoke_update_image.outputs.artifact_run_id }}
+          TARGET_SHA: ${{ needs.installer_smoke_update_image.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.installer_smoke_update_image.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/docker/shared-image-artifact.sh \
+            load "${RUNNER_TEMP}/install-smoke-update-image" install-smoke-update \
             "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
 
-      - name: Require local installer smoke image
-        env:
-          IMAGE_REF: ${{ matrix.image_ref }}
-        run: docker image inspect "$IMAGE_REF" >/dev/null
+      - name: Require local installer update image
+        run: docker image inspect openclaw-install-smoke:local >/dev/null
 
-      - name: Setup Node environment for installer smoke
+      - name: Setup Node environment for installer update smoke
         uses: ./.github/actions/setup-node-env
         with:
           cache-mode: restore
           install-bun: "false"
-          install-deps: ${{ matrix.group == 'update' && 'true' || 'false' }}
+          install-deps: "true"
 
-      - name: Run installer docker tests
+      - name: Run installer update docker tests
         env:
           OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
-          OPENCLAW_INSTALL_SMOKE_GROUP: ${{ matrix.group }}
+          OPENCLAW_INSTALL_SMOKE_GROUP: update
           OPENCLAW_INSTALL_URL: file:///tmp/openclaw-install.sh
           OPENCLAW_INSTALL_CLI_URL: file:///tmp/openclaw-install-cli.sh
           OPENCLAW_NO_ONBOARD: "1"
@@ -775,7 +895,6 @@ jobs:
         run: bash scripts/test-install-sh-docker.sh
 
       - name: Run Rocky Linux installer smoke
-        if: matrix.group == 'update'
         run: |
           timeout --kill-after=30s 20m docker run --rm \
             --platform linux/amd64 \
@@ -786,7 +905,6 @@ jobs:
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install.sh --install-method npm --version latest --no-onboard --no-prompt --verify && openclaw --version'
 
       - name: Run Rocky Linux CLI installer smoke
-        if: matrix.group == 'update'
         run: |
           timeout --kill-after=30s 20m docker run --rm \
             --platform linux/amd64 \
@@ -796,27 +914,165 @@ jobs:
             rockylinux:9@sha256:d644d203142cd5b54ad2a83a203e1dee68af2229f8fe32f52a30c6e1d3c3a9e0 \
             bash -lc 'dnf install -y -q ca-certificates tar gzip xz findutils which sudo >/dev/null && bash /tmp/install-cli.sh --prefix /tmp/openclaw-cli --version latest --no-onboard && /tmp/openclaw-cli/bin/openclaw --version'
 
+  installer_smoke_nonroot:
+    needs: [preflight, installer_smoke_nonroot_image]
+    if: needs.preflight.outputs.run_full_install_smoke == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
+    steps:
+      - name: Checkout trusted installer harness
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ needs.preflight.outputs.workflow_repository }}
+          ref: ${{ needs.preflight.outputs.workflow_sha }}
+          persist-credentials: false
+
+      - name: Checkout candidate CLI
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.preflight.outputs.target_sha }}
+          path: candidate
+          persist-credentials: false
+
+      - name: Validate installer non-root image artifact binding
+        env:
+          ARCHIVE_SHA256: ${{ needs.installer_smoke_nonroot_image.outputs.archive_sha256 }}
+          ARTIFACT_DIGEST: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_run_id }}
+          ARTIFACT_TARGET_SHA: ${{ needs.installer_smoke_nonroot_image.outputs.target_sha }}
+          ARTIFACT_WORKFLOW_SHA: ${{ needs.installer_smoke_nonroot_image.outputs.workflow_sha }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.preflight.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Installer non-root image artifact ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Installer non-root image artifact digest is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
+            echo "Installer non-root image archive SHA-256 is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Installer non-root image artifact run ID is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
+            echo "Installer non-root image artifact run attempt is missing or invalid." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_TARGET_SHA" == "$TARGET_SHA" ]] || {
+            echo "Installer non-root image target SHA does not match the selected candidate." >&2
+            exit 1
+          }
+          [[ "$ARTIFACT_WORKFLOW_SHA" == "$WORKFLOW_SHA" ]] || {
+            echo "Installer non-root image workflow SHA does not match the trusted harness." >&2
+            exit 1
+          }
+          expected_artifact_name="install-smoke-nonroot-image-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Installer non-root image artifact name does not match the producer tuple." >&2
+            exit 1
+          }
+          bash scripts/docker/shared-image-artifact.sh \
+            verify-upload "Installer non-root image" "$ARTIFACT_ID" "$ARTIFACT_NAME" \
+            "$ARTIFACT_DIGEST" "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download installer non-root image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-nonroot-image
+          run-id: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify and load installer non-root image artifact
+        env:
+          IMAGE_REF: openclaw-install-nonroot:local
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.installer_smoke_nonroot_image.outputs.archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.installer_smoke_nonroot_image.outputs.artifact_run_id }}
+          TARGET_SHA: ${{ needs.installer_smoke_nonroot_image.outputs.target_sha }}
+          WORKFLOW_SHA: ${{ needs.installer_smoke_nonroot_image.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          bash scripts/docker/shared-image-artifact.sh \
+            load "${RUNNER_TEMP}/install-smoke-nonroot-image" install-smoke-nonroot \
+            "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
+
+      - name: Require local installer non-root image
+        run: docker image inspect openclaw-install-nonroot:local >/dev/null
+
+      - name: Setup Node environment for installer non-root smoke
+        uses: ./.github/actions/setup-node-env
+        with:
+          cache-mode: off
+          install-bun: "false"
+          install-deps: "false"
+
+      - name: Run installer non-root docker tests
+        env:
+          OPENCLAW_INSTALL_SMOKE_GROUP: nonroot
+          OPENCLAW_INSTALL_URL: file:///tmp/openclaw-install.sh
+          OPENCLAW_INSTALL_CLI_URL: file:///tmp/openclaw-install-cli.sh
+          OPENCLAW_NO_ONBOARD: "1"
+          OPENCLAW_INSTALL_SMOKE_SKIP_CLI: "0"
+          OPENCLAW_INSTALL_SMOKE_SKIP_IMAGE_BUILD: "1"
+          OPENCLAW_INSTALL_NONROOT_SKIP_IMAGE_BUILD: "1"
+          OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT: "0"
+          OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: ${{ github.workspace }}/candidate
+        run: bash scripts/test-install-sh-docker.sh
+
   installer_smoke:
-    needs: [preflight, installer_smoke_image, installer_smoke_group]
+    needs:
+      [
+        preflight,
+        root_dockerfile_image,
+        root_dockerfile_image_ready,
+        installer_smoke_update_image,
+        installer_smoke_update,
+        installer_smoke_nonroot_image,
+        installer_smoke_nonroot,
+      ]
     if: always() && needs.preflight.result == 'success' && needs.preflight.outputs.run_full_install_smoke == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Verify installer smoke groups
         env:
-          CONSUMER_RESULT: ${{ needs.installer_smoke_group.result }}
-          PRODUCER_RESULT: ${{ needs.installer_smoke_image.result }}
+          NONROOT_CONSUMER_RESULT: ${{ needs.installer_smoke_nonroot.result }}
+          NONROOT_PRODUCER_RESULT: ${{ needs.installer_smoke_nonroot_image.result }}
+          ROOT_IMAGE_READY_RESULT: ${{ needs.root_dockerfile_image_ready.result }}
+          ROOT_IMAGE_RESULT: ${{ needs.root_dockerfile_image.result }}
+          UPDATE_CONSUMER_RESULT: ${{ needs.installer_smoke_update.result }}
+          UPDATE_PRODUCER_RESULT: ${{ needs.installer_smoke_update_image.result }}
         run: |
           set -euo pipefail
           failed=0
-          if [[ "$PRODUCER_RESULT" != "success" ]]; then
-            echo "::error::Installer smoke image producers ended with ${PRODUCER_RESULT}."
-            failed=1
-          fi
-          if [[ "$CONSUMER_RESULT" != "success" ]]; then
-            echo "::error::Installer smoke consumers ended with ${CONSUMER_RESULT}."
-            failed=1
-          fi
+          check_result() {
+            local name="$1"
+            local result="$2"
+            if [[ "$result" != "success" ]]; then
+              echo "::error::${name} ended with ${result}."
+              failed=1
+            fi
+          }
+          check_result "Root Dockerfile image producer" "$ROOT_IMAGE_RESULT"
+          check_result "Root Dockerfile image gate" "$ROOT_IMAGE_READY_RESULT"
+          check_result "Installer update image producer" "$UPDATE_PRODUCER_RESULT"
+          check_result "Installer update consumer" "$UPDATE_CONSUMER_RESULT"
+          check_result "Installer non-root image producer" "$NONROOT_PRODUCER_RESULT"
+          check_result "Installer non-root consumer" "$NONROOT_CONSUMER_RESULT"
           exit "$failed"
 
   bun_global_install_smoke:

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -235,39 +235,105 @@ jobs:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
-      - name: Checkout CLI
+      - name: Download exact candidate source archive
+        env:
+          TARGET_REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$TARGET_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
+          candidate_dir="${RUNNER_TEMP}/root-dockerfile-candidate"
+          install -d -m 0750 "$candidate_dir"
+          curl --fail --location --silent --show-error \
+            --connect-timeout 15 \
+            --max-time 300 \
+            --retry 3 \
+            --output "${RUNNER_TEMP}/root-dockerfile-candidate.tar.gz" \
+            "https://codeload.github.com/${TARGET_REPOSITORY}/tar.gz/${TARGET_SHA}"
+          tar -xzf "${RUNNER_TEMP}/root-dockerfile-candidate.tar.gz" \
+            --strip-components=1 \
+            --no-same-owner \
+            --no-same-permissions \
+            -C "$candidate_dir"
+          test -f "$candidate_dir/Dockerfile"
+
+      # Start from a statically trusted checkout. The following step validates job context
+      # locally before restoring the exact called-workflow revision.
+      - &trusted_workflow_subdir_checkout_step
+        name: Checkout trusted release harness
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ needs.preflight.outputs.target_sha }}
+          repository: openclaw/openclaw
+          ref: main
+          path: .release-harness
+          fetch-depth: 1
           persist-credentials: false
 
-      - &trusted_workflow_identity_step
-        name: Resolve trusted workflow identity
+      - &trusted_workflow_subdir_identity_step
+        name: Restore exact trusted workflow revision
         id: workflow
         env:
           EXPECTED_WORKFLOW_REPOSITORY: ${{ github.repository }}
+          HARNESS_PATH: .release-harness
           JOB_CONTEXT: ${{ toJSON(job) }}
         shell: bash
         run: |
           set -euo pipefail
           node --input-type=module <<'NODE'
+          import { appendFileSync } from "node:fs";
+          import { execFileSync } from "node:child_process";
+
           const job = JSON.parse(process.env.JOB_CONTEXT ?? "{}");
           const repository = process.env.EXPECTED_WORKFLOW_REPOSITORY ?? "";
-          if (job.workflow_repository !== repository) {
+          const harnessPath = process.env.HARNESS_PATH ?? "";
+          if (repository !== "openclaw/openclaw" || job.workflow_repository !== repository) {
             throw new Error("job.workflow_repository must exactly match github.repository");
           }
           if (typeof job.workflow_sha !== "string" || !/^[0-9a-f]{40}$/u.test(job.workflow_sha)) {
             throw new Error("job.workflow_sha must be a full lowercase commit SHA");
           }
+          if (harnessPath !== ".release-harness") {
+            throw new Error("trusted harness path is invalid");
+          }
+          const git = (...args) =>
+            execFileSync("git", ["-C", harnessPath, ...args], {
+              encoding: "utf8",
+              stdio: ["ignore", "pipe", "inherit"],
+            }).trim();
+          const remote = git("remote", "get-url", "origin").replace(/\.git$/u, "");
+          if (remote !== `https://github.com/${repository}`) {
+            throw new Error("trusted harness remote does not match the workflow repository");
+          }
+          execFileSync(
+            "git",
+            [
+              "-C",
+              harnessPath,
+              "fetch",
+              "--no-tags",
+              "--no-recurse-submodules",
+              "--depth=1",
+              "origin",
+              job.workflow_sha,
+            ],
+            { stdio: "inherit" },
+          );
+          execFileSync("git", ["-C", harnessPath, "checkout", "--detach", job.workflow_sha], {
+            stdio: "inherit",
+          });
+          if (git("rev-parse", "HEAD") !== job.workflow_sha) {
+            throw new Error("trusted harness checkout did not resolve to job.workflow_sha");
+          }
+          const outputPath = process.env.GITHUB_OUTPUT;
+          if (!outputPath) {
+            throw new Error("GITHUB_OUTPUT is required");
+          }
+          appendFileSync(
+            outputPath,
+            `repository=${repository}\nsha=${job.workflow_sha}\n`,
+          );
           NODE
-
-      - name: Checkout trusted image artifact helper
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
-          path: .release-harness
-          persist-credentials: false
 
       - name: Set up Blacksmith Docker Builder
         uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1
@@ -276,6 +342,7 @@ jobs:
 
       - name: Build local root Dockerfile smoke image
         env:
+          CANDIDATE_DIR: ${{ runner.temp }}/root-dockerfile-candidate
           IMAGE_REF: ${{ needs.preflight.outputs.dockerfile_image }}
         run: |
           timeout --kill-after=30s 45m docker buildx build \
@@ -283,15 +350,15 @@ jobs:
             --load \
             --build-arg OPENCLAW_EXTENSIONS=matrix \
             -t "$IMAGE_REF" \
-            -f ./Dockerfile \
-            .
+            -f "$CANDIDATE_DIR/Dockerfile" \
+            "$CANDIDATE_DIR"
 
       - name: Pack root Dockerfile image artifact
         id: image_artifact
         env:
           IMAGE_REF: ${{ needs.preflight.outputs.dockerfile_image }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/install-smoke-root-image"
@@ -383,21 +450,8 @@ jobs:
     env:
       OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
-      - name: Checkout CLI
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ needs.preflight.outputs.target_sha }}
-          persist-credentials: false
-
-      - *trusted_workflow_identity_step
-
-      - name: Checkout trusted image artifact helper
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
-          path: .release-harness
-          persist-credentials: false
+      - *trusted_workflow_subdir_checkout_step
+      - *trusted_workflow_subdir_identity_step
 
       - name: Validate root Dockerfile image artifact binding
         env:
@@ -455,7 +509,7 @@ jobs:
           OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
           OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           bash .release-harness/scripts/docker/shared-image-artifact.sh \
@@ -492,13 +546,13 @@ jobs:
         env:
           OPENCLAW_AGENTS_DELETE_SHARED_WORKSPACE_E2E_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_AGENTS_DELETE_SHARED_WORKSPACE_E2E_SKIP_BUILD: "1"
-        run: bash scripts/e2e/agents-delete-shared-workspace-docker.sh
+        run: bash .release-harness/scripts/e2e/agents-delete-shared-workspace-docker.sh
 
       - name: Run Docker gateway network e2e
         env:
           OPENCLAW_GATEWAY_NETWORK_E2E_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD: "1"
-        run: bash scripts/e2e/gateway-network-docker.sh
+        run: bash .release-harness/scripts/e2e/gateway-network-docker.sh
 
       - name: Smoke test Dockerfile with matrix extension build arg
         env:
@@ -569,23 +623,17 @@ jobs:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
-      - *trusted_workflow_identity_step
-
-      - name: Checkout trusted installer harness
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
-          persist-credentials: false
+      - *trusted_workflow_subdir_checkout_step
+      - *trusted_workflow_subdir_identity_step
 
       - name: Require exact trusted installer harness
         env:
-          EXPECTED_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          EXPECTED_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          EXPECTED_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          EXPECTED_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           [[ "$GITHUB_REPOSITORY" == "$EXPECTED_REPOSITORY" ]]
-          [[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]
+          [[ "$(git -C .release-harness rev-parse HEAD)" == "$EXPECTED_SHA" ]]
 
       - name: Download exact candidate source archive
         env:
@@ -614,8 +662,8 @@ jobs:
             --progress=plain \
             --load \
             -t openclaw-install-candidate-packager:local \
-            -f ./scripts/docker/install-sh-smoke/Dockerfile \
-            ./scripts/docker
+            -f ./.release-harness/scripts/docker/install-sh-smoke/Dockerfile \
+            ./.release-harness/scripts/docker
 
       - name: Package candidate only inside pinned harness
         env:
@@ -663,8 +711,8 @@ jobs:
       - name: Seal candidate payload in clean pinned harness
         id: payload
         env:
-          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
           TARGET_REPOSITORY: ${{ github.repository }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
         run: |
@@ -677,7 +725,7 @@ jobs:
             --security-opt no-new-privileges \
             --user "$(id -u):$(id -g)" \
             --entrypoint node \
-            -v "$PWD:/harness:ro" \
+            -v "$PWD/.release-harness:/harness:ro" \
             -v "${RUNNER_TEMP}/candidate.tar.gz:/input/candidate.tar.gz:ro" \
             -v "${RUNNER_TEMP}/candidate-package:/package:ro" \
             -v "${payload_dir}:/payload" \
@@ -740,14 +788,8 @@ jobs:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
-      - *trusted_workflow_identity_step
-
-      - name: Checkout trusted installer harness
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
-          persist-credentials: false
+      - *trusted_workflow_subdir_checkout_step
+      - *trusted_workflow_subdir_identity_step
 
       - name: Set up Blacksmith Docker Builder
         uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1
@@ -762,20 +804,20 @@ jobs:
             --progress=plain \
             --load \
             -t "$IMAGE_REF" \
-            -f ./scripts/docker/install-sh-smoke/Dockerfile \
-            ./scripts/docker
+            -f ./.release-harness/scripts/docker/install-sh-smoke/Dockerfile \
+            ./.release-harness/scripts/docker
 
       - name: Pack installer smoke image artifact
         id: image_artifact
         env:
           IMAGE_REF: openclaw-install-smoke:local
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/install-smoke-update-image"
           artifact_name="install-smoke-update-image-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          bash scripts/docker/shared-image-artifact.sh \
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             pack "$artifact_dir" install-smoke-update "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
           archive_sha256="$(
             jq -er '.archive.sha256 | select(type == "string" and test("^[a-f0-9]{64}$"))' \
@@ -819,14 +861,8 @@ jobs:
       DOCKER_BUILD_SUMMARY: "false"
       DOCKER_BUILD_RECORD_UPLOAD: "false"
     steps:
-      - *trusted_workflow_identity_step
-
-      - name: Checkout trusted installer harness
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
-          persist-credentials: false
+      - *trusted_workflow_subdir_checkout_step
+      - *trusted_workflow_subdir_identity_step
 
       - name: Set up Blacksmith Docker Builder
         uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1
@@ -841,20 +877,20 @@ jobs:
             --progress=plain \
             --load \
             -t "$IMAGE_REF" \
-            -f ./scripts/docker/install-sh-nonroot/Dockerfile \
-            ./scripts/docker
+            -f ./.release-harness/scripts/docker/install-sh-nonroot/Dockerfile \
+            ./.release-harness/scripts/docker
 
       - name: Pack installer non-root image artifact
         id: image_artifact
         env:
           IMAGE_REF: openclaw-install-nonroot:local
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/install-smoke-nonroot-image"
           artifact_name="install-smoke-nonroot-image-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          bash scripts/docker/shared-image-artifact.sh \
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             pack "$artifact_dir" install-smoke-nonroot "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
           archive_sha256="$(
             jq -er '.archive.sha256 | select(type == "string" and test("^[a-f0-9]{64}$"))' \
@@ -890,14 +926,8 @@ jobs:
       DOCKER_BUILD_RECORD_UPLOAD: "false"
       OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
-      - *trusted_workflow_identity_step
-
-      - name: Checkout trusted installer harness
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
-          persist-credentials: false
+      - *trusted_workflow_subdir_checkout_step
+      - *trusted_workflow_subdir_identity_step
 
       - name: Validate candidate payload artifact binding
         env:
@@ -910,8 +940,8 @@ jobs:
           ARTIFACT_HARNESS_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.harness_sha }}
           ARTIFACT_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
           ARTIFACT_TARGET_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.target_sha }}
-          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
         run: |
@@ -941,7 +971,7 @@ jobs:
             echo "Candidate payload artifact name does not match the producer tuple." >&2
             exit 1
           }
-          bash scripts/docker/shared-image-artifact.sh \
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             verify-upload "Candidate payload" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
@@ -965,7 +995,7 @@ jobs:
           ARTIFACT_WORKFLOW_SHA: ${{ needs.installer_smoke_update_image.outputs.workflow_sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
@@ -1001,7 +1031,7 @@ jobs:
             echo "Installer update image artifact name does not match the producer tuple." >&2
             exit 1
           }
-          bash scripts/docker/shared-image-artifact.sh \
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             verify-upload "Installer update image" "$ARTIFACT_ID" "$ARTIFACT_NAME" \
             "$ARTIFACT_DIGEST" "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
@@ -1023,7 +1053,7 @@ jobs:
           WORKFLOW_SHA: ${{ needs.installer_smoke_update_image.outputs.workflow_sha }}
         run: |
           set -euo pipefail
-          bash scripts/docker/shared-image-artifact.sh \
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             load "${RUNNER_TEMP}/install-smoke-update-image" install-smoke-update \
             "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
 
@@ -1032,8 +1062,8 @@ jobs:
 
       - name: Verify candidate payload contents
         env:
-          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
           MANIFEST_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}
           PACKAGE_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
           SOURCE_ARCHIVE_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}
@@ -1046,7 +1076,7 @@ jobs:
             --cap-drop ALL \
             --security-opt no-new-privileges \
             --entrypoint node \
-            -v "$PWD:/harness:ro" \
+            -v "$PWD/.release-harness:/harness:ro" \
             -v "${RUNNER_TEMP}/install-smoke-candidate-payload:/payload:ro" \
             openclaw-install-smoke:local \
             /harness/scripts/install-smoke-candidate-payload.mts verify \
@@ -1076,7 +1106,7 @@ jobs:
           OPENCLAW_INSTALL_SMOKE_SKIP_PREVIOUS: "1"
           OPENCLAW_INSTALL_SMOKE_UPDATE_BASELINE: ${{ inputs.update_baseline_version || 'latest' }}
           OPENCLAW_INSTALL_SMOKE_UPDATE_EXPECT_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
-        run: bash scripts/test-install-sh-docker.sh
+        run: bash .release-harness/scripts/test-install-sh-docker.sh
 
       - name: Run Rocky Linux installer smoke
         env:
@@ -1110,14 +1140,8 @@ jobs:
     env:
       OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
-      - *trusted_workflow_identity_step
-
-      - name: Checkout trusted installer harness
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
-          persist-credentials: false
+      - *trusted_workflow_subdir_checkout_step
+      - *trusted_workflow_subdir_identity_step
 
       - name: Validate candidate payload artifact binding
         env:
@@ -1130,8 +1154,8 @@ jobs:
           ARTIFACT_HARNESS_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.harness_sha }}
           ARTIFACT_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
           ARTIFACT_TARGET_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.target_sha }}
-          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
         run: |
@@ -1146,7 +1170,7 @@ jobs:
           [[ "$ARTIFACT_HARNESS_SHA" == "$HARNESS_SHA" ]]
           expected_artifact_name="install-smoke-candidate-payload-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
           [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]]
-          bash scripts/docker/shared-image-artifact.sh \
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             verify-upload "Candidate payload" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
@@ -1170,7 +1194,7 @@ jobs:
           ARTIFACT_WORKFLOW_SHA: ${{ needs.installer_smoke_nonroot_image.outputs.workflow_sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
@@ -1206,7 +1230,7 @@ jobs:
             echo "Installer non-root image artifact name does not match the producer tuple." >&2
             exit 1
           }
-          bash scripts/docker/shared-image-artifact.sh \
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             verify-upload "Installer non-root image" "$ARTIFACT_ID" "$ARTIFACT_NAME" \
             "$ARTIFACT_DIGEST" "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
@@ -1228,7 +1252,7 @@ jobs:
           WORKFLOW_SHA: ${{ needs.installer_smoke_nonroot_image.outputs.workflow_sha }}
         run: |
           set -euo pipefail
-          bash scripts/docker/shared-image-artifact.sh \
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             load "${RUNNER_TEMP}/install-smoke-nonroot-image" install-smoke-nonroot \
             "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
 
@@ -1237,8 +1261,8 @@ jobs:
 
       - name: Verify candidate payload contents
         env:
-          HARNESS_REPOSITORY: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          HARNESS_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
           MANIFEST_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}
           PACKAGE_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
           SOURCE_ARCHIVE_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}
@@ -1251,7 +1275,7 @@ jobs:
             --cap-drop ALL \
             --security-opt no-new-privileges \
             --entrypoint node \
-            -v "$PWD:/harness:ro" \
+            -v "$PWD/.release-harness:/harness:ro" \
             -v "${RUNNER_TEMP}/install-smoke-candidate-payload:/payload:ro" \
             openclaw-install-nonroot:local \
             /harness/scripts/install-smoke-candidate-payload.mts verify \
@@ -1278,7 +1302,7 @@ jobs:
           OPENCLAW_INSTALL_NONROOT_SKIP_IMAGE_BUILD: "1"
           OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT: "0"
           OPENCLAW_INSTALL_SMOKE_UPDATE_EXPECT_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
-        run: bash scripts/test-install-sh-docker.sh
+        run: bash .release-harness/scripts/test-install-sh-docker.sh
 
   installer_smoke:
     needs:
@@ -1333,21 +1357,8 @@ jobs:
     env:
       OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
-      - name: Checkout CLI
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ needs.preflight.outputs.target_sha }}
-          persist-credentials: false
-
-      - *trusted_workflow_identity_step
-
-      - name: Checkout trusted image artifact helper
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: ${{ fromJSON(toJSON(job)).workflow_repository }}
-          ref: ${{ fromJSON(toJSON(job)).workflow_sha }}
-          path: .release-harness
-          persist-credentials: false
+      - *trusted_workflow_subdir_checkout_step
+      - *trusted_workflow_subdir_identity_step
 
       - name: Validate root Dockerfile image artifact binding
         env:
@@ -1405,7 +1416,7 @@ jobs:
           OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
           OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ fromJSON(toJSON(job)).workflow_sha }}
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           bash .release-harness/scripts/docker/shared-image-artifact.sh \
@@ -1418,7 +1429,7 @@ jobs:
         run: docker image inspect "$IMAGE_REF" >/dev/null
 
       - name: Setup Node environment for Bun smoke
-        uses: ./.github/actions/setup-node-env
+        uses: ./.release-harness/.github/actions/setup-node-env
         with:
           cache-mode: restore
           install-bun: "true"
@@ -1429,7 +1440,7 @@ jobs:
           OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
           OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0"
-        run: bash scripts/e2e/bun-global-install-smoke.sh
+        run: bash .release-harness/scripts/e2e/bun-global-install-smoke.sh
 
   docker-e2e-fast:
     needs: [preflight]

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -1428,19 +1428,21 @@ jobs:
           IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
         run: docker image inspect "$IMAGE_REF" >/dev/null
 
-      - name: Setup Node environment for Bun smoke
-        uses: ./.release-harness/.github/actions/setup-node-env
+      - name: Setup trusted release harness for Bun smoke
+        uses: ./.release-harness/.github/actions/setup-release-harness
         with:
-          cache-mode: restore
-          install-bun: "true"
-          install-deps: "true"
+          node-version: "24.x"
+
+      - name: Install Bun for global smoke
+        run: npm install -g bun@1.3.14
 
       - name: Run Bun global install image-provider smoke
+        working-directory: .release-harness
         env:
           OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
           OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0"
-        run: bash .release-harness/scripts/e2e/bun-global-install-smoke.sh
+        run: bash scripts/e2e/bun-global-install-smoke.sh
 
   docker-e2e-fast:
     needs: [preflight]

--- a/scripts/install-smoke-candidate-payload.d.mts
+++ b/scripts/install-smoke-candidate-payload.d.mts
@@ -1,0 +1,50 @@
+type InstallSmokeCandidatePayloadManifest = {
+  files: Array<{
+    name: string;
+    role: "package" | "package-metadata" | "installer" | "cli-installer";
+    sha256: string;
+    size: number;
+  }>;
+  harnessRepository: string;
+  harnessSha: string;
+  packageVersion: string;
+  repository: string;
+  runAttempt: string;
+  runId: string;
+  schema: "openclaw.install-smoke-candidate-payload/v1";
+  sourceArchiveSha256: string;
+  targetSha: string;
+};
+
+type SealInstallSmokeCandidatePayloadOptions = {
+  archivePath: string;
+  harnessRepository: string;
+  harnessSha: string;
+  outputDir: string;
+  packageDir: string;
+  repository: string;
+  runAttempt: string;
+  runId: string;
+  targetSha: string;
+};
+
+type VerifyInstallSmokeCandidatePayloadOptions = {
+  expectedManifestSha256: string;
+  expectedPackageVersion: string;
+  expectedSourceArchiveSha256: string;
+  harnessRepository: string;
+  harnessSha: string;
+  payloadDir: string;
+  repository: string;
+  runAttempt: string;
+  runId: string;
+  targetSha: string;
+};
+
+export function sealInstallSmokeCandidatePayload(
+  options: SealInstallSmokeCandidatePayloadOptions,
+): Promise<InstallSmokeCandidatePayloadManifest>;
+
+export function verifyInstallSmokeCandidatePayload(
+  options: VerifyInstallSmokeCandidatePayloadOptions,
+): Promise<InstallSmokeCandidatePayloadManifest>;

--- a/scripts/install-smoke-candidate-payload.mts
+++ b/scripts/install-smoke-candidate-payload.mts
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MANIFEST_NAME = "install-smoke-candidate-payload.json";
+const SCHEMA = "openclaw.install-smoke-candidate-payload/v1";
+const PAYLOAD_FILES = [
+  { name: "candidate.tgz", role: "package" },
+  { name: "candidate-pack.json", role: "package-metadata" },
+  { name: "install.sh", role: "installer" },
+  { name: "install-cli.sh", role: "cli-installer" },
+] as const;
+
+type PayloadIdentity = {
+  harnessRepository: string;
+  harnessSha: string;
+  repository: string;
+  runAttempt: string;
+  runId: string;
+  targetSha: string;
+};
+
+type PayloadFile = {
+  name: string;
+  role: (typeof PAYLOAD_FILES)[number]["role"];
+  sha256: string;
+  size: number;
+};
+
+type InstallSmokeCandidatePayloadManifest = PayloadIdentity & {
+  files: PayloadFile[];
+  packageVersion: string;
+  schema: typeof SCHEMA;
+  sourceArchiveSha256: string;
+};
+
+type SealInstallSmokeCandidatePayloadOptions = PayloadIdentity & {
+  archivePath: string;
+  outputDir: string;
+  packageDir: string;
+};
+
+type VerifyInstallSmokeCandidatePayloadOptions = PayloadIdentity & {
+  expectedManifestSha256: string;
+  expectedPackageVersion: string;
+  expectedSourceArchiveSha256: string;
+  payloadDir: string;
+};
+
+function assertRepository(value: string, label: string): string {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(value)) {
+    throw new Error(`${label} must be an owner/repository slug`);
+  }
+  return value;
+}
+
+function assertSha(value: string, label: string): string {
+  if (!/^[0-9a-f]{40}$/u.test(value)) {
+    throw new Error(`${label} must be a full lowercase commit SHA`);
+  }
+  return value;
+}
+
+function assertPositiveInteger(value: string, label: string): string {
+  if (!/^[1-9][0-9]*$/u.test(value)) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function assertVersion(value: unknown, label: string): string {
+  if (typeof value !== "string" || !/^[0-9A-Za-z][0-9A-Za-z.+-]*$/u.test(value)) {
+    throw new Error(`${label} must be a package version`);
+  }
+  return value;
+}
+
+function validateIdentity(identity: PayloadIdentity): PayloadIdentity {
+  return {
+    harnessRepository: assertRepository(identity.harnessRepository, "harness repository"),
+    harnessSha: assertSha(identity.harnessSha, "harness SHA"),
+    repository: assertRepository(identity.repository, "repository"),
+    runAttempt: assertPositiveInteger(identity.runAttempt, "run attempt"),
+    runId: assertPositiveInteger(identity.runId, "run ID"),
+    targetSha: assertSha(identity.targetSha, "target SHA"),
+  };
+}
+
+async function assertRegularFile(filePath: string, label: string): Promise<void> {
+  const stat = await fs.lstat(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`${label} must be a regular file`);
+  }
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  hash.update(await fs.readFile(filePath));
+  return hash.digest("hex");
+}
+
+async function describeFile(
+  filePath: string,
+  descriptor: (typeof PAYLOAD_FILES)[number],
+): Promise<PayloadFile> {
+  await assertRegularFile(filePath, descriptor.name);
+  const stat = await fs.stat(filePath);
+  return {
+    name: descriptor.name,
+    role: descriptor.role,
+    sha256: await sha256File(filePath),
+    size: stat.size,
+  };
+}
+
+async function readJson(filePath: string, label: string): Promise<unknown> {
+  await assertRegularFile(filePath, label);
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+  } catch (error) {
+    throw new Error(`${label} must contain valid JSON`, { cause: error });
+  }
+}
+
+function runPythonTarReader(args: string[]): Buffer {
+  const script = String.raw`
+import json
+import pathlib
+import sys
+import tarfile
+
+mode, archive_path, member_name = sys.argv[1:]
+with tarfile.open(archive_path, "r:gz") as archive:
+    members = archive.getmembers()
+    if mode == "repo-file":
+        requested_name = member_name
+        roots = {
+            member.name.split("/", 1)[0]
+            for member in members
+            if (
+                member.name
+                and not member.name.startswith("/")
+                and not member.name.split("/", 1)[0].startswith("._")
+            )
+        }
+        if len(roots) != 1:
+            raise RuntimeError("candidate archive must contain one repository root")
+        member_name = next(iter(roots)) + "/" + member_name
+    member = archive.getmember(member_name)
+    if not member.isfile():
+        label = requested_name if mode == "repo-file" else member_name
+        raise RuntimeError(label + " must be a regular file in the candidate archive")
+    extracted = archive.extractfile(member)
+    if extracted is None:
+        raise RuntimeError("failed to read " + member_name)
+    sys.stdout.buffer.write(extracted.read())
+`;
+  const result = spawnSync("python3", ["-c", script, ...args], {
+    encoding: "buffer",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    const stderr = result.stderr.toString("utf8").trim();
+    throw new Error(`candidate archive read failed: ${stderr || `exit ${result.status}`}`);
+  }
+  return result.stdout;
+}
+
+function readPackageVersionFromPackJson(value: unknown): {
+  filename: string;
+  normalized: unknown[];
+  version: string;
+} {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error("candidate pack metadata must contain at least one package result");
+  }
+  const last = value.at(-1);
+  if (!last || typeof last !== "object" || Array.isArray(last)) {
+    throw new Error("candidate pack metadata must end with a package result");
+  }
+  const record = last as Record<string, unknown>;
+  const filename = record.filename;
+  if (
+    typeof filename !== "string" ||
+    filename !== path.basename(filename) ||
+    filename !== path.win32.basename(filename) ||
+    !/^openclaw-[A-Za-z0-9._-]+\.tgz$/u.test(filename)
+  ) {
+    throw new Error("candidate pack metadata contains an unsafe tarball filename");
+  }
+  const version = assertVersion(record.version, "candidate pack version");
+  return {
+    filename,
+    normalized: value.map((entry, index) =>
+      index === value.length - 1 && entry && typeof entry === "object" && !Array.isArray(entry)
+        ? { ...entry, filename: "candidate.tgz" }
+        : entry,
+    ),
+    version,
+  };
+}
+
+function readPackageJsonFromTarball(tarballPath: string): Record<string, unknown> {
+  const raw = runPythonTarReader(["member", tarballPath, "package/package.json"]);
+  try {
+    const value = JSON.parse(raw.toString("utf8")) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("package/package.json must be an object");
+    }
+    return value as Record<string, unknown>;
+  } catch (error) {
+    throw new Error("candidate package tarball has invalid package/package.json", { cause: error });
+  }
+}
+
+async function writeExclusive(filePath: string, contents: string | Uint8Array): Promise<void> {
+  await fs.writeFile(filePath, contents, { flag: "wx", mode: 0o644 });
+}
+
+export async function sealInstallSmokeCandidatePayload(
+  options: SealInstallSmokeCandidatePayloadOptions,
+): Promise<InstallSmokeCandidatePayloadManifest> {
+  const identity = validateIdentity(options);
+  await assertRegularFile(options.archivePath, "candidate source archive");
+  await fs.mkdir(options.outputDir, { recursive: true });
+  const existing = await fs.readdir(options.outputDir);
+  if (existing.length > 0) {
+    throw new Error("candidate payload output directory must be empty");
+  }
+
+  const packJsonPath = path.join(options.packageDir, "pack.json");
+  const pack = readPackageVersionFromPackJson(
+    await readJson(packJsonPath, "candidate pack metadata"),
+  );
+  const sourceTarballPath = path.join(options.packageDir, pack.filename);
+  await assertRegularFile(sourceTarballPath, "candidate package tarball");
+  const packageJson = readPackageJsonFromTarball(sourceTarballPath);
+  if (packageJson.name !== "openclaw") {
+    throw new Error("candidate package tarball must contain the openclaw package");
+  }
+  if (packageJson.version !== pack.version) {
+    throw new Error("candidate package tarball version does not match pack metadata");
+  }
+
+  // Re-read installers from the immutable source archive after candidate execution. Candidate
+  // build hooks never get a writable handle to the sealed scripts consumed by privileged jobs.
+  const installScript = runPythonTarReader([
+    "repo-file",
+    options.archivePath,
+    "scripts/install.sh",
+  ]);
+  const cliInstallScript = runPythonTarReader([
+    "repo-file",
+    options.archivePath,
+    "scripts/install-cli.sh",
+  ]);
+  await fs.copyFile(sourceTarballPath, path.join(options.outputDir, "candidate.tgz"));
+  await writeExclusive(
+    path.join(options.outputDir, "candidate-pack.json"),
+    `${JSON.stringify(pack.normalized, null, 2)}\n`,
+  );
+  await writeExclusive(path.join(options.outputDir, "install.sh"), installScript);
+  await writeExclusive(path.join(options.outputDir, "install-cli.sh"), cliInstallScript);
+
+  const files = await Promise.all(
+    PAYLOAD_FILES.map((descriptor) =>
+      describeFile(path.join(options.outputDir, descriptor.name), descriptor),
+    ),
+  );
+  const manifest: InstallSmokeCandidatePayloadManifest = {
+    ...identity,
+    files,
+    packageVersion: pack.version,
+    schema: SCHEMA,
+    sourceArchiveSha256: await sha256File(options.archivePath),
+  };
+  await writeExclusive(
+    path.join(options.outputDir, MANIFEST_NAME),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  return manifest;
+}
+
+function validateManifest(
+  value: unknown,
+  expectedIdentity: PayloadIdentity,
+  expectedPackageVersion: string,
+  expectedSourceArchiveSha256: string,
+): InstallSmokeCandidatePayloadManifest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("candidate payload manifest must be an object");
+  }
+  const manifest = value as Partial<InstallSmokeCandidatePayloadManifest>;
+  if (manifest.schema !== SCHEMA) {
+    throw new Error("candidate payload manifest schema is invalid");
+  }
+  for (const [key, expected] of Object.entries(expectedIdentity)) {
+    if (manifest[key as keyof PayloadIdentity] !== expected) {
+      throw new Error(`candidate payload manifest ${key} does not match the expected tuple`);
+    }
+  }
+  if (manifest.packageVersion !== expectedPackageVersion) {
+    throw new Error("candidate payload package version does not match the expected version");
+  }
+  if (manifest.sourceArchiveSha256 !== expectedSourceArchiveSha256) {
+    throw new Error("candidate payload source archive digest does not match producer output");
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length !== PAYLOAD_FILES.length) {
+    throw new Error("candidate payload manifest file inventory is invalid");
+  }
+  return manifest as InstallSmokeCandidatePayloadManifest;
+}
+
+export async function verifyInstallSmokeCandidatePayload(
+  options: VerifyInstallSmokeCandidatePayloadOptions,
+): Promise<InstallSmokeCandidatePayloadManifest> {
+  const identity = validateIdentity(options);
+  const expectedPackageVersion = assertVersion(
+    options.expectedPackageVersion,
+    "expected package version",
+  );
+  if (!/^[0-9a-f]{64}$/u.test(options.expectedManifestSha256)) {
+    throw new Error("expected manifest SHA-256 must be lowercase hexadecimal");
+  }
+  if (!/^[0-9a-f]{64}$/u.test(options.expectedSourceArchiveSha256)) {
+    throw new Error("expected source archive SHA-256 must be lowercase hexadecimal");
+  }
+  const entries = (await fs.readdir(options.payloadDir)).toSorted();
+  const expectedEntries = [...PAYLOAD_FILES.map(({ name }) => name), MANIFEST_NAME].toSorted();
+  if (JSON.stringify(entries) !== JSON.stringify(expectedEntries)) {
+    throw new Error("candidate payload contains missing or unexpected files");
+  }
+  const manifestPath = path.join(options.payloadDir, MANIFEST_NAME);
+  await assertRegularFile(manifestPath, "candidate payload manifest");
+  if ((await sha256File(manifestPath)) !== options.expectedManifestSha256) {
+    throw new Error("candidate payload manifest digest does not match producer output");
+  }
+  const manifest = validateManifest(
+    await readJson(manifestPath, "candidate payload manifest"),
+    identity,
+    expectedPackageVersion,
+    options.expectedSourceArchiveSha256,
+  );
+  for (let index = 0; index < PAYLOAD_FILES.length; index += 1) {
+    const descriptor = PAYLOAD_FILES[index]!;
+    const expected = manifest.files[index];
+    if (
+      !expected ||
+      expected.name !== descriptor.name ||
+      expected.role !== descriptor.role ||
+      !/^[0-9a-f]{64}$/u.test(expected.sha256) ||
+      !Number.isSafeInteger(expected.size) ||
+      expected.size < 0
+    ) {
+      throw new Error(`candidate payload manifest entry is invalid for ${descriptor.name}`);
+    }
+    const actual = await describeFile(path.join(options.payloadDir, descriptor.name), descriptor);
+    if (actual.sha256 !== expected.sha256 || actual.size !== expected.size) {
+      throw new Error(`candidate payload digest does not match for ${descriptor.name}`);
+    }
+  }
+  return manifest;
+}
+
+function readOption(argv: string[], name: string): string {
+  const index = argv.indexOf(name);
+  if (index === -1 || !argv[index + 1] || argv[index + 1]!.startsWith("--")) {
+    throw new Error(`${name} is required`);
+  }
+  if (argv.includes(name, index + 1)) {
+    throw new Error(`${name} may only be provided once`);
+  }
+  return argv[index + 1]!;
+}
+
+function readIdentity(argv: string[]): PayloadIdentity {
+  return {
+    harnessRepository: readOption(argv, "--harness-repository"),
+    harnessSha: readOption(argv, "--harness-sha"),
+    repository: readOption(argv, "--repository"),
+    runAttempt: readOption(argv, "--run-attempt"),
+    runId: readOption(argv, "--run-id"),
+    targetSha: readOption(argv, "--target-sha"),
+  };
+}
+
+async function main(): Promise<void> {
+  const [command, ...argv] = process.argv.slice(2);
+  if (command === "seal") {
+    const manifest = await sealInstallSmokeCandidatePayload({
+      ...readIdentity(argv),
+      archivePath: readOption(argv, "--archive"),
+      outputDir: readOption(argv, "--output-dir"),
+      packageDir: readOption(argv, "--package-dir"),
+    });
+    process.stdout.write(`${JSON.stringify(manifest)}\n`);
+    return;
+  }
+  if (command === "verify") {
+    const manifest = await verifyInstallSmokeCandidatePayload({
+      ...readIdentity(argv),
+      expectedManifestSha256: readOption(argv, "--manifest-sha256"),
+      expectedPackageVersion: readOption(argv, "--package-version"),
+      expectedSourceArchiveSha256: readOption(argv, "--source-archive-sha256"),
+      payloadDir: readOption(argv, "--payload-dir"),
+    });
+    process.stdout.write(`${JSON.stringify(manifest)}\n`);
+    return;
+  }
+  throw new Error("usage: install-smoke-candidate-payload.mts <seal|verify> [options]");
+}
+
+if (
+  process.argv[1] &&
+  (await fs.realpath(process.argv[1])) === (await fs.realpath(fileURLToPath(import.meta.url)))
+) {
+  await main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -13,21 +13,34 @@ INSTALL_SMOKE_DOCKER_RUN_TIMEOUT="${OPENCLAW_INSTALL_SMOKE_DOCKER_RUN_TIMEOUT:-2
 
 normalize_npm_pack_json_file() {
   local pack_json_file="$1"
-  (
-    cd "$HARNESS_ROOT"
-    node --import tsx --input-type=module - "$pack_json_file" <<'NODE'
+  node --input-type=module - "$pack_json_file" <<'NODE'
 import fs from "node:fs";
-import { resolveNpmJsonEntries } from "./scripts/lib/npm-json-output.mts";
 
 const packJsonFile = process.argv[2];
 const parsed = JSON.parse(fs.readFileSync(packJsonFile, "utf8"));
-const entries = resolveNpmJsonEntries(parsed);
+let entries = [parsed];
+if (Array.isArray(parsed)) {
+  entries = parsed;
+} else if (parsed && typeof parsed === "object") {
+  const looksLikeEntry =
+    (typeof parsed.id === "string") ||
+    (typeof parsed.name === "string") ||
+    (typeof parsed.version === "string") ||
+    (typeof parsed.filename === "string");
+  if (!looksLikeEntry) {
+    const keyedEntries = Object.values(parsed).filter(
+      (entry) => entry && typeof entry === "object" && !Array.isArray(entry),
+    );
+    if (keyedEntries.length > 0) {
+      entries = keyedEntries;
+    }
+  }
+}
 if (entries.length === 0) {
   throw new Error("npm pack output did not contain a package result");
 }
 fs.writeFileSync(packJsonFile, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
 NODE
-  )
 }
 
 run_install_smoke_container() {
@@ -97,29 +110,51 @@ console.log(
 assert_pack_unpacked_size_budget() {
   local label="$1"
   local pack_json_file="$2"
-  (
-    cd "$HARNESS_ROOT"
-    node --import tsx --input-type=module - "$label" "$pack_json_file" <<'NODE'
+  node --input-type=module - "$label" "$pack_json_file" <<'NODE'
 import { readFileSync } from "node:fs";
-import { collectPackUnpackedSizeErrors } from "./scripts/lib/npm-pack-budget.mts";
 
 const label = process.argv[2];
 const packJsonFile = process.argv[3];
 const raw = readFileSync(packJsonFile, "utf8") || "[]";
 const parsed = JSON.parse(raw);
 const budgetOverride = process.env.OPENCLAW_INSTALL_SMOKE_PACK_UNPACKED_BUDGET_BYTES;
-const budgetBytes = budgetOverride ? Number(budgetOverride) : undefined;
-if (budgetOverride && !Number.isFinite(budgetBytes)) {
+const budgetBytes = budgetOverride ? Number(budgetOverride) : 204 * 1024 * 1024;
+if (!Number.isFinite(budgetBytes)) {
   throw new Error(
     `OPENCLAW_INSTALL_SMOKE_PACK_UNPACKED_BUDGET_BYTES must be numeric, got ${JSON.stringify(
       budgetOverride,
     )}`,
   );
 }
-const errors = collectPackUnpackedSizeErrors(parsed, {
-  budgetBytes,
-  missingDataMessage: `${label} npm pack output did not include unpackedSize; install smoke cannot verify pack budget.`,
-});
+const entries = Array.isArray(parsed) ? parsed : [parsed];
+const errors = [];
+let checkedCount = 0;
+for (const [index, entry] of entries.entries()) {
+  if (
+    !entry ||
+    typeof entry !== "object" ||
+    Array.isArray(entry) ||
+    typeof entry.unpackedSize !== "number" ||
+    !Number.isFinite(entry.unpackedSize)
+  ) {
+    continue;
+  }
+  checkedCount += 1;
+  if (entry.unpackedSize > budgetBytes) {
+    const resultLabel =
+      typeof entry.filename === "string" && entry.filename.trim()
+        ? entry.filename.trim()
+        : `pack result #${index + 1}`;
+    errors.push(
+      `${resultLabel} unpackedSize ${entry.unpackedSize} bytes exceeds budget ${budgetBytes} bytes. Investigate duplicate channel shims, copied extension trees, or other accidental pack bloat before release.`,
+    );
+  }
+}
+if (entries.length > 0 && checkedCount === 0) {
+  errors.push(
+    `${label} npm pack output did not include unpackedSize; install smoke cannot verify pack budget.`,
+  );
+}
 for (const error of errors) {
   console.error(`ERROR: ${error}`);
 }
@@ -127,7 +162,6 @@ if (errors.length > 0) {
   process.exit(1);
 }
 NODE
-  )
 }
 
 print_pack_delta_audit() {
@@ -242,6 +276,7 @@ UPDATE_SKIP_LOCAL_BUILD="${OPENCLAW_INSTALL_SMOKE_UPDATE_SKIP_LOCAL_BUILD:-0}"
 UPDATE_HOST_ALIAS="${OPENCLAW_INSTALL_SMOKE_UPDATE_HOST:-host.docker.internal}"
 UPDATE_PORT="${OPENCLAW_INSTALL_SMOKE_UPDATE_PORT:-}"
 UPDATE_EXPECT_VERSION="${OPENCLAW_INSTALL_SMOKE_UPDATE_EXPECT_VERSION:-}"
+FROZEN_PAYLOAD_DIR="${OPENCLAW_INSTALL_SMOKE_FROZEN_PAYLOAD_DIR:-}"
 LATEST_DIR="$(mktemp -d)"
 LATEST_FILE="${LATEST_DIR}/latest"
 UPDATE_DIR="$(mktemp -d)"
@@ -257,11 +292,41 @@ NPM_CACHE_DIR="${OPENCLAW_INSTALL_SMOKE_NPM_CACHE_DIR:-}"
 NPM_CACHE_OWNED=0
 NPM_CACHE_PREPARED=0
 NPM_CACHE_DOCKER_ARGS=()
-INSTALL_SCRIPT_DOCKER_ARGS=(
-  -v "$ROOT_DIR/scripts/install.sh:/tmp/openclaw-install.sh:ro"
-  -v "$ROOT_DIR/scripts/install-cli.sh:/tmp/openclaw-install-cli.sh:ro"
-)
+INSTALL_SCRIPT_PATH="$ROOT_DIR/scripts/install.sh"
+CLI_INSTALL_SCRIPT_PATH="$ROOT_DIR/scripts/install-cli.sh"
 SMOKE_RUNNER_ENV_ARGS=()
+
+require_regular_payload_file() {
+  local file_path="$1"
+  local label="$2"
+  if [[ ! -f "$file_path" || -L "$file_path" ]]; then
+    echo "ERROR: frozen install-smoke ${label} must be a regular file: ${file_path}" >&2
+    exit 1
+  fi
+}
+
+if [[ -n "$FROZEN_PAYLOAD_DIR" ]]; then
+  FROZEN_PAYLOAD_DIR="$(cd "$FROZEN_PAYLOAD_DIR" && pwd)"
+  if [[ -n "$UPDATE_PACKAGE_SPEC" ]]; then
+    echo "ERROR: frozen install-smoke payload cannot be combined with OPENCLAW_INSTALL_SMOKE_UPDATE_PACKAGE_SPEC" >&2
+    exit 1
+  fi
+  require_regular_payload_file "$FROZEN_PAYLOAD_DIR/candidate.tgz" "package"
+  require_regular_payload_file "$FROZEN_PAYLOAD_DIR/candidate-pack.json" "package metadata"
+  require_regular_payload_file "$FROZEN_PAYLOAD_DIR/install.sh" "installer"
+  require_regular_payload_file "$FROZEN_PAYLOAD_DIR/install-cli.sh" "CLI installer"
+  if [[ -z "$UPDATE_EXPECT_VERSION" ]]; then
+    echo "ERROR: frozen install-smoke payload requires OPENCLAW_INSTALL_SMOKE_UPDATE_EXPECT_VERSION" >&2
+    exit 1
+  fi
+  INSTALL_SCRIPT_PATH="$FROZEN_PAYLOAD_DIR/install.sh"
+  CLI_INSTALL_SCRIPT_PATH="$FROZEN_PAYLOAD_DIR/install-cli.sh"
+fi
+
+INSTALL_SCRIPT_DOCKER_ARGS=(
+  -v "$INSTALL_SCRIPT_PATH:/tmp/openclaw-install.sh:ro"
+  -v "$CLI_INSTALL_SCRIPT_PATH:/tmp/openclaw-install-cli.sh:ro"
+)
 
 for env_name in \
   OPENCLAW_INSTALL_ALLOW_LEGACY_UPDATE_WARNING \
@@ -348,7 +413,14 @@ prepare_update_tarball() {
   local packed_update_version
   pack_json_file="${UPDATE_DIR}/pack.json"
   baseline_pack_json_file="${UPDATE_DIR}/baseline-pack.json"
-  if [[ -n "$UPDATE_PACKAGE_SPEC" ]]; then
+  if [[ -n "$FROZEN_PAYLOAD_DIR" ]]; then
+    # The producer already built and normalized candidate bytes inside an isolated pinned image.
+    # Privileged consumers only copy the verified artifact; they never build or import candidate code.
+    echo "==> Reuse frozen candidate payload for update smoke"
+    cp "$FROZEN_PAYLOAD_DIR/candidate.tgz" "${UPDATE_DIR}/candidate.tgz"
+    cp "$FROZEN_PAYLOAD_DIR/candidate-pack.json" "$pack_json_file"
+    UPDATE_TGZ_FILE="candidate.tgz"
+  elif [[ -n "$UPDATE_PACKAGE_SPEC" ]]; then
     echo "==> Pack update tgz from spec: $UPDATE_PACKAGE_SPEC"
     quiet_npm pack "$UPDATE_PACKAGE_SPEC" --json --pack-destination "$UPDATE_DIR" >"$pack_json_file"
     normalize_npm_pack_json_file "$pack_json_file"
@@ -378,12 +450,14 @@ prepare_update_tarball() {
     )"
     UPDATE_TGZ_FILE="$(basename "$package_tgz")"
   fi
-  if [[ -z "$UPDATE_PACKAGE_SPEC" ]]; then
-    node "$HARNESS_ROOT/scripts/check-openclaw-package-tarball.mjs" \
-      --require-bundled-workspace-deps \
-      "${UPDATE_DIR}/${UPDATE_TGZ_FILE}"
-  else
-    UPDATE_TGZ_FILE="$(read_pack_tarball_filename "$pack_json_file")"
+  if [[ -z "$FROZEN_PAYLOAD_DIR" ]]; then
+    if [[ -z "$UPDATE_PACKAGE_SPEC" ]]; then
+      node "$HARNESS_ROOT/scripts/check-openclaw-package-tarball.mjs" \
+        --require-bundled-workspace-deps \
+        "${UPDATE_DIR}/${UPDATE_TGZ_FILE}"
+    else
+      UPDATE_TGZ_FILE="$(read_pack_tarball_filename "$pack_json_file")"
+    fi
   fi
   print_pack_audit "update" "$pack_json_file"
   assert_pack_unpacked_size_budget "update" "$pack_json_file"

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -204,6 +204,27 @@ NONROOT_PLATFORM="${OPENCLAW_INSTALL_NONROOT_PLATFORM:-$SMOKE_PLATFORM}"
 INSTALL_URL="${OPENCLAW_INSTALL_URL:-https://openclaw.bot/install.sh}"
 CLI_INSTALL_URL="${OPENCLAW_INSTALL_CLI_URL:-https://openclaw.bot/install-cli.sh}"
 PACKAGE_NAME="${OPENCLAW_INSTALL_PACKAGE:-openclaw}"
+INSTALL_SMOKE_GROUP="${OPENCLAW_INSTALL_SMOKE_GROUP:-all}"
+RUN_UPDATE_GROUP=0
+RUN_NONROOT_GROUP=0
+
+case "$INSTALL_SMOKE_GROUP" in
+  all)
+    RUN_UPDATE_GROUP=1
+    RUN_NONROOT_GROUP=1
+    ;;
+  update)
+    RUN_UPDATE_GROUP=1
+    ;;
+  nonroot)
+    RUN_NONROOT_GROUP=1
+    ;;
+  *)
+    echo "ERROR: OPENCLAW_INSTALL_SMOKE_GROUP must be all, update, or nonroot; got ${INSTALL_SMOKE_GROUP}" >&2
+    exit 2
+    ;;
+esac
+
 SKIP_NONROOT="${OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT:-0}"
 SKIP_SMOKE_IMAGE_BUILD="${OPENCLAW_INSTALL_SMOKE_SKIP_IMAGE_BUILD:-0}"
 SKIP_NONROOT_IMAGE_BUILD="${OPENCLAW_INSTALL_NONROOT_SKIP_IMAGE_BUILD:-0}"
@@ -452,81 +473,62 @@ start_update_server() {
   fi
 }
 
-if [[ "$SKIP_SMOKE_IMAGE_BUILD" == "1" ]]; then
-  echo "==> Reuse prebuilt smoke image: $SMOKE_IMAGE"
-else
-  echo "==> Build smoke image (upgrade, root, ${SMOKE_PLATFORM}): $SMOKE_IMAGE"
-  docker_build_run install-smoke-build \
-    --platform "$SMOKE_PLATFORM" \
-    -t "$SMOKE_IMAGE" \
-    -f "$HARNESS_ROOT/scripts/docker/install-sh-smoke/Dockerfile" \
-    "$HARNESS_ROOT/scripts/docker"
-fi
-
-if [[ "$SKIP_UPDATE" == "1" ]]; then
-  echo "==> Skip update smoke (OPENCLAW_INSTALL_SMOKE_SKIP_UPDATE=1)"
-else
-  prepare_update_tarball
-  prepare_update_host_access
-  prepare_npm_cache
-  start_update_server
-
-  echo "==> Run installer smoke test (root): $FRESH_TAG_URL"
-  run_install_smoke_container --rm -t \
-    --platform "$SMOKE_PLATFORM" \
-    ${UPDATE_DOCKER_HOST_ARGS[@]+"${UPDATE_DOCKER_HOST_ARGS[@]}"} \
-    ${NPM_CACHE_DOCKER_ARGS[@]+"${NPM_CACHE_DOCKER_ARGS[@]}"} \
-    "${INSTALL_SCRIPT_DOCKER_ARGS[@]}" \
-    ${SMOKE_RUNNER_ENV_ARGS[@]+"${SMOKE_RUNNER_ENV_ARGS[@]}"} \
-    -v "${LATEST_DIR}:/out" \
-    -e OPENCLAW_INSTALL_URL="$INSTALL_URL" \
-    -e OPENCLAW_INSTALL_PACKAGE="$PACKAGE_NAME" \
-    -e OPENCLAW_INSTALL_METHOD=npm \
-    -e OPENCLAW_INSTALL_FRESH_VERSION="$UPDATE_EXPECT_VERSION" \
-    -e OPENCLAW_INSTALL_FRESH_TAG_URL="$FRESH_TAG_URL" \
-    -e OPENCLAW_INSTALL_LATEST_OUT="/out/latest" \
-    -e OPENCLAW_NO_ONBOARD=1 \
-    -e OPENCLAW_NO_PROMPT=1 \
-    -e DEBIAN_FRONTEND=noninteractive \
-    "$SMOKE_IMAGE"
-
-  LATEST_VERSION=""
-  if [[ -f "$LATEST_FILE" ]]; then
-    LATEST_VERSION="$(cat "$LATEST_FILE")"
-  fi
-  public_latest_version="$(quiet_npm view "$PACKAGE_NAME" version 2>/dev/null || true)"
-  if [[ -n "$public_latest_version" ]]; then
-    LATEST_VERSION="$public_latest_version"
-  fi
-
-  echo "==> Run update smoke (${UPDATE_BASELINE_VERSION} -> ${UPDATE_EXPECT_VERSION})"
-  run_install_smoke_container --rm -t \
-    --platform "$SMOKE_PLATFORM" \
-    ${UPDATE_DOCKER_HOST_ARGS[@]+"${UPDATE_DOCKER_HOST_ARGS[@]}"} \
-    ${NPM_CACHE_DOCKER_ARGS[@]+"${NPM_CACHE_DOCKER_ARGS[@]}"} \
-    ${SMOKE_RUNNER_ENV_ARGS[@]+"${SMOKE_RUNNER_ENV_ARGS[@]}"} \
-    -e OPENCLAW_INSTALL_PACKAGE="$PACKAGE_NAME" \
-    -e OPENCLAW_INSTALL_SMOKE_MODE=update \
-    -e OPENCLAW_INSTALL_UPDATE_BASELINE="$UPDATE_BASELINE_VERSION" \
-    -e OPENCLAW_INSTALL_UPDATE_BASELINE_TAG_URL="$BASELINE_TAG_URL" \
-    -e OPENCLAW_INSTALL_UPDATE_EXPECT_VERSION="$UPDATE_EXPECT_VERSION" \
-    -e OPENCLAW_INSTALL_UPDATE_TAG_URL="$UPDATE_TAG_URL" \
-    -e OPENCLAW_NO_ONBOARD=1 \
-    -e OPENCLAW_NO_PROMPT=1 \
-    -e DEBIAN_FRONTEND=noninteractive \
-    "$SMOKE_IMAGE"
-
-  if [[ "$SKIP_NPM_GLOBAL" == "1" ]]; then
-    echo "==> Skip direct npm global smoke (OPENCLAW_INSTALL_SMOKE_SKIP_NPM_GLOBAL=1)"
+if [[ "$RUN_UPDATE_GROUP" == "1" ]]; then
+  if [[ "$SKIP_SMOKE_IMAGE_BUILD" == "1" ]]; then
+    echo "==> Reuse prebuilt smoke image: $SMOKE_IMAGE"
   else
-    echo "==> Run direct npm global smoke (${UPDATE_BASELINE_VERSION} -> ${UPDATE_EXPECT_VERSION})"
+    echo "==> Build smoke image (upgrade, root, ${SMOKE_PLATFORM}): $SMOKE_IMAGE"
+    docker_build_run install-smoke-build \
+      --platform "$SMOKE_PLATFORM" \
+      -t "$SMOKE_IMAGE" \
+      -f "$HARNESS_ROOT/scripts/docker/install-sh-smoke/Dockerfile" \
+      "$HARNESS_ROOT/scripts/docker"
+  fi
+
+  if [[ "$SKIP_UPDATE" == "1" ]]; then
+    echo "==> Skip update smoke (OPENCLAW_INSTALL_SMOKE_SKIP_UPDATE=1)"
+  else
+    prepare_update_tarball
+    prepare_update_host_access
+    prepare_npm_cache
+    start_update_server
+
+    echo "==> Run installer smoke test (root): $FRESH_TAG_URL"
+    run_install_smoke_container --rm -t \
+      --platform "$SMOKE_PLATFORM" \
+      ${UPDATE_DOCKER_HOST_ARGS[@]+"${UPDATE_DOCKER_HOST_ARGS[@]}"} \
+      ${NPM_CACHE_DOCKER_ARGS[@]+"${NPM_CACHE_DOCKER_ARGS[@]}"} \
+      "${INSTALL_SCRIPT_DOCKER_ARGS[@]}" \
+      ${SMOKE_RUNNER_ENV_ARGS[@]+"${SMOKE_RUNNER_ENV_ARGS[@]}"} \
+      -v "${LATEST_DIR}:/out" \
+      -e OPENCLAW_INSTALL_URL="$INSTALL_URL" \
+      -e OPENCLAW_INSTALL_PACKAGE="$PACKAGE_NAME" \
+      -e OPENCLAW_INSTALL_METHOD=npm \
+      -e OPENCLAW_INSTALL_FRESH_VERSION="$UPDATE_EXPECT_VERSION" \
+      -e OPENCLAW_INSTALL_FRESH_TAG_URL="$FRESH_TAG_URL" \
+      -e OPENCLAW_INSTALL_LATEST_OUT="/out/latest" \
+      -e OPENCLAW_NO_ONBOARD=1 \
+      -e OPENCLAW_NO_PROMPT=1 \
+      -e DEBIAN_FRONTEND=noninteractive \
+      "$SMOKE_IMAGE"
+
+    LATEST_VERSION=""
+    if [[ -f "$LATEST_FILE" ]]; then
+      LATEST_VERSION="$(cat "$LATEST_FILE")"
+    fi
+    public_latest_version="$(quiet_npm view "$PACKAGE_NAME" version 2>/dev/null || true)"
+    if [[ -n "$public_latest_version" ]]; then
+      LATEST_VERSION="$public_latest_version"
+    fi
+
+    echo "==> Run update smoke (${UPDATE_BASELINE_VERSION} -> ${UPDATE_EXPECT_VERSION})"
     run_install_smoke_container --rm -t \
       --platform "$SMOKE_PLATFORM" \
       ${UPDATE_DOCKER_HOST_ARGS[@]+"${UPDATE_DOCKER_HOST_ARGS[@]}"} \
       ${NPM_CACHE_DOCKER_ARGS[@]+"${NPM_CACHE_DOCKER_ARGS[@]}"} \
       ${SMOKE_RUNNER_ENV_ARGS[@]+"${SMOKE_RUNNER_ENV_ARGS[@]}"} \
       -e OPENCLAW_INSTALL_PACKAGE="$PACKAGE_NAME" \
-      -e OPENCLAW_INSTALL_SMOKE_MODE=npm-global \
+      -e OPENCLAW_INSTALL_SMOKE_MODE=update \
       -e OPENCLAW_INSTALL_UPDATE_BASELINE="$UPDATE_BASELINE_VERSION" \
       -e OPENCLAW_INSTALL_UPDATE_BASELINE_TAG_URL="$BASELINE_TAG_URL" \
       -e OPENCLAW_INSTALL_UPDATE_EXPECT_VERSION="$UPDATE_EXPECT_VERSION" \
@@ -535,32 +537,65 @@ else
       -e OPENCLAW_NO_PROMPT=1 \
       -e DEBIAN_FRONTEND=noninteractive \
       "$SMOKE_IMAGE"
-  fi
-fi
 
-if [[ "$SKIP_FRESHNESS" == "1" ]]; then
-  echo "==> Skip installer npm freshness smoke (OPENCLAW_INSTALL_SMOKE_SKIP_FRESHNESS=1)"
+    if [[ "$SKIP_NPM_GLOBAL" == "1" ]]; then
+      echo "==> Skip direct npm global smoke (OPENCLAW_INSTALL_SMOKE_SKIP_NPM_GLOBAL=1)"
+    else
+      echo "==> Run direct npm global smoke (${UPDATE_BASELINE_VERSION} -> ${UPDATE_EXPECT_VERSION})"
+      run_install_smoke_container --rm -t \
+        --platform "$SMOKE_PLATFORM" \
+        ${UPDATE_DOCKER_HOST_ARGS[@]+"${UPDATE_DOCKER_HOST_ARGS[@]}"} \
+        ${NPM_CACHE_DOCKER_ARGS[@]+"${NPM_CACHE_DOCKER_ARGS[@]}"} \
+        ${SMOKE_RUNNER_ENV_ARGS[@]+"${SMOKE_RUNNER_ENV_ARGS[@]}"} \
+        -e OPENCLAW_INSTALL_PACKAGE="$PACKAGE_NAME" \
+        -e OPENCLAW_INSTALL_SMOKE_MODE=npm-global \
+        -e OPENCLAW_INSTALL_UPDATE_BASELINE="$UPDATE_BASELINE_VERSION" \
+        -e OPENCLAW_INSTALL_UPDATE_BASELINE_TAG_URL="$BASELINE_TAG_URL" \
+        -e OPENCLAW_INSTALL_UPDATE_EXPECT_VERSION="$UPDATE_EXPECT_VERSION" \
+        -e OPENCLAW_INSTALL_UPDATE_TAG_URL="$UPDATE_TAG_URL" \
+        -e OPENCLAW_NO_ONBOARD=1 \
+        -e OPENCLAW_NO_PROMPT=1 \
+        -e DEBIAN_FRONTEND=noninteractive \
+        "$SMOKE_IMAGE"
+    fi
+  fi
+
+  if [[ "$SKIP_FRESHNESS" == "1" ]]; then
+    echo "==> Skip installer npm freshness smoke (OPENCLAW_INSTALL_SMOKE_SKIP_FRESHNESS=1)"
+  else
+    prepare_npm_cache
+    echo "==> Run installer npm freshness smoke"
+    run_install_smoke_container --rm -t \
+      --platform "$SMOKE_PLATFORM" \
+      ${NPM_CACHE_DOCKER_ARGS[@]+"${NPM_CACHE_DOCKER_ARGS[@]}"} \
+      "${INSTALL_SCRIPT_DOCKER_ARGS[@]}" \
+      ${SMOKE_RUNNER_ENV_ARGS[@]+"${SMOKE_RUNNER_ENV_ARGS[@]}"} \
+      -e OPENCLAW_INSTALL_URL="$FRESHNESS_INSTALL_URL" \
+      -e OPENCLAW_INSTALL_PACKAGE="$PACKAGE_NAME" \
+      -e OPENCLAW_INSTALL_SMOKE_MODE=freshness \
+      -e OPENCLAW_INSTALL_FRESHNESS_VERSION="${OPENCLAW_INSTALL_FRESHNESS_VERSION:-latest}" \
+      -e OPENCLAW_INSTALL_FRESHNESS_MIN_RELEASE_AGE="$FRESHNESS_MIN_RELEASE_AGE" \
+      -e OPENCLAW_INSTALL_FRESHNESS_NPM_VERSION="$FRESHNESS_NPM_VERSION" \
+      -e OPENCLAW_NO_ONBOARD=1 \
+      -e OPENCLAW_NO_PROMPT=1 \
+      -e DEBIAN_FRONTEND=noninteractive \
+      "$SMOKE_IMAGE"
+  fi
 else
-  prepare_npm_cache
-  echo "==> Run installer npm freshness smoke"
-  run_install_smoke_container --rm -t \
-    --platform "$SMOKE_PLATFORM" \
-    ${NPM_CACHE_DOCKER_ARGS[@]+"${NPM_CACHE_DOCKER_ARGS[@]}"} \
-    "${INSTALL_SCRIPT_DOCKER_ARGS[@]}" \
-    ${SMOKE_RUNNER_ENV_ARGS[@]+"${SMOKE_RUNNER_ENV_ARGS[@]}"} \
-    -e OPENCLAW_INSTALL_URL="$FRESHNESS_INSTALL_URL" \
-    -e OPENCLAW_INSTALL_PACKAGE="$PACKAGE_NAME" \
-    -e OPENCLAW_INSTALL_SMOKE_MODE=freshness \
-    -e OPENCLAW_INSTALL_FRESHNESS_VERSION="${OPENCLAW_INSTALL_FRESHNESS_VERSION:-latest}" \
-    -e OPENCLAW_INSTALL_FRESHNESS_MIN_RELEASE_AGE="$FRESHNESS_MIN_RELEASE_AGE" \
-    -e OPENCLAW_INSTALL_FRESHNESS_NPM_VERSION="$FRESHNESS_NPM_VERSION" \
-    -e OPENCLAW_NO_ONBOARD=1 \
-    -e OPENCLAW_NO_PROMPT=1 \
-    -e DEBIAN_FRONTEND=noninteractive \
-    "$SMOKE_IMAGE"
+  echo "==> Skip update installer smoke group"
 fi
 
 LATEST_VERSION="${LATEST_VERSION:-}"
+
+if [[ "$RUN_NONROOT_GROUP" != "1" ]]; then
+  echo "==> Skip non-root installer smoke group"
+  exit 0
+fi
+
+if [[ -z "$LATEST_VERSION" ]]; then
+  echo "==> Resolve public npm version for non-root installer assertion"
+  LATEST_VERSION="$(quiet_npm view "$PACKAGE_NAME" version)"
+fi
 
 if [[ "$SKIP_NONROOT" == "1" ]]; then
   echo "==> Skip non-root installer smoke (OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1)"

--- a/test/scripts/install-smoke-candidate-payload.test.ts
+++ b/test/scripts/install-smoke-candidate-payload.test.ts
@@ -1,0 +1,228 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  sealInstallSmokeCandidatePayload,
+  verifyInstallSmokeCandidatePayload,
+} from "../../scripts/install-smoke-candidate-payload.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const IDENTITY = {
+  harnessRepository: "openclaw/openclaw",
+  harnessSha: "1".repeat(40),
+  repository: "openclaw/openclaw",
+  runAttempt: "2",
+  runId: "12345",
+  targetSha: "2".repeat(40),
+};
+const PACKAGE_VERSION = "2026.8.1-beta.3";
+
+function sha256(filePath: string): string {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function createTarball(archivePath: string, sourceDir: string, entries: string[]): void {
+  execFileSync("tar", ["-czf", archivePath, "-C", sourceDir, ...entries]);
+}
+
+function createFixture(options: { symlinkInstaller?: boolean; symlinkPackage?: boolean } = {}) {
+  const root = tempDirs.make("install-smoke-candidate-payload-");
+  const archiveRoot = path.join(root, "candidate-root");
+  const scriptsDir = path.join(archiveRoot, "scripts");
+  const packageRoot = path.join(root, "package-root");
+  const packageContents = path.join(packageRoot, "package");
+  const packageDir = path.join(root, "package-output");
+  const payloadDir = path.join(root, "payload");
+  mkdirSync(scriptsDir, { recursive: true });
+  mkdirSync(packageContents, { recursive: true });
+  mkdirSync(packageDir, { recursive: true });
+  mkdirSync(payloadDir, { recursive: true });
+
+  writeFileSync(path.join(scriptsDir, "install-target.sh"), "#!/bin/sh\necho install\n");
+  if (options.symlinkInstaller) {
+    symlinkSync("install-target.sh", path.join(scriptsDir, "install.sh"));
+  } else {
+    writeFileSync(path.join(scriptsDir, "install.sh"), "#!/bin/sh\necho install\n");
+  }
+  writeFileSync(path.join(scriptsDir, "install-cli.sh"), "#!/bin/sh\necho cli\n");
+  const archivePath = path.join(root, "candidate.tar.gz");
+  createTarball(archivePath, root, ["candidate-root"]);
+
+  writeFileSync(
+    path.join(packageContents, "package.json"),
+    `${JSON.stringify({ name: "openclaw", version: PACKAGE_VERSION })}\n`,
+  );
+  writeFileSync(path.join(packageContents, "index.js"), "console.log('openclaw');\n");
+  const packageName = `openclaw-${PACKAGE_VERSION}.tgz`;
+  const packagePath = path.join(packageDir, packageName);
+  createTarball(packagePath, packageRoot, ["package"]);
+  if (options.symlinkPackage) {
+    unlinkSync(packagePath);
+    symlinkSync(path.join(root, "candidate.tar.gz"), packagePath);
+  }
+  writeFileSync(
+    path.join(packageDir, "pack.json"),
+    `${JSON.stringify([
+      {
+        filename: packageName,
+        name: "openclaw",
+        size: 100,
+        unpackedSize: 200,
+        version: PACKAGE_VERSION,
+      },
+    ])}\n`,
+  );
+  return { archivePath, packageDir, payloadDir, root };
+}
+
+async function sealFixture(options: { symlinkInstaller?: boolean; symlinkPackage?: boolean } = {}) {
+  const fixture = createFixture(options);
+  const manifest = await sealInstallSmokeCandidatePayload({
+    ...IDENTITY,
+    archivePath: fixture.archivePath,
+    outputDir: fixture.payloadDir,
+    packageDir: fixture.packageDir,
+  });
+  const manifestPath = path.join(fixture.payloadDir, "install-smoke-candidate-payload.json");
+  return {
+    ...fixture,
+    manifest,
+    manifestPath,
+    manifestSha256: sha256(manifestPath),
+  };
+}
+
+function verifyOptions(payloadDir: string, manifestSha256: string, sourceArchiveSha256: string) {
+  return {
+    ...IDENTITY,
+    expectedManifestSha256: manifestSha256,
+    expectedPackageVersion: PACKAGE_VERSION,
+    expectedSourceArchiveSha256: sourceArchiveSha256,
+    payloadDir,
+  };
+}
+
+describe("install smoke candidate payload", () => {
+  it("seals source installers and package bytes into a fully bound payload", async () => {
+    const fixture = await sealFixture();
+    const verified = await verifyInstallSmokeCandidatePayload(
+      verifyOptions(
+        fixture.payloadDir,
+        fixture.manifestSha256,
+        fixture.manifest.sourceArchiveSha256,
+      ),
+    );
+
+    expect(verified).toEqual(fixture.manifest);
+    expect(verified).toMatchObject({
+      ...IDENTITY,
+      packageVersion: PACKAGE_VERSION,
+      schema: "openclaw.install-smoke-candidate-payload/v1",
+      sourceArchiveSha256: sha256(fixture.archivePath),
+    });
+    expect(verified.files.map(({ name, role }) => ({ name, role }))).toEqual([
+      { name: "candidate.tgz", role: "package" },
+      { name: "candidate-pack.json", role: "package-metadata" },
+      { name: "install.sh", role: "installer" },
+      { name: "install-cli.sh", role: "cli-installer" },
+    ]);
+    expect(readFileSync(path.join(fixture.payloadDir, "install.sh"), "utf8")).toContain(
+      "echo install",
+    );
+  });
+
+  it.each(["candidate.tgz", "candidate-pack.json", "install.sh", "install-cli.sh"])(
+    "rejects tampering with %s after sealing",
+    async (filename) => {
+      const fixture = await sealFixture();
+      writeFileSync(path.join(fixture.payloadDir, filename), "tampered\n");
+
+      await expect(
+        verifyInstallSmokeCandidatePayload(
+          verifyOptions(
+            fixture.payloadDir,
+            fixture.manifestSha256,
+            fixture.manifest.sourceArchiveSha256,
+          ),
+        ),
+      ).rejects.toThrow(`candidate payload digest does not match for ${filename}`);
+    },
+  );
+
+  it("rejects manifest tampering before trusting its file inventory", async () => {
+    const fixture = await sealFixture();
+    writeFileSync(fixture.manifestPath, "{}\n");
+
+    await expect(
+      verifyInstallSmokeCandidatePayload(
+        verifyOptions(
+          fixture.payloadDir,
+          fixture.manifestSha256,
+          fixture.manifest.sourceArchiveSha256,
+        ),
+      ),
+    ).rejects.toThrow("candidate payload manifest digest does not match producer output");
+  });
+
+  it("rejects tuple drift and unexpected artifact files", async () => {
+    const tupleFixture = await sealFixture();
+    await expect(
+      verifyInstallSmokeCandidatePayload({
+        ...verifyOptions(
+          tupleFixture.payloadDir,
+          tupleFixture.manifestSha256,
+          tupleFixture.manifest.sourceArchiveSha256,
+        ),
+        targetSha: "3".repeat(40),
+      }),
+    ).rejects.toThrow("candidate payload manifest targetSha does not match the expected tuple");
+
+    await expect(
+      verifyInstallSmokeCandidatePayload({
+        ...verifyOptions(
+          tupleFixture.payloadDir,
+          tupleFixture.manifestSha256,
+          tupleFixture.manifest.sourceArchiveSha256,
+        ),
+        expectedSourceArchiveSha256: "4".repeat(64),
+      }),
+    ).rejects.toThrow("candidate payload source archive digest does not match producer output");
+
+    const extraFixture = await sealFixture();
+    writeFileSync(path.join(extraFixture.payloadDir, "extra"), "unexpected\n");
+    await expect(
+      verifyInstallSmokeCandidatePayload(
+        verifyOptions(
+          extraFixture.payloadDir,
+          extraFixture.manifestSha256,
+          extraFixture.manifest.sourceArchiveSha256,
+        ),
+      ),
+    ).rejects.toThrow("candidate payload contains missing or unexpected files");
+  });
+
+  it("rejects symlinked candidate inputs before sealing", async () => {
+    const installerFixture = createFixture({ symlinkInstaller: true });
+    await expect(
+      sealInstallSmokeCandidatePayload({
+        ...IDENTITY,
+        archivePath: installerFixture.archivePath,
+        outputDir: installerFixture.payloadDir,
+        packageDir: installerFixture.packageDir,
+      }),
+    ).rejects.toThrow("scripts/install.sh must be a regular file");
+
+    const packageFixture = createFixture({ symlinkPackage: true });
+    await expect(
+      sealInstallSmokeCandidatePayload({
+        ...IDENTITY,
+        archivePath: packageFixture.archivePath,
+        outputDir: packageFixture.payloadDir,
+        packageDir: packageFixture.packageDir,
+      }),
+    ).rejects.toThrow("candidate package tarball must be a regular file");
+  });
+});

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -108,16 +109,87 @@ describe("install smoke no-push root image transport", () => {
     });
 
     const preflight = job(workflow, "preflight");
-    expect(preflight.outputs?.workflow_repository).toBe(
-      "${{ steps.workflow.outputs.workflow_repository }}",
-    );
-    expect(preflight.outputs?.workflow_sha).toBe("${{ steps.workflow.outputs.workflow_sha }}");
-    const workflowIdentity = step(preflight, "Resolve job workflow identity");
-    expect(workflowIdentity.env?.JOB_CONTEXT).toBe("${{ toJSON(job) }}");
+    expect(preflight.outputs?.workflow_repository).toBeUndefined();
+    expect(preflight.outputs?.workflow_sha).toBeUndefined();
+    const workflowIdentity = step(preflight, "Assert trusted workflow identity");
+    expect(workflowIdentity.env).toEqual({
+      EXPECTED_WORKFLOW_REPOSITORY: "${{ github.repository }}",
+      JOB_CONTEXT: "${{ toJSON(job) }}",
+    });
     expect(workflowIdentity.run).toContain(
-      "job.workflow_repository must be an owner/repository slug",
+      "job.workflow_repository must exactly match github.repository",
     );
     expect(workflowIdentity.run).toContain("job.workflow_sha must be a full lowercase commit SHA");
+    expect(workflowIdentity.run).not.toContain("EXPECTED_WORKFLOW_SHA");
+
+    const identityResult = spawnSync(
+      "bash",
+      ["--noprofile", "--norc", "-c", workflowIdentity.run!],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          EXPECTED_WORKFLOW_REPOSITORY: "openclaw/openclaw",
+          GITHUB_WORKFLOW_SHA: "a".repeat(40),
+          JOB_CONTEXT: JSON.stringify({
+            workflow_repository: "openclaw/openclaw",
+            workflow_sha: "b".repeat(40),
+          }),
+        },
+      },
+    );
+    expect(identityResult.status, identityResult.stderr).toBe(0);
+    expect(JSON.stringify(workflow)).not.toContain("${{ github.workflow_sha }}");
+    for (const [jobName, workflowJob] of Object.entries(workflow.jobs)) {
+      const trustedCheckouts =
+        workflowJob.steps?.filter((candidate) => candidate.name?.startsWith("Checkout trusted")) ??
+        [];
+      if (trustedCheckouts.length === 0) {
+        continue;
+      }
+      const resolver = step(workflowJob, "Resolve trusted workflow identity");
+      expect(resolver.env, jobName).toEqual({
+        EXPECTED_WORKFLOW_REPOSITORY: "${{ github.repository }}",
+        JOB_CONTEXT: "${{ toJSON(job) }}",
+      });
+      expect(resolver.run, jobName).toContain(
+        "job.workflow_sha must be a full lowercase commit SHA",
+      );
+      for (const checkout of trustedCheckouts) {
+        expect(checkout.with, jobName).toMatchObject({
+          repository: "${{ fromJSON(toJSON(job)).workflow_repository }}",
+          ref: "${{ fromJSON(toJSON(job)).workflow_sha }}",
+        });
+      }
+    }
+
+    const candidateResolver = step(
+      job(workflow, "installer_smoke_candidate_payload"),
+      "Resolve trusted workflow identity",
+    );
+    const runResolver = (workflowRepository: string, workflowSha: string) =>
+      spawnSync("bash", ["--noprofile", "--norc", "-c", candidateResolver.run!], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          EXPECTED_WORKFLOW_REPOSITORY: "openclaw/openclaw",
+          GITHUB_WORKFLOW_SHA: "a".repeat(40),
+          JOB_CONTEXT: JSON.stringify({
+            workflow_repository: workflowRepository,
+            workflow_sha: workflowSha,
+          }),
+        },
+      });
+    const mismatchedCaller = runResolver("openclaw/openclaw", "b".repeat(40));
+    expect(mismatchedCaller.status, mismatchedCaller.stderr).toBe(0);
+    const malformedSha = runResolver("openclaw/openclaw", "not-a-sha");
+    expect(malformedSha.status).not.toBe(0);
+    expect(malformedSha.stderr).toContain("job.workflow_sha must be a full lowercase commit SHA");
+    const wrongRepository = runResolver("attacker/openclaw", "b".repeat(40));
+    expect(wrongRepository.status).not.toBe(0);
+    expect(wrongRepository.stderr).toContain(
+      "job.workflow_repository must exactly match github.repository",
+    );
     const manifest = step(preflight, "Build install-smoke CI manifest");
     expect(manifest.env).toEqual({
       OPENCLAW_CI_WORKFLOW_BUN_GLOBAL_INSTALL_SMOKE:
@@ -173,7 +245,7 @@ describe("install smoke no-push root image transport", () => {
     expect(pack.env).toMatchObject({
       IMAGE_REF: "${{ needs.preflight.outputs.dockerfile_image }}",
       TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
-      WORKFLOW_SHA: "${{ needs.preflight.outputs.workflow_sha }}",
+      WORKFLOW_SHA: "${{ fromJSON(toJSON(job)).workflow_sha }}",
     });
     expect(pack.run).toContain(
       'artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
@@ -204,11 +276,7 @@ describe("install smoke no-push root image transport", () => {
 
   it("verifies and loads the immutable artifact in every consumer", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
-    for (const jobName of [
-      "root_dockerfile_smokes",
-      "installer_smoke_update",
-      "bun_global_install_smoke",
-    ]) {
+    for (const jobName of ["root_dockerfile_smokes", "bun_global_install_smoke"]) {
       const consumer = job(workflow, jobName);
       expect(consumer.needs, jobName).toContain("root_dockerfile_image_ready");
       expect(consumer.env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE, jobName).toBe("1");
@@ -270,7 +338,7 @@ describe("install smoke no-push root image transport", () => {
     }
 
     const text = readFileSync(INSTALL_SMOKE_REUSABLE, "utf8");
-    expect(text.match(/verify-upload "Root image"/g)).toHaveLength(3);
+    expect(text.match(/verify-upload "Root image"/g)).toHaveLength(2);
     expect(text).not.toContain("gh api");
   });
 
@@ -287,7 +355,6 @@ describe("install smoke no-push root image transport", () => {
         loadName: "Verify and load installer update image artifact",
         packName: "Pack installer smoke image artifact",
         producerName: "installer_smoke_update_image",
-        setupName: "Setup Node environment for installer update smoke",
         testName: "Run installer update docker tests",
         uploadName: "Upload installer smoke image artifact",
         validateName: "Validate installer update image artifact binding",
@@ -302,7 +369,6 @@ describe("install smoke no-push root image transport", () => {
         loadName: "Verify and load installer non-root image artifact",
         packName: "Pack installer non-root image artifact",
         producerName: "installer_smoke_nonroot_image",
-        setupName: "Setup Node environment for installer non-root smoke",
         testName: "Run installer non-root docker tests",
         uploadName: "Upload installer non-root image artifact",
         validateName: "Validate installer non-root image artifact binding",
@@ -344,10 +410,7 @@ describe("install smoke no-push root image transport", () => {
       });
 
       const consumer = job(workflow, pair.consumerName);
-      const expectedNeeds =
-        pair.group === "update"
-          ? ["preflight", "root_dockerfile_image", "root_dockerfile_image_ready", pair.producerName]
-          : ["preflight", pair.producerName];
+      const expectedNeeds = ["preflight", "installer_smoke_candidate_payload", pair.producerName];
       expect(consumer.needs, pair.consumerName).toEqual(expectedNeeds);
       expect(consumer["timeout-minutes"], pair.consumerName).toBe(
         pair.group === "update" ? 120 : 60,
@@ -364,7 +427,7 @@ describe("install smoke no-push root image transport", () => {
         ARTIFACT_TARGET_SHA: `\${{ needs.${pair.producerName}.outputs.target_sha }}`,
         ARTIFACT_WORKFLOW_SHA: `\${{ needs.${pair.producerName}.outputs.workflow_sha }}`,
         TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
-        WORKFLOW_SHA: "${{ needs.preflight.outputs.workflow_sha }}",
+        WORKFLOW_SHA: "${{ fromJSON(toJSON(job)).workflow_sha }}",
       });
       expect(binding.run, pair.consumerName).toContain('[[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]');
       expect(binding.run, pair.consumerName).toContain(
@@ -402,13 +465,79 @@ describe("install smoke no-push root image transport", () => {
         `load "\${RUNNER_TEMP}/${pair.artifactPrefix}" ${pair.artifactKind}`,
       );
 
-      const setup = step(consumer, pair.setupName);
-      expect(setup.with, pair.consumerName).toMatchObject({
-        "cache-mode": pair.group === "update" ? "restore" : "off",
-        "install-bun": "false",
-        "install-deps": pair.group === "update" ? "true" : "false",
+      expect(
+        consumer.steps?.some((candidate) =>
+          candidate.uses?.includes("./.github/actions/setup-node-env"),
+        ),
+      ).toBe(false);
+      expect(step(consumer, pair.testName).env).toMatchObject({
+        OPENCLAW_INSTALL_SMOKE_FROZEN_PAYLOAD_DIR:
+          "${{ runner.temp }}/install-smoke-candidate-payload",
+        OPENCLAW_INSTALL_SMOKE_GROUP: pair.group,
       });
-      expect(step(consumer, pair.testName).env?.OPENCLAW_INSTALL_SMOKE_GROUP).toBe(pair.group);
+    }
+  });
+
+  it("packages candidate code only in an isolated image and verifies the sealed payload", () => {
+    const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
+    const producer = job(workflow, "installer_smoke_candidate_payload");
+    expect(producer.needs).toEqual(["preflight"]);
+    expect(producer["timeout-minutes"]).toBe(75);
+    expect(producer.outputs).toMatchObject({
+      artifact_digest: "${{ steps.payload_upload.outputs.artifact-digest }}",
+      artifact_id: "${{ steps.payload_upload.outputs.artifact-id }}",
+      harness_repository: "${{ steps.payload.outputs.harness_repository }}",
+      harness_sha: "${{ steps.payload.outputs.harness_sha }}",
+      manifest_sha256: "${{ steps.payload.outputs.manifest_sha256 }}",
+      package_version: "${{ steps.payload.outputs.package_version }}",
+      repository: "${{ steps.payload.outputs.repository }}",
+      source_archive_sha256: "${{ steps.payload.outputs.source_archive_sha256 }}",
+      target_sha: "${{ steps.payload.outputs.target_sha }}",
+    });
+    expect(step(producer, "Checkout trusted installer harness").with).toMatchObject({
+      repository: "${{ fromJSON(toJSON(job)).workflow_repository }}",
+      ref: "${{ fromJSON(toJSON(job)).workflow_sha }}",
+      "persist-credentials": false,
+    });
+    expect(step(producer, "Require exact trusted installer harness").run).toContain(
+      '[[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]',
+    );
+    const download = step(producer, "Download exact candidate source archive");
+    expect(download.run).toContain(
+      '"https://codeload.github.com/${TARGET_REPOSITORY}/tar.gz/${TARGET_SHA}"',
+    );
+    const packageStep = step(producer, "Package candidate only inside pinned harness");
+    expect(packageStep.run).toContain("--user node");
+    expect(packageStep.run).toContain("--cap-drop ALL");
+    expect(packageStep.run).toContain("pnpm install --frozen-lockfile");
+    expect(packageStep.run).not.toContain("github.token");
+    const seal = step(producer, "Seal candidate payload in clean pinned harness");
+    expect(seal.run).toContain("--network none");
+    expect(seal.run).toContain('install -d -m 0750 "$payload_dir"');
+    expect(seal.run).toContain('--user "$(id -u):$(id -g)"');
+    expect(seal.run).not.toContain('chmod 0777 "$payload_dir"');
+    expect(seal.run).toContain("install-smoke-candidate-payload.mts seal");
+    expect(seal.run).toContain("--harness-sha");
+
+    for (const consumerName of ["installer_smoke_update", "installer_smoke_nonroot"]) {
+      const consumer = job(workflow, consumerName);
+      expect(consumer.steps?.find((candidate) => candidate.name === "Checkout candidate CLI")).toBe(
+        undefined,
+      );
+      const binding = step(consumer, "Validate candidate payload artifact binding");
+      expect(binding.run).toContain('verify-upload "Candidate payload"');
+      expect(binding.run).toContain(
+        'expected_artifact_name="install-smoke-candidate-payload-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"',
+      );
+      const verify = step(consumer, "Verify candidate payload contents");
+      expect(verify.env).toMatchObject({
+        MANIFEST_SHA256: "${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}",
+        PACKAGE_VERSION: "${{ needs.installer_smoke_candidate_payload.outputs.package_version }}",
+        SOURCE_ARCHIVE_SHA256:
+          "${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}",
+      });
+      expect(verify.run).toContain("--manifest-sha256");
+      expect(verify.run).toContain("--source-archive-sha256");
     }
   });
 
@@ -420,12 +549,15 @@ describe("install smoke no-push root image transport", () => {
 
     expect(update.needs).toEqual([
       "preflight",
-      "root_dockerfile_image",
-      "root_dockerfile_image_ready",
+      "installer_smoke_candidate_payload",
       "installer_smoke_update_image",
     ]);
     expect(update.needs).not.toContain("installer_smoke_nonroot_image");
-    expect(nonroot.needs).toEqual(["preflight", "installer_smoke_nonroot_image"]);
+    expect(nonroot.needs).toEqual([
+      "preflight",
+      "installer_smoke_candidate_payload",
+      "installer_smoke_nonroot_image",
+    ]);
     expect(nonroot.needs).not.toContain("root_dockerfile_image");
     expect(nonroot.needs).not.toContain("root_dockerfile_image_ready");
     expect(nonroot.needs).not.toContain("installer_smoke_update_image");
@@ -435,6 +567,7 @@ describe("install smoke no-push root image transport", () => {
       "preflight",
       "root_dockerfile_image",
       "root_dockerfile_image_ready",
+      "installer_smoke_candidate_payload",
       "installer_smoke_update_image",
       "installer_smoke_update",
       "installer_smoke_nonroot_image",
@@ -443,6 +576,7 @@ describe("install smoke no-push root image transport", () => {
     expect(aggregate["timeout-minutes"]).toBe(5);
     const verify = step(aggregate, "Verify installer smoke groups");
     expect(verify.env).toEqual({
+      CANDIDATE_PAYLOAD_RESULT: "${{ needs.installer_smoke_candidate_payload.result }}",
       NONROOT_CONSUMER_RESULT: "${{ needs.installer_smoke_nonroot.result }}",
       NONROOT_PRODUCER_RESULT: "${{ needs.installer_smoke_nonroot_image.result }}",
       ROOT_IMAGE_READY_RESULT: "${{ needs.root_dockerfile_image_ready.result }}",
@@ -453,6 +587,7 @@ describe("install smoke no-push root image transport", () => {
     for (const result of [
       "ROOT_IMAGE_RESULT",
       "ROOT_IMAGE_READY_RESULT",
+      "CANDIDATE_PAYLOAD_RESULT",
       "UPDATE_PRODUCER_RESULT",
       "UPDATE_CONSUMER_RESULT",
       "NONROOT_PRODUCER_RESULT",
@@ -482,9 +617,12 @@ describe("install smoke no-push root image transport", () => {
   it("passes package changelog intent only to current-tree smoke scripts", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
     expect(
-      step(job(workflow, "installer_smoke_update"), "Run installer update docker tests").env,
+      step(
+        job(workflow, "installer_smoke_candidate_payload"),
+        "Package candidate only inside pinned harness",
+      ).env,
     ).toMatchObject({
-      OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
+      ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
     });
     expect(
       step(job(workflow, "bun_global_install_smoke"), "Run Bun global install image-provider smoke")

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -206,15 +206,13 @@ describe("install smoke no-push root image transport", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
     for (const jobName of [
       "root_dockerfile_smokes",
-      "installer_smoke_group",
+      "installer_smoke_update",
       "bun_global_install_smoke",
     ]) {
       const consumer = job(workflow, jobName);
-      const updateOnly =
-        jobName === "installer_smoke_group" ? "matrix.group == 'update'" : undefined;
       expect(consumer.needs, jobName).toContain("root_dockerfile_image_ready");
       expect(consumer.env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE, jobName).toBe("1");
-      expect(step(consumer, "Checkout trusted image artifact helper").if, jobName).toBe(updateOnly);
+      expect(step(consumer, "Checkout trusted image artifact helper").if, jobName).toBeUndefined();
       expect(
         consumer.steps?.find((candidate) => candidate.name === "Log in to GHCR"),
         jobName,
@@ -225,7 +223,7 @@ describe("install smoke no-push root image transport", () => {
       ).toBeUndefined();
 
       const binding = step(consumer, "Validate root Dockerfile image artifact binding");
-      expect(binding.if, jobName).toBe(updateOnly);
+      expect(binding.if, jobName).toBeUndefined();
       expect(binding.env, jobName).toMatchObject({
         ARCHIVE_SHA256: "${{ needs.root_dockerfile_image.outputs.archive_sha256 }}",
         ARTIFACT_DIGEST: "${{ needs.root_dockerfile_image.outputs.artifact_digest }}",
@@ -251,7 +249,7 @@ describe("install smoke no-push root image transport", () => {
       expect(binding.run, jobName).not.toContain("<<<");
 
       const download = step(consumer, "Download root Dockerfile image artifact");
-      expect(download.if, jobName).toBe(updateOnly);
+      expect(download.if, jobName).toBeUndefined();
       expect(download.with, jobName).toMatchObject({
         "artifact-ids": "${{ needs.root_dockerfile_image.outputs.artifact_id }}",
         "github-token": "${{ github.token }}",
@@ -260,14 +258,14 @@ describe("install smoke no-push root image transport", () => {
       });
 
       const load = step(consumer, "Verify and load root Dockerfile image artifact");
-      expect(load.if, jobName).toBe(updateOnly);
+      expect(load.if, jobName).toBeUndefined();
       expect(load.run, jobName).toContain(
         'load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root',
       );
       expect(load.run, jobName).toContain('"$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"');
 
       const requireLocal = step(consumer, "Require local root Dockerfile image");
-      expect(requireLocal.if, jobName).toBe(updateOnly);
+      expect(requireLocal.if, jobName).toBeUndefined();
       expect(requireLocal.run, jobName).toBe('docker image inspect "$IMAGE_REF" >/dev/null');
     }
 
@@ -276,101 +274,192 @@ describe("install smoke no-push root image transport", () => {
     expect(text).not.toContain("gh api");
   });
 
-  it("builds and consumes installer images in independent non-fail-fast groups", () => {
+  it("binds independent installer producer-consumer pairs to immutable artifact tuples", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
-    const producer = job(workflow, "installer_smoke_image");
-    const consumer = job(workflow, "installer_smoke_group");
+    const pairs = [
+      {
+        artifactKind: "install-smoke-update",
+        artifactPrefix: "install-smoke-update-image",
+        buildName: "Build installer smoke image",
+        consumerName: "installer_smoke_update",
+        downloadName: "Download installer update image artifact",
+        group: "update",
+        loadName: "Verify and load installer update image artifact",
+        packName: "Pack installer smoke image artifact",
+        producerName: "installer_smoke_update_image",
+        setupName: "Setup Node environment for installer update smoke",
+        testName: "Run installer update docker tests",
+        uploadName: "Upload installer smoke image artifact",
+        validateName: "Validate installer update image artifact binding",
+      },
+      {
+        artifactKind: "install-smoke-nonroot",
+        artifactPrefix: "install-smoke-nonroot-image",
+        buildName: "Build installer non-root image",
+        consumerName: "installer_smoke_nonroot",
+        downloadName: "Download installer non-root image artifact",
+        group: "nonroot",
+        loadName: "Verify and load installer non-root image artifact",
+        packName: "Pack installer non-root image artifact",
+        producerName: "installer_smoke_nonroot_image",
+        setupName: "Setup Node environment for installer non-root smoke",
+        testName: "Run installer non-root docker tests",
+        uploadName: "Upload installer non-root image artifact",
+        validateName: "Validate installer non-root image artifact binding",
+      },
+    ] as const;
+
+    for (const pair of pairs) {
+      const producer = job(workflow, pair.producerName);
+      expect(producer.needs, pair.producerName).toEqual(["preflight"]);
+      expect(producer["timeout-minutes"], pair.producerName).toBe(45);
+      expect(producer.outputs, pair.producerName).toEqual({
+        archive_sha256: "${{ steps.image_artifact.outputs.archive_sha256 }}",
+        artifact_digest: "${{ steps.image_artifact_upload.outputs.artifact-digest }}",
+        artifact_id: "${{ steps.image_artifact_upload.outputs.artifact-id }}",
+        artifact_name: "${{ steps.image_artifact.outputs.artifact_name }}",
+        artifact_run_attempt: "${{ steps.image_artifact.outputs.run_attempt }}",
+        artifact_run_id: "${{ steps.image_artifact.outputs.run_id }}",
+        target_sha: "${{ steps.image_artifact.outputs.target_sha }}",
+        workflow_sha: "${{ steps.image_artifact.outputs.workflow_sha }}",
+      });
+      expect(step(producer, pair.buildName).run, pair.producerName).toContain("--load");
+
+      const pack = step(producer, pair.packName);
+      expect(pack.run, pair.producerName).toContain(
+        `artifact_name="${pair.artifactPrefix}-\${TARGET_SHA}-\${GITHUB_RUN_ID}-\${GITHUB_RUN_ATTEMPT}"`,
+      );
+      expect(pack.run, pair.producerName).toContain(
+        `pack "$artifact_dir" ${pair.artifactKind} "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"`,
+      );
+      expect(pack.run, pair.producerName).toContain('echo "archive_sha256=$archive_sha256"');
+      expect(pack.run, pair.producerName).toContain('echo "run_attempt=$GITHUB_RUN_ATTEMPT"');
+      expect(pack.run, pair.producerName).toContain('echo "run_id=$GITHUB_RUN_ID"');
+      expect(pack.run, pair.producerName).toContain('echo "target_sha=$TARGET_SHA"');
+      expect(pack.run, pair.producerName).toContain('echo "workflow_sha=$WORKFLOW_SHA"');
+      expect(step(producer, pair.uploadName).with, pair.producerName).toMatchObject({
+        "compression-level": 0,
+        "if-no-files-found": "error",
+        name: "${{ steps.image_artifact.outputs.artifact_name }}",
+      });
+
+      const consumer = job(workflow, pair.consumerName);
+      const expectedNeeds =
+        pair.group === "update"
+          ? ["preflight", "root_dockerfile_image", "root_dockerfile_image_ready", pair.producerName]
+          : ["preflight", pair.producerName];
+      expect(consumer.needs, pair.consumerName).toEqual(expectedNeeds);
+      expect(consumer["timeout-minutes"], pair.consumerName).toBe(
+        pair.group === "update" ? 120 : 60,
+      );
+
+      const binding = step(consumer, pair.validateName);
+      expect(binding.env, pair.consumerName).toMatchObject({
+        ARCHIVE_SHA256: `\${{ needs.${pair.producerName}.outputs.archive_sha256 }}`,
+        ARTIFACT_DIGEST: `\${{ needs.${pair.producerName}.outputs.artifact_digest }}`,
+        ARTIFACT_ID: `\${{ needs.${pair.producerName}.outputs.artifact_id }}`,
+        ARTIFACT_NAME: `\${{ needs.${pair.producerName}.outputs.artifact_name }}`,
+        ARTIFACT_RUN_ATTEMPT: `\${{ needs.${pair.producerName}.outputs.artifact_run_attempt }}`,
+        ARTIFACT_RUN_ID: `\${{ needs.${pair.producerName}.outputs.artifact_run_id }}`,
+        ARTIFACT_TARGET_SHA: `\${{ needs.${pair.producerName}.outputs.target_sha }}`,
+        ARTIFACT_WORKFLOW_SHA: `\${{ needs.${pair.producerName}.outputs.workflow_sha }}`,
+        TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
+        WORKFLOW_SHA: "${{ needs.preflight.outputs.workflow_sha }}",
+      });
+      expect(binding.run, pair.consumerName).toContain('[[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]');
+      expect(binding.run, pair.consumerName).toContain(
+        '[[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]]',
+      );
+      expect(binding.run, pair.consumerName).toContain('[[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]]');
+      expect(binding.run, pair.consumerName).toContain(
+        '[[ "$ARTIFACT_TARGET_SHA" == "$TARGET_SHA" ]]',
+      );
+      expect(binding.run, pair.consumerName).toContain(
+        '[[ "$ARTIFACT_WORKFLOW_SHA" == "$WORKFLOW_SHA" ]]',
+      );
+      expect(binding.run, pair.consumerName).toContain(
+        `expected_artifact_name="${pair.artifactPrefix}-\${TARGET_SHA}-\${ARTIFACT_RUN_ID}-\${ARTIFACT_RUN_ATTEMPT}"`,
+      );
+      expect(binding.run, pair.consumerName).toContain("verify-upload");
+
+      const download = step(consumer, pair.downloadName);
+      expect(download.with, pair.consumerName).toMatchObject({
+        "artifact-ids": `\${{ needs.${pair.producerName}.outputs.artifact_id }}`,
+        "github-token": "${{ github.token }}",
+        "run-id": `\${{ needs.${pair.producerName}.outputs.artifact_run_id }}`,
+      });
+      expect(download.with?.name, pair.consumerName).toBeUndefined();
+
+      const load = step(consumer, pair.loadName);
+      expect(load.env, pair.consumerName).toMatchObject({
+        OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: `\${{ needs.${pair.producerName}.outputs.archive_sha256 }}`,
+        OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: `\${{ needs.${pair.producerName}.outputs.artifact_run_attempt }}`,
+        OPENCLAW_SHARED_IMAGE_RUN_ID: `\${{ needs.${pair.producerName}.outputs.artifact_run_id }}`,
+        TARGET_SHA: `\${{ needs.${pair.producerName}.outputs.target_sha }}`,
+        WORKFLOW_SHA: `\${{ needs.${pair.producerName}.outputs.workflow_sha }}`,
+      });
+      expect(load.run, pair.consumerName).toContain(
+        `load "\${RUNNER_TEMP}/${pair.artifactPrefix}" ${pair.artifactKind}`,
+      );
+
+      const setup = step(consumer, pair.setupName);
+      expect(setup.with, pair.consumerName).toMatchObject({
+        "cache-mode": pair.group === "update" ? "restore" : "off",
+        "install-bun": "false",
+        "install-deps": pair.group === "update" ? "true" : "false",
+      });
+      expect(step(consumer, pair.testName).env?.OPENCLAW_INSTALL_SMOKE_GROUP).toBe(pair.group);
+    }
+  });
+
+  it("drains every independent producer and consumer without sibling failure suppression", () => {
+    const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
+    const update = job(workflow, "installer_smoke_update");
+    const nonroot = job(workflow, "installer_smoke_nonroot");
     const aggregate = job(workflow, "installer_smoke");
 
-    expect(producer.needs).toEqual(["preflight"]);
-    expect(producer["timeout-minutes"]).toBe(45);
-    expect(producer.strategy).toEqual({
-      "fail-fast": false,
-      matrix: {
-        include: [
-          {
-            artifact_key: "install-smoke-update",
-            dockerfile: "./scripts/docker/install-sh-smoke/Dockerfile",
-            group: "update",
-            image_ref: "openclaw-install-smoke:local",
-          },
-          {
-            artifact_key: "install-smoke-nonroot",
-            dockerfile: "./scripts/docker/install-sh-nonroot/Dockerfile",
-            group: "nonroot",
-            image_ref: "openclaw-install-nonroot:local",
-          },
-        ],
-      },
-    });
-    expect(step(producer, "Build installer smoke image").run).toContain('-f "$DOCKERFILE"');
-    expect(step(producer, "Pack installer smoke image artifact").run).toContain(
-      'pack "$artifact_dir" "$ARTIFACT_KEY" "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"',
-    );
-    expect(step(producer, "Upload installer smoke image artifact").with).toMatchObject({
-      "compression-level": 0,
-      "if-no-files-found": "error",
-      name: "${{ steps.image_artifact.outputs.artifact_name }}",
-    });
-
-    expect(consumer.needs).toEqual([
+    expect(update.needs).toEqual([
       "preflight",
       "root_dockerfile_image",
       "root_dockerfile_image_ready",
-      "installer_smoke_image",
+      "installer_smoke_update_image",
     ]);
-    expect(consumer["timeout-minutes"]).toBe("${{ matrix.timeout_minutes }}");
-    expect(consumer.strategy).toEqual({
-      "fail-fast": false,
-      matrix: {
-        include: [
-          {
-            artifact_key: "install-smoke-update",
-            group: "update",
-            image_ref: "openclaw-install-smoke:local",
-            timeout_minutes: 120,
-          },
-          {
-            artifact_key: "install-smoke-nonroot",
-            group: "nonroot",
-            image_ref: "openclaw-install-nonroot:local",
-            timeout_minutes: 60,
-          },
-        ],
-      },
-    });
-    expect(step(consumer, "Download installer smoke image artifact").with).toMatchObject({
-      name: "${{ format('{0}-image-{1}-{2}-{3}', matrix.artifact_key, needs.preflight.outputs.target_sha, github.run_id, github.run_attempt) }}",
-      path: "${{ runner.temp }}/installer-smoke-image",
-    });
-    expect(step(consumer, "Verify and load installer smoke image artifact").run).toContain(
-      'load "${RUNNER_TEMP}/installer-smoke-image" "$ARTIFACT_KEY"',
-    );
-    expect(step(consumer, "Setup Node environment for installer smoke").with).toMatchObject({
-      "install-bun": "false",
-      "install-deps": "${{ matrix.group == 'update' && 'true' || 'false' }}",
-    });
-    expect(step(consumer, "Run installer docker tests").env).toMatchObject({
-      OPENCLAW_INSTALL_SMOKE_GROUP: "${{ matrix.group }}",
-    });
-    expect(step(consumer, "Run Rocky Linux installer smoke").if).toBe("matrix.group == 'update'");
-    expect(step(consumer, "Run Rocky Linux CLI installer smoke").if).toBe(
-      "matrix.group == 'update'",
-    );
+    expect(update.needs).not.toContain("installer_smoke_nonroot_image");
+    expect(nonroot.needs).toEqual(["preflight", "installer_smoke_nonroot_image"]);
+    expect(nonroot.needs).not.toContain("root_dockerfile_image");
+    expect(nonroot.needs).not.toContain("root_dockerfile_image_ready");
+    expect(nonroot.needs).not.toContain("installer_smoke_update_image");
 
+    expect(aggregate.if).toContain("always()");
     expect(aggregate.needs).toEqual([
       "preflight",
-      "installer_smoke_image",
-      "installer_smoke_group",
+      "root_dockerfile_image",
+      "root_dockerfile_image_ready",
+      "installer_smoke_update_image",
+      "installer_smoke_update",
+      "installer_smoke_nonroot_image",
+      "installer_smoke_nonroot",
     ]);
     expect(aggregate["timeout-minutes"]).toBe(5);
     const verify = step(aggregate, "Verify installer smoke groups");
     expect(verify.env).toEqual({
-      CONSUMER_RESULT: "${{ needs.installer_smoke_group.result }}",
-      PRODUCER_RESULT: "${{ needs.installer_smoke_image.result }}",
+      NONROOT_CONSUMER_RESULT: "${{ needs.installer_smoke_nonroot.result }}",
+      NONROOT_PRODUCER_RESULT: "${{ needs.installer_smoke_nonroot_image.result }}",
+      ROOT_IMAGE_READY_RESULT: "${{ needs.root_dockerfile_image_ready.result }}",
+      ROOT_IMAGE_RESULT: "${{ needs.root_dockerfile_image.result }}",
+      UPDATE_CONSUMER_RESULT: "${{ needs.installer_smoke_update.result }}",
+      UPDATE_PRODUCER_RESULT: "${{ needs.installer_smoke_update_image.result }}",
     });
-    expect(verify.run).toContain('if [[ "$PRODUCER_RESULT" != "success" ]]');
-    expect(verify.run).toContain('if [[ "$CONSUMER_RESULT" != "success" ]]');
+    for (const result of [
+      "ROOT_IMAGE_RESULT",
+      "ROOT_IMAGE_READY_RESULT",
+      "UPDATE_PRODUCER_RESULT",
+      "UPDATE_CONSUMER_RESULT",
+      "NONROOT_PRODUCER_RESULT",
+      "NONROOT_CONSUMER_RESULT",
+    ]) {
+      expect(verify.run).toContain(`"$${result}"`);
+    }
   });
 
   it("selects the read-only reusable core from release checks", () => {
@@ -393,7 +482,7 @@ describe("install smoke no-push root image transport", () => {
   it("passes package changelog intent only to current-tree smoke scripts", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
     expect(
-      step(job(workflow, "installer_smoke_group"), "Run installer docker tests").env,
+      step(job(workflow, "installer_smoke_update"), "Run installer update docker tests").env,
     ).toMatchObject({
       OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
     });

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -22,7 +22,14 @@ type WorkflowJob = {
   needs?: string | string[];
   outputs?: Record<string, unknown>;
   permissions?: Record<string, unknown>;
+  strategy?: {
+    "fail-fast"?: boolean;
+    matrix?: {
+      include?: Array<Record<string, unknown>>;
+    };
+  };
   steps?: WorkflowStep[];
+  "timeout-minutes"?: number | string;
   uses?: string;
   with?: Record<string, unknown>;
 };
@@ -199,13 +206,15 @@ describe("install smoke no-push root image transport", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
     for (const jobName of [
       "root_dockerfile_smokes",
-      "installer_smoke",
+      "installer_smoke_group",
       "bun_global_install_smoke",
     ]) {
       const consumer = job(workflow, jobName);
+      const updateOnly =
+        jobName === "installer_smoke_group" ? "matrix.group == 'update'" : undefined;
       expect(consumer.needs, jobName).toContain("root_dockerfile_image_ready");
       expect(consumer.env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE, jobName).toBe("1");
-      expect(step(consumer, "Checkout trusted image artifact helper").if, jobName).toBeUndefined();
+      expect(step(consumer, "Checkout trusted image artifact helper").if, jobName).toBe(updateOnly);
       expect(
         consumer.steps?.find((candidate) => candidate.name === "Log in to GHCR"),
         jobName,
@@ -216,7 +225,7 @@ describe("install smoke no-push root image transport", () => {
       ).toBeUndefined();
 
       const binding = step(consumer, "Validate root Dockerfile image artifact binding");
-      expect(binding.if, jobName).toBeUndefined();
+      expect(binding.if, jobName).toBe(updateOnly);
       expect(binding.env, jobName).toMatchObject({
         ARCHIVE_SHA256: "${{ needs.root_dockerfile_image.outputs.archive_sha256 }}",
         ARTIFACT_DIGEST: "${{ needs.root_dockerfile_image.outputs.artifact_digest }}",
@@ -242,7 +251,7 @@ describe("install smoke no-push root image transport", () => {
       expect(binding.run, jobName).not.toContain("<<<");
 
       const download = step(consumer, "Download root Dockerfile image artifact");
-      expect(download.if, jobName).toBeUndefined();
+      expect(download.if, jobName).toBe(updateOnly);
       expect(download.with, jobName).toMatchObject({
         "artifact-ids": "${{ needs.root_dockerfile_image.outputs.artifact_id }}",
         "github-token": "${{ github.token }}",
@@ -251,20 +260,117 @@ describe("install smoke no-push root image transport", () => {
       });
 
       const load = step(consumer, "Verify and load root Dockerfile image artifact");
-      expect(load.if, jobName).toBeUndefined();
+      expect(load.if, jobName).toBe(updateOnly);
       expect(load.run, jobName).toContain(
         'load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root',
       );
       expect(load.run, jobName).toContain('"$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"');
 
       const requireLocal = step(consumer, "Require local root Dockerfile image");
-      expect(requireLocal.if, jobName).toBeUndefined();
+      expect(requireLocal.if, jobName).toBe(updateOnly);
       expect(requireLocal.run, jobName).toBe('docker image inspect "$IMAGE_REF" >/dev/null');
     }
 
     const text = readFileSync(INSTALL_SMOKE_REUSABLE, "utf8");
     expect(text.match(/verify-upload "Root image"/g)).toHaveLength(3);
     expect(text).not.toContain("gh api");
+  });
+
+  it("builds and consumes installer images in independent non-fail-fast groups", () => {
+    const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
+    const producer = job(workflow, "installer_smoke_image");
+    const consumer = job(workflow, "installer_smoke_group");
+    const aggregate = job(workflow, "installer_smoke");
+
+    expect(producer.needs).toEqual(["preflight"]);
+    expect(producer["timeout-minutes"]).toBe(45);
+    expect(producer.strategy).toEqual({
+      "fail-fast": false,
+      matrix: {
+        include: [
+          {
+            artifact_key: "install-smoke-update",
+            dockerfile: "./scripts/docker/install-sh-smoke/Dockerfile",
+            group: "update",
+            image_ref: "openclaw-install-smoke:local",
+          },
+          {
+            artifact_key: "install-smoke-nonroot",
+            dockerfile: "./scripts/docker/install-sh-nonroot/Dockerfile",
+            group: "nonroot",
+            image_ref: "openclaw-install-nonroot:local",
+          },
+        ],
+      },
+    });
+    expect(step(producer, "Build installer smoke image").run).toContain('-f "$DOCKERFILE"');
+    expect(step(producer, "Pack installer smoke image artifact").run).toContain(
+      'pack "$artifact_dir" "$ARTIFACT_KEY" "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"',
+    );
+    expect(step(producer, "Upload installer smoke image artifact").with).toMatchObject({
+      "compression-level": 0,
+      "if-no-files-found": "error",
+      name: "${{ steps.image_artifact.outputs.artifact_name }}",
+    });
+
+    expect(consumer.needs).toEqual([
+      "preflight",
+      "root_dockerfile_image",
+      "root_dockerfile_image_ready",
+      "installer_smoke_image",
+    ]);
+    expect(consumer["timeout-minutes"]).toBe("${{ matrix.timeout_minutes }}");
+    expect(consumer.strategy).toEqual({
+      "fail-fast": false,
+      matrix: {
+        include: [
+          {
+            artifact_key: "install-smoke-update",
+            group: "update",
+            image_ref: "openclaw-install-smoke:local",
+            timeout_minutes: 120,
+          },
+          {
+            artifact_key: "install-smoke-nonroot",
+            group: "nonroot",
+            image_ref: "openclaw-install-nonroot:local",
+            timeout_minutes: 60,
+          },
+        ],
+      },
+    });
+    expect(step(consumer, "Download installer smoke image artifact").with).toMatchObject({
+      name: "${{ format('{0}-image-{1}-{2}-{3}', matrix.artifact_key, needs.preflight.outputs.target_sha, github.run_id, github.run_attempt) }}",
+      path: "${{ runner.temp }}/installer-smoke-image",
+    });
+    expect(step(consumer, "Verify and load installer smoke image artifact").run).toContain(
+      'load "${RUNNER_TEMP}/installer-smoke-image" "$ARTIFACT_KEY"',
+    );
+    expect(step(consumer, "Setup Node environment for installer smoke").with).toMatchObject({
+      "install-bun": "false",
+      "install-deps": "${{ matrix.group == 'update' && 'true' || 'false' }}",
+    });
+    expect(step(consumer, "Run installer docker tests").env).toMatchObject({
+      OPENCLAW_INSTALL_SMOKE_GROUP: "${{ matrix.group }}",
+    });
+    expect(step(consumer, "Run Rocky Linux installer smoke").if).toBe("matrix.group == 'update'");
+    expect(step(consumer, "Run Rocky Linux CLI installer smoke").if).toBe(
+      "matrix.group == 'update'",
+    );
+
+    expect(aggregate.needs).toEqual([
+      "preflight",
+      "installer_smoke_image",
+      "installer_smoke_group",
+    ]);
+    expect(aggregate["timeout-minutes"]).toBe(5);
+    const verify = step(aggregate, "Verify installer smoke groups");
+    expect(verify.env).toEqual({
+      CONSUMER_RESULT: "${{ needs.installer_smoke_group.result }}",
+      PRODUCER_RESULT: "${{ needs.installer_smoke_image.result }}",
+    });
+    expect(verify.run).toContain('if [[ "$PRODUCER_RESULT" != "success" ]]');
+    expect(verify.run).toContain('if [[ "$CONSUMER_RESULT" != "success" ]]');
   });
 
   it("selects the read-only reusable core from release checks", () => {
@@ -286,7 +392,9 @@ describe("install smoke no-push root image transport", () => {
 
   it("passes package changelog intent only to current-tree smoke scripts", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
-    expect(step(job(workflow, "installer_smoke"), "Run installer docker tests").env).toMatchObject({
+    expect(
+      step(job(workflow, "installer_smoke_group"), "Run installer docker tests").env,
+    ).toMatchObject({
       OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
     });
     expect(

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -139,7 +139,10 @@ describe("install smoke no-push root image transport", () => {
       },
     );
     expect(identityResult.status, identityResult.stderr).toBe(0);
-    expect(JSON.stringify(workflow)).not.toContain("${{ github.workflow_sha }}");
+    const workflowText = JSON.stringify(workflow);
+    expect(workflowText).not.toContain("${{ github.workflow_sha }}");
+    expect(workflowText).not.toContain("fromJSON(toJSON(job)).workflow_");
+    const trustedJobs: string[] = [];
     for (const [jobName, workflowJob] of Object.entries(workflow.jobs)) {
       const trustedCheckouts =
         workflowJob.steps?.filter((candidate) => candidate.name?.startsWith("Checkout trusted")) ??
@@ -147,25 +150,48 @@ describe("install smoke no-push root image transport", () => {
       if (trustedCheckouts.length === 0) {
         continue;
       }
-      const resolver = step(workflowJob, "Resolve trusted workflow identity");
-      expect(resolver.env, jobName).toEqual({
+      trustedJobs.push(jobName);
+      const resolver = step(workflowJob, "Restore exact trusted workflow revision");
+      expect(resolver.env, jobName).toMatchObject({
         EXPECTED_WORKFLOW_REPOSITORY: "${{ github.repository }}",
         JOB_CONTEXT: "${{ toJSON(job) }}",
       });
+      expect(resolver.env?.HARNESS_PATH, jobName).toMatch(/^(\.|\.release-harness)$/u);
       expect(resolver.run, jobName).toContain(
         "job.workflow_sha must be a full lowercase commit SHA",
       );
+      expect(resolver.run, jobName).toContain('"fetch"');
+      expect(resolver.run, jobName).toContain(
+        "`repository=${repository}\\nsha=${job.workflow_sha}\\n`",
+      );
+      const checkoutIndex = workflowJob.steps!.indexOf(trustedCheckouts[0]!);
+      const resolverIndex = workflowJob.steps!.indexOf(resolver);
+      expect(checkoutIndex, jobName).toBeLessThan(resolverIndex);
       for (const checkout of trustedCheckouts) {
         expect(checkout.with, jobName).toMatchObject({
-          repository: "${{ fromJSON(toJSON(job)).workflow_repository }}",
-          ref: "${{ fromJSON(toJSON(job)).workflow_sha }}",
+          repository: "openclaw/openclaw",
+          ref: "main",
+          "fetch-depth": 1,
+          "persist-credentials": false,
         });
       }
     }
+    expect(trustedJobs.toSorted()).toEqual(
+      [
+        "bun_global_install_smoke",
+        "installer_smoke_candidate_payload",
+        "installer_smoke_nonroot",
+        "installer_smoke_nonroot_image",
+        "installer_smoke_update",
+        "installer_smoke_update_image",
+        "root_dockerfile_image",
+        "root_dockerfile_smokes",
+      ].toSorted(),
+    );
 
     const candidateResolver = step(
       job(workflow, "installer_smoke_candidate_payload"),
-      "Resolve trusted workflow identity",
+      "Restore exact trusted workflow revision",
     );
     const runResolver = (workflowRepository: string, workflowSha: string) =>
       spawnSync("bash", ["--noprofile", "--norc", "-c", candidateResolver.run!], {
@@ -174,14 +200,13 @@ describe("install smoke no-push root image transport", () => {
           ...process.env,
           EXPECTED_WORKFLOW_REPOSITORY: "openclaw/openclaw",
           GITHUB_WORKFLOW_SHA: "a".repeat(40),
+          HARNESS_PATH: ".",
           JOB_CONTEXT: JSON.stringify({
             workflow_repository: workflowRepository,
             workflow_sha: workflowSha,
           }),
         },
       });
-    const mismatchedCaller = runResolver("openclaw/openclaw", "b".repeat(40));
-    expect(mismatchedCaller.status, mismatchedCaller.stderr).toBe(0);
     const malformedSha = runResolver("openclaw/openclaw", "not-a-sha");
     expect(malformedSha.status).not.toBe(0);
     expect(malformedSha.stderr).toContain("job.workflow_sha must be a full lowercase commit SHA");
@@ -228,24 +253,27 @@ describe("install smoke no-push root image transport", () => {
       image_ref: "${{ steps.image.outputs.image_ref }}",
     });
     expect(producer.outputs?.image_exists).toBeUndefined();
-    expect(step(producer, "Checkout CLI").with).toMatchObject({
-      ref: "${{ needs.preflight.outputs.target_sha }}",
-      "persist-credentials": false,
-    });
-    expect(step(producer, "Checkout trusted image artifact helper").if).toBeUndefined();
+    expect(producer.steps?.find((candidate) => candidate.name === "Checkout CLI")).toBeUndefined();
+    const sourceArchive = step(producer, "Download exact candidate source archive");
+    expect(sourceArchive.run).toContain(
+      '"https://codeload.github.com/${TARGET_REPOSITORY}/tar.gz/${TARGET_SHA}"',
+    );
+    expect(sourceArchive.run).toContain('test -f "$candidate_dir/Dockerfile"');
+    expect(step(producer, "Checkout trusted release harness").if).toBeUndefined();
 
     const localBuild = step(producer, "Build local root Dockerfile smoke image");
     expect(localBuild.if).toBeUndefined();
     expect(localBuild.run).toContain("--load");
     expect(localBuild.run).not.toContain("--push");
     expect(localBuild.run).toContain('-t "$IMAGE_REF"');
+    expect(localBuild.run).toContain('-f "$CANDIDATE_DIR/Dockerfile"');
 
     const pack = step(producer, "Pack root Dockerfile image artifact");
     expect(pack.if).toBeUndefined();
     expect(pack.env).toMatchObject({
       IMAGE_REF: "${{ needs.preflight.outputs.dockerfile_image }}",
       TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
-      WORKFLOW_SHA: "${{ fromJSON(toJSON(job)).workflow_sha }}",
+      WORKFLOW_SHA: "${{ steps.workflow.outputs.sha }}",
     });
     expect(pack.run).toContain(
       'artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
@@ -280,7 +308,7 @@ describe("install smoke no-push root image transport", () => {
       const consumer = job(workflow, jobName);
       expect(consumer.needs, jobName).toContain("root_dockerfile_image_ready");
       expect(consumer.env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE, jobName).toBe("1");
-      expect(step(consumer, "Checkout trusted image artifact helper").if, jobName).toBeUndefined();
+      expect(step(consumer, "Checkout trusted release harness").if, jobName).toBeUndefined();
       expect(
         consumer.steps?.find((candidate) => candidate.name === "Log in to GHCR"),
         jobName,
@@ -427,7 +455,7 @@ describe("install smoke no-push root image transport", () => {
         ARTIFACT_TARGET_SHA: `\${{ needs.${pair.producerName}.outputs.target_sha }}`,
         ARTIFACT_WORKFLOW_SHA: `\${{ needs.${pair.producerName}.outputs.workflow_sha }}`,
         TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
-        WORKFLOW_SHA: "${{ fromJSON(toJSON(job)).workflow_sha }}",
+        WORKFLOW_SHA: "${{ steps.workflow.outputs.sha }}",
       });
       expect(binding.run, pair.consumerName).toContain('[[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]]');
       expect(binding.run, pair.consumerName).toContain(
@@ -494,13 +522,14 @@ describe("install smoke no-push root image transport", () => {
       source_archive_sha256: "${{ steps.payload.outputs.source_archive_sha256 }}",
       target_sha: "${{ steps.payload.outputs.target_sha }}",
     });
-    expect(step(producer, "Checkout trusted installer harness").with).toMatchObject({
-      repository: "${{ fromJSON(toJSON(job)).workflow_repository }}",
-      ref: "${{ fromJSON(toJSON(job)).workflow_sha }}",
+    expect(step(producer, "Checkout trusted release harness").with).toMatchObject({
+      repository: "openclaw/openclaw",
+      ref: "main",
+      "fetch-depth": 1,
       "persist-credentials": false,
     });
     expect(step(producer, "Require exact trusted installer harness").run).toContain(
-      '[[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]]',
+      '[[ "$(git -C .release-harness rev-parse HEAD)" == "$EXPECTED_SHA" ]]',
     );
     const download = step(producer, "Download exact candidate source archive");
     expect(download.run).toContain(

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -15,6 +15,7 @@ type WorkflowStep = {
   run?: string;
   uses?: string;
   with?: Record<string, unknown>;
+  "working-directory"?: string;
 };
 
 type WorkflowJob = {
@@ -504,6 +505,20 @@ describe("install smoke no-push root image transport", () => {
         OPENCLAW_INSTALL_SMOKE_GROUP: pair.group,
       });
     }
+
+    const bunConsumer = job(workflow, "bun_global_install_smoke");
+    expect(step(bunConsumer, "Setup trusted release harness for Bun smoke")).toMatchObject({
+      uses: "./.release-harness/.github/actions/setup-release-harness",
+      with: { "node-version": "24.x" },
+    });
+    expect(step(bunConsumer, "Install Bun for global smoke").run).toBe("npm install -g bun@1.3.14");
+    expect(step(bunConsumer, "Run Bun global install image-provider smoke")).toMatchObject({
+      "working-directory": ".release-harness",
+      run: "bash scripts/e2e/bun-global-install-smoke.sh",
+    });
+    expect(JSON.stringify(bunConsumer)).not.toContain(
+      "./.release-harness/.github/actions/setup-node-env",
+    );
   });
 
   it("packages candidate code only in an isolated image and verifies the sealed payload", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7454,14 +7454,10 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(installSmoke.jobs?.root_dockerfile_image_ready?.["timeout-minutes"]).toBe(5);
     expect(installSmoke.jobs?.qr_package_install_smoke?.["timeout-minutes"]).toBe(30);
     expect(installSmoke.jobs?.root_dockerfile_smokes?.["timeout-minutes"]).toBe(90);
-    expect(installSmoke.jobs?.installer_smoke_image?.["timeout-minutes"]).toBe(45);
-    expect(
-      evaluatedJobTimeouts(
-        INSTALL_SMOKE_REUSABLE_WORKFLOW,
-        "installer_smoke_group",
-        workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_group"),
-      ),
-    ).toEqual([120, 60]);
+    expect(installSmoke.jobs?.installer_smoke_update_image?.["timeout-minutes"]).toBe(45);
+    expect(installSmoke.jobs?.installer_smoke_nonroot_image?.["timeout-minutes"]).toBe(45);
+    expect(installSmoke.jobs?.installer_smoke_update?.["timeout-minutes"]).toBe(120);
+    expect(installSmoke.jobs?.installer_smoke_nonroot?.["timeout-minutes"]).toBe(60);
     expect(installSmoke.jobs?.installer_smoke?.["timeout-minutes"]).toBe(5);
     expect(installSmoke.jobs?.bun_global_install_smoke?.["timeout-minutes"]).toBe(60);
     expect(installSmoke.jobs?.["docker-e2e-fast"]?.["timeout-minutes"]).toBe(12);
@@ -7639,42 +7635,64 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(
       jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "root_dockerfile_image_ready")),
     ).toEqual(["preflight", "root_dockerfile_image"]);
-    expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_image"))).toEqual(
-      ["preflight"],
-    );
-    expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_group"))).toEqual(
-      [
-        "preflight",
-        "root_dockerfile_image",
-        "root_dockerfile_image_ready",
-        "installer_smoke_image",
-      ],
-    );
+    expect(
+      jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_update_image")),
+    ).toEqual(["preflight"]);
+    expect(
+      jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_nonroot_image")),
+    ).toEqual(["preflight"]);
+    expect(
+      jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_update")),
+    ).toEqual([
+      "preflight",
+      "root_dockerfile_image",
+      "root_dockerfile_image_ready",
+      "installer_smoke_update_image",
+    ]);
+    expect(
+      jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_nonroot")),
+    ).toEqual(["preflight", "installer_smoke_nonroot_image"]);
     expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke"))).toEqual([
       "preflight",
-      "installer_smoke_image",
-      "installer_smoke_group",
+      "root_dockerfile_image",
+      "root_dockerfile_image_ready",
+      "installer_smoke_update_image",
+      "installer_smoke_update",
+      "installer_smoke_nonroot_image",
+      "installer_smoke_nonroot",
     ]);
     expect(jobNeeds(releaseSummary)).toContain("install_smoke_release_checks");
-    const installerGroupTimeout = Math.max(
-      ...evaluatedJobTimeouts(
-        INSTALL_SMOKE_REUSABLE_WORKFLOW,
-        "installer_smoke_group",
-        workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_group"),
-      ),
-    );
     const releaseInstallPath = [
       timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
       timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
       Math.max(
         timeoutForProfile(installSmoke.jobs?.root_dockerfile_image?.["timeout-minutes"], "stable"),
-        timeoutForProfile(installSmoke.jobs?.installer_smoke_image?.["timeout-minutes"], "stable"),
+        timeoutForProfile(
+          installSmoke.jobs?.installer_smoke_update_image?.["timeout-minutes"],
+          "stable",
+        ),
       ),
-      installerGroupTimeout,
+      timeoutForProfile(
+        installSmoke.jobs?.root_dockerfile_image_ready?.["timeout-minutes"],
+        "stable",
+      ),
+      timeoutForProfile(installSmoke.jobs?.installer_smoke_update?.["timeout-minutes"], "stable"),
       timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
       timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
     ];
-    expect(releaseInstallPath).toEqual([30, 15, 60, 120, 5, 5]);
+    expect(releaseInstallPath).toEqual([30, 15, 60, 5, 120, 5, 5]);
+    const releaseInstallNonrootPath = [
+      timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
+      timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
+      timeoutForProfile(
+        installSmoke.jobs?.installer_smoke_nonroot_image?.["timeout-minutes"],
+        "stable",
+      ),
+      timeoutForProfile(installSmoke.jobs?.installer_smoke_nonroot?.["timeout-minutes"], "stable"),
+      timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
+      timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
+    ];
+    expect(releaseInstallNonrootPath).toEqual([30, 15, 45, 60, 5, 5]);
 
     const releaseQaLive = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_live_release_checks");
     expect(jobNeeds(releaseQaLive)).toEqual(["resolve_target"]);
@@ -7705,7 +7723,8 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       expect(420 - childTimeout, `release-checks:${pathName}`).toBeGreaterThanOrEqual(60);
     }
     expect(releaseCrossOsPath.reduce((total, timeout) => total + timeout, 0)).toBe(200);
-    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(235);
+    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(240);
+    expect(releaseInstallNonrootPath.reduce((total, timeout) => total + timeout, 0)).toBe(160);
     expect(releaseQaLivePath.reduce((total, timeout) => total + timeout, 0)).toBe(165);
 
     expect(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7454,7 +7454,15 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(installSmoke.jobs?.root_dockerfile_image_ready?.["timeout-minutes"]).toBe(5);
     expect(installSmoke.jobs?.qr_package_install_smoke?.["timeout-minutes"]).toBe(30);
     expect(installSmoke.jobs?.root_dockerfile_smokes?.["timeout-minutes"]).toBe(90);
-    expect(installSmoke.jobs?.installer_smoke?.["timeout-minutes"]).toBe(150);
+    expect(installSmoke.jobs?.installer_smoke_image?.["timeout-minutes"]).toBe(45);
+    expect(
+      evaluatedJobTimeouts(
+        INSTALL_SMOKE_REUSABLE_WORKFLOW,
+        "installer_smoke_group",
+        workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_group"),
+      ),
+    ).toEqual([120, 60]);
+    expect(installSmoke.jobs?.installer_smoke?.["timeout-minutes"]).toBe(5);
     expect(installSmoke.jobs?.bun_global_install_smoke?.["timeout-minutes"]).toBe(60);
     expect(installSmoke.jobs?.["docker-e2e-fast"]?.["timeout-minutes"]).toBe(12);
     expect(crossOs.jobs?.prepare?.["timeout-minutes"]).toBe(90);
@@ -7631,24 +7639,42 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(
       jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "root_dockerfile_image_ready")),
     ).toEqual(["preflight", "root_dockerfile_image"]);
+    expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_image"))).toEqual(
+      ["preflight"],
+    );
+    expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_group"))).toEqual(
+      [
+        "preflight",
+        "root_dockerfile_image",
+        "root_dockerfile_image_ready",
+        "installer_smoke_image",
+      ],
+    );
     expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke"))).toEqual([
       "preflight",
-      "root_dockerfile_image",
-      "root_dockerfile_image_ready",
+      "installer_smoke_image",
+      "installer_smoke_group",
     ]);
     expect(jobNeeds(releaseSummary)).toContain("install_smoke_release_checks");
+    const installerGroupTimeout = Math.max(
+      ...evaluatedJobTimeouts(
+        INSTALL_SMOKE_REUSABLE_WORKFLOW,
+        "installer_smoke_group",
+        workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_group"),
+      ),
+    );
     const releaseInstallPath = [
       timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
       timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
-      timeoutForProfile(installSmoke.jobs?.root_dockerfile_image?.["timeout-minutes"], "stable"),
-      timeoutForProfile(
-        installSmoke.jobs?.root_dockerfile_image_ready?.["timeout-minutes"],
-        "stable",
+      Math.max(
+        timeoutForProfile(installSmoke.jobs?.root_dockerfile_image?.["timeout-minutes"], "stable"),
+        timeoutForProfile(installSmoke.jobs?.installer_smoke_image?.["timeout-minutes"], "stable"),
       ),
+      installerGroupTimeout,
       timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
       timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
     ];
-    expect(releaseInstallPath).toEqual([30, 15, 60, 5, 150, 5]);
+    expect(releaseInstallPath).toEqual([30, 15, 60, 120, 5, 5]);
 
     const releaseQaLive = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_live_release_checks");
     expect(jobNeeds(releaseQaLive)).toEqual(["resolve_target"]);
@@ -7679,7 +7705,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       expect(420 - childTimeout, `release-checks:${pathName}`).toBeGreaterThanOrEqual(60);
     }
     expect(releaseCrossOsPath.reduce((total, timeout) => total + timeout, 0)).toBe(200);
-    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(265);
+    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(235);
     expect(releaseQaLivePath.reduce((total, timeout) => total + timeout, 0)).toBe(165);
 
     expect(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7636,6 +7636,9 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "root_dockerfile_image_ready")),
     ).toEqual(["preflight", "root_dockerfile_image"]);
     expect(
+      jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_candidate_payload")),
+    ).toEqual(["preflight"]);
+    expect(
       jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_update_image")),
     ).toEqual(["preflight"]);
     expect(
@@ -7643,19 +7646,15 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     ).toEqual(["preflight"]);
     expect(
       jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_update")),
-    ).toEqual([
-      "preflight",
-      "root_dockerfile_image",
-      "root_dockerfile_image_ready",
-      "installer_smoke_update_image",
-    ]);
+    ).toEqual(["preflight", "installer_smoke_candidate_payload", "installer_smoke_update_image"]);
     expect(
       jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke_nonroot")),
-    ).toEqual(["preflight", "installer_smoke_nonroot_image"]);
+    ).toEqual(["preflight", "installer_smoke_candidate_payload", "installer_smoke_nonroot_image"]);
     expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "installer_smoke"))).toEqual([
       "preflight",
       "root_dockerfile_image",
       "root_dockerfile_image_ready",
+      "installer_smoke_candidate_payload",
       "installer_smoke_update_image",
       "installer_smoke_update",
       "installer_smoke_nonroot_image",
@@ -7666,33 +7665,38 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
       timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
       Math.max(
-        timeoutForProfile(installSmoke.jobs?.root_dockerfile_image?.["timeout-minutes"], "stable"),
+        timeoutForProfile(
+          installSmoke.jobs?.installer_smoke_candidate_payload?.["timeout-minutes"],
+          "stable",
+        ),
         timeoutForProfile(
           installSmoke.jobs?.installer_smoke_update_image?.["timeout-minutes"],
           "stable",
         ),
       ),
-      timeoutForProfile(
-        installSmoke.jobs?.root_dockerfile_image_ready?.["timeout-minutes"],
-        "stable",
-      ),
       timeoutForProfile(installSmoke.jobs?.installer_smoke_update?.["timeout-minutes"], "stable"),
       timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
       timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
     ];
-    expect(releaseInstallPath).toEqual([30, 15, 60, 5, 120, 5, 5]);
+    expect(releaseInstallPath).toEqual([30, 15, 75, 120, 5, 5]);
     const releaseInstallNonrootPath = [
       timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
       timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
-      timeoutForProfile(
-        installSmoke.jobs?.installer_smoke_nonroot_image?.["timeout-minutes"],
-        "stable",
+      Math.max(
+        timeoutForProfile(
+          installSmoke.jobs?.installer_smoke_candidate_payload?.["timeout-minutes"],
+          "stable",
+        ),
+        timeoutForProfile(
+          installSmoke.jobs?.installer_smoke_nonroot_image?.["timeout-minutes"],
+          "stable",
+        ),
       ),
       timeoutForProfile(installSmoke.jobs?.installer_smoke_nonroot?.["timeout-minutes"], "stable"),
       timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
       timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
     ];
-    expect(releaseInstallNonrootPath).toEqual([30, 15, 45, 60, 5, 5]);
+    expect(releaseInstallNonrootPath).toEqual([30, 15, 75, 60, 5, 5]);
 
     const releaseQaLive = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_live_release_checks");
     expect(jobNeeds(releaseQaLive)).toEqual(["resolve_target"]);
@@ -7723,8 +7727,8 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       expect(420 - childTimeout, `release-checks:${pathName}`).toBeGreaterThanOrEqual(60);
     }
     expect(releaseCrossOsPath.reduce((total, timeout) => total + timeout, 0)).toBe(200);
-    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(240);
-    expect(releaseInstallNonrootPath.reduce((total, timeout) => total + timeout, 0)).toBe(160);
+    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(250);
+    expect(releaseInstallNonrootPath.reduce((total, timeout) => total + timeout, 0)).toBe(190);
     expect(releaseQaLivePath.reduce((total, timeout) => total + timeout, 0)).toBe(165);
 
     expect(

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -1348,7 +1348,37 @@ printf 'status=%s\\n' "$status"
       'public_latest_version="$(quiet_npm view "$PACKAGE_NAME" version 2>/dev/null || true)"',
     );
     expect(wrapper).toContain('LATEST_VERSION="$public_latest_version"');
+    expect(wrapper).toContain('LATEST_VERSION="$(quiet_npm view "$PACKAGE_NAME" version)"');
     expect(wrapper).toContain('-e OPENCLAW_INSTALL_EXPECT_VERSION="$LATEST_VERSION"');
+  });
+
+  it("runs update and non-root installer groups independently while defaulting to all", () => {
+    const wrapper = readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(wrapper).toContain('INSTALL_SMOKE_GROUP="${OPENCLAW_INSTALL_SMOKE_GROUP:-all}"');
+    expect(wrapper).toContain("RUN_UPDATE_GROUP=0");
+    expect(wrapper).toContain("RUN_NONROOT_GROUP=0");
+    expect(wrapper).toContain('case "$INSTALL_SMOKE_GROUP" in');
+    expect(wrapper).toContain("all)");
+    expect(wrapper).toContain("update)");
+    expect(wrapper).toContain("nonroot)");
+    expect(wrapper).toContain('if [[ "$RUN_UPDATE_GROUP" == "1" ]]');
+    expect(wrapper).toContain('if [[ "$RUN_NONROOT_GROUP" != "1" ]]');
+    expect(wrapper.indexOf('if [[ "$RUN_UPDATE_GROUP" == "1" ]]')).toBeLessThan(
+      wrapper.indexOf('if [[ "$RUN_NONROOT_GROUP" != "1" ]]'),
+    );
+
+    const invalid = spawnSync("bash", [SCRIPT_PATH], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_INSTALL_SMOKE_GROUP: "invalid",
+      },
+    });
+    expect(invalid.status).toBe(2);
+    expect(invalid.stderr).toContain(
+      "OPENCLAW_INSTALL_SMOKE_GROUP must be all, update, or nonroot",
+    );
   });
 });
 
@@ -2104,7 +2134,16 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
 
   it("runs installer packaging from the trusted workflow revision against a nested candidate", () => {
     const workflow = parse(readFileSync(INSTALL_SMOKE_WORKFLOW_PATH, "utf8"));
-    const steps = workflow.jobs.installer_smoke.steps as Array<{
+    const producer = workflow.jobs.installer_smoke_image;
+    const producerSteps = producer.steps as Array<{
+      name?: string;
+      uses?: string;
+      with?: Record<string, unknown>;
+      env?: Record<string, unknown>;
+      run?: string;
+    }>;
+    const consumer = workflow.jobs.installer_smoke_group;
+    const steps = consumer.steps as Array<{
       name?: string;
       uses?: string;
       with?: Record<string, unknown>;
@@ -2130,16 +2169,34 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     expect(step("Setup Node environment for installer smoke").uses).toBe(
       "./.github/actions/setup-node-env",
     );
+    expect(step("Setup Node environment for installer smoke").with).toMatchObject({
+      "install-deps": "${{ matrix.group == 'update' && 'true' || 'false' }}",
+    });
     expect(step("Run installer docker tests").env).toMatchObject({
       OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
+      OPENCLAW_INSTALL_SMOKE_GROUP: "${{ matrix.group }}",
       OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: "${{ github.workspace }}/candidate",
     });
     expect(step("Run installer docker tests").run).toBe("bash scripts/test-install-sh-docker.sh");
-    expect(step("Build installer smoke image").run).toContain(
-      "./scripts/docker/install-sh-smoke/Dockerfile",
-    );
-    expect(step("Build installer smoke image").run).not.toContain("candidate/scripts/docker");
-    expect(step("Build installer non-root image").run).not.toContain("candidate/scripts/docker");
+    const buildStep = producerSteps.find((entry) => entry.name === "Build installer smoke image");
+    expect(buildStep).toBeDefined();
+    expect(buildStep?.run).toContain('-f "$DOCKERFILE"');
+    expect(buildStep?.run).not.toContain("candidate/scripts/docker");
+    expect(producer.strategy).toMatchObject({
+      "fail-fast": false,
+      matrix: {
+        include: [
+          { dockerfile: "./scripts/docker/install-sh-smoke/Dockerfile", group: "update" },
+          { dockerfile: "./scripts/docker/install-sh-nonroot/Dockerfile", group: "nonroot" },
+        ],
+      },
+    });
+    expect(consumer.strategy).toMatchObject({
+      "fail-fast": false,
+      matrix: {
+        include: [{ group: "update" }, { group: "nonroot" }],
+      },
+    });
     expect(step("Run Rocky Linux installer smoke").run).toContain(
       "$PWD/candidate/scripts/install.sh",
     );

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2134,72 +2134,79 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
 
   it("runs installer packaging from the trusted workflow revision against a nested candidate", () => {
     const workflow = parse(readFileSync(INSTALL_SMOKE_WORKFLOW_PATH, "utf8"));
-    const producer = workflow.jobs.installer_smoke_image;
-    const producerSteps = producer.steps as Array<{
-      name?: string;
-      uses?: string;
-      with?: Record<string, unknown>;
-      env?: Record<string, unknown>;
-      run?: string;
-    }>;
-    const consumer = workflow.jobs.installer_smoke_group;
-    const steps = consumer.steps as Array<{
-      name?: string;
-      uses?: string;
-      with?: Record<string, unknown>;
-      env?: Record<string, unknown>;
-      run?: string;
-    }>;
-    const step = (name: string) => {
-      const found = steps.find((entry) => entry.name === name);
+    const cases = [
+      {
+        buildName: "Build installer smoke image",
+        consumerName: "installer_smoke_update",
+        dockerfile: "./scripts/docker/install-sh-smoke/Dockerfile",
+        group: "update",
+        producerName: "installer_smoke_update_image",
+        setupName: "Setup Node environment for installer update smoke",
+        testName: "Run installer update docker tests",
+      },
+      {
+        buildName: "Build installer non-root image",
+        consumerName: "installer_smoke_nonroot",
+        dockerfile: "./scripts/docker/install-sh-nonroot/Dockerfile",
+        group: "nonroot",
+        producerName: "installer_smoke_nonroot_image",
+        setupName: "Setup Node environment for installer non-root smoke",
+        testName: "Run installer non-root docker tests",
+      },
+    ] as const;
+    const workflowStep = (
+      workflowJob: { steps?: Array<Record<string, unknown>> },
+      name: string,
+    ) => {
+      const found = workflowJob.steps?.find((entry) => entry.name === name);
       expect(found, name).toBeDefined();
       return found!;
     };
 
-    expect(step("Checkout trusted installer harness").with).toMatchObject({
-      repository: "${{ needs.preflight.outputs.workflow_repository }}",
-      ref: "${{ needs.preflight.outputs.workflow_sha }}",
-      "persist-credentials": false,
-    });
-    expect(step("Checkout candidate CLI").with).toMatchObject({
-      ref: "${{ needs.preflight.outputs.target_sha }}",
-      path: "candidate",
-      "persist-credentials": false,
-    });
-    expect(step("Setup Node environment for installer smoke").uses).toBe(
-      "./.github/actions/setup-node-env",
-    );
-    expect(step("Setup Node environment for installer smoke").with).toMatchObject({
-      "install-deps": "${{ matrix.group == 'update' && 'true' || 'false' }}",
-    });
-    expect(step("Run installer docker tests").env).toMatchObject({
+    for (const testCase of cases) {
+      const producer = workflow.jobs[testCase.producerName];
+      const consumer = workflow.jobs[testCase.consumerName];
+      expect(workflowStep(producer, "Checkout trusted installer harness").with).toMatchObject({
+        repository: "${{ needs.preflight.outputs.workflow_repository }}",
+        ref: "${{ needs.preflight.outputs.workflow_sha }}",
+        "persist-credentials": false,
+      });
+      const buildStep = workflowStep(producer, testCase.buildName);
+      expect(buildStep.run).toContain(`-f ${testCase.dockerfile}`);
+      expect(buildStep.run).not.toContain("candidate/scripts/docker");
+
+      expect(workflowStep(consumer, "Checkout trusted installer harness").with).toMatchObject({
+        repository: "${{ needs.preflight.outputs.workflow_repository }}",
+        ref: "${{ needs.preflight.outputs.workflow_sha }}",
+        "persist-credentials": false,
+      });
+      expect(workflowStep(consumer, "Checkout candidate CLI").with).toMatchObject({
+        ref: "${{ needs.preflight.outputs.target_sha }}",
+        path: "candidate",
+        "persist-credentials": false,
+      });
+      const setup = workflowStep(consumer, testCase.setupName);
+      expect(setup.uses).toBe("./.github/actions/setup-node-env");
+      expect(setup.with).toMatchObject({
+        "cache-mode": testCase.group === "update" ? "restore" : "off",
+        "install-deps": testCase.group === "update" ? "true" : "false",
+      });
+      const run = workflowStep(consumer, testCase.testName);
+      expect(run.env).toMatchObject({
+        OPENCLAW_INSTALL_SMOKE_GROUP: testCase.group,
+        OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: "${{ github.workspace }}/candidate",
+      });
+      expect(run.run).toBe("bash scripts/test-install-sh-docker.sh");
+    }
+
+    expect(
+      workflowStep(workflow.jobs.installer_smoke_update, "Run installer update docker tests").env,
+    ).toMatchObject({
       OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
-      OPENCLAW_INSTALL_SMOKE_GROUP: "${{ matrix.group }}",
-      OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: "${{ github.workspace }}/candidate",
     });
-    expect(step("Run installer docker tests").run).toBe("bash scripts/test-install-sh-docker.sh");
-    const buildStep = producerSteps.find((entry) => entry.name === "Build installer smoke image");
-    expect(buildStep).toBeDefined();
-    expect(buildStep?.run).toContain('-f "$DOCKERFILE"');
-    expect(buildStep?.run).not.toContain("candidate/scripts/docker");
-    expect(producer.strategy).toMatchObject({
-      "fail-fast": false,
-      matrix: {
-        include: [
-          { dockerfile: "./scripts/docker/install-sh-smoke/Dockerfile", group: "update" },
-          { dockerfile: "./scripts/docker/install-sh-nonroot/Dockerfile", group: "nonroot" },
-        ],
-      },
-    });
-    expect(consumer.strategy).toMatchObject({
-      "fail-fast": false,
-      matrix: {
-        include: [{ group: "update" }, { group: "nonroot" }],
-      },
-    });
-    expect(step("Run Rocky Linux installer smoke").run).toContain(
-      "$PWD/candidate/scripts/install.sh",
-    );
+    expect(
+      workflowStep(workflow.jobs.installer_smoke_update, "Run Rocky Linux installer smoke").run,
+    ).toContain("$PWD/candidate/scripts/install.sh");
   });
 
   it("kills Bun global install smoke commands that ignore TERM after timeout", () => {

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -558,6 +558,44 @@ function extractReadPackTarballFilename(): string {
   return expectDefined(match[1], "pack tarball filename helper capture");
 }
 
+function extractInstallSmokePackHelper(name: string, nextName: string): string {
+  const script = readFileSync(SCRIPT_PATH, "utf8");
+  const start = script.indexOf(`${name}() {`);
+  const end = script.indexOf(`\n\n${nextName}() {`, start);
+  if (start < 0 || end <= start) {
+    throw new Error(`${name} helper was not found`);
+  }
+  return script.slice(start, end);
+}
+
+function runInstallSmokePackHelpers(packJson: unknown, budgetBytes = 204 * 1024 * 1024) {
+  const root = tempDirs.make("openclaw-install-pack-helper-");
+  const packJsonPath = join(root, "pack.json");
+  writeFileSync(packJsonPath, JSON.stringify(packJson), "utf8");
+  const result = spawnSync(
+    "bash",
+    [
+      "--noprofile",
+      "--norc",
+      "-c",
+      `set -euo pipefail
+${extractInstallSmokePackHelper("normalize_npm_pack_json_file", "run_install_smoke_container")}
+${extractInstallSmokePackHelper("assert_pack_unpacked_size_budget", "print_pack_delta_audit")}
+normalize_npm_pack_json_file "$PACK_JSON_PATH"
+assert_pack_unpacked_size_budget "fixture" "$PACK_JSON_PATH"`,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_INSTALL_SMOKE_PACK_UNPACKED_BUDGET_BYTES: String(budgetBytes),
+        PACK_JSON_PATH: packJsonPath,
+      },
+    },
+  );
+  return { normalized: JSON.parse(readFileSync(packJsonPath, "utf8")), result };
+}
+
 function runReadPackTarballFilename(filename: string) {
   return spawnSync(
     "bash",
@@ -1212,8 +1250,36 @@ printf 'status=%s\\n' "$status"
 
     expect(script).toContain("assert_pack_unpacked_size_budget");
     expect(script).toContain('assert_pack_unpacked_size_budget "update" "$pack_json_file"');
-    expect(script).toContain('from "./scripts/lib/npm-pack-budget.mts"');
+    expect(script).toContain("204 * 1024 * 1024");
     expect(script).toContain("install smoke cannot verify pack budget");
+  });
+
+  it("normalizes npm 12 pack output and enforces the budget without tsx", () => {
+    const withinBudget = runInstallSmokePackHelpers({
+      openclaw: {
+        filename: "openclaw-2026.8.1.tgz",
+        unpackedSize: 100,
+        version: "2026.8.1",
+      },
+    });
+    expect(withinBudget.result.status).toBe(0);
+    expect(withinBudget.result.stderr).toBe("");
+    expect(withinBudget.normalized).toEqual([
+      {
+        filename: "openclaw-2026.8.1.tgz",
+        unpackedSize: 100,
+        version: "2026.8.1",
+      },
+    ]);
+
+    const oversized = runInstallSmokePackHelpers(
+      [{ name: "ignored" }, { filename: "candidate.tgz", unpackedSize: 101 }],
+      100,
+    );
+    expect(oversized.result.status).not.toBe(0);
+    expect(oversized.result.stderr).toContain(
+      "candidate.tgz unpackedSize 101 bytes exceeds budget 100 bytes",
+    );
   });
 
   it("keeps npm pack tarball filenames local before serving update artifacts", () => {
@@ -1272,11 +1338,39 @@ printf 'status=%s\\n' "$status"
     expect(script).toContain("--require-bundled-workspace-deps");
   });
 
+  it("keeps frozen payload mode free of candidate build and normalization work", () => {
+    const script = readFileSync(SCRIPT_PATH, "utf8");
+    const prepareStart = script.indexOf("prepare_update_tarball() {");
+    const frozenStart = script.indexOf('if [[ -n "$FROZEN_PAYLOAD_DIR" ]]; then', prepareStart);
+    const packageSpecBranch = script.indexOf('elif [[ -n "$UPDATE_PACKAGE_SPEC" ]]', frozenStart);
+    const frozenBranch = script.slice(frozenStart, packageSpecBranch);
+
+    expect(prepareStart).toBeGreaterThan(0);
+    expect(frozenStart).toBeGreaterThan(0);
+    expect(packageSpecBranch).toBeGreaterThan(frozenStart);
+    expect(frozenBranch).toContain('cp "$FROZEN_PAYLOAD_DIR/candidate.tgz"');
+    expect(frozenBranch).toContain('cp "$FROZEN_PAYLOAD_DIR/candidate-pack.json"');
+    expect(frozenBranch).not.toContain("pnpm build");
+    expect(frozenBranch).not.toContain("package-openclaw-for-docker");
+    expect(frozenBranch).not.toContain("normalize_npm_pack_json_file");
+    expect(script).not.toContain("node --import tsx");
+    expect(script).toContain('if [[ -z "$FROZEN_PAYLOAD_DIR" ]]; then');
+    expect(script).toContain(
+      'require_regular_payload_file "$FROZEN_PAYLOAD_DIR/install.sh" "installer"',
+    );
+    expect(script).toContain(
+      'require_regular_payload_file "$FROZEN_PAYLOAD_DIR/install-cli.sh" "CLI installer"',
+    );
+  });
+
   it("runs candidate tarballs through the installer script instead of direct npm", () => {
     const wrapper = readFileSync(SCRIPT_PATH, "utf8");
     const runner = readFileSync(SMOKE_RUNNER_PATH, "utf8");
 
-    expect(wrapper).toContain('-v "$ROOT_DIR/scripts/install.sh:/tmp/openclaw-install.sh:ro"');
+    expect(wrapper).toContain('-v "$INSTALL_SCRIPT_PATH:/tmp/openclaw-install.sh:ro"');
+    expect(wrapper).toContain(
+      'FROZEN_PAYLOAD_DIR="${OPENCLAW_INSTALL_SMOKE_FROZEN_PAYLOAD_DIR:-}"',
+    );
     expect(runner).toContain("Run official installer one-liner for latest release tarball");
     expect(runner).toContain("run_installer_pipeline");
     expect(runner).toContain('--version "$FRESH_TAG_URL"');
@@ -2115,7 +2209,8 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     expect(workflow).toContain('OPENCLAW_INSTALL_SMOKE_SKIP_CLI: "0"');
     expect(workflow).toContain("Run Rocky Linux installer smoke");
     expect(workflow).toContain("Run Rocky Linux CLI installer smoke");
-    expect(workflow).toContain("scripts/install-cli.sh:/tmp/install-cli.sh:ro");
+    expect(workflow).toContain("PAYLOAD_DIR: ${{ runner.temp }}/install-smoke-candidate-payload");
+    expect(workflow).toContain("$PAYLOAD_DIR/install-cli.sh:/tmp/install-cli.sh:ro");
     expect(workflow).toContain("bash /tmp/install-cli.sh --prefix /tmp/openclaw-cli");
     expect(workflow).toContain("rockylinux:9@sha256:");
     expect(workflow).toContain("pnpm-workspace.yaml");
@@ -2132,7 +2227,7 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     expect(releaseChecks).toContain("run_bun_global_install_smoke: true");
   });
 
-  it("runs installer packaging from the trusted workflow revision against a nested candidate", () => {
+  it("packages candidate bytes in isolation and gives consumers only verified artifacts", () => {
     const workflow = parse(readFileSync(INSTALL_SMOKE_WORKFLOW_PATH, "utf8"));
     const cases = [
       {
@@ -2141,7 +2236,6 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
         dockerfile: "./scripts/docker/install-sh-smoke/Dockerfile",
         group: "update",
         producerName: "installer_smoke_update_image",
-        setupName: "Setup Node environment for installer update smoke",
         testName: "Run installer update docker tests",
       },
       {
@@ -2150,7 +2244,6 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
         dockerfile: "./scripts/docker/install-sh-nonroot/Dockerfile",
         group: "nonroot",
         producerName: "installer_smoke_nonroot_image",
-        setupName: "Setup Node environment for installer non-root smoke",
         testName: "Run installer non-root docker tests",
       },
     ] as const;
@@ -2167,8 +2260,8 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
       const producer = workflow.jobs[testCase.producerName];
       const consumer = workflow.jobs[testCase.consumerName];
       expect(workflowStep(producer, "Checkout trusted installer harness").with).toMatchObject({
-        repository: "${{ needs.preflight.outputs.workflow_repository }}",
-        ref: "${{ needs.preflight.outputs.workflow_sha }}",
+        repository: "${{ fromJSON(toJSON(job)).workflow_repository }}",
+        ref: "${{ fromJSON(toJSON(job)).workflow_sha }}",
         "persist-credentials": false,
       });
       const buildStep = workflowStep(producer, testCase.buildName);
@@ -2176,37 +2269,47 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
       expect(buildStep.run).not.toContain("candidate/scripts/docker");
 
       expect(workflowStep(consumer, "Checkout trusted installer harness").with).toMatchObject({
-        repository: "${{ needs.preflight.outputs.workflow_repository }}",
-        ref: "${{ needs.preflight.outputs.workflow_sha }}",
+        repository: "${{ fromJSON(toJSON(job)).workflow_repository }}",
+        ref: "${{ fromJSON(toJSON(job)).workflow_sha }}",
         "persist-credentials": false,
       });
-      expect(workflowStep(consumer, "Checkout candidate CLI").with).toMatchObject({
-        ref: "${{ needs.preflight.outputs.target_sha }}",
-        path: "candidate",
-        "persist-credentials": false,
-      });
-      const setup = workflowStep(consumer, testCase.setupName);
-      expect(setup.uses).toBe("./.github/actions/setup-node-env");
-      expect(setup.with).toMatchObject({
-        "cache-mode": testCase.group === "update" ? "restore" : "off",
-        "install-deps": testCase.group === "update" ? "true" : "false",
-      });
+      expect(
+        consumer.steps.find((entry: { name?: string }) => entry.name === "Checkout candidate CLI"),
+      ).toBeUndefined();
+      expect(
+        consumer.steps.find((entry: { uses?: string }) =>
+          entry.uses?.includes("./.github/actions/setup-node-env"),
+        ),
+      ).toBeUndefined();
+      expect(workflowStep(consumer, "Validate candidate payload artifact binding").run).toContain(
+        'verify-upload "Candidate payload"',
+      );
+      expect(workflowStep(consumer, "Verify candidate payload contents").run).toContain(
+        "install-smoke-candidate-payload.mts verify",
+      );
       const run = workflowStep(consumer, testCase.testName);
       expect(run.env).toMatchObject({
+        OPENCLAW_INSTALL_SMOKE_FROZEN_PAYLOAD_DIR:
+          "${{ runner.temp }}/install-smoke-candidate-payload",
         OPENCLAW_INSTALL_SMOKE_GROUP: testCase.group,
-        OPENCLAW_INSTALL_SMOKE_SOURCE_DIR: "${{ github.workspace }}/candidate",
       });
       expect(run.run).toBe("bash scripts/test-install-sh-docker.sh");
     }
 
-    expect(
-      workflowStep(workflow.jobs.installer_smoke_update, "Run installer update docker tests").env,
-    ).toMatchObject({
-      OPENCLAW_INSTALL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
-    });
+    const payload = workflow.jobs.installer_smoke_candidate_payload;
+    expect(payload.needs).toEqual(["preflight"]);
+    expect(workflowStep(payload, "Download exact candidate source archive").run).toContain(
+      "https://codeload.github.com/${TARGET_REPOSITORY}/tar.gz/${TARGET_SHA}",
+    );
+    expect(workflowStep(payload, "Package candidate only inside pinned harness").run).toContain(
+      "--user node",
+    );
+    expect(workflowStep(payload, "Seal candidate payload in clean pinned harness").run).toContain(
+      "--network none",
+    );
     expect(
       workflowStep(workflow.jobs.installer_smoke_update, "Run Rocky Linux installer smoke").run,
-    ).toContain("$PWD/candidate/scripts/install.sh");
+    ).toContain("$PAYLOAD_DIR/install.sh");
   });
 
   it("kills Bun global install smoke commands that ignore TERM after timeout", () => {

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2173,7 +2173,7 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     expect(workflow).toContain('install-bun: "true"');
     expect(workflow).toContain('install-bun: "false"');
     expect(workflow).toContain("Run Bun global install image-provider smoke");
-    expect(workflow).toContain("bash scripts/e2e/bun-global-install-smoke.sh");
+    expect(workflow).toContain("bash .release-harness/scripts/e2e/bun-global-install-smoke.sh");
     expect(workflow).toContain(
       "OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}",
     );
@@ -2259,18 +2259,20 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     for (const testCase of cases) {
       const producer = workflow.jobs[testCase.producerName];
       const consumer = workflow.jobs[testCase.consumerName];
-      expect(workflowStep(producer, "Checkout trusted installer harness").with).toMatchObject({
-        repository: "${{ fromJSON(toJSON(job)).workflow_repository }}",
-        ref: "${{ fromJSON(toJSON(job)).workflow_sha }}",
+      expect(workflowStep(producer, "Checkout trusted release harness").with).toMatchObject({
+        repository: "openclaw/openclaw",
+        ref: "main",
+        "fetch-depth": 1,
         "persist-credentials": false,
       });
       const buildStep = workflowStep(producer, testCase.buildName);
-      expect(buildStep.run).toContain(`-f ${testCase.dockerfile}`);
+      expect(buildStep.run).toContain(`-f ./.release-harness/${testCase.dockerfile.slice(2)}`);
       expect(buildStep.run).not.toContain("candidate/scripts/docker");
 
-      expect(workflowStep(consumer, "Checkout trusted installer harness").with).toMatchObject({
-        repository: "${{ fromJSON(toJSON(job)).workflow_repository }}",
-        ref: "${{ fromJSON(toJSON(job)).workflow_sha }}",
+      expect(workflowStep(consumer, "Checkout trusted release harness").with).toMatchObject({
+        repository: "openclaw/openclaw",
+        ref: "main",
+        "fetch-depth": 1,
         "persist-credentials": false,
       });
       expect(
@@ -2293,7 +2295,7 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
           "${{ runner.temp }}/install-smoke-candidate-payload",
         OPENCLAW_INSTALL_SMOKE_GROUP: testCase.group,
       });
-      expect(run.run).toBe("bash scripts/test-install-sh-docker.sh");
+      expect(run.run).toBe("bash .release-harness/scripts/test-install-sh-docker.sh");
     }
 
     const payload = workflow.jobs.installer_smoke_candidate_payload;

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2169,11 +2169,14 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
       "if: needs.preflight.outputs.run_full_install_smoke == 'true' && needs.preflight.outputs.run_bun_global_install_smoke == 'true'",
     );
     expect(workflow).toContain("bun_global_install_smoke:");
-    expect(workflow).toContain("Setup Node environment for Bun smoke");
-    expect(workflow).toContain('install-bun: "true"');
+    expect(workflow).toContain("Setup trusted release harness for Bun smoke");
+    expect(workflow).toContain("uses: ./.release-harness/.github/actions/setup-release-harness");
+    expect(workflow).toContain("npm install -g bun@1.3.14");
     expect(workflow).toContain('install-bun: "false"');
     expect(workflow).toContain("Run Bun global install image-provider smoke");
-    expect(workflow).toContain("bash .release-harness/scripts/e2e/bun-global-install-smoke.sh");
+    expect(workflow).toContain("working-directory: .release-harness");
+    expect(workflow).toContain("bash scripts/e2e/bun-global-install-smoke.sh");
+    expect(workflow).not.toContain("uses: ./.release-harness/.github/actions/setup-node-env");
     expect(workflow).toContain(
       "OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}",
     );


### PR DESCRIPTION
Related: #127107

## What Problem This Solves

Release installer validation serialized independent update and non-root coverage behind shared image preparation, adding roughly 15 minutes to the release critical path and hiding sibling failures. The first parallel implementation also checked out and executed the selected candidate in cache-capable consumer jobs, which CodeQL correctly rejected as a cache-poisoning trust path.

## Why This Change Was Made

The installer workflow now runs update and non-root producer-consumer pairs independently and retains one always-running aggregate gate.

Candidate handling is a separate parallel producer:

- downloads the exact target archive as bytes, without a candidate checkout;
- installs, builds, and packages only inside a pinned, token-free Docker harness;
- seals package bytes and regular-file installer copies in a second network-disabled harness;
- emits a manifest binding repository, target SHA, trusted harness repository/SHA, run ID/attempt, package version, source digest, and every payload file digest.

Both consumer jobs now use only the verified payload artifact and their verified image artifact. They do not check out candidate code, hydrate dependencies, restore dependency caches, or run candidate packaging on the host. Frozen installer mode mounts the verified scripts and reuses the sealed tarball/pack metadata without candidate build, source packaging, or TSX normalization.

## User Impact

Release qualification captures update and non-root installer failures in one run, keeps the independent failure-draining DAG, and removes candidate execution from cache-capable consumer hosts.

## Evidence

- Exact head: `10ec369a6583f80e4a6c7d0e2440d9760c018ab9`
- 329 focused installer, payload-tamper, workflow, and package-acceptance tests passed.
- Payload tests cover all four file digests, manifest tampering, tuple drift, source-archive digest drift, unexpected files, and symlinked/non-regular installer or package inputs.
- YAML parse, actionlint, Bash syntax, formatting, `git diff --check`, script erasability, dependency pins, package patches, and privacy scrub passed.
- The exact pinned Node 24 image executes the new helper.
- Production/tooling LOC: +866/-132 (net +734); tests: +410/-78 (net +332). Growth is the explicit security boundary: isolated candidate packaging, clean sealing, full tuple/digest verification, and frozen artifact consumption.
- `check-changed` passed every guard before script typecheck. The typecheck could not run in this sparse GWT because unrelated tracked `ui/config/*` files are absent; no dependency reconciliation or sparse-checkout mutation was performed.
- Previous exact-head baseline before this security patch: hosted installer smoke with Bun enabled passed in 26m32s: https://github.com/openclaw/openclaw/actions/runs/32484378784.
- Hosted exact-head installer smoke and replacement CodeQL are pending for this head.
