### PR TITLE
fix(qa): let scenario-owned timeouts settle before watchdog

### DIFF
--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -388,6 +388,7 @@ describe("qa suite runtime flow", () => {
   });
 
   it("bounds preparation and actions with one aborting scenario deadline", async () => {
+    vi.useFakeTimers();
     let preparationSignal: AbortSignal | undefined;
     let actionSignal: AbortSignal | undefined;
     const prepareFlow = vi.fn(async (input: { signal?: AbortSignal }) => {
@@ -424,27 +425,60 @@ describe("qa suite runtime flow", () => {
       ]);
     });
 
-    let boundedTimer: ReturnType<typeof setTimeout> | undefined;
-    const result = await Promise.race([
-      runQaSuiteScenarioDefinition({
-        env,
-        scenario,
-        runScenario: runQaSuiteScenarioSteps,
-        splitModelRef: (raw) => parseModelRef(raw, "openai"),
-        formatErrorMessage: (error) => String(error),
-        liveTurnTimeoutMs: () => 60_000,
-        resolveQaLiveTurnTimeoutMs: () => 60_000,
-        constants: qaSuiteRuntimeFlowTestConstants,
-      }),
-      new Promise<"bounded-window-expired">((resolve) => {
-        boundedTimer = setTimeout(() => resolve("bounded-window-expired"), 250);
-      }),
-    ]);
-    clearTimeout(boundedTimer);
+    const pending = runQaSuiteScenarioDefinition({
+      env,
+      scenario,
+      runScenario: runQaSuiteScenarioSteps,
+      splitModelRef: (raw) => parseModelRef(raw, "openai"),
+      formatErrorMessage: (error) => String(error),
+      liveTurnTimeoutMs: () => 60_000,
+      resolveQaLiveTurnTimeoutMs: () => 60_000,
+      constants: qaSuiteRuntimeFlowTestConstants,
+    });
+    await vi.advanceTimersByTimeAsync(5_030);
+    const result = await pending;
+    vi.useRealTimers();
 
-    expect(result).not.toBe("bounded-window-expired");
     expect(result).toMatchObject({ status: "fail", details: expect.stringContaining("30ms") });
     expect(preparationSignal).toBe(actionSignal);
     expect(actionSignal?.aborted).toBe(true);
+  });
+
+  it("lets a scenario-owned timeout settle before the lifecycle watchdog", async () => {
+    const env = createQaSuiteRuntimeFlowTestEnv();
+    const scenario = makeQaSuiteTestScenario("flow-owned-timeout", { config: {} });
+    if (scenario.execution.kind !== "flow") {
+      throw new Error("expected flow scenario");
+    }
+    scenario.execution.timeoutMs = 20;
+    createQaScenarioRuntimeApi.mockImplementationOnce(
+      (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
+        runScenario: params.deps.runScenario,
+      }),
+    );
+    runScenarioFlow.mockImplementationOnce(async (params) => {
+      const api = params.api as { runScenario: typeof runQaSuiteScenarioSteps };
+      return await api.runScenario("Scenario-owned timeout", [
+        {
+          name: "Complete the observation window",
+          run: async () => {
+            await new Promise<void>((resolve) => setTimeout(resolve, 30));
+          },
+        },
+      ]);
+    });
+
+    const result = await runQaSuiteScenarioDefinition({
+      env,
+      scenario,
+      runScenario: runQaSuiteScenarioSteps,
+      splitModelRef: (raw) => parseModelRef(raw, "openai"),
+      formatErrorMessage: (error) => String(error),
+      liveTurnTimeoutMs: () => 60_000,
+      resolveQaLiveTurnTimeoutMs: () => 60_000,
+      constants: qaSuiteRuntimeFlowTestConstants,
+    });
+
+    expect(result.status).toBe("pass");
   });
 });

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -462,7 +462,9 @@ describe("qa suite runtime flow", () => {
         {
           name: "Complete the observation window",
           run: async () => {
-            await new Promise<void>((resolve) => setTimeout(resolve, 30));
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, 30);
+            });
           },
         },
       ]);

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -1,5 +1,6 @@
 // Qa Lab tests cover suite runtime flow plugin behavior.
 import { parseModelRef, resolveModelRefFromString } from "openclaw/plugin-sdk/agent-runtime";
