### PR TITLE
feat(mantis): let proof agents extend desktop control

### DIFF
--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -63,8 +63,8 @@ Use `$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD` with `--lane baseline|candidate`:
 - `requests` (redacted provider requests; zero is a valid recorded fact)
 - `press --message-id ID --button INDEX`
 - `delete --message-id ID` (only user messages sent in this session)
-- `desktop --script-file <public-bash> [--timeout-seconds N]` (run an
-  agent-authored extension inside the ephemeral recorded desktop)
+- `desktop --actions-file <public-json> [--timeout-seconds N]` (run an
+  agent-authored click/key/type/sleep action sequence in the recorded desktop)
 - `view --message-id ID` (scroll Desktop to the exact Telegram server message)
 - `screenshot` (returns a public inspection PNG)
 - `finish [--focus-message-id ID]` (focus the named message or the latest sent message, stop, capture, publish facts)
@@ -72,11 +72,13 @@ Use `$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD` with `--lane baseline|candidate`:
 - `abort` (cleanup after scenario failure)
 
 `start` returns the exact command/budget list. When the listed primitives cannot
-exercise the behavior, extend the harness: write a focused Bash script under
-`MANTIS_OUTPUT_DIR` and run it with `desktop`. It executes inside the ephemeral
-desktop with `DISPLAY=:99`; `xdotool`, `wmctrl`, and normal shell tools are
-available. Inspect the result, adjust the script, and continue the proof. Use
-`block` only when the ephemeral desktop itself cannot exercise the behavior.
+exercise the behavior, extend the harness: write a focused JSON action sequence
+under `MANTIS_OUTPUT_DIR` and run it with `desktop`. Actions use Telegram-window
+coordinates: `{"command":"click","x":N,"y":N,"button":1}`,
+`{"command":"key","keys":["ctrl+a"]}`, `{"command":"type","text":"..."}`,
+or `{"command":"sleep","milliseconds":N}`. Inspect a screenshot, adjust the
+sequence, and continue the proof. Use `block` only when the ephemeral desktop
+itself cannot exercise the behavior.
 Raw response events must form a complete provider response; deltas alone do not
 produce a final answer. Copy the terminal item and completed-response structure
 from `responseEvents` in `scripts/e2e/mock-openai-server.mjs`, and use

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -63,15 +63,20 @@ Use `$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD` with `--lane baseline|candidate`:
 - `requests` (redacted provider requests; zero is a valid recorded fact)
 - `press --message-id ID --button INDEX`
 - `delete --message-id ID` (only user messages sent in this session)
+- `desktop --script-file <public-bash> [--timeout-seconds N]` (run an
+  agent-authored extension inside the ephemeral recorded desktop)
 - `view --message-id ID` (scroll Desktop to the exact Telegram server message)
 - `screenshot` (returns a public inspection PNG)
 - `finish [--focus-message-id ID]` (focus the named message or the latest sent message, stop, capture, publish facts)
 - `block --reason TEXT [--missing-primitive NAME]` (clean stop-report)
 - `abort` (cleanup after scenario failure)
 
-`start` returns the exact command/budget list. No generic exec/eval or raw
-Telegram API exists. If the comparison cannot prove the PR's visible behavior,
-use `block` and say why.
+`start` returns the exact command/budget list. When the listed primitives cannot
+exercise the behavior, extend the harness: write a focused Bash script under
+`MANTIS_OUTPUT_DIR` and run it with `desktop`. It executes inside the ephemeral
+desktop with `DISPLAY=:99`; `xdotool`, `wmctrl`, and normal shell tools are
+available. Inspect the result, adjust the script, and continue the proof. Use
+`block` only when the ephemeral desktop itself cannot exercise the behavior.
 Raw response events must form a complete provider response; deltas alone do not
 produce a final answer. Copy the terminal item and completed-response structure
 from `responseEvents` in `scripts/e2e/mock-openai-server.mjs`, and use

--- a/docs/concepts/mantis.md
+++ b/docs/concepts/mantis.md
@@ -202,10 +202,13 @@ in.
 ### Telegram Desktop recorder
 
 The Telegram Desktop recorder is a standalone operator utility, invoked
-directly through `pnpm qa:telegram-desktop-recorder`. It records native
-Telegram Desktop and nothing else: it never drives OpenClaw or sends Telegram
-messages. Whoever runs it owns the turn — start the SUT, send through a real
-Telegram user, then tell the recorder which message to show — and supplies
+directly through `pnpm qa:telegram-desktop-recorder`. It never drives OpenClaw.
+Its normal recording commands do not send Telegram messages. The optional
+`actions` command drives only the measured Telegram window through bounded
+`click`, `key`, `type`, and `sleep` actions; those actions can send as the
+signed-in Telegram user. Whoever runs it owns the turn and those side effects —
+start the SUT, send through a real Telegram user, then tell the recorder which
+message to show — and supplies
 `--user-driver`, the command the recorder shells out to for the TDLib calls it
 cannot make itself (`confirm-qr`, `terminate-session`). Any driver exposing
 those two verbs works, including this repo's

--- a/scripts/e2e/telegram-desktop-recorder-contract.ts
+++ b/scripts/e2e/telegram-desktop-recorder-contract.ts
@@ -70,9 +70,9 @@ export type ViewOptions = {
   sessionPath: string;
 };
 
