### PR TITLE
fix(qa): pin Slack draft progress transport

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.config.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.config.ts
@@ -292,7 +292,14 @@ export function buildSlackQaConfig(
                 ? {
                     streaming: {
                       mode: "progress" as const,
+                      // These scenarios assert the portable draft compositor and
+                      // chat.update identity. Native task streams have their own
+                      // transport proof and do not expose that draft contract.
+                      nativeTransport: false,
                       progress: {
+                        // The per-run command marker is the tool-line correlation
+                        // key; the product default intentionally hides raw commands.
+                        commandText: "raw" as const,
                         label: false,
                         maxLines: 4,
                         toolProgress: progressOverrides.toolProgress,

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -596,12 +596,18 @@ describe("Slack live QA runtime helpers", () => {
 
     expect(progressConfig("slack-progress-commentary-true")).toMatchObject({
       commentary: true,
+      commandText: "raw",
       toolProgress: false,
     });
     expect(progressConfig("slack-progress-commentary-false")).toMatchObject({
       commentary: false,
+      commandText: "raw",
       toolProgress: false,
     });
+    expect(
+      buildScenarioConfig("slack-progress-commentary-true").channels?.slack?.accounts?.sut
+        ?.streaming?.nativeTransport,
+    ).toBe(false);
     expect(
       buildScenarioConfig("slack-progress-commentary-false").agents?.defaults?.verboseDefault,
     ).toBe("off");


### PR DESCRIPTION
## Summary

- pin Slack commentary-progress QA scenarios to the portable draft transport they assert
- opt the QA marker command into raw command rendering so its per-run correlation token remains observable
- cover both transport and command-rendering choices in the scenario config test

## Root cause

The scenarios verify a single editable `chat.postMessage` / `chat.update` draft identity. Slack progress now defaults to native task streaming, which is a different delivery contract. Separately, command progress now safely defaults to status-only text, so the unique marker embedded in the QA command was intentionally absent. The verifier consequently rejected correct native/status-only behavior as missing portable draft progress.

This keeps the product defaults intact and makes the portable-compositor scenarios select the transport and visibility contract they actually test. Native progress transport remains covered by its dedicated Slack trace/runtime tests.

## Verification

- `pnpm exec vitest run extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` (50 passed)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, 0 actionable findings)
- `git diff --check`

## LOC

- QA harness/config: +7/-0
- tests: +6/-0
- production runtime: +0/-0
