### PR TITLE
fix(process): retain live children after signal errors

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -60,7 +60,7 @@ Behavior:
 
 ## Child process bridging
 
-When spawning long-running child processes outside the exec/process tools (CLI respawns, gateway helpers), attach the child-process bridge helper so termination signals forward and listeners detach on exit/error. This avoids orphaned processes on systemd and keeps shutdown consistent across platforms.
+When spawning long-running child processes outside the exec/process tools (CLI respawns, gateway helpers), attach the child-process bridge helper so termination signals forward and listeners detach on exit/close. This avoids orphaned processes on systemd and keeps shutdown consistent across platforms.
 
 ## process tool
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -280,6 +280,60 @@ describe("createChildAdapter", () => {
     expect(disconnectMock).toHaveBeenCalledOnce();
   });
 
+  it("keeps ordinary children supervised through repeated operational errors", async () => {
+    const { child, emitClose, emitExit } = createStubChild(7865);
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    const adapter = await createChildAdapter({
+      argv: ["node", "-e", "setInterval(() => {}, 1000)"],
+      stdinMode: "pipe-open",
+    });
+    const resolved = vi.fn();
+    const rejected = vi.fn();
+    const wait = adapter.wait();
+    void wait.then(resolved, rejected);
+
+    try {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const error = Object.assign(new Error("kill EPERM"), { code: "EPERM" });
+        expect(() => child.emit("error", error)).not.toThrow();
+        expect(child.listenerCount("error")).toBe(1);
+        expect(child.listenerCount("exit")).toBe(1);
+        expect(child.listenerCount("close")).toBe(1);
+        await Promise.resolve();
+        expect(resolved).not.toHaveBeenCalled();
+        expect(rejected).not.toHaveBeenCalled();
+      }
+
+      emitExit(0);
+      emitClose(0);
+      await expect(wait).resolves.toEqual({ code: 0, signal: null });
+    } finally {
+      adapter.dispose();
+    }
+
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.listenerCount("exit")).toBe(0);
+    expect(child.listenerCount("close")).toBe(0);
+  });
+
+  it("fails owned worker authority closed on child process errors", async () => {
+    const { child, disconnectMock } = createStubChild(7866);
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    const adapter = await createChildAdapter({
+      argv: ["node", "worker"],
+      ownedWorker: true,
+    });
+    const wait = adapter.wait();
+    const error = Object.assign(new Error("kill EPERM"), { code: "EPERM" });
+
+    child.emit("error", error);
+
+    await expect(wait).rejects.toBe(error);
+    adapter.dispose();
+    expect(disconnectMock).toHaveBeenCalledOnce();
+    expect(child.listenerCount("error")).toBe(0);
+  });
+
   it("writes secret input to an extra descriptor and zeroes the transient buffer", async () => {
     const { child } = createStubChild();
     const secretStream = new PassThrough();

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -401,9 +401,8 @@ export async function createChildAdapter(params: {
     maybeSettleAfterWindowsExit();
   });
 
-  child.once("error", (error) => {
-    rejectPendingWait(error);
-  });
+  // Worker IPC failures close authority; ordinary post-spawn errors are nonterminal.
+  child.on("error", params.ownedWorker ? rejectPendingWait : () => {});
   child.once("exit", (code, signal) => {
     childExitState = { code, signal };
     scheduleForcedWindowsCloseSettlement();

--- a/test/e2e/qa-lab/runtime/openclaw-exec-process-lifecycle.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openclaw-exec-process-lifecycle.e2e.test.ts
@@ -1,10 +1,13 @@
-import { expect, test } from "vitest";
+import { ChildProcess } from "node:child_process";
+import { constants } from "node:os";
+import { expect, test, vi } from "vitest";
 import {
   getActiveBackgroundExecSessionCount,
   listRunningSessions,
 } from "../../../../src/agents/bash-process-registry.js";
 import { resetProcessRegistryForTests } from "../../../../src/agents/bash-process-registry.test-support.js";
 import { createExecTool, createProcessTool } from "../../../../src/agents/bash-tools.js";
+import { getProcessSupervisor } from "../../../../src/process/supervisor/index.js";
 
 type ExecTool = ReturnType<typeof createExecTool>;
 type ProcessTool = ReturnType<typeof createProcessTool>;
@@ -102,6 +105,22 @@ test("OpenClaw executes and controls the complete real process lifecycle", async
   const cleanupPids = new Set<number>();
 
   try {
+    const missingRunId = `missing-command-${process.pid}`;
+    await expect(
+      getProcessSupervisor().spawn({
+        mode: "child",
+        argv: ["/definitely/not/a/real-openclaw-command"],
+        env: { OPENCLAW_CHILD_OOM_SCORE_ADJ: "0" },
+        runId: missingRunId,
+        sessionId: missingRunId,
+        backendId: "qa-process-lifecycle",
+      }),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(getProcessSupervisor().getRecord(missingRunId)).toMatchObject({
+      state: "exited",
+      terminationReason: "spawn-error",
+    });
+
     const shellMarker = `shell-route-${process.pid}`;
     const foregroundCommand =
       process.platform === "win32"
@@ -191,23 +210,83 @@ test("OpenClaw executes and controls the complete real process lifecycle", async
     expect(textOf(pty)).toContain(`${ptyMarker}:true:exec`);
 
     const killMarker = `kill-target-${process.pid}`;
-    const killTarget = await execTool.execute("kill-background", {
-      command: nodeEvalCommand(
-        `process.stdout.write(${JSON.stringify(killMarker + "\n")});setInterval(() => {}, 1000);`,
-      ),
-      background: true,
+    const spawnedChildren = new Map<number, ChildProcess>();
+    const originalEmit = ChildProcess.prototype.emit;
+    const captureSpawn = vi.spyOn(ChildProcess.prototype, "emit").mockImplementation(function (
+      this: ChildProcess,
+      event,
+      ...args
+    ) {
+      if (event === "spawn" && this.pid !== undefined) {
+        spawnedChildren.set(this.pid, this);
+      }
+      return originalEmit.call(this, event, ...args);
     });
+    let killTarget: ToolResult;
+    try {
+      const childCommand = nodeEvalCommand(
+        `process.stdout.write(${JSON.stringify(killMarker + "\n")});setInterval(() => {}, 1000);`,
+      );
+      killTarget = await execTool.execute("kill-background", {
+        command: process.platform === "win32" ? childCommand : `exec ${childCommand}`,
+        background: true,
+      });
+    } finally {
+      captureSpawn.mockRestore();
+    }
     const killedSession = requireSession(killTarget);
     cleanupPids.add(killedSession.pid);
+    const child = spawnedChildren.get(killedSession.pid);
+    if (!child) {
+      throw new Error(`missing spawned child ${killedSession.pid}`);
+    }
+    const handle = (child as ChildProcess & { _handle: { kill: (signal: number) => number } })
+      ._handle;
+    const originalKill = handle.kill;
+    const observedErrors: Array<NodeJS.ErrnoException> = [];
+    child.on("error", (error) => {
+      observedErrors.push(error);
+    });
+    const errorListenerCount = child.listenerCount("error");
+
+    try {
+      handle.kill = () => -constants.errno.EPERM;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        expect(child.kill("SIGTERM")).toBe(false);
+        expect(child.listenerCount("error")).toBe(errorListenerCount);
+        expect(observedErrors[attempt]).toMatchObject({ code: "EPERM", syscall: "kill" });
+        await Promise.resolve();
+        expect(getProcessSupervisor().getRecord(killedSession.sessionId)).toMatchObject({
+          state: "running",
+          pid: killedSession.pid,
+        });
+        expect(listRunningSessions()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: killedSession.sessionId, exited: false }),
+          ]),
+        );
+        expect(getActiveBackgroundExecSessionCount()).toBe(1);
+        expect(pidExists(killedSession.pid)).toBe(true);
+      }
+    } finally {
+      handle.kill = originalKill;
+    }
+
     const killed = await processTool.execute("kill-session", {
       action: "kill",
       sessionId: killedSession.sessionId,
     });
-    expect(killed.details).toMatchObject({ status: "failed" });
+    expect(killed.details).toMatchObject({ status: "completed" });
     const killedTerminal = await pollTerminal(processTool, killedSession.sessionId);
-    expect(killedTerminal.details).toMatchObject({ status: "failed" });
+    expect(killedTerminal.details).toMatchObject({
+      status: "failed",
+      exitReason: "manual-cancel",
+    });
     await clearFinished(processTool, killedSession.sessionId);
     await expect.poll(() => pidExists(killedSession.pid), POLL_OPTIONS).toBe(false);
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.listenerCount("exit")).toBe(0);
+    expect(child.listenerCount("close")).toBe(0);
     cleanupPids.delete(killedSession.pid);
 
     const finalList = await processTool.execute("list-final", { action: "list" });
@@ -220,6 +299,11 @@ test("OpenClaw executes and controls the complete real process lifecycle", async
         action: "remove",
         sessionId: session.id,
       });
+    }
+    for (const pid of cleanupPids) {
+      if (pidExists(pid)) {
+        process.kill(pid, "SIGKILL");
+      }
     }
     await expect.poll(() => [...cleanupPids].filter(pidExists).length, POLL_OPTIONS).toBe(0);
     resetProcessRegistryForTests();


### PR DESCRIPTION
Closes #127146
Related: #126493

## What Problem This Solves

Fixes an issue where an operator managing a background exec command could lose the ability to stop a still-running child after a failed signal operation. Node can emit a child-process error and return false from kill without terminating the process, but the ordinary child adapter treated that operational event as a spawn failure, discarded supervisor/background-session ownership, and could orphan the live child.

## Why This Change Was Made

The child adapter now keeps one persistent error listener: ordinary post-spawn errors remain nonterminal, while authority-bearing owned workers retain their existing immediate fail-closed rejection. Actual spawn failures remain owned by spawnWithFallback; exit and close retain terminal ownership, Windows drain semantics remain unchanged, and no supervisor workaround or fallback is introduced. The background-process guide now accurately describes the existing bridge exit/close contract, and the QA lifecycle scenario now distinguishes a successfully accepted kill request from the cancelled child's failed terminal status.

This completes the remaining supervised-child sibling of #126493; it does not introduce a new campaign repair or change campaign bookkeeping.

## User Impact

Background commands remain visible, supervised, and cancellable after repeated failed signal operations. A later successful cancellation terminates the actual child, releases the background-work blocker only after real exit, and reports the accepted process-tool action truthfully. Owned worker authority, genuine spawn rejection, cancellation reasons, and terminal process outcomes stay unchanged.

## Evidence

- Direct Node 26 runtime source and pinned Node type definitions confirm that ChildProcess.kill can emit EPERM, return false, and leave the child alive; exit and close remain independent terminal lifecycle events.
- Harmless real-child proof: two kill attempts returned false and emitted EPERM; the exact owned PID remained alive; a subsequent real SIGTERM returned true; close reported SIGTERM and an independent PID probe confirmed the process was gone.
- Baseline QA E2E on exact base e17c858bae068f475fb4938237480dc7525ac849 failed because its stale assertion expected failed while the already-shipped successful kill action returned completed.
- New adapter regression failed on the unfixed implementation because the first operational error removed the only child error listener; ownedWorker rejection already passed. Both pass after the owner-boundary repair.
- Focused owner and sibling coverage: 268 passing tests across child adapter, supervisor, supervisor registry, spawn utility, process bridge, respawn, PTY, cancellation reasons, exec, background registry/control, node worker authority, and service-child lifecycle; one existing platform-specific case skipped.
- Real process-control E2E: 10 passing tests, including an actual nonexistent-command ENOENT recorded as spawn-error; two real EPERM kill failures on the exact supervised background child; retained running supervisor/background ownership and live PID; accepted process-tool cancellation; failed/manual-cancel terminal poll; listener disposal; and independently verified owned-PID cleanup.
- Changed-file validation runs the repository-classified core production/core tests/root tests/docs/tooling typecheck, lint, formatting, dependency, architecture, and safety gates.
- Fresh Codex P1 autoreview reported no accepted or actionable findings.
- Production LOC: +2/-3 (net -1). Tests: +146/-8 (net +138). Docs: +1/-1.
- AI-assisted: yes; dependency source/types, production ownership, sibling behavior, regressions, and all process cleanup were inspected directly.

No changelog, protocol, configuration, persistence, security, authentication, authority, product contract, dependency, SDK, release, publication, or deployment changes.
