### PR TITLE
perf(plugins): reuse provider ownership metadata

### DIFF
--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -21,6 +21,7 @@ type LoadPluginManifestRegistry =
   typeof import("./manifest-registry.js").loadPluginManifestRegistryCore;
 type LoadPluginMetadataSnapshot =
   typeof import("./plugin-metadata-snapshot.js").loadPluginMetadataSnapshot;
+type LoadPluginRegistrySnapshot = typeof import("./plugin-registry.js").loadPluginRegistrySnapshot;
 type ApplyPluginAutoEnable = typeof import("../config/plugin-auto-enable.js").applyPluginAutoEnable;
 type SetActivePluginRegistry = typeof import("./runtime.js").setActivePluginRegistry;
 
@@ -31,12 +32,14 @@ const loadOpenClawPluginsMock = vi.fn<LoadOpenClawPlugins>();
 const isPluginRegistryLoadInFlightMock = vi.fn<IsPluginRegistryLoadInFlight>((_) => false);
 const loadPluginManifestRegistryMock = vi.fn<LoadPluginManifestRegistry>();
 const loadPluginMetadataSnapshotMock = vi.fn<LoadPluginMetadataSnapshot>();
+const loadPluginRegistrySnapshotMock = vi.fn<LoadPluginRegistrySnapshot>();
 const getCurrentPluginMetadataSnapshotMock = vi.fn();
 const applyPluginAutoEnableMock = vi.fn<ApplyPluginAutoEnable>();
 
 let resolveOwningPluginIdsForProvider: typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 let resolveOwningPluginIdsForProviderRef: typeof import("./providers.js").resolveOwningPluginIdsForProviderRef;
 let resolveOwningPluginIdsForModelRef: typeof import("./providers.js").resolveOwningPluginIdsForModelRef;
+let resolveOwningPluginIdsForModelRefs: typeof import("./providers.js").resolveOwningPluginIdsForModelRefs;
 let resolveProviderRefOwnership: typeof import("./providers.js").resolveProviderRefOwnership;
 let resolveActivatableProviderOwnerPluginIds: typeof import("./providers.js").resolveActivatableProviderOwnerPluginIds;
 let resolveEnabledProviderPluginIds: typeof import("./providers.js").resolveEnabledProviderPluginIds;
