### PR TITLE
perf(ci): shard full release repository E2E

### DIFF
--- a/.github/repo-e2e-capabilities.json
+++ b/.github/repo-e2e-capabilities.json
@@ -1,0 +1,12 @@
+{
+  "schema": "openclaw.repo-e2e-capabilities/v1",
+  "schemaVersion": 1,
+  "repoE2eShards": {
+    "agentPluginGateway": true,
+    "gatewayShards": 4,
+    "realGatewayUi": true,
+    "runtimeBuildProfile": "repoE2eRuntime",
+    "sandboxArtifact": true,
+    "uiShards": 4
+  }
+}

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -544,7 +544,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
-      repo_e2e_shards_available: ${{ steps.validate.outputs.repo_e2e_shards_available }}
+      repo_e2e_shards_available: ${{ steps.repo_e2e.outputs.repo_e2e_shards_available }}
       selected_sha: ${{ steps.validate.outputs.selected_sha }}
       trusted_reason: ${{ steps.validate.outputs.trusted_reason }}
       workflow_repository: ${{ steps.workflow.outputs.workflow_repository }}
@@ -587,6 +587,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout trusted repo E2E capability validator
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ steps.workflow.outputs.workflow_repository }}
+          ref: ${{ steps.workflow.outputs.workflow_sha }}
+          path: .release-harness
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Validate selected ref
         id: validate
         env:
@@ -617,7 +626,6 @@ jobs:
           SHARED_IMAGE_ARTIFACT_RUN_ID: ${{ inputs.shared_image_artifact_run_id }}
           SHARED_IMAGE_ARCHIVE_SHA256: ${{ inputs.shared_image_archive_sha256 }}
           SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
