### PR TITLE
fix(release): preserve validation state across reruns

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1229,7 +1229,7 @@ jobs:
           node scripts/full-release-validation-state.mjs plan
 
       - name: Upload immutable release execution plan
-        if: ${{ always() && steps.plan.outputs.sha256 != '' }}
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-execution-plan-${{ github.run_id }}
@@ -1280,7 +1280,7 @@ jobs:
           node scripts/full-release-validation-state.mjs "$FULL_RELEASE_STATE_MODE"
 
       - name: Upload release decision
-        if: always() && steps.state.outputs.state != ''
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-decision-${{ github.run_id }}-${{ github.run_attempt }}
@@ -1347,7 +1347,7 @@ jobs:
         run: *full_release_state
 
       - name: Upload diagnostic drain manifest
-        if: always() && steps.state.outputs.state != ''
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1092,6 +1092,7 @@ jobs:
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
             scripts/release-ci-summary.mjs
+            scripts/lib/full-release-validation-log-checkpoint.mjs
             scripts/lib/plain-gh.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -1228,12 +1229,13 @@ jobs:
           node scripts/full-release-validation-state.mjs plan
 
       - name: Upload immutable release execution plan
-        if: always()
+        if: ${{ always() && steps.plan.outputs.sha256 != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-execution-plan-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-execution-plan
           if-no-files-found: error
+          overwrite: true
 
   release_decision:
     name: Release Decision
@@ -1251,6 +1253,7 @@ jobs:
           sparse-checkout: |
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
+            scripts/lib/full-release-validation-log-checkpoint.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -1318,6 +1321,7 @@ jobs:
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
             scripts/release-ci-summary.mjs
+            scripts/lib/full-release-validation-log-checkpoint.mjs
             scripts/lib/plain-gh.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -1395,6 +1399,7 @@ jobs:
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
             scripts/release-ci-summary.mjs
+            scripts/lib/full-release-validation-log-checkpoint.mjs
             scripts/lib/plain-gh.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1092,16 +1092,10 @@ jobs:
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
             scripts/release-ci-summary.mjs
+            scripts/lib/full-release-validation-log-checkpoint.mjs
             scripts/lib/plain-gh.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
-
-      - name: Restore immutable release execution plan
-        if: ${{ github.run_attempt != 1 }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: full-release-execution-plan-${{ github.run_id }}
-          path: ${{ runner.temp }}/full-release-execution-plan
 
       - name: Seal immutable release execution plan
         id: plan
@@ -1226,12 +1220,13 @@ jobs:
           node scripts/full-release-validation-state.mjs plan
 
       - name: Upload immutable release execution plan
-        if: ${{ always() && github.run_attempt == 1 }}
+        if: ${{ always() && steps.plan.outputs.sha256 != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-execution-plan-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-execution-plan
           if-no-files-found: error
+          overwrite: true
 
   release_decision:
     name: Release Decision
@@ -1249,6 +1244,7 @@ jobs:
           sparse-checkout: |
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
+            scripts/lib/full-release-validation-log-checkpoint.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -1316,6 +1312,7 @@ jobs:
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
             scripts/release-ci-summary.mjs
+            scripts/lib/full-release-validation-log-checkpoint.mjs
             scripts/lib/plain-gh.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -1393,6 +1390,7 @@ jobs:
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
             scripts/release-ci-summary.mjs
+            scripts/lib/full-release-validation-log-checkpoint.mjs
             scripts/lib/plain-gh.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -474,6 +474,8 @@ jobs:
             --jq .content | base64 --decode > "${tooling_dir}/validate-full-release-validation-evidence.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/release-ci-summary.mjs?ref=${WORKFLOW_SHA}" \
             --jq .content | base64 --decode > "${tooling_dir}/release-ci-summary.mjs"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/lib/full-release-validation-log-checkpoint.mjs?ref=${WORKFLOW_SHA}" \
+            --jq .content | base64 --decode > "${tooling_dir}/lib/full-release-validation-log-checkpoint.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/lib/plain-gh.mjs?ref=${WORKFLOW_SHA}" \
             --jq .content | base64 --decode > "${tooling_dir}/lib/plain-gh.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/plugin-sdk-api-release-evidence.mjs?ref=${WORKFLOW_SHA}" \

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -16,6 +16,7 @@ import {
   formatReleaseStateOutcome,
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
+import { readFullReleaseValidationLogCheckpointFromGitHub } from "./lib/full-release-validation-log-checkpoint.mjs";
 import { execGhRead } from "./lib/plain-gh.mjs";
 
 const WORKFLOW = "full-release-validation.yml";
@@ -677,7 +678,66 @@ export function tryReadReleaseDecision(
   }
 }
 
-function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
+export function tryReadReleaseDecisionCheckpoint(
+  parentRunId: string,
+  parentRunAttempt: number,
+  workflowSha: string,
+  targetSha: string,
+  runStatusImpl: (
+    command: string,
+    args: string[],
+    options?: CommandOptions,
+  ) => CommandStatus = runStatus,
+) {
+  const read = (args: string[]) => {
+    const result = runStatusImpl("gh", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeoutMs: GH_READ_TIMEOUT_MS,
+    });
+    if (result.status !== 0) {
+      throw new Error(stringValue(result.stderr, "GitHub API read failed"));
+    }
+    return stringValue(result.stdout);
+  };
+  try {
+    const checkpoint = readFullReleaseValidationLogCheckpointFromGitHub({
+      getJobLog: (jobId) =>
+        read(["api", `repos/openclaw/openclaw/actions/jobs/${String(jobId)}/logs`]),
+      getJobs: () =>
+        JSON.parse(
+          read([
+            "api",
+            `repos/openclaw/openclaw/actions/runs/${parentRunId}/attempts/${parentRunAttempt}/jobs?per_page=100`,
+          ]),
+        ).jobs,
+      getRun: () =>
+        JSON.parse(read(["api", `repos/openclaw/openclaw/actions/runs/${parentRunId}`])),
+      kind: "decision",
+      runAttempt: parentRunAttempt,
+      runId: parentRunId,
+      targetSha,
+      workflowSha,
+    });
+    if (!checkpoint) {
+      return undefined;
+    }
+    return validateReleaseDecisionPayload(checkpoint.payload, {
+      parentRunAttempt,
+      parentRunId,
+      workflowSha,
+    });
+  } catch (error) {
+    if (classifyReleaseGhTransportError(error) === "transient") {
+      console.warn(
+        `Release Decision checkpoint unavailable this poll; retrying: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function waitForWorkflowRun(parentRunId: string, workflowSha: string, targetSha: string) {
   let lastSummary = "";
   let consecutiveErrors = 0;
   const startedAt = Date.now();
@@ -704,12 +764,19 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
       console.log(`Parent run status: ${summary}`);
       lastSummary = summary;
     }
-    if (suite) {
-      const releaseDecision = tryReadReleaseDecision(
-        parentRunId,
-        requiredPositiveInteger(suite.run_attempt, "parent run attempt"),
-        workflowSha,
-      );
+    if (suite && suite.status !== "completed") {
+      const releaseDecision =
+        tryReadReleaseDecision(
+          parentRunId,
+          requiredPositiveInteger(suite.run_attempt, "parent run attempt"),
+          workflowSha,
+        ) ??
+        tryReadReleaseDecisionCheckpoint(
+          parentRunId,
+          requiredPositiveInteger(suite.run_attempt, "parent run attempt"),
+          workflowSha,
+          targetSha,
+        );
       if (releaseDecision && releaseDecisionStopsForeground(releaseDecision.state)) {
         throw new Error(
           `${formatReleaseStateOutcome(releaseDecision)}\nhttps://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
@@ -995,7 +1062,7 @@ function main() {
     }
 
     console.log(`Parent run: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`);
-    const completedRun = waitForWorkflowRun(parentRunId, workflowSha);
+    const completedRun = waitForWorkflowRun(parentRunId, workflowSha, targetSha);
     parentConclusion = stringValue(completedRun.conclusion);
     if (parentConclusion !== "success") {
       throw new Error(

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -16,7 +16,10 @@ import {
   formatReleaseStateOutcome,
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
-import { readFullReleaseValidationLogCheckpointFromGitHub } from "./lib/full-release-validation-log-checkpoint.mjs";
+import {
+  readFullReleaseValidationLogCheckpointFromGitHub,
+  readFullReleaseValidationJobLog,
+} from "./lib/full-release-validation-log-checkpoint.mjs";
 import { execGhRead } from "./lib/plain-gh.mjs";
 
 const WORKFLOW = "full-release-validation.yml";
@@ -701,8 +704,7 @@ export function tryReadReleaseDecisionCheckpoint(
   };
   try {
     const checkpoint = readFullReleaseValidationLogCheckpointFromGitHub({
-      getJobLog: (jobId) =>
-        read(["api", `repos/openclaw/openclaw/actions/jobs/${String(jobId)}/logs`]),
+      getJobLog: (jobId) => readFullReleaseValidationJobLog(read, "openclaw/openclaw", jobId),
       getJobs: () =>
         JSON.parse(
           read([

--- a/scripts/full-release-validation-state.d.mts
+++ b/scripts/full-release-validation-state.d.mts
@@ -1,4 +1,8 @@
 export * from "./full-release-validation-policy.mjs";
+export function emitCheckpoint(
+  lines: string[],
+  write?: (fd: number, buffer: Uint8Array, offset: number, length: number) => number,
+): void;
 export function validateChildBinding(
   child: Record<string, unknown>,
   run: Record<string, unknown>,

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -23,6 +23,7 @@ import {
   releasePlanGateFailures,
   selectReleaseStateArtifacts,
   validateReleaseExecutionPlanArtifact,
+  validateReleaseStateArtifact,
   verifyReleaseStateArtifacts,
 } from "./full-release-validation-policy.mjs";
 import {
@@ -173,19 +174,14 @@ async function checkpointProvenance(signal) {
   };
 }
 
-function emitCheckpoint(kind, payload, provenance) {
-  for (const line of encodeFullReleaseValidationLogCheckpoint({ kind, payload, provenance })) {
+function emitCheckpoint(lines) {
+  for (const line of lines) {
     console.log(line);
   }
 }
 
-async function emitOptionalCheckpoint(kind, payload, signal) {
-  try {
-    const boundedSignal = AbortSignal.any([signal, AbortSignal.timeout(15_000)]);
-    emitCheckpoint(kind, payload, await checkpointProvenance(boundedSignal));
-  } catch (error) {
-    console.error(`[frv] ${kind} checkpoint unavailable: ${String(error?.message ?? error)}`);
-  }
+function checkpointLines(kind, payload, provenance) {
+  return provenance ? encodeFullReleaseValidationLogCheckpoint({ kind, payload, provenance }) : [];
 }
 
 function issue(kind, child, message, extra = {}) {
@@ -433,14 +429,26 @@ function writeExecutionPlan(path, payload) {
   }
 }
 
+function commitExecutionPlan(path, payload, encodedCheckpointLines) {
+  emitCheckpoint(encodedCheckpointLines);
+  writeExecutionPlan(path, payload);
+  process.exitCode = payload.blockers.length > 0 || payload.errors.length > 0 ? 2 : 0;
+}
+
 function appendSummary(mode, payload) {
   if (!process.env.GITHUB_STEP_SUMMARY) {
     return;
   }
-  appendFileSync(
-    process.env.GITHUB_STEP_SUMMARY,
-    `## ${mode === "decision" ? "Release Decision" : "Diagnostic Drain"}\n\n${formatReleaseStateOutcome(payload)}\n`,
-  );
+  try {
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `## ${mode === "decision" ? "Release Decision" : "Diagnostic Drain"}\n\n${formatReleaseStateOutcome(payload)}\n`,
+    );
+  } catch (error) {
+    console.warn(
+      `warning: could not write ${mode} summary: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 export function formatReleaseStateHeartbeat(mode, decision) {
@@ -556,8 +564,7 @@ async function planMode() {
         ),
     });
     const restored = validateReleaseExecutionPlanArtifact(recovered.payload, expected);
-    writeExecutionPlan(outputPath, restored);
-    emitCheckpoint("plan", restored, provenance);
+    commitExecutionPlan(outputPath, restored, checkpointLines("plan", restored, provenance));
     return;
   }
   if (currentAttempt !== 1) {
@@ -566,6 +573,9 @@ async function planMode() {
 
   const planInputs = parsePlanInputs(process.env.FULL_RELEASE_PLAN_INPUTS_JSON);
   const built = buildReleaseExecutionPlan(planInputs);
+  const provenance = expected.targetSha
+    ? await checkpointProvenance(abortController.signal)
+    : undefined;
   let finished = false;
   let plan = buildReleaseExecutionPlanArtifact({
     children: built.children,
@@ -577,7 +587,9 @@ async function planMode() {
     trustedWorkflow: trustedWorkflowFromInputs(planInputs),
   });
   const stop = () => {
-    if (finished) return abortController.abort(new Error("execution plan checkpoint cancelled"));
+    if (finished) {
+      return;
+    }
     abortController.abort(new Error("execution plan collection cancelled"));
     plan = buildReleaseExecutionPlanArtifact({
       blockers: plan.blockers,
@@ -597,9 +609,16 @@ async function planMode() {
       rerunGroup: expected.rerunGroup,
       trustedWorkflow: plan.trustedWorkflow,
     });
-    writeExecutionPlan(outputPath, plan);
+    const terminalPlan = validateReleaseExecutionPlanArtifact(plan, expected);
     finished = true;
-    process.exit(1);
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
+    commitExecutionPlan(
+      outputPath,
+      terminalPlan,
+      checkpointLines("plan", terminalPlan, provenance),
+    );
+    process.exit(process.exitCode);
   };
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
@@ -619,15 +638,11 @@ async function planMode() {
     rerunGroup: expected.rerunGroup,
     trustedWorkflow: trustedWorkflowFromInputs(planInputs),
   });
-  writeExecutionPlan(outputPath, plan);
-  validateReleaseExecutionPlanArtifact(plan, expected);
+  const terminalPlan = validateReleaseExecutionPlanArtifact(plan, expected);
   finished = true;
-  if (expected.targetSha) {
-    await emitOptionalCheckpoint("plan", plan, abortController.signal);
-  }
-  if ((reuse.blockers?.length ?? 0) > 0 || (reuse.errors?.length ?? 0) > 0) {
-    throw new Error("release execution plan could not bind reusable evidence");
-  }
+  process.removeListener("SIGINT", stop);
+  process.removeListener("SIGTERM", stop);
+  commitExecutionPlan(outputPath, terminalPlan, checkpointLines("plan", terminalPlan, provenance));
 }
 
 async function collectMode(mode) {
@@ -670,25 +685,40 @@ async function collectMode(mode) {
   }));
   let finished = false;
   const abortController = new AbortController();
+  const provenance = expected.targetSha
+    ? await checkpointProvenance(abortController.signal)
+    : undefined;
   let decisionReuse = { blockers: [], children: plan, errors: [] };
 
-  const writePayload = (decision, cancellation = {}) => {
-    const payload = buildReleaseStateArtifact({
-      cancellation,
-      children: snapshots,
-      decision,
-      executionPlan,
-      expected,
+  const buildPayload = (decision, cancellation = {}) =>
+    validateReleaseStateArtifact(
+      buildReleaseStateArtifact({
+        cancellation,
+        children: snapshots,
+        decision,
+        executionPlan,
+        expected,
+        mode,
+        releaseProfile,
+        rerunGroup,
+      }),
+      { ...expected, releaseProfile, rerunGroup },
       mode,
-      releaseProfile,
-      rerunGroup,
-    });
+    );
+  const commitPayload = (payload, encodedCheckpointLines) => {
+    finished = true;
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
+    emitCheckpoint(encodedCheckpointLines);
     writeResult(outputPath, payload);
+    process.exitCode =
+      payload.state === "passed" ? 0 : payload.state === "orchestration_error" ? 2 : 1;
     appendSummary(mode, payload);
-    return payload;
   };
   const stop = () => {
-    if (finished) return abortController.abort(new Error(`${mode} checkpoint cancelled`));
+    if (finished) {
+      return;
+    }
     abortController.abort(new Error(`${mode} collector cancelled`));
     const decision = classifyReleaseSnapshot({
       cancelled: true,
@@ -706,9 +736,9 @@ async function collectMode(mode) {
       releaseProfile,
       workflowRef: expected.workflowRef,
     });
-    writePayload(decision, { cancelledRunIds, requested: true });
-    finished = true;
-    process.exit(1);
+    const payload = buildPayload(decision, { cancelledRunIds, requested: true });
+    commitPayload(payload, checkpointLines(mode, payload, provenance));
+    process.exit(process.exitCode);
   };
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
@@ -771,7 +801,7 @@ async function collectMode(mode) {
   }
 
   let nextHeartbeat = 0;
-  while (!finished) {
+  while (true) {
     snapshots = await Promise.all(
       plan.map((child, index) => readChild(child, snapshots[index], abortController.signal)),
     );
@@ -815,13 +845,8 @@ async function collectMode(mode) {
         : decision.state === "orchestration_error" ||
           (decision.state !== "qualifying" && decision.activeRunIds.length === 0);
     if (done) {
-      const payload = writePayload(decision, { cancelledRunIds, requested: false });
-      finished = true;
-      process.exitCode =
-        payload.state === "passed" ? 0 : payload.state === "orchestration_error" ? 2 : 1;
-      if (expected.targetSha) {
-        await emitOptionalCheckpoint(mode, payload, abortController.signal);
-      }
+      const payload = buildPayload(decision, { cancelledRunIds, requested: false });
+      commitPayload(payload, checkpointLines(mode, payload, provenance));
       return;
     }
     await abortableSleep(pollIntervalMs, abortController.signal);

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -571,10 +571,33 @@ async function planMode() {
       readArtifact(outputPath, "execution plan"),
       expected,
     );
-    const provenance = expected.targetSha
+    let finished = false;
+    let provenance;
+    const stop = () => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      abortController.abort(new Error("execution plan restoration cancelled"));
+      try {
+        commitExecutionPlan(outputPath, restored, provenance);
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 2;
+      }
+      process.removeListener("SIGINT", stop);
+      process.removeListener("SIGTERM", stop);
+      process.exit(process.exitCode);
+    };
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+    provenance = expected.targetSha
       ? await bestEffortCheckpointProvenance(abortController.signal)
       : undefined;
+    finished = true;
     commitExecutionPlan(outputPath, restored, provenance);
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
     return;
   }
   if (currentAttempt !== 1) {
@@ -583,10 +606,8 @@ async function planMode() {
 
   const planInputs = parsePlanInputs(process.env.FULL_RELEASE_PLAN_INPUTS_JSON);
   const built = buildReleaseExecutionPlan(planInputs);
-  const provenance = expected.targetSha
-    ? await bestEffortCheckpointProvenance(abortController.signal)
-    : undefined;
   let finished = false;
+  let provenance;
   let plan = buildReleaseExecutionPlanArtifact({
     children: built.children,
     evidenceReuse: evidenceReuseFromInputs(planInputs),
@@ -634,6 +655,9 @@ async function planMode() {
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
 
+  provenance = expected.targetSha
+    ? await bestEffortCheckpointProvenance(abortController.signal)
+    : undefined;
   const reuse = await validateReuse(built.children, planInputs, abortController.signal);
   if (finished) {
     return;
@@ -696,9 +720,7 @@ async function collectMode(mode) {
   }));
   let finished = false;
   const abortController = new AbortController();
-  const provenance = expected.targetSha
-    ? await bestEffortCheckpointProvenance(abortController.signal)
-    : undefined;
+  let provenance;
   let decisionReuse = { blockers: [], children: plan, errors: [] };
 
   const buildPayload = (decision, cancellation = {}) =>
@@ -759,6 +781,9 @@ async function collectMode(mode) {
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
 
+  provenance = expected.targetSha
+    ? await bestEffortCheckpointProvenance(abortController.signal)
+    : undefined;
   if (mode === "decision" && executionPlan.evidenceReuse.requested) {
     decisionReuse = await validateReuse(
       plan,

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -179,6 +179,15 @@ function emitCheckpoint(kind, payload, provenance) {
   }
 }
 
+async function emitOptionalCheckpoint(kind, payload, signal) {
+  try {
+    const boundedSignal = AbortSignal.any([signal, AbortSignal.timeout(15_000)]);
+    emitCheckpoint(kind, payload, await checkpointProvenance(boundedSignal));
+  } catch (error) {
+    console.error(`[frv] ${kind} checkpoint unavailable: ${String(error?.message ?? error)}`);
+  }
+}
+
 function issue(kind, child, message, extra = {}) {
   return {
     child: child.key,
@@ -568,9 +577,7 @@ async function planMode() {
     trustedWorkflow: trustedWorkflowFromInputs(planInputs),
   });
   const stop = () => {
-    if (finished) {
-      return;
-    }
+    if (finished) return abortController.abort(new Error("execution plan checkpoint cancelled"));
     abortController.abort(new Error("execution plan collection cancelled"));
     plan = buildReleaseExecutionPlanArtifact({
       blockers: plan.blockers,
@@ -614,10 +621,10 @@ async function planMode() {
   });
   writeExecutionPlan(outputPath, plan);
   validateReleaseExecutionPlanArtifact(plan, expected);
-  if (expected.targetSha) {
-    emitCheckpoint("plan", plan, await checkpointProvenance(abortController.signal));
-  }
   finished = true;
+  if (expected.targetSha) {
+    await emitOptionalCheckpoint("plan", plan, abortController.signal);
+  }
   if ((reuse.blockers?.length ?? 0) > 0 || (reuse.errors?.length ?? 0) > 0) {
     throw new Error("release execution plan could not bind reusable evidence");
   }
@@ -681,9 +688,7 @@ async function collectMode(mode) {
     return payload;
   };
   const stop = () => {
-    if (finished) {
-      return;
-    }
+    if (finished) return abortController.abort(new Error(`${mode} checkpoint cancelled`));
     abortController.abort(new Error(`${mode} collector cancelled`));
     const decision = classifyReleaseSnapshot({
       cancelled: true,
@@ -811,12 +816,12 @@ async function collectMode(mode) {
           (decision.state !== "qualifying" && decision.activeRunIds.length === 0);
     if (done) {
       const payload = writePayload(decision, { cancelledRunIds, requested: false });
-      if (expected.targetSha) {
-        emitCheckpoint(mode, payload, await checkpointProvenance(abortController.signal));
-      }
       finished = true;
       process.exitCode =
         payload.state === "passed" ? 0 : payload.state === "orchestration_error" ? 2 : 1;
+      if (expected.targetSha) {
+        await emitOptionalCheckpoint(mode, payload, abortController.signal);
+      }
       return;
     }
     await abortableSleep(pollIntervalMs, abortController.signal);

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -572,7 +572,7 @@ async function planMode() {
       expected,
     );
     let finished = false;
-    let provenance;
+    const checkpoint = { provenance: undefined };
     const stop = () => {
       if (finished) {
         return;
@@ -580,7 +580,7 @@ async function planMode() {
       finished = true;
       abortController.abort(new Error("execution plan restoration cancelled"));
       try {
-        commitExecutionPlan(outputPath, restored, provenance);
+        commitExecutionPlan(outputPath, restored, checkpoint.provenance);
       } catch (error) {
         console.error(error instanceof Error ? error.message : String(error));
         process.exitCode = 2;
@@ -591,11 +591,11 @@ async function planMode() {
     };
     process.once("SIGINT", stop);
     process.once("SIGTERM", stop);
-    provenance = expected.targetSha
+    checkpoint.provenance = expected.targetSha
       ? await bestEffortCheckpointProvenance(abortController.signal)
       : undefined;
     finished = true;
-    commitExecutionPlan(outputPath, restored, provenance);
+    commitExecutionPlan(outputPath, restored, checkpoint.provenance);
     process.removeListener("SIGINT", stop);
     process.removeListener("SIGTERM", stop);
     return;
@@ -607,7 +607,7 @@ async function planMode() {
   const planInputs = parsePlanInputs(process.env.FULL_RELEASE_PLAN_INPUTS_JSON);
   const built = buildReleaseExecutionPlan(planInputs);
   let finished = false;
-  let provenance;
+  const checkpoint = { provenance: undefined };
   let plan = buildReleaseExecutionPlanArtifact({
     children: built.children,
     evidenceReuse: evidenceReuseFromInputs(planInputs),
@@ -643,7 +643,7 @@ async function planMode() {
     const terminalPlan = validateReleaseExecutionPlanArtifact(plan, expected);
     finished = true;
     try {
-      commitExecutionPlan(outputPath, terminalPlan, provenance);
+      commitExecutionPlan(outputPath, terminalPlan, checkpoint.provenance);
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));
       process.exitCode = 2;
@@ -655,7 +655,7 @@ async function planMode() {
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
 
-  provenance = expected.targetSha
+  checkpoint.provenance = expected.targetSha
     ? await bestEffortCheckpointProvenance(abortController.signal)
     : undefined;
   const reuse = await validateReuse(built.children, planInputs, abortController.signal);
@@ -675,7 +675,7 @@ async function planMode() {
   });
   const terminalPlan = validateReleaseExecutionPlanArtifact(plan, expected);
   finished = true;
-  commitExecutionPlan(outputPath, terminalPlan, provenance);
+  commitExecutionPlan(outputPath, terminalPlan, checkpoint.provenance);
   process.removeListener("SIGINT", stop);
   process.removeListener("SIGTERM", stop);
 }
@@ -720,7 +720,7 @@ async function collectMode(mode) {
   }));
   let finished = false;
   const abortController = new AbortController();
-  let provenance;
+  const checkpoint = { provenance: undefined };
   let decisionReuse = { blockers: [], children: plan, errors: [] };
 
   const buildPayload = (decision, cancellation = {}) =>
@@ -743,7 +743,7 @@ async function collectMode(mode) {
     writeResult(outputPath, payload);
     process.exitCode =
       payload.state === "passed" ? 0 : payload.state === "orchestration_error" ? 2 : 1;
-    emitBestEffortCheckpoint(mode, payload, provenance);
+    emitBestEffortCheckpoint(mode, payload, checkpoint.provenance);
     appendSummary(mode, payload);
     process.removeListener("SIGINT", stop);
     process.removeListener("SIGTERM", stop);
@@ -781,7 +781,7 @@ async function collectMode(mode) {
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);
 
-  provenance = expected.targetSha
+  checkpoint.provenance = expected.targetSha
     ? await bestEffortCheckpointProvenance(abortController.signal)
     : undefined;
   if (mode === "decision" && executionPlan.evidenceReuse.requested) {

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -27,11 +27,7 @@ import {
   validateReleaseStateArtifact,
   verifyReleaseStateArtifacts,
 } from "./full-release-validation-policy.mjs";
-import {
-  encodeFullReleaseValidationLogCheckpoint,
-  readFullReleaseValidationJobLog,
-  recoverFullReleaseValidationLogCheckpoint,
-} from "./lib/full-release-validation-log-checkpoint.mjs";
+import { encodeFullReleaseValidationLogCheckpoint } from "./lib/full-release-validation-log-checkpoint.mjs";
 
 export * from "./full-release-validation-policy.mjs";
 
@@ -133,24 +129,6 @@ async function githubJobs(runId, signal) {
     .map((line) => JSON.parse(line));
 }
 
-async function githubAttemptJobs(runId, runAttempt, signal) {
-  return (
-    await runGh(
-      [
-        "api",
-        "--paginate",
-        `repos/${process.env.GITHUB_REPOSITORY}/actions/runs/${runId}/attempts/${runAttempt}/jobs?per_page=100`,
-        "--jq",
-        ".jobs[] | @json",
-      ],
-      { signal },
-    )
-  )
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
-}
-
 async function checkpointProvenance(signal) {
   const runId = requiredString(process.env.GITHUB_RUN_ID, "parent run ID");
   const runAttempt = positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt");
@@ -175,26 +153,53 @@ async function checkpointProvenance(signal) {
   };
 }
 
-function emitCheckpoint(lines) {
+export function emitCheckpoint(lines, write = writeSync) {
   const bytes = Buffer.from(`${lines.join("\n")}\n`, "utf8");
   let offset = 0;
+  let retries = 0;
   while (offset < bytes.length) {
     try {
-      const written = writeSync(process.stdout.fd, bytes, offset, bytes.length - offset);
+      const written = write(process.stdout.fd, bytes, offset, bytes.length - offset);
       if (written === 0) {
         throw new Error("checkpoint stdout write made no progress");
       }
       offset += written;
+      retries = 0;
     } catch (error) {
-      if (error?.code !== "EAGAIN" && error?.code !== "EWOULDBLOCK" && error?.code !== "EINTR") {
+      if (!["EAGAIN", "EWOULDBLOCK", "EINTR"].includes(error?.code) || (retries += 1) > 3) {
         throw error;
       }
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, retries);
     }
   }
 }
 
 function checkpointLines(kind, payload, provenance) {
   return provenance ? encodeFullReleaseValidationLogCheckpoint({ kind, payload, provenance }) : [];
+}
+
+function warnDiagnostic(label, error) {
+  console.warn(`warning: ${label}: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+async function bestEffortCheckpointProvenance(signal) {
+  try {
+    return await checkpointProvenance(signal);
+  } catch (error) {
+    warnDiagnostic("could not resolve checkpoint provenance", error);
+    return undefined;
+  }
+}
+
+function emitBestEffortCheckpoint(kind, payload, provenance) {
+  if (!provenance) {
+    return;
+  }
+  try {
+    emitCheckpoint(checkpointLines(kind, payload, provenance));
+  } catch (error) {
+    warnDiagnostic(`could not emit ${kind} checkpoint`, error);
+  }
 }
 
 function issue(kind, child, message, extra = {}) {
@@ -442,10 +447,10 @@ function writeExecutionPlan(path, payload) {
   }
 }
 
-function commitExecutionPlan(path, payload, encodedCheckpointLines) {
-  emitCheckpoint(encodedCheckpointLines);
+function commitExecutionPlan(path, payload, provenance) {
   writeExecutionPlan(path, payload);
   process.exitCode = payload.blockers.length > 0 || payload.errors.length > 0 ? 2 : 0;
+  emitBestEffortCheckpoint("plan", payload, provenance);
 }
 
 function appendSummary(mode, payload) {
@@ -562,22 +567,14 @@ async function planMode() {
   const abortController = new AbortController();
 
   if (process.env.FULL_RELEASE_RESTORE_PLAN === "true") {
-    const provenance = await checkpointProvenance(abortController.signal);
-    const recovered = await recoverFullReleaseValidationLogCheckpoint({
-      currentAttempt,
-      expected: provenance,
-      kind: "plan",
-      listJobsForAttempt: (attempt) =>
-        githubAttemptJobs(provenance.runId, attempt, abortController.signal),
-      readJobLog: (jobId) =>
-        readFullReleaseValidationJobLog(
-          (args) => runGh(args, { signal: abortController.signal }),
-          process.env.GITHUB_REPOSITORY,
-          jobId,
-        ),
-    });
-    const restored = validateReleaseExecutionPlanArtifact(recovered.payload, expected);
-    commitExecutionPlan(outputPath, restored, checkpointLines("plan", restored, provenance));
+    const restored = validateReleaseExecutionPlanArtifact(
+      readArtifact(outputPath, "execution plan"),
+      expected,
+    );
+    const provenance = expected.targetSha
+      ? await bestEffortCheckpointProvenance(abortController.signal)
+      : undefined;
+    commitExecutionPlan(outputPath, restored, provenance);
     return;
   }
   if (currentAttempt !== 1) {
@@ -587,7 +584,7 @@ async function planMode() {
   const planInputs = parsePlanInputs(process.env.FULL_RELEASE_PLAN_INPUTS_JSON);
   const built = buildReleaseExecutionPlan(planInputs);
   const provenance = expected.targetSha
-    ? await checkpointProvenance(abortController.signal)
+    ? await bestEffortCheckpointProvenance(abortController.signal)
     : undefined;
   let finished = false;
   let plan = buildReleaseExecutionPlanArtifact({
@@ -624,13 +621,14 @@ async function planMode() {
     });
     const terminalPlan = validateReleaseExecutionPlanArtifact(plan, expected);
     finished = true;
+    try {
+      commitExecutionPlan(outputPath, terminalPlan, provenance);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 2;
+    }
     process.removeListener("SIGINT", stop);
     process.removeListener("SIGTERM", stop);
-    commitExecutionPlan(
-      outputPath,
-      terminalPlan,
-      checkpointLines("plan", terminalPlan, provenance),
-    );
     process.exit(process.exitCode);
   };
   process.once("SIGINT", stop);
@@ -653,9 +651,9 @@ async function planMode() {
   });
   const terminalPlan = validateReleaseExecutionPlanArtifact(plan, expected);
   finished = true;
+  commitExecutionPlan(outputPath, terminalPlan, provenance);
   process.removeListener("SIGINT", stop);
   process.removeListener("SIGTERM", stop);
-  commitExecutionPlan(outputPath, terminalPlan, checkpointLines("plan", terminalPlan, provenance));
 }
 
 async function collectMode(mode) {
@@ -699,7 +697,7 @@ async function collectMode(mode) {
   let finished = false;
   const abortController = new AbortController();
   const provenance = expected.targetSha
-    ? await checkpointProvenance(abortController.signal)
+    ? await bestEffortCheckpointProvenance(abortController.signal)
     : undefined;
   let decisionReuse = { blockers: [], children: plan, errors: [] };
 
@@ -718,15 +716,15 @@ async function collectMode(mode) {
       { ...expected, releaseProfile, rerunGroup },
       mode,
     );
-  const commitPayload = (payload, encodedCheckpointLines) => {
+  const commitPayload = (payload) => {
     finished = true;
-    process.removeListener("SIGINT", stop);
-    process.removeListener("SIGTERM", stop);
-    emitCheckpoint(encodedCheckpointLines);
     writeResult(outputPath, payload);
     process.exitCode =
       payload.state === "passed" ? 0 : payload.state === "orchestration_error" ? 2 : 1;
+    emitBestEffortCheckpoint(mode, payload, provenance);
     appendSummary(mode, payload);
+    process.removeListener("SIGINT", stop);
+    process.removeListener("SIGTERM", stop);
   };
   const stop = () => {
     if (finished) {
@@ -750,7 +748,12 @@ async function collectMode(mode) {
       workflowRef: expected.workflowRef,
     });
     const payload = buildPayload(decision, { cancelledRunIds, requested: true });
-    commitPayload(payload, checkpointLines(mode, payload, provenance));
+    try {
+      commitPayload(payload);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 2;
+    }
     process.exit(process.exitCode);
   };
   process.once("SIGINT", stop);
@@ -859,7 +862,7 @@ async function collectMode(mode) {
           (decision.state !== "qualifying" && decision.activeRunIds.length === 0);
     if (done) {
       const payload = buildPayload(decision, { cancelledRunIds, requested: false });
-      commitPayload(payload, checkpointLines(mode, payload, provenance));
+      commitPayload(payload);
       return;
     }
     await abortableSleep(pollIntervalMs, abortController.signal);

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -25,6 +25,10 @@ import {
   validateReleaseExecutionPlanArtifact,
   verifyReleaseStateArtifacts,
 } from "./full-release-validation-policy.mjs";
+import {
+  encodeFullReleaseValidationLogCheckpoint,
+  recoverFullReleaseValidationLogCheckpoint,
+} from "./lib/full-release-validation-log-checkpoint.mjs";
 
 export * from "./full-release-validation-policy.mjs";
 
@@ -124,6 +128,60 @@ async function githubJobs(runId, signal) {
     .split("\n")
     .filter(Boolean)
     .map((line) => JSON.parse(line));
+}
+
+async function githubAttemptJobs(runId, runAttempt, signal) {
+  return (
+    await runGh(
+      [
+        "api",
+        "--paginate",
+        `repos/${process.env.GITHUB_REPOSITORY}/actions/runs/${runId}/attempts/${runAttempt}/jobs?per_page=100`,
+        "--jq",
+        ".jobs[] | @json",
+      ],
+      { signal },
+    )
+  )
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+async function githubJobLog(jobId, signal) {
+  return runGh(["api", `repos/${process.env.GITHUB_REPOSITORY}/actions/jobs/${jobId}/logs`], {
+    signal,
+  });
+}
+
+async function checkpointProvenance(signal) {
+  const runId = requiredString(process.env.GITHUB_RUN_ID, "parent run ID");
+  const runAttempt = positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt");
+  const run = await githubJson(`actions/runs/${runId}`, signal);
+  const workflowPath = stringValue(run.path).split("@", 1)[0];
+  if (
+    String(run.id) !== runId ||
+    Number(run.run_attempt) !== runAttempt ||
+    run.event !== "workflow_dispatch" ||
+    run.head_sha !== process.env.GITHUB_SHA ||
+    workflowPath !== ".github/workflows/full-release-validation.yml"
+  ) {
+    throw new Error("checkpoint parent run binding is invalid");
+  }
+  return {
+    runAttempt,
+    runId,
+    targetSha: requiredString(process.env.TARGET_SHA, "target SHA"),
+    workflowId: positiveInteger(run.workflow_id, "checkpoint workflow ID"),
+    workflowPath,
+    workflowSha: requiredString(run.head_sha, "checkpoint workflow SHA"),
+  };
+}
+
+function emitCheckpoint(kind, payload, provenance) {
+  for (const line of encodeFullReleaseValidationLogCheckpoint({ kind, payload, provenance })) {
+    console.log(line);
+  }
 }
 
 function issue(kind, child, message, extra = {}) {
@@ -476,13 +534,21 @@ async function planMode() {
   );
   const expected = planExpected();
   const currentAttempt = positiveInteger(process.env.GITHUB_RUN_ATTEMPT, "parent run attempt");
+  const abortController = new AbortController();
 
   if (process.env.FULL_RELEASE_RESTORE_PLAN === "true") {
-    const restored = validateReleaseExecutionPlanArtifact(
-      readArtifact(outputPath, "execution plan"),
-      expected,
-    );
+    const provenance = await checkpointProvenance(abortController.signal);
+    const recovered = await recoverFullReleaseValidationLogCheckpoint({
+      currentAttempt,
+      expected: provenance,
+      kind: "plan",
+      listJobsForAttempt: (attempt) =>
+        githubAttemptJobs(provenance.runId, attempt, abortController.signal),
+      readJobLog: (jobId) => githubJobLog(jobId, abortController.signal),
+    });
+    const restored = validateReleaseExecutionPlanArtifact(recovered.payload, expected);
     writeExecutionPlan(outputPath, restored);
+    emitCheckpoint("plan", restored, provenance);
     return;
   }
   if (currentAttempt !== 1) {
@@ -491,7 +557,6 @@ async function planMode() {
 
   const planInputs = parsePlanInputs(process.env.FULL_RELEASE_PLAN_INPUTS_JSON);
   const built = buildReleaseExecutionPlan(planInputs);
-  const abortController = new AbortController();
   let finished = false;
   let plan = buildReleaseExecutionPlanArtifact({
     children: built.children,
@@ -548,6 +613,10 @@ async function planMode() {
     trustedWorkflow: trustedWorkflowFromInputs(planInputs),
   });
   writeExecutionPlan(outputPath, plan);
+  validateReleaseExecutionPlanArtifact(plan, expected);
+  if (expected.targetSha) {
+    emitCheckpoint("plan", plan, await checkpointProvenance(abortController.signal));
+  }
   finished = true;
   if ((reuse.blockers?.length ?? 0) > 0 || (reuse.errors?.length ?? 0) > 0) {
     throw new Error("release execution plan could not bind reusable evidence");
@@ -742,6 +811,9 @@ async function collectMode(mode) {
           (decision.state !== "qualifying" && decision.activeRunIds.length === 0);
     if (done) {
       const payload = writePayload(decision, { cancelledRunIds, requested: false });
+      if (expected.targetSha) {
+        emitCheckpoint(mode, payload, await checkpointProvenance(abortController.signal));
+      }
       finished = true;
       process.exitCode =
         payload.state === "passed" ? 0 : payload.state === "orchestration_error" ? 2 : 1;

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  writeSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
@@ -175,8 +176,20 @@ async function checkpointProvenance(signal) {
 }
 
 function emitCheckpoint(lines) {
-  for (const line of lines) {
-    console.log(line);
+  const bytes = Buffer.from(`${lines.join("\n")}\n`, "utf8");
+  let offset = 0;
+  while (offset < bytes.length) {
+    try {
+      const written = writeSync(process.stdout.fd, bytes, offset, bytes.length - offset);
+      if (written === 0) {
+        throw new Error("checkpoint stdout write made no progress");
+      }
+      offset += written;
+    } catch (error) {
+      if (error?.code !== "EAGAIN" && error?.code !== "EWOULDBLOCK" && error?.code !== "EINTR") {
+        throw error;
+      }
+    }
   }
 }
 

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -27,6 +27,7 @@ import {
 } from "./full-release-validation-policy.mjs";
 import {
   encodeFullReleaseValidationLogCheckpoint,
+  readFullReleaseValidationJobLog,
   recoverFullReleaseValidationLogCheckpoint,
 } from "./lib/full-release-validation-log-checkpoint.mjs";
 
@@ -146,12 +147,6 @@ async function githubAttemptJobs(runId, runAttempt, signal) {
     .split("\n")
     .filter(Boolean)
     .map((line) => JSON.parse(line));
-}
-
-async function githubJobLog(jobId, signal) {
-  return runGh(["api", `repos/${process.env.GITHUB_REPOSITORY}/actions/jobs/${jobId}/logs`], {
-    signal,
-  });
 }
 
 async function checkpointProvenance(signal) {
@@ -544,7 +539,12 @@ async function planMode() {
       kind: "plan",
       listJobsForAttempt: (attempt) =>
         githubAttemptJobs(provenance.runId, attempt, abortController.signal),
-      readJobLog: (jobId) => githubJobLog(jobId, abortController.signal),
+      readJobLog: (jobId) =>
+        readFullReleaseValidationJobLog(
+          (args) => runGh(args, { signal: abortController.signal }),
+          process.env.GITHUB_REPOSITORY,
+          jobId,
+        ),
     });
     const restored = validateReleaseExecutionPlanArtifact(recovered.payload, expected);
     writeExecutionPlan(outputPath, restored);

--- a/scripts/lib/full-release-validation-log-checkpoint.d.mts
+++ b/scripts/lib/full-release-validation-log-checkpoint.d.mts
@@ -1,0 +1,29 @@
+type CheckpointKind = "plan" | "decision" | "drain";
+type JsonRecord = Record<string, unknown>;
+
+export function encodeFullReleaseValidationLogCheckpoint(params: {
+  kind: CheckpointKind;
+  payload: unknown;
+  provenance: JsonRecord;
+}): string[];
+export function parseFullReleaseValidationLogCheckpoint(
+  log: string,
+  expected: JsonRecord,
+): { envelope: JsonRecord; payload: unknown } | undefined;
+export function readFullReleaseValidationLogCheckpointFromGitHub(params: {
+  getJobLog: (jobId: unknown) => string;
+  getJobs: () => JsonRecord[];
+  getRun: () => JsonRecord;
+  kind: CheckpointKind;
+  runAttempt: number;
+  runId: string;
+  targetSha: string;
+  workflowSha: string;
+}): JsonRecord | undefined;
+export function recoverFullReleaseValidationLogCheckpoint(params: {
+  currentAttempt: number;
+  expected: JsonRecord;
+  kind: CheckpointKind;
+  listJobsForAttempt: (attempt: number) => Promise<JsonRecord[]>;
+  readJobLog: (jobId: unknown) => Promise<string>;
+}): Promise<JsonRecord>;

--- a/scripts/lib/full-release-validation-log-checkpoint.d.mts
+++ b/scripts/lib/full-release-validation-log-checkpoint.d.mts
@@ -1,6 +1,11 @@
 type CheckpointKind = "plan" | "decision" | "drain";
 type JsonRecord = Record<string, unknown>;
 
+export function readFullReleaseValidationJobLog<T>(
+  read: (args: string[]) => T,
+  repository: string,
+  jobId: unknown,
+): T;
 export function encodeFullReleaseValidationLogCheckpoint(params: {
   kind: CheckpointKind;
   payload: unknown;

--- a/scripts/lib/full-release-validation-log-checkpoint.mjs
+++ b/scripts/lib/full-release-validation-log-checkpoint.mjs
@@ -139,6 +139,37 @@ function markerLines(log) {
     .filter((line) => line.startsWith(`${MARKER} `));
 }
 
+function jobLogArgs(repository, jobId, allowEscapeSequences = true) {
+  return [
+    "api",
+    `repos/${repository}/actions/jobs/${jobId}/logs`,
+    ...(allowEscapeSequences ? ["--allow-escape-sequences"] : []),
+  ];
+}
+
+function isUnknownAllowEscapeSequencesFlag(value) {
+  const stderr = typeof value === "string" ? value : (value?.stderr ?? value?.message);
+  return (
+    typeof stderr === "string" &&
+    stderr.replace(/\r\n?/gu, "\n").split("\n").includes("unknown flag: --allow-escape-sequences")
+  );
+}
+
+export function readFullReleaseValidationJobLog(read, repository, jobId) {
+  const retryWithoutFlag = (error) => {
+    if (!isUnknownAllowEscapeSequencesFlag(error)) {
+      throw error;
+    }
+    return read(jobLogArgs(repository, jobId, false));
+  };
+  try {
+    const result = read(jobLogArgs(repository, jobId));
+    return typeof result?.catch === "function" ? result.catch(retryWithoutFlag) : result;
+  } catch (error) {
+    return retryWithoutFlag(error);
+  }
+}
+
 function exactProducerJob(jobs, producer, expected, runAttempt) {
   const matches = (Array.isArray(jobs) ? jobs : []).filter(
     (job) => job?.name === producer.jobName && Number(job?.run_attempt) === Number(runAttempt),

--- a/scripts/lib/full-release-validation-log-checkpoint.mjs
+++ b/scripts/lib/full-release-validation-log-checkpoint.mjs
@@ -45,16 +45,21 @@ function encodeBase64url(bytes) {
 }
 
 function decodeBase64url(value, label) {
-  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value))
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value)) {
     throw new Error(`${label} is not canonical base64url`);
+  }
   const decoded = Buffer.from(value, "base64url");
-  if (encodeBase64url(decoded) !== value) throw new Error(`${label} is not canonical base64url`);
+  if (encodeBase64url(decoded) !== value) {
+    throw new Error(`${label} is not canonical base64url`);
+  }
   return decoded;
 }
 
 function normalizeKind(value) {
   const kind = requiredString(value, "checkpoint kind");
-  if (!CHECKPOINT_KINDS.has(kind)) throw new Error(`checkpoint kind is invalid: ${kind}`);
+  if (!CHECKPOINT_KINDS.has(kind)) {
+    throw new Error(`checkpoint kind is invalid: ${kind}`);
+  }
   return kind;
 }
 
@@ -319,11 +324,6 @@ function readFullReleaseValidationLogCheckpointAttempt({
   });
   if (checkpoint) {
     return { ...checkpoint, job, sourceAttempt: Number(runAttempt) };
-  }
-  if (job.conclusion === "success") {
-    throw new Error(
-      `completed checkpoint producer omitted its checkpoint at attempt ${runAttempt}`,
-    );
   }
   return undefined;
 }

--- a/scripts/lib/full-release-validation-log-checkpoint.mjs
+++ b/scripts/lib/full-release-validation-log-checkpoint.mjs
@@ -45,21 +45,16 @@ function encodeBase64url(bytes) {
 }
 
 function decodeBase64url(value, label) {
-  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value)) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value))
     throw new Error(`${label} is not canonical base64url`);
-  }
   const decoded = Buffer.from(value, "base64url");
-  if (encodeBase64url(decoded) !== value) {
-    throw new Error(`${label} is not canonical base64url`);
-  }
+  if (encodeBase64url(decoded) !== value) throw new Error(`${label} is not canonical base64url`);
   return decoded;
 }
 
 function normalizeKind(value) {
   const kind = requiredString(value, "checkpoint kind");
-  if (!CHECKPOINT_KINDS.has(kind)) {
-    throw new Error(`checkpoint kind is invalid: ${kind}`);
-  }
+  if (!CHECKPOINT_KINDS.has(kind)) throw new Error(`checkpoint kind is invalid: ${kind}`);
   return kind;
 }
 

--- a/scripts/lib/full-release-validation-log-checkpoint.mjs
+++ b/scripts/lib/full-release-validation-log-checkpoint.mjs
@@ -325,7 +325,12 @@ function readFullReleaseValidationLogCheckpointAttempt({
   if (checkpoint) {
     return { ...checkpoint, job, sourceAttempt: Number(runAttempt) };
   }
-  return undefined;
+  if (job.conclusion === "failure" || job.conclusion === "cancelled") {
+    return undefined;
+  }
+  throw new Error(
+    `checkpoint producer completed without a marker at attempt ${runAttempt} (conclusion: ${String(job.conclusion)})`,
+  );
 }
 
 export function readFullReleaseValidationLogCheckpointFromGitHub({

--- a/scripts/lib/full-release-validation-log-checkpoint.mjs
+++ b/scripts/lib/full-release-validation-log-checkpoint.mjs
@@ -1,0 +1,372 @@
+import { createHash } from "node:crypto";
+import { stripVTControlCharacters } from "node:util";
+
+const FULL_RELEASE_CHECKPOINT_MAX_BYTES = 128 * 1024;
+const FULL_RELEASE_CHECKPOINT_MAX_CHUNKS = 16;
+const FULL_RELEASE_CHECKPOINT_CHUNK_BYTES = 8 * 1024;
+
+const CHECKPOINT_VERSION = 1;
+const MARKER = "[openclaw-frv-checkpoint]";
+const WORKFLOW_NAME = "Full Release Validation";
+const WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
+const TIMESTAMP_PREFIX_PATTERN = /^\s*(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+)?/u;
+const CHECKPOINT_KINDS = new Set(["plan", "decision", "drain"]);
+
+const FULL_RELEASE_CHECKPOINT_PRODUCERS = Object.freeze({
+  decision: { jobKey: "release_decision", jobName: "Release Decision" },
+  drain: { jobKey: "diagnostic_drain", jobName: "Diagnostic Drain" },
+  plan: {
+    jobKey: "release_execution_plan",
+    jobName: "Seal release execution plan",
+  },
+});
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} is required`);
+  }
+  return value.trim();
+}
+
+function positiveInteger(value, label) {
+  const normalized = Number(value);
+  if (!Number.isSafeInteger(normalized) || normalized < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return normalized;
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function encodeBase64url(bytes) {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function decodeBase64url(value, label) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value)) {
+    throw new Error(`${label} is not canonical base64url`);
+  }
+  const decoded = Buffer.from(value, "base64url");
+  if (encodeBase64url(decoded) !== value) {
+    throw new Error(`${label} is not canonical base64url`);
+  }
+  return decoded;
+}
+
+function normalizeKind(value) {
+  const kind = requiredString(value, "checkpoint kind");
+  if (!CHECKPOINT_KINDS.has(kind)) {
+    throw new Error(`checkpoint kind is invalid: ${kind}`);
+  }
+  return kind;
+}
+
+function normalizeProvenance(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("checkpoint provenance must be an object");
+  }
+  return {
+    runAttempt: positiveInteger(value.runAttempt, "checkpoint run attempt"),
+    runId: requiredString(String(value.runId ?? ""), "checkpoint run ID"),
+    targetSha: requiredString(value.targetSha, "checkpoint target SHA"),
+    workflowId: positiveInteger(value.workflowId, "checkpoint workflow ID"),
+    workflowPath: requiredString(value.workflowPath, "checkpoint workflow path"),
+    workflowSha: requiredString(value.workflowSha, "checkpoint workflow SHA"),
+  };
+}
+
+function normalizeEnvelope(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("checkpoint header must be an object");
+  }
+  const kind = normalizeKind(value.kind);
+  const producer = FULL_RELEASE_CHECKPOINT_PRODUCERS[kind];
+  const envelope = {
+    byteLength: positiveInteger(value.byteLength, "checkpoint byte length"),
+    chunkCount: positiveInteger(value.chunkCount, "checkpoint chunk count"),
+    kind,
+    payloadSha256: requiredString(value.payloadSha256, "checkpoint payload digest"),
+    producerJobKey: requiredString(value.producerJobKey, "checkpoint producer job key"),
+    runAttempt: positiveInteger(value.runAttempt, "checkpoint run attempt"),
+    runId: requiredString(String(value.runId ?? ""), "checkpoint run ID"),
+    targetSha: requiredString(value.targetSha, "checkpoint target SHA"),
+    version: positiveInteger(value.version, "checkpoint version"),
+    workflowId: positiveInteger(value.workflowId, "checkpoint workflow ID"),
+    workflowPath: requiredString(value.workflowPath, "checkpoint workflow path"),
+    workflowSha: requiredString(value.workflowSha, "checkpoint workflow SHA"),
+  };
+  if (
+    envelope.version !== CHECKPOINT_VERSION ||
+    envelope.chunkCount > FULL_RELEASE_CHECKPOINT_MAX_CHUNKS ||
+    envelope.byteLength > FULL_RELEASE_CHECKPOINT_MAX_BYTES ||
+    !/^[a-f0-9]{64}$/u.test(envelope.payloadSha256) ||
+    envelope.producerJobKey !== producer.jobKey
+  ) {
+    throw new Error("checkpoint header is invalid");
+  }
+  return envelope;
+}
+
+function assertExpected(envelope, expected) {
+  const normalized = {
+    ...normalizeProvenance(expected),
+    kind: normalizeKind(expected.kind),
+    producerJobKey: requiredString(expected.producerJobKey, "expected producer job key"),
+  };
+  for (const key of [
+    "kind",
+    "producerJobKey",
+    "runAttempt",
+    "runId",
+    "targetSha",
+    "workflowId",
+    "workflowPath",
+    "workflowSha",
+  ]) {
+    if (String(envelope[key]) !== String(normalized[key])) {
+      throw new Error(`checkpoint provenance mismatch: ${key}`);
+    }
+  }
+}
+
+function markerLines(log) {
+  return stripVTControlCharacters(String(log))
+    .replaceAll("\r\n", "\n")
+    .split("\n")
+    .map((line) => line.replace(TIMESTAMP_PREFIX_PATTERN, ""))
+    .filter((line) => line.startsWith(`${MARKER} `));
+}
+
+function exactProducerJob(jobs, producer, expected, runAttempt) {
+  const matches = (Array.isArray(jobs) ? jobs : []).filter(
+    (job) => job?.name === producer.jobName && Number(job?.run_attempt) === Number(runAttempt),
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `checkpoint producer job is not unique for ${producer.jobName} attempt ${runAttempt}`,
+    );
+  }
+  const job = matches[0];
+  if (
+    !Number.isSafeInteger(Number(job.id)) ||
+    String(job.run_id) !== String(expected.runId) ||
+    job.head_sha !== expected.workflowSha ||
+    job.workflow_name !== WORKFLOW_NAME
+  ) {
+    throw new Error(`checkpoint producer job binding is invalid at attempt ${runAttempt}`);
+  }
+  return job;
+}
+
+export function encodeFullReleaseValidationLogCheckpoint({ kind, payload, provenance }) {
+  const normalizedKind = normalizeKind(kind);
+  const normalizedProvenance = normalizeProvenance(provenance);
+  const producer = FULL_RELEASE_CHECKPOINT_PRODUCERS[normalizedKind];
+  const bytes = Buffer.from(JSON.stringify(payload), "utf8");
+  if (bytes.length === 0 || bytes.length > FULL_RELEASE_CHECKPOINT_MAX_BYTES) {
+    throw new Error("checkpoint payload exceeds the size limit");
+  }
+  const chunks = [];
+  for (let offset = 0; offset < bytes.length; offset += FULL_RELEASE_CHECKPOINT_CHUNK_BYTES) {
+    chunks.push(bytes.subarray(offset, offset + FULL_RELEASE_CHECKPOINT_CHUNK_BYTES));
+  }
+  if (chunks.length > FULL_RELEASE_CHECKPOINT_MAX_CHUNKS) {
+    throw new Error("checkpoint payload exceeds the chunk limit");
+  }
+  const payloadSha256 = sha256(bytes);
+  const envelope = {
+    byteLength: bytes.length,
+    chunkCount: chunks.length,
+    kind: normalizedKind,
+    payloadSha256,
+    producerJobKey: producer.jobKey,
+    ...normalizedProvenance,
+    version: CHECKPOINT_VERSION,
+  };
+  return [
+    `${MARKER} header ${encodeBase64url(Buffer.from(JSON.stringify(envelope), "utf8"))}`,
+    ...chunks.map(
+      (chunk, index) =>
+        `${MARKER} chunk ${normalizedKind} ${index + 1}/${chunks.length} ${encodeBase64url(chunk)}`,
+    ),
+    `${MARKER} trailer ${normalizedKind} ${payloadSha256}`,
+  ];
+}
+
+export function parseFullReleaseValidationLogCheckpoint(log, expected) {
+  const lines = markerLines(log);
+  if (lines.length === 0) {
+    return undefined;
+  }
+  const headerMatch = /^\[openclaw-frv-checkpoint\] header ([A-Za-z0-9_-]+)$/u.exec(lines[0]);
+  if (!headerMatch) {
+    throw new Error("checkpoint header is missing or reordered");
+  }
+  let header;
+  try {
+    const headerBytes = decodeBase64url(headerMatch[1], "checkpoint header");
+    header = normalizeEnvelope(
+      JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(headerBytes)),
+    );
+  } catch (error) {
+    throw new Error(
+      `checkpoint header is malformed: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  assertExpected(header, expected);
+  if (lines.length !== header.chunkCount + 2) {
+    throw new Error("checkpoint line count is invalid");
+  }
+  const chunks = [];
+  for (let index = 0; index < header.chunkCount; index += 1) {
+    const match =
+      /^\[openclaw-frv-checkpoint\] chunk ([a-z]+) ([1-9][0-9]*)\/([1-9][0-9]*) ([A-Za-z0-9_-]+)$/u.exec(
+        lines[index + 1],
+      );
+    if (
+      !match ||
+      match[1] !== header.kind ||
+      Number(match[2]) !== index + 1 ||
+      Number(match[3]) !== header.chunkCount
+    ) {
+      throw new Error("checkpoint chunks are missing, duplicated, conflicting, or reordered");
+    }
+    chunks.push(decodeBase64url(match[4], `checkpoint chunk ${index + 1}`));
+  }
+  const trailerMatch = /^\[openclaw-frv-checkpoint\] trailer ([a-z]+) ([a-f0-9]{64})$/u.exec(
+    lines.at(-1),
+  );
+  if (
+    !trailerMatch ||
+    trailerMatch[1] !== header.kind ||
+    trailerMatch[2] !== header.payloadSha256
+  ) {
+    throw new Error("checkpoint trailer is missing or conflicting");
+  }
+  const bytes = Buffer.concat(chunks);
+  if (
+    bytes.length !== header.byteLength ||
+    bytes.length > FULL_RELEASE_CHECKPOINT_MAX_BYTES ||
+    sha256(bytes) !== header.payloadSha256
+  ) {
+    throw new Error("checkpoint payload length or digest is invalid");
+  }
+  try {
+    return {
+      envelope: header,
+      payload: JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)),
+    };
+  } catch (error) {
+    throw new Error(
+      `checkpoint payload is not valid UTF-8 JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+}
+
+function readFullReleaseValidationLogCheckpointAttempt({
+  expected,
+  jobs,
+  kind,
+  readJobLog,
+  runAttempt,
+}) {
+  const producer = FULL_RELEASE_CHECKPOINT_PRODUCERS[normalizeKind(kind)];
+  const candidates = (Array.isArray(jobs) ? jobs : []).filter(
+    (job) => job?.name === producer.jobName,
+  );
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  const job = exactProducerJob(candidates, producer, expected, runAttempt);
+  if (job.status !== "completed") {
+    return undefined;
+  }
+  const checkpoint = parseFullReleaseValidationLogCheckpoint(readJobLog(job.id), {
+    ...expected,
+    kind,
+    producerJobKey: producer.jobKey,
+    runAttempt,
+  });
+  if (checkpoint) {
+    return { ...checkpoint, job, sourceAttempt: Number(runAttempt) };
+  }
+  if (job.conclusion === "success") {
+    throw new Error(
+      `completed checkpoint producer omitted its checkpoint at attempt ${runAttempt}`,
+    );
+  }
+  return undefined;
+}
+
+export function readFullReleaseValidationLogCheckpointFromGitHub({
+  getJobLog,
+  getJobs,
+  getRun,
+  kind,
+  runAttempt,
+  runId,
+  targetSha,
+  workflowSha,
+}) {
+  const run = getRun();
+  const workflowPath = String(run?.path ?? "").split("@", 1)[0];
+  if (
+    String(run?.id) !== String(runId) ||
+    Number(run?.run_attempt) !== Number(runAttempt) ||
+    run?.event !== "workflow_dispatch" ||
+    run?.head_sha !== workflowSha ||
+    workflowPath !== WORKFLOW_PATH
+  ) {
+    throw new Error(`checkpoint parent run binding mismatch: ${runId}`);
+  }
+  return readFullReleaseValidationLogCheckpointAttempt({
+    expected: {
+      runAttempt,
+      runId: String(runId),
+      targetSha,
+      workflowId: run.workflow_id,
+      workflowPath,
+      workflowSha,
+    },
+    jobs: getJobs(),
+    kind,
+    readJobLog: getJobLog,
+    runAttempt,
+  });
+}
+
+export async function recoverFullReleaseValidationLogCheckpoint({
+  currentAttempt,
+  expected,
+  kind,
+  listJobsForAttempt,
+  readJobLog,
+}) {
+  const normalizedCurrentAttempt = positiveInteger(currentAttempt, "current run attempt");
+  for (let attempt = normalizedCurrentAttempt - 1; attempt >= 1; attempt -= 1) {
+    const jobs = await listJobsForAttempt(attempt);
+    const producer = FULL_RELEASE_CHECKPOINT_PRODUCERS[kind];
+    const job = exactProducerJob(jobs, producer, expected, attempt);
+    if (job.status !== "completed") {
+      throw new Error(`checkpoint producer job is incomplete at attempt ${attempt}`);
+    }
+    const log = await readJobLog(job.id);
+    const checkpoint = readFullReleaseValidationLogCheckpointAttempt({
+      expected,
+      jobs,
+      kind,
+      readJobLog: () => log,
+      runAttempt: attempt,
+    });
+    if (checkpoint) {
+      return checkpoint;
+    }
+  }
+  throw new Error(
+    `no recoverable ${kind} checkpoint exists before attempt ${normalizedCurrentAttempt}`,
+  );
+}

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -17,6 +17,7 @@ import {
   validateReleaseExecutionPlanArtifact,
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
+import { readFullReleaseValidationLogCheckpointFromGitHub } from "./lib/full-release-validation-log-checkpoint.mjs";
 import { execGhRead, plainGhEnv, resolvePlainGhBin } from "./lib/plain-gh.mjs";
 
 const DEFAULT_REPO = process.env.OPENCLAW_RELEASE_REPO || "openclaw/openclaw";
@@ -2032,6 +2033,46 @@ export function tryReadReleaseDecisionArtifact(
   }
 }
 
+export function tryReadReleaseDecisionCheckpoint(parent, runId, repository) {
+  const parentRest = githubRestJson(`actions/runs/${runId}`, repository);
+  const rawPlan = tryDownloadExecutionPlan(runId, repository);
+  if (!rawPlan) {
+    return undefined;
+  }
+  const plan = validateReleaseExecutionPlanArtifact(rawPlan, {
+    maxParentRunAttempt: parent.attempt,
+    parentRunId: String(runId),
+    workflowRef: parentRest.head_branch,
+    workflowSha: parentRest.head_sha,
+  });
+  const checkpoint = readFullReleaseValidationLogCheckpointFromGitHub({
+    getJobLog: (jobId) => parentJobLog(jobId, repository),
+    getJobs: () =>
+      githubRestJson(
+        `actions/runs/${runId}/attempts/${parent.attempt}/jobs?per_page=100`,
+        repository,
+      ).jobs ?? [],
+    getRun: () => parentRest,
+    kind: "decision",
+    runAttempt: parent.attempt,
+    runId: String(runId),
+    targetSha: plan.targetSha,
+    workflowSha: parent.headSha,
+  });
+  if (!checkpoint) {
+    return undefined;
+  }
+  return validateReleaseStateArtifact(
+    checkpoint.payload,
+    {
+      parentRunAttempt: parent.attempt,
+      parentRunId: String(runId),
+      workflowSha: parent.headSha,
+    },
+    "decision",
+  );
+}
+
 function releaseDecisionBlockedDuringDrain(parent, runId, repository) {
   const jobs = parent.jobs ?? [];
   const decision = jobs.find((job) => job.name === "Release Decision");
@@ -2044,7 +2085,10 @@ function releaseDecisionBlockedDuringDrain(parent, runId, repository) {
   ) {
     return undefined;
   }
-  return tryReadReleaseDecisionArtifact(parent, runId, repository);
+  return (
+    tryReadReleaseDecisionArtifact(parent, runId, repository) ??
+    tryReadReleaseDecisionCheckpoint(parent, runId, repository)
+  );
 }
 
 function summarizeReleaseCiRun(options) {

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -17,7 +17,10 @@ import {
   validateReleaseExecutionPlanArtifact,
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
-import { readFullReleaseValidationLogCheckpointFromGitHub } from "./lib/full-release-validation-log-checkpoint.mjs";
+import {
+  readFullReleaseValidationLogCheckpointFromGitHub,
+  readFullReleaseValidationJobLog,
+} from "./lib/full-release-validation-log-checkpoint.mjs";
 import { execGhRead, plainGhEnv, resolvePlainGhBin } from "./lib/plain-gh.mjs";
 
 const DEFAULT_REPO = process.env.OPENCLAW_RELEASE_REPO || "openclaw/openclaw";
@@ -358,34 +361,8 @@ function findParentJobsAll(parentRunId, repository = DEFAULT_REPO) {
   return jobs;
 }
 
-function parentJobLogArgs(jobId, repository = DEFAULT_REPO, allowEscapeSequences = true) {
-  const args = ["api", `repos/${repository}/actions/jobs/${jobId}/logs`];
-  if (allowEscapeSequences) {
-    args.push("--allow-escape-sequences");
-  }
-  return args;
-}
-
-function isUnknownAllowEscapeSequencesFlag(error) {
-  if (typeof error !== "object" || error === null || !("stderr" in error)) {
-    return false;
-  }
-  const stderr = error.stderr;
-  return (
-    typeof stderr === "string" &&
-    stderr.replace(/\r\n?/gu, "\n").split("\n").includes("unknown flag: --allow-escape-sequences")
-  );
-}
-
 function parentJobLog(jobId, repository = DEFAULT_REPO) {
-  try {
-    return gh(parentJobLogArgs(jobId, repository));
-  } catch (error) {
-    if (!isUnknownAllowEscapeSequencesFlag(error)) {
-      throw error;
-    }
-    return gh(parentJobLogArgs(jobId, repository, false));
-  }
+  return readFullReleaseValidationJobLog(gh, repository, jobId);
 }
 
 function normalizeOptionalRunId(value, label) {

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -681,8 +681,18 @@ describe("full-release-validation-at-sha", () => {
         workflowSha,
       },
     }).join("\n");
+    const calls: string[][] = [];
     const runStatusImpl = (_command: string, args: string[]) => {
-      const endpoint = args.at(-1) ?? "";
+      calls.push(args);
+      const endpoint = args.find((arg) => arg.includes("/actions/")) ?? "";
+      if (endpoint.endsWith("/actions/jobs/7/logs") && args.includes("--allow-escape-sequences")) {
+        return {
+          signal: null,
+          status: 1,
+          stderr: "unknown flag: --allow-escape-sequences\n",
+          stdout: "",
+        };
+      }
       const stdout = endpoint.endsWith("/actions/runs/123")
         ? JSON.stringify({
             event: "workflow_dispatch",
@@ -715,6 +725,10 @@ describe("full-release-validation-at-sha", () => {
     expect(
       tryReadReleaseDecisionCheckpoint("123", 2, workflowSha, targetSha, runStatusImpl),
     ).toMatchObject(payload);
+    expect(calls.slice(-2)).toEqual([
+      ["api", "repos/openclaw/openclaw/actions/jobs/7/logs", "--allow-escape-sequences"],
+      ["api", "repos/openclaw/openclaw/actions/jobs/7/logs"],
+    ]);
   });
 
   it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -16,10 +16,12 @@ import {
   resolveRemoteTargetRefSha,
   shouldDeleteTemporaryWorkflowRef,
   tryReadReleaseDecision,
+  tryReadReleaseDecisionCheckpoint,
   validateReleaseDecisionPayload,
   verifyTargetRef,
   verifyTrustedWorkflowRef,
 } from "../../scripts/full-release-validation-at-sha.mts";
+import { encodeFullReleaseValidationLogCheckpoint } from "../../scripts/lib/full-release-validation-log-checkpoint.mjs";
 
 const SCRIPT_PATH = resolve("scripts/full-release-validation-at-sha.mjs");
 const CURRENT_WORKFLOW_SOURCE = readFileSync(
@@ -642,6 +644,77 @@ describe("full-release-validation-at-sha", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it("reads a provenance-bound Release Decision from the exact producer log", () => {
+    const workflowSha = "a".repeat(40);
+    const targetSha = "b".repeat(40);
+    const payload = {
+      activeRunIds: ["101"],
+      blockers: [{ child: "normalCi", job: "test", runId: "101" }],
+      cancellation: { cancelledRunIds: [], requested: false },
+      children: {},
+      errors: [],
+      executionPlanSha256: "c".repeat(64),
+      kind: "openclaw.full-release-decision",
+      mode: "decision",
+      parentRunAttempt: 2,
+      parentRunId: "123",
+      releaseProfile: "stable",
+      rerunGroup: "ci",
+      sourceParentRunAttempt: 1,
+      state: "blocked_diagnostics_running",
+      targetSha,
+      version: 2,
+      workflowRef: "main",
+      workflowSha,
+    };
+    const log = encodeFullReleaseValidationLogCheckpoint({
+      kind: "decision",
+      payload,
+      provenance: {
+        runAttempt: 2,
+        runId: "123",
+        targetSha,
+        workflowId: 456,
+        workflowPath: ".github/workflows/full-release-validation.yml",
+        workflowSha,
+      },
+    }).join("\n");
+    const runStatusImpl = (_command: string, args: string[]) => {
+      const endpoint = args.at(-1) ?? "";
+      const stdout = endpoint.endsWith("/actions/runs/123")
+        ? JSON.stringify({
+            event: "workflow_dispatch",
+            head_sha: workflowSha,
+            id: 123,
+            path: ".github/workflows/full-release-validation.yml",
+            run_attempt: 2,
+            workflow_id: 456,
+          })
+        : endpoint.includes("/attempts/2/jobs")
+          ? JSON.stringify({
+              jobs: [
+                {
+                  conclusion: "failure",
+                  head_sha: workflowSha,
+                  id: 7,
+                  name: "Release Decision",
+                  run_attempt: 2,
+                  run_id: 123,
+                  status: "completed",
+                  workflow_name: "Full Release Validation",
+                },
+              ],
+            })
+          : endpoint.endsWith("/actions/jobs/7/logs")
+            ? log
+            : "";
+      return { signal: null, status: 0, stderr: "", stdout };
+    };
+    expect(
+      tryReadReleaseDecisionCheckpoint("123", 2, workflowSha, targetSha, runStatusImpl),
+    ).toMatchObject(payload);
   });
 
   it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {

--- a/test/scripts/full-release-validation-log-checkpoint.test.ts
+++ b/test/scripts/full-release-validation-log-checkpoint.test.ts
@@ -201,7 +201,7 @@ describe("full release validation log checkpoints", () => {
     ).toThrow("header");
   });
 
-  it("searches earlier attempts newest-first and falls past a completed no-marker attempt", async () => {
+  it("searches earlier attempts newest-first and falls past a failed no-marker attempt", async () => {
     const attempts: number[] = [];
     const result = await recoverFullReleaseValidationLogCheckpoint({
       currentAttempt: 4,
@@ -211,7 +211,7 @@ describe("full release validation log checkpoints", () => {
         attempts.push(attempt);
         return [
           {
-            conclusion: "success",
+            conclusion: attempt === 3 ? "failure" : "success",
             head_sha: SHA,
             id: attempt,
             name: "Seal release execution plan",
@@ -227,6 +227,41 @@ describe("full release validation log checkpoints", () => {
     });
     expect(attempts).toEqual([3, 2]);
     expect(result).toMatchObject({ payload: { source: 2 }, sourceAttempt: 2 });
+  });
+
+  it.each([
+    "success",
+    "neutral",
+    "skipped",
+    "timed_out",
+    "action_required",
+    "stale",
+    "startup_failure",
+    "unknown",
+  ])("fails closed on a completed %s attempt without a checkpoint marker", async (conclusion) => {
+    await expect(
+      recoverFullReleaseValidationLogCheckpoint({
+        currentAttempt: 3,
+        expected: provenance(3),
+        kind: "plan",
+        listJobsForAttempt: async (attempt) => [
+          {
+            conclusion: attempt === 2 ? conclusion : "success",
+            head_sha: SHA,
+            id: attempt,
+            name: "Seal release execution plan",
+            run_attempt: attempt,
+            run_id: 123,
+            status: "completed",
+            workflow_name: "Full Release Validation",
+          },
+        ],
+        readJobLog: async (jobId) =>
+          Number(jobId) === 2
+            ? "completed without emission"
+            : checkpointLog("plan", { source: 1 }, 1),
+      }),
+    ).rejects.toThrow("completed without a marker");
   });
 
   it.each([

--- a/test/scripts/full-release-validation-log-checkpoint.test.ts
+++ b/test/scripts/full-release-validation-log-checkpoint.test.ts
@@ -201,33 +201,36 @@ describe("full release validation log checkpoints", () => {
     ).toThrow("header");
   });
 
-  it("searches earlier attempts newest-first and falls past a failed no-marker attempt", async () => {
-    const attempts: number[] = [];
-    const result = await recoverFullReleaseValidationLogCheckpoint({
-      currentAttempt: 4,
-      expected: provenance(4),
-      kind: "plan",
-      listJobsForAttempt: async (attempt) => {
-        attempts.push(attempt);
-        return [
-          {
-            conclusion: attempt === 3 ? "failure" : "success",
-            head_sha: SHA,
-            id: attempt,
-            name: "Seal release execution plan",
-            run_attempt: attempt,
-            run_id: 123,
-            status: "completed",
-            workflow_name: "Full Release Validation",
-          },
-        ];
-      },
-      readJobLog: async (jobId) =>
-        Number(jobId) === 3 ? "failed before emission" : checkpointLog("plan", { source: 2 }, 2),
-    });
-    expect(attempts).toEqual([3, 2]);
-    expect(result).toMatchObject({ payload: { source: 2 }, sourceAttempt: 2 });
-  });
+  it.each(["failure", "cancelled"])(
+    "searches earlier attempts newest-first and falls past a %s no-marker attempt",
+    async (conclusion) => {
+      const attempts: number[] = [];
+      const result = await recoverFullReleaseValidationLogCheckpoint({
+        currentAttempt: 4,
+        expected: provenance(4),
+        kind: "plan",
+        listJobsForAttempt: async (attempt) => {
+          attempts.push(attempt);
+          return [
+            {
+              conclusion: attempt === 3 ? conclusion : "success",
+              head_sha: SHA,
+              id: attempt,
+              name: "Seal release execution plan",
+              run_attempt: attempt,
+              run_id: 123,
+              status: "completed",
+              workflow_name: "Full Release Validation",
+            },
+          ];
+        },
+        readJobLog: async (jobId) =>
+          Number(jobId) === 3 ? "failed before emission" : checkpointLog("plan", { source: 2 }, 2),
+      });
+      expect(attempts).toEqual([3, 2]);
+      expect(result).toMatchObject({ payload: { source: 2 }, sourceAttempt: 2 });
+    },
+  );
 
   it.each([
     "success",
@@ -331,7 +334,7 @@ describe("full release validation log checkpoints", () => {
     const workflow = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
     expect(workflow).not.toContain("Restore immutable release execution plan");
     expect(workflow).toContain("FULL_RELEASE_RESTORE_PLAN: ${{ github.run_attempt != 1 }}");
-    expect(workflow).toContain("if: ${{ always() && steps.plan.outputs.sha256 != '' }}");
+    expect(workflow.match(/if: always\(\)/gu)?.length).toBeGreaterThanOrEqual(4);
     expect(workflow).toContain("overwrite: true");
     expect(
       workflow.match(/scripts\/lib\/full-release-validation-log-checkpoint\.mjs/gu),

--- a/test/scripts/full-release-validation-log-checkpoint.test.ts
+++ b/test/scripts/full-release-validation-log-checkpoint.test.ts
@@ -1,0 +1,283 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  encodeFullReleaseValidationLogCheckpoint,
+  parseFullReleaseValidationLogCheckpoint,
+  readFullReleaseValidationLogCheckpointFromGitHub,
+  recoverFullReleaseValidationLogCheckpoint,
+} from "../../scripts/lib/full-release-validation-log-checkpoint.mjs";
+
+const SHA = "a".repeat(40);
+const TARGET_SHA = "b".repeat(40);
+
+function provenance(runAttempt = 1) {
+  return {
+    runAttempt,
+    runId: "123",
+    targetSha: TARGET_SHA,
+    workflowId: 456,
+    workflowPath: ".github/workflows/full-release-validation.yml",
+    workflowSha: SHA,
+  };
+}
+
+function expected(kind: "plan" | "decision" | "drain", runAttempt = 1) {
+  const producerJobKey = {
+    decision: "release_decision",
+    drain: "diagnostic_drain",
+    plan: "release_execution_plan",
+  }[kind];
+  return { ...provenance(runAttempt), kind, producerJobKey };
+}
+
+function checkpointLog(kind: "plan" | "decision" | "drain", payload: unknown, runAttempt = 1) {
+  return encodeFullReleaseValidationLogCheckpoint({
+    kind,
+    payload,
+    provenance: provenance(runAttempt),
+  }).join("\n");
+}
+
+describe("full release validation log checkpoints", () => {
+  it("round-trips exact JSON bytes through timestamped ANSI logs", () => {
+    const payload = { children: ["npm", "clawhub"], state: "passed" };
+    const log = checkpointLog("decision", payload)
+      .split("\n")
+      .map((line) => `2026-08-21T12:34:56.000Z \u001b[32m${line}\u001b[0m`)
+      .join("\r\n");
+    expect(parseFullReleaseValidationLogCheckpoint(log, expected("decision"))).toMatchObject({
+      payload,
+    });
+  });
+
+  it("bounds payload bytes and chunks", () => {
+    expect(() => checkpointLog("plan", { value: "x".repeat(128 * 1024) })).toThrow("size limit");
+    const payload = { value: "x".repeat(70_000) };
+    const lines = checkpointLog("plan", payload).split("\n");
+    expect(lines.length).toBeGreaterThan(3);
+    expect(
+      parseFullReleaseValidationLogCheckpoint(lines.join("\n"), expected("plan"))?.payload,
+    ).toEqual(payload);
+  });
+
+  it.each([
+    ["duplicate header", (lines: string[]) => [lines[0], ...lines]],
+    ["missing chunk", (lines: string[]) => lines.toSpliced(1, 1)],
+    ["reordered chunk", (lines: string[]) => [lines[0], lines[2], lines[1], ...lines.slice(3)]],
+    [
+      "conflicting trailer",
+      (lines: string[]) => [...lines.slice(0, -1), lines.at(-1)!.replace(/[a-f0-9]$/u, "f")],
+    ],
+    ["bad base64", (lines: string[]) => lines.with(1, `${lines[1]}=`)],
+  ])("fails closed on %s", (_name, mutate) => {
+    const lines = checkpointLog("drain", { value: "x".repeat(20_000) }).split("\n");
+    expect(() =>
+      parseFullReleaseValidationLogCheckpoint(mutate(lines).join("\n"), expected("drain")),
+    ).toThrow();
+  });
+
+  it("fails closed on provenance mismatch", () => {
+    expect(() =>
+      parseFullReleaseValidationLogCheckpoint(
+        checkpointLog("plan", { state: "sealed" }),
+        expected("plan", 2),
+      ),
+    ).toThrow("runAttempt");
+  });
+
+  it("keeps envelope fields allowlisted and does not print ambient secret text", () => {
+    const lines = encodeFullReleaseValidationLogCheckpoint({
+      kind: "plan",
+      payload: { state: "sealed" },
+      provenance: { ...provenance(), token: "plaintext-secret" },
+    });
+    expect(lines.join("\n")).not.toContain("plaintext-secret");
+    const parsed = parseFullReleaseValidationLogCheckpoint(lines.join("\n"), expected("plan"));
+    expect(parsed?.envelope).not.toHaveProperty("token");
+  });
+
+  it("requires one exact non-matrix producer job", () => {
+    const job = {
+      head_sha: SHA,
+      id: 7,
+      name: "Release Decision",
+      run_attempt: 2,
+      run_id: 123,
+      status: "completed",
+      workflow_name: "Full Release Validation",
+    };
+    const read = (jobs: Record<string, unknown>[]) =>
+      readFullReleaseValidationLogCheckpointFromGitHub({
+        getJobLog: () => checkpointLog("decision", { state: "passed" }, 2),
+        getJobs: () => jobs,
+        getRun: () => ({
+          event: "workflow_dispatch",
+          head_sha: SHA,
+          id: 123,
+          path: ".github/workflows/full-release-validation.yml",
+          run_attempt: 2,
+          workflow_id: 456,
+        }),
+        kind: "decision",
+        runAttempt: 2,
+        runId: "123",
+        targetSha: TARGET_SHA,
+        workflowSha: SHA,
+      });
+    expect(read([job])).toMatchObject({ job });
+    expect(read([])).toBeUndefined();
+    expect(() => read([job, { ...job, id: 8 }])).toThrow("not unique");
+    expect(() => read([{ ...job, run_id: 124 }])).toThrow("binding is invalid");
+  });
+
+  it("treats an active producer as not ready and a malformed completed producer as fatal", async () => {
+    const active = {
+      head_sha: SHA,
+      id: 7,
+      name: "Release Decision",
+      run_attempt: 2,
+      run_id: 123,
+      status: "in_progress",
+      workflow_name: "Full Release Validation",
+    };
+    expect(
+      readFullReleaseValidationLogCheckpointFromGitHub({
+        getJobs: () => [active],
+        getRun: () => ({
+          event: "workflow_dispatch",
+          head_sha: SHA,
+          id: 123,
+          path: ".github/workflows/full-release-validation.yml",
+          run_attempt: 2,
+          workflow_id: 456,
+        }),
+        kind: "decision",
+        getJobLog: () => {
+          throw new Error("must not read");
+        },
+        runAttempt: 2,
+        runId: "123",
+        targetSha: TARGET_SHA,
+        workflowSha: SHA,
+      }),
+    ).toBeUndefined();
+    expect(
+      readFullReleaseValidationLogCheckpointFromGitHub({
+        getJobs: () => [{ ...active, conclusion: "success", status: "completed" }],
+        getRun: () => ({
+          event: "workflow_dispatch",
+          head_sha: SHA,
+          id: 123,
+          path: ".github/workflows/full-release-validation.yml",
+          run_attempt: 2,
+          workflow_id: 456,
+        }),
+        kind: "decision",
+        getJobLog: () => `${checkpointLog("decision", { state: "passed" }, 2)}\nextra`,
+        runAttempt: 2,
+        runId: "123",
+        targetSha: TARGET_SHA,
+        workflowSha: SHA,
+      }),
+    ).toMatchObject({ payload: { state: "passed" } });
+    expect(() =>
+      readFullReleaseValidationLogCheckpointFromGitHub({
+        getJobs: () => [{ ...active, conclusion: "success", status: "completed" }],
+        getRun: () => ({
+          event: "workflow_dispatch",
+          head_sha: SHA,
+          id: 123,
+          path: ".github/workflows/full-release-validation.yml",
+          run_attempt: 2,
+          workflow_id: 456,
+        }),
+        kind: "decision",
+        getJobLog: () => "[openclaw-frv-checkpoint] chunk decision 1/1 e30",
+        runAttempt: 2,
+        runId: "123",
+        targetSha: TARGET_SHA,
+        workflowSha: SHA,
+      }),
+    ).toThrow("header");
+  });
+
+  it("searches earlier attempts newest-first and falls past pre-emission failures", async () => {
+    const attempts: number[] = [];
+    const result = await recoverFullReleaseValidationLogCheckpoint({
+      currentAttempt: 4,
+      expected: provenance(4),
+      kind: "plan",
+      listJobsForAttempt: async (attempt) => {
+        attempts.push(attempt);
+        return [
+          {
+            conclusion: attempt === 3 ? "failure" : "success",
+            head_sha: SHA,
+            id: attempt,
+            name: "Seal release execution plan",
+            run_attempt: attempt,
+            run_id: 123,
+            status: "completed",
+            workflow_name: "Full Release Validation",
+          },
+        ];
+      },
+      readJobLog: async (jobId) =>
+        Number(jobId) === 3 ? "failed before emission" : checkpointLog("plan", { source: 2 }, 2),
+    });
+    expect(attempts).toEqual([3, 2]);
+    expect(result).toMatchObject({ payload: { source: 2 }, sourceAttempt: 2 });
+  });
+
+  it("recovers Decision and Drain from independent source attempts", async () => {
+    const recover = (kind: "decision" | "drain", sourceAttempt: number) =>
+      recoverFullReleaseValidationLogCheckpoint({
+        currentAttempt: 4,
+        expected: provenance(4),
+        kind,
+        listJobsForAttempt: async (attempt) => [
+          {
+            conclusion: attempt === sourceAttempt ? "success" : "failure",
+            head_sha: SHA,
+            id: kind === "decision" ? 100 + attempt : 200 + attempt,
+            name: kind === "decision" ? "Release Decision" : "Diagnostic Drain",
+            run_attempt: attempt,
+            run_id: 123,
+            status: "completed",
+            workflow_name: "Full Release Validation",
+          },
+        ],
+        readJobLog: async (jobId) => {
+          const attempt = Number(jobId) % 100;
+          return attempt === sourceAttempt
+            ? checkpointLog(kind, { kind, sourceAttempt }, sourceAttempt)
+            : "failed before emission";
+        },
+      });
+    await expect(recover("decision", 3)).resolves.toMatchObject({ sourceAttempt: 3 });
+    await expect(recover("drain", 1)).resolves.toMatchObject({ sourceAttempt: 1 });
+  });
+
+  it("keeps workflow retries recovery-only and re-uploads the validated plan", () => {
+    const workflow = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
+    expect(workflow).not.toContain("Restore immutable release execution plan");
+    expect(workflow).toContain("FULL_RELEASE_RESTORE_PLAN: ${{ github.run_attempt != 1 }}");
+    expect(workflow).toContain("if: ${{ always() && steps.plan.outputs.sha256 != '' }}");
+    expect(workflow).toContain("overwrite: true");
+    expect(
+      workflow.match(/scripts\/lib\/full-release-validation-log-checkpoint\.mjs/gu),
+    ).toHaveLength(4);
+    expect(workflow).not.toContain("gh run rerun");
+  });
+
+  it("keeps child dispatches attempt-one-only and watchers artifact-first", () => {
+    const workflow = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
+    expect(workflow.match(/github\.run_attempt == 1/gu)?.length).toBeGreaterThanOrEqual(7);
+    const atSha = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
+    const summary = readFileSync("scripts/release-ci-summary.mjs", "utf8");
+    expect(atSha).toContain("tryReadReleaseDecision(");
+    expect(atSha).toContain("??\n        tryReadReleaseDecisionCheckpoint(");
+    expect(summary).toContain("tryReadReleaseDecisionArtifact(parent, runId, repository) ??");
+    expect(summary).toContain("tryReadReleaseDecisionCheckpoint(parent, runId, repository)");
+  });
+});

--- a/test/scripts/full-release-validation-log-checkpoint.test.ts
+++ b/test/scripts/full-release-validation-log-checkpoint.test.ts
@@ -201,7 +201,7 @@ describe("full release validation log checkpoints", () => {
     ).toThrow("header");
   });
 
-  it("searches earlier attempts newest-first and falls past pre-emission failures", async () => {
+  it("searches earlier attempts newest-first and falls past a completed no-marker attempt", async () => {
     const attempts: number[] = [];
     const result = await recoverFullReleaseValidationLogCheckpoint({
       currentAttempt: 4,
@@ -211,7 +211,7 @@ describe("full release validation log checkpoints", () => {
         attempts.push(attempt);
         return [
           {
-            conclusion: attempt === 3 ? "failure" : "success",
+            conclusion: "success",
             head_sha: SHA,
             id: attempt,
             name: "Seal release execution plan",
@@ -228,6 +228,40 @@ describe("full release validation log checkpoints", () => {
     expect(attempts).toEqual([3, 2]);
     expect(result).toMatchObject({ payload: { source: 2 }, sourceAttempt: 2 });
   });
+
+  it.each([
+    ["partial", "[openclaw-frv-checkpoint] chunk plan 1/1 e30"],
+    [
+      "duplicate",
+      `${checkpointLog("plan", { source: 2 }, 2)}\n${checkpointLog("plan", { source: 2 }, 2)}`,
+    ],
+    ["conflicting", checkpointLog("plan", { source: 2 }, 2).replace(/[a-f0-9]$/u, "f")],
+  ])(
+    "fails closed on a %s newest-attempt checkpoint instead of using older state",
+    async (_, log) => {
+      await expect(
+        recoverFullReleaseValidationLogCheckpoint({
+          currentAttempt: 3,
+          expected: provenance(3),
+          kind: "plan",
+          listJobsForAttempt: async (attempt) => [
+            {
+              conclusion: "success",
+              head_sha: SHA,
+              id: attempt,
+              name: "Seal release execution plan",
+              run_attempt: attempt,
+              run_id: 123,
+              status: "completed",
+              workflow_name: "Full Release Validation",
+            },
+          ],
+          readJobLog: async (jobId) =>
+            Number(jobId) === 2 ? log : checkpointLog("plan", { source: 1 }, 1),
+        }),
+      ).rejects.toThrow();
+    },
+  );
 
   it("recovers Decision and Drain from independent source attempts", async () => {
     const recover = (kind: "decision" | "drain", sourceAttempt: number) =>

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -1052,6 +1052,10 @@ if (endpoint.endsWith("/actions/runs/77")) {
 } else if (endpoint.includes("/attempts/1/jobs")) {
   console.log(JSON.stringify({id: 999, name: "Seal release execution plan", run_id: 77, run_attempt: 1, head_sha: process.env.GITHUB_SHA, workflow_name: "Full Release Validation", status: "completed", conclusion: "success"}));
 } else if (endpoint.includes("/actions/jobs/999/logs")) {
+  if (args.includes("--allow-escape-sequences")) {
+    console.error("unknown flag: --allow-escape-sequences");
+    process.exit(1);
+  }
   process.stdout.write(readFileSync(process.env.FRV_CHECKPOINT_LOG, "utf8"));
 } else {
   console.error("unexpected gh call: " + args.join(" "));

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -17,7 +17,10 @@ import {
   validateReleaseExecutionPlanArtifact,
   verifyReleaseStateArtifacts,
 } from "../../scripts/full-release-validation-state.mjs";
-import { encodeFullReleaseValidationLogCheckpoint } from "../../scripts/lib/full-release-validation-log-checkpoint.mjs";
+import {
+  encodeFullReleaseValidationLogCheckpoint,
+  parseFullReleaseValidationLogCheckpoint,
+} from "../../scripts/lib/full-release-validation-log-checkpoint.mjs";
 import { waitForChildClose, waitForFile } from "../helpers/process-wait.js";
 
 const SCRIPT = resolve("scripts/full-release-validation-state.mjs");
@@ -1090,165 +1093,22 @@ if (endpoint.endsWith("/actions/runs/77")) {
     });
   });
 
-  it("keeps a canonical plan when optional checkpoint provenance fails", () => {
-    const root = mkdtempSync(join(tmpdir(), "frv-plan-checkpoint-failure-"));
-    const gh = join(root, "gh");
-    const output = join(root, "full-release-execution-plan.json");
-    writeFileSync(gh, '#!/bin/sh\necho "Bad credentials" >&2\nexit 1\n');
-    chmodSync(gh, 0o755);
-    const result = spawnSync(process.execPath, [SCRIPT, "plan"], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        FULL_RELEASE_EXECUTION_PLAN_PATH: output,
-        FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify({
-          children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
-          dockerPreflightResult: "skipped",
-          evidenceReuse: false,
-          parentRunAttempt: 1,
-          parentRunId: "77",
-          prepareCandidateResult: "skipped",
-          rerunGroup: "ci",
-          resolveTargetResult: "success",
-          trustedWorkflow: TRUSTED_MAIN,
-          workflowRef: "release-ci/tooling",
-          workflowSha: SHA,
-        }),
-        GITHUB_REF_NAME: "release-ci/tooling",
-        GITHUB_REPOSITORY: "openclaw/openclaw",
-        GITHUB_RUN_ATTEMPT: "1",
-        GITHUB_RUN_ID: "77",
-        GITHUB_SHA: SHA,
-        PATH: `${root}:${process.env.PATH}`,
-        RELEASE_PROFILE: "stable",
-        RERUN_GROUP: "ci",
-        TARGET_SHA,
-      },
-      timeout: 10_000,
-    });
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stderr).toContain("plan checkpoint unavailable:");
-    expect(result.stderr).toContain("Bad credentials");
-    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
-      errors: [],
-      parentRunAttempt: 1,
-    });
-  });
-
-  it.each(["decision", "drain"] as const)(
-    "keeps canonical %s state when optional checkpoint provenance fails",
-    (mode) => {
-      const root = mkdtempSync(join(tmpdir(), `frv-${mode}-checkpoint-failure-`));
-      const gh = join(root, "gh");
-      const output = join(root, `${mode}.json`);
-      const executionPlanPath = join(root, "full-release-execution-plan.json");
-      writeFileSync(
-        executionPlanPath,
-        JSON.stringify(
-          executionPlan({
-            children: { normalCi: { result: "success", runAttempt: 1, runId: "101" } },
-            dockerPreflightResult: "skipped",
-            prepareCandidateResult: "skipped",
-            rerunGroup: "ci",
-            resolveTargetResult: "success",
-          }),
-        ),
-      );
-      writeFileSync(
-        gh,
-        `#!/bin/sh
-case "$*" in
-  *"/actions/runs/77") echo "Bad credentials" >&2; exit 1 ;;
-  *"/jobs?"*) exit 0 ;;
-esac
-printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/ci.yml@refs/heads/release-ci/tooling","display_title":"CI full-release-validation-77-1-ci","head_branch":"release-ci/tooling","head_sha":"${SHA}","run_attempt":1,"status":"completed","conclusion":"success","created_at":"2026-08-21T00:00:00Z","updated_at":"2026-08-21T00:01:00Z","html_url":"https://example.invalid/runs/101"}'
-`,
-      );
-      chmodSync(gh, 0o755);
-      const result = spawnSync(process.execPath, [SCRIPT, mode], {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          FAIL_FAST: "false",
-          FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
-          FULL_RELEASE_STATE_PATH: output,
-          GITHUB_REF_NAME: "release-ci/tooling",
-          GITHUB_REPOSITORY: "openclaw/openclaw",
-          GITHUB_RUN_ATTEMPT: "2",
-          GITHUB_RUN_ID: "77",
-          GITHUB_SHA: SHA,
-          PATH: `${root}:${process.env.PATH}`,
-          RELEASE_PROFILE: "stable",
-          RERUN_GROUP: "ci",
-          TARGET_SHA,
-        },
-        timeout: 10_000,
-      });
-      expect(result.status, result.stderr).toBe(0);
-      expect(result.stderr).toContain(`${mode} checkpoint unavailable:`);
-      expect(result.stderr).toContain("Bad credentials");
-      expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
-        cancellation: { requested: false },
-        state: "passed",
-      });
-    },
-  );
-
-  it("does not replace a completed plan when SIGTERM interrupts checkpoint provenance", async () => {
-    const root = mkdtempSync(join(tmpdir(), "frv-plan-checkpoint-signal-"));
-    const gh = join(root, "gh");
-    const ghReady = join(root, "gh-ready");
-    const output = join(root, "full-release-execution-plan.json");
-    writeFileSync(gh, '#!/bin/sh\nprintf ready > "$FRV_GH_READY"\nsleep 30\n');
-    chmodSync(gh, 0o755);
-    const childProcess = spawn(process.execPath, [SCRIPT, "plan"], {
-      env: {
-        ...process.env,
-        FRV_GH_READY: ghReady,
-        FULL_RELEASE_EXECUTION_PLAN_PATH: output,
-        FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify({
-          children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
-          dockerPreflightResult: "skipped",
-          evidenceReuse: false,
-          parentRunAttempt: 1,
-          parentRunId: "77",
-          prepareCandidateResult: "skipped",
-          rerunGroup: "ci",
-          resolveTargetResult: "success",
-          trustedWorkflow: TRUSTED_MAIN,
-          workflowRef: "release-ci/tooling",
-          workflowSha: SHA,
-        }),
-        GITHUB_REF_NAME: "release-ci/tooling",
-        GITHUB_REPOSITORY: "openclaw/openclaw",
-        GITHUB_RUN_ATTEMPT: "1",
-        GITHUB_RUN_ID: "77",
-        GITHUB_SHA: SHA,
-        PATH: `${root}:${process.env.PATH}`,
-        RELEASE_PROFILE: "stable",
-        RERUN_GROUP: "ci",
-        TARGET_SHA,
-      },
-      stdio: "ignore",
-    });
-    await waitForFile(ghReady, 5_000);
-    const exitPromise = waitForChildClose(childProcess);
-    const started = Date.now();
-    childProcess.kill("SIGTERM");
-    await exitPromise;
-    expect(Date.now() - started).toBeLessThan(2_000);
-    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
-      errors: [],
-      parentRunAttempt: 1,
-    });
-  });
-
   it("writes the execution plan immediately when SIGTERM interrupts a stalled reuse API", async () => {
     const root = mkdtempSync(join(tmpdir(), "frv-plan-signal-"));
     const gh = join(root, "gh");
     const ghReady = join(root, "gh-ready");
+    const githubOutput = join(root, "github-output");
     const output = join(root, "full-release-execution-plan.json");
-    writeFileSync(gh, '#!/bin/sh\nprintf ready > "$FRV_GH_READY"\nsleep 30\n');
+    writeFileSync(
+      gh,
+      `#!/bin/sh
+case "$*" in
+  *"/actions/runs/77") printf '%s\\n' '{"id":77,"event":"workflow_dispatch","run_attempt":1,"head_sha":"${SHA}","workflow_id":456,"path":".github/workflows/full-release-validation.yml"}'; exit 0 ;;
+esac
+printf ready > "$FRV_GH_READY"
+sleep 30
+`,
+    );
     chmodSync(gh, 0o755);
     const childProcess = spawn(process.execPath, [SCRIPT, "plan"], {
       env: {
@@ -1280,27 +1140,46 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
         GITHUB_RUN_ATTEMPT: "1",
         GITHUB_RUN_ID: "77",
         GITHUB_SHA: SHA,
+        GITHUB_OUTPUT: githubOutput,
         PATH: `${root}:${process.env.PATH}`,
         RELEASE_PROFILE: "stable",
         RERUN_GROUP: "ci",
         TARGET_SHA,
       },
-      stdio: "ignore",
+      stdio: ["ignore", "pipe", "ignore"],
     });
+    const stdout: Buffer[] = [];
+    childProcess.stdout?.on("data", (chunk) => stdout.push(chunk));
     await waitForFile(ghReady, 5_000);
     const exitPromise = waitForChildClose(childProcess);
     const started = Date.now();
     childProcess.kill("SIGTERM");
-    await exitPromise;
+    const exit = await exitPromise;
     expect(Date.now() - started).toBeLessThan(2_000);
-    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+    expect(exit.code).toBe(2);
+    const artifact = JSON.parse(readFileSync(output, "utf8"));
+    expect(artifact).toMatchObject({
       errors: [expect.objectContaining({ kind: "collector_cancelled" })],
       parentRunAttempt: 1,
     });
+    expect(readFileSync(githubOutput, "utf8")).toContain(`sha256=${artifact.sha256}`);
+    expect(
+      parseFullReleaseValidationLogCheckpoint(Buffer.concat(stdout).toString("utf8"), {
+        kind: "plan",
+        producerJobKey: "release_execution_plan",
+        runAttempt: 1,
+        runId: "77",
+        targetSha: TARGET_SHA,
+        workflowId: 456,
+        workflowPath: ".github/workflows/full-release-validation.yml",
+        workflowSha: SHA,
+      })?.payload,
+    ).toEqual(artifact);
   });
 
-  it("records target resolution failure even when no target SHA exists", () => {
+  it("keeps the committed result when the human summary cannot be written", () => {
     const root = mkdtempSync(join(tmpdir(), "frv-state-target-failure-"));
+    const githubOutput = join(root, "github-output");
     const output = join(root, "decision.json");
     const executionPlanPath = join(root, "full-release-execution-plan.json");
     writeFileSync(
@@ -1337,6 +1216,8 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
         GITHUB_RUN_ATTEMPT: "2",
         GITHUB_RUN_ID: "77",
         GITHUB_SHA: SHA,
+        GITHUB_OUTPUT: githubOutput,
+        GITHUB_STEP_SUMMARY: root,
         RELEASE_PROFILE: "stable",
         RERUN_GROUP: "ci",
         TARGET_SHA: "",
@@ -1345,6 +1226,7 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       timeout: 10_000,
     });
     expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("warning: could not write decision summary");
     const artifact = JSON.parse(readFileSync(output, "utf8"));
     expect(artifact).toMatchObject({
       state: "blocked_complete",
@@ -1356,12 +1238,46 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
         message: expect.stringContaining("Resolve target ref"),
       }),
     );
+    expect(readFileSync(githubOutput, "utf8")).toContain("state=blocked_complete");
+  });
+
+  it("does not commit state when checkpoint provenance cannot be resolved", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-state-provenance-failure-"));
+    const gh = join(root, "gh");
+    const output = join(root, "decision.json");
+    const executionPlanPath = join(root, "full-release-execution-plan.json");
+    writeFileSync(executionPlanPath, JSON.stringify(executionPlan({ rerunGroup: "ci" })));
+    writeFileSync(gh, '#!/bin/sh\nprintf "Bad credentials\\n" >&2\nexit 1\n');
+    chmodSync(gh, 0o755);
+    const result = spawnSync(process.execPath, [SCRIPT, "decision"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAIL_FAST: "false",
+        FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+        FULL_RELEASE_STATE_PATH: output,
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        PATH: `${root}:${process.env.PATH}`,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA,
+      },
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("Bad credentials");
+    expect(() => readFileSync(output, "utf8")).toThrow();
   });
 
   it("writes an immediate terminal handoff with active identity on SIGTERM", async () => {
     const root = mkdtempSync(join(tmpdir(), "frv-state-signal-"));
     const gh = join(root, "gh");
     const ghReady = join(root, "gh-ready");
+    const githubOutput = join(root, "github-output");
     const output = join(root, "drain.json");
     const executionPlanPath = join(root, "full-release-execution-plan.json");
     writeFileSync(
@@ -1379,6 +1295,10 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
     writeFileSync(
       gh,
       `#!/bin/sh
+if echo "$*" | grep -q '/actions/runs/77$'; then
+  printf '%s\\n' '{"id":77,"event":"workflow_dispatch","run_attempt":2,"head_sha":"${SHA}","workflow_id":456,"path":".github/workflows/full-release-validation.yml"}'
+  exit 0
+fi
 printf ready > "$FRV_GH_READY"
 if [ "$1" = "api" ] && echo "$2" | grep -q '/jobs'; then
   exit 0
@@ -1400,22 +1320,40 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
         GITHUB_RUN_ATTEMPT: "2",
         GITHUB_RUN_ID: "77",
         GITHUB_SHA: SHA,
+        GITHUB_OUTPUT: githubOutput,
         PATH: `${root}:${process.env.PATH}`,
         RELEASE_PROFILE: "stable",
         RERUN_GROUP: "ci",
         TARGET_SHA: "b".repeat(40),
       },
-      stdio: "ignore",
+      stdio: ["ignore", "pipe", "ignore"],
     });
+    const stdout: Buffer[] = [];
+    childProcess.stdout?.on("data", (chunk) => stdout.push(chunk));
     await waitForFile(ghReady, 5_000);
     const exitPromise = waitForChildClose(childProcess);
     childProcess.kill("SIGTERM");
-    await exitPromise;
-    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+    const exit = await exitPromise;
+    expect(exit.code).toBe(1);
+    const artifact = JSON.parse(readFileSync(output, "utf8"));
+    expect(artifact).toMatchObject({
       activeRunIds: ["101"],
       cancellation: { requested: true },
       state: "cancelled_with_children",
     });
+    expect(readFileSync(githubOutput, "utf8")).toContain("state=cancelled_with_children");
+    expect(
+      parseFullReleaseValidationLogCheckpoint(Buffer.concat(stdout).toString("utf8"), {
+        kind: "drain",
+        producerJobKey: "diagnostic_drain",
+        runAttempt: 2,
+        runId: "77",
+        targetSha: TARGET_SHA,
+        workflowId: 456,
+        workflowPath: ".github/workflows/full-release-validation.yml",
+        workflowSha: SHA,
+      })?.payload,
+    ).toEqual(artifact);
   });
 
   it("cancels only the exact affected child and never cancels from drain", () => {
@@ -1428,6 +1366,10 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       `#!/bin/sh
 printf '%s\\n' "$*" >> "$FRV_GH_CALLS"
 if [ "$1" = "run" ] && [ "$2" = "cancel" ]; then
+  exit 0
+fi
+if echo "$*" | grep -q '/actions/runs/77$'; then
+  printf '%s\\n' '{"id":77,"event":"workflow_dispatch","run_attempt":2,"head_sha":"${SHA}","workflow_id":456,"path":".github/workflows/full-release-validation.yml"}'
   exit 0
 fi
 case "$*" in

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -1276,8 +1276,9 @@ sleep 30
   it("writes an immediate terminal handoff with active identity on SIGTERM", async () => {
     const root = mkdtempSync(join(tmpdir(), "frv-state-signal-"));
     const gh = join(root, "gh");
-    const ghReady = join(root, "gh-ready");
     const githubOutput = join(root, "github-output");
+    const largeJobName = "n".repeat(200);
+    const largeJobUrl = `https://example.invalid/${"u".repeat(1000)}`;
     const output = join(root, "drain.json");
     const executionPlanPath = join(root, "full-release-execution-plan.json");
     writeFileSync(
@@ -1299,8 +1300,12 @@ if echo "$*" | grep -q '/actions/runs/77$'; then
   printf '%s\\n' '{"id":77,"event":"workflow_dispatch","run_attempt":2,"head_sha":"${SHA}","workflow_id":456,"path":".github/workflows/full-release-validation.yml"}'
   exit 0
 fi
-printf ready > "$FRV_GH_READY"
-if [ "$1" = "api" ] && echo "$2" | grep -q '/jobs'; then
+if [ "$1" = "api" ] && echo "$*" | grep -q '/jobs'; then
+  i=0
+  while [ "$i" -lt 94 ]; do
+    printf '%s\\n' '{"name":"${largeJobName}","status":"in_progress","conclusion":null,"html_url":"${largeJobUrl}"}'
+    i=$((i + 1))
+  done
   exit 0
 fi
 printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/ci.yml@refs/heads/release-ci/tooling","display_title":"CI full-release-validation-77-1-ci","head_branch":"release-ci/tooling","head_sha":"${SHA}","run_attempt":1,"status":"in_progress","conclusion":null,"created_at":"2026-08-21T00:00:00Z","updated_at":"2026-08-21T00:01:00Z","html_url":"https://example.invalid/runs/101"}'
@@ -1311,7 +1316,6 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       env: {
         ...process.env,
         FAIL_FAST: "false",
-        FRV_GH_READY: ghReady,
         FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
         FULL_RELEASE_POLL_INTERVAL_MS: "60000",
         FULL_RELEASE_STATE_PATH: output,
@@ -1329,8 +1333,22 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       stdio: ["ignore", "pipe", "ignore"],
     });
     const stdout: Buffer[] = [];
-    childProcess.stdout?.on("data", (chunk) => stdout.push(chunk));
-    await waitForFile(ghReady, 5_000);
+    const heartbeat = new Promise<void>((markHeartbeat, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("timeout waiting for drain heartbeat")),
+        5_000,
+      );
+      let stdoutText = "";
+      childProcess.stdout?.on("data", (chunk) => {
+        stdout.push(chunk);
+        stdoutText += chunk.toString("utf8");
+        if (stdoutText.includes("drain heartbeat:")) {
+          clearTimeout(timeout);
+          markHeartbeat();
+        }
+      });
+    });
+    await heartbeat;
     const exitPromise = waitForChildClose(childProcess);
     childProcess.kill("SIGTERM");
     const exit = await exitPromise;
@@ -1342,18 +1360,22 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       state: "cancelled_with_children",
     });
     expect(readFileSync(githubOutput, "utf8")).toContain("state=cancelled_with_children");
-    expect(
-      parseFullReleaseValidationLogCheckpoint(Buffer.concat(stdout).toString("utf8"), {
-        kind: "drain",
-        producerJobKey: "diagnostic_drain",
-        runAttempt: 2,
-        runId: "77",
-        targetSha: TARGET_SHA,
-        workflowId: 456,
-        workflowPath: ".github/workflows/full-release-validation.yml",
-        workflowSha: SHA,
-      })?.payload,
-    ).toEqual(artifact);
+    const log = Buffer.concat(stdout).toString("utf8");
+    const checkpoint = parseFullReleaseValidationLogCheckpoint(log, {
+      kind: "drain",
+      producerJobKey: "diagnostic_drain",
+      runAttempt: 2,
+      runId: "77",
+      targetSha: TARGET_SHA,
+      workflowId: 456,
+      workflowPath: ".github/workflows/full-release-validation.yml",
+      workflowSha: SHA,
+    });
+    expect(checkpoint?.envelope.byteLength).toBeGreaterThan(120 * 1024);
+    expect(log.match(/^\[openclaw-frv-checkpoint\] /gmu)).toHaveLength(
+      Number(checkpoint?.envelope.chunkCount) + 2,
+    );
+    expect(checkpoint?.payload).toEqual(artifact);
   });
 
   it("cancels only the exact affected child and never cancels from drain", () => {

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -17,12 +17,31 @@ import {
   validateReleaseExecutionPlanArtifact,
   verifyReleaseStateArtifacts,
 } from "../../scripts/full-release-validation-state.mjs";
+import { encodeFullReleaseValidationLogCheckpoint } from "../../scripts/lib/full-release-validation-log-checkpoint.mjs";
 import { waitForChildClose, waitForFile } from "../helpers/process-wait.js";
 
 const SCRIPT = resolve("scripts/full-release-validation-state.mjs");
 const SHA = "a".repeat(40);
 const TARGET_SHA = "b".repeat(40);
 const TRUSTED_MAIN = { fullRef: "refs/heads/main", ref: "main", sha: SHA };
+
+function writeCheckpointGh(path: string) {
+  writeFileSync(
+    path,
+    `#!/usr/bin/env node
+const runId = process.env.GITHUB_RUN_ID;
+console.log(JSON.stringify({
+  event: "workflow_dispatch",
+  head_sha: process.env.GITHUB_SHA,
+  id: Number(runId),
+  path: ".github/workflows/full-release-validation.yml",
+  run_attempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+  workflow_id: 456,
+}));
+`,
+  );
+  chmodSync(path, 0o755);
+}
 
 function evidenceManifest() {
   return { runAttempt: 1, runId: "99", targetSha: TARGET_SHA };
@@ -640,6 +659,7 @@ describe("collector subprocess", () => {
     const output = join(root, "full-release-execution-plan.json");
     const validator = join(root, "release-evidence-validator.mjs");
     const validatorArgs = join(root, "validator-args.json");
+    writeCheckpointGh(join(root, "gh"));
     writeFileSync(
       validator,
       `import { writeFileSync } from "node:fs";
@@ -707,6 +727,7 @@ console.log(JSON.stringify({
         GITHUB_RUN_ID: "77",
         GITHUB_SHA: SHA,
         OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR: validator,
+        PATH: `${root}:${process.env.PATH}`,
         RELEASE_PROFILE: "stable",
         RERUN_GROUP: "all",
         TARGET_SHA,
@@ -764,6 +785,7 @@ console.log(JSON.stringify({
       gh,
       `#!/bin/sh
 case "$*" in
+  *"/actions/runs/77") printf '%s\\n' '{"id":77,"event":"workflow_dispatch","path":".github/workflows/full-release-validation.yml","head_sha":"${SHA}","run_attempt":2,"workflow_id":456}'; exit 0 ;;
   *"/jobs?"*) exit 0 ;;
 esac
 printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/ci.yml@refs/heads/release-ci/tooling","display_title":"CI full-release-validation-77-1-ci","head_branch":"release-ci/tooling","head_sha":"${SHA}","run_attempt":1,"status":"completed","conclusion":"success","created_at":"2026-08-21T00:00:00Z","updated_at":"2026-08-21T00:01:00Z","html_url":"https://example.invalid/runs/101"}'
@@ -928,6 +950,7 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
     const output = join(root, "full-release-execution-plan.json");
     const decisionOutput = join(root, "full-release-decision.json");
     const validator = join(root, "release-evidence-validator.mjs");
+    writeCheckpointGh(join(root, "gh"));
     writeFileSync(
       validator,
       'console.error("sealed reuse selection rejected"); process.exit(1);\n',
@@ -960,6 +983,7 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       GITHUB_RUN_ID: "77",
       GITHUB_SHA: SHA,
       OPENCLAW_RELEASE_CI_SUMMARY_VALIDATOR: validator,
+      PATH: `${root}:${process.env.PATH}`,
       RELEASE_PROFILE: "stable",
       RERUN_GROUP: "all",
       TARGET_SHA,
@@ -998,18 +1022,56 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
 
   it("adopts the immutable attempt-one plan on an attempt-two collector retry", () => {
     const root = mkdtempSync(join(tmpdir(), "frv-plan-restore-"));
+    const gh = join(root, "gh");
+    const log = join(root, "checkpoint.log");
     const output = join(root, "full-release-execution-plan.json");
     const sealed = executionPlan({ rerunGroup: "ci" });
-    writeFileSync(output, JSON.stringify(sealed));
+    writeFileSync(
+      log,
+      encodeFullReleaseValidationLogCheckpoint({
+        kind: "plan",
+        payload: sealed,
+        provenance: {
+          runAttempt: 1,
+          runId: "77",
+          targetSha: TARGET_SHA,
+          workflowId: 456,
+          workflowPath: ".github/workflows/full-release-validation.yml",
+          workflowSha: SHA,
+        },
+      }).join("\n"),
+    );
+    writeFileSync(
+      gh,
+      `#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+const args = process.argv.slice(2);
+const endpoint = args.find((arg) => arg.includes("/actions/")) ?? "";
+if (endpoint.endsWith("/actions/runs/77")) {
+  console.log(JSON.stringify({id: 77, event: "workflow_dispatch", run_attempt: 2, head_sha: process.env.GITHUB_SHA, workflow_id: 456, path: ".github/workflows/full-release-validation.yml"}));
+} else if (endpoint.includes("/attempts/1/jobs")) {
+  console.log(JSON.stringify({id: 999, name: "Seal release execution plan", run_id: 77, run_attempt: 1, head_sha: process.env.GITHUB_SHA, workflow_name: "Full Release Validation", status: "completed", conclusion: "success"}));
+} else if (endpoint.includes("/actions/jobs/999/logs")) {
+  process.stdout.write(readFileSync(process.env.FRV_CHECKPOINT_LOG, "utf8"));
+} else {
+  console.error("unexpected gh call: " + args.join(" "));
+  process.exit(2);
+}
+`,
+    );
+    chmodSync(gh, 0o755);
     const result = spawnSync(process.execPath, [SCRIPT, "plan"], {
       env: {
         ...process.env,
+        FRV_CHECKPOINT_LOG: log,
         FULL_RELEASE_EXECUTION_PLAN_PATH: output,
         FULL_RELEASE_RESTORE_PLAN: "true",
         GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
         GITHUB_RUN_ATTEMPT: "2",
         GITHUB_RUN_ID: "77",
         GITHUB_SHA: SHA,
+        PATH: `${root}:${process.env.PATH}`,
         RELEASE_PROFILE: "stable",
         RERUN_GROUP: "ci",
         TARGET_SHA,

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -18,10 +18,7 @@ import {
   validateReleaseExecutionPlanArtifact,
   verifyReleaseStateArtifacts,
 } from "../../scripts/full-release-validation-state.mjs";
-import {
-  encodeFullReleaseValidationLogCheckpoint,
-  parseFullReleaseValidationLogCheckpoint,
-} from "../../scripts/lib/full-release-validation-log-checkpoint.mjs";
+import { parseFullReleaseValidationLogCheckpoint } from "../../scripts/lib/full-release-validation-log-checkpoint.mjs";
 import { waitForChildClose, waitForFile } from "../helpers/process-wait.js";
 
 const SCRIPT = resolve("scripts/full-release-validation-state.mjs");
@@ -1082,7 +1079,7 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
     const githubOutput = join(root, "github-output");
     const output = join(root, "full-release-execution-plan.json");
     writeCheckpointGh(join(root, "gh"));
-    const result = spawnSync("/bin/sh", ["-c", 'exec 1>&-; exec "$NODE" "$SCRIPT" plan'], {
+    spawnSync("/bin/sh", ["-c", 'exec 1>&-; exec "$NODE" "$SCRIPT" plan'], {
       encoding: "utf8",
       env: {
         ...process.env,
@@ -1119,7 +1116,7 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
     expect(readFileSync(githubOutput, "utf8")).toContain(`sha256=${artifact.sha256}`);
   });
 
-  it("writes the execution plan immediately when SIGTERM interrupts a stalled reuse API", async () => {
+  it("writes the execution plan immediately when SIGTERM interrupts stalled provenance", async () => {
     const root = mkdtempSync(join(tmpdir(), "frv-plan-signal-"));
     const gh = join(root, "gh");
     const ghReady = join(root, "gh-ready");
@@ -1128,9 +1125,6 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
     writeFileSync(
       gh,
       `#!/bin/sh
-case "$*" in
-  *"/actions/runs/77") printf '%s\\n' '{"id":77,"event":"workflow_dispatch","run_attempt":1,"head_sha":"${SHA}","workflow_id":456,"path":".github/workflows/full-release-validation.yml"}'; exit 0 ;;
-esac
 printf ready > "$FRV_GH_READY"
 sleep 30
 `,
@@ -1174,8 +1168,6 @@ sleep 30
       },
       stdio: ["ignore", "pipe", "ignore"],
     });
-    const stdout: Buffer[] = [];
-    childProcess.stdout?.on("data", (chunk) => stdout.push(chunk));
     await waitForFile(ghReady, 5_000);
     const exitPromise = waitForChildClose(childProcess);
     const started = Date.now();
@@ -1189,19 +1181,56 @@ sleep 30
       parentRunAttempt: 1,
     });
     expect(readFileSync(githubOutput, "utf8")).toContain(`sha256=${artifact.sha256}`);
-    expect(
-      parseFullReleaseValidationLogCheckpoint(Buffer.concat(stdout).toString("utf8"), {
-        kind: "plan",
-        producerJobKey: "release_execution_plan",
-        runAttempt: 1,
-        runId: "77",
-        targetSha: TARGET_SHA,
-        workflowId: 456,
-        workflowPath: ".github/workflows/full-release-validation.yml",
-        workflowSha: SHA,
-      })?.payload,
-    ).toEqual(artifact);
   });
+
+  it.each(["decision", "drain"] as const)(
+    "writes canonical %s state when SIGTERM interrupts stalled provenance",
+    async (mode) => {
+      const root = mkdtempSync(join(tmpdir(), `frv-${mode}-provenance-signal-`));
+      const gh = join(root, "gh");
+      const ghReady = join(root, "gh-ready");
+      const output = join(root, `${mode}.json`);
+      const executionPlanPath = join(root, "full-release-execution-plan.json");
+      writeFileSync(executionPlanPath, JSON.stringify(executionPlan({ rerunGroup: "ci" })));
+      writeFileSync(
+        gh,
+        `#!/bin/sh
+printf ready > "$FRV_GH_READY"
+sleep 30
+`,
+      );
+      chmodSync(gh, 0o755);
+      const childProcess = spawn(process.execPath, [SCRIPT, mode], {
+        env: {
+          ...process.env,
+          FAIL_FAST: "false",
+          FRV_GH_READY: ghReady,
+          FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+          FULL_RELEASE_STATE_PATH: output,
+          GITHUB_REF_NAME: "release-ci/tooling",
+          GITHUB_REPOSITORY: "openclaw/openclaw",
+          GITHUB_RUN_ATTEMPT: "2",
+          GITHUB_RUN_ID: "77",
+          GITHUB_SHA: SHA,
+          PATH: `${root}:${process.env.PATH}`,
+          RELEASE_PROFILE: "stable",
+          RERUN_GROUP: "ci",
+          TARGET_SHA,
+        },
+        stdio: "ignore",
+      });
+      await waitForFile(ghReady, 5_000);
+      const exitPromise = waitForChildClose(childProcess);
+      const started = Date.now();
+      childProcess.kill("SIGTERM");
+      const exit = await exitPromise;
+      expect(Date.now() - started).toBeLessThan(2_000);
+      expect(exit.code).not.toBe(0);
+      expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+        errors: [expect.objectContaining({ kind: "collector_cancelled" })],
+      });
+    },
+  );
 
   it("keeps the committed result when the human summary cannot be written", () => {
     const root = mkdtempSync(join(tmpdir(), "frv-state-target-failure-"));

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -1090,6 +1090,159 @@ if (endpoint.endsWith("/actions/runs/77")) {
     });
   });
 
+  it("keeps a canonical plan when optional checkpoint provenance fails", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-plan-checkpoint-failure-"));
+    const gh = join(root, "gh");
+    const output = join(root, "full-release-execution-plan.json");
+    writeFileSync(gh, '#!/bin/sh\necho "Bad credentials" >&2\nexit 1\n');
+    chmodSync(gh, 0o755);
+    const result = spawnSync(process.execPath, [SCRIPT, "plan"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FULL_RELEASE_EXECUTION_PLAN_PATH: output,
+        FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify({
+          children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
+          dockerPreflightResult: "skipped",
+          evidenceReuse: false,
+          parentRunAttempt: 1,
+          parentRunId: "77",
+          prepareCandidateResult: "skipped",
+          rerunGroup: "ci",
+          resolveTargetResult: "success",
+          trustedWorkflow: TRUSTED_MAIN,
+          workflowRef: "release-ci/tooling",
+          workflowSha: SHA,
+        }),
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "1",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        PATH: `${root}:${process.env.PATH}`,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA,
+      },
+      timeout: 10_000,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("plan checkpoint unavailable:");
+    expect(result.stderr).toContain("Bad credentials");
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      errors: [],
+      parentRunAttempt: 1,
+    });
+  });
+
+  it.each(["decision", "drain"] as const)(
+    "keeps canonical %s state when optional checkpoint provenance fails",
+    (mode) => {
+      const root = mkdtempSync(join(tmpdir(), `frv-${mode}-checkpoint-failure-`));
+      const gh = join(root, "gh");
+      const output = join(root, `${mode}.json`);
+      const executionPlanPath = join(root, "full-release-execution-plan.json");
+      writeFileSync(
+        executionPlanPath,
+        JSON.stringify(
+          executionPlan({
+            children: { normalCi: { result: "success", runAttempt: 1, runId: "101" } },
+            dockerPreflightResult: "skipped",
+            prepareCandidateResult: "skipped",
+            rerunGroup: "ci",
+            resolveTargetResult: "success",
+          }),
+        ),
+      );
+      writeFileSync(
+        gh,
+        `#!/bin/sh
+case "$*" in
+  *"/actions/runs/77") echo "Bad credentials" >&2; exit 1 ;;
+  *"/jobs?"*) exit 0 ;;
+esac
+printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/ci.yml@refs/heads/release-ci/tooling","display_title":"CI full-release-validation-77-1-ci","head_branch":"release-ci/tooling","head_sha":"${SHA}","run_attempt":1,"status":"completed","conclusion":"success","created_at":"2026-08-21T00:00:00Z","updated_at":"2026-08-21T00:01:00Z","html_url":"https://example.invalid/runs/101"}'
+`,
+      );
+      chmodSync(gh, 0o755);
+      const result = spawnSync(process.execPath, [SCRIPT, mode], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAIL_FAST: "false",
+          FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+          FULL_RELEASE_STATE_PATH: output,
+          GITHUB_REF_NAME: "release-ci/tooling",
+          GITHUB_REPOSITORY: "openclaw/openclaw",
+          GITHUB_RUN_ATTEMPT: "2",
+          GITHUB_RUN_ID: "77",
+          GITHUB_SHA: SHA,
+          PATH: `${root}:${process.env.PATH}`,
+          RELEASE_PROFILE: "stable",
+          RERUN_GROUP: "ci",
+          TARGET_SHA,
+        },
+        timeout: 10_000,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stderr).toContain(`${mode} checkpoint unavailable:`);
+      expect(result.stderr).toContain("Bad credentials");
+      expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+        cancellation: { requested: false },
+        state: "passed",
+      });
+    },
+  );
+
+  it("does not replace a completed plan when SIGTERM interrupts checkpoint provenance", async () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-plan-checkpoint-signal-"));
+    const gh = join(root, "gh");
+    const ghReady = join(root, "gh-ready");
+    const output = join(root, "full-release-execution-plan.json");
+    writeFileSync(gh, '#!/bin/sh\nprintf ready > "$FRV_GH_READY"\nsleep 30\n');
+    chmodSync(gh, 0o755);
+    const childProcess = spawn(process.execPath, [SCRIPT, "plan"], {
+      env: {
+        ...process.env,
+        FRV_GH_READY: ghReady,
+        FULL_RELEASE_EXECUTION_PLAN_PATH: output,
+        FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify({
+          children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
+          dockerPreflightResult: "skipped",
+          evidenceReuse: false,
+          parentRunAttempt: 1,
+          parentRunId: "77",
+          prepareCandidateResult: "skipped",
+          rerunGroup: "ci",
+          resolveTargetResult: "success",
+          trustedWorkflow: TRUSTED_MAIN,
+          workflowRef: "release-ci/tooling",
+          workflowSha: SHA,
+        }),
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "1",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        PATH: `${root}:${process.env.PATH}`,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA,
+      },
+      stdio: "ignore",
+    });
+    await waitForFile(ghReady, 5_000);
+    const exitPromise = waitForChildClose(childProcess);
+    const started = Date.now();
+    childProcess.kill("SIGTERM");
+    await exitPromise;
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      errors: [],
+      parentRunAttempt: 1,
+    });
+  });
+
   it("writes the execution plan immediately when SIGTERM interrupts a stalled reuse API", async () => {
     const root = mkdtempSync(join(tmpdir(), "frv-plan-signal-"));
     const gh = join(root, "gh");

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -11,6 +11,7 @@ import {
   buildReleaseStateArtifact,
   classifyReleaseGhTransportError,
   classifyReleaseSnapshot,
+  emitCheckpoint,
   formatReleaseStateOutcome,
   selectReleaseStateArtifacts,
   validateChildBinding,
@@ -183,6 +184,28 @@ describe("full release execution plan", () => {
     expect(
       classifyReleaseGhTransportError(Object.assign(new Error(message), { stderr: message })),
     ).toBe(expected);
+  });
+
+  it.each(["EBADF", "EPIPE"])("surfaces terminal checkpoint write error %s once", (code) => {
+    let writes = 0;
+    expect(() =>
+      emitCheckpoint(["checkpoint"], () => {
+        writes += 1;
+        throw Object.assign(new Error(code), { code });
+      }),
+    ).toThrow(code);
+    expect(writes).toBe(1);
+  });
+
+  it("bounds transient checkpoint write retries without spinning", () => {
+    let writes = 0;
+    expect(() =>
+      emitCheckpoint(["checkpoint"], () => {
+        writes += 1;
+        throw Object.assign(new Error("temporarily unavailable"), { code: "EAGAIN" });
+      }),
+    ).toThrow("temporarily unavailable");
+    expect(writes).toBe(4);
   });
 
   it("keeps required coverage selected when dispatch output is missing", () => {
@@ -1025,52 +1048,13 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
 
   it("adopts the immutable attempt-one plan on an attempt-two collector retry", () => {
     const root = mkdtempSync(join(tmpdir(), "frv-plan-restore-"));
-    const gh = join(root, "gh");
-    const log = join(root, "checkpoint.log");
+    writeCheckpointGh(join(root, "gh"));
     const output = join(root, "full-release-execution-plan.json");
     const sealed = executionPlan({ rerunGroup: "ci" });
-    writeFileSync(
-      log,
-      encodeFullReleaseValidationLogCheckpoint({
-        kind: "plan",
-        payload: sealed,
-        provenance: {
-          runAttempt: 1,
-          runId: "77",
-          targetSha: TARGET_SHA,
-          workflowId: 456,
-          workflowPath: ".github/workflows/full-release-validation.yml",
-          workflowSha: SHA,
-        },
-      }).join("\n"),
-    );
-    writeFileSync(
-      gh,
-      `#!/usr/bin/env node
-import { readFileSync } from "node:fs";
-const args = process.argv.slice(2);
-const endpoint = args.find((arg) => arg.includes("/actions/")) ?? "";
-if (endpoint.endsWith("/actions/runs/77")) {
-  console.log(JSON.stringify({id: 77, event: "workflow_dispatch", run_attempt: 2, head_sha: process.env.GITHUB_SHA, workflow_id: 456, path: ".github/workflows/full-release-validation.yml"}));
-} else if (endpoint.includes("/attempts/1/jobs")) {
-  console.log(JSON.stringify({id: 999, name: "Seal release execution plan", run_id: 77, run_attempt: 1, head_sha: process.env.GITHUB_SHA, workflow_name: "Full Release Validation", status: "completed", conclusion: "success"}));
-} else if (endpoint.includes("/actions/jobs/999/logs")) {
-  if (args.includes("--allow-escape-sequences")) {
-    console.error("unknown flag: --allow-escape-sequences");
-    process.exit(1);
-  }
-  process.stdout.write(readFileSync(process.env.FRV_CHECKPOINT_LOG, "utf8"));
-} else {
-  console.error("unexpected gh call: " + args.join(" "));
-  process.exit(2);
-}
-`,
-    );
-    chmodSync(gh, 0o755);
+    writeFileSync(output, JSON.stringify(sealed));
     const result = spawnSync(process.execPath, [SCRIPT, "plan"], {
       env: {
         ...process.env,
-        FRV_CHECKPOINT_LOG: log,
         FULL_RELEASE_EXECUTION_PLAN_PATH: output,
         FULL_RELEASE_RESTORE_PLAN: "true",
         GITHUB_REF_NAME: "release-ci/tooling",
@@ -1091,6 +1075,48 @@ if (endpoint.endsWith("/actions/runs/77")) {
       parentRunAttempt: 1,
       sha256: sealed.sha256,
     });
+  });
+
+  it("keeps the canonical plan when checkpoint stdout is closed", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-plan-stdout-failure-"));
+    const githubOutput = join(root, "github-output");
+    const output = join(root, "full-release-execution-plan.json");
+    writeCheckpointGh(join(root, "gh"));
+    const result = spawnSync("/bin/sh", ["-c", 'exec 1>&-; exec "$NODE" "$SCRIPT" plan'], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FULL_RELEASE_EXECUTION_PLAN_PATH: output,
+        FULL_RELEASE_PLAN_INPUTS_JSON: JSON.stringify({
+          children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
+          dockerPreflightResult: "skipped",
+          evidenceReuse: false,
+          parentRunAttempt: 1,
+          parentRunId: "77",
+          prepareCandidateResult: "skipped",
+          rerunGroup: "ci",
+          resolveTargetResult: "success",
+          trustedWorkflow: TRUSTED_MAIN,
+          workflowRef: "release-ci/tooling",
+          workflowSha: SHA,
+        }),
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        GITHUB_RUN_ATTEMPT: "1",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        GITHUB_OUTPUT: githubOutput,
+        NODE: process.execPath,
+        PATH: `${root}:${process.env.PATH}`,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        SCRIPT,
+        TARGET_SHA,
+      },
+      timeout: 10_000,
+    });
+    const artifact = JSON.parse(readFileSync(output, "utf8"));
+    expect(readFileSync(githubOutput, "utf8")).toContain(`sha256=${artifact.sha256}`);
   });
 
   it("writes the execution plan immediately when SIGTERM interrupts a stalled reuse API", async () => {
@@ -1241,7 +1267,59 @@ sleep 30
     expect(readFileSync(githubOutput, "utf8")).toContain("state=blocked_complete");
   });
 
-  it("does not commit state when checkpoint provenance cannot be resolved", () => {
+  it("keeps the canonical result when GITHUB_OUTPUT cannot be written", () => {
+    const root = mkdtempSync(join(tmpdir(), "frv-state-output-failure-"));
+    const output = join(root, "decision.json");
+    const executionPlanPath = join(root, "full-release-execution-plan.json");
+    writeFileSync(
+      executionPlanPath,
+      JSON.stringify(
+        executionPlan(
+          {
+            children: { normalCi: { result: "skipped", runAttempt: "", runId: "" } },
+            dockerPreflightResult: "skipped",
+            prepareCandidateResult: "skipped",
+            rerunGroup: "ci",
+            resolveTargetResult: "failure",
+          },
+          {
+            expected: {
+              parentRunAttempt: 1,
+              parentRunId: "77",
+              targetSha: "",
+              workflowRef: "release-ci/tooling",
+              workflowSha: SHA,
+            },
+          },
+        ),
+      ),
+    );
+    const result = spawnSync(process.execPath, [SCRIPT, "decision"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAIL_FAST: "false",
+        FULL_RELEASE_EXECUTION_PLAN_PATH: executionPlanPath,
+        FULL_RELEASE_STATE_PATH: output,
+        GITHUB_REF_NAME: "release-ci/tooling",
+        GITHUB_RUN_ATTEMPT: "2",
+        GITHUB_RUN_ID: "77",
+        GITHUB_SHA: SHA,
+        GITHUB_OUTPUT: root,
+        RELEASE_PROFILE: "stable",
+        RERUN_GROUP: "ci",
+        TARGET_SHA: "",
+      },
+      timeout: 10_000,
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("EISDIR");
+    expect(JSON.parse(readFileSync(output, "utf8"))).toMatchObject({
+      state: "blocked_complete",
+    });
+  });
+
+  it("keeps canonical state when checkpoint provenance cannot be resolved", () => {
     const root = mkdtempSync(join(tmpdir(), "frv-state-provenance-failure-"));
     const gh = join(root, "gh");
     const output = join(root, "decision.json");
@@ -1269,8 +1347,8 @@ sleep 30
       timeout: 10_000,
     });
     expect(result.status).toBe(2);
-    expect(result.stderr).toContain("Bad credentials");
-    expect(() => readFileSync(output, "utf8")).toThrow();
+    expect(result.stderr).toContain("warning: could not resolve checkpoint provenance");
+    expect(JSON.parse(readFileSync(output, "utf8"))).toHaveProperty("state");
   });
 
   it("writes an immediate terminal handoff with active identity on SIGTERM", async () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6458,6 +6458,12 @@ describe("package artifact reuse", () => {
       "full-release-validation-${{ inputs.full_release_validation_run_id }}-${{ steps.full_run.outputs.attempt }}",
     );
     expect(trustedTooling.env?.WORKFLOW_SHA).toBe("${{ github.sha }}");
+    expect(trustedTooling.run).toContain(
+      "scripts/lib/full-release-validation-log-checkpoint.mjs?ref=${WORKFLOW_SHA}",
+    );
+    expect(trustedTooling.run).toContain(
+      '"${tooling_dir}/lib/full-release-validation-log-checkpoint.mjs"',
+    );
     expect(validateManifest.env).toMatchObject({
       RUN_JSON_FILE: "${{ runner.temp }}/full-release-validation-run.json",
       TRUSTED_WORKFLOW_FULL_REF: "${{ github.ref }}",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3006,9 +3006,11 @@ describe("package acceptance workflow", () => {
       "fail-on-cache-miss": "${{ github.run_attempt != 1 }}",
       key: "full-release-execution-plan-v1-${{ github.run_id }}",
     });
-    expect(planUpload.if).toBe("${{ always() && steps.plan.outputs.sha256 != '' }}");
+    expect(planUpload.if).toBe("always()");
     expect(planUpload.with?.name).toBe("full-release-execution-plan-${{ github.run_id }}");
     expect(planUpload.with?.overwrite).toBe(true);
+    expect(decisionUpload.if).toBe("always()");
+    expect(drainUpload.if).toBe("always()");
     expect(manifestStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");
     expect(manifestStep.run).toContain(
       'EVIDENCE_MANIFEST="$(jq -c \'.evidenceReuse.sourceManifest // empty\' "$RELEASE_EXECUTION_PLAN_PATH")"',

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3006,8 +3006,9 @@ describe("package acceptance workflow", () => {
       "fail-on-cache-miss": "${{ github.run_attempt != 1 }}",
       key: "full-release-execution-plan-v1-${{ github.run_id }}",
     });
-    expect(planUpload.if).toBe("always()");
+    expect(planUpload.if).toBe("${{ always() && steps.plan.outputs.sha256 != '' }}");
     expect(planUpload.with?.name).toBe("full-release-execution-plan-${{ github.run_id }}");
+    expect(planUpload.with?.overwrite).toBe(true);
     expect(manifestStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");
     expect(manifestStep.run).toContain(
       'EVIDENCE_MANIFEST="$(jq -c \'.evidenceReuse.sourceManifest // empty\' "$RELEASE_EXECUTION_PLAN_PATH")"',

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2999,8 +2999,9 @@ describe("package acceptance workflow", () => {
     expect(planStep.run).not.toContain("EVIDENCE_MANIFEST");
     expect(planStep.run).toContain('--arg evidenceRunId "$EVIDENCE_RUN_ID"');
     expect(planStep.run).toContain('--argjson trustedWorkflow "$TRUSTED_WORKFLOW_JSON"');
-    expect(planUpload.if).toBe("${{ always() && github.run_attempt == 1 }}");
+    expect(planUpload.if).toBe("${{ always() && steps.plan.outputs.sha256 != '' }}");
     expect(planUpload.with?.name).toBe("full-release-execution-plan-${{ github.run_id }}");
+    expect(planUpload.with?.overwrite).toBe(true);
     expect(manifestStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");
     expect(manifestStep.run).toContain(
       'EVIDENCE_MANIFEST="$(jq -c \'.evidenceReuse.sourceManifest // empty\' "$RELEASE_EXECUTION_PLAN_PATH")"',
@@ -3065,7 +3066,7 @@ describe("package acceptance workflow", () => {
       (job.steps ?? []).filter((step) => step.uses?.startsWith("actions/download-artifact@")),
     );
 
-    expect(downloadSteps).toHaveLength(6);
+    expect(downloadSteps).toHaveLength(5);
     for (const step of downloadSteps) {
       expect(step.uses).toBe(DOWNLOAD_ARTIFACT_V8);
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rerunning a failed Full Release Validation parent job could lose attempt-scoped artifacts, preventing the parent from adopting its already-dispatched child runs and forcing operators toward another full validation cycle.

## Why This Change Was Made

Adds a bounded, provenance-bound recovery journal to the exact Plan, Release Decision, and Diagnostic Drain producer logs. Canonical validated JSON artifacts remain authoritative: reruns recover and re-upload the immutable attempt-one Plan, while Decision and Drain remain independently sourced per attempt. The journal cannot dispatch children or authorize publication.

The codec fails closed on malformed, conflicting, reordered, oversized, non-canonical, digest-mismatched, or provenance-mismatched records and binds the exact REST run and producer job identity. All job-log readers preserve GitHub CLI ANSI output handling and retry without `--allow-escape-sequences` only for the exact legacy unknown-flag failure. Producers finalize canonical JSON before attempting the journal; provenance/API/SIGTERM failures abort only the optional journal and remain visible diagnostics without changing Plan, Decision, or Drain outcomes.

Production change: net +599 lines excluding workflow YAML and tests, under the reviewed 600-line ceiling.

## User Impact

Release operators can rerun failed FRV parent collectors without redispatching the long-running child graph. Watchers remain artifact-first and can use the active producer journal only for early blocker visibility.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/full-release-validation-log-checkpoint.test.ts test/scripts/full-release-validation-state.test.ts test/scripts/full-release-validation-at-sha.test.ts test/scripts/release-ci-summary.test.ts`
  - 162 tests passed on exact head `9354542db85c79379877dca3b8963ebf9750e38e` after rebasing onto current `main`.
  - Caller-level tests force the flagged job-log read to fail with the exact legacy CLI error and verify the unflagged retry.
  - Injected checkpoint provenance failures preserve canonical Plan, Decision, and Drain state; SIGTERM during journal emission cannot replace a completed Plan.
- Combined five-file run: 338/339 passed; one unrelated package-acceptance subprocess timed out under local saturation, then its exact failed test passed alone in 5.57s.
- `actionlint .github/workflows/full-release-validation.yml`
- `node --check` on changed JavaScript entry points
- `oxfmt --check` on all changed script and focused test files
- `git diff --check`
- Blacksmith Testbox `tbx_01m0jm5r8f6tpkvvp7exj3gdr2`
  - `node scripts/check-changed.mjs && pnpm check:workflows`
  - passed in 4m34s
  - https://github.com/openclaw/openclaw/actions/runs/32505738466
- Autoreview: clean, no accepted/actionable P0 findings; patch correct at 0.98 confidence.
- Live GitHub API inspection confirmed exact-attempt job responses expose the run ID, run attempt, head SHA, workflow name, status, conclusion, and job ID used by the recovery binding.

Live non-publishing FRV rerun proof will run only after independent PR review and landing.
