### PR TITLE
fix(gateway): keep side chat available for tool-heavy sessions

### DIFF
--- a/src/gateway/session-companion-context.test.ts
+++ b/src/gateway/session-companion-context.test.ts
@@ -130,6 +130,34 @@ describe("session companion context", () => {
     );
   });
 
+  it("keeps complete recent context when older tool rows exhaust the scan byte budget", async () => {
+    const scope = createScope("companion-context-byte-budget");
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    const messages = Array.from({ length: 384 }, (_, index) => {
+      const isContextMessage = index % 9 === 0;
+      return {
+        eventId: `message-${index}`,
+        parentId: index === 0 ? null : `message-${index - 1}`,
+        message: isContextMessage
+          ? { role: "user" as const, content: `useful ${index}`, timestamp: index }
+          : { role: "toolResult" as const, content: "x".repeat(4000), timestamp: index },
+      };
+    });
+    await persistSessionTranscriptTurn(scope, { messages, touchSessionEntry: true });
+
+    const result = await defaultSessionCompanionContextReader.read(scope);
+
+    expect(result.kind).toBe("ready");
+    if (result.kind !== "ready") {
+      return;
+    }
+    expect(result.context.messages.length).toBeGreaterThan(0);
+    expect(result.context.messages.at(-1)?.text).toBe("useful 378");
+    expect(result.context.messages.every((message) => message.text.startsWith("useful"))).toBe(
+      true,
+    );
+  });
+
   it.each([
     { expectedKind: "ready", unsupportedCount: 4095 },
     { expectedKind: "unavailable", unsupportedCount: 4096 },

--- a/src/gateway/session-companion-context.ts
+++ b/src/gateway/session-companion-context.ts
@@ -142,6 +142,7 @@ async function readSessionCompanionContext(params: {
     let rawBytes = 0;
     let scannedMessages = 0;
     let totalMessages = 0;
+    let stoppedAtOlderByteBoundary = false;
     let snapshot:
       | {
           activeLeafEntryId?: string | null;
@@ -163,8 +164,17 @@ async function readSessionCompanionContext(params: {
         ),
         offset,
       });
-      if (params.signal?.aborted || page.events.length !== page.scannedMessages) {
+      if (params.signal?.aborted) {
         return { kind: "unavailable" };
+      }
+      if (page.events.length !== page.scannedMessages) {
+        if (contextMessages.length === 0) {
+          return { kind: "unavailable" };
+        }
+        // A partial older page can contain holes around oversized rows. Keep
+        // only the complete newer pages, then verify their snapshot below.
+        stoppedAtOlderByteBoundary = true;
+        break;
       }
       const pageSnapshot = {
         activeLeafEntryId: page.activeLeafEntryId,
@@ -193,7 +203,11 @@ async function readSessionCompanionContext(params: {
         break;
       }
     }
-    if (contextMessages.length < CONTEXT_MAX_MESSAGES && offset < totalMessages) {
+    if (
+      contextMessages.length < CONTEXT_MAX_MESSAGES &&
+      offset < totalMessages &&
+      !stoppedAtOlderByteBoundary
+    ) {
       return { kind: "unavailable" };
     }
     const fence = readSessionTranscriptBoundedMessageTailPage(scope, {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users asking the session companion about a tool-heavy session could receive “Couldn't load this session's history” even though the session transcript was healthy and readable.

## Why This Change Was Made

The companion now retains complete recent transcript pages when an older page reaches the bounded raw-read budget. It still rejects an incomplete newest page, stale projections, and snapshots that change during the read, so the existing fail-closed safety boundaries remain intact.

AI-assisted implementation; the complete owner path, regression fixture, and proof results were reviewed before publication.

## User Impact

Side chat remains available on long, tool-heavy sessions and answers from the newest complete context instead of failing the whole request because older raw tool output exhausted the scan budget.

## Evidence

### Isolated Control UI proof

Copied the affected session databases into an isolated state directory, disabled channel startup, ran the exact committed Gateway on loopback, and routed the companion's model call to the repository's deterministic mock OpenAI server. No live provider credential or operator Gateway was used.

**Session loaded with side chat available**

![Side chat loaded](https://github.com/user-attachments/assets/6703112d-0069-48d0-b21f-8658dcaa9bff)

**Same question that previously produced the history-unavailable error**

![Side chat question](https://github.com/user-attachments/assets/5ef22b3c-45ad-4207-a171-4faef13edcc4)

**Answer returned through the real Gateway companion path**

![Side chat answer](https://github.com/user-attachments/assets/01423c82-7b23-4ace-9ea1-2b900893695b)

https://github.com/user-attachments/assets/49632df5-743e-4840-a66e-3a3fafd139ae

### Regression and checks

- Pre-fix owner-boundary regression: failed in both Gateway projects with `expected 'unavailable' to be 'ready'`.
- `node scripts/run-vitest.mjs src/gateway/session-companion-context.test.ts` — 22/22 passed across both Gateway projects.
- `node scripts/check-changed.mjs -- src/gateway/session-companion-context.ts src/gateway/session-companion-context.test.ts` — passed.
- `pnpm build` — passed, including runtime postbuild, plugin SDK export checks, and Control UI build.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- Production delta: +16/-2. Test delta: +28/-0.
