### PR TITLE
fix(tui): stop local shell commands when exiting

### DIFF
--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -4,6 +4,13 @@ import { EventEmitter } from "node:events";
 import { join } from "node:path";
 import type { OverlayHandle } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
+
+const killTreeMocks = vi.hoisted(() => ({ killProcessTree: vi.fn() }));
+
+vi.mock("../process/kill-tree.js", () => ({
+  killProcessTree: killTreeMocks.killProcessTree,
+}));
+
 import { createLocalShellRunner } from "./tui-local-shell.js";
 
 const createSelector = () => {
@@ -49,7 +56,7 @@ function createShellHarness(params?: {
     return lastSelector;
   });
   const spawnCommand = params?.spawnCommand ?? vi.fn();
-  const { runLocalShellLine } = createLocalShellRunner({
+  const { close, runLocalShellLine } = createLocalShellRunner({
     chatLog,
     tui,
     openOverlay,
@@ -67,22 +74,130 @@ function createShellHarness(params?: {
     closeOverlay,
     createSelectorSpy,
     spawnCommand,
+    requestRender: tui.requestRender,
+    close,
     runLocalShellLine,
     getLastSelector: () => lastSelector,
   };
 }
 
 function requireSpawnOptions(spawnCommand: ReturnType<typeof vi.fn>): {
+  detached?: boolean;
   env?: Record<string, string>;
 } {
   const call = spawnCommand.mock.calls[0];
   if (!call) {
     throw new Error("expected spawn command call");
   }
-  return call[1] as { env?: Record<string, string> };
+  return call[1] as { detached?: boolean; env?: Record<string, string> };
+}
+
+function createRunningChild(pid: number) {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    kill: vi.fn(),
+    pid,
+    signalCode: null,
+    stderr: new EventEmitter(),
+    stdout: new EventEmitter(),
+  });
+  return child;
+}
+
+function closeChild(child: ReturnType<typeof createRunningChild>, signal: NodeJS.Signals | null) {
+  Object.assign(child, { exitCode: signal ? null : 0, signalCode: signal });
+  child.emit("close", signal ? null : 0, signal);
 }
 
 describe("createLocalShellRunner", () => {
+  it("exposes a lifecycle close owner", () => {
+    const harness = createShellHarness();
+
+    expect(harness.close).toEqual(expect.any(Function));
+  });
+
+  it("ignores command starts after close", async () => {
+    const harness = createShellHarness();
+    harness.close();
+
+    await harness.runLocalShellLine("!echo late");
+
+    expect(harness.spawnCommand).not.toHaveBeenCalled();
+    expect(harness.openOverlay).not.toHaveBeenCalled();
+  });
+
+  it("retires pending approval without accepting stale selector callbacks", async () => {
+    const harness = createShellHarness();
+    const run = harness.runLocalShellLine("!echo late");
+    const selector = harness.getLastSelector();
+    const messageCount = harness.messages.length;
+    const renderCount = harness.requestRender.mock.calls.length;
+
+    harness.close();
+    await run;
+    selector?.onSelect?.({ value: "yes", label: "Yes" });
+
+    expect(harness.messages).toHaveLength(messageCount);
+    expect(harness.requestRender).toHaveBeenCalledTimes(renderCount);
+    expect(harness.closeOverlay).toHaveBeenCalledOnce();
+    expect(harness.spawnCommand).not.toHaveBeenCalled();
+  });
+
+  it("retires overlapping process groups once", async () => {
+    killTreeMocks.killProcessTree.mockReset();
+    const children = [createRunningChild(201), createRunningChild(202)];
+    const spawnCommand = vi.fn(() => children.shift()!);
+    const harness = createShellHarness({
+      spawnCommand: spawnCommand as unknown as typeof import("node:child_process").spawn,
+    });
+    const first = harness.runLocalShellLine("!first");
+    harness.getLastSelector()?.onSelect?.({ value: "yes", label: "Yes" });
+    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledTimes(1));
+    const second = harness.runLocalShellLine("!second");
+    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledTimes(2));
+    const [firstChild, secondChild] = spawnCommand.mock.results.map(
+      (result) => result.value as ReturnType<typeof createRunningChild>,
+    );
+    if (!firstChild || !secondChild) {
+      throw new Error("expected two spawned local shell children");
+    }
+
+    harness.close();
+    harness.close();
+    await Promise.all([first, second]);
+
+    const detached = process.platform !== "win32";
+    expect(killTreeMocks.killProcessTree.mock.calls).toEqual([
+      [201, { detached, graceMs: 1_000 }],
+      [202, { detached, graceMs: 1_000 }],
+    ]);
+    closeChild(firstChild, "SIGTERM");
+    closeChild(secondChild, "SIGKILL");
+  });
+
+  it("clears normal completion listeners and never renders output after close", async () => {
+    killTreeMocks.killProcessTree.mockReset();
+    const child = createRunningChild(203);
+    const harness = createShellHarness({
+      spawnCommand: vi.fn(() => child) as unknown as typeof import("node:child_process").spawn,
+    });
+    const run = harness.runLocalShellLine("!quiet");
+    harness.getLastSelector()?.onSelect?.({ value: "yes", label: "Yes" });
+    await vi.waitFor(() => expect(child.listenerCount("close")).toBe(1));
+    const messageCount = harness.messages.length;
+
+    harness.close();
+    child.stdout.emit("data", Buffer.from("late output"));
+    closeChild(child, "SIGTERM");
+    await run;
+
+    expect(harness.messages).toHaveLength(messageCount);
+    expect(child.listenerCount("close")).toBe(0);
+    expect(child.listenerCount("error")).toBe(0);
+    expect(child.stdout.listenerCount("data")).toBe(0);
+    expect(killTreeMocks.killProcessTree).toHaveBeenCalledTimes(1);
+  });
+
   it("logs denial on subsequent ! attempts without re-prompting", async () => {
     const harness = createShellHarness();
 
@@ -274,7 +389,7 @@ describe("createLocalShellRunner", () => {
       stderr,
       on: (event: string, callback: (...args: unknown[]) => void) => {
         if (event === "close") {
-          setImmediate(() => callback(0, null));
+          setTimeout(() => callback(0, null), 200);
         }
       },
     }));

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -1,9 +1,10 @@
 // Launches and manages the local shell process used by TUI local mode.
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
 import type { Component, OverlayHandle, SelectItem } from "@earendil-works/pi-tui";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { tryProcessCwd } from "../infra/safe-cwd.js";
+import { killProcessTree } from "../process/kill-tree.js";
 import { createSearchableSelectList } from "./components/selectors.js";
 import { formatTuiErrorMessage } from "./tui-formatters.js";
 
@@ -29,9 +30,35 @@ type LocalShellDeps = {
   maxOutputChars?: number;
 };
 
+const LOCAL_SHELL_FORCE_EXIT_MS = 1_000;
+
+type ActiveLocalShell = {
+  child: ChildProcess;
+  finishRun: () => void;
+  removeOutputListeners: () => void;
+};
+
+function isChildRunning(child: ChildProcess): boolean {
+  return child.exitCode === null && child.signalCode === null;
+}
+
+function stopLocalShell(child: ChildProcess): void {
+  if (child.pid) {
+    killProcessTree(child.pid, {
+      detached: process.platform !== "win32",
+      graceMs: LOCAL_SHELL_FORCE_EXIT_MS,
+    });
+    return;
+  }
+  child.kill("SIGTERM");
+}
+
 export function createLocalShellRunner(deps: LocalShellDeps) {
   let localExecAsked = false;
   let localExecAllowed = false;
+  let closed = false;
+  let pendingApproval: { handle: OverlayHandle; resolve: (allowed: boolean) => void } | null = null;
+  const active = new Set<ActiveLocalShell>();
   const createSelector = deps.createSelector ?? createSearchableSelectList;
   const spawnCommand = deps.spawnCommand ?? spawn;
   const getCwd = deps.getCwd ?? tryProcessCwd;
@@ -61,6 +88,11 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
         2,
       );
       selector.onSelect = (item: SelectItem) => {
+        if (closed) {
+          resolve(false);
+          return;
+        }
+        pendingApproval = null;
         deps.closeOverlay(overlayHandle);
         if (item.value === "yes") {
           localExecAllowed = true;
@@ -73,17 +105,26 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
         deps.tui.requestRender();
       };
       selector.onCancel = () => {
+        if (closed) {
+          resolve(false);
+          return;
+        }
+        pendingApproval = null;
         deps.closeOverlay(overlayHandle);
         deps.chatLog.addSystem("local shell: cancelled");
         deps.tui.requestRender();
         resolve(false);
       };
       const overlayHandle: OverlayHandle = deps.openOverlay(selector);
+      pendingApproval = { handle: overlayHandle, resolve };
       deps.tui.requestRender();
     });
   };
 
   const runLocalShellLine = async (line: string) => {
+    if (closed) {
+      return;
+    }
     const cmd = line.slice(1);
     // NOTE: A lone '!' is handled by the submit handler as a normal message.
     // Keep this guard anyway in case this is called directly.
@@ -98,7 +139,7 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
     }
 
     const allowed = await ensureLocalExecAllowed();
-    if (!allowed) {
+    if (!allowed || closed) {
       return;
     }
 
@@ -125,10 +166,12 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
         // Intentionally a shell: this is an operator-only local TUI feature (prefixed with `!`)
         // and is gated behind an explicit in-session approval prompt.
         shell: true,
+        detached: process.platform !== "win32",
         cwd,
         env: { ...env, OPENCLAW_SHELL: "tui-local" },
       });
 
+      let finishRun = () => {};
       let stdout = "";
       let stderr = "";
       let error: Error | undefined;
@@ -136,16 +179,43 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
       const stderrDecoder = new StringDecoder("utf8");
       // Pipe errors are incidental; close owns completion after any recorded spawn error.
       const ignoreOutputStreamError = () => {};
+      const onStdout = (buf: Buffer) => {
+        stdout = appendWithCap(stdout, stdoutDecoder.write(buf));
+      };
+      const onStderr = (buf: Buffer) => {
+        stderr = appendWithCap(stderr, stderrDecoder.write(buf));
+      };
+      const removeOutputListeners = () => {
+        child.stdout?.removeListener("error", ignoreOutputStreamError);
+        child.stderr?.removeListener("error", ignoreOutputStreamError);
+        child.stdout?.removeListener("data", onStdout);
+        child.stderr?.removeListener("data", onStderr);
+      };
       child.stdout.on("error", ignoreOutputStreamError);
       child.stderr.on("error", ignoreOutputStreamError);
-      child.stdout.on("data", (buf) => {
-        stdout = appendWithCap(stdout, stdoutDecoder.write(buf));
-      });
-      child.stderr.on("data", (buf) => {
-        stderr = appendWithCap(stderr, stderrDecoder.write(buf));
-      });
+      child.stdout.on("data", onStdout);
+      child.stderr.on("data", onStderr);
 
-      child.on("close", (code, signal) => {
+      const owned: ActiveLocalShell = {
+        child,
+        finishRun: () => finishRun(),
+        removeOutputListeners,
+      };
+      active.add(owned);
+
+      const clearOwned = () => {
+        removeOutputListeners();
+        active.delete(owned);
+      };
+
+      const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+        clearOwned();
+        child.removeListener?.("error", onError);
+        child.removeListener?.("close", onClose);
+        if (closed) {
+          finishRun();
+          return;
+        }
         stdout = appendWithCap(stdout, stdoutDecoder.end());
         stderr = appendWithCap(stderr, stderrDecoder.end());
         // Keep the tail (consistent with the streaming appendWithCap above) so a
@@ -164,14 +234,44 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
         const status = error ? `error: ${formatTuiErrorMessage(error)}` : `exit ${code ?? "?"}`;
         deps.chatLog.addSystem(`[local] ${status}${signal ? ` (signal ${signal})` : ""}`);
         deps.tui.requestRender();
-        resolve();
-      });
+        finishRun();
+      };
 
