### PR TITLE
fix(codex): fall back to OpenClaw harness when no native binary exists for the platform

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -188,6 +188,23 @@ describe("Codex agent harness supports()", () => {
     });
   });
 
+  it("rejects platforms with no native Codex app-server binary", () => {
+    const originalPlatform = process.platform;
+    const originalArch = process.arch;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    Object.defineProperty(process, "arch", { value: "riscv64" });
+    try {
+      expect(harness.supports({ provider: "codex", requestedRuntime: "codex" })).toEqual({
+        supported: false,
+        reason: "no native Codex app-server binary is published for this platform (linux-riscv64)",
+        fallbackRuntime: "openclaw",
+      });
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+      Object.defineProperty(process, "arch", { value: originalArch });
+    }
+  });
+
   it("uses the attempt-scoped Codex config before the live Gateway config", async () => {
     runCodexAppServerAttempt.mockResolvedValueOnce({ stopReason: "stop" });
     const attemptHarness = createCodexAppServerAgentHarness({

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -49,6 +49,24 @@ const CODEX_APP_SERVER_CONTEXT_ENGINE_HOST_CAPABILITIES = [
   "thread-bootstrap-projection",
 ] as const satisfies readonly ContextEngineHostCapability[];
 
+// Mirrors extensions/codex/package.json's openclaw.install.requiredPlatformPackages:
+// the @openai/codex binary only ships native artifacts for these platform/arch
+// pairs. Selecting the harness on any other pair lets the app-server process
+// spawn and then exit immediately with "Unsupported platform" instead of
+// letting implicit selection fall back to the OpenClaw runtime.
+const CODEX_APP_SERVER_SUPPORTED_PLATFORMS = new Set([
+  "linux-x64",
+  "linux-arm64",
+  "darwin-x64",
+  "darwin-arm64",
+  "win32-x64",
+  "win32-arm64",
+  ]);
+
+function isCodexAppServerPlatformSupported(): boolean {
+  return CODEX_APP_SERVER_SUPPORTED_PLATFORMS.has(`${process.platform}-${process.arch}`);
+}
+
 type CodexAppServerAgentHarness = AgentHarnessV2 & {
   cloudPlacement?: { mode: "remote-exec" };
 };
@@ -188,6 +206,13 @@ export function createCodexAppServerAgentHarness(
       return await loadCodexEffectiveMcpCatalog(params, { bindingStore: options.bindingStore });
     },
     supports: (ctx) => {
+      if (!isCodexAppServerPlatformSupported()) {
+        return {
+          supported: false,
+          reason: `no native Codex app-server binary is published for this platform (${process.platform}-${process.arch})`,
+          fallbackRuntime: "openclaw",
+        };
+      }
       const provider = ctx.provider.trim().toLowerCase();
       if (!providerIds.has(provider)) {
         return {


### PR DESCRIPTION
Closes #90587

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users on platforms without a published `@openai/codex` binary (confirmed: Linux RISC-V64) hit a hard crash the first time they open a session — `run error: codex app-server exited: ... Error: Unsupported platform: linux (riscv64)` — instead of OpenClaw silently running on its built-in embedded runtime.

## Why This Change Was Made

`extensions/codex/harness.ts`'s `supports()` decides whether the Codex app-server harness can handle a request. It checked provider id, auth compatibility, and transport overrides, but never checked whether a native Codex binary actually exists for the current OS/architecture. `extensions/codex/package.json`'s `openclaw.install.requiredPlatformPackages` already documents the six platform/arch pairs `@openai/codex` publishes binaries for (linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, win32-arm64). `supports()` now checks `process.platform`/`process.arch` against that same list and returns `{ supported: false, fallbackRuntime: "openclaw" }` for anything else. The existing implicit-selection path in `src/agents/harness/selection.ts` (`resolveAgentHarnessAvailabilityDecision`) already falls back to the built-in OpenClaw runtime whenever `supports()` reports unsupported for an implicitly-selected Codex harness, so no other code needed to change — this PR only adds the missing capability check. No product or config decision is required; this only prevents selecting a harness that would immediately crash.

## User Impact

Users on platforms without a published Codex binary (Linux RISC-V64, and any other unsupported OS/arch pair) now get a working session on the built-in OpenClaw runtime instead of an opaque native-binary crash on their first message.

## Evidence

- Root cause traced by reading `extensions/codex/harness.ts`'s `supports()`, `src/agents/harness/selection.ts`'s `resolveAgentHarnessAvailabilityDecision()` (confirms unsupported harnesses fall back automatically), and `extensions/codex/package.json`'s `openclaw.install.requiredPlatformPackages` (the authoritative list of platforms `@openai/codex` ships binaries for).
- Added a regression test in `extensions/codex/harness.test.ts` ("rejects platforms with no native Codex app-server binary") that stubs `process.platform`/`process.arch` to `linux`/`riscv64` and asserts `supports()` returns `{ supported: false, reason: ..., fallbackRuntime: "openclaw" }`.
- No `pnpm install`/full workspace is available in this environment, so `pnpm build && pnpm check && pnpm test` could not be run locally. Verified both changed files are syntactically valid TypeScript via `ts.transpileModule` (TypeScript 5.6.3, ES2022/ESNext target) with zero diagnostics.
---
This PR was drafted with AI assistance (Claude). I reviewed the diagnosis and diff and understand what the code does, flagging per the AI-assisted PR guidance in CONTRIBUTING.md.