### PR TITLE
perf(test): speed up server preference observations

### DIFF
--- a/ui/src/app/server-prefs.test.ts
+++ b/ui/src/app/server-prefs.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError, type GatewayBrowserClient } from "../api/gateway.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
+import { waitForFast } from "../test-helpers/wait-for.ts";
 import { configWithPrefs, createServerPrefsWriter } from "./server-prefs.test-support.ts";
 import {
   applyServerUiPrefs,
@@ -154,7 +155,7 @@ describe("applyServerUiPrefs", () => {
     const client = createServerPrefsWriter(request, scope);
 
     pushServerUiPrefs(client, { themeMode: "dark" });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(localStorage.getItem(`openclaw.control.serverPrefs.pending.v1:${scope}`)).toBeNull(),
     );
 
@@ -171,7 +172,7 @@ describe("applyServerUiPrefs", () => {
     const request = vi.fn(async () => ({}));
     const client = createServerPrefsWriter(request, scope);
     pushServerUiPrefs(client, { themeMode: "dark" });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(localStorage.getItem(`openclaw.control.serverPrefs.pending.v1:${scope}`)).toBeNull(),
     );
 
@@ -460,7 +461,7 @@ describe("pushServerUiPrefs", () => {
     expect(onThemeChanged).not.toHaveBeenCalled();
 
     requestGate.resolve({});
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey(scope))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey(scope))).toBeNull());
   });
 
   it("keeps a synced default reset as a pending offline null intent", () => {
@@ -526,7 +527,7 @@ describe("pushServerUiPrefs", () => {
 
     pushServerUiPrefs(createClient(request, scope), prefs ?? {}, { afterCommit });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(afterCommit).toHaveBeenCalledWith({
         needsRefresh: false,
         retainedLocal: true,
@@ -582,7 +583,7 @@ describe("pushServerUiPrefs", () => {
     });
 
     pushServerUiPrefs(createClient(request, scope), prefs ?? {}, { afterCommit });
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(afterCommit).toHaveBeenCalledWith({
         needsRefresh: false,
         retainedLocal: true,
@@ -617,7 +618,7 @@ describe("pushServerUiPrefs", () => {
     const client = createClient(request);
 
     pushServerUiPrefs(client, { themeMode: "dark" }, { afterCommit });
-    await vi.waitFor(() => expect(afterCommit).toHaveBeenCalledOnce());
+    await waitForFast(() => expect(afterCommit).toHaveBeenCalledOnce());
     expect(afterCommit).toHaveBeenCalledWith({ needsRefresh: false });
 
     expect(request).toHaveBeenCalledExactlyOnceWith("config.patch", {
@@ -660,7 +661,7 @@ describe("pushServerUiPrefs", () => {
 
     flight.resolve({});
 
-    await vi.waitFor(() => expect(readPending(scope)).toEqual({ locale: "fr" }));
+    await waitForFast(() => expect(readPending(scope)).toEqual({ locale: "fr" }));
   });
 
   it("drops only this tab's validation-rejected keys from persisted pending", async () => {
@@ -674,7 +675,7 @@ describe("pushServerUiPrefs", () => {
 
     pushServerUiPrefs(client, { theme: "knot" });
 
-    await vi.waitFor(() => expect(readPending(scope)).toEqual({ locale: "fr" }));
+    await waitForFast(() => expect(readPending(scope)).toEqual({ locale: "fr" }));
   });
 
   it("overwrites only a same-key sibling value when this tab persists later", () => {
@@ -711,7 +712,7 @@ describe("pushServerUiPrefs", () => {
     pushServerUiPrefs(client, { themeMode: "light" });
     resolveFirst?.();
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(request.mock.calls[1]?.[1]).toEqual({
       raw: JSON.stringify({ ui: { prefs: { themeMode: "light" } } }),
       note: "control-ui prefs sync",
@@ -734,7 +735,7 @@ describe("pushServerUiPrefs", () => {
     request.mockResolvedValue({});
     flushServerUiPrefs(client);
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
   });
 
   it("retains in-memory pending intent when localStorage is unavailable", async () => {
@@ -777,7 +778,7 @@ describe("pushServerUiPrefs", () => {
 
     flushServerUiPrefs(client);
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
   });
 
   it("supersedes a hung prior-connection request on same-client flush", async () => {
@@ -793,7 +794,7 @@ describe("pushServerUiPrefs", () => {
     flushServerUiPrefs(client);
 
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
   });
 
   it("ignores a superseded request rejection while its replacement is pending", async () => {
@@ -815,7 +816,7 @@ describe("pushServerUiPrefs", () => {
 
     expect(localStorage.getItem(pendingKey("ws://gw"))).not.toBeNull();
     second.resolve({});
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
   });
 
   it("reconciles the refreshed snapshot again after clearing its pending shadow", async () => {
@@ -842,7 +843,7 @@ describe("pushServerUiPrefs", () => {
       },
     );
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
 
     expect(onApplied).toHaveBeenCalledWith({ themeMode: "light" });
     expect(loadSettings().themeMode).toBe("light");
@@ -858,7 +859,7 @@ describe("pushServerUiPrefs", () => {
 
     pushServerUiPrefs(client, { themeMode: "dark" }, { afterCommit });
 
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(afterCommit).toHaveBeenCalledWith({
         needsRefresh: true,
       }),
@@ -908,7 +909,7 @@ describe("pushServerUiPrefs", () => {
     });
     resolveRequest?.();
 
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://a"))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey("ws://a"))).toBeNull());
     expect(JSON.parse(localStorage.getItem(pendingKey("ws://b")) ?? "{}")).toEqual({
       locale: "de",
     });
@@ -1074,7 +1075,7 @@ describe("pushServerUiPrefs", () => {
       firstClient;
     (writer.state as { connected: boolean }).connected = true;
     flushServerUiPrefs(writer);
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://first"))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey("ws://first"))).toBeNull());
     expect(localStorage.getItem(pendingKey(""))).toBeNull();
 
     localStorage.setItem(pendingKey("ws://second"), JSON.stringify({ themeMode: "dark" }));
@@ -1102,7 +1103,7 @@ describe("pushServerUiPrefs", () => {
     expect(request.mock.calls[0]?.[1]).toMatchObject({
       raw: JSON.stringify({ ui: { prefs: { locale: "de" } } }),
     });
-    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://first"))).toBeNull());
+    await waitForFast(() => expect(localStorage.getItem(pendingKey("ws://first"))).toBeNull());
     expect(localStorage.getItem(pendingKey(""))).toBeNull();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The Control UI server-preference regression suite spends nearly a full second waiting for Vitest's default 50 ms polling interval after mocked preference acknowledgments have already settled. This slows repeated developer and CI runs despite the actual storage, reconnect, and configuration work completing promptly.

## Why This Change Was Made

Reuse the existing Control UI `waitForFast` test helper for 18 genuinely asynchronous pending-preference, acknowledgment, and queued-write observations. Keep synchronous request-ordering barriers and both fake-timer polling calls unchanged so simulated 250 ms conflict retries, 1,000 ms redrains, lifecycle ordering, and all existing assertions retain their exact contracts.

## User Impact

No production or user-facing behavior changes. The same 51 server-preference regression tests run substantially faster while preserving read-only authorization, cross-tab persistence, last-writer-wins, reconnect, and fake-timer coverage.

## Evidence

- Same Blacksmith Testbox, identical checkout and cache, three pre-edit and three post-edit runs.
- Pre-edit wall samples: 2.28 s cold, 1.97 s warm, 1.99 s warm; test-body samples: 996 ms, 1,002 ms, 1,004 ms.
- Post-edit wall samples: 1.14 s, 0.99 s, 1.05 s; test-body samples: 104 ms, 99 ms, 103 ms.
- Warm median wall: **1.99 s to 1.05 s, saving 0.94 s (47.2%)**. Median test-body time: **1,002 ms to 103 ms, saving 899 ms (89.7%)**.
- All 64 owner/sibling/integration tests passed: `node scripts/run-vitest.mjs ui/src/app/server-prefs.test.ts ui/src/app/server-prefs.read-only.test.ts ui/src/app/app-host.server-prefs.test.ts`.
- Complete clean-machine changed gate passed: `node scripts/check-changed.mjs -- ui/src/app/server-prefs.test.ts`.
- Independent structured autoreview: clean, no actionable findings.
- Production LOC: +0/-0. Tests: +19/-18. No assertions, test cases, owner code, snapshots, baselines, dependencies, or deadlines changed.
