### PR TITLE
fix(ci): prevent manual candidates from writing shared caches

### DIFF
--- a/.github/actions/setup-android-toolchain/action.yml
+++ b/.github/actions/setup-android-toolchain/action.yml
@@ -1,22 +1,49 @@
 name: Setup Android toolchain
 description: Set up the pinned Java and Android SDK toolchain used by OpenClaw builds.
+inputs:
+  cache-mode:
+    description: Cache authority for this job (off, restore, or read-write).
+    required: false
+    default: "off"
+outputs:
+  cache-mode:
+    description: Validated cache authority for downstream save gates.
+    value: ${{ inputs.cache-mode }}
 runs:
   using: composite
   steps:
+    - name: Validate cache mode
+      shell: bash
+      env:
+        CACHE_MODE: ${{ inputs.cache-mode }}
+      run: |
+        case "$CACHE_MODE" in
+          off|restore|read-write) ;;
+          *)
+            echo "::error::Invalid cache-mode input: '$CACHE_MODE' (expected off, restore, or read-write)"
+            exit 2
+            ;;
+        esac
+
     - name: Setup Java
       uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
       with:
         distribution: temurin
         # Keep sdkmanager on the stable JDK path for Linux CI runners.
         java-version: 17
-        cache: gradle
-        cache-dependency-path: |
-          apps/android/**/*.gradle*
-          apps/android/**/gradle-wrapper.properties
-          apps/android/gradle/libs.versions.toml
 
-    - name: Cache Android SDK
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+    - name: Setup Gradle cache
+      if: inputs.cache-mode != 'off'
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+      with:
+        cache-provider: basic
+        cache-read-only: ${{ inputs.cache-mode != 'read-write' }}
+        add-job-summary: never
+
+    - name: Restore Android SDK cache
+      id: android-sdk-cache
+      if: inputs.cache-mode != 'off'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ~/.android-sdk
         key: ${{ runner.os }}-android-sdk-v1-cmdline-14742923-platform-37.0-build-tools-36.0.0
@@ -56,3 +83,10 @@ runs:
           "platform-tools" \
           "platforms;android-37.0" \
           "build-tools;36.0.0"
