### PR TITLE
fix(release): preserve validation plan across reruns

### DIFF
--- a/.agents/skills/openclaw-testing/SKILL.md
+++ b/.agents/skills/openclaw-testing/SKILL.md
@@ -350,9 +350,10 @@ the failure to that exact active run.
 The child-dispatch jobs record run ID, run attempt, and URL, then finish. The
 parent seals those tuples, original dispatch titles, gate coverage, reuse
 policy, and original parent attempt in one immutable
-`full-release-execution-plan-<run-id>` artifact. Collector retries restore that
-artifact and adopt its children; they never reconstruct the plan or redispatch
-tests.
+`full-release-execution-plan-<run-id>` artifact and exact run-ID cache entry.
+Collector retries restore the cached bytes, validate them, and re-upload the
+artifact for their attempt before adopting its children; they never reconstruct
+the plan or redispatch tests.
 `Release Decision` polls those exact identities and can report
 `blocked_diagnostics_running` before unrelated children finish.
 For reused evidence, it also repeats the canonical target, policy, changed-path,

--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -57,10 +57,12 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
   child that owns a blocking failure.
 - After dispatch, one immutable execution-plan artifact records the original
   parent attempt, exact child tuples and titles, selected coverage, gates, and
-  reuse identity. Decision, Drain, manifest writing, evidence validation, and
-  final verification consume that plan. A collector retry restores it and
-  adopts the same children; missing plan state is an orchestration failure, not
-  permission to redispatch.
+  reuse identity. The same bytes are saved under an exact run-ID cache key.
+  Decision, Drain, manifest writing, evidence validation, and final verification
+  consume the artifact for their current attempt. A collector retry restores
+  the cached plan, validates it, re-uploads its artifact, and adopts the same
+  children; missing plan state is an orchestration failure, not permission to
+  reconstruct the plan or redispatch.
 - Reused evidence is not trusted merely because plan sealing found it. Release
   Decision repeats the sealed target SHA, evidence SHA, policy, changed paths,
   selected run, root run, source manifest, trusted tooling identity, and
@@ -321,7 +323,8 @@ The `full-release-diagnostics-<run-id>-<attempt>` artifact is the terminal
 failure and timing manifest. Use it after an early blocker instead of
 restarting `all` merely to discover what the still-running children found.
 The stable `full-release-execution-plan-<run-id>` artifact is the identity
-source for every collector attempt.
+source within each collector attempt; retry attempts restore its immutable
+run-ID-cached bytes first.
 
 ## Failure Triage
 

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1096,12 +1096,15 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
-      - name: Restore immutable release execution plan
+      # Parent reruns hide prior-attempt artifacts. This exact-key cache is immutable;
+      # a miss fails closed instead of reconstructing or redispatching child identities.
+      - name: Restore immutable release execution plan for parent rerun
         if: ${{ github.run_attempt != 1 }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          name: full-release-execution-plan-${{ github.run_id }}
           path: ${{ runner.temp }}/full-release-execution-plan
+          key: full-release-execution-plan-v1-${{ github.run_id }}
+          fail-on-cache-miss: true
 
       - name: Seal immutable release execution plan
         id: plan
@@ -1225,8 +1228,15 @@ jobs:
           fi
           node scripts/full-release-validation-state.mjs plan
 
+      - name: Preserve immutable release execution plan for parent reruns
+        if: ${{ github.run_attempt == 1 && steps.plan.outcome == 'success' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ runner.temp }}/full-release-execution-plan
+          key: full-release-execution-plan-v1-${{ github.run_id }}
+
       - name: Upload immutable release execution plan
-        if: ${{ always() && github.run_attempt == 1 }}
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: full-release-execution-plan-${{ github.run_id }}

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1098,13 +1098,12 @@ jobs:
 
       # Parent reruns hide prior-attempt artifacts. This exact-key cache is immutable;
       # a miss fails closed instead of reconstructing or redispatching child identities.
-      - name: Restore immutable release execution plan for parent rerun
-        if: ${{ github.run_attempt != 1 }}
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Cache immutable release execution plan
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ runner.temp }}/full-release-execution-plan
           key: full-release-execution-plan-v1-${{ github.run_id }}
-          fail-on-cache-miss: true
+          fail-on-cache-miss: ${{ github.run_attempt != 1 }}
 
       - name: Seal immutable release execution plan
         id: plan
@@ -1227,13 +1226,6 @@ jobs:
             )"
           fi
           node scripts/full-release-validation-state.mjs plan
