### PR TITLE
feat: add one-off /followup command

### DIFF
--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -41,7 +41,9 @@ Same-turn steering is the default. A prompt that arrives mid-run is injected int
 - `collect`: do not steer. Coalesce queued messages into a **single** followup turn after the quiet window. If messages target different channels/threads, they drain individually to preserve routing.
 - `interrupt`: abort the active run for that session, then run the newest message.
 
-For runtime-specific timing and dependency behavior, see [Steering queue](/concepts/queue-steering). For the explicit `/steer <message>` command, see [Steer](/tools/steer).
+For runtime-specific timing and dependency behavior, see [Steering queue](/concepts/queue-steering).
+Use [`/steer <message>`](/tools/steer) for one explicit steer or
+[`/followup <message>`](/tools/followup) for one explicit later turn.
 
 Configure globally or per channel via `messages.queue`:
 
@@ -124,8 +126,10 @@ so lost local handles cannot leave a still-queued prompt running.
 embedded runtime. Local `steer` injects into an active embedded run when that
 runtime accepts steering and otherwise becomes a followup; `followup` and
 `collect` remain local pending work; `interrupt` aborts the active local run
-before starting the newest message. The explicit `/steer <message>` command is
-not a local-mode command.
+before starting the newest message. The explicit `/followup <message>` command
+queues only its payload without changing the stored mode, avoiding a temporary
+`/queue followup` switch followed by `/queue steer`. Explicit `/steer <message>`
+and `/followup <message>` are not local-mode commands.
 
 ## Scope and guarantees
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1453,6 +1453,7 @@
                   "tools/agent-send",
                   "tools/goal",
                   "tools/steer",
+                  "tools/followup",
                   "tools/subagents",
                   "tools/swarm",
                   "tools/acp-agents",

--- a/docs/tools/followup.md
+++ b/docs/tools/followup.md
@@ -1,0 +1,49 @@
+---
+summary: "Queue one later turn without changing the session queue mode"
+read_when:
+  - Using /followup while an agent is already running
+  - Comparing one-off followups with /queue followup
+title: "Followup"
+sidebarTitle: "Followup"
+---
+
+`/followup` queues one message for a separate agent turn after the current run
+ends. It does not change the session's stored `/queue` mode.
+
+## Current session
+
+Use top-level `/followup` when the current run should finish before OpenClaw
+starts a separate turn:
+
+```text
+/followup when you finish, explain why you chose that approach
+```
+
+Behavior:
+
+- Targets the current session.
+- Applies `followup` mode only to the supplied message.
+- Leaves the session's stored `/queue` mode unchanged.
+- Starts normally when the session is idle.
+
+This avoids changing the session to `/queue followup`, sending one message,
+and then changing it back to `/queue steer`.
+
+## Followup vs queue
+
+Use:
+
+- `/followup <message>` when one message should wait for a later turn.
+- `/queue followup` when future normal messages should all wait for later turns.
+- `/queue steer` when future normal messages should guide active runs by default.
+- `/steer <message>` when one message should guide the active run now.
+
+The explicit `/followup` command is Gateway-backed. In `openclaw chat` or
+`openclaw tui --local`, select `/queue followup`, send the message, and restore
+the preferred mode afterward.
+
+## Related
+
+- [Slash commands](/tools/slash-commands)
+- [Command queue](/concepts/queue)
+- [Steer](/tools/steer)

--- a/docs/tools/followup.md
+++ b/docs/tools/followup.md
@@ -38,6 +38,12 @@ Use:
 - `/queue steer` when future normal messages should guide active runs by default.
 - `/steer <message>` when one message should guide the active run now.
 
+If an installed skill already uses the name `followup`, that skill keeps the
+direct `/followup` command after upgrade. Use `/skill followup [input]` as its
+stable explicit form. In that workspace, use the session-level `/queue`
+sequence for queue followups; OpenClaw does not silently take the existing
+skill command away.
+
 The explicit `/followup` command is Gateway-backed. In `openclaw chat` or
 `openclaw tui --local`, select `/queue followup`, send the message, and restore
 the preferred mode afterward.

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -203,6 +203,7 @@ plugins.
     | `/models [provider] [page] [limit=<n>\|all]` | List configured/auth-available providers or models |
     | `/queue <mode>` | Manage active-run queue behavior. See [Queue](/concepts/queue) and [Queue steering](/concepts/queue-steering) |
     | `/steer <message>` | Inject guidance into the active run. Alias: `/tell`. See [Steer](/tools/steer) |
