### PR TITLE
fix(auto-reply): cap trailing blank lines in chunkByNewline to the chunk limit

### DIFF
--- a/src/auto-reply/chunk.plugin-runtime.test.ts
+++ b/src/auto-reply/chunk.plugin-runtime.test.ts
@@ -65,7 +65,7 @@ describe("plugin newline chunk delivery", () => {
       transportLimit: 2,
       expected: ["ok", "😀"],
     },
-  ])("$name", async ({ text, limit, transportLimit, options, expected }) => {
+  ])("$name", ({ text, limit, transportLimit, options, expected }) => {
     const accepted: string[] = [];
     const plugin = definePluginEntry({
       id: "newline-report-test",
@@ -98,7 +98,7 @@ describe("plugin newline chunk delivery", () => {
     });
     const api = registry.createApi(record, { config: {} });
 
-    await plugin.register(api);
+    plugin.register(api);
 
     expect(accepted).toEqual(expected);
   });

--- a/src/auto-reply/chunk.plugin-runtime.test.ts
+++ b/src/auto-reply/chunk.plugin-runtime.test.ts
@@ -1,0 +1,105 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it } from "vitest";
+import { createPluginRecord } from "../plugins/loader-records.js";
+import { createPluginRegistry } from "../plugins/registry.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+
+const report = "Backup completed successfully.";
+
+describe("plugin newline chunk delivery", () => {
+  it.each([
+    {
+      name: "does not overflow a full report with its terminating blank line",
+      text: `${report}\n\n`,
+      limit: 30,
+      transportLimit: 30,
+      expected: [report],
+    },
+    {
+      name: "preserves a terminating blank line that fits",
+      text: `${report}\n\n`,
+      limit: 32,
+      transportLimit: 32,
+      expected: [`${report}\n\n`],
+    },
+    {
+      name: "bounds the last report after earlier lines were delivered",
+      text: `${report}\n${report}\n\n`,
+      limit: 31,
+      transportLimit: 31,
+      expected: [report, `${report}\n`],
+    },
+    {
+      name: "preserves ordinary blank lines between reports",
+      text: `${report}\n\n${report}`,
+      limit: 32,
+      transportLimit: 32,
+      expected: [report, `\n${report}`],
+    },
+    {
+      name: "preserves an unsplit long line without adding excess blank lines",
+      text: `${report}\n\n`,
+      limit: 10,
+      transportLimit: 30,
+      options: { splitLongLines: false },
+      expected: [report],
+    },
+    {
+      name: "keeps an indivisible astral character without adding blank lines",
+      text: "😀\n\n",
+      limit: 1,
+      transportLimit: 2,
+      expected: ["😀"],
+    },
+    {
+      name: "reserves a complete astral character after leading blank lines",
+      text: "\n😀",
+      limit: 2,
+      transportLimit: 2,
+      expected: ["😀"],
+    },
+    {
+      name: "reserves a complete astral character after interior blank lines",
+      text: "ok\n\n😀",
+      limit: 2,
+      transportLimit: 2,
+      expected: ["ok", "😀"],
+    },
+  ])("$name", async ({ text, limit, transportLimit, options, expected }) => {
+    const accepted: string[] = [];
+    const plugin = definePluginEntry({
+      id: "newline-report-test",
+      name: "Newline report test",
+      description: "Exercises the injected text helper from a plugin entry.",
+      register(api) {
+        for (const chunk of api.runtime.channel.text.chunkByNewline(text, limit, options)) {
+          // This transport is intentionally bounded independently of the chunker.
+          // The long-line opt-out and indivisible-code-point cases use wider transports.
+          if (chunk.length > transportLimit) {
+            throw new Error(
+              `Transport rejected ${chunk.length} UTF-16 units; limit ${transportLimit}`,
+            );
+          }
+          accepted.push(chunk);
+        }
+      },
+    });
+    const registry = createPluginRegistry({
+      runtime: createPluginRuntime(),
+      logger: { info() {}, warn() {}, error() {} },
+      activateGlobalSideEffects: false,
+    });
+    const record = createPluginRecord({
+      id: plugin.id,
+      source: "/virtual/newline-report-test/index.ts",
+      origin: "global",
+      enabled: true,
+      configSchema: true,
+    });
+    const api = registry.createApi(record, { config: {} });
+
+    await plugin.register(api);
+
+    expect(accepted).toEqual(expected);
+  });
+});

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -552,6 +552,68 @@ describe("chunkByNewline", () => {
       expected: ["Line one\n\n"],
     },
     {
+      name: "caps trailing blank lines to the final chunk's remaining space",
+      text: "x" + "\n".repeat(50),
+      limit: 10,
+      expected: ["x" + "\n".repeat(9)],
+    },
+    {
+      name: "does not append blank lines to a full chunk",
+      text: "abcdefghij\n\n",
+      limit: 10,
+      expected: ["abcdefghij"],
+    },
+    {
+      name: "counts astral text in UTF-16 units before appending blank lines",
+      text: "😀\n\n",
+      limit: 3,
+      expected: ["😀\n"],
+    },
+    {
+      name: "reserves a whole first code point after leading blank lines",
+      text: "\n😀",
+      limit: 2,
+      expected: ["😀"],
+    },
+    {
+      name: "reserves a whole first code point after interior blank lines",
+      text: "a\n\n😀",
+      limit: 2,
+      expected: ["a", "😀"],
+    },
+    {
+      name: "normalizes fractional limits for leading and trailing blank lines",
+      text: "\n😀\n\n",
+      limit: 2.9,
+      expected: ["😀"],
+    },
+    {
+      name: "keeps an indivisible code point without adding blank lines",
+      text: "😀\n\n",
+      limit: 1,
+      expected: ["😀"],
+    },
+    {
+      name: "keeps unsplit long lines without appending excess blank lines",
+      text: "abcdefghij\n\n",
+      limit: 3,
+      options: { splitLongLines: false },
+      expected: ["abcdefghij"],
+    },
+    {
+      name: "counts untrimmed text when bounding trailing blank lines",
+      text: "  x \n\n",
+      limit: 5,
+      options: { trimLines: false },
+      expected: ["  x \n"],
+    },
+    {
+      name: "preserves trailing blank lines when the limit is disabled",
+      text: "x\n\n",
+      limit: 0,
+      expected: ["x\n\n"],
+    },
+    {
       name: "keeps whitespace when trimLines is false",
       text: "  indented line  \nNext",
       limit: 1000,
@@ -608,24 +670,6 @@ describe("chunkByNewline", () => {
     expect(chunks).toEqual(["😀", "😀"]);
     expect(chunks).not.toContain("");
     expect(chunks.join("")).toBe(text);
-  });
-
-  it("caps trailing blank lines so the final chunk never exceeds the limit", () => {
-    // Mid-message blank lines are capped to `lineLimit - 1`; trailing blank lines
-    // fold onto the last chunk and must honor the same headroom, otherwise a run
-    // of trailing newlines pushes the last chunk past the platform length limit.
-    const text = "x" + "\n".repeat(50);
-    const limit = 10;
-    const chunks = chunkByNewline(text, limit);
-
-    expect(chunks.length).toBeGreaterThan(0);
-    for (const chunk of chunks) {
-      expect(chunk.length, `chunk ${JSON.stringify(chunk)} exceeds limit`).toBeLessThanOrEqual(
-        limit,
-      );
-    }
-    // The single line plus as many trailing newlines as fit (limit - 1) are retained.
-    expect(chunks).toEqual(["x" + "\n".repeat(limit - 1)]);
   });
 });
 

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -620,7 +620,9 @@ describe("chunkByNewline", () => {
 
     expect(chunks.length).toBeGreaterThan(0);
     for (const chunk of chunks) {
-      expect(chunk.length, `chunk ${JSON.stringify(chunk)} exceeds limit`).toBeLessThanOrEqual(limit);
+      expect(chunk.length, `chunk ${JSON.stringify(chunk)} exceeds limit`).toBeLessThanOrEqual(
+        limit,
+      );
     }
     // The single line plus as many trailing newlines as fit (limit - 1) are retained.
     expect(chunks).toEqual(["x" + "\n".repeat(limit - 1)]);

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -609,6 +609,22 @@ describe("chunkByNewline", () => {
     expect(chunks).not.toContain("");
     expect(chunks.join("")).toBe(text);
   });
+
+  it("caps trailing blank lines so the final chunk never exceeds the limit", () => {
+    // Mid-message blank lines are capped to `lineLimit - 1`; trailing blank lines
+    // fold onto the last chunk and must honor the same headroom, otherwise a run
+    // of trailing newlines pushes the last chunk past the platform length limit.
+    const text = "x" + "\n".repeat(50);
+    const limit = 10;
+    const chunks = chunkByNewline(text, limit);
+
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const chunk of chunks) {
+      expect(chunk.length, `chunk ${JSON.stringify(chunk)} exceeds limit`).toBeLessThanOrEqual(limit);
+    }
+    // The single line plus as many trailing newlines as fit (limit - 1) are retained.
+    expect(chunks).toEqual(["x" + "\n".repeat(limit - 1)]);
+  });
 });
 
 describe("chunkTextWithMode", () => {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -117,6 +117,7 @@ export function resolveChunkMode(
 /**
  * Split text on newlines, trimming line whitespace.
  * Blank lines are folded into the next non-empty line as leading "\n" prefixes.
+ * Leading and trailing blank lines are capped to the available UTF-16 space.
  * Long lines can be split by length (default) or kept intact via splitLongLines:false.
  */
 export function chunkByNewline(
@@ -148,12 +149,13 @@ export function chunkByNewline(
       continue;
     }
 
-    const maxPrefix = Math.max(0, lineLimit - 1);
-    const cappedBlankLines = pendingBlankLines > 0 ? Math.min(pendingBlankLines, maxPrefix) : 0;
-    const prefix = cappedBlankLines > 0 ? "\n".repeat(cappedBlankLines) : "";
+    const lineValue = trimLines ? trimmed : line;
+    // Leave room for the first whole code point before folding in blank lines.
+    const firstCodePointLength = avoidTrailingHighSurrogateBreak(lineValue, 0, 1);
+    const maxPrefix = Math.max(0, lineLimit - firstCodePointLength);
+    const prefix = "\n".repeat(Math.min(pendingBlankLines, maxPrefix));
     pendingBlankLines = 0;
 
-    const lineValue = trimLines ? trimmed : line;
     if (!splitLongLines || lineValue.length + prefix.length <= lineLimit) {
       chunks.push(prefix + lineValue);
       continue;
@@ -171,8 +173,10 @@ export function chunkByNewline(
     }
   }
 
-  if (pendingBlankLines > 0 && chunks.length > 0) {
-    chunks[chunks.length - 1] += "\n".repeat(pendingBlankLines);
+  const lastChunk = chunks.at(-1);
+  if (pendingBlankLines > 0 && lastChunk !== undefined) {
+    const trailingLines = Math.min(pendingBlankLines, Math.max(0, lineLimit - lastChunk.length));
+    chunks[chunks.length - 1] = lastChunk + "\n".repeat(trailingLines);
   }
 
   return chunks;

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -116,17 +116,8 @@ export function resolveChunkMode(
 
 /**
  * Split text on newlines, trimming line whitespace.
- *
- * Contract: every returned chunk is no longer than `maxLineLength` (code-point
- * units), including folded leading or trailing blank-line prefixes. Blank lines
- * are folded into the next non-empty line as leading "\n" prefixes (capped to
- * the remaining headroom), and a run of trailing blank lines is capped to the
- * final chunk's remaining headroom so it never exceeds the limit.
- *
+ * Blank lines are folded into the next non-empty line as leading "\n" prefixes.
  * Long lines can be split by length (default) or kept intact via splitLongLines:false.
- * This helper is exposed to plugin consumers as `channelRuntime.text.chunkByNewline`;
- * bundled delivery routes use the markdown-aware `chunkTextWithMode`/
- * `chunkMarkdownTextWithMode` dispatchers instead.
  */
 export function chunkByNewline(
   text: string,
@@ -181,19 +172,7 @@ export function chunkByNewline(
   }
 
   if (pendingBlankLines > 0 && chunks.length > 0) {
-    // Trailing blank lines have no following line to fold into, so cap them to
-    // the remaining headroom on the final chunk just like mid-message blank
-    // lines are capped to `lineLimit - 1`; otherwise a run of trailing newlines
-    // could push the last chunk past the platform length limit.
-    const lastIndex = chunks.length - 1;
-    const lastChunk = chunks[lastIndex];
-    if (lastChunk !== undefined) {
-      const remaining = Math.max(0, lineLimit - lastChunk.length);
-      const cappedTrailing = Math.min(pendingBlankLines, remaining);
-      if (cappedTrailing > 0) {
-        chunks[lastIndex] = `${lastChunk}${"\n".repeat(cappedTrailing)}`;
-      }
-    }
+    chunks[chunks.length - 1] += "\n".repeat(pendingBlankLines);
   }
 
   return chunks;

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -172,7 +172,19 @@ export function chunkByNewline(
   }
 
   if (pendingBlankLines > 0 && chunks.length > 0) {
-    chunks[chunks.length - 1] += "\n".repeat(pendingBlankLines);
+    // Trailing blank lines have no following line to fold into, so cap them to
+    // the remaining headroom on the final chunk just like mid-message blank
+    // lines are capped to `lineLimit - 1`; otherwise a run of trailing newlines
+    // could push the last chunk past the platform length limit.
+    const lastIndex = chunks.length - 1;
+    const lastChunk = chunks[lastIndex];
+    if (lastChunk !== undefined) {
+      const remaining = Math.max(0, lineLimit - lastChunk.length);
+      const cappedTrailing = Math.min(pendingBlankLines, remaining);
+      if (cappedTrailing > 0) {
+        chunks[lastIndex] = `${lastChunk}${"\n".repeat(cappedTrailing)}`;
+      }
+    }
   }
 
   return chunks;

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -116,8 +116,17 @@ export function resolveChunkMode(
 
 /**
  * Split text on newlines, trimming line whitespace.
- * Blank lines are folded into the next non-empty line as leading "\n" prefixes.
+ *
+ * Contract: every returned chunk is no longer than `maxLineLength` (code-point
+ * units), including folded leading or trailing blank-line prefixes. Blank lines
+ * are folded into the next non-empty line as leading "\n" prefixes (capped to
+ * the remaining headroom), and a run of trailing blank lines is capped to the
+ * final chunk's remaining headroom so it never exceeds the limit.
+ *
  * Long lines can be split by length (default) or kept intact via splitLongLines:false.
+ * This helper is exposed to plugin consumers as `channelRuntime.text.chunkByNewline`;
+ * bundled delivery routes use the markdown-aware `chunkTextWithMode`/
+ * `chunkMarkdownTextWithMode` dispatchers instead.
  */
 export function chunkByNewline(
   text: string,


### PR DESCRIPTION
## What Problem This Solves

The plugin runtime's `channel.text.chunkByNewline` can exceed its available UTF-16 budget solely because it folds in blank lines. Trailing newlines were appended without a cap, and leading/interior blank lines reserved only one UTF-16 unit even when the next character needs a complete surrogate pair.

## Why This Change Was Made

The repair belongs in the shared newline chunker. It caps trailing blank lines to the last chunk's remaining headroom and reuses the existing Unicode boundary helper to reserve space for the first complete character before adding a prefix. There is no downstream guard, duplicate chunker, new configuration, or new API surface.

The existing `splitLongLines: false` opt-out, indivisible surrogate pairs at a one-unit limit, nonpositive-limit bypass, and fitting whitespace are preserved. These intentional exceptions mean this helper does not promise that every chunk is shorter than the supplied limit.

The three original contributor commits and attribution remain in history. The current Markdown fence-whitespace repair and its regression coverage are preserved. Thanks to @LiuwqGit for the trailing-newline diagnosis and original patch.

## User Impact

Plugins consuming this existing runtime helper no longer gain avoidable over-limit output from normalized blank lines. Bundled outbound delivery uses different paragraph/Markdown helpers; this does not change its routing.

## Evidence

The intentionally regression-only [baseline stage](https://github.com/openclaw/openclaw/pull/127253/commits/0c40344b72129032a947f15aba6dd338b9fe47c5) produced the expected failures in [hosted CI](https://github.com/openclaw/openclaw/actions/runs/33156806291/job/98801634465):

- Owner suite: 9 failed / 77 passed. The failures include trailing headroom, Unicode prefix reservation, fractional limits, unsplit long lines, and untrimmed text.
- Public-runtime consumer: 6 failed / 2 passed. Actual bounded-transport rejections included 32 units against limits30/31, and3/4 units against limit2. Both ordinary-newline controls passed.
- CI ran the PR merge reference `1dc781794331e7a2af1f9ef290d1546de086d941`, combining the baseline stage above with `14d6bb81ad7e998ee3ac54f3fb06e67be157c1d2`. This was secretless fork CI; contributor source was not executed on the maintainer host.

The public-runtime test uses the public plugin entry, a real registry-created plugin API, and the actual injected runtime. Its in-memory transport checks the output budget independently. This is plugin-runtime consumer proof, not channel-network or Gateway delivery proof. No bundled production caller uses this helper, so an authentic bundled Gateway route for it is unavailable.

The canonical repair is present at [the final reviewed head](https://github.com/openclaw/openclaw/pull/127253/commits/c53ea5f8853d0a841c4d6084d438e0357504d083). [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33158912890).

CI executed merge reference `442b6e8c1c885409fe7af4b44b182eaa797d4ee0`, combining that head with `0e1afb2e8c16a816722435349f55a98ad9aa124e`. The changed files and the shared UTF-16/runtime-registry dependencies at that merge match the reviewed source blobs.

The [fresh exact-head ClawSweeper terminal trace](https://github.com/openclaw/openclaw/pull/127253#issuecomment-5372376143) also records the same focused tests passing: **8 public-runtime cases and 86 owner cases**, two Vitest shards in44.59seconds. The command was `node scripts/run-vitest.mjs src/auto-reply/chunk.test.ts src/auto-reply/chunk.plugin-runtime.test.ts --reporter=dot`. This is terminal regression proof, not authenticated channel-network proof.

The review's prior unconditional-length concern is resolved by preserving and documenting the exceptions; the small owner-level production increase is justified below. Removing surplus normalized blank lines is intentional and consistent with the existing prefix cap. The review's remaining exact-head proof request is satisfied by the passing CI and terminal trace above.

The first repaired-head run caught an unnecessary `await` in the new consumer test: plugin registration returns `void`. The follow-up removes only that `await` and the test callback's `async`; fixtures, assertions, and the real runtime path are unchanged. The observed lint failure is [recorded here](https://github.com/openclaw/openclaw/actions/runs/33158007865/job/98805612126).

Production LOC against the frozen main baseline: +10/-6 (net+4); tests: +167/-0. The small production increase implements the two missing budget calculations at their owner and documents the Unicode invariant; no additional helper or wrapper is introduced.

<details>
<summary>Original contributor description (historical; current evidence above supersedes its claims)</summary>

The original description is retained for attribution and context. Its test results refer to the contributor's earlier head and are not current validation. Its unconditional length claim is superseded by the explicit long-line and indivisible-character exceptions above.

## What Problem This Solves

Fixes a limit-violation in the shipped channel-runtime text helper `chunkByNewline`. The function caps blank lines in the **middle** of a message to `maxLineLength - 1`, but appended trailing blank lines to the final chunk with no cap, so input ending in a run of newlines produced a chunk far larger than the configured limit (e.g. `chunkByNewline("x" + "\n".repeat(50), 10)` returned a 51-character chunk against a limit of 10). `chunkByNewline` is a shipped plugin-runtime contract (`channelRuntime.text.chunkByNewline`), so third-party channel plugins calling it directly could emit over-limit outbound messages.

## Why This Change Was Made

The fix caps trailing blank lines to the final chunk's remaining headroom, mirroring the existing mid-message cap:

```js
const remaining = Math.max(0, lineLimit - lastChunk.length);
const cappedTrailing = Math.min(pendingBlankLines, remaining);
```

Trailing blank lines that fit within the limit are still preserved verbatim (the existing `preserves trailing blank lines on the last chunk` behavior is unchanged); only the excess beyond the chunk limit is dropped, consistent with how mid-message blank lines are already handled. The function's JSDoc now documents the limit invariant so the shipped contract is explicit, addressing the prior "undocumented compatibility contract" concern.

## User Impact

Plugin consumers of `channelRuntime.text.chunkByNewline` now receive chunks that always respect the configured `maxLineLength`, so downstream senders no longer receive over-limit final segments.

## Evidence

**Contract surface** — `chunkByNewline` is exposed to plugins via `channelRuntime.text`:

```
src/plugins/runtime/runtime-channel.ts:    chunkByNewline,
src/plugins/runtime/types-channel.ts:    chunkByNewline: typeof import("../../auto-reply/chunk.js").chunkByNewline;
```

**Bundled delivery is unaffected** — bundled channels route outbound replies through the markdown-aware dispatchers, not this helper. Verified the active outbound chunkers already trim trailing whitespace and never exceed the limit at realistic per-channel limits (e.g. IRC uses `chunkTextForOutbound`, limit 350):

```
chunkTextForOutbound("x" + "\n".repeat(400), 350)         → max chunk length 1   ✓ (trailing blanks trimmed)
chunkTextForOutbound("y".repeat(200) + "\n".repeat(500), 350) → max chunk length 200 ✓
chunkTextForOutbound("a".repeat(1000), 350)              → max chunk length 350 ✓
chunkTextForOutbound("hello world\n".repeat(50), 350)    → max chunk length 347 ✓
```

So this fix does not alter any bundled delivery path; it corrects the separately-shipped `chunkByNewline` contract.

**Before the fix (real function, limit 10):**

```
chunkByNewline("x" + "\n".repeat(50), 10) → ["x" + "\n".repeat(50)]  last chunk length 51 > 10  ✗
```

**After the fix:**

```
chunkByNewline("x" + "\n".repeat(50), 10) → ["x" + "\n".repeat(9)]   last chunk length 10 ≤ 10  ✓
```

**Regression test** added: `caps trailing blank lines so the final chunk never exceeds the limit` — fails before the fix, passes after.

**Test runs:**
- `src/auto-reply` suite: 79 files / 1025 tests pass (including the existing `preserves trailing blank lines on the last chunk` case).
- mattermost `reply-delivery.test.ts`: 13 tests pass.
- `oxlint` clean; `oxfmt --check` clean; `tsgo` no errors in the changed files.

</details>