-      child.on("error", (err) => {
+      const onError = (err: Error) => {
         error = err;
-      });
+      };
+      child.on("close", onClose);
+      child.on("error", onError);
+
+      let settled = false;
+      finishRun = () => {
+        if (!settled) {
+          settled = true;
+          resolve();
+        }
+      };
     });
   };
 
-  return { runLocalShellLine };
+  const close = (): void => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    if (pendingApproval) {
+      deps.closeOverlay(pendingApproval.handle);
+      pendingApproval.resolve(false);
+      pendingApproval = null;
+    }
+    for (const owned of active) {
+      owned.removeOutputListeners();
+      owned.finishRun();
+      if (!isChildRunning(owned.child)) {
+        continue;
+      }
+      stopLocalShell(owned.child);
+    }
+  };
+
+  return { close, runLocalShellLine };
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1505,6 +1505,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   const deferredFinish = createDeferredTuiFinish();
   // The backend can own requestExit before the editor/coalescer exists.
   let disposeSubmitBurst = () => {};
+  let closeLocalShell = () => {};
   const forceExit = () => {
     try {
       process.stderr.write("openclaw tui forcing exit\n");
@@ -1520,6 +1521,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     }
     exitRequested = true;
     authChild.close();
+    closeLocalShell();
     // Exit owns the input boundary before transport teardown can race a buffered submit.
     disposeSubmitBurst();
     connectionGeneration += 1;
@@ -1592,12 +1594,16 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     requestExit,
   });
 
