### PR TITLE
fix(test): nostr doctor and state-store suites fail Windows teardown with EBUSY

### DIFF
--- a/extensions/nostr/doctor-contract-api.test.ts
+++ b/extensions/nostr/doctor-contract-api.test.ts
@@ -40,6 +40,7 @@ describe("nostr doctor state migration", () => {
   });
 
   afterEach(async () => {
+    resetPluginStateStoreForTests();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 

--- a/extensions/nostr/src/nostr-state-store.test.ts
+++ b/extensions/nostr/src/nostr-state-store.test.ts
@@ -49,6 +49,9 @@ async function withTempStateDir<T>(fn: (dir: string) => Promise<T>) {
     } else {
       process.env.OPENCLAW_STATE_DIR = previous;
     }
+    // The keyed store keeps the state database open under the temporary dir, so Windows
+    // fails the removal with EBUSY unless the cached handle is released first.
+    resetPluginStateStoreForTests();
     await fs.rm(dir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
Related: #119796

## What Problem This Solves

Contributors on Windows cannot run the two `extensions/nostr` suites that write through the
plugin state store: they fail in teardown with `EBUSY`, so a green local run is impossible even
when every assertion in the suite passes. Both fixtures remove a temporary state directory while
the state database opened underneath it is still cached. On Linux unlinking an open file
succeeds, so CI never sees it.

```
Error: EBUSY: resource busy or locked, unlink
  'C:\...\Temp\openclaw-nostr-doctor-fNLnDc\state\openclaw.sqlite-shm'
Error: EBUSY: resource busy or locked, unlink
  'C:\...\Temp\openclaw-nostr-5CsTCQ\state\openclaw.sqlite'
```

Every failure is in teardown, never in an assertion. The exact file named varies between the
database and its `-wal` / `-shm` companions, because the removal walks the directory.

## Why This Change Was Made

Both fixtures call `resetPluginStateStoreForTests()` when they set the fixture up and never
again, so the store opened during the test is still cached when the directory is removed:

- `doctor-contract-api.test.ts` resets in `beforeEach` and removes the directory in `afterEach`.
- `nostr-state-store.test.ts` resets inside `withTempStateDir` before running the body and
  removes the directory in the same helper's `finally`.

The repair is the ordering the fixtures merged in #126352 now use: reset the plugin state store
immediately before the removal, so the cached handle is released first. Two lines of teardown
plus a comment; tests only, no production file is touched.

## User Impact

Contributors on Windows can run both `extensions/nostr` suites to completion instead of reading a
teardown failure that has nothing to do with the code under test. Behavior on Linux and macOS is
unchanged.

## Evidence

Windows 11, Node 24.18.1, `origin/main` `3ae7ba31946`, both arms on the same tree — the second arm
is that tree with only these two files patched.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts --configLoader runner <target>
```

| target | `main` | with this branch |
|---|---|---|
| `extensions/nostr/doctor-contract-api.test.ts` | 2 failed (2) | **2 passed (2)** |
| `extensions/nostr/src/nostr-state-store.test.ts` | 4 failed / 5 passed (9) | **9 passed (9)** |
| `extensions/nostr/` | 6 failed / 273 passed (279) | **279 passed (279)** |
| the whole `extension-messaging` shard | 2 files failed / 132 passed (134) | **134 files passed**, 1486 passed / 3 skipped |

The shard has no other failure on this machine, so these two suites are its only Windows
teardown red.

Both added calls are load-bearing: each suite fails on `main` with its own removal path, and the
two teardowns are independent.

- `./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.extensions.test.json --noEmit` -> exit 0
- `./node_modules/.bin/oxlint <the two files>` -> exit 0
- `./node_modules/.bin/oxfmt --check <the two files>` -> exit 0

## Relationship to the other repairs in this class

Disjoint from every open or merged repair of the same Windows teardown class, so they can land in
any order:

```
#126352 (merged)  eight extensions/ files: acpx, active-memory, codex, device-pair,
                  memory-core, msteams, alibaba, openai
#119964 (open)    three extensions/zalouser/ files
#127201 (merged)  src/gateway/github-publication.test-support.ts, landed `60ae513bd9c6`
this PR           extensions/nostr/doctor-contract-api.test.ts
                  extensions/nostr/src/nostr-state-store.test.ts
```

`extensions/nostr` was found by sweeping every `doctor-contract-api.test.ts` on `main` for a
fixture that removes its state directory without releasing the store first; the state-store suite
surfaced when the whole `extensions/nostr` directory was run. Suites that already reset in their
teardown, such as `extensions/voice-call/doctor-contract-api.test.ts`, are untouched.

