### PR TITLE
fix(gateway): refresh health after runtime inspection failure

### DIFF
--- a/src/cli/gateway-cli/health-route.test.ts
+++ b/src/cli/gateway-cli/health-route.test.ts
@@ -126,6 +126,38 @@ describe("runGatewayHealthJsonRoute", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("preserves structured Gateway health request errors", async () => {
+    const runtime = createRuntime();
+    const error = new Error("health snapshot unavailable");
+    const callGateway = vi.fn(async () => {
+      throw error;
+    });
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_request_error",
+        code: "UNAVAILABLE",
+        message: "health snapshot unavailable",
+      },
+    };
+    const formatGatewayClientRequestErrorJson = vi.fn(() => payload);
+    const formatGatewayTransportErrorJson = vi.fn();
+
+    await runGatewayHealthJsonRoute({ rpc: { json: true, timeout: "10000" } }, runtime as never, {
+      callGateway,
+      readNonObservingHealthConfig: async () => ({}),
+      emitReachableGatewayAuthDiagnostic: vi.fn(async () => false) as never,
+      formatGatewayAuthErrorJson: vi.fn(() => null) as never,
+      formatGatewayClientRequestErrorJson: formatGatewayClientRequestErrorJson as never,
+      formatGatewayTransportErrorJson: formatGatewayTransportErrorJson as never,
+    });
+
+    expect(formatGatewayClientRequestErrorJson).toHaveBeenCalledWith(error);
+    expect(formatGatewayTransportErrorJson).not.toHaveBeenCalled();
+    expect(runtime.writeJson).toHaveBeenCalledWith(payload, 2);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("preserves structured auth errors when reachability is unknown", async () => {
     const runtime = createRuntime();
     const error = new Error("gateway health requires credentials");

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -140,7 +140,7 @@ export const healthHandlers: GatewayRequestHandlers = {
           context.getRuntimeSnapshot(),
         );
       } catch {
-        cachedDiffersFromRuntime = false;
+        cachedDiffersFromRuntime = true;
       }
     }
     if (

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4575,6 +4575,53 @@ describe("gateway healthHandlers.health cache freshness", () => {
     });
   });
 
+  it("rejects cached health when runtime inspection and refresh both fail", async () => {
+    const cached = createHealthSnapshot({});
+    const refreshHealthSnapshot = vi.fn().mockRejectedValue(new Error("collector failed"));
+    const { respond } = await requestHealthSnapshot({
+      cached,
+      refreshHealthSnapshot,
+      context: {
+        getRuntimeSnapshot: () => {
+          throw new Error("runtime inspection failed");
+        },
+      },
+    });
+
+    expect(refreshHealthSnapshot).toHaveBeenCalledWith({
+      probe: false,
+      includeSensitive: false,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: "Error: collector failed",
+      }),
+    );
+  });
+
+  it("refreshes cached health when runtime inspection fails", async () => {
+    const cached = createHealthSnapshot({});
+    const fresh = createHealthSnapshot({ ts: cached.ts + 1 });
+    const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({
+      cached,
+      fresh,
+      context: {
+        getRuntimeSnapshot: () => {
+          throw new Error("runtime inspection failed");
+        },
+      },
+    });
+
+    expect(refreshHealthSnapshot).toHaveBeenCalledWith({
+      probe: false,
+      includeSensitive: false,
+    });
+    expect(respond).toHaveBeenCalledWith(true, fresh, undefined);
+  });
+
   it("refreshes cached health when runtime channel lifecycle has changed", async () => {
     const cached = createSingleChannelHealthSnapshot({
       channelId: "discord",


### PR DESCRIPTION
Closes #127167

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators or monitoring scripts running `openclaw health --json` or `openclaw gateway health --json` would receive a stale healthy snapshot and exit code zero when live channel-runtime inspection failed and health collection could not refresh that snapshot.

## Why This Change Was Made

The documented cache contract permits reuse only when a fresh snapshot is verified unchanged against live channel runtime. Treat an inspection failure as an unverified cache and reuse the existing foreground passive refresh: successful collection returns fresh data, while failed collection returns the existing typed `UNAVAILABLE` Gateway request error. This changes one production token without adding a branch, protocol field, fallback, retry, configuration, or dependency.

## User Impact

Both machine-readable health commands now report a structured `gateway_request_error` and exit nonzero if the Gateway cannot produce a verified health snapshot. If collection succeeds despite the unavailable runtime snapshot, callers receive the fresh health snapshot. Verified cache hits, background refreshes, explicit probes, account/lifecycle invalidation, and successful health collection remain unchanged.

## Evidence

- Before the fix, both new owner-boundary cases failed in both Gateway test projects: the response was `respond(true, { ok: true, ... }, undefined, { cached: true })` instead of the existing `UNAVAILABLE` error or newly collected snapshot.
- After the fix, the complete cache-freshness describe block, runtime-snapshot health-state case, and both CLI error-route cases passed across three Vitest shards (35 passing assertions/tests).
- The complete Gateway health-state suite and both CLI health suites passed across three Vitest shards (83 passing tests).
- Existing coverage preserves verified cached success, background-refresh throttling, stale-cache refresh, explicit admin probes, runtime lifecycle changes, added/removed accounts, and successful collector behavior after runtime inspection failure.
- Focused formatter check and the repository-owned changed-file gate cover the three changed files.
- Fresh independent structured code review reported no actionable P0/P1 findings.
- Isolated Blacksmith Testbox: `tbx_01m0j12s2rh7xc41hc3h6xkrx1`; prepared run: https://github.com/openclaw/openclaw/actions/runs/32477121136.
- A deliberately broader legacy Gateway suite exposed two unrelated existing exec-approval failures; the affected cache suite and all relevant state/CLI suites pass when scoped to their documented owners.
- The cached-health QA scenario and live Gateway proof were intentionally not run because this repair explicitly prohibits starting or touching any live Gateway/service/operator state.
- Production LOC: `+1/-1` (net `0`); regression tests: `+79/-0`.
- AI-assisted; no transcript included.
