### PR TITLE
fix: hide internal completion wakes from chat history

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-active-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce-active-wake.ts
@@ -2,6 +2,7 @@
  * Active-requester wake and steering for subagent announcements.
  */
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
+import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
 import { sessionDeliveryChannel } from "../../../utils/delivery-context.shared.js";
 import type { EmbeddedAgentQueueMessageOptions } from "../../embedded-agent-runner/run-state.js";
 import type { EmbeddedAgentQueueMessageOutcome } from "../../embedded-agent-runner/runs.js";
@@ -186,6 +187,7 @@ export async function maybeSteerSubagentAnnounce(params: {
   requesterSessionKey: string;
   requesterAgentId?: string;
   steerMessage: string;
+  createUserTurnTranscriptRecorder?: (sessionId: string) => UserTurnTranscriptRecorder;
   signal?: AbortSignal;
   isSourceSessionEffectsAllowed?: () => boolean;
 }): Promise<
@@ -230,6 +232,9 @@ export async function maybeSteerSubagentAnnounce(params: {
     steeringMode: "all",
     ...(queueSettings.debounceMs !== undefined ? { debounceMs: queueSettings.debounceMs } : {}),
     waitForTranscriptCommit: true,
+    ...(params.createUserTurnTranscriptRecorder
+      ? { userTurnTranscriptRecorder: params.createUserTurnTranscriptRecorder(sessionId) }
+      : {}),
   };
   const queueOutcome = await resolveActiveWakeWithRetries(
     sessionId,

--- a/src/agents/subagents/announce/subagent-announce-delivery.runtime.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.runtime.ts
@@ -70,6 +70,8 @@ type RequesterSessionEntryResult = {
   cfg: ReturnType<typeof getRuntimeConfig>;
   entry: ReturnType<typeof loadSessionEntry>;
   canonicalKey: string;
+  agentId?: string;
+  storePath?: string;
 };
 
 export function tryResolveSubagentRequesterAgentId(
@@ -124,7 +126,7 @@ function loadDefaultRequesterSessionEntry(
     agentId,
     clone: false,
   });
-  return { cfg, entry, canonicalKey };
+  return { cfg, entry, canonicalKey, agentId, storePath };
 }
 
 const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1,9 +1,18 @@
 // Subagent announce delivery tests cover the last-mile routing used when child
 // runs report progress or completion back to the requester session.
+import fs from "node:fs";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import type { SessionEntry } from "../../../config/sessions.js";
+import { formatSqliteSessionFileMarker } from "../../../config/sessions/legacy-sqlite-marker.js";
+import {
+  loadTranscriptEvents,
+  replaceSessionEntry,
+} from "../../../config/sessions/session-accessor.js";
 import type { callGateway as runtimeCallGateway } from "../../../gateway/call.js";
 import type { dispatchGatewayMethodInProcess as runtimeDispatchGatewayMethodInProcess } from "../../../gateway/server-plugins.js";
+import { buildSessionHistorySnapshot } from "../../../gateway/session-history-state.js";
 import {
   OutboundDeliveryError,
   PlatformMessageNotDispatchedError,
@@ -56,6 +65,8 @@ const sessionDeliveryQueueMocks = vi.hoisted(() => ({
   releaseSessionDeliveryClaim: vi.fn(async () => {}),
   scheduleSessionDelivery: vi.fn(async () => true),
 }));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("../completion/subagent-completion-delivery.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../completion/subagent-completion-delivery.js")>()),
@@ -185,6 +196,41 @@ function createQueueOutcomeSequenceMock(
   });
 }
 