+    | `/followup <message>` | Queue one later turn without changing the session queue mode. See [Followup](/tools/followup) |
 
     <AccordionGroup>
       <Accordion title="verbose / trace / fast / reasoning safety">

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -121,6 +121,7 @@ Session controls:
 - `/activation <mention|always>`
 - `/queue <steer|followup|collect|interrupt> [debounce:<duration>] [cap:<n>] [drop:<summarize|old|new>]`
 - `/queue default` (or `/queue reset`) clears the session override
+- `/followup <message>` queues one later turn without changing the session queue mode
 
 Session lifecycle:
 
@@ -139,8 +140,8 @@ Local mode implements the same queue modes inside the embedded runtime. A
 mid-run prompt follows the session's `/queue` policy: `steer` injects when the
 runtime can accept it, `followup` waits for a separate turn, `collect` combines
 pending prompts, and `interrupt` stops the current run before starting the new
-one. Explicit `/steer <message>` is Gateway-only; use `/queue steer` plus a
-normal message in local mode.
+one. Explicit `/steer <message>` and `/followup <message>` are Gateway-only;
+select the matching `/queue` mode and send a normal message in local mode.
 
 OpenClaw:
 

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -477,6 +477,15 @@ export function buildBuiltinChatCommands(
         args: [defineCommandArgument("message", "Steering message", { captureRemaining: true })],
       },
     ),
