### PR TITLE
perf(sessions): index pending conversation replies

### DIFF
--- a/src/sessions/conversation-turns.test.ts
+++ b/src/sessions/conversation-turns.test.ts
@@ -176,6 +176,151 @@ describe("conversation turn correlation", () => {
     await expect(first.wait()).resolves.toBeUndefined();
   });
 
+  it("claims an exact reply without visiting unrelated pending turns", async () => {
+    const turns = Array.from({ length: 64 }, (_, index) =>
+      registerPendingConversationTurn({
+        agentId: `agent-${index % 4}`,
+        id: `turn-${index}`,
+        conversationRef: `conv-${(index * 7) % 13}`,
+        sessionId: `session-${(index * 11) % 17}`,
+        timeoutMs: 5_000,
+      }),
+    );
+    for (const [index, turn] of turns.entries()) {
+      turn.setOutboundMessageId(`outbound-${index}`);
+      turn.markReady();
+    }
+
+    const registry: Map<unknown, unknown> | undefined = Object.getOwnPropertyDescriptor(
+      globalThis,
+      Symbol.for("openclaw.pendingConversationTurns"),
+    )?.value;
+    if (!registry) {
+      throw new Error("pending-turn registry was not initialized");
+    }
+    const valuesDescriptor = Object.getOwnPropertyDescriptor(registry, "values");
+    registry.values = () => {
+      throw new Error("exact reply scanned the global pending-turn registry");
+    };
+    try {
+      const target = 37;
+      const claim = await claimPendingConversationTurnReply({
+        agentId: `agent-${target % 4}`,
+        conversationRef: `conv-${(target * 7) % 13}`,
+        sessionId: `session-${(target * 11) % 17}`,
+        messageId: "inbound-target",
+        replyToId: `outbound-${target}`,
+        text: "exact high-cardinality reply",
+      });
+      expect(claim?.turnId).toBe(`turn-${target}`);
+      claim?.complete();
+    } finally {
+      if (valuesDescriptor) {
+        Object.defineProperty(registry, "values", valuesDescriptor);
+      } else {
+        Reflect.deleteProperty(registry, "values");
+      }
+      for (const turn of turns) {
+        turn.cancel();
+      }
+    }
+  });
+
+  it("isolates outbound id collisions and claims the oldest eligible turn", async () => {
+    const wrongSession = registerPendingConversationTurn({
+      agentId: "collision-agent",
+      id: "wrong-session",
+      conversationRef: "collision-conv",
+      sessionId: "other-session",
+      timeoutMs: 5_000,
+    });
+    const oldestEligible = registerPendingConversationTurn({
+      agentId: "collision-agent",
+      id: "oldest-eligible",
+      conversationRef: "collision-conv",
+      sessionId: "collision-session",
+      timeoutMs: 5_000,
+    });
+    const newerEligible = registerPendingConversationTurn({
+      agentId: "collision-agent",
+      id: "newer-eligible",
+      conversationRef: "collision-conv",
+      sessionId: "collision-session",
+      timeoutMs: 5_000,
+    });
+    for (const turn of [wrongSession, oldestEligible, newerEligible]) {
+      turn.setOutboundMessageId("provider-collision");
+      turn.markReady();
+    }
+
+    const claim = await claimPendingConversationTurnReply({
+      agentId: "collision-agent",
+      conversationRef: "collision-conv",
+      sessionId: "collision-session",
+      messageId: "collision-reply",
+      replyToId: "provider-collision",
+      text: "oldest eligible",
+    });
+    expect(claim?.turnId).toBe("oldest-eligible");
+    claim?.complete();
+    wrongSession.cancel();
+    newerEligible.cancel();
+  });
+
+  it("retires replaced and timed-out outbound index entries before turn id reuse", async () => {
+    const replaced = registerPendingConversationTurn({
+      agentId: "main",
+      id: "replaced-turn",
+      conversationRef: "conv_replaced",
+      sessionId: "session-main",
+      timeoutMs: 5_000,
+    });
+    replaced.setOutboundMessageId("outbound-old");
+    replaced.setOutboundMessageId("outbound-new");
+    replaced.markReady();
+    await expect(
+      claimPendingConversationTurnReply({
+        agentId: "main",
+        conversationRef: "conv_replaced",
+        sessionId: "session-main",
+        messageId: "reply-old",
+        replyToId: "outbound-old",
+        text: "stale replacement",
+      }),
+    ).resolves.toBeUndefined();
+
+    const expired = registerPendingConversationTurn({
+      agentId: "main",
+      id: "retired-turn",
+      conversationRef: "conv_retired",
+      sessionId: "session-main",
+      timeoutMs: 0,
+    });
+    expired.setOutboundMessageId("outbound-retired");
+    expired.markReady();
+    await expect(expired.wait()).resolves.toBeUndefined();
+    const reused = registerPendingConversationTurn({
+      agentId: "main",
+      id: "retired-turn",
+      conversationRef: "conv_retired",
+      sessionId: "session-main",
+      timeoutMs: 5_000,
+    });
+    reused.setOutboundMessageId("outbound-retired");
+    reused.markReady();
+    const claim = await claimPendingConversationTurnReply({
+      agentId: "main",
+      conversationRef: "conv_retired",
+      sessionId: "session-main",
+      messageId: "reply-current",
+      replyToId: "outbound-retired",
+      text: "current reuse",
+    });
+    expect(claim?.turnId).toBe("retired-turn");
+    claim?.complete();
+    replaced.cancel();
+  });
+
   it("does not consume an unsolicited message when only one turn is pending", async () => {
     const pending = register();
     pending.setOutboundMessageId("outbound-1");

--- a/src/sessions/conversation-turns.ts
+++ b/src/sessions/conversation-turns.ts
@@ -55,8 +55,29 @@ const pendingTurns = resolveGlobalSingleton(
     }
   },
 );
