### PR TITLE
fix: preserve binding ownership and task visibility

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3455,7 +3455,7 @@ src/plugins/config-schema.ts	6
 src/plugins/contracts/inventory/bundled-capability-metadata.ts	3
 src/plugins/contracts/registry.ts	1
 src/plugins/contracts/tts-contract-suites.ts	31
-src/plugins/conversation-binding.ts	2
+src/plugins/conversation-binding.ts	1
 src/plugins/current-plugin-metadata-snapshot.ts	1
 src/plugins/dashboard-capabilities.ts	1
 src/plugins/dev-source-root.ts	1

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -434,6 +434,12 @@ metadata. Replacing either starts fresh target metadata, so a new session cannot
 inherit the previous plugin owner, agent, or label. Keep conversation transport
 details and explicit lifecycle settings separate from target metadata.
 
+Preserve opaque plugin ownership metadata when projecting binding records.
+Plugin-owned targets do not require an OpenClaw agent id; use
+`isPluginOwnedSessionBindingRecord(...)` from
+`openclaw/plugin-sdk/conversation-binding-runtime` to distinguish them from
+agent-owned targets before resolving an agent.
+
 ## Approvals and channel capabilities
 
 Most channel plugins do not need approval-specific code. Core owns same-chat

--- a/extensions/feishu/src/thread-bindings.plugin.test.ts
+++ b/extensions/feishu/src/thread-bindings.plugin.test.ts
@@ -1,0 +1,93 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import {
+  createEmptyPluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  getSessionBindingService,
+  resolveRuntimeConversationBindingRoute,
+} from "openclaw/plugin-sdk/conversation-binding-runtime";
+import { resolvePluginConversationBindingApproval } from "openclaw/plugin-sdk/conversation-runtime";
+import { createInteractiveConversationBindingHelpers } from "openclaw/plugin-sdk/plugin-runtime";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { createFeishuThreadBindingManager } from "./thread-bindings.js";
+
+beforeEach(() => {
+  setActivePluginRegistry(createEmptyPluginRegistry());
+});
+
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+});
+
+it("approves, routes, and detaches an opaque Feishu plugin target without inventing an agent owner", async () => {
+  await withStateDirEnv("feishu-plugin-binding-", async ({ tempRoot }) => {
+    const cfg = {
+      agents: { entries: { alpha: {}, beta: {} } },
+      bindings: [{ agentId: "alpha", match: { channel: "feishu" } }],
+    } satisfies OpenClawConfig;
+    const manager = createFeishuThreadBindingManager({ cfg, accountId: "default" });
+    const owner = { pluginId: "fixture-runtime", pluginRoot: tempRoot };
+    const conversation = {
+      channel: "feishu",
+      accountId: "default",
+      conversationId: "oc_group:topic:om_root",
+      parentConversationId: "oc_group",
+    };
+    const binding = { summary: "Plugin-owned thread", data: { externalThread: "thread-17" } };
+    const helpers = createInteractiveConversationBindingHelpers({
+      registration: owner,
+      senderId: "user-1",
+      conversation,
+    });
+    try {
+      const requested = await helpers.requestConversationBinding(binding);
+      expect(requested.status).toBe("pending");
+      if (requested.status !== "pending") {
+        throw new Error("Expected a plugin binding approval request");
+      }
+      await expect(
+        resolvePluginConversationBindingApproval({
+          approvalId: requested.approvalId,
+          decision: "allow-once",
+          senderId: "user-1",
+        }),
+      ).resolves.toMatchObject({ status: "approved", binding: { ...owner, ...binding } });
+
+      const approvedRecord = expectDefined(
+        getSessionBindingService().resolveByConversation(conversation),
+        "approved Feishu plugin binding",
+      );
+      const record = await getSessionBindingService().bind({
+        conversation,
+        targetSessionKey: approvedRecord.targetSessionKey,
+        targetKind: approvedRecord.targetKind,
+      });
+      expect(record.targetSessionKey).toMatch(/^plugin-binding:fixture-runtime:/);
+      expect(record.metadata?.agentId).toBeUndefined();
+      const route = resolveAgentRoute({
+        cfg,
+        channel: "feishu",
+        accountId: "default",
+        peer: { kind: "group", id: conversation.conversationId },
+      });
+      expect(resolveRuntimeConversationBindingRoute({ route, conversation })).toMatchObject({
+        pluginId: owner.pluginId,
+        route,
+        bindingRecord: record,
+      });
+      await expect(helpers.getCurrentConversationBinding()).resolves.toMatchObject({
+        ...owner,
+        ...binding,
+      });
+      await expect(helpers.detachConversationBinding()).resolves.toEqual({ removed: true });
+      expect(getSessionBindingService().resolveByConversation(conversation)).toBeNull();
+    } finally {
+      manager.stop();
+    }
+  });
+});

