### PR TITLE
fix(ui): remove redundant mobile header alerts

### DIFF
--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -386,6 +386,7 @@ describe("OpenClaw shell update affordance", () => {
     const container = document.createElement("div");
     document.body.append(container);
     const shared = {
+      mobileNavLayout: false,
       onboarding: false,
       updateAvailable: {
         currentVersion: "2026.7.1",
@@ -454,28 +455,56 @@ describe("OpenClaw shell update affordance", () => {
     container.remove();
   });
 
-  it("treats a closed mobile drawer as hidden navigation", () => {
-    expect(
-      navigationSurfaceIsHidden({
+  it("keeps attention in the closed mobile drawer while preserving stale-client refresh", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    try {
+      const navigationSurfaceHidden = navigationSurfaceIsHidden({
         onboarding: false,
         navCollapsed: false,
         navDrawerOpen: false,
         mobileNavLayout: true,
-      }),
-    ).toBe(true);
-    expect(
-      navigationSurfaceIsHidden({
-        onboarding: false,
-        navCollapsed: false,
-        navDrawerOpen: true,
+      });
+      expect(navigationSurfaceHidden).toBe(true);
+      const shared = {
+        navigationSurfaceHidden,
         mobileNavLayout: true,
-      }),
-    ).toBe(false);
+        onboarding: false,
+        updateAvailable: {
+          currentVersion: "2026.7.1",
+          latestVersion: "2026.7.2",
+          channel: "stable" as const,
+        },
+        updateBusy: false,
+        canUpdate: true,
+        onUpdate: vi.fn(),
+        refreshRequired: false,
+        onRefresh: vi.fn(),
+      };
+
+      render(renderFloatingUpdateCard(shared), container);
+      expect(
+        container.querySelector("openclaw-sidebar-attention.sidebar-attention--floating"),
+      ).toBeNull();
+
+      render(
+        renderFloatingUpdateCard({ ...shared, updateAvailable: null, refreshRequired: true }),
+        container,
+      );
+      const refreshCard = container.querySelector<
+        HTMLElement & { updateComplete: Promise<boolean> }
+      >("openclaw-sidebar-update-card");
+      await refreshCard?.updateComplete;
+      expect(refreshCard?.querySelector(".sidebar-update-card")).not.toBeNull();
+    } finally {
+      container.remove();
+    }
   });
 
   it("keeps the stale-client refresh visible during onboarding", () => {
     const container = document.createElement("div");
     const shared = {
+      mobileNavLayout: false,
       onboarding: true,
       updateAvailable: null,
       updateBusy: false,

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -620,6 +620,7 @@ export function renderApplicationShell(host: ShellViewHost) {
         ${renderScopeUpgradeBanner(host, gatewaySnapshot, mergedChatChrome)}
         ${renderFloatingUpdateCard({
           navigationSurfaceHidden,
+          mobileNavLayout,
           onboarding,
           compact: mergedChatChrome,
           updateAvailable: overlaySnapshot.updateAvailable,

--- a/ui/src/app/navigation-surface.browser.test.ts
+++ b/ui/src/app/navigation-surface.browser.test.ts
@@ -50,6 +50,7 @@ describe.skipIf(!hasBrowserLayout)("navigation surface browser layout", () => {
           <main class="content">
             ${renderFloatingUpdateCard({
               navigationSurfaceHidden: true,
+              mobileNavLayout: false,
               onboarding: false,
               updateAvailable: null,
               updateBusy: false,

--- a/ui/src/app/navigation-surface.ts
+++ b/ui/src/app/navigation-surface.ts
@@ -16,6 +16,7 @@ export function navigationSurfaceIsHidden(params: {
 
 export function renderFloatingUpdateCard(params: {
   navigationSurfaceHidden: boolean;
+  mobileNavLayout: boolean;
   onboarding: boolean;
   compact?: boolean;
   updateAvailable: ApplicationContext["overlays"]["snapshot"]["updateAvailable"];
@@ -36,7 +37,10 @@ export function renderFloatingUpdateCard(params: {
 }) {
   // A stale client must always have a visible refresh action, including during
   // onboarding, even though update-available actions stay hidden there.
-  const showAttention = params.navigationSurfaceHidden && !params.onboarding && !params.compact;
+  // Mobile keeps attention in its drawer; desktop collapse has no drawer, so
+  // it still needs the floating copy while navigation is hidden.
+  const desktopNavigationHidden = params.navigationSurfaceHidden && !params.mobileNavLayout;
+  const showAttention = desktopNavigationHidden && !params.onboarding && !params.compact;
   const showUpdateCard =
     !params.compact &&
     (params.onboarding ? params.refreshRequired : params.navigationSurfaceHidden);

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -691,6 +691,107 @@ suite.define(() => {
     );
   });
 
+  it("keeps mobile attention in the drawer while desktop remains unchanged", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": {
+              jobs: [
+                {
+                  id: "release-digest",
+                  name: "Release digest",
+                  enabled: true,
+                  createdAtMs: 0,
+                  updatedAtMs: 0,
+                  schedule: { kind: "every", everyMs: 60_000 },
+                  sessionTarget: "isolated",
+                  wakeMode: "now",
+                  payload: { kind: "agentTurn", message: "test" },
+                  state: {
+                    lastRunStatus: "error",
+                    lastError: "Provider request failed",
+                  },
+                },
+              ],
+              snapshotRevision: "sidebar-mobile-attention",
+              total: 1,
+              offset: 0,
+              limit: 50,
+              hasMore: false,
+              nextOffset: null,
+            },
+            "models.authStatus": { providers: [], ts: 1 },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("cron.list");
+        await gateway.emitGatewayEvent("update.available", {
+          schedule: {
+            autoEnabled: false,
+            channel: "dev",
+            install: { kind: "git", git: { status: "behind", commitsBehind: 246 } },
+            target: {
+              kind: "git",
+              commitsBehind: 246,
+              upstreamRef: "origin/main",
+              upstreamSha: "9f3c21a0000000000000000000000000000000aa",
+            },
+          },
+          updateAvailable: {
+            channel: "dev",
+            commitsBehind: 246,
+            currentSha: "1111111111111111111111111111111111111111",
+            currentVersion: "2026.8.1",
+            latestVersion: "2026.8.1",
+            upstreamRef: "origin/main",
+            upstreamSha: "9f3c21a0000000000000000000000000000000aa",
+          },
+        });
+
+        const sidebar = page.locator("openclaw-app-sidebar");
+        const sidebarUpdate = sidebar.locator('[data-attention-kind="updateAvailable"]');
+        const sidebarAutomation = sidebar.locator('[data-attention-kind="cronFailed"]');
+        await expect.poll(() => sidebarUpdate.count()).toBe(1);
+        await expect.poll(() => sidebarAutomation.count()).toBe(1);
+        await captureUiProof(page, "08-desktop-attention-unchanged.png");
+
+        await page.setViewportSize({ height: 852, width: 393 });
+        await expect
+          .poll(() => page.locator(".shell").getAttribute("class"))
+          .toContain("shell--mobile-nav");
+        await page.evaluate(
+          () =>
+            new Promise<void>((resolve) => {
+              requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+            }),
+        );
+        const floatingKinds = await page
+          .locator(".sidebar-attention--floating [data-attention-kind]")
+          .evaluateAll((elements) =>
+            elements.map((element) => element.getAttribute("data-attention-kind")),
+          );
+        await captureUiProof(page, "09-mobile-attention-closed.png");
+
+        await visibleDrawerButton(page).click();
+        await expect
+          .poll(() => page.locator(".shell").getAttribute("class"))
+          .toContain("shell--nav-drawer-open");
+        await expect.poll(() => sidebarUpdate.isVisible()).toBe(true);
+        await expect.poll(() => sidebarAutomation.isVisible()).toBe(true);
+        await captureUiProof(page, "10-mobile-attention-drawer.png");
+
+        expect(floatingKinds).toEqual([]);
+      },
+    );
+  });
+
   it("passes failed run outcomes through the desktop and drawer sidebar", async () => {
     await suite.withPage(
       {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where mobile users opening the New Session screen saw floating update/commits-behind and failed-Automation icons above the page even though the same alerts already live in the navigation drawer.

## Why This Change Was Made

The navigation surface now receives the prepared mobile-layout fact and avoids mounting the duplicate floating attention component when the hidden navigation is a mobile drawer. The canonical drawer alerts, stale-client refresh card, and desktop collapsed-navigation behavior remain unchanged.

## User Impact

Mobile pages keep a clean header/content area while update and Automation alerts remain available in the drawer. Desktop behavior is unchanged.

AI-assisted implementation; the change and evidence were reviewed before submission.

## Evidence

Actual Control UI captures below use the real app with a deterministic mocked Gateway. Mobile: 393 × 852. Desktop: 1440 × 900.

### Mobile — closed drawer

| Before | After |
| --- | --- |
| ![Mobile before: redundant update and Automation icons float above New Session](https://github.com/user-attachments/assets/a406584b-0193-4b52-9cda-85a615a5e937) | ![Mobile after: clean New Session header and content area](https://github.com/user-attachments/assets/f98fc011-3a15-4aee-b279-a85fce214460) |

### Desktop — unchanged

| Before | After |
| --- | --- |
| ![Desktop before](https://github.com/user-attachments/assets/48243654-8580-4dd3-bbca-14a60b4c0433) | ![Desktop after, unchanged](https://github.com/user-attachments/assets/6b90b169-8222-4642-964b-f42a80ca51cd) |

### Mobile drawer — alerts retained

![Mobile drawer after: update and Automation alerts remain in the sidebar footer](https://github.com/user-attachments/assets/1b2030e4-930a-4d63-bab1-f401c253c373)

### Validation

- Pre-fix unit reproduction: the closed-mobile assertion failed because `openclaw-sidebar-attention.sidebar-attention--floating` was present.
- Pre-fix browser reproduction: the actual app returned `updateAvailable` and `cronFailed` floating attention kinds.
- `node scripts/run-vitest.mjs ui/src/app/app-host-native-shell.test.ts` — 24 passed.
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=… OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-customization.e2e.test.ts -t "keeps mobile attention in the drawer"` — passed.
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=… node ../scripts/run-vitest.mjs run --config vitest.config.ts --project browser src/app/navigation-surface.browser.test.ts` from `ui/` — passed.
- `node scripts/check-changed.mjs -- <five changed UI files>` — passed (format, guards, dead exports, i18n, typechecks, lint).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --parallel-tests "node scripts/check-changed.mjs -- <five changed UI files>"` — clean; no accepted/actionable findings.

Production delta: +5 net lines. Test delta: +131 net lines.

The configured Blacksmith Testbox backend was unavailable because its CLI is not installed on this host, so trusted-source validation used the documented local fallback.
