### PR TITLE
fix(ui): make Lobsterdex Copy link recover from clipboard failures

### DIFF
--- a/ui/src/pages/lobsterdex/lobsterdex-page.e2e.test.ts
+++ b/ui/src/pages/lobsterdex/lobsterdex-page.e2e.test.ts
@@ -1,0 +1,196 @@
+import { expect, it } from "vitest";
+import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { installMockGateway } from "../../test-helpers/control-ui-e2e.ts";
+
+type ClipboardFaultState = {
+  asyncWrites: string[];
+  execSucceeds: boolean;
+  legacyWrites: string[];
+  mode: "defer" | "missing" | "reject";
+  pendingRejects: Array<(reason?: unknown) => void>;
+};
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI Lobsterdex clipboard E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
+suite.define(() => {
+  it("falls back, announces failure, and keeps feedback with the newest copy", async () => {
+    await suite.withPage(
+      {
+        hasTouch: true,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 844, width: 390 },
+      },
+      async ({ page }) => {
+        await page.addInitScript(() => {
+          const state: ClipboardFaultState = {
+            asyncWrites: [],
+            execSucceeds: true,
+            legacyWrites: [],
+            mode: "reject",
+            pendingRejects: [],
+          };
+          Object.defineProperty(window, "lobsterdexClipboardFault", { value: state });
+          Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            get: () =>
+              state.mode === "missing"
+                ? undefined
+                : {
+                    writeText(text: string) {
+                      state.asyncWrites.push(text);
+                      if (state.mode === "reject") {
+                        return Promise.reject(
+                          new DOMException("Clipboard access denied", "NotAllowedError"),
+                        );
+                      }
+                      return new Promise<void>((_resolve, reject) => {
+                        state.pendingRejects.push(reject);
+                      });
+                    },
+                  },
+          });
+          document.execCommand = (command: string) => {
+            if (command !== "copy") {
+              return false;
+            }
+            state.legacyWrites.push(
+              document.querySelector<HTMLTextAreaElement>("textarea")?.value ?? "",
+            );
+            return state.execSucceeds;
+          };
+        });
+        const gateway = await installMockGateway(page);
+        const response = await page.goto(`${suite.server.baseUrl}settings/lobsterdex`);
+        expect(response?.status()).toBe(200);
+
+        const pageRoot = page.locator("openclaw-lobsterdex-page");
+        const copyButtons = pageRoot.getByRole("button", { name: "Copy link" });
+        await expect.poll(() => copyButtons.count()).toBeGreaterThan(1);
+        const crimson = copyButtons.nth(0);
+        const blue = copyButtons.nth(1);
+        const crimsonUrl = `${new URL(suite.server.baseUrl).origin}/settings/lobsterdex#lobsterdex-crimson`;
+        const blueUrl = `${new URL(suite.server.baseUrl).origin}/settings/lobsterdex#lobsterdex-blue`;
+        const requestsBeforeCopy = (await gateway.getRequests()).length;
+
+        await crimson.focus();
+        await page.keyboard.press("Enter");
+        await expect
+          .poll(() =>
+            page.evaluate(
+              () =>
+                (window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState })
+                  .lobsterdexClipboardFault,
+            ),
+          )
+          .toMatchObject({ asyncWrites: [crimsonUrl], legacyWrites: [crimsonUrl] });
+
+        await page.evaluate(() => {
+          (
+            window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState }
+          ).lobsterdexClipboardFault.mode = "missing";
+        });
+        await blue.tap();
+        await expect
+          .poll(() =>
+            page.evaluate(
+              () =>
+                (window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState })
+                  .lobsterdexClipboardFault,
+            ),
+          )
+          .toMatchObject({ asyncWrites: [crimsonUrl], legacyWrites: [crimsonUrl, blueUrl] });
+
+        await page.evaluate(() => {
+          const state = (
+            window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState }
+          ).lobsterdexClipboardFault;
+          state.mode = "reject";
+          state.execSucceeds = false;
+        });
+        await crimson.tap();
+        await expect.poll(() => pageRoot.getByRole("alert").textContent()).toBe("Copy failed");
+        await pageRoot.evaluate((element) => {
+          const parent = element.parentElement;
+          if (!parent) {
+            throw new Error("Lobsterdex page has no route host");
+          }
+          element.remove();
+          parent.append(element);
+        });
+        await expect.poll(() => pageRoot.getByRole("alert").count()).toBe(0);
+
+        await page.evaluate(() => {
+          const state = (
+            window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState }
+          ).lobsterdexClipboardFault;
+          state.mode = "defer";
+          state.execSucceeds = true;
+          state.asyncWrites = [];
+          state.legacyWrites = [];
+          state.pendingRejects = [];
+        });
+        await crimson.focus();
+        await page.keyboard.press("Enter");
+        await blue.tap();
+        await expect
+          .poll(() =>
+            page.evaluate(
+              () =>
+                (window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState })
+                  .lobsterdexClipboardFault.pendingRejects.length,
+            ),
+          )
+          .toBe(2);
+        expect(await pageRoot.getByRole("alert").count()).toBe(0);
+
+        await page.evaluate(() => {
+          const state = (
+            window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState }
+          ).lobsterdexClipboardFault;
+          state.pendingRejects[1]?.(new DOMException("Newer write rejected", "NotAllowedError"));
+        });
+        await blue.locator('path[d="M20 6 9 17l-5-5"]').waitFor();
+        expect(await crimson.locator('path[d="M20 6 9 17l-5-5"]').count()).toBe(0);
+        await expect
+          .poll(() =>
+            page.evaluate(
+              () =>
+                (window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState })
+                  .lobsterdexClipboardFault.legacyWrites,
+            ),
+          )
+          .toEqual([blueUrl]);
+
+        await page.evaluate(() => {
+          const state = (
+            window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState }
+          ).lobsterdexClipboardFault;
+          state.pendingRejects[0]?.(new DOMException("Older write rejected", "NotAllowedError"));
+        });
+        await page.evaluate(
+          () =>
+            new Promise<void>((resolve) => {
+              window.setTimeout(resolve, 0);
+            }),
+        );
+        expect(await crimson.locator('path[d="M20 6 9 17l-5-5"]').count()).toBe(0);
+        expect(await blue.locator('path[d="M20 6 9 17l-5-5"]').count()).toBe(1);
+        expect(
+          await page.evaluate(
+            () =>
+              (window as typeof window & { lobsterdexClipboardFault: ClipboardFaultState })
+                .lobsterdexClipboardFault.legacyWrites,
+          ),
+        ).toEqual([blueUrl]);
+        await expect.poll(() => blue.locator('path[d="M20 6 9 17l-5-5"]').count()).toBe(0);
+        expect((await gateway.getRequests()).length).toBe(requestsBeforeCopy);
+      },
+    );
+  });
+});

