### PR TITLE
perf(build): run declaration partitions concurrently when memory allows

### DIFF
--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -10,6 +10,7 @@ import {
   type SpawnSyncReturns,
 } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { BUNDLED_PLUGIN_PATH_PREFIX } from "./lib/bundled-plugin-paths.mjs";
@@ -43,6 +44,7 @@ const DEFAULT_WINDOWS_TSDOWN_MAX_OLD_SPACE_MB = 8192;
 const TSDOWN_MAX_OLD_SPACE_MB_ENV = "OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB";
 const MIN_TSDOWN_MAX_OLD_SPACE_MB = 2048;
 const TSDOWN_CGROUP_MEMORY_HEADROOM_MB = 768;
+const TSDOWN_DECLARATION_CPUS_PER_CHILD = 4;
 const CGROUP_MEMORY_LIMIT_PATHS = [
   "/sys/fs/cgroup/memory.max",
   "/sys/fs/cgroup/memory/memory.limit_in_bytes",
@@ -508,6 +510,30 @@ function parseProcMemTotalBytes(value: string) {
   return Number(parsed);
 }
 
+function parseProcMemAvailableBytes(value: string) {
+  const match = value.match(/^MemAvailable:\s+(\d+)\s+kB$/imu);
+  const kibibytes = match?.[1];
+  if (!kibibytes) {
+    return null;
+  }
+  const parsed = BigInt(kibibytes) * 1024n;
+  if (parsed <= 0n || parsed > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return null;
+  }
+  return Number(parsed);
+}
+
+function readProcMemAvailableBytes(params: MemoryLimitParams = {}) {
+  const fsImpl = params.fs ?? fs;
+  try {
+    return parseProcMemAvailableBytes(
+      fsImpl.readFileSync(params.procMeminfoPath ?? PROC_MEMINFO_PATH, "utf8"),
+    );
+  } catch {
+    return null;
+  }
+}
+
 function readProcMemTotalBytes(params: MemoryLimitParams = {}) {
   const configuredTotal = params.procMemTotalBytes;
   if (configuredTotal && Number.isFinite(configuredTotal) && configuredTotal > 0) {
@@ -552,6 +578,40 @@ function resolveTsdownMaxOldSpaceMb(params: MemoryLimitParams = {}) {
     limitMb - TSDOWN_CGROUP_MEMORY_HEADROOM_MB,
   );
   return Math.min(defaultMaxOldSpaceMb, cgroupCap);
+}
+
+// DTS partitions are disjoint emit-only graphs, so they may fan out.
+// Bound each child by cgroup/MemAvailable and cores; constrained hosts retain
+// #116021's sequential peak-memory behavior.
+export function resolveTsdownDeclarationConcurrency(
+  params: MemoryLimitParams & {
+    partitionCount: number;
+    availableMemoryBytes?: number | null;
+    cpuCount?: number;
+  },
+) {
+  if (params.partitionCount <= 1) {
+    return Math.max(1, params.partitionCount);
+  }
+  const perChildMb = resolveTsdownMaxOldSpaceMb(params) + TSDOWN_CGROUP_MEMORY_HEADROOM_MB;
+  const cgroupLimitBytes = readCgroupMemoryLimitBytes(params);
+  const procAvailableBytes =
+    params.availableMemoryBytes === undefined
+      ? readProcMemAvailableBytes(params)
+      : params.availableMemoryBytes;
+  const availableBytes =
+    cgroupLimitBytes === null
+      ? procAvailableBytes
+      : Math.min(cgroupLimitBytes, procAvailableBytes ?? cgroupLimitBytes);
+  if (availableBytes === null) {
+    return 1;
+  }
+  const memoryBound = Math.floor(availableBytes / 1024 / 1024 / perChildMb);
+  const cpuCount = params.cpuCount ?? os.availableParallelism();
+  // Each tsdown child is itself multi-threaded (rolldown + TypeScript emit);
+  // oversubscribing cores makes every partition slower without saving wall time.
+  const cpuBound = Math.floor(cpuCount / TSDOWN_DECLARATION_CPUS_PER_CHILD);
+  return Math.max(1, Math.min(params.partitionCount, memoryBound, cpuBound));
 }
 
 function parseMaxOldSpaceSizeMb(value: unknown, fallbackMb: number) {
@@ -736,7 +796,7 @@ export function resolveTsdownBuildInvocation(
   };
 }
 
-/** Builds declarations in dependency order without overlapping the largest graphs. */
+/** Builds runtime bundles first, then declaration graphs that capacity permits to fan out. */
 export function resolveTsdownBuildInvocations(params: TsdownBuildParams = {}) {
   const forwardedArgs = params.args ?? [];
   const env = params.env ?? process.env;
@@ -1046,18 +1106,55 @@ if (isMainModule()) {
   pruneStaleRuntimeSymlinks();
   cleanTsdownOutputRoots({ roots: resolveTsdownCleanOutputRoots(args.forwardedArgs) });
   const invocations = resolveTsdownBuildInvocations({ args: args.forwardedArgs });
-  let result: TsdownBuildResult | undefined;
-  for (const [index, invocation] of invocations.entries()) {
+  const isBlocking = (candidate: TsdownBuildResult) =>
+    candidate.status !== 0 ||
+    candidate.hasIneffectiveDynamicImport ||
+    candidate.fatalUnresolvedImport;
+  async function runIndexedInvocation(index: number) {
     const startedAt = performance.now();
-    result = await runTsdownBuildInvocation(invocation);
+    const indexedResult = await runTsdownBuildInvocation(invocations[index]!);
     // Per-invocation timing separates the AI-declarations pass from the main
     // graph in CI logs; the combined step is otherwise a single opaque cost.
     console.log(
       `[tsdown-build] invocation ${index + 1}/${invocations.length} finished in ${((performance.now() - startedAt) / 1000).toFixed(1)}s`,
     );
-    if (result.status !== 0 || result.hasIneffectiveDynamicImport || result.fatalUnresolvedImport) {
+    return indexedResult;
+  }
+  // Runtime bundles run in order; the trailing declaration partitions share no
+  // outputs and fan out up to the memory/CPU-derived concurrency.
+  const firstDeclarationIndex = invocations.findIndex((invocation) =>
+    isUnifiedDtsGroup(readForwardedOption(invocation.args, ["--filter", "-F"])),
+  );
+  const serialCount = firstDeclarationIndex === -1 ? invocations.length : firstDeclarationIndex;
+  let result: TsdownBuildResult | undefined;
+  for (let index = 0; index < serialCount; index += 1) {
+    result = await runIndexedInvocation(index);
+    if (isBlocking(result)) {
       break;
     }
+  }
+  if ((result === undefined || !isBlocking(result)) && serialCount < invocations.length) {
+    const concurrency = resolveTsdownDeclarationConcurrency({
+      partitionCount: invocations.length - serialCount,
+    });
+    console.log(`[tsdown-build] declaration partitions running ${concurrency} at a time`);
+    let nextIndex = serialCount;
+    let blockingResult: TsdownBuildResult | undefined;
+    const workers = Array.from({ length: concurrency }, async () => {
+      while (nextIndex < invocations.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        result = await runIndexedInvocation(index);
+        if (isBlocking(result)) {
+          // Keep the first blocking partition; idle workers stop claiming more
+          // while in-flight siblings finish so their failures are still logged.
+          blockingResult ??= result;
+          nextIndex = invocations.length;
+        }
+      }
+    });
+    await Promise.all(workers);
+    result = blockingResult ?? result;
   }
 
   if (!result) {

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -22,6 +22,7 @@ import {
   resolveTsdownBuildInvocation,
   resolveTsdownBuildInvocations,
   resolveTsdownCleanOutputRoots,
+  resolveTsdownDeclarationConcurrency,
   runTsdownBuildInvocation,
 } from "../../scripts/tsdown-build.mts";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -156,7 +157,7 @@ describe("resolveTsdownBuildInvocation", () => {
     expect(result.args.slice(-2)).toEqual(["--format", "esm"]);
   });
 
-  it("builds AI, packages, runtime, and bounded declarations sequentially", () => {
+  it("builds AI, packages, runtime, and bounded declaration partitions", () => {
     const results = resolveTsdownBuildInvocations({
       args: ["--format", "esm"],
       platform: "linux",
@@ -202,7 +203,7 @@ describe("resolveTsdownBuildInvocation", () => {
     expect(results[1]?.args).not.toContain("--filter");
   });
 
-  it("serializes declaration graphs when --dts overrides the no-DTS environment", () => {
+  it("emits declaration graphs when --dts overrides the no-DTS environment", () => {
     const results = resolveTsdownBuildInvocations({
       args: ["--dts"],
       platform: "linux",
@@ -928,6 +929,45 @@ describe("createTsdownOutputScanner", () => {
     );
 
     expect(scanner.finish().fatalUnresolvedImport).toBeNull();
+  });
+});
+
+describe("resolveTsdownDeclarationConcurrency", () => {
+  const GiB = 1024 * 1024 * 1024;
+  // Default 12 GiB heap + 768 MiB headroom per child; fixtures bypass the host.
+  const base = { ...NO_MEMORY_LIMIT, platform: "linux", partitionCount: 8, env: {} };
+
+  it.each([
+    {
+      name: "stays serial when memory is unknown",
+      availableMemoryBytes: null,
+      cpuCount: 64,
+      want: 1,
+    },
+    {
+      name: "stays serial on a 16 GiB CI host",
+      availableMemoryBytes: 16 * GiB,
+      cpuCount: 64,
+      want: 1,
+    },
+    { name: "fans out by memory", availableMemoryBytes: 85 * GiB, cpuCount: 64, want: 6 },
+    { name: "bounds by cores", availableMemoryBytes: 120 * GiB, cpuCount: 8, want: 2 },
+    { name: "never exceeds partitions", availableMemoryBytes: 512 * GiB, cpuCount: 128, want: 8 },
+  ])("$name", ({ availableMemoryBytes, cpuCount, want }) => {
+    expect(resolveTsdownDeclarationConcurrency({ ...base, availableMemoryBytes, cpuCount })).toBe(
+      want,
+    );
+  });
+
+  it("caps available memory at the cgroup limit", () => {
+    expect(
+      resolveTsdownDeclarationConcurrency({
+        ...base,
+        cgroupMemoryLimitBytes: 7 * GiB,
+        availableMemoryBytes: 120 * GiB,
+        cpuCount: 64,
+      }),
+    ).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

### High Level TLDR

OpenClaw now runs independent unified declaration partitions concurrently on hosts with enough available memory and CPU, while constrained hosts remain sequential.

## What Problem This Solves

Builds spend most of their time serially emitting eight independent unified declaration graphs. #116021 deliberately split those graphs to cap peak declaration memory, but the sequential wrapper leaves well-provisioned builders underused.

## Why This Change Was Made

Keep the runtime, package, and AI builds ordered; then run only the trailing, emit-only unified DTS partitions through a bounded worker pool. The limit is the minimum of cgroup memory and current MemAvailable, plus available CPU capacity, using each child heap cap plus 768 MiB headroom. Unknown or constrained memory resolves to one worker, preserving #116021 behavior. No new configuration or environment variable is introduced. A first blocking partition stops idle workers from claiming more work while already-running siblings finish and report diagnostics.

## User Impact

Developers and CI builders with sufficient capacity complete normal builds substantially faster without changing the declaration partition layout or constrained-host peak-memory behavior. Constrained hosts remain sequential.

## Evidence

### Verification

- `pnpm test test/scripts/tsdown-build.test.ts test/scripts/tsdown-config.test.ts` — 69 passed.
- `pnpm check:changed` — passed (scripts, root-test, and tooling lanes).
- `OPENCLAW_BUILD_CACHE=0 pnpm build` in this worktree — passed. Phase timings: total 1m53.8s; `tsdown-unified` 1m01.2s; packages 10.1s; AI 2.53s; all postbuild guards passed. The unified build logged six concurrent DTS workers and produced 1,879 declaration files.
- Prior controlled serial baseline on this 32-core/124 GiB host: total 4m03s and `tsdown-unified` 3m11s. Two patched runs completed in 1m38s/1m42s, with `tsdown-unified` in 1m01s/1m00s. The same 1,879 declaration paths were emitted. Serial declaration output is already nondeterministic in TypeScript union-member ordering; normalized serial/parallel output differed only in that semantic ordering.
- Production/tooling LOC: +102/-5 (net +97). Tests: +42/-2 (net +40).
- AI-assisted; uncommitted Codex autoreview (`gpt-5.6-sol`, high) reported no accepted/actionable findings.