### PR TITLE
perf(agents): reuse active Gateway plugin generation

### DIFF
--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -56,23 +56,19 @@ export function createPreparedInboundRegistryLoader(): PreparedInboundRegistryLo
       return existing;
     }
     const activeRegistry = getActivePluginRegistry();
-    const activeWorkspaceDir = getActivePluginRegistryWorkspaceDir();
-    // Reuse is generation-bound: the requesting snapshot must BE the process-current
-    // published generation, or a leaked/older active registry could satisfy the
-    // manifest match (bundled records compare by id+origin only) and serve another
-    // generation's plugins. Identity, not equivalence, is the authority check here.
-    const currentGenerationSnapshot = getCurrentPluginMetadataSnapshot({
-      config: input.config,
-      workspaceDir: metadataSnapshot.workspaceDir,
-      allowWorkspaceScopedSnapshot: true,
-    });
+    // Identity is the generation authority. Manifest equivalence alone could let a
+    // stale active registry satisfy a newer bundled snapshot.
     const reusableGatewayRegistry =
       input.allowGatewaySubagentBinding === true &&
       input.env === undefined &&
       getActivePluginRuntimeSubagentMode() === "gateway-bindable" &&
       activeRegistry &&
-      currentGenerationSnapshot === metadataSnapshot &&
-      (activeWorkspaceDir === undefined || activeWorkspaceDir === metadataSnapshot.workspaceDir) &&
+      getActivePluginRegistryWorkspaceDir() === metadataSnapshot.workspaceDir &&
+      getCurrentPluginMetadataSnapshot({
+        config: input.config,
+        workspaceDir: metadataSnapshot.workspaceDir,
+        allowWorkspaceScopedSnapshot: true,
+      }) === metadataSnapshot &&
       registryMatchesManifestPluginIds(
         activeRegistry,
         metadataSnapshot.manifestRegistry.plugins,
@@ -113,11 +109,6 @@ export function prepareWorkspacePluginRegistries(
   const inboundPluginRegistry = input.readOnly
     ? undefined
     : loadInboundRegistry?.(input, metadataSnapshot);
-  // Extending the reused Gateway generation inherits its artifact preference: the
-  // Gateway loader realizes built artifacts, so the delta load must not re-import
-  // the same plugins through source transforms. Isolated loads keep source truth.
-  const extendsActiveGatewayGeneration =
-    inboundPluginRegistry !== undefined && inboundPluginRegistry === getActivePluginRegistry();
   const runtimePluginRegistry =
     input.runtimePluginSelections || !inboundPluginRegistry
       ? loadAgentRuntimePluginRegistryHandle({
@@ -131,11 +122,7 @@ export function prepareWorkspacePluginRegistries(
           ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
           ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
           metadataSnapshot,
-          // Lifecycle-selected callers and delta loads extending the active Gateway
-          // generation both stay on built artifacts; isolated loads keep source truth.
-          ...(preferBuiltPluginArtifacts || extendsActiveGatewayGeneration
-            ? { preferBuiltPluginArtifacts: true }
-            : {}),
+          ...(preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
           selections: input.runtimePluginSelections,
         })
       : inboundPluginRegistry;

--- a/src/agents/prepared-model-runtime.plugin-context.test.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.test.ts
@@ -36,7 +36,7 @@ describe("prepared model runtime plugin metadata ownership", () => {
       inlineProviderModels: [],
       pluginMetadataSnapshot: gatewaySnapshot,
     };
-    const resolveMetadata = vi.spyOn(pluginMetadata, "loadPluginMetadataSnapshot");
+    const resolveMetadata = vi.spyOn(pluginMetadata, "resolvePluginMetadataSnapshot");
     const getCurrentMetadata = vi.spyOn(currentPluginMetadata, "getCurrentPluginMetadataSnapshot");
 
     try {

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -74,9 +74,8 @@ function resolveColdMetadataSnapshot(
   input: PreparedModelRuntimeInput,
   env: NodeJS.ProcessEnv,
 ): PluginMetadataSnapshot {
-  // Resolve (slot-probing) instead of load: in the gateway the published current
-  // generation satisfies this read, which keeps snapshot identity stable for the
-  // generation-bound registry reuse in the inbound loader.
+  // Slot probing preserves the published Gateway generation identity; cold callers
+  // still fall through to a fresh metadata load.
   const resolvedMetadataSnapshot = resolvePluginMetadataSnapshot({
     config: input.config,
     env,

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -407,9 +407,8 @@ describe("prepared model runtime Gateway catalog mode", () => {
     );
     expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
     expect(mocks.loadStaticCatalog).not.toHaveBeenCalled();
-    // Two slot-probing resolutions share the published generation: the prepared
-    // cold plugin context and the model-id normalization lane. Neither builds a
-    // catalog; the laziness guards above are the eager-work protections.
+    // The prepared plugin context and model-id normalization probe the same
+    // published metadata generation without starting catalog discovery.
     expect(mocks.resolvePluginMetadataSnapshot).toHaveBeenCalledTimes(2);
     expect(configuredRuntimeModelCount).toBe(1);
     expect(generatedCatalogReadCount).toBe(0);

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -122,34 +122,36 @@ describe("agent runtime plugin registries", () => {
     );
   });
 
-  it("reuses the Gateway inbound registry and loads only its selected provider delta", () => {
+  it("reuses the current Gateway generation and loads only the imported-plugin delta", () => {
     const config = {} as never;
-    const gatewayPlugin = {
-      id: "gateway-owned",
-      origin: "bundled",
-      rootDir: "/dist/extensions/gateway-owned",
-      source: "/dist/extensions/gateway-owned/index.js",
-      status: "loaded",
+    const workspaceDir = "/tmp/default-workspace";
+    const activeRegistry = {
+      plugins: [
+        { id: "gateway-owned", origin: "bundled", status: "loaded" },
+        {
+          id: "deferred",
+          origin: "bundled",
+          status: "loaded",
+          format: "openclaw",
+          imported: false,
+        },
+      ],
     };
-    const activeRegistry = { plugins: [gatewayPlugin] };
-    const selectedRegistry = { plugins: [gatewayPlugin, { id: "selected-provider" }] };
     const metadataSnapshot = {
-      ...createMetadataSnapshot("/tmp/default-workspace", undefined),
+      ...createMetadataSnapshot(workspaceDir, undefined),
       manifestRegistry: {
         diagnostics: [],
         plugins: [
-          {
-            id: "gateway-owned",
-            origin: "bundled",
-            rootDir: "/extensions/gateway-owned",
-            source: "/extensions/gateway-owned/index.ts",
-          },
+          { id: "gateway-owned", origin: "bundled" },
+          { id: "deferred", origin: "bundled" },
         ],
       },
     };
+    const selectedRegistry = { plugins: [...activeRegistry.plugins, { id: "selected-provider" }] };
     hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
+    hoisted.getActivePluginRegistryWorkspaceDir.mockReturnValue(workspaceDir);
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
-    hoisted.getCurrentPluginMetadataSnapshot.mockImplementation(() => metadataSnapshot);
+    hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue(metadataSnapshot);
     hoisted.loadPluginRegistryHandle.mockReturnValue(selectedRegistry);
     hoisted.resolveAgentRuntimePluginLoadPlan.mockImplementation(({ basePluginIds }) => ({
       config,
@@ -162,71 +164,82 @@ describe("agent runtime plugin registries", () => {
         allowGatewaySubagentBinding: true,
         config,
         runtimePluginSelections: [{ provider: "selected", modelId: "model" }],
-        workspaceDir: "/tmp/default-workspace",
+        workspaceDir,
       },
       metadataSnapshot as never,
       createPreparedInboundRegistryLoader(),
+      true,
     );
 
     expect(prepared.inboundPluginRegistry).toBe(activeRegistry);
     expect(prepared.runtimePluginRegistry).toBe(selectedRegistry);
+    expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ basePluginIds: ["gateway-owned"] }),
+    );
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledOnce();
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
       expect.objectContaining({
         onlyPluginIds: ["gateway-owned", "selected-provider"],
+        preferBuiltPluginArtifacts: true,
       }),
     );
   });
 
-  it("refuses Gateway registry reuse for a non-current metadata generation", () => {
+  it.each([
+    {
+      name: "custom environment",
+      input: { env: { OPENCLAW_STATE_DIR: "/tmp/custom-state" } },
+    },
+    {
+      name: "non-bindable mode",
+      setup: () => hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("default"),
+    },
+    {
+      name: "different workspace",
+      setup: () => hoisted.getActivePluginRegistryWorkspaceDir.mockReturnValue("/tmp/other"),
+    },
+    {
+      name: "stale metadata generation",
+      setup: () => hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue({}),
+    },
+    {
+      name: "manifest mismatch",
+      setup: (activeRegistry: { plugins: Array<{ origin: string }> }) => {
+        activeRegistry.plugins[0]!.origin = "external";
+      },
+    },
+  ])("refuses Gateway registry reuse for $name", ({ input, setup }) => {
     const config = {} as never;
-    const gatewayPlugin = {
-      id: "gateway-owned",
-      origin: "bundled",
-      rootDir: "/dist/extensions/gateway-owned",
-      source: "/dist/extensions/gateway-owned/index.js",
-      status: "loaded",
+    const workspaceDir = "/tmp/default-workspace";
+    const activeRegistry = {
+      plugins: [{ id: "gateway-owned", origin: "bundled", status: "loaded" }],
     };
-    const activeRegistry = { plugins: [gatewayPlugin] };
     const metadataSnapshot = {
-      ...createMetadataSnapshot("/tmp/default-workspace", undefined),
+      ...createMetadataSnapshot(workspaceDir, undefined),
       manifestRegistry: {
         diagnostics: [],
-        plugins: [
-          {
-            id: "gateway-owned",
-            origin: "bundled",
-            rootDir: "/extensions/gateway-owned",
-            source: "/extensions/gateway-owned/index.ts",
-          },
-        ],
+        plugins: [{ id: "gateway-owned", origin: "bundled" }],
       },
     };
     hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
+    hoisted.getActivePluginRegistryWorkspaceDir.mockReturnValue(workspaceDir);
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
-    // A different (older/leaked) generation is current: identity must fail closed.
-    hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue(
-      createMetadataSnapshot("/tmp/default-workspace", undefined),
-    );
-    hoisted.loadPluginRegistryHandle.mockReturnValue({ plugins: [] });
-    hoisted.resolveAgentRuntimePluginLoadPlan.mockImplementation(({ basePluginIds }) => ({
-      config,
-      pluginIds: basePluginIds,
-    }));
+    hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue(metadataSnapshot);
+    setup?.(activeRegistry);
 
-    const loadInboundRegistry = createPreparedInboundRegistryLoader();
-    const inbound = loadInboundRegistry(
+    const inbound = createPreparedInboundRegistryLoader()(
       {
         agentDir: "/tmp/agent",
         allowGatewaySubagentBinding: true,
         config,
-        workspaceDir: "/tmp/default-workspace",
+        workspaceDir,
+        ...input,
       },
       metadataSnapshot as never,
     );
 
     expect(inbound).not.toBe(activeRegistry);
-    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalled();
+    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledOnce();
   });
 
   it("keeps direct no-current loads on the requested workspace", () => {


### PR DESCRIPTION
## What Problem This Solves

Corrects the active Gateway generation reuse that landed in #126630 while this replacement was under review. The landed version inferred built-artifact preference from active-registry identity and allowed an undefined active workspace to match any prepared workspace. This replacement keeps generation reuse, slot-probing metadata resolution, and delta-only plugin loading while restoring explicit lifecycle ownership.

Supersedes the implementation in #126630 while preserving Peter Steinberger's co-author credit.

## Why This Change Was Made

The prepared runtime reuses the active Gateway registry only when the caller has Gateway binding authority, uses the default process environment, matches the active workspace and bindable mode, supplies the exact current metadata object, and matches the active registry records to that metadata generation.

Selected runtime plugins load as a delta seeded from imported inbound plugin IDs, so deferred records remain eligible for their scoped load. `preferBuiltPluginArtifacts` remains owned by the prepared generation introduced in #125957; this change removes the duplicate `extendsActiveGatewayGeneration` inference.

## User Impact

Gateway startup keeps the reuse optimization while stale, mismatched, isolated, and custom-environment runtimes continue through the existing independent load path. No config or public API changes.

## Evidence

- Restacked exact head: `aa25d4ebf888bab6172a370c5a51ac6aabcf8fe1`
- Focused exact-head proof: 7 files across 2 Vitest shards, 85 tests passed
- Covers accepted current-generation reuse and rejection for stale generation, custom env, non-bindable mode, workspace mismatch, and manifest mismatch
- Proves selected-runtime seeding excludes deferred plugin records
- `git diff --check`: passed
- Corrective diff against current main: production +11/-25 (net -14); tests +64/-52 (net +12)
- Pre-restack equivalent implementation proof on Blacksmith Testbox `tbx_01m0jjw54pmrrgwmcspxcakvfr`: `pnpm build`, singleton packaging, and explicit changed gates passed
- Same-Testbox isolated Gateway startup, 3 runs per implementation, `preparedRuntimeScaleMany`:
  - branch-cut main `a2f0b84e8adad3c29e11d6510809779963d748ee`: readyz median 9247ms; model-runtime median 371.9ms; plugin imports 4; source transforms 0
  - reviewed implementation: readyz median 8118ms; model-runtime median 349.2ms; plugin imports 4; source transforms 0
  - delta: readyz -12.2%; model-runtime -6.1%; no import or source-transform regression
- Testbox Actions lease: https://github.com/openclaw/openclaw/actions/runs/32503768585
