### PR TITLE
fix(cli): render Nodes validation failures

### DIFF
--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -249,6 +249,72 @@ describe("nodes-cli coverage", () => {
     expect(callGateway.mock.calls.map(([call]) => call.method)).toEqual(["node.pair.reject"]);
   });
 
+  it.each([
+    {
+      label: "status with an invalid last-connected duration",
+      command: "status",
+      args: ["nodes", "status", "--last-connected", "not-a-duration"],
+      message: "Invalid --last-connected: Invalid duration",
+    },
+    {
+      label: "list with an invalid last-connected duration",
+      command: "list",
+      args: ["nodes", "list", "--last-connected", "not-a-duration"],
+      message: "Invalid --last-connected: Invalid duration",
+    },
+    {
+      label: "status with an empty last-connected duration",
+      command: "status",
+      args: ["nodes", "status", "--last-connected", ""],
+      message: "Invalid --last-connected",
+    },
+    {
+      label: "list with a blank last-connected duration",
+      command: "list",
+      args: ["nodes", "list", "--last-connected", "   "],
+      message: "Invalid --last-connected",
+    },
+    {
+      label: "invoke with a blank node",
+      command: "invoke",
+      args: ["nodes", "invoke", "--node", "   ", "--command", "canvas.eval"],
+      message: "--node and --command required",
+    },
+    {
+      label: "invoke with a blank command",
+      command: "invoke",
+      args: ["nodes", "invoke", "--node", "mac-1", "--command", "   "],
+      message: "--node and --command required",
+    },
+    {
+      label: "rename with a blank name",
+      command: "rename",
+      args: ["nodes", "rename", "--node", "mac-1", "--name", "   "],
+      message: "--name must not be empty",
+    },
+  ])("reports $label once before calling the gateway", async ({ command, args, message }) => {
+    await expect(sharedProgram.parseAsync(args, { from: "user" })).rejects.toThrow("__exit__:1");
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(runtimeErrors).toEqual([expect.stringContaining(`nodes ${command} failed: ${message}`)]);
+    expect(defaultRuntime.exit).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["invoke node", ["nodes", "invoke", "--command", "canvas.eval"]],
+    ["invoke command", ["nodes", "invoke", "--node", "mac-1"]],
+    ["rename name", ["nodes", "rename", "--node", "mac-1"]],
+  ])("preserves Commander validation for a missing %s", async (_label, args) => {
+    await withSuppressedStderr(async () => {
+      await expect(sharedProgram.parseAsync(args, { from: "user" })).rejects.toMatchObject({
+        code: "commander.missingMandatoryOptionValue",
+      });
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
+  });
+
   it("blocks system.run on nodes invoke", async () => {
     await expect(
       sharedProgram.parseAsync(["nodes", "invoke", "--node", "mac-1", "--command", "system.run"], {

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -6,7 +6,7 @@ import {
 import type { Command } from "commander";
 import { randomIdempotencyKey } from "../../gateway/call.js";
 import { defaultRuntime } from "../../runtime.js";
-import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
+import { runNodesCommand } from "./cli-utils.js";
 import {
   callNodesGatewayCli,
   nodesCallOpts,
@@ -41,10 +41,7 @@ export function registerNodesInvokeCommands(nodes: Command) {
           const nodeQuery = normalizeOptionalString(opts.node) ?? "";
           const command = normalizeOptionalString(opts.command) ?? "";
           if (!nodeQuery || !command) {
-            const { error } = getNodesTheme();
-            defaultRuntime.error(error("--node and --command required"));
-            defaultRuntime.exit(1);
-            return;
+            throw new Error("--node and --command required");
           }
           if (BLOCKED_NODE_INVOKE_COMMANDS.has(normalizeLowercaseStringOrEmpty(command))) {
             throw new Error(

--- a/src/cli/nodes-cli/register.pairing.ts
+++ b/src/cli/nodes-cli/register.pairing.ts
@@ -230,15 +230,13 @@ export function registerNodesPairingCommands(nodes: Command) {
       .requiredOption("--name <displayName>", "New display name")
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("rename", async () => {
-          const nodeId = await resolveCliNodeId(opts, normalizeOptionalString(opts.node) ?? "");
           const name = normalizeOptionalString(opts.name) ?? "";
           if (!name) {
-            defaultRuntime.error(
+            throw new Error(
               `--name must not be empty. Run ${formatCliCommand("openclaw nodes list")} to see paired nodes, then rerun with --name <displayName>.`,
             );
-            defaultRuntime.exit(1);
-            return;
           }
+          const nodeId = await resolveCliNodeId(opts, normalizeOptionalString(opts.node) ?? "");
           const result = await callNodesGatewayCli("node.rename", opts, {
             nodeId,
             displayName: name,

--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -160,26 +160,14 @@ function formatPendingApprovalCommand(raw: unknown, opts: NodesRpcOpts): string 
   return formatCliCommand(args.map(quoteCliArg).join(" "));
 }
 
-function parseSinceMs(raw: unknown, label: string): number | undefined {
-  if (raw === undefined || raw === null) {
-    return undefined;
-  }
-  const value = normalizeOptionalString(raw) ?? (typeof raw === "number" ? String(raw) : null);
-  if (value === null) {
-    defaultRuntime.error(`${label}: invalid duration value`);
-    defaultRuntime.exit(1);
-    return undefined;
-  }
-  if (!value) {
+function parseSinceMs(raw: string | undefined, label: string): number | undefined {
+  if (raw === undefined) {
     return undefined;
   }
   try {
-    return parseDurationMs(value);
+    return parseDurationMs(raw);
   } catch (err) {
-    const message = formatErrorMessage(err);
-    defaultRuntime.error(`${label}: ${message}`);
-    defaultRuntime.exit(1);
-    return undefined;
+    throw new Error(`${label}: ${formatErrorMessage(err)}`, { cause: err });
   }
 }
 

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -385,6 +385,37 @@ describe("cli program (nodes basics)", () => {
   });
 
   it.each([
+    { command: "status", duration: "24h" },
+    { command: "status", duration: "1h30m" },
+    { command: "status", duration: "0" },
+    { command: "status", duration: " 24H " },
+    { command: "list", duration: "24h" },
+    { command: "list", duration: "1h30m" },
+    { command: "list", duration: "0" },
+    { command: "list", duration: " 24H " },
+  ])("preserves nodes $command --last-connected $duration", async ({ command, duration }) => {
+    const node = {
+      nodeId: "recent-node",
+      displayName: "Recent Node",
+      paired: true,
+      connected: true,
+      lastConnectedAtMs: Date.now() + 60_000,
+    };
+    programGatewayCallMock.mockImplementation(async (...args: unknown[]) => {
+      const { method } = (args[0] ?? {}) as { method?: string };
+      return method === "node.pair.list" ? { pending: [], paired: [node] } : { nodes: [node] };
+    });
+
+    await runProgram(["nodes", command, "--last-connected", duration, "--json"]);
+
+    const result = writeJsonArgAt(0) as {
+      nodes?: Array<{ nodeId: string }>;
+      paired?: Array<{ nodeId: string }>;
+    };
+    expect((result.nodes ?? result.paired)?.map(({ nodeId }) => nodeId)).toEqual(["recent-node"]);
+  });
+
+  it.each([
     {
       label: "paired node details",
       node: {
@@ -846,6 +877,32 @@ describe("cli program (nodes basics)", () => {
 
     await runProgram(["nodes", "remove", "--node", "iOS Node"]);
     expectGatewayRequest("node.pair.remove", { nodeId: "ios-node" });
+  });
+
+  it("runs nodes rename and preserves the successful node.rename payload", async () => {
+    programGatewayCallMock.mockImplementation(async (...args: unknown[]) => {
+      const { method } = (args[0] ?? {}) as { method?: string };
+      return method === "node.list"
+        ? { nodes: [{ nodeId: "ios-node", displayName: "iOS Node", paired: true }] }
+        : { ok: true, nodeId: "ios-node", displayName: "Renamed Node" };
+    });
+
+    await runProgram([
+      "nodes",
+      "rename",
+      "--node",
+      "iOS Node",
+      "--name",
+      " Renamed Node ",
+      "--json",
+    ]);
+
+    expectGatewayRequest("node.rename", { nodeId: "ios-node", displayName: "Renamed Node" });
+    expect(writeJsonArgAt(0)).toEqual({
+      ok: true,
+      nodeId: "ios-node",
+      displayName: "Renamed Node",
+    });
   });
 
   it("runs nodes invoke and calls node.invoke", async () => {

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -381,6 +381,101 @@ describe("cli json stdout contract", () => {
 
   it.each([
     {
+      name: "status with an invalid duration in human mode",
+      args: ["nodes", "status", "--last-connected", "not-a-duration"],
+      message: "Invalid --last-connected: Invalid duration",
+      human: true,
+    },
+    {
+      name: "status with JSON before its invalid duration",
+      args: ["nodes", "status", "--json", "--last-connected", "not-a-duration"],
+      message: "Invalid --last-connected: Invalid duration",
+    },
+    {
+      name: "status with JSON after its invalid duration",
+      args: ["nodes", "status", "--last-connected", "not-a-duration", "--json"],
+      message: "Invalid --last-connected: Invalid duration",
+    },
+    {
+      name: "list with an invalid duration in human mode",
+      args: ["nodes", "list", "--last-connected", "not-a-duration"],
+      message: "Invalid --last-connected: Invalid duration",
+      human: true,
+    },
+    {
+      name: "list with JSON before its invalid duration",
+      args: ["nodes", "list", "--json", "--last-connected", "not-a-duration"],
+      message: "Invalid --last-connected: Invalid duration",
+    },
+    {
+      name: "list with JSON after its invalid duration",
+      args: ["nodes", "list", "--last-connected", "not-a-duration", "--json"],
+      message: "Invalid --last-connected: Invalid duration",
+    },
+    {
+      name: "invoke with an explicitly JSON blank node",
+      args: ["nodes", "invoke", "--node", "   ", "--command", "canvas.eval", "--json"],
+      message: "--node and --command required",
+    },
+    {
+      name: "invoke with an implicitly JSON blank node",
+      args: ["nodes", "invoke", "--node", "   ", "--command", "canvas.eval"],
+      message: "--node and --command required",
+    },
+    {
+      name: "invoke with an explicitly JSON blank command",
+      args: ["nodes", "invoke", "--node", "mac-1", "--command", "   ", "--json"],
+      message: "--node and --command required",
+    },
+    {
+      name: "invoke with an implicitly JSON blank command",
+      args: ["nodes", "invoke", "--node", "mac-1", "--command", "   "],
+      message: "--node and --command required",
+    },
+    {
+      name: "rename with a blank name",
+      args: ["nodes", "rename", "--node", "mac-1", "--name", "   ", "--json"],
+      message: "--name must not be empty",
+    },
+  ])("renders nodes $name through the shared validation owner", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const denyNetwork = Buffer.from(
+          `import net from "node:net";
+           net.Socket.prototype.connect = function () { throw new Error("AUTOQA_NETWORK_FORBIDDEN"); };
+           globalThis.fetch = async () => { throw new Error("AUTOQA_NETWORK_FORBIDDEN"); };`,
+        ).toString("base64");
+        const result = runBuiltCli(tempHome, testCase.args, {
+          NODE_OPTIONS: `--permission --allow-fs-read=* --import=data:text/javascript;base64,${denyNetwork}`,
+          NODE_DISABLE_COMPILE_CACHE: "1",
+          OPENCLAW_NO_RESPAWN: "1",
+          OPENCLAW_LOG_LEVEL: "silent",
+          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+          OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+        });
+
+        expect(result.status, result.stderr).toBe(1);
+        if ("human" in testCase && testCase.human) {
+          expect(result.stdout).toBe("");
+          expect(result.stderr).toContain(`nodes ${testCase.args[1]} failed:`);
+        } else {
+          expect(JSON.parse(result.stdout)).toEqual({
+            ok: false,
+            error: {
+              type: "cli_error",
+              message: expect.stringContaining(testCase.message),
+            },
+          });
+        }
+        expect(result.stderr).toContain(testCase.message);
+        expect(result.stderr).not.toContain("AUTOQA_NETWORK_FORBIDDEN");
+      },
+      { prefix: "openclaw-nodes-json-failure-e2e-" },
+    );
+  });
+
+  it.each([
+    {
       name: "search with a leaf JSON flag",
       args: ["skills", "search", "fixture", "--json"],
       message: "ClawHub /api/v1/search failed (400): offline fixture",


### PR DESCRIPTION
Closes #127191

## What Problem This Solves

Fixes an issue where users running Nodes CLI commands in machine-readable mode received exit code 1 with an empty stdout document when `nodes status` or `nodes list` received an invalid `--last-connected` duration, or when `nodes invoke` received a blank `--node` or `--command`. A blank `nodes rename --name` also attempted to resolve the node before validating the name, producing an unrelated Gateway error instead of the actionable input error.

## Why This Change Was Made

All affected leaf actions already have a shared command error owner, but their local validation bypassed it by printing and terminating directly. Throw contextual validation errors into the existing wrapper, simplify duration parsing to its actual Commander input, and validate rename names before node resolution. This removes 17 production lines and deliberately leaves parent-position `nodes --json <subcommand>` parsing, required-option parsing, successful command payloads, and intentional `nodes push` result-then-exit behavior unchanged.

## User Impact

Nodes validation failures now reliably emit one canonical `cli_error` JSON document in explicit or implicit machine-output mode, while human-mode commands retain actionable diagnostics through the existing shared CLI wrapper. Invalid input is rejected before any node lookup or Gateway RPC; valid duration forms, successful status/list/invoke/rename commands, and missing required options keep their existing behavior.

## Evidence

- Exact unmodified production base plus the new permission-restricted real-entrypoint matrix: **11 expected failures**. Explicit and implicit JSON commands emitted empty stdout; human commands bypassed their shared wrapper; blank rename resolved the node and surfaced a credentials error before validating the name.
- Repaired focused hosted proof: **143 tests passed** across the Nodes validation owner, Nodes program behavior, Nodes push exit semantics, and complete real-entrypoint JSON contract:
  `node scripts/run-vitest.mjs src/cli/nodes-cli.coverage.test.ts src/cli/program.nodes-basic.e2e.test.ts src/cli/program.nodes-push.e2e.test.ts test/cli-json-stdout.e2e.test.ts`
- The real-entrypoint cases run with Node permissions, no filesystem writes/child processes/workers/addons, isolated missing config/state, and a socket/fetch tripwire. They cover human output; leaf JSON before and after invalid options for both status and list; explicit and implicit JSON for blank invoke node and command; and blank rename before node resolution.
- Additional owner/program coverage confirms zero RPCs before validation; a single failure/exit; unchanged Commander missing-required-option errors; valid `24h`, `1h30m`, `0`, and normalized ` 24H ` durations; successful Nodes payloads; and unchanged intentional push exit behavior.
- Repository-selected changed-file gate, formatting, and `git diff --check` pass. Production delta: **+8/-25, net -17 lines**. No changelog, configuration, persistence, protocol, dependency, or Gateway/operator-state changes.
- AI-assisted implementation and review.
