### PR TITLE
perf(clickclack): avoid duplicate upload buffer

### DIFF
--- a/extensions/clickclack/src/http-client.test.ts
+++ b/extensions/clickclack/src/http-client.test.ts
@@ -641,6 +641,14 @@ describe("ClickClack HTTP client", () => {
   });
 
   it("uploads multipart bytes with filename and MIME, then attaches by id", async () => {
+    const NativeBlob = Blob;
+    let uploadBlobPart: BlobPart | undefined;
+    class CapturingBlob extends NativeBlob {
+      constructor(parts?: BlobPart[], options?: BlobPropertyBag) {
+        uploadBlobPart = parts?.[0];
+        super(parts, options);
+      }
+    }
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -669,15 +677,24 @@ describe("ClickClack HTTP client", () => {
       fetch: fetchMock as unknown as typeof fetch,
     });
 
-    const upload = await client.createUpload({
-      workspaceId: "wsp_1",
-      buffer: Buffer.from("const proof = true;"),
-      filename: "viewer-proof.ts",
-      contentType: "text/typescript",
-      nonce: "upload-queue-1",
-    });
+    const uploadBuffer = Buffer.from("const proof = true;");
+    vi.stubGlobal("Blob", CapturingBlob);
+    const upload = await client
+      .createUpload({
+        workspaceId: "wsp_1",
+        buffer: uploadBuffer,
+        filename: "viewer-proof.ts",
+        contentType: "text/typescript",
+        nonce: "upload-queue-1",
+      })
+      .finally(() => vi.unstubAllGlobals());
     await client.attachUpload("msg_1", upload.id);
 
+    expect(uploadBlobPart).toBeInstanceOf(Uint8Array);
+    const uploadBytes = uploadBlobPart as Uint8Array;
+    expect(uploadBytes.buffer).toBe(uploadBuffer.buffer);
+    expect(uploadBytes.byteOffset).toBe(uploadBuffer.byteOffset);
+    expect(uploadBytes.byteLength).toBe(uploadBuffer.byteLength);
     const uploadRequest = fetchMock.mock.calls[0];
     expect(uploadRequest?.[0]).toBe(
       "https://clickclack.example/api/uploads?workspace_id=wsp_1&nonce=upload-queue-1",

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -474,7 +474,10 @@ export function createClickClackClient(options: ClientOptions) {
       nonce?: string;
     }): Promise<ClickClackUpload> => {
       const form = new FormData();
-      const bytes = new Uint8Array(params.buffer);
+      const bytes: Uint8Array<ArrayBuffer> =
+        params.buffer.buffer instanceof ArrayBuffer
+          ? new Uint8Array(params.buffer.buffer, params.buffer.byteOffset, params.buffer.byteLength)
+          : Uint8Array.from(params.buffer);
       form.append("file", new Blob([bytes], { type: params.contentType }), params.filename);
       const query = new URLSearchParams({ workspace_id: params.workspaceId });
       if (params.nonce) {


### PR DESCRIPTION
## What Problem This Solves

ClickClack media uploads copied the complete outbound `Buffer` before `Blob` captured the multipart body. At the 64 MiB supported upload limit, multipart construction retained two additional media-sized ArrayBuffers and spent about 97 ms synchronously preparing one upload.

## Why This Change Was Made

The ClickClack HTTP owner now passes an offset-correct `Uint8Array` view over a normal Node `Buffer` backing store instead of copying it. A rare `SharedArrayBuffer` backing still uses `Uint8Array.from` because `BlobPart` requires an `ArrayBuffer`-backed view. Multipart bytes, offset/length, filename, MIME type, nonce, authentication, upload-first ordering, and attach behavior remain unchanged.

## User Impact

Large ClickClack media sends use less transient memory and spend less synchronous CPU time constructing multipart bodies. Delivery behavior and public/plugin/protocol contracts are unchanged.

## Evidence

- Exact current-main red regression: before the production edit, the Blob part used a different backing store from the source Buffer; the ownership assertion failed. The two owner files were unchanged through the final current-main rebase.
- Node 26.5.1, seven-sample median at 64 MiB: construction 97.027 ms → 54.109 ms (44.2% lower); transient ArrayBuffer growth +128 MiB → +64 MiB. At 1 MiB, growth likewise changed +2 MiB → +1 MiB.
- Final rebased head: 30/30 focused HTTP-client tests passed. Patch-identical full ClickClack coverage passed 33 files / 362 tests.
- `node scripts/check-changed.mjs -- extensions/clickclack/src/http-client.ts extensions/clickclack/src/http-client.test.ts` passed extension production/test typechecks, lint, formatting, dead exports, import cycles, boundaries, and repository guards.
- Patch ID remained `f86eaa010b2e612cc704b4461a1ed510dc1a8385` across integration/rebase; `git diff --check` passed.
- Fresh final-head autoreview: TruffleHog clean; no accepted/actionable findings; `patch is correct` confidence 0.99.

Risk is low: production is +4/-1 and only removes a redundant local copy. Blob capture, request body shape, bytes, delivery ordering/recovery, and provider semantics are unchanged.

AI-assisted. I understand the change and verified the final patch; no agent transcript is included because transcript-sharing consent was not provided.
