### PR TITLE
fix(ui): keep mobile sessions visible

### DIFF
--- a/ui/src/e2e/session-management.mobile-roster.e2e.test.ts
+++ b/ui/src/e2e/session-management.mobile-roster.e2e.test.ts
@@ -1,0 +1,86 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  captureUiProof,
+  captureUiProofEnabled,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  requireRecord,
+  sessionsListResponse,
+  uiProofArtifactDir,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+suite.define(() => {
+  it("keeps profile-less run sessions visible in the mobile drawer", async () => {
+    const sessionKeys = ["agent:main:mobile-one", "agent:main:mobile-two"] as const;
+    const context = await suite.browser.newContext({
+      hasTouch: true,
+      locale: "en-US",
+      recordVideo: captureUiProofEnabled
+        ? { dir: uiProofArtifactDir, size: { height: 844, width: 390 } }
+        : undefined,
+      serviceWorkers: "block",
+      viewport: { height: 844, width: 390 },
+    });
+    const page = await context.newPage();
+    const proofVideo = page.video();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          {
+            createdVia: "run",
+            derivedTitle: "Mobile session one",
+            key: sessionKeys[0],
+            kind: "direct",
+            updatedAt: 2,
+          },
+          {
+            createdVia: "run",
+            derivedTitle: "Mobile session two",
+            key: sessionKeys[1],
+            kind: "direct",
+            updatedAt: 1,
+          },
+        ]),
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
+      const drawerToggle = page
+        .locator(".topbar-nav-toggle:visible, .chat-pane__nav-toggle:visible")
+        .first();
+      await drawerToggle.click();
+      await expect
+        .poll(() => page.locator(".shell").getAttribute("class"))
+        .toContain("shell--nav-drawer-open");
+
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.list")).some((request) => {
+            const params = requireRecord(request.params);
+            return params.agentId === "main" && params.includeDerivedTitles === true;
+          }),
+        )
+        .toBe(true);
+      for (const [index, title] of ["Mobile session one", "Mobile session two"].entries()) {
+        await page
+          .locator(`[data-session-key="${sessionKeys[index]}"]`)
+          .getByText(title, { exact: true })
+          .waitFor({ state: "visible" });
+      }
+      await captureUiProof(page, "mobile-profile-less-run-sessions.png");
+    } finally {
+      await context.close();
+      if (proofVideo) {
+        await proofVideo.saveAs(
+          path.join(uiProofArtifactDir, "mobile-profile-less-run-sessions.webm"),
+        );
+      }
+    }
+  });
+});

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -68,14 +68,15 @@ describe("resolveSessionNavigation", () => {
     ]);
   });
 
