### PR TITLE
fix(claws): remove exec approvals when a Claw agent is removed

### DIFF
--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
+import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -7,7 +8,9 @@ import {
   AgentConfigPreconditionError,
   deleteAgentConfigEntry,
 } from "../gateway/server-methods/agents-config-mutations.js";
+import { withAgentExecApprovalsRemoved } from "../infra/exec-approvals.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { digestClawAgentConfig } from "./agent-config-digest.js";
 import {
   deletionEffects,
@@ -16,6 +19,25 @@ import {
 } from "./lifecycle-delete-support.js";
 
 export type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
+
+type ClawAgentConfigRemovalParams = {
+  agentId: string;
+  expectedDigest: string;
+  expectedRemovalSurfaceDigest: string;
+  expectedState: "present" | "missing";
+  fallbackWorkspace: string;
+  config?: OpenClawConfig;
+  commitConfig?: ConfigCommit;
+  trashPath?: ClawTrashPath;
+  onModified: () => Error;
+};
+
+type ClawAgentConfigRemovalResult = {
+  agentRemoved: boolean;
+  cleanupTargets?: ClawCleanupTargets;
+  configBeforeDelete: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+};
 
 export { digestClawAgentConfig } from "./agent-config-digest.js";
 
@@ -32,31 +54,11 @@ export function digestClawAgentRemovalSurface(config: OpenClawConfig, agentId: s
   return `sha256:${createHash("sha256").update(stableStringify(surface)).digest("hex")}`;
 }
 
-export async function claimClawAgentConfigRemoval(params: {
-  agentId: string;
-  expectedDigest: string;
-  expectedRemovalSurfaceDigest: string;
-  expectedState: "present" | "missing";
-  fallbackWorkspace: string;
-  config?: OpenClawConfig;
-  commitConfig?: ConfigCommit;
-  trashPath?: ClawTrashPath;
-  onModified: () => Error;
-}): Promise<{
-  agentRemoved: boolean;
-  cleanupTargets?: ClawCleanupTargets;
-  configBeforeDelete: OpenClawConfig;
-  nextConfig: OpenClawConfig;
-}> {
+async function commitClawAgentConfigRemoval(
+  params: ClawAgentConfigRemovalParams,
+): Promise<ClawAgentConfigRemovalResult> {
   if (params.commitConfig) {
-    let result:
-      | {
-          agentRemoved: boolean;
-          cleanupTargets?: ClawCleanupTargets;
-          configBeforeDelete: OpenClawConfig;
-          nextConfig: OpenClawConfig;
-        }
-      | undefined;
+    let result: ClawAgentConfigRemovalResult | undefined;
     await params.commitConfig((config) => {
       const effects = deletionEffects(config, params.agentId, params.fallbackWorkspace);
       const agent = listAgentEntries(config).find((candidate) => candidate.id === params.agentId);
@@ -147,5 +149,37 @@ export async function claimClawAgentConfigRemoval(params: {
       configBeforeDelete,
       nextConfig: latestConfig,
     };
+  }
+}
+
+export async function claimClawAgentConfigRemoval(params: ClawAgentConfigRemovalParams) {
+  const config = params.config ?? getRuntimeConfig();
+  const effects = deletionEffects(config, params.agentId, params.fallbackWorkspace);
+  // beginAgentDeletion takes over an existing journal row instead of refusing it, so rolling back
+  // a row this call did not open would erase another deletion's record.
+  const existingJournal = readAgentDeletionJournal(params.agentId);
+  const deletion = beginAgentDeletion({
+    agentId: params.agentId,
+    workspaceDir: effects.workspace,
+    agentDir: effects.agentDir,
+    sessionsDir: effects.sessionsDir,
+    // Claw removal owns selective cleanup and may retain modified or untracked workspace entries,
+    // so the journal must not claim authority to trash them.
+    deleteFiles: existingJournal?.deleteFiles ?? false,
+  });
+  try {
+    const result = await withAgentExecApprovalsRemoved(params.agentId, async () =>
+      commitClawAgentConfigRemoval({ ...params, config }),
+    );
+    deletion.commit();
+    // The journal fences only the roster and approvals commit here; Claw's own filesystem cleanup
+    // runs afterwards and may legitimately end partial, so completion is recorded now.
+    deletion.finish();
+    return result;
+  } catch (error) {
+    if (!existingJournal) {
+      deletion.rollback();
+    }
+    throw error;
   }
 }

--- a/src/claws/lifecycle-remove-approvals.test.ts
+++ b/src/claws/lifecycle-remove-approvals.test.ts
@@ -1,0 +1,156 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
+import { withTempHomeConfig, writeOpenClawConfig } from "../config/test-helpers.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadExecApprovals, saveExecApprovals } from "../infra/exec-approvals.js";
+import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { applyClawAddPlan } from "./add.js";
+import {
+  claimClawAgentConfigRemoval,
+  digestClawAgentRemovalSurface,
+} from "./lifecycle-config-removal.js";
+import { applyClawRemovePlan, buildClawRemovePlan } from "./lifecycle-state.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawSourceIdentity } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  envSnapshot.restore();
+});
+
+async function buildApprovalFixture() {
+  const root = tempDirs.make("openclaw-claw-remove-approvals-");
+  const parsed = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "worker", name: "Worker" },
+  });
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.diagnostics));
+  }
+  const source: ClawSourceIdentity = {
+    kind: "package",
+    name: "@acme/worker",
+    version: "1.0.0",
+    packageRoot: root,
+    manifestPath: join(root, "openclaw.claw.json"),
+    integrityKind: "artifact",
+    integrity: "sha256:manifest",
+    byteLength: 100,
+  };
+  return await buildClawAddPlan({
+    manifest: parsed.manifest,
+    source,
+    context: { workspace: join(root, "workspace-worker") },
+  });
+}
+
+describe("Claw exec approvals removal", () => {
+  it.each([
+    { label: "config-file commit", useCommitConfig: false },
+    { label: "commitConfig seam", useCommitConfig: true },
+  ])("removes only the claw agent policy through the $label", async ({ useCommitConfig }) => {
+    const addPlan = await buildApprovalFixture();
+
+    await withTempHomeConfig({}, async ({ home }) => {
+      const env = { OPENCLAW_STATE_DIR: join(home, ".openclaw") };
+      setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+      let config: OpenClawConfig = {};
+      await applyClawAddPlan(addPlan, {
+        consentPlanIntegrity: addPlan.planIntegrity,
+        env,
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+      });
+      await writeOpenClawConfig(home, config);
+      saveExecApprovals({
+        version: 1,
+        agents: {
+          "*": { security: "deny" },
+          worker: {
+            security: "allowlist",
+            allowlist: [{ pattern: "/usr/bin/rm" }],
+          },
+          kept: {
+            security: "allowlist",
+            allowlist: [{ pattern: "/usr/bin/keep" }],
+          },
+        },
+      });
+      const plan = useCommitConfig
+        ? await buildClawRemovePlan("worker", { env, config })
+        : await buildClawRemovePlan("worker");
+      const common = {
+        consentPlanIntegrity: plan.planIntegrity,
+        trashPath: async () => true,
+      };
+
+      const result = useCommitConfig
+        ? await applyClawRemovePlan(plan, {
+            ...common,
+            env,
+            config,
+            commitConfig: async (transform) => {
+              config = transform(config);
+            },
+          })
+        : await applyClawRemovePlan(plan, common);
+
+      expect(result).toMatchObject({ status: "complete", agentRemoved: true });
+      expect(loadExecApprovals().agents).toEqual({
+        "*": { security: "deny" },
+        kept: {
+          security: "allowlist",
+          allowlist: [expect.objectContaining({ pattern: "/usr/bin/keep" })],
+        },
+      });
+      expect(readAgentDeletionJournal("worker")).toMatchObject({
+        cleanupCompleted: true,
+        deleteFiles: false,
+      });
+    });
+  });
+
+  // beginAgentDeletion takes over an existing journal row, so a failed Claw removal must not roll
+  // back a deletion another path started.
+  it.each([
+    { label: "keeps a pre-existing journal", seedJournal: true },
+    { label: "rolls back the journal it opened", seedJournal: false },
+  ])("$label when the config commit fails", async ({ seedJournal }) => {
+    const root = tempDirs.make("openclaw-claw-remove-journal-");
+    setTestEnvValue("OPENCLAW_STATE_DIR", join(root, "state"));
+    if (seedJournal) {
+      beginAgentDeletion({
+        agentId: "worker",
+        agentDir: join(root, "agent"),
+        workspaceDir: join(root, "workspace"),
+        sessionsDir: join(root, "sessions"),
+      });
+    }
+
+    await expect(
+      claimClawAgentConfigRemoval({
+        agentId: "worker",
+        expectedDigest: "sha256:unused",
+        expectedRemovalSurfaceDigest: digestClawAgentRemovalSurface({}, "worker"),
+        expectedState: "present",
+        fallbackWorkspace: join(root, "workspace"),
+        config: {},
+        commitConfig: async () => {
+          throw new Error("claw commit failed");
+        },
+        onModified: () => new Error("claw agent modified"),
+      }),
+    ).rejects.toThrow("claw commit failed");
+
+    expect(readAgentDeletionJournal("worker") === undefined).toBe(!seedJournal);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`openclaw claws remove <agent>` deletes the Claw agent, reports `status: complete`,
`agentRemoved: true` — and leaves that agent's exec-approvals policy behind in the shared state DB.
Policy is keyed by the raw agent id (`src/infra/exec-approvals-resolver.ts:162` reads
`file.agents?.[agentKey]`), so a later agent created with the same id silently inherits the removed
agent's allowlist.

Reproduced against real `applyClawRemovePlan` in an isolated `OPENCLAW_STATE_DIR`, on both branches
of `claimClawAgentConfigRemoval` — including the one the real CLI takes
(`src/cli/claws-cli.runtime.ts:631` passes neither `config` nor `commitConfig`, so it goes through
`deleteAgentConfigEntry`):

```
status=complete agentRemoved=true
approvals after remove = {
  "*":      {"security":"deny"},
  "worker": {"security":"allowlist","allowlist":[{"pattern":"/usr/bin/rm"}]},   <-- survives
  "kept":   {"security":"deny"}
}
```

## Why This Change Was Made

`claws` is the third agent-removal path, and the only one that never opened an agent-deletion
journal at all. The other two both fence the config write:

- `src/gateway/server-methods/agents.ts:1113` — `beginAgentDeletion(...)` then
  `cron.removeAgentJobsTransactional(agentId, () => withAgentExecApprovalsRemoved(agentId, () => deleteAgentConfigEntry(...)))`
- `src/commands/agents.commands.delete.ts:283` — `beginAgentDeletion(...)`, commit inside
  `withAgentExecApprovalsRemoved`, `deletion.commit()` / `deletion.rollback()`

`withAgentExecApprovalsRemoved` (`src/infra/exec-approvals-store.ts:217`) throws
`ExecApprovalsMutationFencedError` unless `readAgentDeletionJournal(agentId)` already holds an
`operationId`, so the journal is a precondition of the fix, not an optional extra.

This is the same defect class as #127037 (which fixed the CLI path), one path over.

## User Impact

`claws remove` now removes the Claw agent's exec-approvals policy along with the agent, so a
recreated agent starts from the wildcard/default policy instead of inheriting stale grants. The
wildcard `"*"` entry and unrelated agents are untouched. Cron behaviour is unchanged — Claw cron is
declaration-owned and already reconciled through `options.cronGateway`.

Two lifecycle details are deliberate and carry inline comments:

- `beginAgentDeletionJournal` **takes over** an existing journal row rather than refusing it, so a
  rollback here would erase a deletion this call did not start. The rollback is guarded to journals
  this call opened, matching `agents.commands.delete.ts:311`.
- `deleteFiles: false`, because Claw removal owns selective cleanup and deliberately retains
  modified or untracked workspace entries; the journal must not claim authority to trash them. An
  inherited journal keeps its own value.

The journal is finished as soon as the roster and approvals commit lands. Claw's filesystem cleanup
runs afterwards and may legitimately end `partial`; leaving the journal open would wedge recreation
with `agent "<id>" deletion cleanup is still pending` (`src/agents/agent-create.ts:272`).

## Evidence

Production `+58/-24` (net +34; ~16 of the additions are the type extraction that removes a
duplicated inline type). Tests `+156/-0`.

`node scripts/run-vitest.mjs src/claws/lifecycle-remove-approvals.test.ts`
- Before the fix: 2/2 failed — the `worker` policy survived removal.
- After: 4/4 pass.

The journal-ownership guard is proven both ways: reverting `if (!existingJournal)` to an
unconditional `deletion.rollback()` fails the new `keeps a pre-existing journal` case and passes the
other three.

`node scripts/run-vitest.mjs src/claws/lifecycle-remove-approvals.test.ts src/claws/lifecycle-state.test.ts src/claws/lifecycle-state-mcp.test.ts src/claws/bootstrap.test.ts src/infra/exec-approvals-store.test.ts`
- 5 files, 77 tests passed.

`node scripts/check-changed.mjs -- <both files>` — all lanes ok except `format changed files`, which
fails only because this linked worktree has no `node_modules/.bin/oxfmt`. Formatting verified
directly with the checkout's binary: `oxfmt --check` reports both files correctly formatted.

`$autoreview --mode uncommitted` — clean, no accepted or actionable findings.