+async function createRequesterTranscriptFixture(sessionId: string) {
+  const dir = tempDirs.make("openclaw-subagent-announce-transcript-");
+  const sessionKey = "agent:main:slack:channel:C123:thread:171.222";
+  const storePath = path.join(dir, "agents", "main", "sessions", "sessions.json");
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  const entry: SessionEntry = {
+    sessionId,
+    sessionFile: formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath }),
+    updatedAt: Date.now(),
+  };
+  await replaceSessionEntry({ storePath, sessionKey }, entry);
+  return { agentId: "main", entry, sessionId, sessionKey, storePath };
+}
+
+async function readRequesterTranscriptMessages(fixture: {
+  agentId: string;
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+}): Promise<Array<Record<string, unknown>>> {
+  return (
+    await loadTranscriptEvents({
+      agentId: fixture.agentId,
+      sessionId: fixture.sessionId,
+      sessionKey: fixture.sessionKey,
+      storePath: fixture.storePath,
+    })
+  )
+    .map((event) => (event as { message?: unknown }).message)
+    .filter(
+      (message): message is Record<string, unknown> =>
+        Boolean(message) && typeof message === "object" && !Array.isArray(message),
+    );
+}
+
 const longChildCompletionOutput = [
   "34/34 tests pass, clean build. Now docker repro:",
   "Root cause: the requester's announce delivery accepted a prefix-only assistant payload as delivered.",
@@ -275,18 +321,43 @@ async function deliverSlackThreadAnnouncement(params: {
   requesterAbandoned?: boolean;
   isSourceSessionEffectsAllowed?: () => boolean;
   isCompletionOwnedByRequesterYield?: () => boolean;
+  requesterSessionActivity?: () => { sessionId: string; isActive: boolean };
+  requesterTranscriptFixture?:
+    | Awaited<ReturnType<typeof createRequesterTranscriptFixture>>
+    | (() => Awaited<ReturnType<typeof createRequesterTranscriptFixture>>);
 }) {
   // Slack thread delivery exercises all origins because direct, session, and
   // completion routing can differ after a child run outlives its requester.
+  const requesterTranscriptFixture = params.requesterTranscriptFixture;
+  const resolveRequesterTranscriptFixture =
+    typeof requesterTranscriptFixture === "function"
+      ? requesterTranscriptFixture
+      : () => requesterTranscriptFixture;
   testing.setDepsForTest({
     callGateway: params.callGateway,
-    getRequesterSessionActivity: () => ({
-      sessionId: params.sessionId ?? "requester-session-4",
-      isActive: params.isActive === true,
-    }),
+    getRequesterSessionActivity:
+      params.requesterSessionActivity ??
+      (() => ({
+        sessionId: params.sessionId ?? "requester-session-4",
+        isActive: params.isActive === true,
+      })),
     isRequesterSessionAbandoned: () => params.requesterAbandoned === true,
     getRuntimeConfig: () => ({}) as never,
     sendMessage: params.sendMessage ?? runtimeSendMessage,
+    ...(params.requesterTranscriptFixture
+      ? {
+          loadRequesterSessionEntry: (sessionKey: string) => {
+            const fixture = resolveRequesterTranscriptFixture();
+            return {
+              cfg: {} as never,
+              entry: fixture?.entry,
+              canonicalKey: sessionKey,
+              agentId: fixture?.agentId,
+              storePath: fixture?.storePath,
+            };
+          },
+        }
+      : {}),
     ...(params.queueEmbeddedAgentMessageWithOutcome
       ? { queueEmbeddedAgentMessageWithOutcome: params.queueEmbeddedAgentMessageWithOutcome }
       : {}),
@@ -1318,13 +1389,27 @@ describe("deliverSubagentAnnouncement active requester steering", () => {
 describe("deliverSubagentAnnouncement completion delivery", () => {
   it("uses an active requester queue as the completion handoff when message-tool delivery is not required", async () => {
     const callGateway = createGatewayMock();
-    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
+    const transcript = await createRequesterTranscriptFixture("requester-session-1");
+    const queueEmbeddedAgentMessageWithOutcome = vi.fn<QueueEmbeddedAgentMessageWithOutcome>(
+      async (sessionId, _text, options) => {
+        await options?.userTurnTranscriptRecorder?.persistApproved();
+        return {
+          queued: true,
+          sessionId,
+          target: "embedded_run",
+          gatewayHealth: "live",
+          enqueuedAtMs: 4_100,
+          deliveredAtMs: 4_200,
+        };
+      },
+    );
     const result = await deliverSlackThreadAnnouncement({
       callGateway,
       sessionId: "requester-session-1",
       isActive: true,
       directIdempotencyKey: "announce-1",
       queueEmbeddedAgentMessageWithOutcome,
+      requesterTranscriptFixture: transcript,
     });
 
     expectRecordFields(result, {
@@ -1336,14 +1421,42 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledWith(
       "requester-session-1",
       "child done",
-      {
+      expect.objectContaining({
         steeringMode: "all",
         debounceMs: 500,
         waitForTranscriptCommit: true,
         deliveryTimeoutMs: 120_000,
-      },
+        userTurnTranscriptRecorder: expect.any(Object),
+      }),
     );
     expect(callGateway).not.toHaveBeenCalled();
+
+    const rawMessages = await readRequesterTranscriptMessages(transcript);
+    expect(rawMessages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        content: "child done",
+        provenance: expect.objectContaining({
+          kind: "inter_session",
+          sourceTool: "subagent_announce",
+        }),
+      }),
+    ]);
+    const assistantReply = {
+      role: "assistant" as const,
+      content: [
+        { type: "text" as const, text: "Created." },
+        {
+          type: "image" as const,
+          source: { type: "url" as const, url: "/api/chat/media/outgoing/generated.png" },
+        },
+      ],
+      __openclaw: { seq: 2 },
+    };
+    expect(
+      buildSessionHistorySnapshot({ rawMessages: [...rawMessages, assistantReply] }).history
+        .messages,
+    ).toEqual([assistantReply]);
   });
 
   it("waits through compaction on the completion handoff wake (86566)", async () => {
@@ -2396,22 +2509,24 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       1,
       "requester-session-4",
       "child done",
-      {
+      expect.objectContaining({
         debounceMs: 500,
         deliveryTimeoutMs: 120_000,
         steeringMode: "all",
         waitForTranscriptCommit: true,
-      },
+        userTurnTranscriptRecorder: expect.any(Object),
+      }),
     );
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenNthCalledWith(
       2,
       "requester-session-4",
       "child done",
-      {
+      expect.objectContaining({
         debounceMs: 500,
         deliveryTimeoutMs: 120_000,
         steeringMode: "all",
-      },
+        userTurnTranscriptRecorder: expect.any(Object),
+      }),
     );
     expect(sendMessage).not.toHaveBeenCalled();
   });
@@ -2467,6 +2582,113 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
     expect(callGateway).toHaveBeenCalledTimes(4);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("persists fallback-steered completion provenance after the requester session rotates", async () => {
+    const previousTestFast = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    try {
+      const transcriptA = await createRequesterTranscriptFixture("requester-session-direct");
+      const transcriptB = await createRequesterTranscriptFixture("requester-session-fallback");
+      let currentTranscript = transcriptA;
+      let activityReadCount = 0;
+      const callGateway = vi.fn(async () => {
+        throw new Error("UNAVAILABLE: gateway lost final output");
+      }) as unknown as typeof runtimeCallGateway;
+      let firstRecorder: unknown;
+      let queueCallCount = 0;
+      const queueEmbeddedAgentMessageWithOutcome = vi.fn<QueueEmbeddedAgentMessageWithOutcome>(
+        async (sessionId, _text, options) => {
+          queueCallCount += 1;
+          if (queueCallCount === 1) {
+            expect(sessionId).toBe(transcriptA.sessionId);
+            firstRecorder = options?.userTurnTranscriptRecorder;
+            currentTranscript = transcriptB;
+            return {
+              queued: false,
+              sessionId,
+              reason: "not_streaming",
+              gatewayHealth: "live",
+            };
+          }
+          expect(sessionId).toBe(transcriptB.sessionId);
+          expect(options?.userTurnTranscriptRecorder).not.toBe(firstRecorder);
+          await options?.userTurnTranscriptRecorder?.persistApproved();
+          return {
+            queued: true,
+            sessionId,
+            target: "embedded_run",
+            gatewayHealth: "live",
+          };
+        },
+      );
+
+      const result = await deliverSlackThreadAnnouncement({
+        callGateway,
+        isActive: true,
+        directIdempotencyKey: "announce-retryable-direct-fallback",
+        queueEmbeddedAgentMessageWithOutcome,
+        requesterSessionActivity: () => ({
+          sessionId: activityReadCount++ === 0 ? transcriptA.sessionId : transcriptB.sessionId,
+          isActive: true,
+        }),
+        requesterTranscriptFixture: () => currentTranscript,
+        internalEvents: taskCompletionEvents({
+          childSessionId: "child-session-id",
+          taskLabel: "fallback persistence smoke",
+        }),
+      });
+
+      expectRecordFields(result, {
+        delivered: true,
+        path: "steered",
+        phases: [
+          {
+            phase: "direct-primary",
+            delivered: false,
+            path: "direct",
+            error: "UNAVAILABLE: gateway lost final output",
+          },
+          {
+            phase: "steer-fallback",
+            delivered: true,
+            path: "steered",
+            error: undefined,
+          },
+        ],
+      });
+      expect(callGateway).toHaveBeenCalledTimes(4);
+      expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
+
+      expect(await readRequesterTranscriptMessages(transcriptA)).toEqual([]);
+      const rawMessages = await readRequesterTranscriptMessages(transcriptB);
+      expect(rawMessages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: "child done",
+          provenance: expect.objectContaining({
+            kind: "inter_session",
+            sourceTool: "subagent_announce",
+          }),
+        }),
+      ]);
+      const assistantReply = {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: "visible final reply" }],
+        __openclaw: { seq: 2 },
+      };
+      const history = buildSessionHistorySnapshot({
+        rawMessages: [...rawMessages, assistantReply],
+      }).history.messages;
+      expect(history).toEqual([assistantReply]);
+      expect(JSON.stringify(history)).not.toContain("child done");
+    } finally {
+      if (previousTestFast === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousTestFast;
+      }
+    }
   });
 
   it("reports failure for Telegram DMs when announce-agent delivery fails", async () => {
@@ -2553,12 +2775,13 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledWith(
       "requester-session-telegram",
       "child done",
-      {
+      expect.objectContaining({
         steeringMode: "all",
         debounceMs: 500,
         waitForTranscriptCommit: true,
         deliveryTimeoutMs: 10,
-      },
+        userTurnTranscriptRecorder: expect.any(Object),
+      }),
     );
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -10,8 +10,13 @@ import {
   releaseSessionDeliveryClaim,
 } from "../../../infra/session-delivery-queue-storage.js";
 import { defaultRuntime } from "../../../runtime.js";
-import { isAgentMediatedCompletionSourceTool } from "../../../sessions/input-provenance.js";
+import {
+  isAgentMediatedCompletionSourceTool,
+  type InputProvenance,
+} from "../../../sessions/input-provenance.js";
 import { isCronSessionKey } from "../../../sessions/session-key-utils.js";
+import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
+import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../../utils/message-channel.js";
 import { hasGeneratedMediaCompletionEvent } from "../../internal-event-contract.js";
 import {
@@ -71,6 +76,60 @@ function collectExpectedMediaFromInternalEvents(events: AgentInternalEvent[] | u
   return {
     expectedMediaUrls,
     ...(expectedMediaUrls.length > 0 ? { expectedMediaAttachments } : {}),
+  };
+}
+
+function createCompletionUserTurnTranscriptRecorderFactory(params: {
+  directIdempotencyKey: string;
+  requesterAgentId?: string;
+  sourceSessionKey?: string;
+  sourceChannel?: string;
+  sourceTool?: string;
+  targetRequesterSessionKey: string;
+  triggerMessage: string;
+}): (sessionId: string) => UserTurnTranscriptRecorder {
+  const provenance: InputProvenance = {
+    kind: "inter_session",
+    ...(params.sourceSessionKey ? { sourceSessionKey: params.sourceSessionKey } : {}),
+    sourceChannel: params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+    sourceTool: params.sourceTool ?? "subagent_announce",
+  };
+  const recorders = new Map<string, UserTurnTranscriptRecorder>();
+  return (sessionId) => {
+    const existing = recorders.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+    // Retries targeting one session share a recorder. A successor session gets
+    // its own target guard while the logical idempotency key remains stable.
+    const recorder = createUserTurnTranscriptRecorder({
+      input: {
+        text: params.triggerMessage,
+        idempotencyKey: `${params.directIdempotencyKey}:active-wake`,
+        provenance,
+      },
+      target: () => {
+        const loaded = loadRequesterSessionEntry(
+          params.targetRequesterSessionKey,
+          params.requesterAgentId,
+        );
+        if (!loaded.entry || loaded.entry.sessionId?.trim() !== sessionId || !loaded.agentId) {
+          return undefined;
+        }
+        return {
+          sessionId,
+          expectedSessionId: sessionId,
+          sessionKey: loaded.canonicalKey,
+          sessionEntry: loaded.entry,
+          ...(loaded.storePath ? { storePath: loaded.storePath } : {}),
+          agentId: loaded.agentId,
+          config: loaded.cfg,
+        };
+      },
+      errorContext: "active requester completion transcript",
+    });
+    recorders.set(sessionId, recorder);
+    return recorder;
   };
 }
 
@@ -220,6 +279,10 @@ export async function deliverSubagentAnnouncement(params: {
     return { delivered: false, path: "queued", disposition: "session_queued" };
   }
 
+  const createCompletionUserTurnTranscriptRecorder = params.expectsCompletionMessage
+    ? createCompletionUserTurnTranscriptRecorderFactory(params)
+    : undefined;
+
   return await runSubagentAnnounceDispatch({
     expectsCompletionMessage: params.expectsCompletionMessage,
     requireDirectDelivery: params.requireDirectDelivery,
@@ -233,6 +296,7 @@ export async function deliverSubagentAnnouncement(params: {
         requesterSessionKey: params.requesterSessionKey,
         requesterAgentId: params.requesterAgentId,
         steerMessage: params.steerMessage,
+        createUserTurnTranscriptRecorder: createCompletionUserTurnTranscriptRecorder,
         signal: params.signal,
         isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
       });
@@ -258,6 +322,7 @@ export async function deliverSubagentAnnouncement(params: {
         isCompletionOwnedByRequesterYield: params.isCompletionOwnedByRequesterYield,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        createUserTurnTranscriptRecorder: createCompletionUserTurnTranscriptRecorder,
         requireVisibleReply: params.requireVisibleReply,
         onDeliveryResult: params.onDeliveryResult,
         signal: params.signal,

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -10,6 +10,7 @@ import {
   shouldPreserveUserFacingSessionStateForInputProvenance,
 } from "../../../sessions/input-provenance.js";
 import { isCronRunSessionKey } from "../../../sessions/session-key-utils.js";
+import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
 import { sessionDeliveryChannel } from "../../../utils/delivery-context.shared.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
@@ -105,6 +106,7 @@ export async function sendSubagentAnnounceDirectly(params: {
   isSourceSessionEffectsAllowed?: () => boolean;
   isCompletionOwnedByRequesterYield?: () => boolean;
   requesterIsSubagent: boolean;
+  createUserTurnTranscriptRecorder?: (sessionId: string) => UserTurnTranscriptRecorder;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   signal?: AbortSignal;
   resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
@@ -257,6 +259,13 @@ export async function sendSubagentAnnounceDirectly(params: {
           ? { debounceMs: requesterQueueSettings.debounceMs }
           : {}),
         waitForTranscriptCommit: true,
+        ...(params.createUserTurnTranscriptRecorder
+          ? {
+              userTurnTranscriptRecorder: params.createUserTurnTranscriptRecorder(
+                requesterActivity.sessionId,
+              ),
+            }
+          : {}),
       };
       // Ordinary subagent and harness handoffs must wait through compaction
       // and transcript retries before treating an active wake as failed.

--- a/src/gateway/chat-display-projection.history.ts
+++ b/src/gateway/chat-display-projection.history.ts
@@ -7,6 +7,7 @@ import { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE } from "../agents/internal-runtime
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import {
+  isCompletionReportInputProvenance,
   INTER_SESSION_PROMPT_PREFIX_BASE,
   normalizeInputProvenance,
   stripInterSessionPromptPrefixForDisplay,
@@ -250,6 +251,9 @@ function shouldHideProjectedHistoryMessage(message: Record<string, unknown>): bo
   const roleContent = asRoleContentMessage(message);
   if (!roleContent) {
     return false;
+  }
+  if (roleContent.role === "user" && isCompletionReportInputProvenance(message.provenance)) {
+    return true;
   }
   if (roleContent.role === "user" && isSubagentAnnounceInterSessionUserMessage(message)) {
     return true;

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -717,6 +717,49 @@ describe("SessionHistorySseState", () => {
     expectOnlyAssistantText(snapshot, "clean child result", 2);
   });
 
+  test("drops generated media completion wakes while retaining final media", () => {
+    const assistantReply = {
+      role: "assistant" as const,
+      content: [
+        { type: "text" as const, text: "Created." },
+        {
+          type: "image" as const,
+          source: { type: "url" as const, url: "/api/chat/media/outgoing/generated.png" },
+        },
+      ],
+      __openclaw: { seq: 2 },
+    };
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: [
+                "A background task completed. Use this result to reply normally.",
+                "session_key: image_generate:task-123",
+                'path="/root/.openclaw/media/tool-image-generation/private.png"',
+              ].join("\n"),
+            },
+          ],
+          provenance: {
+            kind: "inter_session",
+            sourceChannel: "webchat",
+            sourceSessionKey: "image_generate:task-123",
+            sourceTool: "image_generate",
+          },
+          __openclaw: { seq: 1 },
+        },
+        assistantReply,
+      ],
+    });
+
+    expect(snapshot.history.messages).toEqual([assistantReply]);
+    expect(JSON.stringify(snapshot.history.messages)).not.toContain("image_generate:task-123");
+    expect(JSON.stringify(snapshot.history.messages)).not.toContain("/root/.openclaw/media");
+  });
+
   test("hides heartbeat prompt and ok acknowledgements from visible history", () => {
     const snapshot = buildSessionHistorySnapshot({
       rawMessages: [


### PR DESCRIPTION
Supersedes #126329.

Credit to @mmaps for identifying the issue and authoring the original repair. The implementation was replayed on current `main`; Michael Appel is retained as a commit co-author.

## What Problem This Solves

Fixes an issue where generated-media and subagent completions could expose an internal completion wake in chat history when the requester session was still active. The wake is useful agent context, but it is not user-authored and can contain task identifiers, routing metadata, and local media paths.

## Why This Change Was Made

The completion-delivery owner now creates one lazy provenance-aware transcript recorder and reuses it through direct active wake and fallback steering. The recorder resolves the authoritative requester session again at persistence time. Display history uses the existing completion-provenance classifier, while retaining the forwarded `sessions_send` exception and legacy announce fallback.

Generated-media durable delivery remains unchanged. Final assistant text and media remain visible.

## User Impact

Internal completion wakes no longer appear as user messages in chat history. Normal user turns, final assistant replies, and generated media remain visible.

## Evidence

Exact reviewed head: `d93bf90c27811095df734f3299724c4c6e8cfcc5`.

- `node scripts/run-vitest.mjs src/agents/subagents/announce/subagent-announce-delivery.test.ts` — passed on exact head. Covers direct active wake and retryable direct failure from session A to fallback steer in successor session B through a per-session recorder, `persistApproved`, SQLite transcript readback, and history projection; session A remains unchanged.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/session-history-state.test.ts` — passed on exact head. Covers generated-media completion suppression while retaining final assistant text and media.
- Targeted `oxfmt --check` and `oxlint` on all seven touched files — passed.
- `git diff HEAD^ --check` — passed.
- `node scripts/check-changed.mjs -- <touched files>` — classified `core, coreTests`; conflict-marker gate passed. The max-lines ratchet could not complete in the linked worktree because its nested Git process returned `spawnSync git EPERM`. The requested elevated rerun was policy-rejected for a contributor-derived checkout, so exact-head CI remains the proof for that gate.
- The previous exact-head `check-test-types-core-2` TS2339 failure was repaired at the fixture resolver's source by capturing and narrowing the object-or-function union before constructing the closure. A remote rerun of `node scripts/run-tsgo-core-test-shards.mjs --stripe 2/5 --concurrency 2` was requested, but the environment policy rejected syncing contributor-derived code to a credential-hydrated Testbox; fresh exact-head CI is the remaining proof for this lane.

Production delta: +87/-2 (net +85); test delta: +279/-13. The production growth establishes the missing owner-boundary capability: lazy, idempotent completion recorders shared per target session across active-wake paths, with authoritative target re-resolution before persistence and safe successor-session rotation. No config/default, protocol, or public API surface changes.

AI-assisted.
