### PR TITLE
improve(ui): declutter Automations across desktop and mobile

### DIFF
--- a/test/scripts/vitest-e2e-global-setup.test.ts
+++ b/test/scripts/vitest-e2e-global-setup.test.ts
@@ -7,12 +7,7 @@ import {
   forceKillVitestProcessGroup,
   forwardSignalToVitestProcessGroup,
 } from "../../scripts/vitest-process-group.mts";
-import {
-  isProcessAlive,
-  waitForChildClose,
-  waitForDead,
-  waitForPidFile,
-} from "../helpers/process-wait.js";
+import { waitForChildClose, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
 import { runE2eGlobalSetup } from "../vitest/vitest.e2e.global-setup.js";
 
 type SetupCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
@@ -127,8 +122,12 @@ await runE2eSetupCommand([${JSON.stringify(fixturePath)}], process.env);`;
     } finally {
       forceKillVitestProcessGroup(runner);
       for (const pid of pids) {
-        if (isProcessAlive(pid)) {
+        try {
           process.kill(pid, "SIGKILL");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+            throw error;
+          }
         }
       }
       fs.rmSync(fixtureDir, { force: true, recursive: true });

--- a/ui/src/e2e/cron-descriptions.e2e.test.ts
+++ b/ui/src/e2e/cron-descriptions.e2e.test.ts
@@ -24,7 +24,7 @@ function cronJob(id: string, name: string) {
 }
 
 suite.define(() => {
-  it("shows saved descriptions in compact rows and task details for every payload kind", async () => {
+  it("shows saved descriptions in list rows and task details for every payload kind", async () => {
     const jobs = [
       {
         ...cronJob("described-event", "System reminder"),
@@ -81,7 +81,7 @@ suite.define(() => {
 
         for (const job of jobs) {
           const description = page.locator(`[data-test-id="cron-row-description-${job.id}"]`);
-          expect((await description.textContent())?.trim()).toBe(`· ${job.description.trim()}`);
+          expect((await description.textContent())?.trim()).toBe(job.description.trim());
           expect(await description.getAttribute("title")).toBe(
             `Description: ${job.description.trim()}`,
           );
@@ -89,14 +89,6 @@ suite.define(() => {
         expect(
           await page.locator(`[data-test-id="cron-row-description-${undescribedJob.id}"]`).count(),
         ).toBe(0);
-
-        const describedRow = await page
-          .locator(`[data-test-id="cron-row-${jobs[1].id}"]`)
-          .boundingBox();
-        const undescribedRow = await page
-          .locator(`[data-test-id="cron-row-${undescribedJob.id}"]`)
-          .boundingBox();
-        expect(describedRow?.height).toBe(undescribedRow?.height);
 
         for (const job of jobs) {
           const row = page.locator(`[data-test-id="cron-row-${job.id}"]`);

--- a/ui/src/pages/cron/stats.ts
+++ b/ui/src/pages/cron/stats.ts
@@ -1,6 +1,5 @@
 import { html } from "lit";
 import type { CronJob, CronStatus } from "../../api/types.ts";
-import { icon } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatNextRun } from "../../lib/presenter.ts";
 
@@ -30,9 +29,10 @@ export function renderCronStats(props: {
   return html`
     <div class="cron-stats">
       <div class="cron-stat">
-        <span class="cron-stat__label">${t("cron.stats.tasks")}</span>
         <span class="cron-stat__value">${total}</span>
+        <span class="cron-stat__label">${t("cron.stats.tasks")}</span>
       </div>
+      <span class="cron-stat__separator" aria-hidden="true">·</span>
       <button
         type="button"
         class="cron-stat cron-stat--action"
@@ -44,7 +44,6 @@ export function renderCronStats(props: {
           void props.onRunsFiltersChange({ cronRunsStatuses: ["error"] });
         }}
       >
-        <span class="cron-stat__label">${t("cron.stats.failing")}</span>
         <span
           class="cron-stat__value ${typeof failing === "number" && failing > 0
             ? "cron-stat__value--danger"
@@ -52,8 +51,9 @@ export function renderCronStats(props: {
         >
           ${failing ?? t("common.na")}
         </span>
-        <span class="cron-stat__go" aria-hidden="true">${icon("chevronRight")}</span>
+        <span class="cron-stat__label">${t("cron.stats.failing")}</span>
       </button>
+      <span class="cron-stat__separator" aria-hidden="true">·</span>
       <div class="cron-stat">
         <span class="cron-stat__label">${t("cron.stats.nextWake")}</span>
         <span class="cron-stat__value cron-stat__value--time">

--- a/ui/src/pages/cron/view-auto-disabled.test.ts
+++ b/ui/src/pages/cron/view-auto-disabled.test.ts
@@ -19,9 +19,14 @@ it("labels an auto-disabled job distinctly from an operator pause", () => {
   const container = renderView({ jobs: [paused, autoDisabled] });
   const rows = Array.from(container.querySelectorAll(".cron-table__row"));
   expect(rows[0]?.textContent).toContain("Paused");
+  expect(rows[0]?.querySelector(".cron-table__state--paused")?.getAttribute("aria-label")).toBe(
+    "Paused",
+  );
   const note = rows[1]?.querySelector("[data-test-id='cron-row-auto-disabled-job-auto']");
   expect(note?.textContent?.trim()).toBe("Auto-disabled · 10 run failures");
   expect(note?.getAttribute("title")).toBe("provider exploded");
-  // Escalated failure keeps the error dot even though the job is disabled.
-  expect(rows[1]?.querySelector(".cron-table__dot--error")).not.toBeNull();
+  // Escalated failure keeps a visible error marker even though the job is disabled.
+  expect(rows[1]?.querySelector(".cron-table__state--error")?.getAttribute("aria-label")).toBe(
+    "Auto-disabled · 10 run failures",
+  );
 });

--- a/ui/src/pages/cron/view-description.test.ts
+++ b/ui/src/pages/cron/view-description.test.ts
@@ -26,7 +26,7 @@ describe("cron view saved descriptions", () => {
       );
 
       expect(description).toBeInstanceOf(HTMLSpanElement);
-      expect(description?.textContent?.trim()).toBe("· Summarize overnight deployment activity");
+      expect(description?.textContent?.trim()).toBe("Summarize overnight deployment activity");
       expect(description?.title).toBe("Description: Summarize overnight deployment activity");
       description?.click();
       expect(onSelectJob).toHaveBeenCalledWith(job);

--- a/ui/src/pages/cron/view-running-state.test.ts
+++ b/ui/src/pages/cron/view-running-state.test.ts
@@ -13,5 +13,8 @@ it("shows Running instead of a past-due next-run time while a run executes", () 
   const container = renderView({ jobs: [running] });
   const row = container.querySelector(".cron-table__row");
   expect(row?.querySelector(".cron-table__running")?.textContent).toBe("Running");
+  expect(row?.querySelector(".cron-table__state--running")?.getAttribute("aria-label")).toBe(
+    "Running",
+  );
   expect(row?.textContent).not.toContain("ago");
 });

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -137,7 +137,9 @@ describe("cron view list pane", () => {
     expect(rows[0]?.textContent).toContain("Cron 0 9 * * *");
     expect(rows[1]?.classList.contains("cron-table__row--paused")).toBe(true);
     expect(rows[1]?.textContent).toContain("Paused");
-    expect(rows[2]?.querySelector(".cron-table__dot--error")).not.toBeNull();
+    expect(rows[2]?.querySelector(".cron-table__state--error")?.getAttribute("aria-label")).toBe(
+      "Error",
+    );
     expect(rows[2]?.querySelector(".cron-last-glyph--error")).not.toBeNull();
     expect(rows[2]?.querySelector(".cron-table__last-run")?.getAttribute("aria-label")).toBe(
       "Error",

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -436,7 +436,10 @@ export function renderCron(props: CronProps) {
 function renderAdminRequired(props: CronProps) {
   return props.canManage
     ? nothing
-    : html`<div class="callout warning" role="note">${t("cron.adminRequired")}</div>`;
+    : html`<div class="cron-admin-note" role="note">
+        <span aria-hidden="true">${icon("lock")}</span>
+        <span>${t("cron.adminRequired")}</span>
+      </div>`;
 }
 
 // ── List view ──
@@ -474,17 +477,23 @@ function renderListView(props: CronProps) {
     !hasAnyJobsFilters &&
     props.canManage;
   const children = [
-    renderSettingsSection({}, renderCronStats(props)),
-    renderAdminRequired(props),
-    props.status && !props.status.enabled
-      ? html`
-          <div class="cron-error-banner" data-test-id="cron-scheduler-banner">
-            <strong>${t("cron.list.schedulerOff")}</strong> ${t("cron.runNotStarted.stopped")}
-          </div>
-        `
-      : nothing,
-    props.error ? html`<div class="cron-error-banner">${props.error}</div>` : nothing,
-    renderToolbar(props, hasAdvancedJobsFilters),
+    html`
+      <div class="cron-overview-header">
+        <div class="cron-overview-summary">
+          ${renderCronStats(props)} ${renderAdminRequired(props)}
+        </div>
+        ${props.status && !props.status.enabled
+          ? html`
+              <div class="cron-error-banner" data-test-id="cron-scheduler-banner">
+                <strong>${t("cron.list.schedulerOff")}</strong>
+                ${t("cron.runNotStarted.stopped")}
+              </div>
+            `
+          : nothing}
+        ${props.error ? html`<div class="cron-error-banner">${props.error}</div>` : nothing}
+        ${renderToolbar(props, hasAdvancedJobsFilters)}
+      </div>
+    `,
     html`
       <div
         id="cron-list-panel"
@@ -524,66 +533,71 @@ function renderListTabs(props: CronProps) {
   });
 }
 
-// One toolbar row for both list tabs: view switch left, tab filters middle, refresh + New right.
+// Navigation and primary actions stay stable above the task-only filter row.
 function renderToolbar(props: CronProps, hasAdvancedJobsFilters: boolean) {
   return html`
     <div class="cron-toolbar">
-      ${renderListTabs(props)}
+      <div class="cron-toolbar__primary">
+        ${renderListTabs(props)}
+        <div class="cron-toolbar__end">
+          <button
+            type="button"
+            class="btn btn--sm btn--ghost cron-refresh ${props.loading
+              ? "cron-refresh--loading"
+              : ""}"
+            ?disabled=${props.loading}
+            title=${props.loading ? t("cron.list.refreshing") : t("cron.list.refresh")}
+            aria-label=${t("cron.list.refresh")}
+            @click=${props.onRefresh}
+          >
+            ${icon("refresh")}
+          </button>
+          ${props.canManage
+            ? html`
+                <button
+                  type="button"
+                  class="btn primary btn--sm cron-new-task"
+                  data-test-id="cron-new-task"
+                  @click=${() => props.onOpenCreate()}
+                >
+                  ${icon("plus")} ${t("cron.list.newTask")}
+                </button>
+              `
+            : nothing}
+        </div>
+      </div>
       ${props.listTab === "tasks"
         ? html`
-            ${renderSegmented<CronJobsEnabledFilter>({
-              value: props.jobsEnabledFilter,
-              options: ENABLED_TABS.map((tab) => ({
-                value: tab.value,
-                label: t(tab.labelKey),
-                testId: `cron-tab-${tab.value}`,
-              })),
-              ariaLabel: t("cron.tabs.filterLabel"),
-              onChange: (value) => void props.onJobsFiltersChange({ cronJobsEnabledFilter: value }),
-            })}
-            <div class="cron-search-box">
-              <span class="cron-search-box__icon" aria-hidden="true">${icon("search")}</span>
-              <input
-                type="search"
-                class="settings-input"
-                .value=${props.jobsQuery}
-                aria-label=${t("cron.list.searchPlaceholder")}
-                placeholder=${t("cron.list.searchPlaceholder")}
-                @input=${(e: Event) =>
-                  props.onJobsFiltersChange({
-                    cronJobsQuery: (e.target as HTMLInputElement).value,
-                  })}
-              />
+            <div class="cron-toolbar__filters">
+              <div class="cron-search-box">
+                <span class="cron-search-box__icon" aria-hidden="true">${icon("search")}</span>
+                <input
+                  type="search"
+                  class="settings-input"
+                  .value=${props.jobsQuery}
+                  aria-label=${t("cron.list.searchPlaceholder")}
+                  placeholder=${t("cron.list.searchPlaceholder")}
+                  @input=${(e: Event) =>
+                    props.onJobsFiltersChange({
+                      cronJobsQuery: (e.target as HTMLInputElement).value,
+                    })}
+                />
+              </div>
+              ${renderSegmented<CronJobsEnabledFilter>({
+                value: props.jobsEnabledFilter,
+                options: ENABLED_TABS.map((tab) => ({
+                  value: tab.value,
+                  label: t(tab.labelKey),
+                  testId: `cron-tab-${tab.value}`,
+                })),
+                ariaLabel: t("cron.tabs.filterLabel"),
+                onChange: (value) =>
+                  void props.onJobsFiltersChange({ cronJobsEnabledFilter: value }),
+              })}
+              ${renderJobsFilterPopover(props, hasAdvancedJobsFilters)}
             </div>
-            ${renderJobsFilterPopover(props, hasAdvancedJobsFilters)}
           `
         : nothing}
-      <div class="cron-toolbar__end">
-        <button
-          type="button"
-          class="btn btn--sm btn--ghost cron-refresh ${props.loading
-            ? "cron-refresh--loading"
-            : ""}"
-          ?disabled=${props.loading}
-          title=${props.loading ? t("cron.list.refreshing") : t("cron.list.refresh")}
-          aria-label=${t("cron.list.refresh")}
-          @click=${props.onRefresh}
-        >
-          ${icon("refresh")}
-        </button>
-        ${props.canManage
-          ? html`
-              <button
-                type="button"
-                class="btn primary btn--sm cron-new-task"
-                data-test-id="cron-new-task"
-                @click=${() => props.onOpenCreate()}
-              >
-                ${icon("plus")} ${t("cron.list.newTask")}
-              </button>
-            `
-          : nothing}
-      </div>
     </div>
   `;
 }
@@ -713,13 +727,13 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
 
 function renderJobsTable(props: CronProps, hasAnyJobsFilters: boolean) {
   return html`
-    <div class="cron-table">
+    <div class="cron-table ${props.canManage ? "" : "cron-table--read-only"}">
       <div class="cron-table__head" role="row">
         <span>${t("cron.jobs.name")}</span>
         <span>${t("cron.jobs.schedule")}</span>
         <span>${t("cron.jobs.nextRun")}</span>
         <span>${t("cron.jobs.lastRun")}</span>
-        <span aria-hidden="true"></span>
+        ${props.canManage ? html`<span aria-hidden="true"></span>` : nothing}
       </div>
       ${props.jobs.length === 0
         ? html`
@@ -753,11 +767,11 @@ function renderJobRow(job: CronJob, props: CronProps) {
   const description = job.description?.trim();
   const nextRunAtMs = job.state?.nextRunAtMs;
   const hasNextRun = typeof nextRunAtMs === "number" && Number.isFinite(nextRunAtMs);
-  const dotVariant = isCronJobActiveFailure(job)
-    ? "cron-table__dot--error"
-    : job.enabled
-      ? "cron-table__dot--active"
-      : "";
+  const nextRun = isCronJobRunning(job)
+    ? html`<span class="cron-table__running">${t("cron.runs.runStatusRunning")}</span>`
+    : hasNextRun
+      ? formatRelativeTimestamp(nextRunAtMs)
+      : t("common.na");
   return html`
     <div
       class="cron-table__row ${job.enabled ? "" : "cron-table__row--paused"}"
@@ -773,37 +787,44 @@ function renderJobRow(job: CronJob, props: CronProps) {
       }}
     >
       <span class="cron-table__name">
-        <span class="cron-table__dot ${dotVariant}" aria-hidden="true"></span>
-        <span class="cron-table__name-text">${job.name}</span>
-        ${description
-          ? html`
-              <span
-                class="cron-table__description"
-                data-test-id=${`cron-row-description-${job.id}`}
-                title=${`${t("cron.form.description")}: ${description}`}
-                >· ${description}</span
-              >
-            `
-          : nothing}
-        ${job.trigger ? renderTriggerIndicator() : nothing}
-        ${job.enabled ? nothing : renderDisabledNote(job)}
+        ${renderJobStateIndicator(job)}
+        <span class="cron-table__name-copy">
+          <span class="cron-table__name-line">
+            <span class="cron-table__name-text">${job.name}</span>
+            ${job.trigger ? renderTriggerIndicator() : nothing}
+          </span>
+          ${description || !job.enabled
+            ? html`
+                <span class="cron-table__name-meta">
+                  ${description
+                    ? html`
+                        <span
+                          class="cron-table__description"
+                          data-test-id=${`cron-row-description-${job.id}`}
+                          title=${`${t("cron.form.description")}: ${description}`}
+                          >${description}</span
+                        >
+                      `
+                    : nothing}
+                  ${description && !job.enabled
+                    ? html`<span class="cron-table__meta-separator" aria-hidden="true">·</span>`
+                    : nothing}
+                  ${job.enabled ? nothing : renderDisabledNote(job)}
+                </span>
+              `
+            : nothing}
+        </span>
       </span>
-      <span class="cron-table__cell">${formatCronSchedule(job)}</span>
-      <span class="cron-table__cell">
-        ${isCronJobRunning(job)
-          ? html`<span class="cron-table__running">${t("cron.runs.runStatusRunning")}</span>`
-          : hasNextRun
-            ? formatRelativeTimestamp(nextRunAtMs)
-            : t("common.na")}
-      </span>
-      <span class="cron-table__cell cron-table__last">${renderLastRunCell(job)}</span>
-      <span
-        class="cron-table__actions"
-        @click=${(e: Event) => e.stopPropagation()}
-        @keydown=${(e: Event) => e.stopPropagation()}
-      >
-        ${props.canManage
-          ? html`
+      ${renderJobCell("cron-table__schedule", t("cron.jobs.schedule"), formatCronSchedule(job))}
+      ${renderJobCell("cron-table__next", t("cron.jobs.nextRun"), nextRun)}
+      ${renderJobCell("cron-table__last", t("cron.jobs.lastRun"), renderLastRunCell(job))}
+      ${props.canManage
+        ? html`
+            <span
+              class="cron-table__actions"
+              @click=${(e: Event) => e.stopPropagation()}
+              @keydown=${(e: Event) => e.stopPropagation()}
+            >
               <button
                 type="button"
                 class="btn btn--sm btn--ghost cron-row-run"
@@ -820,11 +841,60 @@ function renderJobRow(job: CronJob, props: CronProps) {
                 testId: `cron-row-toggle-${job.id}`,
               })}
               ${renderJobMenu(props, job)}
-            `
-          : nothing}
-      </span>
+            </span>
+          `
+        : nothing}
     </div>
   `;
+}
+
+function renderJobCell(className: string, label: string, value: unknown) {
+  return html`<span class="cron-table__cell ${className}">
+    <span class="cron-table__cell-label">${label}</span>
+    <span class="cron-table__cell-value">${value}</span>
+  </span>`;
+}
+
+function renderJobStateIndicator(job: CronJob) {
+  const autoDisabled = job.state?.autoDisabled;
+  const state = isCronJobRunning(job)
+    ? {
+        className: "cron-table__state--running",
+        iconName: "loader" as const,
+        label: t("cron.runs.runStatusRunning"),
+      }
+    : autoDisabled
+      ? {
+          className: "cron-table__state--error",
+          iconName: "lock" as const,
+          label: disabledNoteLabel(job),
+        }
+      : isCronJobActiveFailure(job)
+        ? {
+            className: "cron-table__state--error",
+            iconName: "alertTriangle" as const,
+            label: t("cron.runs.runStatusError"),
+          }
+        : !job.enabled
+          ? {
+              className: "cron-table__state--paused",
+              iconName: "pause" as const,
+              label: t("cron.list.paused"),
+            }
+          : {
+              className: "cron-table__state--active",
+              iconName: null,
+              label: t("cron.detail.active"),
+            };
+  return html`<span
+    class="cron-table__state ${state.className}"
+    role="img"
+    aria-label=${state.label}
+    title=${state.label}
+    >${state.iconName
+      ? icon(state.iconName)
+      : html`<span class="cron-table__state-dot"></span>`}</span
+  >`;
 }
 
 function renderTriggerIndicator() {
@@ -842,12 +912,7 @@ function renderDisabledNote(job: CronJob) {
   if (!autoDisabled) {
     return html`<span class="muted cron-table__paused-note">${t("cron.list.paused")}</span>`;
   }
-  const label = t(
-    autoDisabled.reason === "schedule-errors"
-      ? "cron.list.autoDisabledScheduleErrors"
-      : "cron.list.autoDisabledRunFailures",
-    { count: String(autoDisabled.consecutiveErrors) },
-  );
+  const label = disabledNoteLabel(job);
   const lastError = job.state?.lastError?.trim();
   return html`<span
     class="cron-table__paused-note cron-table__auto-disabled"
@@ -855,6 +920,19 @@ function renderDisabledNote(job: CronJob) {
     title=${lastError ? formatUiExternalText(lastError) : label}
     >${label}</span
   >`;
+}
+
+function disabledNoteLabel(job: CronJob) {
+  const autoDisabled = job.state?.autoDisabled;
+  if (!autoDisabled) {
+    return t("cron.list.paused");
+  }
+  return t(
+    autoDisabled.reason === "schedule-errors"
+      ? "cron.list.autoDisabledScheduleErrors"
+      : "cron.list.autoDisabledRunFailures",
+    { count: String(autoDisabled.consecutiveErrors) },
+  );
 }
 
 function renderLastRunCell(job: CronJob) {

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -15,81 +15,72 @@
   overflow: visible;
 }
 
-/* ── Stat grid (escape hatch inside one group) ── */
+/* ── Compact overview chrome ── */
+
+.cron-page[data-panel-mode="overview"] .settings-page {
+  gap: var(--space-4);
+}
+
+.cron-overview-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.cron-overview-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
 
 .cron-stats {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-4);
-  padding: var(--space-3) var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
 }
 
 .cron-stat {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
+  align-items: baseline;
+  gap: var(--space-1);
   min-width: 0;
 }
 
-/* Failing stat is a drill-down into run history filtered to errors. It sits
-   inside the stats group, so it is a bare button (no card chrome). */
+/* Failing is still a drill-down into run history, but reads as one fact in the
+   summary rather than a third competing card. */
 .cron-stat--action {
   position: relative;
-  text-align: left;
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-1);
   font: inherit;
   color: inherit;
   cursor: var(--cursor-action);
   border: 0;
   background: transparent;
-  margin: calc(-1 * var(--space-2));
-  padding: var(--space-2);
-  border-radius: var(--radius-md);
-  transition: background var(--duration-fast) var(--ease-out);
+  padding: 2px;
+  margin: -2px;
+  border-radius: var(--radius-sm);
+  transition: color var(--duration-fast) var(--ease-out);
 }
 
 .cron-stat--action:hover {
-  background: var(--bg-hover);
-}
-
-.cron-stat__go {
-  position: absolute;
-  top: 50%;
-  right: var(--space-3);
-  transform: translateY(-50%);
-  display: inline-flex;
-  color: var(--muted);
-  opacity: 0;
-  transition: opacity var(--duration-fast) var(--ease-out);
-}
-
-.cron-stat__go svg {
-  width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-}
-
-.cron-stat--action:hover .cron-stat__go,
-.cron-stat--action:focus-visible .cron-stat__go {
-  opacity: 1;
+  color: var(--text-strong);
 }
 
 .cron-stat__label {
-  color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  color: inherit;
 }
 
 .cron-stat__value {
   color: var(--text-strong);
-  font-size: 22px;
+  font-size: inherit;
   font-weight: 650;
-  line-height: 1.1;
-  min-height: 24px;
-  display: flex;
-  align-items: center;
 }
 
 .cron-stat__value--danger {
@@ -97,13 +88,29 @@
 }
 
 .cron-stat__value--time {
-  font-size: 14px;
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: block;
-  line-height: 24px;
+}
+
+.cron-stat__separator {
+  color: var(--border-strong);
+}
+
+.cron-admin-note {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  margin-left: auto;
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+}
+
+.cron-admin-note svg {
+  width: 12px;
+  height: 12px;
 }
 
 /* Tab panel wrapping the tab-dependent sections; keeps the settings-page
@@ -111,17 +118,30 @@
 .cron-tab-panel {
   display: flex;
   flex-direction: column;
-  gap: var(--space-7);
+  gap: var(--space-4);
   min-width: 0;
 }
 
-/* ── One-row list toolbar (view switch, filters, refresh + New automation) ── */
+/* ── List toolbar ── */
 
 .cron-toolbar {
   display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.cron-toolbar__primary,
+.cron-toolbar__filters {
+  display: flex;
   align-items: center;
   gap: var(--space-2);
-  flex-wrap: wrap;
+  width: 100%;
+  min-width: 0;
+}
+
+.cron-toolbar__primary {
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
 }
 
 /* Toolbar buttons share the settings control height with the adjacent
@@ -134,9 +154,8 @@
 
 .cron-search-box {
   position: relative;
-  flex: 1 1 220px;
-  min-width: 180px;
-  max-width: 420px;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .cron-search-box__icon {
@@ -263,13 +282,20 @@
 
 /* ── Jobs table (escape hatch inside the tasks group) ── */
 
+.cron-table {
+  --cron-table-columns: minmax(220px, 1.8fr) minmax(160px, 1.05fr) minmax(110px, 0.7fr)
+    minmax(130px, 0.8fr) 116px;
+}
+
+.cron-table--read-only {
+  --cron-table-columns: minmax(220px, 1.8fr) minmax(160px, 1.05fr) minmax(110px, 0.7fr)
+    minmax(130px, 0.8fr);
+}
+
 .cron-table__head,
 .cron-table__row {
   display: grid;
-  grid-template-columns: minmax(180px, 1.6fr) minmax(150px, 1.1fr) minmax(110px, 0.8fr) minmax(
-      140px,
-      0.9fr
-    ) 116px;
+  grid-template-columns: var(--cron-table-columns);
   gap: var(--space-3);
   align-items: center;
   padding: 0 var(--space-4);
@@ -309,7 +335,7 @@
 
 .cron-table__name {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   min-width: 0;
   color: var(--text-strong);
@@ -317,33 +343,84 @@
   font-weight: 600;
 }
 
-.cron-table__dot {
+.cron-table__state {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-top: 2px;
+  color: var(--muted);
+}
+
+.cron-table__state svg {
+  width: 13px;
+  height: 13px;
+  stroke: currentColor;
+  fill: none;
+}
+
+.cron-table__state-dot {
   width: 8px;
   height: 8px;
   border-radius: 999px;
-  background: var(--muted);
-  opacity: 0.5;
-}
-
-.cron-table__dot--active {
   background: var(--ok);
-  opacity: 1;
 }
 
-.cron-table__dot--error {
-  background: var(--danger);
-  opacity: 1;
+.cron-table__state--running {
+  color: var(--accent-2);
+}
+
+.cron-table__state--running svg {
+  animation: cron-state-spin 1s linear infinite;
+}
+
+.cron-table__state--error {
+  color: var(--danger);
+}
+
+.cron-table__state--paused {
+  color: var(--muted);
+}
+
+@keyframes cron-state-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cron-table__state--running svg {
+    animation: none;
+  }
+}
+
+.cron-table__name-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.cron-table__name-line,
+.cron-table__name-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
 }
 
 .cron-table__name-text {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .cron-table__description {
-  flex: 1 1 0;
+  flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
   color: var(--muted);
@@ -358,8 +435,12 @@
   font-size: var(--control-ui-text-xs);
 }
 
+.cron-table__meta-separator {
+  color: var(--muted);
+}
+
 .cron-table__running {
-  color: var(--accent);
+  color: var(--accent-2);
 }
 
 .cron-table__auto-disabled {
@@ -369,6 +450,17 @@
 .cron-table__cell {
   color: var(--text);
   font-size: 12.5px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cron-table__cell-label {
+  display: none;
+}
+
+.cron-table__cell-value {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1039,40 +1131,96 @@
 /* ── Responsive ── */
 
 @media (max-width: 900px) {
-  /* Stack table rows into label-free cards; hide the head and secondary cells. */
+  /* Keep every table fact, but label and arrange it as a compact card. */
   .cron-table__head {
     display: none;
   }
 
   .cron-table__row {
-    grid-template-columns: minmax(0, 1fr) 116px;
-    row-gap: 4px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-2) var(--space-3);
+    padding-top: var(--space-3);
+    padding-bottom: var(--space-3);
   }
 
   .cron-table__name {
-    grid-column: 1;
+    grid-column: 1 / -1;
   }
 
-  .cron-table__actions {
-    grid-column: 2;
-    grid-row: 1;
+  .cron-table__schedule {
+    grid-column: 1 / -1;
   }
 
   .cron-table__cell {
-    grid-column: 1;
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-1);
     color: var(--muted);
     font-size: var(--control-ui-text-sm);
+    white-space: normal;
+  }
+
+  .cron-table__cell-label {
+    display: inline;
+    flex: 0 0 auto;
+    color: var(--muted);
+    font-size: var(--control-ui-text-xs);
+    font-weight: 600;
+  }
+
+  .cron-table__cell-label::after {
+    content: ":";
+  }
+
+  .cron-table__cell-value {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .cron-table__actions {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+    padding-left: 24px;
   }
 }
 
 @media (max-width: 560px) {
   .cron-stats {
-    grid-template-columns: 1fr;
+    flex-wrap: wrap;
+  }
+
+  .cron-overview-summary {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .cron-admin-note {
+    margin-left: 0;
+  }
+
+  .cron-toolbar__filters {
+    flex-wrap: wrap;
   }
 
   .cron-search-box {
-    max-width: none;
     flex-basis: 100%;
+  }
+
+  .cron-filter-popover__trigger {
+    margin-left: auto;
+  }
+
+  .cron-new-task {
+    width: 32px;
+    padding: 0;
+    justify-content: center;
+    font-size: 0;
+  }
+
+  .cron-new-task svg {
+    width: 14px;
+    height: 14px;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Automations page gives summary, navigation, filters, schedule metadata, run state, and management controls similar visual weight. This makes the list harder to scan on desktop and turns each mobile row into an ambiguous stack of unlabeled values.

## Why This Change Was Made

This UI-only change preserves the existing Automations structure and every scheduling, filtering, execution, permission, and history behavior while tightening the hierarchy. Operational state now uses the left marker (idle, running, failed, paused, or auto-disabled), conditional configuration remains an icon-only secondary fact, descriptions get their own quiet line, read-only mode no longer reserves an empty action column, and mobile rows label schedule/next/last facts explicitly.

No Gateway, cron-service, persistence, protocol, or feature behavior changes are included. AI-assisted; implementation and evidence were reviewed by the authoring agent.

## User Impact

Operators can scan more automations with less visual noise on desktop and mobile without losing information. Running, failing, paused, auto-disabled, skipped, conditional, and never-run rows remain distinguishable, exact schedule and timing facts remain visible, and administrator/read-only capabilities are unchanged.

Production LOC: +422/-196 (net +226) | Tests: +14/-4. The production growth is the responsive presentation and explicit accessible state treatment required to preserve the same information and actions across both layouts.

## Evidence

### Before

| Desktop | Mobile |
| --- | --- |
| ![Automations before desktop](https://github.com/user-attachments/assets/fc9ad0d9-e3d8-42be-8ad1-dfe38c3d7ade) | ![Automations before mobile](https://github.com/user-attachments/assets/4369c0fd-965d-4ee8-a9f0-8228999954e5) |

### After — administrator

The fixture covers enabled/idle, running, conditional + skipped, failed, paused, both auto-disabled reasons, and never-run rows.

| Desktop | Mobile |
| --- | --- |
| ![Automations after administrator desktop](https://github.com/user-attachments/assets/8b228104-7440-4604-950e-6a1b3d658beb) | ![Automations after administrator mobile](https://github.com/user-attachments/assets/5f423743-4d46-4d9e-9168-84aac2aae135) |

### After — read-only

| Desktop | Mobile |
| --- | --- |
| ![Automations after read-only desktop](https://github.com/user-attachments/assets/4404c438-57ea-45eb-a3d3-e3fc5c94cfc3) | ![Automations after read-only mobile](https://github.com/user-attachments/assets/4fade2dc-b72e-4141-b0d4-80dd33e49cfc) |

### Validation

- `node scripts/run-vitest.mjs ui/src/pages/cron` — 9 files, 95 tests passed
- `node scripts/check-changed.mjs` — passed, including core-test/UI typechecks and lint
- Temporary mocked-Gateway visual proof — 4/4 desktop/mobile administrator/read-only captures passed on exact head; capture file removed before commit
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings

