### PR TITLE
fix(release): support frozen beta manifest layouts

### DIFF
--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -476,8 +476,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.preflight.outputs.checkout_revision }}
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: false
+          filter: blob:none
           persist-credentials: false
           submodules: false
 

--- a/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
+++ b/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
@@ -77,17 +77,14 @@ function extractStatusSection(text, title) {
   return stripAnsi(section.join("\n"));
 }
 
-function readSharedAuthProfileStoreText(stateDir) {
-  const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
+function readAuthProfileStoreText(dbPath, query, storeKey) {
   if (!fs.existsSync(dbPath)) {
     return "";
   }
   let db;
   try {
     db = new DatabaseSync(dbPath, { readOnly: true });
-    const row = db
-      .prepare("SELECT store_json FROM auth_profile_stores WHERE store_key = ?")
-      .get("shared");
+    const row = db.prepare(query).get(storeKey);
     return typeof row?.store_json === "string" ? row.store_json : "";
   } catch {
     return "";
@@ -96,10 +93,50 @@ function readSharedAuthProfileStoreText(stateDir) {
   }
 }
 
+function readCurrentAuthProfileStoreText(stateDir) {
+  const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
+  return readAuthProfileStoreText(
+    dbPath,
+    "SELECT store_json FROM auth_profile_stores WHERE store_key = ?",
+    "shared",
+  );
+}
+
+function readLegacyAuthProfileStoreText(stateDir) {
+  const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  return readAuthProfileStoreText(
+    dbPath,
+    "SELECT store_json FROM auth_profile_store WHERE store_key = ?",
+    "primary",
+  );
+}
+
 function assertOnboardState() {
-  const home = process.argv[3];
+  const expectedLayout = process.argv[3];
+  const home = process.argv[4];
+  if (expectedLayout !== "legacy" && expectedLayout !== "current") {
+    throw new Error(`unsupported onboard auth profile store layout: ${expectedLayout}`);
+  }
   const stateDir = path.join(home, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
+
+  if (!fs.existsSync(configPath)) {
+    throw new Error("onboard did not write openclaw.json");
+  }
+  const legacyAuthStoreText = readLegacyAuthProfileStoreText(stateDir);
+  const currentAuthStoreText = readCurrentAuthProfileStoreText(stateDir);
+  if (legacyAuthStoreText && currentAuthStoreText) {
+    throw new Error("onboard persisted mixed legacy and current auth profile stores");
+  }
+  const observedLayout = legacyAuthStoreText ? "legacy" : currentAuthStoreText ? "current" : "";
+  if (!observedLayout) {
+    throw new Error("onboard did not persist auth profile store");
+  }
+  if (observedLayout !== expectedLayout) {
+    throw new Error(
+      `onboard persisted ${observedLayout} auth profile store; expected ${expectedLayout}`,
+    );
+  }
   const legacyAuthDatabase = path.join(
     stateDir,
     "agents",
@@ -107,14 +144,10 @@ function assertOnboardState() {
     "agent",
     "openclaw-agent.sqlite",
   );
-
-  if (!fs.existsSync(configPath)) {
-    throw new Error("onboard did not write openclaw.json");
-  }
-  if (fs.existsSync(legacyAuthDatabase)) {
+  if (expectedLayout === "current" && fs.existsSync(legacyAuthDatabase)) {
     throw new Error("onboard created the retired main-agent auth database");
   }
-  const authStoreText = readSharedAuthProfileStoreText(stateDir);
+  const authStoreText = expectedLayout === "legacy" ? legacyAuthStoreText : currentAuthStoreText;
   if (!authStoreText) {
     throw new Error("onboard did not persist auth profile store");
   }

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -14,6 +14,7 @@ HOST_BUILD="${OPENCLAW_NPM_ONBOARD_HOST_BUILD:-1}"
 PACKAGE_TGZ="${OPENCLAW_CURRENT_PACKAGE_TGZ:-}"
 CHANNEL="${OPENCLAW_NPM_ONBOARD_CHANNEL:-telegram}"
 USE_SOURCE_PLUGIN_PACKAGE="${OPENCLAW_NPM_ONBOARD_USE_SOURCE_PLUGIN_PACKAGE:-0}"
+AUTH_PROFILE_STORE_CUTOVER_SHA="a8a9f284fb91af6a9d78fe66f9141eb01e009b21"
 JSON_ARTIFACT_MAX_BYTES="$(
   docker_e2e_read_positive_int_env OPENCLAW_NPM_ONBOARD_JSON_ARTIFACT_MAX_BYTES 1048576
 )"
@@ -23,6 +24,50 @@ STATUS_TEXT_MAX_BYTES="$(
 run_log=""
 plugin_pack_dir=""
 plugin_package_args=()
+
+resolve_auth_profile_store_layout() {
+  local selected_sha="${OPENCLAW_DOCKER_E2E_SELECTED_SHA:-}"
+  local source_sha
+  source_sha="$(git -C "$SOURCE_ROOT" rev-parse HEAD)"
+  if [ -z "$selected_sha" ]; then
+    selected_sha="$source_sha"
+  fi
+  if [[ ! "$selected_sha" =~ ^[0-9a-f]{40}$ ]] || [ "$source_sha" != "$selected_sha" ]; then
+    echo "Cannot bind npm onboarding auth layout to candidate $selected_sha at $source_sha." >&2
+    return 1
+  fi
+
+  if [ "$(git -C "$SOURCE_ROOT" rev-parse --is-shallow-repository)" = "true" ]; then
+    git -C "$SOURCE_ROOT" fetch --no-tags --filter=blob:none --deepen=1024 origin \
+      "$selected_sha" "$AUTH_PROFILE_STORE_CUTOVER_SHA"
+  elif ! git -C "$SOURCE_ROOT" cat-file -e "$AUTH_PROFILE_STORE_CUTOVER_SHA^{commit}"; then
+    git -C "$SOURCE_ROOT" fetch --no-tags --filter=blob:none --depth=1024 origin \
+      "$AUTH_PROFILE_STORE_CUTOVER_SHA"
+  fi
+
+  if ! git -C "$SOURCE_ROOT" merge-base "$AUTH_PROFILE_STORE_CUTOVER_SHA" "$selected_sha" \
+    >/dev/null; then
+    echo "Cannot prove candidate $selected_sha auth layout ancestry relative to $AUTH_PROFILE_STORE_CUTOVER_SHA." >&2
+    return 1
+  fi
+  set +e
+  git -C "$SOURCE_ROOT" merge-base --is-ancestor \
+    "$AUTH_PROFILE_STORE_CUTOVER_SHA" "$selected_sha"
+  local ancestry_status=$?
+  set -e
+  if [ "$ancestry_status" -eq 0 ]; then
+    printf '%s\n' "current"
+  elif [ "$ancestry_status" -eq 1 ]; then
+    # Frozen release branches can diverge before the cutover; absence of the
+    # cutover commit is the legacy contract, not a requirement to follow main.
+    printf '%s\n' "legacy"
+  else
+    echo "Cannot determine candidate $selected_sha auth layout ancestry relative to $AUTH_PROFILE_STORE_CUTOVER_SHA." >&2
+    return 1
+  fi
+}
+
+AUTH_PROFILE_STORE_LAYOUT="$(resolve_auth_profile_store_layout)"
 
 cleanup() {
   if [ -n "${PACKAGE_TGZ:-}" ]; then
@@ -103,6 +148,7 @@ echo "Running npm tarball onboard/channel/agent Docker E2E ($CHANNEL)..."
 if ! docker_e2e_run_with_harness \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e OPENCLAW_NPM_ONBOARD_CHANNEL="$CHANNEL" \
+  -e "OPENCLAW_NPM_ONBOARD_AUTH_LAYOUT=$AUTH_PROFILE_STORE_LAYOUT" \
   -e "OPENCLAW_NPM_ONBOARD_JSON_ARTIFACT_MAX_BYTES=$JSON_ARTIFACT_MAX_BYTES" \
   -e "OPENCLAW_NPM_ONBOARD_STATUS_TEXT_MAX_BYTES=$STATUS_TEXT_MAX_BYTES" \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
@@ -208,7 +254,8 @@ openclaw onboard --non-interactive --accept-risk \
   --skip-health \
   --json >/tmp/openclaw-onboard.json
 
-node scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs assert-onboard-state "$HOME"
+node scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs \
+  assert-onboard-state "$OPENCLAW_NPM_ONBOARD_AUTH_LAYOUT" "$HOME"
 
 openclaw_e2e_assert_dep_absent "$DEP_SENTINEL" "$HOME/.openclaw"
 

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -54,6 +54,19 @@ const REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>(
   REVIEWED_CODEX_SOURCE_LAYOUTS.flatMap((layout) => [...layout]),
 );
 
+const REVIEWED_LEGACY_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+  ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
+  ["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts", 1],
+]);
+const REVIEWED_CURRENT_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>();
+const REVIEWED_PLUGIN_RUNNER_SOURCE_LAYOUTS: ReadonlyArray<ReadonlyMap<string, number>> = [
+  REVIEWED_LEGACY_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS,
+  REVIEWED_CURRENT_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS,
+];
+const REVIEWED_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>(
+  REVIEWED_PLUGIN_RUNNER_SOURCE_LAYOUTS.flatMap((layout) => [...layout]),
+);
+
 // Generated chunks can contain multiple reviewed execution sites. Counts are
 // part of the contract so an added or missing site fails the release scan.
 const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<string, number>([
@@ -144,16 +157,41 @@ function resolveReviewedCodexSourceLayout(
   });
 }
 
+function resolveReviewedPluginRunnerSourceLayout(
+  reviewedCriticalFindings: readonly string[],
+): string[] | undefined {
+  const observedSourceFindings = reviewedCriticalFindings
+    .filter((key) => REVIEWED_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS.has(key))
+    .toSorted();
+  return REVIEWED_PLUGIN_RUNNER_SOURCE_LAYOUTS.map(expandReviewedFindingCounts).find((layout) => {
+    const expectedSourceFindings = layout.toSorted();
+    return (
+      expectedSourceFindings.length === observedSourceFindings.length &&
+      expectedSourceFindings.every((key, index) => key === observedSourceFindings[index])
+    );
+  });
+}
+
 function requiredReviewedFindingsForPackage(
   packageName: string,
   reviewedCriticalFindings: readonly string[],
+  allReviewedCriticalFindings: readonly string[],
 ): string[] {
   const commonFindings = [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS].flatMap(
     ([key, count]) =>
       key.startsWith(`${packageName}:`) ? Array.from({ length: count }, () => key) : [],
   );
+  const runnerSourceLayout = resolveReviewedPluginRunnerSourceLayout(allReviewedCriticalFindings);
+  if (!runnerSourceLayout) {
+    throw new Error(
+      "reviewed plugin runner source findings must match exactly one complete known layout.",
+    );
+  }
+  const runnerSourceFindings = runnerSourceLayout.filter((key) =>
+    key.startsWith(`${packageName}:`),
+  );
   if (packageName !== "@openclaw/codex") {
-    return commonFindings;
+    return [...commonFindings, ...runnerSourceFindings];
   }
   const sourceLayout = resolveReviewedCodexSourceLayout(reviewedCriticalFindings);
   if (!sourceLayout) {
@@ -161,13 +199,14 @@ function requiredReviewedFindingsForPackage(
       "@openclaw/codex: reviewed source findings must match exactly one complete known layout.",
     );
   }
-  return [...commonFindings, ...sourceLayout];
+  return [...commonFindings, ...sourceLayout, ...runnerSourceFindings];
 }
 
 function isReviewedPublishableCriticalFinding(key: string): boolean {
   return (
     REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
     REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
+    REVIEWED_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
     OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
   );
 }
@@ -357,12 +396,13 @@ describe("publishable plugin npm package install security scan", () => {
     const publishablePackageNames = new Set(
       publishablePluginPackages.map((plugin) => plugin.packageName),
     );
+    const reviewedFindingKeys = [
+      ...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.keys(),
+      ...REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.keys(),
+      ...REVIEWED_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS.keys(),
+    ];
     const missingPackages = [
-      ...new Set(
-        [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.keys()].map((key) =>
-          key.slice(0, key.indexOf(":")),
-        ),
-      ),
+      ...new Set(reviewedFindingKeys.map((key) => key.slice(0, key.indexOf(":")))),
     ].filter((packageName) => !publishablePackageNames.has(packageName));
 
     expect(missingPackages.toSorted()).toStrictEqual([]);
@@ -471,6 +511,50 @@ describe("publishable plugin npm package install security scan", () => {
     expect(resolveReviewedCodexSourceLayout([relocatedFinding])).toBeUndefined();
   });
 
+  it("accepts either complete reviewed plugin runner source layout", () => {
+    const legacyLayout = expandReviewedFindingCounts(
+      REVIEWED_LEGACY_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS,
+    );
+    const currentLayout = expandReviewedFindingCounts(
+      REVIEWED_CURRENT_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS,
+    );
+
+    expect(resolveReviewedPluginRunnerSourceLayout(legacyLayout)).toEqual(legacyLayout);
+    expect(resolveReviewedPluginRunnerSourceLayout(currentLayout)).toEqual(currentLayout);
+  });
+
+  const invalidPluginRunnerSourceLayouts: Array<[name: string, findings: string[]]> = [
+    ["partial legacy Codex-only", ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts"]],
+    [
+      "mixed transition OpenCode-only",
+      ["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts"],
+    ],
+    [
+      "duplicate occurrence",
+      [
+        ...expandReviewedFindingCounts(
+          REVIEWED_LEGACY_PLUGIN_RUNNER_SOURCE_CRITICAL_FINDING_COUNTS,
+        ),
+        "@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts",
+      ],
+    ],
+  ];
+
+  test.each(invalidPluginRunnerSourceLayouts)(
+    "rejects a %s plugin runner source layout",
+    (_name, findings) => {
+      expect(resolveReviewedPluginRunnerSourceLayout(findings)).toBeUndefined();
+    },
+  );
+
+  test.each([
+    "@openclaw/codex:dangerous-exec:src/relocated/node-cli-sessions.ts",
+    "@openclaw/opencode-provider:dangerous-exec:src/session-catalog.ts",
+    "@openclaw/codex:dangerous-exec:src/future-runner.ts",
+  ])("does not review an unknown or relocated plugin runner finding: %s", (finding) => {
+    expect(isReviewedPublishableCriticalFinding(finding)).toBe(false);
+  });
+
   test.concurrent.each(publishablePluginPackages)(
     "keeps $packageName files clear of unexpected critical hits",
     async (plugin) => {
@@ -479,8 +563,15 @@ describe("publishable plugin npm package install security scan", () => {
         throw new Error(`Missing package scan result for ${plugin.packageName}`);
       }
       expect(result.unexpectedCriticalFindings.toSorted()).toStrictEqual([]);
+      const allReviewedCriticalFindings = [...scanResultsByPackageName.values()].flatMap(
+        (scanResult) => scanResult.reviewedCriticalFindings,
+      );
       const expectedReviewedCriticalFindings = [
-        ...requiredReviewedFindingsForPackage(plugin.packageName, result.reviewedCriticalFindings),
+        ...requiredReviewedFindingsForPackage(
+          plugin.packageName,
+          result.reviewedCriticalFindings,
+          allReviewedCriticalFindings,
+        ),
         ...result.expectedReviewedCriticalFindings,
       ];
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2716,6 +2716,21 @@ docker_e2e_docker_run_cmd run demo
     expect(script).not.toContain("/tmp/openclaw-channel-add.log");
   });
 
+  it("binds npm onboarding auth layout to the exact candidate ancestry", () => {
+    const script = readFileSync(NPM_ONBOARD_CHANNEL_AGENT_DOCKER_E2E_PATH, "utf8");
+
+    expectTextToIncludeAll(script, [
+      'AUTH_PROFILE_STORE_CUTOVER_SHA="a8a9f284fb91af6a9d78fe66f9141eb01e009b21"',
+      'selected_sha="${OPENCLAW_DOCKER_E2E_SELECTED_SHA:-}"',
+      "fetch --no-tags --filter=blob:none --deepen=1024 origin",
+      'merge-base "$AUTH_PROFILE_STORE_CUTOVER_SHA" "$selected_sha"',
+      'merge-base --is-ancestor \\\n    "$AUTH_PROFILE_STORE_CUTOVER_SHA" "$selected_sha"',
+      "OPENCLAW_NPM_ONBOARD_AUTH_LAYOUT=$AUTH_PROFILE_STORE_LAYOUT",
+    ]);
+    expect(script).toContain('elif [ "$ancestry_status" -eq 1 ]; then');
+    expect(script).toContain('if ! git -C "$SOURCE_ROOT" merge-base');
+  });
+
   it("keeps real-TTY onboarding drivers aligned with the first-agent prompt", () => {
     expectOrderedScriptFragments(readFileSync(RELEASE_TYPED_ONBOARDING_SCENARIO_PATH, "utf8"), [
       'wait_for_log "Continue?"',

--- a/test/scripts/npm-onboard-channel-agent-assertions.test.ts
+++ b/test/scripts/npm-onboard-channel-agent-assertions.test.ts
@@ -37,7 +37,7 @@ function writeOnboardConfig(home: string): void {
   );
 }
 
-function writeSharedAuthProfileStoreSqlite(home: string, store: unknown): void {
+function writeCurrentAuthProfileStoreSqlite(home: string, store: unknown): void {
   const stateDir = path.join(home, ".openclaw", "state");
   fs.mkdirSync(stateDir, { recursive: true });
   const db = new DatabaseSync(path.join(stateDir, "openclaw.sqlite"));
@@ -60,6 +60,29 @@ function writeSharedAuthProfileStoreSqlite(home: string, store: unknown): void {
   }
 }
 
+function writeLegacyAuthProfileStoreSqlite(home: string, store: unknown): void {
+  const agentDir = path.join(home, ".openclaw", "agents", "main", "agent");
+  fs.mkdirSync(agentDir, { recursive: true });
+  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS auth_profile_store (
+        store_key TEXT NOT NULL PRIMARY KEY,
+        store_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+    `);
+    db.prepare(
+      `
+        INSERT INTO auth_profile_store (store_key, store_json, updated_at)
+        VALUES (?, ?, ?)
+      `,
+    ).run("primary", JSON.stringify(store), Date.now());
+  } finally {
+    db.close();
+  }
+}
+
 function runAssert(home: string, channel: string, ...tokens: string[]) {
   return spawnSync(
     process.execPath,
@@ -75,8 +98,8 @@ function runAssert(home: string, channel: string, ...tokens: string[]) {
   );
 }
 
-function runOnboardAssert(home: string) {
-  return spawnSync(process.execPath, [assertionsPath, "assert-onboard-state", home], {
+function runOnboardAssert(home: string, layout: "current" | "legacy") {
+  return spawnSync(process.execPath, [assertionsPath, "assert-onboard-state", layout, home], {
     encoding: "utf8",
     env: {
       ...process.env,
@@ -218,33 +241,36 @@ describe("npm onboard channel agent assertions", () => {
     }
   });
 
-  it("validates OpenAI env refs from the shared SQLite auth profile store", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
-    const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
+  it.each([
+    ["legacy", writeLegacyAuthProfileStoreSqlite],
+    ["current", writeCurrentAuthProfileStoreSqlite],
+  ] as const)(
+    "validates OpenAI env refs from the %s SQLite auth profile store",
+    (layout, writeStore) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
 
-    try {
-      writeOnboardConfig(tempDir);
-      writeSharedAuthProfileStoreSqlite(tempDir, {
-        version: 1,
-        profiles: {
-          "openai:api-key": {
-            type: "api_key",
-            provider: "openai",
-            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+      try {
+        writeOnboardConfig(tempDir);
+        writeStore(tempDir, {
+          version: 1,
+          profiles: {
+            "openai:api-key": {
+              type: "api_key",
+              provider: "openai",
+              keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+            },
           },
-        },
-      });
+        });
 
-      const result = runOnboardAssert(tempDir);
+        const result = runOnboardAssert(tempDir, layout);
 
-      expect(result.status).toBe(0);
-      expect(result.stderr).toBe("");
-      expect(fs.existsSync(agentDir)).toBe(false);
-      expect(fs.existsSync(path.join(agentDir, "auth-profiles.json"))).toBe(false);
-    } finally {
-      fs.rmSync(tempDir, { force: true, recursive: true });
-    }
-  });
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe("");
+      } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("rejects auth profile stores without a usable OpenAI env ref", () => {
     const cases: unknown[] = [
@@ -262,9 +288,9 @@ describe("npm onboard channel agent assertions", () => {
 
       try {
         writeOnboardConfig(tempDir);
-        writeSharedAuthProfileStoreSqlite(tempDir, store);
+        writeCurrentAuthProfileStoreSqlite(tempDir, store);
 
-        const result = runOnboardAssert(tempDir);
+        const result = runOnboardAssert(tempDir, "current");
 
         expect(result.status).not.toBe(0);
         expect(result.stderr).toContain("auth profile did not persist OPENAI_API_KEY env ref");
@@ -278,7 +304,7 @@ describe("npm onboard channel agent assertions", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
     try {
       writeOnboardConfig(tempDir);
-      writeSharedAuthProfileStoreSqlite(tempDir, {
+      writeCurrentAuthProfileStoreSqlite(tempDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -289,7 +315,7 @@ describe("npm onboard channel agent assertions", () => {
         },
       });
 
-      const result = runOnboardAssert(tempDir);
+      const result = runOnboardAssert(tempDir, "current");
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("auth profile persisted the raw OpenAI test key");
@@ -298,13 +324,75 @@ describe("npm onboard channel agent assertions", () => {
     }
   });
 
-  it("rejects a fresh install that recreates the retired main-agent auth database", () => {
+  it("rejects mixed legacy and current auth profile stores", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+    try {
+      writeOnboardConfig(tempDir);
+      const store = {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      };
+      writeLegacyAuthProfileStoreSqlite(tempDir, store);
+      writeCurrentAuthProfileStoreSqlite(tempDir, store);
+
+      const result = runOnboardAssert(tempDir, "current");
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "onboard persisted mixed legacy and current auth profile stores",
+      );
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it.each([
+    ["current", "legacy", writeCurrentAuthProfileStoreSqlite],
+    ["legacy", "current", writeLegacyAuthProfileStoreSqlite],
+  ] as const)(
+    "rejects the %s layout when the candidate requires %s",
+    (observedLayout, expectedLayout, writeStore) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+      try {
+        writeOnboardConfig(tempDir);
+        writeStore(tempDir, {
+          version: 1,
+          profiles: {
+            "openai:api-key": {
+              type: "api_key",
+              provider: "openai",
+              keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+            },
+          },
+        });
+
+        const result = runOnboardAssert(tempDir, expectedLayout);
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          `onboard persisted ${observedLayout} auth profile store; expected ${expectedLayout}`,
+        );
+      } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+      }
+    },
+  );
+
+  it("keeps the current-layout ban on the retired main-agent database", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
     const legacyAgentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
 
     try {
       writeOnboardConfig(tempDir);
-      writeSharedAuthProfileStoreSqlite(tempDir, {
+      writeCurrentAuthProfileStoreSqlite(tempDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -317,10 +405,25 @@ describe("npm onboard channel agent assertions", () => {
       fs.mkdirSync(legacyAgentDir, { recursive: true });
       new DatabaseSync(path.join(legacyAgentDir, "openclaw-agent.sqlite")).close();
 
-      const result = runOnboardAssert(tempDir);
+      const result = runOnboardAssert(tempDir, "current");
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("onboard created the retired main-agent auth database");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a missing auth profile store", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+    try {
+      writeOnboardConfig(tempDir);
+
+      const result = runOnboardAssert(tempDir, "legacy");
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("onboard did not persist auth profile store");
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
     }

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -755,6 +755,16 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       "${{ fromJson(needs.preflight.outputs.plugin_prerelease_extension_matrix) }}",
     );
     expect(
+      extensionShard.steps.find((step: WorkflowStep) => step.name === "Checkout").with,
+    ).toEqual({
+      "fetch-depth": 0,
+      "fetch-tags": false,
+      filter: "blob:none",
+      "persist-credentials": false,
+      ref: "${{ needs.preflight.outputs.checkout_revision }}",
+      submodules: false,
+    });
+    expect(
       extensionShard.steps.find((step: WorkflowStep) => step.name === "Run extension shard").run,
     ).toContain("--retry=1");
     expect(inspector.name).toBe("plugin-prerelease-inspector");


### PR DESCRIPTION
Related: #127115

## What Problem This Solves

Fixes release validation failures where a frozen beta candidate predating the shared-auth cutover is checked by newer trusted tooling. The current harness required only the post-cutover auth store, the extension shard lacked candidate history, and the plugin security inventory accepted only one source layout.

## Why This Change Was Made

The release harness now selects the legacy or current onboarding auth store from the exact candidate's ancestry of `a8a9f284fb91af6a9d78fe66f9141eb01e009b21`, rejects mixed, missing, mismatched, or indeterminate layouts, and keeps the current-layout ban on the retired database. The extension shard checks out complete blobless history, and the scanner uses the exact reviewed mutually exclusive legacy/current inventory compatibility from `ce19e1cd7a700d648ff90a1aafbe8ee394613c44`.

This branch is exactly two signed commits on `0368cbf252d861b7be7d57df23300618be6ab030`; it does not adopt current `main` or candidate product bytes.

## User Impact

No product behavior changes. Maintainers can validate the frozen beta candidate with fail-closed trusted tooling instead of receiving false manifest failures from release-era layout differences.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/npm-install-security-scan.release.test.ts` - 109 passed
- `node scripts/run-vitest.mjs test/scripts/plugin-prerelease-test-plan.test.ts` - 14 passed
- `node scripts/run-vitest.mjs test/scripts/npm-onboard-channel-agent-assertions.test.ts` - 18 passed
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` - 200 passed
- `actionlint .github/workflows/plugin-prerelease.yml`
- `bash -n scripts/e2e/npm-onboard-channel-agent-docker.sh`
- targeted `pnpm format:check` and `git diff --check`
- Production/tooling LOC: +95/-14; tests and scanner contracts: +260/-41

References OCF-121