-
-      - name: Preserve immutable release execution plan for parent reruns
-        if: ${{ github.run_attempt == 1 && steps.plan.outcome == 'success' }}
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ${{ runner.temp }}/full-release-execution-plan
-          key: full-release-execution-plan-v1-${{ github.run_id }}
 
       - name: Upload immutable release execution plan
         if: always()

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -45,12 +45,16 @@ first-failure path is preferable; Release Decision then cancels only the exact
 still-active child that owns the blocking failure.
 
 After dispatch, the parent writes one immutable
-`full-release-execution-plan-<run-id>` artifact. It records selected and
+`full-release-execution-plan-<run-id>` artifact and preserves the same bytes in
+an exact run-ID Actions cache. It records selected and
 required coverage, gate results, reuse identity, the original parent attempt,
 and every exact child run ID, attempt, title, workflow ref, and Tooling SHA.
 Decision, Drain, manifest generation, evidence verification, and the final
-verifier consume this artifact. Collector retries restore it and adopt the
-same children; they never rebuild the plan or redispatch tests.
+verifier consume the artifact for their current attempt. Collector retries
+restore the immutable cached copy, validate it, and upload the artifact again
+for the retry; they never rebuild the plan or redispatch tests. A missing or
+evicted cache fails closed, so start a new validation instead of retrying that
+stale parent.
 Release Decision also repeats canonical reuse-chain validation before a reused
 run can pass. The sealed target SHA, evidence SHA, policy, changed-path set,
 selected run, root run, source manifest, trusted tooling identity, and child

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -54,6 +54,10 @@ const ANDROID_RELEASE_WORKFLOW = ".github/workflows/android-release.yml";
 const STABLE_MAIN_CLOSEOUT_WORKFLOW = ".github/workflows/openclaw-stable-main-closeout.yml";
 const WINDOWS_NODE_RELEASE_WORKFLOW = ".github/workflows/windows-node-release.yml";
 const FULL_RELEASE_VALIDATION_WORKFLOW = ".github/workflows/full-release-validation.yml";