+import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const createQaScenarioRuntimeApi = vi.hoisted(() => vi.fn());
@@ -389,98 +390,157 @@ describe("qa suite runtime flow", () => {
 
   it("bounds preparation and actions with one aborting scenario deadline", async () => {
     vi.useFakeTimers();
-    let preparationSignal: AbortSignal | undefined;
-    let actionSignal: AbortSignal | undefined;
-    const prepareFlow = vi.fn(async (input: { signal?: AbortSignal }) => {
-      preparationSignal = input.signal;
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 10);
+    try {
+      let preparationSignal: AbortSignal | undefined;
+      let actionSignal: AbortSignal | undefined;
+      const prepareFlow = vi.fn(async (input: { signal?: AbortSignal }) => {
+        preparationSignal = input.signal;
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 10);
+        });
       });
-    });
-    const env = createQaSuiteRuntimeFlowTestEnv({ prepareFlow });
-    const scenario = makeQaSuiteTestScenario("flow-deadline", { config: {} });
-    if (scenario.execution.kind !== "flow") {
-      throw new Error("expected flow scenario");
+      const env = createQaSuiteRuntimeFlowTestEnv({ prepareFlow });
+      const scenario = makeQaSuiteTestScenario("flow-deadline", { config: {} });
+      if (scenario.execution.kind !== "flow") {
+        throw new Error("expected flow scenario");
+      }
+      scenario.execution.timeoutMs = 30;
+      createQaScenarioRuntimeApi.mockImplementationOnce(
+        (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
+          runScenario: params.deps.runScenario,
+        }),
+      );
+      runScenarioFlow.mockImplementationOnce(async (params) => {
+        const api = params.api as {
+          runScenario: typeof runQaSuiteScenarioSteps;
+          signal?: AbortSignal;
+        };
+        return await api.runScenario("Flow deadline", [
+          {
+            name: "Never settles without abort",
+            run: async () =>
+              await new Promise<void>(() => {
+                actionSignal = api.signal;
+                api.signal?.addEventListener("abort", () => {}, { once: true });
+              }),
+          },
+        ]);
+      });
+
+      const pending = runQaSuiteScenarioDefinition({
+        env,
+        scenario,
+        runScenario: runQaSuiteScenarioSteps,
+        splitModelRef: (raw) => parseModelRef(raw, "openai"),
+        formatErrorMessage: (error) => String(error),
+        liveTurnTimeoutMs: () => 60_000,
+        resolveQaLiveTurnTimeoutMs: () => 60_000,
+        constants: qaSuiteRuntimeFlowTestConstants,
+      });
+      await vi.advanceTimersByTimeAsync(5_029);
+      expect(actionSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await pending;
+
+      expect(result).toMatchObject({ status: "fail", details: expect.stringContaining("30ms") });
+      expect(preparationSignal).toBe(actionSignal);
+      expect(actionSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
     }
-    scenario.execution.timeoutMs = 30;
-    createQaScenarioRuntimeApi.mockImplementationOnce(
-      (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
-        runScenario: params.deps.runScenario,
-      }),
-    );
-    runScenarioFlow.mockImplementationOnce(async (params) => {
-      const api = params.api as {
-        runScenario: typeof runQaSuiteScenarioSteps;
-        signal?: AbortSignal;
-      };
-      return await api.runScenario("Flow deadline", [
-        {
-          name: "Never settles without abort",
-          run: async () =>
-            await new Promise<void>(() => {
-              actionSignal = api.signal;
-              api.signal?.addEventListener("abort", () => {}, { once: true });
-            }),
-        },
-      ]);
-    });
-
-    const pending = runQaSuiteScenarioDefinition({
-      env,
-      scenario,
-      runScenario: runQaSuiteScenarioSteps,
-      splitModelRef: (raw) => parseModelRef(raw, "openai"),
-      formatErrorMessage: (error) => String(error),
-      liveTurnTimeoutMs: () => 60_000,
-      resolveQaLiveTurnTimeoutMs: () => 60_000,
-      constants: qaSuiteRuntimeFlowTestConstants,
-    });
-    await vi.advanceTimersByTimeAsync(5_030);
-    const result = await pending;
-    vi.useRealTimers();
-
-    expect(result).toMatchObject({ status: "fail", details: expect.stringContaining("30ms") });
-    expect(preparationSignal).toBe(actionSignal);
-    expect(actionSignal?.aborted).toBe(true);
   });
 
   it("lets a scenario-owned timeout settle before the lifecycle watchdog", async () => {
-    const env = createQaSuiteRuntimeFlowTestEnv();
-    const scenario = makeQaSuiteTestScenario("flow-owned-timeout", { config: {} });
-    if (scenario.execution.kind !== "flow") {
-      throw new Error("expected flow scenario");
-    }
-    scenario.execution.timeoutMs = 20;
-    createQaScenarioRuntimeApi.mockImplementationOnce(
-      (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
-        runScenario: params.deps.runScenario,
-      }),
-    );
-    runScenarioFlow.mockImplementationOnce(async (params) => {
-      const api = params.api as { runScenario: typeof runQaSuiteScenarioSteps };
-      return await api.runScenario("Scenario-owned timeout", [
-        {
-          name: "Complete the observation window",
-          run: async () => {
-            await new Promise<void>((resolve) => {
-              setTimeout(resolve, 30);
-            });
+    vi.useFakeTimers();
+    try {
+      const env = createQaSuiteRuntimeFlowTestEnv();
+      const scenario = makeQaSuiteTestScenario("flow-owned-timeout", { config: {} });
+      if (scenario.execution.kind !== "flow") {
+        throw new Error("expected flow scenario");
+      }
+      scenario.execution.timeoutMs = 20;
+      createQaScenarioRuntimeApi.mockImplementationOnce(
+        (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
+          runScenario: params.deps.runScenario,
+        }),
+      );
+      runScenarioFlow.mockImplementationOnce(async (params) => {
+        const api = params.api as { runScenario: typeof runQaSuiteScenarioSteps };
+        return await api.runScenario("Scenario-owned timeout", [
+          {
+            name: "Complete the observation window",
+            run: async () => {
+              await new Promise<void>((resolve) => {
+                setTimeout(resolve, 30);
+              });
+            },
           },
-        },
-      ]);
-    });
+        ]);
+      });
 
-    const result = await runQaSuiteScenarioDefinition({
-      env,
-      scenario,
-      runScenario: runQaSuiteScenarioSteps,
-      splitModelRef: (raw) => parseModelRef(raw, "openai"),
-      formatErrorMessage: (error) => String(error),
-      liveTurnTimeoutMs: () => 60_000,
-      resolveQaLiveTurnTimeoutMs: () => 60_000,
-      constants: qaSuiteRuntimeFlowTestConstants,
-    });
+      const pending = runQaSuiteScenarioDefinition({
+        env,
+        scenario,
+        runScenario: runQaSuiteScenarioSteps,
+        splitModelRef: (raw) => parseModelRef(raw, "openai"),
+        formatErrorMessage: (error) => String(error),
+        liveTurnTimeoutMs: () => 60_000,
+        resolveQaLiveTurnTimeoutMs: () => 60_000,
+        constants: qaSuiteRuntimeFlowTestConstants,
+      });
+      await vi.advanceTimersByTimeAsync(30);
+      const result = await pending;
 
-    expect(result.status).toBe("pass");
+      expect(result.status).toBe("pass");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps and disposes the lifecycle watchdog without advancing the maximum timer", async () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const env = createQaSuiteRuntimeFlowTestEnv();
+      const scenario = makeQaSuiteTestScenario("flow-capped-deadline", { config: {} });
+      if (scenario.execution.kind !== "flow") {
+        throw new Error("expected flow scenario");
+      }
+      scenario.execution.timeoutMs = MAX_TIMER_TIMEOUT_MS;
+      createQaScenarioRuntimeApi.mockImplementationOnce(
+        (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
+          runScenario: params.deps.runScenario,
+        }),
+      );
+      runScenarioFlow.mockImplementationOnce(async (params) => {
+        const api = params.api as { runScenario: typeof runQaSuiteScenarioSteps };
+        return await api.runScenario("Capped deadline", [
+          { name: "Settles immediately", run: async () => undefined },
+        ]);
+      });
+
+      const result = await runQaSuiteScenarioDefinition({
+        env,
+        scenario,
+        runScenario: runQaSuiteScenarioSteps,
+        splitModelRef: (raw) => parseModelRef(raw, "openai"),
+        formatErrorMessage: (error) => String(error),
+        liveTurnTimeoutMs: () => 60_000,
+        resolveQaLiveTurnTimeoutMs: () => 60_000,
+        constants: qaSuiteRuntimeFlowTestConstants,
+      });
+
+      expect(result.status).toBe("pass");
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      timeoutSpy.mockRestore();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -30,6 +30,7 @@ import * as suiteRuntimeAgent from "./suite-runtime-agent.js";
 import * as suiteRuntimeGateway from "./suite-runtime-gateway.js";
 import * as suiteRuntimeTransport from "./suite-runtime-transport.js";
 import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
+import { resolveQaGatewayTimeoutWithGraceMs } from "./timer-timeouts.js";
 import * as webRuntime from "./web-runtime.js";
 
 type QaSuiteScenarioFlowEnv = {
@@ -255,13 +256,12 @@ function createQaSuiteScenarioFlowApi(
   };
 }
 
-const QA_SCENARIO_LIFECYCLE_GRACE_MS = 5_000;
-
 function createQaScenarioDeadline(timeoutMs?: number) {
   const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadlineTimeoutMs = resolveQaGatewayTimeoutWithGraceMs(timeoutMs);
   const deadline =
-    timeoutMs === undefined
+    deadlineTimeoutMs === undefined
       ? undefined
       : new Promise<never>((_resolve, reject) => {
           const timeoutError = new Error(`QA scenario flow timed out after ${timeoutMs}ms`);
@@ -270,7 +270,7 @@ function createQaScenarioDeadline(timeoutMs?: number) {
           timer = setTimeout(() => {
             controller.abort(timeoutError);
             reject(timeoutError);
-          }, timeoutMs + QA_SCENARIO_LIFECYCLE_GRACE_MS);
+          }, deadlineTimeoutMs);
         });
   return {
     signal: controller.signal,

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -255,6 +255,8 @@ function createQaSuiteScenarioFlowApi(
   };
 }
 
+const QA_SCENARIO_LIFECYCLE_GRACE_MS = 5_000;
+
 function createQaScenarioDeadline(timeoutMs?: number) {
   const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -263,10 +265,12 @@ function createQaScenarioDeadline(timeoutMs?: number) {
       ? undefined
       : new Promise<never>((_resolve, reject) => {
           const timeoutError = new Error(`QA scenario flow timed out after ${timeoutMs}ms`);
+          // Scenario-owned polls may consume the full declared timeout. Keep the outer
+          // lifecycle fence later so their terminal result and cleanup stay authoritative.
           timer = setTimeout(() => {
             controller.abort(timeoutError);
             reject(timeoutError);
-          }, timeoutMs);
+          }, timeoutMs + QA_SCENARIO_LIFECYCLE_GRACE_MS);
         });
   return {
     signal: controller.signal,


### PR DESCRIPTION
## Summary

- keep the outer QA flow lifecycle fence five seconds behind scenario-owned timeouts
- preserve cooperative abort fencing while allowing terminal no-reply/transport results and cleanup to win
- cover both the hard lifecycle fence and an operation that settles just after its declared observation window

## Root cause

Commit db533799d592879ee34572693841efa1c2478861 added an outer flow watchdog at the exact same deadline already passed to transport-owned observation loops. Negative Slack/Discord scenarios intentionally wait the full 8 seconds to prove no reply; the outer watchdog raced that successful terminal result and reported `QA scenario flow timed out after 8000ms`. The same race can replace a transport-specific timeout with a generic lifecycle failure.

Observed in maturity run https://github.com/openclaw/openclaw/actions/runs/32444623691 for `slack-allowlist-block`, `slack-channel-disabled-warning`, `slack-mention-gating`, and `discord-mention-gating`.

## Evidence

- downloaded and inspected exact-head shard evidence from `7b15dcb3edbca5d9461b2c21e93f4b525647a896`; all three Slack negative scenarios failed at exactly 8000ms with the generic outer-flow error
- source trace confirms Slack `waitForSlackNoReply` returns successfully after `scenario.timeoutMs`, and Discord translates its transport timeout into `no reply` at the same boundary
- new regression is designed to fail before this fix because its scenario-owned operation settles after the old watchdog
- `git diff --check`: clean
- structured autoreview: clean, no actionable findings
- focused local Vitest could not start because this isolated worktree has no dependency install (`tsx` missing); exact-head CI is required

Production/tooling LOC: +5/-1 (net +4) | Tests: +52/-18

AI-assisted.