### PR TITLE
fix(memory-core): read dreaming narrative from the terminal reply instead of racing the session store (#123360)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -568,18 +568,116 @@ describe("runDreamNarrative", () => {
   });
 
   it("writes the terminal reply text without polling the session store", async () => {
+    vi.useFakeTimers();
+    try {
+      const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+      const subagent = createMockSubagent("");
+      subagent.waitForRun.mockResolvedValue({
+        status: "ok",
+        terminalReply: {
+          disposition: "visible",
+          text: "The terminal reply carried the diary safely.",
+        },
+      });
+      // Simulate the sibling-cleanup race from #123360: the store never shows the
+      // completed run's text within the settle window.
+      subagent.getSessionMessages.mockResolvedValue({ messages: [] });
+      const logger = createMockLogger();
+
+      const operation = runDreamNarrative({
+        agentId: "main",
+        subagent,
+        workspaceDir,
+        data: {
+          phase: "light",
+          snippets: ["The narrative raced a sibling phase's cleanup."],
+        },
+        nowMs: Date.parse("2026-04-05T03:00:00Z"),
+        timezone: "UTC",
+        logger,
+      });
+      await flushNarrativeSettleTimers(operation);
+
+      expect(subagent.getSessionMessages).not.toHaveBeenCalled();
+      const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+      expect(content).toContain("The terminal reply carried the diary safely.");
+      expect(content).not.toContain("A memory trace surfaced");
+      expectLogExcludes(logger.warn, "produced no text");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { label: "empty", reply: { disposition: "empty" } },
+    { label: "silent", reply: { disposition: "silent" } },
+    // `message-tool-not-called` is an explicit no-text fact too; history must
+    // not resurface a transcript for it.
+    {
+      label: "empty (message-tool-not-called)",
+      reply: { disposition: "empty", code: "message-tool-not-called" },
+    },
+  ] as const)(
+    "treats an explicit $label terminal reply as authoritative no-text and never reads history",
+    async ({ reply }) => {
+      vi.useFakeTimers();
+      try {
+        const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+        const subagent = createMockSubagent("");
+        subagent.waitForRun.mockResolvedValue({
+          status: "ok",
+          // Any `text` beside a non-visible disposition must be ignored.
+          terminalReply: { ...reply, text: "text that must be ignored" },
+        });
+        // The store holds an OLD narrative from a previous run; reading it would
+        // resurface stale text over the authoritative no-text result.
+        subagent.getSessionMessages.mockResolvedValue({
+          messages: [
+            { role: "user", content: "prompt" },
+            { role: "assistant", content: "A stale narrative from a previous run." },
+          ],
+        });
+        const logger = createMockLogger();
+
+        const operation = runDreamNarrative({
+          agentId: "main",
+          subagent,
+          workspaceDir,
+          data: {
+            phase: "rem",
+            snippets: ["The run was silent, so history must not speak for it."],
+          },
+          nowMs: Date.parse("2026-04-05T03:00:00Z"),
+          timezone: "UTC",
+          logger,
+        });
+        await flushNarrativeSettleTimers(operation);
+
+        expect(subagent.getSessionMessages).not.toHaveBeenCalled();
+        const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+        expect(content).toContain("A memory trace surfaced");
+        expect(content).not.toContain("A stale narrative from a previous run.");
+        expect(content).not.toContain("text that must be ignored");
+        expectLogIncludes(logger.warn, "produced no text");
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("treats a visible terminal reply with only whitespace as no-text", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = createMockSubagent("");
     subagent.waitForRun.mockResolvedValue({
       status: "ok",
-      terminalReply: {
-        disposition: "visible",
-        text: "The terminal reply carried the diary safely.",
-      },
+      terminalReply: { disposition: "visible", text: "   \n  " },
     });
-    // Simulate the sibling-cleanup race from #123360: the store never shows the
-    // completed run's text within the settle window.
-    subagent.getSessionMessages.mockResolvedValue({ messages: [] });
+    subagent.getSessionMessages.mockResolvedValue({
+      messages: [
+        { role: "user", content: "prompt" },
+        { role: "assistant", content: "A stale narrative from a previous run." },
+      ],
+    });
     const logger = createMockLogger();
 
     await runDreamNarrative({
@@ -588,7 +686,7 @@ describe("runDreamNarrative", () => {
       workspaceDir,
       data: {
         phase: "light",
-        snippets: ["The narrative raced a sibling phase's cleanup."],
+        snippets: ["A blank diary page must not borrow yesterday's words."],
       },
       nowMs: Date.parse("2026-04-05T03:00:00Z"),
       timezone: "UTC",
@@ -597,50 +695,10 @@ describe("runDreamNarrative", () => {
 
     expect(subagent.getSessionMessages).not.toHaveBeenCalled();
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-    expect(content).toContain("The terminal reply carried the diary safely.");
-    expect(content).not.toContain("A memory trace surfaced");
-    expectLogExcludes(logger.warn, "produced no text");
+    expect(content).toContain("A memory trace surfaced");
+    expect(content).not.toContain("A stale narrative from a previous run.");
+    expectLogIncludes(logger.warn, "produced no text");
   });
-
-  it.each(["empty", "silent"] as const)(
-    "treats an explicit %s terminal reply as authoritative no-text and never reads history",
-    async (disposition) => {
-      const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
-      const subagent = createMockSubagent("");
-      subagent.waitForRun.mockResolvedValue({
-        status: "ok",
-        terminalReply: { disposition },
-      });
-      // The store holds an OLD narrative from a previous run; reading it would
-      // resurface stale text over the authoritative no-text result.
-      subagent.getSessionMessages.mockResolvedValue({
-        messages: [
-          { role: "user", content: "prompt" },
-          { role: "assistant", content: "A stale narrative from a previous run." },
-        ],
-      });
-      const logger = createMockLogger();
-
-      await runDreamNarrative({
-        agentId: "main",
-        subagent,
-        workspaceDir,
-        data: {
-          phase: "rem",
-          snippets: ["The run was silent, so history must not speak for it."],
-        },
-        nowMs: Date.parse("2026-04-05T03:00:00Z"),
-        timezone: "UTC",
-        logger,
-      });
-
-      expect(subagent.getSessionMessages).not.toHaveBeenCalled();
-      const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-      expect(content).toContain("A memory trace surfaced");
-      expect(content).not.toContain("A stale narrative from a previous run.");
-      expectLogIncludes(logger.warn, "produced no text");
-    },
-  );
 
   it("falls back after settled assistant text never appears", async () => {
     vi.useFakeTimers();

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -602,50 +602,45 @@ describe("runDreamNarrative", () => {
     expectLogExcludes(logger.warn, "produced no text");
   });
 
-  it("falls back to settled store reads when the terminal reply is empty", async () => {
-    vi.useFakeTimers();
-    try {
+  it.each(["empty", "silent"] as const)(
+    "treats an explicit %s terminal reply as authoritative no-text and never reads history",
+    async (disposition) => {
       const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
       const subagent = createMockSubagent("");
       subagent.waitForRun.mockResolvedValue({
         status: "ok",
-        terminalReply: { disposition: "empty" },
+        terminalReply: { disposition },
       });
-      subagent.getSessionMessages
-        .mockResolvedValueOnce({
-          messages: [{ role: "user", content: "prompt" }],
-        })
-        .mockResolvedValueOnce({
-          messages: [
-            { role: "user", content: "prompt" },
-            { role: "assistant", content: "The store settled the diary after all." },
-          ],
-        });
+      // The store holds an OLD narrative from a previous run; reading it would
+      // resurface stale text over the authoritative no-text result.
+      subagent.getSessionMessages.mockResolvedValue({
+        messages: [
+          { role: "user", content: "prompt" },
+          { role: "assistant", content: "A stale narrative from a previous run." },
+        ],
+      });
       const logger = createMockLogger();
 
-      const operation = runDreamNarrative({
+      await runDreamNarrative({
         agentId: "main",
         subagent,
         workspaceDir,
         data: {
           phase: "rem",
-          snippets: ["The terminal reply was empty, so the store settled it."],
+          snippets: ["The run was silent, so history must not speak for it."],
         },
         nowMs: Date.parse("2026-04-05T03:00:00Z"),
         timezone: "UTC",
         logger,
       });
-      await flushNarrativeSettleTimers(operation);
 
-      expect(subagent.getSessionMessages).toHaveBeenCalledTimes(2);
+      expect(subagent.getSessionMessages).not.toHaveBeenCalled();
       const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
-      expect(content).toContain("The store settled the diary after all.");
-      expect(content).not.toContain("A memory trace surfaced");
-      expectLogExcludes(logger.warn, "produced no text");
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+      expect(content).toContain("A memory trace surfaced");
+      expect(content).not.toContain("A stale narrative from a previous run.");
+      expectLogIncludes(logger.warn, "produced no text");
+    },
+  );
 
   it("falls back after settled assistant text never appears", async () => {
     vi.useFakeTimers();

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -567,6 +567,86 @@ describe("runDreamNarrative", () => {
     }
   });
 
+  it("writes the terminal reply text without polling the session store", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.waitForRun.mockResolvedValue({
+      status: "ok",
+      terminalReply: {
+        disposition: "visible",
+        text: "The terminal reply carried the diary safely.",
+      },
+    });
+    // Simulate the sibling-cleanup race from #123360: the store never shows the
+    // completed run's text within the settle window.
+    subagent.getSessionMessages.mockResolvedValue({ messages: [] });
+    const logger = createMockLogger();
+
+    await runDreamNarrative({
+      agentId: "main",
+      subagent,
+      workspaceDir,
+      data: {
+        phase: "light",
+        snippets: ["The narrative raced a sibling phase's cleanup."],
+      },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    expect(subagent.getSessionMessages).not.toHaveBeenCalled();
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("The terminal reply carried the diary safely.");
+    expect(content).not.toContain("A memory trace surfaced");
+    expectLogExcludes(logger.warn, "produced no text");
+  });
+
+  it("falls back to settled store reads when the terminal reply is empty", async () => {
+    vi.useFakeTimers();
+    try {
+      const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+      const subagent = createMockSubagent("");
+      subagent.waitForRun.mockResolvedValue({
+        status: "ok",
+        terminalReply: { disposition: "empty" },
+      });
+      subagent.getSessionMessages
+        .mockResolvedValueOnce({
+          messages: [{ role: "user", content: "prompt" }],
+        })
+        .mockResolvedValueOnce({
+          messages: [
+            { role: "user", content: "prompt" },
+            { role: "assistant", content: "The store settled the diary after all." },
+          ],
+        });
+      const logger = createMockLogger();
+
+      const operation = runDreamNarrative({
+        agentId: "main",
+        subagent,
+        workspaceDir,
+        data: {
+          phase: "rem",
+          snippets: ["The terminal reply was empty, so the store settled it."],
+        },
+        nowMs: Date.parse("2026-04-05T03:00:00Z"),
+        timezone: "UTC",
+        logger,
+      });
+      await flushNarrativeSettleTimers(operation);
+
+      expect(subagent.getSessionMessages).toHaveBeenCalledTimes(2);
+      const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+      expect(content).toContain("The store settled the diary after all.");
+      expect(content).not.toContain("A memory trace surfaced");
+      expectLogExcludes(logger.warn, "produced no text");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("falls back after settled assistant text never appears", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -33,10 +33,20 @@ export type SubagentSurface = {
     lightContext?: boolean;
     deliver?: boolean;
   }) => Promise<{ runId: string }>;
-  waitForRun: (params: {
-    runId: string;
-    timeoutMs?: number;
-  }) => Promise<{ status: string; error?: string }>;
+  waitForRun: (params: { runId: string; timeoutMs?: number }) => Promise<{
+    status: string;
+    error?: string;
+    /**
+     * Authoritative final assistant text captured by the run registry while the
+     * raw text was still available. Preferred over polling the session store,
+     * which lags a completed run (see readSettledNarrativeText) and can stay
+     * empty past the settle budget when a sibling phase's cleanup races it (#123360).
+     */
+    terminalReply?: {
+      disposition: "visible" | "silent" | "empty";
+      text?: string;
+    };
+  }>;
   getSessionMessages: (params: {
     sessionKey: string;
     limit?: number;
@@ -386,6 +396,25 @@ async function readSettledNarrativeText(params: {
     }
   }
   return null;
+}
+
+/**
+ * Extracts the diary text from the run result's terminal reply, when the run
+ * registry captured one. The terminal reply is the authoritative final
+ * assistant text built at completion time, so it is visible even while the
+ * session store lags behind the completed run. Reading it first removes the
+ * sibling-cleanup race (#123360): a first-finishing phase's cleanup can keep
+ * the store empty past the settle budget, discarding a phase that succeeded.
+ */
+function extractTerminalReplyNarrativeText(
+  result: Awaited<ReturnType<SubagentSurface["waitForRun"]>>,
+): string | null {
+  const reply = result.terminalReply;
+  if (reply?.disposition !== "visible") {
+    return null;
+  }
+  const text = typeof reply.text === "string" ? reply.text.trim() : "";
+  return text.length > 0 ? text : null;
 }
 
 // ── Date formatting ────────────────────────────────────────────────────
@@ -812,6 +841,7 @@ async function generateAndAppendDreamNarrative(
   await withNarrativeSessionLock(sessionKey, async () => {
     const attempts: Array<{ sessionKey: string; runId: string | null }> = [];
     let successfulSessionKey: string | null = null;
+    let terminalText: string | null = null;
     try {
       const attemptModels = params.model ? [params.model, undefined] : [undefined];
 
@@ -858,6 +888,7 @@ async function generateAndAppendDreamNarrative(
 
           if (result.status === "ok") {
             successfulSessionKey = attemptSessionKey;
+            terminalText = extractTerminalReplyNarrativeText(result);
             break;
           }
 
@@ -908,10 +939,15 @@ async function generateAndAppendDreamNarrative(
         return;
       }
 
-      const narrative = await readSettledNarrativeText({
-        subagent: params.subagent,
-        sessionKey: successfulSessionKey,
-      });
+      // Prefer the terminal reply the run registry captured at completion time.
+      // It is authoritative and immune to the sibling-cleanup race (#123360);
+      // only poll the store when the run result did not carry visible text.
+      const narrative =
+        terminalText ??
+        (await readSettledNarrativeText({
+          subagent: params.subagent,
+          sessionKey: successfulSessionKey,
+        }));
       if (!narrative) {
         params.logger.warn(
           `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry.`,

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -399,22 +399,28 @@ async function readSettledNarrativeText(params: {
 }
 
 /**
- * Extracts the diary text from the run result's terminal reply, when the run
- * registry captured one. The terminal reply is the authoritative final
- * assistant text built at completion time, so it is visible even while the
- * session store lags behind the completed run. Reading it first removes the
- * sibling-cleanup race (#123360): a first-finishing phase's cleanup can keep
- * the store empty past the settle budget, discarding a phase that succeeded.
+ * Classifies the run result's terminal reply for diary use. The terminal
+ * reply is the authoritative completion-time fact, so an explicit
+ * non-visible disposition (silent/empty) means "this run produced no diary
+ * text" — the transcript must not be read for it, or an older narrative from
+ * a previous run could resurface (#127184 review). Only an absent terminal
+ * reply (legacy runtime) falls back to the transcript.
  */
-function extractTerminalReplyNarrativeText(
+type TerminalReplyNarrative =
+  | { kind: "visible"; text: string }
+  | { kind: "non-visible" }
+  | { kind: "absent" };
+
+function classifyTerminalReplyNarrative(
   result: Awaited<ReturnType<SubagentSurface["waitForRun"]>>,
-): string | null {
+): TerminalReplyNarrative {
   const reply = result.terminalReply;
-  if (reply?.disposition !== "visible") {
-    return null;
+  if (!reply) {
+    return { kind: "absent" };
   }
-  const text = typeof reply.text === "string" ? reply.text.trim() : "";
-  return text.length > 0 ? text : null;
+  const text =
+    reply.disposition === "visible" && typeof reply.text === "string" ? reply.text.trim() : "";
+  return text ? { kind: "visible", text } : { kind: "non-visible" };
 }
 
 // ── Date formatting ────────────────────────────────────────────────────
@@ -841,7 +847,7 @@ async function generateAndAppendDreamNarrative(
   await withNarrativeSessionLock(sessionKey, async () => {
     const attempts: Array<{ sessionKey: string; runId: string | null }> = [];
     let successfulSessionKey: string | null = null;
-    let terminalText: string | null = null;
+    let terminalReply: TerminalReplyNarrative | null = null;
     try {
       const attemptModels = params.model ? [params.model, undefined] : [undefined];
 
@@ -888,7 +894,7 @@ async function generateAndAppendDreamNarrative(
 
           if (result.status === "ok") {
             successfulSessionKey = attemptSessionKey;
-            terminalText = extractTerminalReplyNarrativeText(result);
+            terminalReply = classifyTerminalReplyNarrative(result);
             break;
           }
 
@@ -940,14 +946,19 @@ async function generateAndAppendDreamNarrative(
       }
 
       // Prefer the terminal reply the run registry captured at completion time.
-      // It is authoritative and immune to the sibling-cleanup race (#123360);
-      // only poll the store when the run result did not carry visible text.
+      // A visible reply is immune to the sibling-cleanup race (#123360); an
+      // explicit non-visible reply is authoritative no-text and must not read
+      // history (an older narrative could resurface); only an absent reply
+      // (legacy runtime) falls back to polling the session store.
       const narrative =
-        terminalText ??
-        (await readSettledNarrativeText({
-          subagent: params.subagent,
-          sessionKey: successfulSessionKey,
-        }));
+        terminalReply?.kind === "visible"
+          ? terminalReply.text
+          : terminalReply?.kind === "absent"
+            ? await readSettledNarrativeText({
+                subagent: params.subagent,
+                sessionKey: successfulSessionKey,
+              })
+            : null;
       if (!narrative) {
         params.logger.warn(
           `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry.`,


### PR DESCRIPTION
Fixes #123360
(_AI-assisted contribution._)

## What Problem This Solves

Fixes an issue where users with nightly dream diary generation enabled (light/REM/deep phases running concurrently) would lose most of their diary entries: on multi-phase nights, every phase except the first finisher silently discarded its successfully generated narrative and wrote a "A memory trace surfaced, but details were unavailable in this run" placeholder instead. Reporter @nissanlogan measured 40 of 104 nights writing fallback entries, with every multi-phase night losing all but one phase's narrative.

## Why This Change Was Made

The narrative reader polls the session store up to five times over a fixed 1,250 ms settle budget after `waitForRun` returns `ok`, because a completed run can reach the reader before its transcript is visible. A first-finishing phase's cleanup keeps sibling reads empty past that budget, so the budget is structurally unable to win the race — widening it would only move the loss point.

Instead of racing the store, the change consumes the authoritative completion-time fact the gateway already produces: the `terminalReply` on the `agent.wait` result (captured while the raw text is still available, sanitized and capped by the producer). The terminal reply is classified into three states:

- `visible` → the diary entry is written from the terminal text; the store is never polled;
- explicit `non-visible` (silent/empty) → authoritative no-text: the fallback entry is written and history is NOT read, so an older narrative from a previous run cannot resurface;
- `absent` (legacy runtime result without the field) → the existing settle/poll fallback, unchanged.

## User Impact

Users with `dreaming.enabled` now keep all three phase narratives on multi-phase nights instead of losing every phase but the first. The sweep also stops burning the 1.25 s settle budget per phase on the healthy path (zero store polls when the terminal reply is visible). No configuration changes.

## Evidence

- **Runtime trace (after-fix, real production module, concurrent phases, race shape):** three phases ran concurrently with real timers, each run completing with a visible terminal reply while the session store stayed empty past the settle budget. All three narratives were retained, `storeReads=0` per phase, no fallback placeholder, sweep wall time 22 ms:

```
[trace] light: memory-core: dream diary entry written for light phase [workspace=<tmp>].
[trace] light: outcome={"status":"completed"} storeReads=0 deletes=2
[trace] rem:   memory-core: dream diary entry written for rem phase [workspace=<tmp>].
[trace] rem:   outcome={"status":"completed"} storeReads=0 deletes=2
[trace] deep:  memory-core: dream diary entry written for deep phase [workspace=<tmp>].
[trace] deep:  outcome={"status":"completed"} storeReads=0 deletes=2
[trace] sweep wall time: 22 ms (23–38 ms across re-runs, vs. 1,250 ms of settle budget the old path would burn)

[trace] DREAMS.md after sweep:
  # Dream Diary
  <!-- openclaw:dreaming:diary:start -->
  *April 5, 2026 at 3:00 AM UTC*
  Light traced the morning through terminal-reply prose.
  ---
  *April 5, 2026 at 3:00 AM UTC*
  Rem dreamed in terminal-reply loops and lullabies.
  ---
  *April 5, 2026 at 3:00 AM UTC*
  Deep carried the night in terminal-reply verse.
  <!-- openclaw:dreaming:diary:end -->
```

- **Regression test** (fails on pre-fix code): store mocked to stay empty (the #123360 shape); asserts the diary entry is written from the terminal reply and `getSessionMessages` is never called.
- **Contract tests**: explicit `empty` and `silent` terminal replies (including `message-tool-not-called`) write the fallback entry without reading history, ignore any `text` beside a non-visible disposition, and whitespace-only visible text is treated as no-text; absent terminal replies keep the settle fallback (existing behavior, tests unchanged).
- **Suites**: `dreaming-narrative.test.ts` 39/39; adjacent `dreaming.test.ts` + `dreaming-phases.test.ts` 94/94. `oxlint` and `oxfmt` clean.
- **Pre-existing, unrelated:** on Windows, the touched suite reports a post-test teardown `EBUSY` unlink of `openclaw-agent.sqlite`, reproducing on clean `main` without these changes.