-  const { runLocalShellLine } = createLocalShellRunner({
+  const { close, runLocalShellLine } = createLocalShellRunner({
     chatLog,
     tui,
     openOverlay,
     closeOverlay,
   });
+  closeLocalShell = close;
+  if (exitRequested) {
+    closeLocalShell();
+  }
   updateAutocompleteProvider();
   const notifySubmitError = (action: TuiSubmitAction, error: unknown) => {
     const message = formatTuiErrorMessage(error);


### PR DESCRIPTION
Closes #127164

## What Problem This Solves

Fixes an issue where operators exiting the TUI while approved `!command` work was still running could leave those host command process trees alive after OpenClaw exited.

## Why This Change Was Made

The local-shell runner now owns every overlapping child for its full lifecycle, rejects work after shutdown begins, and retires each tree through the shared cross-platform process-tree helper. POSIX commands use detached process groups, while the existing Windows tree semantics remain centralized in the shared helper. TUI exit closes this owner before transport and UI teardown, and late child output can no longer update the retired UI.

## User Impact

Approved local shell commands no longer outlive a TUI session after `/exit` or another TUI shutdown path. Commands that finish normally retain the existing approval, environment, output, and status behavior.

## Evidence

- Focused lifecycle and process-tree tests: 39 passed (`src/tui/tui-local-shell.test.ts`, `src/process/kill-tree.test.ts`).
- `pnpm check:changed` passed, including production and test typechecks, changed-file lint, import-cycle checks, and repository guards.
- Regression coverage proves overlapping trees are each retired exactly once, shutdown closes pending approval, post-close starts are rejected, and late output/listeners cannot write to the retired TUI.

Production LOC: +121/-15 (net +106) | Tests: +118/-3
