### PR TITLE
fix(process): keep large command queues responsive

### DIFF
--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -3,7 +3,7 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 // lanes, with per-member reservations. Split out of command-queue.ts to keep
 // that file within its size budget; the queue supplies its own `drainLane` so
 // this module never has to import back into it.
-import { getQueueState, normalizeLane } from "./command-queue.state.js";
+import { getQueueState, normalizeLane, peekLaneQueue } from "./command-queue.state.js";
 import { CommandLane } from "./lanes.js";
 
 /** Drains a single lane. Supplied by command-queue.ts to avoid a cycle. */
@@ -235,7 +235,7 @@ function resolveNextGroupLane(group: LaneGroupState): string | undefined {
     | undefined;
   for (const lane of group.members) {
     const state = getQueueState().lanes.get(lane);
-    const head = state?.queue[0];
+    const head = state ? peekLaneQueue(state.queue) : undefined;
     if (!state || !head || state.draining || resolveLaneBlockReason(lane) !== null) {
       continue;
     }

--- a/src/process/command-queue.state.ts
+++ b/src/process/command-queue.state.ts
@@ -9,13 +9,15 @@ export type CommandLaneTaskMarker = Readonly<{
   generation: number;
 }>;
 
+export type QueuePriority = -1 | 0 | 1;
+
 export type QueueEntry = {
   task: (marker: CommandLaneTaskMarker) => Promise<unknown>;
   resolve: (value: unknown) => void;
   reject: (reason?: unknown) => void;
   enqueuedAt: number;
   sequence: number;
-  priority: number;
+  priority: QueuePriority;
   warnAfterMs: number;
   queuedAheadAtEnqueue: number;
   activeAheadAtEnqueue: number;
@@ -27,14 +29,121 @@ export type QueueEntry = {
   onWait?: (waitMs: number, queuedAhead: number) => void;
 };
 
+type QueueRing = {
+  entries: Array<QueueEntry | undefined>;
+  head: number;
+  length: number;
+};
+
+/** Three fixed FIFO rings, one for each supported priority. */
+type LaneQueue = {
+  background: QueueRing;
+  normal: QueueRing;
+  foreground: QueueRing;
+  length: number;
+};
+
 export type LaneState = {
   lane: string;
-  queue: QueueEntry[];
+  queue: LaneQueue;
   activeTaskIds: Set<number>;
   maxConcurrent: number;
   draining: boolean;
   generation: number;
 };
+
+const INITIAL_QUEUE_RING_CAPACITY = 16;
+
+function createQueueRing(): QueueRing {
+  return { entries: [], head: 0, length: 0 };
+}
+
+export function createLaneQueue(): LaneQueue {
+  return {
+    background: createQueueRing(),
+    normal: createQueueRing(),
+    foreground: createQueueRing(),
+    length: 0,
+  };
+}
+
+function getPriorityRing(queue: LaneQueue, priority: QueuePriority): QueueRing {
+  switch (priority) {
+    case 1:
+      return queue.foreground;
+    case -1:
+      return queue.background;
+    default:
+      return queue.normal;
+  }
+}
+
+function appendQueueRing(ring: QueueRing, entry: QueueEntry): void {
+  if (ring.length === ring.entries.length) {
+    const nextCapacity = Math.max(INITIAL_QUEUE_RING_CAPACITY, ring.length * 2);
+    const nextEntries: Array<QueueEntry | undefined> = Array.from({ length: nextCapacity });
+    for (let index = 0; index < ring.length; index += 1) {
+      nextEntries[index] = ring.entries[(ring.head + index) % ring.entries.length];
+    }
+    ring.entries = nextEntries;
+    ring.head = 0;
+  }
+  ring.entries[(ring.head + ring.length) % ring.entries.length] = entry;
+  ring.length += 1;
+}
+
+function peekQueueRing(ring: QueueRing): QueueEntry | undefined {
+  return ring.length > 0 ? ring.entries[ring.head] : undefined;
+}
+
+function dequeueQueueRing(ring: QueueRing): QueueEntry | undefined {
+  if (ring.length === 0) {
+    return undefined;
+  }
+  const entry = ring.entries[ring.head];
+  ring.entries[ring.head] = undefined;
+  ring.length -= 1;
+  if (ring.length === 0) {
+    // Release a drained burst's backing allocation rather than retaining each
+    // lane's historical high-water capacity indefinitely.
+    ring.entries = [];
+    ring.head = 0;
+  } else {
+    ring.head = (ring.head + 1) % ring.entries.length;
+  }
+  return entry;
+}
+
+/** Append to one of three fixed priority FIFOs and return the queued work ahead. */
+export function enqueueLaneQueue(queue: LaneQueue, entry: QueueEntry): number {
+  const ring = getPriorityRing(queue, entry.priority);
+  const queuedAhead =
+    ring.length +
+    (entry.priority <= 0 ? queue.foreground.length : 0) +
+    (entry.priority < 0 ? queue.normal.length : 0);
+  appendQueueRing(ring, entry);
+  queue.length += 1;
+  return queuedAhead;
+}
+
+export function peekLaneQueue(queue: LaneQueue): QueueEntry | undefined {
+  return (
+    peekQueueRing(queue.foreground) ??
+    peekQueueRing(queue.normal) ??
+    peekQueueRing(queue.background)
+  );
+}
+
+export function dequeueLaneQueue(queue: LaneQueue): QueueEntry | undefined {
+  const entry =
+    dequeueQueueRing(queue.foreground) ??
+    dequeueQueueRing(queue.normal) ??
+    dequeueQueueRing(queue.background);
+  if (entry) {
+    queue.length -= 1;
+  }
+  return entry;
+}
 
 /**
  * Keep queue runtime state on globalThis so every bundled entry/chunk shares
@@ -47,40 +156,50 @@ export function getQueueState() {
     lanes: new Map<string, LaneState>(),
     nextTaskId: 1,
     nextQueueSequence: 1,
+    queueFormatVersion: 1,
   }));
   if (!state.nextQueueSequence) {
     state.nextQueueSequence = 1;
   }
-  let maxQueueSequence = state.nextQueueSequence - 1;
-  for (const lane of state.lanes.values()) {
-    for (const [index, entry] of (
-      lane.queue as Array<
-        QueueEntry & {
-          activeAheadAtEnqueue?: number;
-          priority?: number;
-          queuedAheadAtEnqueue?: number;
-          sequence?: number;
+  // SIGUSR1 restarts can preserve the singleton created by the shipped array-backed queue.
+  // Convert it once so steady-state state reads do not rescan every queued entry.
+  if (state.queueFormatVersion !== 1) {
+    let maxQueueSequence = state.nextQueueSequence - 1;
+    type LegacyQueueEntry = QueueEntry & {
+      activeAheadAtEnqueue?: number;
+      priority?: number;
+      queuedAheadAtEnqueue?: number;
+      sequence?: number;
+    };
+    type LegacyLaneState = Omit<LaneState, "queue"> & {
+      queue: LaneQueue | LegacyQueueEntry[];
+    };
+    for (const lane of state.lanes.values() as Iterable<LegacyLaneState>) {
+      if (!Array.isArray(lane.queue)) {
+        continue;
+      }
+      const legacyQueue = lane.queue;
+      const queue = createLaneQueue();
+      for (const [index, entry] of legacyQueue.entries()) {
+        entry.priority = entry.priority === 1 || entry.priority === -1 ? entry.priority : 0;
+        if (typeof entry.sequence !== "number") {
+          entry.sequence = state.nextQueueSequence++;
         }
-      >
-    ).entries()) {
-      if (typeof entry.priority !== "number") {
-        entry.priority = 0;
-      }
-      if (typeof entry.sequence !== "number") {
-        entry.sequence = state.nextQueueSequence++;
-      } else {
         maxQueueSequence = Math.max(maxQueueSequence, entry.sequence);
+        if (typeof entry.queuedAheadAtEnqueue !== "number") {
+          entry.queuedAheadAtEnqueue = index;
+        }
+        if (typeof entry.activeAheadAtEnqueue !== "number") {
+          entry.activeAheadAtEnqueue = lane.activeTaskIds.size;
+        }
+        enqueueLaneQueue(queue, entry);
       }
-      if (typeof entry.queuedAheadAtEnqueue !== "number") {
-        entry.queuedAheadAtEnqueue = index;
-      }
-      if (typeof entry.activeAheadAtEnqueue !== "number") {
-        entry.activeAheadAtEnqueue = lane.activeTaskIds.size;
-      }
+      lane.queue = queue;
     }
-  }
-  if (state.nextQueueSequence <= maxQueueSequence) {
-    state.nextQueueSequence = maxQueueSequence + 1;
+    if (state.nextQueueSequence <= maxQueueSequence) {
+      state.nextQueueSequence = maxQueueSequence + 1;
+    }
+    state.queueFormatVersion = 1;
   }
   return state;
 }

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -1,5 +1,6 @@
 // Command queue tests cover bounded command execution and queue ordering.
 import { AsyncLocalStorage } from "node:async_hooks";
+import { spawnSync } from "node:child_process";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -224,6 +225,114 @@ describe("command queue", () => {
     await blocker;
     await Promise.all([first, second]);
     expect(calls).toEqual(["first", "second"]);
+  });
+
+  it("preserves priority and FIFO order across partial drains and resumed growth", async () => {
+    const lane = "priority-fifo-resume";
+    const calls: string[] = [];
+    const enqueue = (label: string, priority?: "foreground" | "background") =>
+      enqueueCommandInLane(
+        lane,
+        async () => {
+          calls.push(label);
+        },
+        { priority },
+      );
+
+    setCommandLaneConcurrency(lane, 0);
+    const normal = Array.from({ length: 20 }, (_, index) => enqueue(`normal-${index}`));
+
+    setCommandLaneConcurrency(lane, 5);
+    setCommandLaneConcurrency(lane, 0);
+    await Promise.all(normal.slice(0, 5));
+
+    const resumedNormal = Array.from({ length: 20 }, (_, index) => enqueue(`normal-${index + 20}`));
+    const background = Array.from({ length: 18 }, (_, index) =>
+      enqueue(`background-${index}`, "background"),
+    );
+    const foreground = Array.from({ length: 18 }, (_, index) =>
+      enqueue(`foreground-${index}`, "foreground"),
+    );
+    setCommandLaneConcurrency(lane, 1);
+    await Promise.all([...normal, ...resumedNormal, ...background, ...foreground]);
+
+    expect(calls).toEqual([
+      ...Array.from({ length: 5 }, (_, index) => `normal-${index}`),
+      ...Array.from({ length: 18 }, (_, index) => `foreground-${index}`),
+      ...Array.from({ length: 35 }, (_, index) => `normal-${index + 5}`),
+      ...Array.from({ length: 18 }, (_, index) => `background-${index}`),
+    ]);
+  });
+
+  it("avoids quadratic array work as a paused queue doubles", () => {
+    const script = String.raw`
+      const { enqueueCommandInLane, setCommandLaneConcurrency } = await import(
+        "./src/process/command-queue.ts"
+      );
+      const originalFindIndex = Array.prototype.findIndex;
+      const originalShift = Array.prototype.shift;
+      let enqueueComparisons = 0;
+      let shiftedSlots = 0;
+
+      Array.prototype.findIndex = function (predicate, thisArg) {
+        return originalFindIndex.call(this, (value, index, array) => {
+          enqueueComparisons += 1;
+          return predicate.call(thisArg, value, index, array);
+        });
+      };
+      Array.prototype.shift = function () {
+        shiftedSlots += this.length;
+        return originalShift.call(this);
+      };
+
+      const measureQueueWork = async (count) => {
+        const lane = "linear-queue-" + count;
+        setCommandLaneConcurrency(lane, 0);
+        const comparisonStart = enqueueComparisons;
+        const tasks = Array.from({ length: count }, (_, index) =>
+          enqueueCommandInLane(lane, async () => index),
+        );
+        const enqueueWork = enqueueComparisons - comparisonStart;
+        const shiftedSlotStart = shiftedSlots;
+        setCommandLaneConcurrency(lane, count);
+        const dequeueWork = shiftedSlots - shiftedSlotStart;
+        await Promise.all(tasks);
+        return { enqueueWork, dequeueWork };
+      };
+
+      const smaller = await measureQueueWork(256);
+      const larger = await measureQueueWork(512);
+      process.stdout.write(JSON.stringify({ smaller, larger }));
+    `;
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NODE_OPTIONS: undefined,
+          VITEST: undefined,
+          VITEST_POOL_ID: undefined,
+          VITEST_WORKER_ID: undefined,
+        },
+        timeout: 60_000,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    const measurements = JSON.parse(result.stdout) as {
+      smaller: { enqueueWork: number; dequeueWork: number };
+      larger: { enqueueWork: number; dequeueWork: number };
+    };
+    expect(measurements.larger.enqueueWork).toBeLessThanOrEqual(
+      measurements.smaller.enqueueWork * 3 + 512,
+    );
+    expect(measurements.larger.dequeueWork).toBeLessThanOrEqual(
+      measurements.smaller.dequeueWork * 3 + 512,
+    );
   });
 
   it("reports queueAhead after priority insertion", async () => {
@@ -727,18 +836,25 @@ describe("command queue", () => {
     await expect(second).resolves.toBe("second");
   });
 
-  it("clearCommandLane rejects pending promises", async () => {
+  it("clearCommandLane rejects pending promises at every priority", async () => {
     // First task blocks the lane.
     const { task: first, release } = enqueueBlockedMainTask(async () => "first");
 
-    // Second task is queued behind the first.
-    const second = enqueueCommandInLane(CommandLane.Main, async () => "second");
+    const background = enqueueCommandInLane(CommandLane.Main, async () => "background", {
+      priority: "background",
+    });
+    const normal = enqueueCommandInLane(CommandLane.Main, async () => "normal");
+    const foreground = enqueueCommandInLane(CommandLane.Main, async () => "foreground", {
+      priority: "foreground",
+    });
+    const rejectionChecks = [background, normal, foreground].map((task) =>
+      expect(task).rejects.toBeInstanceOf(CommandLaneClearedError),
+    );
 
     const removed = clearCommandLane();
-    expect(removed).toBe(1); // only the queued (not active) entry
+    expect(removed).toBe(3); // only the queued (not active) entries
 
-    // The queued promise should reject.
-    await expect(second).rejects.toBeInstanceOf(CommandLaneClearedError);
+    await Promise.all(rejectionChecks);
 
     // Let the active task finish normally.
     release();

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -21,11 +21,15 @@ import {
   validateCommandLaneGroupSpec,
 } from "./command-queue.capacity-groups.js";
 import {
+  createLaneQueue,
+  dequeueLaneQueue,
+  enqueueLaneQueue,
   type CommandLaneTaskMarker,
   getQueueState,
   type LaneState,
   normalizeLane,
   type QueueEntry,
+  type QueuePriority,
 } from "./command-queue.state.js";
 import type { CommandQueueEnqueueOptions } from "./command-queue.types.js";
 import {
@@ -172,7 +176,7 @@ function getLaneState(lane: string): LaneState {
   }
   const created: LaneState = {
     lane,
-    queue: [],
+    queue: createLaneQueue(),
     activeTaskIds: new Set(),
     maxConcurrent: 1,
     draining: false,
@@ -218,7 +222,7 @@ function normalizeTaskTimeoutMs(value: number | undefined): number | undefined {
   return clampPositiveTimerTimeoutMs(value);
 }
 
-function resolveQueuePriority(priority: CommandQueueEnqueueOptions["priority"]): number {
+function resolveQueuePriority(priority: CommandQueueEnqueueOptions["priority"]): QueuePriority {
   switch (priority) {
     case "foreground":
       return 1;
@@ -230,18 +234,8 @@ function resolveQueuePriority(priority: CommandQueueEnqueueOptions["priority"]):
 }
 
 function enqueueLaneEntry(state: LaneState, entry: QueueEntry): void {
-  const insertAt = state.queue.findIndex(
-    (queued) =>
-      queued.priority < entry.priority ||
-      (queued.priority === entry.priority && queued.sequence > entry.sequence),
-  );
-  entry.queuedAheadAtEnqueue = insertAt < 0 ? state.queue.length : insertAt;
+  entry.queuedAheadAtEnqueue = enqueueLaneQueue(state.queue, entry);
   entry.activeAheadAtEnqueue = state.activeTaskIds.size;
-  if (insertAt < 0) {
-    state.queue.push(entry);
-    return;
-  }
-  state.queue.splice(insertAt, 0, entry);
 }
 
 async function runQueueEntryTask(
@@ -395,7 +389,7 @@ function drainLane(
       state.queue.length > 0 &&
       canAdmitInGroup(lane)
     ) {
-      const entry = state.queue.shift() as QueueEntry;
+      const entry = dequeueLaneQueue(state.queue) as QueueEntry;
       const waitedMs = Date.now() - entry.enqueuedAt;
       const activeBeforeStart = state.activeTaskIds.size;
       const taskId = getQueueState().nextTaskId++;
@@ -692,8 +686,8 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
     return 0;
   }
   const removed = state.queue.length;
-  const pending = state.queue.splice(0);
-  for (const entry of pending) {
+  let entry: QueueEntry | undefined;
+  while ((entry = dequeueLaneQueue(state.queue))) {
     entry.reject(new CommandLaneClearedError(cleaned));
   }
   return removed;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where large bursts of same-priority queued commands became progressively slower to enqueue and start. A 10,000-command burst spent 3.23 seconds enqueueing and 1.89 seconds draining because each operation repeatedly scanned or shifted the full pending array.

## Why This Change Was Made

The process command-queue owner now uses three fixed-priority FIFO circular queues, giving append and head removal amortized constant-time behavior while retaining existing foreground/normal/background priority and FIFO ordering. The process-global singleton performs one versioned in-memory conversion after a SIGUSR1 restart so pending work created by the prior array-backed implementation is preserved; there is no persisted migration or public contract change.

## User Impact

Large command bursts remain responsive instead of blocking the process for seconds. Queue priority, lane/group arbitration, wait diagnostics, cancellation/clear behavior, restart preservation, and admission policy are unchanged.

## Evidence

- Exact pre-fix proof: 512 paused enqueues performed 130,816 comparisons and draining performed 131,328 shifted-slot operations. The current-main owner files were unchanged from that red baseline before this patch.
- Node 26.5.1 benchmark at 10,000 commands: enqueue 3,228.9 ms → 65.7 ms (49.1×); drain 1,887.2 ms → 59.3 ms (31.8×). The 5K→10K slope fell from 4.56×/4.34× to 2.09×/2.18×.
- Final rebased head: 77/77 focused queue tests. The patch-identical pre-rebase head also passed the complete `src/process` suite (385 passed, 8 skipped) and 22/22 embedded-agent lane caller tests.
- `node scripts/check-changed.mjs -- <four changed paths>` passed all core/core-test typechecks, changed-file lint, formatting, dead exports, import cycles, and repository guards. The patch ID is byte-identical after the non-overlapping rebase.
- Fresh final-head autoreview: TruffleHog clean; no accepted/actionable findings; `patch is correct` confidence 0.98.

Risk is low-to-moderate and internal: the queue representation changes, but the tests cover partial drain/growth wraparound, every priority, capacity-group arbitration, clear/reject, restart migration, caller liveness, and backing allocation release.

AI-assisted. I understand the change and verified the final patch; no agent transcript is included because transcript-sharing consent was not provided.
