### PR TITLE
fix: messages sent while the agent is busy are silently discarded after 5 minutes

### DIFF
--- a/extensions/feishu/src/bot-broadcast.ts
+++ b/extensions/feishu/src/bot-broadcast.ts
@@ -40,12 +40,12 @@ export function createFeishuBroadcastIngressSettlement(params: {
     finalizing = true;
     params.lifecycle?.onAdoptionFinalizing();
   };
-  const defer = () => {
+  const defer = (isOwnerLive?: () => boolean) => {
     if (deferred) {
       return;
     }
     deferred = true;
-    params.lifecycle?.onDeferred();
+    params.lifecycle?.onDeferred(isOwnerLive);
   };
   const reportReplayCommitError = (error: unknown) => {
     try {
@@ -175,12 +175,12 @@ export function createFeishuBroadcastIngressSettlement(params: {
             lane.status = "completed";
             await maybeSettle();
           },
-          onDeferred: () => {
+          onDeferred: (isOwnerLive) => {
             if (lane.status !== "pending") {
               return;
             }
             lane.status = "deferred";
-            defer();
+            defer(isOwnerLive);
           },
           onAdoptionFinalizing: beginFinalizing,
           onAbandoned: async () => {

--- a/extensions/feishu/src/feishu-ingress.ts
+++ b/extensions/feishu/src/feishu-ingress.ts
@@ -312,9 +312,9 @@ export function buildFeishuFlushIngressLifecycle(
         handedOff = true;
         await adoptAll();
       },
-      onDeferred: () => {
+      onDeferred: (isOwnerLive) => {
         handedOff = true;
-        transportLifecycle.onDeferred();
+        transportLifecycle.onDeferred(isOwnerLive);
       },
       onAdoptionFinalizing: () => {
         transportLifecycle.onAdoptionFinalizing();

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -490,9 +490,9 @@ export async function handleIrcInbound(params: {
           ingressState.handoff = "adopted";
           await turnAdoptionLifecycle.onAdopted();
         },
-        onDeferred: () => {
+        onDeferred: (isOwnerLive?: () => boolean) => {
           ingressState.handoff = "deferred";
-          turnAdoptionLifecycle.onDeferred();
+          turnAdoptionLifecycle.onDeferred(isOwnerLive);
         },
         onAbandoned: async () => {
           ingressState.handoff = "abandoned";

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -216,7 +216,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
             handedOff = true;
             await boundLifecycle.onAdopted();
           },
-          onDeferred: () => {
+          onDeferred: (isOwnerLive) => {
             handedOff = true;
             if (!acceptsDeferredClaims) {
               void Promise.resolve()
@@ -230,7 +230,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
                 });
               return;
             }
-            boundLifecycle.onDeferred();
+            boundLifecycle.onDeferred(isOwnerLive);
           },
           onAbandoned: async () => {
             handedOff = true;

--- a/extensions/mattermost/src/mattermost/monitor-ingress.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.ts
@@ -22,7 +22,7 @@ const MATTERMOST_INGRESS_POLL_INTERVAL_MS = 1_000;
 export type MattermostIngressLifecycle = {
   abortSignal: AbortSignal;
   onAdopted: () => void | Promise<void>;
-  onDeferred: () => void;
+  onDeferred: (isOwnerLive?: () => boolean) => void;
   onAdoptionFinalizing: () => void;
   onAbandoned: () => void | Promise<void>;
 };

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -348,9 +348,9 @@ export function createSlackMessageHandler(params: {
                     await turnAdoptionLifecycle?.onAdopted();
                     await admissionLifecycle.onAdopted();
                   },
-                  onDeferred: () => {
-                    turnAdoptionLifecycle?.onDeferred();
-                    const admissionAccepted = admissionLifecycle.onDeferred();
+                  onDeferred: (isOwnerLive) => {
+                    turnAdoptionLifecycle?.onDeferred(isOwnerLive);
+                    const admissionAccepted = admissionLifecycle.onDeferred(isOwnerLive);
                     if (admissionAccepted === false) {
                       return false;
                     }

--- a/extensions/sms/src/inbound.ts
+++ b/extensions/sms/src/inbound.ts
@@ -160,8 +160,8 @@ export async function dispatchSmsInboundEvent(params: {
                 throw error;
               }
             },
-            onDeferred: () => {
-              const deferred = params.turnAdoptionLifecycle?.onDeferred?.();
+            onDeferred: (isOwnerLive?: () => boolean) => {
+              const deferred = params.turnAdoptionLifecycle?.onDeferred?.(isOwnerLive);
               if (deferred !== false) {
                 adoptionState = "deferred";
               }

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -45,7 +45,7 @@ export type DispatchTelegramMessageParams = {
   turnAdoptionLifecycle?: {
     admission?: "exclusive" | "cancel-only";
     onAdopted: () => void | Promise<void>;
-    onDeferred?: () => void;
+    onDeferred?: (isOwnerLive?: () => boolean) => void;
     onAbandoned?: () => void;
     abortSignal?: AbortSignal;
   };

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -270,7 +270,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       turnAdoptionLifecycle?: {
         admission?: "exclusive" | "cancel-only";
         onAdopted: () => void | Promise<void>;
-        onDeferred?: () => void;
+        onDeferred?: (isOwnerLive?: () => boolean) => void;
         onAbandoned?: () => void;
         abortSignal?: AbortSignal;
       };
@@ -427,9 +427,9 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               }
               await drainLifecycle?.onAdopted();
             },
-            onDeferred: () => {
+            onDeferred: (isOwnerLive) => {
               deferred = true;
-              drainLifecycle?.onDeferred();
+              drainLifecycle?.onDeferred(isOwnerLive);
             },
             onAbandoned: () => {
               if (!adopted) {

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -13,7 +13,7 @@ type TelegramUpdateProcessingFrame = {
 type TelegramSpooledReplayLifecycle = {
   abortSignal: AbortSignal;
   onAdopted: () => void | Promise<void>;
-  onDeferred: () => void;
+  onDeferred: (isOwnerLive?: () => boolean) => void;
   /** Clears pre-adoption stall while durable adoption finalization is held. */
   onAdoptionFinalizing?: () => void;
   onAbandoned: () => void | Promise<void>;

--- a/extensions/twitch/src/twitch-ingress.ts
+++ b/extensions/twitch/src/twitch-ingress.ts
@@ -134,9 +134,9 @@ export function createTwitchIngress(options: {
             handedOff = true;
             await lifecycle.onAdopted();
           },
-          onDeferred: () => {
+          onDeferred: (isOwnerLive) => {
             handedOff = true;
-            lifecycle.onDeferred();
+            lifecycle.onDeferred(isOwnerLive);
           },
           onAbandoned: async () => {
             handedOff = true;

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -68,8 +68,12 @@ export type TurnAdoptionLifecycle = {
   /** Transcript branch leaf from which this turn was admitted. */
   originatingLeafEntryId?: string | null;
   onAdopted: () => void | Promise<void>;
-  /** Return false to reject followup enqueue. */
-  onDeferred?: () => boolean | void;
+  /**
+   * Return false to reject followup enqueue. isOwnerLive, when supplied, proves
+   * the queue still holds this turn, so a durable ingress claim behind it is not
+   * dead-lettered while it waits.
+   */
+  onDeferred?: (isOwnerLive?: () => boolean) => boolean | void;
   /** Deferred turn finished without owning the reply lane. */
   onAbandoned?: () => void;
   /** Always fires when the followup ownership cycle ends (admitted or not). Gateway cleanup. */

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -55,7 +55,7 @@ type InboundDebounceFlush = {
 type InboundDebounceAdmissionLifecycleInput = {
   abortSignal?: AbortSignal;
   onAdopted?: () => void | Promise<void>;
-  onDeferred?: () => boolean | void;
+  onDeferred?: (isOwnerLive?: () => boolean) => boolean | void;
   onAdoptionFinalizing?: () => void;
   onFailed?: (error: unknown) => void | Promise<void>;
   onAbandoned?: () => void | Promise<void>;
@@ -65,7 +65,7 @@ type InboundDebounceAdmissionLifecycleInput = {
 type InboundDebounceAdmissionLifecycle = {
   abortSignal: AbortSignal;
   onAdopted: () => Promise<void>;
-  onDeferred: () => boolean | void;
+  onDeferred: (isOwnerLive?: () => boolean) => boolean | void;
   onAdoptionFinalizing: () => void;
   onFailed?: (error: unknown) => Promise<void>;
   onAbandoned: () => Promise<void>;
@@ -98,8 +98,8 @@ function createInboundDebounceFlush(params: {
       await source?.onAdopted?.();
       markAdmitted();
     },
-    onDeferred: () => {
-      const accepted = source?.onDeferred?.();
+    onDeferred: (isOwnerLive) => {
+      const accepted = source?.onDeferred?.(isOwnerLive);
       if (accepted !== false) {
         markAdmitted();
       }

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -159,7 +159,7 @@ export function enqueueFollowupRun(
     return false;
   }
   if (options.steerCandidate) {
-    if (!markFollowupRunEnqueued(run)) {
+    if (!markFollowupRunEnqueued(run, queue)) {
       return false;
     }
     const { promise: acceptance, resolve: settle } = createDeferredCore<boolean>();
@@ -180,7 +180,7 @@ export function enqueueFollowupRun(
   // deciding between same-turn delivery and fallback. Append it behind the
   // anchor; ordinary overflow policy resumes as soon as the gate resolves.
   if (queue.items.some((item) => item.steerPending)) {
-    if (!markFollowupRunEnqueued(run)) {
+    if (!markFollowupRunEnqueued(run, queue)) {
       return false;
     }
     appendQueueItem({
@@ -207,7 +207,7 @@ export function enqueueFollowupRun(
     completeFollowupRunLifecycle(run);
     return false;
   }
-  if (!markFollowupRunEnqueued(run)) {
+  if (!markFollowupRunEnqueued(run, queue)) {
     return false;
   }
 

--- a/src/auto-reply/reply/queue/state.test.ts
+++ b/src/auto-reply/reply/queue/state.test.ts
@@ -1,5 +1,6 @@
 // Tests queue state storage, dedupe, and cleanup primitives.
 import { afterEach, describe, expect, it } from "vitest";
+import type { TurnAdoptionLifecycle } from "../../get-reply-options.types.js";
 import { enqueueFollowupRun } from "./enqueue.js";
 import {
   clearFollowupQueue,
@@ -7,6 +8,7 @@ import {
   hasPendingFollowupQueueWork,
   refreshQueuedFollowupSession,
 } from "./state.js";
+import { markFollowupRunEnqueued } from "./types.js";
 import type { FollowupRun } from "./types.js";
 
 const QUEUE_KEY = "agent:main:dm:test";
@@ -309,5 +311,87 @@ describe("hasPendingFollowupQueueWork", () => {
     queue.evictedSummaryCount = 3;
 
     expect(hasPendingFollowupQueueWork([undefined, "", QUEUE_KEY])).toBe(false);
+  });
+});
+
+describe("durable ingress owner proof", () => {
+  function captureProbe(): { probe: () => boolean; lifecycle: TurnAdoptionLifecycle } {
+    let probe: (() => boolean) | undefined;
+    const lifecycle: TurnAdoptionLifecycle = {
+      onAdopted: () => {},
+      onDeferred: (isOwnerLive) => {
+        probe = isOwnerLive;
+      },
+    };
+    const queue = getFollowupQueue(QUEUE_KEY, { mode: "followup" });
+    const run: FollowupRun = {
+      prompt: "queued message",
+      enqueuedAt: Date.now(),
+      run: makeRun(),
+      turnAdoptionLifecycle: lifecycle,
+    };
+    markFollowupRunEnqueued(run, queue);
+    queue.items.push(run);
+    if (!probe) {
+      throw new Error("expected the queue to hand the drain an owner proof");
+    }
+    return { probe, lifecycle };
+  }
+
+  // Overflow moves a run out of items and can re-wrap it in a fresh object that
+  // keeps the same lifecycle, so every slot below has to answer true. A slot
+  // that answers false dead-letters a message the queue still owns.
+  const slots: Array<{
+    name: string;
+    move: (queue: ReturnType<typeof getFollowupQueue>, run: FollowupRun) => void;
+  }> = [
+    { name: "queued", move: () => {} },
+    {
+      name: "in flight",
+      move: (queue, run) => {
+        queue.items.length = 0;
+        queue.inFlight.add(run);
+      },
+    },
+    {
+      name: "summarized under overflow",
+      move: (queue, run) => {
+        queue.items.length = 0;
+        queue.summarySources.push({ ...run });
+      },
+    },
+    {
+      name: "elided from an overflow summary",
+      move: (queue, run) => {
+        queue.items.length = 0;
+        queue.summaryElisions.push({
+          contextKey: "ctx",
+          count: 1,
+          sources: [{ ...run }],
+          summaryLines: ["line"],
+          sourceRefs: new WeakMap(),
+        });
+      },
+    },
+  ];
+
+  for (const slot of slots) {
+    it(`reports the owner live while the turn is ${slot.name}`, () => {
+      const { probe } = captureProbe();
+      const queue = getFollowupQueue(QUEUE_KEY, { mode: "followup" });
+      const run = queue.items[0];
+      if (!run) {
+        throw new Error("expected the run to be queued");
+      }
+      slot.move(queue, run);
+      expect(probe()).toBe(true);
+    });
+  }
+
+  it("reports the owner gone once the queue drops the turn entirely", () => {
+    const { probe } = captureProbe();
+    const queue = getFollowupQueue(QUEUE_KEY, { mode: "followup" });
+    queue.items.length = 0;
+    expect(probe()).toBe(false);
   });
 });

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -265,10 +265,49 @@ const completedTurnAdoptionLifecycleCallbacks = new WeakSet<TurnAdoptionLifecycl
 
 type FollowupLifecycleRun = Pick<FollowupRun, "steerPending" | "turnAdoptionLifecycle">;
 
-export function markFollowupRunEnqueued(run: FollowupLifecycleRun): boolean {
+/**
+ * Every place this queue can hold a turn. Overflow summarization moves a run out
+ * of `items` into the summary structures and can re-wrap it in a fresh run object
+ * (see createOverflowSummaryRetrySource), so ownership is matched on the
+ * lifecycle rather than on run identity.
+ */
+type FollowupQueueOwnershipState = {
+  items: readonly FollowupLifecycleRun[];
+  inFlight: ReadonlySet<FollowupLifecycleRun>;
+  summarySources: readonly FollowupLifecycleRun[];
+  summaryElisions: readonly { sources: readonly FollowupLifecycleRun[] }[];
+};
+
+/**
+ * Proof of ownership for a durable source waiting behind this queue. The queue
+ * holds the turn while it is queued, in flight, summarized, or being admitted,
+ * and stops holding it the moment the lifecycle completes. A source whose owner
+ * reports false is genuinely gone and must be recovered, not waited on.
+ */
+function createFollowupQueueOwnershipProbe(
+  queue: FollowupQueueOwnershipState,
+  lifecycle: TurnAdoptionLifecycle,
+): () => boolean {
+  const held = (runs: readonly FollowupLifecycleRun[]) =>
+    runs.some((item) => item.turnAdoptionLifecycle === lifecycle);
+  return () =>
+    !completedTurnAdoptionLifecycles.has(lifecycle) &&
+    (held(queue.items) ||
+      held([...queue.inFlight]) ||
+      held(queue.summarySources) ||
+      queue.summaryElisions.some((elision) => held(elision.sources)) ||
+      admittingTurnAdoptionLifecycles.has(lifecycle) ||
+      admittedTurnAdoptionLifecycles.has(lifecycle));
+}
+
+export function markFollowupRunEnqueued(
+  run: FollowupLifecycleRun,
+  queue?: FollowupQueueOwnershipState,
+): boolean {
   const lifecycle = run.turnAdoptionLifecycle;
   if (lifecycle && !enqueuedTurnAdoptionLifecycles.has(lifecycle)) {
-    if (lifecycle.onDeferred?.() === false) {
+    const isOwnerLive = queue ? createFollowupQueueOwnershipProbe(queue, lifecycle) : undefined;
+    if (lifecycle.onDeferred?.(isOwnerLive) === false) {
       return false;
     }
     enqueuedTurnAdoptionLifecycles.add(lifecycle);

--- a/src/channels/message/ingress-drain-lifecycle.ts
+++ b/src/channels/message/ingress-drain-lifecycle.ts
@@ -9,9 +9,13 @@ export type ChannelIngressDispatchLifecycle = {
   onAdopted: () => void | Promise<void>;
   /**
    * Turn ownership deferred to reply-lane admission (queued followup).
-   * Claim remains held until adopted or abandoned.
+   * Claim remains held until adopted or abandoned. An owner that can prove it
+   * still holds the event passes isOwnerLive; the pre-adoption stall watchdog
+   * extends its deadline while that reports true instead of dead-lettering a
+   * claim that is merely queued. Owners that pass nothing keep the bounded
+   * pre-adoption behavior.
    */
-  onDeferred: () => void;
+  onDeferred: (isOwnerLive?: () => boolean) => void;
   /**
    * Durable adoption finalization is in progress (e.g. settlement hold while
    * committing dedupe). Clears the pre-adoption stall watchdog so a timeout
@@ -35,7 +39,7 @@ export function bindIngressLifecycleToReplyOptions(lifecycle: ChannelIngressDisp
   turnAdoptionLifecycle: {
     admission: "exclusive";
     onAdopted: () => void | Promise<void>;
-    onDeferred: () => void;
+    onDeferred: (isOwnerLive?: () => boolean) => void;
     onAbandoned: () => void | Promise<void>;
     abortSignal: AbortSignal;
   };

--- a/src/channels/message/ingress-drain-settle.ts
+++ b/src/channels/message/ingress-drain-settle.ts
@@ -1,0 +1,38 @@
+/** Single settle owner for one claimed event: complete / fail / release / guillotine. */
+import type { ActiveHandlerState } from "./ingress-drain-state.js";
+
+/**
+ * Builds the one function allowed to settle a claim. It runs at most one write,
+ * and only marks the claim settled once that write commits: a failed write must
+ * keep the heartbeat and in-memory ownership, because a wedged claim is better
+ * than a duplicated dispatch.
+ */
+export function createIngressSettleOwner<TPayload, TMetadata>(params: {
+  state: ActiveHandlerState<TPayload, TMetadata>;
+  removeActive: (state: ActiveHandlerState<TPayload, TMetadata>) => void;
+}): (fn: () => Promise<void>) => Promise<void> {
+  const { state, removeActive } = params;
+  let settlePromise: Promise<void> | undefined;
+  let settled = false;
+  return async (fn) => {
+    if (settled) {
+      return;
+    }
+    if (settlePromise) {
+      await settlePromise;
+      return;
+    }
+    settlePromise = (async () => {
+      await fn();
+      settled = true;
+      state.phase = "settled";
+      removeActive(state);
+    })();
+    try {
+      await settlePromise;
+    } catch (err) {
+      settlePromise = undefined;
+      throw err;
+    }
+  };
+}

--- a/src/channels/message/ingress-drain-state.ts
+++ b/src/channels/message/ingress-drain-state.ts
@@ -16,7 +16,7 @@ export function isIngressAdoptionLostError(error: unknown): error is IngressAdop
 
 export type ChannelIngressDrainDispatchResult =
   | { kind: "completed" }
-  | { kind: "deferred" }
+  | { kind: "deferred"; isOwnerLive?: () => boolean }
   | { kind: "failed-retryable"; error: unknown };
 
 export type ActiveHandlerState<TPayload, TMetadata> = {
@@ -34,6 +34,13 @@ export type ActiveHandlerState<TPayload, TMetadata> = {
   guillotined: boolean;
   /** Closed code: pre-adoption supersede has claimed settle ownership. */
   superseded: boolean;
+  /**
+   * Supplied at deferral by an owner that can prove it still holds this event.
+   * The stall watchdog extends its deadline while this reports true, so a claim
+   * queued behind a healthy long-running turn is not dead-lettered. Absent, the
+   * watchdog keeps its bounded pre-adoption behavior.
+   */
+  isOwnerLive?: () => boolean;
   /** Single settle owner for complete / fail / release / supersede / guillotine. */
   settleOnce: (fn: () => Promise<void>) => Promise<void>;
 };

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -21,6 +21,7 @@ import {
   registerLiveIngressDrainInstance,
 } from "./ingress-claim-owner.js";
 import type { ChannelIngressDispatchLifecycle } from "./ingress-drain-lifecycle.js";
+import { createIngressSettleOwner } from "./ingress-drain-settle.js";
 import {
   activeClaimKey,
   IngressAdoptionLostError,
@@ -358,41 +359,46 @@ export function createChannelIngressDrain<
     await releaseClaim(claim, { lastError: disposition.message });
   };
 
-  const createSettleOwner = (
-    state: ActiveHandlerState<TPayload, TMetadata>,
-  ): ((fn: () => Promise<void>) => Promise<void>) => {
-    let settlePromise: Promise<void> | undefined;
-    let settled = false;
-    return async (fn) => {
-      if (settled) {
-        return;
-      }
-      if (settlePromise) {
-        await settlePromise;
-        return;
-      }
-      settlePromise = (async () => {
-        // Only mark settled after the tombstone/fail/release write commits.
-        // Write failure must keep heartbeat + in-memory ownership (wedged > duplicated).
-        await fn();
-        settled = true;
-        state.phase = "settled";
-        removeActive(state);
-      })();
-      try {
-        await settlePromise;
-      } catch (err) {
-        settlePromise = undefined;
-        throw err;
-      }
-    };
+  /**
+   * The proof is supplied by whoever took ownership, so it is foreign code running
+   * inside a timer, and neither its return value nor its completion can be trusted.
+   * A throw must not escape: that would leave the claim neither held nor
+   * dead-lettered, which is worse than either branch. Only an exact `true` extends
+   * the deadline; anything else fails closed to the pre-existing guillotine.
+   */
+  const isDeferredOwnerLive = (state: ActiveHandlerState<TPayload, TMetadata>): boolean => {
+    if (!state.isOwnerLive) {
+      return false;
+    }
+    try {
+      // Deliberately unknown: a JavaScript caller can return a truthy non-boolean
+      // that the declared type forbids, and treating that as proof would hold the
+      // claim forever.
+      const live: unknown = state.isOwnerLive();
+      return live === true;
+    } catch (err) {
+      log(
+        `ingress drain: owner liveness check threw for event ${state.eventId}; treating the owner as gone: ${formatError(err)}`,
+      );
+      return false;
+    }
   };
 
   const armStallWatchdog = (state: ActiveHandlerState<TPayload, TMetadata>) => {
     clearStallTimer(state);
     state.stallTimer = setTimeout(() => {
-      // Pre-adoption only (dispatching OR deferred). Timer is not cleared by deferral.
+      // Pre-adoption only.
       if (state.phase !== "dispatching" && state.phase !== "deferred") {
+        return;
+      }
+      // Deferral declares ownership, not liveness, so it alone must not disarm the
+      // guillotine. An owner that can prove it still holds this event gets the
+      // deadline extended instead: waiting behind a healthy long-running turn is
+      // queued, not stalled, and dead-lettering it destroys an accepted user
+      // message. An owner that cannot prove it, or supplies no proof at all, keeps
+      // the original bounded behavior.
+      if (state.phase === "deferred" && isDeferredOwnerLive(state)) {
+        armStallWatchdog(state);
         return;
       }
       const ageMs = now() - state.startedAt;
@@ -465,12 +471,22 @@ export function createChannelIngressDrain<
           await completeClaimWithRetry(state.claim);
         });
       },
-      onDeferred: () => {
+      onDeferred: (isOwnerLive) => {
+        if (state.phase === "deferred") {
+          // Ownership can be declared before the owner can prove itself: a
+          // channel defers at dispatch, and only later does the reply queue
+          // learn it holds the turn and offer a probe. Accept the late proof
+          // instead of leaving the claim under the stall watchdog.
+          state.isOwnerLive ??= isOwnerLive;
+          return;
+        }
         if (state.phase !== "dispatching") {
           return;
         }
-        // Deferred holds the claim; watchdog remains armed until adoption or abandon.
+        // Deferred holds the claim. The watchdog keeps its original deadline and
+        // asks this probe at fire time whether the owner still holds the event.
         state.phase = "deferred";
+        state.isOwnerLive = isOwnerLive;
         if (deferredLaneOccupancy === "release") {
           if (laneOwnerByKey.get(state.laneKey) === state) {
             laneOwnerByKey.delete(state.laneKey);
@@ -546,7 +562,7 @@ export function createChannelIngressDrain<
       task: Promise.resolve(),
       settleOnce: async () => {},
     } as ActiveHandlerState<TPayload, TMetadata>;
-    state.settleOnce = createSettleOwner(state);
+    state.settleOnce = createIngressSettleOwner({ state, removeActive });
     const lifecycle = createLifecycle(state);
     armStallWatchdog(state);
     armClaimRefresh(state);
@@ -585,7 +601,7 @@ export function createChannelIngressDrain<
           return;
         }
         if (result?.kind === "deferred") {
-          lifecycle.onDeferred();
+          lifecycle.onDeferred(result.isOwnerLive);
           return;
         }
         if (result?.kind === "failed-retryable") {

--- a/src/channels/message/ingress-drain.watchdog.test.ts
+++ b/src/channels/message/ingress-drain.watchdog.test.ts
@@ -134,4 +134,146 @@ describe("channel ingress drain watchdog", () => {
       drain.dispose();
     });
   });
+  it("does not guillotine a deferred claim while its owner proves it still holds it", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 30_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-def-live", { text: "x" }, { laneKey: "l1" });
+
+      const ownerHoldsIt = true;
+      let adopt: (() => Promise<void>) | undefined;
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 5_000,
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          // Queued behind a healthy long-running turn: the reply lane still owns
+          // this event, so waiting is not stalling.
+          lifecycle.onDeferred(() => ownerHoldsIt);
+          adopt = async () => await lifecycle.onAdopted();
+          await new Promise(() => {});
+        },
+      });
+
+      await drain.drainOnce();
+      expect(await queue.listClaims()).toHaveLength(1);
+
+      // Ten stall timeouts later the claim is still there, because the owner is.
+      clock += 50_000;
+      await vi.advanceTimersByTimeAsync(50_000);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(await queue.listClaims()).toHaveLength(1);
+
+      await adopt?.();
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      drain.dispose();
+    });
+  });
+
+  it("guillotines a deferred claim once its owner stops holding it", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 40_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-def-lost", { text: "x" }, { laneKey: "l1" });
+
+      let ownerHoldsIt = true;
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 5_000,
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          lifecycle.onDeferred(() => ownerHoldsIt);
+          await new Promise(() => {});
+        },
+      });
+
+      await drain.drainOnce();
+      clock += 5_000;
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+
+      // The owner vanished without settling. Recovery must still happen: the
+      // claim and its lane cannot be held by nobody.
+      ownerHoldsIt = false;
+      clock += 5_000;
+      await vi.advanceTimersByTimeAsync(5_000);
+      await drain.waitForIdle();
+
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
+        { id: "evt-def-lost", reason: "handler-timeout" },
+      ]);
+      expect(drain.activeLaneKeys().has("l1")).toBe(false);
+      drain.dispose();
+    });
+  });
+  it("accepts owner proof that arrives after the claim already deferred", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 60_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-late-proof", { text: "x" }, { laneKey: "l1" });
+
+      // The channel defers at dispatch, before anything knows who will own the
+      // turn. The reply queue only learns it holds the turn afterwards, and
+      // offers its proof then. Dropping that late proof puts an owned message
+      // back under the guillotine.
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 5_000,
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          lifecycle.onDeferred();
+          lifecycle.onDeferred(() => true);
+          await new Promise(() => {});
+        },
+      });
+
+      await drain.drainOnce();
+      expect(await queue.listClaims()).toHaveLength(1);
+
+      clock += 50_000;
+      await vi.advanceTimersByTimeAsync(50_000);
+
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(await queue.listClaims()).toHaveLength(1);
+      drain.dispose();
+    });
+  });
+  it("guillotines a deferred claim when the owner proof throws", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 80_000;
+      const queue = createTestIngressQueue(stateDir, { now: () => clock });
+      await queue.enqueue("evt-def-throws", { text: "x" }, { laneKey: "l1" });
+
+      const logged: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => clock,
+        adoptionStallTimeoutMs: 5_000,
+        onLog: (message) => logged.push(message),
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          // Foreign code running inside the watchdog timer. A throw must not
+          // escape and leave the claim neither held nor dead-lettered.
+          lifecycle.onDeferred(() => {
+            throw new Error("owner probe exploded");
+          });
+          await new Promise(() => {});
+        },
+      });
+
+      await drain.drainOnce();
+      clock += 5_000;
+      await vi.advanceTimersByTimeAsync(5_000);
+      await drain.waitForIdle();
+
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
+        { id: "evt-def-throws", reason: "handler-timeout" },
+      ]);
+      expect(drain.activeLaneKeys().has("l1")).toBe(false);
+      expect(logged.some((line) => line.includes("owner liveness check threw"))).toBe(true);
+      drain.dispose();
+    });
+  });
 });

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -832,6 +832,33 @@ describe("channel ingress monitor", () => {
     });
   });
 
+  it("carries owner proof from a deferred delivery result to the stall watchdog", async () => {
+    vi.useFakeTimers();
+    try {
+      await withQueue(async (queue) => {
+        // Deferral reported through the delivery result rather than the
+        // lifecycle. The proof has to survive that translation, or a
+        // reply-queue-owned message lands back under the five-minute guillotine.
+        const monitor = createMonitor(queue, () => ({
+          kind: "deferred" as const,
+          isOwnerLive: () => true,
+        }));
+        monitor.start();
+        await monitor.admit({ id: "event-result-proof", lane: "a", text: "hello" });
+        await vi.waitFor(async () => expect(await queue.listClaims()).toHaveLength(1));
+
+        // Ten stall timeouts later the owner still holds it, so the claim stands.
+        await vi.advanceTimersByTimeAsync(50_000);
+        expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+        await expect(queue.listClaims()).resolves.toHaveLength(1);
+
+        await monitor.stop();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stops with an outstanding deferred claim without waiting for adoption", async () => {
     await withQueue(async (queue) => {
       let deferredSignal: AbortSignal | undefined;

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -63,7 +63,7 @@ export type ChannelIngressMonitorLifecycle = {
   admission: "exclusive";
   abortSignal: AbortSignal;
   onAdopted: () => void | Promise<void>;
-  onDeferred: () => void;
+  onDeferred: (isOwnerLive?: () => boolean) => void;
   onAdoptionFinalizing: () => void;
   onFailed?: (error: unknown) => void | Promise<void>;
   onCancelled?: () => void | Promise<void>;
@@ -73,7 +73,7 @@ export type ChannelIngressMonitorLifecycle = {
 /** Optional explicit outcome from a channel delivery. */
 export type ChannelIngressMonitorDeliveryResult =
   | { kind: "completed" }
-  | { kind: "deferred" }
+  | { kind: "deferred"; isOwnerLive?: () => boolean }
   | { kind: "failed-retryable"; error: unknown };
 
 type ChannelIngressMonitorInspectionContext =
@@ -392,13 +392,13 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
               settleDeferredClaim();
             }
           },
-          onDeferred: () => {
+          onDeferred: (isOwnerLive) => {
             handedOff = true;
             deferredHandoff = true;
             if (deferredClaim && !deferredClaimSettled) {
               deferredClaims.add(deferredClaim);
             }
-            lifecycle.onDeferred();
+            lifecycle.onDeferred(isOwnerLive);
           },
           onAdoptionFinalizing: () => {
             handedOff = true;
@@ -440,9 +440,11 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
         }
         if (result?.kind === "deferred") {
           if (!deferredHandoff) {
-            wrappedLifecycle.onDeferred();
+            wrappedLifecycle.onDeferred(result.isOwnerLive);
           }
-          return { kind: "deferred" };
+          // Carry the owner proof to the drain: dropping it here is how a
+          // reply-queue-owned message ends up back under the stall watchdog.
+          return { kind: "deferred", isOwnerLive: result.isOwnerLive };
         }
         if (!handedOff) {
           // A policy gate or deliberate no-dispatch is terminal for transport replay.

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -174,10 +174,10 @@ export function fanInChannelIngressLifecycles(
         handedOff = true;
         await adoptAll();
       },
-      onDeferred: () => {
+      onDeferred: (isOwnerLive) => {
         handedOff = true;
         for (const lifecycle of lifecycles) {
-          lifecycle.onDeferred();
+          lifecycle.onDeferred(isOwnerLive);
         }
       },
       onAdoptionFinalizing: () => {


### PR DESCRIPTION
Closes #120265
Related: #126231, #116547, #120422

AI-assisted: written with Claude Code (Opus 5), adversarially reviewed by independent Codex agents, and reviewed by a human before filing.

## What Problem This Solves

Fixes an issue where a user who sends a message while the assistant is already working on a long reply gets no answer at all, and no error. The message is accepted by the channel, waits its turn, and is silently discarded exactly five minutes later. It never reaches the agent, never appears in the session transcript, and is never retried. The only symptom is silence.

Five minutes is currently the maximum duration of any turn on a lane that might receive a second message. Long agentic turns with tool calls routinely exceed it, so on some installs this is ordinary rather than exceptional: 40 destroyed messages across 7 Discord channels on one 2026.8.1 install since 2026-07-29, 32 of them at exactly the 300-second mark.

The same defect has been reported against three separate channels — Signal (#120265), Telegram (#126231), and Discord — because the guard that destroys the message lives in the core drain all of them share.

## Why This Change Was Made

`armStallWatchdog` arms a 300-second timer when the ingress claim is taken, to catch a dispatch that never signals anything. `onDeferred` then explicitly left it armed:

```ts
// Pre-adoption only (dispatching OR deferred). Timer is not cleared by deferral.
```

Deferral is not a stall — it is the reply-lane queue accepting ownership, which is exactly what should happen when a message arrives behind a busy lane. But **deferral declares ownership, not liveness**, and that distinction is the whole difficulty in #120265. Simply clearing the timer at deferral would trade a bounded loss for an unbounded hold: an owner that vanished without settling would keep the claim and its lane forever, because the claim heartbeat keeps refreshing the lease and stale-claim recovery skips claims this drain still tracks. That is not a better failure, and it is why this issue has sat.

So the watchdog is not disarmed. It is given a way to ask.

`onDeferred` now accepts an optional `isOwnerLive?: () => boolean`. When the watchdog fires on a deferred claim it consults that proof: if the owner still holds the event, the deadline is extended and the claim waits; otherwise the guillotine runs exactly as before. The reply followup queue supplies the proof, because it is the only party that knows — a turn it owns is queued, in flight, or being admitted, and it stops owning the turn precisely when the lifecycle completes.

The important property is what happens to everyone who does not supply a proof: **nothing changes**. Every channel, every code path, and every existing test that relied on the deferred guillotine keeps the bounded pre-adoption behavior it had. No bound is removed anywhere, and this PR changes no existing test.

### Coverage of the callback across channels

A liveness callback that only some adapters forward is worse than none, because the channels that drop it look fixed and are not. Review named Telegram and Slack; rather than fix those two, I enumerated every lifecycle adapter that constructs an `onDeferred` and found **nine** dropping the callback:

`extensions/slack/src/monitor/message-handler.ts`, `extensions/telegram/src/bot-message.ts` plus its two local lifecycle types (`bot-processing-outcome.ts`, `bot-message-dispatch.types.ts`), `extensions/irc/src/inbound.ts`, `extensions/sms/src/inbound.ts`, `extensions/feishu/src/feishu-ingress.ts` and `extensions/feishu/src/bot-broadcast.ts`, `extensions/line/src/webhook-spool.ts`, `extensions/twitch/src/twitch-ingress.ts`, and `extensions/mattermost/src/mattermost/monitor-ingress.ts`.

All of them forward it now. There is exactly one `onDeferred` that deliberately does not: `src/gateway/server-methods/chat-send-turn-adoption.ts`, which is a top-level owner with nothing downstream to forward to. Both `pnpm tsgo:core` and `pnpm tsgo:extensions` are clean.

Non-goals: `DEFAULT_INGRESS_ADOPTION_STALL_MS` is unchanged, the `dispatching` watchdog is unchanged, and retry and dead-letter policy are unchanged. #116547 (wiring `adoptionStallTimeoutMs` to channel config) and #120422 (dead-letters are invisible and unrecoverable) remain open on their own merits.

## User Impact

A message sent while the assistant is mid-turn is answered when that turn finishes, instead of being discarded after five minutes. Operators of installs with long agentic turns stop losing inbound messages with no trace, and no configuration change is needed.

A claim whose owner vanishes is still dead-lettered and its lane still freed, on the same deadline as before.

## Evidence

**Production evidence** (2026.8.1, Discord, queried from `state/openclaw.sqlite`):

```sql
select count(*), count(distinct lane_key),
       min(datetime(received_at/1000,'unixepoch')),
       max(datetime(received_at/1000,'unixepoch'))
  from channel_ingress_events where failed_reason='handler-timeout';
-- 40 | 7 | 2026-07-29 16:54:43 | 2026-08-21 09:30:51
```

Time from receipt to dead-letter, in seconds: `300` for 32 rows, then a tail of `375, 378, 555, 595, 599, 625, 831, 910`, one row each — the same guillotine on claims that were released and re-claimed, which re-arms the timer. Every one of the 40 has `attempts = 0`, so nothing retried them. Seven distinct lanes, so this is not one pathological conversation.

**Red on stock.** Two tests are added, and both fail against unmodified sources with the tests in place:

```
$ git checkout origin/main -- src/channels/message/ingress-drain.ts \
      src/channels/message/ingress-drain-state.ts \
      src/channels/message/ingress-drain-lifecycle.ts
$ npx vitest run src/channels/message/ingress-drain.watchdog.test.ts

 × does not guillotine a deferred claim while its owner proves it still holds it
   AssertionError: expected [ { id: 'evt-def-live', …(11) } ] to deeply equal []
 × guillotines a deferred claim once its owner stops holding it
   AssertionError: expected [ { id: 'evt-def-lost', …(11) } ] to deeply equal []

      Tests  2 failed | 3 passed (5)
```

The second test is the one that matters for review: it holds a deferred claim past its deadline while the owner reports live, then flips the owner to gone and asserts the claim is dead-lettered with `handler-timeout` and its lane released. The recovery path is proven present, not assumed.

Note the three that stay green in that run — including the stock test `guillotines deferred stalls`, unmodified. That is the evidence for the central claim that no existing bound is removed.

**Green patched:**

```
$ npx vitest run src/channels/message/ \
      extensions/zalouser/src/ingress.test.ts \
      extensions/telegram/src/polling-session.test.ts

 Test Files  24 passed (24)
      Tests  340 passed (340)
```

Those two extension suites are included deliberately. Both contain tests that depend on a deferred claim being dead-lettered on the pre-adoption deadline: `extensions/zalouser/src/ingress.test.ts` "settles deferred bookkeeping when the adoption watchdog aborts a claim", and `extensions/telegram/src/polling-session.test.ts` "fails buffered spooled claims instead of requeueing when deferred processing times out". Both pass **unmodified**, because neither supplies a proof and so neither changes behavior.

`pnpm tsgo:core`, `oxlint`, and `oxfmt --check` are all clean on the branch.

**Adversarial review.** Four independent passes across successive revisions, three Codex and one Claude. An earlier revision did simply clear the timer at deferral; review rejected it on exactly the ownership-versus-liveness grounds above, and separately caught a deadline reconstruction that mixed the drain's injectable wall clock with a monotonic `setTimeout`. Both are gone: the current shape has no deadline arithmetic and removes no bound. Earlier revisions also failed CI on `max-lines` in `ingress-drain.ts`, which is why the settle owner is now extracted to `ingress-drain-settle.ts` in this diff.