+const pendingTurnsByOutboundId = resolveGlobalSingleton(
+  Symbol.for("openclaw.pendingConversationTurnsByOutboundId"),
+  () => new Map<string, Set<PendingConversationTurn>>(),
+  (turns) => turns.clear(),
+);
 function pendingTurnKey(agentId: string, id: string): string {
   return JSON.stringify([agentId, id]);
+}
+
+function outboundMessageKey(agentId: string, outboundMessageId: string): string {
+  return JSON.stringify([agentId, outboundMessageId]);
+}
+
+function removePendingOutboundMembership(pending: PendingConversationTurn): void {
+  if (!pending.outboundMessageId) {
+    return;
+  }
+  const key = outboundMessageKey(pending.agentId, pending.outboundMessageId);
+  const bucket = pendingTurnsByOutboundId.get(key);
+  bucket?.delete(pending);
+  if (bucket?.size === 0) {
+    pendingTurnsByOutboundId.delete(key);
+  }
 }
 
 /** Registers one process-local waiter; transcript correlation remains durable after completion. */
@@ -110,6 +131,7 @@ export function registerPendingConversationTurn(params: {
     }
     settled = true;
     markCorrelationReady();
+    removePendingOutboundMembership(pending);
     if (pendingTurns.get(key) === pending) {
       pendingTurns.delete(key);
     }
@@ -145,10 +167,16 @@ export function registerPendingConversationTurn(params: {
       if (pendingTurns.get(key) !== pending) {
         return;
       }
+      removePendingOutboundMembership(pending);
       pending.outboundMessageId = normalizeOptionalString(messageId);
       if (!pending.outboundMessageId) {
         pending.settle(undefined);
+        return;
       }
+      const outboundKey = outboundMessageKey(pending.agentId, pending.outboundMessageId);
+      const bucket = pendingTurnsByOutboundId.get(outboundKey) ?? new Set();
+      bucket.add(pending);
+      pendingTurnsByOutboundId.set(outboundKey, bucket);
     },
     markReady: () => {
       if (pendingTurns.get(key) !== pending) {
@@ -199,23 +227,29 @@ export async function claimPendingConversationTurnReply(params: {
   if (!agentId) {
     return undefined;
   }
-  const pending = [...pendingTurns.values()]
-    .filter(
-      (candidate) =>
-        !candidate.claimed &&
-        candidate.agentId === agentId &&
-        (candidate.conversationRef === params.conversationRef ||
-          // Some transports promote an unthreaded message into a thread whose
-          // id is that message id. Require the attested parent conversation too;
-          // shared-main sessions can contain unrelated peers.
-          (!candidate.threadId &&
-            threadId === replyToId &&
-            parentConversationRef === candidate.conversationRef)) &&
-        candidate.sessionId === params.sessionId &&
-        (!candidate.threadId || !threadId || candidate.threadId === threadId),
-    )
-    .toSorted((left, right) => left.createdAt - right.createdAt)
-    .find((candidate) => candidate.outboundMessageId === replyToId);
+  let pending: PendingConversationTurn | undefined;
+  const candidates = pendingTurnsByOutboundId.get(outboundMessageKey(agentId, replyToId));
+  for (const candidate of candidates ?? []) {
+    if (
+      candidate.claimed ||
+      candidate.agentId !== agentId ||
+      candidate.outboundMessageId !== replyToId ||
+      (candidate.conversationRef !== params.conversationRef &&
+        // Some transports promote an unthreaded message into a thread whose
+        // id is that message id. Require the attested parent conversation too;
+        // shared-main sessions can contain unrelated peers.
+        (candidate.threadId ||
+          threadId !== replyToId ||
+          parentConversationRef !== candidate.conversationRef)) ||
+      candidate.sessionId !== params.sessionId ||
+      (candidate.threadId && threadId && candidate.threadId !== threadId)
+    ) {
+      continue;
+    }
+    if (!pending || candidate.createdAt < pending.createdAt) {
+      pending = candidate;
+    }
+  }
   if (!pending) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #127173. Every exactly correlated conversation reply previously copied, filtered, and sorted the process-wide pending-turn registry before matching its outbound message ID. Completing N unique pending turns visited N(N+1)/2 entries synchronously on the Gateway ingress thread.

## Why This Change Was Made

Index pending turns by the exact agent and outbound message ID at the existing pending-turn lifecycle owner. Maintain collision buckets during outbound-ID replacement, and remove membership on completion, timeout, cancellation, and abort. Select the oldest eligible reply from its bucket while preserving agent, session, conversation, thread, claim, and transcript-durability checks.

The primary registry still owns cancellation by turn ID. The secondary index is bounded by active waiters and is cleared through their existing settlement and Gateway restart lifecycle. No configuration or storage-schema change is involved.

## User Impact

Correlated reply bursts avoid global scans and temporary arrays/sorts, reducing synchronous ingress work and allocation pressure. Reply routing, cancellation, retry behavior, and durable capture remain unchanged.

## Evidence

- Rebased head: `be9686c20bdccf1e00042b85a492d68d8424db0e`. `git range-diff` confirms the original patch is unchanged; the production owner is byte-identical to the reviewed source.
- **83 focused tests passed** across pending-turn correlation, reply capture, Gateway turn execution, Gateway methods, and portal HTTP proxy coverage:

  ```sh
  OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
    src/sessions/conversation-turns.test.ts \
    src/auto-reply/reply/conversation-turn-capture.test.ts \
    src/gateway/conversation-turn.test.ts \
    src/gateway/server-methods/conversations.test.ts \
    src/gateway/portals/portal-http-proxy.test.ts
  ```

- Changed-file formatting, production/test typechecks, lint, boundary/storage guards, dead-export scans, and import-cycle checks passed:

  ```sh
  node scripts/check-changed.mjs -- \
    src/sessions/conversation-turns.ts src/sessions/conversation-turns.test.ts
  git diff --check origin/main...HEAD
  ```

- Direct source-level 1,000-reply regression: main visits **500,500** global registry entries; the candidate visits **zero**. All replies match correctly, and both registries are empty after completion and restart. The zero-scan assertion fails on main and passes on the candidate. The harness redirects imports only to isolated copies of the same normalization/singleton helpers; it is an owner-level runtime proof, not a live-channel run.
- Fresh independent Codex autoreview: no actionable P0-P2 findings. Independent lifecycle review also found no blocker.
- The old failed CI job used a released ephemeral port in an unrelated portal test. This rebase includes its canonical repair in #130920; the portal suite now passes.

### ClawSweeper findings and rank-up moves

The equal-timestamp reverse-assignment concern was checked against the sole production registrar in `src/gateway/conversation-turn.ts`: it registers and immediately assigns the prepared outbound ID without an intervening await, and never reassigns it. A transport ID mismatch cancels the turn. Bucket insertion therefore retains registration order in the real flow. An extra registration ordinal and reverse-assignment-only test are intentionally skipped; existing collision, replacement, and lifecycle coverage remain.

Production: +51/-17, net +34. Tests: +145. The added state is the lifecycle-owned index needed to avoid global scans; a channel-local cache or linear scan would not fix the owning bottleneck.
