### PR TITLE
fix: keep Codex compaction visible after completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.
 - **Onboarding migration menu:** group Claude, Codex, Hermes, and plugin-provided imports under a single **Import from another agent** setup choice while preserving detected source hints, manual paths, and Back navigation before import begins. Fixes #126440. Thanks @shakkernerd.
 - **Onboarding provider hook loading:** scope selected-model hook fallback to the chosen provider so metadata-only setup providers do not load unrelated plugins before configuration completes. Fixes #126408. Thanks @shakkernerd.

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -32,6 +32,7 @@ import {
   type CodexAppServerLiveThreadOwnership,
 } from "./client-runtime.js";
 import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
+import { persistCodexContextCompactionActivity } from "./context-compaction-activity.js";
 import { readCodexThreadContextSnapshot } from "./event-projector-usage.js";
 import {
   readCodexNotificationThreadId,
@@ -70,7 +71,7 @@ type CodexAppServerCompactOptions = {
 };
 
 type CodexNativeCompactionCompletion =
-  | { completed: true; tokensAfter?: number }
+  | { completed: true; turnId?: string; itemId?: string; tokensAfter?: number }
   | { completed: false; reason: string };
 
 function watchCodexNativeCompactionCompletion(params: {
@@ -111,7 +112,12 @@ function watchCodexNativeCompactionCompletion(params: {
     resolveCompletion(result);
   };
   const complete = () =>
-    finish({ completed: true, ...(tokensAfter !== undefined ? { tokensAfter } : {}) });
+    finish({
+      completed: true,
+      ...(compactionTurnId ? { turnId: compactionTurnId } : {}),
+      ...(compactionItemId ? { itemId: compactionItemId } : {}),
+      ...(tokensAfter !== undefined ? { tokensAfter } : {}),
+    });
   const fail = (reason: string) => finish({ completed: false, reason });
   const retireUnconfirmed = (reason: string) => {
     if (settled || retirementStarted) {
@@ -742,6 +748,18 @@ async function compactCodexNativeThread(
             throw new Error(completion.reason);
           }
           tokensAfter = completion.tokensAfter;
+          if (completion.turnId && completion.itemId) {
+            await persistCodexContextCompactionActivity({
+              sessionTarget: params.sessionTarget,
+              config: params.config,
+              cwd: params.workspaceDir,
+              runId: params.runId,
+              threadId: binding.threadId,
+              turnId: completion.turnId,
+              itemId: completion.itemId,
+              timestamp: Date.now(),
+            });
+          }
           embeddedAgentLog.info("completed codex app-server compaction", {
             sessionId: params.sessionId,
             threadId: binding.threadId,

--- a/extensions/codex/src/app-server/context-compaction-activity.test.ts
+++ b/extensions/codex/src/app-server/context-compaction-activity.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { persistCodexContextCompactionActivity } from "./context-compaction-activity.js";
+
+const appendMessage = vi.hoisted(() => vi.fn());
+const publishUpdate = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/session-transcript-runtime", () => ({
+  appendSessionTranscriptMessageByIdentity: appendMessage,
+  publishSessionTranscriptUpdateByIdentity: publishUpdate,
+}));
+
+beforeEach(() => {
+  appendMessage.mockReset();
+  publishUpdate.mockReset();
+});
+
+describe("persistCodexContextCompactionActivity", () => {
+  it("publishes one model-excluded activity and leaves replay deduplication to transcript identity", async () => {
+    appendMessage
+      .mockImplementationOnce(async (params: { message: unknown }) => ({
+        appended: true,
+        message: params.message,
+        messageId: "activity-message",
+      }))
+      .mockResolvedValueOnce({
+        appended: false,
+        message: {},
+        messageId: "activity-message",
+      });
+    const params = {
+      run: {
+        runId: "run-1",
+        workspaceDir: "/workspace",
+        sessionTarget: {
+          agentId: "main",
+          sessionId: "session-1",
+          sessionKey: "agent:main:dashboard:session-1",
+          storePath: "/state/openclaw-agent.sqlite",
+        },
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "compact-1",
+      timestamp: 123,
+    } as Parameters<typeof persistCodexContextCompactionActivity>[0];
+
+    await persistCodexContextCompactionActivity(params);
+    await persistCodexContextCompactionActivity(params);
+
+    expect(appendMessage).toHaveBeenCalledTimes(2);
+    expect(appendMessage.mock.calls[0]?.[0]).toMatchObject({
+      eventId: "codex-context-compaction:thread-1:turn-1:compact-1",
+      message: {
+        role: "custom",
+        customType: "openclaw.context-compaction",
+        content: "Context compacted",
+        display: true,
+        excludeFromContext: true,
+        idempotencyKey: "codex-context-compaction:thread-1:turn-1:compact-1",
+      },
+    });
+    expect(publishUpdate).toHaveBeenCalledOnce();
+    expect(publishUpdate.mock.calls[0]?.[0]).toMatchObject({
+      update: {
+        messageId: "activity-message",
+        runId: "run-1",
+      },
+    });
+  });
+});

--- a/extensions/codex/src/app-server/context-compaction-activity.test.ts
+++ b/extensions/codex/src/app-server/context-compaction-activity.test.ts
@@ -28,15 +28,13 @@ describe("persistCodexContextCompactionActivity", () => {
         messageId: "activity-message",
       });
     const params = {
-      run: {
-        runId: "run-1",
-        workspaceDir: "/workspace",
-        sessionTarget: {
-          agentId: "main",
-          sessionId: "session-1",
-          sessionKey: "agent:main:dashboard:session-1",
-          storePath: "/state/openclaw-agent.sqlite",
-        },
+      runId: "run-1",
+      cwd: "/workspace",
+      sessionTarget: {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:dashboard:session-1",
+        storePath: "/state/openclaw-agent.sqlite",
       },
       threadId: "thread-1",
       turnId: "turn-1",

--- a/extensions/codex/src/app-server/context-compaction-activity.ts
+++ b/extensions/codex/src/app-server/context-compaction-activity.ts
@@ -1,0 +1,73 @@
+import {
+  embeddedAgentLog,
+  formatErrorMessage,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  appendSessionTranscriptMessageByIdentity,
+  publishSessionTranscriptUpdateByIdentity,
+} from "openclaw/plugin-sdk/session-transcript-runtime";
+
+const CONTEXT_COMPACTION_CUSTOM_TYPE = "openclaw.context-compaction";
+
+export async function persistCodexContextCompactionActivity(params: {
+  run: EmbeddedRunAttemptParams;
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  timestamp: number;
+}): Promise<void> {
+  const target = params.run.sessionTarget;
+  if (!target?.sessionId || !target.sessionKey || !target.storePath) {
+    return;
+  }
+  const activityId = `codex-context-compaction:${params.threadId}:${params.turnId}:${params.itemId}`;
+  const message = {
+    role: "custom" as const,
+    customType: CONTEXT_COMPACTION_CUSTOM_TYPE,
+    content: "Context compacted",
+    display: true,
+    excludeFromContext: true,
+    details: {
+      kind: "context_compaction",
+      backend: "codex-app-server",
+      threadId: params.threadId,
+      turnId: params.turnId,
+      itemId: params.itemId,
+      runId: params.run.runId,
+    },
+    timestamp: params.timestamp,
+    idempotencyKey: activityId,
+  };
+  try {
+    const appended = await appendSessionTranscriptMessageByIdentity({
+      agentId: target.agentId,
+      sessionId: target.sessionId,
+      sessionKey: target.sessionKey,
+      storePath: target.storePath,
+      config: params.run.config,
+      cwd: params.run.workspaceDir,
+      eventId: activityId,
+      message,
+    });
+    if (!appended?.appended) {
+      return;
+    }
+    await publishSessionTranscriptUpdateByIdentity({
+      agentId: target.agentId,
+      sessionId: target.sessionId,
+      sessionKey: target.sessionKey,
+      storePath: target.storePath,
+      update: {
+        message: appended.message,
+        messageId: appended.messageId,
+        runId: params.run.runId,
+      },
+    });
+  } catch (error) {
+    embeddedAgentLog.warn("failed to persist codex context compaction activity", {
+      error: formatErrorMessage(error),
+      itemId: params.itemId,
+    });
+  }
+}

--- a/extensions/codex/src/app-server/context-compaction-activity.ts
+++ b/extensions/codex/src/app-server/context-compaction-activity.ts
@@ -11,13 +11,16 @@ import {
 const CONTEXT_COMPACTION_CUSTOM_TYPE = "openclaw.context-compaction";
 
 export async function persistCodexContextCompactionActivity(params: {
-  run: EmbeddedRunAttemptParams;
+  sessionTarget?: EmbeddedRunAttemptParams["sessionTarget"];
+  config?: EmbeddedRunAttemptParams["config"];
+  cwd?: string;
+  runId?: string;
   threadId: string;
   turnId: string;
   itemId: string;
   timestamp: number;
 }): Promise<void> {
-  const target = params.run.sessionTarget;
+  const target = params.sessionTarget;
   if (!target?.sessionId || !target.sessionKey || !target.storePath) {
     return;
   }
@@ -34,7 +37,7 @@ export async function persistCodexContextCompactionActivity(params: {
       threadId: params.threadId,
       turnId: params.turnId,
       itemId: params.itemId,
-      runId: params.run.runId,
+      ...(params.runId ? { runId: params.runId } : {}),
     },
     timestamp: params.timestamp,
     idempotencyKey: activityId,
@@ -45,8 +48,8 @@ export async function persistCodexContextCompactionActivity(params: {
       sessionId: target.sessionId,
       sessionKey: target.sessionKey,
       storePath: target.storePath,
-      config: params.run.config,
-      cwd: params.run.workspaceDir,
+      config: params.config,
+      cwd: params.cwd,
       eventId: activityId,
       message,
     });
@@ -61,7 +64,7 @@ export async function persistCodexContextCompactionActivity(params: {
       update: {
         message: appended.message,
         messageId: appended.messageId,
-        runId: params.run.runId,
+        ...(params.runId ? { runId: params.runId } : {}),
       },
     });
   } catch (error) {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { AttemptFailureSource, EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { persistCodexContextCompactionActivity } from "./context-compaction-activity.js";
 import { CodexAssistantProjection } from "./event-projector-assistant.js";
 import { CodexProjectionDiagnostics } from "./event-projector-diagnostics.js";
 import { CodexEventProjection } from "./event-projector-events.js";
@@ -519,6 +520,13 @@ export class CodexAppServerEventProjector {
           trigger: this.params.trigger,
           channelId: this.params.messageChannel ?? this.params.messageProvider ?? undefined,
         },
+      });
+      await persistCodexContextCompactionActivity({
+        run: this.params,
+        threadId: this.threadId,
+        turnId: this.turnId,
+        itemId,
+        timestamp: this.nextTranscriptTimestamp(),
       });
       this.emitCompactionEnd(itemId, true);
     }

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -522,7 +522,10 @@ export class CodexAppServerEventProjector {
         },
       });
       await persistCodexContextCompactionActivity({
-        run: this.params,
+        sessionTarget: this.params.sessionTarget,
+        config: this.params.config,
+        cwd: this.params.workspaceDir,
+        runId: this.params.runId,
         threadId: this.threadId,
         turnId: this.turnId,
         itemId,

--- a/packages/agent-core/src/harness/messages.ts
+++ b/packages/agent-core/src/harness/messages.ts
@@ -143,6 +143,9 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
             timestamp: message.timestamp,
           };
         case "custom": {
+          if (message.excludeFromContext) {
+            return undefined;
+          }
           const content =
             typeof message.content === "string"
               ? [{ type: "text" as const, text: message.content }]

--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -133,6 +133,19 @@ function toolResultEntry(
 }
 
 describe("buildSessionContext", () => {
+  it("keeps display-only custom activity out of model input", () => {
+    const activity = {
+      role: "custom" as const,
+      customType: "openclaw.context-compaction",
+      content: "Context compacted",
+      display: true,
+      excludeFromContext: true,
+      timestamp: Date.parse(timestamp),
+    };
+
+    expect(convertToLlm([activity])).toEqual([]);
+  });
+
   it("keeps private shell executions in history without projecting them into context", () => {
     const hiddenEntry = bashEntry("hidden", "initial", "private shell output", true);
     const visibleEntry = bashEntry("visible", "hidden", "visible shell output", false);

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -427,6 +427,8 @@ export interface CustomMessage<T = unknown> {
   content: string | (TextContent | ImageContent)[];
   /** Whether UI surfaces should display this message. */
   display: boolean;
+  /** Keep display-only application activity out of future model context. */
+  excludeFromContext?: boolean;
   /** Optional application-specific metadata. */
   details?: T;
   /** Millisecond timestamp for transcript ordering. */

--- a/ui/src/pages/chat/chat-progress.ts
+++ b/ui/src/pages/chat/chat-progress.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { t } from "../../i18n/index.ts";
 import type { ChatItem, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
@@ -10,6 +11,25 @@ type WorkingProgress = {
 type WorkingProgressCache = WorkingProgress & {
   runId: string | null;
 };
+
+const CONTEXT_COMPACTION_CUSTOM_TYPE = "openclaw.context-compaction";
+
+export function projectContextCompactionActivity(message: unknown): unknown {
+  const record = asRecord(message);
+  if (record?.role !== "custom" || record.customType !== CONTEXT_COMPACTION_CUSTOM_TYPE) {
+    return message;
+  }
+  const metadata = asRecord(record["__openclaw"]);
+  return {
+    ...record,
+    role: "assistant",
+    content: [{ type: "text", text: t("chat.composer.contextCompacted") }],
+    __openclaw: {
+      ...metadata,
+      runtimeActivityKind: "context_compaction",
+    },
+  };
+}
 
 const workingProgressBySession = new Map<string, WorkingProgressCache>();
 let anonymousWorkingProgressId = 0;

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -24,6 +24,7 @@ import {
   buildCompactionDividerItem,
   buildResetDividerItem,
   clearWorkingProgress,
+  projectContextCompactionActivity,
   resolveWorkingProgress,
   shouldRenderQueuedSendInThread,
 } from "./chat-progress.ts";
@@ -214,7 +215,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
   }
   for (let i = 0; i < history.length; i++) {
-    const msg = history[i];
+    const msg = projectContextCompactionActivity(history[i]);
     const itemKey = historyKeys[i] ?? messageKey(msg, i);
     const normalized = safeNormalizeMessage(msg);
     if (!normalized) {

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -542,6 +542,10 @@ export function assistantGroupCanOwnActiveRunStatus(group: MessageGroup): boolea
   return (
     group.role.toLowerCase() === "assistant" &&
     !assistantGroupIsForwardedBoundary(group) &&
+    !group.messages.every(
+      ({ message }) =>
+        asRecord(asRecord(message)?.["__openclaw"])?.runtimeActivityKind === "context_compaction",
+    ) &&
     groupHasVisibleReplyContent(group)
   );
 }

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -86,12 +86,18 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       currentGroup?.role === "assistant" &&
       isKeyedAssistantStreamFallbackMessage(currentGroup.messages[0]?.message) !==
         isKeyedAssistantStreamFallbackMessage(item.message);
+    const splitsRuntimeActivity =
+      role === "assistant" &&
+      currentGroup?.role === "assistant" &&
+      isContextCompactionActivity(currentGroup.messages[0]?.message) !==
+        isContextCompactionActivity(item.message);
 
     if (
       !currentGroup ||
       startsProjectedTurn ||
       currentGroup.role !== role ||
       splitsAssistantCommentary ||
+      splitsRuntimeActivity ||
       (shouldSplitBySender &&
         (currentGroup.senderLabel !== senderLabel ||
           senderIdentityKey(currentGroup.sender) !== senderIdentityKey(sender)))
@@ -542,12 +548,13 @@ export function assistantGroupCanOwnActiveRunStatus(group: MessageGroup): boolea
   return (
     group.role.toLowerCase() === "assistant" &&
     !assistantGroupIsForwardedBoundary(group) &&
-    !group.messages.every(
-      ({ message }) =>
-        asRecord(asRecord(message)?.["__openclaw"])?.runtimeActivityKind === "context_compaction",
-    ) &&
+    !group.messages.every(({ message }) => isContextCompactionActivity(message)) &&
     groupHasVisibleReplyContent(group)
   );
+}
+
+function isContextCompactionActivity(message: unknown): boolean {
+  return asRecord(asRecord(message)?.["__openclaw"])?.runtimeActivityKind === "context_compaction";
 }
 
 // History carries no final-vs-commentary marker (commentary exists only as

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -757,6 +757,35 @@ describe("collapseCompletedTurnWork", () => {
     expect(requireGroup(items[2]).role).toBe("assistant");
   });
 
+  it("keeps durable context compaction inside completed work instead of treating it as the reply", () => {
+    const items = collapsedItems({
+      messages: [
+        userMessage("do it", 1_000),
+        {
+          role: "custom",
+          customType: "openclaw.context-compaction",
+          content: "Context compacted",
+          display: true,
+          excludeFromContext: true,
+          timestamp: 2_000,
+        },
+        assistantMessage("All done.", 3_000),
+      ],
+    });
+
+    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group"]);
+    const work = requireWorkGroup(items[1]);
+    expect(work.groups).toHaveLength(1);
+    expect(work.groups[0]?.messages[0]?.message).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Context compacted" }],
+      __openclaw: { runtimeActivityKind: "context_compaction" },
+    });
+    expect(requireGroup(items[2]).messages[0]?.message).toMatchObject({
+      content: "All done.",
+    });
+  });
+
   it.each([
     {
       role: "assistant",


### PR DESCRIPTION
Fixes #127206

## What Problem This Solves

Fixes an issue where users running Codex sessions would see a successful context-compaction status disappear from the composer after five seconds, leaving no durable evidence in the completed transcript or after reload.

## Why This Change Was Made

Successful native Codex compactions are now persisted as idempotent display-only transcript activity, published immediately, excluded from future model context, and reconstructed as non-final activity inside completed `Worked for` traces. Manual OpenClaw checkpoint compaction and historical sessions remain unchanged.

## User Impact

Users can inspect where native Codex context compaction occurred after the temporary composer status clears and after reopening the session, without adding checkpoint semantics or model-context tokens.

## Evidence

Initial implementation proof:

- Core production typecheck passed.
- Core test typecheck shards passed.
- Control UI typecheck passed.
- Codex extension typecheck passed after correcting the append API call.
- Changed-file formatting, lint, i18n, plugin-boundary, dependency, coercion, and dead-export guards passed.

Focused persistence, replay-deduplication, reload rendering, and live forced-compaction proof are still in progress. This draft PR was opened early by request and is not yet ready to land.

## Visual Evidence

**Before:** compaction completed, but no durable compaction activity remained in the transcript.

<img width="2104" height="1772" alt="Completed transcript without durable compaction activity" src="https://github.com/user-attachments/assets/99a662d7-9d86-4b32-af46-e1791814133d" />

**After:** the exact-head live session retains `Context compacted` after completion and reload.

<img width="1366" height="1163" alt="Completed transcript retaining Context compacted activity" src="https://github.com/user-attachments/assets/2038368f-5e18-4802-b196-ac92d0c8311c" />
