### PR TITLE
fix(test): gateway publication suite fails Windows teardown with EBUSY

### DIFF
--- a/src/gateway/github-publication.test-support.ts
+++ b/src/gateway/github-publication.test-support.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, beforeEach, vi } from "vitest";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
   type OpenClawStateDatabase,
@@ -349,6 +350,9 @@ export function installGitHubPublicationTestHarness(): void {
   });
 
   afterEach(async () => {
+    // Agent close releases leases through shared state; closing shared state first can
+    // reopen it during teardown and leave a Windows handle under the fixture root.
+    closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     vi.unstubAllEnvs();
     await fs.rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## What Problem This Solves

Contributors on Windows cannot run `src/gateway/github-publication.test.ts` to green: one case
fails in teardown with `EBUSY`, never in an assertion. The shared harness removes its temporary
state directory while a per-agent SQLite handle opened underneath it is still cached. On Linux
unlinking an open file succeeds, so CI never sees it.

```
Error: EBUSY: resource busy or locked, unlink
  'C:\...\Temp\openclaw-publication-FOQReU\agents\main\agent\openclaw-agent.sqlite'
```

The failing case is `projects an accepted worker publication exactly once across
transcript-report restart`. It fails three times per run because `vitest.gateway.config.ts`
runs the file under each of `gateway-core`, `gateway-client`, and `gateway-server`.

## Why This Change Was Made

`installGitHubPublicationTestHarness()` closes the shared state database and then removes the
fixture root, but the transcript-report path opens a per-agent database under that root and
`closeOpenClawStateDatabaseForTest()` does not release it.

Adding `closeOpenClawAgentDatabasesForTest()` *after* the shared-state close does not fix it —
it only moves the lock to `state\openclaw.sqlite-wal`. The agent close releases leases *through*
shared state, so closing shared state first lets the agent close reopen it, leaving a fresh
handle that nothing closes. This is the ordering the zalo and zalouser fixtures already document
and use, at `extensions/zalouser/src/ingress.test-support.ts:79-86`:

> Agent close releases leases through shared state; closing shared state first can reopen it
> during teardown and leave Windows handles under the state dir.

The neighbouring file in this same directory already teardowns in the correct order —
`src/gateway/github-publication-transcript.test.ts:13-16` — and it covers the same transcript
reporter that the failing case restarts. One of the two files covering this feature got the
ordering; the harness did not.

Tests only; no production file is touched.

## User Impact

Contributors on Windows can run the gateway GitHub publication suites to completion instead of
reading a teardown failure that has nothing to do with the code under test. Behavior on Linux
and macOS is unchanged, and no `fs.rm` retry budget is added, so nothing is masked by retries.

## Evidence

Windows 11, Node v24.18.1, both arms on the same tree — `origin/main` `9050d9b0a79` and that
tree with only this one file patched.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts \
  --configLoader runner src/gateway/github-publication.test.ts
```

| arm | result |
|---|---|
| `origin/main` `9050d9b0a79` | 3 failed / 60 passed (63) — `EBUSY ... unlink ...\agents\main\agent\openclaw-agent.sqlite` |
| this branch | **63 passed (63)** |

@MohammedAlkindi, who reported this file, independently reproduced both arms on a second
Windows host with the same command - 3 failed / 60 passed (63) on base blob `079cf082ba8a1`,
63 passed (63) with the ordering applied - on Node v24.18.0 rather than v24.18.1, so the two
runs are independent on the runtime as well:
https://github.com/openclaw/openclaw/pull/127201#issuecomment-5374724471

The ordering is the whole fix. Measured separately at `587c7524e58`, with the two calls in the
reverse order the run stays red and the lock simply moves:

| teardown order | result |
|---|---|
| state close -> `rm` (as shipped) | 3 failed, lock on `agents\main\agent\openclaw-agent.sqlite` |
| state close -> agent close -> `rm` | 3 failed, lock on `state\openclaw.sqlite-wal` |
| **agent close -> state close -> `rm`** | **63 passed** |
| agent close -> state close -> `rm` with `maxRetries: 20, retryDelay: 25` | 63 passed |

The last two rows are the same result, so the retry budget is not load-bearing here and is
deliberately left out of this change.

Both files that import the patched harness, run together on this branch:

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts --configLoader runner \
  src/gateway/github-publication.test.ts src/gateway/github-publication-boundaries.test.ts
```
-> `6 passed (6)` files, `150 passed (150)` tests.

- `./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.core.test.gateway-root.json --noEmit` -> exit 0
- `./node_modules/.bin/oxlint src/gateway/github-publication.test-support.ts` -> exit 0
- `./node_modules/.bin/oxfmt --check src/gateway/github-publication.test-support.ts` -> exit 0

Out of scope, recorded so it is not attributed to this class: on the same base
`src/gateway/github-publication-git-index.test.ts` fails 24 cases on Windows with **zero**
`EBUSY` — every one is `fatal: unable to access '//./nul': Invalid argument` from
`core.hooksPath=${os.devNull}`. That is a different Windows defect and this branch does not
touch it.

## Relationship to the other repairs for #119796

This is disjoint from the other repairs for #119796 and can land in any order relative to them.

- #126352 is **merged** (2026-08-21). It repaired eight fixtures under `extensions/` for this
  same class, adding `closeOpenClawAgentDatabasesForTest()` before fixture removal in three of
  them (`alibaba`, `codex`, `openai`) and `resetPluginStateStoreForTests()` in the rest. None of
  those fixtures also close shared state, so the ordering question did not arise there; here it
  does, and the order used is the one the zalo and zalouser fixtures already document.
- #119964 is open and owns three files, all under `extensions/zalouser/`.
- This PR owns one file, `src/gateway/github-publication.test-support.ts`, and is the first
  instance of this class reported outside `extensions/`. It was surfaced by @MohammedAlkindi in
  https://github.com/openclaw/openclaw/issues/119796#issuecomment-5362989344; the ordering
  diagnosis and the measurements above are in the reply at
  https://github.com/openclaw/openclaw/issues/119796#issuecomment-5370372187, which the reporter
  confirmed in https://github.com/openclaw/openclaw/issues/119796#issuecomment-5374724201.

No `src/gateway` test appears in the hardcoded Windows CI file lists, so nothing upstream would
have surfaced this.

AI-assisted.

