### PR TITLE
improve: show condition activity in automation history

### DIFF
--- a/ui/src/e2e/cron-trigger-filter.e2e.test.ts
+++ b/ui/src/e2e/cron-trigger-filter.e2e.test.ts
@@ -25,6 +25,10 @@ const conditionalJob = {
   name: "Conditional job",
   payload: { kind: "systemEvent", text: "conditional" },
   trigger: { script: "json({ fire: true })" },
+  state: {
+    triggerEvalCount: 42,
+    lastTriggerEvalAtMs: Date.now() - 3 * 60_000,
+  },
 };
 const plainJob = {
   ...baseJob,
@@ -90,6 +94,17 @@ suite.define(() => {
           .poll(async () => page.locator('[data-test-id="cron-row-plain-job"]').count())
           .toBe(0);
         expect(await conditionalRow.count()).toBe(1);
+
+        await conditionalRow.click();
+        await page.getByRole("tab", { name: "Run history", exact: true }).click();
+        const activity = page.locator('[data-test-id="cron-condition-activity"]');
+        await activity.waitFor();
+        await expect.poll(() => activity.textContent()).toContain("42");
+        await expect.poll(() => activity.textContent()).toContain("3m ago");
+        await expect.poll(() => activity.textContent()).toContain("Never");
+        await expect
+          .poll(() => page.locator(".cron-empty-state").textContent())
+          .toContain("No payload runs yet");
       },
     );
   });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6422,6 +6422,20 @@ export const en: TranslationMap = {
       noMatching: "No matching runs.",
       emptyTitle: "No runs yet",
       emptyHint: "Runs show up here once an automation fires.",
+      conditionActivity: "Condition activity",
+      conditionActivityHint: "Checks run on schedule before the payload starts.",
+      checks: "Checks",
+      lastChecked: "Last checked",
+      lastFired: "Last fired",
+      notChecked: "Not checked yet",
+      neverFired: "Never",
+      emptyConditionTitle: "No payload runs yet",
+      emptyConditionHint:
+        "The condition has been checked {count} times without matching. Run history starts when the payload executes.",
+      emptyConditionHintOne:
+        "The condition has been checked once without matching. Run history starts when the payload executes.",
+      emptyConditionUnchecked:
+        "The condition has not been checked yet. Run history starts when the payload executes.",
       loadMore: "Load more runs",
       runStatusOk: "OK",
       runStatusError: "Error",

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -37,6 +37,11 @@ type CronRunsSectionProps = {
   runsDeliveryStatuses: CronDeliveryStatus[];
   runsQuery: string;
   runsSortDir: CronSortDir;
+  conditionActivity?: {
+    checkCount: number;
+    lastCheckedAtMs?: number;
+    lastFiredAtMs?: number;
+  };
   onLoadMoreRuns: () => void;
   onRunsFiltersChange: (patch: {
     cronRunsStatuses?: CronRunsStatusValue[];
@@ -46,6 +51,49 @@ type CronRunsSectionProps = {
   }) => void | Promise<void>;
   onNavigateToChat?: (sessionKey: string) => void;
 };
+
+function renderConditionMetric(label: string, value: string) {
+  return html`
+    <div class="cron-condition-activity__metric">
+      <dt>${label}</dt>
+      <dd>${value}</dd>
+    </div>
+  `;
+}
+
+function renderConditionActivity(activity: NonNullable<CronRunsSectionProps["conditionActivity"]>) {
+  const lastChecked = formatRelativeTimestamp(activity.lastCheckedAtMs, {
+    fallback: t("cron.runs.notChecked"),
+  });
+  const lastFired = formatRelativeTimestamp(activity.lastFiredAtMs, {
+    fallback: t("cron.runs.neverFired"),
+  });
+  return html`
+    <div class="cron-condition-activity" data-test-id="cron-condition-activity">
+      <div class="cron-condition-activity__intro">
+        <div class="settings-row__title">
+          <span class="cron-condition-activity__icon" aria-hidden="true">${icon("gitBranch")}</span>
+          ${t("cron.runs.conditionActivity")}
+        </div>
+        <div class="settings-row__desc">${t("cron.runs.conditionActivityHint")}</div>
+      </div>
+      <dl class="cron-condition-activity__metrics">
+        ${renderConditionMetric(t("cron.runs.checks"), String(activity.checkCount))}
+        ${renderConditionMetric(t("cron.runs.lastChecked"), lastChecked)}
+        ${renderConditionMetric(t("cron.runs.lastFired"), lastFired)}
+      </dl>
+    </div>
+  `;
+}
+
+function conditionEmptyHint(activity: NonNullable<CronRunsSectionProps["conditionActivity"]>) {
+  if (activity.checkCount === 0) {
+    return t("cron.runs.emptyConditionUnchecked");
+  }
+  const key =
+    activity.checkCount === 1 ? "cron.runs.emptyConditionHintOne" : "cron.runs.emptyConditionHint";
+  return t(key, { count: String(activity.checkCount) });
+}
 
 function getRunStatusOptions(): Array<{ value: CronRunsStatusValue; label: string }> {
   return [
@@ -179,6 +227,7 @@ export function renderRunsSection(props: CronRunsSectionProps) {
   // selected attributes preserve non-first values.
   return html`
     <div class="cron-runs">
+      ${props.conditionActivity ? renderConditionActivity(props.conditionActivity) : nothing}
       <div class="cron-run-filters">
         <div class="cron-search-box cron-run-filter-search">
           <span class="cron-search-box__icon" aria-hidden="true">${icon("search")}</span>
@@ -247,8 +296,16 @@ export function renderRunsSection(props: CronRunsSectionProps) {
           ? html`<div class="muted cron-runs__empty">${t("cron.runs.noMatching")}</div>`
           : html`
               <div class="cron-empty-state">
-                <div class="cron-empty-state__title">${t("cron.runs.emptyTitle")}</div>
-                <div class="cron-empty-state__copy">${t("cron.runs.emptyHint")}</div>
+                <div class="cron-empty-state__title">
+                  ${props.conditionActivity
+                    ? t("cron.runs.emptyConditionTitle")
+                    : t("cron.runs.emptyTitle")}
+                </div>
+                <div class="cron-empty-state__copy">
+                  ${props.conditionActivity
+                    ? conditionEmptyHint(props.conditionActivity)
+                    : t("cron.runs.emptyHint")}
+                </div>
               </div>
             `
         : html`

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -963,6 +963,13 @@ function renderDetailView(props: CronProps, mode: CronPanelMode) {
   const selectedJob = mode === "job" ? (props.editingJob ?? undefined) : undefined;
   const hasDetailTabs = mode === "job" && Boolean(selectedJob);
   const showHistory = mode === "job" && props.detailTab === "history";
+  const conditionActivity = selectedJob?.trigger
+    ? {
+        checkCount: selectedJob.state?.triggerEvalCount ?? 0,
+        lastCheckedAtMs: selectedJob.state?.lastTriggerEvalAtMs,
+        lastFiredAtMs: selectedJob.state?.lastTriggerFireAtMs,
+      }
+    : undefined;
   const children = [
     html`
       <div class="cron-back-row">
@@ -991,7 +998,9 @@ function renderDetailView(props: CronProps, mode: CronPanelMode) {
         ${showHistory
           ? renderSettingsSection(
               { title: t("cron.detail.historyTitle") },
-              html`<div class="cron-history">${renderRunsSection(props)}</div>`,
+              html`<div class="cron-history">
+                ${renderRunsSection({ ...props, conditionActivity })}
+              </div>`,
             )
           : renderEditor(props, mode)}
       </div>

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -859,6 +859,62 @@
   gap: var(--space-3);
 }
 
+.cron-condition-activity {
+  display: grid;
+  grid-template-columns: minmax(190px, 1.4fr) minmax(390px, 2fr);
+  align-items: center;
+  gap: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+
+.cron-condition-activity__intro {
+  min-width: 0;
+}
+
+.cron-condition-activity__intro .settings-row__title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.cron-condition-activity__icon {
+  display: inline-flex;
+  color: var(--accent-2);
+}
+
+.cron-condition-activity__icon svg {
+  width: 13px;
+  height: 13px;
+  stroke: currentColor;
+  fill: none;
+}
+
+.cron-condition-activity__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  min-width: 0;
+  margin: 0;
+}
+
+.cron-condition-activity__metric {
+  min-width: 0;
+  padding-left: var(--space-4);
+  border-left: 1px solid var(--border);
+}
+
+.cron-condition-activity__metric dt {
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+}
+
+.cron-condition-activity__metric dd {
+  margin: 2px 0 0;
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .cron-run-filters {
   display: flex;
   align-items: center;
@@ -868,6 +924,17 @@
 
 .cron-run-filter-search {
   flex: 1 1 220px;
+}
+
+@media (max-width: 768px) {
+  .cron-condition-activity {
+    grid-template-columns: 1fr;
+  }
+
+  .cron-condition-activity__metric:first-child {
+    padding-left: 0;
+    border-left: 0;
+  }
 }
 
 /* Match the .btn--sm dropdown triggers beside it instead of the native look. */


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Conditional automations can be evaluated repeatedly without firing their payload. The job-level Run history previously showed only “No runs yet,” so operators could not tell whether the condition was being checked or the automation had never been evaluated.

## Why This Change Was Made

Show the existing trigger evaluation count, last-check time, and last-fire time above job-level Run history, and clarify that the empty history refers to payload runs. Global Run history and backend persistence remain unchanged.

## User Impact

Operators can distinguish a condition that has been checked without matching from a payload that has run, without turning every non-match into a noisy run-history entry.

AI-assisted: yes. The implementation and evidence were reviewed by the author.

## Evidence

- Pre-fix browser regression failed waiting for the missing condition-activity surface.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cron-trigger-filter.e2e.test.ts`
- `node scripts/run-vitest.mjs ui/src/pages/cron/view-run-history.test.ts`
- `node scripts/check-changed.mjs -- ui/src/e2e/cron-trigger-filter.e2e.test.ts ui/src/i18n/locales/en.ts ui/src/pages/cron/view-runs.ts ui/src/pages/cron/view.ts ui/src/styles/cron.css`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- Mocked Gateway browser proof inspected at 1440×960 and 720×1000.

### Before

![Conditional automation Run history before](https://github.com/user-attachments/assets/d3fde7e2-f2e7-4910-bb3e-6679bda27077)

### After

![Conditional automation Run history after](https://github.com/user-attachments/assets/be25aa96-d03d-49e6-9fb6-da2122e41d59)

### Narrow viewport

![Conditional automation Run history at 720 pixels](https://github.com/user-attachments/assets/063091ae-92ec-482d-a8c6-fcccb2491b22)
