### PR TITLE
fix(ui): expose active split pane to assistive tech

### DIFF
--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import type { ApplicationContext } from "../../app/context.ts";
 import { nativeGatewaysCapability } from "../../app/native-gateways.runtime.ts";
@@ -55,6 +55,7 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
       class="chat-split-view__cell ${options.splitMode && options.active
         ? "chat-split-view__cell--active"
         : ""} ${options.narrow && !options.active ? "chat-split-view__cell--narrow-hidden" : ""}"
+      aria-current=${options.splitMode && options.active ? "true" : nothing}
       style="flex: ${options.weight} 1 0"
       @pointerdown=${() => options.onFocusPane(options.pane.id)}
       @focusin=${() => options.onFocusPane(options.pane.id)}

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -654,9 +654,11 @@ describe("chat page split layout host", () => {
     await page.updateComplete;
 
     const panes = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
+    const cells = [...page.querySelectorAll<HTMLElement>(".chat-split-view__cell")];
     const dividers = page.querySelectorAll<RenderedDivider>("resizable-divider");
     expect(panes.map((pane) => pane.paneId)).toEqual(["p1", "p2"]);
     expect(panes.map((pane) => pane.active)).toEqual([false, true]);
+    expect(cells.map((cell) => cell.getAttribute("aria-current"))).toEqual([null, "true"]);
     expect(dividers).toHaveLength(1);
     expect(itemAt(dividers, 0, "split divider").orientation).toBe("vertical");
     expect(
@@ -666,6 +668,15 @@ describe("chat page split layout host", () => {
     ).toBe(true);
     expect(panes.every((pane) => pane.onOpenSplitView === undefined)).toBe(true);
     expect(panes[0]?.chatMessagesBySession).toBe(panes[1]?.chatMessagesBySession);
+
+    itemAt(cells, 0, "split cell").dispatchEvent(new Event("pointerdown"));
+    await page.updateComplete;
+
+    expect(
+      [...page.querySelectorAll<HTMLElement>(".chat-split-view__cell")].map((cell) =>
+        cell.getAttribute("aria-current"),
+      ),
+    ).toEqual(["true", null]);
   });
 
   it("declares split panes, session switches, pane closes, and page disposal", async () => {


### PR DESCRIPTION
Closes #127212.

## What Problem This Solves

Fixes an issue where screen-reader users of Control UI split view could not determine which pane was active and would receive interaction or output.

## Why This Change Was Made

Flagged by @gonzoblasco in #126714 (https://github.com/openclaw/openclaw/pull/126714#issuecomment-5370773440) — thanks.

In this PR, the existing split-pane owner exposes `aria-current="true"` on the active pane only, so the state follows the same pointer and focus activation path as the existing active class. This PR makes no visual change: it adds no CSS, and the accent bar was deliberately not added because #126714 removed that visual weight by design.

## User Impact

With this PR, assistive technology can identify the current split pane, and that semantic state moves when the operator activates another pane. Visual appearance and interaction behavior remain unchanged.

## Evidence

- Added owner-level DOM coverage asserting that `aria-current="true"` is present only on the active split pane and migrates after pointer activation.
- Source inspection confirms classic single-pane mode and inactive split panes omit the attribute.
- No CSS files changed.
- Tests and checks were not run in this publication phase; formal validation is deferred to Testbox closeout.
