### PR TITLE
fix(qa): label execution configuration selects

### DIFF
--- a/extensions/qa-lab/web/src/app.browser.test.ts
+++ b/extensions/qa-lab/web/src/app.browser.test.ts
@@ -205,6 +205,38 @@ afterEach(() => {
 });
 
 describe("QA Lab runner browser interactions", () => {
+  it("labels every execution configuration select", async () => {
+    const root = await mountRunner({
+      alternateModel: "mock-openai/gpt-5.6-luna-alt",
+      channel: null,
+      channelDriver: "qa-channel",
+      evidenceMode: "full",
+      fastMode: false,
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      profile: "all",
+      providerMode: "mock-openai",
+      runtimePair: null,
+      runtimePairLane: null,
+      scenarioIds: ["dm-chat-baseline"],
+    });
+
+    root.querySelector<HTMLButtonElement>("[data-sidebar-panel='config']")?.click();
+    const selects = [...root.querySelectorAll<HTMLSelectElement>(".config-field select")];
+
+    expect(selects).toHaveLength(9);
+    expect(selects.map((select) => select.labels?.[0]?.textContent?.trim())).toEqual([
+      "Profile",
+      "Provider lane",
+      "Channel driver",
+      "Execution channel",
+      "Evidence mode",
+      "Runtime pair",
+      "Runtime-pair lane",
+      "Primary model",
+      "Alternate model",
+    ]);
+  });
+
   it("sends group conversation messages from the interactive chat composer", async () => {
     const root = await mountRunner(
       {

--- a/extensions/qa-lab/web/src/ui-render-shell.ts
+++ b/extensions/qa-lab/web/src/ui-render-shell.ts
@@ -72,7 +72,7 @@ function renderModelSelect(params: {
   }
   return `
     <div class="config-field">
-      <span class="config-label">${esc(params.label)}</span>
+      <label class="config-label" for="${esc(params.id)}">${esc(params.label)}</label>
       <select id="${esc(params.id)}"${params.disabled ? " disabled" : ""}>
         ${options
           .map(
@@ -117,7 +117,7 @@ export function renderSidebar(state: UiState): string {
           ? `<div class="sidebar-section sidebar-panel-body">
               <div class="sidebar-section-title"><h3>Configuration</h3></div>
               <div class="config-field">
-                <span class="config-label">Profile</span>
+                <label class="config-label" for="run-profile">Profile</label>
                 <select id="run-profile"${isRunning ? " disabled" : ""}>
                   ${profiles
                     .map(
@@ -128,14 +128,14 @@ export function renderSidebar(state: UiState): string {
                 </select>
               </div>
               <div class="config-field">
-                <span class="config-label">Provider lane</span>
+                <label class="config-label" for="provider-mode">Provider lane</label>
                 <select id="provider-mode"${isRunning ? " disabled" : ""}>
                   <option value="mock-openai"${selection?.providerMode === "mock-openai" ? " selected" : ""}>Synthetic (mock)</option>
                   <option value="live-frontier"${selection?.providerMode === "live-frontier" ? " selected" : ""}>Real frontier providers</option>
                 </select>
               </div>
               <div class="config-field">
-                <span class="config-label">Channel driver</span>
+                <label class="config-label" for="channel-driver">Channel driver</label>
                 <select id="channel-driver"${isRunning ? " disabled" : ""}>
                   <option value="qa-channel"${selection?.channelDriver === "qa-channel" ? " selected" : ""}>Synthetic QA channel</option>
                   <option value="crabline"${selection?.channelDriver === "crabline" ? " selected" : ""}>Crabline channel driver</option>
@@ -143,7 +143,7 @@ export function renderSidebar(state: UiState): string {
                 </select>
               </div>
               <div class="config-field">
-                <span class="config-label">Execution channel</span>
+                <label class="config-label" for="execution-channel">Execution channel</label>
                 <select id="execution-channel"${isRunning ? " disabled" : ""}>
                   <option value=""${selection?.channel ? "" : " selected"}>Catalog/default</option>
                   ${channels
@@ -155,21 +155,21 @@ export function renderSidebar(state: UiState): string {
                 </select>
               </div>
               <div class="config-field">
-                <span class="config-label">Evidence mode</span>
+                <label class="config-label" for="evidence-mode">Evidence mode</label>
                 <select id="evidence-mode"${isRunning ? " disabled" : ""}>
                   <option value="full"${selection?.evidenceMode === "full" ? " selected" : ""}>Full</option>
                   <option value="slim"${selection?.evidenceMode === "slim" ? " selected" : ""}>Slim</option>
                 </select>
               </div>
               <div class="config-field">
-                <span class="config-label">Runtime pair</span>
+                <label class="config-label" for="runtime-pair">Runtime pair</label>
                 <select id="runtime-pair"${isRunning ? " disabled" : ""}>
                   <option value=""${selection?.runtimePair ? "" : " selected"}>Single runtime</option>
                   <option value="openclaw,codex"${selection?.runtimePair ? " selected" : ""}>OpenClaw × Codex</option>
                 </select>
               </div>
               <div class="config-field">
-                <span class="config-label">Runtime-pair lane</span>
+                <label class="config-label" for="runtime-pair-lane">Runtime-pair lane</label>
                 <select id="runtime-pair-lane"${isRunning ? " disabled" : ""}>
                   <option value=""${selection?.runtimePairLane ? "" : " selected"}>Profile/default</option>
                   ${(["core", "extended", "soak"] as const)


### PR DESCRIPTION
## What Problem This Solves

QA Lab’s nine execution-critical Configuration selects displayed label text but exposed no accessible names. Screen-reader and voice-control users encountered nine anonymous comboboxes for Profile, provider/channel routing, evidence/runtime selection, and primary/alternate models.

## Why This Change Was Made

The canonical sidebar renderer emitted each visible label as an unrelated `<span>`. This replaces those spans with native `<label for="…">` elements for all seven directly rendered selects and the shared model-select renderer used by the remaining two. Existing IDs, classes, options, and event handling remain unchanged.

Production LOC: +8/-8 (net 0) | Tests: +32/-0

## User Impact

Every execution Configuration select now exposes the visible field label as its accessible name. Clicking labels and assistive-technology navigation work through the browser’s native label association, with no visual or selection-behavior change.

## Evidence

Authentic pre-fix proof used the real source renderer in Chromium. After opening Config, all nine controls appeared as anonymous `combobox` nodes. The regression test failed with nine `undefined` native label associations.

On final rebased head `831ac3880ec9327232903e74180d6320e97344c1`:

- the same source-Chromium AX snapshot reports the exact names `Profile`, `Provider lane`, `Channel driver`, `Execution channel`, `Evidence mode`, `Runtime pair`, `Runtime-pair lane`, `Primary model`, and `Alternate model`;
- an in-page DOM check confirms all nine `select.labels[0]` values and reported zero page errors;
- 35/35 QA Lab web owner tests passed;
- every changed-file format, typecheck, lint, dead-code, and guard command passed (the final sidecar guard was rerun after supplying the worktree-local dependency link its first environment-only attempt lacked);
- the rebase onto current `origin/main` was patch-identical (`4eb737a49d5cd0b1594abdf3d4cf1f173eb961ce`);
- fresh final Codex autoreview found no accepted/actionable finding and rated the patch correct at 0.99 confidence;
- four live open issue/PR search variants found no exact duplicate.

The inspected Chromium screenshot shows all nine visible labels and selects with no clipping, overlap, error overlay, or layout regression:

![QA Lab Configuration sidebar with nine labeled selects](https://ampcode.com/user-content/artifacts/f04519b5e8acaf0713ddd0cbf09743db3f606b2d757d35e88b9044f6151b5fb2-file.png)

`pnpm qa:lab:build` currently fails unchanged on both current main and this branch because the existing Vite config does not resolve the separately introduced `openclaw/plugin-sdk/time-runtime` import. That independent baseline build defect is not masked or modified here.

AI-assisted implementation and verification; no agent transcript is attached.