+const ACTIONS_CACHE_RESTORE_V5 =
+  "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae";
+const ACTIONS_CACHE_SAVE_V5 =
+  "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae";
 const CI_WORKFLOW = ".github/workflows/ci.yml";
 const PERFORMANCE_WORKFLOW = ".github/workflows/openclaw-performance.yml";
 const FULL_RELEASE_CHILD_DISPATCHES = [
@@ -2967,6 +2971,14 @@ describe("package acceptance workflow", () => {
     const decisionUpload = workflowStep(decision, "Upload release decision");
     const drainUpload = workflowStep(drain, "Upload diagnostic drain manifest");
     const planStep = workflowStep(executionPlan, "Seal immutable release execution plan");
+    const planRestore = workflowStep(
+      executionPlan,
+      "Restore immutable release execution plan for parent rerun",
+    );
+    const planPreserve = workflowStep(
+      executionPlan,
+      "Preserve immutable release execution plan for parent reruns",
+    );
     const planUpload = workflowStep(executionPlan, "Upload immutable release execution plan");
     const manifestStep = workflowStep(summary, "Write release validation manifest");
     const selectState = workflowStep(summary, "Select newest compatible release state artifacts");
@@ -2999,7 +3011,14 @@ describe("package acceptance workflow", () => {
     expect(planStep.run).not.toContain("EVIDENCE_MANIFEST");
     expect(planStep.run).toContain('--arg evidenceRunId "$EVIDENCE_RUN_ID"');
     expect(planStep.run).toContain('--argjson trustedWorkflow "$TRUSTED_WORKFLOW_JSON"');
-    expect(planUpload.if).toBe("${{ always() && github.run_attempt == 1 }}");
+    expect(planRestore.uses).toBe(ACTIONS_CACHE_RESTORE_V5);
+    expect(planRestore.with).toMatchObject({
+      "fail-on-cache-miss": true,
+      key: "full-release-execution-plan-v1-${{ github.run_id }}",
+    });
+    expect(planPreserve.uses).toBe(ACTIONS_CACHE_SAVE_V5);
+    expect(planPreserve.with?.key).toBe("full-release-execution-plan-v1-${{ github.run_id }}");
+    expect(planUpload.if).toBe("always()");
     expect(planUpload.with?.name).toBe("full-release-execution-plan-${{ github.run_id }}");
     expect(manifestStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");
     expect(manifestStep.run).toContain(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3017,7 +3017,9 @@ describe("package acceptance workflow", () => {
       key: "full-release-execution-plan-v1-${{ github.run_id }}",
     });
     expect(planPreserve.uses).toBe(ACTIONS_CACHE_SAVE_V5);
-    expect(planPreserve.with?.key).toBe("full-release-execution-plan-v1-${{ github.run_id }}");
+    expect(planPreserve.with?.key).toBe(
+      "full-release-execution-plan-v1-${{ github.run_id }}",
+    );
     expect(planUpload.if).toBe("always()");
     expect(planUpload.with?.name).toBe("full-release-execution-plan-${{ github.run_id }}");
     expect(manifestStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");
@@ -3084,7 +3086,7 @@ describe("package acceptance workflow", () => {
       (job.steps ?? []).filter((step) => step.uses?.startsWith("actions/download-artifact@")),
     );
 
-    expect(downloadSteps).toHaveLength(6);
+    expect(downloadSteps).toHaveLength(5);
     for (const step of downloadSteps) {
       expect(step.uses).toBe(DOWNLOAD_ARTIFACT_V8);
     }

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -54,10 +54,8 @@ const ANDROID_RELEASE_WORKFLOW = ".github/workflows/android-release.yml";
 const STABLE_MAIN_CLOSEOUT_WORKFLOW = ".github/workflows/openclaw-stable-main-closeout.yml";
 const WINDOWS_NODE_RELEASE_WORKFLOW = ".github/workflows/windows-node-release.yml";
 const FULL_RELEASE_VALIDATION_WORKFLOW = ".github/workflows/full-release-validation.yml";
-const ACTIONS_CACHE_RESTORE_V5 =
-  "actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae";
-const ACTIONS_CACHE_SAVE_V5 =
-  "actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae";
+const ACTIONS_CACHE_V5 =
+  "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae";
 const CI_WORKFLOW = ".github/workflows/ci.yml";
 const PERFORMANCE_WORKFLOW = ".github/workflows/openclaw-performance.yml";
 const FULL_RELEASE_CHILD_DISPATCHES = [
@@ -2971,14 +2969,7 @@ describe("package acceptance workflow", () => {
     const decisionUpload = workflowStep(decision, "Upload release decision");
     const drainUpload = workflowStep(drain, "Upload diagnostic drain manifest");
     const planStep = workflowStep(executionPlan, "Seal immutable release execution plan");
-    const planRestore = workflowStep(
-      executionPlan,
-      "Restore immutable release execution plan for parent rerun",
-    );
-    const planPreserve = workflowStep(
-      executionPlan,
-      "Preserve immutable release execution plan for parent reruns",
-    );
+    const planCache = workflowStep(executionPlan, "Cache immutable release execution plan");
     const planUpload = workflowStep(executionPlan, "Upload immutable release execution plan");
     const manifestStep = workflowStep(summary, "Write release validation manifest");
     const selectState = workflowStep(summary, "Select newest compatible release state artifacts");
@@ -3011,15 +3002,11 @@ describe("package acceptance workflow", () => {
     expect(planStep.run).not.toContain("EVIDENCE_MANIFEST");
     expect(planStep.run).toContain('--arg evidenceRunId "$EVIDENCE_RUN_ID"');
     expect(planStep.run).toContain('--argjson trustedWorkflow "$TRUSTED_WORKFLOW_JSON"');
-    expect(planRestore.uses).toBe(ACTIONS_CACHE_RESTORE_V5);
-    expect(planRestore.with).toMatchObject({
-      "fail-on-cache-miss": true,
+    expect(planCache.uses).toBe(ACTIONS_CACHE_V5);
+    expect(planCache.with).toMatchObject({
+      "fail-on-cache-miss": "${{ github.run_attempt != 1 }}",
       key: "full-release-execution-plan-v1-${{ github.run_id }}",
     });
-    expect(planPreserve.uses).toBe(ACTIONS_CACHE_SAVE_V5);
-    expect(planPreserve.with?.key).toBe(
-      "full-release-execution-plan-v1-${{ github.run_id }}",
-    );
     expect(planUpload.if).toBe("always()");
     expect(planUpload.with?.name).toBe("full-release-execution-plan-${{ github.run_id }}");
     expect(manifestStep.env).not.toHaveProperty("EVIDENCE_MANIFEST");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -54,8 +54,7 @@ const ANDROID_RELEASE_WORKFLOW = ".github/workflows/android-release.yml";
 const STABLE_MAIN_CLOSEOUT_WORKFLOW = ".github/workflows/openclaw-stable-main-closeout.yml";
 const WINDOWS_NODE_RELEASE_WORKFLOW = ".github/workflows/windows-node-release.yml";
 const FULL_RELEASE_VALIDATION_WORKFLOW = ".github/workflows/full-release-validation.yml";
-const ACTIONS_CACHE_V5 =
-  "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae";
+const ACTIONS_CACHE_V5 = "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae";
 const CI_WORKFLOW = ".github/workflows/ci.yml";
 const PERFORMANCE_WORKFLOW = ".github/workflows/openclaw-performance.yml";
 const FULL_RELEASE_CHILD_DISPATCHES = [


### PR DESCRIPTION
## Summary

- preserve the attempt-one Full Release Validation execution plan under an exact run-ID cache key
- restore and validate those immutable bytes on a parent rerun, then upload the normal plan artifact for that attempt
- fail closed on a missing/evicted cache; never reconstruct child identity or dispatch a second child

## Root cause

PR #127014 made parent reruns depend on `full-release-execution-plan-<run-id>` from attempt one. GitHub makes prior-attempt artifacts unavailable when the parent workflow is rerun, so the plan restore fails before Release Decision or Diagnostic Drain can adopt the original child.

The controlled post-merge proof reproduced this exactly:

- attempt one sealed and uploaded the plan, then the selected npm Telegram child failed independently
- attempt three failed in `Restore immutable release execution plan`: https://github.com/openclaw/openclaw/actions/runs/32502046941/job/96834858649
- the parent run now exposes no downloadable artifacts from attempt one: https://github.com/openclaw/openclaw/actions/runs/32502046941

## Why this owner

The repository already pins official `actions/cache` v5. Its combined action restores before the plan is validated and saves in a success-only post-step after attempt one seals the plan. The parent run ID is unique, contains no secrets, and is stable across attempts. That makes the cache a narrow cross-attempt transport, while the validated artifact remains the per-attempt evidence surface consumed by Decision, Drain, summary, and external verification.

This avoids custom child discovery, log parsing, mutable repository state, and any second workflow-dispatch POST. Cache eviction remains explicit: the rerun fails closed and the operator starts a new validation.

Direct pinned-action inspection:

- `fail-on-cache-miss` is an explicit input and the save post-step is gated by `success()`: https://github.com/actions/cache/blob/27d5ce7f107fe9357f9df03efb73ab90386fccae/action.yml#L21-L44
- restore uses the exact primary key, accepts no prefix fallback unless `restore-keys` is supplied, and throws on a required miss: https://github.com/actions/cache/blob/27d5ce7f107fe9357f9df03efb73ab90386fccae/src/restoreImpl.ts#L32-L76
- the post-step reuses the primary key, does not overwrite an exact hit, and saves the configured path on an attempt-one miss: https://github.com/actions/cache/blob/27d5ce7f107fe9357f9df03efb73ab90386fccae/src/saveImpl.ts#L35-L73

## Verification

Not run locally. Per the validation constraint, GitHub owns formatting, workflow parsing, tests, and the controlled parent-rerun proof.

Exact-head controlled proof: https://github.com/openclaw/openclaw/actions/runs/32544655324

- attempt one dispatched exactly one npm Telegram child, https://github.com/openclaw/openclaw/actions/runs/32544680489, which failed on the intentionally nonexistent `openclaw@0.0.0-frv-proof` package
- attempt one sealed cache key `full-release-execution-plan-v1-32544655324`
- whole-parent attempt two skipped every child-dispatch job and restored that exact key successfully
- attempt two re-uploaded artifact https://github.com/openclaw/openclaw/actions/runs/32544655324/artifacts/9468152008
- restored plan SHA-256 remained `5af98eba5a581bf55b1bd8ff09313a66f9064a574fdeebef5f8100845a92820e`
- restored plan remained owned by parent attempt one and retained child run `32544680489`, attempt one
- attempt two was red only because Release Decision correctly preserved the deliberately failed child outcome

Exact-head PR CI is green with no failed or active checks. The workflow regression asserts:

- the exact pinned combined cache action
- the exact run-ID key with no prefix fallback
- cache miss is fatal only on a parent rerun
- the plan artifact uploads on every parent attempt
- the canonical artifact-download count reflects the removed cross-attempt download

## Diff audit

- release workflow: `+7/-5`
- tests: `+9/-2`
- docs and operator skills: `+19/-11`
- product runtime: `+0/-0`

The workflow growth is the explicit cross-attempt custody boundary. No child dispatch, release policy, or product behavior changes.
