### PR TITLE
fix(llama-cpp): local memory indexing fails on embedding inputs over 512 tokens

### DIFF
--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   discoverServer: vi.fn(),
   ensureModel: vi.fn(),
+  ensureChat: vi.fn(),
   prepareServer: vi.fn(),
   inspectRuntime: vi.fn(),
   genericCreate: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock("openclaw/plugin-sdk/embedding-providers", async (importOriginal) => ({
 vi.mock("./src/managed-server.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./src/managed-server.js")>()),
   ensureLlamaCppModel: mocks.ensureModel,
+  ensureManagedLlamaServerForChat: mocks.ensureChat,
   prepareManagedLlamaServer: mocks.prepareServer,
   inspectLlamaServerRuntime: mocks.inspectRuntime,
 }));
@@ -60,6 +62,7 @@ beforeEach(() => {
   previousPluginRegistry = getActivePluginRegistry();
   mocks.discoverServer.mockReset();
   mocks.ensureModel.mockResolvedValue("/models/model.gguf");
+  mocks.ensureChat.mockResolvedValue(undefined);
   mocks.prepareServer.mockResolvedValue({});
   mocks.inspectRuntime.mockResolvedValue({
     engine: "llama.cpp",
@@ -281,15 +284,61 @@ describe("llama.cpp provider plugin", () => {
     );
     expect(mocks.prepareServer).toHaveBeenCalledWith(
       expect.objectContaining({
-        chatModelPath: undefined,
         embeddingModelPath: "/models/model.gguf",
       }),
+    );
+    expect(mocks.prepareServer).not.toHaveBeenCalledWith(
+      expect.objectContaining({ chatModelPath: expect.anything() }),
     );
     expect(result.runtime?.cacheKeyData).toEqual({
       provider: "local",
       model: "/models/custom-embedding.gguf",
     });
   });
+
+  it.each([
+    ["uses an active custom local model", { enabled: true, provider: "local" }],
+    ["uses another memory provider", { enabled: true, provider: "openai" }],
+    ["has memory search disabled", { enabled: false, provider: "local" }],
+  ] as const)(
+    "keeps chat preparation independent from embedding config when memory %s",
+    async (_label, searchConfig) => {
+      const staleEmbeddingSource = "hf:retired-org/removed-embedding-model-GGUF/embedding.gguf";
+      const configured = configuredOptions();
+      const providerConfig = configured.config.models.providers[LLAMA_CPP_PROVIDER_ID];
+      const config = {
+        ...configured.config,
+        memory: {
+          search: {
+            ...searchConfig,
+            local: { modelPath: staleEmbeddingSource },
+          },
+        },
+      };
+      const provider = registerTextProvider();
+      const selectedModel = expectDefined(providerConfig.models[0], "managed chat model");
+      const inner = vi.fn(() => ({}) as never);
+      const wrapped = provider.wrapStreamFn?.({
+        config,
+        provider: LLAMA_CPP_PROVIDER_ID,
+        modelId: selectedModel.id,
+        model: {
+          ...selectedModel,
+          provider: LLAMA_CPP_PROVIDER_ID,
+          baseUrl: providerConfig.baseUrl,
+        },
+        streamFn: inner,
+      } as never);
+
+      await wrapped?.({} as never, { messages: [] } as never, {});
+
+      expect(mocks.ensureChat).toHaveBeenCalledWith({
+        provider: providerConfig,
+        model: expect.objectContaining({ id: selectedModel.id }),
+      });
+      expect(inner).toHaveBeenCalledOnce();
+    },
+  );
 
   it("keeps registered text setup chat-capable when local memory is enabled", async () => {
     const provider = registerTextProvider();
@@ -340,11 +389,15 @@ describe("llama.cpp provider plugin", () => {
 
   it("preserves default local index identity across old and managed cache paths", () => {
     const modelCacheDir = path.join(os.tmpdir(), "managed-llama-models");
+    const options = configuredOptions();
+    Object.assign(options.config.models.providers[LLAMA_CPP_PROVIDER_ID], {
+      params: { modelCacheDir },
+    });
     const identity = llamaCppEmbeddingProviderAdapter.resolveIndexIdentity?.({
-      config: {},
-      provider: "local",
-      model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
-      local: { modelPath: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL, modelCacheDir },
+      ...options,
+      local: {
+        modelPath: path.join(modelCacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
+      },
     });
 
     expect(identity).toMatchObject({

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -11,11 +11,9 @@ import {
   DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID,
-  DEFAULT_LLAMA_CPP_MODEL_ID,
   LLAMA_CPP_PROVIDER_ID,
   resolveLegacyLlamaCppModelCacheDir,
   resolveLlamaCppModelCacheDir,
-  resolveLlamaCppModelSource,
 } from "./defaults.js";
 import { selectLlamaServerAsset } from "./llama-server-install.js";
 import { resolveManagedLlamaCppProviderConfig } from "./managed-provider-config.js";
@@ -31,6 +29,11 @@ type LlamaCppLocalOptions = {
   modelCacheDir?: string;
 };
 
+type LlamaCppEmbeddingModel = {
+  source: string;
+  isDefault: boolean;
+};
+
 const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
 const preparedEmbeddingServers = new Map<string, Promise<void>>();
 
@@ -42,6 +45,14 @@ type LlamaCppModelIdentity = {
 
 function readLocalOptions(options: { local?: unknown }): LlamaCppLocalOptions {
   return (options.local as LlamaCppLocalOptions | undefined) ?? {};
+}
+
+function readIdentityLocalOptions(options: EmbeddingProviderCreateOptions): LlamaCppLocalOptions {
+  const local = readLocalOptions(options);
+  const provider = options.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+  return provider?.localService
+    ? { ...local, modelCacheDir: resolveLlamaCppModelCacheDir(provider) }
+    : local;
 }
 
 function createCacheKeyData(model: string, dimensions?: number): Record<string, unknown> {
@@ -98,6 +109,16 @@ function resolveModelIdentity(
   };
 }
 
+function resolveLlamaCppEmbeddingModel(localValue?: unknown): LlamaCppEmbeddingModel {
+  const local = readLocalOptions({ local: localValue });
+  const source = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
+  const identity = resolveModelIdentity(local, source);
+  return {
+    source,
+    isDefault: identity.model === DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+  };
+}
+
 function resolveConfiguredProvider(options: EmbeddingProviderCreateOptions): ModelProviderConfig {
   return resolveManagedLlamaCppProviderConfig(options.config);
 }
@@ -113,46 +134,21 @@ function resolveProviderPort(provider: ModelProviderConfig): number {
 async function prepareEmbeddingServer(
   options: EmbeddingProviderCreateOptions,
   embeddingSource: string,
+  embeddingModelIsDefault: boolean,
 ): Promise<void> {
   const provider = resolveConfiguredProvider(options);
-  const configuredPrimary = options.config.agents?.defaults?.model;
-  const primaryRef =
-    typeof configuredPrimary === "string" ? configuredPrimary : configuredPrimary?.primary;
-  const primaryId = primaryRef?.startsWith(`${LLAMA_CPP_PROVIDER_ID}/`)
-    ? primaryRef.slice(LLAMA_CPP_PROVIDER_ID.length + 1)
-    : undefined;
-  const chatModel =
-    provider.models.find((model) => model.id === primaryId) ??
-    provider.models.find((model) => model.id !== DEFAULT_LLAMA_CPP_MODEL_ID) ??
-    provider.models[0];
   const cacheDir = resolveLlamaCppModelCacheDir(provider);
-  const key = JSON.stringify([provider.baseUrl, chatModel?.id ?? null, embeddingSource, cacheDir]);
+  const key = JSON.stringify([provider.baseUrl, embeddingSource, cacheDir]);
   const pending =
     preparedEmbeddingServers.get(key) ??
     (async () => {
-      const [chatModelPath, embeddingModelPath] = await Promise.all([
-        chatModel
-          ? ensureLlamaCppModel({
-              source: resolveLlamaCppModelSource(chatModel),
-              cacheDir,
-              download: false,
-            })
-          : Promise.resolve(undefined),
-        ensureLlamaCppModel({
-          source: embeddingSource,
-          cacheDir,
-          download: true,
-        }),
-      ]);
-      const configuredContext = chatModel?.params?.contextSize;
+      const embeddingModelPath = await ensureLlamaCppModel({
+        source: embeddingSource,
+        cacheDir,
+        download: true,
+      });
       await prepareManagedLlamaServer({
-        ...(chatModel ? { chatModelId: chatModel.id } : {}),
-        chatModelPath,
-        contextSize:
-          typeof configuredContext === "number" && configuredContext > 0
-            ? Math.floor(configuredContext)
-            : chatModel?.contextTokens,
-        maxTokens: chatModel?.maxTokens,
+        embeddingModelIsDefault,
         embeddingModelPath,
         port: resolveProviderPort(provider),
       });
@@ -217,14 +213,15 @@ export const llamaCppEmbeddingProviderAdapter: EmbeddingProviderAdapter = {
   formatSetupError: (error) =>
     `Managed local embeddings are unavailable. Run \`openclaw configure\`, choose llama.cpp, and retry. ${error instanceof Error ? error.message : String(error)}`,
   resolveIndexIdentity: (options) => {
-    const local = readLocalOptions(options);
+    const local = readIdentityLocalOptions(options);
     const modelPath = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
     return resolveModelIdentity(local, modelPath, options.dimensions);
   },
   create: async (options) => {
-    const local = readLocalOptions(options);
-    const modelPath = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
-    await prepareEmbeddingServer(options, modelPath);
+    const local = readIdentityLocalOptions(options);
+    const embeddingModel = resolveLlamaCppEmbeddingModel(local);
+    const identity = resolveModelIdentity(local, embeddingModel.source, options.dimensions);
+    await prepareEmbeddingServer(options, embeddingModel.source, embeddingModel.isDefault);
     const genericAdapter = getEmbeddingProvider("openai-compatible", options.config);
     if (!genericAdapter) {
       throw new Error("OpenAI-compatible embedding transport is unavailable.");
@@ -238,7 +235,6 @@ export const llamaCppEmbeddingProviderAdapter: EmbeddingProviderAdapter = {
     if (!result.provider) {
       return result;
     }
-    const identity = resolveModelIdentity(local, modelPath, options.dimensions);
     return {
       provider: wrapProvider({
         provider: result.provider,

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -18,6 +18,7 @@ vi.mock("./llama-server-install.js", async (importOriginal) => ({
 import { selectLlamaServerAsset } from "./llama-server-install.js";
 import {
   ensureLlamaCppModel,
+  ensureManagedLlamaServerForChat,
   inspectLlamaServerRuntime,
   prepareManagedLlamaServer,
 } from "./managed-server.js";
@@ -60,7 +61,7 @@ describe("managed llama-server", () => {
     );
   });
 
-  it("writes separate chat and embedding presets without unwired capabilities", async () => {
+  it("writes a 2048-token physical batch in the combined preset", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-preset-"));
     const presetPath = path.join(tempRoot, "models.ini");
     const asset = selectLlamaServerAsset("darwin", "arm64");
@@ -80,13 +81,14 @@ describe("managed llama-server", () => {
         chatModelPath: "/models/chat.gguf",
         contextSize: 8192,
         maxTokens: 2048,
+        embeddingModelIsDefault: true,
         embeddingModelPath: "/models/embedding.gguf",
         port: 19_432,
       });
       const preset = await fs.readFile(presetPath, "utf8");
       expect(preset).toContain("[chat-model]\nmodel = /models/chat.gguf\nctx-size = 8192");
       expect(preset).toContain(
-        "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf\nembedding = true",
+        "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf\nubatch-size = 2048\nembedding = true",
       );
       expect(preset).not.toMatch(/mmproj|draft/iu);
     } finally {
@@ -94,7 +96,7 @@ describe("managed llama-server", () => {
     }
   });
 
-  it("writes an embedding-only preset without requiring a chat model", async () => {
+  it("preserves the llama.cpp physical batch default for a custom embedding model", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-embedding-only-"));
     const presetPath = path.join(tempRoot, "models.ini");
     const asset = selectLlamaServerAsset("darwin", "arm64");
@@ -118,6 +120,58 @@ describe("managed llama-server", () => {
         "version = 1\n\n[embeddinggemma-300m-qat-q8_0]\nmodel = /models/custom-embedding.gguf\nembedding = true\n",
       );
       expect(preset).not.toContain("jinja");
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a custom embedding model when chat prepares the shared restart preset", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-chat-preset-"));
+    const presetPath = path.join(tempRoot, "models.ini");
+    const chatModelPath = path.join(tempRoot, "chat.gguf");
+    const embeddingModelPath = path.join(tempRoot, "custom-embedding.gguf");
+    const asset = selectLlamaServerAsset("darwin", "arm64");
+    installMocks.ensureLlamaServerInstalled.mockResolvedValue({
+      command: path.join(tempRoot, "llama-server"),
+      asset,
+    });
+    installMocks.resolveManagedLlamaServerPaths.mockReturnValue({
+      installDir: tempRoot,
+      command: path.join(tempRoot, "llama-server"),
+      presetPath,
+    });
+
+    try {
+      await Promise.all([
+        fs.writeFile(chatModelPath, "GGUF"),
+        fs.writeFile(embeddingModelPath, "GGUF"),
+      ]);
+      await Promise.all([
+        prepareManagedLlamaServer({
+          embeddingModelPath,
+          port: 19_434,
+        }),
+        ensureManagedLlamaServerForChat({
+          provider: {
+            baseUrl: "http://127.0.0.1:19434/v1",
+            localService: { command: path.join(tempRoot, "llama-server"), args: [] },
+            models: [],
+            params: { modelCacheDir: tempRoot },
+          },
+          model: {
+            id: "chat-model",
+            params: { modelPath: chatModelPath, contextSize: 8192 },
+            maxTokens: 2048,
+          },
+        }),
+      ]);
+
+      const preset = await fs.readFile(presetPath, "utf8");
+      expect(preset).toContain(`[chat-model]\nmodel = ${chatModelPath}\nctx-size = 8192`);
+      expect(preset).toContain(
+        `[embeddinggemma-300m-qat-q8_0]\nmodel = ${embeddingModelPath}\nembedding = true`,
+      );
+      expect(preset).not.toContain("ubatch-size");
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -70,6 +70,11 @@ export type LlamaServerRuntimeFacts = {
 
 const modelPromises = new Map<string, Promise<string>>();
 const chatPreparationPromises = new Map<string, Promise<void>>();
+// Chat and embedding share one restart preset. Serialize read-modify-write updates so neither
+// path can discard the other model stanza during concurrent preparation.
+const presetWritePromises = new Map<string, Promise<void>>();
+// Pooled embeddings must fit one input in one physical batch. Match llama.cpp's EmbeddingGemma preset.
+const LLAMA_CPP_EMBEDDING_UBATCH_SIZE = 2048;
 
 function parseHuggingFaceSource(source: string): {
   user: string;
@@ -300,43 +305,69 @@ function assertIniValue(value: string, label: string): string {
   return value;
 }
 
-function renderLlamaServerPreset(params: {
-  chatModelId?: string;
-  chatModelPath?: string;
+function renderChatModelSection(params: {
+  id: string;
+  modelPath: string;
   contextSize?: number;
   maxTokens?: number;
-  embeddingModelId: string;
-  embeddingModelPath: string;
 }): string {
-  const embeddingId = assertIniValue(params.embeddingModelId, "llama.cpp embedding model id");
-  if (embeddingId.includes("]")) {
+  const id = assertIniValue(params.id, "llama.cpp model id");
+  if (id.includes("]")) {
     throw new Error("llama.cpp model ids cannot contain ]");
   }
-  const lines = ["version = 1", ""];
-  if (params.chatModelId || params.chatModelPath) {
-    if (!params.chatModelId || !params.chatModelPath) {
-      throw new Error("llama.cpp chat model id and path must be provided together");
-    }
-    const chatId = assertIniValue(params.chatModelId, "llama.cpp model id");
-    if (chatId.includes("]")) {
-      throw new Error("llama.cpp model ids cannot contain ]");
-    }
-    lines.push(
-      `[${chatId}]`,
-      `model = ${assertIniValue(params.chatModelPath, "llama.cpp model path")}`,
-      `ctx-size = ${params.contextSize ?? DEFAULT_LLAMA_CPP_CONTEXT_SIZE}`,
-      `n-predict = ${params.maxTokens ?? 2048}`,
-      "jinja = true",
-      "",
-    );
-  }
-  lines.push(
-    `[${embeddingId}]`,
-    `model = ${assertIniValue(params.embeddingModelPath, "llama.cpp embedding model path")}`,
+  return [
+    `[${id}]`,
+    `model = ${assertIniValue(params.modelPath, "llama.cpp model path")}`,
+    `ctx-size = ${params.contextSize ?? DEFAULT_LLAMA_CPP_CONTEXT_SIZE}`,
+    `n-predict = ${params.maxTokens ?? 2048}`,
+    "jinja = true",
+  ].join("\n");
+}
+
+function renderEmbeddingModelSection(params: { isDefault?: boolean; modelPath: string }): string {
+  return [
+    `[${DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID}]`,
+    `model = ${assertIniValue(params.modelPath, "llama.cpp embedding model path")}`,
+    ...(params.isDefault ? [`ubatch-size = ${LLAMA_CPP_EMBEDDING_UBATCH_SIZE}`] : []),
     "embedding = true",
+  ].join("\n");
+}
+
+function readModelSection(contents: string | undefined, id: string): string | undefined {
+  if (!contents) {
+    return undefined;
+  }
+  const lines = contents.split(/\r?\n/u);
+  const start = lines.indexOf(`[${id}]`);
+  if (start < 0) {
+    return undefined;
+  }
+  let end = start + 1;
+  while (end < lines.length && !/^\[[^\]]+\]$/u.test(lines[end] ?? "")) {
+    end += 1;
+  }
+  return lines.slice(start, end).join("\n").trimEnd();
+}
+
+function readChatModelSection(contents: string | undefined): string | undefined {
+  const id = contents
+    ?.split(/\r?\n/u)
+    .map((line) => /^\[([^\]]+)\]$/u.exec(line)?.[1])
+    .find((candidate) => candidate && candidate !== DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID);
+  return id ? readModelSection(contents, id) : undefined;
+}
+
+function renderLlamaServerPreset(params: {
+  chatSection?: string;
+  embeddingSection: string;
+}): string {
+  return [
+    "version = 1",
     "",
-  );
-  return lines.join("\n");
+    ...(params.chatSection ? [params.chatSection, ""] : []),
+    params.embeddingSection,
+    "",
+  ].join("\n");
 }
 
 async function writePreset(presetPath: string, contents: string): Promise<void> {
@@ -344,6 +375,68 @@ async function writePreset(presetPath: string, contents: string): Promise<void> 
   const temporary = `${presetPath}.tmp-${randomUUID()}`;
   await fsp.writeFile(temporary, contents, { mode: 0o600 });
   await fsp.rename(temporary, presetPath);
+}
+
+async function updatePreset(
+  presetPath: string,
+  params: {
+    chatModelId?: string;
+    chatModelPath?: string;
+    contextSize?: number;
+    maxTokens?: number;
+    embeddingModelIsDefault?: boolean;
+    embeddingModelPath?: string;
+    defaultEmbeddingModelPath?: string;
+  },
+): Promise<void> {
+  const previous = presetWritePromises.get(presetPath) ?? Promise.resolve();
+  const pending = previous
+    .catch(() => undefined)
+    .then(async () => {
+      const existing = await fsp.readFile(presetPath, "utf8").catch((error: unknown) => {
+        if (asOptionalRecord(error)?.code === "ENOENT") {
+          return undefined;
+        }
+        throw error;
+      });
+      if (params.chatModelId || params.chatModelPath) {
+        if (!params.chatModelId || !params.chatModelPath) {
+          throw new Error("llama.cpp chat model id and path must be provided together");
+        }
+      }
+      const chatSection = params.chatModelPath
+        ? renderChatModelSection({
+            id: params.chatModelId ?? DEFAULT_LLAMA_CPP_MODEL_ID,
+            modelPath: params.chatModelPath,
+            contextSize: params.contextSize,
+            maxTokens: params.maxTokens,
+          })
+        : readChatModelSection(existing);
+      const embeddingSection = params.embeddingModelPath
+        ? renderEmbeddingModelSection({
+            isDefault: params.embeddingModelIsDefault,
+            modelPath: params.embeddingModelPath,
+          })
+        : (readModelSection(existing, DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID) ??
+          (params.defaultEmbeddingModelPath
+            ? renderEmbeddingModelSection({
+                isDefault: true,
+                modelPath: params.defaultEmbeddingModelPath,
+              })
+            : undefined));
+      if (!embeddingSection) {
+        throw new Error("llama.cpp embedding model path is required for a new managed preset");
+      }
+      await writePreset(presetPath, renderLlamaServerPreset({ chatSection, embeddingSection }));
+    });
+  presetWritePromises.set(presetPath, pending);
+  try {
+    await pending;
+  } finally {
+    if (presetWritePromises.get(presetPath) === pending) {
+      presetWritePromises.delete(presetPath);
+    }
+  }
 }
 
 async function findAvailableLlamaServerPort(preferred = LLAMA_CPP_DEFAULT_PORT): Promise<number> {
@@ -370,26 +463,26 @@ export async function prepareManagedLlamaServer(params: {
   chatModelPath?: string;
   contextSize?: number;
   maxTokens?: number;
-  embeddingModelPath: string;
+  embeddingModelIsDefault?: boolean;
+  embeddingModelPath?: string;
+  defaultEmbeddingModelPath?: string;
   port?: number;
 }): Promise<ManagedLlamaServer> {
   const { command, asset } = await ensureLlamaServerInstalled();
   const { presetPath } = resolveManagedLlamaServerPaths(asset);
-  await writePreset(
-    presetPath,
-    renderLlamaServerPreset({
-      ...(params.chatModelPath
-        ? {
-            chatModelId: params.chatModelId ?? DEFAULT_LLAMA_CPP_MODEL_ID,
-            chatModelPath: params.chatModelPath,
-          }
-        : {}),
-      contextSize: params.contextSize,
-      maxTokens: params.maxTokens,
-      embeddingModelId: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID,
-      embeddingModelPath: params.embeddingModelPath,
-    }),
-  );
+  await updatePreset(presetPath, {
+    ...(params.chatModelPath
+      ? {
+          chatModelId: params.chatModelId ?? DEFAULT_LLAMA_CPP_MODEL_ID,
+          chatModelPath: params.chatModelPath,
+        }
+      : {}),
+    contextSize: params.contextSize,
+    maxTokens: params.maxTokens,
+    embeddingModelIsDefault: params.embeddingModelIsDefault,
+    embeddingModelPath: params.embeddingModelPath,
+    defaultEmbeddingModelPath: params.defaultEmbeddingModelPath,
+  });
   const port = params.port ?? (await findAvailableLlamaServerPort());
   const rootUrl = `http://127.0.0.1:${port}`;
   return {
@@ -469,7 +562,7 @@ export async function ensureManagedLlamaServerForChat(params: {
             ? Math.floor(configuredContext)
             : params.model.contextTokens,
         maxTokens: params.model.maxTokens,
-        embeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
+        defaultEmbeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
         port: Number.isInteger(port) && port > 0 ? port : undefined,
       });
     })();

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -252,6 +252,7 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
       chatModelPath,
       contextSize,
       maxTokens: selected.model.maxTokens,
+      embeddingModelIsDefault: true,
       embeddingModelPath,
       port: readConfiguredPort(managedExisting),
     });


### PR DESCRIPTION
Closes #127283

Related: #125881

## What Problem This Solves

Managed local llama.cpp memory embeddings can fail when an otherwise valid input tokenizes to more than 512 tokens. The generated default EmbeddingGemma preset inherited llama.cpp's 512-token physical micro-batch default, so a reproduced 531-token input returned HTTP 500 and left the memory index dirty.

## Why This Change Was Made

The managed default EmbeddingGemma stanza now emits:

```ini
ubatch-size = 2048
```

This matches the EmbeddingGemma preset in the pinned llama.cpp b10357 source. Arbitrary custom GGUF embedding models keep llama.cpp's existing physical-batch default.

The generated `models.ini` is shared by chat and embedding workloads, so this change also makes stanza ownership explicit:

- embedding preparation validates the embedding source and updates the embedding stanza;
- chat preparation updates the chat stanza without reading, validating, or downloading memory embedding configuration;
- serialized atomic read/merge/write updates preserve both stanzas when chat and embedding prepare concurrently; and
- an existing successfully prepared custom embedding stanza survives chat activity, idle service restarts, fallback activation, per-agent configuration differences, and Gateway process restarts.

Default-model identity also uses the managed provider's actual `modelCacheDir`, so supported absolute cache-path aliases still receive the EmbeddingGemma-specific batch setting.

This is separate from #125881: that change addresses embedding context allocation with `ctx-size`; this change addresses the physical micro-batch limit.

## User Impact

Users of the default managed local embedding model can index larger valid memory chunks without manually editing generated configuration. Stale or unavailable custom embedding paths cannot block unrelated managed chat, and custom embedding models keep their previous batch behavior.

## Evidence

### Before

Observed on OpenClaw 2026.8.1-beta.2 with managed llama.cpp b10357 and EmbeddingGemma:

```text
openai-compatible embeddings failed: HTTP 500:
{"error":{"code":500,"message":"input (531 tokens) is too large to process. increase the physical batch size (current batch size: 512)","type":"server_error"}}

Dirty: yes
Semantic vectors: unavailable
```

Increasing the physical micro-batch allowed the same indexes to complete with embeddings, vector storage, semantic vectors, and FTS ready.

### Dependency contract

The pinned llama.cpp b10357 source defaults `n_ubatch` to 512, requires pooled embedding inputs to fit in one physical micro-batch, reports this exact error when an input exceeds it, and sets `n_ubatch = 2048` in its EmbeddingGemma preset.

### Automated validation

- Red proof: inactive/non-local/custom chat cases and the shared-preset lifecycle failed before the ownership fix.
- Focused provider + preset suite: 25/25 passed.
- Full `pnpm test:extension llama-cpp` after the final rebase: 12 files, 98/98 passed.
- Direct `oxfmt`, `oxlint`, and `git diff --check`: passed.
- TruffleHog scan: clean.
- Independent read-only review of the final ownership/concurrency diff: no actionable P0-P3 findings.
- The local all-extension typecheck exceeded the 6 GB host's memory budget without producing a diagnostic; exact-head GitHub CI is the authoritative production/test typecheck.

### AI assistance

AI-assisted PR. The issue was reproduced on a live OpenClaw installation, dependency behavior was verified against the pinned llama.cpp source, and the patch and tests were prepared with AI assistance.