-  it("hides system-created probe sessions unless showSystem opts in", () => {
+  it("hides explicitly system-created sessions unless showSystem opts in", () => {
     const rows: GatewaySessionRow[] = [
       { key: "agent:main:chat", kind: "direct", updatedAt: 300 },
       {
         key: "agent:main:explicit:healthcheck",
         kind: "direct",
         updatedAt: 200,
-        createdVia: "run",
+        createdVia: "internal",
+        createdActor: { type: "system" },
       },
     ];
 
@@ -98,16 +99,15 @@ describe("resolveSessionNavigation", () => {
     ]);
   });
 
-  it("keeps a selected system-classified session visible with showSystem off", () => {
-    // Accepted-tradeoff escape hatch: a profile-less explicit CLI session
-    // matches the system classifier, but selecting it must always surface it.
+  it("keeps a selected system session visible with showSystem off", () => {
     const rows: GatewaySessionRow[] = [
       { key: "agent:main:chat", kind: "direct", updatedAt: 300 },
       {
         key: "agent:main:explicit:incident-debug",
         kind: "direct",
         updatedAt: 200,
-        createdVia: "run",
+        createdVia: "internal",
+        createdActor: { type: "system" },
       },
     ];
 
@@ -425,7 +425,7 @@ describe("isSystemCreatedSessionRow", () => {
   });
 
   it.each([
-    ["run + no actor + unnamed is system", { createdVia: "run" }, true],
+    ["run + no actor stays visible", { createdVia: "run" }, false],
     ["internal + no actor + unnamed is system", { createdVia: "internal" }, true],
     ["system actor is system regardless of via", { createdActor: { type: "system" } }, true],
     [

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -233,34 +233,15 @@ type VisibleSessionRowOptions = {
   archivedFilter?: SessionArchivedFilter;
 };
 
-/**
- * Machine-created probe/system rows (health-check turns, internal effect
- * sessions), classified from recorded creation provenance only — never from
- * message text, which rots and false-positives real chats. Rows without
- * recorded provenance (legacy stores) stay visible.
- *
- * Accepted tradeoff: a profile-less client's unnamed `run` session is
- * indistinguishable from a probe and hides by default too. Operator-named CLI
- * sessions are stamped at creation and remain visible. Unnamed rows stay fully
- * reachable: the selected session always renders in the sidebar, the Sessions
- * page never applies this filter, and the sort-menu toggle reveals all rows.
- */
+/** Machine-created rows are hidden only from explicit provenance. A profile-less
+ * `run` has no actor, so treating an absent actor as system-owned hides real chats. */
 export function isSystemCreatedSessionRow(row: GatewaySessionRow): boolean {
   // Cron rows are owned by the automation toggle; cron creation stamps a
   // system actor, so classifying them here would demand both toggles at once.
   if (isCronSessionKey(row.key)) {
     return false;
   }
-  if (row.createdActor?.type === "system") {
-    return true;
-  }
-  if (row.createdVia !== "run" && row.createdVia !== "internal") {
-    return false;
-  }
-  if (row.createdActor?.type === "human") {
-    return false;
-  }
-  return !(row.label?.trim() || row.displayName?.trim() || row.subject?.trim());
+  return row.createdActor?.type === "system" || row.createdVia === "internal";
 }
 
 export function sessionMatchesArchivedFilter(


### PR DESCRIPTION
The observed bug was mobile-only: a fresh mobile Control UI profile could show an empty **Sessions** drawer even though `sessions.list` returned conversations. We did not reproduce a desktop symptom.

The cause is the shared visibility classifier, not mobile layout. Current `main@ab7d5c92ace7` treats a profile-less `createdVia: "run"` row as system-created when it has no human actor, `label`, `displayName`, or `subject`; `derivedTitle` is ignored. This PR stops using a missing human actor as system evidence while preserving explicit system, internal, and cron suppression.

## What Problem This Solves

Fixes the empty mobile roster for profile-less Gateway runs with a derived title but no actor or explicit display metadata.

## Why This Change Was Made

The Gateway legitimately records `{ via: "run" }` without an actor when no authenticated profile exists. The shared classifier owns the repair so all consumers remain consistent.

## User Impact

The reported conversations appear in the mobile drawer with default settings; no “show system sessions” opt-in is required.

## Evidence

Same mocked Gateway response, two profile-less `run` sessions, and 390×844 touch viewport.

**Before — direct base `b9249ffa5ca4`**

![Mobile drawer with an empty Sessions section before the fix](https://github.com/user-attachments/assets/9dfebcb4-8825-4aba-8cf6-954d39dee428)

The Gateway returned both sessions; the drawer rendered neither.

**Current main — `ab7d5c92ace7`**

The PR regressions still fail against the exact current-main classifier:

- owner test: `run + no actor stays visible` receives `true` for system-created instead of `false`;
- mobile E2E: times out waiting for the first returned session row to become visible.

**After — PR `80d6179b85a5`**

![Mobile drawer showing both returned sessions after the fix](https://github.com/user-attachments/assets/4f45c9ac-4133-4a5f-8282-faeefce1d14b)

Both returned titles are visible.

## How to Verify

1. Return an actor-less `createdVia: "run"` session with `derivedTitle` but no `label`, `displayName`, or `subject`.
2. Open the drawer at a 390×844 touch viewport with default preferences.
3. Confirm the returned session appears under **Sessions**.

## Implementation Notes

This reverses PR #121855’s accepted tradeoff that treated ambiguous unnamed profile-less `run` rows as probes. An actor-less probe without explicit system provenance may now appear; producers requiring suppression should record system/internal provenance at creation.

Supporting checks: 27 focused tests; `node scripts/check-changed.mjs`; clean branch-mode autoreview.

AI-assisted: yes. The owner boundary and mobile behavior were reviewed directly.
