### PR TITLE
fix(ui): restore editable map-valued settings

### DIFF
--- a/ui/src/components/config-form-map-integrity.browser.test.ts
+++ b/ui/src/components/config-form-map-integrity.browser.test.ts
@@ -1,5 +1,5 @@
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ConfigFormCollectionDraft } from "./config-form-collection-draft.ts";
 import { analyzeConfigSchema, renderConfigForm } from "./config-form.ts";
 
@@ -12,6 +12,75 @@ function expectElement<T extends Element>(element: T | null | undefined, label: 
 }
 
 describe("config form map integrity", () => {
+  it("keeps plain-string record keys editable through nested maps", () => {
+    const analysis = analyzeConfigSchema({
+      type: "object",
+      properties: {
+        values: {
+          type: "object",
+          propertyNames: { type: "string" },
+          additionalProperties: {
+            type: "object",
+            propertyNames: { type: "string" },
+            additionalProperties: { type: "string" },
+          },
+        },
+      },
+    });
+
+    expect(analysis.unsupportedPaths).toEqual([]);
+
+    const container = document.createElement("div");
+    const onPatch = vi.fn();
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {},
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: { values: { primary: { region: "west" } } },
+        showAdvanced: true,
+        onShowAdvanced: () => {},
+        onPatch,
+      }),
+      container,
+    );
+
+    expect(container.querySelectorAll(".cfg-map")).toHaveLength(2);
+    expect(container.textContent).not.toContain("Unsupported schema node");
+
+    const nestedKey = expectElement(
+      container.querySelector<HTMLInputElement>('[aria-label="Key: region"]'),
+      "nested map key",
+    );
+    nestedKey.value = "zone";
+    nestedKey.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["values", "primary"], { zone: "west" });
+  });
+
+  it.each([
+    ["pattern", { type: "string", pattern: "^[a-z]+$" }],
+    ["minimum length", { type: "string", minLength: 1 }],
+    ["enumeration", { enum: ["primary"] }],
+    ["boolean", true],
+    ["null", null],
+    ["array", [{ type: "string" }]],
+    ["wrong type", { type: "number" }],
+    ["inherited type", Object.assign(Object.create({ type: "string" }), { unknown: true })],
+  ])("keeps %s property-name constraints fail-closed", (_label, propertyNames) => {
+    const analysis = analyzeConfigSchema({
+      type: "object",
+      properties: {
+        values: {
+          type: "object",
+          propertyNames,
+          additionalProperties: { type: "string" },
+        },
+      },
+    });
+
+    expect(analysis.unsupportedPaths).toEqual(["values"]);
+  });
+
   it("retains unset map drafts until the collection source changes", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -146,7 +146,18 @@ function hasOnlySupportedConstraintKeywords(schema: JsonSchema): boolean {
 }
 
 function hasOnlySupportedFormKeywords(schema: JsonSchema): boolean {
-  return Object.keys(schema).every((key) => SUPPORTED_FORM_SCHEMA_KEYS.has(key));
+  return Object.keys(schema).every(
+    (key) =>
+      SUPPORTED_FORM_SCHEMA_KEYS.has(key) ||
+      // JSON object keys are already strings; constrained names must remain fail-closed.
+      (key === "propertyNames" &&
+        typeof schema.propertyNames === "object" &&
+        schema.propertyNames !== null &&
+        !Array.isArray(schema.propertyNames) &&
+        Object.keys(schema.propertyNames).length === 1 &&
+        Object.hasOwn(schema.propertyNames, "type") &&
+        schema.propertyNames.type === "string"),
+  );
 }
 
 function schemaAllowsNull(schema: JsonSchema, seen = new Set<JsonSchema>()): boolean {

--- a/ui/src/lib/config-form-utils.ts
+++ b/ui/src/lib/config-form-utils.ts
@@ -9,6 +9,7 @@ export type JsonSchema = {
   tags?: string[];
   "x-tags"?: string[];
   properties?: Record<string, JsonSchema>;
+  propertyNames?: JsonSchema | boolean;
   required?: string[];
   items?: JsonSchema | JsonSchema[];
   additionalItems?: JsonSchema | boolean;


### PR DESCRIPTION
Related: #120736

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users editing ordinary string-keyed settings in the Control UI would see "Unsupported schema node. Use Raw mode." instead of an editable form. This currently affects 40 settings, including environment variables, authentication profiles, default agent models, request headers, skill entries, and plugin entries.

## Why This Change Was Made

Zod emits `propertyNames: { "type": "string" }` for unconstrained record keys, but the Control UI schema analyzer rejected every `propertyNames` keyword. JSON object keys are already strings, so accept only that exact, semantically empty constraint at the owning analyzer boundary. Pattern-, length-, enum-, malformed-, and inherited-key constraints remain unsupported and fail closed; no Gateway schema, public configuration, migration, or validation contract changes.

## User Impact

Operators can add and edit ordinary map-valued settings directly in the Settings form instead of switching to Raw mode. The live generated configuration schema now has 21 unsupported fields instead of 61; genuinely constrained key schemas remain protected.

## Evidence

- Before the fix, the focused nested-map regression failed for the intended reason: `unsupportedPaths` contained `values` instead of being empty.
- After the fix, the same regression renders nested map controls, edits an existing key, and verifies the exact update reaches the Settings patch callback. Eight constrained or malformed key-schema cases remain fail-closed.
- Focused owner, rendering, composition, constrained-parent, and redacted-secret suites: **5 files, 68 tests passed**.

  ```bash
  node scripts/run-vitest.mjs \
    ui/src/components/config-form-map-integrity.browser.test.ts \
    ui/src/components/config-form-rejection-integrity.browser.test.ts \
    ui/src/components/config-form-composition-integrity.browser.test.ts \
    ui/src/components/config-form.browser.test.ts \
    ui/src/lib/config-form-utils.node.test.ts
  ```

- Full Control UI typecheck passed with the authentic locked `pako@3.0.1` declarations exposed through an external temporary project wrapper because this linked checkout resolves an unrelated stale shared `pako@1.0.11` installation. No dependency or repository changes were needed.
- Direct focused `oxfmt` and `oxlint` checks pass; direct execution against the current generated schema confirms exactly **40** newly editable fields while constrained browser profiles, access groups, agent entries, and Gateway identity scopes remain unsupported.
- Real isolated Control UI before the fix visibly showed `Unsupported schema node. Use Raw mode.` for Environment Variable Overrides; the original before screenshot was accidentally overwritten. After the fix, a personally inspected local screenshot of the same real Settings surface shows `Custom entries` and `Add Entry`; the UI used the exact current source against an older isolated trusted Gateway whose relevant schema/analyzer owner files were verified unchanged. Model, provider, credential, personal-Gateway, and mutation calls were blocked throughout. Public image attachment is blocked because this machine's device classification cannot be independently verified; no screenshot was uploaded.
- Production change: **+13/-1, net +12**; the additional lines enforce the exact fail-closed dependency contract. Regression tests: **+70/-1, net +69**.
