### PR TITLE
fix(qa): retain Slack presentation history

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/scenario-runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-runtime.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runSlackScenario } from "./scenario-runtime.js";
 import type { SlackQaScenarioImplementation, SlackQaScenarioRun } from "./slack-live.contracts.js";
-import { slackQaMpimAppMentionDedupeScenario } from "./slack-live.scenario-implementations.js";
+import {
+  slackQaMpimAppMentionDedupeScenario,
+  slackQaTablePresentationNativeScenario,
+} from "./slack-live.scenario-implementations.js";
 
 const { runSlackApprovalScenario, runSlackCodexApprovalScenario } = vi.hoisted(() => ({
   runSlackApprovalScenario: vi.fn(),
@@ -122,6 +125,59 @@ describe("Slack scenario runtime capture merge", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  it("captures the native table write before waiting for its final reply", async () => {
+    const builtRun = slackQaTablePresentationNativeScenario.buildRun("U_SUT");
+    if (
+      builtRun.kind === "approval" ||
+      builtRun.kind === "codex-approval" ||
+      builtRun.kind === "direct-transport"
+    ) {
+      throw new Error("expected Slack native table message scenario");
+    }
+    const summaryText = builtRun.input.match(/SLACK_QA_TABLE_SUMMARY_[A-Z0-9]+/u)?.[0];
+    const finalMarker = builtRun.matchText;
+    if (!summaryText) {
+      throw new Error("missing Slack native table summary marker");
+    }
+    const readMessageWrites = vi
+      .fn()
+      .mockResolvedValue([{ channelId: "C_TABLE", text: summaryText, ts: "2.000000" }]);
+    const history = vi.fn().mockResolvedValue({
+      messages: [{ bot_id: "B_SUT", text: finalMarker, ts: "3.000000", user: "U_SUT" }],
+    });
+    const run = { ...builtRun, afterReply: undefined };
+    const environment = {
+      channelId: "C_TABLE",
+      configureScenario: vi.fn().mockResolvedValue({
+        cfg: {},
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        run,
+      }),
+      context: {
+        driverClient: {
+          chat: {
+            postMessage: vi.fn().mockResolvedValue({ channel: "C_TABLE", ts: "1.000000" }),
+          },
+        },
+        sutReadClient: { conversations: { history } },
+      },
+      getMessageWriteCursor: () => 0,
+      observedMessages: [],
+      readMessageWrites,
+      scenario: { id: "slack-table-presentation-native", timeoutMs: 1_000, title: "table" },
+      sutIdentity: { botId: "B_SUT", userId: "U_SUT" },
+    };
+
+    await expect(
+      runSlackScenario(environment as never, slackQaTablePresentationNativeScenario),
+    ).resolves.toEqual(
+      expect.objectContaining({ details: expect.stringContaining("reply matched") }),
+    );
+    expect(readMessageWrites.mock.invocationCallOrder[0]).toBeLessThan(
+      history.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it("returns structured RTT evidence for a matched reply", async () => {

--- a/extensions/qa-lab/src/live-transports/slack/scenario-runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-runtime.ts
@@ -1,8 +1,10 @@
+import { setTimeout as sleep } from "node:timers/promises";
 import type { SlackQaScenarioEnvironment } from "./scenario-environment.js";
 import { runSlackApprovalScenario } from "./slack-live.approvals.js";
 import { runSlackCodexApprovalScenario } from "./slack-live.codex-approval-runner.js";
 import type {
   SlackQaMessageScenarioRun,
+  SlackObservedMessage,
   SlackQaScenarioImplementation,
 } from "./slack-live.contracts.js";
 import {
@@ -15,6 +17,31 @@ import {
   collectSlackBlockText,
   sendSlackChannelMessage,
 } from "./slack-live.observations.js";
+
+async function waitForSlackPreReplyCapture(params: {
+  capture: NonNullable<SlackQaMessageScenarioRun["captureBeforeReply"]>;
+  channelId: string;
+  readMessages: () => Promise<SlackObservedMessage[]>;
+  scenarioId: string;
+  timeoutMs: number;
+}) {
+  const deadline = Date.now() + params.timeoutMs;
+  while (true) {
+    const messages = (await params.readMessages()).filter(
+      (message) => message.channelId === params.channelId,
+    );
+    if (params.capture(messages)) {
+      return;
+    }
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error(
+        `timed out after ${params.timeoutMs}ms waiting for ${params.scenarioId} write capture`,
+      );
+    }
+    await sleep(Math.min(25, remainingMs));
+  }
+}
 
 export {
   slackQaAllowlistBlockScenario,
@@ -85,6 +112,17 @@ async function runSlackMessageScenario(params: {
       return {
         details: ["no reply", beforeRunDetails, afterNoReplyDetails].filter(Boolean).join("; "),
       };
+    }
+    if (params.run.captureBeforeReply) {
+      // Native presentation identity belongs to the successful write capture. Resolve it
+      // before shared channel history can evict the earlier message while awaiting the final reply.
+      await waitForSlackPreReplyCapture({
+        capture: params.run.captureBeforeReply,
+        channelId,
+        readMessages: () => params.environment.readMessageWrites(messageWriteCursor),
+        scenarioId: params.scenarioId,
+        timeoutMs: params.timeoutMs,
+      });
     }
     const reply = await waitForSlackScenarioReply({
       channelId,

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
@@ -118,6 +118,7 @@ export function assertSlackCodexApprovalModelSupported(modelRef: string) {
 
 export type SlackQaMessageScenarioRun = {
   afterNoReply?: (context: SlackQaScenarioContext) => Promise<string | void>;
+  captureBeforeReply?: (messages: readonly SlackObservedMessage[]) => boolean;
   cleanup?: (context: Omit<SlackQaScenarioContext, "sentTs">) => Promise<void>;
   kind?: "message";
   expectReply: boolean;

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
@@ -330,6 +330,11 @@ export type SlackMessage = Omit<z.infer<typeof slackHistoryMessageSchema>, "ts">
 export const slackHistorySchema = z.object({
   ok: z.boolean().optional(),
   messages: z.array(slackHistoryMessageSchema).optional(),
+  response_metadata: z
+    .object({
+      next_cursor: z.string().optional(),
+    })
+    .optional(),
 });
 
 export const slackRepliesSchema = z.object({

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
@@ -330,11 +330,6 @@ export type SlackMessage = Omit<z.infer<typeof slackHistoryMessageSchema>, "ts">
 export const slackHistorySchema = z.object({
   ok: z.boolean().optional(),
   messages: z.array(slackHistoryMessageSchema).optional(),
-  response_metadata: z
-    .object({
-      next_cursor: z.string().optional(),
-    })
-    .optional(),
 });
 
 export const slackRepliesSchema = z.object({

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
@@ -26,6 +26,10 @@ import {
 } from "./slack-live.contracts.js";
 import { buildSlackInvalidBlocksTableProbe } from "./slack-live.invalid-blocks.js";
 
+// Isolated Slack flows share one live QA channel. Presentation sends precede
+// their final markers, so retain enough history to survive concurrent traffic.
+const SLACK_QA_CHANNEL_HISTORY_LIMIT = 200;
+
 export async function getSlackIdentity(token: string): Promise<SlackAuthIdentity> {
   const client = createSlackWebClient(token, { timeout: SLACK_QA_WEB_API_TIMEOUT_MS });
   const auth = slackAuthTestSchema.parse(await client.auth.test());
@@ -70,7 +74,7 @@ export async function listSlackMessages(params: {
     await params.client.conversations.history({
       channel: params.channelId,
       inclusive: true,
-      limit: 50,
+      limit: SLACK_QA_CHANNEL_HISTORY_LIMIT,
       oldest: params.oldestTs,
     }),
   );

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
@@ -26,6 +26,10 @@ import {
 import { buildSlackInvalidBlocksTableProbe } from "./slack-live.invalid-blocks.js";
 import { loadSlackQaRuntime } from "./slack-plugin.runtime.js";
 
+// Isolated Slack flows share one live QA channel. Presentation sends precede
+// their final markers, so retain enough history to survive concurrent traffic.
+const SLACK_QA_CHANNEL_HISTORY_LIMIT = 200;
+
 export async function getSlackIdentity(token: string): Promise<SlackAuthIdentity> {
   const { createSlackWebClient } = loadSlackQaRuntime();
   const client = createSlackWebClient(token, { timeout: SLACK_QA_WEB_API_TIMEOUT_MS });
@@ -71,7 +75,7 @@ export async function listSlackMessages(params: {
     await params.client.conversations.history({
       channel: params.channelId,
       inclusive: true,
-      limit: 50,
+      limit: SLACK_QA_CHANNEL_HISTORY_LIMIT,
       oldest: params.oldestTs,
     }),
   );

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
@@ -26,10 +26,7 @@ import {
 import { buildSlackInvalidBlocksTableProbe } from "./slack-live.invalid-blocks.js";
 import { loadSlackQaRuntime } from "./slack-plugin.runtime.js";
 
-// Isolated flows share one channel, so presentation sends can move across pages
-// before their final markers arrive. Cap traversal to bound each polling pass.
-const SLACK_QA_CHANNEL_HISTORY_PAGE_LIMIT = 200;
-const SLACK_QA_CHANNEL_HISTORY_MAX_PAGES = 5;
+const SLACK_QA_CHANNEL_HISTORY_LIMIT = 50;
 
 export async function getSlackIdentity(token: string): Promise<SlackAuthIdentity> {
   const { createSlackWebClient } = loadSlackQaRuntime();
@@ -72,25 +69,15 @@ export async function listSlackMessages(params: {
   client: WebClient;
   oldestTs: string;
 }) {
-  const messages: NonNullable<ReturnType<typeof slackHistorySchema.parse>["messages"]> = [];
-  let cursor: string | undefined;
-  for (let page = 0; page < SLACK_QA_CHANNEL_HISTORY_MAX_PAGES; page += 1) {
-    const history = slackHistorySchema.parse(
-      await params.client.conversations.history({
-        ...(cursor ? { cursor } : {}),
-        channel: params.channelId,
-        inclusive: true,
-        limit: SLACK_QA_CHANNEL_HISTORY_PAGE_LIMIT,
-        oldest: params.oldestTs,
-      }),
-    );
-    messages.push(...(history.messages ?? []));
-    cursor = history.response_metadata?.next_cursor?.trim() || undefined;
-    if (!cursor) {
-      break;
-    }
-  }
-  return messages;
+  const history = slackHistorySchema.parse(
+    await params.client.conversations.history({
+      channel: params.channelId,
+      inclusive: true,
+      limit: SLACK_QA_CHANNEL_HISTORY_LIMIT,
+      oldest: params.oldestTs,
+    }),
+  );
+  return history.messages ?? [];
 }
 
 export async function listSlackThreadMessages(params: {
@@ -269,20 +256,26 @@ export async function waitForSlackStoredMessage(params: {
   client: WebClient;
   description: string;
   matchesMessage: (message: SlackMessage) => boolean;
-  oldestTs: string;
+  messageId: string;
   sutIdentity: SlackAuthIdentity;
   timeoutMs: number;
 }) {
   const startedAt = Date.now();
   while (true) {
-    const messages = await listSlackMessages({
-      channelId: params.channelId,
-      client: params.client,
-      oldestTs: params.oldestTs,
-    });
+    // The capture owner supplies the successful post timestamp. Querying that exact
+    // boundary keeps concurrent shared-channel traffic from evicting the evidence.
+    const history = slackHistorySchema.parse(
+      await params.client.conversations.history({
+        channel: params.channelId,
+        inclusive: true,
+        latest: params.messageId,
+        limit: 1,
+      }),
+    );
+    const messages = history.messages ?? [];
     const message = messages.find(
       (entry) =>
-        entry.ts !== params.oldestTs &&
+        entry.ts === params.messageId &&
         isSutSlackMessage(entry, params.sutIdentity) &&
         params.matchesMessage(entry),
     );

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
@@ -72,7 +72,7 @@ export async function listSlackMessages(params: {
   client: WebClient;
   oldestTs: string;
 }) {
-  const messages: SlackMessage[] = [];
+  const messages: NonNullable<ReturnType<typeof slackHistorySchema.parse>["messages"]> = [];
   let cursor: string | undefined;
   for (let page = 0; page < SLACK_QA_CHANNEL_HISTORY_MAX_PAGES; page += 1) {
     const history = slackHistorySchema.parse(

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.observations.ts
@@ -26,9 +26,10 @@ import {
 import { buildSlackInvalidBlocksTableProbe } from "./slack-live.invalid-blocks.js";
 import { loadSlackQaRuntime } from "./slack-plugin.runtime.js";
 
-// Isolated Slack flows share one live QA channel. Presentation sends precede
-// their final markers, so retain enough history to survive concurrent traffic.
-const SLACK_QA_CHANNEL_HISTORY_LIMIT = 200;
+// Isolated flows share one channel, so presentation sends can move across pages
+// before their final markers arrive. Cap traversal to bound each polling pass.
+const SLACK_QA_CHANNEL_HISTORY_PAGE_LIMIT = 200;
+const SLACK_QA_CHANNEL_HISTORY_MAX_PAGES = 5;
 
 export async function getSlackIdentity(token: string): Promise<SlackAuthIdentity> {
   const { createSlackWebClient } = loadSlackQaRuntime();
@@ -71,15 +72,25 @@ export async function listSlackMessages(params: {
   client: WebClient;
   oldestTs: string;
 }) {
-  const history = slackHistorySchema.parse(
-    await params.client.conversations.history({
-      channel: params.channelId,
-      inclusive: true,
-      limit: SLACK_QA_CHANNEL_HISTORY_LIMIT,
-      oldest: params.oldestTs,
-    }),
-  );
-  return history.messages ?? [];
+  const messages: SlackMessage[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < SLACK_QA_CHANNEL_HISTORY_MAX_PAGES; page += 1) {
+    const history = slackHistorySchema.parse(
+      await params.client.conversations.history({
+        ...(cursor ? { cursor } : {}),
+        channel: params.channelId,
+        inclusive: true,
+        limit: SLACK_QA_CHANNEL_HISTORY_PAGE_LIMIT,
+        oldest: params.oldestTs,
+      }),
+    );
+    messages.push(...(history.messages ?? []));
+    cursor = history.response_metadata?.next_cursor?.trim() || undefined;
+    if (!cursor) {
+      break;
+    }
+  }
+  return messages;
 }
 
 export async function listSlackThreadMessages(params: {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -993,38 +993,43 @@ describe("Slack live QA runtime helpers", () => {
       throw new Error("missing Slack chart scenario verifier");
     }
     const accessibleText = renderExpectedSlackChartAccessibleText(summaryText);
-    const history = vi.fn(async () => ({
-      messages: [
-        {
-          blocks: [
-            {
-              type: "data_visualization",
-              title: "QA latency trend",
-              chart: {
-                type: "line",
-                series: [
+    const history = vi.fn(async (request: { limit: number }) => ({
+      // Shared-channel concurrency can push the earlier chart beyond the old
+      // 50-message observation window before the final marker arrives.
+      messages:
+        request.limit >= 200
+          ? [
+              {
+                blocks: [
                   {
-                    name: "Latency",
-                    data: [
-                      { label: "P50", value: 120 },
-                      { label: "P95", value: 240 },
-                    ],
+                    type: "data_visualization",
+                    title: "QA latency trend",
+                    chart: {
+                      type: "line",
+                      series: [
+                        {
+                          name: "Latency",
+                          data: [
+                            { label: "P50", value: 120 },
+                            { label: "P95", value: 240 },
+                          ],
+                        },
+                      ],
+                      axis_config: {
+                        categories: ["P50", "P95"],
+                        x_label: "Percentile",
+                        y_label: "Milliseconds",
+                      },
+                    },
                   },
                 ],
-                axis_config: {
-                  categories: ["P50", "P95"],
-                  x_label: "Percentile",
-                  y_label: "Milliseconds",
-                },
+                // Slack history flattens the top-level accessibility newlines on readback.
+                text: accessibleText.replace(/\s+/gu, " "),
+                ts: "2.000000",
+                user: "U999999999",
               },
-            },
-          ],
-          // Slack history flattens the top-level accessibility newlines on readback.
-          text: accessibleText.replace(/\s+/gu, " "),
-          ts: "2.000000",
-          user: "U999999999",
-        },
-      ],
+            ]
+          : [],
     }));
 
     await expect(
@@ -1041,7 +1046,7 @@ describe("Slack live QA runtime helpers", () => {
     expect(history).toHaveBeenCalledWith({
       channel: "C123456789",
       inclusive: true,
-      limit: 50,
+      limit: 200,
       oldest: "1.000000",
     });
   });

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -1322,12 +1322,10 @@ describe("Slack live QA runtime helpers", () => {
       throw new Error("missing Slack chart scenario verifier");
     }
     const accessibleText = renderExpectedSlackChartAccessibleText(summaryText);
-    const history = vi.fn(async (request: { limit: number }) => ({
-      // Shared-channel concurrency can push the earlier chart beyond the old
-      // 50-message observation window before the final marker arrives.
-      messages:
-        request.limit >= 200
-          ? [
+    const history = vi.fn(async (request: { cursor?: string }) =>
+      request.cursor === "page-2"
+        ? {
+            messages: [
               {
                 blocks: [
                   {
@@ -1357,9 +1355,13 @@ describe("Slack live QA runtime helpers", () => {
                 ts: "2.000000",
                 user: "U999999999",
               },
-            ]
-          : [],
-    }));
+            ],
+          }
+        : {
+            messages: [],
+            response_metadata: { next_cursor: "page-2" },
+          },
+    );
 
     await expect(
       afterReply(
@@ -1372,8 +1374,15 @@ describe("Slack live QA runtime helpers", () => {
         } as never,
       ),
     ).resolves.toBe("verified native data_visualization block and deterministic accessible text");
-    expect(history).toHaveBeenCalledWith({
+    expect(history).toHaveBeenNthCalledWith(1, {
       channel: "C123456789",
+      inclusive: true,
+      limit: 200,
+      oldest: "1.000000",
+    });
+    expect(history).toHaveBeenNthCalledWith(2, {
+      channel: "C123456789",
+      cursor: "page-2",
       inclusive: true,
       limit: 200,
       oldest: "1.000000",

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -29,7 +29,6 @@ import {
   buildSlackApprovalCheckpointMessage,
   collectSlackActionValues,
   extractSlackNativeApprovalId,
-  listSlackMessages,
   runSlackTableInvalidBlocksFallbackScenario,
 } from "./slack-live.observations.js";
 import * as slackScenarioImplementations from "./slack-live.scenario-implementations.js";
@@ -127,32 +126,6 @@ describe("Slack live QA runtime helpers", () => {
     expect(testing.resolveSlackRateLimitDelayMs({ retryAfter: 10 })).toBe(10_000);
     expect(testing.resolveSlackRateLimitDelayMs({ retryAfter: 0 })).toBeUndefined();
     expect(testing.resolveSlackRateLimitDelayMs(new Error("network failed"))).toBeUndefined();
-  });
-
-  it("bounds paginated history work and surfaces Slack rate limits for poller backoff", async () => {
-    const history = vi
-      .fn()
-      .mockResolvedValueOnce({ messages: [], response_metadata: { next_cursor: "page-2" } })
-      .mockResolvedValueOnce({ messages: [], response_metadata: { next_cursor: "page-3" } })
-      .mockRejectedValueOnce({ retryAfter: 10 });
-
-    await expect(
-      listSlackMessages({
-        channelId: "C123456789",
-        client: { conversations: { history } } as never,
-        oldestTs: "1.000000",
-      }),
-    ).rejects.toEqual({ retryAfter: 10 });
-    expect(history).toHaveBeenCalledTimes(3);
-
-    history.mockReset();
-    history.mockResolvedValue({ messages: [], response_metadata: { next_cursor: "more" } });
-    await listSlackMessages({
-      channelId: "C123456789",
-      client: { conversations: { history } } as never,
-      oldestTs: "1.000000",
-    });
-    expect(history).toHaveBeenCalledTimes(5);
   });
 
   beforeEach(() => {
@@ -1349,46 +1322,43 @@ describe("Slack live QA runtime helpers", () => {
       throw new Error("missing Slack chart scenario verifier");
     }
     const accessibleText = renderExpectedSlackChartAccessibleText(summaryText);
-    const history = vi.fn(async (request: { cursor?: string }) =>
-      request.cursor === "page-2"
-        ? {
-            messages: [
-              {
-                blocks: [
+    const history = vi.fn(async () => ({
+      messages: [
+        {
+          blocks: [
+            {
+              type: "data_visualization",
+              title: "QA latency trend",
+              chart: {
+                type: "line",
+                series: [
                   {
-                    type: "data_visualization",
-                    title: "QA latency trend",
-                    chart: {
-                      type: "line",
-                      series: [
-                        {
-                          name: "Latency",
-                          data: [
-                            { label: "P50", value: 120 },
-                            { label: "P95", value: 240 },
-                          ],
-                        },
-                      ],
-                      axis_config: {
-                        categories: ["P50", "P95"],
-                        x_label: "Percentile",
-                        y_label: "Milliseconds",
-                      },
-                    },
+                    name: "Latency",
+                    data: [
+                      { label: "P50", value: 120 },
+                      { label: "P95", value: 240 },
+                    ],
                   },
                 ],
-                // Slack history flattens the top-level accessibility newlines on readback.
-                text: accessibleText.replace(/\s+/gu, " "),
-                ts: "2.000000",
-                user: "U999999999",
+                axis_config: {
+                  categories: ["P50", "P95"],
+                  x_label: "Percentile",
+                  y_label: "Milliseconds",
+                },
               },
-            ],
-          }
-        : {
-            messages: [],
-            response_metadata: { next_cursor: "page-2" },
-          },
-    );
+            },
+          ],
+          // Slack history flattens the top-level accessibility newlines on readback.
+          text: accessibleText.replace(/\s+/gu, " "),
+          ts: "2.000000",
+          user: "U999999999",
+        },
+      ],
+    }));
+    run.verifyObserved?.({
+      finalMessage: {} as never,
+      messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
+    });
 
     await expect(
       afterReply(
@@ -1401,18 +1371,12 @@ describe("Slack live QA runtime helpers", () => {
         } as never,
       ),
     ).resolves.toBe("verified native data_visualization block and deterministic accessible text");
-    expect(history).toHaveBeenNthCalledWith(1, {
+    expect(history).toHaveBeenCalledOnce();
+    expect(history).toHaveBeenCalledWith({
       channel: "C123456789",
       inclusive: true,
-      limit: 200,
-      oldest: "1.000000",
-    });
-    expect(history).toHaveBeenNthCalledWith(2, {
-      channel: "C123456789",
-      cursor: "page-2",
-      inclusive: true,
-      limit: 200,
-      oldest: "1.000000",
+      latest: "2.000000",
+      limit: 1,
     });
   });
 
@@ -1436,6 +1400,10 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
+    run.verifyObserved?.({
+      finalMessage: {} as never,
+      messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
+    });
     const result = expect(
       afterReply(
         {} as never,
@@ -1529,6 +1497,10 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
+    run.verifyObserved?.({
+      finalMessage: {} as never,
+      messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
+    });
 
     await expect(
       afterReply(
@@ -1541,6 +1513,13 @@ describe("Slack live QA runtime helpers", () => {
         } as never,
       ),
     ).resolves.toBe("verified native data_table block and deterministic accessible text");
+    expect(history).toHaveBeenCalledOnce();
+    expect(history).toHaveBeenCalledWith({
+      channel: "C123456789",
+      inclusive: true,
+      latest: "2.000000",
+      limit: 1,
+    });
   });
 
   it("rejects fallback-only Slack table delivery", async () => {
@@ -1562,6 +1541,10 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
+    run.verifyObserved?.({
+      finalMessage: {} as never,
+      messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
+    });
     const result = expect(
       afterReply(
         {} as never,

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -1318,8 +1318,9 @@ describe("Slack live QA runtime helpers", () => {
     const input = run && "input" in run ? run.input : "";
     const summaryText = input.match(/SLACK_QA_CHART_SUMMARY_[A-Z0-9]+/u)?.[0];
     const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
-    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
-    if (!summaryText || !afterReply || !verifyObserved) {
+    const captureBeforeReply =
+      run && "captureBeforeReply" in run ? run.captureBeforeReply : undefined;
+    if (!summaryText || !afterReply || !captureBeforeReply) {
       throw new Error("missing Slack chart scenario verifier");
     }
     const accessibleText = renderExpectedSlackChartAccessibleText(summaryText);
@@ -1356,10 +1357,9 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
-    verifyObserved({
-      finalMessage: {} as never,
-      messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
-    });
+    expect(
+      captureBeforeReply([{ channelId: "C123456789", text: summaryText, ts: "2.000000" }]),
+    ).toBe(true);
 
     await expect(
       afterReply(
@@ -1388,8 +1388,9 @@ describe("Slack live QA runtime helpers", () => {
     const input = run && "input" in run ? run.input : "";
     const summaryText = input.match(/SLACK_QA_CHART_SUMMARY_[A-Z0-9]+/u)?.[0];
     const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
-    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
-    if (!summaryText || !afterReply || !verifyObserved) {
+    const captureBeforeReply =
+      run && "captureBeforeReply" in run ? run.captureBeforeReply : undefined;
+    if (!summaryText || !afterReply || !captureBeforeReply) {
       throw new Error("missing Slack chart scenario verifier");
     }
     const accessibleText = renderExpectedSlackChartAccessibleText(summaryText);
@@ -1402,10 +1403,9 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
-    verifyObserved({
-      finalMessage: {} as never,
-      messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
-    });
+    expect(
+      captureBeforeReply([{ channelId: "C123456789", text: summaryText, ts: "2.000000" }]),
+    ).toBe(true);
     const result = expect(
       afterReply(
         {} as never,
@@ -1453,7 +1453,9 @@ describe("Slack live QA runtime helpers", () => {
         },
       }),
     );
-    expect(run && "matchText" in run ? run.matchText : "").toBe(summaryText);
+    expect(run && "matchText" in run ? run.matchText : "").toMatch(
+      /^SLACK_QA_TABLE_DONE_[A-Z0-9]+$/u,
+    );
   });
 
   it("verifies the SUT-owned native table and exact accessible top-level text", async () => {
@@ -1462,8 +1464,9 @@ describe("Slack live QA runtime helpers", () => {
     const input = run && "input" in run ? run.input : "";
     const summaryText = input.match(/SLACK_QA_TABLE_SUMMARY_[A-Z0-9]+/u)?.[0];
     const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
-    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
-    if (!summaryText || !afterReply || !verifyObserved) {
+    const captureBeforeReply =
+      run && "captureBeforeReply" in run ? run.captureBeforeReply : undefined;
+    if (!summaryText || !afterReply || !captureBeforeReply) {
       throw new Error("missing Slack table scenario verifier");
     }
     const accessibleText = renderExpectedSlackTableAccessibleText(summaryText);
@@ -1500,10 +1503,9 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
-    verifyObserved({
-      finalMessage: {} as never,
-      messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
-    });
+    expect(
+      captureBeforeReply([{ channelId: "C123456789", text: summaryText, ts: "2.000000" }]),
+    ).toBe(true);
 
     await expect(
       afterReply(
@@ -1532,8 +1534,9 @@ describe("Slack live QA runtime helpers", () => {
     const input = run && "input" in run ? run.input : "";
     const summaryText = input.match(/SLACK_QA_TABLE_SUMMARY_[A-Z0-9]+/u)?.[0];
     const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
-    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
-    if (!summaryText || !afterReply || !verifyObserved) {
+    const captureBeforeReply =
+      run && "captureBeforeReply" in run ? run.captureBeforeReply : undefined;
+    if (!summaryText || !afterReply || !captureBeforeReply) {
       throw new Error("missing Slack table scenario verifier");
     }
     const history = vi.fn(async () => ({
@@ -1545,10 +1548,9 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
-    verifyObserved({
-      finalMessage: {} as never,
-      messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
-    });
+    expect(
+      captureBeforeReply([{ channelId: "C123456789", text: summaryText, ts: "2.000000" }]),
+    ).toBe(true);
     const result = expect(
       afterReply(
         {} as never,

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -29,6 +29,7 @@ import {
   buildSlackApprovalCheckpointMessage,
   collectSlackActionValues,
   extractSlackNativeApprovalId,
+  listSlackMessages,
   runSlackTableInvalidBlocksFallbackScenario,
 } from "./slack-live.observations.js";
 import * as slackScenarioImplementations from "./slack-live.scenario-implementations.js";
@@ -126,6 +127,32 @@ describe("Slack live QA runtime helpers", () => {
     expect(testing.resolveSlackRateLimitDelayMs({ retryAfter: 10 })).toBe(10_000);
     expect(testing.resolveSlackRateLimitDelayMs({ retryAfter: 0 })).toBeUndefined();
     expect(testing.resolveSlackRateLimitDelayMs(new Error("network failed"))).toBeUndefined();
+  });
+
+  it("bounds paginated history work and surfaces Slack rate limits for poller backoff", async () => {
+    const history = vi
+      .fn()
+      .mockResolvedValueOnce({ messages: [], response_metadata: { next_cursor: "page-2" } })
+      .mockResolvedValueOnce({ messages: [], response_metadata: { next_cursor: "page-3" } })
+      .mockRejectedValueOnce({ retryAfter: 10 });
+
+    await expect(
+      listSlackMessages({
+        channelId: "C123456789",
+        client: { conversations: { history } } as never,
+        oldestTs: "1.000000",
+      }),
+    ).rejects.toEqual({ retryAfter: 10 });
+    expect(history).toHaveBeenCalledTimes(3);
+
+    history.mockReset();
+    history.mockResolvedValue({ messages: [], response_metadata: { next_cursor: "more" } });
+    await listSlackMessages({
+      channelId: "C123456789",
+      client: { conversations: { history } } as never,
+      oldestTs: "1.000000",
+    });
+    expect(history).toHaveBeenCalledTimes(5);
   });
 
   beforeEach(() => {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -1322,38 +1322,43 @@ describe("Slack live QA runtime helpers", () => {
       throw new Error("missing Slack chart scenario verifier");
     }
     const accessibleText = renderExpectedSlackChartAccessibleText(summaryText);
-    const history = vi.fn(async () => ({
-      messages: [
-        {
-          blocks: [
-            {
-              type: "data_visualization",
-              title: "QA latency trend",
-              chart: {
-                type: "line",
-                series: [
+    const history = vi.fn(async (request: { limit: number }) => ({
+      // Shared-channel concurrency can push the earlier chart beyond the old
+      // 50-message observation window before the final marker arrives.
+      messages:
+        request.limit >= 200
+          ? [
+              {
+                blocks: [
                   {
-                    name: "Latency",
-                    data: [
-                      { label: "P50", value: 120 },
-                      { label: "P95", value: 240 },
-                    ],
+                    type: "data_visualization",
+                    title: "QA latency trend",
+                    chart: {
+                      type: "line",
+                      series: [
+                        {
+                          name: "Latency",
+                          data: [
+                            { label: "P50", value: 120 },
+                            { label: "P95", value: 240 },
+                          ],
+                        },
+                      ],
+                      axis_config: {
+                        categories: ["P50", "P95"],
+                        x_label: "Percentile",
+                        y_label: "Milliseconds",
+                      },
+                    },
                   },
                 ],
-                axis_config: {
-                  categories: ["P50", "P95"],
-                  x_label: "Percentile",
-                  y_label: "Milliseconds",
-                },
+                // Slack history flattens the top-level accessibility newlines on readback.
+                text: accessibleText.replace(/\s+/gu, " "),
+                ts: "2.000000",
+                user: "U999999999",
               },
-            },
-          ],
-          // Slack history flattens the top-level accessibility newlines on readback.
-          text: accessibleText.replace(/\s+/gu, " "),
-          ts: "2.000000",
-          user: "U999999999",
-        },
-      ],
+            ]
+          : [],
     }));
 
     await expect(
@@ -1370,7 +1375,7 @@ describe("Slack live QA runtime helpers", () => {
     expect(history).toHaveBeenCalledWith({
       channel: "C123456789",
       inclusive: true,
-      limit: 50,
+      limit: 200,
       oldest: "1.000000",
     });
   });

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -1318,7 +1318,8 @@ describe("Slack live QA runtime helpers", () => {
     const input = run && "input" in run ? run.input : "";
     const summaryText = input.match(/SLACK_QA_CHART_SUMMARY_[A-Z0-9]+/u)?.[0];
     const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
-    if (!summaryText || !afterReply) {
+    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
+    if (!summaryText || !afterReply || !verifyObserved) {
       throw new Error("missing Slack chart scenario verifier");
     }
     const accessibleText = renderExpectedSlackChartAccessibleText(summaryText);
@@ -1355,7 +1356,7 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
-    run.verifyObserved?.({
+    verifyObserved({
       finalMessage: {} as never,
       messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
     });
@@ -1387,7 +1388,8 @@ describe("Slack live QA runtime helpers", () => {
     const input = run && "input" in run ? run.input : "";
     const summaryText = input.match(/SLACK_QA_CHART_SUMMARY_[A-Z0-9]+/u)?.[0];
     const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
-    if (!summaryText || !afterReply) {
+    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
+    if (!summaryText || !afterReply || !verifyObserved) {
       throw new Error("missing Slack chart scenario verifier");
     }
     const accessibleText = renderExpectedSlackChartAccessibleText(summaryText);
@@ -1400,7 +1402,7 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
-    run.verifyObserved?.({
+    verifyObserved({
       finalMessage: {} as never,
       messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
     });
@@ -1460,7 +1462,8 @@ describe("Slack live QA runtime helpers", () => {
     const input = run && "input" in run ? run.input : "";
     const summaryText = input.match(/SLACK_QA_TABLE_SUMMARY_[A-Z0-9]+/u)?.[0];
     const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
-    if (!summaryText || !afterReply) {
+    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
+    if (!summaryText || !afterReply || !verifyObserved) {
       throw new Error("missing Slack table scenario verifier");
     }
     const accessibleText = renderExpectedSlackTableAccessibleText(summaryText);
@@ -1497,7 +1500,7 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
-    run.verifyObserved?.({
+    verifyObserved({
       finalMessage: {} as never,
       messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
     });
@@ -1529,7 +1532,8 @@ describe("Slack live QA runtime helpers", () => {
     const input = run && "input" in run ? run.input : "";
     const summaryText = input.match(/SLACK_QA_TABLE_SUMMARY_[A-Z0-9]+/u)?.[0];
     const afterReply = run && "afterReply" in run ? run.afterReply : undefined;
-    if (!summaryText || !afterReply) {
+    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
+    if (!summaryText || !afterReply || !verifyObserved) {
       throw new Error("missing Slack table scenario verifier");
     }
     const history = vi.fn(async () => ({
@@ -1541,7 +1545,7 @@ describe("Slack live QA runtime helpers", () => {
         },
       ],
     }));
-    run.verifyObserved?.({
+    verifyObserved({
       finalMessage: {} as never,
       messages: [{ channelId: "C123456789", text: summaryText, ts: "2.000000" }],
     });

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
@@ -6,6 +6,7 @@ import {
   SLACK_QA_REACTION_VERIFY_TIMEOUT_MS,
   SLACK_QA_NATIVE_DATA_VERIFY_TIMEOUT_MS,
   SLACK_QA_LOG_TAIL_TIMEOUT_MS,
+  type SlackObservedMessage,
   type SlackQaScenarioImplementation,
   type SlackQaScenarioContext,
 } from "./slack-live.contracts.js";
@@ -24,6 +25,18 @@ import {
   renderSlackTableAccessibleText,
   buildSlackProgressCommentaryRun,
 } from "./slack-live.scenario-fixtures.js";
+
+function requireCapturedMessageId(params: {
+  description: string;
+  messages: readonly SlackObservedMessage[];
+  marker: string;
+}) {
+  const messageId = params.messages.find((message) => message.text.includes(params.marker))?.ts;
+  if (!messageId) {
+    throw new Error(`Slack ${params.description} write capture did not retain its message id`);
+  }
+  return messageId;
+}
 
 export const slackQaCanaryScenario: SlackQaScenarioImplementation = {
   buildRun: (sutUserId) => {
@@ -329,6 +342,7 @@ export const slackQaChartPresentationNativeScenario: SlackQaScenarioImplementati
     const summaryText = `SLACK_QA_CHART_SUMMARY_${suffix}`;
     const finalMarker = `SLACK_QA_CHART_DONE_${suffix}`;
     const messageToolArgs = buildSlackChartMessageToolArgs(summaryText);
+    let messageId: string | undefined;
     return {
       expectReply: true,
       input: [
@@ -337,14 +351,24 @@ export const slackQaChartPresentationNativeScenario: SlackQaScenarioImplementati
         `After the chart send succeeds, reply with only this exact marker: ${finalMarker}`,
       ].join(" "),
       matchText: finalMarker,
+      verifyObserved: ({ messages }) => {
+        messageId = requireCapturedMessageId({
+          description: "native chart",
+          marker: summaryText,
+          messages,
+        });
+      },
       afterReply: async (_message, context) => {
+        if (!messageId) {
+          throw new Error("Slack native chart verification did not retain its message id");
+        }
         await waitForSlackStoredMessage({
           channelId: context.channelId,
           client: context.sutReadClient,
           description: "message with native chart",
           matchesMessage: (message) =>
             isExpectedSlackNativeChartMessage(message, renderSlackChartAccessibleText(summaryText)),
-          oldestTs: context.sentTs,
+          messageId,
           sutIdentity: context.sutIdentity,
           timeoutMs: SLACK_QA_NATIVE_DATA_VERIFY_TIMEOUT_MS,
         });
@@ -360,6 +384,7 @@ export const slackQaTablePresentationNativeScenario: SlackQaScenarioImplementati
     const suffix = randomUUID().slice(0, 8).toUpperCase();
     const summaryText = `SLACK_QA_TABLE_SUMMARY_${suffix}`;
     const messageToolArgs = buildSlackTableMessageToolArgs(summaryText);
+    let messageId: string | undefined;
     return {
       expectReply: true,
       input: [
@@ -367,14 +392,24 @@ export const slackQaTablePresentationNativeScenario: SlackQaScenarioImplementati
         `Call the message tool exactly once with these exact arguments: ${JSON.stringify(messageToolArgs)}.`,
       ].join(" "),
       matchText: summaryText,
+      verifyObserved: ({ messages }) => {
+        messageId = requireCapturedMessageId({
+          description: "native table",
+          marker: summaryText,
+          messages,
+        });
+      },
       afterReply: async (_message, context) => {
+        if (!messageId) {
+          throw new Error("Slack native table verification did not retain its message id");
+        }
         await waitForSlackStoredMessage({
           channelId: context.channelId,
           client: context.sutReadClient,
           description: "message with native table",
           matchesMessage: (message) =>
             isExpectedSlackNativeTableMessage(message, renderSlackTableAccessibleText(summaryText)),
-          oldestTs: context.sentTs,
+          messageId,
           sutIdentity: context.sutIdentity,
           timeoutMs: SLACK_QA_NATIVE_DATA_VERIFY_TIMEOUT_MS,
         });

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
@@ -26,16 +26,11 @@ import {
   buildSlackProgressCommentaryRun,
 } from "./slack-live.scenario-fixtures.js";
 
-function requireCapturedMessageId(params: {
-  description: string;
+function findCapturedMessageId(params: {
   messages: readonly SlackObservedMessage[];
   marker: string;
 }) {
-  const messageId = params.messages.find((message) => message.text.includes(params.marker))?.ts;
-  if (!messageId) {
-    throw new Error(`Slack ${params.description} write capture did not retain its message id`);
-  }
-  return messageId;
+  return params.messages.find((message) => message.text.includes(params.marker))?.ts;
 }
 
 export const slackQaCanaryScenario: SlackQaScenarioImplementation = {
@@ -351,12 +346,9 @@ export const slackQaChartPresentationNativeScenario: SlackQaScenarioImplementati
         `After the chart send succeeds, reply with only this exact marker: ${finalMarker}`,
       ].join(" "),
       matchText: finalMarker,
-      verifyObserved: ({ messages }) => {
-        messageId = requireCapturedMessageId({
-          description: "native chart",
-          marker: summaryText,
-          messages,
-        });
+      captureBeforeReply: (messages) => {
+        messageId = findCapturedMessageId({ marker: summaryText, messages });
+        return messageId !== undefined;
       },
       afterReply: async (_message, context) => {
         if (!messageId) {
@@ -383,6 +375,7 @@ export const slackQaTablePresentationNativeScenario: SlackQaScenarioImplementati
   buildRun: (sutUserId) => {
     const suffix = randomUUID().slice(0, 8).toUpperCase();
     const summaryText = `SLACK_QA_TABLE_SUMMARY_${suffix}`;
+    const finalMarker = `SLACK_QA_TABLE_DONE_${suffix}`;
     const messageToolArgs = buildSlackTableMessageToolArgs(summaryText);
     let messageId: string | undefined;
     return {
@@ -390,14 +383,12 @@ export const slackQaTablePresentationNativeScenario: SlackQaScenarioImplementati
       input: [
         `<@${sutUserId}> Slack native table QA check ${summaryText}.`,
         `Call the message tool exactly once with these exact arguments: ${JSON.stringify(messageToolArgs)}.`,
+        `After the table send succeeds, reply with only this exact marker: ${finalMarker}`,
       ].join(" "),
-      matchText: summaryText,
-      verifyObserved: ({ messages }) => {
-        messageId = requireCapturedMessageId({
-          description: "native table",
-          marker: summaryText,
-          messages,
-        });
+      matchText: finalMarker,
+      captureBeforeReply: (messages) => {
+        messageId = findCapturedMessageId({ marker: summaryText, messages });
+        return messageId !== undefined;
       },
       afterReply: async (_message, context) => {
         if (!messageId) {


### PR DESCRIPTION
## What Problem This Solves

Slack native chart/table QA runs share one live channel. The native presentation is written before the scenario's final reply, but the old verifier rediscovered it through the newest 50 channel messages. Concurrent QA traffic could evict that earlier write and produce a false 15-second timeout after delivery had succeeded.

The table flow also used the native table summary itself as its reply match, so it could time out in the initial shared-history scan before the branch's exact-message verification ran.

## Why This Change Was Made

The QA capture store already owns the successful Slack write response and its exact timestamp. Chart and table scenarios now resolve that timestamp from capture before waiting for the model's separate final marker, then read back exactly that stored Slack message with `latest`, `inclusive: true`, and `limit: 1`.

This removes shared channel position from native-presentation identity. It keeps the existing observation deadline and avoids broad pagination or larger timeouts.

## User Impact

Maturity and release QA no longer report native Slack chart/table failures merely because concurrent scenarios produced newer channel traffic. Product Slack delivery behavior is unchanged; only the QA observation owner changes.

## Evidence

- Original live failure: maturity run `32501067103`; `slack-chart-presentation-native` and `slack-table-presentation-native` timed out after their tool sends succeeded.
- Exact head: `6e72372a2d72f292d0898aa67ef4007c6c37052d` rebased onto current `main` without conflicts.
- Integrated runner-order regression proves the successful native table write is captured before the final-reply history request.
- Focused Slack verification: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/scenario-runtime.test.ts extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` — 70/70 passed.
- `node scripts/check-changed.mjs -- <five changed Slack files>` — passed all selected extension/test, formatting, typecheck, lint, dependency, dead-code, boundary, and import-cycle lanes.
- Fresh P0-P2 autoreview against `origin/main` — scoped clean; patch correct (0.89 confidence).
- Exact-head credentialed Slack proof remains unavailable because `OPENCLAW_RELEASE_QA_SLACK_LIVE_CI_ENABLED=false`; no live-proof claim is made. The repair is deterministic QA-only ordering and exact-readback logic.
