### PR TITLE
fix(auth): stop advising a retry when the auth store needs migration

### DIFF
--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -79,7 +79,11 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
     writePersistedAuthProfileStoreRaw(unreadableStore, agentDir);
     const updater = vi.fn(() => true);
 
-    await expect(updateAuthProfileStoreWithLock({ agentDir, updater })).resolves.toBeNull();
+    // The unreadable store names its own remediation; a null return would make
+    // callers report generic lock contention instead.
+    await expect(updateAuthProfileStoreWithLock({ agentDir, updater })).rejects.toThrow(
+      "is unreadable; run openclaw doctor --fix",
+    );
     expect(updater).not.toHaveBeenCalled();
     expect(readPersistedAuthProfileStoreRaw(agentDir)).toEqual(unreadableStore);
   });

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -862,7 +862,7 @@ function mergeRuntimeExternalProfileState(params: {
   return merged;
 }
 
-/** Apply an auth store update inside the SQLite write lock. */
+/** Apply an auth store update inside the SQLite write lock; null on write failure, rethrows credential-boundary errors. */
 export async function updateAuthProfileStoreWithLock(params: {
   agentDir?: string;
   sharedStoreWrite?: boolean;
@@ -896,6 +896,14 @@ export async function updateAuthProfileStoreWithLock(params: {
       { sharedStoreWrite: params.sharedStoreWrite, stateDir: params.stateDir },
     );
   } catch (error) {
+    // Credential-boundary failures name their own remediation; collapsing them
+    // into `null` makes callers report a lock-contention retry that never clears.
+    const isCredentialBoundaryFailure =
+      error instanceof AuthProfileMigrationRequiredError ||
+      error instanceof AuthProfileStoreUnreadableError;
+    if (isCredentialBoundaryFailure) {
+      throw error;
+    }
     const message = error instanceof Error ? error.message : String(error);
     authProfilesLog.warn(`auth profile store update failed: ${message}`, {
       agentDir,

--- a/src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { clearAuthProfileMigrationDiagnostics } from "./legacy-source-diagnostic.js";
 import { loadPersistedAuthProfileStore } from "./persisted.js";
 import {
   inspectPersistedAuthProfileStateRaw,
@@ -16,9 +17,13 @@ import {
 } from "./sqlite.js";
 import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
 import type { ApiKeyCredential } from "./types.js";
-import { persistAuthProfileBatch } from "./upsert-with-lock.js";
+import { persistAuthProfileBatch, upsertAuthProfileWithLockOrThrow } from "./upsert-with-lock.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  clearAuthProfileMigrationDiagnostics();
+});
 
 function apiKey(key: string): ApiKeyCredential {
   return { type: "api_key", provider: "openai", key };
@@ -162,6 +167,30 @@ describe("auth profile batch persistence", () => {
         order: { openai: ["openai:existing"] },
       });
       expect(loadPersistedAuthProfileStore(agentDir)?.profiles["openai:portable"]).toBeUndefined();
+    });
+  });
+
+  it("reports the migration remediation instead of lock-contention retry advice", async () => {
+    await withAgentDir(async (agentDir) => {
+      // Credentials still living in the retired JSON store: the write can never
+      // succeed, so retry advice would loop the operator forever.
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        JSON.stringify({
+          version: 1,
+          profiles: { "openai:legacy": apiKey("sk-json-era") },
+        }),
+      );
+
+      const failure = await upsertAuthProfileWithLockOrThrow({
+        agentDir,
+        profileId: "openai:new",
+        credential: apiKey("sk-new"),
+      }).catch((error: unknown) => error);
+
+      expect(String(failure)).toContain("requires legacy credential migration");
+      expect(String(failure)).toContain("openclaw doctor --fix");
+      expect(String(failure)).not.toContain("lock may be busy");
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators upgrading an install whose credentials still live in the retired `auth-profiles.json` store would be told to wait and retry forever when any auth profile write ran (onboarding, `models auth login`, `models auth order set`, plugin API-key setup).

The command printed two contradictory lines and exited 1:

```
[agents/auth-profiles] auth profile store update failed: Auth profile store <state>/agents/main/agent/openclaw-agent.sqlite requires legacy credential migration; run openclaw doctor --fix.
Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.
```

The first line is correct and actionable. The second is a generic lock-contention fallback that does not apply — nothing is locked, the store needs migration, and retrying can never succeed. An operator who reads the last line (the one closest to the prompt) retries indefinitely.

Verified pre-existing: reproduces identically on a build of `main` from before any recent auth-store work, so this is not a regression from the shared-auth-ownership change.

## Why This Change Was Made

The bug is an asymmetry at the store boundary, not bad message copy.

`assertAuthProfileMigrationReady` throws `AuthProfileMigrationRequiredError` deliberately — it is a fail-closed credential gate, and the error carries both a typed code (`AUTH_PROFILE_MIGRATION_REQUIRED`) and its own remediation. Every **read** path lets that error through. The **write** path did not: `updateAuthProfileStoreWithLock` wrapped its transaction in a blanket `catch` that logged a warn and returned `null`, erasing the error's identity. Callers only ever see `null`, so the only thing any of them can say is "the write failed" — and the shipped guess for that was lock contention.

The fix rethrows the two errors that name their own remediation (`AuthProfileMigrationRequiredError`, `AuthProfileStoreUnreadableError`) and keeps `null` for genuine write failures, which is what the lock hint was always meant to describe.

Because the identity is restored at the producer, all three sibling call sites are fixed by the one change rather than by three message edits:

- `upsertAuthProfileWithLockOrThrow` (`src/agents/auth-profiles/upsert-with-lock.ts`)
- `models auth logout` (`src/commands/models/auth-logout.ts`)
- `models auth order set` / `order clear` (`src/commands/models/auth-order.ts`)

**Blast radius:** rethrowing changes behavior for ~20 call sites of a plugin-SDK-exported function, so each was traced. The doctor stale-OAuth-shadow repair already catches and downgrades to a warning; the two importer plugins (`migrate-hermes`, `codex`) and the doctor credential path already threw a vaguer error on `null`; and the runtime usage/OAuth paths are only reachable after credentials loaded successfully, which means the boundary already passed. In every case the new behavior is the same or a strictly better message.

**Also fixed:** `src/agents/auth-profiles/source-check.test.ts` asserted the same bug's other half as expected behavior — an unreadable store returning `null`, which callers were equally mistranslating into "lock busy". Updated to the canonical contract; the test's real intent (updater never runs, corrupt row untouched) is preserved.

## User Impact

Operators on an unmigrated install now get one correct, actionable line instead of two contradictory ones:

```
Auth profile store <state>/agents/main/agent/openclaw-agent.sqlite requires legacy credential migration; run openclaw doctor --fix.
```

The redundant warn line disappears too, since the rethrow happens before the log. No config surface added; no CLI flags changed.

## Evidence

**Reproduction** (isolated state dir, never touches `~/.openclaw`) — against a build of unmodified `main`, this fails with the two lines quoted above:

```bash
S=$(mktemp -d); mkdir -p "$S/agents/main/agent"
cat > "$S/agents/main/agent/auth-profiles.json" <<'JSON'
{ "version": 1, "profiles": { "anthropic:api-key": { "type": "api_key", "provider": "anthropic", "key": "sk-ant-json-era" } } }
JSON
cat > "$S/openclaw.json" <<'CFG'
{ "gateway": { "mode": "local", "port": 19513 }, "agents": { "entries": { "main": {} } } }
CFG
OPENCLAW_STATE_DIR="$S" OPENCLAW_SKIP_CHANNELS=1 OPENAI_API_KEY=sk-fake \
  node dist/index.js onboard --non-interactive --accept-risk --skip-health --mode local \
  --auth-choice openai-api-key --gateway-port 19513 --skip-bootstrap --skip-skills
```

After the fix, one line, exit 1:

```
Auth profile store /var/folders/.../agents/main/agent/openclaw-agent.sqlite requires legacy credential migration; run openclaw doctor --fix.
```

**Remediation loop proven end-to-end.** Ran the command the message points at, then re-ran onboard on the same state dir: `openclaw doctor --fix` exited 0, migrated the JSON into SQLite and archived it (`auth-profiles.json.migrated-2026-08-20T23-39-17.222Z-...`), and the same onboard command then exited 0. This also confirms the doctor repair paths downstream of the changed producer are unaffected.

**Sibling call sites verified live** on an unmigrated store — both now print the migration remediation instead of their own generic hints:

- `openclaw models auth order set --provider anthropic anthropic:api-key`
- `openclaw models auth logout anthropic-api-key --yes`

**Regression test** — `src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts`, a real store test rather than a mock. Verified it fails on pre-fix production code for the intended reason:

```
AssertionError: expected 'Error: Failed to update auth profile …' to contain 'requires legacy credential migration'
Received: "Error: Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry."
```

**Suites** (all green):

- `src/agents/auth-profiles` — 28 files, 400 tests
- `src/commands/doctor` — 69 files, 1272 tests
- `src/commands/models`, `src/system-agent`, `src/plugins` — 418 files, 6521 tests
- `node scripts/check-changed.mjs` — exit 0 (lint, tsgo shards, native state schema guard, database-first legacy-store guard, runtime sidecar loaders, import cycles, webhook/pairing guards)
- `pnpm build` — exit 0

**Autoreview:** Codex `gpt-5.6-sol`, `xhigh` — clean, 0 accepted/actionable findings.

**LOC delta** (`git diff --numstat`): production `src/agents/auth-profiles/store.ts` +9/-1 (net **+8**); tests +35/-2. The production growth is a credential-boundary ownership fix: the discrimination has to happen where the error identity still exists, and there is no smaller shape that stops the boundary error from being laundered into a retry hint. The absorbing alternative — re-deriving the reason in each caller via `assertAuthProfileMigrationReady` — was rejected: it re-runs the file-existence check, only fixes one of three siblings, and is exactly the multi-signal inference the recorded fact at the producer exists to avoid.
