### PR TITLE
fix(ui): make Automations task rows accessible

### DIFF
--- a/ui/src/e2e/cron-remove.e2e.test.ts
+++ b/ui/src/e2e/cron-remove.e2e.test.ts
@@ -63,7 +63,11 @@ suite.define(() => {
         expect(response?.status()).toBe(200);
         const row = page.locator(`[data-test-id="cron-row-${job.id}"]`);
         await row.waitFor({ state: "visible", timeout: 10_000 });
-        await row.locator(".cron-table__name-text").click();
+        expect(await page.locator(".cron-table__head").getAttribute("role")).toBeNull();
+        expect(await row.getAttribute("role")).toBeNull();
+        const openTask = row.getByRole("button", { name: /Nightly digest/ });
+        await openTask.focus();
+        await page.keyboard.press("Enter");
         const detail = page.locator('.cron-page[data-panel-mode="job"]');
         await detail.waitFor({ state: "visible" });
 

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -116,7 +116,22 @@ describe("cron view list pane", () => {
     expect(onJobsFiltersReset).toHaveBeenCalledTimes(1);
   });
 
-  it("renders table rows with schedule and status cells and selects on click", () => {
+  it("does not expose table rows without complete table semantics", () => {
+    const container = renderView({ jobs: [createJob("job-1")] });
+
+    for (const row of container.querySelectorAll('[role="row"]')) {
+      expect(row.closest('[role="table"], [role="grid"], [role="treegrid"]')).not.toBeNull();
+      expect(
+        Array.from(row.children).every((child) =>
+          child.matches(
+            '[role="cell"], [role="gridcell"], [role="columnheader"], [role="rowheader"]',
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("renders table rows with independent native buttons for opening tasks", () => {
     const onSelectJob = vi.fn();
     const job = createJob("job-1", {
       trigger: { script: "json({ fire: true })" },
@@ -134,6 +149,7 @@ describe("cron view list pane", () => {
 
     const rows = Array.from(container.querySelectorAll(".cron-table__row"));
     expect(rows).toHaveLength(3);
+    expect(rows[0]?.getAttribute("role")).toBeNull();
     expect(rows[0]?.textContent).toContain("Cron 0 9 * * *");
     expect(rows[1]?.classList.contains("cron-table__row--paused")).toBe(true);
     expect(rows[1]?.textContent).toContain("Paused");
@@ -150,7 +166,7 @@ describe("cron view list pane", () => {
       "Trigger configured",
     );
 
-    (rows[1] as HTMLElement).click();
+    getElement(rows[1] as Element, ".cron-table__name", HTMLButtonElement).click();
     expect(onSelectJob).toHaveBeenCalledWith(paused);
   });
 

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -728,7 +728,7 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
 function renderJobsTable(props: CronProps, hasAnyJobsFilters: boolean) {
   return html`
     <div class="cron-table ${props.canManage ? "" : "cron-table--read-only"}">
-      <div class="cron-table__head" role="row">
+      <div class="cron-table__head">
         <span>${t("cron.jobs.name")}</span>
         <span>${t("cron.jobs.schedule")}</span>
         <span>${t("cron.jobs.nextRun")}</span>
@@ -775,18 +775,10 @@ function renderJobRow(job: CronJob, props: CronProps) {
   return html`
     <div
       class="cron-table__row ${job.enabled ? "" : "cron-table__row--paused"}"
-      role="button"
-      tabindex="0"
       data-test-id=${`cron-row-${job.id}`}
       @click=${() => props.onSelectJob(job)}
-      @keydown=${(e: KeyboardEvent) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          props.onSelectJob(job);
-        }
-      }}
     >
-      <span class="cron-table__name">
+      <button type="button" class="cron-table__name">
         ${renderJobStateIndicator(job)}
         <span class="cron-table__name-copy">
           <span class="cron-table__name-line">
@@ -814,17 +806,13 @@ function renderJobRow(job: CronJob, props: CronProps) {
               `
             : nothing}
         </span>
-      </span>
+      </button>
       ${renderJobCell("cron-table__schedule", t("cron.jobs.schedule"), formatCronSchedule(job))}
       ${renderJobCell("cron-table__next", t("cron.jobs.nextRun"), nextRun)}
       ${renderJobCell("cron-table__last", t("cron.jobs.lastRun"), renderLastRunCell(job))}
       ${props.canManage
         ? html`
-            <span
-              class="cron-table__actions"
-              @click=${(e: Event) => e.stopPropagation()}
-              @keydown=${(e: Event) => e.stopPropagation()}
-            >
+            <span class="cron-table__actions" @click=${(e: Event) => e.stopPropagation()}>
               <button
                 type="button"
                 class="btn btn--sm btn--ghost cron-row-run"

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -324,7 +324,7 @@
 }
 
 .cron-table__row:hover,
-.cron-table__row:focus-visible {
+.cron-table__row:focus-within {
   background: var(--bg-hover);
 }
 
@@ -338,9 +338,13 @@
   align-items: flex-start;
   gap: 10px;
   min-width: 0;
+  padding: 0;
+  border: 0;
   color: var(--text-strong);
+  background: transparent;
   font-size: 13px;
   font-weight: 600;
+  text-align: left;
 }
 
 .cron-table__state {


### PR DESCRIPTION
## What Problem This Solves

Fixes two accessibility issues where users navigating Automations with a keyboard or assistive technology encountered invalid and ambiguous task-list semantics. The visual column heading was exposed as an orphan ARIA row without a table/grid owner or cell roles, while each task row was exposed as one large button containing separate Run, enable/disable, and menu controls.

## Why This Change Was Made

The visual CSS grid no longer claims partial table semantics, and each task's name/details cell is now the native button that opens that task. The neutral row remains a convenient pointer target, while Run, enable/disable, and menu actions remain independent sibling controls. This preserves existing task behavior and reconnect/removal ownership without adding a second interaction model or changing Gateway contracts.

Production LOC: +9/-17 (net -8) | Tests: +23/-3

## User Impact

Keyboard and assistive-technology users now get one named native control for opening a task instead of a faux button containing other interactive controls. Automations no longer exposes unsupported partial table roles, while pointer users retain the existing large row target and all inline actions.

## Evidence

Authentic regressions were captured before the production edit:

- the ARIA-invariant regression found an exposed `role="row"` without a `table`, `grid`, or `treegrid` ancestor and failed with `expected null not to be null`;
- the task-row regression found the row still exposed as `role="button"` and failed with `expected 'button' to be null`.

Post-fix verification on commit `b80171047846d6f7459ead226c345988bc6c4cfb`:

- 85/85 focused Automations owner/page/view tests passed;
- 1/1 real source-mode Chromium mocked-Gateway E2E passed, exercising the named native task button with Enter, removal, and reconnect fencing;
- a separate 390×844 source-Chromium run passed and confirmed the focused task facts/actions remain visible without clipping;
- the full changed-file format, type, lint, and test gate passed;
- focused Stylelint passed for `ui/src/styles/cron.css`;
- fresh Codex autoreview found no actionable issue through P3 (patch-correct confidence 0.96).

No exact open duplicate was found across live issue/PR searches for Automations row/table/nested-interactive accessibility. The original partial-role implementation traces to PR #105174 (`17a533ce268…`).

| Before | After |
| --- | --- |
| ![Automations task list before the semantics repair](https://ampcode.com/user-content/artifacts/17aebe701dec54a614d5b1b23cd7c91d8789db05d6ba6fb1986767214a080d72-file.png) | ![Automations task list after the semantics repair](https://ampcode.com/user-content/artifacts/64ddf2970b75782821e2b8251d386128f66f6ffd0559cc658901dfe8be788ee0-file.png) |

Mobile source-Chromium proof:

![Automations task row focused at 390 by 844 CSS pixels](https://ampcode.com/user-content/artifacts/66eb2f0cc3d9ee081f339b0a54cec469e4901f3b00cae0c15980c69b228ac762-file.png)

AI-assisted implementation and verification; no agent transcript is attached.