+    defineBuiltinCommand(
+      "followup",
+      "Queue one message after the active run without changing queue mode.",
+      "management",
+      "standard",
+      {
+        args: [defineCommandArgument("message", "Followup message", { captureRemaining: true })],
+      },
+    ),
     defineBuiltinCommand("config", "Show or set config values.", "management", "power", {
       args: [
         defineCommandArgument("action", "show | get | set | unset", {

--- a/src/auto-reply/reply/commands-followup.test.ts
+++ b/src/auto-reply/reply/commands-followup.test.ts
@@ -1,0 +1,49 @@
+// Tests /followup message rewriting and its one-turn queue override.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { handleFollowupCommand } from "./commands-followup.js";
+import { buildCommandTestParams } from "./commands.test-harness.js";
+
+const baseCfg = {
+  commands: { text: true },
+  session: { mainKey: "main", scope: "per-sender" },
+} as OpenClawConfig;
+
+function buildParams(commandBody: string) {
+  return buildCommandTestParams(commandBody, baseCfg);
+}
+
+describe("handleFollowupCommand", () => {
+  it("queues only the supplied message without changing the stored session mode", async () => {
+    const params = buildParams("/followup explain the decision afterward");
+    params.sessionEntry = {
+      sessionId: "session-active",
+      updatedAt: Date.now(),
+      queueMode: "steer",
+    };
+
+    const result = await handleFollowupCommand(params, true);
+
+    expect(result).toEqual({ shouldContinue: true });
+    expect(params.ctx.BodyForAgent).toBe("explain the decision afterward");
+    expect(params.command.commandBodyNormalized).toBe("explain the decision afterward");
+    expect(params.directives).toMatchObject({
+      hasQueueDirective: true,
+      queueMode: "followup",
+      queueReset: false,
+    });
+    expect(params.sessionEntry.queueMode).toBe("steer");
+  });
+
+  it("returns usage when the message is missing", async () => {
+    const params = buildParams("/followup");
+
+    const result = await handleFollowupCommand(params, true);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "Usage: /followup <message>" },
+    });
+    expect(params.directives.hasQueueDirective).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/commands-followup.test.ts
+++ b/src/auto-reply/reply/commands-followup.test.ts
@@ -46,4 +46,21 @@ describe("handleFollowupCommand", () => {
     });
     expect(params.directives.hasQueueDirective).toBe(false);
   });
+
+  it("leaves an existing followup skill in control of the direct command", async () => {
+    const params = buildParams("/followup skill input");
+    params.loadSkillCommands = async () => [
+      {
+        name: "followup_2",
+        skillName: "followup",
+        description: "Existing followup skill",
+      },
+    ];
+
+    const result = await handleFollowupCommand(params, true);
+
+    expect(result).toBeNull();
+    expect(params.command.commandBodyNormalized).toBe("/followup skill input");
+    expect(params.directives.hasQueueDirective).toBe(false);
+  });
 });

--- a/src/auto-reply/reply/commands-followup.ts
+++ b/src/auto-reply/reply/commands-followup.ts
@@ -1,0 +1,29 @@
+// Implements a one-message followup queue override without changing session settings.
+import { applyCommandTextToParams } from "./command-context-rewrite.js";
+import { commandReply, defineAuthorizedTextCommand } from "./command-gates.js";
+import type { CommandHandler } from "./commands-types.js";
+
+const FOLLOWUP_USAGE = "Usage: /followup <message>";
+
+function parseFollowupMessage(raw: string): string | null {
+  const match = raw.trim().match(/^\/followup(?:\s+([\s\S]*))?$/i);
+  if (!match) {
+    return null;
+  }
+  return (match[1] ?? "").trim();
+}
+
+export const handleFollowupCommand: CommandHandler = defineAuthorizedTextCommand(
+  { label: "/followup", match: parseFollowupMessage },
+  (params, message) => {
+    if (!message) {
+      return commandReply(FOLLOWUP_USAGE);
+    }
+
+    applyCommandTextToParams(params, message);
+    params.directives.hasQueueDirective = true;
+    params.directives.queueReset = false;
+    params.directives.queueMode = "followup";
+    return { shouldContinue: true };
+  },
+);

--- a/src/auto-reply/reply/commands-followup.ts
+++ b/src/auto-reply/reply/commands-followup.ts
@@ -1,4 +1,5 @@
 // Implements a one-message followup queue override without changing session settings.
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { applyCommandTextToParams } from "./command-context-rewrite.js";
 import { commandReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
@@ -15,9 +16,17 @@ function parseFollowupMessage(raw: string): string | null {
 
 export const handleFollowupCommand: CommandHandler = defineAuthorizedTextCommand(
   { label: "/followup", match: parseFollowupMessage },
-  (params, message) => {
+  async (params, message) => {
     if (!message) {
       return commandReply(FOLLOWUP_USAGE);
+    }
+
+    const skillCommands = params.skillCommands ?? (await params.loadSkillCommands?.()) ?? [];
+    const hasExistingFollowupSkill = skillCommands.some(
+      (command) => normalizeOptionalLowercaseString(command.skillName) === "followup",
+    );
+    if (hasExistingFollowupSkill) {
+      return null;
     }
 
     applyCommandTextToParams(params, message);

--- a/src/auto-reply/reply/commands-handlers.order.ts
+++ b/src/auto-reply/reply/commands-handlers.order.ts
@@ -27,6 +27,7 @@ export const commandHandlerOrder = [
   "diagnostics",
   "tasks",
   "steer",
+  "followup",
   "allowlist",
   "approve",
   "context",

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -9,6 +9,7 @@ import { handleConfigCommand, handleDebugCommand } from "./commands-config.js";
 import { handleContextCommand } from "./commands-context-command.js";
 import { handleDiagnosticsCommand } from "./commands-diagnostics.js";
 import { handleDockCommand } from "./commands-dock.js";
+import { handleFollowupCommand } from "./commands-followup.js";
 import { handleGoalCommand } from "./commands-goal.js";
 import { commandHandlerOrder, type CommandHandlerId } from "./commands-handlers.order.js";
 import {
@@ -66,6 +67,7 @@ const commandHandlersById = {
   fast: handleFastCommand,
   goal: handleGoalCommand,
   help: handleHelpCommand,
+  followup: handleFollowupCommand,
   learn: handleLearnCommand,
   loop: handleLoopCommand,
   login: handleLoginCommand,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -143,7 +143,9 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
   opts?: GetReplyOptions;
   skillFilter?: string[];
 }): Promise<
-  { handled: true; reply: ReplyPayload | ReplyPayload[] | undefined } | { handled: false }
+  | { handled: true; reply: ReplyPayload | ReplyPayload[] | undefined }
+  | { handled: false }
+  | { handled: false; queueModeOverride: "followup" }
 > {
   if (!shouldRunNativeSlashCommandFastPath(params.ctx)) {
     return { handled: false };
@@ -345,6 +347,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     command.isAuthorizedSender &&
     (command.commandBodyNormalized === "/compact" ||
       command.commandBodyNormalized.startsWith("/compact "));
+  const commandDirectives = clearInlineDirectives(sessionState.triggerBodyNormalized);
   const commandResult = compactNeedsModelSelection
     ? { shouldContinue: true, reply: undefined }
     : await (
@@ -356,7 +359,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
         command,
         agentId: params.agentId,
         agentDir: params.agentDir,
-        directives: clearInlineDirectives(sessionState.triggerBodyNormalized),
+        directives: commandDirectives,
         elevated: {
           enabled: false,
           allowed: false,
@@ -496,6 +499,9 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
       handled: true,
       reply: markCommandReplyForDelivery(inlineActionResult.reply),
     };
+  }
+  if (commandDirectives.hasQueueDirective && commandDirectives.queueMode === "followup") {
+    return { handled: false, queueModeOverride: "followup" };
   }
   return { handled: false };
 }

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -15,6 +15,7 @@ import {
 import { listSessionStateEventsSince } from "../../sessions/session-state-events.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
+import { handleFollowupCommand } from "./commands-followup.js";
 import { handleGoalCommand } from "./commands-goal.js";
 import { buildFastReplyCommandContext, initFastReplySessionState } from "./get-reply-fast-path.js";
 import {
@@ -173,11 +174,15 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     mocks.ensureAgentWorkspace.mockReset();
     mocks.handleCommands.mockReset();
     mocks.handleCommands.mockImplementation(async (params: unknown) => {
-      const result = await handleGoalCommand(
+      const goalResult = await handleGoalCommand(
         params as Parameters<typeof handleGoalCommand>[0],
         true,
       );
-      return result ?? { shouldContinue: true, reply: undefined };
+      const followupResult = await handleFollowupCommand(
+        params as Parameters<typeof handleFollowupCommand>[0],
+        true,
+      );
+      return goalResult ?? followupResult ?? { shouldContinue: true, reply: undefined };
     });
     mocks.handleInlineActions.mockReset();
     mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
@@ -756,6 +761,76 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(preparedReplyParams.command.commandBodyNormalized).toBe(continuationPrompt);
     expect(preparedReplyParams.sessionCtx.BodyForAgent).toBe(continuationPrompt);
     expect(mocks.handleInlineActions).toHaveBeenCalledTimes(2);
+  });
+
+  it("carries a native /followup override through ordinary queue admission", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-followup-fast-"));
+    const targetSessionKey = "agent:main:telegram:123";
+    const storePath = path.join(home, "sessions.json");
+    await seedFastPathSessionStore(storePath, {
+      [targetSessionKey]: {
+        sessionId: "native-followup-active",
+        updatedAt: Date.now(),
+        queueMode: "steer",
+      },
+    });
+    const cfg = markCompleteReplyConfig({
+      agents: {
+        defaults: {
+          model: "anthropic/claude-opus-4-6",
+          workspace: path.join(home, "workspace"),
+        },
+      },
+      session: { store: storePath },
+    } as OpenClawConfig);
+    const continueDirectives = async (params: unknown) =>
+      createGetReplyContinueDirectivesResult({
+        body: (params as { triggerBodyNormalized: string }).triggerBodyNormalized,
+        abortKey: targetSessionKey,
+        from: "telegram:user:42",
+        to: "telegram:123",
+        senderId: "telegram:user:42",
+        commandSource: (params as { triggerBodyNormalized: string }).triggerBodyNormalized,
+        senderIsOwner: true,
+        resetHookTriggered: false,
+      });
+    mocks.resolveReplyDirectives.mockImplementation(continueDirectives);
+    mocks.handleInlineActions.mockImplementation(async (params: unknown) => {
+      const input = params as {
+        cleanedBody: string;
+        directives: Record<string, unknown>;
+      };
+      return {
+        kind: "continue",
+        directives: input.directives,
+        abortedLastRun: false,
+        cleanedBody: input.cleanedBody,
+      };
+    });
+
+    await expect(
+      getReplyFromConfig(
+        buildGetReplyCtx({
+          Body: "/followup explain the decision afterward",
+          BodyForAgent: "/followup explain the decision afterward",
+          RawBody: "/followup explain the decision afterward",
+          CommandBody: "/followup explain the decision afterward",
+          CommandSource: "native",
+          CommandAuthorized: true,
+          SessionKey: "telegram:slash:123",
+          CommandTargetSessionKey: targetSessionKey,
+        }),
+        undefined,
+        cfg,
+      ),
+    ).resolves.toEqual({ text: "ok" });
+
+    const preparedReplyParams = requirePreparedReplyParams();
+    expect(preparedReplyParams.opts?.queueModeOverride).toBe("followup");
+    expect(preparedReplyParams.command.commandBodyNormalized).toBe(
+      "explain the decision afterward",
+    );
+    expect(readFastPathSessionEntry(storePath, targetSessionKey).queueMode).toBe("steer");
   });
 
   it("uses native command target session keys during fast bootstrap", () => {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -501,6 +501,10 @@ export async function getReplyFromConfig(
     logResolverTiming("completed", "native_slash_command_fast_path");
     return nativeSlashCommandFastReply.reply;
   }
+  const optsAfterNativeSlashFastPath =
+    "queueModeOverride" in nativeSlashCommandFastReply
+      ? { ...optsWithSkillFilter, queueModeOverride: nativeSlashCommandFastReply.queueModeOverride }
+      : optsWithSkillFilter;
 
   const workspace = await traceGetReplyPhase("reply.ensure_workspace", async () =>
     useFastTestBootstrap
@@ -670,8 +674,8 @@ export async function getReplyFromConfig(
   // Utility-model narration is turn-local decoration. Initialize the durable
   // session first, then keep it completely outside model-locked native runs.
   const optsWithSessionSkillOverrides = sessionEntry.toolOverrides?.skills
-    ? { ...optsWithSkillFilter, skillOverrides: sessionEntry.toolOverrides.skills }
-    : optsWithSkillFilter;
+    ? { ...optsAfterNativeSlashFastPath, skillOverrides: sessionEntry.toolOverrides.skills }
+    : optsAfterNativeSlashFastPath;
   const resolvedOpts = attachProgressNarratorToReplyOptions({
     cfg,
     agentId,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1015,11 +1015,12 @@ export async function getReplyFromConfig(
     contextTokens,
     inlineStatusRequested,
     directiveAck,
-    perMessageQueueMode,
+    perMessageQueueMode: parsedPerMessageQueueMode,
     perMessageQueueOptions,
   } = directiveResult.result;
   let { directives, cleanedBody, resolvedThinkLevel, resolvedReasoningLevel } =
     directiveResult.result;
+  let perMessageQueueMode = parsedPerMessageQueueMode;
   provider = resolvedProvider;
   model = resolvedModel;
 
@@ -1110,6 +1111,9 @@ export async function getReplyFromConfig(
   }
   await maybeEmitMissingResetHooks();
   directives = inlineActionResult.directives;
+  if (directives.hasQueueDirective && !directives.queueReset) {
+    perMessageQueueMode = directives.queueMode;
+  }
   cleanedBody = inlineActionResult.cleanedBody;
   const explicitSkillSelections = inlineActionResult.explicitSkillSelections;
   abortedLastRun = inlineActionResult.abortedLastRun ?? abortedLastRun;

--- a/src/skills/discovery/chat-command-invocation.ts
+++ b/src/skills/discovery/chat-command-invocation.ts
@@ -152,6 +152,13 @@ export function resolveSkillCommandInvocation(params: {
   const command = params.skillCommands.find(
     (entry) => normalizeOptionalLowercaseString(entry.name) === commandName,
   );
+  if (!command && commandName === "followup") {
+    const existingFollowupSkill = findSkillCommand(params.skillCommands, commandName);
+    if (existingFollowupSkill) {
+      const args = match[2]?.trim();
+      return { command: existingFollowupSkill, args: args || undefined };
+    }
+  }
   if (!command) {
     return null;
   }

--- a/src/skills/discovery/chat-commands.test.ts
+++ b/src/skills/discovery/chat-commands.test.ts
@@ -236,6 +236,17 @@ describe("resolveSkillCommandInvocation", () => {
     });
     expect(invocation).toBeNull();
   });
+
+  it("keeps a colliding followup skill reachable by its original direct command", () => {
+    const invocation = resolveSkillCommandInvocation({
+      commandBodyNormalized: "/followup existing behavior",
+      skillCommands: [{ name: "followup_2", skillName: "followup", description: "Existing skill" }],
+    });
+
+    expect(invocation?.command.name).toBe("followup_2");
+    expect(invocation?.command.skillName).toBe("followup");
+    expect(invocation?.args).toBe("existing behavior");
+  });
 });
 
 describe("resolveSkillReferenceInvocations", () => {


### PR DESCRIPTION
Closes #127208

## What Problem This Solves

OpenClaw exposes a one-off `/steer <message>` command, but sending one message as a followup currently requires changing the session queue mode, sending the message, and changing the mode back. That workflow is clunky and can accidentally leave later messages in `followup` mode.

## Why This Change Was Made

This adds an authorized `/followup <message>` command that mirrors `/steer` at the command layer. It rewrites the current command payload and applies `queueMode: "followup"` only to that message. It does not update the session entry, so a stored default such as `steer` remains unchanged.

The command is registered in the built-in command registry and runtime handler order. Both ordinary text-command handling and the native slash-command fast path propagate the one-message override into queue admission. An ingress-to-admission regression test covers the native path.

For upgrade compatibility, an installed skill whose canonical name is already `followup` keeps ownership of direct `/followup`; the built-in handler defers and skill resolution maps the original name to the existing skill even if its generated registry name was deduplicated. `/skill followup [input]` remains the stable explicit form. This behavior is documented and covered by focused tests.

## User Impact

Users without a colliding skill can send:

```text
/followup when you finish, explain why you chose that approach
```

The message waits for a separate turn after the active run, while subsequent normal messages continue using the session's existing queue mode. This removes the `/queue followup` → send message → `/queue steer` sequence for one-off followups.

Existing skills named `followup` retain their direct command behavior after upgrade instead of being silently displaced.

## Evidence

- `pnpm test src/auto-reply/reply/commands-followup.test.ts src/auto-reply/reply/commands-steer.test.ts src/auto-reply/reply/get-reply.fast-path.test.ts src/auto-reply/commands-registry.test.ts src/skills/discovery/chat-commands.test.ts` — 110 focused tests passed on latest rebased SHA `2d2fe71d`, including native ingress-to-admission propagation, unchanged stored `steer` mode, and skill-name collision behavior.
- `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.commands.json --builders 1` — passed after rebase.
- `pnpm build` — passed after rebase; all build phases, plugin SDK export checks, CLI bootstrap checks, runtime post-build validation, and Control UI performance guard completed successfully.
- Repository `autoreview --mode branch --base origin/main` — clean; TruffleHog clean, no accepted/actionable findings, overall patch correct with 0.99 confidence.
- Earlier `pnpm check:changed` run — formatting, repository policy checks, dead-code checks, and core typechecking passed. The broad core-test shard runner was stopped after an extended silent wait; the directly relevant command graph was run separately and passed.
- Live channel proof has been requested through the repository's suggested Mantis Telegram workflow after the native-path repair.

This contribution was developed with AI assistance (OpenAI Codex). The implementation, tests, documentation, diff, and validation results were reviewed before submission and again after addressing ClawSweeper feedback.
