### PR TITLE
fix(qa): restore QA Lab web build

### DIFF
--- a/extensions/qa-lab/web/vite.config.ts
+++ b/extensions/qa-lab/web/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
         import.meta.dirname,
         "../../../packages/normalization-core/src/utf16-slice.ts",
       ),
+      "openclaw/plugin-sdk/time-runtime": path.resolve(
+        import.meta.dirname,
+        "../../../packages/plugin-sdk/src/time-runtime.ts",
+      ),
     },
   },
   build: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers starting or building QA Lab would hit a Vite missing-export failure after the web UI's duration formatter moved behind the Plugin SDK time-runtime seam.

`pnpm qa:lab:build` failed on current main with:

```text
[MISSING_EXPORT] "formatDurationCompact" is not exported by "__vite-optional-peer-dep:openclaw/plugin-sdk/time-runtime:@openclaw/qa-lab"
```

Because the standard QA Lab Docker startup builds this UI unless explicitly skipped, the missing resolver also blocked the default `qa:lab:up` path when no prebuilt UI was available.

## Why This Change Was Made

The QA Lab Vite source resolver now maps `openclaw/plugin-sdk/time-runtime` through the canonical workspace `@openclaw/plugin-sdk` facade, matching its existing browser aliases for the error and text-utility SDK runtimes. This keeps extension production code on the public SDK seam and preserves the dependency centralization from #126119 instead of restoring a direct `pretty-ms` dependency.

No config-string unit test was added: the real `pnpm qa:lab:build` command is the authoritative regression boundary and failed before this change for the exact missing alias.

## User Impact

Developers can build and start QA Lab normally again. The generated UI and runtime behavior are unchanged; this only restores source-time resolution for the existing SDK import.

## Evidence

- Authentic pre-fix reproduction on current main: `pnpm qa:lab:build` failed with the missing `formatDurationCompact` export shown above.
- Post-fix, post-rebase `pnpm qa:lab:build` passed: Vite transformed 46 modules and emitted the complete production bundle in 108 ms.
- QA Lab web owner suite passed: 5 files, 35/35 tests.
- Full `node scripts/check-changed.mjs` passed, including the extension-to-core source boundary guard; the exact production build, boundary guard, and all 35 owner tests passed again after rebase.
- Patch ID is `88588345576dac9659006c4118ca51dbd83c584d` on current `origin/main`.
- Deslop pass found no cleanup; two fresh Codex autoreviews were clean and rated the original patch and CI follow-up correct at 0.99 confidence.
- Four live duplicate searches found no exact open issue or PR.

Production LOC: +4/-0; tests: +0/-0. The four lines add the missing canonical resolver capability at the existing Vite alias owner.

AI-assisted implementation and verification; no agent transcript is attached.
