### PR TITLE
fix(ci): support single QA shard artifacts

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -894,8 +894,8 @@ jobs:
         working-directory: selected
         run: |
           set -euo pipefail
-          mapfile -t status_paths < <(find .artifacts/qa-profile-shards -mindepth 2 -maxdepth 2 -type f -name qa-profile-run-status.json | sort)
-          mapfile -t evidence_paths < <(find .artifacts/qa-profile-shards -mindepth 2 -maxdepth 2 -type f -name qa-evidence.json | sort)
+          mapfile -t status_paths < <(find .artifacts/qa-profile-shards -mindepth 1 -maxdepth 2 -type f -name qa-profile-run-status.json | sort)
+          mapfile -t evidence_paths < <(find .artifacts/qa-profile-shards -mindepth 1 -maxdepth 2 -type f -name qa-evidence.json | sort)
           if [[ "${#status_paths[@]}" -ne "$SHARD_COUNT" || "${#evidence_paths[@]}" -ne "$SHARD_COUNT" ]]; then
             echo "Expected ${SHARD_COUNT} completed status and evidence files; found ${#status_paths[@]} statuses and ${#evidence_paths[@]} evidence files." >&2
             exit 1

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -8421,7 +8421,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "Expected ${SHARD_COUNT} completed status and evidence files",
     );
     expect(aggregateStep.run).toContain("Timed-out QA shard cannot contribute partial evidence");
-    expect(aggregateStep.run).toContain("-mindepth 2 -maxdepth 2");
+    expect(aggregateStep.run).toContain("-mindepth 1 -maxdepth 2");
     expect(aggregateStep.run).toContain("aggregateQaProfileEvidenceShards");
     expect(aggregateStep.run).toContain("if jq -e '.timedOut == true'");
     expect(aggregateStep.env?.OUTPUT_DIR).toContain(


### PR DESCRIPTION
## What Problem This Solves

A QA profile can resolve to one shard. `actions/download-artifact` extracts one pattern match directly into the configured directory, but the aggregator searched only named artifact subdirectories. The run therefore found zero status/evidence files and failed despite a completed shard.

## Why This Change Was Made

The aggregator now searches both the direct single-artifact layout and the existing named-subdirectory layout. Its exact expected shard-count check remains unchanged.

## User Impact

Maintainers can run valid one-shard QA profiles without a false aggregation failure. Multi-shard evidence validation is unchanged.

## Evidence

- `git diff --check`
- `actionlint .github/workflows/qa-profile-evidence.yml`
- Verified the workflow discovery bounds include depth 1 and depth 2.
- AI-assisted. Structured autoreview is currently blocked because the required host `trufflehog` binary is not installed; its skill forbids auto-installation.
