### PR TITLE
test(agents): canonicalize macOS tmpdir fixtures

### DIFF
--- a/src/agents/sandbox/fs-bridge.test-helpers.ts
+++ b/src/agents/sandbox/fs-bridge.test-helpers.ts
@@ -170,7 +170,7 @@ export async function withTempDir<T>(
   prefix: string,
   run: (stateDir: string) => Promise<T>,
 ): Promise<T> {
-  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  const stateDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), prefix)));
   try {
     return await run(stateDir);
   } finally {

--- a/src/agents/tools/skill-workshop-tool.collection-restore.test.ts
+++ b/src/agents/tools/skill-workshop-tool.collection-restore.test.ts
@@ -21,7 +21,9 @@ describe("skill_workshop collection restore", () => {
       prefix: "openclaw-skill-collection-restore-state-",
     });
     cleanups.push(async () => await testState.cleanup());
-    const workspaceDir = await tempDirs.make("openclaw-skill-collection-restore-");
+    const workspaceDir = await fs.realpath(
+      await tempDirs.make("openclaw-skill-collection-restore-"),
+    );
     const proposal = await proposeCreateSkill({
       workspaceDir,
       env: testState.env,


### PR DESCRIPTION
## What Problem This Solves

Two tests fail on every clean `origin/main` checkout on macOS while passing on Linux CI: `fs-bridge.boundary.test.ts` ("rejects a regular file replaced by a FIFO at descriptor open") and `skill-workshop-tool.collection-restore.test.ts` ("restores a canonical cleanup through the configured workspace alias").

## Why This Change Was Made

Both are the documented macOS tmpdir trap (`docs/reference/test.md`): `os.tmpdir()` returns the `/var` symlink while production resolvers return the canonical `/private/var` path. In the FIFO test the descriptor-open spy compared different spellings of the same path so the race injection never fired; in the workshop test the proposal ownership ledger held the `/var` fixture path while reconciliation looked up its canonical equivalent. Canonicalizing the fixture roots with `fs.realpath` fixes both while preserving every protected assertion (O_NONBLOCK, FIFO rejection, no-Docker execution; explicit symlink-alias restore scenario).

## User Impact

None at runtime — test-only. macOS contributors get a green `src/agents` lane on clean main.

## Evidence

Both failures reproduced pre-fix on clean main (M3 Ultra); post-fix both files green plus 144 focused tests; `pnpm check:changed` green; autoreview clean. Production LOC +0/−0; tests +4/−2.
