### PR TITLE
fix(tui): clear stale status after aborted runs

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -2386,6 +2386,21 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     }
   });
 
+  it("clears stale streaming when an inactive ordinary abort leaves no tracked run", () => {
+    const { state, setActivityStatus, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-stale", activityStatus: "streaming" },
+    });
+
+    handleChatEvent({
+      runId: "run-aborted",
+      state: "aborted",
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(state.activityStatus).toBe("idle");
+    expect(setActivityStatus).toHaveBeenCalledWith("idle");
+  });
+
   it("does not force idle for an inactive final while another tracked run is active", () => {
     const { state, setActivityStatus, handleChatEvent } = createConcurrentRunHarness("partial");
     state.activityStatus = "streaming";

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -163,6 +163,8 @@ export function createEventHandlers(context: EventHandlerContext) {
     forgetLocalRunId,
     clearLocalRunIds,
     clearLocalBtwRunIds,
+    isLocalBtwRunId,
+    forgetLocalBtwRunId,
     streamingWatchdogMs: context.streamingWatchdogMs,
     localMode,
   });
@@ -346,7 +348,6 @@ export function createEventHandlers(context: EventHandlerContext) {
       });
     }
     if (evt.state === "aborted") {
-      forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
       // Determine content from the message and stream, not the user-visible
       // fallbacks: attachment-only aborts remain cancellation diagnostics.
@@ -367,7 +368,6 @@ export function createEventHandlers(context: EventHandlerContext) {
       });
     }
     if (evt.state === "error") {
-      forgetLocalBtwRunId?.(evt.runId);
       renderTerminalRunError({
         runId: evt.runId,
         errorMessage: evt.errorMessage ?? "unknown",

--- a/src/tui/tui-run-lifecycle.ts
+++ b/src/tui/tui-run-lifecycle.ts
@@ -31,6 +31,8 @@ type TuiRunLifecycleContext = {
   isLocalRunId?: (runId: string) => boolean;
   forgetLocalRunId?: (runId: string) => void;
   clearLocalRunIds?: () => void;
+  isLocalBtwRunId?: (runId: string) => boolean;
+  forgetLocalBtwRunId?: (runId: string) => void;
   clearLocalBtwRunIds?: () => void;
   streamingWatchdogMs?: number;
   localMode?: boolean;
@@ -49,6 +51,8 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
     isLocalRunId,
     forgetLocalRunId,
     clearLocalRunIds,
+    isLocalBtwRunId,
+    forgetLocalBtwRunId,
     clearLocalBtwRunIds,
     localMode,
   } = context;
@@ -306,6 +310,8 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
     wasActiveRun: boolean;
     status: "aborted" | "error";
   }) => {
+    const preserveInactiveStreaming = isLocalBtwRunId?.(params.runId) ?? false;
+    forgetLocalBtwRunId?.(params.runId);
     runCoordinator.noteCompletedRun(params.runId);
     runCoordinator.dropSessionRun(params.runId);
     clearActiveRunIfMatch(params.runId);
@@ -315,8 +321,13 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
       if (params.wasActiveRun) {
         setActivityStatus(params.status);
         clearStreamingWatchdog();
-      } else if (streamingWatchdogRunId === params.runId) {
-        clearStreamingWatchdog();
+      } else {
+        if (streamingWatchdogRunId === params.runId) {
+          clearStreamingWatchdog();
+        }
+        if (!preserveInactiveStreaming) {
+          clearStaleStreamingIfNoTrackedRunRemains();
+        }
       }
     }
     void refreshSessionInfo?.();


### PR DESCRIPTION
Closes #127238

## What Problem This Solves

Fixes an issue where TUI users could keep seeing a processing status after an ordinary chat run aborts when that terminal event no longer matches the active run slot.

## Why This Change Was Made

The run lifecycle now clears stale streaming activity for inactive ordinary aborted or errored runs once no tracked run remains. Local `/btw` terminal events still preserve global activity, so background side-question cleanup does not hide an unrelated active status.

## User Impact

Users can abort a run without the TUI status indicator staying stuck on processing after the run has already ended.

## Evidence

Before the fix, the new regression failed on current main with `expected 'run-stale' to be null`.

Validated on the rebased branch:

- `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`
- `pnpm exec oxfmt --check --threads=1 src/tui/tui-run-lifecycle.ts src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts`
- `pnpm exec oxlint src/tui/tui-run-lifecycle.ts src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
