### PR TITLE
fix(ui): retire stale plugin lifecycle feedback

### DIFF
--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -760,6 +760,57 @@ describe("PluginsPage", () => {
     expect(calls).toContainEqual(["plugins.list", {}]);
   });
 
+  it("does not let an older uninstall republish its page notice after a newer row action", async () => {
+    const uninstallResult = deferred<unknown>();
+    const enabledPlugin = createPlugin({ enabled: true, state: "enabled" });
+    const removable = createPlugin({
+      id: "community-thing",
+      name: "Community Thing",
+      origin: "global",
+      removable: true,
+      featured: false,
+    });
+    const { client, request } = createClient(async (method) => {
+      if (method === "plugins.uninstall") {
+        return uninstallResult.promise;
+      }
+      if (method === "plugins.setEnabled") {
+        return { ok: true, plugin: enabledPlugin, restartRequired: false };
+      }
+      if (method === "plugins.list") {
+        return createResult(enabledPlugin);
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    const harness = createGateway(client);
+    const { page } = await mountPage(
+      createContext(harness.gateway),
+      createPluginsRouteData(harness.gateway, {
+        plugins: [createPlugin(), removable],
+        diagnostics: [],
+        mutationAllowed: true,
+      }),
+    );
+
+    const uninstall = page.uninstall("community-thing", "plugin:community-thing");
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("plugins.uninstall", { pluginId: "community-thing" }),
+    );
+    await page.updateEnabled("workboard", true);
+
+    uninstallResult.resolve({
+      ok: true,
+      pluginId: "community-thing",
+      restartRequired: true,
+      removed: ["config entry", "install record", "directory"],
+    });
+    await uninstall;
+    await page.updateComplete;
+
+    expect(page.querySelector(".plugins-page-notice")).toBeNull();
+    expect(page.messages["plugin:workboard"]?.text).toContain("Enabled Workboard");
+  });
+
   it("adds an MCP server through the shared config seam", async () => {
     const { client } = createClient(async (method) => {
       if (method === "plugins.list") {

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -717,6 +717,7 @@ class PluginsPage extends OpenClawLightDomElement {
       refreshError: string | null,
       client: GatewayBrowserClient,
       isCurrent: () => boolean,
+      isLatest: () => boolean,
     ) => Promise<void>,
     onError: (error: unknown) => void = (error) => {
       this.setMessage(rowKey, {
@@ -730,10 +731,12 @@ class PluginsPage extends OpenClawLightDomElement {
     if (!scope || !this.canMutate() || this.busy[rowKey]) {
       return;
     }
+    this.pageNotice = null;
     const mutationToken = ++this.mutationToken;
     this.mutationTokens.set(rowKey, mutationToken);
     const isCurrent = () =>
       this.gateway.isCurrent(scope) && this.mutationTokens.get(rowKey) === mutationToken;
+    const isLatest = () => isCurrent() && this.mutationToken === mutationToken;
     this.setBusy(rowKey, true);
     if (!options.preserveMessageWhilePending) {
       this.setMessage(rowKey, null);
@@ -747,7 +750,7 @@ class PluginsPage extends OpenClawLightDomElement {
       if (!isCurrent()) {
         return;
       }
-      await onSuccess(mutation.value, mutation.refreshError, scope.client, isCurrent);
+      await onSuccess(mutation.value, mutation.refreshError, scope.client, isCurrent, isLatest);
     } catch (error) {
       if (isCurrent()) {
         onError(error);
@@ -840,19 +843,21 @@ class PluginsPage extends OpenClawLightDomElement {
     await this.runPluginMutation(
       rowKey,
       (client) => uninstallPlugin(client, pluginId),
-      async (result, refreshError, client) => {
+      async (result, refreshError, client, _isCurrent, isLatest) => {
         this.setPendingRemoval(rowKey, false);
         // Removal hides its row, so keep the restart reminder on the page.
-        this.pageNotice = {
-          kind: "success",
-          text: [
-            t("pluginsPage.removedRestart", { name: result.pluginId }),
-            ...(result.warnings ?? []).map((warning) => formatUiExternalText(warning)),
-            refreshError ? t("pluginsPage.configRefreshFailed", { error: refreshError }) : null,
-          ]
-            .filter(Boolean)
-            .join("\n"),
-        };
+        if (isLatest()) {
+          this.pageNotice = {
+            kind: "success",
+            text: [
+              t("pluginsPage.removedRestart", { name: result.pluginId }),
+              ...(result.warnings ?? []).map((warning) => formatUiExternalText(warning)),
+              refreshError ? t("pluginsPage.configRefreshFailed", { error: refreshError }) : null,
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          };
+        }
         await this.refreshCatalogAfterMutation(client);
       },
     );

--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -676,6 +676,42 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
         "Removed calendar-plus",
       );
 
+      await gateway.setMethodResponse("plugins.list", uninstalledInventory);
+      await page.getByRole("tab", { name: /^Discover/u }).click();
+      const searchCountBeforeReinstall = (await gateway.getRequests("plugins.search")).length;
+      await page.getByRole("searchbox", { name: "Search plugins" }).fill("calendar");
+      await waitForNextRequest(gateway, "plugins.search", searchCountBeforeReinstall);
+      const reinstallRow = page.locator(
+        '[data-package-name="calendar-plus"][data-plugin-status="not-installed"]',
+      );
+      await reinstallRow.waitFor({ state: "visible" });
+      await gateway.setMethodResponse("plugins.install", installResult);
+      await gateway.setMethodResponse("plugins.list", finalInventory);
+      const installCountBeforeReinstall = (await gateway.getRequests("plugins.install")).length;
+      await reinstallRow
+        .getByRole("button", { name: "Install Calendar Plus", exact: true })
+        .click();
+      const reinstallRequest = await waitForNextRequest(
+        gateway,
+        "plugins.install",
+        installCountBeforeReinstall,
+      );
+      expect(requestParams(reinstallRequest)).toEqual({
+        source: "clawhub",
+        packageName: "calendar-plus",
+      });
+      const reinstalledRow = page.locator(
+        '[data-package-name="calendar-plus"][data-plugin-status="enabled"]',
+      );
+      await reinstalledRow.waitFor({ state: "attached" });
+      await captureScreenshot(page, "11-reinstalled-feedback-desktop.png");
+      expect(await page.locator(".plugins-page-notice").count()).toBe(0);
+      expect(await reinstalledRow.getByRole("status").textContent()).toContain(
+        "Installed Calendar Plus",
+      );
+
+      await page.getByRole("tab", { name: /^Installed/u }).click();
+      await page.getByRole("searchbox", { name: "Search plugins" }).fill("");
       await page.setViewportSize(mobileViewport);
       await expect
         .poll(() =>


### PR DESCRIPTION
## What Problem This Solves

Fixes two manifestations of stale Plugins-page lifecycle feedback:

- uninstalling and then reinstalling a plugin could leave a page-level “Removed” notice beside the row’s current “Installed” result;
- a delayed uninstall on one row could republish its global removal notice after a newer lifecycle action had started on another row.

## Why This Change Was Made

The shared plugin-mutation owner now retires an obsolete page-level notice whenever it accepts a newer install, enable, disable, or uninstall action. Its existing monotonic mutation token also acts as the page-wide action epoch: successful uninstall publishes a removal notice only while it still owns the newest accepted action. Per-row mutation tokens continue to own independent row completion, so overlapping actions still reconcile their committed plugin and catalog state.

Production LOC: +16/-12 | Tests: +87/-0

## User Impact

Plugin lifecycle feedback now reflects the newest accepted action. Reinstalling a plugin after removal shows only the current installed result, and a late completion on another row cannot restore obsolete page-level feedback.

## Evidence

An authentic real source-mode Chromium regression was captured before the production edit. The full lifecycle flow installed Calendar Plus, enabled Workboard, uninstalled Calendar Plus, switched to Discover, searched, and reinstalled the exact package. The baseline failed because `.plugins-page-notice` still contained one stale removal notice after the row reported successful installation (`expected 0, received 1`).

ClawSweeper then identified the cross-row ordering case. A focused pre-fix regression deferred `plugins.uninstall`, completed a newer enable action on another row, and resolved the older uninstall. The existing branch failed because the old completion republished “Removed community-thing” (`expected null`, received the stale success notice). The final owner repair makes that same regression pass while retaining the newer row’s “Enabled Workboard” result.

Final verification on rebased head `eb613fbe7a7c4a7ce3a65075cc7759598b49e2e4`:

- 78/78 plugin owner/unit tests passed;
- all 6/6 Plugins mocked-Gateway E2E cases passed;
- the full changed-file format, type, lint, guard, and test gate passed;
- the rebase onto current `origin/main` was patch-identical;
- fresh final Codex autoreview found no accepted/actionable finding and rated the patch correct at 0.97 confidence;
- live open issue/PR searches found no exact duplicate.

The browser scenario also asserts the exact reinstall request `{ source: "clawhub", packageName: "calendar-plus" }`, the enabled installed row, current row-scoped success feedback, the absent stale page notice, and the existing Installed/mobile continuation.

| Before | After |
| --- | --- |
| ![Plugins page showing contradictory Removed and Installed notices](https://ampcode.com/user-content/artifacts/b3cdebe8b94b2ce347cec924b78dc61b2d5c5727cb722944e047712fe72a1b61-file.png) | ![Plugins page showing only the current Installed notice](https://ampcode.com/user-content/artifacts/1b3a2ff55a4870b6271472e70d89cef5cd122d8d9b4e09d4a5213f816b667b2b-file.png) |

AI-assisted implementation and verification; no agent transcript is attached.
