### PR TITLE
fix(ui): keep segmented selections visible in forced colors

### DIFF
--- a/ui/src/e2e/config-controls-visual.e2e.test.ts
+++ b/ui/src/e2e/config-controls-visual.e2e.test.ts
@@ -108,6 +108,90 @@ async function captureBrowserSettingProof(
 }
 
 suite.define(() => {
+  it("keeps selected segmented options distinct in forced colors", async () => {
+    const cases = [
+      {
+        colorScheme: "dark" as const,
+        config: { ui: { prefs: { themeMode: "dark" } } },
+        featureMethods: undefined,
+        route: "settings/appearance",
+        selected: "Dark",
+        unselected: "Light",
+      },
+      {
+        colorScheme: "light" as const,
+        config: { update: { auto: { enabled: true }, channel: "beta" } },
+        featureMethods: ["config.get", "config.set", "config.apply", "update.run"],
+        route: "settings/updates",
+        selected: "Beta",
+        unselected: "Stable",
+      },
+    ];
+
+    for (const scenario of cases) {
+      await suite.withPage(
+        {
+          colorScheme: scenario.colorScheme,
+          forcedColors: "active",
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1280 },
+        },
+        async ({ page }) => {
+          await installMockGateway(page, {
+            featureMethods: scenario.featureMethods,
+            methodResponses: {
+              "config.get": {
+                config: scenario.config,
+                hash: `forced-colors-${scenario.route}`,
+                issues: [],
+                raw: JSON.stringify(scenario.config),
+                runtimeConfig: scenario.config,
+                valid: true,
+              },
+            },
+            operatorScopes: ["operator.read", "operator.admin"],
+          });
+
+          const response = await page.goto(`${suite.server.baseUrl}${scenario.route}`);
+          expect(response?.status()).toBe(200);
+          expect(await page.evaluate(() => matchMedia("(forced-colors: active)").matches)).toBe(
+            true,
+          );
+
+          const selected = page.getByRole("radio", { name: scenario.selected, exact: true });
+          const unselected = page.getByRole("radio", { name: scenario.unselected, exact: true });
+          await selected.waitFor();
+          expect(await selected.getAttribute("aria-checked")).toBe("true");
+          expect(await unselected.getAttribute("aria-checked")).toBe("false");
+          if (captureUiProofEnabled) {
+            await mkdir(uiProofArtifactDir, { recursive: true });
+            await selected
+              .locator(
+                "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' settings-row ')][1]",
+              )
+              .screenshot({
+                animations: "disabled",
+                path: path.join(
+                  uiProofArtifactDir,
+                  `segmented-forced-colors-${scenario.colorScheme}.png`,
+                ),
+              });
+          }
+          expect(
+            await selected.evaluate((element) => {
+              const style = getComputedStyle(element);
+              return { outlineStyle: style.outlineStyle, outlineWidth: style.outlineWidth };
+            }),
+          ).toEqual({ outlineStyle: "solid", outlineWidth: "2px" });
+          expect(
+            await unselected.evaluate((element) => getComputedStyle(element).outlineStyle),
+          ).toBe("none");
+        },
+      );
+    }
+  });
+
   it("keeps checked switches on the scene accent on the security page", async () => {
     await suite.withPage(
       {

--- a/ui/src/e2e/config-controls-visual.e2e.test.ts
+++ b/ui/src/e2e/config-controls-visual.e2e.test.ts
@@ -181,12 +181,36 @@ suite.define(() => {
           expect(
             await selected.evaluate((element) => {
               const style = getComputedStyle(element);
-              return { outlineStyle: style.outlineStyle, outlineWidth: style.outlineWidth };
+              return {
+                textDecorationLine: style.textDecorationLine,
+                textDecorationThickness: style.textDecorationThickness,
+              };
             }),
-          ).toEqual({ outlineStyle: "solid", outlineWidth: "2px" });
+          ).toEqual({ textDecorationLine: "underline", textDecorationThickness: "2px" });
           expect(
-            await unselected.evaluate((element) => getComputedStyle(element).outlineStyle),
+            await unselected.evaluate((element) => getComputedStyle(element).textDecorationLine),
           ).toBe("none");
+
+          await selected.focus();
+          expect(await selected.evaluate((element) => element.matches(":focus-visible"))).toBe(
+            true,
+          );
+          expect(
+            await selected.evaluate((element) => {
+              const style = getComputedStyle(element);
+              return {
+                outlineOffset: style.outlineOffset,
+                outlineStyle: style.outlineStyle,
+                outlineWidth: style.outlineWidth,
+                textDecorationLine: style.textDecorationLine,
+              };
+            }),
+          ).toEqual({
+            outlineOffset: "2px",
+            outlineStyle: "solid",
+            outlineWidth: "2px",
+            textDecorationLine: "underline",
+          });
         },
       );
     }

--- a/ui/src/styles/settings-controls.css
+++ b/ui/src/styles/settings-controls.css
@@ -91,9 +91,14 @@ wa-radio-group.settings-segmented::part(radios) {
 }
 
 @media (forced-colors: active) {
-  .settings-segmented__btn.settings-segmented__btn--active {
+  .settings-segmented__btn--active {
+    text-decoration: underline 2px;
+    text-underline-offset: 3px;
+  }
+
+  .settings-segmented__btn:focus-visible {
     outline: 2px solid Highlight;
-    outline-offset: -2px;
+    outline-offset: 2px;
   }
 }
 

--- a/ui/src/styles/settings-controls.css
+++ b/ui/src/styles/settings-controls.css
@@ -90,6 +90,13 @@ wa-radio-group.settings-segmented::part(radios) {
   cursor: not-allowed;
 }
 
+@media (forced-colors: active) {
+  .settings-segmented__btn.settings-segmented__btn--active {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}
+
 input.settings-input,
 select.settings-select:not([multiple]) {
   height: var(--settings-control-height);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users relying on Windows High Contrast or another forced-colors mode could not visually distinguish the selected option in shared segmented controls. The checked radio semantics remained available to assistive technology, but selected options such as Appearance mode, Updates channel, Sessions filters, Skills filters, and Model Providers settings looked identical to their unchecked siblings.

## Why This Change Was Made

AI-assisted. The shared segmented-control owner now gives the selected option a persistent underline in forced-colors mode and reserves a separate system `Highlight` outline for keyboard focus. This preserves two independent visual channels—selection and transient focus—without changing normal palettes, radio semantics, values, or keyboard behavior.

The fix is at the shared owner used by 19 production render sites in 17 files. A route-specific override would leave the same defect in sibling callers. No net-neutral change can add both missing forced-color channels; production code adds 12 focused CSS lines, with 108 lines of browser regression coverage.

Live searches for `forced colors`, `forced-colors`, and `segmented high contrast` found no exact open issue or PR.

## User Impact

In forced-colors mode, users can identify the selected segmented option by its underline and can independently identify keyboard focus by the system highlight outline across all shared callers.

## Evidence

Authentic pre-fix source-Chromium regression using the exact final assertions:

```text
FAIL keeps selected segmented options distinct in forced colors
Expected textDecorationLine: "underline", textDecorationThickness: "2px"
Received textDecorationLine: "none", textDecorationThickness: "auto"
1 failed | 4 skipped
```

Post-fix source-Chromium mocked-Gateway E2E exercises Appearance in a dark system palette and Updates in a light system palette. It verifies forced-colors media, preserved ARIA checked state, selected-only underline, and a simultaneous separate 2px focus outline:

```text
config-controls-visual.e2e.test.ts: 5/5 passed
```

The exact changed-file gate passed formatting, UI/core-test typechecks, i18n verification, lint/stylelint, dead exports, and policy guards. Fresh independent high-mode review found no P0-P3 or nit findings after the selection indicator was separated from the focus indicator, and judged the shared-owner fix the best approach. The repository Codex autoreview helper's previously disclosed authentication failure prevented that helper from running; independent high-mode review is the substitute.

### Before: selected Dark has no persistent visual mark

![Forced-colors segmented controls before the fix](https://ampcode.com/user-content/artifacts/8595dbbcf40372da1a7f2915a95498789c0b632cdf6db928e4a28ae8ab7e95d5-file.png)

### After: selected Dark retains its underline in a dark system palette

![Forced-colors segmented controls after the fix in dark mode](https://ampcode.com/user-content/artifacts/898cb1f6e80897e0cd86e948f69c8e6ec2dfb55c99a27ae6d7a083ff1967b0d2-file.png)

### After: selected Beta retains its underline in a light system palette

![Forced-colors segmented controls after the fix in light mode](https://ampcode.com/user-content/artifacts/bf5faff239d6a90d107dfafc2ea144affddec0d8df80f78f0db246867d28c987-file.png)
