### PR TITLE
fix(qa): restore scenario discovery by execution path

### DIFF
--- a/extensions/qa-lab/src/coverage-report.test.ts
+++ b/extensions/qa-lab/src/coverage-report.test.ts
@@ -405,6 +405,103 @@ describe("qa coverage report", () => {
     expect(report).not.toContain("### Unknown Scenario Coverage IDs");
   });
 
+  it.each(["script", "vitest", "playwright"] as const)(
+    "finds %s scenarios by execution paths outside their code refs",
+    (executionKind) => {
+      const executionPath = `test/producers/${executionKind}-only.ts`;
+      const scenario = scenarioWithCoverage({
+        primary: [TEST_EXECUTABLE_COVERAGE_ID],
+        executionKind,
+        executionPath,
+      });
+
+      expect(findQaScenarioMatches([scenario], executionPath)).toMatchObject([
+        { id: scenario.id, executionKind, executionPath },
+      ]);
+    },
+  );
+
+  it("finds every shared execution-path owner in deterministic scenario order", () => {
+    const executionPath = "test/producers/shared-evidence.ts";
+    const scenario = scenarioWithCoverage({
+      primary: [TEST_EXECUTABLE_COVERAGE_ID],
+      executionKind: "script",
+      executionPath,
+    });
+    const scenarios = [
+      { ...scenario, id: "zulu-owner" },
+      { ...scenario, id: "alpha-owner" },
+    ];
+
+    expect(findQaScenarioMatches(scenarios, executionPath).map(({ id }) => id)).toStrictEqual([
+      "alpha-owner",
+      "zulu-owner",
+    ]);
+  });
+
+  it("normalizes portable execution-path query separators", () => {
+    const executionPath = "test/producers/windows-evidence.ts";
+    const scenario = scenarioWithCoverage({
+      primary: [TEST_EXECUTABLE_COVERAGE_ID],
+      executionKind: "script",
+      executionPath,
+    });
+
+    expect(findQaScenarioMatches([scenario], executionPath.replaceAll("/", "\\"))).toMatchObject([
+      { id: scenario.id, executionPath },
+    ]);
+  });
+
+  it("finds every cataloged native scenario by its authoritative execution path", () => {
+    const scenarios = readQaScenarioPack().scenarios;
+    for (const scenario of scenarios) {
+      if (scenario.execution.kind !== "flow") {
+        expect(
+          findQaScenarioMatches(scenarios, scenario.execution.path).map(({ id }) => id),
+          scenario.id,
+        ).toContain(scenario.id);
+      }
+    }
+  });
+
+  it.each([
+    ["name", "metadata-proof"],
+    ["title", "scenario-title"],
+    ["tag", "scenario-category"],
+    ["coverage", TEST_EXECUTABLE_COVERAGE_ID],
+    ["code reference", "src/metadata/code-reference.ts"],
+    ["documentation reference", "docs/metadata/reference.md"],
+    ["source path", "qa/scenarios/metadata/flow-proof.yaml"],
+    ["capability", "scenario-capability"],
+  ] as const)("preserves existing flow scenario matching by %s", (_field, query) => {
+    const scenario = {
+      ...scenarioWithCoverage({
+        primary: [TEST_EXECUTABLE_COVERAGE_ID],
+        sourcePath: "qa/scenarios/metadata/flow-proof.yaml",
+      }),
+      id: "metadata-proof",
+      title: "scenario-title",
+      category: "scenario-category",
+      capabilities: ["scenario-capability"],
+      codeRefs: ["src/metadata/code-reference.ts"],
+      docsRefs: ["docs/metadata/reference.md"],
+    };
+
+    expect(findQaScenarioMatches([scenario], query).map(({ id }) => id)).toStrictEqual([
+      scenario.id,
+    ]);
+  });
+
+  it.each([
+    ["Gateway loopback and LAN access", "docker-gateway-network"],
+    ["qa-lab", "docker-gateway-network"],
+    ["runtime", "clawhub-marketplace-list"],
+  ] as const)("does not broaden ordinary metadata query %s", (query, unrelatedScenarioId) => {
+    const matches = findQaScenarioMatches(readQaScenarioPack().scenarios, query);
+
+    expect(matches.map(({ id }) => id)).not.toContain(unrelatedScenarioId);
+  });
+
   it("renders Playwright matches as qa suite targets", () => {
     const matches = findQaScenarioMatches(
       readQaScenarioPack().scenarios,

--- a/extensions/qa-lab/src/coverage-report.ts
+++ b/extensions/qa-lab/src/coverage-report.ts
@@ -3,6 +3,7 @@ import {
   normalizeOptionalString as stringifyConfigValue,
   normalizeStringEntriesLower,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRepoRootRelativeRef } from "./cli-paths.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 import {
   readQaScorecardTaxonomyReport,
@@ -168,7 +169,18 @@ export function findQaScenarioMatches(
   return scenarios
     .filter((scenario) => {
       const haystack = scenarioSearchText(scenario);
-      return tokens.every((token) => haystack.includes(token));
+      return tokens.every((token) => {
+        if (haystack.includes(token)) {
+          return true;
+        }
+        const executionPathQuery = token.replaceAll("\\", "/");
+        return (
+          executionPathQuery.includes("/") &&
+          isRepoRootRelativeRef(executionPathQuery) &&
+          scenario.execution.kind !== "flow" &&
+          normalizeSearchText(scenario.execution.path).includes(executionPathQuery)
+        );
+      });
     })
     .map(summarizeScenarioSearchMatch)
     .toSorted((left, right) => left.id.localeCompare(right.id));


### PR DESCRIPTION
Closes #127180

AI-assisted.

## What Problem This Solves

Fixes an issue where maintainers using `openclaw qa coverage --match <file-path>` received no scenario owners, or only a subset of the owners, when the requested file was declared solely as a native scenario's authoritative execution path.

## Why This Change Was Made

Preserve the existing generic scenario-metadata search unchanged and separately match validated, repository-relative path-shaped tokens against script, Vitest, and Playwright execution paths. Existing whitespace-token conjunction, deterministic scenario ordering, flow behavior, output shape, and portable Windows separators remain intact.

## User Impact

Every native QA scenario is discoverable by its actual execution file. Shared evidence producers now return every owning scenario, while existing human-text, scenario-name, tag, coverage, documentation, source, and capability searches keep their previous results.

## Evidence

Before the fix, the actual QA coverage command handler returned zero owners for both `scripts/e2e/qa-cli-onboarding.mjs` and `src/gateway/server.auth.modes.test.ts`, only 5/20 owners for the shared Docker evidence producer, and only 2/10 owners for the shared TUI evidence producer.

After the fix, direct command-handler proof finds each previously omitted standalone owner and all Docker 20/20 and TUI 10/10 shared owners in deterministic scenario-ID order. All 176 native scenarios across 141 execution paths are discoverable. A distinct corpus of 2,650 existing queries, expanded adversarially to all 6,222 searchable metadata values, changes only the two intended shared file-path results. Existing `Gateway loopback and LAN access`, `qa-lab`, and `runtime` queries remain at 1, 268, and 264 results; Windows-style execution-path queries also resolve correctly.

Focused owner, command-handler, and catalog proof: 242 passing tests.

```sh
env OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-183-vitest-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-qa.config.ts --configLoader runner extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/scenario-catalog.test.ts
env OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-183-vitest-cache node scripts/check-changed.mjs -- extensions/qa-lab/src/coverage-report.ts extensions/qa-lab/src/coverage-report.test.ts
git diff --check
```

The full changed gate, production and test typechecks, targeted lint, repository guards, independent adversarial exact-head review, and fresh isolated Codex autoreview passed. Production delta: +13/-1 (net +12); regression tests: +97/-0. No schema, output, parser, configuration, persistence, dependency, or changelog changes.
