### PR TITLE
improve(googlechat): speed up dense bullet list formatting

### DIFF
--- a/extensions/googlechat/src/format.test.ts
+++ b/extensions/googlechat/src/format.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { formatGoogleChatTextChunks, GOOGLE_CHAT_FORMAT_PROFILE } from "./format.js";
 
 const formatGoogleChatText = (text: string) => formatGoogleChatTextChunks(text).join("");
@@ -102,6 +102,26 @@ describe("formatGoogleChatText", () => {
   it("uses semantic list depth instead of authored indentation width", () => {
     expect(formatGoogleChatText("- parent\n    - child")).toBe("* parent\n    * child");
     expect(formatGoogleChatText("   - top-level")).toBe("* top-level");
+  });
+
+  it("keeps dense bullet-list formatting work bounded", () => {
+    const input = Array.from({ length: 1_000 }, (_, index) => `- row ${index}`).join("\n");
+    const expected = input.replace(/^- /gmu, "* ");
+    const sliceSpy = vi.spyOn(String.prototype, "slice");
+    let fullMessagePrefixSlices = 0;
+    try {
+      expect(formatGoogleChatText(input)).toBe(expected);
+      fullMessagePrefixSlices = sliceSpy.mock.calls.reduce((count, [start, end], index) => {
+        const source = sliceSpy.mock.contexts[index];
+        return String(source).length === input.length && start === 0 && end !== undefined
+          ? count + 1
+          : count;
+      }, 0);
+    } finally {
+      sliceSpy.mockRestore();
+    }
+
+    expect(fullMessagePrefixSlices).toBeLessThan(50);
   });
 
   it("neutralizes nested markup inside native link labels", () => {

--- a/extensions/googlechat/src/format.ts
+++ b/extensions/googlechat/src/format.ts
@@ -113,15 +113,23 @@ function projectGoogleChatLinkLabels(ir: MarkdownIR): MarkdownIR {
 }
 
 function markGoogleChatBulletLists(ir: MarkdownIR, markerToken: string): MarkdownIR {
-  let text = ir.text;
+  let characters: string[] | undefined;
   for (const item of ir.listItems ?? []) {
     const marker = item.listMarker;
-    if (item.kind !== "bullet" || !marker || text.slice(marker.start, marker.end) !== "• ") {
+    if (
+      item.kind !== "bullet" ||
+      !marker ||
+      marker.end !== marker.start + 2 ||
+      ir.text[marker.start] !== "•" ||
+      ir.text[marker.start + 1] !== " "
+    ) {
       continue;
     }
-    text = `${text.slice(0, marker.start)}${markerToken}${text.slice(marker.end)}`;
+    characters ??= ir.text.split("");
+    characters[marker.start] = markerToken[0] ?? "";
+    characters[marker.start + 1] = markerToken[1] ?? "";
   }
-  return text === ir.text ? ir : { ...ir, text };
+  return characters ? { ...ir, text: characters.join("") } : ir;
 }
 
 function projectUnsafeCodeFallbacks(ir: MarkdownIR): MarkdownIR {


### PR DESCRIPTION
## What Problem This Solves

Resolves an issue where formatting dense Google Chat bullet lists repeatedly rebuilt the complete message around every list marker, making outbound preparation grow quadratically with list length.

## Why This Change Was Made

Google Chat's semantic bullet projection now writes equal-width private marker tokens into one lazily allocated UTF-16 code-unit buffer. Existing marker positions, sanitization, rendering, and chunking remain unchanged.

## User Impact

Large Google Chat bullet lists are prepared substantially faster. Rendered output, chunk boundaries, and public behavior are unchanged.

## Evidence

- Exact-current deterministic red/green: the 1,000-bullet owner test failed on the base with 1,004 full-message prefix slices and passes with 3.
- Fresh Node 24 benchmark, 9 samples after 3 warmups:
  - 2,000 bullets: 50.077 ms → 34.282 ms median (31.5% lower)
  - 4,000 bullets: 151.604 ms → 95.524 ms median (37.0% lower)
  - output bytes and chunk counts were identical at every measured size.
- Differential: 450 representative/adversarial Unicode and Markdown cases, 3,620 chunks, 237,204 output bytes; exact SHA-256 matched: `84a8173f1f472092fdb5949bb529f75d34dbac39a2d1bc141f9bcd027c482ed9`.
- Focused/sibling tests: 54/54 passed across Google Chat formatting/channel and outbound message planning.
- `node scripts/check-changed.mjs -- extensions/googlechat/src/format.ts extensions/googlechat/src/format.test.ts` passed.
- `pnpm build` passed, including plugin control-plane and Control UI performance gates.
- Bundled Codex autoreview: TruffleHog clean; no accepted/actionable findings; patch correct at 0.99 confidence.
