### PR TITLE
fix(ui): announce custom theme import results

### DIFF
--- a/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
@@ -600,6 +600,42 @@ suite.define(() => {
     }
   });
 
+  it("announces a failed custom-theme import", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse({}, "custom-theme-invalid-1"),
+          },
+        });
+        await page.route("https://tweakcn.com/r/themes/network-failure", async (route) => {
+          await route.fulfill({ status: 503 });
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
+        expect(response?.status()).toBe(200);
+        await waitForControlUiSettingsTakeover(page);
+        await gateway.waitForRequest("config.get");
+
+        await page.locator(".settings-theme-card--custom").click();
+        const importer = page.locator(".settings-theme-import");
+        await importer.locator("input").fill("https://tweakcn.com/themes/network-failure");
+        await importer.locator("button.primary").click();
+
+        await expect
+          .poll(async () => (await importer.getByRole("alert").textContent())?.trim())
+          .toBe("tweakcn import failed (503).");
+        expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+        await captureViewport(page, "07-custom-theme-import-error-announced.png");
+      },
+    );
+  });
+
   it("keeps Clear authoritative after a delayed custom-theme replacement", async () => {
     const existingTheme = await importCustomThemeFromUrl(
       "existing",
@@ -693,6 +729,7 @@ suite.define(() => {
       await expect
         .poll(() => importer.locator(".settings-theme-import__message").textContent())
         .toContain("removed");
+      await expect.poll(() => importer.getByRole("status").count()).toBe(1);
       const afterDelayedResponse = await readThemeImportRaceState(page);
       expect(beforeReplace).toMatchObject({
         clawSelected: false,
@@ -797,6 +834,7 @@ suite.define(() => {
       await expect
         .poll(() => importer.locator(".settings-theme-import__message").textContent())
         .toContain("Imported");
+      await expect.poll(() => importer.getByRole("status").count()).toBe(1);
       expect(await gateway.getRequests("config.patch")).toHaveLength(0);
     } finally {
       releaseImport();

--- a/ui/src/pages/config/view-appearance.ts
+++ b/ui/src/pages/config/view-appearance.ts
@@ -293,6 +293,9 @@ export function renderAppearanceSection(
                       ? html`<div
                           class="settings-theme-import__message settings-theme-import__message--${props
                             .customThemeImportMessage.kind}"
+                          role=${props.customThemeImportMessage.kind === "error"
+                            ? "alert"
+                            : "status"}
                         >
                           ${props.customThemeImportMessage.text}
                         </div>`


### PR DESCRIPTION
## What Problem This Solves

Custom-theme imports on Appearance end with a visible success or error message, but those asynchronous results render as a plain `div`. Screen-reader users therefore receive no announcement when an import fails, succeeds, or is cleared.

The same message owner already distinguishes `success` from `error`; only the live-region semantics were missing.

## Why This Change Was Made

The Appearance renderer now maps the existing result kind to the matching semantic role:

- import failures use `role="alert"` for assertive feedback;
- successful imports and clears use `role="status"` for polite feedback.

This is the canonical render boundary for every custom-theme result. Import parsing, persistence, Gateway synchronization, race retirement, and theme activation are unchanged.

The source-mode Chromium regression exercises a valid tweakcn URL whose real HTTP request resolves with 503, then requires the visible error through the `alert` role. Existing delayed-import and delayed-replacement/clear scenarios now also require their successful result through the `status` role.

## User Impact

Screen readers now announce custom-theme failures promptly and successful import/clear outcomes politely. Sighted presentation and all existing import behavior remain unchanged.

### Before

The error was visible, but the executed DOM probe found no `role` or live-region semantics.

![Before: visible custom-theme error without live-region semantics](https://ampcode.com/user-content/artifacts/36cd66a0b0c10ca64ffd3eee54404125a8f7ba48cfb537309eae48d74269d3c1-file.png)

### After

The real source-mode route shows the asynchronous 503 result while the browser test resolves the same message through `getByRole("alert")`.

![After: asynchronous custom-theme failure announced as an alert](https://ampcode.com/user-content/artifacts/6225251f799fb0c2e780e6c45a3435b52ab99d0d05f9b80c2a70e6dc896a6cf9-file.png)

Both screenshots were inspected; semantic proof comes from the executed DOM-role assertions rather than the images.

## Evidence

- Authentic pre-fix source-Chromium regression: error, import-success, and clear-success role assertions all failed because the result count was zero for both `alert` and `status`.
- Post-fix `ui/src/e2e/appearance-settings-defaults.e2e.test.ts`: 6/6 passed, including the routed HTTP 503 failure, delayed import ownership, and delayed replacement/clear retirement.
- Relevant owner suites: 3 files, 85/85 passed (`view.browser`, custom-theme page ownership, and importer helpers).
- Full `node scripts/check-changed.mjs` passed after correcting the worktree's UI dependency symlink; the first run's only failure was local resolution of already-declared `pako` from the root package instead of `ui/node_modules`.
- Deslop found no cleanup. Final Codex autoreview was clean and rated the patch correct at 0.99 confidence after its requested asynchronous-network regression was added.
- Independent lane duplicate searches found no exact open issue or PR.

Production LOC: +3/-0; tests: +38/-0. The production growth is one semantic role binding at the existing result renderer; no state or behavior branch was added.

AI-assisted implementation and verification; no agent transcript is attached.
