### PR TITLE
fix(macos): keep Cron run history matched to the selected job

### DIFF
--- a/apps/macos/Sources/OpenClaw/CronJobsStore.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobsStore.swift
@@ -39,11 +39,9 @@ final class CronJobsStore {
     }
 
     func start() {
-        guard !self.isPreview else { return }
-        guard self.eventTask == nil else { return }
+        guard !self.isPreview, self.eventTask == nil else { return }
         self.eventTask = Task { [weak self, gateway] in
-            let stream = await gateway.subscribe()
-            for await push in stream {
+            for await push in await gateway.subscribe() {
                 guard !Task.isCancelled, let self else { return }
                 self.handle(push: push)
             }
@@ -54,13 +52,10 @@ final class CronJobsStore {
     }
 
     func stop() {
-        self.refreshTask?.cancel()
-        self.refreshTask = nil
+        SimpleTaskSupport.stop(task: &self.refreshTask)
         self.invalidateRuns()
-        self.eventTask?.cancel()
-        self.eventTask = nil
-        self.pollTask?.cancel()
-        self.pollTask = nil
+        SimpleTaskSupport.stop(task: &self.eventTask)
+        SimpleTaskSupport.stop(task: &self.pollTask)
     }
 
     func refreshJobs() async {
@@ -95,7 +90,6 @@ final class CronJobsStore {
         if self.selectedJobId != id {
             self.selectedJobId = id
             self.runEntries = []
-            self.lastError = nil
         }
         self.refreshRuns(jobId: id)
     }
@@ -108,28 +102,18 @@ final class CronJobsStore {
         self.isLoadingRuns = true
         self.lastError = nil
         SimpleTaskSupport.schedule(task: &self.runsTask, delay: delay) { [weak self] in
-            guard let self, self.runsGeneration == generation, self.selectedJobId == jobId else { return }
-            defer {
-                if self.runsGeneration == generation, self.selectedJobId == jobId {
-                    self.isLoadingRuns = false
-                    self.runsTask = nil
-                }
-            }
+            guard let self, self.ownsRunsRequest(generation, jobId: jobId) else { return }
             do {
                 let entries = try await self.gateway.cronRuns(jobId: jobId, limit: limit)
-                guard self.runsGeneration == generation,
-                      self.selectedJobId == jobId,
-                      !Task.isCancelled
-                else { return }
+                guard self.ownsRunsRequest(generation, jobId: jobId) else { return }
                 self.runEntries = entries
             } catch {
-                guard self.runsGeneration == generation,
-                      self.selectedJobId == jobId,
-                      !Task.isCancelled
-                else { return }
+                guard self.ownsRunsRequest(generation, jobId: jobId) else { return }
                 self.logger.error("cron.runs failed \(error.localizedDescription, privacy: .public)")
                 self.lastError = error.localizedDescription
             }
+            self.isLoadingRuns = false
+            self.runsTask = nil
         }
     }
 
@@ -210,6 +194,10 @@ final class CronJobsStore {
         self.invalidateRuns()
         self.selectedJobId = nil
         self.runEntries = []
+    }
+
+    private func ownsRunsRequest(_ generation: UInt64, jobId: String) -> Bool {
+        self.runsGeneration == generation && self.selectedJobId == jobId && !Task.isCancelled
     }
 
     private func invalidateRuns() {

--- a/apps/macos/Sources/OpenClaw/CronJobsStore.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobsStore.swift
@@ -27,19 +27,26 @@ final class CronJobsStore {
     private var runsTask: Task<Void, Never>?
     private var eventTask: Task<Void, Never>?
     private var pollTask: Task<Void, Never>?
+    private var runsGeneration: UInt64 = 0
 
+    private let gateway: GatewayConnection
     private let interval: TimeInterval = 30
     private let isPreview: Bool
 
-    init(isPreview: Bool = ProcessInfo.processInfo.isPreview) {
+    init(gateway: GatewayConnection = .shared, isPreview: Bool = ProcessInfo.processInfo.isPreview) {
+        self.gateway = gateway
         self.isPreview = isPreview
     }
 
     func start() {
         guard !self.isPreview else { return }
         guard self.eventTask == nil else { return }
-        GatewayPushSubscription.restartTask(task: &self.eventTask) { [weak self] push in
-            self?.handle(push: push)
+        self.eventTask = Task { [weak self, gateway] in
+            let stream = await gateway.subscribe()
+            for await push in stream {
+                guard !Task.isCancelled, let self else { return }
+                self.handle(push: push)
+            }
         }
         SimpleTaskSupport.startDetachedLoop(task: &self.pollTask, interval: self.interval) { [weak self] in
             await self?.refreshJobs()
@@ -49,8 +56,7 @@ final class CronJobsStore {
     func stop() {
         self.refreshTask?.cancel()
         self.refreshTask = nil
-        self.runsTask?.cancel()
-        self.runsTask = nil
+        self.invalidateRuns()
         self.eventTask?.cancel()
         self.eventTask = nil
         self.pollTask?.cancel()
@@ -65,12 +71,17 @@ final class CronJobsStore {
         defer { self.isLoadingJobs = false }
 
         do {
-            if let status = try? await GatewayConnection.shared.cronStatus() {
+            if let status = try? await self.gateway.cronStatus() {
                 self.schedulerEnabled = status.enabled
                 self.schedulerStorePath = status.sqlitePath ?? status.storePath
                 self.schedulerNextWakeAtMs = status.nextWakeAtMs
             }
-            self.jobs = try await GatewayConnection.shared.cronList(includeDisabled: true)
+            self.jobs = try await self.gateway.cronList(includeDisabled: true)
+            if let selectedJobId = self.selectedJobId,
+               !self.jobs.contains(where: { $0.id == selectedJobId })
+            {
+                self.clearSelectedJob()
+            }
             if self.jobs.isEmpty {
                 self.statusMessage = "No cron jobs yet."
             }
@@ -80,22 +91,51 @@ final class CronJobsStore {
         }
     }
 
-    func refreshRuns(jobId: String, limit: Int = 200) async {
-        guard !self.isLoadingRuns else { return }
-        self.isLoadingRuns = true
-        defer { self.isLoadingRuns = false }
+    func selectJob(_ id: String) {
+        if self.selectedJobId != id {
+            self.selectedJobId = id
+            self.runEntries = []
+            self.lastError = nil
+        }
+        self.refreshRuns(jobId: id)
+    }
 
-        do {
-            self.runEntries = try await GatewayConnection.shared.cronRuns(jobId: jobId, limit: limit)
-        } catch {
-            self.logger.error("cron.runs failed \(error.localizedDescription, privacy: .public)")
-            self.lastError = error.localizedDescription
+    func refreshRuns(jobId: String, limit: Int = 200, delay: TimeInterval = 0) {
+        guard self.selectedJobId == jobId else { return }
+        // Claim before scheduling so late completions cannot own a newer selection.
+        self.runsGeneration &+= 1
+        let generation = self.runsGeneration
+        self.isLoadingRuns = true
+        self.lastError = nil
+        SimpleTaskSupport.schedule(task: &self.runsTask, delay: delay) { [weak self] in
+            guard let self, self.runsGeneration == generation, self.selectedJobId == jobId else { return }
+            defer {
+                if self.runsGeneration == generation, self.selectedJobId == jobId {
+                    self.isLoadingRuns = false
+                    self.runsTask = nil
+                }
+            }
+            do {
+                let entries = try await self.gateway.cronRuns(jobId: jobId, limit: limit)
+                guard self.runsGeneration == generation,
+                      self.selectedJobId == jobId,
+                      !Task.isCancelled
+                else { return }
+                self.runEntries = entries
+            } catch {
+                guard self.runsGeneration == generation,
+                      self.selectedJobId == jobId,
+                      !Task.isCancelled
+                else { return }
+                self.logger.error("cron.runs failed \(error.localizedDescription, privacy: .public)")
+                self.lastError = error.localizedDescription
+            }
         }
     }
 
     func runJob(id: String, force: Bool = true) async {
         do {
-            try await GatewayConnection.shared.cronRun(jobId: id, force: force)
+            try await self.gateway.cronRun(jobId: id, force: force)
         } catch {
             self.lastError = error.localizedDescription
         }
@@ -103,12 +143,11 @@ final class CronJobsStore {
 
     func removeJob(id: String) async {
         do {
-            try await GatewayConnection.shared.cronRemove(jobId: id)
-            await self.refreshJobs()
+            try await self.gateway.cronRemove(jobId: id)
             if self.selectedJobId == id {
-                self.selectedJobId = nil
-                self.runEntries = []
+                self.clearSelectedJob()
             }
+            await self.refreshJobs()
         } catch {
             self.lastError = error.localizedDescription
         }
@@ -116,7 +155,7 @@ final class CronJobsStore {
 
     func setJobEnabled(id: String, enabled: Bool) async {
         do {
-            try await GatewayConnection.shared.cronUpdate(
+            try await self.gateway.cronUpdate(
                 jobId: id,
                 patch: ["enabled": AnyCodable(enabled)])
             await self.refreshJobs()
@@ -130,9 +169,9 @@ final class CronJobsStore {
         payload: [String: AnyCodable]) async throws
     {
         if let id {
-            try await GatewayConnection.shared.cronUpdate(jobId: id, patch: payload)
+            try await self.gateway.cronUpdate(jobId: id, patch: payload)
         } else {
-            try await GatewayConnection.shared.cronAdd(payload: payload)
+            try await self.gateway.cronAdd(payload: payload)
         }
         await self.refreshJobs()
     }
@@ -157,7 +196,7 @@ final class CronJobsStore {
         // Keep UI in sync with the gateway scheduler.
         self.scheduleRefresh(delayMs: 250)
         if evt.action == "finished", let selected = self.selectedJobId, selected == evt.jobId {
-            self.scheduleRunsRefresh(jobId: selected, delayMs: 200)
+            self.refreshRuns(jobId: selected, delay: 0.2)
         }
     }
 
@@ -167,11 +206,15 @@ final class CronJobsStore {
         }
     }
 
-    private func scheduleRunsRefresh(jobId: String, delayMs: Int = 200) {
-        SimpleTaskSupport.schedule(task: &self.runsTask, delay: TimeInterval(delayMs) / 1000) { [weak self] in
-            await self?.refreshRuns(jobId: jobId)
-        }
+    private func clearSelectedJob() {
+        self.invalidateRuns()
+        self.selectedJobId = nil
+        self.runEntries = []
     }
 
-    // MARK: - (no additional RPC helpers)
+    private func invalidateRuns() {
+        self.runsGeneration &+= 1
+        SimpleTaskSupport.stop(task: &self.runsTask)
+        self.isLoadingRuns = false
+    }
 }

--- a/apps/macos/Sources/OpenClaw/CronSettings+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Layout.swift
@@ -150,7 +150,7 @@ extension CronSettings {
                     LazyVStack(alignment: .leading, spacing: 4) {
                         ForEach(self.store.jobs) { job in
                             Button {
-                                self.selectJob(job.id)
+                                self.store.selectJob(job.id)
                             } label: {
                                 self.jobRow(job)
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -182,11 +182,6 @@ extension CronSettings {
             self.detail
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
-    }
-
-    private func selectJob(_ id: String) {
-        self.store.selectedJobId = id
-        Task { await self.store.refreshRuns(jobId: id) }
     }
 
     @ViewBuilder

--- a/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Rows.swift
@@ -149,7 +149,7 @@ extension CronSettings {
                     .font(.headline)
                 Spacer()
                 Button {
-                    Task { await self.store.refreshRuns(jobId: job.id) }
+                    self.store.refreshRuns(jobId: job.id)
                 } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1570,9 +1570,11 @@ extension GatewayConnection {
     }
 
     func cronRuns(jobId: String, limit: Int = 200) async throws -> [CronRunLogEntry] {
-        let data = try await requestRaw(
-            method: .cronRuns,
-            params: ["id": AnyCodable(jobId), "limit": AnyCodable(limit)])
+        // Superseded history requests must not activate shared Gateway recovery.
+        let data = try await self.request(
+            method: Method.cronRuns.rawValue,
+            params: ["id": AnyCodable(jobId), "limit": AnyCodable(limit)],
+            retryTransportFailures: false)
         return try Self.decodeCronRunsResponse(data)
     }
 

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -291,6 +291,7 @@ actor GatewayConnection {
         do {
             return try await client.request(method: method, params: params, timeoutMs: timeoutMs)
         } catch {
+            try Task.checkCancellation()
             if allowTLSRepair,
                let tlsError = error as? GatewayTLSValidationError,
                await GatewayTLSRepairCoordinator.shared.repair(
@@ -1570,11 +1571,9 @@ extension GatewayConnection {
     }
 
     func cronRuns(jobId: String, limit: Int = 200) async throws -> [CronRunLogEntry] {
-        // Superseded history requests must not activate shared Gateway recovery.
-        let data = try await self.request(
-            method: Method.cronRuns.rawValue,
-            params: ["id": AnyCodable(jobId), "limit": AnyCodable(limit)],
-            retryTransportFailures: false)
+        let data = try await requestRaw(
+            method: .cronRuns,
+            params: ["id": AnyCodable(jobId), "limit": AnyCodable(limit)])
         return try Self.decodeCronRunsResponse(data)
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
@@ -61,7 +61,7 @@ private final class CronGatewayFixture: @unchecked Sendable {
     let session: GatewayTestWebSocketSession
     let gateway: GatewayConnection
 
-    init(recoveryEligible: Bool = false) {
+    init(recoveryEligible: Bool = false, initialRunsFailure: (any Error & Sendable)? = nil) {
         let requests = CronGatewayRequestLog()
         self.requests = requests
         self.session = GatewayTestWebSocketSession(taskFactory: {
@@ -70,7 +70,14 @@ private final class CronGatewayFixture: @unchecked Sendable {
                       let request = Self.decodeRequest(message)
                 else { return }
                 await requests.append(request)
-                guard request.method != "cron.runs" else { return }
+                guard request.method != "cron.runs" else {
+                    if let initialRunsFailure,
+                       await requests.requestCount(method: "cron.runs") == 1
+                    {
+                        throw initialRunsFailure
+                    }
+                    return
+                }
                 let payload: String
                 switch request.method {
                 case "cron.status":
@@ -412,14 +419,8 @@ struct CronJobsStoreTests {
         #expect(store.lastError == nil)
     }
 
-    @Test func `superseded history does not activate recovery on a production Gateway connection`() async throws {
-        let isolatedIdentity = FileManager.default.temporaryDirectory
-            .appendingPathComponent("openclaw-autoqa-185-cron-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: isolatedIdentity, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: isolatedIdentity) }
-
-        try await DeviceIdentityStore.withStateDirectory(isolatedIdentity) {
-            let fixture = CronGatewayFixture(recoveryEligible: true)
+    @Test func `superseded history never activates the local Gateway or its launch agent`() async throws {
+        try await self.withLocalGatewayRecovery { fixture in
             let store = CronJobsStore(gateway: fixture.gateway)
             defer { store.stop() }
             store.selectJob("job-a")
@@ -436,7 +437,28 @@ struct CronJobsStoreTests {
             #expect(await fixture.requests.endpointLookupCount() == 2)
             #expect(fixture.session.snapshotMakeCount() == 1)
             #expect(fixture.session.snapshotCancelCount() == 0)
-            await fixture.gateway.shutdown()
+            #expect(GatewayProcessManager.shared.status == .stopped)
+            #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
+        }
+    }
+
+    @Test func `uncancelled history transport failures activate the Gateway and retry`() async throws {
+        try await self.withLocalGatewayRecovery(initialRunsFailure: URLError(.networkConnectionLost)) { fixture in
+            let store = CronJobsStore(gateway: fixture.gateway)
+            defer { store.stop() }
+
+            store.selectJob("job-a")
+
+            _ = try #require(await fixture.waitForRequest(jobId: "job-a"))
+            let recoveredRequest = try #require(await fixture.waitForRequest(jobId: "job-a", occurrence: 1))
+            #expect(GatewayProcessManager.shared.status != .stopped)
+            try await fixture.respond(to: recoveredRequest, jobId: "job-a", summary: "recovered history")
+            try #require(await self.waitUntil { !store.isLoadingRuns })
+
+            #expect(store.runEntries.map(\.jobId) == ["job-a"])
+            #expect(store.runEntries.first?.summary == "recovered history")
+            #expect(store.lastError == nil)
+            #expect(await fixture.requests.requestCount(method: "cron.runs", jobId: "job-a") == 2)
         }
     }
 
@@ -471,6 +493,62 @@ struct CronJobsStoreTests {
             runAtMs: nil,
             durationMs: nil,
             nextRunAtMs: nil)
+    }
+
+    private func withLocalGatewayRecovery(
+        initialRunsFailure: (any Error & Sendable)? = nil,
+        _ operation: (CronGatewayFixture) async throws -> Void) async throws
+    {
+        let isolatedState = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-autoqa-185-cron-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: isolatedState, withIntermediateDirectories: true)
+        let configURL = isolatedState.appendingPathComponent("openclaw.json")
+        try Data(#"{"gateway":{"mode":"local","port":49185}}"#.utf8).write(to: configURL)
+        defer { try? FileManager.default.removeItem(at: isolatedState) }
+
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": configURL.path,
+            "OPENCLAW_STATE_DIR": isolatedState.path,
+        ]) {
+            try await DeviceIdentityStore.withStateDirectory(isolatedState) {
+                let fixture = CronGatewayFixture(
+                    recoveryEligible: true,
+                    initialRunsFailure: initialRunsFailure)
+                let manager = GatewayProcessManager.shared
+                let priorMode = AppStateStore.shared.connectionMode
+                AppStateStore.shared.connectionMode = .local
+                manager._testResetGatewayStartTask()
+                manager.setTestingStatus(.stopped)
+                manager.setTestingConnection(fixture.gateway)
+                manager.setTestingSkipControlChannelRefresh(true)
+                GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(
+                    isolatedState.appendingPathComponent("disable-launch-agent"))
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+                GatewayLaunchAgentManager.setTestingDaemonStatusPayload(
+                    #"{"ok":true,"service":{"loaded":false}}"#)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+                defer {
+                    manager._testResetGatewayStartTask()
+                    manager.setTestingStatus(.stopped)
+                    manager.setTestingConnection(nil)
+                    manager.setTestingSkipControlChannelRefresh(false)
+                    manager.setTestingDesiredActive(false)
+                    GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+                    GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                    GatewayLaunchAgentManager.setTestingDaemonStatusPayload(nil)
+                    GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+                    AppStateStore.shared.connectionMode = priorMode
+                }
+
+                do {
+                    try await operation(fixture)
+                    await fixture.gateway.shutdown()
+                } catch {
+                    await fixture.gateway.shutdown()
+                    throw error
+                }
+            }
+        }
     }
 
     private func waitUntil(

--- a/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
@@ -1,0 +1,487 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+@testable import OpenClawKit
+
+private struct CronGatewayRequest: Sendable {
+    let id: String
+    let method: String
+    let jobId: String?
+}
+
+private actor CronGatewayRequestLog {
+    private var requests: [CronGatewayRequest] = []
+    private var endpointLookups = 0
+    private var availableJobs = ["job-a", "job-b"]
+    private var nextEventSequence = 0
+
+    func append(_ request: CronGatewayRequest) {
+        self.requests.append(request)
+    }
+
+    func lookupEndpoint() {
+        self.endpointLookups += 1
+    }
+
+    func endpointLookupCount() -> Int {
+        self.endpointLookups
+    }
+
+    func request(jobId: String, occurrence: Int = 0) -> CronGatewayRequest? {
+        let matches = self.requests.filter { $0.method == "cron.runs" && $0.jobId == jobId }
+        guard matches.indices.contains(occurrence) else { return nil }
+        return matches[occurrence]
+    }
+
+    func requestCount(method: String, jobId: String? = nil) -> Int {
+        self.requests.count { $0.method == method && (jobId == nil || $0.jobId == jobId) }
+    }
+
+    func removeJob(_ jobId: String) {
+        self.availableJobs.removeAll { $0 == jobId }
+    }
+
+    func jobsResponse() -> String {
+        let jobs = self.availableJobs.map { jobId in
+            #"{"id":"\#(jobId)","name":"\#(jobId)","enabled":true,"createdAtMs":0,"updatedAtMs":0,"# +
+                #""schedule":{"kind":"every","everyMs":1000},"sessionTarget":"isolated","wakeMode":"now","# +
+                #""payload":{"kind":"systemEvent","text":"test"},"state":{}}"#
+        }.joined(separator: ",")
+        return #"{"jobs":[\#(jobs)]}"#
+    }
+
+    func eventSequence() -> Int {
+        self.nextEventSequence += 1
+        return self.nextEventSequence
+    }
+}
+
+private final class CronGatewayFixture: @unchecked Sendable {
+    let requests: CronGatewayRequestLog
+    let session: GatewayTestWebSocketSession
+    let gateway: GatewayConnection
+
+    init(recoveryEligible: Bool = false) {
+        let requests = CronGatewayRequestLog()
+        self.requests = requests
+        self.session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                guard sendIndex > 0,
+                      let request = Self.decodeRequest(message)
+                else { return }
+                await requests.append(request)
+                guard request.method != "cron.runs" else { return }
+                let payload: String
+                switch request.method {
+                case "cron.status":
+                    payload = #"{"enabled":true,"storePath":"/tmp/cron-tests","jobs":2}"#
+                case "cron.list":
+                    payload = await requests.jobsResponse()
+                case "cron.remove":
+                    if let jobId = request.jobId {
+                        await requests.removeJob(jobId)
+                    }
+                    payload = #"{"ok":true}"#
+                default:
+                    payload = #"{"ok":true}"#
+                }
+                socket.emitReceiveSuccess(.data(Data(
+                    #"{"type":"res","id":"\#(request.id)","ok":true,"payload":\#(payload)}"#.utf8)))
+            })
+        })
+        if recoveryEligible {
+            self.gateway = GatewayConnection(
+                endpointProvider: {
+                    await requests.lookupEndpoint()
+                    return GatewayConnection.EndpointSnapshot(
+                        config: (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil),
+                        routeAuthority: nil)
+                },
+                supportsSharedEndpointRecovery: true,
+                activationBindingKeyProvider: { nil },
+                sessionBox: WebSocketSessionBox(session: self.session))
+        } else {
+            self.gateway = GatewayConnection(
+                configProvider: {
+                    await requests.lookupEndpoint()
+                    return (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil)
+                },
+                sessionBox: WebSocketSessionBox(session: self.session))
+        }
+    }
+
+    private static func decodeRequest(_ message: URLSessionWebSocketTask.Message) -> CronGatewayRequest? {
+        let data: Data? = switch message {
+        case let .data(data): data
+        case let .string(value): value.data(using: .utf8)
+        @unknown default: nil
+        }
+        guard let data,
+              let frame = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = frame["id"] as? String,
+              let method = frame["method"] as? String
+        else { return nil }
+        let parameters = frame["params"] as? [String: Any]
+        return CronGatewayRequest(id: id, method: method, jobId: parameters?["id"] as? String)
+    }
+
+    func waitForRequest(
+        jobId: String,
+        occurrence: Int = 0,
+        timeout: Duration = .seconds(2)) async -> CronGatewayRequest?
+    {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if let request = await self.requests.request(jobId: jobId, occurrence: occurrence) {
+                return request
+            }
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return await self.requests.request(jobId: jobId, occurrence: occurrence)
+    }
+
+    func respond(
+        to request: CronGatewayRequest,
+        jobId: String,
+        summary: String = "completed") async throws
+    {
+        let socket = try await self.readySocket()
+        let response = #"{"type":"res","id":"\#(request.id)","ok":true,"payload":{"entries":["# +
+            #"{"ts":1700000000000,"jobId":"\#(jobId)","action":"finished","# +
+            #""status":"ok","summary":"\#(summary)"}]}}"#
+        socket.emitReceiveSuccessOnce(.data(Data(response.utf8)))
+    }
+
+    func fail(_ request: CronGatewayRequest, message: String) async throws {
+        let socket = try await self.readySocket()
+        let response = #"{"type":"res","id":"\#(request.id)","ok":false,"# +
+            #""error":{"code":"INVALID_REQUEST","message":"\#(message)"}}"#
+        socket.emitReceiveSuccessOnce(.data(Data(response.utf8)))
+    }
+
+    func sendFinishedEvent(jobId: String) async throws {
+        let socket = try await self.readySocket()
+        let sequence = await self.requests.eventSequence()
+        let event = #"{"type":"event","event":"cron","seq":\#(sequence),"# +
+            #""payload":{"jobId":"\#(jobId)","action":"finished"}}"#
+        socket.emitReceiveSuccessOnce(.data(Data(event.utf8)))
+    }
+
+    private func readySocket() async throws -> GatewayTestWebSocketTask {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if let socket = self.session.latestTask(), socket.hasPendingReceiveHandler() {
+                return socket
+            }
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return try #require(self.session.latestTask())
+    }
+}
+
+@Suite(.serialized)
+@MainActor
+struct CronJobsStoreTests {
+    @Test func `selecting another job sends its history request while the previous request is pending`() async throws {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop() }
+        store.selectJob("job-a")
+        let firstRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
+        store.runEntries = [self.entry(jobId: "job-a", summary: "old A")]
+        store.lastError = "old A error"
+
+        store.selectJob("job-b")
+
+        #expect(store.selectedJobId == "job-b")
+        #expect(store.runEntries.isEmpty)
+        #expect(store.lastError == nil)
+        #expect(store.isLoadingRuns)
+        let secondRequest = try #require(await fixture.waitForRequest(jobId: "job-b"))
+        try await fixture.respond(to: secondRequest, jobId: "job-b", summary: "current B")
+        try #require(await self.waitUntil { !store.isLoadingRuns })
+        #expect(store.runEntries.map(\.jobId) == ["job-b"])
+        #expect(store.runEntries.first?.summary == "current B")
+
+        try await fixture.respond(to: firstRequest, jobId: "job-a", summary: "stale A")
+        await Task.yield()
+
+        #expect(store.runEntries.map(\.jobId) == ["job-b"])
+        #expect(store.runEntries.first?.summary == "current B")
+        #expect(!store.isLoadingRuns)
+        #expect(store.lastError == nil)
+        #expect(fixture.session.snapshotMakeCount() == 1)
+        #expect(fixture.session.snapshotCancelCount() == 0)
+        #expect(await fixture.requests.endpointLookupCount() == 2)
+    }
+
+    @Test func `late failure from a superseded job preserves the selected jobs own failure`() async throws {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop() }
+        store.selectJob("job-a")
+        let firstRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
+        store.runEntries = [self.entry(jobId: "job-a", summary: "old A")]
+
+        store.selectJob("job-b")
+        #expect(store.runEntries.isEmpty)
+        let selectedRequest = try #require(await fixture.waitForRequest(jobId: "job-b"))
+        try await fixture.fail(selectedRequest, message: "selected job B failed")
+        try #require(await self.waitUntil { !store.isLoadingRuns })
+        let selectedError = try #require(store.lastError)
+        #expect(selectedError.contains("selected job B failed"))
+        #expect(store.runEntries.isEmpty)
+
+        try await fixture.fail(firstRequest, message: "stale job A failed")
+        await Task.yield()
+
+        #expect(store.selectedJobId == "job-b")
+        #expect(store.runEntries.isEmpty)
+        #expect(store.lastError == selectedError)
+        #expect(!store.isLoadingRuns)
+    }
+
+    @Test
+    func `manual refresh replaces the selected jobs pending request without accepting stale success`() async throws {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop() }
+        store.selectJob("job-a")
+        let originalRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
+
+        store.refreshRuns(jobId: "job-a")
+
+        let replacement = try #require(await fixture.waitForRequest(jobId: "job-a", occurrence: 1))
+        #expect(store.isLoadingRuns)
+        try await fixture.fail(replacement, message: "manual refresh failed")
+        try #require(await self.waitUntil { !store.isLoadingRuns })
+        let replacementError = try #require(store.lastError)
+
+        try await fixture.respond(to: originalRequest, jobId: "job-a", summary: "stale manual result")
+        await Task.yield()
+
+        #expect(store.runEntries.isEmpty)
+        #expect(store.lastError == replacementError)
+        #expect(!store.isLoadingRuns)
+        #expect(fixture.session.snapshotMakeCount() == 1)
+        #expect(fixture.session.snapshotCancelCount() == 0)
+    }
+
+    @Test func `manual refresh after failure clears the old error and publishes the successful retry`() async throws {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop() }
+        store.selectJob("job-a")
+        let failedRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
+        try await fixture.fail(failedRequest, message: "temporary history failure")
+        try #require(await self.waitUntil { store.lastError != nil })
+
+        store.refreshRuns(jobId: "job-a")
+
+        #expect(store.lastError == nil)
+        #expect(store.isLoadingRuns)
+        let retry = try #require(await fixture.waitForRequest(jobId: "job-a", occurrence: 1))
+        try await fixture.respond(to: retry, jobId: "job-a", summary: "recovered history")
+        try #require(await self.waitUntil { !store.isLoadingRuns })
+
+        #expect(store.runEntries.map(\.jobId) == ["job-a"])
+        #expect(store.runEntries.first?.summary == "recovered history")
+        #expect(store.lastError == nil)
+    }
+
+    @Test func `finished events refresh only the job still selected after their debounce`() async throws {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop() }
+        store.start()
+        try #require(await self.waitUntil { store.jobs.count == 2 })
+        store.selectJob("job-a")
+        let firstRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
+        try await fixture.respond(to: firstRequest, jobId: "job-a")
+        try #require(await self.waitUntil { !store.isLoadingRuns })
+
+        try await fixture.sendFinishedEvent(jobId: "job-a")
+        try #require(await self.waitUntil { store.isLoadingRuns })
+        store.selectJob("job-b")
+        let selectedRequest = try #require(await fixture.waitForRequest(jobId: "job-b"))
+        try await fixture.respond(to: selectedRequest, jobId: "job-b")
+        try #require(await self.waitUntil { !store.isLoadingRuns })
+
+        #expect(await fixture.waitForRequest(
+            jobId: "job-a",
+            occurrence: 1,
+            timeout: .milliseconds(300)) == nil)
+        #expect(store.runEntries.map(\.jobId) == ["job-b"])
+
+        try await fixture.sendFinishedEvent(jobId: "job-b")
+        let eventRequest = try #require(await fixture.waitForRequest(jobId: "job-b", occurrence: 1))
+        try await fixture.respond(to: eventRequest, jobId: "job-b", summary: "event B")
+        try #require(await self.waitUntil { !store.isLoadingRuns })
+
+        #expect(store.runEntries.map(\.jobId) == ["job-b"])
+        #expect(store.runEntries.first?.summary == "event B")
+        #expect(await fixture.requests.requestCount(method: "cron.runs", jobId: "job-a") == 1)
+    }
+
+    @Test(arguments: ["selection", "manual", "event"], ["success", "failure"])
+    func `stopping the pane rejects late completions from every history entry point`(
+        source: String,
+        outcome: String) async throws
+    {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop() }
+        if source == "event" {
+            store.start()
+            try #require(await self.waitUntil { store.jobs.count == 2 })
+        }
+        store.selectJob("job-a")
+        var pending = try #require(await fixture.waitForRequest(jobId: "job-a"))
+        if source != "selection" {
+            try await fixture.respond(to: pending, jobId: "job-a", summary: "existing history")
+            try #require(await self.waitUntil { !store.isLoadingRuns })
+            if source == "manual" {
+                store.refreshRuns(jobId: "job-a")
+            } else {
+                try await fixture.sendFinishedEvent(jobId: "job-a")
+            }
+            pending = try #require(await fixture.waitForRequest(jobId: "job-a", occurrence: 1))
+        }
+        let previousHistory = store.runEntries.map(\.summary)
+        let previousError = store.lastError
+
+        store.stop()
+
+        #expect(!store.isLoadingRuns)
+        if outcome == "success" {
+            try await fixture.respond(to: pending, jobId: "job-a", summary: "late history")
+        } else {
+            try await fixture.fail(pending, message: "late history failure")
+        }
+        await Task.yield()
+
+        #expect(store.selectedJobId == "job-a")
+        #expect(store.runEntries.map(\.summary) == previousHistory)
+        #expect(store.lastError == previousError)
+        #expect(!store.isLoadingRuns)
+        #expect(fixture.session.snapshotCancelCount() == 0)
+    }
+
+    @Test func `removing the selected job cancels its pending history before refreshing jobs`() async throws {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop() }
+        store.selectJob("job-a")
+        let pending = try #require(await fixture.waitForRequest(jobId: "job-a"))
+        store.runEntries = [self.entry(jobId: "job-a", summary: "removed history")]
+
+        await store.removeJob(id: "job-a")
+
+        #expect(store.selectedJobId == nil)
+        #expect(store.runEntries.isEmpty)
+        #expect(!store.isLoadingRuns)
+        #expect(store.jobs.map(\.id) == ["job-b"])
+        try await fixture.respond(to: pending, jobId: "job-a", summary: "late removed job")
+        await Task.yield()
+
+        #expect(store.selectedJobId == nil)
+        #expect(store.runEntries.isEmpty)
+        #expect(store.lastError == nil)
+    }
+
+    @Test
+    func `job list refresh invalidates pending history when another client removed its selected job`() async throws {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        defer { store.stop() }
+        store.selectJob("job-a")
+        let pending = try #require(await fixture.waitForRequest(jobId: "job-a"))
+        store.runEntries = [self.entry(jobId: "job-a", summary: "old history")]
+        await fixture.requests.removeJob("job-a")
+
+        await store.refreshJobs()
+
+        #expect(store.selectedJobId == nil)
+        #expect(store.runEntries.isEmpty)
+        #expect(!store.isLoadingRuns)
+        #expect(store.jobs.map(\.id) == ["job-b"])
+        try await fixture.fail(pending, message: "removed job completed late")
+        await Task.yield()
+
+        #expect(store.runEntries.isEmpty)
+        #expect(store.lastError == nil)
+    }
+
+    @Test func `superseded history does not activate recovery on a production Gateway connection`() async throws {
+        let isolatedIdentity = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-autoqa-185-cron-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: isolatedIdentity, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: isolatedIdentity) }
+
+        try await DeviceIdentityStore.withStateDirectory(isolatedIdentity) {
+            let fixture = CronGatewayFixture(recoveryEligible: true)
+            let store = CronJobsStore(gateway: fixture.gateway)
+            defer { store.stop() }
+            store.selectJob("job-a")
+            _ = try #require(await fixture.waitForRequest(jobId: "job-a"))
+
+            store.selectJob("job-b")
+
+            let selectedRequest = try #require(await fixture.waitForRequest(jobId: "job-b"))
+            try await fixture.respond(to: selectedRequest, jobId: "job-b")
+            try #require(await self.waitUntil { !store.isLoadingRuns })
+
+            #expect(store.runEntries.map(\.jobId) == ["job-b"])
+            #expect(store.lastError == nil)
+            #expect(await fixture.requests.endpointLookupCount() == 2)
+            #expect(fixture.session.snapshotMakeCount() == 1)
+            #expect(fixture.session.snapshotCancelCount() == 0)
+            await fixture.gateway.shutdown()
+        }
+    }
+
+    @Test func `starting and stopping retains normal scheduler and job refresh behavior`() async throws {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+
+        store.start()
+        try #require(await self.waitUntil { store.jobs.count == 2 })
+
+        #expect(store.schedulerEnabled == true)
+        #expect(store.schedulerStorePath == "/tmp/cron-tests")
+        #expect(store.jobs.map(\.id) == ["job-a", "job-b"])
+        #expect(store.lastError == nil)
+        #expect(await fixture.requests.requestCount(method: "cron.status") == 1)
+        #expect(await fixture.requests.requestCount(method: "cron.list") == 1)
+
+        store.stop()
+
+        #expect(!store.isLoadingRuns)
+        #expect(fixture.session.snapshotCancelCount() == 0)
+    }
+
+    private func entry(jobId: String, summary: String) -> CronRunLogEntry {
+        CronRunLogEntry(
+            ts: 1_700_000_000_000,
+            jobId: jobId,
+            action: "finished",
+            status: "ok",
+            error: nil,
+            summary: summary,
+            runAtMs: nil,
+            durationMs: nil,
+            nextRunAtMs: nil)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool) async -> Bool
+    {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return condition()
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -224,6 +224,112 @@ private func assertConfigLookupCannotRecreateRoute(
 }
 
 @Suite(.serialized) struct GatewayConnectionControlTests {
+    @Test @MainActor
+    func `cancelled pending request never activates local gateway recovery`() async throws {
+        try await self.withIsolatedRecoveryFixture { _, _, _ in } operation: { connection, session in
+            let request = Task {
+                try await connection.request(method: "status", params: nil)
+            }
+            try #require(await self.waitForRequest(on: session))
+
+            request.cancel()
+
+            do {
+                _ = try await request.value
+                Issue.record("expected the cancelled caller to throw CancellationError")
+            } catch is CancellationError {} catch {
+                Issue.record("unexpected cancellation error: \(error)")
+            }
+
+            #expect(GatewayProcessManager.shared.status == .stopped)
+            #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
+            #expect(session.snapshotMakeCount() == 1)
+            #expect(session.latestTask()?.snapshotSendCount() == 2)
+        }
+    }
+
+    @Test @MainActor
+    func `genuine transport failure still activates and retries local gateway recovery`() async throws {
+        try await self.assertUncancelledFailureRecovers(URLError(.networkConnectionLost))
+    }
+
+    @Test @MainActor
+    func `send-side cancellation without caller cancellation still activates gateway recovery`() async throws {
+        try await self.assertUncancelledFailureRecovers(CancellationError())
+    }
+
+    @Test @MainActor
+    func `gateway response errors never activate transport recovery`() async throws {
+        try await self.withIsolatedRecoveryFixture { socket, message, sendIndex in
+            guard sendIndex > 0,
+                  let id = GatewayWebSocketTestSupport.requestID(from: message)
+            else { return }
+            let response = #"{"type":"res","id":"\#(id)","ok":false,"# +
+                #""error":{"code":"INVALID_REQUEST","message":"response rejected"}}"#
+            socket.emitReceiveSuccess(.data(Data(response.utf8)))
+        } operation: { connection, session in
+            do {
+                _ = try await connection.request(method: "status", params: nil)
+                Issue.record("expected the Gateway response error")
+            } catch is GatewayResponseError {} catch {
+                Issue.record("unexpected response error: \(error)")
+            }
+
+            #expect(GatewayProcessManager.shared.status == .stopped)
+            #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)
+            #expect(session.snapshotMakeCount() == 1)
+            #expect(session.latestTask()?.snapshotSendCount() == 2)
+        }
+    }
+
+    @Test func `uncancelled trusted TLS mismatch still repairs its stored pin`() async throws {
+        try await withFakeGatewayTLSKeychain {
+            let url = try #require(URL(string: "wss://gateway.example.ts.net"))
+            let storeKey = "autoqa-185-tls-recovery"
+            GatewayTLSStore.saveFingerprint("old", stableID: storeKey)
+            let route = try #require(GatewayTLSRoute.resolve(
+                url: url,
+                connectionMode: .remote,
+                configuredFingerprint: nil,
+                storedFingerprint: "old",
+                storeKey: storeKey))
+            let failure = GatewayTLSValidationFailure(
+                kind: .pinMismatch,
+                host: "gateway.example.ts.net",
+                storeKey: storeKey,
+                expectedFingerprint: "old",
+                observedFingerprint: "new",
+                systemTrustOk: true,
+                port: 443)
+            let requests = WebSocketMessageRecorder()
+            let session = GatewayTestWebSocketSession(taskFactory: {
+                GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                    guard sendIndex > 0 else { return }
+                    requests.append(message)
+                    if requests.snapshot().count == 1 {
+                        throw GatewayTLSValidationError(failure: failure, context: "isolated TLS test")
+                    }
+                    guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+                    socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                })
+            })
+            let connection = GatewayConnection(
+                testEndpointProvider: {
+                    GatewayConnection.EndpointSnapshot(
+                        config: (url: url, token: nil, password: nil),
+                        tls: route,
+                        routeAuthority: nil)
+                },
+                sessionBox: WebSocketSessionBox(session: session))
+
+            _ = try await connection.request(method: "status", params: nil)
+
+            #expect(GatewayTLSStore.loadFingerprint(stableID: storeKey) == "new")
+            #expect(requests.snapshot().count == 2)
+            await connection.shutdown()
+        }
+    }
+
     @Test func `operator widget capability refresh is shared and retained`() async throws {
         let rawOldSurface = "http://127.0.0.1:18789/__openclaw__/cap/old-token"
         let rawNewSurface = "http://127.0.0.1:18789/__openclaw__/cap/new-token"
@@ -709,6 +815,111 @@ private func assertConfigLookupCannotRecreateRoute(
         @unknown default:
             nil
         }
+    }
+
+    @MainActor
+    private func withIsolatedRecoveryFixture<T>(
+        _ sendHook: @escaping GatewayTestWebSocketTask.SendHook,
+        operation: (GatewayConnection, GatewayTestWebSocketSession) async throws -> T) async throws -> T
+    {
+        let isolatedState = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-gateway-recovery-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: isolatedState, withIntermediateDirectories: true)
+        let configURL = isolatedState.appendingPathComponent("openclaw.json")
+        let port = Int.random(in: 30000...59999)
+        try Data(#"{"gateway":{"mode":"local","port":\#(port)}}"#.utf8).write(to: configURL)
+        defer { try? FileManager.default.removeItem(at: isolatedState) }
+
+        return try await TestIsolation.withEnvValues([
+            "OPENCLAW_PROFILE": "autoqa-185-tests",
+            "OPENCLAW_CONFIG_PATH": configURL.path,
+            "OPENCLAW_STATE_DIR": isolatedState.path,
+        ]) {
+            try await DeviceIdentityStore.withStateDirectory(isolatedState) {
+                let session = GatewayTestWebSocketSession(taskFactory: {
+                    GatewayTestWebSocketTask(sendHook: sendHook)
+                })
+                let connection = GatewayConnection(
+                    endpointProvider: {
+                        GatewayConnection.EndpointSnapshot(
+                            config: (url: URL(string: "ws://127.0.0.1:\(port)")!, token: nil, password: nil),
+                            routeAuthority: nil)
+                    },
+                    supportsSharedEndpointRecovery: true,
+                    activationBindingKeyProvider: { nil },
+                    sessionBox: WebSocketSessionBox(session: session))
+                let manager = GatewayProcessManager.shared
+                let priorMode = AppStateStore.shared.connectionMode
+                AppStateStore.shared.connectionMode = .local
+                manager._testResetGatewayStartTask()
+                manager.setTestingStatus(.stopped)
+                manager.setTestingConnection(connection)
+                manager.setTestingSkipControlChannelRefresh(true)
+                GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(
+                    isolatedState.appendingPathComponent("disable-launch-agent"))
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+                GatewayLaunchAgentManager.setTestingDaemonStatusPayload(
+                    #"{"ok":true,"service":{"loaded":false}}"#)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+                defer {
+                    manager._testResetGatewayStartTask()
+                    manager.setTestingStatus(.stopped)
+                    manager.setTestingConnection(nil)
+                    manager.setTestingSkipControlChannelRefresh(false)
+                    manager.setTestingDesiredActive(false)
+                    GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
+                    GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                    GatewayLaunchAgentManager.setTestingDaemonStatusPayload(nil)
+                    GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+                    AppStateStore.shared.connectionMode = priorMode
+                }
+
+                do {
+                    let result = try await operation(connection, session)
+                    await connection.shutdown()
+                    return result
+                } catch {
+                    await connection.shutdown()
+                    throw error
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func assertUncancelledFailureRecovers(_ failure: any Error & Sendable) async throws {
+        let requests = WebSocketMessageRecorder()
+        try await self.withIsolatedRecoveryFixture { socket, message, sendIndex in
+            guard sendIndex > 0,
+                  let id = GatewayWebSocketTestSupport.requestID(from: message),
+                  let data = Self.messageData(message),
+                  let frame = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return }
+            if frame["method"] as? String == "status" {
+                requests.append(message)
+                if requests.snapshot().count == 1 {
+                    throw failure
+                }
+            }
+            socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+        } operation: { connection, session in
+            _ = try await connection.request(method: "status", params: nil)
+
+            #expect(GatewayProcessManager.shared.status != .stopped)
+            #expect(requests.snapshot().count == 2)
+            #expect(session.snapshotMakeCount() >= 1)
+        }
+    }
+
+    private func waitForRequest(on session: GatewayTestWebSocketSession) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while ContinuousClock.now < deadline {
+            if session.latestTask()?.snapshotSendCount() ?? 0 >= 2 {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return false
     }
 
     private func assertDeviceTokenIsolation(


### PR DESCRIPTION
Closes #127255

AI-assisted; final implementation and validation reviewed by the author.

## What Problem This Solves

Fixes an issue where operators using the native macOS Cron pane could see job A's run history or request error beneath job B after switching jobs while A's history request was still pending. The previous in-flight request also suppressed B's history request, leaving the selected job without a fresh result.

## Why This Change Was Made

The existing `CronJobsStore` is the lifecycle owner for selected-job run history, but selection and manual refresh previously launched unowned view tasks while finished-event refresh used a separate store-owned task. The repair consolidates selection, manual refresh, and debounced finished-event refresh under one synchronously claimed store-owned request generation so superseded, stopped, or removed-job requests cannot commit stale entries, errors, or loading state.

The shared `GatewayConnection` recovery owner now checks the caller task's cancellation immediately on request failure, before TLS repair, process activation, transport retry, or tunnel recovery. Cron history therefore uses its original canonical `requestRaw` path and normal transport recovery: superseded requests cannot activate a Gateway, while genuine non-cancelled outages retain their existing recovery and retry behavior. A send-side `CancellationError` without caller-task cancellation still follows the existing recovery path. No protocol, configuration, product-default, persistence, or public behavior changes are introduced.

## User Impact

Switching Cron jobs immediately clears the previous job's history and requests the newly selected job, even if the previous request has not completed. Late responses or failures from an earlier selection cannot appear under the current job. Manual refresh, finished-job updates, pane shutdown, and job removal follow the same ownership and cancellation rules.

## Evidence

- Red-before-green request ownership: the original owner test failed with `Selecting job B must immediately send cron.runs while job A is pending`; the repaired owner passes the same delayed-WebSocket scenario.
- Red-before-green shared activation: cancelling a pending production Gateway request incorrectly changed the real process manager from `.stopped` to `.starting`; the repaired owner returns `CancellationError`, preserves `.stopped`, issues no intercepted launch-agent command, and creates no recovery socket or retry.
- Red-before-green outage recovery: the former Cron-only `retryTransportFailures: false` workaround failed because the second genuine-outage `cron.runs` request never appeared; restoring canonical `requestRaw` activates the real recovery owner, sends the retry, and loads the recovered history.
- Focused Cron owner proof: `OPENCLAW_PROFILE=autoqa-185-tests OPENCLAW_STATE_DIR=/tmp/openclaw-autoqa-185-test-state OPENCLAW_CONFIG_PATH=/tmp/openclaw-autoqa-185-test-config.json swift test --package-path apps/macos --scratch-path apps/macos/.build/arm64 --filter CronJobsStoreTests` passed 11 named tests / 16 concrete cases, including stale success and failure, row/error clearing, manual replacement and retry, witnessed event debounce, stop from selection/manual/event, selected-job removal, external deletion, actual no-activation A→B supersession, and genuine outage activation/retry.
- Full Cron surface: the isolated `swift test --package-path apps/macos --scratch-path apps/macos/.build/arm64 --filter Cron` run passed all 34 concrete Cron store, model, and editor cases.
- Shared recovery boundary: five real `GatewayConnection` regressions passed, covering cancelled caller/no manager activation/no daemon/no retry, uncancelled `URLError` activation and retry, uncancelled send-side `CancellationError` activation and retry, typed response-error exclusion, and production TLS repair with an in-memory fake keychain changing the pin from `old` to `new` before a successful retry.
- Owner and sibling proof: 91 concrete Swift cases passed: 34 Cron cases; 25 Gateway channel request, connect, and shutdown cases; 12 Gateway connection cancellation, recovery, TLS, and shutdown-generation cases; all 15 launch-agent lifecycle cases; and five isolated process-manager activation/readiness cases. One legacy all-suites invocation exposed an existing static named-profile port reservation incompatibility, so the actual affected owners were run as separate isolated suites without touching the operator profile.
- Native gates: `scripts/lint-swift.sh macos` reported zero violations across 356 files; `scripts/format-swift.sh macos` reported zero formatting changes across 359 files.
- Complete changed-path gate: `node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/CronJobsStore.swift apps/macos/Sources/OpenClaw/CronSettings+Layout.swift apps/macos/Sources/OpenClaw/CronSettings+Rows.swift apps/macos/Sources/OpenClaw/GatewayConnection.swift apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift` passed all dependency/ownership/Swift checks, all 487 macOS-related Vitest cases across seven shards, and the native SQLite schema guard unchanged at v9.
- Fresh signed real-app proof: the repaired `ai.openclaw.mac.autoqa185.debug` bundle passed `codesign --verify --deep --strict` under Peter Steinberger's matching Developer ID team `Y5PE65HELJ`. Its isolated `autoqa-185` named profile and separate loopback Gateway recorded Alpha's held request at `1787332949985` and Beta's request at `1787332958085`: Beta dispatched 8.100 seconds later while Alpha was still pending, inside the actual 15-second request deadline. Beta displayed only its own history; releasing Alpha's late response left Beta unchanged. Native manual refresh sent Beta request three, and a real `cron` finished event sent debounced Beta request four. The operator's separate running app, Gateway, default profile, and settings were untouched.

  Beta selected and displaying its own history while Alpha's response remains held:

  ![Fresh signed native Cron pane showing Beta history while Alpha remains pending](https://github.com/user-attachments/assets/9df6cd39-09e1-4c3f-99e7-d24cae25573f)

  Beta remains correct after the delayed Alpha response is released:

  ![Fresh signed native Cron pane preserving Beta history after Alpha responds late](https://github.com/user-attachments/assets/f01a0cd4-283e-4c51-be50-67af173b2843)

  Native manual refresh followed by a real debounced finished event still shows only Beta history:

  ![Fresh signed native Cron pane preserving Beta history after manual refresh and finished event](https://github.com/user-attachments/assets/7ddd440c-9846-416f-affb-9d8cb69ed412)

  A separate signed base-app screenshot could not be safely captured because the installed base app shares its bundle identifier with the operator's running instance, and the UI automation correctly refused ambiguous targeting. The failing pre-fix real-WebSocket regressions supply the before proof; all three fresh after screenshots were personally inspected and contain only synthetic task data.
- Independent adversarial review explicitly adjudicated the shared caller-cancellation boundary, preserved local outage recovery, send-side cancellation distinction, TLS repair, shutdown generations, all Cron callers, and production LOC; no actionable findings.
- Fresh isolated Codex autoreview passed with no accepted or actionable findings.
- Production: +72/-45 lines (net +27), reduced by 32.5% from the previous net +40 through canonical task-stop reuse, one generation/selection/current-task ownership predicate, single-owner completion cleanup, and deletion of redundant state assignments and the Cron-specific recovery exception. The remaining growth is required for a real injected production Gateway collaborator, synchronously claimed request generation, and selected-job lifecycle invalidation; there is no test-only production API.
- Exact reviewed head: `942c90a2eb939c1448f176ab3c7b0898421985fe`.
- Required exact-head CI: https://github.com/openclaw/openclaw/actions/runs/32508954184.
- CI note: the first macOS Swift attempt reached an unrelated existing shared `ChatViewModelTests` optimistic-message timing flake before macOS app tests; only the failed exact-head jobs were rerun, with no unrelated product or test changes.
