### PR TITLE
fix: /restart restarts the gateway over and over instead of once

### DIFF
--- a/src/auto-reply/reply/commands-session-restart.test.ts
+++ b/src/auto-reply/reply/commands-session-restart.test.ts
@@ -186,6 +186,79 @@ describe("handleRestartCommand", () => {
     }
   });
 
+  it("adopts the durable ingress claim before scheduling the restart", async () => {
+    const order: string[] = [];
+    mocks.scheduleGatewaySigusr1Restart.mockImplementationOnce((_opts) => {
+      order.push("schedule");
+      return { scheduled: true };
+    });
+    const handler = () => {};
+    process.on("SIGUSR1", handler);
+    try {
+      await handleRestartCommand(
+        restartCommandParams({
+          opts: {
+            turnAdoptionLifecycle: {
+              onAdopted: () => {
+                order.push("adopt");
+              },
+            },
+          } as HandleCommandsParams["opts"],
+        }),
+        true,
+      );
+    } finally {
+      process.removeListener("SIGUSR1", handler);
+    }
+
+    // Unadopted at restart => drain releases with recordAttempt:false and the
+    // successor replays /restart, restarting again forever.
+    expect(order).toEqual(["adopt", "schedule"]);
+  });
+
+  it("adopts the durable ingress claim before the fallback restart path", async () => {
+    const order: string[] = [];
+    mocks.triggerOpenClawRestart.mockImplementationOnce(() => {
+      order.push("trigger");
+      return { ok: true, method: "launchctl" };
+    });
+
+    await handleRestartCommand(
+      restartCommandParams({
+        opts: {
+          turnAdoptionLifecycle: {
+            onAdopted: () => {
+              order.push("adopt");
+            },
+          },
+        } as HandleCommandsParams["opts"],
+      }),
+      true,
+    );
+
+    expect(order).toEqual(["adopt", "trigger"]);
+  });
+
+  it("does not restart when ingress adoption was lost to another owner", async () => {
+    await expect(
+      handleRestartCommand(
+        restartCommandParams({
+          opts: {
+            turnAdoptionLifecycle: {
+              onAdopted: () => {
+                throw new Error("ingress adoption lost: guillotined");
+              },
+            },
+          } as HandleCommandsParams["opts"],
+        }),
+        true,
+      ),
+    ).rejects.toThrow("ingress adoption lost");
+
+    expect(mocks.triggerOpenClawRestart).not.toHaveBeenCalled();
+    expect(mocks.scheduleGatewaySigusr1Restart).not.toHaveBeenCalled();
+  });
+
   it("rejects authorized non-owner restart commands", async () => {
     const result = await handleRestartCommand(
       restartCommandParams({

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -611,6 +611,13 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
   if (!isRestartEnabled(params.cfg)) {
     return sessionCommandReply("⚠️ /restart is disabled (commands.restart=false).");
   }
+  // Restart tears this process down before the dispatch that carries /restart can
+  // return, so the durable ingress claim would still be held when admission closes.
+  // The drain then releases it without spending retry budget and the successor
+  // replays /restart forever. Adopt here: the command is not idempotent, so losing
+  // the acknowledgement beats an unbounded restart loop. Adoption loss throws,
+  // which correctly aborts the restart because another owner holds the event.
+  await params.opts?.turnAdoptionLifecycle?.onAdopted();
   const hasSigusr1Listener = process.listenerCount("SIGUSR1") > 0;
   const sentinelPayload = buildRestartCommandSentinel(params);
   if (hasSigusr1Listener) {


### PR DESCRIPTION
Related: #125918

AI-assisted: written with Claude Code (Opus 5). The diagnosis, the production evidence below, and the red/green verification were reviewed by a human before filing.

## What Problem This Solves

Fixes an issue where an operator who sends `/restart` in a chat channel gets an unbounded restart loop instead of one restart. The gateway restarts roughly every 30 seconds and does not stop on its own.

Every restart in the loop is a clean, planned shutdown, so `openclaw status` reports a healthy gateway the whole time and nothing in the logs looks like a crash. The channel receives a new "Restarting OpenClaw in-process (SIGUSR1)" acknowledgement on every cycle, and the agent is unusable until the operator stops the service by hand or disables the command with `commands.restart=false`.

Observed on 2026.8.1 with Discord, but nothing in the path is channel-specific: any channel with a durable ingress queue can reproduce it.

## Why This Change Was Made

`/restart` is dispatched from a durable `channel_ingress_events` row. The row's claim is settled when dispatch finishes, but the restart the command schedules closes root-work admission before that happens. The dispatch then fails with `GatewayDrainingError`, and the drain releases the row without spending its retry budget — the deferral contract added in #125918:

```ts
if (err instanceof GatewayDrainingError) {
  // Root dispatch closes before durable transport admission during restart.
  // Preserve the row for the successor without spending its failure budget.
  await releaseClaim(claim, { recordAttempt: false });
  return;
}
```

That is correct for an ordinary inbound message, which must survive a planned restart. It is wrong for the one message that caused the restart: the successor gateway claims the same row, runs `/restart` again, and schedules another restart. Because the release never records an attempt, `retry-limit-exceeded` can never fire, so nothing bounds the loop.

The fix keeps the #125918 contract untouched and settles the claim at the only place that knows the command is not idempotent. `handleRestartCommand` adopts its own ingress claim before scheduling the restart, which tombstones the row. The restart scheduler's own delay is the window this needs.

The trade is explicit: if the process dies between adoption and delivery of the acknowledgement, the operator loses the acknowledgement rather than the command being replayed. Losing an acknowledgement is recoverable; an unbounded restart loop is not. Adoption throws when the claim was guillotined or superseded, which correctly aborts the restart, because another owner then holds the event.

Non-goals: the drain's `GatewayDrainingError` branch, the retry policy, and every other command are unchanged.

## User Impact

`/restart` restarts the gateway once. Operators no longer have to stop the service by hand or set `commands.restart=false` to escape a restart loop, and the channel gets one acknowledgement instead of one per cycle.

## Evidence

**Production incident (2026.8.1, Discord).** One `/restart` produced six restarts, roughly 30 seconds apart, each a clean planned shutdown:

```
18:12:49 · 18:13:22 · 18:13:53 · 18:14:23 · 18:14:54 · 18:15:23
pids 78809 -> 79469 -> 80242 -> 80987 -> 81726 -> 83509
every boot: outcome=planned_restart  reason=/restart   shutdown completed cleanly
```

The gateway log shows admission closing 2.2 s after the command arrived, well before dispatch returned:

```
10:12:49.184Z gateway/admission  admission closed: restart-signal fence
10:12:49.193Z gateway/admission  admission closed: restart drain
10:12:49.195Z gateway            received SIGUSR1; restarting
10:12:52.394Z gateway/shutdown   shutdown completed cleanly in 3155ms
```

The queue rows identify the release path without needing a log line on that branch. The `/restart` row was still `pending` after the sixth restart, with `attempts=0`, `last_attempt_at` NULL and `last_error` NULL, and `updated_at` 158 s after `received_at` — it was released repeatedly:

```
event      status   attempts  received  updated   last_attempt_at  content
1540302…4  pending  0         10:12:46  10:15:24  NULL             /restart
1540302…3  pending  0         10:12:48  10:12:48  NULL             "Restarting OpenClaw in-process (SIGUSR1)"
1540302…6  pending  0         10:13:21  10:13:21  NULL             "Restarting OpenClaw in-process (SIGUSR1)"
1540302…1  pending  0         10:13:51  10:13:51  NULL             "Restarting OpenClaw in-process (SIGUSR1)"
1540303…2  pending  0         10:14:22  10:14:22  NULL             "Restarting OpenClaw in-process (SIGUSR1)"
1540303…8  pending  0         10:14:52  10:14:52  NULL             "Restarting OpenClaw in-process (SIGUSR1)"
1540303…3  pending  0         10:15:22  10:15:22  NULL             "Restarting OpenClaw in-process (SIGUSR1)"
```

Six acknowledgements for one command, and the command row outliving all of them. That release signature is unique to the `GatewayDrainingError` branch: stale-claim recovery writes `last_attempt_at` (`ingress-queue.ts` `releaseClaimIfStillStale`), and the ordinary retryable release writes `last_error` (`applyFailureDisposition`). Both are NULL here.

Scope of that claim: this identifies the release path by elimination from the persisted row state, not by observing the branch execute — the branch emits no log line. The regression tests below cover the fix directly.

**Regression tests.** Three tests added to `src/auto-reply/reply/commands-session-restart.test.ts`: adoption precedes the SIGUSR1 schedule, adoption precedes the fallback restart trigger, and adoption loss aborts the restart entirely (asserting that neither restart path is reached).

Red on stock, with the source file restored from `origin/main` and the tests left in place:

```
$ git checkout origin/main -- src/auto-reply/reply/commands-session.ts
$ npx vitest run src/auto-reply/reply/commands-session-restart.test.ts

 FAIL  handleRestartCommand > adopts the durable ingress claim before scheduling the restart
 FAIL  handleRestartCommand > adopts the durable ingress claim before the fallback restart path
   AssertionError: expected [ 'trigger' ] to deeply equal [ 'adopt', 'trigger' ]
 FAIL  handleRestartCommand > does not restart when ingress adoption was lost to another owner
   AssertionError: promise resolved "{ shouldContinue: false, …(1) }" instead of rejecting

 Test Files  1 failed (1)
      Tests  3 failed | 6 passed (9)
```

Green patched, together with every ingress-drain suite, confirming the drain contract is unchanged:

```
$ npx vitest run src/auto-reply/reply/commands-session-restart.test.ts \
    src/channels/message/ingress-drain.test.ts \
    src/channels/message/ingress-drain.watchdog.test.ts \
    src/channels/message/ingress-drain.debounce-failure.test.ts \
    src/channels/message/ingress-drain-lifecycle.test.ts \
    src/channels/message/ingress-drain-lanes.test.ts

 Test Files  6 passed (6)
      Tests  43 passed (43)
```

`pnpm tsgo:core` is clean on the branch.
