### PR TITLE
improve(terminal): speed up fitting table rendering

### DIFF
--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -70,6 +70,21 @@ describe("renderTable", () => {
     vi.restoreAllMocks();
   });
 
+  it("renders fitting ASCII cells without grapheme segmentation", () => {
+    const segment = vi.spyOn(Intl.Segmenter.prototype, "segment");
+
+    const out = renderTable({
+      border: "ascii",
+      columns: [{ key: "Name", header: "Name" }],
+      rows: [{ Name: "alpha" }, { Name: "beta" }],
+    });
+
+    expect(out).toBe(
+      ["+-------+", "| Name  |", "+-------+", "| alpha |", "| beta  |", "+-------+", ""].join("\n"),
+    );
+    expect(segment).not.toHaveBeenCalled();
+  });
+
   it.each(["$&", "$`", "$'", "$$"])(
     "displays a literal %s home path in terminal tables",
     (pattern) => {

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -55,8 +55,9 @@ function padCell(text: string, width: number, align: Align): string {
   // A single grapheme wider than the cell (e.g. a width-2 CJK/emoji glyph in a
   // width-1 column) survives wrapLine intact, so clamp here to keep every cell
   // exactly `width` columns and preserve the border-alignment invariant.
-  const content = visibleWidth(text) > width ? truncateToVisibleWidth(text, width) : text;
-  const w = visibleWidth(content);
+  const textWidth = visibleWidth(text);
+  const content = textWidth > width ? truncateToVisibleWidth(text, width) : text;
+  const w = content === text ? textWidth : visibleWidth(content);
   if (w >= width) {
     return content;
   }
@@ -364,6 +365,11 @@ function activeOsc8After(tokens: readonly AnsiToken[]): Osc8Link | undefined {
 
 function wrapLine(text: string, width: number): string[] {
   if (width <= 0) {
+    return [text];
+  }
+  // Fitting edge-trimmed ASCII is one column per code unit and needs no ANSI/grapheme scan.
+  // Keep edge whitespace on the full path, where wrapping preserves its trimming semantics.
+  if (text.length <= width && /^[!-~](?:[ -~]*[!-~])?$/u.test(text)) {
     return [text];
   }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary latency and allocation when users render CLI tables whose cells already fit and contain ordinary printable ASCII. Those common cells were still routed through ANSI tokenization and Unicode grapheme segmentation, and padding measured unchanged text twice.

## Why This Change Was Made

The table owner now returns fitting edge-trimmed printable ASCII directly from wrapping and reuses the width already measured by padding when no truncation occurred. ANSI/OSC, Unicode, controls, newlines, tabs, edge whitespace, wrapping, and truncation retain the existing path and semantics.

Production LOC: +8/-2. Tests: +15/-0. The small positive production delta is the narrow eligibility check plus an invariant comment; moving this to shared grapheme helpers would still tokenize every cell and would broaden behavior beyond the table owner.

## User Impact

Large CLI status, plugin, skill, hook, device, and directory tables render substantially faster without any output or command behavior change. Small tables remain behaviorally identical.

## Evidence

- Current-main red/green: `node scripts/run-vitest.mjs packages/terminal-core/src/table.test.ts` failed before the production change because three fitting cells invoked `Intl.Segmenter`; exact-head passes 59/59.
- Exact-head terminal-core suite: 11 files, 170 passed / 1 skipped.
- Fresh Node 24.15 benchmark, 5,000 rows × 6 fitting cells: median 441.777 ms → 72.721 ms (6.07× faster, 83.5% lower). All runs emitted exactly 605,484 bytes with SHA-256 `346fe3afa41adec067118dc81cd1f48ffd015a5a1a9bf398e5c4faac93de8e49`.
- Independent 1,000-case differential spanning ASCII, edge whitespace, Unicode, combining/wide graphemes, ANSI/C1/OSC-8, controls, newlines, widths, padding, borders, and alignment: all outputs equal; aggregate SHA-256 `3b1a73c7304406190b7c735ab895c6bbb9170435ce5f34eab7eeb869cb73cdee`.
- `node scripts/check-changed.mjs -- packages/terminal-core/src/table.ts packages/terminal-core/src/table.test.ts` passed all selected format, lint, typecheck, dead-export, architecture, and cycle gates.
- `pnpm build` passed, including terminal packages, runtime/plugin postbuild, startup metadata, and Control UI performance checks; only pre-existing third-party direct-`eval` warnings appeared.
- Fresh bundled Codex autoreview (`gpt-5.6-sol`, high): no findings; patch correct, confidence 0.99. TruffleHog preflight clean.
- Live issue/PR overlap searches found no active implementation; merged #90464 optimizes ANSI scanning during truncation and is distinct.

AI-assisted change. I understand the owner path and verified the dependency source (`string-width` 8.2.2) used by width measurement. No agent transcript is included.
