### PR TITLE
fix(gateway): keep public media resolvable in sensitive command replies

### DIFF
--- a/src/gateway/server-methods/chat-send-nonagent-finalization.ts
+++ b/src/gateway/server-methods/chat-send-nonagent-finalization.ts
@@ -268,20 +268,11 @@ export async function finalizeChatSendNonAgentReplies(params: {
   const ttsSupplementMarker = finalPayloads
     .map((payload) => buildMediaOnlyTtsSupplementTranscriptMarker(payload))
     .find((marker): marker is GatewayInjectedTtsSupplementMarker => Boolean(marker));
+  const persistableAssistantContent = hasSensitiveMedia
+    ? assistantContent?.filter((block) => block.sensitive !== true)
+    : assistantContent;
   const persistedAssistantContent = replaceAssistantContentTextBlocks(
-    hasSensitiveMedia
-      ? await buildAssistantDisplayContentFromReplyPayloads({
-          sessionKey: transcriptSessionKey,
-          agentId: transcriptAgentId,
-          payloads: finalPayloads,
-          managedMediaLocalRoots: mediaLocalRoots,
-          includeSensitiveMedia: false,
-          onManagedMediaPrepareError: (message) => {
-            managedMediaPrepareFailed = true;
-            context.logGateway.warn(`webchat media embedding skipped attachment: ${message}`);
-          },
-        })
-      : assistantContent,
+    persistableAssistantContent,
     mediaMessage,
   );
   const persistedContentForAppend = hasAssistantDisplayMediaContent(persistedAssistantContent)
@@ -321,10 +312,10 @@ export async function finalizeChatSendNonAgentReplies(params: {
       cfg,
     });
     if (appended.ok) {
-      if (appended.messageId && assistantContent?.length) {
+      if (appended.messageId && persistedContentForAppend?.length) {
         attachManagedOutgoingMediaToMessage({
           messageId: appended.messageId,
-          blocks: assistantContent,
+          blocks: persistedContentForAppend,
         });
       }
       message = broadcastAssistantContent?.length

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -59,6 +59,8 @@ import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.pa
 import { withEnvAsync } from "../../test-utils/env.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { consumeCronCreatorAuthorityGrant } from "../cron-creator-authority-grant.js";
+import { parseManagedOutgoingArtifactId } from "../managed-image-attachments.js";
+import { listManagedImageRecordEntries } from "../managed-image-record-store.js";
 import { createChatRunState } from "../server-chat-state.js";
 import { STALE_WORKER_BUILD_REASON } from "../worker-environments/admission.js";
 import { handleChatSend, handleChatSendWithRuntimeTools } from "./chat-send-handler.js";
@@ -4752,6 +4754,89 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(serializedTranscript).not.toContain("data:image/png");
     expect(serializedTranscript).not.toContain("terminalText");
     expect(serializedTranscript).not.toContain(setupCode);
+  });
+
+  it("reuses public managed media identity when excluding sensitive pairing QR content", async () => {
+    await withTranscriptFixtureState(
+      "openclaw-chat-send-command-public-media-pair-qr-",
+      async (dir) => {
+        const audioPath = path.join(dir, "public.mp3");
+        fs.writeFileSync(audioPath, Buffer.from("managed public audio"));
+        const setupCode = "openclaw-test-mixed-public-media-pairing-code";
+        const recordsBefore = new Set(
+          listManagedImageRecordEntries({ stateDir: suiteFixtureRoot }).map(
+            ({ record }) => record.attachmentId,
+          ),
+        );
+        mockState.dispatchedReplies = [
+          {
+            kind: "block",
+            payload: {
+              text: "Public audio is ready.",
+              mediaUrl: audioPath,
+              mediaUrls: [audioPath],
+              trustedLocalMedia: true,
+            },
+          },
+          {
+            kind: "final",
+            payload: {
+              text: "Scan to continue:",
+              channelData: {
+                openclawPairingQr: {
+                  setupCode,
+                  expiresAtMs: Date.now() + 10 * 60_000,
+                },
+              },
+              sensitiveMedia: true,
+            },
+          },
+        ];
+        const { send } = createChatRequestFixture();
+
+        const payload = await send({
+          idempotencyKey: "idem-command-public-media-pair-qr",
+          message: "/pair qr",
+        });
+
+        const broadcastContent = getMessageContent(payload);
+        const broadcastAudio = managedAudioBlocks(broadcastContent);
+        expect(broadcastAudio).toHaveLength(1);
+        expectManagedAudioBlock(broadcastAudio[0], "public.mp3");
+        expect(broadcastContent).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ type: "openclaw_pairing_qr", sensitive: true }),
+          ]),
+        );
+
+        const transcriptMessages = await readActiveAssistantTranscriptMessages();
+        const transcriptMessage = transcriptMessages.at(-1);
+        const transcriptContent = Array.isArray(transcriptMessage?.content)
+          ? (transcriptMessage.content as Array<Record<string, unknown>>)
+          : [];
+        const transcriptAudio = managedAudioBlocks(transcriptContent);
+        expect(transcriptAudio).toHaveLength(1);
+        expect(transcriptAudio[0]?.artifactId).toBe(broadcastAudio[0]?.artifactId);
+        const serializedTranscript = JSON.stringify(transcriptMessages);
+        expect(serializedTranscript).not.toContain("openclaw_pairing_qr");
+        expect(serializedTranscript).not.toContain("terminalText");
+        expect(serializedTranscript).not.toContain(setupCode);
+
+        const artifactId = String(transcriptAudio[0]?.artifactId);
+        const parsedArtifact = parseManagedOutgoingArtifactId(artifactId);
+        expect(parsedArtifact).not.toBeNull();
+        const createdRecords = listManagedImageRecordEntries({ stateDir: suiteFixtureRoot }).filter(
+          ({ record }) => !recordsBefore.has(record.attachmentId),
+        );
+        expect(createdRecords).toHaveLength(1);
+        expect(createdRecords[0]?.record).toMatchObject({
+          attachmentId: parsedArtifact?.attachmentId,
+          sessionKey: "agent:main:main",
+          messageId: findAssistantTranscriptUpdates().at(-1)?.messageId,
+          original: { filename: "public.mp3" },
+        });
+      },
+    );
   });
 
   it("keeps visible slash-command finals alongside earlier block text", async () => {


### PR DESCRIPTION
## What Problem This Solves

A non-agent WebChat reply that combined public managed media with a sensitive display payload built assistant content twice. Each build staged fresh attachment identities: the transcript referenced the second set, while post-append promotion assigned the transcript message ID to the first. Exact transcript-membership authorization then rejected both public artifacts, and one public item consumed two records/files.

## Why This Change Was Made

- build the managed assistant block graph once
- derive the persistence-safe projection by filtering sensitive display blocks from that existing graph
- retain the already-staged IDs for unaffected public image/audio/video/file blocks
- promote the exact block set appended to the transcript rather than the broader broadcast projection

## User Impact

Public media in mixed sensitive command replies now remains resolvable both in the live WebChat response and in persisted history. Sensitive pairing QR/setup data remains broadcast-only, and each public attachment is staged exactly once.

## Evidence

- Authentic Gateway production-boundary regression sends one public MP3 block plus a sensitive pairing-QR final.
- The regression asserts that broadcast includes the QR and one audio block, transcript history excludes QR/setup data, broadcast and transcript use the same artifact ID, exactly one managed record is created, and that record is attached to the appended transcript message.
- `node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts` — 406/406 passed across the two Gateway projects selected by the repository runner.
- `pnpm check:changed` — passed every changed-file lane.
- `git diff --check` and Oxfmt — passed.
- Deslop/manual diff review — no behavior-neutral cleanup needed.
- A live screenshot is not feasible because no deterministic built-in command emits this mixed plugin/public-media/pairing-QR composition; the Gateway test exercises the real non-agent finalization and managed-record owners directly.
- Exact-head hosted CI — [run 32497789875](https://github.com/openclaw/openclaw/actions/runs/32497789875) completed with `success` on exact head `959610c38f42d3cd314236d489b37a76e13fce16`; it had no failing jobs and `openclaw/ci-gate` succeeded. No rerun was triggered.
- Mandatory autoreview — TruffleHog clean; Codex v0.149 failed before returning structured review output. It was not rerun on unchanged code.

Closes #127227