@@ -502,7 +505,8 @@ describe("resolvePluginProviders", () => {
         await vi.importActual<typeof import("./plugin-registry.js")>("./plugin-registry.js");
       return {
         ...actual,
-        loadPluginRegistrySnapshot: () => createProviderRegistrySnapshotFixture(),
+        loadPluginRegistrySnapshot: (...args: Parameters<LoadPluginRegistrySnapshot>) =>
+          loadPluginRegistrySnapshotMock(...args),
         resolvePluginContributionOwners: resolvePluginContributionOwnersFixture,
         resolveProviderOwners: resolveProviderOwnersFixture,
       };
@@ -519,6 +523,7 @@ describe("resolvePluginProviders", () => {
       resolveOwningPluginIdsForProvider,
       resolveOwningPluginIdsForProviderRef,
       resolveOwningPluginIdsForModelRef,
+      resolveOwningPluginIdsForModelRefs,
       resolveProviderRefOwnership,
       resolveEnabledProviderPluginIds,
       resolveCatalogHookProviderPluginIds,
@@ -547,9 +552,13 @@ describe("resolvePluginProviders", () => {
     });
 
     expectOwningPluginIds("setup-only-cli");
+    loadPluginMetadataSnapshotMock.mockClear();
+    loadPluginRegistrySnapshotMock.mockClear();
     expect(resolveOwningPluginIdsForProviderRef({ provider: "setup-only-cli" })).toEqual([
       "setup-only-backend-owner",
     ]);
+    expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+    expect(loadPluginRegistrySnapshotMock).toHaveBeenCalledOnce();
   });
 
   it("maps explicit provider refs to provider or cli-backend owners", () => {
@@ -588,6 +597,18 @@ describe("resolvePluginProviders", () => {
     setOwningProviderManifestPlugins();
 
     expectModelOwningPluginIds("claude-cli/claude-sonnet-4-6", ["anthropic"]);
+  });
+
+  it("reuses one registry snapshot across explicit model ownership lookups", () => {
+    setOwningProviderManifestPlugins();
+
+    expect(
+      resolveOwningPluginIdsForModelRefs({
+        models: ["openai/gpt-5.6-luna", "claude-cli/claude-sonnet-4-6"],
+      }),
+    ).toEqual(["anthropic", "openai"]);
+    expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+    expect(loadPluginRegistrySnapshotMock).toHaveBeenCalledOnce();
   });
 
   it("maps manifest model catalog provider aliases to owning plugin ids", () => {
@@ -734,6 +755,10 @@ describe("resolvePluginProviders", () => {
     isPluginRegistryLoadInFlightMock.mockReset();
     isPluginRegistryLoadInFlightMock.mockReturnValue(false);
     loadPluginMetadataSnapshotMock.mockReset();
+    loadPluginRegistrySnapshotMock.mockReset();
+    loadPluginRegistrySnapshotMock.mockImplementation(() =>
+      createProviderRegistrySnapshotFixture(),
+    );
     getCurrentPluginMetadataSnapshotMock.mockReset();
     getCurrentPluginMetadataSnapshotMock.mockReturnValue(undefined);
     const provider: ProviderPlugin = {

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -13,7 +13,6 @@ import {
 } from "./manifest-owner-policy.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
-import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import {
   loadPluginRegistrySnapshot,
@@ -40,6 +39,18 @@ type ProviderRefOwnership =
   | { status: "unowned" }
   | { status: "owned"; pluginIds: string[] }
   | { status: "ambiguous"; pluginIds: string[] };
+type ProviderOwnershipLookupParams = {
+  provider: string;
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+  manifestRegistry?: PluginManifestRegistry;
+  metadataSnapshot?: Pick<PluginMetadataSnapshot, "owners" | "manifestRegistry" | "byPluginId">;
+};
+type ProviderOwnershipContext = {
+  manifestRegistry: PluginManifestRegistry;
+  metadataSnapshot?: ProviderOwnershipLookupParams["metadataSnapshot"];
+};
 
 function loadProviderRegistrySnapshot(params: ProviderManifestLoadParams): PluginRegistrySnapshot {
   if (params.registry) {
@@ -535,19 +546,11 @@ function resolvePreferredManifestPluginIds(
   return undefined;
 }
 
-export function resolveOwningPluginIdsForProvider(params: {
-  provider: string;
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  manifestRegistry?: PluginManifestRegistry;
-  metadataSnapshot?: Pick<PluginMetadataSnapshot, "owners" | "manifestRegistry" | "byPluginId">;
-}): string[] | undefined {
-  const normalizedProvider = normalizeProviderId(params.provider);
-  if (!normalizedProvider) {
-    return undefined;
-  }
-
+function resolveProviderOwnershipContext(
+  params: ProviderOwnershipLookupParams,
+): ProviderOwnershipContext {
+  // Provider and CLI-backend ownership are one fallback decision. Prepare their
+  // process-stable metadata once so a miss cannot rebuild discovery for each branch.
   const metadataSnapshot =
     params.metadataSnapshot ??
     (params.manifestRegistry
@@ -558,6 +561,33 @@ export function resolveOwningPluginIdsForProvider(params: {
           ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
           allowWorkspaceScopedSnapshot: true,
         }));
+  const config = params.config ?? {};
+  const env = params.env ?? process.env;
+  const manifestRegistry =
+    params.manifestRegistry ??
+    metadataSnapshot?.manifestRegistry ??
+    resolveManifestRegistry({
+      config,
+      workspaceDir: params.workspaceDir,
+      env,
+      registry: loadProviderRegistrySnapshot({
+        config,
+        workspaceDir: params.workspaceDir,
+        env,
+      }),
+      includeDisabled: true,
+    });
+  return {
+    manifestRegistry,
+    ...(metadataSnapshot ? { metadataSnapshot } : {}),
+  };
+}
+
+function resolveOwningPluginIdsForProviderFromContext(
+  normalizedProvider: string,
+  context: ProviderOwnershipContext,
+): string[] | undefined {
+  const metadataSnapshot = context.metadataSnapshot;
   if (metadataSnapshot) {
     const ownerIds = resolveOwningPluginIdsForProviderFromSnapshot(
       metadataSnapshot,
@@ -568,45 +598,31 @@ export function resolveOwningPluginIdsForProvider(params: {
     }
   }
 
-  const manifestRegistry =
-    params.manifestRegistry ??
-    metadataSnapshot?.manifestRegistry ??
-    loadPluginMetadataSnapshot({
-      config: params.config ?? {},
-      workspaceDir: params.workspaceDir,
-      env: params.env ?? process.env,
-    }).manifestRegistry;
-
-  const pluginIds = manifestRegistry.plugins
+  const pluginIds = context.manifestRegistry.plugins
     .filter((plugin) => pluginOwnsProviderRef(plugin, normalizedProvider))
     .map((plugin) => plugin.id);
 
   return pluginIds.length > 0 ? pluginIds : undefined;
 }
 
-function resolveOwningPluginIdsForCliBackend(params: {
-  backend: string;
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  manifestRegistry?: PluginManifestRegistry;
-  metadataSnapshot?: Pick<PluginMetadataSnapshot, "owners" | "manifestRegistry">;
-}): string[] | undefined {
-  const normalizedBackend = normalizeProviderId(params.backend);
-  if (!normalizedBackend) {
+export function resolveOwningPluginIdsForProvider(
+  params: ProviderOwnershipLookupParams,
+): string[] | undefined {
+  const normalizedProvider = normalizeProviderId(params.provider);
+  if (!normalizedProvider) {
     return undefined;
   }
+  return resolveOwningPluginIdsForProviderFromContext(
+    normalizedProvider,
+    resolveProviderOwnershipContext(params),
+  );
+}
 
-  const metadataSnapshot =
-    params.metadataSnapshot ??
-    (params.manifestRegistry
-      ? undefined
-      : getCurrentPluginMetadataSnapshot({
-          config: params.config,
-          env: params.env,
-          ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-          allowWorkspaceScopedSnapshot: true,
-        }));
+function resolveOwningPluginIdsForCliBackendFromContext(
+  normalizedBackend: string,
+  context: ProviderOwnershipContext,
+): string[] | undefined {
+  const metadataSnapshot = context.metadataSnapshot;
   if (metadataSnapshot) {
     const ownerIds = listNormalizedOwnerMapPluginIds(
       metadataSnapshot.owners.cliBackends,
@@ -617,16 +633,7 @@ function resolveOwningPluginIdsForCliBackend(params: {
     }
   }
 
-  const manifestRegistry =
-    params.manifestRegistry ??
-    metadataSnapshot?.manifestRegistry ??
-    loadPluginMetadataSnapshot({
-      config: params.config ?? {},
-      workspaceDir: params.workspaceDir,
-      env: params.env ?? process.env,
-    }).manifestRegistry;
-
-  const pluginIds = manifestRegistry.plugins
+  const pluginIds = context.manifestRegistry.plugins
     .filter(
       (plugin) =>
         plugin.cliBackends.some(
@@ -642,50 +649,24 @@ function resolveOwningPluginIdsForCliBackend(params: {
   return deduped.length > 0 ? deduped : undefined;
 }
 
-export function resolveOwningPluginIdsForProviderRef(params: {
-  provider: string;
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  manifestRegistry?: PluginManifestRegistry;
-  metadataSnapshot?: Pick<PluginMetadataSnapshot, "owners" | "manifestRegistry" | "byPluginId">;
-}): string[] | undefined {
+export function resolveOwningPluginIdsForProviderRef(
+  params: ProviderOwnershipLookupParams,
+): string[] | undefined {
+  const normalizedProvider = normalizeProviderId(params.provider);
+  if (!normalizedProvider) {
+    return undefined;
+  }
+  const context = resolveProviderOwnershipContext(params);
   return (
-    resolveOwningPluginIdsForProvider(params) ??
-    resolveOwningPluginIdsForCliBackend({
-      backend: params.provider,
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-      manifestRegistry: params.manifestRegistry,
-      metadataSnapshot: params.metadataSnapshot,
-    })
+    resolveOwningPluginIdsForProviderFromContext(normalizedProvider, context) ??
+    resolveOwningPluginIdsForCliBackendFromContext(normalizedProvider, context)
   );
 }
 
-export function resolveProviderRefOwnership(params: {
-  provider: string;
-  config?: PluginLoadOptions["config"];
-  workspaceDir?: string;
-  env?: PluginLoadOptions["env"];
-  manifestRegistry?: PluginManifestRegistry;
-  metadataSnapshot?: Pick<PluginMetadataSnapshot, "owners" | "manifestRegistry" | "byPluginId">;
-}): ProviderRefOwnership {
-  const providerOwnerIds = resolveOwningPluginIdsForProvider(params);
-  const providerOwnership = classifyProviderRefOwnership(providerOwnerIds);
-  if (providerOwnership.status !== "unowned") {
-    return providerOwnership;
-  }
-  return classifyProviderRefOwnership(
-    resolveOwningPluginIdsForCliBackend({
-      backend: params.provider,
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-      manifestRegistry: params.manifestRegistry,
-      metadataSnapshot: params.metadataSnapshot,
-    }),
-  );
+export function resolveProviderRefOwnership(
+  params: ProviderOwnershipLookupParams,
+): ProviderRefOwnership {
+  return classifyProviderRefOwnership(resolveOwningPluginIdsForProviderRef(params));
 }
 
 export function resolveOwningPluginIdsForModelRef(params: {
@@ -702,23 +683,13 @@ export function resolveOwningPluginIdsForModelRef(params: {
   }
 
   if (parsed.provider) {
-    const providerOwners = resolveOwningPluginIdsForProvider({
+    return resolveOwningPluginIdsForProviderRef({
       provider: parsed.provider,
       config: params.config,
       workspaceDir: params.workspaceDir,
       env: params.env,
       manifestRegistry: params.manifestRegistry,
     });
-    return (
-      providerOwners ??
-      resolveOwningPluginIdsForCliBackend({
-        backend: parsed.provider,
-        config: params.config,
-        workspaceDir: params.workspaceDir,
-        env: params.env,
-        manifestRegistry: params.manifestRegistry,
-      })
-    );
   }
 
   const manifestRegistry = resolveManifestRegistry({
@@ -749,8 +720,13 @@ export function resolveOwningPluginIdsForModelRefs(params: {
   env?: PluginLoadOptions["env"];
   manifestRegistry?: PluginManifestRegistry;
 }): string[] {
-  const registry = params.manifestRegistry ? undefined : loadProviderRegistrySnapshot(params);
-  const manifestRegistry = params.manifestRegistry;
+  const manifestRegistry =
+    params.manifestRegistry ??
+    resolveManifestRegistry({
+      ...params,
+      registry: loadProviderRegistrySnapshot(params),
+      includeDisabled: true,
+    });
   return sortUniqueStrings(
     params.models.flatMap(
       (model) =>
@@ -759,8 +735,7 @@ export function resolveOwningPluginIdsForModelRefs(params: {
           config: params.config,
           workspaceDir: params.workspaceDir,
           env: params.env,
-          ...(manifestRegistry ? { manifestRegistry } : {}),
-          ...(registry ? { registry } : {}),
+          manifestRegistry,
         }) ?? [],
     ),
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where provider ownership checks without an explicit or current lifecycle snapshot repeated full plugin registry and manifest preparation: once for a direct-provider miss and again for the CLI-backend fallback. Explicit model-ref batches could repeat the same work for each model.

## Why This Change Was Made

Provider and CLI-backend ownership now share one immutable manifest/metadata context per decision, and model-ref batches carry one prepared manifest across all lookups. Explicit manifests and current metadata retain precedence; aliases, disabled/workspace/config/env behavior, ambiguity classification, result ordering, and lifecycle freshness remain unchanged. No cache is added.

This is AI-assisted. No agent transcript is attached.

## User Impact

Provider-selection and activation paths avoid duplicate plugin discovery work. In the same isolated 10-call harness, median cold-fallback wall time improved from 133.569 ms to 68.850 ms per call (48.5% lower), median CPU from 1415.651 ms to 741.814 ms per 10 calls (47.6% lower), and first-round RSS growth from 12.516 MiB to 7.676 MiB (38.7% lower). Prepared lifecycle-snapshot lookups remain effectively free.

## Evidence

- Exact-current-main pre-fix regression: 2 failed / 58 passed. A setup-only CLI-backend lookup rebuilt plugin metadata twice, and a two-model ownership batch rebuilt it three times.
- Exact final-head focused and sibling tests:
  - `node scripts/run-vitest.mjs src/plugins/providers.test.ts src/plugins/provider-runtime.test.ts src/plugins/providers.runtime.consult-current-snapshot.test.ts src/plugins/providers.setup-trust.test.ts --reporter=verbose`
  - 4 files, 135 tests passed.
- `node scripts/check-changed.mjs -- src/plugins/providers.ts src/plugins/providers.test.ts` passed formatting, core/core-test typechecks, lint, dead exports, database/schema guards, plugin boundaries, and import-cycle checks.
- `pnpm build` passed on exact final main plus this commit, including all public Plugin SDK subpaths and Control UI budgets.
- `git show --check HEAD` passed.
- Fresh structured autoreview on exact final commit `191ee5e4d5b2c96f15b958a7acebd6158863b55b`: TruffleHog clean; no accepted/actionable findings; patch correct confidence 0.97.
- Exact live open PR/issue searches found no duplicate for `resolveOwningPluginIdsForProviderRef`; broader provider-ownership results were unrelated metadata validation, doctor-route, or model-alias work.