### PR TITLE
feat(opencode): add anonymous Ox Alpha preview

### DIFF
--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -23,7 +23,7 @@ provider ids split so upstream per-model routing stays correct.
 <Tabs>
   <Tab title="Zen catalog">
     **Best for:** the curated OpenCode multi-model proxy (Claude, GPT, Gemini, GLM,
-    DeepSeek, Kimi, MiniMax, Qwen).
+    DeepSeek, Kimi, MiniMax, Qwen, and the key-free Ox Alpha Free preview).
 
     <Steps>
       <Step title="Run onboarding">
@@ -99,10 +99,10 @@ provider ids split so upstream per-model routing stays correct.
 
 ### Zen
 
-| Property         | Value                                                                                                                 |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
-| Runtime provider | `opencode`                                                                                                            |
-| Example models   | `opencode/gpt-5.6-sol`, `opencode/kimi-k3`, `opencode/gemini-3.6-flash`, `opencode/minimax-m3`, `opencode/big-pickle` |
+| Property         | Value                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Runtime provider | `opencode`                                                                                                                  |
+| Example models   | `opencode/gpt-5.6-sol`, `opencode/kimi-k3`, `opencode/gemini-3.6-flash`, `opencode/minimax-m3`, `opencode/x-preview-f-free` |
 
 Run `openclaw models list --provider opencode` for the current active list,
 which also includes the promoted free-tier rows `opencode/big-pickle`,
@@ -110,6 +110,11 @@ which also includes the promoted free-tier rows `opencode/big-pickle`,
 `opencode/ling-3.0-tiny-free`, `opencode/longcat-2.0-free`,
 `opencode/mimo-v2.5-free`,
 `opencode/nemotron-3-ultra-free`, and `opencode/north-mini-code-free`.
+
+`opencode/x-preview-f-free` (Ox Alpha Free) accepts text, tool calls, and
+streaming without an OpenCode API key. It has a verified 1,000,000-token input
+cap and 131,072-token output cap. Other Zen refs continue to require an
+OpenCode API key.
 
 Live discovery safely intersects OpenCode's returned IDs with trusted OpenClaw
 metadata. A key-scoped response can omit models that are unavailable to that

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -113,8 +113,9 @@ which also includes the promoted free-tier rows `opencode/big-pickle`,
 
 `opencode/x-preview-f-free` (Ox Alpha Free) accepts text, tool calls, and
 streaming without an OpenCode API key. It has a verified 1,000,000-token input
-cap and 131,072-token output cap. Other Zen refs continue to require an
-OpenCode API key.
+cap and 131,072-token output cap. Reasoning is mandatory: use `low`, `high`,
+or `max` (the default); `off` is not supported. Other Zen refs continue to
+require an OpenCode API key.
 
 Live discovery safely intersects OpenCode's returned IDs with trusted OpenClaw
 metadata. A key-scoped response can omit models that are unavailable to that

