### PR TITLE
fix(cli): report exact Claude stream failures

### DIFF
--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -140,7 +140,10 @@ export function normalizeClaudeCliStreamJsonRecord(
   return normalized ? { line: JSON.stringify(parsed), omittedRawChars } : undefined;
 }
 
-function streamJsonOutputLimitErrorText(kind: "raw" | "line" | "lines", limit: number): string {
+export function streamJsonOutputLimitErrorText(
+  kind: "raw" | "line" | "lines",
+  limit: number,
+): string {
   if (kind === "line") {
     return `CLI JSONL line exceeded ${limit} characters; refusing to parse output.`;
   }

--- a/src/agents/cli-runner/claude-live-turn.test.ts
+++ b/src/agents/cli-runner/claude-live-turn.test.ts
@@ -847,7 +847,7 @@ describe("Claude live turn output bounds and result projection", () => {
     });
 
     await expect(startLiveTurn("run-live-oversized-line", false)).rejects.toThrow(
-      "Claude CLI JSONL line exceeded output limit.",
+      "CLI JSONL line exceeded 8388608 characters; refusing to parse output.",
     );
   });
 
@@ -855,14 +855,17 @@ describe("Claude live turn output bounds and result projection", () => {
     {
       name: "a coalesced blank-frame flood",
       createChunk: () => "\n".repeat(20_001),
+      expectedError: "CLI JSONL output exceeded 20000 lines; refusing to parse output.",
     },
     {
       name: "whitespace-only records exceeding the raw budget",
       createChunk: () => `${" ".repeat(4_300_000)}\n${" ".repeat(4_300_000)}\n`,
+      expectedError: "CLI JSONL output exceeded 8388608 characters; refusing to parse output.",
     },
     {
       name: "valid JSON padded beyond the raw budget",
       createChunk: () => `${" ".repeat(4_300_000)}{}\n${" ".repeat(4_300_000)}{}\n`,
+      expectedError: "CLI JSONL output exceeded 8388608 characters; refusing to parse output.",
     },
     {
       name: "internal formatting around compacted Claude media",
@@ -886,14 +889,32 @@ describe("Claude live turn output bounds and result projection", () => {
         }).replace('"message":', `"message":${" ".repeat(4_300_000)}`);
         return `${line}\n${line}\n`;
       },
+      expectedError: "CLI JSONL output exceeded 8388608 characters; refusing to parse output.",
     },
-  ])("rejects $name from the managed Claude live session", async ({ createChunk }) => {
+  ])("reports the exact limit for $name", async ({ createChunk, expectedError }) => {
     const live: ReturnType<typeof mockClaudeLiveRun> = mockClaudeLiveRun(supervisorSpawnMock, {
       onWrite: () => live.spawnInput.onStdout?.(createChunk()),
     });
 
-    await expect(startLiveTurn("run-live-output-budget", false)).rejects.toThrow(
-      "Claude CLI turn output exceeded limit.",
+    await expect(startLiveTurn("run-live-output-budget", false)).rejects.toThrow(expectedError);
+  });
+
+  it("reports backend JSONL parser failures without relabeling them as output limits", async () => {
+    mockClaudeLiveRun(supervisorSpawnMock, {
+      events: [{ type: "system", subtype: "init", session_id: "live-parser-error" }],
+    });
+
+    await expectRejectsWithFields(
+      startLiveTurn("run-live-parser-error", false, {
+        parseJsonlEvent: () => {
+          throw new Error("invalid custom event");
+        },
+      }),
+      {
+        name: "FailoverError",
+        reason: "format",
+        message: "CLI backend claude-cli JSONL parser failed: invalid custom event",
+      },
     );
   });
 

--- a/src/agents/cli-runner/claude-live-turn.ts
+++ b/src/agents/cli-runner/claude-live-turn.ts
@@ -26,6 +26,7 @@ import {
   createCliJsonlStreamingParser,
   frameBoundedCliJsonlChunk,
   normalizeClaudeCliStreamJsonRecord,
+  streamJsonOutputLimitErrorText,
 } from "../cli-output-stream.js";
 import { parseCliOutput } from "../cli-output.js";
 import type { FailoverError } from "../failover-error.js";
@@ -360,10 +361,11 @@ function applyBackgroundTasksChanged(
 
 function pushTurnLine(host: ClaudeLiveTurnHost, turn: ClaudeLiveTurn, line: string): boolean {
   turn.streamingParser.push(`${line}\n`);
-  if (!turn.streamingParser.getErrorText()) {
+  const errorText = turn.streamingParser.getErrorText();
+  if (!errorText) {
     return true;
   }
-  host.close("abort", createClaudeOutputLimitError(host, "Claude CLI turn output exceeded limit."));
+  host.close("abort", createClaudeOutputLimitError(host, errorText));
   return false;
 }
 
@@ -492,7 +494,10 @@ export function acceptClaudeStdout(host: ClaudeLiveTurnHost, chunk: string): voi
     ) {
       host.close(
         "abort",
-        createClaudeOutputLimitError(host, "Claude CLI JSONL line exceeded output limit."),
+        createClaudeOutputLimitError(
+          host,
+          streamJsonOutputLimitErrorText("line", maxPendingLineChars),
+        ),
       );
     }
   } catch (error) {


### PR DESCRIPTION
Closes #127168

## What Problem This Solves

### Root cause

Managed Claude live turns asked the shared JSONL parser only whether it had failed, then replaced the parser-owned bounded diagnostic with `Claude CLI turn output exceeded limit.` This erased the actual raw-character, line-count, single-line, or backend-parser failure. The non-live CLI path already preserved `getErrorText()`.

## Fix

The live-turn boundary now propagates the parser's exact bounded error text while preserving the existing `format` failover classification and safety limits. The separate live stdout framer uses the parser's canonical output-limit formatter, so it cannot drift from parser diagnostics.

Owner-boundary regressions cover raw-character, line-count, single-line, media-padding, and backend-parser failures. No limits, fallback behavior, configuration, or public API changed.

Production delta: +12/-4 (net +8). Tests: +25/-4 (net +21). The production growth is the smallest coherent shape: one exported canonical formatter plus propagation of the already-owned parser value across the live-turn boundary.

## Evidence

### Exact-head proof

Head: `53ddfac3b65852886c101f5756ceb0bf5f01449a`

- Current `main` live Telegram reproduction: generic `Claude CLI turn output exceeded limit.` diagnostic; provider requests: 0.
- Focused owner-prefix Vitest: 14 files, 229 tests passed.
- `oxfmt --check`: passed for all 3 changed files.
- Targeted Oxlint: passed for all 3 changed files.
- `pnpm tsgo`: passed.
- `pnpm check:test-types`: passed.
- Local ClawSweeper exact-head review: patch correct; 0 findings; security cleared; no maintainer decision; 0 Rank-up moves.
- Final real-user Telegram DM through the managed Claude live stdio fixture: exact `CLI JSONL output exceeded 20000 lines; refusing to parse output.` in the run-scoped Gateway log; Telegram returned the safe retry reply; 2 typing events + 1 SUT message recorded; provider requests: 0.
- Hosted exact-head CI: `openclaw/ci-gate` passed; all required checks successful.

AI-assisted by Codex (OpenAI). Investigation context and sanitized production evidence are recorded in #127168.

