### PR TITLE
perf(sessions): avoid loading full transcripts for newest-event checks

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -403,14 +403,14 @@ export function findTranscriptEventInDatabase(
   match: (event: TranscriptEvent) => boolean,
 ): { event: TranscriptEvent } | undefined {
   const db = getSessionKysely(database.db);
-  const rows = executeSqliteQuerySync(
+  const rows = iterateSqliteQuerySync(
     database.db,
     db
       .selectFrom("transcript_events")
       .select(["event_json"])
       .where("session_id", "=", sessionId)
       .orderBy("seq", "desc"),
-  ).rows;
+  );
   for (const row of rows) {
     try {
       const event = JSON.parse(row.event_json) as TranscriptEvent;

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -593,6 +593,36 @@ describe("session accessor seam", () => {
       [header, older, newer],
     );
 
+    const databasePath = expectDefined(
+      resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+      "transcript find database path",
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    const originalPrepare = database.db.prepare.bind(database.db);
+    let transcriptRowsRead = 0;
+    // Count SQLite rows rather than matcher calls: eager materialization happens before matching.
+    const prepareSpy = vi.spyOn(database.db, "prepare").mockImplementation((sql) => {
+      const statement = originalPrepare(sql);
+      return new Proxy(statement, {
+        get(target, property) {
+          if (property === "iterate") {
+            return (...params: Parameters<typeof target.iterate>) => {
+              const iterator = target.iterate(...params);
+              return (function* () {
+                for (const row of iterator) {
+                  if ("event_json" in row) {
+                    transcriptRowsRead += 1;
+                  }
+                  yield row;
+                }
+              })() as ReturnType<typeof target.iterate>;
+            };
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    });
     const seen: unknown[] = [];
     const found = await findTranscriptEvent(
       { sessionId: "session-find", sessionKey: "agent:main:main", storePath },
@@ -600,10 +630,11 @@ describe("session accessor seam", () => {
         seen.push(event);
         return (event as { type?: string }).type === "message";
       },
-    );
+    ).finally(() => prepareSpy.mockRestore());
     // Newest-first with early exit: the older message is never visited.
     expect(found).toEqual({ event: newer });
     expect(seen).toEqual([newer]);
+    expect(transcriptRowsRead).toBe(1);
 
     await replaceTranscriptEvents(
       { agentId: "main", sessionId: "session-falsy", sessionKey: "agent:main:falsy", storePath },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where transcript existence and assistant-idempotency checks loaded every SQLite `event_json` row before testing the newest event, so a newest-row match still scaled with the complete transcript size.

## Why This Change Was Made

The canonical newest-first lookup now consumes the existing synchronous SQLite iterator directly and stops stepping rows as soon as its matcher succeeds. Ordering, malformed-row skipping, first-match behavior, transaction lifetime, schema, and public APIs are unchanged.

This is AI-assisted. No agent transcript is attached.

## User Impact

Large sessions no longer incur transcript-sized CPU and heap work for newest-event checks. In a 10,002-row, approximately 40 MiB fixture, five newest-row probes improved from 50,010 rows stepped, 225.416 ms wall time, and +217.335 MiB heap to 5 rows, 5.213 ms, and +0.662 MiB heap (about 43x faster wall time).

## Evidence

- Pre-fix focused regression: failed with `expected 3 rows, received 1`, proving eager materialization occurred before the matcher returned.
- Final-head focused and sibling tests:
  - `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/gateway/server-methods/chat.inject.parentid.test.ts --reporter=dot`
  - 108 session-accessor tests and 6 Gateway tests passed.
- `node scripts/check-changed.mjs -- src/config/sessions/session-accessor.sqlite-read.ts src/config/sessions/session-accessor.test.ts` passed formatting, core/core-test typechecks, lint, dead exports, database/schema guards, and import-cycle checks.
- `git diff --check origin/main...HEAD` passed.
- Fresh structured autoreview on the exact branch head: clean, no accepted/actionable findings; patch correct confidence 0.99.
- Live open PR/issue searches found no duplicate for `findTranscriptEvent` or lazy SQLite transcript scanning. Open PRs #125221, #124899, and #124749 touch adjacent transcript code for distinct idempotency-key or rewrite-conflict work.
