### PR TITLE
perf(agents): avoid full roster projection for point lookups

### DIFF
--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -223,6 +223,25 @@ describe("agent roster resolution", () => {
     expect(resolveAgentConfig({ agents: { defaults, list: [] } }, "main")).toBeUndefined();
   });
 
+  it("does not project unrelated keyed entries while resolving one agent", () => {
+    let unrelatedEntryReads = 0;
+    const entries = new Proxy(
+      { main: { name: "Primary" }, worker: { name: "Worker" } },
+      {
+        get(target, property, receiver) {
+          if (property === "worker") {
+            unrelatedEntryReads += 1;
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+    const config = { agents: { ownership: "explicit" as const, entries } };
+
+    expect(resolveAgentConfig(config, "main")?.name).toBe("Primary");
+    expect(unrelatedEntryReads).toBe(0);
+  });
+
   it("keeps the retained legacy owner on the inherited workspace before config write", () => {
     const cfg = migratePersistedImplicitMainRoster({
       agents: {

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -1,5 +1,6 @@
 /** Resolves configured agent ids, directories, workspaces, and merged agent defaults. */
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeOptionalString,
   readStringValue,
@@ -94,17 +95,12 @@ function stripNullBytes(s: string): string {
 /** Lists valid configured agent entries from config. */
 export function listAgentEntriesWithSource(cfg: OpenClawConfig): ListedAgentEntry[] {
   const roster = readAgentRosterProperty(cfg);
-  if (
-    roster?.kind === "entries" &&
-    roster.value &&
-    typeof roster.value === "object" &&
-    !Array.isArray(roster.value)
-  ) {
+  if (roster?.kind === "entries" && isRecord(roster.value)) {
     return Object.entries(roster.value).flatMap(([id, entry]) =>
-      entry !== null && typeof entry === "object" && !Array.isArray(entry)
+      isRecord(entry)
         ? [
             {
-              entry: { ...(entry as Omit<AgentEntry, "id">), id },
+              entry: { ...entry, id },
               source: { kind: "entries" as const, key: id },
             },
           ]
@@ -286,7 +282,28 @@ export function tryResolveDefaultAgentId(cfg: OpenClawConfig): string | undefine
 
 export function resolveAgentEntry(cfg: OpenClawConfig, agentId: string): AgentEntry | undefined {
   const id = normalizeAgentId(agentId);
-  return listAgentEntries(cfg).find((entry) => normalizeAgentId(entry.id) === id);
+  // Point lookups are hot; the public list helper must clone every keyed entry.
+  // Traverse the roster directly so a match does not project unrelated agents.
+  const roster = readAgentRosterProperty(cfg);
+  if (roster?.kind === "entries" && isRecord(roster.value)) {
+    const entries = roster.value;
+    for (const key in entries) {
+      if (!Object.hasOwn(entries, key)) {
+        continue;
+      }
+      const entry = entries[key];
+      if (isRecord(entry) && normalizeAgentId(key) === id) {
+        return { ...entry, id: key };
+      }
+    }
+    return undefined;
+  }
+  if (roster?.kind === "list" && Array.isArray(roster.value)) {
+    return (roster.value as AgentEntry[]).find(
+      (entry) => entry !== null && typeof entry === "object" && normalizeAgentId(entry.id) === id,
+    );
+  }
+  return undefined;
 }
 
 /** Resolves the authored entry object for in-place canonical config mutations. */


### PR DESCRIPTION
## What Problem This Solves

Repeated per-agent configuration lookups projected and cloned the entire keyed agent roster before selecting one entry. Ordinary turns, cron runs, tools, status, and channel paths call this owner frequently, so lookup allocation and CPU grew with every configured agent even when the requested agent was first.

## Why This Change Was Made

Point lookups now traverse the authoritative keyed roster in its existing enumeration order and clone only the matching entry. The legacy list representation keeps its direct ordered lookup, while full-list callers keep the existing projection helper unchanged.

Production LOC: +26/-9 (net +17) | Tests: +19/-0. The production growth is the direct keyed/list owner split required to avoid materializing every keyed entry while preserving normalized-ID order and malformed-entry handling.

## User Impact

Agent-scoped operations avoid roster-wide object projection on each lookup. Output, selection order, defaults, configuration semantics, and public contracts are unchanged.

## Evidence

- Credible regression: the focused owner test fails on the exact parent with `unrelatedEntryReads = 1` and passes on this head with `0`.
- Current-head focused/sibling validation: 267 tests passed across agent scope, roster migration, and config write/merge suites.
- `pnpm check:changed`: passed (`core`, `coreTests`; formatting, typechecks, lint, dead exports, guards, import cycles).
- `pnpm build`: passed.
- `git diff --check`: passed.
- Deterministic 1,000-entry benchmark from the isolated owner lane: first-entry point lookup was 9.07× faster; exact returned config/reference behavior and missing-ID behavior matched.
- Bundled Codex `gpt-5.6-sol`/high autoreview: clean, patch correct (0.98), no accepted/actionable findings. TruffleHog preflight clean.
- The reviewed patch and current-main integration have the same stable patch ID: `f50269dcc03fa60a5be21f0278d3a9f24d67b6d8`.