+
+    - name: Save Android SDK cache
+      if: inputs.cache-mode == 'read-write' && steps.android-sdk-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/.android-sdk
+        key: ${{ steps.android-sdk-cache.outputs.cache-primary-key }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -171,6 +171,8 @@ jobs:
 
       - name: Setup Android toolchain
         uses: ./.github/actions/setup-android-toolchain
+        with:
+          cache-mode: read-write
 
       - name: Create apps-signing read token
         if: ${{ steps.release_source.outputs.fallback_base_tag == '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
     timeout-minutes: 20
     outputs:
       checkout_revision: ${{ steps.checkout_ref.outputs.sha }}
+      candidate_trust: ${{ steps.candidate_trust.outputs.trust }}
+      cache_mode: ${{ steps.candidate_trust.outputs.cache_mode }}
+      cache_write_allowed: ${{ steps.candidate_trust.outputs.cache_write_allowed }}
       diff_base_revision: ${{ steps.diff_base.outputs.sha }}
       diff_head_revision: ${{ steps.diff_base.outputs.head_sha }}
       docs_only: ${{ steps.manifest.outputs.docs_only }}
@@ -137,6 +140,14 @@ jobs:
       run_protocol_event_coverage: ${{ steps.manifest.outputs.run_protocol_event_coverage }}
       android_matrix: ${{ steps.manifest.outputs.android_matrix }}
     steps:
+      - name: Checkout trusted CI harness
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .ci-harness
+          sparse-checkout: .github/actions
+          persist-credentials: false
+
       - name: Validate release-gate dispatch
         if: github.event_name == 'workflow_dispatch' && inputs.release_gate
         env:
@@ -372,6 +383,7 @@ jobs:
         id: target_context_target
         if: inputs.target_context_ref != ''
         env:
+          GH_TOKEN: ${{ github.token }}
           TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TARGET_REF: ${{ inputs.target_ref }}
         run: |
@@ -384,11 +396,77 @@ jobs:
             echo "target_context_ref requires target_ref to be a full commit SHA." >&2
             exit 1
           fi
+          branch_sha="$(git ls-remote --heads origin "refs/heads/${TARGET_CONTEXT_REF}" | awk 'NR == 1 { print $1 }')"
+          if [[ ! "$branch_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "target_context_ref branch ${TARGET_CONTEXT_REF} does not exist." >&2
+            exit 1
+          fi
+          comparison_status="$(
+            gh api "repos/${GITHUB_REPOSITORY}/compare/${TARGET_REF}...${branch_sha}" --jq .status
+          )"
+          if [[ "$comparison_status" != "ahead" && "$comparison_status" != "identical" ]]; then
+            echo "target_ref must be the declared release branch head or one of its ancestors." >&2
+            exit 1
+          fi
           echo "eligible=true" >> "$GITHUB_OUTPUT"
+
+      - name: Classify candidate cache trust
+        id: candidate_trust
+        env:
+          CHECKOUT_REVISION: ${{ steps.checkout_ref.outputs.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          HISTORICAL_TARGET: ${{ steps.historical_target.outputs.eligible || 'false' }}
+          RELEASE_CANDIDATE_TARGET: ${{ steps.release_candidate_target.outputs.eligible || 'false' }}
+          RELEASE_GATE: ${{ inputs.release_gate && 'true' || 'false' }}
+          TARGET_CONTEXT_TARGET: ${{ steps.target_context_target.outputs.eligible || 'false' }}
+          TARGET_REF: ${{ inputs.target_ref }}
+          WORKFLOW_REVISION: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+
+          trust=untrusted
+          cache_mode=off
+          cache_write_allowed=false
+
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            trust=main
+            cache_mode=restore
+            cache_write_allowed=true
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            trust=pull-request
+            cache_mode=restore
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            default_sha="$(git ls-remote origin "refs/heads/${DEFAULT_BRANCH}" | awk 'NR == 1 { print $1 }')"
+            if [[ "$RELEASE_GATE" == "true" ]]; then
+              trust=pull-request
+              cache_mode=restore
+            elif [[
+              "$HISTORICAL_TARGET" == "true" ||
+              "$RELEASE_CANDIDATE_TARGET" == "true" ||
+              "$TARGET_CONTEXT_TARGET" == "true"
+            ]]; then
+              trust=release
+              cache_mode=restore
+              cache_write_allowed=true
+            elif [[ -n "$default_sha" && "$CHECKOUT_REVISION" == "$default_sha" ]]; then
+              trust=main
+              cache_mode=restore
+              cache_write_allowed=true
+            elif [[ -z "$TARGET_REF" && "$CHECKOUT_REVISION" == "$WORKFLOW_REVISION" ]]; then
+              trust=workflow
+              cache_mode=restore
+            fi
+          fi
+
+          {
+            echo "trust=$trust"
+            echo "cache_mode=$cache_mode"
+            echo "cache_write_allowed=$cache_write_allowed"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Ensure preflight base commit
         if: github.event_name != 'workflow_dispatch'
-        uses: ./.github/actions/ensure-base-commit
+        uses: ./.ci-harness/.github/actions/ensure-base-commit
         with:
           base-sha: ${{ steps.diff_base.outputs.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
@@ -396,7 +474,7 @@ jobs:
       - name: Detect docs-only changes
         id: docs_scope
         if: github.event_name != 'workflow_dispatch'
-        uses: ./.github/actions/detect-docs-changes
+        uses: ./.ci-harness/.github/actions/detect-docs-changes
         with:
           base-sha: ${{ steps.diff_base.outputs.sha }}
 
@@ -433,9 +511,9 @@ jobs:
       # install and run through tsx.
       - name: Setup manifest pnpm
         if: github.event_name == 'workflow_dispatch'
-        uses: ./.github/actions/setup-pnpm-store-cache
+        uses: ./.ci-harness/.github/actions/setup-pnpm-store-cache
         with:
-          cache-mode: restore
+          cache-mode: ${{ steps.candidate_trust.outputs.cache_mode }}
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install manifest dependencies
@@ -943,9 +1021,9 @@ jobs:
       # Blacksmith jobs fan out. Cache publication belongs to the trusted warmer.
       - name: Restore exact dependency cache
         if: vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.repository == 'openclaw/openclaw' && steps.manifest.outputs.run_node == 'true' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ steps.candidate_trust.outputs.cache_mode }}
           dependency-cache: "true"
           install-bun: "false"
 
@@ -1015,6 +1093,14 @@ jobs:
           fi
           git -C "$GITHUB_WORKSPACE" checkout --detach refs/remotes/origin/checkout
 
+      - name: Checkout trusted CI harness
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .ci-harness
+          sparse-checkout: .github/actions
+          persist-credentials: false
+
       - name: Resolve security diff base
         id: diff_base
         env:
@@ -1044,7 +1130,7 @@ jobs:
 
       - name: Ensure security base commit
         if: github.event_name != 'workflow_dispatch'
-        uses: ./.github/actions/ensure-base-commit
+        uses: ./.ci-harness/.github/actions/ensure-base-commit
         with:
           base-sha: ${{ steps.diff_base.outputs.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
@@ -1147,7 +1233,7 @@ jobs:
           REQUESTED_NODE_VERSION: "24.x"
         run: |
           set -euo pipefail
-          source .github/actions/setup-pnpm-store-cache/ensure-node.sh
+          source .ci-harness/.github/actions/setup-pnpm-store-cache/ensure-node.sh
           openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
       - name: Audit production dependencies
@@ -1170,6 +1256,7 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
 
@@ -1200,6 +1287,15 @@ jobs:
 
             git -C "$workdir" checkout --force --detach "$CHECKOUT_SHA" || return 1
             test -f "$workdir/.github/actions/setup-node-env/action.yml" || return 1
+            harness_dir="$workdir/.ci-harness"
+            git init "$harness_dir" >/dev/null
+            git -C "$harness_dir" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
+            git -C "$harness_dir" -c protocol.version=2 fetch \
+              --no-tags --no-recurse-submodules --depth=1 origin \
+              "+${WORKFLOW_SHA}:refs/remotes/origin/ci-harness" || return 1
+            git -C "$harness_dir" sparse-checkout set .github/actions || return 1
+            git -C "$harness_dir" checkout --force --detach "$WORKFLOW_SHA" || return 1
+            test -f "$harness_dir/.github/actions/setup-node-env/action.yml" || return 1
             echo "checkout attempt ${attempt}/5 succeeded"
           }
 
@@ -1215,9 +1311,9 @@ jobs:
           exit 1
 
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
 
   # Build dist once for Node-relevant changes and share it with downstream jobs.
@@ -1237,15 +1333,15 @@ jobs:
       - *linux_node_checkout_step
       - name: Ensure secrets base commit (PR fast path)
         if: github.event_name == 'pull_request'
-        uses: ./.github/actions/ensure-base-commit
+        uses: ./.ci-harness/.github/actions/ensure-base-commit
         with:
           base-sha: ${{ needs.preflight.outputs.diff_base_revision }}
           fetch-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           node-compile-cache: "true"
           node-compile-cache-scope: "build"
@@ -1254,6 +1350,7 @@ jobs:
           dependency-cache: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
 
       - name: Restore build-all step cache
+        if: needs.preflight.outputs.cache_mode != 'off'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .artifacts/build-all-cache
@@ -1263,6 +1360,7 @@ jobs:
 
       - name: Restore dist build cache
         id: dist_build_cache
+        if: needs.preflight.outputs.cache_mode != 'off'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -1516,9 +1614,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           dependency-cache: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
           restore-test-caches: ${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid') && 'true' || 'false' }}
@@ -1546,16 +1644,12 @@ jobs:
     runs-on: ${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid') && 'ubuntu-24.04' || github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: ${{ needs.preflight.outputs.checkout_revision }}
-          persist-credentials: false
+      - *linux_node_checkout_step
 
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           # Same-repo Blacksmith runs restore the dependency cache published by
           # preflight; hosted paths use the pnpm store cache instead.
@@ -1596,9 +1690,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           node-version: "24.x"
           install-bun: "false"
           # Same-repo Blacksmith runs restore the dependency cache published by
@@ -1608,7 +1702,7 @@ jobs:
 
       - &cache_playwright_chromium
         name: Cache Playwright Chromium
-        if: needs.preflight.outputs.compatibility_target != 'true'
+        if: needs.preflight.outputs.cache_mode != 'off' && needs.preflight.outputs.compatibility_target != 'true'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
@@ -1671,9 +1765,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           node-version: "24.x"
           install-bun: "false"
           # The github/hybrid planner profile uses the Actions pnpm-store cache
@@ -1726,9 +1820,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           node-version: "24.x"
           install-bun: "false"
           # The github/hybrid planner profile uses the Actions pnpm-store cache
@@ -1787,9 +1881,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           node-version: "24.x"
           install-bun: "false"
           # Same-repo Blacksmith runs restore the dependency cache published by
@@ -1876,9 +1970,9 @@ jobs:
           echo "RATCHET_RELEASE_MERGE_TREE=true" >> "$GITHUB_ENV"
 
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: ${{ matrix.task == 'bun-launcher' && 'true' || 'false' }}
           # Same-repo Blacksmith runs restore the dependency cache published by
           # preflight; hosted paths use the pnpm store cache instead.
@@ -1971,9 +2065,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           # The github/hybrid planner profile uses the Actions pnpm-store cache
           # on either runner backend; all-Blacksmith mode restores preflight's tree.
@@ -2155,9 +2249,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           # Same-repo Blacksmith runs restore the dependency cache published by
           # preflight; hosted paths use the pnpm store cache instead.
@@ -2198,9 +2292,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           # Same-repo Blacksmith runs restore the dependency cache published by
           # preflight; hosted paths use the pnpm store cache instead.
@@ -2238,9 +2332,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           node-version: "22.22.3"
           install-bun: "false"
           build-all-cache-scope: full
@@ -2275,9 +2369,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           node-version: "${{ matrix.node_version || '24.x' }}"
           install-bun: "false"
           # Blacksmith shards restore the exact dependency archive;
@@ -2290,11 +2384,40 @@ jobs:
       - name: Setup Go for docs i18n
         if: matrix.requires_go == true
         # The current workflow validates frozen targets whose go.mod may predate this patch pin.
-        # Keep the runner toolchain owned by the workflow while using the target only for cache keys.
+        # Keep the runner toolchain owned by the workflow; cache publication is gated separately.
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.12"
-          cache-dependency-path: scripts/docs-i18n/go.sum
+          cache: false
+
+      - name: Resolve docs i18n Go cache
+        id: docs-i18n-go-cache-key
+        if: matrix.requires_go == true && needs.preflight.outputs.cache_mode != 'off'
+        env:
+          DEPENDENCY_HASH: ${{ hashFiles('scripts/docs-i18n/go.sum') }}
+        run: |
+          set -euo pipefail
+          arch="$(node -p process.arch)"
+          image_prefix=""
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            image_prefix="${ImageOS-undefined}-"
+          fi
+          version="$(go env GOVERSION)"
+          {
+            echo "key=setup-go-${RUNNER_OS}-${arch}-${image_prefix}go-${version#go}-${DEPENDENCY_HASH}"
+            echo "paths<<EOF"
+            go env GOMODCACHE
+            go env GOCACHE
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore docs i18n Go cache
+        id: docs-i18n-go-cache
+        if: matrix.requires_go == true && needs.preflight.outputs.cache_mode != 'off'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.docs-i18n-go-cache-key.outputs.paths }}
+          key: ${{ steps.docs-i18n-go-cache-key.outputs.key }}
 
       - name: Verify docs i18n Go toolchain
         if: matrix.requires_go == true
@@ -2367,6 +2490,13 @@ jobs:
           fi
           node --import tsx "$runner"
 
+      - name: Save docs i18n Go cache
+        if: always() && matrix.requires_go == true && needs.preflight.outputs.cache_write_allowed == 'true' && steps.docs-i18n-go-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.docs-i18n-go-cache-key.outputs.paths }}
+          key: ${{ steps.docs-i18n-go-cache.outputs.cache-primary-key }}
+
   # Types, lint, and format check shards.
   check-shard:
     permissions:
@@ -2411,9 +2541,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           # The github/hybrid planner profile uses the Actions pnpm-store cache
           # on either runner backend; all-Blacksmith mode restores preflight's tree.
@@ -2429,7 +2559,7 @@ jobs:
           echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
 
       - name: Cache extension package boundary artifacts for hosted lint
-        if: matrix.task == 'lint' && (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository))
+        if: needs.preflight.outputs.cache_mode != 'off' && matrix.task == 'lint' && (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository))
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -2728,9 +2858,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           dependency-cache: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
 
@@ -2765,9 +2895,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           dependency-cache: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && vars.OPENCLAW_CI_RUNNER_BACKEND != 'hybrid' && github.event_name != 'workflow_dispatch' && github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false' }}
 
@@ -2843,20 +2973,20 @@ jobs:
       - *linux_node_checkout_step
       - name: Ensure Plugin SDK API diff base commit
         if: matrix.group == 'plugin-sdk-api-diff'
-        uses: ./.github/actions/ensure-base-commit
+        uses: ./.ci-harness/.github/actions/ensure-base-commit
         with:
           base-sha: ${{ needs.preflight.outputs.diff_base_revision }}
           fetch-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.repository.default_branch }}
       - name: Ensure Plugin SDK API diff head commit
         if: matrix.group == 'plugin-sdk-api-diff'
-        uses: ./.github/actions/ensure-base-commit
+        uses: ./.ci-harness/.github/actions/ensure-base-commit
         with:
           base-sha: ${{ needs.preflight.outputs.diff_head_revision }}
           fetch-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_gate && format('refs/pull/{0}/merge', inputs.pull_request_number) || github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.repository.default_branch }}
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           # The github/hybrid planner profile uses the Actions pnpm-store cache
           # on either runner backend; all-Blacksmith mode restores preflight's tree.
@@ -2927,7 +3057,7 @@ jobs:
 
       - name: Cache extension package boundary artifacts
         id: extension-package-boundary-cache
-        if: matrix.group == 'extension-package-boundary'
+        if: needs.preflight.outputs.cache_mode != 'off' && matrix.group == 'extension-package-boundary'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -3130,9 +3260,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
           # Same-repo Blacksmith runs restore the dependency cache published by
           # preflight; hosted paths use the pnpm store cache instead.
@@ -3271,6 +3401,7 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_SHA: ${{ needs.preflight.outputs.checkout_revision }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           git init "$GITHUB_WORKSPACE"
@@ -3314,6 +3445,15 @@ jobs:
           }
           fetch_checkout_ref
           git -C "$GITHUB_WORKSPACE" checkout --detach refs/remotes/origin/checkout
+          harness_dir="$GITHUB_WORKSPACE/.ci-harness"
+          git init "$harness_dir"
+          git -C "$harness_dir" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
+          git -C "$harness_dir" -c protocol.version=2 fetch \
+            --no-tags --no-recurse-submodules --depth=1 origin \
+            "+${WORKFLOW_SHA}:refs/remotes/origin/ci-harness"
+          git -C "$harness_dir" sparse-checkout set .github/actions
+          git -C "$harness_dir" checkout --force --detach "$WORKFLOW_SHA"
+          test -f "$harness_dir/.github/actions/setup-node-env/action.yml"
 
       - name: Try to exclude workspace from Windows Defender (best-effort)
         shell: pwsh
@@ -3339,13 +3479,13 @@ jobs:
           REQUESTED_NODE_VERSION: "22.x"
         run: |
           set -euo pipefail
-          source .github/actions/setup-pnpm-store-cache/ensure-node.sh
+          source .ci-harness/.github/actions/setup-pnpm-store-cache/ensure-node.sh
           openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
       - name: Setup pnpm
-        uses: ./.github/actions/setup-pnpm-store-cache
+        uses: ./.ci-harness/.github/actions/setup-pnpm-store-cache
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           node-version: 22.x
 
       - name: Runtime versions
@@ -3410,9 +3550,9 @@ jobs:
       - *platform_checkout_step
 
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
 
       - name: TS tests (macOS)
@@ -3511,17 +3651,20 @@ jobs:
           toolchain_key="$(printf '%s\n%s\n' "$xcode_version" "$swift_version" | shasum -a 256 | awk '{print $1}')"
           echo "key=$toolchain_key" >> "$GITHUB_OUTPUT"
 
-      - name: Cache SwiftPM
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore SwiftPM cache
+        id: swiftpm-cache
+        if: needs.preflight.outputs.cache_mode != 'off'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/Library/Caches/org.swift.swiftpm
           key: ${{ runner.os }}-swiftpm-${{ hashFiles('apps/macos/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-swiftpm-
 
-      - name: Cache Swift build directory
+      - name: Restore Swift build directory cache
         id: swift-build-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: needs.preflight.outputs.cache_mode != 'off'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: apps/macos/.build
           key: ${{ runner.os }}-swift-build-v3-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package.swift', 'apps/macos/Package.resolved', 'apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/OpenClawKit/Package.swift', 'apps/shared/OpenClawKit/Sources/**', 'apps/swabble/Package.swift', 'apps/swabble/Sources/**') }}
@@ -3655,6 +3798,20 @@ jobs:
           done
           exit 1
 
+      - name: Save SwiftPM cache
+        if: needs.preflight.outputs.cache_write_allowed == 'true' && steps.swiftpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ steps.swiftpm-cache.outputs.cache-primary-key }}
+
+      - name: Save Swift build directory cache
+        if: needs.preflight.outputs.cache_write_allowed == 'true' && steps.swift-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: apps/macos/.build
+          key: ${{ steps.swift-build-cache.outputs.cache-primary-key }}
+
   ios-build:
     permissions:
       contents: read
@@ -3686,9 +3843,9 @@ jobs:
           swift --version
 
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
 
       - name: Install iOS Swift tooling
@@ -3898,20 +4055,22 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.workflow_sha }}
-          path: .ci-workflow
-          sparse-checkout: .github/actions/setup-android-toolchain
+          path: .ci-harness
+          sparse-checkout: .github/actions
           persist-credentials: false
 
       - name: Setup Android toolchain
         # Frozen targets keep their Gradle task contract, but CI toolchain pins remain
         # workflow-owned as before. Load them from the workflow revision so old targets work.
-        uses: ./.ci-workflow/.github/actions/setup-android-toolchain
+        uses: ./.ci-harness/.github/actions/setup-android-toolchain
+        with:
+          cache-mode: ${{ needs.preflight.outputs.cache_write_allowed == 'true' && 'read-write' || needs.preflight.outputs.cache_mode }}
 
       - name: Setup Node environment for native resources
         if: needs.preflight.outputs.use_compatible_android_ci != 'true'
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           install-bun: "false"
 
       # Same-repo runs carry the Gradle user home (dependency, wrapper, and
@@ -4059,9 +4218,9 @@ jobs:
     steps:
       - *linux_node_checkout_step
       - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+        uses: ./.ci-harness/.github/actions/setup-node-env
         with:
-          cache-mode: restore
+          cache-mode: ${{ needs.preflight.outputs.cache_mode }}
           node-version: "24.x"
           install-bun: "false"
           dependency-cache: ${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.run_attempt > 1)) && 'false' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'true' || 'false') }}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -25,6 +25,8 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const CHECKOUT_V6 = "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10";
 const CACHE_V5 = "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae";
+const CACHE_SAVE_V5 = "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae";
+const SETUP_GRADLE_V6 = "gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb";
 const SETUP_GO_V6 = "actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c";
 const UPLOAD_ARTIFACT_V7 = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 const DOWNLOAD_ARTIFACT_V8 = "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c";
@@ -163,7 +165,7 @@ function runWorkflowShellScript(
     const moduleRoot = options.cwd ?? process.cwd();
     const rewritten = script
       .replace(
-        /node (?:--import tsx )?--input-type=module <<'([A-Z][A-Z0-9_]*)'\n([\s\S]*?)\n\1(?=\n|$)/gu,
+        /node (?:(?:--import tsx |"\$\{manifest_node_args\[@\]\}" ))?--input-type=module <<'([A-Z][A-Z0-9_]*)'\n([\s\S]*?)\n\1(?=\n|$)/gu,
         (_match, _marker: string, body: string) => {
           const modulePath = path.join(
             moduleRoot,
@@ -433,10 +435,42 @@ function runCiManifestFixture(options: {
   }
 }
 
-function runTargetContextValidation(targetContextRef: string, targetRef: string) {
+function runTargetContextValidation(
+  targetContextRef: string,
+  targetRef: string,
+  comparisonStatus = "ahead",
+) {
   const root = tempDirs.make("openclaw-ci-target-context-");
   const outputPath = path.join(root, "github-output");
+  const binPath = path.join(root, "bin");
+  const branchSha = "b".repeat(40);
+  mkdirSync(binPath);
   writeFileSync(outputPath, "", "utf8");
+  writeFileSync(
+    path.join(binPath, "git"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "ls-remote" && "$2" == "--heads" && "$3" == "origin" ]]; then
+  printf '%s\\t%s\\n' "$MOCK_BRANCH_SHA" "$4"
+  exit 0
+fi
+exit 2
+`,
+    "utf8",
+  );
+  writeFileSync(
+    path.join(binPath, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == "api" ]]
+[[ "$2" == "repos/openclaw/openclaw/compare/${targetRef}...${branchSha}" ]]
+[[ "$3" == "--jq" && "$4" == ".status" ]]
+printf '%s\\n' "$MOCK_COMPARE_STATUS"
+`,
+    "utf8",
+  );
+  chmodSync(path.join(binPath, "git"), 0o755);
+  chmodSync(path.join(binPath, "gh"), 0o755);
   const step = expectDefined(
     readCiWorkflow().jobs.preflight.steps.find(
       (candidate: WorkflowStep) => candidate.name === "Validate target context",
@@ -450,12 +484,77 @@ function runTargetContextValidation(targetContextRef: string, targetRef: string)
       encoding: "utf8",
       env: {
         ...process.env,
+        GITHUB_REPOSITORY: "openclaw/openclaw",
         GITHUB_OUTPUT: outputPath,
+        MOCK_BRANCH_SHA: branchSha,
+        MOCK_COMPARE_STATUS: comparisonStatus,
+        PATH: `${binPath}:${process.env.PATH ?? ""}`,
         TARGET_CONTEXT_REF: targetContextRef,
         TARGET_REF: targetRef,
       },
     },
   );
+  return {
+    output: `${run.stdout}${run.stderr}`,
+    outputs: readWorkflowOutputs(outputPath),
+    status: run.status,
+  };
+}
+
+function runCandidateTrustClassification(options: {
+  checkoutRevision: string;
+  defaultRevision?: string;
+  eventName: "pull_request" | "push" | "workflow_dispatch";
+  historicalTarget?: boolean;
+  ref?: string;
+  releaseCandidateTarget?: boolean;
+  releaseGate?: boolean;
+  targetContextTarget?: boolean;
+  targetRef?: string;
+  workflowRevision?: string;
+}) {
+  const root = tempDirs.make("openclaw-ci-candidate-trust-");
+  const outputPath = path.join(root, "github-output");
+  const binPath = path.join(root, "bin");
+  const defaultRevision = options.defaultRevision ?? "b".repeat(40);
+  mkdirSync(binPath);
+  writeFileSync(outputPath, "", "utf8");
+  writeFileSync(
+    path.join(binPath, "git"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == "ls-remote" && "$2" == "origin" && "$3" == "refs/heads/main" ]]
+printf '%s\\trefs/heads/main\\n' "$MOCK_DEFAULT_SHA"
+`,
+    "utf8",
+  );
+  chmodSync(path.join(binPath, "git"), 0o755);
+  const step = expectDefined(
+    readCiWorkflow().jobs.preflight.steps.find(
+      (candidate: WorkflowStep) => candidate.name === "Classify candidate cache trust",
+    ),
+    "candidate cache trust step",
+  );
+  const script = expectDefined(step.run, "candidate cache trust script");
+  const run = spawnSync("bash", ["-c", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CHECKOUT_REVISION: options.checkoutRevision,
+      DEFAULT_BRANCH: "main",
+      GITHUB_EVENT_NAME: options.eventName,
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_REF: options.ref ?? "",
+      HISTORICAL_TARGET: String(options.historicalTarget ?? false),
+      MOCK_DEFAULT_SHA: defaultRevision,
+      PATH: `${binPath}:${process.env.PATH ?? ""}`,
+      RELEASE_CANDIDATE_TARGET: String(options.releaseCandidateTarget ?? false),
+      RELEASE_GATE: String(options.releaseGate ?? false),
+      TARGET_CONTEXT_TARGET: String(options.targetContextTarget ?? false),
+      TARGET_REF: options.targetRef ?? "",
+      WORKFLOW_REVISION: options.workflowRevision ?? "a".repeat(40),
+    },
+  });
   return {
     output: `${run.stdout}${run.stderr}`,
     outputs: readWorkflowOutputs(outputPath),
@@ -2760,7 +2859,7 @@ NODE
     expect(job.permissions).toEqual({ contents: "read" });
     expect(job.strategy).toBeUndefined();
     expect(job.steps[0]).toEqual(jobs["pnpm-store-warmup"].steps[0]);
-    expect(job.steps[1].uses).toBe("./.github/actions/setup-node-env");
+    expect(job.steps[1].uses).toBe("./.ci-harness/.github/actions/setup-node-env");
     const run = job.steps[2] as WorkflowStep;
     const parallelism = run.env?.OPENCLAW_DOCKER_ALL_PARALLELISM;
     expect(run).toMatchObject({
@@ -2845,7 +2944,7 @@ NODE
     expect(
       workflow.jobs.android.steps.filter(
         (step: WorkflowStep) =>
-          step.uses === "./.ci-workflow/.github/actions/setup-android-toolchain",
+          step.uses === "./.ci-harness/.github/actions/setup-android-toolchain",
       ),
     ).toHaveLength(1);
     expect(
@@ -2854,9 +2953,17 @@ NODE
       ),
     ).toHaveLength(1);
 
-    const cacheStep = expectDefined(
-      action.runs.steps.find((step: WorkflowStep) => step.name === "Cache Android SDK"),
-      "Android SDK cache step",
+    const sdkRestoreStep = expectDefined(
+      action.runs.steps.find((step: WorkflowStep) => step.name === "Restore Android SDK cache"),
+      "Android SDK cache restore step",
+    );
+    const sdkSaveStep = expectDefined(
+      action.runs.steps.find((step: WorkflowStep) => step.name === "Save Android SDK cache"),
+      "Android SDK cache save step",
+    );
+    const gradleCacheStep = expectDefined(
+      action.runs.steps.find((step: WorkflowStep) => step.name === "Setup Gradle cache"),
+      "Gradle cache setup step",
     );
     const javaStep = expectDefined(
       action.runs.steps.find((step: WorkflowStep) => step.name === "Setup Java"),
@@ -2869,21 +2976,32 @@ NODE
 
     expect(javaStep.uses).toBe("actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287");
     expect(javaStep.with).toMatchObject({
-      cache: "gradle",
       distribution: "temurin",
       "java-version": 17,
     });
-    expect(javaStep.with?.["cache-dependency-path"]).toContain(
-      "apps/android/gradle/libs.versions.toml",
-    );
-    expect(cacheStep.with?.key).toContain(`platform-${appCompileSdk}.0-`);
+    expect(action.inputs["cache-mode"].default).toBe("off");
+    expect(sdkRestoreStep.if).toBe("inputs.cache-mode != 'off'");
+    expect(sdkRestoreStep.uses).toBe(CACHE_V5);
+    expect(sdkRestoreStep.with?.key).toContain(`platform-${appCompileSdk}.0-`);
+    expect(sdkSaveStep.if).toContain("inputs.cache-mode == 'read-write'");
+    expect(sdkSaveStep.uses).toBe(CACHE_SAVE_V5);
+    expect(sdkSaveStep.with?.key).toBe("${{ steps.android-sdk-cache.outputs.cache-primary-key }}");
+    expect(gradleCacheStep).toMatchObject({
+      if: "inputs.cache-mode != 'off'",
+      uses: SETUP_GRADLE_V6,
+      with: {
+        "add-job-summary": "never",
+        "cache-provider": "basic",
+        "cache-read-only": "${{ inputs.cache-mode != 'read-write' }}",
+      },
+    });
     expect(installStep.run).toContain(`"${packageId}"`);
     expect(installStep.run).toContain(
       'yes | sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null || [[ "${PIPESTATUS[1]}" -eq 0 ]]',
     );
   });
 
-  it("validates frozen target context without binding it to the live branch head", () => {
+  it("binds frozen target context to the declared live release branch", () => {
     const workflow = readCiWorkflow();
     const input = workflow.on.workflow_dispatch.inputs.target_context_ref;
     const step = expectDefined(
@@ -2902,14 +3020,19 @@ NODE
       type: "string",
     });
     expect(step.if).toBe("inputs.target_context_ref != ''");
-    expect(step.run).not.toContain("ls-remote");
-    expect(step.run).not.toContain("EXPECTED_SHA");
-    expect(step.run).not.toContain("git ");
+    expect(step.run).toContain("git ls-remote --heads origin");
+    expect(step.run).toContain(
+      'gh api "repos/${GITHUB_REPOSITORY}/compare/${TARGET_REF}...${branch_sha}"',
+    );
+    expect(step.run).toContain('"$comparison_status" != "ahead"');
+    expect(step.run).toContain('"$comparison_status" != "identical"');
 
     for (const contextRef of ["release/2026.8.1", "extended-stable/2026.8.33"]) {
-      const result = runTargetContextValidation(contextRef, targetSha);
-      expect(result.status, `${contextRef}: ${result.output}`).toBe(0);
-      expect(result.outputs.eligible).toBe("true");
+      for (const comparisonStatus of ["ahead", "identical"]) {
+        const result = runTargetContextValidation(contextRef, targetSha, comparisonStatus);
+        expect(result.status, `${contextRef}: ${result.output}`).toBe(0);
+        expect(result.outputs.eligible).toBe("true");
+      }
     }
 
     for (const contextRef of [
@@ -2933,6 +3056,14 @@ NODE
         "target_context_ref requires target_ref to be a full commit SHA.",
       );
     }
+
+    for (const comparisonStatus of ["behind", "diverged"]) {
+      const result = runTargetContextValidation("release/2026.8.1", targetSha, comparisonStatus);
+      expect(result.status, comparisonStatus).toBe(1);
+      expect(result.output).toContain(
+        "target_ref must be the declared release branch head or one of its ancestors.",
+      );
+    }
   });
 
   it("loads Android CI setup from the workflow revision for frozen targets", () => {
@@ -2946,10 +3077,10 @@ NODE
 
     expect(actionCheckout.uses).toBe(CHECKOUT_V6);
     expect(actionCheckout.with).toMatchObject({
-      path: ".ci-workflow",
+      path: ".ci-harness",
       "persist-credentials": false,
       ref: "${{ github.workflow_sha }}",
-      "sparse-checkout": ".github/actions/setup-android-toolchain",
+      "sparse-checkout": ".github/actions",
     });
     expect(checkoutIndex).toBeLessThan(actionCheckoutIndex);
     expect(actionCheckoutIndex).toBeLessThan(setupIndex);
@@ -3034,7 +3165,7 @@ NODE
       ":wear-shared:assembleDebug",
       ":wear-shared:lintDebug",
     ]);
-    expect(nativeResourcesSetup.uses).toBe("./.github/actions/setup-node-env");
+    expect(nativeResourcesSetup.uses).toBe("./.ci-harness/.github/actions/setup-node-env");
     expect(nativeResourcesSetup.if).toBe(
       "needs.preflight.outputs.use_compatible_android_ci != 'true'",
     );
@@ -3326,7 +3457,7 @@ NODE
       expect(evaluateWorkflowExpression(setup.with?.["dependency-cache"], context), jobName).toBe(
         "false",
       );
-      expect(setup.with?.["cache-mode"], jobName).toBe("restore");
+      expect(setup.with?.["cache-mode"], jobName).toBe("${{ needs.preflight.outputs.cache_mode }}");
     }
   });
 
@@ -3491,8 +3622,10 @@ NODE
       const conditionalMode =
         typeof caller.mode === "string" &&
         caller.mode.startsWith("${{") &&
-        caller.mode.includes("'restore'") &&
-        (caller.mode.includes("'off'") || caller.mode.includes("'read-write'"));
+        (caller.mode.includes("needs.preflight.outputs.cache_mode") ||
+          caller.mode.includes("steps.candidate_trust.outputs.cache_mode") ||
+          (caller.mode.includes("'restore'") &&
+            (caller.mode.includes("'off'") || caller.mode.includes("'read-write'"))));
       expect(staticMode || conditionalMode, `${caller.file}: ${caller.step.name}`).toBe(true);
       for (const legacyInput of legacyInputs) {
         expect(caller.step.with, `${caller.file}: ${legacyInput}`).not.toHaveProperty(legacyInput);
@@ -3533,9 +3666,13 @@ NODE
       /(?:^|\n)\s*(?:\.artifacts\/build-all-cache|dist\/|dist-runtime\/|packages\/\*\/dist\/|extensions\/\*\/dist\/|~\/\.cache\/ms-playwright|~\/\.local\/share\/pnpm|~\/\.cache\/pnpm|node_modules)(?:\n|$)/u;
     for (const { file, step } of directCaches) {
       if (step.uses?.startsWith("actions/cache/save@")) {
-        expect(String(step.if), `${file}: ${step.name}`).toContain(
-          ".outputs.cache-mode == 'read-write'",
-        );
+        const condition = String(step.if);
+        expect(
+          condition.includes(".outputs.cache-mode == 'read-write'") ||
+            condition.includes("inputs.cache-mode == 'read-write'") ||
+            condition.includes("needs.preflight.outputs.cache_write_allowed == 'true'"),
+          `${file}: ${step.name}`,
+        ).toBe(true);
       }
       if (step.uses?.startsWith("actions/cache@")) {
         expect(nodeCachePathPattern.test(String(step.with?.path)), `${file}: ${step.name}`).toBe(
@@ -3641,7 +3778,7 @@ NODE
 
     const dependencySetups = Object.entries(workflow.jobs).flatMap(([jobName, job]) =>
       ((job as { steps?: WorkflowStep[] }).steps ?? []).flatMap((candidate) =>
-        candidate.uses === "./.github/actions/setup-node-env" &&
+        candidate.uses?.endsWith("/.github/actions/setup-node-env") &&
         candidate.with?.["dependency-cache"] !== undefined
           ? [{ jobName, step: candidate }]
           : [],
@@ -3651,7 +3788,7 @@ NODE
     expect(preflightRestore?.step).toMatchObject({
       if: expect.stringContaining("steps.manifest.outputs.run_node == 'true'"),
       with: {
-        "cache-mode": "restore",
+        "cache-mode": "${{ steps.candidate_trust.outputs.cache_mode }}",
         "dependency-cache": "true",
         "install-bun": "false",
       },
@@ -3692,7 +3829,9 @@ NODE
       expect(Array.isArray(needs) ? needs : [needs], jobName).toContain("preflight");
       expect(consumer.with, jobName).not.toHaveProperty("save-dependency-cache");
       expect(consumer.with?.["dependency-cache"], jobName).toContain("'true' || 'false'");
-      expect(consumer.with?.["cache-mode"], jobName).toBe("restore");
+      expect(consumer.with?.["cache-mode"], jobName).toBe(
+        "${{ needs.preflight.outputs.cache_mode }}",
+      );
       expect(consumer.with?.["dependency-cache"], jobName).toContain(
         "vars.OPENCLAW_CI_RUNNER_BACKEND",
       );
@@ -3711,12 +3850,21 @@ NODE
     }
     for (const { jobName, step: setup } of Object.entries(workflow.jobs).flatMap(([jobName, job]) =>
       ((job as { steps?: WorkflowStep[] }).steps ?? [])
-        .filter((candidate) => candidate.uses === "./.github/actions/setup-node-env")
+        .filter((candidate) => candidate.uses?.endsWith("/.github/actions/setup-node-env"))
         .map((candidate) => ({ jobName, step: candidate })),
     )) {
       expect(setup.with, jobName).not.toHaveProperty("sticky-disk");
       expect(setup.with, jobName).not.toHaveProperty("save-sticky-disk");
-      expect(["off", "restore", "read-write"], jobName).toContain(setup.with?.["cache-mode"]);
+      expect(
+        [
+          "off",
+          "restore",
+          "read-write",
+          "${{ needs.preflight.outputs.cache_mode }}",
+          "${{ steps.candidate_trust.outputs.cache_mode }}",
+        ],
+        jobName,
+      ).toContain(setup.with?.["cache-mode"]);
     }
 
     const warmer = parse(readFileSync(".github/workflows/vitest-cache-warm.yml", "utf8"));
@@ -4225,7 +4373,7 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
       "${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid') && (matrix.task == 'bundled-protocol' || matrix.task == 'contracts-plugins-ci-routing' || matrix.task == 'ci-routing' || matrix.task == 'bun-launcher') && 'true' || 'false' }}";
 
     expect(setupNodeStep.with).toMatchObject({
-      "cache-mode": "restore",
+      "cache-mode": "${{ needs.preflight.outputs.cache_mode }}",
       "node-compile-cache": "true",
       "node-compile-cache-scope": "test",
       "vitest-fs-cache": "true",
@@ -4284,7 +4432,7 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     expect(compileConfigureStep.run).toContain("NODE_COMPILE_CACHE_PORTABLE=1");
     expect(compileConfigureStep.run).toContain("OPENCLAW_NODE_COMPILE_CACHE_WRITER=0");
     expect(buildSetupNodeStep.with).toMatchObject({
-      "cache-mode": "restore",
+      "cache-mode": "${{ needs.preflight.outputs.cache_mode }}",
       "node-compile-cache": "true",
       "node-compile-cache-scope": "build",
     });
@@ -4563,7 +4711,7 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
       expect(gate.if).toContain("vars.OPENCLAW_CI_RUNNER_BACKEND != 'github'");
     }
     expect(hostedLintCache.if).toBe(
-      "matrix.task == 'lint' && (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository))",
+      "needs.preflight.outputs.cache_mode != 'off' && matrix.task == 'lint' && (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository))",
     );
     expect(hostedLintCache.uses).toBe(CACHE_V5);
     expect(hostedLintCache.with).toEqual(boundaryCache.with);
@@ -5240,6 +5388,168 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     expect(finalCheck).toBeGreaterThan(exactFetch);
   });
 
+  it("keeps manual candidates separate from trusted cache authority", () => {
+    const workflow = readCiWorkflow();
+    const preflight = workflow.jobs.preflight;
+    const trustStep = expectDefined(
+      preflight.steps.find((step: WorkflowStep) => step.name === "Classify candidate cache trust"),
+      "candidate cache trust step",
+    );
+    const nativeCheckout = expectDefined(
+      workflow.jobs["native-i18n"].steps.find((step: WorkflowStep) => step.name === "Checkout"),
+      "native i18n checkout",
+    );
+
+    expect(preflight.outputs).toMatchObject({
+      candidate_trust: "${{ steps.candidate_trust.outputs.trust }}",
+      cache_mode: "${{ steps.candidate_trust.outputs.cache_mode }}",
+      cache_write_allowed: "${{ steps.candidate_trust.outputs.cache_write_allowed }}",
+    });
+    expect(trustStep.env).toMatchObject({
+      CHECKOUT_REVISION: "${{ steps.checkout_ref.outputs.sha }}",
+      DEFAULT_BRANCH: "${{ github.event.repository.default_branch }}",
+      TARGET_REF: "${{ inputs.target_ref }}",
+      WORKFLOW_REVISION: "${{ github.workflow_sha }}",
+    });
+    expect(trustStep.run).toContain("trust=untrusted");
+    expect(trustStep.run).toContain("cache_mode=off");
+    expect(trustStep.run).toContain("cache_write_allowed=false");
+    expect(trustStep.run).toContain('elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]');
+    expect(trustStep.run).toContain('"$RELEASE_GATE" == "true"');
+    expect(trustStep.run).toContain('"$CHECKOUT_REVISION" == "$default_sha"');
+    expect(trustStep.run).toContain('"$CHECKOUT_REVISION" == "$WORKFLOW_REVISION"');
+    expect(trustStep.run).toContain("cache_write_allowed=true");
+
+    const ciLocalActions = Object.values(workflow.jobs).flatMap(
+      (job) =>
+        (job as { steps?: WorkflowStep[] }).steps?.filter((step) =>
+          step.uses?.includes("/.github/actions/"),
+        ) ?? [],
+    );
+    expect(ciLocalActions.length).toBeGreaterThan(0);
+    for (const step of ciLocalActions) {
+      expect(step.uses, step.name).toContain("./.ci-harness/.github/actions/");
+    }
+
+    expect(nativeCheckout.uses).toBeUndefined();
+    expect(nativeCheckout.env).toMatchObject({
+      CHECKOUT_SHA: "${{ needs.preflight.outputs.checkout_revision }}",
+      WORKFLOW_SHA: "${{ github.workflow_sha }}",
+    });
+    expect(nativeCheckout.run).toContain('harness_dir="$workdir/.ci-harness"');
+    expect(nativeCheckout.run).toContain('"+${WORKFLOW_SHA}:refs/remotes/origin/ci-harness"');
+    expect(nativeCheckout.run).toContain("sparse-checkout set .github/actions");
+
+    for (const [jobName, job] of Object.entries(workflow.jobs)) {
+      for (const step of (job as { steps?: WorkflowStep[] }).steps ?? []) {
+        if (step.uses?.startsWith("actions/cache/restore@")) {
+          expect(String(step.if), `${jobName}: ${step.name}`).toContain(
+            "preflight.outputs.cache_mode != 'off'",
+          );
+        }
+        if (step.uses?.startsWith("actions/cache/save@")) {
+          expect(String(step.if), `${jobName}: ${step.name}`).toContain(
+            "preflight.outputs.cache_write_allowed == 'true'",
+          );
+        }
+      }
+    }
+
+    const goSetup = expectDefined(
+      workflow.jobs["checks-node-core-test-nondist-shard"].steps.find(
+        (step: WorkflowStep) => step.name === "Setup Go for docs i18n",
+      ),
+      "docs i18n Go setup",
+    );
+    expect(goSetup.with?.cache).toBe(false);
+  });
+
+  it("classifies cache write authority from proven candidate identity", () => {
+    const workflowRevision = "a".repeat(40);
+    const defaultRevision = "b".repeat(40);
+    const arbitraryRevision = "c".repeat(40);
+    const cases = [
+      {
+        expected: { cache_mode: "off", cache_write_allowed: "false", trust: "untrusted" },
+        options: {
+          checkoutRevision: arbitraryRevision,
+          eventName: "workflow_dispatch" as const,
+          targetRef: arbitraryRevision,
+          workflowRevision,
+        },
+      },
+      {
+        expected: { cache_mode: "restore", cache_write_allowed: "false", trust: "workflow" },
+        options: {
+          checkoutRevision: workflowRevision,
+          eventName: "workflow_dispatch" as const,
+          workflowRevision,
+        },
+      },
+      {
+        expected: { cache_mode: "restore", cache_write_allowed: "true", trust: "main" },
+        options: {
+          checkoutRevision: defaultRevision,
+          defaultRevision,
+          eventName: "workflow_dispatch" as const,
+          targetRef: defaultRevision,
+          workflowRevision,
+        },
+      },
+      {
+        expected: { cache_mode: "restore", cache_write_allowed: "true", trust: "release" },
+        options: {
+          checkoutRevision: arbitraryRevision,
+          eventName: "workflow_dispatch" as const,
+          targetContextTarget: true,
+          targetRef: arbitraryRevision,
+          workflowRevision,
+        },
+      },
+      {
+        expected: {
+          cache_mode: "restore",
+          cache_write_allowed: "false",
+          trust: "pull-request",
+        },
+        options: {
+          checkoutRevision: arbitraryRevision,
+          eventName: "workflow_dispatch" as const,
+          releaseGate: true,
+          targetRef: arbitraryRevision,
+          workflowRevision,
+        },
+      },
+      {
+        expected: {
+          cache_mode: "restore",
+          cache_write_allowed: "false",
+          trust: "pull-request",
+        },
+        options: {
+          checkoutRevision: arbitraryRevision,
+          eventName: "pull_request" as const,
+          workflowRevision,
+        },
+      },
+      {
+        expected: { cache_mode: "restore", cache_write_allowed: "true", trust: "main" },
+        options: {
+          checkoutRevision: defaultRevision,
+          eventName: "push" as const,
+          ref: "refs/heads/main",
+          workflowRevision,
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = runCandidateTrustClassification(testCase.options);
+      expect(result.status, result.output).toBe(0);
+      expect(result.outputs).toMatchObject(testCase.expected);
+    }
+  });
+
   it("uses the maintained checkout across workflow sanity jobs", () => {
     const workflow = readWorkflowSanityWorkflow();
 
@@ -5405,7 +5715,7 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
       (step: WorkflowStep) => step.name === "Setup Node environment",
     );
     expect(macosNodeSetup.with).toMatchObject({
-      "cache-mode": "restore",
+      "cache-mode": "${{ needs.preflight.outputs.cache_mode }}",
       "install-bun": "false",
     });
   });
@@ -6539,7 +6849,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       JSON.parse(readFileSync("ui/package.json", "utf8")).devDependencies.playwright,
     );
     expect(uiBrowserCache).toMatchObject({
-      if: "needs.preflight.outputs.compatibility_target != 'true'",
+      if: "needs.preflight.outputs.cache_mode != 'off' && needs.preflight.outputs.compatibility_target != 'true'",
       uses: CACHE_V5,
       with: {
         key: "${{ runner.os }}-playwright-chromium-" + playwrightVersion,
@@ -6619,9 +6929,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       uiE2e.steps.find((step: WorkflowStep) => step.name === "Setup Node environment"),
       "Control UI E2E Node setup",
     );
-    expect(uiE2eSetup.uses).toBe("./.github/actions/setup-node-env");
+    expect(uiE2eSetup.uses).toBe("./.ci-harness/.github/actions/setup-node-env");
     const expectedSharedUiE2eSetup = {
-      "cache-mode": "restore",
+      "cache-mode": "${{ needs.preflight.outputs.cache_mode }}",
       "node-version": "24.x",
       "install-bun": "false",
       "dependency-cache":
@@ -6775,7 +7085,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
           evaluateWorkflowExpression(setup.with?.["dependency-cache"], context),
           assertionName,
         ).toBe(expected.dependencyCache);
-        expect(setup.with?.["cache-mode"], assertionName).toBe("restore");
+        expect(setup.with?.["cache-mode"], assertionName).toBe(
+          "${{ needs.preflight.outputs.cache_mode }}",
+        );
       }
     }
 
@@ -7179,15 +7491,41 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     const verifyGoStep = nodeTestJob.steps.find(
       (step: WorkflowStep) => step.name === "Verify docs i18n Go toolchain",
     );
+    const resolveGoCacheStep = nodeTestJob.steps.find(
+      (step: WorkflowStep) => step.name === "Resolve docs i18n Go cache",
+    );
+    const restoreGoCacheStep = nodeTestJob.steps.find(
+      (step: WorkflowStep) => step.name === "Restore docs i18n Go cache",
+    );
+    const saveGoCacheStep = nodeTestJob.steps.find(
+      (step: WorkflowStep) => step.name === "Save docs i18n Go cache",
+    );
     expect(setupGoStep).toMatchObject({
       if: "matrix.requires_go == true",
       uses: SETUP_GO_V6,
       with: {
+        cache: false,
         "go-version": "1.25.12",
-        "cache-dependency-path": "scripts/docs-i18n/go.sum",
       },
     });
     expect(setupGoStep.with).not.toHaveProperty("go-version-file");
+    expect(resolveGoCacheStep).toMatchObject({
+      if: "matrix.requires_go == true && needs.preflight.outputs.cache_mode != 'off'",
+      env: {
+        DEPENDENCY_HASH: "${{ hashFiles('scripts/docs-i18n/go.sum') }}",
+      },
+    });
+    expect(resolveGoCacheStep.run).toContain(
+      "key=setup-go-${RUNNER_OS}-${arch}-${image_prefix}go-${version#go}-${DEPENDENCY_HASH}",
+    );
+    expect(restoreGoCacheStep).toMatchObject({
+      if: "matrix.requires_go == true && needs.preflight.outputs.cache_mode != 'off'",
+      uses: CACHE_V5,
+    });
+    expect(saveGoCacheStep).toMatchObject({
+      if: expect.stringContaining("needs.preflight.outputs.cache_write_allowed == 'true'"),
+      uses: CACHE_SAVE_V5,
+    });
     expect(verifyGoStep).toMatchObject({
       if: "matrix.requires_go == true",
       run: 'test "$(go env GOVERSION)" = "go1.25.12"',


### PR DESCRIPTION
## What Problem This Solves

Fixes a CI security issue where an arbitrary `workflow_dispatch.target_ref` could run candidate-controlled steps before shared cache writers completed, allowing an untrusted manual target to influence caches used by later trusted runs.

CodeQL scope:
- https://github.com/openclaw/openclaw/security/code-scanning/725
- https://github.com/openclaw/openclaw/security/code-scanning/726
- https://github.com/openclaw/openclaw/security/code-scanning/809

## Why This Change Was Made

CI preflight now owns one canonical candidate trust decision and exports `candidate_trust`, `cache_mode`, and `cache_write_allowed`. Trust defaults to `untrusted` with caches off; pull requests restore only; exact main and validated release identities may write. Release context authorization additionally proves the target SHA is the named release branch head or an ancestor of it.

Workflow-owned local actions are loaded from an exact `github.workflow_sha` harness, separately from candidate code. Every direct cache surface now consumes the canonical mode or write authorization, including dependency warmup, build/dist, Playwright, extension artifacts, Vitest/Node, Go, Swift, Android SDK, Gradle, Windows, and macOS. Implicit read-write Go/Java caches were replaced with restore/save-aware flows; Gradle uses the maintained `gradle/actions/setup-gradle` basic provider in native read-only mode for non-writers.

The architectural owner is CI preflight. Candidate identity is established once there; cache consumers no longer re-derive trust from event shape.

## User Impact

No product-facing behavior changes. Maintainers retain pull-request restores and exact main/release cache publication, while arbitrary manual targets can still run tests without reading or writing shared caches.

## Evidence

Exact head: `63c4cf5d4ca2d46c6e208777baec3137118600be`

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`: 124 passed, 2 skipped
- `node scripts/run-vitest.mjs test/scripts/pr-ci-dispatch.test.ts test/scripts/pr-prepare-gates.test.ts test/scripts/full-release-validation-at-sha.test.ts`: 67 passed
- `actionlint -shellcheck '' -pyflakes '' .github/workflows/ci.yml .github/workflows/android-release.yml`: passed
- `pre-commit run zizmor --files .github/workflows/ci.yml .github/workflows/android-release.yml`: passed
- YAML parse and `git diff --check`: passed
- changed-file policy, formatting, dependency-pin, patch, conflict-marker, and declaration guards: passed
- local test-root typecheck reached one environment-only failure: the shared linked `node_modules` contains `pako@1.0.11` while this checkout requires `pako@3.0.1`; no dependency install was run inside the Codex worktree. Hosted CI remains authoritative for that lane.

Privacy scrub: no personal paths, private hosts/IPs, phone numbers, or non-public email addresses in the diff.

LOC proof:
- CI production/config: `+279/-85`
- tests: `+381/-42`

Positive production growth is justified by the cache-write security invariant and its explicit owner/lifecycle boundaries. No changelog entry: this is internal CI hardening with no shipped user-facing surface.