--- a/extensions/opencode/gateway-auth-api.ts
+++ b/extensions/opencode/gateway-auth-api.ts
@@ -1,0 +1,19 @@
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { OPENCODE_ZEN_OX_ALPHA_MODEL_ID } from "./provider-catalog.js";
+
+const OPENCODE_ZEN_ANONYMOUS_AUTH_MARKER = "opencode-zen-anonymous";
+
+/** Resolves the one Zen model OpenCode currently serves without a key. */
+export function resolveOpencodeZenAnonymousAuth(modelId: string | undefined) {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  const bareModelId = normalized.startsWith("opencode/")
+    ? normalized.slice("opencode/".length)
+    : normalized;
+  return bareModelId === OPENCODE_ZEN_OX_ALPHA_MODEL_ID
+    ? {
+        apiKey: OPENCODE_ZEN_ANONYMOUS_AUTH_MARKER,
+        source: "OpenCode Zen Ox Alpha Free (anonymous route)",
+        mode: "api-key" as const,
+      }
+    : undefined;
+}

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -89,6 +89,7 @@ const ACTIVE_MODEL_IDS = [
   "qwen3.6-plus",
   "qwen3.5-plus",
   "big-pickle",
+  "x-preview-f-free",
   "deepseek-v4-flash-free",
   "mimo-v2.5-free",
   "ling-3.0-tiny-free",
@@ -138,6 +139,12 @@ describe("opencode provider plugin", () => {
       groupId: "opencode",
       groupHint: "Shared API key infrastructure for Zen + Go",
     });
+    expect(provider.resolveSyntheticAuth?.({ modelId: "x-preview-f-free" } as never)).toEqual({
+      apiKey: "opencode-zen-anonymous",
+      source: "OpenCode Zen Ox Alpha Free (anonymous route)",
+      mode: "api-key",
+    });
+    expect(provider.resolveSyntheticAuth?.({ modelId: "gpt-5.6-sol" } as never)).toBeUndefined();
   });
 
   it("registers image media understanding through the OpenCode plugin", async () => {
@@ -219,6 +226,18 @@ describe("opencode provider plugin", () => {
     expect(opus46.reasoning).toBe(true);
     expect(opus46.contextWindow).toBe(1_000_000);
     expect(opus46.maxTokens).toBe(128_000);
+
+    expect(requireMapEntry(models, "x-preview-f-free")).toMatchObject({
+      name: "Ox Alpha Free",
+      api: "openai-completions",
+      baseUrl: "https://opencode.ai/zen/v1",
+      input: ["text"],
+      reasoning: true,
+      requiresApiKey: false,
+      contextWindow: 1_000_000,
+      maxTokens: 131_072,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
 
     expect(requireMapEntry(models, "gpt-5.5")).toMatchObject({
       api: "openai-responses",
@@ -382,6 +401,7 @@ describe("opencode provider plugin", () => {
       "minimax-m2.7",
       "kimi-k3",
       "big-pickle",
+      "x-preview-f-free",
       "deepseek-v4-flash-free",
       "mimo-v2.5-free",
       "laguna-s-2.1-free",
@@ -436,6 +456,24 @@ describe("opencode provider plugin", () => {
       input: ["text", "image"],
       cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
       contextWindow: 1_048_576,
+      maxTokens: 131_072,
+    });
+    const manifestOxAlpha = requireRecord(
+      manifestModels.find(
+        (model) => requireRecord(model, "manifest model").id === "x-preview-f-free",
+      ),
+      "manifest Ox Alpha Free",
+    );
+    expect(manifestOxAlpha).toMatchObject({
+      name: "Ox Alpha Free",
+      api: "openai-completions",
+      provider: "opencode",
+      baseUrl: "https://opencode.ai/zen/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      requiresApiKey: false,
+      contextWindow: 1_000_000,
       maxTokens: 131_072,
     });
   });

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -145,6 +145,13 @@ describe("opencode provider plugin", () => {
       source: "OpenCode Zen Ox Alpha Free (anonymous route)",
       mode: "api-key",
     });
+    expect(
+      provider.resolveSyntheticAuth?.({ modelId: "opencode/x-preview-f-free" } as never),
+    ).toEqual({
+      apiKey: "opencode-zen-anonymous",
+      source: "OpenCode Zen Ox Alpha Free (anonymous route)",
+      mode: "api-key",
+    });
     expect(provider.resolveSyntheticAuth?.({ modelId: "gpt-5.6-sol" } as never)).toBeUndefined();
   });
 

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -130,6 +130,7 @@ describe("opencode provider plugin", () => {
   it("registers only the Zen auth choice from its own provider manifest", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 
+    expect(manifest.syntheticAuthRefs).toEqual(["opencode"]);
     expect(provider.id).toBe("opencode");
     expect(provider.envVars).toEqual(["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"]);
     expect(provider.auth.map((method) => method.id)).toEqual(["api-key"]);

--- a/extensions/opencode/index.ts
+++ b/extensions/opencode/index.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { createOpenAICompatibleCompletionsThinkingOffWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveOpencodeZenAnonymousAuth } from "./gateway-auth-api.js";
 import { opencodeMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { applyOpencodeZenProviderConfig, OPENCODE_ZEN_DEFAULT_MODEL_REF } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
@@ -14,7 +15,6 @@ import {
   buildStaticOpencodeZenProviderConfig,
   listOpencodeZenModelCatalogEntries,
   normalizeOpencodeZenBaseUrl,
-  OPENCODE_ZEN_OX_ALPHA_MODEL_ID,
   resolveOpencodeZenModel,
   resolveOpencodeZenStarterModel,
 } from "./provider-catalog.js";
@@ -23,7 +23,6 @@ import { registerOpenCodeSessionCatalog } from "./session-catalog-plugin.js";
 import { wrapOpencodeProviderStream } from "./stream.js";
 
 const PROVIDER_ID = "opencode";
-const OPENCODE_ZEN_ANONYMOUS_AUTH_MARKER = "opencode-zen-anonymous";
 const MINIMAX_MODERN_MODEL_MATCHERS = ["minimax-m2.7"] as const;
 type OpencodeZenCatalogAuth = { apiKey?: string; discoveryApiKey?: string };
 
@@ -104,14 +103,7 @@ export default defineSingleProviderPluginEntry({
         : undefined;
     },
     resolveDynamicModel: ({ modelId }) => resolveOpencodeZenModel(modelId),
-    resolveSyntheticAuth: ({ modelId }) =>
-      normalizeLowercaseStringOrEmpty(modelId) === OPENCODE_ZEN_OX_ALPHA_MODEL_ID
-        ? {
-            apiKey: OPENCODE_ZEN_ANONYMOUS_AUTH_MARKER,
-            source: "OpenCode Zen Ox Alpha Free (anonymous route)",
-            mode: "api-key" as const,
-          }
-        : undefined,
+    resolveSyntheticAuth: ({ modelId }) => resolveOpencodeZenAnonymousAuth(modelId),
     catalog: {
       order: "simple",
       run: async (ctx) => {

--- a/extensions/opencode/index.ts
+++ b/extensions/opencode/index.ts
@@ -14,6 +14,7 @@ import {
   buildStaticOpencodeZenProviderConfig,
   listOpencodeZenModelCatalogEntries,
   normalizeOpencodeZenBaseUrl,
+  OPENCODE_ZEN_OX_ALPHA_MODEL_ID,
   resolveOpencodeZenModel,
   resolveOpencodeZenStarterModel,
 } from "./provider-catalog.js";
@@ -22,6 +23,7 @@ import { registerOpenCodeSessionCatalog } from "./session-catalog-plugin.js";
 import { wrapOpencodeProviderStream } from "./stream.js";
 
 const PROVIDER_ID = "opencode";
+const OPENCODE_ZEN_ANONYMOUS_AUTH_MARKER = "opencode-zen-anonymous";
 const MINIMAX_MODERN_MODEL_MATCHERS = ["minimax-m2.7"] as const;
 type OpencodeZenCatalogAuth = { apiKey?: string; discoveryApiKey?: string };
 
@@ -102,6 +104,14 @@ export default defineSingleProviderPluginEntry({
         : undefined;
     },
     resolveDynamicModel: ({ modelId }) => resolveOpencodeZenModel(modelId),
+    resolveSyntheticAuth: ({ modelId }) =>
+      normalizeLowercaseStringOrEmpty(modelId) === OPENCODE_ZEN_OX_ALPHA_MODEL_ID
+        ? {
+            apiKey: OPENCODE_ZEN_ANONYMOUS_AUTH_MARKER,
+            source: "OpenCode Zen Ox Alpha Free (anonymous route)",
+            mode: "api-key" as const,
+          }
+        : undefined,
     catalog: {
       order: "simple",
       run: async (ctx) => {

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -8,6 +8,9 @@
     "onStartup": true
   },
   "providerCatalogEntry": "./provider-discovery.ts",
+  "nonSecretAuthMarkers": [
+    "opencode-zen-anonymous"
+  ],
   "enabledByDefault": true,
   "providers": [
     "opencode"
@@ -408,6 +411,32 @@
             "contextWindow": 200000,
             "contextTokens": 160000,
             "maxTokens": 32000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "maxTokensField": "max_tokens",
+              "supportsDeveloperRole": false,
+              "supportsStrictMode": false
+            }
+          },
+          {
+            "id": "x-preview-f-free",
+            "name": "Ox Alpha Free",
+            "api": "openai-completions",
+            "provider": "opencode",
+            "baseUrl": "https://opencode.ai/zen/v1",
+            "reasoning": true,
+            "requiresApiKey": false,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
             "compat": {
               "supportsUsageInStreaming": true,
               "maxTokensField": "max_tokens",

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -11,6 +11,9 @@
   "nonSecretAuthMarkers": [
     "opencode-zen-anonymous"
   ],
+  "syntheticAuthRefs": [
+    "opencode"
+  ],
   "enabledByDefault": true,
   "providers": [
     "opencode"

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -442,6 +442,8 @@
             "maxTokens": 131072,
             "compat": {
               "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["low", "high", "max"],
               "maxTokensField": "max_tokens",
               "supportsDeveloperRole": false,
               "supportsStrictMode": false

--- a/extensions/opencode/provider-catalog.ts
+++ b/extensions/opencode/provider-catalog.ts
@@ -144,9 +144,10 @@ const MODEL_CAPABILITY_ROWS = [
   ["qwen3.6-plus", 262144, 65536, TI],
   ["qwen3.5-plus", 262144, 65536, TI],
   ["big-pickle", 200000, 32000, T, undefined, INPUT_160],
-  // Zen does not publish capability metadata for this stealth row. The public
-  // API accepts a 1M-token text prompt and rejects max_tokens above 131,072.
-  [OPENCODE_ZEN_OX_ALPHA_MODEL_ID, 1000000, 131072, T],
+  // Zen does not publish capability metadata for this stealth row. Its public
+  // API accepts a 1M-token text prompt, caps max_tokens at 131,072, and accepts
+  // only low, high, or max reasoning effort.
+  [OPENCODE_ZEN_OX_ALPHA_MODEL_ID, 1000000, 131072, T, E_LOW_HIGH_MAX],
   ["deepseek-v4-flash-free", 200000, 128000, T, E_LOW_HIGH_MAX],
   ["mimo-v2.5-free", 200000, 32000, TI],
   ["ling-3.0-flash-free", 262144, 32768, T, E_LMH, DEPRECATED],

--- a/extensions/opencode/provider-catalog.ts
+++ b/extensions/opencode/provider-catalog.ts
@@ -14,6 +14,7 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-shared";
 
 const PROVIDER_ID = "opencode";
+export const OPENCODE_ZEN_OX_ALPHA_MODEL_ID = "x-preview-f-free";
 
 const OPENCODE_ZEN_OPENAI_BASE_URL = "https://opencode.ai/zen/v1";
 const OPENCODE_ZEN_ANTHROPIC_BASE_URL = "https://opencode.ai/zen";
@@ -36,6 +37,7 @@ type ZenModelCapabilities = {
   reasoningEfforts?: readonly string[];
   status?: "deprecated";
   replacedBy?: string;
+  requiresApiKey?: boolean;
 };
 
 const T = ["text"] as const;
@@ -142,6 +144,9 @@ const MODEL_CAPABILITY_ROWS = [
   ["qwen3.6-plus", 262144, 65536, TI],
   ["qwen3.5-plus", 262144, 65536, TI],
   ["big-pickle", 200000, 32000, T, undefined, INPUT_160],
+  // Zen does not publish capability metadata for this stealth row. The public
+  // API accepts a 1M-token text prompt and rejects max_tokens above 131,072.
+  [OPENCODE_ZEN_OX_ALPHA_MODEL_ID, 1000000, 131072, T],
   ["deepseek-v4-flash-free", 200000, 128000, T, E_LOW_HIGH_MAX],
   ["mimo-v2.5-free", 200000, 32000, TI],
   ["ling-3.0-flash-free", 262144, 32768, T, E_LMH, DEPRECATED],
@@ -162,6 +167,7 @@ const MODEL_CAPABILITIES = Object.fromEntries(
       maxTokens,
       input,
       ...(reasoningEfforts ? { reasoningEfforts } : {}),
+      ...(id === OPENCODE_ZEN_OX_ALPHA_MODEL_ID ? { requiresApiKey: false } : {}),
       ...metadata,
     },
   ]),
@@ -311,6 +317,7 @@ const MODEL_COSTS: Record<ZenModelId, ModelDefinitionConfig["cost"]> = {
   "north-mini-code-free": FREE_COST,
   "qwen3.5-plus": { input: 0.2, output: 1.2, cacheRead: 0.02, cacheWrite: 0.25 },
   "qwen3.6-plus": { input: 0.5, output: 3, cacheRead: 0.05, cacheWrite: 0.625 },
+  "x-preview-f-free": FREE_COST,
 };
 
 const MODEL_NAMES: Record<ZenModelId, string> = {
@@ -376,6 +383,7 @@ const MODEL_NAMES: Record<ZenModelId, string> = {
   "north-mini-code-free": "North Mini Code Free",
   "qwen3.5-plus": "Qwen3.5 Plus",
   "qwen3.6-plus": "Qwen3.6 Plus",
+  "x-preview-f-free": "Ox Alpha Free",
 };
 
 type OpencodeZenModelDefinition = ModelDefinitionConfig & {
@@ -428,6 +436,7 @@ function buildOpencodeZenModel(modelId: ZenModelId): OpencodeZenModelDefinition 
     cost: MODEL_COSTS[modelId],
     contextWindow: capabilities.contextWindow,
     ...(capabilities.contextTokens ? { contextTokens: capabilities.contextTokens } : {}),
+    ...(capabilities.requiresApiKey === false ? { requiresApiKey: false } : {}),
     maxTokens: capabilities.maxTokens,
     ...(transport.api === "openai-responses" && !capabilities.reasoningEfforts?.includes("none")
       ? { thinkingLevelMap: { off: null } }

--- a/extensions/opencode/provider-discovery.test.ts
+++ b/extensions/opencode/provider-discovery.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import provider from "./provider-discovery.js";
+
+describe("OpenCode provider discovery", () => {
+  it("resolves Ox Alpha anonymous auth without loading the full plugin", () => {
+    expect(provider.resolveSyntheticAuth?.({ modelId: "x-preview-f-free" } as never)).toEqual({
+      apiKey: "opencode-zen-anonymous",
+      source: "OpenCode Zen Ox Alpha Free (anonymous route)",
+      mode: "api-key",
+    });
+    expect(
+      provider.resolveSyntheticAuth?.({ modelId: "deepseek-v4-flash-free" } as never),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/opencode/provider-discovery.ts
+++ b/extensions/opencode/provider-discovery.ts
@@ -1,5 +1,6 @@
 // Opencode Zen provider module exposes offline catalog metadata to core discovery.
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import { resolveOpencodeZenAnonymousAuth } from "./gateway-auth-api.js";
 import { buildStaticOpencodeZenProviderConfig } from "./provider-catalog.js";
 
 const opencodeProviderDiscovery: ProviderPlugin = {
@@ -7,6 +8,7 @@ const opencodeProviderDiscovery: ProviderPlugin = {
   label: "OpenCode Zen",
   docsPath: "/providers/models",
   auth: [],
+  resolveSyntheticAuth: ({ modelId }) => resolveOpencodeZenAnonymousAuth(modelId),
   staticCatalog: {
     order: "simple",
     run: async () => ({

--- a/extensions/opencode/provider-policy-api.test.ts
+++ b/extensions/opencode/provider-policy-api.test.ts
@@ -92,4 +92,17 @@ describe("opencode provider policy public artifact", () => {
       }),
     ).toEqual({ levels: [{ id: "off", label: "always on" }], defaultLevel: "off" });
   });
+
+  it("keeps Ox Alpha's mandatory reasoning profile exact", () => {
+    expect(
+      resolveThinkingProfile({
+        provider: "opencode",
+        modelId: "x-preview-f-free",
+        compat: { supportedReasoningEfforts: ["low", "high", "max"] },
+      }),
+    ).toEqual({
+      levels: [{ id: "low" }, { id: "high" }, { id: "max" }],
+      defaultLevel: "max",
+    });
+  });
 });

--- a/extensions/opencode/provider-policy-api.ts
+++ b/extensions/opencode/provider-policy-api.ts
@@ -10,6 +10,11 @@ const FIXED_REASONING_PROFILE = {
   defaultLevel: "off",
 } as const satisfies ProviderThinkingProfile;
 
+const OX_ALPHA_THINKING_PROFILE = {
+  levels: [{ id: "low" }, { id: "high" }, { id: "max" }],
+  defaultLevel: "max",
+} as const satisfies ProviderThinkingProfile;
+
 const THINKING_LEVEL_IDS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
 
 function resolveEffortThinkingProfile(
@@ -37,6 +42,9 @@ function resolveEffortThinkingProfile(
 
 export function resolveThinkingProfile(params: ProviderDefaultThinkingPolicyContext) {
   const modelId = params.modelId.trim().toLowerCase();
+  if (modelId === "x-preview-f-free") {
+    return OX_ALPHA_THINKING_PROFILE;
+  }
   if (modelId.startsWith("claude-")) {
     return resolveClaudeThinkingProfile(modelId);
   }

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -337,6 +337,24 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
+  it("omits credentials for an explicitly anonymous model", async () => {
+    mockOpenAIOptionsRef.options = [];
+    mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+
+    const result = await streamSimpleOpenAICompletions(
+      { ...model, provider: "public-preview", requiresApiKey: false },
+      context,
+    ).result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(mockOpenAIOptionsRef.options).toContainEqual(
+      expect.objectContaining({
+        apiKey: "unused",
+        defaultHeaders: { Authorization: null },
+      }),
+    );
+  });
+
   it("surfaces chat-completions refusal deltas as visible assistant text", async () => {
     mockChunksRef.chunks = [makeRefusalChunk("I can't help with that.")];
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -692,7 +692,7 @@ export const streamSimpleOpenAICompletions: StreamFunction<
   SimpleStreamOptions
 > = (model: Model<"openai-completions">, context: Context, options?: SimpleStreamOptions) => {
   const apiKey = options?.apiKey || getEnvApiKey(model.provider);
-  if (!apiKey) {
+  if (!apiKey && model.requiresApiKey !== false) {
     throw new Error(`No API key for provider: ${model.provider}`);
   }
 
@@ -723,11 +723,16 @@ function createClient(
   sessionId?: string,
   compat: ResolvedOpenAICompletionsCompat = resolveOpenAICompletionsCompat(model),
 ) {
-  if (!apiKey) {
+  if (!apiKey && model.requiresApiKey !== false) {
     throw new Error(`No API key for provider: ${model.provider}`);
   }
 
-  const headers = { ...model.headers };
+  const headers: Record<string, string | null> = { ...model.headers };
+  if (model.requiresApiKey === false) {
+    // The OpenAI SDK requires an apiKey constructor value and otherwise adds a
+    // bearer header. This model contract intentionally omits credentials.
+    headers.Authorization = null;
+  }
   if (model.provider === "github-copilot") {
     const hasImages = hasCopilotVisionInput(context.messages);
     const copilotHeaders = buildCopilotDynamicHeaders({
@@ -762,7 +767,7 @@ function createClient(
       : headers;
 
   return new OpenAI({
-    apiKey,
+    apiKey: apiKey || "unused",
     baseURL: isCloudflareProvider(model.provider) ? resolveCloudflareBaseUrl(model) : model.baseUrl,
     dangerouslyAllowBrowser: true,
     defaultHeaders,

--- a/packages/ai/src/transports/openai-completions-transport.test.ts
+++ b/packages/ai/src/transports/openai-completions-transport.test.ts
@@ -364,4 +364,17 @@ describe("openai completions transport", () => {
     expect(request.headers.get("api-version")).toBe("proxy-header");
     expect(request.headers.get("x-tenant")).toBe("acme");
   });
+
+  it("omits authorization for explicitly anonymous OpenAI-compatible models", async () => {
+    const request = await captureTransportRequest(
+      makeCompletionsModel({
+        id: "anonymous-preview",
+        name: "Anonymous Preview",
+        provider: "public-preview",
+        requiresApiKey: false,
+      }),
+    );
+
+    expect(request.headers.get("authorization")).toBeNull();
+  });
 });

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -129,10 +129,19 @@ function buildOpenAICompletionsClientConfig(
   optionHeaders?: Record<string, string>,
 ): {
   baseURL: string;
-  defaultHeaders: Record<string, string>;
+  defaultHeaders: Record<string, string | null>;
   defaultQuery?: Record<string, string>;
 } {
-  const headers = buildOpenAIClientHeaders(model, context, optionHeaders);
+  const headers: Record<string, string | null> = buildOpenAIClientHeaders(
+    model,
+    context,
+    optionHeaders,
+  );
+  if (model.requiresApiKey === false) {
+    // The SDK receives a non-empty sentinel for its constructor invariant, but
+    // anonymous model contracts must never turn that sentinel into a bearer token.
+    headers.Authorization = null;
+  }
   const defaultQuery: Record<string, string> = {};
   let baseURL = model.baseUrl;
   let isAzureHost = false;

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -683,6 +683,8 @@ export interface Model<TApi extends Api = Api> {
   maxTokens: number;
   /** Provider-specific request/runtime parameters passed through to provider plugins. */
   params?: Record<string, unknown>;
+  /** Whether this model requires request credentials. Defaults to true. */
+  requiresApiKey?: boolean;
   headers?: Record<string, string>;
   /** Sends runtime credentials as Authorization: Bearer instead of provider-specific key headers. */
   authHeader?: boolean;

--- a/src/agents/model-auth-model.ts
+++ b/src/agents/model-auth-model.ts
@@ -165,7 +165,11 @@ export async function hasAvailableAuthForProvider(params: {
   ) {
     return true;
   }
-  const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({ cfg, provider });
+  const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({
+    cfg,
+    provider,
+    modelId: params.modelId,
+  });
   if (
     syntheticLocalAuth &&
     (!authConfig.isConfigBackedInlineProviderApiKey({

--- a/src/agents/model-auth-provider.ts
+++ b/src/agents/model-auth-provider.ts
@@ -566,6 +566,7 @@ export async function resolveApiKeyForProviderCore(params: {
   const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({
     cfg,
     provider,
+    modelId: params.modelId,
     modelApi: params.modelApi,
     secretSentinels: params.secretSentinels,
     allowPluginSyntheticAuth: params.allowAuthProfileFallback !== false,

--- a/src/agents/model-auth-runtime.ts
+++ b/src/agents/model-auth-runtime.ts
@@ -235,6 +235,28 @@ type SyntheticProviderAuthResolution = {
   blockedOnManagedSecretRef?: boolean;
 };
 
+function resolvePluginSyntheticAuth(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  modelId?: string;
+  modelApi?: string;
+}): ResolvedProviderAuth | undefined {
+  const providerConfig = authConfig.resolveProviderConfig(params.cfg, params.provider);
+  return (
+    resolveProviderSyntheticAuthWithPlugin({
+      provider: params.provider,
+      config: params.cfg,
+      context: {
+        config: params.cfg,
+        provider: params.provider,
+        modelId: params.modelId,
+        providerConfig,
+      },
+      modelApi: params.modelApi,
+    }) ?? undefined
+  );
+}
+
 function resolveProviderSyntheticRuntimeAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -250,24 +272,8 @@ function resolveProviderSyntheticRuntimeAuth(params: {
     return { blockedOnManagedSecretRef: true };
   }
 
-  const resolveFromConfig = (
-    config: OpenClawConfig | undefined,
-  ): ResolvedProviderAuth | undefined => {
-    const providerConfig = authConfig.resolveProviderConfig(config, params.provider);
-    return (
-      resolveProviderSyntheticAuthWithPlugin({
-        provider: params.provider,
-        config,
-        context: {
-          config,
-          provider: params.provider,
-          modelId: params.modelId,
-          providerConfig,
-        },
-        modelApi: params.modelApi,
-      }) ?? undefined
-    );
-  };
+  const resolveFromConfig = (config: OpenClawConfig | undefined) =>
+    resolvePluginSyntheticAuth({ ...params, cfg: config });
 
   const directAuth = resolveFromConfig(params.cfg);
   if (!directAuth) {
@@ -307,10 +313,15 @@ export function resolveSyntheticLocalProviderAuth(params: {
   secretSentinels?: boolean;
   allowPluginSyntheticAuth?: boolean;
 }): ResolvedProviderAuth | null {
-  // Prepared direct attempts may use local no-auth config, but must not widen
-  // back into an unprepared plugin-owned credential source.
-  const syntheticProviderAuth =
-    params.allowPluginSyntheticAuth === false ? {} : resolveProviderSyntheticRuntimeAuth(params);
+  // Prepared direct attempts cannot borrow plugin credentials. A manifest-declared
+  // non-secret marker is transport setup, though, not a credential fallback.
+  const syntheticProviderAuth: SyntheticProviderAuthResolution =
+    params.allowPluginSyntheticAuth === false
+      ? (() => {
+          const auth = resolvePluginSyntheticAuth(params);
+          return auth?.apiKey && isNonSecretApiKeyMarker(auth.apiKey) ? { auth } : {};
+        })()
+      : resolveProviderSyntheticRuntimeAuth(params);
   if (syntheticProviderAuth.auth) {
     return syntheticProviderAuth.auth;
   }

--- a/src/agents/model-auth-runtime.ts
+++ b/src/agents/model-auth-runtime.ts
@@ -238,6 +238,7 @@ type SyntheticProviderAuthResolution = {
 function resolveProviderSyntheticRuntimeAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
+  modelId?: string;
   modelApi?: string;
   secretSentinels?: boolean;
 }): SyntheticProviderAuthResolution {
@@ -260,6 +261,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
         context: {
           config,
           provider: params.provider,
+          modelId: params.modelId,
           providerConfig,
         },
         modelApi: params.modelApi,
@@ -300,6 +302,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
 export function resolveSyntheticLocalProviderAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
+  modelId?: string;
   modelApi?: string;
   secretSentinels?: boolean;
   allowPluginSyntheticAuth?: boolean;

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -118,7 +118,10 @@ vi.mock("../plugins/provider-runtime.js", () => {
         };
       };
       modelApi?: string;
-      context: { providerConfig?: { api?: string; baseUrl?: string; models?: unknown[] } };
+      context: {
+        modelId?: string;
+        providerConfig?: { api?: string; baseUrl?: string; models?: unknown[] };
+      };
     }) => {
       if (params.provider === "plugin-web") {
         if (
@@ -150,6 +153,13 @@ vi.mock("../plugins/provider-runtime.js", () => {
           apiKey: "native-cli-access-token",
           source: "Native CLI auth",
           mode: "oauth" as const,
+        };
+      }
+      if (params.provider === "anonymous-preview" && params.context.modelId === "preview") {
+        return {
+          apiKey: "gcp-vertex-credentials",
+          source: "Anonymous preview route",
+          mode: "api-key" as const,
         };
       }
       const effectiveApi = params.modelApi ?? params.context.providerConfig?.api;
@@ -1518,6 +1528,31 @@ describe("resolveApiKeyForProviderCore", () => {
       source: "Native CLI auth",
       mode: "oauth",
     });
+  });
+
+  it("keeps manifest-declared non-secret plugin auth on a prepared direct route", async () => {
+    await expect(
+      resolveApiKeyForProviderCore({
+        provider: "anonymous-preview",
+        modelId: "preview",
+        allowAuthProfileFallback: false,
+        store: { version: 1, profiles: {} },
+      }),
+    ).resolves.toEqual({
+      apiKey: "gcp-vertex-credentials",
+      source: "Anonymous preview route",
+      mode: "api-key",
+    });
+  });
+
+  it("does not borrow secret plugin auth on a prepared direct route", async () => {
+    await expect(
+      resolveApiKeyForProviderCore({
+        provider: "native-cli",
+        allowAuthProfileFallback: false,
+        store: { version: 1, profiles: {} },
+      }),
+    ).rejects.toThrow('No API key found for provider "native-cli"');
   });
 
   it("reuses the loaded auth profile store after deferring an explicit synthetic profile", async () => {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -195,6 +195,8 @@ export type ModelDefinitionConfig = {
   thinkingLevelMap?: ThinkingLevelMap;
   /** Provider-specific request/runtime parameters passed through to provider plugins. */
   params?: Record<string, unknown>;
+  /** Whether this model requires request credentials. Defaults to true. */
+  requiresApiKey?: boolean;
   /** Optional agent execution runtime override for this provider/model pair. */
   agentRuntime?: AgentRuntimePolicyConfig;
   /** Static headers merged into requests for this model. */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -430,6 +430,7 @@ const ModelDefinitionSchema = z
     maxTokens: z.number().positive().optional(),
     thinkingLevelMap: ThinkingLevelMapSchema.optional(),
     params: z.record(z.string(), z.unknown()).optional(),
+    requiresApiKey: z.boolean().optional(),
     agentRuntime: ModelAgentRuntimePolicySchema,
     headers: z.record(z.string(), z.string()).optional(),
     compat: ModelCompatSchema,

--- a/src/plugins/provider-catalog-result.ts
+++ b/src/plugins/provider-catalog-result.ts
@@ -42,6 +42,7 @@ const MODEL_DEFINITION_CONFIG_KEYS = [
   "maxTokens",
   "thinkingLevelMap",
   "params",
+  "requiresApiKey",
   "agentRuntime",
   "headers",
   "compat",

--- a/src/plugins/provider-external-auth.types.ts
+++ b/src/plugins/provider-external-auth.types.ts
@@ -15,6 +15,8 @@ export type ProviderAuthOptionBag = {
 export type ProviderResolveSyntheticAuthContext = {
   config?: OpenClawConfig;
   provider: string;
+  /** Exact requested model when auth availability is model-specific. */
+  modelId?: string;
   providerConfig?: ModelProviderConfig;
 };
 


### PR DESCRIPTION
## Summary

### High Level TLDR

OpenCode Zen Ox Alpha is now a first-class anonymous OpenAI-compatible model route. The final transport fix prevents its internal route marker from becoming an Authorization header, so the real Gateway request stays credential-free.

### Root Cause

The model is intentionally served by OpenCode without an API key. Its plugin emits a non-secret marker only so the direct auth resolver can select the route. The active Gateway uses the `openai-completions` transport, whose client configuration did not translate `requiresApiKey: false` into `Authorization: null`; the SDK therefore sent the marker as a bearer credential and Zen rejected it with HTTP 401.

The repair keeps the marker internal and makes the generic anonymous-model contract suppress Authorization at the transport boundary. Secret-backed plugin auth remains unavailable on direct routes.

### Real behavior proof

A fresh, isolated local Gateway with the built branch and only the OpenCode plugin enabled ran:

```sh
openclaw agent --agent main --session-key agent:main:oc-ox-local-gateway-proof --model opencode/x-preview-f-free --thinking max --message "Reply exactly OX_LOCAL_GATEWAY_OK" --json
```

Observed result: the Gateway transport logged HTTP 200 from `https://opencode.ai/zen/v1/chat/completions`, and the agent returned `OX_LOCAL_GATEWAY_OK`; the resolved provider/model were `opencode/x-preview-f-free`, with a 1,000,000-token context window and `thinking=max`.

## Verification

- `node scripts/run-vitest.mjs packages/ai/src/transports/openai-completions-transport.test.ts packages/ai/src/providers/openai-completions.test.ts src/agents/model-auth.test.ts extensions/opencode/index.test.ts extensions/opencode/provider-discovery.test.ts` (174 tests passed)
- `pnpm tsgo:prod`
- `git diff --check`
- Direct Zen request without Authorization: HTTP 200 before the Gateway test.

## What was not tested

- The managed Gateway was not updated with this final transport commit.
- Zen capabilities not exercised in the proof remain out of scope: image input, tool calling, very-large-context requests, and every thinking level beyond `max`.
