### PR TITLE
improve(ui): skip video pacing in ordinary browser tests

### DIFF
--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -68,6 +68,12 @@ async function captureProof(page: Page, name: string): Promise<void> {
   await page.screenshot({ fullPage: true, path: path.join(proofDir, name) });
 }
 
+async function holdProof(page: Page, durationMs = 500): Promise<void> {
+  if (proofDir) {
+    await page.waitForTimeout(durationMs);
+  }
+}
+
 async function createContext(): Promise<BrowserContext> {
   const context = await browser.newContext({
     locale: "en-US",
@@ -189,13 +195,13 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       expect(await mobile.page.locator(".sidebar-update-card--floating").count()).toBe(0);
       expect(await mobile.page.locator(".chat-header-session-menu__status-dot").count()).toBe(1);
       await captureProof(mobile.page, "mobile-compact-header.png");
-      await mobile.page.waitForTimeout(500);
+      await holdProof(mobile.page);
       await menu.click();
       const status = mobile.page.getByText("Limited access", { exact: true });
       await status.waitFor();
       await mobile.page.getByText("Update available v2.0.0", { exact: true }).waitFor();
       await captureProof(mobile.page, "mobile-status-menu.png");
-      await mobile.page.waitForTimeout(500);
+      await holdProof(mobile.page);
       await status.click();
       await mobile.page.getByText("This browser has limited access.", { exact: true }).waitFor();
       await mobile.page
@@ -203,10 +209,10 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
         .first()
         .waitFor({ state: "hidden" });
       await captureProof(mobile.page, "mobile-access-details.png");
-      await mobile.page.waitForTimeout(700);
+      await holdProof(mobile.page, 700);
       await mobile.page.getByRole("button", { name: "Collapse limited access banner" }).click();
       await menu.waitFor();
-      await mobile.page.waitForTimeout(500);
+      await holdProof(mobile.page);
     } finally {
       await closeProofContext(mobile, "mobile-compact-header");
     }
@@ -219,10 +225,10 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       await desktop.page.locator(".shell-chrome-controls__search").first().waitFor();
       await desktop.page.locator(".chat-side-panel-toggle").first().waitFor();
       await captureProof(desktop.page, "desktop-unchanged.png");
-      await desktop.page.waitForTimeout(500);
+      await holdProof(desktop.page);
       await desktop.page.getByRole("button", { name: "Collapse limited access banner" }).click();
       await desktop.page.getByRole("button", { name: "Show limited access details" }).waitFor();
-      await desktop.page.waitForTimeout(500);
+      await holdProof(desktop.page);
     } finally {
       await closeProofContext(desktop, "desktop-unchanged");
     }


### PR DESCRIPTION
## What Problem This Solves

The Control UI browser suite paid 3.2 seconds of proof-video pacing on every normal run after the compact mobile-header coverage added in #126788, even though ordinary CI does not record a video.

## Why This Change Was Made

Keep the existing six frame-hold durations only when the suite's existing proof-artifact directory enables recording. This follows the established optional-proof helper in the neighboring sidebar suite and preserves all browser interactions, screenshots, recordings, ownership boundaries, and assertions.

## User Impact

Developers and CI get the same mobile/desktop access-status coverage faster; shipped product behavior does not change. Explicit screenshot and video capture retains the original 500/700 ms presentation cadence.

## Evidence

- Eight interleaved before/after samples on one Blacksmith Testbox, with an excluded warmup, one Vitest worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`: mean full-file wall `32.21s -> 28.50s` (`-3.71s`, `-11.5%`); mean affected case `6.05s -> 2.87s` (`-3.17s`, `-52.5%`); all 16 runs preserved `12/12` passing tests.
- Explicit proof mode produced all four expected PNG screenshots and both nonempty WebM videos while retaining the original pacing.
- Fault injection disabled the real compact-status dot: the accelerated browser case failed with `expected +0 to be 1`; restoring the production component made it pass again.
- The compact session-menu owner's separate focused suite passed `10/10` tests.
- The complete changed-file gate, formatting, lint, typecheck, dead-export checks, and an independent clean review were run before publication.
- Test-only diff: production `+0/-0`; tests `+12/-6`.
- AI-assisted; no generated artifacts, dependency changes, or release files are included.
