### PR TITLE
fix(codex): backport native support for newly available models

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -119,6 +119,51 @@ describe("Codex agent harness supports()", () => {
     expect(!result.supported ? result.reason : undefined).toContain("not declared");
   });
 
+  it("lets explicitly selected Codex discover unlisted models with its own account", () => {
+    expect(
+      harness.supports({
+        provider: "openai",
+        modelId: "gpt-future",
+        requestedRuntime: "codex",
+        modelProvider: {
+          requestTransportOverrides: "none",
+          preparedAuth: { source: "harness" },
+        },
+      }),
+    ).toEqual({ supported: true, priority: 100 });
+  });
+
+  it.each([
+    {
+      label: "automatic runtime selection",
+      requestedRuntime: "auto" as const,
+      modelProvider: { preparedAuth: { source: "harness" as const } },
+    },
+    {
+      label: "an authored endpoint",
+      requestedRuntime: "codex" as const,
+      modelProvider: {
+        baseUrl: "https://relay.example.test/v1",
+        preparedAuth: { source: "harness" as const },
+      },
+    },
+    {
+      label: "an owner-selected credential",
+      requestedRuntime: "codex" as const,
+      modelProvider: { preparedAuth: { source: "profile" as const, mode: "api-key" } },
+    },
+  ])("does not infer native model access for $label", ({ requestedRuntime, modelProvider }) => {
+    const result = harness.supports({
+      provider: "openai",
+      modelId: "gpt-future",
+      requestedRuntime,
+      modelProvider: { requestTransportOverrides: "none", ...modelProvider },
+    });
+
+    expect(result.supported).toBe(false);
+    expect(!result.supported ? result.reason : undefined).toContain("not declared");
+  });
+
   it.each([
     {
       label: "forwarded OAuth subscription",

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -135,6 +135,19 @@ export function createCodexAppServerAgentHarness(options: {
       }
       const preparedAuth = ctx.modelProvider?.preparedAuth;
       const runtimePolicy = ctx.modelProvider?.runtimePolicy;
+      // Codex owns discovery and auth for new first-party models. Only trust that
+      // native account when no authored transport or host credential is involved.
+      const nativeAccountOwnsUnobservedModel =
+        provider === "openai" &&
+        ctx.requestedRuntime === "codex" &&
+        Boolean(ctx.modelId?.trim()) &&
+        preparedAuth?.source === "harness" &&
+        preparedAuth.mode === undefined &&
+        preparedAuth.requirement === undefined &&
+        ctx.modelProvider?.api === undefined &&
+        ctx.modelProvider?.baseUrl === undefined &&
+        ctx.modelProvider?.azureApiVersion === undefined &&
+        ctx.modelProvider?.request === undefined;
       if (runtimePolicy) {
         const compatible = runtimePolicy.compatibleIds.some(
           (id) => id.trim().toLowerCase() === normalizedHarnessRuntimeId,
@@ -145,7 +158,7 @@ export function createCodexAppServerAgentHarness(options: {
             reason: "Codex cannot reproduce the prepared provider route",
           };
         }
-      } else if (ctx.modelProvider && provider !== "codex") {
+      } else if (ctx.modelProvider && provider !== "codex" && !nativeAccountOwnsUnobservedModel) {
         return {
           supported: false,
           reason: "provider route compatibility with Codex is not declared",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the pinned release rejects newly available first-party Codex models even when the existing native account can use them.

## Why This Change Was Made

Backports the reviewed change already merged to main in #127322 while preserving the existing release line. Native model discovery applies only when Codex is explicitly selected and no authored endpoint, transport override, or owner-supplied credential conflicts.

## User Impact

Agents on the existing pinned release can use newly available models without silently falling back or changing their authentication setup.

## Evidence

The release branch passes 86 focused Codex harness and OpenAI provider tests. The corresponding main change passed 280 routing, authentication, selection, and harness tests.