-          WORKFLOW_SHA: ${{ steps.workflow.outputs.workflow_sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -768,48 +776,36 @@ jobs:
               ;;
           esac
 
-          repo_e2e_shards_available=true
-          if [[ "$selected_sha" != "$WORKFLOW_SHA" ]]; then
-            repo_e2e_shards_available=false
-          fi
-          required_repo_e2e_paths=(
-            scripts/agent-plugin-gateway-e2e.ts
-            scripts/build-all.mts
-            scripts/ensure-playwright-chromium.mts
-            test/vitest/vitest.e2e.config.ts
-            test/vitest/vitest.e2e.global-setup.ts
-            test/vitest/vitest.ui-e2e.config.ts
-            test/vitest/vitest.ui-e2e.global-setup.ts
-            test/vitest/vitest.ui-e2e.sequencer.ts
-          )
-          for required_path in "${required_repo_e2e_paths[@]}"; do
-            if ! git cat-file -e "${selected_sha}:${required_path}" 2>/dev/null; then
-              repo_e2e_shards_available=false
-              break
-            fi
-          done
-          if [[ "$repo_e2e_shards_available" == "true" ]] &&
-            ! git grep -Fq 'repoE2eRuntime:' "$selected_sha" -- scripts/build-all.mts; then
-            repo_e2e_shards_available=false
-          fi
-          if [[ "$repo_e2e_shards_available" == "true" ]] &&
-            ! git grep -Fq 'OPENCLAW_E2E_USE_PREBUILT_DIST' "$selected_sha" -- test/vitest/vitest.e2e.global-setup.ts; then
-            repo_e2e_shards_available=false
-          fi
-          if [[ "$repo_e2e_shards_available" == "true" ]] &&
-            ! git grep -Fq 'OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY' "$selected_sha" -- test/vitest/vitest.ui-e2e.config.ts; then
-            repo_e2e_shards_available=false
-          fi
-
-          echo "repo_e2e_shards_available=$repo_e2e_shards_available" >> "$GITHUB_OUTPUT"
           echo "selected_sha=$selected_sha" >> "$GITHUB_OUTPUT"
           echo "trusted_reason=$trusted_reason" >> "$GITHUB_OUTPUT"
           {
             echo "Validated ref: \`${INPUT_REF}\`"
             echo "Resolved SHA: \`$selected_sha\`"
             echo "Trust reason: \`$trusted_reason\`"
-            echo "Repo E2E mode: \`$([[ "$repo_e2e_shards_available" == "true" ]] && echo sharded || echo legacy)\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Resolve repo E2E capability
+        id: repo_e2e
+        env:
+          CAPABILITY_PATH: .github/repo-e2e-capabilities.json
+          SELECTED_SHA: ${{ steps.validate.outputs.selected_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          manifest_path="${RUNNER_TEMP}/repo-e2e-capabilities.json"
+          rm -f "$manifest_path"
+          if git cat-file -e "${SELECTED_SHA}:${CAPABILITY_PATH}" 2>/dev/null; then
+            manifest_size="$(git cat-file -s "${SELECTED_SHA}:${CAPABILITY_PATH}")"
+            if [[ "$manifest_size" =~ ^[0-9]+$ && "$manifest_size" -le 8192 ]]; then
+              git show "${SELECTED_SHA}:${CAPABILITY_PATH}" > "$manifest_path"
+            else
+              printf '{"invalid":"oversized"}\n' > "$manifest_path"
+            fi
+          fi
+          node .release-harness/scripts/validate-repo-e2e-capability.mjs \
+            --manifest "$manifest_path" \
+            --github-output "$GITHUB_OUTPUT" \
+            --github-step-summary "$GITHUB_STEP_SUMMARY"
 
   validate_live_suite_filter:
     runs-on: ubuntu-24.04
@@ -1039,6 +1035,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
+          cache-mode: restore
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
           build-all-cache-scope: full
@@ -1055,8 +1052,9 @@ jobs:
           WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
         run: |
           set -euo pipefail
-          artifact_name="repo-e2e-runtime-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          archive_name="${artifact_name}.tar.zst"
+          artifact_stem="repo-e2e-runtime-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          archive_name="${artifact_stem}.tar.zst"
+          artifact_name="$archive_name"
           archive_path="${RUNNER_TEMP}/${archive_name}"
           bundle_root="${RUNNER_TEMP}/repo-e2e-runtime-bundle"
           archive_root="repo-e2e-runtime"
@@ -1235,6 +1233,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
+          cache-mode: restore
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
@@ -1249,7 +1248,7 @@ jobs:
           TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
         run: |
           set -euo pipefail
-          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}.tar.zst"
           [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
             echo "Repo E2E runtime artifact name does not match the target and producer run attempt." >&2
             exit 1
@@ -1396,6 +1395,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
+          cache-mode: restore
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
@@ -1410,7 +1410,7 @@ jobs:
           TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
         run: |
           set -euo pipefail
-          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}.tar.zst"
           [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
             echo "Repo E2E runtime artifact name does not match the target and producer run attempt." >&2
             exit 1
@@ -1501,6 +1501,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
+          cache-mode: restore
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
@@ -1560,6 +1561,7 @@ jobs:
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
+          cache-mode: restore
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
@@ -1574,7 +1576,7 @@ jobs:
           TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
         run: |
           set -euo pipefail
-          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}.tar.zst"
           [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
             echo "Repo E2E runtime artifact name does not match the target and producer run attempt." >&2
             exit 1

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -544,6 +544,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
+      repo_e2e_shards_available: ${{ steps.validate.outputs.repo_e2e_shards_available }}
       selected_sha: ${{ steps.validate.outputs.selected_sha }}
       trusted_reason: ${{ steps.validate.outputs.trusted_reason }}
       workflow_repository: ${{ steps.workflow.outputs.workflow_repository }}
@@ -766,12 +767,45 @@ jobs:
               ;;
           esac
 
+          repo_e2e_shards_available=true
+          required_repo_e2e_paths=(
+            scripts/agent-plugin-gateway-e2e.ts
+            scripts/build-all.mts
+            scripts/docker/shared-image-artifact.sh
+            scripts/ensure-playwright-chromium.mts
+            test/vitest/vitest.e2e.config.ts
+            test/vitest/vitest.e2e.global-setup.ts
+            test/vitest/vitest.ui-e2e.config.ts
+            test/vitest/vitest.ui-e2e.global-setup.ts
+            test/vitest/vitest.ui-e2e.sequencer.ts
+          )
+          for required_path in "${required_repo_e2e_paths[@]}"; do
+            if ! git cat-file -e "${selected_sha}:${required_path}" 2>/dev/null; then
+              repo_e2e_shards_available=false
+              break
+            fi
+          done
+          if [[ "$repo_e2e_shards_available" == "true" ]] &&
+            ! git grep -Fq 'qaRuntime:' "$selected_sha" -- scripts/build-all.mts; then
+            repo_e2e_shards_available=false
+          fi
+          if [[ "$repo_e2e_shards_available" == "true" ]] &&
+            ! git grep -Fq 'OPENCLAW_E2E_USE_PREBUILT_DIST' "$selected_sha" -- test/vitest/vitest.e2e.global-setup.ts; then
+            repo_e2e_shards_available=false
+          fi
+          if [[ "$repo_e2e_shards_available" == "true" ]] &&
+            ! git grep -Fq 'OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY' "$selected_sha" -- test/vitest/vitest.ui-e2e.config.ts; then
+            repo_e2e_shards_available=false
+          fi
+
+          echo "repo_e2e_shards_available=$repo_e2e_shards_available" >> "$GITHUB_OUTPUT"
           echo "selected_sha=$selected_sha" >> "$GITHUB_OUTPUT"
           echo "trusted_reason=$trusted_reason" >> "$GITHUB_OUTPUT"
           {
             echo "Validated ref: \`${INPUT_REF}\`"
             echo "Resolved SHA: \`$selected_sha\`"
             echo "Trust reason: \`$trusted_reason\`"
+            echo "Repo E2E mode: \`$([[ "$repo_e2e_shards_available" == "true" ]] && echo sharded || echo legacy)\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   validate_live_suite_filter:
@@ -974,11 +1008,315 @@ jobs:
             sleep $((attempt * 15))
           done
 
-  validate_repo_e2e:
+  prepare_repo_e2e_runtime:
     needs: validate_selected_ref
-    if: inputs.include_repo_e2e && inputs.live_suite_filter == ''
+    if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
     continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
+    timeout-minutes: 25
+    env:
+      OPENCLAW_BUILD_PRIVATE_QA: "1"
+      OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "true"
+          build-all-cache-scope: full
+
+      - name: Build private QA runtime once
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: pnpm build qaRuntime
+
+      - name: Pack repo E2E runtime
+        run: >-
+          tar --posix -cf repo-e2e-runtime.tar.zst
+          --use-compress-program zstdmt
+          dist dist-runtime packages/*/dist
+
+      - name: Upload repo E2E runtime
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: repo-e2e-runtime-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: repo-e2e-runtime.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
+  prepare_repo_e2e_sandbox:
+    needs: validate_selected_ref
+    if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
+    continue-on-error: ${{ inputs.advisory }}
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
+    timeout-minutes: 25
+    outputs:
+      archive_sha256: ${{ steps.pack.outputs.archive_sha256 }}
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Build repo E2E sandbox image
+        run: scripts/sandbox-setup.sh
+
+      - name: Pack repo E2E sandbox image
+        id: pack
+        env:
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          artifact_dir="${RUNNER_TEMP}/repo-e2e-sandbox-artifact"
+          scripts/docker/shared-image-artifact.sh \
+            pack \
+            "$artifact_dir" \
+            repo-e2e-sandbox \
+            "$TARGET_SHA" \
+            "$WORKFLOW_SHA" \
+            openclaw-sandbox:bookworm-slim
+          archive_sha256="$(jq -er '.archive.sha256' "$artifact_dir/shared-image-artifact.json")"
+          echo "archive_sha256=$archive_sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload repo E2E sandbox image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: repo-e2e-sandbox-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/repo-e2e-sandbox-artifact
+          if-no-files-found: error
+          retention-days: 1
+
+  validate_repo_e2e_gateway:
+    needs: [validate_selected_ref, prepare_repo_e2e_runtime, prepare_repo_e2e_sandbox]
+    if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
+    continue-on-error: ${{ inputs.advisory }}
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      OPENCLAW_BUILD_PRIVATE_QA: "1"
+      OPENCLAW_E2E_USE_PREBUILT_DIST: "1"
+      OPENCLAW_E2E_WORKERS: "1"
+      OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "true"
+
+      - name: Download repo E2E runtime
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: repo-e2e-runtime-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/repo-e2e-runtime
+
+      - name: Extract repo E2E runtime
+        run: >-
+          tar --extract
+          --file .artifacts/repo-e2e-runtime/repo-e2e-runtime.tar.zst
+          --use-compress-program unzstd
+
+      - name: Download repo E2E sandbox image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: repo-e2e-sandbox-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/repo-e2e-sandbox
+
+      - name: Load repo E2E sandbox image
+        env:
+          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.prepare_repo_e2e_sandbox.outputs.archive_sha256 }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ github.run_id }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        run: >-
+          scripts/docker/shared-image-artifact.sh
+          load
+          .artifacts/repo-e2e-sandbox
+          repo-e2e-sandbox
+          "$TARGET_SHA"
+          "$WORKFLOW_SHA"
+          openclaw-sandbox:bookworm-slim
+
+      - name: Run repo Gateway E2E shard
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: >-
+          node scripts/run-vitest.mjs run
+          --config test/vitest/vitest.e2e.config.ts
+          --shard "$SHARD_INDEX/4"
+
+  validate_repo_e2e_agent_plugin:
+    needs: [validate_selected_ref, prepare_repo_e2e_runtime]
+    if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
+    continue-on-error: ${{ inputs.advisory }}
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
+    timeout-minutes: 20
+    env:
+      OPENCLAW_BUILD_PRIVATE_QA: "1"
+      OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+
+      - name: Download repo E2E runtime
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: repo-e2e-runtime-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/repo-e2e-runtime
+
+      - name: Extract repo E2E runtime
+        run: >-
+          tar --extract
+          --file .artifacts/repo-e2e-runtime/repo-e2e-runtime.tar.zst
+          --use-compress-program unzstd
+
+      - name: Run Agent Plugin Gateway E2E
+        run: pnpm test:e2e:agent-plugin-gateway
+
+  validate_repo_e2e_ui:
+    needs: validate_selected_ref
+    if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
+    continue-on-error: ${{ inputs.advisory }}
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY: "1"
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install Playwright Chromium
+        run: node --import tsx scripts/ensure-playwright-chromium.mts
+
+      - name: Run Control UI E2E shard
+        env:
+          OPENCLAW_UI_E2E_DIAGNOSTIC_DIR: .artifacts/control-ui-e2e-timeouts/shard-${{ matrix.shard }}-attempt-${{ github.run_attempt }}
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: >-
+          node scripts/run-vitest.mjs run
+          --config test/vitest/vitest.ui-e2e.config.ts
+          --configLoader runner
+          --shard "$SHARD_INDEX/4"
+
+      - name: Upload Control UI E2E timeout diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-control-ui-e2e-timeout-${{ matrix.shard }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/control-ui-e2e-timeouts/shard-${{ matrix.shard }}-attempt-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+  validate_repo_e2e_ui_real_gateway:
+    needs: [validate_selected_ref, prepare_repo_e2e_runtime]
+    if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
+    continue-on-error: ${{ inputs.advisory }}
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}
+    timeout-minutes: 25
+    env:
+      OPENCLAW_BUILD_PRIVATE_QA: "1"
+      OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+
+      - name: Download repo E2E runtime
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: repo-e2e-runtime-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/repo-e2e-runtime
+
+      - name: Extract repo E2E runtime
+        run: >-
+          tar --extract
+          --file .artifacts/repo-e2e-runtime/repo-e2e-runtime.tar.zst
+          --use-compress-program unzstd
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-1.62.1
+
+      - name: Install Playwright Chromium
+        run: node --import tsx scripts/ensure-playwright-chromium.mts
+
+      - name: Run Control UI real-Gateway E2E
+        run: >-
+          node scripts/run-vitest.mjs run
+          --config test/vitest/vitest.ui-e2e.config.ts
+          --configLoader runner
+          ui/src/e2e/mcp-app-conformance.e2e.test.ts
+          ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+          ui/src/e2e/logs-lifecycle.e2e.test.ts
+
+  validate_repo_e2e_legacy:
+    needs: validate_selected_ref
+    if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available != 'true'
+    continue-on-error: ${{ inputs.advisory }}
+    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 90
     env:
       OPENCLAW_BUILD_PRIVATE_QA: "1"
@@ -990,6 +1328,7 @@ jobs:
         with:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -999,7 +1338,7 @@ jobs:
           install-bun: "true"
           build-all-cache-scope: full
 
-      - name: Build dist for repo E2E
+      - name: Build dist for legacy repo E2E
         env:
           NODE_OPTIONS: --max-old-space-size=8192
         run: pnpm build
@@ -1010,8 +1349,73 @@ jobs:
       - name: Build sandbox image
         run: scripts/sandbox-setup.sh
 
-      - name: Run repo E2E suite
+      - name: Run legacy repo E2E suite
         run: pnpm test:e2e
+
+  validate_repo_e2e:
+    needs:
+      - validate_selected_ref
+      - prepare_repo_e2e_runtime
+      - prepare_repo_e2e_sandbox
+      - validate_repo_e2e_gateway
+      - validate_repo_e2e_agent_plugin
+      - validate_repo_e2e_ui
+      - validate_repo_e2e_ui_real_gateway
+      - validate_repo_e2e_legacy
+    if: ${{ always() && inputs.include_repo_e2e && inputs.live_suite_filter == '' }}
+    continue-on-error: ${{ inputs.advisory }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Verify repo E2E lanes
+        env:
+          AGENT_PLUGIN_RESULT: ${{ needs.validate_repo_e2e_agent_plugin.result }}
+          GATEWAY_RESULT: ${{ needs.validate_repo_e2e_gateway.result }}
+          LEGACY_RESULT: ${{ needs.validate_repo_e2e_legacy.result }}
+          REPO_E2E_SHARDS_AVAILABLE: ${{ needs.validate_selected_ref.outputs.repo_e2e_shards_available }}
+          RUNTIME_RESULT: ${{ needs.prepare_repo_e2e_runtime.result }}
+          SANDBOX_RESULT: ${{ needs.prepare_repo_e2e_sandbox.result }}
+          UI_REAL_GATEWAY_RESULT: ${{ needs.validate_repo_e2e_ui_real_gateway.result }}
+          UI_RESULT: ${{ needs.validate_repo_e2e_ui.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          require_result() {
+            local label="$1"
+            local actual="$2"
+            local expected="$3"
+            if [[ "$actual" != "$expected" ]]; then
+              echo "$label result was '$actual', expected '$expected'." >&2
+              return 1
+            fi
+          }
+
+          failures=0
+          if [[ "$REPO_E2E_SHARDS_AVAILABLE" == "true" ]]; then
+            for entry in \
+              "runtime:$RUNTIME_RESULT" \
+              "sandbox:$SANDBOX_RESULT" \
+              "gateway:$GATEWAY_RESULT" \
+              "agent-plugin:$AGENT_PLUGIN_RESULT" \
+              "ui:$UI_RESULT" \
+              "ui-real-gateway:$UI_REAL_GATEWAY_RESULT"; do
+              require_result "${entry%%:*}" "${entry#*:}" success || failures=1
+            done
+            require_result legacy "$LEGACY_RESULT" skipped || failures=1
+          else
+            require_result legacy "$LEGACY_RESULT" success || failures=1
+            for entry in \
+              "runtime:$RUNTIME_RESULT" \
+              "sandbox:$SANDBOX_RESULT" \
+              "gateway:$GATEWAY_RESULT" \
+              "agent-plugin:$AGENT_PLUGIN_RESULT" \
+              "ui:$UI_RESULT" \
+              "ui-real-gateway:$UI_REAL_GATEWAY_RESULT"; do
+              require_result "${entry%%:*}" "${entry#*:}" skipped || failures=1
+            done
+          fi
+          exit "$failures"
 
   validate_special_e2e:
     needs: validate_selected_ref

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -617,6 +617,7 @@ jobs:
           SHARED_IMAGE_ARTIFACT_RUN_ID: ${{ inputs.shared_image_artifact_run_id }}
           SHARED_IMAGE_ARCHIVE_SHA256: ${{ inputs.shared_image_archive_sha256 }}
           SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.workflow_sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -768,10 +769,12 @@ jobs:
           esac
 
           repo_e2e_shards_available=true
+          if [[ "$selected_sha" != "$WORKFLOW_SHA" ]]; then
+            repo_e2e_shards_available=false
+          fi
           required_repo_e2e_paths=(
             scripts/agent-plugin-gateway-e2e.ts
             scripts/build-all.mts
-            scripts/docker/shared-image-artifact.sh
             scripts/ensure-playwright-chromium.mts
             test/vitest/vitest.e2e.config.ts
             test/vitest/vitest.e2e.global-setup.ts
@@ -786,7 +789,7 @@ jobs:
             fi
           done
           if [[ "$repo_e2e_shards_available" == "true" ]] &&
-            ! git grep -Fq 'qaRuntime:' "$selected_sha" -- scripts/build-all.mts; then
+            ! git grep -Fq 'repoE2eRuntime:' "$selected_sha" -- scripts/build-all.mts; then
             repo_e2e_shards_available=false
           fi
           if [[ "$repo_e2e_shards_available" == "true" ]] &&
@@ -1011,12 +1014,20 @@ jobs:
   prepare_repo_e2e_runtime:
     needs: validate_selected_ref
     if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
-    continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
     timeout-minutes: 25
     env:
       OPENCLAW_BUILD_PRIVATE_QA: "1"
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
+    outputs:
+      archive_name: ${{ steps.pack.outputs.archive_name }}
+      archive_sha256: ${{ steps.pack.outputs.archive_sha256 }}
+      artifact_digest: ${{ steps.upload.outputs.artifact-digest }}
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      artifact_name: ${{ steps.pack.outputs.artifact_name }}
+      artifact_run_attempt: ${{ steps.pack.outputs.run_attempt }}
+      artifact_run_id: ${{ steps.pack.outputs.run_id }}
+      manifest_sha256: ${{ steps.pack.outputs.manifest_sha256 }}
     steps:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1035,36 +1046,122 @@ jobs:
       - name: Build private QA runtime once
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build qaRuntime
+        run: pnpm build repoE2eRuntime
 
       - name: Pack repo E2E runtime
-        run: >-
-          tar --posix -cf repo-e2e-runtime.tar.zst
-          --use-compress-program zstdmt
-          dist dist-runtime packages/*/dist
+        id: pack
+        env:
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          artifact_name="repo-e2e-runtime-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          archive_name="${artifact_name}.tar.zst"
+          archive_path="${RUNNER_TEMP}/${archive_name}"
+          bundle_root="${RUNNER_TEMP}/repo-e2e-runtime-bundle"
+          archive_root="repo-e2e-runtime"
+          runtime_root="${bundle_root}/${archive_root}"
+          manifest_path="${bundle_root}/manifest.json"
+          rm -rf "$bundle_root"
+          mkdir -p "$runtime_root/packages"
+          cp -a dist dist-runtime "$runtime_root/"
+          for package_dist in packages/*/dist; do
+            package_parent="${runtime_root}/$(dirname "$package_dist")"
+            mkdir -p "$package_parent"
+            cp -a "$package_dist" "$package_parent/"
+          done
+
+          jq -n \
+            --arg archiveRoot "$archive_root" \
+            --arg buildCommand "pnpm build repoE2eRuntime" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg runAttempt "$GITHUB_RUN_ATTEMPT" \
+            --arg runId "$GITHUB_RUN_ID" \
+            --arg sourceJob "prepare_repo_e2e_runtime" \
+            --arg targetSha "$TARGET_SHA" \
+            --arg workflowSha "$WORKFLOW_SHA" \
+            '{
+              version: 1,
+              repository: $repository,
+              workflowSha: $workflowSha,
+              targetSha: $targetSha,
+              archiveRoot: $archiveRoot,
+              buildCommand: $buildCommand,
+              sourceJob: $sourceJob,
+              runId: $runId,
+              runAttempt: $runAttempt
+            }' > "$manifest_path"
+
+          LC_ALL=C tar \
+            --create \
+            --format=posix \
+            --sort=name \
+            --one-file-system \
+            --numeric-owner \
+            --owner=0 \
+            --group=0 \
+            --no-xattrs \
+            --no-acls \
+            --pax-option=delete=atime,delete=ctime \
+            -C "$bundle_root" \
+            manifest.json \
+            "$archive_root" |
+            zstd -T0 -3 -q -o "$archive_path"
+          {
+            echo "archive_name=$archive_name"
+            echo "archive_path=$archive_path"
+            echo "archive_sha256=$(sha256sum "$archive_path" | awk '{print $1}')"
+            echo "artifact_name=$artifact_name"
+            echo "manifest_sha256=$(sha256sum "$manifest_path" | awk '{print $1}')"
+            echo "run_attempt=$GITHUB_RUN_ATTEMPT"
+            echo "run_id=$GITHUB_RUN_ID"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload repo E2E runtime
+        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: repo-e2e-runtime-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: repo-e2e-runtime.tar.zst
+          name: ${{ steps.pack.outputs.artifact_name }}
+          path: ${{ steps.pack.outputs.archive_path }}
+          archive: false
           if-no-files-found: error
           retention-days: 1
+
+      - name: Verify uploaded repo E2E runtime digest
+        env:
+          ACTUAL_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+          EXPECTED_DIGEST: ${{ steps.pack.outputs.archive_sha256 }}
+        run: |
+          set -euo pipefail
+          [[ "$ACTUAL_DIGEST" == "$EXPECTED_DIGEST" ]]
 
   prepare_repo_e2e_sandbox:
     needs: validate_selected_ref
     if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
-    continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 25
     outputs:
       archive_sha256: ${{ steps.pack.outputs.archive_sha256 }}
+      artifact_digest: ${{ steps.upload.outputs.artifact-digest }}
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      artifact_name: ${{ steps.pack.outputs.artifact_name }}
+      artifact_run_attempt: ${{ steps.pack.outputs.run_attempt }}
+      artifact_run_id: ${{ steps.pack.outputs.run_id }}
     steps:
       - name: Checkout selected ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout trusted image artifact helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+          fetch-depth: 1
+          path: .release-harness
           persist-credentials: false
 
       - name: Build repo E2E sandbox image
@@ -1078,7 +1175,8 @@ jobs:
         run: |
           set -euo pipefail
           artifact_dir="${RUNNER_TEMP}/repo-e2e-sandbox-artifact"
-          scripts/docker/shared-image-artifact.sh \
+          artifact_name="repo-e2e-sandbox-${TARGET_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
             pack \
             "$artifact_dir" \
             repo-e2e-sandbox \
@@ -1086,20 +1184,26 @@ jobs:
             "$WORKFLOW_SHA" \
             openclaw-sandbox:bookworm-slim
           archive_sha256="$(jq -er '.archive.sha256' "$artifact_dir/shared-image-artifact.json")"
-          echo "archive_sha256=$archive_sha256" >> "$GITHUB_OUTPUT"
+          {
+            echo "archive_sha256=$archive_sha256"
+            echo "artifact_name=$artifact_name"
+            echo "run_attempt=$GITHUB_RUN_ATTEMPT"
+            echo "run_id=$GITHUB_RUN_ID"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload repo E2E sandbox image
+        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: repo-e2e-sandbox-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.pack.outputs.artifact_name }}
           path: ${{ runner.temp }}/repo-e2e-sandbox-artifact
           if-no-files-found: error
+          compression-level: 0
           retention-days: 1
 
   validate_repo_e2e_gateway:
     needs: [validate_selected_ref, prepare_repo_e2e_runtime, prepare_repo_e2e_sandbox]
     if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
-    continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 35
     strategy:
@@ -1119,39 +1223,136 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Checkout trusted artifact helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+          fetch-depth: 1
+          path: .release-harness
+          persist-credentials: false
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
+      - name: Validate repo E2E runtime artifact binding
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+        run: |
+          set -euo pipefail
+          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Repo E2E runtime artifact name does not match the target and producer run attempt." >&2
+            exit 1
+          }
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Repo E2E runtime" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
       - name: Download repo E2E runtime
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: repo-e2e-runtime-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          artifact-ids: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_id }}
           path: .artifacts/repo-e2e-runtime
+          run-id: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+          skip-decompress: true
+          digest-mismatch: error
 
-      - name: Extract repo E2E runtime
-        run: >-
-          tar --extract
-          --file .artifacts/repo-e2e-runtime/repo-e2e-runtime.tar.zst
-          --use-compress-program unzstd
+      - name: Bounded extract repo E2E runtime
+        env:
+          ARCHIVE_NAME: ${{ needs.prepare_repo_e2e_runtime.outputs.archive_name }}
+          ARCHIVE_SHA256: ${{ needs.prepare_repo_e2e_runtime.outputs.archive_sha256 }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          MANIFEST_SHA256: ${{ needs.prepare_repo_e2e_runtime.outputs.manifest_sha256 }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          archive_path=".artifacts/repo-e2e-runtime/${ARCHIVE_NAME}"
+          extract_root="${RUNNER_TEMP}/repo-e2e-runtime-extract"
+          runtime_root="${extract_root}/repo-e2e-runtime"
+          [[ "$(sha256sum "$archive_path" | awk '{print $1}')" == "$ARCHIVE_SHA256" ]]
+          rm -rf "$extract_root"
+          python3 .release-harness/scripts/release-telegram-candidate-archive.py extract-zstd \
+            "$archive_path" \
+            "$extract_root" \
+            --allowed-root repo-e2e-runtime \
+            --max-members 250000 \
+            --max-expanded-bytes 2147483648 \
+            --max-stream-bytes 536870912 \
+            --max-extension-total-bytes 67108864 \
+            --max-path-bytes 67108864
+          manifest_path="${extract_root}/manifest.json"
+          [[ "$(sha256sum "$manifest_path" | awk '{print $1}')" == "$MANIFEST_SHA256" ]]
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg runAttempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg runId "$ARTIFACT_RUN_ID" \
+            --arg targetSha "$TARGET_SHA" \
+            --arg workflowSha "$WORKFLOW_SHA" \
+            '
+              .version == 1 and
+              .repository == $repository and
+              .workflowSha == $workflowSha and
+              .targetSha == $targetSha and
+              .archiveRoot == "repo-e2e-runtime" and
+              .buildCommand == "pnpm build repoE2eRuntime" and
+              .sourceJob == "prepare_repo_e2e_runtime" and
+              .runId == $runId and
+              .runAttempt == $runAttempt
+            ' "$manifest_path" >/dev/null
+          cp -a "${runtime_root}/." .
+
+      - name: Validate repo E2E sandbox artifact binding
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+        run: |
+          set -euo pipefail
+          expected_artifact_name="repo-e2e-sandbox-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Repo E2E sandbox artifact name does not match the target and producer run attempt." >&2
+            exit 1
+          }
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Repo E2E sandbox" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Download repo E2E sandbox image
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: repo-e2e-sandbox-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          artifact-ids: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_id }}
           path: .artifacts/repo-e2e-sandbox
+          run-id: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Load repo E2E sandbox image
         env:
           OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.prepare_repo_e2e_sandbox.outputs.archive_sha256 }}
-          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ github.run_attempt }}
-          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ github.run_id }}
+          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_run_attempt }}
+          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_run_id }}
           TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
         run: >-
-          scripts/docker/shared-image-artifact.sh
+          bash .release-harness/scripts/docker/shared-image-artifact.sh
           load
           .artifacts/repo-e2e-sandbox
           repo-e2e-sandbox
@@ -1170,7 +1371,6 @@ jobs:
   validate_repo_e2e_agent_plugin:
     needs: [validate_selected_ref, prepare_repo_e2e_runtime]
     if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
-    continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     env:
@@ -1184,23 +1384,97 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Checkout trusted artifact helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+          fetch-depth: 1
+          path: .release-harness
+          persist-credentials: false
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
+      - name: Validate repo E2E runtime artifact binding
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+        run: |
+          set -euo pipefail
+          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Repo E2E runtime artifact name does not match the target and producer run attempt." >&2
+            exit 1
+          }
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Repo E2E runtime" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
       - name: Download repo E2E runtime
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: repo-e2e-runtime-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          artifact-ids: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_id }}
           path: .artifacts/repo-e2e-runtime
+          run-id: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+          skip-decompress: true
+          digest-mismatch: error
 
-      - name: Extract repo E2E runtime
-        run: >-
-          tar --extract
-          --file .artifacts/repo-e2e-runtime/repo-e2e-runtime.tar.zst
-          --use-compress-program unzstd
+      - name: Bounded extract repo E2E runtime
+        env:
+          ARCHIVE_NAME: ${{ needs.prepare_repo_e2e_runtime.outputs.archive_name }}
+          ARCHIVE_SHA256: ${{ needs.prepare_repo_e2e_runtime.outputs.archive_sha256 }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          MANIFEST_SHA256: ${{ needs.prepare_repo_e2e_runtime.outputs.manifest_sha256 }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          archive_path=".artifacts/repo-e2e-runtime/${ARCHIVE_NAME}"
+          extract_root="${RUNNER_TEMP}/repo-e2e-runtime-extract"
+          runtime_root="${extract_root}/repo-e2e-runtime"
+          [[ "$(sha256sum "$archive_path" | awk '{print $1}')" == "$ARCHIVE_SHA256" ]]
+          rm -rf "$extract_root"
+          python3 .release-harness/scripts/release-telegram-candidate-archive.py extract-zstd \
+            "$archive_path" \
+            "$extract_root" \
+            --allowed-root repo-e2e-runtime \
+            --max-members 250000 \
+            --max-expanded-bytes 2147483648 \
+            --max-stream-bytes 536870912 \
+            --max-extension-total-bytes 67108864 \
+            --max-path-bytes 67108864
+          manifest_path="${extract_root}/manifest.json"
+          [[ "$(sha256sum "$manifest_path" | awk '{print $1}')" == "$MANIFEST_SHA256" ]]
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg runAttempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg runId "$ARTIFACT_RUN_ID" \
+            --arg targetSha "$TARGET_SHA" \
+            --arg workflowSha "$WORKFLOW_SHA" \
+            '
+              .version == 1 and
+              .repository == $repository and
+              .workflowSha == $workflowSha and
+              .targetSha == $targetSha and
+              .archiveRoot == "repo-e2e-runtime" and
+              .buildCommand == "pnpm build repoE2eRuntime" and
+              .sourceJob == "prepare_repo_e2e_runtime" and
+              .runId == $runId and
+              .runAttempt == $runAttempt
+            ' "$manifest_path" >/dev/null
+          cp -a "${runtime_root}/." .
 
       - name: Run Agent Plugin Gateway E2E
         run: pnpm test:e2e:agent-plugin-gateway
@@ -1208,7 +1482,6 @@ jobs:
   validate_repo_e2e_ui:
     needs: validate_selected_ref
     if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
-    continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 25
     strategy:
@@ -1232,7 +1505,7 @@ jobs:
           install-bun: "false"
 
       - name: Cache Playwright Chromium
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
@@ -1262,7 +1535,6 @@ jobs:
   validate_repo_e2e_ui_real_gateway:
     needs: [validate_selected_ref, prepare_repo_e2e_runtime]
     if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available == 'true'
-    continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 25
     env:
@@ -1276,26 +1548,100 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Checkout trusted artifact helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ needs.validate_selected_ref.outputs.workflow_repository }}
+          ref: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+          fetch-depth: 1
+          path: .release-harness
+          persist-credentials: false
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
+      - name: Validate repo E2E runtime artifact binding
+        env:
+          ARTIFACT_DIGEST: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+        run: |
+          set -euo pipefail
+          expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
+            echo "Repo E2E runtime artifact name does not match the target and producer run attempt." >&2
+            exit 1
+          }
+          bash .release-harness/scripts/docker/shared-image-artifact.sh \
+            verify-upload "Repo E2E runtime" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
       - name: Download repo E2E runtime
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: repo-e2e-runtime-${{ needs.validate_selected_ref.outputs.selected_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          artifact-ids: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_id }}
           path: .artifacts/repo-e2e-runtime
+          run-id: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+          skip-decompress: true
+          digest-mismatch: error
 
-      - name: Extract repo E2E runtime
-        run: >-
-          tar --extract
-          --file .artifacts/repo-e2e-runtime/repo-e2e-runtime.tar.zst
-          --use-compress-program unzstd
+      - name: Bounded extract repo E2E runtime
+        env:
+          ARCHIVE_NAME: ${{ needs.prepare_repo_e2e_runtime.outputs.archive_name }}
+          ARCHIVE_SHA256: ${{ needs.prepare_repo_e2e_runtime.outputs.archive_sha256 }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}
+          MANIFEST_SHA256: ${{ needs.prepare_repo_e2e_runtime.outputs.manifest_sha256 }}
+          TARGET_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
+          WORKFLOW_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
+        run: |
+          set -euo pipefail
+          archive_path=".artifacts/repo-e2e-runtime/${ARCHIVE_NAME}"
+          extract_root="${RUNNER_TEMP}/repo-e2e-runtime-extract"
+          runtime_root="${extract_root}/repo-e2e-runtime"
+          [[ "$(sha256sum "$archive_path" | awk '{print $1}')" == "$ARCHIVE_SHA256" ]]
+          rm -rf "$extract_root"
+          python3 .release-harness/scripts/release-telegram-candidate-archive.py extract-zstd \
+            "$archive_path" \
+            "$extract_root" \
+            --allowed-root repo-e2e-runtime \
+            --max-members 250000 \
+            --max-expanded-bytes 2147483648 \
+            --max-stream-bytes 536870912 \
+            --max-extension-total-bytes 67108864 \
+            --max-path-bytes 67108864
+          manifest_path="${extract_root}/manifest.json"
+          [[ "$(sha256sum "$manifest_path" | awk '{print $1}')" == "$MANIFEST_SHA256" ]]
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg runAttempt "$ARTIFACT_RUN_ATTEMPT" \
+            --arg runId "$ARTIFACT_RUN_ID" \
+            --arg targetSha "$TARGET_SHA" \
+            --arg workflowSha "$WORKFLOW_SHA" \
+            '
+              .version == 1 and
+              .repository == $repository and
+              .workflowSha == $workflowSha and
+              .targetSha == $targetSha and
+              .archiveRoot == "repo-e2e-runtime" and
+              .buildCommand == "pnpm build repoE2eRuntime" and
+              .sourceJob == "prepare_repo_e2e_runtime" and
+              .runId == $runId and
+              .runAttempt == $runAttempt
+            ' "$manifest_path" >/dev/null
+          cp -a "${runtime_root}/." .
 
       - name: Cache Playwright Chromium
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.62.1
@@ -1315,7 +1661,6 @@ jobs:
   validate_repo_e2e_legacy:
     needs: validate_selected_ref
     if: inputs.include_repo_e2e && inputs.live_suite_filter == '' && needs.validate_selected_ref.outputs.repo_e2e_shards_available != 'true'
-    continue-on-error: ${{ inputs.advisory }}
     runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 90
     env:

--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -341,13 +341,17 @@ export const BUILD_ALL_PROFILES: Record<string, string[]> = {
   ],
   repoE2eRuntime: [
     "plugins:assets:build",
-    "tsdown",
+    "tsdown-ai",
+    "tsdown-packages",
+    "tsdown-unified",
     "external-plugins:local-dist",
     "check-cli-bootstrap-imports",
     "plugins:assets:copy",
     "runtime-postbuild",
     "build-stamp",
     "runtime-postbuild-stamp",
+    "write-plugin-sdk-entry-dts",
+    "check-plugin-sdk-exports",
     "ui:build",
   ],
   sourcePerformance: [
@@ -401,11 +405,6 @@ export const BUILD_ALL_PROFILE_STEP_ENV: Record<string, Record<string, NodeJS.Pr
     },
   },
   qaRuntime: {
-    tsdown: {
-      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
-    },
-  },
-  repoE2eRuntime: {
     tsdown: {
       OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
     },

--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -339,6 +339,17 @@ export const BUILD_ALL_PROFILES: Record<string, string[]> = {
     "build-stamp",
     "runtime-postbuild-stamp",
   ],
+  repoE2eRuntime: [
+    "plugins:assets:build",
+    "tsdown",
+    "external-plugins:local-dist",
+    "check-cli-bootstrap-imports",
+    "plugins:assets:copy",
+    "runtime-postbuild",
+    "build-stamp",
+    "runtime-postbuild-stamp",
+    "ui:build",
+  ],
   sourcePerformance: [
     "plugins:assets:build",
     "tsdown",
@@ -390,6 +401,11 @@ export const BUILD_ALL_PROFILE_STEP_ENV: Record<string, Record<string, NodeJS.Pr
     },
   },
   qaRuntime: {
+    tsdown: {
+      OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
+    },
+  },
+  repoE2eRuntime: {
     tsdown: {
       OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
     },

--- a/scripts/docker/shared-image-artifact.sh
+++ b/scripts/docker/shared-image-artifact.sh
@@ -146,7 +146,8 @@ verify_uploaded_artifact() {
   if [[ -z "${artifact_name// }" || "$artifact_name" == *$'\n'* || "$artifact_name" == *$'\r'* ]]; then
     fail "$artifact_label artifact name is missing or invalid."
   fi
-  if [[ "$artifact_name" != *"-${artifact_run_id}-${artifact_run_attempt}" ]]; then
+  local producer_suffix="-${artifact_run_id}-${artifact_run_attempt}"
+  if [[ "$artifact_name" != *"$producer_suffix" && "$artifact_name" != *"${producer_suffix}.tar.zst" ]]; then
     fail "$artifact_label artifact name does not bind the producer run attempt."
   fi
   if [[ ! "${GITHUB_REPOSITORY:-}" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then

--- a/scripts/validate-repo-e2e-capability.mjs
+++ b/scripts/validate-repo-e2e-capability.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { appendFileSync, lstatSync, readFileSync } from "node:fs";
+
+const MAX_MANIFEST_BYTES = 8 * 1024;
+const EXPECTED_SCHEMA = "openclaw.repo-e2e-capabilities/v1";
+const EXPECTED_ROOT_KEYS = ["repoE2eShards", "schema", "schemaVersion"];
+const EXPECTED_SHARD_KEYS = [
+  "agentPluginGateway",
+  "gatewayShards",
+  "realGatewayUi",
+  "runtimeBuildProfile",
+  "sandboxArtifact",
+  "uiShards",
+];
+
+function parseArgs(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--") || value === undefined) {
+      throw new Error(
+        "usage: validate-repo-e2e-capability.mjs --manifest <path> --github-output <path> --github-step-summary <path>",
+      );
+    }
+    values.set(name, value);
+  }
+  for (const required of ["--manifest", "--github-output", "--github-step-summary"]) {
+    if (!values.has(required)) {
+      throw new Error(`${required} is required`);
+    }
+  }
+  return values;
+}
+
+function hasExactKeys(value, expectedKeys) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const actualKeys = Object.keys(value).toSorted();
+  return (
+    actualKeys.length === expectedKeys.length &&
+    actualKeys.every((key, index) => key === expectedKeys[index])
+  );
+}
+
+function validateManifest(manifestPath) {
+  let stat;
+  try {
+    stat = lstatSync(manifestPath);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return { available: false, reason: "missing" };
+    }
+    throw error;
+  }
+  if (!stat.isFile() || stat.size > MAX_MANIFEST_BYTES) {
+    return { available: false, reason: "invalid" };
+  }
+
+  let value;
+  try {
+    value = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch {
+    return { available: false, reason: "invalid" };
+  }
+  if (!hasExactKeys(value, EXPECTED_ROOT_KEYS)) {
+    return { available: false, reason: "invalid" };
+  }
+  if (value.schema !== EXPECTED_SCHEMA || value.schemaVersion !== 1) {
+    return { available: false, reason: "unsupported" };
+  }
+  if (!hasExactKeys(value.repoE2eShards, EXPECTED_SHARD_KEYS)) {
+    return { available: false, reason: "invalid" };
+  }
+
+  const capability = value.repoE2eShards;
+  const valid =
+    capability.agentPluginGateway === true &&
+    capability.gatewayShards === 4 &&
+    capability.realGatewayUi === true &&
+    capability.runtimeBuildProfile === "repoE2eRuntime" &&
+    capability.sandboxArtifact === true &&
+    capability.uiShards === 4;
+  return valid
+    ? { available: true, reason: "contract-v1" }
+    : { available: false, reason: "unsupported" };
+}
+
+const args = parseArgs(process.argv.slice(2));
+const result = validateManifest(args.get("--manifest"));
+const mode = result.available ? "sharded" : "legacy";
+appendFileSync(
+  args.get("--github-output"),
+  `repo_e2e_shards_available=${result.available}\nrepo_e2e_capability_reason=${result.reason}\n`,
+);
+appendFileSync(
+  args.get("--github-step-summary"),
+  `Repo E2E mode: \`${mode}\`\nRepo E2E capability: \`${result.reason}\`\n`,
+);

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -452,6 +452,7 @@ describe("resolveBuildAllSteps", () => {
     for (const profile of [
       "gatewayWatch",
       "qaRuntime",
+      "repoE2eRuntime",
       "sourcePerformance",
       "cliStartup",
     ] as const) {
@@ -551,7 +552,7 @@ describe("resolveBuildAllSteps", () => {
       });
     }
 
-    for (const profile of ["gatewayWatch", "qaRuntime"]) {
+    for (const profile of ["gatewayWatch", "qaRuntime", "repoE2eRuntime"]) {
       const tsdown = resolveBuildAllSteps(profile).find((step) => step.label === "tsdown");
       if (!tsdown) {
         throw new Error(`Missing ${profile} tsdown step`);
@@ -584,6 +585,20 @@ describe("resolveBuildAllSteps", () => {
       "runtime-postbuild",
       "build-stamp",
       "runtime-postbuild-stamp",
+    ]);
+  });
+
+  it("uses a repo E2E runtime profile with private QA runtime and Control UI assets", () => {
+    expect(resolveBuildAllSteps("repoE2eRuntime").map((step) => step.label)).toEqual([
+      "plugins:assets:build",
+      "tsdown",
+      "external-plugins:local-dist",
+      "check-cli-bootstrap-imports",
+      "plugins:assets:copy",
+      "runtime-postbuild",
+      "build-stamp",
+      "runtime-postbuild-stamp",
+      "ui:build",
     ]);
   });
 
@@ -641,7 +656,7 @@ describe("resolveBuildAllSteps", () => {
   });
 
   it("keeps generated static plugin assets enabled for QA-backed profiles", () => {
-    for (const profile of ["qaRuntime", "sourcePerformance"] as const) {
+    for (const profile of ["qaRuntime", "repoE2eRuntime", "sourcePerformance"] as const) {
       const runtimePostbuild = resolveBuildAllSteps(profile).find(
         (step) => step.label === "runtime-postbuild",
       );
@@ -665,7 +680,13 @@ describe("resolveBuildAllSteps", () => {
   });
 
   it("copies generated plugin assets before runtime postbuild snapshots static outputs", () => {
-    for (const profile of ["full", "ciArtifacts", "qaRuntime", "sourcePerformance"]) {
+    for (const profile of [
+      "full",
+      "ciArtifacts",
+      "qaRuntime",
+      "repoE2eRuntime",
+      "sourcePerformance",
+    ]) {
       const labels = resolveBuildAllSteps(profile).map((step) => step.label);
       const lastTsdown = profile === "full" ? "tsdown-unified" : "tsdown";
       expect(labels.indexOf("plugins:assets:copy")).toBeGreaterThan(labels.indexOf(lastTsdown));
@@ -701,8 +722,8 @@ describe("resolveBuildAllSteps", () => {
     );
   });
 
-  it("includes ui:build in the full and ciArtifacts profiles after runtime postbuild", () => {
-    for (const profile of ["full", "ciArtifacts"]) {
+  it("includes ui:build in UI-bearing profiles after runtime postbuild", () => {
+    for (const profile of ["full", "ciArtifacts", "repoE2eRuntime"]) {
       const labels = resolveBuildAllSteps(profile).map((step) => step.label);
       const lastTsdown = profile === "full" ? "tsdown-unified" : "tsdown";
       expect(labels).toContain("ui:build");
@@ -712,7 +733,9 @@ describe("resolveBuildAllSteps", () => {
       expect(labels.indexOf("ui:build")).toBeGreaterThan(labels.indexOf("runtime-postbuild-stamp"));
       // ui:build must run before write-build-info so the build manifest can
       // see the final dist/control-ui assets.
-      expect(labels.indexOf("ui:build")).toBeLessThan(labels.indexOf("write-build-info"));
+      if (labels.includes("write-build-info")) {
+        expect(labels.indexOf("ui:build")).toBeLessThan(labels.indexOf("write-build-info"));
+      }
     }
   });
 

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -452,7 +452,6 @@ describe("resolveBuildAllSteps", () => {
     for (const profile of [
       "gatewayWatch",
       "qaRuntime",
-      "repoE2eRuntime",
       "sourcePerformance",
       "cliStartup",
     ] as const) {
@@ -472,6 +471,20 @@ describe("resolveBuildAllSteps", () => {
         OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
       });
     }
+  });
+
+  it("keeps repository E2E runtime declarations for package compatibility proofs", () => {
+    const steps = resolveBuildAllSteps("repoE2eRuntime");
+    expect(steps.map((step) => step.label)).toEqual(
+      expect.arrayContaining([
+        "tsdown-ai",
+        "tsdown-packages",
+        "tsdown-unified",
+        "write-plugin-sdk-entry-dts",
+        "check-plugin-sdk-exports",
+      ]),
+    );
+    expect(steps.some((step) => step.label === "tsdown")).toBe(false);
   });
 
   it("skips global declarations on CI artifacts and self-builds the plugin-sdk gate", () => {
@@ -552,7 +565,7 @@ describe("resolveBuildAllSteps", () => {
       });
     }
 
-    for (const profile of ["gatewayWatch", "qaRuntime", "repoE2eRuntime"]) {
+    for (const profile of ["gatewayWatch", "qaRuntime"]) {
       const tsdown = resolveBuildAllSteps(profile).find((step) => step.label === "tsdown");
       if (!tsdown) {
         throw new Error(`Missing ${profile} tsdown step`);
@@ -562,6 +575,16 @@ describe("resolveBuildAllSteps", () => {
         "OPENCLAW_PRESERVE_CLI_STARTUP_METADATA",
       );
     }
+
+    const repoE2eTsdown = resolveBuildAllSteps("repoE2eRuntime").find(
+      (step) => step.label === "tsdown-unified",
+    );
+    if (!repoE2eTsdown) {
+      throw new Error("Missing repoE2eRuntime tsdown-unified step");
+    }
+    expect(resolveBuildAllStep(repoE2eTsdown, { env: {} }).options.env).not.toHaveProperty(
+      "OPENCLAW_PRESERVE_CLI_STARTUP_METADATA",
+    );
   });
 
   it("uses a minimal built runtime profile for gateway watch regression", () => {
@@ -591,13 +614,17 @@ describe("resolveBuildAllSteps", () => {
   it("uses a repo E2E runtime profile with private QA runtime and Control UI assets", () => {
     expect(resolveBuildAllSteps("repoE2eRuntime").map((step) => step.label)).toEqual([
       "plugins:assets:build",
-      "tsdown",
+      "tsdown-ai",
+      "tsdown-packages",
+      "tsdown-unified",
       "external-plugins:local-dist",
       "check-cli-bootstrap-imports",
       "plugins:assets:copy",
       "runtime-postbuild",
       "build-stamp",
       "runtime-postbuild-stamp",
+      "write-plugin-sdk-entry-dts",
+      "check-plugin-sdk-exports",
       "ui:build",
     ]);
   });
@@ -664,11 +691,7 @@ describe("resolveBuildAllSteps", () => {
         throw new Error(`Missing ${profile} runtime-postbuild step`);
       }
 
-      expect(
-        expectDefined(BUILD_ALL_PROFILE_STEP_ENV[profile], `${profile} build step env`)[
-          "runtime-postbuild"
-        ],
-      ).toBeUndefined();
+      expect(BUILD_ALL_PROFILE_STEP_ENV[profile]?.["runtime-postbuild"]).toBeUndefined();
       expect(
         resolveBuildAllStep(runtimePostbuild, {
           env: { OPENCLAW_RUNTIME_POSTBUILD_STATIC_ASSETS: "1" },

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4140,7 +4140,9 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
       "${{ steps.validate.outputs.repo_e2e_shards_available }}",
     );
     expect(validateStep.run).toContain("required_repo_e2e_paths=(");
-    expect(validateStep.run).toContain("scripts/docker/shared-image-artifact.sh");
+    expect(validateStep.env.WORKFLOW_SHA).toBe("${{ steps.workflow.outputs.workflow_sha }}");
+    expect(validateStep.run).toContain('if [[ "$selected_sha" != "$WORKFLOW_SHA" ]]');
+    expect(validateStep.run).toContain("repoE2eRuntime:");
     expect(validateStep.run).toContain("OPENCLAW_E2E_USE_PREBUILT_DIST");
     expect(validateStep.run).toContain("OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY");
     expect(validateStep.run).toContain(
@@ -4157,27 +4159,113 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
       OPENCLAW_BUILD_PRIVATE_QA: "1",
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
     });
+    expect(runtime).not.toHaveProperty("continue-on-error");
+    expect(runtime.outputs).toMatchObject({
+      archive_name: "${{ steps.pack.outputs.archive_name }}",
+      archive_sha256: "${{ steps.pack.outputs.archive_sha256 }}",
+      artifact_digest: "${{ steps.upload.outputs.artifact-digest }}",
+      artifact_id: "${{ steps.upload.outputs.artifact-id }}",
+      artifact_name: "${{ steps.pack.outputs.artifact_name }}",
+      artifact_run_attempt: "${{ steps.pack.outputs.run_attempt }}",
+      artifact_run_id: "${{ steps.pack.outputs.run_id }}",
+      manifest_sha256: "${{ steps.pack.outputs.manifest_sha256 }}",
+    });
     expect(
       runtime.steps.find((step: WorkflowStep) => step.name === "Build private QA runtime once")
         ?.run,
-    ).toBe("pnpm build qaRuntime");
+    ).toBe("pnpm build repoE2eRuntime");
+    const packRuntime = runtime.steps.find(
+      (step: WorkflowStep) => step.name === "Pack repo E2E runtime",
+    );
+    expect(packRuntime?.run).toContain('--arg buildCommand "pnpm build repoE2eRuntime"');
+    expect(packRuntime?.run).toContain("manifest.json");
+    expect(packRuntime?.run).toContain('archive_sha256=$(sha256sum "$archive_path"');
+    const uploadRuntime = runtime.steps.find(
+      (step: WorkflowStep) => step.name === "Upload repo E2E runtime",
+    );
+    expect(uploadRuntime).toMatchObject({
+      id: "upload",
+      uses: UPLOAD_ARTIFACT_V7,
+      with: {
+        archive: false,
+        "if-no-files-found": "error",
+        name: "${{ steps.pack.outputs.artifact_name }}",
+        path: "${{ steps.pack.outputs.archive_path }}",
+      },
+    });
     expect(
-      runtime.steps.find((step: WorkflowStep) => step.name === "Pack repo E2E runtime")?.run,
-    ).toContain("dist dist-runtime packages/*/dist");
-    expect(
-      runtime.steps.find((step: WorkflowStep) => step.name === "Upload repo E2E runtime")?.uses,
-    ).toBe(UPLOAD_ARTIFACT_V7);
+      runtime.steps.find(
+        (step: WorkflowStep) => step.name === "Verify uploaded repo E2E runtime digest",
+      )?.run,
+    ).toContain('[[ "$ACTUAL_DIGEST" == "$EXPECTED_DIGEST" ]]');
 
     const sandbox = jobs.prepare_repo_e2e_sandbox;
+    expect(sandbox).not.toHaveProperty("continue-on-error");
     expect(sandbox.outputs.archive_sha256).toBe("${{ steps.pack.outputs.archive_sha256 }}");
+    expect(sandbox.outputs).toMatchObject({
+      artifact_digest: "${{ steps.upload.outputs.artifact-digest }}",
+      artifact_id: "${{ steps.upload.outputs.artifact-id }}",
+      artifact_name: "${{ steps.pack.outputs.artifact_name }}",
+      artifact_run_attempt: "${{ steps.pack.outputs.run_attempt }}",
+      artifact_run_id: "${{ steps.pack.outputs.run_id }}",
+    });
+    expect(
+      sandbox.steps.find(
+        (step: WorkflowStep) => step.name === "Checkout trusted image artifact helper",
+      )?.with,
+    ).toMatchObject({
+      repository: "${{ needs.validate_selected_ref.outputs.workflow_repository }}",
+      ref: "${{ needs.validate_selected_ref.outputs.workflow_sha }}",
+      path: ".release-harness",
+    });
     expect(
       sandbox.steps.find((step: WorkflowStep) => step.name === "Build repo E2E sandbox image")?.run,
     ).toBe("scripts/sandbox-setup.sh");
     expect(
       sandbox.steps.find((step: WorkflowStep) => step.name === "Pack repo E2E sandbox image")?.run,
-    ).toContain("scripts/docker/shared-image-artifact.sh");
+    ).toContain(".release-harness/scripts/docker/shared-image-artifact.sh");
+    expect(
+      sandbox.steps.find((step: WorkflowStep) => step.name === "Upload repo E2E sandbox image")
+        ?.with,
+    ).toMatchObject({ "compression-level": 0 });
+
+    const expectRuntimeConsumer = (job: { steps: WorkflowStep[]; [key: string]: unknown }) => {
+      expect(job).not.toHaveProperty("continue-on-error");
+      expect(
+        job.steps.find((step: WorkflowStep) => step.name === "Checkout trusted artifact helper")
+          ?.with,
+      ).toMatchObject({
+        repository: "${{ needs.validate_selected_ref.outputs.workflow_repository }}",
+        ref: "${{ needs.validate_selected_ref.outputs.workflow_sha }}",
+        path: ".release-harness",
+      });
+      expect(
+        job.steps.find(
+          (step: WorkflowStep) => step.name === "Validate repo E2E runtime artifact binding",
+        )?.run,
+      ).toContain('verify-upload "Repo E2E runtime"');
+      expect(
+        job.steps.find((step: WorkflowStep) => step.name === "Download repo E2E runtime")?.with,
+      ).toMatchObject({
+        "artifact-ids": "${{ needs.prepare_repo_e2e_runtime.outputs.artifact_id }}",
+        "digest-mismatch": "error",
+        "github-token": "${{ github.token }}",
+        "run-id": "${{ needs.prepare_repo_e2e_runtime.outputs.artifact_run_id }}",
+        "skip-decompress": true,
+      });
+      const extractRuntime = job.steps.find(
+        (step: WorkflowStep) => step.name === "Bounded extract repo E2E runtime",
+      );
+      expect(extractRuntime?.run).toContain(
+        ".release-harness/scripts/release-telegram-candidate-archive.py extract-zstd",
+      );
+      expect(extractRuntime?.run).toContain("--allowed-root repo-e2e-runtime");
+      expect(extractRuntime?.run).toContain('.buildCommand == "pnpm build repoE2eRuntime"');
+      expect(extractRuntime?.run).not.toContain("tar --extract");
+    };
 
     const gateway = jobs.validate_repo_e2e_gateway;
+    expectRuntimeConsumer(gateway);
     expect(gateway.needs).toEqual([
       "validate_selected_ref",
       "prepare_repo_e2e_runtime",
@@ -4193,12 +4281,26 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     });
     expect(
       gateway.steps.find((step: WorkflowStep) => step.name === "Load repo E2E sandbox image")?.run,
-    ).toContain("scripts/docker/shared-image-artifact.sh");
+    ).toContain(".release-harness/scripts/docker/shared-image-artifact.sh");
+    expect(
+      gateway.steps.find(
+        (step: WorkflowStep) => step.name === "Validate repo E2E sandbox artifact binding",
+      )?.run,
+    ).toContain('verify-upload "Repo E2E sandbox"');
+    expect(
+      gateway.steps.find((step: WorkflowStep) => step.name === "Download repo E2E sandbox image")
+        ?.with,
+    ).toMatchObject({
+      "artifact-ids": "${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_id }}",
+      "github-token": "${{ github.token }}",
+      "run-id": "${{ needs.prepare_repo_e2e_sandbox.outputs.artifact_run_id }}",
+    });
     expect(
       gateway.steps.find((step: WorkflowStep) => step.name === "Run repo Gateway E2E shard")?.run,
     ).toContain('--shard "$SHARD_INDEX/4"');
 
     const agentPlugin = jobs.validate_repo_e2e_agent_plugin;
+    expectRuntimeConsumer(agentPlugin);
     expect(agentPlugin.needs).toEqual(["validate_selected_ref", "prepare_repo_e2e_runtime"]);
     expect(
       agentPlugin.steps.find((step: WorkflowStep) => step.name === "Run Agent Plugin Gateway E2E")
@@ -4206,6 +4308,7 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     ).toBe("pnpm test:e2e:agent-plugin-gateway");
 
     const ui = jobs.validate_repo_e2e_ui;
+    expect(ui).not.toHaveProperty("continue-on-error");
     expect(ui.strategy).toMatchObject({
       "fail-fast": false,
       matrix: { shard: [1, 2, 3, 4] },
@@ -4214,16 +4317,25 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     expect(
       ui.steps.find((step: WorkflowStep) => step.name === "Run Control UI E2E shard")?.run,
     ).toContain('--shard "$SHARD_INDEX/4"');
+    expect(
+      ui.steps.find((step: WorkflowStep) => step.name === "Cache Playwright Chromium")?.uses,
+    ).toBe("actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae");
 
     const realGateway = jobs.validate_repo_e2e_ui_real_gateway;
+    expectRuntimeConsumer(realGateway);
     const realGatewayRun = realGateway.steps.find(
       (step: WorkflowStep) => step.name === "Run Control UI real-Gateway E2E",
     )?.run;
     expect(realGatewayRun).toContain("mcp-app-conformance.e2e.test.ts");
     expect(realGatewayRun).toContain("control-ui-auth-transports.e2e.test.ts");
     expect(realGatewayRun).toContain("logs-lifecycle.e2e.test.ts");
+    expect(
+      realGateway.steps.find((step: WorkflowStep) => step.name === "Cache Playwright Chromium")
+        ?.uses,
+    ).toBe("actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae");
 
     const legacy = jobs.validate_repo_e2e_legacy;
+    expect(legacy).not.toHaveProperty("continue-on-error");
     expect(legacy.if).toContain("repo_e2e_shards_available != 'true'");
     expect(legacy["timeout-minutes"]).toBe(90);
     expect(
@@ -4246,6 +4358,7 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     );
     expect(gate["runs-on"]).toBe("ubuntu-24.04");
     expect(gate["timeout-minutes"]).toBe(5);
+    expect(gate["continue-on-error"]).toBe("${{ inputs.advisory }}");
     const gateStep = gate.steps.find((step: WorkflowStep) => step.name === "Verify repo E2E lanes");
     expect(gateStep.env).toMatchObject({
       GATEWAY_RESULT: "${{ needs.validate_repo_e2e_gateway.result }}",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4135,17 +4135,38 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     const validateStep = validateRef.steps.find(
       (step: WorkflowStep) => step.name === "Validate selected ref",
     );
+    const capabilityCheckout = validateRef.steps.find(
+      (step: WorkflowStep) => step.name === "Checkout trusted repo E2E capability validator",
+    );
+    const capabilityStep = validateRef.steps.find(
+      (step: WorkflowStep) => step.name === "Resolve repo E2E capability",
+    );
 
     expect(validateRef.outputs.repo_e2e_shards_available).toBe(
-      "${{ steps.validate.outputs.repo_e2e_shards_available }}",
+      "${{ steps.repo_e2e.outputs.repo_e2e_shards_available }}",
     );
-    expect(validateStep.run).toContain("required_repo_e2e_paths=(");
-    expect(validateStep.env.WORKFLOW_SHA).toBe("${{ steps.workflow.outputs.workflow_sha }}");
-    expect(validateStep.run).toContain('if [[ "$selected_sha" != "$WORKFLOW_SHA" ]]');
-    expect(validateStep.run).toContain("repoE2eRuntime:");
-    expect(validateStep.run).toContain("OPENCLAW_E2E_USE_PREBUILT_DIST");
-    expect(validateStep.run).toContain("OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY");
-    expect(validateStep.run).toContain(
+    expect(capabilityCheckout?.with).toMatchObject({
+      repository: "${{ steps.workflow.outputs.workflow_repository }}",
+      ref: "${{ steps.workflow.outputs.workflow_sha }}",
+      path: ".release-harness",
+      "persist-credentials": false,
+    });
+    expect(capabilityStep?.env).toMatchObject({
+      CAPABILITY_PATH: ".github/repo-e2e-capabilities.json",
+      SELECTED_SHA: "${{ steps.validate.outputs.selected_sha }}",
+    });
+    expect(capabilityStep?.run).toContain(
+      "node .release-harness/scripts/validate-repo-e2e-capability.mjs",
+    );
+    expect(capabilityStep?.run).toContain('git show "${SELECTED_SHA}:${CAPABILITY_PATH}"');
+    expect(capabilityStep?.run).not.toContain("WORKFLOW_SHA");
+    expect(validateStep.run).not.toContain("required_repo_e2e_paths=(");
+    expect(validateStep.env).not.toHaveProperty("WORKFLOW_SHA");
+    expect(validateStep.run).not.toContain('if [[ "$selected_sha" != "$WORKFLOW_SHA" ]]');
+    expect(validateStep.run).not.toContain("repoE2eRuntime:");
+    expect(validateStep.run).not.toContain("OPENCLAW_E2E_USE_PREBUILT_DIST");
+    expect(validateStep.run).not.toContain("OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY");
+    expect(validateStep.run).not.toContain(
       'echo "repo_e2e_shards_available=$repo_e2e_shards_available" >> "$GITHUB_OUTPUT"',
     );
 
@@ -4180,6 +4201,7 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     expect(packRuntime?.run).toContain('--arg buildCommand "pnpm build repoE2eRuntime"');
     expect(packRuntime?.run).toContain("manifest.json");
     expect(packRuntime?.run).toContain('archive_sha256=$(sha256sum "$archive_path"');
+    expect(packRuntime?.run).toContain('artifact_name="$archive_name"');
     const uploadRuntime = runtime.steps.find(
       (step: WorkflowStep) => step.name === "Upload repo E2E runtime",
     );
@@ -4244,6 +4266,13 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
           (step: WorkflowStep) => step.name === "Validate repo E2E runtime artifact binding",
         )?.run,
       ).toContain('verify-upload "Repo E2E runtime"');
+      expect(
+        job.steps.find(
+          (step: WorkflowStep) => step.name === "Validate repo E2E runtime artifact binding",
+        )?.run,
+      ).toContain(
+        'expected_artifact_name="repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}.tar.zst"',
+      );
       expect(
         job.steps.find((step: WorkflowStep) => step.name === "Download repo E2E runtime")?.with,
       ).toMatchObject({
@@ -4342,6 +4371,34 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
       legacy.steps.find((step: WorkflowStep) => step.name === "Run legacy repo E2E suite")?.run,
     ).toBe("pnpm test:e2e");
 
+    for (const [jobName, job] of Object.entries({
+      prepare_repo_e2e_runtime: runtime,
+      validate_repo_e2e_gateway: gateway,
+      validate_repo_e2e_agent_plugin: agentPlugin,
+      validate_repo_e2e_ui: ui,
+      validate_repo_e2e_ui_real_gateway: realGateway,
+      validate_repo_e2e_legacy: legacy,
+    })) {
+      expect(
+        job.steps.find((step: WorkflowStep) => step.name === "Setup Node environment")?.with?.[
+          "cache-mode"
+        ],
+        jobName,
+      ).toBe("restore");
+    }
+    for (const job of [ui, realGateway]) {
+      expect(
+        job.steps.filter((step: WorkflowStep) => step.name === "Cache Playwright Chromium"),
+      ).toEqual([
+        expect.objectContaining({
+          uses: "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae",
+        }),
+      ]);
+      expect(
+        job.steps.some((step: WorkflowStep) => step.uses?.startsWith("actions/cache/save@")),
+      ).toBe(false);
+    }
+
     const gate = jobs.validate_repo_e2e;
     expect(gate.needs).toEqual([
       "validate_selected_ref",
@@ -4359,6 +4416,13 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     expect(gate["runs-on"]).toBe("ubuntu-24.04");
     expect(gate["timeout-minutes"]).toBe(5);
     expect(gate["continue-on-error"]).toBe("${{ inputs.advisory }}");
+    expect(
+      gate.steps.some(
+        (step: WorkflowStep) =>
+          step.uses === "./.github/actions/setup-node-env" ||
+          step.uses?.startsWith("actions/cache/"),
+      ),
+    ).toBe(false);
     const gateStep = gate.steps.find((step: WorkflowStep) => step.name === "Verify repo E2E lanes");
     expect(gateStep.env).toMatchObject({
       GATEWAY_RESULT: "${{ needs.validate_repo_e2e_gateway.result }}",
@@ -4369,6 +4433,98 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     });
     expect(gateStep.run).toContain('require_result legacy "$LEGACY_RESULT" skipped');
     expect(gateStep.run).toContain('require_result legacy "$LEGACY_RESULT" success');
+  });
+
+  it("uses the target-owned repo E2E capability across mixed target and tooling SHAs", () => {
+    const workflow = parse(
+      readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"),
+    );
+    const capabilityStep = workflow.jobs.validate_selected_ref.steps.find(
+      (step: WorkflowStep) => step.name === "Resolve repo E2E capability",
+    );
+    const root = tempDirs.make("openclaw-repo-e2e-capability-");
+    runGit(root, ["init", "-q", "-b", "main"]);
+    runGit(root, ["config", "commit.gpgsign", "false"]);
+    runGit(root, ["config", "user.email", "ci-fixture@example.com"]);
+    runGit(root, ["config", "user.name", "CI Fixture"]);
+
+    writeFileSync(path.join(root, "fixture.txt"), "legacy\n", "utf8");
+    runGit(root, ["add", "fixture.txt"]);
+    runGit(root, ["commit", "-q", "-m", "legacy target"]);
+    const legacySha = runGit(root, ["rev-parse", "HEAD"]);
+
+    mkdirSync(path.join(root, ".github"), { recursive: true });
+    writeFileSync(
+      path.join(root, ".github", "repo-e2e-capabilities.json"),
+      readFileSync(".github/repo-e2e-capabilities.json", "utf8"),
+      "utf8",
+    );
+    runGit(root, ["add", ".github/repo-e2e-capabilities.json"]);
+    runGit(root, ["commit", "-q", "-m", "capable target"]);
+    const capableSha = runGit(root, ["rev-parse", "HEAD"]);
+
+    writeFileSync(path.join(root, ".github", "repo-e2e-capabilities.json"), "{}\n", "utf8");
+    runGit(root, ["add", ".github/repo-e2e-capabilities.json"]);
+    runGit(root, ["commit", "-q", "-m", "invalid target"]);
+    const invalidSha = runGit(root, ["rev-parse", "HEAD"]);
+
+    writeFileSync(path.join(root, "fixture.txt"), "newer tooling\n", "utf8");
+    runGit(root, ["add", "fixture.txt"]);
+    runGit(root, ["commit", "-q", "-m", "newer tooling"]);
+    const toolingSha = runGit(root, ["rev-parse", "HEAD"]);
+    expect(toolingSha).not.toBe(capableSha);
+
+    const harnessScripts = path.join(root, ".release-harness", "scripts");
+    mkdirSync(harnessScripts, { recursive: true });
+    writeFileSync(
+      path.join(harnessScripts, "validate-repo-e2e-capability.mjs"),
+      readFileSync("scripts/validate-repo-e2e-capability.mjs", "utf8"),
+      "utf8",
+    );
+
+    const runCapability = (selectedSha: string) => {
+      const githubOutput = path.join(root, `output-${selectedSha}`);
+      const githubSummary = path.join(root, `summary-${selectedSha}`);
+      writeFileSync(githubOutput, "", "utf8");
+      writeFileSync(githubSummary, "", "utf8");
+      const run = runWorkflowShellScript(capabilityStep.run, {
+        cwd: root,
+        env: {
+          ...process.env,
+          CAPABILITY_PATH: ".github/repo-e2e-capabilities.json",
+          GITHUB_OUTPUT: githubOutput,
+          GITHUB_STEP_SUMMARY: githubSummary,
+          RUNNER_TEMP: root,
+          SELECTED_SHA: selectedSha,
+          WORKFLOW_SHA: toolingSha,
+        },
+      });
+      return {
+        ...run,
+        outputs: readWorkflowOutputs(githubOutput),
+      };
+    };
+
+    const capable = runCapability(capableSha);
+    expect(capable.status, `${capable.stdout}\n${capable.stderr}`).toBe(0);
+    expect(capable.outputs).toMatchObject({
+      repo_e2e_capability_reason: "contract-v1",
+      repo_e2e_shards_available: "true",
+    });
+
+    const legacy = runCapability(legacySha);
+    expect(legacy.status, `${legacy.stdout}\n${legacy.stderr}`).toBe(0);
+    expect(legacy.outputs).toMatchObject({
+      repo_e2e_capability_reason: "missing",
+      repo_e2e_shards_available: "false",
+    });
+
+    const invalid = runCapability(invalidSha);
+    expect(invalid.status, `${invalid.stdout}\n${invalid.stderr}`).toBe(0);
+    expect(invalid.outputs).toMatchObject({
+      repo_e2e_capability_reason: "invalid",
+      repo_e2e_shards_available: "false",
+    });
   });
 
   it("persists Node 22 declarations through trusted bounded artifacts", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4115,18 +4115,6 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     const releaseChecks = parse(
       readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"),
     );
-    expect(releaseChecks.jobs.validate_repo_e2e.env).toMatchObject({
-      OPENCLAW_BUILD_PRIVATE_QA: "1",
-      OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
-    });
-    expect(releaseChecks.jobs.validate_repo_e2e["timeout-minutes"]).toBe(90);
-    const repoE2eSteps = releaseChecks.jobs.validate_repo_e2e.steps as WorkflowStep[];
-    const sandboxSetupIndex = repoE2eSteps.findIndex(
-      (step) => step.name === "Build sandbox image" && step.run === "scripts/sandbox-setup.sh",
-    );
-    const repoE2eIndex = repoE2eSteps.findIndex((step) => step.name === "Run repo E2E suite");
-    expect(sandboxSetupIndex).toBeGreaterThanOrEqual(0);
-    expect(repoE2eIndex).toBeGreaterThan(sandboxSetupIndex);
     const targetedGroupStep = releaseChecks.jobs.plan_docker_lane_groups.steps.find(
       (step: WorkflowStep) => step.name === "Build targeted Docker lane groups",
     );
@@ -4136,6 +4124,138 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     expect(releaseChecks.jobs.validate_docker_lanes["timeout-minutes"]).toBe(
       "${{ matrix.group.timeout_minutes || 60 }}",
     );
+  });
+
+  it("fans repo E2E out behind one compatibility-preserving aggregate gate", () => {
+    const workflow = parse(
+      readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"),
+    );
+    const jobs = workflow.jobs;
+    const validateRef = jobs.validate_selected_ref;
+    const validateStep = validateRef.steps.find(
+      (step: WorkflowStep) => step.name === "Validate selected ref",
+    );
+
+    expect(validateRef.outputs.repo_e2e_shards_available).toBe(
+      "${{ steps.validate.outputs.repo_e2e_shards_available }}",
+    );
+    expect(validateStep.run).toContain("required_repo_e2e_paths=(");
+    expect(validateStep.run).toContain("scripts/docker/shared-image-artifact.sh");
+    expect(validateStep.run).toContain("OPENCLAW_E2E_USE_PREBUILT_DIST");
+    expect(validateStep.run).toContain("OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY");
+    expect(validateStep.run).toContain(
+      'echo "repo_e2e_shards_available=$repo_e2e_shards_available" >> "$GITHUB_OUTPUT"',
+    );
+
+    const runtime = jobs.prepare_repo_e2e_runtime;
+    expect(runtime.needs).toBe("validate_selected_ref");
+    expect(runtime.if).toContain("repo_e2e_shards_available == 'true'");
+    expect(runtime["runs-on"]).toBe(
+      "${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}",
+    );
+    expect(runtime.env).toMatchObject({
+      OPENCLAW_BUILD_PRIVATE_QA: "1",
+      OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
+    });
+    expect(
+      runtime.steps.find((step: WorkflowStep) => step.name === "Build private QA runtime once")
+        ?.run,
+    ).toBe("pnpm build qaRuntime");
+    expect(
+      runtime.steps.find((step: WorkflowStep) => step.name === "Pack repo E2E runtime")?.run,
+    ).toContain("dist dist-runtime packages/*/dist");
+    expect(
+      runtime.steps.find((step: WorkflowStep) => step.name === "Upload repo E2E runtime")?.uses,
+    ).toBe(UPLOAD_ARTIFACT_V7);
+
+    const sandbox = jobs.prepare_repo_e2e_sandbox;
+    expect(sandbox.outputs.archive_sha256).toBe("${{ steps.pack.outputs.archive_sha256 }}");
+    expect(
+      sandbox.steps.find((step: WorkflowStep) => step.name === "Build repo E2E sandbox image")?.run,
+    ).toBe("scripts/sandbox-setup.sh");
+    expect(
+      sandbox.steps.find((step: WorkflowStep) => step.name === "Pack repo E2E sandbox image")?.run,
+    ).toContain("scripts/docker/shared-image-artifact.sh");
+
+    const gateway = jobs.validate_repo_e2e_gateway;
+    expect(gateway.needs).toEqual([
+      "validate_selected_ref",
+      "prepare_repo_e2e_runtime",
+      "prepare_repo_e2e_sandbox",
+    ]);
+    expect(gateway.strategy).toMatchObject({
+      "fail-fast": false,
+      matrix: { shard: [1, 2, 3, 4] },
+    });
+    expect(gateway.env).toMatchObject({
+      OPENCLAW_E2E_USE_PREBUILT_DIST: "1",
+      OPENCLAW_E2E_WORKERS: "1",
+    });
+    expect(
+      gateway.steps.find((step: WorkflowStep) => step.name === "Load repo E2E sandbox image")?.run,
+    ).toContain("scripts/docker/shared-image-artifact.sh");
+    expect(
+      gateway.steps.find((step: WorkflowStep) => step.name === "Run repo Gateway E2E shard")?.run,
+    ).toContain('--shard "$SHARD_INDEX/4"');
+
+    const agentPlugin = jobs.validate_repo_e2e_agent_plugin;
+    expect(agentPlugin.needs).toEqual(["validate_selected_ref", "prepare_repo_e2e_runtime"]);
+    expect(
+      agentPlugin.steps.find((step: WorkflowStep) => step.name === "Run Agent Plugin Gateway E2E")
+        ?.run,
+    ).toBe("pnpm test:e2e:agent-plugin-gateway");
+
+    const ui = jobs.validate_repo_e2e_ui;
+    expect(ui.strategy).toMatchObject({
+      "fail-fast": false,
+      matrix: { shard: [1, 2, 3, 4] },
+    });
+    expect(ui.env.OPENCLAW_UI_E2E_SKIP_REAL_GATEWAY).toBe("1");
+    expect(
+      ui.steps.find((step: WorkflowStep) => step.name === "Run Control UI E2E shard")?.run,
+    ).toContain('--shard "$SHARD_INDEX/4"');
+
+    const realGateway = jobs.validate_repo_e2e_ui_real_gateway;
+    const realGatewayRun = realGateway.steps.find(
+      (step: WorkflowStep) => step.name === "Run Control UI real-Gateway E2E",
+    )?.run;
+    expect(realGatewayRun).toContain("mcp-app-conformance.e2e.test.ts");
+    expect(realGatewayRun).toContain("control-ui-auth-transports.e2e.test.ts");
+    expect(realGatewayRun).toContain("logs-lifecycle.e2e.test.ts");
+
+    const legacy = jobs.validate_repo_e2e_legacy;
+    expect(legacy.if).toContain("repo_e2e_shards_available != 'true'");
+    expect(legacy["timeout-minutes"]).toBe(90);
+    expect(
+      legacy.steps.find((step: WorkflowStep) => step.name === "Run legacy repo E2E suite")?.run,
+    ).toBe("pnpm test:e2e");
+
+    const gate = jobs.validate_repo_e2e;
+    expect(gate.needs).toEqual([
+      "validate_selected_ref",
+      "prepare_repo_e2e_runtime",
+      "prepare_repo_e2e_sandbox",
+      "validate_repo_e2e_gateway",
+      "validate_repo_e2e_agent_plugin",
+      "validate_repo_e2e_ui",
+      "validate_repo_e2e_ui_real_gateway",
+      "validate_repo_e2e_legacy",
+    ]);
+    expect(gate.if).toBe(
+      "${{ always() && inputs.include_repo_e2e && inputs.live_suite_filter == '' }}",
+    );
+    expect(gate["runs-on"]).toBe("ubuntu-24.04");
+    expect(gate["timeout-minutes"]).toBe(5);
+    const gateStep = gate.steps.find((step: WorkflowStep) => step.name === "Verify repo E2E lanes");
+    expect(gateStep.env).toMatchObject({
+      GATEWAY_RESULT: "${{ needs.validate_repo_e2e_gateway.result }}",
+      LEGACY_RESULT: "${{ needs.validate_repo_e2e_legacy.result }}",
+      REPO_E2E_SHARDS_AVAILABLE:
+        "${{ needs.validate_selected_ref.outputs.repo_e2e_shards_available }}",
+      UI_RESULT: "${{ needs.validate_repo_e2e_ui.result }}",
+    });
+    expect(gateStep.run).toContain('require_result legacy "$LEGACY_RESULT" skipped');
+    expect(gateStep.run).toContain('require_result legacy "$LEGACY_RESULT" success');
   });
 
   it("persists Node 22 declarations through trusted bounded artifacts", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3818,9 +3818,24 @@ describe("package artifact reuse", () => {
     );
     expect(workflow).toContain("bash .release-harness/scripts/ci-live-command-retry.sh");
     expect(workflow).toContain("use_github_hosted_runners:");
-    expect(workflow).toMatch(
-      /validate_repo_e2e:[\s\S]*?runs-on: \$\{\{ inputs\.use_github_hosted_runners && 'ubuntu-24\.04' \|\| 'blacksmith-8vcpu-ubuntu-2404' \}\}/u,
+    for (const jobName of [
+      "prepare_repo_e2e_sandbox",
+      "validate_repo_e2e_gateway",
+      "validate_repo_e2e_agent_plugin",
+      "validate_repo_e2e_ui",
+      "validate_repo_e2e_legacy",
+    ]) {
+      expect(workflowJob(LIVE_E2E_WORKFLOW, jobName)["runs-on"]).toBe(
+        "${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}",
+      );
+    }
+    expect(workflowJob(LIVE_E2E_WORKFLOW, "prepare_repo_e2e_runtime")["runs-on"]).toBe(
+      "${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}",
     );
+    expect(workflowJob(LIVE_E2E_WORKFLOW, "validate_repo_e2e_ui_real_gateway")["runs-on"]).toBe(
+      "${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-16vcpu-ubuntu-2404' }}",
+    );
+    expect(workflowJob(LIVE_E2E_WORKFLOW, "validate_repo_e2e")["runs-on"]).toBe("ubuntu-24.04");
     expect(workflow).toMatch(
       /validate_special_e2e:[\s\S]*?runs-on: \$\{\{ inputs\.use_github_hosted_runners && 'ubuntu-24\.04' \|\| 'blacksmith-8vcpu-ubuntu-2404' \}\}/u,
     );

--- a/test/scripts/shared-image-artifact.test.ts
+++ b/test/scripts/shared-image-artifact.test.ts
@@ -309,6 +309,25 @@ describe("shared Docker image artifacts", () => {
       );
 
       writeFileSync(fixture.ghLog, "");
+      const rawArchiveName = `repo-e2e-runtime-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}.tar.zst`;
+      const rawArchive = verifyUploadedArtifact(fixture, {
+        artifactName: rawArchiveName,
+        env: { FAKE_ARTIFACT_NAME: rawArchiveName },
+      });
+      expect(rawArchive.status, `${rawArchive.stdout}\n${rawArchive.stderr}`).toBe(0);
+
+      writeFileSync(fixture.ghLog, "");
+      const unsupportedSuffix = verifyUploadedArtifact(fixture, {
+        artifactName: `${ARTIFACT_NAME}.zip`,
+        env: { FAKE_ARTIFACT_NAME: `${ARTIFACT_NAME}.zip` },
+      });
+      expect(unsupportedSuffix.status).not.toBe(0);
+      expect(unsupportedSuffix.stderr).toContain(
+        "artifact name does not bind the producer run attempt",
+      );
+      expect(readFileSync(fixture.ghLog, "utf8")).toBe("");
+
+      writeFileSync(fixture.ghLog, "");
       const digestMismatch = verifyUploadedArtifact(fixture, {
         artifactDigest: "e".repeat(64),
       });


### PR DESCRIPTION
Related: #127014

## What Problem This Solves

Resolves a problem where release repository E2E built once and then ran Gateway, agent-plugin Gateway, and UI coverage serially in one job. A late Gateway failure could consume nearly an hour and prevent the other suites from running.

## Why This Change Was Made

The workflow now builds one private-QA runtime artifact, runs four Gateway shards, agent-plugin Gateway, four UI shards, and real-Gateway UI independently, then preserves the existing `validate_repo_e2e` aggregate gate. A versioned target capability manifest enables the sharded contract for mixed frozen target/tooling SHAs; older or invalid targets use the legacy path.

Artifact producers and consumers bind exact IDs, digests, run attempts, target/tooling SHAs, safe extraction, and trusted harness validation. The six repository-E2E Node setup callers are restore-only under the current cache-authority contract; Playwright remains restore-only and the aggregate gate owns no cache.

The shared repository-E2E runtime now uses the canonical split declaration build (`tsdown-ai`, `tsdown-packages`, and `tsdown-unified`) plus the plugin-SDK declaration/export gates. This preserves package compatibility proofs without falling back to the slow singular `tsdown` graph.

## User Impact

Release qualification should collect complete repository E2E failures in one pass and reduce this lane from roughly 55 minutes toward 15-25 minutes without removing coverage.

## Evidence

- Exact head: `a190f4d5c247a2d55aa6d947e65c08a1998feca8`, based on `main` at `e66d7c5cac65fa9391904648eb81861276bc5725`.
- Focused workflow, capability, build-profile, and artifact tests: 415 passed, 2 skipped. The only combined-run retry was the offline pnpm hard-link cache guard; its exact focused retry passed.
- Updated build-profile contract: 54 passed.
- Package compatibility proof with the declaration-complete prebuilt runtime: 1 passed.
- Actionlint, YAML/JSON parsing, targeted formatting, shell syntax, script lint, script erasability, `git diff --check`, privacy scan, and local structured autoreview passed.
- Cache-authority guards prove exactly six restore callers, restore-only Playwright caches, a cache-free aggregate, and preserve the repository-wide four-writer invariant.

## Hosted Proof

- Sharded proof at prior head: https://github.com/openclaw/openclaw/actions/runs/32484143871
  - Capability routing selected the sharded graph; the legacy job skipped.
  - Four UI shards, agent-plugin Gateway, real-Gateway UI, OpenShell, runtime preparation, and sandbox preparation passed.
  - All four Gateway shards ran with fail-fast disabled; the aggregate waited for every lane and correctly reported only `gateway=failure`.
  - One failure class was owned by this PR: the shared runtime omitted declarations required by the package compatibility E2E. The current head fixes that producer contract.
  - Remaining Gateway failures are target-code regressions or current test drift, not sharding exclusions; examples include stale embedded-run mocks, reply-dispatch publication, onboarding agent-name requirements, heartbeat declarations, subagent lifecycle timing, and Codex auth migration state.
- Legacy compatibility proof against frozen target `225aa5a1782325a9ad4e543947b1ff7659a60cce`: https://github.com/openclaw/openclaw/actions/runs/32484152197
  - The capability manifest was absent, so only the legacy job ran and all sharded jobs skipped.
  - OpenShell passed. The legacy suite independently reproduced overlapping target-code failures before its Vitest worker exited unexpectedly.
  - The aggregate waited for the legacy lane and correctly reported only `legacy=failure`.
- Corrective exact-head sharded proof: https://github.com/openclaw/openclaw/actions/runs/32494803571
  - Completed in 30m49s. Only this invalidated surface was restarted; the legacy routing proof remains valid.
  - Runtime preparation passed in 7m56s with the declaration-complete split graph. The `@openclaw/ai` packed-package install/typecheck passed in Gateway shard 3, clearing the PR-owned missing-declaration failure.
  - All four UI shards, agent-plugin Gateway, real-Gateway UI, OpenShell, runtime preparation, and sandbox preparation passed.
  - All four Gateway shards ran to completion with fail-fast disabled and retained target-code/test failures: subagent lifecycle retry/grace, Telegram ingress coalescing, stale embedded-run mocks, unavailable Codex harness registration, ClawHub search expectations, Codex auth canonical-store assertions, OpenAI compaction replay, and onboarding agent-name requirements.
  - The aggregate waited for every lane and reported only `gateway=failure`; runtime, sandbox, agent-plugin, UI, and real-Gateway UI were `success`, while legacy was `skipped`.

Exact-head ClawSweeper found no actionable source-level defect. The PR remains draft for maintainer review because current-target Gateway regressions are outside this workflow-performance branch.
