### PR TITLE
fix(gateway): prune idle tool event recipients

### DIFF
--- a/src/gateway/server-chat-state.test.ts
+++ b/src/gateway/server-chat-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createChatAbortMarker,
   createChatRunState,
@@ -6,6 +6,33 @@ import {
 } from "./server-chat-state.js";
 
 describe("createChatRunState", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("prunes expired tool-event recipients while preserving the late-event grace window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const state = createChatRunState();
+    state.toolEventRecipients.add("active-expired", "conn-active");
+
+    vi.advanceTimersByTime(9 * 60_000 + 31_000);
+    state.toolEventRecipients.add("finalized-expired", "conn-final");
+    state.toolEventRecipients.markFinal("finalized-expired");
+    vi.advanceTimersByTime(2_000);
+    state.toolEventRecipients.add("finalized-grace", "conn-grace");
+    state.toolEventRecipients.markFinal("finalized-grace");
+    state.toolEventRecipients.add("recent", "conn-recent");
+    vi.advanceTimersByTime(29_000);
+
+    state.toolEventRecipients.pruneExpired(Date.now());
+
+    expect(state.runs.has("active-expired")).toBe(false);
+    expect(state.runs.has("finalized-expired")).toBe(false);
+    expect(state.runs.has("finalized-grace")).toBe(true);
+    expect(state.runs.has("recent")).toBe(true);
+  });
+
   it("clears transient projection state without dropping run ownership or abort tombstones", () => {
     const state = createChatRunState();
     state.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });

--- a/src/gateway/server-chat-state.ts
+++ b/src/gateway/server-chat-state.ts
@@ -332,6 +332,7 @@ export type ToolEventRecipientRegistry = {
   add: (runId: string, connId: string) => void;
   get: (runId: string) => ReadonlySet<string> | undefined;
   markFinal: (runId: string) => void;
+  pruneExpired: (now?: number) => void;
 };
 
 export type SessionEventSubscriberRegistry = {
@@ -632,11 +633,10 @@ export function createSessionMessageSubscriberRegistry(
 function createToolEventRecipientRegistryForStore(
   store: ChatRunRecordStore,
 ): ToolEventRecipientRegistry {
-  const prune = () => {
+  const pruneExpired = (now = Date.now()) => {
     if (store.runs.size === 0) {
       return;
     }
-    const now = Date.now();
     for (const [runId, record] of store.runs) {
       const entry = record.toolRecipient;
       if (!entry) {
@@ -668,7 +668,7 @@ function createToolEventRecipientRegistryForStore(
         updatedAt: now,
       };
     }
-    prune();
+    pruneExpired(now);
   };
 
   const get = (runId: string) => {
@@ -676,8 +676,9 @@ function createToolEventRecipientRegistryForStore(
     if (!entry) {
       return undefined;
     }
-    entry.updatedAt = Date.now();
-    prune();
+    const now = Date.now();
+    entry.updatedAt = now;
+    pruneExpired(now);
     return entry.connIds;
   };
 
@@ -686,9 +687,10 @@ function createToolEventRecipientRegistryForStore(
     if (!entry) {
       return;
     }
-    entry.finalizedAt = Date.now();
-    prune();
+    const now = Date.now();
+    entry.finalizedAt = now;
+    pruneExpired(now);
   };
 
-  return { add, get, markFinal };
+  return { add, get, markFinal, pruneExpired };
 }

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -287,6 +287,27 @@ describe("startGatewayMaintenanceTimers", () => {
     await stopMaintenanceTimers(timers);
   });
 
+  it("prunes idle tool-event recipients by their active and finalized lifetimes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    deps.chatRunState.toolEventRecipients.add("active-expired", "conn-active");
+
+    await vi.advanceTimersByTimeAsync(9 * 60_000 + 31_000);
+    deps.chatRunState.toolEventRecipients.add("finalized-expired", "conn-final");
+    deps.chatRunState.toolEventRecipients.markFinal("finalized-expired");
+    deps.chatRunState.toolEventRecipients.add("recent", "conn-recent");
+
+    const timers = startGatewayMaintenanceTimers(deps);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deps.chatRunState.runs.has("active-expired")).toBe(false);
+    expect(deps.chatRunState.runs.has("finalized-expired")).toBe(false);
+    expect(deps.chatRunState.runs.has("recent")).toBe(true);
+    await stopMaintenanceTimers(timers);
+  });
+
   it("runs queue media cleanup at startup and hourly", async () => {
     vi.useFakeTimers();
     const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -235,6 +235,7 @@ export function startGatewayMaintenanceTimers(params: {
   const dedupeCleanup = setInterval(() => {
     const AGENT_RUN_SEQ_MAX = 10_000;
     const now = Date.now();
+    params.chatRunState.toolEventRecipients.pruneExpired(now);
     void performDevicePairSetupCompletionGc(now);
     if (now - deliveryQueueMediaGcStartedAtMs >= DELIVERY_QUEUE_MEDIA_GC_INTERVAL_MS) {
       void performDeliveryQueueMediaGc();


### PR DESCRIPTION
Closes #127157

## What Problem This Solves

An idle Gateway retained expired tool-event recipient records because cleanup only ran during later recipient-registry operations. Completed runs could keep their historical run and connection IDs after the existing grace period had elapsed.

## Why This Change Was Made

Expose the registry's existing expiration routine to the Gateway's existing 60-second maintenance sweep. Keep the next-expiry bound so maintenance and tool events avoid scanning before cleanup is due. Preserve the post-prune audience lookup and release only empty run records.

## User Impact

Expired recipients are reclaimed on the next maintenance tick after their existing 10-minute active TTL or 30-second finalized grace. Recent recipients, late-event grace, registered run contexts, and other retained run state keep their existing behavior. No per-run timers, configuration, storage, or permission changes are introduced.

## Evidence

- The maintenance regression failed against unchanged main because an expired active recipient remained after the first tick. Removing only the maintenance hook also makes the final dedicated regression fail on the same assertion.
- Normal compiled-runner proof: `node scripts/run-vitest.mjs src/gateway/server-chat-state.test.ts src/gateway/server-maintenance.test.ts src/gateway/server-maintenance.recipients.test.ts` passed all 74 tests across three files. The regression covers idle cleanup, finalized grace, subsequent expiration, recent recipients, and preserved registrations.
- Fresh independent Codex review of the final three-file scope: no actionable P0-P2 findings.
- Targeted lint, changed-file formatting, line-cap and other completed static guards passed. Local `check:changed` stopped at the core TypeScript graph boundary because the borrowed compiler installation is outside the task checkout; no guard or dependency installation was changed. Exact-head hosted CI completed the required gates for `a6005b81e6ccd95a9e6791abb76116005c221536`: [run 35177855253](https://github.com/openclaw/openclaw/actions/runs/35177855253).
- Production delta: +16/-11 lines, net +5. The 68-line regression uses the existing maintenance-state fixture in a dedicated sibling file because the original maintenance test file is already at its line cap; its existing coverage is unchanged.

Refreshed onto main `8dd36a07c761d08229937f32c99a5456facfab4e`, including the shared CI repairs in #150455. The complete three-file patch is byte-identical to the reviewed and tested change. The local results above precede this mechanical refresh; exact-head CI has now passed as linked above.
