### PR TITLE
fix(sessions): preserve ownership across lifecycle and maintenance

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -262,10 +262,7 @@ export function readSessionEntryStore(
   const db = getSessionKysely(database.db);
   const rows = executeSqliteQuerySync(
     database.db,
-    db
-      .selectFrom("session_nodes")
-      .select(["current_session_id", "entry_json", "session_key", "updated_at"])
-      .orderBy("session_key"),
+    db.selectFrom("session_nodes").selectAll().orderBy("session_key"),
   ).rows;
   const store: Record<string, SessionEntry> = {};
   for (const row of rows) {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -627,7 +627,7 @@ export function planSessionLifecycleArtifactCleanup(
     ) {
       continue;
     }
-    const entry = parseSessionEntryRow(row);
+    const entry = projectedStore[row.session_key];
     const sessionIds = uniqueStrings([
       row.current_session_id,
       ...(entry ? collectSessionStateIdsForEntry(entry) : []),

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -11,7 +11,11 @@ import {
   type SessionStateDeletePlan,
 } from "./session-accessor.sqlite-archive.js";
 import type { SessionLifecycleArchivedTranscript } from "./session-accessor.sqlite-contract.js";
-import { readSessionEntryCount, writeSessionEntry } from "./session-accessor.sqlite-entry-store.js";
+import {
+  readSessionEntryCount,
+  readSessionEntryStore,
+  writeSessionEntry,
+} from "./session-accessor.sqlite-entry-store.js";
 import { emitCommittedSessionEntryRemovals } from "./session-accessor.sqlite-identity.js";
 import {
   assertPlannedLifecycleArtifactEntriesUnchanged,
@@ -96,24 +100,6 @@ function hasStaleSqliteSessionEntryCandidate(
     }
     return isCandidate(normalizeStoreSessionKey(row.session_key), entry);
   });
-}
-
-function loadSqliteSessionMaintenanceStore(
-  database: OpenClawAgentDatabase,
-): Record<string, SessionEntry> {
-  const db = getSessionKysely(database.db);
-  const rows = executeSqliteQuerySync(
-    database.db,
-    db.selectFrom("session_nodes").select(["session_key", "entry_json"]).orderBy("session_key"),
-  ).rows;
-  const store: Record<string, SessionEntry> = {};
-  for (const row of rows) {
-    const entry = parseSessionEntryRow(row);
-    if (entry) {
-      store[row.session_key] = entry;
-    }
-  }
-  return store;
 }
 
 export function applySessionEntryMaintenance(
@@ -203,7 +189,7 @@ export function applySessionEntryMaintenance(
     };
   }
 
-  const store = loadSqliteSessionMaintenanceStore(database);
+  const store = readSessionEntryStore(database);
   const preserveKeys =
     collectSessionMaintenancePreserveKeysForStore({
       storePath: params.storePath,

--- a/src/config/sessions/session-accessor.sqlite-status.ts
+++ b/src/config/sessions/session-accessor.sqlite-status.ts
@@ -52,10 +52,7 @@ export function readSessionEntriesByStatus(
     return [];
   }
   const db = getNodeSqliteKysely<SessionStatusDatabase>(database.db);
-  let query = db
-    .selectFrom("session_nodes")
-    .select(["session_key", "entry_json", "current_session_id", "updated_at"])
-    .where("status", "in", selectedStatuses);
+  let query = db.selectFrom("session_nodes").selectAll().where("status", "in", selectedStatuses);
   if (selectedSessionKeys) {
     query = query.where("session_key", "in", selectedSessionKeys);
   }

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -33,6 +33,7 @@ import {
   appendTranscriptEvent,
   appendTranscriptMessage,
   applySessionEntryLifecycleMutation,
+  assignSessionOwner,
   commitReplySessionInitialization,
   countSessionEntryRowsReadOnly,
   createSessionEntryWithTranscript,
@@ -2119,6 +2120,11 @@ describe("session accessor seam", () => {
       ],
       skipMaintenance: true,
     });
+    const doneOwner = { id: "done-owner", type: "human" as const };
+    assignSessionOwner(
+      { sessionKey: "agent:main:done", storePath },
+      { assignedBy: doneOwner, owner: doneOwner },
+    );
 
     const result = await applySessionEntryReplacements({
       storePath,
@@ -2169,9 +2175,12 @@ describe("session accessor seam", () => {
       "agent:main:other",
       "agent:main:shared-running",
     ]);
-    expect(
-      listSessionEntriesByStatus({ storePath }, ["done"]).map((entry) => entry.sessionKey),
-    ).toEqual(["agent:main:done", "agent:main:shared-done"]);
+    const doneSessions = listSessionEntriesByStatus({ storePath }, ["done"]);
+    expect(doneSessions.map((entry) => entry.sessionKey)).toEqual([
+      "agent:main:done",
+      "agent:main:shared-done",
+    ]);
+    expect(doneSessions[0]?.entry.owner?.actor).toEqual(doneOwner);
 
     const other = loadSessionEntry({ sessionKey: "agent:main:other", storePath });
     expect(other).toBeDefined();
@@ -2592,6 +2601,8 @@ describe("session accessor seam", () => {
       sessionId: "lifecycle-prepare",
       updatedAt: 10,
     });
+    const owner = { id: "lifecycle-owner", type: "human" as const };
+    assignSessionOwner(scope, { assignedBy: owner, owner });
     const builderStarted = createDeferred();
     const builderGate = createDeferred();
     const pendingMutation = applySessionEntryLifecycleMutation({
@@ -2696,6 +2707,8 @@ describe("session accessor seam", () => {
       sessionId: scope.sessionId,
       updatedAt: 10,
     });
+    const owner = { id: "lifecycle-owner", type: "human" as const };
+    assignSessionOwner(scope, { assignedBy: owner, owner });
     await replaceTranscriptEvents(scope, [
       {
         id: "event-1",

--- a/src/gateway/server-methods/sessions-mutations.perf.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.perf.test.ts
@@ -54,6 +54,20 @@ function humanClient(): GatewayClient {
   };
 }
 
+function isWholeSessionStoreProjection(normalizedSql: string): boolean {
+  const source = ' from "session_nodes" order by "session_key"';
+  if (!normalizedSql.startsWith("select ") || !normalizedSql.endsWith(source)) {
+    return false;
+  }
+  const selection = normalizedSql.slice("select ".length, -source.length);
+  return (
+    selection === "*" ||
+    ['"current_session_id"', '"entry_json"', '"session_key"', '"updated_at"'].every((column) =>
+      selection.includes(column),
+    )
+  );
+}
+
 test("single non-label sessions.patch avoids a whole-store projection", async () => {
   await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
     const targetKey = "agent:main:single-patch-target";
@@ -74,13 +88,7 @@ test("single non-label sessions.patch avoids a whole-store projection", async ()
       ["whole-store-projection"] as const,
       (sql) => {
         const normalized = sql.toLowerCase().replaceAll(/\s+/g, " ").trim();
-        return normalized.includes(
-          'select "current_session_id", "entry_json", "session_key", "updated_at"',
-        ) &&
-          normalized.includes('from "session_nodes"') &&
-          normalized.includes('order by "session_key"')
-          ? "whole-store-projection"
-          : null;
+        return isWholeSessionStoreProjection(normalized) ? "whole-store-projection" : null;
       },
     );
     const respond = vi.fn();
@@ -159,13 +167,7 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
       ["whole-store-projection", "transcript-full-hydration"] as const,
       (sql) => {
         const normalized = sql.toLowerCase().replaceAll(/\s+/g, " ").trim();
-        if (
-          normalized.includes(
-            'select "current_session_id", "entry_json", "session_key", "updated_at"',
-          ) &&
-          normalized.includes('from "session_nodes"') &&
-          normalized.includes('order by "session_key"')
-        ) {
+        if (isWholeSessionStoreProjection(normalized)) {
           return "whole-store-projection";
         }
         const fromIndex = normalized.indexOf(" from ");

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
+  assignSessionOwner,
   loadSessionEntry as loadInternalSessionEntry,
   patchSessionEntryCore as patchInternalSessionEntry,
   replaceSessionEntry as replaceInternalSessionEntry,
@@ -61,6 +62,11 @@ describe("session-store-runtime compatibility surface", () => {
       storePath,
       entry,
     });
+  }
+
+  function assignOwner(sessionKey: string): void {
+    const actor = { id: "profile-owner", type: "human" as const };
+    assignSessionOwner({ sessionKey, storePath }, { assignedBy: actor, owner: actor });
   }
 
   function expectRecoveryCleared(params: {
@@ -321,15 +327,13 @@ describe("session-store-runtime compatibility surface", () => {
   });
 
   it("applies whole-store compatibility mutations through SQLite rows", async () => {
-    await seedSessionEntry("agent:main:remove", {
-      sessionId: "session-remove",
-      updatedAt: 10,
-    });
+    await seedSessionEntry("agent:main:remove", { sessionId: "session-remove", updatedAt: 10 });
     await seedSessionEntry("agent:main:update", {
       model: "gpt-5.5",
       sessionId: "session-update",
       updatedAt: 10,
     });
+    ["agent:main:remove", "agent:main:update"].forEach(assignOwner);
 
     await expect(
       updateSessionStore(
@@ -829,6 +833,7 @@ describe("session-store-runtime compatibility surface", () => {
         sessionId: "session-active",
         updatedAt: now,
       });
+      assignOwner(staleSessionKey);
 
       await patchSessionEntry({
         sessionKey: activeSessionKey,
@@ -996,20 +1001,16 @@ describe("session-store-runtime compatibility surface", () => {
   });
 
   it("cleans lifecycle artifacts through the accessor-backed SDK wrapper", async () => {
-    const sessionKey = "agent:main:lifecycle-owned-old";
+    const sessionId = "lifecycle-owned-old";
+    const sessionKey = `agent:main:${sessionId}`;
     const oldTimestamp = Date.now() - 600_000;
-    await seedSessionEntry(sessionKey, {
-      sessionId: "lifecycle-owned-old",
-      updatedAt: oldTimestamp,
-    });
-    await seedSessionEntry("agent:main:regular", {
-      sessionId: "regular",
-      updatedAt: Date.now(),
-    });
+    await seedSessionEntry(sessionKey, { sessionId, updatedAt: oldTimestamp });
+    await seedSessionEntry("agent:main:regular", { sessionId: "regular", updatedAt: Date.now() });
+    assignOwner(sessionKey);
     await appendTranscriptEvent(
-      { agentId: "main", sessionKey, sessionId: "lifecycle-owned-old", storePath },
+      { agentId: "main", sessionKey, sessionId, storePath },
       {
-        runId: "lifecycle-owned-old",
+        runId: sessionId,
         timestamp: new Date(oldTimestamp).toISOString(),
         type: "metadata",
       },


### PR DESCRIPTION
## What Problem This Solves

Sessions with an assigned owner can no longer be updated, reset, deleted, archived, or pruned reliably. Three SQLite readers built detached session snapshots without the owner columns, while transaction validation reread the same rows with their owner attached. The resulting false compare-and-swap conflicts also made automatic retention silently leave stale owned sessions behind. Status-filtered session reads separately dropped assigned ownership.

## Why This Change Was Made

- Read complete SQLite rows in the canonical whole-store and status readers so their existing owner projection sees the same authoritative state as exact-row validation.
- Reuse the existing owner-complete whole-store snapshot when planning lifecycle cleanup.
- Delete the duplicate owner-blind maintenance store loader and reuse the canonical reader.
- Preserve lazily added owner columns, older SQLite stores, independently projected participants, canonical doctor repair, existing maintenance policy, and synchronous transaction boundaries.

Production LOC: +9/-29 (net -20). Tests: +32/-18 (net +14). No SQLite schema, public API, configuration, dependency, or protocol change.

## User Impact

Assigned sessions can be updated, reset, deleted, and archived normally; stale assigned sessions are again removed by configured retention; plugin compatibility mutations work for assigned sessions; and status-filtered session listings retain their assigned owner.

## Evidence

Before the production fix, real owner-boundary regressions failed on all six affected paths:

```text
node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts
# 3 failed: status owner omitted, lifecycle upsert false conflict, lifecycle removal false conflict

node scripts/run-vitest.mjs src/plugin-sdk/session-store-runtime.test.ts
# 3 failed: whole-store update/delete false conflict, stale assigned session not pruned,
#            lifecycle cleanup/archive false conflict
```

After the fix:

```text
node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/plugin-sdk/session-store-runtime.test.ts
# 135 passed

node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-owner.test.ts src/config/sessions/session-accessor.sqlite-replacement-projection.test.ts src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts src/commands/doctor-session-canonical-keys.test.ts src/commands/doctor-session-canonical-keys.owner-repair.test.ts src/agents/main-session-recovery/main-session-recovery-store.test.ts src/agents/main-session-recovery/main-session-restart-recovery.test.ts
# 222 passed

node scripts/run-tsgo.mjs -p tsconfig.core.json --moduleResolution bundler --module preserve --incremental --tsBuildInfoFile .artifacts/tsgo-cache/owner-qa-core-bundler.tsbuildinfo
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/config/sessions/session-accessor.sqlite-entry-store.ts src/config/sessions/session-accessor.sqlite-status.ts src/config/sessions/session-accessor.sqlite-lifecycle-state.ts src/config/sessions/session-accessor.sqlite-maintenance.ts src/config/sessions/session-accessor.test.ts src/plugin-sdk/session-store-runtime.test.ts
node_modules/.bin/oxfmt --check src/config/sessions/session-accessor.sqlite-entry-store.ts src/config/sessions/session-accessor.sqlite-status.ts src/config/sessions/session-accessor.sqlite-lifecycle-state.ts src/config/sessions/session-accessor.sqlite-maintenance.ts src/config/sessions/session-accessor.test.ts src/plugin-sdk/session-store-runtime.test.ts
node --import tsx scripts/check-import-cycles.ts
node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main
node --import tsx scripts/check-max-lines-ratchet.mts --base origin/main
git diff --check
```

The linked local checkout currently has an unrelated dangling shared workspace-package symlink for `@openclaw/session-url-contract`; its normal NodeNext core typecheck cannot resolve that existing dependency. The source-path/bundler core typecheck above passes without modifying shared dependencies; clean exact-head hosted CI supplies the authoritative normal NodeNext typecheck.

Independent in-session source review found no P0-P2 issues. Related but separate QA follow-ups: deprecated whole-store session mutations currently omit session identity notifications; the watchdog can lose queued recovery state or abort configured long maintenance early; subagent restart recovery can mistake hidden reasoning for completed visible work.