-export type ExecOptions = {
-  command: "exec";
-  scriptFile: string;
+export type ActionsOptions = {
+  actionsFile: string;
+  command: "actions";
   sessionPath: string;
   timeoutSeconds: number;
 };
@@ -107,7 +107,7 @@ export type ArtifactsOptions = {
 
 type RecorderOptions =
   | ArtifactsOptions
-  | ExecOptions
+  | ActionsOptions
   | RecoverOptions
   | ScreenshotOptions
   | StartOptions
@@ -121,7 +121,7 @@ export function recorderUsageText(): string {
     "  pnpm qa:telegram-desktop-recorder artifacts --session <recorder.json>",
     '  pnpm qa:telegram-desktop-recorder start --output-dir <dir> --chat <-100groupId> --user-driver "<space-separated cmd prefix>" [options]',
     "  pnpm qa:telegram-desktop-recorder view --session <recorder.json> --message-id <id>",
-    "  pnpm qa:telegram-desktop-recorder exec --session <recorder.json> --script-file <script> [--timeout-seconds <seconds>]",
+    "  pnpm qa:telegram-desktop-recorder actions --session <recorder.json> --actions-file <json> [--timeout-seconds <seconds>]",
     "  pnpm qa:telegram-desktop-recorder screenshot --session <recorder.json> [--output <png>]",
     "  pnpm qa:telegram-desktop-recorder recover --session <recorder.json>",
     "  pnpm qa:telegram-desktop-recorder stop --session <recorder.json> [--crop telegram-window] [--keep-box]",
@@ -172,7 +172,7 @@ export function parseRecorderArgs(argv: string[]): RecorderOptions {
     throw new Error(recorderUsageText());
   }
   const parsedCommand = z
-    .enum(["artifacts", "exec", "recover", "screenshot", "start", "status", "stop", "view"])
+    .enum(["actions", "artifacts", "recover", "screenshot", "start", "status", "stop", "view"])
     .safeParse(rawCommand);
   if (!parsedCommand.success) {
     throw new Error(`Unknown command: ${rawCommand}\n\n${recorderUsageText()}`);
@@ -214,8 +214,8 @@ export function parseRecorderArgs(argv: string[]): RecorderOptions {
         ])
       : command === "view"
         ? new Set(["--message-id", "--session"])
-        : command === "exec"
-          ? new Set(["--script-file", "--session", "--timeout-seconds"])
+        : command === "actions"
+          ? new Set(["--actions-file", "--session", "--timeout-seconds"])
           : command === "screenshot"
             ? new Set(["--output", "--session"])
             : command === "stop"
@@ -277,10 +277,10 @@ export function parseRecorderArgs(argv: string[]): RecorderOptions {
     positiveInteger(messageId, "--message-id");
     return { command, messageId, sessionPath };
   }
-  if (command === "exec") {
+  if (command === "actions") {
     return {
+      actionsFile: requiredString(values, "--actions-file"),
       command,
-      scriptFile: requiredString(values, "--script-file"),
       sessionPath,
       timeoutSeconds: positiveInteger(values.get("--timeout-seconds") ?? "60", "--timeout-seconds"),
     };

--- a/scripts/e2e/telegram-desktop-recorder-contract.ts
+++ b/scripts/e2e/telegram-desktop-recorder-contract.ts
@@ -27,6 +27,7 @@ const recorderSessionBaseSchema = z.object({
   /** Telegram Desktop window as placed on the recorded desktop; the crop uses it. */
   window: z.object({
     height: z.number().int().positive(),
+    id: z.string().regex(/^0x[0-9a-f]+$/iu),
     width: z.number().int().positive(),
     x: z.number().int().nonnegative(),
     y: z.number().int().nonnegative(),

--- a/scripts/e2e/telegram-desktop-recorder-contract.ts
+++ b/scripts/e2e/telegram-desktop-recorder-contract.ts
@@ -70,6 +70,13 @@ export type ViewOptions = {
   sessionPath: string;
 };
 
+export type ExecOptions = {
+  command: "exec";
+  scriptFile: string;
+  sessionPath: string;
+  timeoutSeconds: number;
+};
+
 export type ScreenshotOptions = {
   command: "screenshot";
   output?: string;
@@ -100,6 +107,7 @@ export type ArtifactsOptions = {
 
 type RecorderOptions =
   | ArtifactsOptions
+  | ExecOptions
   | RecoverOptions
   | ScreenshotOptions
   | StartOptions
@@ -113,6 +121,7 @@ export function recorderUsageText(): string {
     "  pnpm qa:telegram-desktop-recorder artifacts --session <recorder.json>",
     '  pnpm qa:telegram-desktop-recorder start --output-dir <dir> --chat <-100groupId> --user-driver "<space-separated cmd prefix>" [options]',
     "  pnpm qa:telegram-desktop-recorder view --session <recorder.json> --message-id <id>",
+    "  pnpm qa:telegram-desktop-recorder exec --session <recorder.json> --script-file <script> [--timeout-seconds <seconds>]",
     "  pnpm qa:telegram-desktop-recorder screenshot --session <recorder.json> [--output <png>]",
     "  pnpm qa:telegram-desktop-recorder recover --session <recorder.json>",
     "  pnpm qa:telegram-desktop-recorder stop --session <recorder.json> [--crop telegram-window] [--keep-box]",
@@ -163,7 +172,7 @@ export function parseRecorderArgs(argv: string[]): RecorderOptions {
     throw new Error(recorderUsageText());
   }
   const parsedCommand = z
-    .enum(["artifacts", "recover", "screenshot", "start", "status", "stop", "view"])
+    .enum(["artifacts", "exec", "recover", "screenshot", "start", "status", "stop", "view"])
     .safeParse(rawCommand);
   if (!parsedCommand.success) {
     throw new Error(`Unknown command: ${rawCommand}\n\n${recorderUsageText()}`);
@@ -205,11 +214,13 @@ export function parseRecorderArgs(argv: string[]): RecorderOptions {
         ])
       : command === "view"
         ? new Set(["--message-id", "--session"])
-        : command === "screenshot"
-          ? new Set(["--output", "--session"])
-          : command === "stop"
-            ? new Set(["--crop", "--session"])
-            : new Set(["--session"]);
+        : command === "exec"
+          ? new Set(["--script-file", "--session", "--timeout-seconds"])
+          : command === "screenshot"
+            ? new Set(["--output", "--session"])
+            : command === "stop"
+              ? new Set(["--crop", "--session"])
+              : new Set(["--session"]);
   for (const flag of values.keys()) {
     if (!allowed.has(flag)) {
       throw new Error(`${flag} is not available for ${command}.`);
@@ -265,6 +276,14 @@ export function parseRecorderArgs(argv: string[]): RecorderOptions {
     const messageId = requiredString(values, "--message-id");
     positiveInteger(messageId, "--message-id");
     return { command, messageId, sessionPath };
+  }
+  if (command === "exec") {
+    return {
+      command,
+      scriptFile: requiredString(values, "--script-file"),
+      sessionPath,
+      timeoutSeconds: positiveInteger(values.get("--timeout-seconds") ?? "60", "--timeout-seconds"),
+    };
   }
   if (command === "screenshot") {
     return { command, output: values.get("--output"), sessionPath };

--- a/scripts/e2e/telegram-desktop-recorder.ts
+++ b/scripts/e2e/telegram-desktop-recorder.ts
@@ -26,8 +26,8 @@ import {
 import {
   parseRecorderArgs,
   readRecorderSession,
+  type ActionsOptions,
   type ArtifactsOptions,
-  type ExecOptions,
   type RecoverOptions,
   recorderUsageText,
   TELEGRAM_DESKTOP_AWS_IMAGE,
@@ -816,32 +816,82 @@ export async function viewRecorder(
   });
 }
 
-export async function execRecorder(
+const desktopActionsSchema = z
+  .array(
+    z.discriminatedUnion("command", [
+      z.object({
+        button: z.number().int().min(1).max(5).default(1),
+        command: z.literal("click"),
+        x: z.number().int().nonnegative(),
+        y: z.number().int().nonnegative(),
+      }),
+      z.object({
+        command: z.literal("key"),
+        keys: z
+          .array(z.string().regex(/^[A-Za-z0-9_+:-]+$/u))
+          .min(1)
+          .max(20),
+      }),
+      z.object({ command: z.literal("sleep"), milliseconds: z.number().int().min(1).max(30_000) }),
+      z.object({
+        command: z.literal("type"),
+        delayMs: z.number().int().min(0).max(1_000).default(5),
+        text: z.string().min(1).max(10_000),
+      }),
+    ]),
+  )
+  .min(1)
+  .max(100);
+
+export async function runRecorderActions(
   cwd: string,
-  opts: ExecOptions,
+  opts: ActionsOptions,
   operations: RecorderOperations = defaultOperations,
-): Promise<{ stderr: string; stdout: string }> {
+): Promise<{ results: Array<{ command: string; stderr: string; stdout: string }> }> {
   const sessionPath = resolveRecorderPath(cwd, opts.sessionPath, "--session");
-  const scriptPath = resolveRecorderPath(cwd, opts.scriptFile, "--script-file");
-  const scriptStat = fs.lstatSync(scriptPath);
-  if (!scriptStat.isFile() || scriptStat.isSymbolicLink() || scriptStat.size > 64 * 1024) {
-    throw new Error("--script-file must be a regular file no larger than 64 KiB.");
+  const actionsPath = resolveRecorderPath(cwd, opts.actionsFile, "--actions-file");
+  const actionsStat = fs.lstatSync(actionsPath);
+  if (!actionsStat.isFile() || actionsStat.isSymbolicLink() || actionsStat.size > 64 * 1024) {
+    throw new Error("--actions-file must be a regular file no larger than 64 KiB.");
   }
-  const script = fs.readFileSync(scriptPath, "utf8");
-  if (!script.trim()) {
-    throw new Error("--script-file must not be empty.");
-  }
+  const actions = desktopActionsSchema.parse(JSON.parse(fs.readFileSync(actionsPath, "utf8")));
   const session = readRecorderSession(sessionPath);
+  for (const action of actions) {
+    if (
+      action.command === "click" &&
+      (action.x >= session.window.width || action.y >= session.window.height)
+    ) {
+      throw new Error("click coordinates must stay inside the Telegram window.");
+    }
+  }
   const crabboxBin = process.env.OPENCLAW_TELEGRAM_USER_CRABBOX_BIN?.trim() || "crabbox";
   const inspect = await sessionInspect({ crabboxBin, cwd, operations, session });
-  return await operations.sshRun({
-    command: `set -euo pipefail\nexport DISPLAY=:99\n${script}`,
-    cwd,
-    inspect,
-    run: operations.runCommand,
-    stdio: "pipe",
-    timeoutMs: opts.timeoutSeconds * 1000,
-  });
+  const results: Array<{ command: string; stderr: string; stdout: string }> = [];
+  for (const action of actions) {
+    if (action.command === "sleep") {
+      await sleep(action.milliseconds);
+      results.push({ command: "sleep", stderr: "", stdout: "" });
+      continue;
+    }
+    const telegramWindow =
+      'win="$(wmctrl -lx | awk \'tolower($0) ~ /telegramdesktop/ {print $1; exit}\')"\ntest -n "$win"\n';
+    const actionCommand =
+      action.command === "click"
+        ? `xdotool windowactivate --sync "$win" mousemove --window "$win" ${action.x} ${action.y} click ${action.button}`
+        : action.command === "key"
+          ? `xdotool key --window "$win" ${action.keys.map(shellQuote).join(" ")}`
+          : `xdotool type --window "$win" --delay ${action.delayMs} -- ${shellQuote(action.text)}`;
+    const result = await operations.sshRun({
+      command: `export DISPLAY=:99\n${telegramWindow}${actionCommand}`,
+      cwd,
+      inspect,
+      run: operations.runCommand,
+      stdio: "pipe",
+      timeoutMs: opts.timeoutSeconds * 1000,
+    });
+    results.push({ command: action.command, ...result });
+  }
+  return { results };
 }
 
 async function captureScreenshot(params: {
@@ -1096,8 +1146,8 @@ async function main(): Promise<void> {
     console.log(`Telegram Desktop opened message ${opts.messageId}.`);
     return;
   }
-  if (opts.command === "exec") {
-    console.log(JSON.stringify(await execRecorder(cwd, opts), null, 2));
+  if (opts.command === "actions") {
+    console.log(JSON.stringify(await runRecorderActions(cwd, opts), null, 2));
     return;
   }
   if (opts.command === "screenshot") {

--- a/scripts/e2e/telegram-desktop-recorder.ts
+++ b/scripts/e2e/telegram-desktop-recorder.ts
@@ -175,14 +175,13 @@ export DISPLAY=:99
 win="$(wmctrl -lx | awk 'tolower($0) ~ /telegramdesktop/ {print $1; exit}')"
 test -n "$win"
 eval "$(xdotool getwindowgeometry --shell "$win")"
-printf '%s %s %s %s\n' "$X" "$Y" "$WIDTH" "$HEIGHT"`;
+printf '%s %s %s %s %s\n' "$win" "$X" "$Y" "$WIDTH" "$HEIGHT"`;
 }
 
-function renderHideTelegramWindow(): string {
+function renderHideTelegramWindow(windowId: string): string {
   return `set -euo pipefail
 export DISPLAY=:99
-win="$(wmctrl -lx | awk 'tolower($0) ~ /telegramdesktop/ {print $1; exit}')"
-test -n "$win"
+win=${shellQuote(windowId)}
 xdotool windowminimize "$win"
 sleep 0.2`;
 }
@@ -237,19 +236,26 @@ exit 1`;
 
 export function parseWindowGeometry(raw: string): {
   height: number;
+  id: string;
   width: number;
   x: number;
   y: number;
 } {
-  const parts = raw.trim().split(/\s+/u).map(Number);
-  if (parts.length !== 4 || parts.some((value) => !Number.isFinite(value) || value < 0)) {
+  const [id, ...rawGeometry] = raw.trim().split(/\s+/u);
+  const parts = rawGeometry.map(Number);
+  if (
+    !id ||
+    !/^0x[0-9a-f]+$/iu.test(id) ||
+    parts.length !== 4 ||
+    parts.some((value) => !Number.isFinite(value) || value < 0)
+  ) {
     throw new Error(`Telegram Desktop window geometry was not readable: ${raw.trim()}`);
   }
   const [x, y, width, height] = parts as [number, number, number, number];
   if (width < 200 || height < 200) {
     throw new Error(`Telegram Desktop window is too small to crop: ${width}x${height}`);
   }
-  return { height, width, x, y };
+  return { height, id, width, x, y };
 }
 
 function driverCommand(userDriver: string[], args: string[]) {
@@ -612,7 +618,7 @@ async function startRecorderAttempt(
     // The lane clears prior history before recorder start. Keep the empty chat hidden until
     // the first session-owned send is ready, so setup frames reveal neither account UI nor chat.
     await operations.sshRun({
-      command: renderHideTelegramWindow(),
+      command: renderHideTelegramWindow(windowGeometry.id),
       cwd,
       inspect,
       run: operations.runCommand,
@@ -873,8 +879,17 @@ export async function runRecorderActions(
       results.push({ command: "sleep", stderr: "", stdout: "" });
       continue;
     }
-    const telegramWindow =
-      'win="$(wmctrl -lx | awk \'tolower($0) ~ /telegramdesktop/ {print $1; exit}\')"\ntest -n "$win"\n';
+    const telegramWindow = `win=${shellQuote(session.window.id)}
+if ! wmctrl -lx | awk -v win="$win" 'tolower($1) == tolower(win) && tolower($0) ~ /telegramdesktop/ {found=1} END {exit !found}'; then
+  echo "Recorded Telegram window $win no longer exists." >&2
+  exit 1
+fi
+eval "$(xdotool getwindowgeometry --shell "$win")"
+if [ "$X" -ne ${session.window.x} ] || [ "$Y" -ne ${session.window.y} ] || [ "$WIDTH" -ne ${session.window.width} ] || [ "$HEIGHT" -ne ${session.window.height} ]; then
+  echo "Recorded Telegram window $win moved or resized." >&2
+  exit 1
+fi
+`;
     const actionCommand =
       action.command === "click"
         ? `xdotool windowactivate --sync "$win" mousemove --window "$win" ${action.x} ${action.y} click ${action.button}`

--- a/scripts/e2e/telegram-desktop-recorder.ts
+++ b/scripts/e2e/telegram-desktop-recorder.ts
@@ -27,6 +27,7 @@ import {
   parseRecorderArgs,
   readRecorderSession,
   type ArtifactsOptions,
+  type ExecOptions,
   type RecoverOptions,
   recorderUsageText,
   TELEGRAM_DESKTOP_AWS_IMAGE,
@@ -815,6 +816,34 @@ export async function viewRecorder(
   });
 }
 
+export async function execRecorder(
+  cwd: string,
+  opts: ExecOptions,
+  operations: RecorderOperations = defaultOperations,
+): Promise<{ stderr: string; stdout: string }> {
+  const sessionPath = resolveRecorderPath(cwd, opts.sessionPath, "--session");
+  const scriptPath = resolveRecorderPath(cwd, opts.scriptFile, "--script-file");
+  const scriptStat = fs.lstatSync(scriptPath);
+  if (!scriptStat.isFile() || scriptStat.isSymbolicLink() || scriptStat.size > 64 * 1024) {
+    throw new Error("--script-file must be a regular file no larger than 64 KiB.");
+  }
+  const script = fs.readFileSync(scriptPath, "utf8");
+  if (!script.trim()) {
+    throw new Error("--script-file must not be empty.");
+  }
+  const session = readRecorderSession(sessionPath);
+  const crabboxBin = process.env.OPENCLAW_TELEGRAM_USER_CRABBOX_BIN?.trim() || "crabbox";
+  const inspect = await sessionInspect({ crabboxBin, cwd, operations, session });
+  return await operations.sshRun({
+    command: `set -euo pipefail\nexport DISPLAY=:99\n${script}`,
+    cwd,
+    inspect,
+    run: operations.runCommand,
+    stdio: "pipe",
+    timeoutMs: opts.timeoutSeconds * 1000,
+  });
+}
+
 async function captureScreenshot(params: {
   crop: ReturnType<typeof proofViewport>;
   cwd: string;
@@ -1065,6 +1094,10 @@ async function main(): Promise<void> {
   if (opts.command === "view") {
     await viewRecorder(cwd, opts);
     console.log(`Telegram Desktop opened message ${opts.messageId}.`);
+    return;
+  }
+  if (opts.command === "exec") {
+    console.log(JSON.stringify(await execRecorder(cwd, opts), null, 2));
     return;
   }
   if (opts.command === "screenshot") {

--- a/scripts/e2e/telegram-mantis-lane.ts
+++ b/scripts/e2e/telegram-mantis-lane.ts
@@ -112,7 +112,7 @@ const commandOptions: Record<string, readonly string[]> = {
   abort: ["--lane"],
   block: ["--lane", "--missing-primitive", "--reason"],
   delete: ["--lane", "--message-id"],
-  desktop: ["--lane", "--script-file", "--timeout-seconds"],
+  desktop: ["--lane", "--actions-file", "--timeout-seconds"],
   finish: ["--lane", "--focus-message-id"],
   mock: ["--lane", "--response-file", "--response-events-file", "--chunk-delay-ms"],
   observe: ["--lane", "--seconds", "--since"],
@@ -1034,51 +1034,54 @@ async function observerAction(
   return response;
 }
 
-async function runDesktopExtension(
+async function runDesktopActions(
   state: ActiveSession,
   values: Map<string, string>,
-  outputRoot: string,
+  roots: Roots,
 ): Promise<Record<string, unknown>> {
-  const extension = readPublicFile(
-    outputRoot,
-    required(values, "--script-file"),
-    "--script-file",
+  const actions = readPublicFile(
+    roots.outputRoot,
+    required(values, "--actions-file"),
+    "--actions-file",
     64 * 1024,
   );
-  if (!extension.text.trim()) {
-    throw new Error("--script-file must not be empty.");
+  if (!actions.text.trim()) {
+    throw new Error("--actions-file must not be empty.");
   }
   const timeoutSeconds = values.has("--timeout-seconds")
     ? numberOption(values, "--timeout-seconds", 300, 1)
     : 60;
-  const privateScript = path.join(
+  const privateActions = path.join(
     state.privateDir,
-    `desktop-extension-${state.invocations.length + 1}.sh`,
+    `desktop-actions-${state.invocations.length + 1}.json`,
   );
   fs.mkdirSync(state.privateDir, { recursive: true });
-  fs.writeFileSync(privateScript, extension.text, { mode: 0o640 });
+  fs.writeFileSync(privateActions, actions.text, { mode: 0o640 });
+  const actionsSha256 = createHash("sha256").update(actions.text).digest("hex");
+  appendInvocation(state, "desktop", {
+    actionsFile: actions.relative,
+    actionsSha256,
+    timeoutSeconds,
+  });
+  saveActive(roots.sessionRoot, state);
   const result = z
-    .object({ stderr: z.string(), stdout: z.string() })
+    .object({
+      results: z.array(z.object({ command: z.string(), stderr: z.string(), stdout: z.string() })),
+    })
     .parse(
       JSON.parse(
         await runCommandOutput(requiredEnv("OPENCLAW_TELEGRAM_DESKTOP_RECORDER_CMD"), [
-          "exec",
+          "actions",
           "--session",
           recorderRelativePath(state.recorderSession),
-          "--script-file",
-          recorderRelativePath(privateScript),
+          "--actions-file",
+          recorderRelativePath(privateActions),
           "--timeout-seconds",
           String(timeoutSeconds),
         ]),
       ),
     );
-  const scriptSha256 = createHash("sha256").update(extension.text).digest("hex");
-  appendInvocation(state, "desktop", {
-    scriptFile: extension.relative,
-    scriptSha256,
-    timeoutSeconds,
-  });
-  return { ...result, scriptSha256 };
+  return { ...result, actionsSha256 };
 }
 
 async function focusMessage(state: ActiveSession, messageId: string): Promise<void> {
@@ -1494,7 +1497,7 @@ async function main(): Promise<void> {
     if (cli.command === "mock") {
       outputJson(updateMockResponse(state, cli.values, roots.outputRoot));
     } else if (cli.command === "desktop") {
-      outputJson(await runDesktopExtension(state, cli.values, roots.outputRoot));
+      outputJson(await runDesktopActions(state, cli.values, roots));
     } else if (cli.command === "send") {
       const sent = await sendVisibleMessage(state, cli.values, roots, credential.sutToken);
       outputJson({ ...sent.response, revealedMessageId: sent.revealedMessageId });

--- a/scripts/e2e/telegram-mantis-lane.ts
+++ b/scripts/e2e/telegram-mantis-lane.ts
@@ -112,6 +112,7 @@ const commandOptions: Record<string, readonly string[]> = {
   abort: ["--lane"],
   block: ["--lane", "--missing-primitive", "--reason"],
   delete: ["--lane", "--message-id"],
+  desktop: ["--lane", "--script-file", "--timeout-seconds"],
   finish: ["--lane", "--focus-message-id"],
   mock: ["--lane", "--response-file", "--response-events-file", "--chunk-delay-ms"],
   observe: ["--lane", "--seconds", "--since"],
@@ -1033,6 +1034,53 @@ async function observerAction(
   return response;
 }
 
+async function runDesktopExtension(
+  state: ActiveSession,
+  values: Map<string, string>,
+  outputRoot: string,
+): Promise<Record<string, unknown>> {
+  const extension = readPublicFile(
+    outputRoot,
+    required(values, "--script-file"),
+    "--script-file",
+    64 * 1024,
+  );
+  if (!extension.text.trim()) {
+    throw new Error("--script-file must not be empty.");
+  }
+  const timeoutSeconds = values.has("--timeout-seconds")
+    ? numberOption(values, "--timeout-seconds", 300, 1)
+    : 60;
+  const privateScript = path.join(
+    state.privateDir,
+    `desktop-extension-${state.invocations.length + 1}.sh`,
+  );
+  fs.mkdirSync(state.privateDir, { recursive: true });
+  fs.writeFileSync(privateScript, extension.text, { mode: 0o640 });
+  const result = z
+    .object({ stderr: z.string(), stdout: z.string() })
+    .parse(
+      JSON.parse(
+        await runCommandOutput(requiredEnv("OPENCLAW_TELEGRAM_DESKTOP_RECORDER_CMD"), [
+          "exec",
+          "--session",
+          recorderRelativePath(state.recorderSession),
+          "--script-file",
+          recorderRelativePath(privateScript),
+          "--timeout-seconds",
+          String(timeoutSeconds),
+        ]),
+      ),
+    );
+  const scriptSha256 = createHash("sha256").update(extension.text).digest("hex");
+  appendInvocation(state, "desktop", {
+    scriptFile: extension.relative,
+    scriptSha256,
+    timeoutSeconds,
+  });
+  return { ...result, scriptSha256 };
+}
+
 async function focusMessage(state: ActiveSession, messageId: string): Promise<void> {
   if (!/^\d+$/u.test(messageId) || BigInt(messageId) < 1n) {
     throw new Error("--message-id must be a positive Telegram server message id.");
@@ -1445,6 +1493,8 @@ async function main(): Promise<void> {
     const credential = credentialSchema.parse(readJson(roots.credentialFile));
     if (cli.command === "mock") {
       outputJson(updateMockResponse(state, cli.values, roots.outputRoot));
+    } else if (cli.command === "desktop") {
+      outputJson(await runDesktopExtension(state, cli.values, roots.outputRoot));
     } else if (cli.command === "send") {
       const sent = await sendVisibleMessage(state, cli.values, roots, credential.sutToken);
       outputJson({ ...sent.response, revealedMessageId: sent.revealedMessageId });

--- a/test/scripts/telegram-desktop-recorder.test.ts
+++ b/test/scripts/telegram-desktop-recorder.test.ts
@@ -9,12 +9,12 @@ import {
 } from "../../scripts/e2e/telegram-desktop-crabbox.ts";
 import {
   confirmQrLink,
-  execRecorder,
   parseRecorderArgs,
   parseWindowGeometry,
   readRecorderSession,
   recoverRecorderStartup,
   recorderArtifacts,
+  runRecorderActions,
   screenshotRecorder,
   type RecorderOperations,
   type RecorderSession,
@@ -136,28 +136,34 @@ describe("Telegram Desktop recorder CLI", () => {
     });
     expect(
       parseRecorderArgs([
-        "exec",
+        "actions",
         "--session",
         "recorder.json",
-        "--script-file",
-        "click.sh",
+        "--actions-file",
+        "click.json",
         "--timeout-seconds",
         "90",
       ]),
     ).toEqual({
-      command: "exec",
-      scriptFile: "click.sh",
+      actionsFile: "click.json",
+      command: "actions",
       sessionPath: "recorder.json",
       timeoutSeconds: 90,
     });
   });
 
-  it("runs an agent-authored extension inside the recorded desktop", async () => {
+  it("runs agent-authored actions inside the recorded desktop", async () => {
     const root = makeTempDir();
     const sessionPath = path.join(root, "recorder.json");
-    const scriptPath = path.join(root, "click.sh");
+    const actionsPath = path.join(root, "click.json");
     writeRecorderSession(sessionPath, testSession());
-    fs.writeFileSync(scriptPath, "xdotool click 1\nprintf 'clicked\\n'\n");
+    fs.writeFileSync(
+      actionsPath,
+      JSON.stringify([
+        { command: "click", x: 120, y: 240 },
+        { command: "sleep", milliseconds: 5 },
+      ]),
+    );
     const sshRun = vi.fn<RecorderOperations["sshRun"]>(async () => ({
       stderr: "",
       stdout: "clicked\n",
@@ -177,21 +183,26 @@ describe("Telegram Desktop recorder CLI", () => {
     } satisfies RecorderOperations;
 
     await expect(
-      execRecorder(
+      runRecorderActions(
         root,
         {
-          command: "exec",
-          scriptFile: "click.sh",
+          actionsFile: "click.json",
+          command: "actions",
           sessionPath: "recorder.json",
           timeoutSeconds: 90,
         },
         operations,
       ),
-    ).resolves.toEqual({ stderr: "", stdout: "clicked\n" });
+    ).resolves.toEqual({
+      results: [
+        { command: "click", stderr: "", stdout: "clicked\n" },
+        { command: "sleep", stderr: "", stdout: "" },
+      ],
+    });
     expect(sshRun).toHaveBeenCalledWith(
       expect.objectContaining({
         command: expect.stringContaining(
-          "export DISPLAY=:99\nxdotool click 1\nprintf 'clicked\\n'",
+          'xdotool windowactivate --sync "$win" mousemove --window "$win" 120 240 click 1',
         ),
         stdio: "pipe",
         timeoutMs: 90_000,

--- a/test/scripts/telegram-desktop-recorder.test.ts
+++ b/test/scripts/telegram-desktop-recorder.test.ts
@@ -60,7 +60,7 @@ function testSession(): RecorderSession {
     },
     schemaVersion: 1,
     startedAt: "2026-08-15T12:00:00.000Z",
-    window: { height: 1000, width: 650, x: 635, y: 40 },
+    window: { height: 1000, id: "0x04600007", width: 650, x: 635, y: 40 },
     userDriver: ["python3", "driver.py", "--account", "qa shared"],
   };
 }
@@ -152,7 +152,7 @@ describe("Telegram Desktop recorder CLI", () => {
     });
   });
 
-  it("runs agent-authored actions inside the recorded desktop", async () => {
+  it("targets the recorded Telegram window instead of the first matching window", async () => {
     const root = makeTempDir();
     const sessionPath = path.join(root, "recorder.json");
     const actionsPath = path.join(root, "click.json");
@@ -208,6 +208,11 @@ describe("Telegram Desktop recorder CLI", () => {
         timeoutMs: 90_000,
       }),
     );
+    const actionCommand = sshRun.mock.calls[0]?.[0].command;
+    expect(actionCommand).toContain("win='0x04600007'");
+    expect(actionCommand).toContain("tolower($1) == tolower(win)");
+    expect(actionCommand).toContain('[ "$WIDTH" -ne 650 ]');
+    expect(actionCommand).not.toContain("{print $1; exit}");
   });
 
   it("requires start inputs and a -100 private-group chat id", () => {
@@ -540,7 +545,7 @@ describe("Telegram Desktop recorder remote contract", () => {
           throw new Error("first desktop stayed on QR");
         }
         if (command.includes("getwindowgeometry")) {
-          return { stderr: "", stdout: "635 40 650 1000" };
+          return { stderr: "", stdout: "0x04600007 635 40 650 1000" };
         }
         return { stderr: "", stdout: "" };
       }),
@@ -579,7 +584,7 @@ describe("Telegram Desktop recorder remote contract", () => {
         return { stderr: "", stdout: "tg://login?token=open-target-chat" };
       }
       if (command.includes("getwindowgeometry")) {
-        return { stderr: "", stdout: "635 40 650 1000" };
+        return { stderr: "", stdout: "0x04600007 635 40 650 1000" };
       }
       return { stderr: "", stdout: "" };
     });
@@ -860,14 +865,15 @@ describe("Telegram Desktop recorder window geometry", () => {
   });
 
   it("parses the measured window and rejects unusable geometry", () => {
-    expect(parseWindowGeometry(" 636 45 648 995 \n")).toEqual({
+    expect(parseWindowGeometry(" 0x04600007 636 45 648 995 \n")).toEqual({
       height: 995,
+      id: "0x04600007",
       width: 648,
       x: 636,
       y: 45,
     });
-    expect(() => parseWindowGeometry("636 45 648")).toThrow("was not readable");
-    expect(() => parseWindowGeometry("636 45 10 10")).toThrow("too small to crop");
+    expect(() => parseWindowGeometry("0x04600007 636 45 648")).toThrow("was not readable");
+    expect(() => parseWindowGeometry("0x04600007 636 45 10 10")).toThrow("too small to crop");
   });
 
   it("crops the recorded window instead of a fixed rectangle", async () => {
@@ -875,7 +881,7 @@ describe("Telegram Desktop recorder window geometry", () => {
     const sessionPath = path.join(root, "recorder.json");
     writeRecorderSession(sessionPath, {
       ...testSession(),
-      window: { height: 995, width: 648, x: 636, y: 45 },
+      window: { height: 995, id: "0x04600007", width: 648, x: 636, y: 45 },
     });
     const cropped = vi.fn(async () => ({ crop: "", fps: 24, outputWidth: 648 }));
     const sshRun = vi.fn<RecorderOperations["sshRun"]>(async () => ({ stderr: "", stdout: "" }));

--- a/test/scripts/telegram-desktop-recorder.test.ts
+++ b/test/scripts/telegram-desktop-recorder.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../scripts/e2e/telegram-desktop-crabbox.ts";
 import {
   confirmQrLink,
+  execRecorder,
   parseRecorderArgs,
   parseWindowGeometry,
   readRecorderSession,
@@ -133,6 +134,69 @@ describe("Telegram Desktop recorder CLI", () => {
       command: "artifacts",
       sessionPath: "recorder.json",
     });
+    expect(
+      parseRecorderArgs([
+        "exec",
+        "--session",
+        "recorder.json",
+        "--script-file",
+        "click.sh",
+        "--timeout-seconds",
+        "90",
+      ]),
+    ).toEqual({
+      command: "exec",
+      scriptFile: "click.sh",
+      sessionPath: "recorder.json",
+      timeoutSeconds: 90,
+    });
+  });
+
+  it("runs an agent-authored extension inside the recorded desktop", async () => {
+    const root = makeTempDir();
+    const sessionPath = path.join(root, "recorder.json");
+    const scriptPath = path.join(root, "click.sh");
+    writeRecorderSession(sessionPath, testSession());
+    fs.writeFileSync(scriptPath, "xdotool click 1\nprintf 'clicked\\n'\n");
+    const sshRun = vi.fn<RecorderOperations["sshRun"]>(async () => ({
+      stderr: "",
+      stdout: "clicked\n",
+    }));
+    const operations = {
+      createCroppedMotionPreview: vi.fn(async () => ({ crop: "", fps: 24, outputWidth: 650 })),
+      createMotionPreview: vi.fn(async () => ({})),
+      inspectCrabbox: vi.fn(async () => ({
+        sshHost: "host",
+        sshKey: "/tmp/key",
+        sshPort: "22",
+        sshUser: "user",
+      })),
+      runCommand: vi.fn(async () => ({ stderr: "", stdout: "" })),
+      scpFromRemote: vi.fn(async () => undefined),
+      sshRun,
+    } satisfies RecorderOperations;
+
+    await expect(
+      execRecorder(
+        root,
+        {
+          command: "exec",
+          scriptFile: "click.sh",
+          sessionPath: "recorder.json",
+          timeoutSeconds: 90,
+        },
+        operations,
+      ),
+    ).resolves.toEqual({ stderr: "", stdout: "clicked\n" });
+    expect(sshRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: expect.stringContaining(
+          "export DISPLAY=:99\nxdotool click 1\nprintf 'clicked\\n'",
+        ),
+        stdio: "pipe",
+        timeoutMs: 90_000,
+      }),
+    );
   });
 
   it("requires start inputs and a -100 private-group chat id", () => {

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -52,7 +52,7 @@ async function setupHarness(
   fs.writeFileSync(trimmedVideo, Buffer.alloc(10_001));
   fs.writeFileSync(
     recorderCommand,
-    `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(recorderLog)}\ncp ${JSON.stringify(path.join(root, "mock-response.json"))} ${JSON.stringify(recorderControlLog)}\n${options.failRecorder ? "exit 1\n" : ""}if [ "$1" = artifacts ]; then\n  printf '%s\\n' ${JSON.stringify(JSON.stringify({ artifacts: { previewGifCropped: previewGif, screenshot, trimmedVideoCropped: trimmedVideo } }))}\nelif [ "$1" = exec ]; then\n  printf '%s\\n' ${JSON.stringify(JSON.stringify({ stderr: "", stdout: "clicked\n" }))}\nfi\n`,
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(recorderLog)}\ncp ${JSON.stringify(path.join(root, "mock-response.json"))} ${JSON.stringify(recorderControlLog)}\n${options.failRecorder ? "exit 1\n" : ""}if [ "$1" = artifacts ]; then\n  printf '%s\\n' ${JSON.stringify(JSON.stringify({ artifacts: { previewGifCropped: previewGif, screenshot, trimmedVideoCropped: trimmedVideo } }))}\nelif [ "$1" = actions ]; then\n  printf '%s\\n' ${JSON.stringify(JSON.stringify({ results: [{ command: "click", stderr: "", stdout: "clicked\n" }] }))}\nfi\n`,
     { mode: 0o755 },
   );
   fs.writeFileSync(userDriverCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
@@ -340,32 +340,56 @@ describe("Telegram Mantis free-form lane", () => {
     }
   });
 
-  it("runs a scenario extension inside the ephemeral desktop", async () => {
+  it("runs scenario-authored actions inside the ephemeral desktop", async () => {
     const harness = await setupHarness();
-    const extension = path.join(harness.outputRoot, "click-picker.sh");
-    fs.writeFileSync(extension, "xdotool click 1\n");
+    const actions = path.join(harness.outputRoot, "click-picker.json");
+    fs.writeFileSync(actions, JSON.stringify([{ command: "click", x: 120, y: 240 }]));
     try {
       const result = await runLane(harness.env, [
         "desktop",
         "--lane",
         "candidate",
-        "--script-file",
-        extension,
+        "--actions-file",
+        actions,
         "--timeout-seconds",
         "90",
       ]);
       expect(JSON.parse(result.stdout)).toMatchObject({
-        stdout: "clicked\n",
-        scriptSha256: expect.stringMatching(/^[0-9a-f]{64}$/u),
+        actionsSha256: expect.stringMatching(/^[0-9a-f]{64}$/u),
+        results: [{ command: "click", stdout: "clicked\n" }],
       });
       expect(fs.readFileSync(harness.recorderLog, "utf8")).toContain(
-        "exec --session attempt/recorder.json --script-file attempt/desktop-extension-2.sh --timeout-seconds 90",
+        "actions --session attempt/recorder.json --actions-file attempt/desktop-actions-2.json --timeout-seconds 90",
       );
       const state = JSON.parse(
         fs.readFileSync(path.join(harness.sessionRoot, "candidate.active.json"), "utf8"),
       );
       expect(state.invocations.at(-1)).toMatchObject({
-        args: { scriptFile: "click-picker.sh", timeoutSeconds: 90 },
+        args: { actionsFile: "click-picker.json", timeoutSeconds: 90 },
+        command: "desktop",
+      });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("records desktop actions before a timeout or failure", async () => {
+    const harness = await setupHarness({ failRecorder: true });
+    const actions = path.join(harness.outputRoot, "failed-actions.json");
+    fs.writeFileSync(actions, JSON.stringify([{ command: "click", x: 120, y: 240 }]));
+    try {
+      await expect(
+        runLane(harness.env, ["desktop", "--lane", "candidate", "--actions-file", actions]),
+      ).rejects.toThrow();
+      const state = JSON.parse(
+        fs.readFileSync(path.join(harness.sessionRoot, "candidate.active.json"), "utf8"),
+      );
+      expect(state.invocations.at(-1)).toMatchObject({
+        args: {
+          actionsFile: "failed-actions.json",
+          actionsSha256: expect.stringMatching(/^[0-9a-f]{64}$/u),
+          timeoutSeconds: 60,
+        },
         command: "desktop",
       });
     } finally {

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -52,7 +52,7 @@ async function setupHarness(
   fs.writeFileSync(trimmedVideo, Buffer.alloc(10_001));
   fs.writeFileSync(
     recorderCommand,
-    `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(recorderLog)}\ncp ${JSON.stringify(path.join(root, "mock-response.json"))} ${JSON.stringify(recorderControlLog)}\n${options.failRecorder ? "exit 1\n" : ""}if [ "$1" = artifacts ]; then\n  printf '%s\\n' ${JSON.stringify(JSON.stringify({ artifacts: { previewGifCropped: previewGif, screenshot, trimmedVideoCropped: trimmedVideo } }))}\nfi\n`,
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(recorderLog)}\ncp ${JSON.stringify(path.join(root, "mock-response.json"))} ${JSON.stringify(recorderControlLog)}\n${options.failRecorder ? "exit 1\n" : ""}if [ "$1" = artifacts ]; then\n  printf '%s\\n' ${JSON.stringify(JSON.stringify({ artifacts: { previewGifCropped: previewGif, screenshot, trimmedVideoCropped: trimmedVideo } }))}\nelif [ "$1" = exec ]; then\n  printf '%s\\n' ${JSON.stringify(JSON.stringify({ stderr: "", stdout: "clicked\n" }))}\nfi\n`,
     { mode: 0o755 },
   );
   fs.writeFileSync(userDriverCommand, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
@@ -335,6 +335,39 @@ describe("Telegram Mantis free-form lane", () => {
         runLane(harness.env, ["send", "--lane", "candidate", "--text-file", outside]),
       ).rejects.toThrow("--text-file must be inside the Mantis output directory");
       expect(harness.requests).toEqual([]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("runs a scenario extension inside the ephemeral desktop", async () => {
+    const harness = await setupHarness();
+    const extension = path.join(harness.outputRoot, "click-picker.sh");
+    fs.writeFileSync(extension, "xdotool click 1\n");
+    try {
+      const result = await runLane(harness.env, [
+        "desktop",
+        "--lane",
+        "candidate",
+        "--script-file",
+        extension,
+        "--timeout-seconds",
+        "90",
+      ]);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        stdout: "clicked\n",
+        scriptSha256: expect.stringMatching(/^[0-9a-f]{64}$/u),
+      });
+      expect(fs.readFileSync(harness.recorderLog, "utf8")).toContain(
+        "exec --session attempt/recorder.json --script-file attempt/desktop-extension-2.sh --timeout-seconds 90",
+      );
+      const state = JSON.parse(
+        fs.readFileSync(path.join(harness.sessionRoot, "candidate.active.json"), "utf8"),
+      );
+      expect(state.invocations.at(-1)).toMatchObject({
+        args: { scriptFile: "click-picker.sh", timeoutSeconds: 90 },
+        command: "desktop",
+      });
     } finally {
       await harness.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes Mantis stopping with a blocked result whenever a visible Telegram interaction is missing from its fixed primitive list, even though the recorded desktop can perform it.

## Why This Change Was Made

Adds one generic `desktop` action seam. The proof agent writes a focused JSON sequence under its run output and can click, type, or send keys only inside the Telegram window, then continues observing and recording through the normal lane. The prompt requires using this seam before declaring a missing primitive.

The first implementation allowed shell and was rejected before proof. The final broker accepts only typed click/key/type/sleep actions, bounds clicks to the measured Telegram window, shell-quotes text, and records the action file path, hash, and timeout before execution. No profile, terminal, filesystem, or network command surface.

Production/prompt: +171/-9 (net +162). Tests: +133/-1. Growth is the generic desktop-control broker and its validation; it replaces future one-off Telegram UI primitives.

## User Impact

Mantis can teach itself the UI sequence a PR needs—such as clicking an inline picker button—rather than immediately posting an unhelpful blocked proof.

## Evidence

- Focused Mantis/recorder suite: 81/81 passed.
- `pnpm tsgo:scripts`: passed.
- `pnpm tsgo:test:root`: passed.
- Targeted Oxlint and Oxfmt: passed.
- Exact-head ClawSweeper: code correct, zero findings; owner-authorized bounded desktop-control scope awaits live proof.
- Live #124222 rerun: https://github.com/openclaw/openclaw/actions/runs/32502297770

Test audit: the lane regression fails before this change because `desktop` is unknown; recorder coverage protects the typed window-control boundary, and failure coverage proves attempt facts persist before execution.

Performance: normal runs are unchanged. The fallback adds commands only when the agent explicitly needs extra desktop interaction.

Codex runtime checked directly: `../codex/codex-rs/exec/src/lib.rs:751-775`, `:885-912`, and `:1064-1127` confirm the output-schema, turn-start, and unprivileged sandbox behavior used by this workflow.
