### PR TITLE
fix: recover Cloud Workers profile saves after reconnect

### DIFF
--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -278,6 +278,114 @@ suite.define(() => {
     }
   });
 
+  it("releases a retired profile save after reconnect while preserving the draft", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1_000, width: 1_440 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["config.patch", "environments.list"],
+      methodResponses: {
+        "config.get": configResponse({}, "cloud-workers-reconnect-1"),
+        "environments.list": { environments: [], profiles: [] },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/cloud-workers`);
+      await page.getByRole("button", { name: "Add profile" }).click();
+      const editor = page.locator(".settings-section", {
+        has: page.getByRole("heading", { name: "Add profile", exact: true }),
+      });
+      const profileId = page.getByLabel("Profile ID");
+      const backend = page.getByLabel("Crabbox backend");
+      await profileId.fill("reconnect-proof");
+      await backend.fill("hetzner");
+      await waitForSettledFormControls(page, [
+        { locator: profileId, value: "reconnect-proof" },
+        { locator: backend, value: "hetzner" },
+      ]);
+
+      await gateway.deferNext("config.patch");
+      await editor.getByRole("button", { name: "Save" }).click();
+      await gateway.waitForRequest("config.patch");
+      await expect.poll(() => profileId.isDisabled()).toBe(true);
+
+      const socketCount = await gateway.getSocketCount();
+      const configGetCount = (await gateway.getRequests("config.get")).length;
+      await gateway.setMethodResponse(
+        "config.get",
+        configResponse({}, "cloud-workers-reconnect-2"),
+      );
+      await gateway.closeLatest(1012, "cloud worker save reconnect proof");
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+      await expect
+        .poll(async () => (await gateway.getRequests("config.get")).length)
+        .toBeGreaterThan(configGetCount);
+
+      await expect.poll(() => profileId.isEnabled()).toBe(true);
+      await expect.poll(() => backend.isEnabled()).toBe(true);
+      await expect.poll(() => profileId.inputValue()).toBe("reconnect-proof");
+      await expect.poll(() => backend.inputValue()).toBe("hetzner");
+      await expect.poll(() => editor.getByRole("button", { name: "Save" }).isEnabled()).toBe(true);
+      await expect
+        .poll(() => editor.getByRole("button", { name: "Cancel" }).isEnabled())
+        .toBe(true);
+
+      await gateway.resolveDeferred("config.patch", {
+        ok: true,
+        hash: "retired-cloud-workers-save",
+        config: {},
+      });
+      await expect.poll(() => profileId.inputValue()).toBe("reconnect-proof");
+      await expect.poll(() => page.getByText("Gateway restart required.").count()).toBe(0);
+      await expect.poll(() => page.getByRole("alert").count()).toBe(0);
+
+      await gateway.deferNext("config.patch");
+      const retryRequestCount = (await gateway.getRequests("config.patch")).length;
+      await editor.getByRole("button", { name: "Save" }).click();
+      const retryPatch = await waitForConfigPatch(gateway, retryRequestCount);
+      expect(retryPatch).toMatchObject({
+        cloudWorkers: {
+          profiles: {
+            "reconnect-proof": {
+              provider: "crabbox",
+              settings: { provider: "hetzner" },
+            },
+          },
+        },
+      });
+      const savedProfile = {
+        provider: "crabbox",
+        install: "bundle",
+        settings: {
+          provider: "hetzner",
+          class: "standard",
+          ttl: "8h",
+          idleTimeout: "45m",
+        },
+      };
+      await gateway.setMethodResponse(
+        "config.get",
+        configResponse(
+          { cloudWorkers: { profiles: { "reconnect-proof": savedProfile } } },
+          "cloud-workers-reconnect-3",
+        ),
+      );
+      await gateway.resolveDeferred("config.patch", {
+        ok: true,
+        hash: "cloud-workers-reconnect-3",
+        config: { cloudWorkers: { profiles: { "reconnect-proof": savedProfile } } },
+      });
+      await page.getByText("Gateway restart required.", { exact: true }).waitFor();
+      await expect.poll(() => page.getByLabel("Profile ID").count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("deletes a profile only after confirmation", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -64,10 +64,10 @@ class CloudWorkersPage extends OpenClawLightDomElement {
 
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
-    invalidateRequests: () => this.resetCatalog(),
+    invalidateRequests: () => this.resetGatewayState(),
     onSnapshot: (change) => {
       if (change.initial) {
-        this.resetCatalog();
+        this.resetGatewayState();
       }
     },
     ensureInitialData: () => void this.loadCatalog(),
@@ -85,7 +85,8 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     super.disconnectedCallback();
   }
 
-  private resetCatalog() {
+  private resetGatewayState() {
+    this.busyProfileId = null;
     this.advertisedProfileIds = new Set();
     this.catalogLoaded = false;
     this.catalogLoading = false;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators saving a Cloud Workers profile would remain permanently stuck on `Saving…` when the Gateway reconnected before `config.patch` settled. The same mounted editor retained its draft, but Profile ID, backend, Save, and Cancel all stayed disabled after the Gateway was connected again.

## Why This Change Was Made

AI-assisted. Cloud Workers already uses the page Gateway lifecycle as the authority for retiring in-flight requests. Its invalidator reset catalog ownership but omitted `busyProfileId`, while the retired request's guarded `finally` correctly refused to mutate current state. The page's existing Gateway reset now releases busy ownership together with catalog request state, preserving the editor and draft and keeping retired completions silent.

The browser regression exercises the real same-client reconnect order: defer `config.patch`, reconnect, verify recovery and exact preserved draft, settle the retired request silently, then issue exactly one fresh retry and complete it.

Production LOC: +4/-3 (net +1). Tests: +108/-0. The one production line adds the missing lifecycle ownership transition; no request, config, permission, or persistence behavior changes.

Provenance: the Cloud Workers profile editor was introduced in #124864 (`78beccf053974beb42d561471f35fe4954c52c61`, 2026-08-17). Live searches for `cloud workers reconnect saving`, `cloud workers stuck`, and `cloud-workers config.patch` found no exact open issue or PR.

## User Impact

After a transient Gateway reconnect, operators keep their in-progress Cloud Workers profile draft and can immediately retry or cancel instead of reloading the page and re-entering the profile.

## Evidence

Authentic pre-fix source-Chromium regression:

```text
FAIL releases a retired profile save after reconnect while preserving the draft
expected false to be true
ui/src/e2e/cloud-workers-settings.e2e.test.ts:325
profileId.isEnabled() remained false
```

Exact post-fix proof on the rebased head:

```text
cloud-workers-settings.e2e.test.ts: 4/4 passed
cloud-worker-config.test.ts: 11/11 passed
```

The exact changed-file gate passed formatting, UI/core-test typechecks, i18n verification, lint, dead exports, and policy guards. The pre/post rebase patch IDs match (`d421a539ec764cd0c3dfb7c3b96320c63f7f384d`), and the focused browser and owner tests passed again after rebasing.

Fresh independent high-mode review found no P0-P3 issues and judged the Gateway invalidator the correct owner-boundary fix. The repository Codex autoreview helper's previously disclosed authentication failure prevented the lead from rerunning that helper; independent high-mode review is the substitute.

### Before: draft preserved but permanently busy

![Cloud Workers profile fields disabled on Saving after reconnect](https://ampcode.com/user-content/artifacts/d874608eb15d37522586547e6bf36472cb22b758157c3747ddac460e32227d9a-file.png)

### After: same draft recovered with Save and Cancel enabled

![Cloud Workers profile fields recovered after reconnect](https://ampcode.com/user-content/artifacts/fed89324a6730bcd2882ce9d0bc2ada06ebb753b0d290033967bc6289ca69410-file.png)