--- a/extensions/feishu/src/thread-bindings.test.ts
+++ b/extensions/feishu/src/thread-bindings.test.ts
@@ -44,7 +44,7 @@ describe("Feishu thread bindings", () => {
   it("binds and resolves a Feishu topic conversation", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
     createFeishuThreadBindingManager({
-      cfg: { ...baseCfg, agents: { list: [{ id: "main" }, { id: "codex" }] } },
+      cfg: { ...baseCfg, agents: { entries: { main: {}, codex: {} } } },
       accountId: "default",
     });
 
@@ -255,9 +255,10 @@ describe("Feishu thread bindings", () => {
     ).toBeNull();
   });
 
-  it.each([false, true])(
-    "preserves conversation delivery fields without inheriting another target's owner (replace=%s)",
-    async (replace) => {
+  it.each(["refresh", "session", "kind"] as const)(
+    "preserves conversation delivery fields without inheriting another target's owner (%s)",
+    async (change) => {
+      const replace = change !== "refresh";
       vi.spyOn(Date, "now").mockReturnValue(1_700_000_100_000);
       const manager = createFeishuThreadBindingManager({ cfg: baseCfg, accountId: "default" });
 
@@ -272,12 +273,17 @@ describe("Feishu thread bindings", () => {
           boundBy: "system",
           deliveryTo: "user:ou_sender_1",
           deliveryThreadId: "om_topic_root",
+          pluginBindingOwner: "plugin",
+          pluginId: "fixture-plugin",
+          pluginRoot: "/fixture/plugin",
+          data: { threadId: "plugin-thread" },
         },
       });
 
       await getSessionBindingService().bind({
-        targetSessionKey: replace ? "agent:main:subagent:replacement" : "agent:main:subagent:child",
-        targetKind: "subagent",
+        targetSessionKey:
+          change === "session" ? "agent:main:subagent:replacement" : "agent:main:subagent:child",
+        targetKind: change === "kind" ? "session" : "subagent",
         conversation: {
           channel: "feishu",
           accountId: "default",
@@ -298,8 +304,9 @@ describe("Feishu thread bindings", () => {
         }),
       ).toEqual({
         bindingId: "default:oc_group_chat:topic:om_topic_root:sender:ou_sender_1",
-        targetSessionKey: replace ? "agent:main:subagent:replacement" : "agent:main:subagent:child",
-        targetKind: "subagent",
+        targetSessionKey:
+          change === "session" ? "agent:main:subagent:replacement" : "agent:main:subagent:child",
+        targetKind: change === "kind" ? "session" : "subagent",
         conversation: {
           channel: "feishu",
           accountId: "default",
@@ -310,6 +317,14 @@ describe("Feishu thread bindings", () => {
         boundAt: 1_700_000_100_000,
         expiresAt: 1_700_086_500_000,
         metadata: {
+          ...(!replace
+            ? {
+                pluginBindingOwner: "plugin",
+                pluginId: "fixture-plugin",
+                pluginRoot: "/fixture/plugin",
+                data: { threadId: "plugin-thread" },
+              }
+            : {}),
           agentId: replace ? "main" : "previous-agent",
           label: "child",
           boundBy: replace ? undefined : "system",

--- a/extensions/feishu/src/thread-bindings.ts
+++ b/extensions/feishu/src/thread-bindings.ts
@@ -1,6 +1,7 @@
 import { resolveSessionAgentIdStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
 // Feishu plugin module implements thread bindings behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { isPluginOwnedSessionBindingRecord } from "openclaw/plugin-sdk/conversation-binding-runtime";
 import {
   resolveThreadBindingIdleTimeoutMsForChannel,
   resolveThreadBindingMaxAgeMsForChannel,
@@ -30,6 +31,7 @@ type FeishuThreadBindingRecord = {
   boundBy?: string;
   boundAt: number;
   lastActivityAt: number;
+  metadata?: Record<string, unknown>;
 };
 
 type FeishuThreadBindingManager = {
@@ -111,6 +113,7 @@ function toSessionBindingRecord(
     boundAt: record.boundAt,
     expiresAt,
     metadata: {
+      ...record.metadata,
       agentId: record.agentId,
       label: record.label,
       boundBy: record.boundBy,
@@ -200,6 +203,8 @@ export function createFeishuThreadBindingManager(params: {
         existingLocal.targetKind === storedTargetKind
           ? existingLocal
           : undefined;
+      // A plugin's opaque target has no agent owner, including on metadata-omitting refreshes.
+      const targetMetadata = { ...previous?.metadata, ...metadata };
       const now = Date.now();
       const record: FeishuThreadBindingRecord = {
         accountId,
@@ -219,14 +224,17 @@ export function createFeishuThreadBindingManager(params: {
         agentId:
           normalizeOptionalString(metadata?.agentId) ??
           previous?.agentId ??
-          resolveSessionAgentIdStrict({
-            config: params.cfg,
-            sessionKey: normalizedTargetSessionKey,
-          }),
+          (isPluginOwnedSessionBindingRecord({ metadata: targetMetadata })
+            ? undefined
+            : resolveSessionAgentIdStrict({
+                config: params.cfg,
+                sessionKey: normalizedTargetSessionKey,
+              })),
         label: normalizeOptionalString(metadata?.label) ?? previous?.label,
         boundBy: normalizeOptionalString(metadata?.boundBy) ?? previous?.boundBy,
         boundAt: now,
         lastActivityAt: now,
+        metadata: targetMetadata,
       };
       getState().bindingsByAccountConversation.set(
         resolveBindingKey({ accountId, conversationId: normalizedConversationId }),

--- a/src/agents/subagents/registry/subagent-list.ts
+++ b/src/agents/subagents/registry/subagent-list.ts
@@ -97,10 +97,9 @@ function buildLatestSubagentRunIndex(
 ) {
   const now = options?.now ?? Date.now();
   const readIndex = buildSubagentRunReadIndexFromRuns({ runs, now });
-  const latestByChildSessionKey = new Map(readIndex.latestRunsByChildSessionKey);
 
   const childSessionsByController = new Map<string, string[]>();
-  for (const [childSessionKey, entry] of latestByChildSessionKey.entries()) {
+  for (const [childSessionKey, entry] of readIndex.latestRunsByChildSessionKey) {
     const controllerSessionKey =
       entry.controllerSessionKey?.trim() || entry.requesterSessionKey?.trim();
     if (!controllerSessionKey) {
@@ -128,7 +127,6 @@ function buildLatestSubagentRunIndex(
   }
 
   return {
-    latestByChildSessionKey,
     childSessionsByController,
     readIndex,
   };

--- a/src/agents/subagents/spawn/subagent-spawn-ownership.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-ownership.ts
@@ -12,7 +12,6 @@ import {
 
 type SubagentSpawnOwnership = {
   controllerSessionKey: string;
-  threadBindingRequesterSessionKey: string;
   completionRequesterSessionKey: string;
   completionRequesterDisplayKey: string;
 };
@@ -48,7 +47,6 @@ export function resolveSubagentSpawnOwnership(params: {
 
   return {
     controllerSessionKey,
-    threadBindingRequesterSessionKey: controllerSessionKey,
     completionRequesterSessionKey,
     completionRequesterDisplayKey,
   };

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -263,7 +263,7 @@ export async function spawnSubagentDirect(
         agentId: targetAgentId,
         label: label || undefined,
         mode: spawnMode,
-        requesterSessionKey: ownership.threadBindingRequesterSessionKey,
+        requesterSessionKey: ownership.controllerSessionKey,
         requester: {
           channel: childSessionOrigin?.channel,
           accountId: childSessionOrigin?.accountId,

--- a/src/agents/tools/subagents-tool.test.ts
+++ b/src/agents/tools/subagents-tool.test.ts
@@ -1,5 +1,6 @@
 // Subagents tool tests cover requester-scoped task listing and cancellation.
 import { describe, expect, it, vi } from "vitest";
+import type { cancelDetachedTaskRunById } from "../../tasks/task-executor.js";
 import type { TaskRecord, TaskRuntime, TaskStatus } from "../../tasks/task-registry.types.js";
 import { TASK_STATUS_DETAIL_MAX_CHARS } from "../../tasks/task-status.js";
 import { SUBAGENT_ENDED_REASON_KILLED } from "../subagents/registry/subagent-lifecycle-events.js";
@@ -206,6 +207,50 @@ describe("subagents tool", () => {
     );
     expect(cancelTask).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["list", "cancel"] as const)(
+    "keeps %s available when an unrelated retained task has ambiguous ownership",
+    async (action) => {
+      const config = { agents: { entries: { alpha: {}, beta: {} } } };
+      const cancelTask = vi.fn<typeof cancelDetachedTaskRunById>().mockResolvedValue({
+        found: true,
+        cancelled: true,
+      });
+      const tool = createSubagentsTool({
+        agentSessionKey: "agent:alpha:main",
+        config,
+        listTasks: () => [
+          task({
+            taskId: "legacy-orphan",
+            runtime: "cli",
+            ownerKey: "global",
+            requesterSessionKey: "global",
+          }),
+          task({
+            taskId: "owned-task",
+            runtime: "cli",
+            ownerKey: "agent:alpha:main",
+            requesterSessionKey: "agent:alpha:main",
+          }),
+        ],
+        cancelTask,
+      });
+
+      const result = await tool.execute(action, { action, taskId: "owned-task" });
+
+      if (action === "list") {
+        expect(result.details).toMatchObject({
+          status: "ok",
+          taskTotal: 1,
+          tasks: [expect.objectContaining({ taskId: "owned-task" })],
+        });
+        expect(cancelTask).not.toHaveBeenCalled();
+      } else {
+        expect(result.details).toMatchObject({ status: "cancelled", taskId: "owned-task" });
+        expect(cancelTask).toHaveBeenCalledExactlyOnceWith({ cfg: config, taskId: "owned-task" });
+      }
+    },
+  );
 
   it("preserves blocked terminal outcomes and actionable terminal failure reasons", async () => {
     const tasks = [

--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -9,8 +9,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { listTaskRecordsUnsorted } from "../../tasks/runtime-internal.js";
 import { cancelDetachedTaskRunById } from "../../tasks/task-executor.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
+import { resolveTaskSessionAgentId } from "../../tasks/task-session-identity.js";
 import { TASK_STATUS_DETAIL_MAX_CHARS, sanitizeTaskStatusText } from "../../tasks/task-status.js";
-import { resolveSessionAgentId } from "../agent-scope.js";
 import { optionalPositiveIntegerSchema, optionalStringEnum } from "../schema/typebox.js";
 import {
   DEFAULT_RECENT_MINUTES,
@@ -58,20 +58,16 @@ function taskUpdatedAt(task: TaskRecord): number {
   return task.lastEventAt ?? task.endedAt ?? task.startedAt ?? task.createdAt;
 }
 
-function resolveTaskRequesterAgentId(task: TaskRecord, cfg: OpenClawConfig): string | undefined {
-  if (task.requesterAgentId) {
-    return task.requesterAgentId;
-  }
-  return resolveSessionAgentId({ sessionKey: task.ownerKey, config: cfg });
-}
-
 function taskOwnerMatches(
   task: TaskRecord,
   sessionKey: string,
   agentId: string,
   cfg: OpenClawConfig,
 ): boolean {
-  return task.ownerKey === sessionKey && resolveTaskRequesterAgentId(task, cfg) === agentId;
+  return (
+    task.ownerKey === sessionKey &&
+    resolveTaskSessionAgentId(task.ownerKey, task.requesterAgentId, cfg) === agentId
+  );
 }
 
 function listTreeTasks(
@@ -89,7 +85,11 @@ function listTreeTasks(
       if (task.scopeKind !== "session" || visibleTasks.has(task.taskId)) {
         continue;
       }
-      const taskRequesterAgentId = resolveTaskRequesterAgentId(task, cfg);
+      const taskRequesterAgentId = resolveTaskSessionAgentId(
+        task.ownerKey,
+        task.requesterAgentId,
+        cfg,
+      );
       if (!visibleSessions.has(`${taskRequesterAgentId ?? ""}\0${task.ownerKey}`)) {
         continue;
       }

--- a/src/auto-reply/reply/dispatch-from-config.context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.context.ts
@@ -4,7 +4,7 @@ import { normalizeChatType } from "../../channels/chat-type.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
-import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding.js";
+import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding-metadata.js";
 import { isAcpSessionKey } from "../../routing/session-key.js";
 import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import type { FinalizedMsgContext } from "../templating.js";

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -19,10 +19,8 @@ import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import { logVerbose } from "../../globals.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
-import {
-  isPluginOwnedSessionBindingRecord,
-  toPluginConversationBinding,
-} from "../../plugins/conversation-binding.js";
+import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding-metadata.js";
+import { toPluginConversationBinding } from "../../plugins/conversation-binding.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { resolveSilentReplyPolicyFromPolicies } from "../../shared/silent-reply-policy.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -614,12 +614,6 @@ vi.mock("../../plugins/conversation-binding.js", () => ({
     pluginConversationBindingMocks.shownFallbackNoticeBindingIds.has(
       JSON.stringify([scope?.channel, scope?.accountId, bindingId]),
     ),
-  isPluginOwnedSessionBindingRecord: (
-    record: SessionBindingRecord | null | undefined,
-  ): record is SessionBindingRecord =>
-    record?.metadata != null &&
-    typeof record.metadata === "object" &&
-    (record.metadata as { pluginBindingOwner?: string }).pluginBindingOwner === "plugin",
   markPluginBindingFallbackNoticeShown: (
     bindingId: string,
     scope?: { channel: string; accountId: string },

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -68,7 +68,7 @@ import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding.js";
+import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding-metadata.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";

--- a/src/channels/plugins/binding-routing.ts
+++ b/src/channels/plugins/binding-routing.ts
@@ -11,6 +11,7 @@ import {
   type ConversationRef,
   type SessionBindingRecord,
 } from "../../infra/outbound/session-binding-service.js";
+import { isPluginOwnedBindingMetadata } from "../../plugins/conversation-binding-metadata.js";
 import type { ResolvedAgentRoute } from "../../routing/resolve-route.js";
 import { deriveLastRoutePolicy } from "../../routing/resolve-route.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
@@ -67,21 +68,6 @@ function resolveConfiguredBindingConversationRef(
     conversationId: params.conversationId,
     parentConversationId: params.parentConversationId,
   };
-}
-
-function resolvePluginOwnedRuntimeBindingPluginId(
-  record: SessionBindingRecord | null,
-): string | undefined {
-  const metadata = record?.metadata;
-  if (!metadata || typeof metadata !== "object") {
-    return undefined;
-  }
-  const pluginId = metadata.pluginId;
-  const isPluginOwned =
-    metadata.pluginBindingOwner === "plugin" &&
-    typeof pluginId === "string" &&
-    typeof metadata.pluginRoot === "string";
-  return isPluginOwned ? pluginId.trim() || undefined : undefined;
 }
 
 /**
@@ -182,7 +168,9 @@ export function resolveRuntimeConversationBindingRoute(
       bindingRecord.conversation,
     );
   }
-  const pluginId = resolvePluginOwnedRuntimeBindingPluginId(bindingRecord);
+  const pluginId = isPluginOwnedBindingMetadata(bindingRecord.metadata)
+    ? bindingRecord.metadata.pluginId.trim()
+    : undefined;
   if (pluginId) {
     // Plugin-owned binding records are observed but not route-rewritten by core; the owning
     // plugin is responsible for its runtime target handoff.

--- a/src/gateway/server-methods/chat-origin-routing.ts
+++ b/src/gateway/server-methods/chat-origin-routing.ts
@@ -7,7 +7,7 @@ import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../../../packages/gateway-prot
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
-import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding.js";
+import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding-metadata.js";
 import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import {

--- a/src/infra/outbound/account-scoped-conversation-bindings.test.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.test.ts
@@ -104,42 +104,61 @@ describe("account-scoped conversation binding expiry", () => {
     });
   });
 
-  it("preserves the complete opaque adapter metadata envelope through recreation", async () => {
-    const manager = createManager();
-    const metadata = {
-      agentId: "main",
-      label: "durable label",
-      boundBy: "operator",
-      pluginBindingOwner: "owner-plugin",
-      pluginId: "opaque-plugin",
-      nested: { ownerEpoch: 7, capabilities: ["approve", "resume"] },
-    };
-    const conversation = {
-      channel: "imessage",
-      accountId: manager.accountId,
-      conversationId: "chat:opaque-metadata",
-    };
-    const bound = await getSessionBindingService().bind({
-      targetSessionKey: "agent:main:acp:opaque-session",
-      targetKind: "session",
-      conversation,
-      metadata,
-    });
+  it.each(["agent", "plugin"] as const)(
+    "preserves opaque %s binding metadata through recreation",
+    async (ownerKind) => {
+      const cfg = {
+        ...baseCfg,
+        agents: { entries: { alpha: {}, beta: {} } },
+      } satisfies OpenClawConfig;
+      const manager = createManager({ cfg });
+      const metadata = {
+        ...(ownerKind === "agent" ? { agentId: "alpha" } : {}),
+        label: "durable label",
+        boundBy: "operator",
+        pluginBindingOwner: "plugin",
+        pluginId: "opaque-plugin",
+        pluginRoot: "/plugins/opaque-plugin",
+        nested: { ownerEpoch: 7, capabilities: ["approve", "resume"] },
+      };
+      const conversation = {
+        channel: "imessage",
+        accountId: manager.accountId,
+        conversationId: "chat:opaque-metadata",
+      };
+      const bound = await getSessionBindingService().bind({
+        targetSessionKey:
+          ownerKind === "agent"
+            ? "agent:alpha:acp:opaque-session"
+            : "plugin-binding:opaque-plugin:opaque-session",
+        targetKind: "session",
+        conversation,
+        metadata,
+      });
 
-    expect(bound.bindingId).toBe("ttl-owner:chat:opaque-metadata");
-    expect(bound.metadata).toMatchObject(metadata);
-    expect(manager.getByConversationId(conversation.conversationId)?.targetKind).toBe("acp");
+      expect(bound.bindingId).toBe("ttl-owner:chat:opaque-metadata");
+      expect(bound.metadata).toMatchObject(metadata);
+      expect(bound.metadata?.agentId).toBe(ownerKind === "agent" ? "alpha" : undefined);
+      expect(manager.getByConversationId(conversation.conversationId)?.targetKind).toBe("acp");
+      await expect(
+        getSessionBindingService().bind({
+          conversation,
+          targetSessionKey: bound.targetSessionKey,
+          targetKind: bound.targetKind,
+        }),
+      ).resolves.toMatchObject({ metadata });
 
-    manager.stop();
-    closeOpenClawStateDatabaseForTest();
-    createManager();
+      manager.stop();
+      closeOpenClawStateDatabaseForTest();
+      createManager({ cfg });
 
-    expect(getSessionBindingService().resolveByConversation(conversation)).toMatchObject({
-      bindingId: "ttl-owner:chat:opaque-metadata",
-      targetKind: "session",
-      metadata,
-    });
-  });
+      expect(getSessionBindingService().resolveByConversation(conversation)).toMatchObject({
+        bindingId: "ttl-owner:chat:opaque-metadata",
+        targetKind: "session",
+        metadata,
+      });
+    },
+  );
 
   it("keeps the previously committed account binding visible when its replacement write fails", () => {
     const manager = createManager();

--- a/src/infra/outbound/account-scoped-conversation-bindings.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.ts
@@ -6,6 +6,7 @@ import {
   resolveThreadBindingMaxAgeMsForChannel,
 } from "../../channels/thread-bindings-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isPluginOwnedBindingMetadata } from "../../plugins/conversation-binding-metadata.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import {
@@ -197,6 +198,8 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
             ? existing
             : undefined;
         const existingLocal = previous ? asAccountBindingRecord(previous) : undefined;
+        // Preserve plugin ownership on refresh without assigning its opaque target an agent.
+        const metadata = { ...previous?.metadata, ...input.metadata };
         const record: AccountScopedConversationBindingRecord<TKind> = {
           accountId,
           conversationId: normalizedConversationId,
@@ -205,19 +208,18 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
           agentId:
             normalizeOptionalString(input.metadata?.agentId) ??
             existingLocal?.agentId ??
-            resolveSessionAgentId({
-              config: params.cfg,
-              sessionKey: normalizedTargetSessionKey,
-            }),
+            (isPluginOwnedBindingMetadata(metadata)
+              ? undefined
+              : resolveSessionAgentId({
+                  config: params.cfg,
+                  sessionKey: normalizedTargetSessionKey,
+                })),
           label: normalizeOptionalString(input.metadata?.label) ?? existingLocal?.label,
           boundBy: normalizeOptionalString(input.metadata?.boundBy) ?? existingLocal?.boundBy,
           boundAt: now,
           lastActivityAt: now,
         };
-        return asSessionBindingRecord(record, {
-          ...previous?.metadata,
-          ...input.metadata,
-        });
+        return asSessionBindingRecord(record, metadata);
       },
     );
     return current;

--- a/src/plugin-sdk/conversation-binding-runtime.ts
+++ b/src/plugin-sdk/conversation-binding-runtime.ts
@@ -12,5 +12,5 @@ export {
   type SessionBindingRecord,
   getSessionBindingService,
 } from "../infra/outbound/session-binding-service.js";
-export { isPluginOwnedSessionBindingRecord } from "../plugins/conversation-binding.js";
+export { isPluginOwnedSessionBindingRecord } from "../plugins/conversation-binding-metadata.js";
 export { buildPairingReply } from "../pairing/pairing-messages.js";

--- a/src/plugins/conversation-binding-metadata.ts
+++ b/src/plugins/conversation-binding-metadata.ts
@@ -1,0 +1,29 @@
+export type PluginBindingMetadata = {
+  pluginBindingOwner: "plugin";
+  pluginId: string;
+  pluginName?: string;
+  pluginRoot: string;
+  summary?: string;
+  detachHint?: string;
+  data?: Record<string, unknown>;
+  bindingAttemptId?: string;
+};
+
+export function isPluginOwnedBindingMetadata(metadata: unknown): metadata is PluginBindingMetadata {
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+  // SAFETY: The object guard permits property inspection; required fields are checked below.
+  const record = metadata as Record<string, unknown>;
+  return (
+    record.pluginBindingOwner === "plugin" &&
+    typeof record.pluginId === "string" &&
+    typeof record.pluginRoot === "string"
+  );
+}
+
+export function isPluginOwnedSessionBindingRecord(
+  record: { metadata?: Record<string, unknown> } | null | undefined,
+): boolean {
+  return isPluginOwnedBindingMetadata(record?.metadata);
+}

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -120,6 +120,8 @@ let buildPluginBindingApprovalCustomId: typeof import("./conversation-binding.js
 let bindPluginSessionConversation: typeof import("./session-conversation-binding.js").bindPluginSessionConversation;
 let detachPluginConversationBinding: typeof import("./conversation-binding.js").detachPluginConversationBinding;
 let getCurrentPluginConversationBinding: typeof import("./conversation-binding.js").getCurrentPluginConversationBinding;
+let hasShownPluginBindingFallbackNotice: typeof import("./conversation-binding.js").hasShownPluginBindingFallbackNotice;
+let markPluginBindingFallbackNoticeShown: typeof import("./conversation-binding.js").markPluginBindingFallbackNoticeShown;
 let parsePluginBindingApprovalCustomId: typeof import("./conversation-binding.js").parsePluginBindingApprovalCustomId;
 let requestPluginConversationBinding: typeof import("./conversation-binding.js").requestPluginConversationBinding;
 let resolvePluginConversationBindingApproval: typeof import("./conversation-binding.js").resolvePluginConversationBindingApproval;
@@ -176,6 +178,8 @@ beforeAll(async () => {
     buildPluginBindingApprovalCustomId,
     detachPluginConversationBinding,
     getCurrentPluginConversationBinding,
+    hasShownPluginBindingFallbackNotice,
+    markPluginBindingFallbackNoticeShown,
     parsePluginBindingApprovalCustomId,
     requestPluginConversationBinding,
     resolvePluginConversationBindingApproval,
@@ -469,6 +473,18 @@ describe("plugin conversation binding approvals", () => {
     registerSessionBindingAdapter(createAdapter("discord", "isolated"));
     registerSessionBindingAdapter(createAdapter("telegram", "default"));
     registerSessionBindingAdapter(createAdapter("webchat", "default"));
+  });
+
+  it("bounds fallback notice suppression to recent binding IDs", () => {
+    for (let index = 0; index < 4_096; index += 1) {
+      markPluginBindingFallbackNoticeShown(`binding-${index}`);
+    }
+    expect(hasShownPluginBindingFallbackNotice("binding-0")).toBe(true);
+    markPluginBindingFallbackNoticeShown("binding-4096");
+
+    expect(hasShownPluginBindingFallbackNotice("binding-1")).toBe(false);
+    expect(hasShownPluginBindingFallbackNotice("binding-0")).toBe(true);
+    expect(hasShownPluginBindingFallbackNotice("binding-4096")).toBe(true);
   });
 
   it("restores the prior Control UI binding when provider publication fails", async () => {

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -491,6 +491,22 @@ describe("plugin conversation binding approvals", () => {
     expect(hasShownPluginBindingFallbackNotice(bindingId)).toBe(true);
   });
 
+  it("bounds historical fallback notices while preserving recent suppression and lifecycle cleanup", async () => {
+    const scope = { channel: "discord", accountId: "default" };
+    for (let index = 0; index <= 4096; index += 1) {
+      markPluginBindingFallbackNoticeShown(`binding-${index}`, scope);
+    }
+
+    expect(hasShownPluginBindingFallbackNotice("binding-0", scope)).toBe(false);
+    expect(hasShownPluginBindingFallbackNotice("binding-1", scope)).toBe(true);
+    expect(hasShownPluginBindingFallbackNotice("binding-4096", scope)).toBe(true);
+    markPluginBindingFallbackNoticeShown("binding-4097", scope);
+    expect(hasShownPluginBindingFallbackNotice("binding-2", scope)).toBe(false);
+    expect(hasShownPluginBindingFallbackNotice("binding-1", scope)).toBe(true);
+    await drainGlobalSingletonLifecycleState();
+    expect(hasShownPluginBindingFallbackNotice("binding-4096", scope)).toBe(false);
+  });
+
   it("restores the prior Control UI binding when provider publication fails", async () => {
     const previous: SessionBindingRecord = {
       bindingId: "binding-prior",

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
+import { createDedupeCache, type DedupeCache } from "../infra/dedupe.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { buildChannelAccountKey } from "../infra/outbound/session-binding-normalization.js";
@@ -18,6 +19,10 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import {
+  isPluginOwnedBindingMetadata,
+  type PluginBindingMetadata,
+} from "./conversation-binding-metadata.js";
 import {
   buildPluginBindingSessionKey,
   normalizeChannel,
@@ -35,7 +40,6 @@ import { getActivePluginRegistry } from "./runtime.js";
 const log = createSubsystemLogger("plugins/binding");
 
 const PLUGIN_BINDING_CUSTOM_ID_PREFIX = "pluginbind";
-const PLUGIN_BINDING_OWNER = "plugin";
 const LEGACY_CODEX_PLUGIN_SESSION_PREFIXES = [
   "openclaw-app-server:thread:",
   "openclaw-codex-app-server:thread:",
@@ -92,17 +96,6 @@ type PluginBindingIdentity = {
   pluginId: string;
   pluginName?: string;
   pluginRoot: string;
-};
-
-type PluginBindingMetadata = {
-  pluginBindingOwner: "plugin";
-  pluginId: string;
-  pluginName?: string;
-  pluginRoot: string;
-  summary?: string;
-  detachHint?: string;
-  data?: Record<string, unknown>;
-  bindingAttemptId?: string;
 };
 
 type PluginBindingResolveResult =
@@ -169,31 +162,16 @@ function addPendingPluginBindingRequest(request: PendingPluginBindingRequest): v
 }
 
 type PluginBindingGlobalState = {
-  fallbackNoticeBindingIds: Set<string>;
+  fallbackNoticeBindingIds: DedupeCache;
   approvalsCache: PluginBindingApprovalsState | null;
-};
-
-type PluginConversationBindingState = {
-  ref: ConversationRef;
-  record:
-    | {
-        bindingId: string;
-        conversation: ConversationRef;
-        boundAt: number;
-        metadata?: Record<string, unknown>;
-        targetSessionKey: string;
-      }
-    | null
-    | undefined;
-  binding: PluginConversationBinding | null;
-  isLegacyForeignBinding: boolean;
 };
 
 const pluginBindingGlobalStateKey = Symbol.for("openclaw.plugins.binding.global-state");
 const pluginBindingGlobalState = resolveGlobalSingleton<PluginBindingGlobalState>(
   pluginBindingGlobalStateKey,
   () => ({
-    fallbackNoticeBindingIds: new Set<string>(),
+    // Retain recent outage notices without keeping every historical binding forever.
+    fallbackNoticeBindingIds: createDedupeCache({ ttlMs: 0, maxSize: 4_096 }),
     approvalsCache: null,
   }),
   (state) => {
@@ -449,7 +427,7 @@ function buildBindingMetadata(params: {
   bindingAttemptId?: string;
 }): PluginBindingMetadata {
   return {
-    pluginBindingOwner: PLUGIN_BINDING_OWNER,
+    pluginBindingOwner: "plugin",
     pluginId: params.pluginId,
     pluginName: params.pluginName,
     pluginRoot: params.pluginRoot,
@@ -458,29 +436,6 @@ function buildBindingMetadata(params: {
     data: normalizeBindingData(params.data),
     bindingAttemptId: normalizeOptionalString(params.bindingAttemptId),
   };
-}
-
-function isPluginOwnedBindingMetadata(metadata: unknown): metadata is PluginBindingMetadata {
-  if (!metadata || typeof metadata !== "object") {
-    return false;
-  }
-  const record = metadata as Record<string, unknown>;
-  return (
-    record.pluginBindingOwner === PLUGIN_BINDING_OWNER &&
-    typeof record.pluginId === "string" &&
-    typeof record.pluginRoot === "string"
-  );
-}
-
-export function isPluginOwnedSessionBindingRecord(
-  record:
-    | {
-        metadata?: Record<string, unknown>;
-      }
-    | null
-    | undefined,
-): boolean {
-  return isPluginOwnedBindingMetadata(record?.metadata);
 }
 
 export function toPluginConversationBinding(
@@ -527,7 +482,7 @@ function withConversationBindingContext(
 
 function resolvePluginConversationBindingState(params: {
   conversation: PluginBindingConversation;
-}): PluginConversationBindingState {
+}) {
   const ref = toConversationRef(params.conversation);
   const record = getSessionBindingService().resolveByConversation(ref);
   const binding = toPluginConversationBinding(record);
@@ -662,21 +617,21 @@ export function hasShownPluginBindingFallbackNotice(
   scope?: SessionBindingScope,
 ): boolean {
   const normalized = buildPluginBindingFallbackNoticeKey(bindingId, scope);
-  if (!normalized) {
-    return false;
+  const cache = pluginBindingGlobalState.fallbackNoticeBindingIds;
+  const shown = cache.peek(normalized);
+  if (shown) {
+    cache.check(normalized);
   }
-  return pluginBindingGlobalState.fallbackNoticeBindingIds.has(normalized);
+  return shown;
 }
 
 export function markPluginBindingFallbackNoticeShown(
   bindingId: string,
   scope?: SessionBindingScope,
 ): void {
-  const normalized = buildPluginBindingFallbackNoticeKey(bindingId, scope);
-  if (!normalized) {
-    return;
-  }
-  pluginBindingGlobalState.fallbackNoticeBindingIds.add(normalized);
+  pluginBindingGlobalState.fallbackNoticeBindingIds.check(
+    buildPluginBindingFallbackNoticeKey(bindingId, scope),
+  );
 }
 
 function buildPendingReply(request: PendingPluginBindingRequest): ReplyPayload {
@@ -777,26 +732,8 @@ export async function requestPluginConversationBinding(params: {
     };
   }
 
-  if (state.binding && state.binding.pluginRoot === params.pluginRoot) {
-    const rebound = await bindConversationNow({
-      identity: params,
-      conversation,
-      summary: params.binding?.summary,
-      detachHint: params.binding?.detachHint,
-      data: params.binding?.data,
-    });
-    logPluginBindingLifecycleEvent({
-      event: "auto-refresh",
-      pluginId: params.pluginId,
-      pluginRoot: params.pluginRoot,
-      channel: state.ref.channel,
-      accountId: state.ref.accountId,
-      conversationId: state.ref.conversationId,
-    });
-    return { status: "bound", binding: rebound };
-  }
-
   if (
+    state.binding ||
     hasPersistentApproval({
       pluginRoot: params.pluginRoot,
       channel: state.ref.channel,
@@ -811,7 +748,7 @@ export async function requestPluginConversationBinding(params: {
       data: params.binding?.data,
     });
     logPluginBindingLifecycleEvent({
-      event: "auto-approved",
+      event: state.binding ? "auto-refresh" : "auto-approved",
       pluginId: params.pluginId,
       pluginRoot: params.pluginRoot,
       channel: state.ref.channel,

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -123,6 +123,7 @@ type PluginBindingResolveResult =
 // Chat approvals get the exec-style 30-minute decision window, with abandoned payloads capped.
 const PENDING_PLUGIN_BINDING_REQUEST_TTL_MS = 30 * 60_000;
 const MAX_PENDING_PLUGIN_BINDING_REQUESTS = 512;
+const MAX_FALLBACK_NOTICE_BINDING_IDS = 4_096;
 const pendingRequests = resolveGlobalMap<string, PendingPluginBindingRequestEntry>(
   Symbol.for("openclaw.pluginBindingPendingRequests"),
   (requests) => {
@@ -724,7 +725,13 @@ export function hasShownPluginBindingFallbackNotice(bindingId: string): boolean 
   if (!normalized) {
     return false;
   }
-  return getPluginBindingGlobalState().fallbackNoticeBindingIds.has(normalized);
+  const bindingIds = getPluginBindingGlobalState().fallbackNoticeBindingIds;
+  if (!bindingIds.has(normalized)) {
+    return false;
+  }
+  bindingIds.delete(normalized);
+  bindingIds.add(normalized);
+  return true;
 }
 
 export function markPluginBindingFallbackNoticeShown(bindingId: string): void {
@@ -732,7 +739,17 @@ export function markPluginBindingFallbackNoticeShown(bindingId: string): void {
   if (!normalized) {
     return;
   }
-  getPluginBindingGlobalState().fallbackNoticeBindingIds.add(normalized);
+  const bindingIds = getPluginBindingGlobalState().fallbackNoticeBindingIds;
+  bindingIds.delete(normalized);
+  bindingIds.add(normalized);
+  // Keep recent outage suppression while allowing historical binding churn to retire.
+  while (bindingIds.size > MAX_FALLBACK_NOTICE_BINDING_IDS) {
+    const oldestBindingId = bindingIds.keys().next().value;
+    if (oldestBindingId === undefined) {
+      break;
+    }
+    bindingIds.delete(oldestBindingId);
+  }
 }
 
 function buildPendingReply(request: PendingPluginBindingRequest): ReplyPayload {

--- a/src/tasks/task-owner-access.ts
+++ b/src/tasks/task-owner-access.ts
@@ -1,6 +1,5 @@
 // Normalizes task owner keys and checks requester access to task records.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { resolveSessionAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
@@ -13,6 +12,7 @@ import {
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
 import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
+import { resolveTaskSessionAgentId } from "./task-session-identity.js";
 import { buildTaskStatusSnapshot } from "./task-status.js";
 
 type TaskOwnerIdentity = {
@@ -36,17 +36,11 @@ function canOwnerAccessTask(task: TaskRecord, identity: TaskOwnerIdentity): bool
   if (!callerAgentId) {
     return false;
   }
-  let taskAgentId = task.requesterAgentId ?? parseAgentSessionKey(task.ownerKey)?.agentId;
-  if (!taskAgentId) {
-    try {
-      taskAgentId = resolveSessionAgentId({
-        sessionKey: task.ownerKey,
-        config: identity.config ?? getRuntimeConfig(),
-      });
-    } catch {
-      return false;
-    }
-  }
+  const taskAgentId = resolveTaskSessionAgentId(
+    task.ownerKey,
+    task.requesterAgentId,
+    identity.config ?? getRuntimeConfig,
+  );
   return (
     Boolean(taskAgentId) &&
     normalizeOptionalString(taskAgentId) === normalizeOptionalString(callerAgentId)

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -1,7 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { resolveSessionAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
 import { clearTaskActivity } from "./task-registry-activity.js";
 import { isActiveTaskStatus, ensureLinkedTaskFlowRegistryReady } from "./task-registry-common.js";
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
@@ -37,6 +35,7 @@ import {
 } from "./task-registry-state.js";
 import { getTaskRegistryStore, resetTaskRegistryRuntimeForTests } from "./task-registry.store.js";
 import type { TaskRecord, TaskStatus } from "./task-registry.types.js";
+import { resolveTaskSessionAgentId } from "./task-session-identity.js";
 
 export function listTaskRecordsUnsorted(): TaskRecord[] {
   ensureTaskRegistryReady();
@@ -65,16 +64,7 @@ function taskMatchesRelatedSession(
     if (!sessionAgentId) {
       return true;
     }
-    let candidateAgentId =
-      normalizeOptionalString(candidate.agentId) ?? parseAgentSessionKey(candidate.key)?.agentId;
-    if (!candidateAgentId && cfg && candidate.key) {
-      try {
-        candidateAgentId = resolveSessionAgentId({ config: cfg, sessionKey: candidate.key });
-      } catch {
-        return false;
-      }
-    }
-    return candidateAgentId === sessionAgentId;
+    return resolveTaskSessionAgentId(candidate.key, candidate.agentId, cfg) === sessionAgentId;
   });
 }
 
@@ -86,28 +76,14 @@ function taskMatchesAgent(
   if (!agentId) {
     return true;
   }
-  const explicitAgentId = normalizeOptionalString(task.agentId);
-  if (explicitAgentId) {
-    return explicitAgentId === agentId;
+  const knownAgentId =
+    normalizeOptionalString(task.agentId) ?? normalizeOptionalString(task.requesterAgentId);
+  if (knownAgentId) {
+    return knownAgentId === agentId;
   }
-  const requesterAgentId = normalizeOptionalString(task.requesterAgentId);
-  if (requesterAgentId) {
-    return requesterAgentId === agentId;
-  }
-  return [task.requesterSessionKey, task.childSessionKey, task.ownerKey].some((candidate) => {
-    const parsedAgentId = parseAgentSessionKey(candidate)?.agentId;
-    if (parsedAgentId) {
-      return parsedAgentId === agentId;
-    }
-    if (!candidate || !cfg) {
-      return false;
-    }
-    try {
-      return resolveSessionAgentId({ config: cfg, sessionKey: candidate }) === agentId;
-    } catch {
-      return false;
-    }
-  });
+  return [task.requesterSessionKey, task.childSessionKey, task.ownerKey].some(
+    (candidate) => resolveTaskSessionAgentId(candidate, undefined, cfg) === agentId,
+  );
 }
 
 function taskUpdatedAt(task: TaskRecord): number {

--- a/src/tasks/task-session-identity.ts
+++ b/src/tasks/task-session-identity.ts
@@ -1,0 +1,22 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveSessionAgentId } from "../agents/agent-scope.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+/** Retained rows with unresolved owners stay inaccessible without hiding other tasks. */
+export function resolveTaskSessionAgentId(
+  sessionKey: string | undefined,
+  agentId?: string,
+  cfg?: OpenClawConfig | (() => OpenClawConfig),
+): string | undefined {
+  const knownAgentId =
+    normalizeOptionalString(agentId) ?? parseAgentSessionKey(sessionKey)?.agentId;
+  if (knownAgentId || !sessionKey || !cfg) {
+    return knownAgentId;
+  }
+  try {
+    return resolveSessionAgentId({ sessionKey, config: typeof cfg === "function" ? cfg() : cfg });
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Closes #127141

## What Problem This Solves

Fixes an issue where plugin-owned conversations could lose their owner in Feishu or fail to bind in Feishu/iMessage when multiple OpenClaw agents are configured. An unrelated retained task with an ambiguous owner could also make the subagents tool fail both listing and cancellation. Long-running Gateways retained every historical plugin fallback-notice ID.

## Why This Change Was Made

Binding owners and routing now share one lightweight metadata classifier. Feishu preserves opaque plugin metadata, and Feishu/iMessage no longer invent an OpenClaw agent identity for an external plugin target. Same-target refreshes preserve ownership; replacing the target session or kind starts fresh metadata. Explicit agent identities and strict agent-owned resolution remain intact.

The task ledger shares its existing fail-closed identity resolution with the subagents tool. Unresolved retained rows remain inaccessible without aborting operations on valid owned tasks. Redundant subagent ownership aliases, copied maps, duplicate classifiers, and identical immediate-binding branches are removed. The existing shared dedupe cache replaces the unbounded fallback-notice set.

No new config, environment variable, public SDK subpath, SQLite schema, or migration is introduced. The existing public ownership-classifier export stays available at the same SDK subpath.

## User Impact

Plugin-owned Feishu/iMessage targets keep their opaque ownership and metadata through supported refreshes; iMessage also preserves them through database reopen. Valid task listing/cancellation continues when unrelated historical task rows cannot resolve an agent. Fallback notices stay suppressed for the 4,096 most recently used binding IDs; an old evicted binding may show the informational notice again. This accepts the bounded-history tradeoff identified in the previous ClawSweeper review while reusing the canonical cache.

## Evidence

- Captured failures before the fixes for task list/cancel, opaque plugin ownership, Feishu approval/refresh, and notice eviction. The final focused suite passes 256 tests, including real binding-service approval → route → refresh → detach, database reopen, cross-owner access checks, delivery dispatch, and subagent lifecycle siblings.
- Full candidate build passed (`OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`), including runtime/plugin declarations, CLI/bootstrap checks, packaging, SDK exports, and Control UI. Core production/test type checks, scoped core lint, import cycles, database-first, schema, webhook, pairing, SDK surface/boundary, and dead-export guards passed. Five doctor-contract tests also passed. Local plugin production/test type checks and plugin lint hit eight errors in untouched Telegram files because the installed grammY/types are older than the lockfile; no dependency reconciliation or source workaround was applied. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33346007480) passed, including plugin production/test types and lint, confirming the local dependency drift.
- Independent owner/caller/sibling review found no additional correctness defects. Fresh isolated Codex autoreview completed clean at P0–P2 on the complete candidate with full owner/cache source context.
- Real built Gateway + actual Feishu SDK and signed webhook ingress, with synthetic HTTPS API and mock model provider: **PASS**. In an explicit multi-agent roster, request → approval through a fixture command calling the real resolver → plain-message plugin claim → detach → normal model reply all passed. The approved record retained opaque plugin metadata without an agent ID. Cleanup confirmed the Gateway stopped and reported zero cleanup errors. Initial fixture attempts exposed invalid roster/bootstrap assumptions and separate registration-local state; these were corrected in the proof fixture, not product code. Native Feishu approval buttons and authenticated external accounts are not covered.

LOC: production **+130/−180 (net −50)**; tests/test support **+229/−47 (net +182)**; docs **+6**; assertion baseline **+1/−1**. The extra tests cover observed failures rather than mirroring the new helper implementation.

### Explicit follow-ups and proof limits

The broader audit found separate persistence-failure bugs in Telegram, Matrix, and Discord. Eight pre-fix owner tests reproduce them; those tests and the proposed publication-order repair are retained separately pending the required persistent-store design acceptance. This PR does not change those stores.

Delayed plugin approval can still overwrite a later owner during asynchronous binding preparation. A complete repair needs conditional commit at the service/adapter owner plus lifecycle fencing; merging duplicate immediate-bind branches here does not fix that race.

Native Feishu plugin-binding approval buttons have no pluginbind callback consumer. The isolated proof uses a synthetic fixture command that invokes the real approval resolver; it does not claim native-button support. No authenticated Feishu or iMessage account is used by this proof.
