### PR TITLE
refactor(approvals): unify native client setup

### DIFF
--- a/src/infra/exec-approval-surface.test.ts
+++ b/src/infra/exec-approval-surface.test.ts
@@ -38,10 +38,14 @@ type ExecApprovalSurfaceModule = typeof import("./exec-approval-surface.js");
 let resolveExecApprovalInitiatingSurfaceState: ExecApprovalSurfaceModule["resolveExecApprovalInitiatingSurfaceState"];
 let resolveApprovalInitiatingSurfaceState: ExecApprovalSurfaceModule["resolveApprovalInitiatingSurfaceState"];
 let supportsNativeExecApprovalClient: ExecApprovalSurfaceModule["supportsNativeExecApprovalClient"];
+let describeNativeExecApprovalClientSetup: ExecApprovalSurfaceModule["describeNativeExecApprovalClientSetup"];
+let describeNativePluginApprovalClientSetup: ExecApprovalSurfaceModule["describeNativePluginApprovalClientSetup"];
 
 describe("resolveExecApprovalInitiatingSurfaceState", () => {
   beforeAll(async () => {
     ({
+      describeNativeExecApprovalClientSetup,
+      describeNativePluginApprovalClientSetup,
       resolveApprovalInitiatingSurfaceState,
       resolveExecApprovalInitiatingSurfaceState,
       supportsNativeExecApprovalClient,
@@ -317,5 +321,55 @@ describe("resolveExecApprovalInitiatingSurfaceState", () => {
     });
 
     expect(supportsNativeExecApprovalClient("matrix")).toBe(true);
+  });
+
+  it("routes normalized setup parameters to the selected approval hook", () => {
+    const describeExecApprovalSetup = vi.fn(() => "exec setup");
+    const describePluginApprovalSetup = vi.fn(() => "plugin setup");
+    getChannelPluginMock.mockReturnValue({
+      meta: { label: "Telegram" },
+      approvalCapability: { describeExecApprovalSetup, describePluginApprovalSetup },
+    });
+
+    expect(
+      describeNativeExecApprovalClientSetup({
+        channel: " Telegram ",
+        channelLabel: " Telegram Custom ",
+        accountId: " primary ",
+      }),
+    ).toBe("exec setup");
+    expect(describeExecApprovalSetup).toHaveBeenCalledWith({
+      channel: "telegram",
+      channelLabel: "Telegram Custom",
+      accountId: "primary",
+    });
+
+    expect(describeNativePluginApprovalClientSetup({ channel: " TELEGRAM " })).toBe("plugin setup");
+    expect(describePluginApprovalSetup).toHaveBeenCalledWith({
+      channel: "telegram",
+      channelLabel: "Telegram",
+      accountId: undefined,
+    });
+  });
+
+  it.each([undefined, "web", "tui"])("suppresses setup guidance for %s", (channel) => {
+    expect(describeNativeExecApprovalClientSetup({ channel })).toBeNull();
+    expect(describeNativePluginApprovalClientSetup({ channel })).toBeNull();
+    expect(getChannelPluginMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to the sibling approval hook", () => {
+    const describeExecApprovalSetup = vi.fn(() => "exec setup");
+    const describePluginApprovalSetup = vi.fn(() => "plugin setup");
+    getChannelPluginMock.mockImplementation((channel: string) => ({
+      meta: { label: channel },
+      approvalCapability:
+        channel === "telegram" ? { describePluginApprovalSetup } : { describeExecApprovalSetup },
+    }));
+
+    expect(describeNativeExecApprovalClientSetup({ channel: "telegram" })).toBeNull();
+    expect(describePluginApprovalSetup).not.toHaveBeenCalled();
+    expect(describeNativePluginApprovalClientSetup({ channel: "matrix" })).toBeNull();
+    expect(describeExecApprovalSetup).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/exec-approval-surface.ts
+++ b/src/infra/exec-approval-surface.ts
@@ -112,44 +112,39 @@ export function listNativeExecApprovalClientLabels(params?: {
     .toSorted((a, b) => a.localeCompare(b));
 }
 
-/** Returns channel-specific setup guidance for native exec approvals, when available. */
-export function describeNativeExecApprovalClientSetup(params: {
+type NativeApprovalClientSetupParams = {
   channel?: string | null;
   channelLabel?: string | null;
   accountId?: string | null;
-}): string | null {
+};
+
+function describeNativeApprovalClientSetup(
+  params: NativeApprovalClientSetupParams,
+  approvalKind: ChannelApprovalKind,
+): string | null {
   const channel = normalizeMessageChannel(params.channel);
   if (!channel || channel === INTERNAL_MESSAGE_CHANNEL || channel === "tui") {
     return null;
   }
   const channelLabel = normalizeOptionalString(params.channelLabel) ?? labelForChannel(channel);
   const accountId = normalizeOptionalString(params.accountId);
-  return (
-    resolveChannelApprovalCapability(getChannelPlugin(channel))?.describeExecApprovalSetup?.({
-      channel,
-      channelLabel,
-      accountId,
-    }) ?? null
-  );
+  const capability = resolveChannelApprovalCapability(getChannelPlugin(channel));
+  const setupParams = { channel, channelLabel, accountId };
+  return approvalKind === "exec"
+    ? (capability?.describeExecApprovalSetup?.(setupParams) ?? null)
+    : (capability?.describePluginApprovalSetup?.(setupParams) ?? null);
+}
+
+/** Returns channel-specific setup guidance for native exec approvals, when available. */
+export function describeNativeExecApprovalClientSetup(
+  params: NativeApprovalClientSetupParams,
+): string | null {
+  return describeNativeApprovalClientSetup(params, "exec");
 }
 
 /** Returns channel-specific setup guidance for native plugin approvals, when available. */
-export function describeNativePluginApprovalClientSetup(params: {
-  channel?: string | null;
-  channelLabel?: string | null;
-  accountId?: string | null;
-}): string | null {
-  const channel = normalizeMessageChannel(params.channel);
-  if (!channel || channel === INTERNAL_MESSAGE_CHANNEL || channel === "tui") {
-    return null;
-  }
-  const channelLabel = normalizeOptionalString(params.channelLabel) ?? labelForChannel(channel);
-  const accountId = normalizeOptionalString(params.accountId);
-  return (
-    resolveChannelApprovalCapability(getChannelPlugin(channel))?.describePluginApprovalSetup?.({
-      channel,
-      channelLabel,
-      accountId,
-    }) ?? null
-  );
+export function describeNativePluginApprovalClientSetup(
+  params: NativeApprovalClientSetupParams,
+): string | null {
+  return describeNativeApprovalClientSetup(params, "plugin");
 }


### PR DESCRIPTION
## What Problem This Solves

Native exec and plugin approval setup guidance duplicated the same channel normalization, built-in surface suppression, label fallback, account normalization, and capability lookup. Keeping those flows separate made behavior drift more likely when either approval kind changed.

This is a maintainer-requested duplication-reduction refactor; it does not change the public approval contract.

## Why This Change Was Made

The change moves the shared setup flow into one private helper keyed by approval kind while preserving the existing exported wrappers. Hook dispatch remains kind-specific and calls the selected method directly on the capability object, so method binding and the existing no-cross-fallback behavior remain intact.

## User Impact

No user-visible behavior change. Maintainers now have one canonical normalization and capability-resolution path for native approval client setup guidance.

Production LOC: +23/-28 (net -5)  
Tests: +54/-0

## Evidence

- `node scripts/run-vitest.mjs src/infra/exec-approval-surface.test.ts` — 16/16 passed
- `node scripts/run-vitest.mjs src/infra/exec-approval-reply.test.ts` — 41/41 passed
- `pnpm format src/infra/exec-approval-surface.ts src/infra/exec-approval-surface.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- `node --import tsx scripts/check-deadcode-exports.mts` — production, full-tree, and script scans passed with zero entries
- Exact-head autoreview at `3b6185c811d9a59c3f95a319795a969acce39f59` — clean, no accepted/actionable findings

Pending before merge:

- Exact-head hosted Testbox/Crabbox and CI
- The focused agent E2E command was attempted locally but did not reach the test because the shared GWT install resolved `@openclaw/ai` to a stale parent-clone build artifact. Remote hydrated proof will run against the exact PR head.
