### PR TITLE
improve(cron): reuse resolved schedule timezone [AI]

### DIFF
--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -37,7 +37,7 @@ function resolveCachedCron(expr: string, timezone: string): Cron {
   return next;
 }
 
-function resolveCronFromSchedule(schedule: { tz?: string; expr?: unknown }): Cron | undefined {
+function resolveCronFromSchedule(schedule: { tz?: string; expr?: unknown }) {
   if (typeof schedule.expr !== "string") {
     throw new Error("invalid cron schedule: expr is required");
   }
@@ -45,7 +45,8 @@ function resolveCronFromSchedule(schedule: { tz?: string; expr?: unknown }): Cro
   if (!expr) {
     return undefined;
   }
-  return resolveCachedCron(expr, resolveCronTimezone(schedule.tz));
+  const timezone = resolveCronTimezone(schedule.tz);
+  return { cron: resolveCachedCron(expr, timezone), timezone };
 }
 
 function hasNearbyCronTimezoneTransition(
@@ -249,16 +250,16 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
     return undefined;
   }
 
-  const cron = resolveCronFromSchedule(schedule);
-  if (!cron) {
+  const resolvedCron = resolveCronFromSchedule(schedule);
+  if (!resolvedCron) {
     return undefined;
   }
+  const { cron, timezone } = resolvedCron;
   const nextMs = cron.nextRun(new Date(nowMs))?.getTime();
   if (nextMs === undefined) {
     return undefined;
   }
 
-  const timezone = resolveCronTimezone(schedule.tz);
   const normalizedNextMs = resolveValidatedNextCronOccurrenceMs(cron, nowMs, nextMs, timezone);
   if (normalizedNextMs !== undefined) {
     return normalizedNextMs;
@@ -292,12 +293,12 @@ export function computePreviousRunAtMs(schedule: CronSchedule, nowMs: number): n
   if (schedule.kind !== "cron" || asDateTimestampMs(nowMs) === undefined) {
     return undefined;
   }
-  const cron = resolveCronFromSchedule(schedule);
-  if (!cron) {
+  const resolvedCron = resolveCronFromSchedule(schedule);
+  if (!resolvedCron) {
     return undefined;
   }
+  const { cron, timezone } = resolvedCron;
   let previousMs = cron.previousRuns(1, new Date(nowMs))[0]?.getTime();
-  const timezone = resolveCronTimezone(schedule.tz);
   if (
     previousMs !== undefined &&
     previousMs < nowMs &&


### PR DESCRIPTION
## What Problem This Solves

Cron next/previous-run computation resolved the effective timezone once for the cached evaluator and then resolved it again for transition normalization. For schedules without an explicit timezone, each duplicate resolution rebuilt `Intl.DateTimeFormat().resolvedOptions()` state on ordinary scheduler recomputation.

## Why This Change Was Made

The canonical schedule resolver now returns the cached Cron evaluator together with the exact effective timezone used to construct it. Both next- and previous-run normalization reuse that prepared value. Empty/invalid expressions, cache keys, DST and historical transition handling, retries, and scheduler lifecycle remain unchanged.

This is AI-assisted work. No agent transcript is attached or published.

## User Impact

Timezone-aware cron behavior and timestamps are unchanged, while ordinary scheduler computation performs less repeated locale/timezone setup.

## Evidence

- Fresh exact-current Node 24.15.0 instrumentation: 100 default-zone next-run probes constructed zero-argument `Intl.DateTimeFormat` **200 → 100** times.
- Actual owner benchmark, 10,000 computations × 7 samples: median **4,487.451 ms → 3,739.415 ms** (**16.7% lower**); all sample checksums were identical (`5976704`).
- Independent differential on the unchanged owner patch: **54,008** exact next/previous output-or-error comparisons across supported IANA zones, default zones, historical/future dates, DST gaps/folds, sparse schedules, and invalid inputs matched byte-for-byte.
- Focused scheduler/DST/regression suite: **4 files, 77 tests passed** on the final pushed commit.
- `node scripts/check-changed.mjs -- src/cron/schedule.ts`: passed on the final pushed commit.
- `pnpm build`: passed; only existing third-party direct-`eval` warnings.
- Fresh final-head bundled Codex autoreview: TruffleHog clean; no accepted/actionable findings; patch correct at 0.99 confidence.
- Native maintainer review artifacts validated on exact head with no findings; the Croner 10.0.1 implementation and all direct scheduling/timer/schema callers were inspected.
- [Exact-head CI run 32509368023](https://github.com/openclaw/openclaw/actions/runs/32509368023): passed. The hosted prepare gate accepted this exact head; Blacksmith Testbox, ARM Testbox, and Build Artifacts Testbox were correctly not applicable.
- [ClawSweeper exact-head run 32509505769](https://github.com/openclaw/clawsweeper/actions/runs/32509505769): patch correct (0.88), no findings, security cleared, and **no rank-up moves**. Its immutable artifact also completed `pnpm openclaw cron --help` and observed `Usage:` on the PR head.
- `git diff --check`: clean.

Production LOC: +9/-8 (net +1). No test-only seam or implementation-coupled allocation test was added; existing DST/error/cache suites plus the deterministic operation proof and broad differential cover the behavior contract.
