### PR TITLE
fix(diagnostics-otel): preserve model latency and memory ranges

### DIFF
--- a/extensions/diagnostics-otel/src/service-constants.ts
+++ b/extensions/diagnostics-otel/src/service-constants.ts
@@ -53,9 +53,9 @@ export const GEN_AI_OPERATION_DURATION_BUCKETS = [
 const OTEL_DEFAULT_HISTOGRAM_BUCKETS = [
   0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000,
 ];
-// Agent run / harness durations routinely exceed the SDK default's 10s ceiling.
-// Extend the existing layout through one hour without changing prior buckets.
-export const AGENT_DURATION_MS_BUCKETS = [
+// Model calls routinely exceed the SDK default's 10s ceiling. Extend the
+// existing layout through ten minutes without changing prior buckets.
+export const MODEL_DURATION_MS_BUCKETS = [
   ...OTEL_DEFAULT_HISTOGRAM_BUCKETS,
   15000,
   20000,
@@ -67,9 +67,30 @@ export const AGENT_DURATION_MS_BUCKETS = [
   240000,
   300000,
   600000,
+];
+// Agent run / harness durations can outlive a single model call. Extend the
+// model layout through one hour without changing its finite buckets.
+export const AGENT_DURATION_MS_BUCKETS = [
+  ...MODEL_DURATION_MS_BUCKETS,
   900000,
   1_800_000,
   3_600_000,
+];
+// Process memory values are emitted in bytes and routinely exceed the SDK's
+// unit-agnostic 10,000 ceiling. Match the Prometheus byte scale through 16 GiB.
+export const MEMORY_BYTES_BUCKETS = [
+  ...OTEL_DEFAULT_HISTOGRAM_BUCKETS,
+  16384,
+  65536,
+  262144,
+  1048576,
+  4194304,
+  16777216,
+  67108864,
+  268435456,
+  1073741824,
+  4294967296,
+  17179869184,
 ];
 // openclaw.context.tokens records context window limit/used token counts, which
 // range from a few thousand to >1M for large-context models. Keep the prior

--- a/extensions/diagnostics-otel/src/service-metrics.ts
+++ b/extensions/diagnostics-otel/src/service-metrics.ts
@@ -4,6 +4,8 @@ import {
   CONTEXT_TOKENS_BUCKETS,
   GEN_AI_OPERATION_DURATION_BUCKETS,
   GEN_AI_TOKEN_USAGE_BUCKETS,
+  MEMORY_BYTES_BUCKETS,
+  MODEL_DURATION_MS_BUCKETS,
 } from "./service-constants.js";
 
 const DEFAULT_METRIC_NAME_PREFIX = "openclaw.";
@@ -184,6 +186,7 @@ export function createDiagnosticsMetrics(
   const modelCallDurationHistogram = createHistogram("openclaw.model_call.duration_ms", {
     unit: "ms",
     description: "Model call duration",
+    advice: { explicitBucketBoundaries: MODEL_DURATION_MS_BUCKETS },
   });
   const modelCallRequestBytesHistogram = createHistogram("openclaw.model_call.request_bytes", {
     unit: "By",
@@ -198,6 +201,7 @@ export function createDiagnosticsMetrics(
     {
       unit: "ms",
       description: "Elapsed time before the first streamed model response event",
+      advice: { explicitBucketBoundaries: MODEL_DURATION_MS_BUCKETS },
     },
   );
   const modelFailoverCounter = createCounter("openclaw.model.failover", {
@@ -219,22 +223,27 @@ export function createDiagnosticsMetrics(
   const memoryRssHistogram = createHistogram("openclaw.memory.rss_bytes", {
     unit: "By",
     description: "Resident set size reported by diagnostic memory samples",
+    advice: { explicitBucketBoundaries: MEMORY_BYTES_BUCKETS },
   });
   const memoryHeapUsedHistogram = createHistogram("openclaw.memory.heap_used_bytes", {
     unit: "By",
     description: "Heap used bytes reported by diagnostic memory samples",
+    advice: { explicitBucketBoundaries: MEMORY_BYTES_BUCKETS },
   });
   const memoryHeapTotalHistogram = createHistogram("openclaw.memory.heap_total_bytes", {
     unit: "By",
     description: "Heap total bytes reported by diagnostic memory samples",
+    advice: { explicitBucketBoundaries: MEMORY_BYTES_BUCKETS },
   });
   const memoryExternalHistogram = createHistogram("openclaw.memory.external_bytes", {
     unit: "By",
     description: "External memory bytes reported by diagnostic memory samples",
+    advice: { explicitBucketBoundaries: MEMORY_BYTES_BUCKETS },
   });
   const memoryArrayBuffersHistogram = createHistogram("openclaw.memory.array_buffers_bytes", {
     unit: "By",
     description: "ArrayBuffer bytes reported by diagnostic memory samples",
+    advice: { explicitBucketBoundaries: MEMORY_BYTES_BUCKETS },
   });
   const memoryPressureCounter = createCounter("openclaw.memory.pressure", {
     unit: "1",

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -4330,6 +4330,40 @@ describe("diagnostics-otel service", () => {
     }
   });
 
+  test("advertises domain buckets for model timing and memory histograms", async () => {
+    const priorSdkBoundaries = [
+      0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000,
+    ];
+    await startOtelService({ metrics: true });
+
+    const modelDurationMetrics = [
+      "openclaw.model_call.duration_ms",
+      "openclaw.model_call.time_to_first_byte_ms",
+    ];
+    for (const metricName of modelDurationMetrics) {
+      const options = histogramCreateOptions(metricName);
+      expect(options?.unit).toBe("ms");
+      expect(options?.advice?.explicitBucketBoundaries).toEqual(
+        expect.arrayContaining([...priorSdkBoundaries, 30000, 600000]),
+      );
+    }
+
+    const memoryMetrics = [
+      "openclaw.memory.rss_bytes",
+      "openclaw.memory.heap_used_bytes",
+      "openclaw.memory.heap_total_bytes",
+      "openclaw.memory.external_bytes",
+      "openclaw.memory.array_buffers_bytes",
+    ];
+    for (const metricName of memoryMetrics) {
+      const options = histogramCreateOptions(metricName);
+      expect(options?.unit).toBe("By");
+      expect(options?.advice?.explicitBucketBoundaries).toEqual(
+        expect.arrayContaining([...priorSdkBoundaries, 1_048_576, 1_073_741_824, 17_179_869_184]),
+      );
+    }
+  });
+
   test.each([
     ["bounds agent identifiers on model usage metric attributes", "Bearer sk-test-secret-value"],
     [


### PR DESCRIPTION
Related: #96592
Related: #97098

## What Problem This Solves

Fixes an issue where operators using OpenTelemetry could not diagnose model latency or process memory in absolute terms because the affected histograms used the SDK's unit-agnostic default finite buckets, which end at 10,000. Model calls beyond 10 seconds and byte-valued memory samples beyond 10 KB therefore accumulated only in the unbounded bucket.

A current production observation included repeated RSS-growth warnings and critical memory-pressure events, but the exported histogram layout prevented useful absolute percentile analysis.

## Why This Change Was Made

Apply domain-specific OpenTelemetry histogram advice only to the two affected model-duration instruments and the five diagnostic memory instruments. The new layouts preserve every previous SDK finite bucket, extend model timing through 10 minutes, and follow the existing Prometheus byte scale through 16 GiB.

This deliberately keeps the narrower policy established by #96592 instead of reviving the all-duration policy closed in #97098. Unrelated duration and byte histograms are unchanged.

## User Impact

Operators can distinguish realistic model-call latencies and process-memory levels in OTLP backends without collector-side bucket configuration. Existing bucket series remain available; newly collected samples gain useful finite ranges.

AI-assisted: yes. I reviewed the implementation and validation results.

## Evidence

- Regression test proved red before the fix: `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts -t 'advertises domain buckets for model timing and memory histograms'` failed because model-duration advice was `undefined`.
- The same focused test passes after the fix: 1 passed, 191 skipped.
- Complete owner suite: `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts` - 192 passed.
- Real OpenTelemetry 2.10.0 in-memory export: `openclaw.model_call.duration_ms` reports a 600000 ms maximum finite boundary including 30000; `openclaw.memory.rss_bytes` reports a 17179869184 byte maximum finite boundary including 1073741824.
- `git diff --check` - passed.
- `$autoreview --mode uncommitted` - clean, no accepted/actionable findings.
- Exact-head PR CI: run https://github.com/openclaw/openclaw/actions/runs/32514795167 passed all selected jobs and `openclaw/ci-gate` at `6ace98742174b15437344384492ba92e694c9171`.
- `node scripts/check-changed.mjs -- <files>` passed repository guards, formatting, contract tests, boundary checks, patch checks, and dead-export checks before extension typecheck. Local typecheck could not use a current clean dependency tree because the disk had 189 MiB free; the existing shared install produced unrelated stale-contract errors in `acpx`, `cua-computer`, `fs-safe`, and `terminal-core`. Exact-head hosted CI supplied the clean dependency proof.
- Clean Blacksmith Testbox attempt: `tbx_01m0jsa5nk00v8f4jfh3m60jh3`, run https://github.com/openclaw/openclaw/actions/runs/32513549476. Hydration succeeded, but targeted sync timed out and full-sync fallback emitted no completion marker for five minutes, so no remote command ran.
