### PR TITLE
fix(cli): tell config get apart a typo from an unset key

### DIFF
--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -320,6 +320,13 @@ function schemasAtPath(
   return schemas;
 }
 
+export function isConfigSchemaPath(
+  schema: JsonSchemaRecord | undefined,
+  path: readonly PathSegment[],
+): boolean {
+  return schemasAtPath(schema, path).length > 0;
+}
+
 function schemaPrefersArrayAtPath(
   schema: JsonSchemaRecord | undefined,
   path: readonly PathSegment[],

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -98,7 +98,43 @@ vi.mock("../secrets/resolve.js", () => ({
 }));
 
 vi.mock("../config/runtime-schema.js", () => ({
-  buildRuntimeConfigSchemaFromRegistry: () => ({ uiHints: {} }),
+  buildRuntimeConfigSchemaFromRegistry: () => ({
+    schema: {
+      type: "object",
+      properties: {
+        models: {
+          type: "object",
+          properties: {
+            providers: {
+              type: "object",
+              additionalProperties: {
+                type: "object",
+                properties: {
+                  models: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: { id: { type: "string" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        gateway: {
+          type: "object",
+          properties: {
+            bind: { type: "string" },
+            port: { type: "number" },
+          },
+        },
+      },
+    },
+    uiHints: {},
+    version: "test",
+    generatedAt: "2026-03-25T00:00:00.000Z",
+  }),
   readBestEffortRuntimeConfigSchema: () => mockReadBestEffortRuntimeConfigSchema(),
 }));
 
@@ -1303,6 +1339,7 @@ describe("config cli", () => {
 
       expect(mockReadConfigFileSnapshot).toHaveBeenCalledWith({ observe: false });
       expect(parseLastLogPayload()).toBe(18789);
+      expect(mockExit).not.toHaveBeenCalled();
     });
 
     it("redacts sensitive values", async () => {
@@ -1358,19 +1395,64 @@ describe("config cli", () => {
       expect(mockWriteStdout).toHaveBeenCalledWith("60\n");
     });
 
-    it("outputs JSON error to stdout when path is not found and --json is set", async () => {
+    it.each([
+      {
+        name: "valid but unset schema path",
+        path: "gateway.bind",
+        message:
+          "Config path is valid but unset: gateway.bind. The runtime default applies until you set an authored value with openclaw config set gateway.bind <value>.",
+      },
+      {
+        name: "valid but unset array path",
+        path: "models.providers.example.models[0].id",
+        message:
+          "Config path is valid but unset: models.providers.example.models[0].id. The runtime default applies until you set an authored value with openclaw config set 'models.providers.example.models[0].id' <value>.",
+      },
+      {
+        name: "unknown path",
+        path: "nonexistent.path",
+        message:
+          "Unknown config path: nonexistent.path. Run openclaw config schema to inspect valid paths.",
+      },
+    ])("reports a $name to the operator", async (testCase) => {
       setGatewaySnapshot();
 
-      await expect(
-        runConfigCommand(["config", "get", "nonexistent.path", "--json"]),
-      ).rejects.toThrow(ExitError);
+      await expect(runConfigCommand(["config", "get", testCase.path])).rejects.toThrow(ExitError);
+
+      expectErrorIncludes(testCase.message);
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(mockLog).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        name: "valid but unset schema path",
+        path: "gateway.bind",
+        message:
+          "Config path is valid but unset: gateway.bind. The runtime default applies until you set an authored value with openclaw config set gateway.bind <value>.",
+      },
+      {
+        name: "unknown path",
+        path: "nonexistent.path",
+        message:
+          "Unknown config path: nonexistent.path. Run openclaw config schema to inspect valid paths.",
+      },
+    ])("outputs a JSON error for a $name", async (testCase) => {
+      setGatewaySnapshot();
+
+      await expect(runConfigCommand(["config", "get", testCase.path, "--json"])).rejects.toThrow(
+        ExitError,
+      );
 
       expect(mockError).not.toHaveBeenCalled();
-      const payload = parseLastLogPayload() as { error: { type: string; message: string } };
-      expect(payload.error).toEqual({
-        type: "cli_error",
-        message: "Config path not found: nonexistent.path",
+      expect(parseLastLogPayload()).toEqual({
+        ok: false,
+        error: {
+          type: "cli_error",
+          message: testCase.message,
+        },
       });
+      expect(mockExit).toHaveBeenCalledWith(1);
     });
 
     it.each([

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -38,6 +38,7 @@ import { normalizeConfigMutationModelRefs } from "./config-cli-model-normalizati
 import {
   formatConfigUnsetMissingPathMessage,
   getAtPath,
+  isConfigSchemaPath,
   parseConfigSetPath,
   unsetAtPath,
 } from "./config-cli-path.js";
@@ -67,6 +68,7 @@ import {
 import { resolveConfigSetMode } from "./config-set-parser.js";
 import { formatCliJsonFailure } from "./failure-output.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
+import { quoteCliArg } from "./quote-cli-arg.js";
 
 export { parseConfigSetPath } from "./config-cli-path.js";
 
@@ -171,21 +173,20 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
     if (!pluginMetadataSnapshot) {
       throw new Error("Config plugin metadata unavailable; refusing to display config values.");
     }
-    const { uiHints } = buildRuntimeConfigSchemaFromRegistry(
+    const { schema, uiHints } = buildRuntimeConfigSchemaFromRegistry(
       pluginMetadataSnapshot.manifestRegistry,
     );
     const res = getAtPath(redactConfigObject(snapshot.config, uiHints), parsedPath);
     if (!res.found) {
+      const message = isConfigSchemaPath(schema, parsedPath)
+        ? `Config path is valid but unset: ${opts.path}. The runtime default applies until you set an authored value with ${formatCliCommand(`openclaw config set ${quoteCliArg(opts.path)} <value>`)}.`
+        : `Unknown config path: ${opts.path}. Run ${formatCliCommand("openclaw config schema")} to inspect valid paths.`;
       if (opts.json) {
-        writeRuntimeJson(runtime, formatCliJsonFailure(`Config path not found: ${opts.path}`));
+        writeRuntimeJson(runtime, formatCliJsonFailure(message));
         runtime.exit(1);
         return;
       }
-      runtime.error(
-        danger(
-          `Config path not found: ${opts.path}. Run ${formatCliCommand("openclaw config validate")} to inspect config shape.`,
-        ),
-      );
+      runtime.error(danger(message));
       runtime.exit(1);
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

`openclaw config get <path>` could not tell an operator whether they had a typo or an unset setting.
A real schema key with no authored value and a key that does not exist produced the identical
message and exit code:

```
gateway.port              -> 18997                                          exit 0
gateway.bind              -> Config path not found: gateway.bind. Run openclaw config validate ...    exit 1
gateway.mode              -> Config path not found: gateway.mode. ...        exit 1
logging.level             -> Config path not found: logging.level. ...       exit 1
cron.enabled              -> Config path not found: cron.enabled. ...        exit 1
approvals.exec.security   -> Config path not found: approvals.exec.security. ...  exit 1
bogus.path                -> Config path not found: bogus.path. ...          exit 1
gateway.bogus             -> Config path not found: gateway.bogus. ...       exit 1
```

The first five are real properties (`openclaw config schema` lists them); the last two are not.

The suggested next step did not help either case. `config validate` only reports whether the current
file parses and validates — with a valid file it prints `Config valid: ~/.openclaw/openclaw.json`
and says nothing about which paths exist.

## Why This Change Was Made

`config unset` already makes this distinction. `formatConfigUnsetMissingPathMessage`
(`src/cli/config-cli-path.ts:215`) has a separate, accurate message for a path that only exists once
runtime defaults are applied. `config get` never got the same treatment — and `config unset`'s own
fallback tells the operator to "Run `openclaw config get <path>` first if you are unsure of the
path", advice that could not work while `config get` answered identically for both.

The schema needed to answer this was already in hand: `runConfigGet` calls
`buildRuntimeConfigSchemaFromRegistry(...)` and used only `uiHints` from the result. The path-walking
machinery was there too — `schemasAtPath` (`src/cli/config-cli-path.ts:306`), already used by
`setAtPath`, and already index-aware so array paths are not misreported as unknown.

## User Impact

```
openclaw config get gateway.mode
  Config path is valid but unset: gateway.mode. The runtime default applies until you set an
  authored value with openclaw config set gateway.mode <value>.

openclaw config get gateway.bogus
  Unknown config path: gateway.bogus. Run openclaw config schema to inspect valid paths.
```

The set hint names the operator's actual path, so it is runnable as printed. Both cases still exit 1,
and `--json` carries the same distinction through `formatCliJsonFailure`. The success path, the
redaction behaviour, and all exit codes are unchanged.

## Evidence

Production `+15/-7` (net +8): one exported predicate over the existing `schemasAtPath`, and the
message split in `runConfigGet`. Tests `+91/-9`.

`node scripts/run-vitest.mjs src/cli/config-cli.test.ts` — 195 tests passed. New coverage: a set
path returns its value; a valid-but-unset path (including an array-index path) reports "valid but
unset"; an unknown path reports "unknown"; both failures exit 1 in text and `--json`.

`oxfmt --check` clean on all three files. `$autoreview --mode uncommitted` clean, no accepted or
actionable findings.
