### PR TITLE
refactor(gateway): flatten HTTP request stages

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -137,15 +137,13 @@ function isWebSocketUpgradeRequest(req: IncomingMessage): boolean {
   );
 }
 
-type GatewayHttpRequestStage = {
-  run: () => Promise<boolean> | boolean;
-};
+type GatewayHttpRequestStage = () => Promise<boolean> | boolean;
 
 async function runGatewayHttpRequestStages(
   stages: readonly GatewayHttpRequestStage[],
 ): Promise<boolean> {
   for (const stage of stages) {
-    if (await stage.run()) {
+    if (await stage()) {
       return true;
     }
   }
@@ -335,34 +333,30 @@ export function createGatewayHttpServer(opts: {
         return true;
       };
       const requestStages: GatewayHttpRequestStage[] = [
-        {
-          run: () =>
-            handleGatewayProbeRequest(
-              req,
-              res,
-              scopedRequestPath,
-              resolvedAuthValue,
-              trustedProxies,
-              allowRealIpFallback,
-              rateLimiter,
-              getReadiness,
-              getStartup,
-            ),
-        },
+        () =>
+          handleGatewayProbeRequest(
+            req,
+            res,
+            scopedRequestPath,
+            resolvedAuthValue,
+            trustedProxies,
+            allowRealIpFallback,
+            rateLimiter,
+            getReadiness,
+            getStartup,
+          ),
       ];
       const addRequestStage = (
         enabled: boolean,
-        run: GatewayHttpRequestStage["run"],
+        stage: GatewayHttpRequestStage,
         admitted = false,
       ) => {
         if (enabled) {
-          requestStages.push({
-            run: admitted ? () => runWithGatewayHttpWorkAdmission(res, run) : run,
-          });
+          requestStages.push(admitted ? () => runWithGatewayHttpWorkAdmission(res, stage) : stage);
         }
       };
-      const addAdmittedStage = (enabled: boolean, run: GatewayHttpRequestStage["run"]) =>
-        addRequestStage(enabled, run, true);
+      const addAdmittedStage = (enabled: boolean, stage: GatewayHttpRequestStage) =>
+        addRequestStage(enabled, stage, true);
 
       const workerGatewayRoute = classifyWorkerGatewayPath(scopedRequestPath);
       addRequestStage(workerGatewayRoute !== "outside", () => {
@@ -519,8 +513,8 @@ export function createGatewayHttpServer(opts: {
         configSnapshot.mcp?.apps?.enabled === true &&
         (mcpAppRoute === "shell" || mcpAppRoute === "view")
       ) {
-        requestStages.push({
-          run: async () =>
+        requestStages.push(
+          async () =>
             await runWithGatewayHttpWorkAdmission(res, async () => {
               const standalone = await getMcpAppStandaloneModule();
               return await standalone.handleMcpAppStandaloneHttpRequest(req, res, {
@@ -528,7 +522,7 @@ export function createGatewayHttpServer(opts: {
                 sandboxOrigin: configSnapshot.mcp?.apps?.sandboxOrigin,
               });
             }),
-        });
+        );
       }
       // Core and recovery routes run first, then plugin routes, then read-only Control UI
       // surfaces. Non-GET requests the SPA does not claim reach the startup 503 before final 404.
@@ -538,46 +532,42 @@ export function createGatewayHttpServer(opts: {
         let pluginRequestOperatorScopes: string[] | undefined;
         // Auth and dispatch stay separate so authorized context reaches the handler.
         requestStages.push(
-          {
-            run: async () => {
-              if (
-                !(shouldEnforcePluginGatewayAuth ?? shouldEnforceDefaultPluginGatewayAuth)(
-                  pluginPathContext,
-                ) ||
-                (await getCachedPluginGatewayAuthBypassPaths(configSnapshot)).has(scopedRequestPath)
-              ) {
-                return false;
-              }
-              // Bypass paths come only from activated channel plugins; every other protected
-              // route must authorize before runtime scopes are derived.
-              const { authorizePluginGatewayHttpRequestOrReply } = await getHttpAuthUtilsModule();
-              const { resolvePluginRouteRuntimeOperatorScopes } =
-                await getPluginRouteRuntimeScopesModule();
-              const authResult = await authorizePluginGatewayHttpRequestOrReply({
-                req,
-                res,
-                ...routeAuth,
-                requestPath: scopedRequestPath,
-                resolveOperatorScopes: resolvePluginRouteRuntimeOperatorScopes,
-              });
-              if (!authResult) {
-                return true;
-              }
-              pluginGatewayAuthSatisfied = true;
-              pluginGatewayRequestAuth = authResult.requestAuth;
-              pluginRequestOperatorScopes = authResult.operatorScopes;
+          async () => {
+            if (
+              !(shouldEnforcePluginGatewayAuth ?? shouldEnforceDefaultPluginGatewayAuth)(
+                pluginPathContext,
+              ) ||
+              (await getCachedPluginGatewayAuthBypassPaths(configSnapshot)).has(scopedRequestPath)
+            ) {
               return false;
-            },
+            }
+            // Bypass paths come only from activated channel plugins; every other protected
+            // route must authorize before runtime scopes are derived.
+            const { authorizePluginGatewayHttpRequestOrReply } = await getHttpAuthUtilsModule();
+            const { resolvePluginRouteRuntimeOperatorScopes } =
+              await getPluginRouteRuntimeScopesModule();
+            const authResult = await authorizePluginGatewayHttpRequestOrReply({
+              req,
+              res,
+              ...routeAuth,
+              requestPath: scopedRequestPath,
+              resolveOperatorScopes: resolvePluginRouteRuntimeOperatorScopes,
+            });
+            if (!authResult) {
+              return true;
+            }
+            pluginGatewayAuthSatisfied = true;
+            pluginGatewayRequestAuth = authResult.requestAuth;
+            pluginRequestOperatorScopes = authResult.operatorScopes;
+            return false;
           },
-          {
-            run: () =>
-              handlePluginRequest(req, res, pluginPathContext, {
-                gatewayAuthSatisfied: pluginGatewayAuthSatisfied,
-                gatewayRequestAuth: pluginGatewayRequestAuth,
-                gatewayRequestOperatorScopes: pluginRequestOperatorScopes,
-                gatewayRequestClientIp: requestClientIp,
-              }),
-          },
+          () =>
+            handlePluginRequest(req, res, pluginPathContext, {
+              gatewayAuthSatisfied: pluginGatewayAuthSatisfied,
+              gatewayRequestAuth: pluginGatewayRequestAuth,
+              gatewayRequestOperatorScopes: pluginRequestOperatorScopes,
+              gatewayRequestClientIp: requestClientIp,
+            }),
         );
       }
 


### PR DESCRIPTION
## What Problem This Solves

The gateway HTTP router still wrapped every ordered request stage in a `{ run }` object even though the stage contract no longer carries metadata. This residue from the earlier route-staging consolidation adds structure without owning behavior and makes the canonical short-circuit flow harder to scan.

This is part of an explicitly maintainer-authorized, bounded refactor campaign.

## Why This Change Was Made

The gateway HTTP request router now owns one canonical array of callable stages and invokes each callback directly. Admission remains an explicit wrapper only for admitted stages.

The change removes the object shell from the initial probe, MCP app, plugin-auth, and plugin-dispatch stages while preserving:

- exact stage order and first-`true` short-circuit behavior
- `false` fallthrough and exception propagation to the existing outer 500 handler
- admitted versus non-admitted execution
- plugin auth before plugin dispatch with the same captured mutable state
- the pre-config liveness fast path

No routes, error policy, tests, docs, changelog, config, protocol, or public surface changed. Production LOC is `+55/-65` (net `-10`); tests are `+0/-0`.

Open PR #119446 adds `cfg: configSnapshot` inside the unchanged plugin authorization call. Its exact one-line semantic delta remains compatible with this callable flow; the deterministic combined resolution contains both changes and no additional behavior.

## User Impact

No user-visible behavior changes. This only removes obsolete internal routing structure from the gateway HTTP owner.

## Evidence

- `pnpm format src/gateway/server-http.ts`
- `node scripts/run-vitest.mjs src/gateway/server-http.request-trace.test.ts` - 14 passed
- `node scripts/run-vitest.mjs src/gateway/server-http.mcp-app-admission.test.ts` - 8 passed
- `node scripts/run-vitest.mjs src/gateway/server-http.probe.test.ts` - 58 passed
- `node scripts/check-changed.mjs -- src/gateway/server-http.ts` - passed on Blacksmith Testbox `tbx_01m0jg1wdx5jajp6225n3s9yqh`
- Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/32499461145
- `git diff --check`
- autoreview: clean, no accepted/actionable findings
- signed head: `0a1c4c117b80f48e56fe1519cbcce61e2fa1f6a0`

AI-assisted: yes.
