### PR TITLE
fix(sessions): preserve sessions when age pruning is disabled

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -75,6 +75,9 @@ function hasStaleSqliteSessionEntryCandidate(
   maxAgeMs: number,
   isCandidate: (key: string, entry: SessionEntry) => boolean,
 ): boolean {
+  if (maxAgeMs <= 0) {
+    return false;
+  }
   const cutoffMs = Date.now() - maxAgeMs;
   const db = getSessionKysely(database.db);
   const rows = executeSqliteQuerySync(

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -298,6 +298,9 @@ export function pruneStaleEntries(
   } = {},
 ): number {
   const maxAgeMs = overrideMaxAgeMs ?? resolveMaintenanceConfigFromInput().pruneAfterMs;
+  if (maxAgeMs <= 0) {
+    return 0;
+  }
   const cutoffMs = Date.now() - maxAgeMs;
   let pruned = 0;
   for (const [key, entry] of Object.entries(store)) {

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -811,45 +811,45 @@ describe("session-store-runtime compatibility surface", () => {
     });
   });
 
-  it("preserves resolved maintenance settings through entry patches", async () => {
-    const staleSessionKey = "agent:main:stale";
-    const activeSessionKey = "agent:main:active";
-    const now = Date.now();
-    await seedSessionEntry(staleSessionKey, {
-      sessionId: "session-stale",
-      updatedAt: now - 8 * DAY_MS,
-    });
-    await seedSessionEntry(activeSessionKey, {
-      sessionId: "session-active",
-      updatedAt: now,
-    });
+  it.each([
+    { pruneAfterMs: 7 * DAY_MS, staleSessionPresent: false },
+    { pruneAfterMs: 0, staleSessionPresent: true },
+    { pruneAfterMs: -DAY_MS, staleSessionPresent: true },
+  ])(
+    "applies age retention $pruneAfterMs through entry patches",
+    async ({ pruneAfterMs, staleSessionPresent }) => {
+      const staleSessionKey = "agent:main:stale";
+      const activeSessionKey = "agent:main:active";
+      const now = Date.now();
+      await seedSessionEntry(staleSessionKey, {
+        sessionId: "session-stale",
+        updatedAt: now - 8 * DAY_MS,
+      });
+      await seedSessionEntry(activeSessionKey, {
+        sessionId: "session-active",
+        updatedAt: now,
+      });
 
-    await expect(
-      patchSessionEntry({
+      await patchSessionEntry({
         sessionKey: activeSessionKey,
         storePath,
         maintenanceConfig: {
           mode: "enforce",
-          pruneAfterMs: 7 * DAY_MS,
+          pruneAfterMs,
           modelRunPruneAfterMs: DAY_MS,
-          maxEntries: 1,
+          maxEntries: 100,
           resetArchiveRetentionMs: 7 * DAY_MS,
           maxDiskBytes: null,
           highWaterBytes: null,
         },
         update: () => ({ model: "gpt-5.5" }),
-      }),
-    ).resolves.toMatchObject({
-      model: "gpt-5.5",
-      sessionId: "session-active",
-    });
+      });
 
-    expect(getSessionEntry({ sessionKey: activeSessionKey, storePath })).toMatchObject({
-      model: "gpt-5.5",
-      sessionId: "session-active",
-    });
-    expect(getSessionEntry({ sessionKey: staleSessionKey, storePath })).toBeUndefined();
-  });
+      expect(getSessionEntry({ sessionKey: staleSessionKey, storePath }) != null).toBe(
+        staleSessionPresent,
+      );
+    },
+  );
 
   it("forwards maintenance suppression through entry patches", async () => {
     const staleSessionKey = "agent:main:stale";


### PR DESCRIPTION
Supersedes #121106. Thanks @zenglingbiao for the report, root-cause identification, and initial fix.

## What Problem This Solves

Fixes an issue where plugins disabling age-based session pruning with a non-positive retention could silently delete every inactive eligible session during an entry patch.

## Why This Change Was Made

The maintenance owner treated the retention as cutoff arithmetic without first handling its disabled state. Age pruning now returns before mutation for non-positive retention, and the SQLite preflight returns before querying or loading the full store. Positive retention behavior is unchanged.

## User Impact

Plugins can set age retention to zero or a negative value to disable age pruning without losing eligible session routing/history. The disabled path also avoids an unnecessary stale-row scan and full-store load.

## Evidence

- Red on current main: the public Plugin SDK patch regression expected `session-stale` to survive with `pruneAfterMs: 0`; it received `undefined`.
- Green: grouped owner proof — 90 tests across 5 files, including positive, zero, and negative public Plugin SDK → SQLite cases.
- Green: targeted Oxfmt, type-aware Oxlint, `git diff --check`, `pnpm tsgo`, and `pnpm check:test-types`.
- Green: exact-head hosted `openclaw/ci-gate` (attempt 2). Attempt 1 had one unrelated `doctor-lint.test.ts` Crabbox-profile timeout; rerun passed.
- Green: exact-head local ClawSweeper — correct, 0 findings, 0 security concerns, no maintainer decision, 0 Rank-up moves.
- Green: exact-head real-user Telegram DM — SUT replied `OPENCLAW_E2E_OK`; two typing events; `pruneAfterMs: 0` fixture retained target + fresh peer, `removedKeys: []`, no maintenance failure, scratch state removed.
- Production/test LOC: +6/-0 production; +28/-28 tests.

Public-review warning-projection suggestion intentionally skipped: the sole production caller passes the active session in `preserveKeys`, so it returns before cutoff evaluation; that helper predicts only active-session eviction and cannot report the eligible peer deletion fixed here. Changing its unreachable direct-call semantics would broaden this repair without user-visible coverage.