--- a/ui/src/pages/lobsterdex/lobsterdex-page.ts
+++ b/ui/src/pages/lobsterdex/lobsterdex-page.ts
@@ -5,14 +5,18 @@ import { getLobsterdexEntries } from "../../components/lobster-dex.ts";
 import type { LobsterPetPaletteId } from "../../components/lobster-pet-contract.ts";
 import { LOBSTER_PET_PALETTES } from "../../components/lobster-pet.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { copyToClipboard } from "../../lib/clipboard.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
-import { renderLobsterdex } from "./view.ts";
+import { renderLobsterdex, type LobsterdexCopyFeedback } from "./view.ts";
 
 class LobsterdexPage extends OpenClawLightDomElement {
-  @state() private copiedPaletteId: LobsterPetPaletteId | null = null;
+  @state() private copyFeedback: LobsterdexCopyFeedback | null = null;
+  private copyAttempt = 0;
   private copyResetTimer: number | null = null;
 
   override disconnectedCallback(): void {
+    this.copyAttempt += 1;
+    this.copyFeedback = null;
     if (this.copyResetTimer !== null) {
       window.clearTimeout(this.copyResetTimer);
       this.copyResetTimer = null;
@@ -54,18 +58,23 @@ class LobsterdexPage extends OpenClawLightDomElement {
   }
 
   private readonly copyLink = async (paletteId: LobsterPetPaletteId): Promise<void> => {
-    const url = `${location.origin}${location.pathname}#lobsterdex-${paletteId}`;
-    try {
-      await navigator.clipboard.writeText(url);
-    } catch {
-      return;
-    }
-    this.copiedPaletteId = paletteId;
+    const attempt = ++this.copyAttempt;
+    this.copyFeedback = null;
     if (this.copyResetTimer !== null) {
       window.clearTimeout(this.copyResetTimer);
+      this.copyResetTimer = null;
     }
+    const url = `${location.origin}${location.pathname}#lobsterdex-${paletteId}`;
+    const copied = await copyToClipboard(
+      url,
+      () => this.isConnected && attempt === this.copyAttempt,
+    );
+    if (!this.isConnected || attempt !== this.copyAttempt) {
+      return;
+    }
+    this.copyFeedback = { paletteId, status: copied ? "copied" : "error" };
     this.copyResetTimer = window.setTimeout(() => {
-      this.copiedPaletteId = null;
+      this.copyFeedback = null;
       this.copyResetTimer = null;
     }, 1_500);
   };
@@ -77,7 +86,7 @@ class LobsterdexPage extends OpenClawLightDomElement {
       </section>
       ${renderSettingsWorkspace(
         renderLobsterdex(getLobsterdexEntries(), {
-          copiedPaletteId: this.copiedPaletteId,
+          copyFeedback: this.copyFeedback,
           onCopyLink: (paletteId) => void this.copyLink(paletteId),
         }),
       )}

--- a/ui/src/pages/lobsterdex/view.ts
+++ b/ui/src/pages/lobsterdex/view.ts
@@ -20,8 +20,13 @@ type LobsterdexViewEntry = {
 
 type LobsterdexViewEntries = ReadonlyMap<string, LobsterdexViewEntry>;
 
+export type LobsterdexCopyFeedback = {
+  paletteId: LobsterPetPaletteId;
+  status: "copied" | "error";
+};
+
 type LobsterdexViewProps = {
-  copiedPaletteId?: LobsterPetPaletteId | null;
+  copyFeedback?: LobsterdexCopyFeedback | null;
   onCopyLink?: (paletteId: LobsterPetPaletteId) => void;
 };
 
@@ -47,6 +52,9 @@ export function renderLobsterdex(entries: LobsterdexViewEntries, props: Lobsterd
         </div>
         <span class="lobsterdex-page__count">${countLabel}</span>
       </header>
+      ${props.copyFeedback?.status === "error"
+        ? html`<div class="callout danger" role="alert">${t("common.copyFailed")}</div>`
+        : nothing}
       <div class="lobsterdex-page__grid" aria-label=${countLabel}>
         ${LOBSTER_PET_PALETTES.map((palette) => {
           const look = canonicalLobsterLook(palette);
@@ -78,7 +86,10 @@ export function renderLobsterdex(entries: LobsterdexViewEntries, props: Lobsterd
                 @click=${() => props.onCopyLink?.(palette.id)}
               >
                 <span aria-hidden="true"
-                  >${props.copiedPaletteId === palette.id ? icons.check : icons.link}</span
+                  >${props.copyFeedback?.status === "copied" &&
+                  props.copyFeedback.paletteId === palette.id
+                    ? icons.check
+                    : icons.link}</span
                 >
               </button>
               <div


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting **Copy link** on the Lobsterdex page would receive no copied deep link and no feedback when browser clipboard access was unavailable or rejected. It also fixes two out-of-order effects from an older copy: stealing the visible check/reset state and, after async rejection, entering legacy fallback late enough to overwrite the actual clipboard with an older deep link.

The copied value remains the exact local route deep link. This action does not write through the Gateway.

## Why This Change Was Made

The page now uses OpenClaw's canonical `copyToClipboard` transport, which falls back from the async Clipboard API to the supported legacy path. A page-local monotonic attempt owner ensures only the newest still-mounted activation may publish localized failure feedback or hold the existing 1.5-second success check/reset lease. The same owner is passed into the shared fallback-retirement contract landed by #127181, so a rejected stale async write cannot perform a later `execCommand` write. Disconnect retires pending work and clears feedback.

This deliberately does not add a success toast or change the existing check-icon preference.

Live searches for Lobsterdex/Copy link/clipboard variants found no exact open issue or PR. Adjacent PR #117430 updates shared clipboard and copy-button owners but does not touch this direct Lobsterdex caller.

## User Impact

Lobsterdex deep links now copy through the browser-compatible fallback when async clipboard access rejects or is missing. If both transports fail, users receive a localized accessible **Copy failed** alert. Rapid copy actions retain both clipboard and feedback ownership for the newest selected palette only.

## Evidence

Authentic pre-fix source-Chromium fallback regression at 390×844 with touch enabled:

```text
asyncWrites: ["http://127.0.0.1:<port>/settings/lobsterdex#lobsterdex-crimson"]
legacyWrites: []
Expected legacyWrites: [the same exact crimson deep link]
```

After #127181 landed the shared fallback-retirement seam, the strengthened caller regression failed authentically on the old Lobsterdex implementation. The newer blue async write rejected and copied through fallback; the older crimson write then rejected and overwrote the final legacy payload:

```text
Expected legacyWrites: [blueUrl]
Received legacyWrites: [blueUrl, crimsonUrl]
```

Passing verification on exact head `64128bf330847124023317cb67a61f83ef66aeac`:

```text
ui/src/pages/lobsterdex/view.test.ts: 1/1 passed
ui/src/pages/lobsterdex/lobsterdex-page.e2e.test.ts: 1/1 passed
scripts/check-changed.mjs: passed all selected lanes
Codex autoreview P0-P3: clean, confidence 0.93
```

The mocked-Gateway source E2E covers keyboard and touch activation; async rejection and missing Clipboard API fallback with exact URL payloads; total transport failure with localized alert semantics; a newer rejected blue write falling back before an older rejected crimson write; newest-only final clipboard payload and check/reset ownership; detach/reappend cleanup; and zero copy-triggered Gateway requests.

The changed-file gate passed formatting, policy guards, dead exports, i18n verification, core/UI typechecks, oxlint, and stylelint. Independent review identified disconnect cleanup as the first P2 gap; final review after adopting the shared stale-fallback owner found no accepted/actionable P0-P3 findings and judged the patch correct.

### Before: clipboard failure is silent

![Lobsterdex copy failure before the fix](https://ampcode.com/user-content/artifacts/71d4aad9cf2fa3458614fcce8051950b2e5205f8c20ee97be0ea8bc465a89598-file.png)

### After: localized accessible failure feedback

![Lobsterdex copy failure after the fix](https://ampcode.com/user-content/artifacts/723f5551f94a7e4a8770638b4bfc56485d2a5c27578acaa30499217e4aee5729-file.png)
