### PR TITLE
fix(qa): exercise a real config restart boundary

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.config-restart.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.config-restart.test.ts
@@ -6,12 +6,31 @@ describe("QA config-restart scenario catalog", () => {
   it("waits for the restart wake before using restored capabilities", () => {
     const flow = JSON.stringify(readQaScenarioById("config-restart-capability-flip"));
     const restartPatchIndex = flow.indexOf('"note":{"ref":"wakeMarker"}');
+    const restartOwnedPathIndex = flow.indexOf('"gateway.terminal.enabled"');
     const wakeWaitIndex = flow.indexOf("candidate.text.includes(wakeMarker)");
     const capabilityPollIndex = flow.indexOf('"saveAs":"afterTools"');
 
     expect(restartPatchIndex).toBeGreaterThanOrEqual(0);
+    expect(restartOwnedPathIndex).toBeGreaterThanOrEqual(0);
+    expect(restartOwnedPathIndex).toBeLessThan(wakeWaitIndex);
     expect(wakeWaitIndex).toBeGreaterThan(restartPatchIndex);
     expect(capabilityPollIndex).toBeGreaterThan(wakeWaitIndex);
     expect(flow.indexOf('"call":"runAgentPrompt"')).toBeGreaterThan(capabilityPollIndex);
+  });
+
+  it("restores the complete terminal subtree, including its absence", () => {
+    const flow = JSON.stringify(readQaScenarioById("config-restart-capability-flip"));
+
+    expect(flow).toContain(
+      '"expr":"original.config.gateway && Object.prototype.hasOwnProperty.call(original.config.gateway, \'terminal\') ? structuredClone(original.config.gateway.terminal) : undefined"',
+    );
+    expect(flow).toContain('"expr":"originalTerminal?.enabled === false ? true : false"');
+    expect(flow).toContain(
+      '"expr":"originalTerminal !== undefined && Object.prototype.hasOwnProperty.call(originalTerminal, \'enabled\')"',
+    );
+    expect(flow).toContain(
+      '"terminal":{"expr":"originalTerminal === undefined ? null : (originalTerminalEnabledPresent ? originalTerminal : { ...originalTerminal, enabled: null })"}',
+    );
+    expect(flow.match(/"gateway\.terminal\.enabled"/g)).toHaveLength(1);
   });
 });

--- a/qa/scenarios/config/config-restart-capability-flip.yaml
+++ b/qa/scenarios/config/config-restart-capability-flip.yaml
@@ -53,6 +53,16 @@ flow:
         - set: originalImageGenerationModelPrimary
           value:
             expr: "original.config.agents?.defaults?.mediaModels?.image?.primary ?? null"
+        - set: originalTerminal
+          value:
+            expr: "original.config.gateway && Object.prototype.hasOwnProperty.call(original.config.gateway, 'terminal') ? structuredClone(original.config.gateway.terminal) : undefined"
+        - set: restartTerminalEnabled
+          value:
+            # Terminal is enabled unless explicitly false. This expression flips both effective states.
+            expr: "originalTerminal?.enabled === false ? true : false"
+        - set: originalTerminalEnabledPresent
+          value:
+            expr: "originalTerminal !== undefined && Object.prototype.hasOwnProperty.call(originalTerminal, 'enabled')"
         - set: denied
           value:
             expr: "Array.isArray(originalToolsDeny) ? originalToolsDeny.map((entry) => String(entry)) : []"
@@ -109,6 +119,10 @@ flow:
                             image:
                               primary:
                                 ref: originalImageGenerationModelPrimary
+                      gateway:
+                        terminal:
+                          enabled:
+                            ref: restartTerminalEnabled
                     sessionKey:
                       ref: sessionKey
                     deliveryContext:
@@ -118,6 +132,7 @@ flow:
                       ref: wakeMarker
                     replacePaths:
                       - tools.deny
+                      - gateway.terminal.enabled
               - call: waitForGatewayHealthy
                 args:
                   - ref: env
@@ -236,6 +251,9 @@ flow:
                       tools:
                         deny:
                           expr: "originalToolsDeny === undefined ? null : originalToolsDeny"
+                      gateway:
+                        terminal:
+                          expr: "originalTerminal === undefined ? null : (originalTerminalEnabledPresent ? originalTerminal : { ...originalTerminal, enabled: null })"
                     replacePaths:
                       - tools.deny
               - call: waitForGatewayHealthy


### PR DESCRIPTION
## Summary

- Make the config restart capability scenario toggle a safe restart-owned Gateway terminal setting.
- Restore the exact prior setting in cleanup.
- Assert the restart-owned path is applied before waiting for the sentinel wake.

## Root cause

`config-restart-capability-flip` restored `tools.deny` and `agents.defaults.mediaModels`, but both surfaces now hot reload. The scenario nevertheless waited for a restart sentinel that could never be emitted. Run 32444623691 timed out twice at 360 seconds; Gateway logs show only `config hot reload applied (tools.deny)` and no restart.

## Validation

- Pre-fix live evidence: `config-restart-capability-flip`, run 32444623691, two 360-second sentinel waits.
- Catalog regression asserts a restart-owned path precedes the wake wait.
- `git diff --check`
- Autoreview: clean, 0.99.
- Focused Vitest/live scenario is delegated to PR CI because isolated worktrees intentionally have no reconciled dependencies.

## LOC

- Production: 0
- QA scenario/test: +19 / -0

No config schema/default or public runtime contract changes.
