### PR TITLE
test(gateway): repair release-validation fixtures

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -699,6 +699,7 @@ profiles["catalog-search"] = {
     skills: [
       {
         score: 99,
+        source: "clawhub",
         slug: "calendar-skill",
         ownerHandle: "acme",
         displayName: "Calendar Skill",

--- a/src/commands/onboard-guided.inference.e2e.test.ts
+++ b/src/commands/onboard-guided.inference.e2e.test.ts
@@ -97,7 +97,12 @@ describe("guided onboarding inference composition", () => {
         })}\n`,
       );
 
-      const prompter = createWizardPrompter(undefined, { selectValues: ["full", "use"] });
+      const prompter = createWizardPrompter(
+        {
+          text: vi.fn(async ({ initialValue }) => initialValue ?? ""),
+        },
+        { selectValues: ["full", "use"] },
+      );
       const runSetupMemoryImportStep = vi.fn(async () => ({
         status: "skipped" as const,
         providers: [],


### PR DESCRIPTION
## What Problem This Solves

Resolves two release-validation failures where test fixtures no longer matched the contracts exercised by current onboarding and ClawHub catalog paths.

## Why This Change Was Made

The guided onboarding E2E now preserves each text prompt's supplied default, matching interactive prompt behavior instead of returning an unconditional empty string. The ClawHub catalog fixture now identifies its skill result with the required `source: "clawhub"` discriminator.

Both changes are test-only and leave production behavior unchanged.

## User Impact

No user-visible behavior changes. Release validation can exercise the existing onboarding and ClawHub search flows without failing on stale fixture data.

## Evidence

- `node --check scripts/e2e/lib/clawhub-fixture-server.cjs`
- `node_modules/.bin/oxfmt --check src/commands/onboard-guided.inference.e2e.test.ts scripts/e2e/lib/clawhub-fixture-server.cjs`
- `git diff --check origin/main...HEAD`
- autoreview: clean, no accepted/actionable findings
- Focused local E2E startup was blocked before test execution by a stale shared dependency install: the built Anthropic contract requested `googleFlashSupportsMinimalThinking` from `@openclaw/ai/transports`, which the linked install did not export. Exact-head CI provides the clean-install proof.
