### PR TITLE
Accept newer stable Codex app-server releases on the pinned branch

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -431,19 +431,19 @@ describe("CodexAppServerClient", () => {
     expect(harness.writes).toHaveLength(1);
   });
 
-  it("blocks stable Codex app-server versions newer than generated schemas", async () => {
-    const newerVersion = "0.146.1";
-    const { harness, initializing, outbound } = startInitialize();
-    harness.send({
-      id: outbound.id,
-      result: { userAgent: `openclaw/${newerVersion} (macOS; test)` },
-    });
+  it.each(["0.146.1", "0.149.0"])(
+    "accepts newer stable Codex app-server version %s",
+    async (newerVersion) => {
+      const { harness, initializing, outbound } = startInitialize();
+      harness.send({
+        id: outbound.id,
+        result: { userAgent: `openclaw/${newerVersion} (macOS; test)` },
+      });
 
-    await expect(initializing).rejects.toThrow(
-      `Codex app-server ${CODEX_APP_SERVER_VERSION} is required`,
-    );
-    expect(harness.writes).toHaveLength(1);
-  });
+      await expect(initializing).resolves.toBeUndefined();
+      expect(harness.writes).toHaveLength(2);
+    },
+  );
 
   it("blocks app-server initialize responses without a version", async () => {
     const { harness, initializing, outbound } = startInitialize();

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -1047,8 +1047,20 @@ class CodexAppServerVersionError extends Error {
 
 function assertSupportedCodexAppServerVersion(response: CodexInitializeResponse): string {
   const detectedVersion = readCodexVersionFromUserAgent(response.userAgent);
-  if (detectedVersion !== CODEX_APP_SERVER_VERSION) {
+  // External app-servers may advance independently of OpenClaw's bundled runtime.
+  // Keep the reviewed stable release as a compatibility floor, not an exact pin.
+  if (
+    !detectedVersion ||
+    !/^\d+\.\d+\.\d+$/.test(detectedVersion) ||
+    detectedVersion.localeCompare(CODEX_APP_SERVER_VERSION, "en", { numeric: true }) < 0
+  ) {
     throw new CodexAppServerVersionError(detectedVersion);
+  }
+  if (detectedVersion !== CODEX_APP_SERVER_VERSION) {
+    embeddedAgentLog.warn(
+      "codex app-server is newer than OpenClaw's managed runtime; continuing with normal startup validation",
+      { detectedVersion, validatedVersion: CODEX_APP_SERVER_VERSION },
+    );
   }
   return detectedVersion;
 }


### PR DESCRIPTION
The current release branch rejects every Codex app-server newer than its bundled version even though the same compatibility issue was already fixed on main. This backports the existing public fix while keeping the pinned release, current dependency tree, and existing minimum supported version intact. Older versions and prereleases remain rejected.