### PR TITLE
fix(ci): align lifecycle retry fixtures with terminal replies

### DIFF
--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -236,7 +236,11 @@ describe("subagent registry lifecycle error grace", () => {
       const run = mod
         .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
         .find((candidate) => candidate.runId === runId);
-      if (run?.cleanupHandled === false) {
+      if (
+        run?.cleanupHandled === false &&
+        run.delivery?.status === "pending" &&
+        run.delivery.payload
+      ) {
         return;
       }
       await vi.advanceTimersByTimeAsync(1);
@@ -282,12 +286,13 @@ describe("subagent registry lifecycle error grace", () => {
     throw new Error(`expected ${expectedCount} agent call(s), got ${getAgentCalls().length}`);
   };
 
-  const waitForFrozenResultText = async (runId: string, expectedText: string) => {
+  const waitForFrozenResult = async (runId: string, matches: (resultText: string) => boolean) => {
     for (let attempt = 0; attempt < 80; attempt += 1) {
       const run = mod
         .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
         .find((candidate) => candidate.runId === runId);
-      if (run?.completion?.resultText === expectedText) {
+      const resultText = run?.completion?.resultText;
+      if (run && typeof resultText === "string" && matches(resultText)) {
         return run;
       }
       await vi.advanceTimersByTimeAsync(1);
@@ -296,11 +301,15 @@ describe("subagent registry lifecycle error grace", () => {
     throw new Error(`run ${runId} frozen result did not refresh`);
   };
 
+  const waitForFrozenResultText = async (runId: string, expectedText: string) =>
+    waitForFrozenResult(runId, (resultText) => resultText === expectedText);
+
   function registerCompletionRun(
     runId: string,
     childSuffix: string,
     task: string,
     requesterTurnRunId?: string,
+    expectsCompletionMessage = true,
   ) {
     mod.registerSubagentRun({
       runId,
@@ -311,7 +320,7 @@ describe("subagent registry lifecycle error grace", () => {
       requesterDisplayKey: MAIN_REQUESTER_DISPLAY_KEY,
       task,
       cleanup: "keep",
-      expectsCompletionMessage: true,
+      expectsCompletionMessage,
     });
   }
 
@@ -451,10 +460,18 @@ describe("subagent registry lifecycle error grace", () => {
       }),
     );
 
-    emitLifecycleEvent("run-yield-alpha", { phase: "end", endedAt: Date.now() });
+    emitLifecycleEvent("run-yield-alpha", {
+      phase: "end",
+      endedAt: Date.now(),
+      terminalReply: { disposition: "visible", text: "alpha complete" },
+    });
     await waitForAgentCallCount(1);
 
-    emitLifecycleEvent("run-yield-beta", { phase: "end", endedAt: Date.now() + 1 });
+    emitLifecycleEvent("run-yield-beta", {
+      phase: "end",
+      endedAt: Date.now() + 1,
+      terminalReply: { disposition: "visible", text: "beta complete" },
+    });
     await waitForAgentCallCount(2);
     const betaBeforeYield = mod
       .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
@@ -583,7 +600,11 @@ describe("subagent registry lifecycle error grace", () => {
     expect(getRequesterWakeCalls()).toHaveLength(0);
     expect(liveChild.execution.status).toBe("running");
 
-    emitLifecycleEvent("run-frozen-live-child", { phase: "end", endedAt: Date.now() + 1 });
+    emitLifecycleEvent("run-frozen-live-child", {
+      phase: "end",
+      endedAt: Date.now() + 1,
+      terminalReply: { disposition: "visible", text: "live child complete" },
+    });
     await waitForAgentCallCount(1);
     await waitForDeliveredCleanup("run-frozen-live-child");
 
@@ -616,7 +637,11 @@ describe("subagent registry lifecycle error grace", () => {
     await vi.advanceTimersByTimeAsync(20_000);
     expect(getAgentCalls()).toHaveLength(0);
 
-    emitLifecycleEvent("run-transient-error", { phase: "end", endedAt: 1_250 });
+    emitLifecycleEvent("run-transient-error", {
+      phase: "end",
+      endedAt: 1_250,
+      terminalReply: { disposition: "visible", text: "Final answer transient" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(1);
@@ -650,7 +675,11 @@ describe("subagent registry lifecycle error grace", () => {
     agentCallPlan = ["throw", "ok"];
 
     const endedAt = Date.now();
-    emitLifecycleEvent("run-freeze", { phase: "end", endedAt });
+    emitLifecycleEvent("run-freeze", {
+      phase: "end",
+      endedAt,
+      terminalReply: { disposition: "visible", text: "Final answer X" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(1);
@@ -661,7 +690,11 @@ describe("subagent registry lifecycle error grace", () => {
     await waitForCleanupHandledFalse("run-freeze");
 
     setAssistantOutput("agent:main:subagent:freeze", "Late reply Y");
-    emitLifecycleEvent("run-freeze", { phase: "end", endedAt: endedAt + 100 });
+    emitLifecycleEvent("run-freeze", {
+      phase: "end",
+      endedAt: endedAt + 100,
+      terminalReply: { disposition: "visible", text: "Final answer X" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(2);
@@ -680,7 +713,14 @@ describe("subagent registry lifecycle error grace", () => {
     agentCallPlan = ["throw", "ok"];
 
     const endedAt = Date.now();
-    emitLifecycleEvent("run-refresh", { phase: "end", endedAt });
+    emitLifecycleEvent("run-refresh", {
+      phase: "end",
+      endedAt,
+      terminalReply: {
+        disposition: "visible",
+        text: "Both spawned. Waiting for completion events...",
+      },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(1);
@@ -713,7 +753,14 @@ describe("subagent registry lifecycle error grace", () => {
     );
     expect((runAfterRefresh?.completion?.capturedAt ?? 0) >= firstCapturedAt).toBe(true);
 
-    emitLifecycleEvent("run-refresh", { phase: "end", endedAt: endedAt + 300 });
+    emitLifecycleEvent("run-refresh", {
+      phase: "end",
+      endedAt: endedAt + 300,
+      terminalReply: {
+        disposition: "visible",
+        text: "All 3 subagents complete. Here's the final summary.",
+      },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(2);
@@ -729,7 +776,14 @@ describe("subagent registry lifecycle error grace", () => {
     agentCallPlan = ["throw", "ok"];
 
     const endedAt = Date.now();
-    emitLifecycleEvent("run-refresh-silent", { phase: "end", endedAt });
+    emitLifecycleEvent("run-refresh-silent", {
+      phase: "end",
+      endedAt,
+      terminalReply: {
+        disposition: "visible",
+        text: "All work complete, final summary",
+      },
+    });
     await flushAsync();
     await waitForCleanupHandledFalse("run-refresh-silent");
     await waitForFrozenResultText("run-refresh-silent", "All work complete, final summary");
@@ -747,7 +801,14 @@ describe("subagent registry lifecycle error grace", () => {
       .find((candidate) => candidate.runId === "run-refresh-silent");
     expect(runAfterSilent?.completion?.resultText).toBe("All work complete, final summary");
 
-    emitLifecycleEvent("run-refresh-silent", { phase: "end", endedAt: endedAt + 300 });
+    emitLifecycleEvent("run-refresh-silent", {
+      phase: "end",
+      endedAt: endedAt + 300,
+      terminalReply: {
+        disposition: "visible",
+        text: "All work complete, final summary",
+      },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(2);
@@ -758,28 +819,23 @@ describe("subagent registry lifecycle error grace", () => {
   });
 
   it("regression, captures frozen completion output with 100KB cap and retains it for keep-mode cleanup", async () => {
-    registerCompletionRun("run-capped", "capped", "capped result test");
+    registerCompletionRun("run-capped", "capped", "capped result test", undefined, false);
     setAssistantOutput("agent:main:subagent:capped", "x".repeat(120 * 1024));
 
     emitLifecycleEvent("run-capped", { phase: "end", endedAt: Date.now() });
     await flushAsync();
 
-    await waitForAgentCallCount(1);
-    const cappedResults = getAgentResultsForChildSession("agent:main:subagent:capped");
-    expect(cappedResults).toHaveLength(1);
-    expect(cappedResults[0]).toContain("[truncated: frozen completion output exceeded 100KB");
-    expect(Buffer.byteLength(cappedResults[0] ?? "", "utf8")).toBeLessThanOrEqual(100 * 1024);
-
-    const run = mod
-      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
-      .find((candidate) => candidate.runId === "run-capped");
-    if (!run) {
-      throw new Error("expected capped run to exist");
-    }
+    const run = await waitForFrozenResult("run-capped", (resultText) =>
+      resultText.includes("[truncated: frozen completion output exceeded 100KB"),
+    );
+    expect(getAgentCalls()).toHaveLength(0);
     expect(run.runId).toBe("run-capped");
     expect(typeof run.completion?.resultText).toBe("string");
     expect(run.completion?.resultText).toContain(
       "[truncated: frozen completion output exceeded 100KB",
+    );
+    expect(Buffer.byteLength(run.completion?.resultText ?? "", "utf8")).toBeLessThanOrEqual(
+      100 * 1024,
     );
     expect(run.completion?.capturedAt).toBeTypeOf("number");
   });
@@ -823,7 +879,11 @@ describe("subagent registry lifecycle error grace", () => {
     expect(getAgentCalls()).toHaveLength(0);
 
     // Before the grace window, the run successfully ends (non-aborted)
-    emitLifecycleEvent("run-timeout-cancel", { phase: "end", endedAt: 4_500 });
+    emitLifecycleEvent("run-timeout-cancel", {
+      phase: "end",
+      endedAt: 4_500,
+      terminalReply: { disposition: "visible", text: "Final answer after recovery" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(1);
@@ -857,8 +917,16 @@ describe("subagent registry lifecycle error grace", () => {
     agentCallPlan = ["throw", "throw", "ok", "ok"];
 
     const parallelEndedAt = Date.now();
-    emitLifecycleEvent("run-parallel-a", { phase: "end", endedAt: parallelEndedAt });
-    emitLifecycleEvent("run-parallel-b", { phase: "end", endedAt: parallelEndedAt + 1 });
+    emitLifecycleEvent("run-parallel-a", {
+      phase: "end",
+      endedAt: parallelEndedAt,
+      terminalReply: { disposition: "visible", text: "Final answer A" },
+    });
+    emitLifecycleEvent("run-parallel-b", {
+      phase: "end",
+      endedAt: parallelEndedAt + 1,
+      terminalReply: { disposition: "visible", text: "Final answer B" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(2);
@@ -868,8 +936,16 @@ describe("subagent registry lifecycle error grace", () => {
     setAssistantOutput("agent:main:subagent:parallel-a", "Late overwrite");
     setAssistantOutput("agent:main:subagent:parallel-b", "Late overwrite");
 
-    emitLifecycleEvent("run-parallel-a", { phase: "end", endedAt: parallelEndedAt + 100 });
-    emitLifecycleEvent("run-parallel-b", { phase: "end", endedAt: parallelEndedAt + 101 });
+    emitLifecycleEvent("run-parallel-a", {
+      phase: "end",
+      endedAt: parallelEndedAt + 100,
+      terminalReply: { disposition: "visible", text: "Final answer A" },
+    });
+    emitLifecycleEvent("run-parallel-b", {
+      phase: "end",
+      endedAt: parallelEndedAt + 101,
+      terminalReply: { disposition: "visible", text: "Final answer B" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(4);


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the Gateway shard's lifecycle-retry fixtures still modeled required subagent completions without producer-owned terminal replies.

## Why This Change Was Made

Required-success events now carry the terminal reply owned by the producer, retry synchronization waits for the durable pending delivery payload, and the transcript-cap case is explicitly modeled as an optional completion-message fallback. Production behavior and refresh expectations are unchanged.

## User Impact

No runtime behavior changes. Maintainers get an accurate Gateway release-validation signal instead of fixture failures caused by the newer terminal-reply contract.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts` - 12/12 passed on rebased head.
- Historical shard order: `subagent-announce.format.e2e.test.ts`, `gateway.test.ts`, then `subagent-registry.lifecycle-retry-grace.e2e.test.ts` - 109/109 passed.
- `git diff --check` passed.
- `node scripts/check-changed.mjs -- src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts` passed all guards through the core-test typecheck; that lane then hit an unrelated isolated-install baseline error because `ui/vite.config.ts` could not resolve declarations for existing dependency `pako`.
