### PR TITLE
improve(agents): avoid duplicate tool catalog fingerprinting

### DIFF
--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -274,6 +274,7 @@ function registerToolSearchCatalog(params: {
   catalogRef: ToolSearchCatalogRef;
   entries: ToolSearchCatalogEntry[];
   append?: boolean;
+  fingerprint?: string;
 }): ToolSearchCatalogSession {
   const prior = params.append ? params.catalogRef.current : undefined;
   const byId = new Map((prior?.entries ?? []).map((entry) => [entry.id, entry]));
@@ -289,7 +290,13 @@ function registerToolSearchCatalog(params: {
     describeCount: prior?.describeCount ?? 0,
     callCount: prior?.callCount ?? 0,
   };
-  catalogFingerprints.set(next, catalogEntriesFingerprint(next.entries));
+  // The supplied fingerprint describes the input entries. Duplicate IDs are
+  // last-write-wins, so recompute when registration changed the entry set.
+  const fingerprint =
+    params.fingerprint !== undefined && next.entries.length === params.entries.length
+      ? params.fingerprint
+      : catalogEntriesFingerprint(next.entries);
+  catalogFingerprints.set(next, fingerprint);
   params.catalogRef.current = next;
   params.catalogRef.onChange?.();
   return next;
@@ -437,8 +444,15 @@ export function applyToolCatalogCompaction(
     }
     visible.push(tool);
   }
-  const incomingFingerprint = catalogEntriesFingerprint(catalog);
+  // Hook-wrapped entries carry run context and have fresh executable identities, so
+  // their snapshots cannot be reused and would only retain the completed run.
+  const hasHookBoundEntry = catalog.some((entry) =>
+    isToolWrappedWithBeforeToolCallHook(entry.tool as AnyAgentTool),
+  );
+  const reusableKey = hasHookBoundEntry ? undefined : reusableCatalogKey(params);
   const existingCatalog = catalogRef.current;
+  const incomingFingerprint =
+    existingCatalog || reusableKey ? catalogEntriesFingerprint(catalog) : undefined;
   if (existingCatalog && catalogFingerprints.get(existingCatalog) === incomingFingerprint) {
     return {
       tools: visible,
@@ -449,14 +463,8 @@ export function applyToolCatalogCompaction(
     };
   }
 
-  // Hook-wrapped entries carry run context and have fresh executable identities, so
-  // their snapshots cannot be reused and would only retain the completed run.
-  const hasHookBoundEntry = catalog.some((entry) =>
-    isToolWrappedWithBeforeToolCallHook(entry.tool as AnyAgentTool),
-  );
-  const reusableKey = hasHookBoundEntry ? undefined : reusableCatalogKey(params);
   const reusableSnapshot = reusableKey ? reusableCatalogSnapshots.get(reusableKey) : undefined;
-  if (reusableSnapshot?.fingerprint === incomingFingerprint) {
+  if (reusableSnapshot && reusableSnapshot.fingerprint === incomingFingerprint) {
     restoreToolSearchCatalog({
       catalogRef,
       entries: reusableSnapshot.entries,
@@ -475,7 +483,11 @@ export function applyToolCatalogCompaction(
     };
   }
 
-  const registered = registerToolSearchCatalog({ catalogRef, entries: catalog });
+  const registered = registerToolSearchCatalog({
+    catalogRef,
+    entries: catalog,
+    fingerprint: incomingFingerprint,
+  });
   rememberReusableCatalog(reusableKey, registered);
   return {
     tools: visible,

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -3677,6 +3677,70 @@ describe("Tool Search", () => {
     expect(testing.getReusableCatalogSnapshotCountForTest()).toBe(snapshotsBefore);
   });
 
+  it("serializes a fresh hook-bound catalog schema only once", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const config = { tools: { toolSearch: true } } as never;
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("fake_hook_bound_schema", "Hook-bound schema probe");
+    let schemaTraversalCount = 0;
+    target.parameters = new Proxy(
+      { type: "object", properties: { value: { type: "string" } } },
+      {
+        ownKeys: (schema) => {
+          schemaTraversalCount += 1;
+          return Reflect.ownKeys(schema);
+        },
+      },
+    );
+
+    const result = applyToolSearchCatalog({
+      tools: [codeTool, target],
+      config,
+      sessionId: "session-hook-bound-schema",
+      runId: "run-hook-bound-schema",
+      catalogRef,
+      toolHookContext: {
+        agentId: "agent-main",
+        sessionId: "session-hook-bound-schema",
+        sessionKey: "agent:main:main",
+        runId: "run-hook-bound-schema",
+      },
+    });
+
+    expect(result.catalogRegistered).toBe(true);
+    expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual([
+      "fake_hook_bound_schema",
+    ]);
+    expect(schemaTraversalCount).toBe(1);
+  });
+
+  it("preserves last-wins replacement when duplicate catalog ids reorder", () => {
+    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+    const config = { tools: { toolSearch: true } } as never;
+    const catalogRef = createToolSearchCatalogRef();
+    const first = fakeTool("fake_duplicate_id", "First executable");
+    const second = fakeTool("fake_duplicate_id", "Second executable");
+    const params = {
+      config,
+      sessionId: "session-duplicate-id-order",
+      catalogRef,
+    };
+
+    applyToolSearchCatalog({ ...params, tools: [codeTool, first, second] });
+    expect(catalogRef.current?.entries.map((entry) => entry.description)).toEqual([
+      "Second executable",
+    ]);
+
+    const reordered = applyToolSearchCatalog({
+      ...params,
+      tools: [codeTool, second, first],
+    });
+    expect(reordered.catalogReused).toBe(false);
+    expect(catalogRef.current?.entries.map((entry) => entry.description)).toEqual([
+      "First executable",
+    ]);
+  });
+
   it("does not reuse when a same-named tool uses a different executable", () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const original = pluginTool("fake_exec_swap", "Stable description");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where tool-search-enabled agent turns could traverse and serialize the complete tool catalog schema twice before inference when the fresh hook-bound catalog could not be reused.

## Why This Change Was Made

Catalog compaction now computes a fingerprint only when an existing or reusable snapshot must be compared, then carries that exact fingerprint into registration. Fresh non-reusable catalogs let registration compute it once. Registration remains the canonical owner of sorting and last-write-wins duplicate-ID replacement: if registration changes the input entry set, it recomputes the fingerprint over the registered entries instead of reusing the input fingerprint.

Catalog exposure, ordering, duplicate-ID replacement, policy, schemas, executable identities, telemetry counters, run/hook lifetimes, and invalidation behavior remain unchanged; no cache or public surface is added.

This is AI-assisted. No agent transcript is attached.

## User Impact

Agent turn preparation does one catalog-schema traversal instead of two on the affected path. In the same owner-path benchmark, the ordinary 72-tool catalog improved from 18.671 ms to 10.199 ms median (45.4% lower) and a 1,000-tool catalog improved from 242.935 ms to 138.939 ms (42.8% lower); schema/order/identity checksums were unchanged.

## Evidence

- Current-main regression before the production repair: `serializes a fresh hook-bound catalog schema only once` failed with 2 traversals instead of 1.
- Exact-head review additionally reproduced stale reuse when duplicate IDs reordered; the final registration guard and `preserves last-wins replacement when duplicate catalog ids reorder` regression resolve it.
- Exact integration stable patch-id: `d3eec8f1025b5529b1d7dbad8eef16e00783d83c`.
- Focused traversal + duplicate-ID regressions: 2 passed / 131 skipped.
- Eight focused/sibling Tool Search files: 287 tests passed across two Vitest shards.
- `node scripts/check-changed.mjs -- src/agents/tool-search-catalog.ts src/agents/tool-search.test.ts`: passed all routed core/core-test formatting, type, lint, dead-export, boundary, cycle, and policy guards on the exact head.
- `pnpm build`: passed all runtime, 61 external-plugin, Plugin SDK declaration, CLI bootstrap, and Control UI budget phases before the review-only duplicate-ID bookkeeping guard; exact-head CI and native prepare gates re-run the full required build/check surface.
- `git show --check HEAD`: passed.
- Fresh exact-commit structured autoreview on `26eaa396d162a65cbd2475d5caf20bafd3f8aa6e`: TruffleHog clean; no actionable findings; `patch is correct`, confidence 0.98.
- Production diff: +22/-10. Test diff: +64/-0. No generated, lockfile, config, protocol, or SDK-surface change.
- Exact live open PR/issue searches found no duplicate for tool-catalog fingerprint traversal/reuse.
