### PR TITLE
perf(test): speed up board provider snapshot observations

### DIFF
--- a/ui/src/lib/board/provider.test.ts
+++ b/ui/src/lib/board/provider.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { GatewayBoardProvider } from "./gateway-provider.ts";
 import { registerBoardProviderLeaseCases } from "./provider.lease-cases.test-support.ts";
 import {
@@ -102,7 +103,7 @@ describe("board providers", () => {
     );
 
     try {
-      await vi.waitFor(() => expect(writable.provider.snapshot$.value).toEqual(snapshot));
+      await waitForFast(() => expect(writable.provider.snapshot$.value).toEqual(snapshot));
 
       writable.update(client, true, {
         canPinWidgets: false,
@@ -181,7 +182,7 @@ describe("board providers", () => {
     );
 
     try {
-      await vi.waitFor(() => expect(lease.provider.snapshot$.value).toEqual(snapshot));
+      await waitForFast(() => expect(lease.provider.snapshot$.value).toEqual(snapshot));
       await expect(lease.provider.applyOps([])).rejects.toThrow();
       await expect(lease.provider.pinWidget({ docId: "cv-upgraded" })).rejects.toThrow();
       await expect(lease.provider.pinMcpApp({ viewId: "app-upgraded" })).rejects.toThrow();
@@ -272,7 +273,7 @@ describe("board providers", () => {
     const cached = boardProviderForSession(sessionKey);
 
     try {
-      await vi.waitFor(() => expect(writer.provider.snapshot$.value).toEqual(previousSnapshot));
+      await waitForFast(() => expect(writer.provider.snapshot$.value).toEqual(previousSnapshot));
 
       writer.update(nextClient, true, {
         canPinWidgets: true,
@@ -281,7 +282,7 @@ describe("board providers", () => {
         canGrant: false,
       });
 
-      await vi.waitFor(() => expect(writer.provider.snapshot$.value).toEqual(nextSnapshot));
+      await waitForFast(() => expect(writer.provider.snapshot$.value).toEqual(nextSnapshot));
       expect(approver.provider.snapshot$.value).toEqual(nextSnapshot);
       expect(boardProviderForSession(sessionKey)).toBe(cached);
       expect(removePreviousListener).toHaveBeenCalledOnce();
@@ -318,7 +319,7 @@ describe("board providers", () => {
       },
     };
     const first = acquireBoardProviderForSession(snapshot.sessionKey, client as never);
-    await vi.waitFor(() => expect(first.provider.snapshot$.value).toEqual(snapshot));
+    await waitForFast(() => expect(first.provider.snapshot$.value).toEqual(snapshot));
     const command = vi.fn();
     first.provider.events.subscribe(command);
 
@@ -342,7 +343,7 @@ describe("board providers", () => {
 
     const second = acquireBoardProviderForSession(snapshot.sessionKey, client as never);
     expect(second.provider).not.toBe(first.provider);
-    await vi.waitFor(() => expect(second.provider.snapshot$.value).toEqual(snapshot));
+    await waitForFast(() => expect(second.provider.snapshot$.value).toEqual(snapshot));
     expect(listeners.size).toBe(1);
     second.release();
     expect(listeners.size).toBe(0);
@@ -370,7 +371,7 @@ describe("board providers", () => {
       expect(sessionHasBoard(sessionKey)).toBe(true);
 
       resolveSnapshot?.(emptySnapshot);
-      await vi.waitFor(() => expect(lease.provider.snapshot$.value).toEqual(emptySnapshot));
+      await waitForFast(() => expect(lease.provider.snapshot$.value).toEqual(emptySnapshot));
 
       expect(hasLoadedBoardSnapshot(lease.provider)).toBe(true);
       expect(sessionHasBoard(sessionKey)).toBe(false);
@@ -610,7 +611,7 @@ describe("board providers", () => {
         return () => {};
       },
     });
-    await vi.waitFor(() => expect(provider.snapshot$.value.revision).toBe(1));
+    await waitForFast(() => expect(provider.snapshot$.value.revision).toBe(1));
 
     listener?.({
       event: "board.changed",
@@ -679,7 +680,7 @@ describe("board providers", () => {
         return () => {};
       },
     });
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(initial));
+    await waitForFast(() => expect(provider.snapshot$.value).toEqual(initial));
 
     listener?.({
       event: "board.changed",
@@ -766,7 +767,7 @@ describe("board providers", () => {
         return () => {};
       },
     });
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(populated));
+    await waitForFast(() => expect(provider.snapshot$.value).toEqual(populated));
 
     listener?.({
       event: "board.changed",
@@ -821,7 +822,7 @@ describe("board providers", () => {
         return () => {};
       },
     });
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(populated));
+    await waitForFast(() => expect(provider.snapshot$.value).toEqual(populated));
 
     listener?.({
       event: "board.changed",
@@ -873,7 +874,7 @@ describe("board providers", () => {
       request: request as never,
       addEventListener: () => () => {},
     });
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(populated));
+    await waitForFast(() => expect(provider.snapshot$.value).toEqual(populated));
 
     const olderMutation = provider.applyOps([{ kind: "tab_delete", tabId: "main" }]);
     const newerMutation = provider.applyOps([
@@ -925,7 +926,7 @@ describe("board providers", () => {
       request: request as never,
       addEventListener: () => () => {},
     });
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(populated));
+    await waitForFast(() => expect(provider.snapshot$.value).toEqual(populated));
 
     const refresh = provider.activate();
     await vi.waitFor(() => expect(getCount).toBe(2));
@@ -988,7 +989,7 @@ describe("board providers", () => {
       request: request as never,
       addEventListener: () => () => {},
     });
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(initial));
+    await waitForFast(() => expect(provider.snapshot$.value).toEqual(initial));
 
     const refresh = provider.refreshWidgetFrame("alpha");
     await vi.waitFor(() => expect(getCount).toBe(2));


### PR DESCRIPTION
## What Problem This Solves

The Control UI board-provider test suite repeatedly waits for Vitest's 50 ms polling interval after an already-resolved Gateway snapshot is ready. Those incidental observation delays add roughly 0.7 seconds to every focused board-provider run without improving snapshot-generation, lease, or mutation-race coverage.

## Why This Change Was Made

Use the existing Control UI `waitForFast` helper for 14 already-resolved initial or explicitly fulfilled snapshot observations in `ui/src/lib/board/provider.test.ts`. Preserve all 11 ordering-sensitive waits in that file, all imported lease-lifecycle waits, all Gateway-provider waits, fake-timer backoff, widget-ticket generation, stale-response fencing, and deletion/recreation checkpoints. The helper changes the poll interval from 50 ms to 1 ms while retaining Vitest's existing timeout and assertions. No production code or snapshots change.

## User Impact

No user-visible behavior changes. Maintainers and CI get faster board-provider coverage without weakening the behavioral invariants that protect dashboard state.

## Evidence

AI-assisted maintainer-requested, test-only performance work. Same Blacksmith Testbox and immutable baseline blob, one worker, distinct per-variant module caches, import diagnostics, GNU `/usr/bin/time -v`, two excluded warmups, and eight counterbalanced/interleaved samples per variant:

- Median wall: **2.650 s -> 1.945 s**, **0.705 s / 26.6% faster**.
- Edited provider test body: **1,293 ms -> 597.5 ms**, **695.5 ms faster**.
- Combined test-body median: **1,560 ms -> 865 ms**; Vitest median: **1.925 s -> 1.240 s**.
- Import median: **169.5 ms -> 175.5 ms**; user CPU: **1.375 s -> 1.360 s**; system CPU: **0.195 s -> 0.195 s**.
- Maximum RSS median: **519,860 KiB -> 522,252 KiB**; every sample preserved **45/45 passing tests**.
- Fault proof 1: disabling the refresh-generation fence caused stale revision 6 to resurrect a deleted revision-0 board; the optimized regression failed, then passed after owner restoration.
- Fault proof 2: disabling the mutation-generation fence caused a stale revision-0 mutation to overwrite current revision 6; the optimized regression failed, then passed after owner restoration.
- Focused board, Gateway, lease, MCP-app, widget, dashboard, and isolated chat siblings: **122 tests passed**.
- Real Chromium with a mocked Gateway: **9 dashboard E2E scenarios passed**, including lease renewal, retained board runtime, offscreen lease bounds, pending-snapshot retention, and split-chat lifecycle; **15 board-layout browser scenarios passed**.
- Exact changed-file gate, format check, diff check, and independent autoreview passed.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/32474446538

Production LOC: **+0/-0**. Tests: **+15/-14**.
