### PR TITLE
fix(agents): preserve opaque session key casing

### DIFF
--- a/src/agents/subagents/registry/subagent-session-reconciliation.test.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionStorePathCore, type SessionEntry } from "../../../config/sessions.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import {
+  resolveSubagentSessionCompletion,
+  type SubagentSessionStoreCache,
+} from "./subagent-session-reconciliation.js";
+
+const configuredStorePath = "/virtual/openclaw-subagent-reconciliation-sessions.json";
+const cfg = {
+  session: { store: configuredStorePath },
+} satisfies OpenClawConfig;
+const storePath = resolveSessionStorePathCore(configuredStorePath, { agentId: "main" });
+
+const terminalSession: SessionEntry = {
+  sessionId: "sibling-session",
+  status: "done",
+  startedAt: 1_000,
+  updatedAt: 2_000,
+  endedAt: 2_000,
+};
+
+function resolveCompletion(childSessionKey: string, storedSessionKey: string) {
+  const storeCache: SubagentSessionStoreCache = new Map([
+    [storePath, { [storedSessionKey]: terminalSession }],
+  ]);
+  return resolveSubagentSessionCompletion({
+    childSessionKey,
+    fallbackEndedAt: 3_000,
+    notBeforeMs: 0,
+    storeCache,
+    cfg,
+  });
+}
+
+describe("subagent session reconciliation keys", () => {
+  it("matches case-insensitive structural session-key segments", () => {
+    expect(
+      resolveCompletion("Agent:MAIN:telegram:group:ROOM", "agent:main:telegram:group:room"),
+    ).toMatchObject({ endedAt: 2_000, outcome: { status: "ok" } });
+  });
+
+  it.each([
+    {
+      channel: "Matrix",
+      childSessionKey: "agent:main:matrix:group:!Room:server",
+      storedSessionKey: "agent:main:matrix:group:!room:server",
+    },
+    {
+      channel: "Signal",
+      childSessionKey: "agent:main:signal:group:AbCdEf==",
+      storedSessionKey: "agent:main:signal:group:abcdef==",
+    },
+  ])(
+    "does not match a case-distinct $channel opaque peer",
+    ({ childSessionKey, storedSessionKey }) => {
+      expect(resolveCompletion(childSessionKey, storedSessionKey)).toBeNull();
+    },
+  );
+});

--- a/src/agents/subagents/registry/subagent-session-reconciliation.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.ts
@@ -14,6 +14,7 @@ import {
   listSessionEntriesReadOnly,
   loadSessionEntryReadOnly,
 } from "../../../config/sessions/session-accessor.js";
+import { normalizeStoreSessionKey } from "../../../config/sessions/store-entry.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SubagentRunOutcome } from "../announce/subagent-announce-output.js";
 import {
@@ -69,20 +70,6 @@ function freshSessionStartedAt(
   return notBeforeMs === undefined || startedAt >= notBeforeMs ? startedAt : undefined;
 }
 
-function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
-  const direct = store[sessionKey];
-  if (direct) {
-    return direct;
-  }
-  const normalized = sessionKey.trim().toLowerCase();
-  for (const [key, entry] of Object.entries(store)) {
-    if (key.trim().toLowerCase() === normalized) {
-      return entry;
-    }
-  }
-  return undefined;
-}
-
 /** Load a child session entry using the agent-specific session store path. */
 export function loadSubagentSessionEntry(params: {
   childSessionKey: string;
@@ -106,7 +93,7 @@ export function loadSubagentSessionEntry(params: {
     );
     params.storeCache?.set(storePath, store);
   }
-  return findSessionEntryByKey(store, key);
+  return store[key] ?? store[normalizeStoreSessionKey(key)];
 }
 
 /** Resolve a child session entry without depending on the file-backed store shape. */


### PR DESCRIPTION
## Problem

Subagent reconciliation lowercased whole session keys when an exact key was absent. Matrix room IDs and Signal group IDs are opaque and case-sensitive, so a terminal case-distinct sibling could be mistaken for the child run and reported as a successful completion.

## Root cause

`loadSubagentSessionEntry` reimplemented session-key comparison with an `Object.entries()` lowercase scan instead of using the session store's canonical key normalizer.

## Fix

Keep the exact fast path, then perform one lookup with `normalizeStoreSessionKey`. This preserves structural casing normalization without folding opaque peer IDs, removes the O(N) fallback scan, and adds owner-boundary coverage for Matrix, Signal, and the structural control.

Supersedes #122142 and #122141. Based on the root-cause fix and regression coverage contributed by @Alix-007 in #122142; commit credit retained.

## Proof

- Pre-fix production SQLite probe: Matrix and Signal each returned `completion`/`ok` for an absent mixed-case child with only the lowercase sibling stored.
- Regression test before fix: 2 opaque-collision failures; structural control passed.
- `node scripts/run-vitest.mjs src/agents/subagents/registry`: 17 files, 534 tests passed.
- Focused Oxfmt and Oxlint: passed.
- `pnpm tsgo`: passed.
- `pnpm check:test-types`: passed.
- Post-fix production SQLite probe: Matrix `missing`; Signal `missing`; structural control `completion`.
- Production LOC: +2/−15 (net −13). Tests: +60.

Telegram exact-head drive passed after the local model-review gate. A real QA user sent `Please answer with OPENCLAW_E2E_OK only.` in a DM (Bot API message 1750); the SUT emitted two typing events and replied `OPENCLAW_E2E_OK` (message 1751). In the same run, production SQLite reconciliation reported Matrix `missing`, Signal `missing`, and structural casing `completion`; all three scenario assertions passed. One mock-provider request was recorded. Side effects: one user message and one SUT reply; no edits, deletions, or reactions.

## Maintainer decision

Proceed with the focused canonical lookup repair. A wider session audit is not required for this PR. This task explicitly stops before merge.
