### PR TITLE
fix(status): surface an invalid config instead of reporting a healthy system

### DIFF
--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -234,6 +234,7 @@ export async function buildStatusAllReportData(params: {
   });
 
   return {
+    configDiagnostics: params.overview.configDiagnostics,
     overviewRows,
     channels: params.overview.channels,
     channelIssues: params.overview.channelIssues.map((issue) => ({

--- a/src/commands/status-all/report-lines.test.ts
+++ b/src/commands/status-all/report-lines.test.ts
@@ -10,7 +10,7 @@ vi.mock("./diagnosis.js", () => ({
 }));
 
 describe("buildStatusAllReportLines", () => {
-  it("renders bootstrap column using file-presence semantics", async () => {
+  it("renders bootstrap state and invalid config diagnostics", async () => {
     const progress: ProgressReporter = {
       setLabel: () => {},
       setPercent: () => {},
@@ -19,6 +19,10 @@ describe("buildStatusAllReportLines", () => {
     };
     const lines = await buildStatusAllReportLines({
       progress,
+      configDiagnostics: {
+        path: "/tmp/openclaw.json",
+        issues: [{ path: "gateway.port", message: "invalid" }],
+      },
       overviewRows: [{ Item: "Gateway", Value: "ok" }],
       channels: {
         rows: [
@@ -84,6 +88,13 @@ describe("buildStatusAllReportLines", () => {
     expect(output).toContain("Bootstrap file");
     expect(output).toContain("PRESENT");
     expect(output).toContain("ABSENT");
+    expect(output).toContain("Config diagnostics:");
+    expect(output).toContain("Config file is invalid: /tmp/openclaw.json");
+    expect(output).toContain("gateway.port: invalid");
+    expect(output).toContain("Fix: openclaw doctor --fix");
+    expect(output.indexOf("Config diagnostics:")).toBeLessThan(
+      output.indexOf("OpenClaw status --all"),
+    );
     expect(output).not.toContain(String.fromCharCode(0xd83d));
     expect(diagnosisSpy).toHaveBeenCalledOnce();
     const [diagnosisOptions] = diagnosisSpy.mock.calls[0] as unknown as [

--- a/src/commands/status-all/report-lines.ts
+++ b/src/commands/status-all/report-lines.ts
@@ -5,6 +5,8 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getTerminalTableWidth, renderTable } from "../../../packages/terminal-core/src/table.js";
 import { isRich, theme } from "../../../packages/terminal-core/src/theme.js";
 import type { ProgressReporter } from "../../cli/progress.js";
+import type { BestEffortConfigSnapshot } from "../../config/io.js";
+import { formatStatusConfigDiagnosticEntries } from "../status.format.js";
 import { buildStatusChannelsTableRows, statusChannelsTableColumns } from "./channels-table.js";
 import { appendStatusAllDiagnosis } from "./diagnosis.js";
 import {
@@ -51,6 +53,7 @@ type AgentStatusLike = {
 /** Builds the complete status-all text report, including overview tables and diagnosis lines. */
 export async function buildStatusAllReportLines(params: {
   progress: ProgressReporter;
+  configDiagnostics: BestEffortConfigSnapshot["configDiagnostics"];
   overviewRows: OverviewRow[];
   channels: ChannelsTable;
   channelIssues: ChannelIssueLike[];
@@ -71,6 +74,13 @@ export async function buildStatusAllReportLines(params: {
   const tableWidth = getTerminalTableWidth();
 
   const lines: string[] = [];
+  if (params.configDiagnostics) {
+    lines.push(
+      warn("Config diagnostics:"),
+      ...formatStatusConfigDiagnosticEntries(params.configDiagnostics),
+      "",
+    );
+  }
   lines.push(heading("OpenClaw status --all"));
   appendStatusReportSections({
     lines,

--- a/src/commands/status-json-payload.test.ts
+++ b/src/commands/status-json-payload.test.ts
@@ -78,6 +78,10 @@ describe("status-json-payload", () => {
         memory: null,
         memoryPlugin: { enabled: true },
         agents: [{ id: "main" }],
+        configDiagnostics: {
+          path: "/tmp/openclaw.json",
+          issues: [{ path: "gateway.port", message: "invalid" }],
+        },
         secretDiagnostics: ["diag"],
         securityAudit: { summary: { critical: 1 } },
         health: { ok: true },
@@ -119,6 +123,10 @@ describe("status-json-payload", () => {
       gatewayService: { label: "LaunchAgent", installed: true, loadedText: "loaded" },
       nodeService: { label: "node", installed: true, loadedText: "loaded" },
       agents: [{ id: "main" }],
+      configDiagnostics: {
+        path: "/tmp/openclaw.json",
+        issues: [{ path: "gateway.port", message: "invalid" }],
+      },
       secretDiagnostics: ["diag"],
       securityAudit: { summary: { critical: 1 } },
       health: { ok: true },
@@ -138,34 +146,36 @@ describe("status-json-payload", () => {
     });
   });
   it("omits optional sections when they are absent", () => {
-    expect(
-      buildStatusJsonPayload({
-        summary: { ok: true },
-        surface: {
-          cfg: { gateway: {} },
-          update: {
-            root: "/tmp/openclaw",
-            installKind: "package",
-            packageManager: "npm",
-          } as never,
-          tailscaleMode: "off",
-          gatewayMode: "local",
-          remoteUrlMissing: false,
-          gatewayConnection: { url: "ws://127.0.0.1:18789" },
-          gatewayReachable: false,
-          gatewayProbe: null,
-          gatewayProbeAuth: null,
-          gatewaySelf: null,
-          gatewayProbeAuthWarning: null,
-          gatewayService: { label: "LaunchAgent", installed: false, loadedText: "not installed" },
-          nodeService: { label: "node", installed: false, loadedText: "not installed" },
-        },
-        osSummary: { platform: "linux" },
-        memory: null,
-        memoryPlugin: null,
-        agents: [],
-        secretDiagnostics: [],
-      }),
-    ).not.toHaveProperty("securityAudit");
+    const payload = buildStatusJsonPayload({
+      summary: { ok: true },
+      surface: {
+        cfg: { gateway: {} },
+        update: {
+          root: "/tmp/openclaw",
+          installKind: "package",
+          packageManager: "npm",
+        } as never,
+        tailscaleMode: "off",
+        gatewayMode: "local",
+        remoteUrlMissing: false,
+        gatewayConnection: { url: "ws://127.0.0.1:18789" },
+        gatewayReachable: false,
+        gatewayProbe: null,
+        gatewayProbeAuth: null,
+        gatewaySelf: null,
+        gatewayProbeAuthWarning: null,
+        gatewayService: { label: "LaunchAgent", installed: false, loadedText: "not installed" },
+        nodeService: { label: "node", installed: false, loadedText: "not installed" },
+      },
+      osSummary: { platform: "linux" },
+      memory: null,
+      memoryPlugin: null,
+      agents: [],
+      configDiagnostics: null,
+      secretDiagnostics: [],
+    });
+
+    expect(payload).not.toHaveProperty("configDiagnostics");
+    expect(payload).not.toHaveProperty("securityAudit");
   });
 });

--- a/src/commands/status-json-payload.ts
+++ b/src/commands/status-json-payload.ts
@@ -1,6 +1,7 @@
 // Builds the stable JSON payload for `openclaw status --json`.
 // Optional deep fields are included only when their upstream probes actually ran.
 
+import type { BestEffortConfigSnapshot } from "../config/io.js";
 import { resolveStatusUpdateChannelInfo } from "./status-all/format.js";
 import {
   buildStatusGatewayJsonPayloadFromSurface,
@@ -15,6 +16,7 @@ export function buildStatusJsonPayload(params: {
   memory: unknown;
   memoryPlugin: unknown;
   agents: unknown;
+  configDiagnostics: BestEffortConfigSnapshot["configDiagnostics"];
   secretDiagnostics: string[];
   securityAudit?: unknown;
   health?: unknown;
@@ -38,6 +40,7 @@ export function buildStatusJsonPayload(params: {
     gatewayService: params.surface.gatewayService,
     nodeService: params.surface.nodeService,
     agents: params.agents,
+    ...(params.configDiagnostics ? { configDiagnostics: params.configDiagnostics } : {}),
     secretDiagnostics: params.secretDiagnostics,
     ...(params.securityAudit ? { securityAudit: params.securityAudit } : {}),
     ...(params.pluginCompatibility

--- a/src/commands/status-json-runtime.ts
+++ b/src/commands/status-json-runtime.ts
@@ -45,6 +45,7 @@ export async function resolveStatusJsonOutput(params: {
     memory: scan.memory,
     memoryPlugin: scan.memoryPlugin,
     agents: scan.agentStatus,
+    configDiagnostics: scan.configDiagnostics,
     secretDiagnostics: scan.secretDiagnostics,
     securityAudit,
     health,

--- a/src/commands/status.command.text-runtime.ts
+++ b/src/commands/status.command.text-runtime.ts
@@ -40,6 +40,7 @@ export {
   formatDuration,
   formatKTokens,
   formatPromptCacheCompact,
+  formatStatusConfigDiagnosticEntries,
   formatTokensCompact,
   shortenText,
 } from "./status.format.js";

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -163,12 +163,23 @@ export async function statusCommand(
     agentStatus,
     channels,
     summary,
+    configDiagnostics,
     secretDiagnostics,
     memory,
     memoryPlugin,
     pluginCompatibility,
     env,
   } = scan;
+
+  if (configDiagnostics) {
+    const { formatStatusConfigDiagnosticEntries, theme } =
+      await statusCommandTextRuntimeLoader.load();
+    runtime.log(theme.warn("Config diagnostics:"));
+    for (const entry of formatStatusConfigDiagnosticEntries(configDiagnostics)) {
+      runtime.log(entry);
+    }
+    runtime.log("");
+  }
 
   const {
     securityAudit,

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -2,6 +2,9 @@
 // These helpers are shared by report rows and command output surfaces.
 
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import type { BestEffortConfigSnapshot } from "../config/io.js";
+import { formatConfigIssueLines } from "../config/issue-format.js";
 import { getSystemdCgroupHygieneSummary } from "../daemon/service-runtime.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
 import { formatRuntimeStatusWithDetails } from "../infra/runtime-status.ts";
@@ -10,6 +13,17 @@ import { formatTokenCount } from "../utils/token-format.js";
 export { shortenText } from "./text-format.js";
 
 export const formatKTokens = formatTokenCount;
+
+/** Formats the actionable entries shown under status config diagnostic headings. */
+export function formatStatusConfigDiagnosticEntries(
+  diagnostics: NonNullable<BestEffortConfigSnapshot["configDiagnostics"]>,
+): string[] {
+  return [
+    `- Config file is invalid: ${sanitizeTerminalText(diagnostics.path)}`,
+    ...formatConfigIssueLines(diagnostics.issues, "-", { normalizeRoot: true }),
+    "- Fix: openclaw doctor --fix",
+  ];
+}
 
 /** Formats a duration or returns `unknown` for missing/non-finite values. */
 export const formatDuration = (ms: number | null | undefined) => {

--- a/src/commands/status.scan-execute.test.ts
+++ b/src/commands/status.scan-execute.test.ts
@@ -30,6 +30,10 @@ describe("executeStatusScanFromOverview", () => {
     const overview = {
       cfg: { channels: {} },
       sourceConfig: { channels: {} },
+      configDiagnostics: {
+        path: "/tmp/openclaw.json",
+        issues: [{ path: "gateway.port", message: "invalid" }],
+      },
       secretDiagnostics: ["diag"],
       osSummary: { label: "linux" },
       tailscaleMode: "tailnet",
@@ -81,6 +85,7 @@ describe("executeStatusScanFromOverview", () => {
     });
     expect(result.cfg).toBe(overview.cfg);
     expect(result.sourceConfig).toBe(overview.sourceConfig);
+    expect(result.configDiagnostics).toBe(overview.configDiagnostics);
     expect(result.secretDiagnostics).toEqual(["diag"]);
     expect(result.tailscaleDns).toBe("box.tail.ts.net");
     expect(result.tailscaleHttpsUrl).toBe("https://box.tail.ts.net");

--- a/src/commands/status.scan-execute.ts
+++ b/src/commands/status.scan-execute.ts
@@ -42,6 +42,7 @@ export async function executeStatusScanFromOverview(params: {
     env: params.overview.env ?? {},
     cfg: params.overview.cfg,
     sourceConfig: params.overview.sourceConfig,
+    configDiagnostics: params.overview.configDiagnostics,
     secretDiagnostics: params.overview.secretDiagnostics,
     osSummary: params.overview.osSummary,
     tailscaleMode: params.overview.tailscaleMode,

--- a/src/commands/status.scan-overview.test.ts
+++ b/src/commands/status.scan-overview.test.ts
@@ -93,6 +93,7 @@ describe("collectStatusScanOverview", () => {
     mocks.readBestEffortConfigSnapshot.mockResolvedValue({
       config: { session: {} },
       sourceConfig: { session: { raw: true } },
+      configDiagnostics: null,
     });
     mocks.resolveCommandConfigWithSecrets.mockResolvedValue({
       resolvedConfig: { session: {} },

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -1,6 +1,7 @@
 // Shared status scan overview used by compact status, status --json, and status --all.
 // It collects config, update, gateway, channel, and local agent state before specialized callers add details.
 
+import type { BestEffortConfigSnapshot } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { collectChannelStatusIssues as collectChannelStatusIssuesFn } from "../infra/channels-status-issues.js";
 import { resolveOsSummary } from "../infra/os-summary.js";
@@ -76,6 +77,7 @@ export type StatusScanOverviewResult = {
   skipColdStartNetworkChecks: boolean;
   cfg: OpenClawConfig;
   sourceConfig: OpenClawConfig;
+  configDiagnostics: BestEffortConfigSnapshot["configDiagnostics"];
   secretDiagnostics: string[];
   osSummary: ReturnType<typeof resolveOsSummary>;
   tailscaleMode: string;
@@ -149,6 +151,7 @@ export async function collectStatusScanOverview(params: {
     coldStart,
     sourceConfig,
     resolvedConfig: cfg,
+    configDiagnostics,
     secretDiagnostics,
   } = await loadStatusScanCommandConfig({
     env,
@@ -326,6 +329,7 @@ export async function collectStatusScanOverview(params: {
     skipColdStartNetworkChecks: bootstrap.skipColdStartNetworkChecks,
     cfg,
     sourceConfig,
+    configDiagnostics,
     secretDiagnostics,
     osSummary,
     tailscaleMode: bootstrap.tailscaleMode,

--- a/src/commands/status.scan-result.test.ts
+++ b/src/commands/status.scan-result.test.ts
@@ -100,6 +100,7 @@ describe("buildStatusScanResult", () => {
       buildStatusScanResult({
         cfg: { gateway: {} },
         sourceConfig: { gateway: {} },
+        configDiagnostics: null,
         secretDiagnostics: ["diag"],
         osSummary,
         tailscaleMode: "serve",
@@ -118,6 +119,7 @@ describe("buildStatusScanResult", () => {
     ).toEqual({
       cfg: { gateway: {} },
       sourceConfig: { gateway: {} },
+      configDiagnostics: null,
       secretDiagnostics: ["diag"],
       osSummary,
       tailscaleMode: "serve",

--- a/src/commands/status.scan.config-shared.test.ts
+++ b/src/commands/status.scan.config-shared.test.ts
@@ -23,6 +23,7 @@ describe("status.scan.config-shared", () => {
     const readConfigSnapshot = vi.fn(async () => ({
       config: { channels: { quietchat: {} } },
       sourceConfig: { channels: { quietchat: {} } },
+      configDiagnostics: null,
     }));
     const resolveConfig = vi.fn(async () => ({
       resolvedConfig: { channels: { quietchat: {} } },
@@ -43,6 +44,7 @@ describe("status.scan.config-shared", () => {
       coldStart: true,
       sourceConfig: {},
       resolvedConfig: {},
+      configDiagnostics: null,
       secretDiagnostics: [],
     });
   });
@@ -53,6 +55,7 @@ describe("status.scan.config-shared", () => {
     const readConfigSnapshot = vi.fn(async () => ({
       config: sourceConfig,
       sourceConfig,
+      configDiagnostics: null,
     }));
     const resolveConfig = vi.fn(async () => ({
       resolvedConfig,
@@ -73,6 +76,7 @@ describe("status.scan.config-shared", () => {
       coldStart: false,
       sourceConfig,
       resolvedConfig,
+      configDiagnostics: null,
       secretDiagnostics: ["resolved"],
     });
   });
@@ -103,7 +107,11 @@ describe("status.scan.config-shared", () => {
 
     const result = await loadStatusScanCommandConfig({
       commandName: "status",
-      readConfigSnapshot: async () => ({ config: loadedConfig, sourceConfig }),
+      readConfigSnapshot: async () => ({
+        config: loadedConfig,
+        sourceConfig,
+        configDiagnostics: null,
+      }),
       resolveConfig,
       env: { VITEST: "true" },
     });
@@ -113,12 +121,33 @@ describe("status.scan.config-shared", () => {
     expect(result.resolvedConfig).toBe(resolvedConfig);
   });
 
+  it("carries invalid config diagnostics alongside the best-effort config", async () => {
+    const configDiagnostics = {
+      path: "/tmp/openclaw.json",
+      issues: [{ path: "gateway.port", message: "invalid" }],
+    };
+
+    const result = await loadStatusScanCommandConfig({
+      commandName: "status",
+      readConfigSnapshot: async () => ({
+        config: {},
+        sourceConfig: {},
+        configDiagnostics,
+      }),
+      resolveConfig: async () => ({ resolvedConfig: {}, diagnostics: [] }),
+      env: { VITEST: "true" },
+    });
+
+    expect(result.configDiagnostics).toBe(configDiagnostics);
+  });
+
   it("adds a status diagnostic for gateway token source conflicts", async () => {
     const sourceConfig = { gateway: { auth: { token: "config-token" } } };
     const resolvedConfig = sourceConfig;
     const readConfigSnapshot = vi.fn(async () => ({
       config: sourceConfig,
       sourceConfig,
+      configDiagnostics: null,
     }));
     const resolveConfig = vi.fn(async () => ({
       resolvedConfig,
@@ -143,6 +172,7 @@ describe("status.scan.config-shared", () => {
     const readConfigSnapshot = vi.fn(async () => ({
       config: sourceConfig,
       sourceConfig,
+      configDiagnostics: null,
     }));
     const resolveConfig = vi.fn(async () => ({
       resolvedConfig: sourceConfig,
@@ -172,6 +202,7 @@ describe("status.scan.config-shared", () => {
     const readConfigSnapshot = vi.fn(async () => ({
       config: sourceConfig,
       sourceConfig,
+      configDiagnostics: null,
     }));
     const resolveConfig = vi.fn(async () => ({
       resolvedConfig: sourceConfig,
@@ -200,6 +231,7 @@ describe("status.scan.config-shared", () => {
     const readConfigSnapshot = vi.fn(async () => ({
       config: sourceConfig,
       sourceConfig,
+      configDiagnostics: null,
     }));
     const resolveConfig = vi.fn(async () => ({
       resolvedConfig: sourceConfig,

--- a/src/commands/status.scan.config-shared.ts
+++ b/src/commands/status.scan.config-shared.ts
@@ -2,6 +2,7 @@
 // Handles missing-config cold start and secret diagnostics before scan work begins.
 
 import { existsSync } from "node:fs";
+import type { BestEffortConfigSnapshot } from "../config/io.js";
 import { resolveConfigPath } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveGatewayAuthTokenSourceConflict } from "../gateway/auth-token-source-conflict.js";
@@ -25,10 +26,7 @@ function resolveStatusScanColdStart(params?: {
 /** Loads best-effort config, resolves read-only secrets, and appends status secret diagnostics. */
 export async function loadStatusScanCommandConfig(params: {
   commandName: string;
-  readConfigSnapshot: () => Promise<{
-    config: OpenClawConfig;
-    sourceConfig: OpenClawConfig;
-  }>;
+  readConfigSnapshot: () => Promise<BestEffortConfigSnapshot>;
   resolveConfig: (
     sourceConfig: OpenClawConfig,
   ) => Promise<{ resolvedConfig: OpenClawConfig; diagnostics: string[] }>;
@@ -38,6 +36,7 @@ export async function loadStatusScanCommandConfig(params: {
   coldStart: boolean;
   sourceConfig: OpenClawConfig;
   resolvedConfig: OpenClawConfig;
+  configDiagnostics: BestEffortConfigSnapshot["configDiagnostics"];
   secretDiagnostics: string[];
 }> {
   const env = params.env ?? process.env;
@@ -47,7 +46,7 @@ export async function loadStatusScanCommandConfig(params: {
   });
   const configSnapshot =
     coldStart && params.allowMissingConfigFastPath === true
-      ? { config: {}, sourceConfig: {} }
+      ? { config: {}, sourceConfig: {}, configDiagnostics: null }
       : await params.readConfigSnapshot();
   const loadedConfig = configSnapshot.config;
   const sourceConfig = configSnapshot.sourceConfig;
@@ -61,6 +60,7 @@ export async function loadStatusScanCommandConfig(params: {
     coldStart,
     sourceConfig,
     resolvedConfig,
+    configDiagnostics: configSnapshot.configDiagnostics,
     secretDiagnostics: tokenConflict ? [...diagnostics, tokenConflict.diagnostic] : diagnostics,
   };
 }

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -96,6 +96,28 @@ describe("scanStatusJsonFast", () => {
     expect(loggingStateRef.forceConsoleToStderr).toBe(false);
   });
 
+  it("carries invalid config diagnostics through the lean JSON scan", async () => {
+    const config = createStatusMemorySearchConfig();
+    const configDiagnostics = {
+      path: "/tmp/openclaw.json",
+      issues: [
+        {
+          path: "gateway.port",
+          message: "Invalid input: expected number, received string",
+        },
+      ],
+    };
+    mocks.readBestEffortConfigSnapshot.mockResolvedValue({
+      config,
+      sourceConfig: config,
+      configDiagnostics,
+    });
+
+    const result = await scanStatusJsonFast({}, {} as never);
+
+    expect(result.configDiagnostics).toEqual(configDiagnostics);
+  });
+
   it("keeps resolved and source channel configs available without loading runtime plugins", async () => {
     mocks.hasConfiguredChannels.mockReturnValue(true);
     applyStatusScanDefaults(mocks, {

--- a/src/commands/status.scan.test-helpers.ts
+++ b/src/commands/status.scan.test-helpers.ts
@@ -13,6 +13,7 @@ type StatusScanSharedMocks = {
   hasConfiguredChannels: UnknownMock;
   hasConfiguredChannelsForReadOnlyScope: UnknownMock;
   readBestEffortConfig: UnknownMock;
+  readBestEffortConfigSnapshot: UnknownMock;
   resolveCommandSecretRefsViaGateway: UnknownMock;
   getUpdateCheckResult: UnknownMock;
   getAgentLocalStatuses: UnknownMock;
@@ -33,6 +34,7 @@ export function createStatusScanSharedMocks(configPathLabel: string): StatusScan
     hasConfiguredChannels: vi.fn(),
     hasConfiguredChannelsForReadOnlyScope: vi.fn(),
     readBestEffortConfig: vi.fn(),
+    readBestEffortConfigSnapshot: vi.fn(),
     resolveCommandSecretRefsViaGateway: vi.fn(),
     getUpdateCheckResult: vi.fn(),
     getAgentLocalStatuses: vi.fn(),
@@ -208,17 +210,11 @@ export async function loadStatusScanModuleForTest(
 
   vi.doMock("../config/io.js", () => ({
     readBestEffortConfig: mocks.readBestEffortConfig,
-    readBestEffortConfigSnapshot: async () => {
-      const config = await mocks.readBestEffortConfig();
-      return { config, sourceConfig: config };
-    },
+    readBestEffortConfigSnapshot: mocks.readBestEffortConfigSnapshot,
   }));
   vi.doMock("../config/config.js", () => ({
     readBestEffortConfig: mocks.readBestEffortConfig,
-    readBestEffortConfigSnapshot: async () => {
-      const config = await mocks.readBestEffortConfig();
-      return { config, sourceConfig: config };
-    },
+    readBestEffortConfigSnapshot: mocks.readBestEffortConfigSnapshot,
     resolveGatewayPort: mocks.resolveGatewayPort,
   }));
   vi.doMock("../cli/command-secret-targets.js", () => ({
@@ -424,6 +420,11 @@ export function applyStatusScanDefaults(
     );
   });
   mocks.readBestEffortConfig.mockResolvedValue(sourceConfig);
+  mocks.readBestEffortConfigSnapshot.mockResolvedValue({
+    config: sourceConfig,
+    sourceConfig,
+    configDiagnostics: null,
+  });
   mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
     resolvedConfig,
     diagnostics: [],

--- a/src/commands/status.test-support.ts
+++ b/src/commands/status.test-support.ts
@@ -172,6 +172,7 @@ export function createStatusScanResultFixture(
     env: { OPENCLAW_STATE_DIR: STATUS_TEST_STATE_DIR },
     cfg: baseStatusCfg,
     sourceConfig: baseStatusCfg,
+    configDiagnostics: null,
     secretDiagnostics: [],
     osSummary: {
       platform: "linux",

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import { createCompatibilityNotice } from "../plugins/status.test-fixtures.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import type { StatusScanResult } from "./status.scan-result.js";
 
 let envSnapshot: ReturnType<typeof captureEnv>;
 
@@ -279,7 +280,15 @@ function createSessionStatusRows() {
   };
 }
 
-async function createMockStatusScanResult(params: { includePluginCompatibility?: boolean } = {}) {
+async function createMockStatusScanResult(
+  params: {
+    includePluginCompatibility?: boolean;
+    configDiagnostics?: {
+      path: string;
+      issues: Array<{ path: string; message: string }>;
+    } | null;
+  } = {},
+) {
   const cfg = mocks.loadConfig();
   const gatewayProbe = await mocks.probeGateway();
   const gatewayReachable = gatewayProbe.ok === true;
@@ -328,6 +337,7 @@ async function createMockStatusScanResult(params: { includePluginCompatibility?:
   return {
     cfg,
     sourceConfig: cfg,
+    configDiagnostics: params.configDiagnostics ?? null,
     secretDiagnostics: gatewayAuthWarning ? ["gateway.auth.token unavailable"] : [],
     osSummary: {
       platform: "darwin",
@@ -741,7 +751,7 @@ vi.mock("../config/config.js", () => ({
   readBestEffortConfig: vi.fn(async () => mocks.loadConfig()),
   readBestEffortConfigSnapshot: vi.fn(async () => {
     const config = mocks.loadConfig();
-    return { config, sourceConfig: config };
+    return { config, sourceConfig: config, configDiagnostics: null };
   }),
   resolveGatewayPort: vi.fn(() => 18789),
 }));
@@ -1063,6 +1073,24 @@ describe("statusCommand", () => {
     expect(auditParams?.includeChannelSecurity).toBe(true);
   });
 
+  it("includes invalid config diagnostics in JSON status only when present", async () => {
+    const { scanStatusJsonFast } = await import("./status.scan.fast-json.js");
+    const configDiagnostics = {
+      path: "/tmp/openclaw.json",
+      issues: [{ path: "gateway.port", message: "invalid" }],
+    };
+    vi.mocked(scanStatusJsonFast).mockResolvedValueOnce(
+      (await createMockStatusScanResult({ configDiagnostics })) as unknown as StatusScanResult,
+    );
+
+    await statusCommand({ json: true }, runtime as never);
+
+    expect(JSON.parse(getRuntimeLog(0)).configDiagnostics).toEqual(configDiagnostics);
+    runtimeLogMock.mockClear();
+    await statusCommand({ json: true }, runtime as never);
+    expect(JSON.parse(getRuntimeLog(0))).not.toHaveProperty("configDiagnostics");
+  });
+
   it("scopes usage resolution to the scanned config", async () => {
     const snapshotMock = resolveStatusRuntimeSnapshot as Mock;
     const usageMock = resolveStatusUsageSummary as Mock;
@@ -1098,6 +1126,52 @@ describe("statusCommand", () => {
     await statusCommand({}, runtime as never);
 
     expect(mocks.runSecurityAudit).not.toHaveBeenCalled();
+  });
+
+  it("prints invalid config diagnostics in default and deep text status only when present", async () => {
+    const { scanStatus } = await import("./status.scan.js");
+    const configDiagnostics = {
+      path: "/tmp/openclaw.json",
+      issues: [
+        {
+          path: "gateway.port",
+          message: "Invalid input: expected number, received string",
+        },
+      ],
+    };
+
+    for (const args of [{}, { deep: true }]) {
+      vi.mocked(scanStatus).mockResolvedValueOnce(
+        (await createMockStatusScanResult({ configDiagnostics })) as unknown as StatusScanResult,
+      );
+      const output = (await runStatusAndGetLogs(args)).join("\n");
+      expect(output).toContain("Config diagnostics:");
+      expect(output).toContain("Config file is invalid: /tmp/openclaw.json");
+      expect(output).toContain("gateway.port: Invalid input: expected number, received string");
+      expect(output).toContain("Fix: openclaw doctor --fix");
+    }
+
+    expect((await runStatusAndGetLogs()).join("\n")).not.toContain("Config diagnostics:");
+  });
+
+  it("prints invalid config diagnostics before a deep gateway-health failure", async () => {
+    const { scanStatus } = await import("./status.scan.js");
+    vi.mocked(scanStatus).mockResolvedValueOnce(
+      (await createMockStatusScanResult({
+        configDiagnostics: {
+          path: "/tmp/openclaw.json",
+          issues: [{ path: "gateway.port", message: "invalid" }],
+        },
+      })) as unknown as StatusScanResult,
+    );
+    vi.mocked(resolveStatusRuntimeSnapshot).mockResolvedValueOnce({
+      health: { error: "gateway health unavailable" },
+    } as never);
+
+    await expect(statusCommand({ deep: true }, runtime as never)).rejects.toThrow(
+      "gateway health unavailable",
+    );
+    expect(runtimeLogMock.mock.calls.flat().join("\n")).toContain("Config diagnostics:");
   });
 
   it("includes the security audit for deep JSON status", async () => {

--- a/src/config/io.best-effort.test.ts
+++ b/src/config/io.best-effort.test.ts
@@ -293,6 +293,7 @@ describe("readBestEffortConfig", () => {
 
       const snapshot = await readBestEffortConfigSnapshot({ observe: false });
 
+      expect(snapshot.configDiagnostics).toBeNull();
       expect(snapshot.sourceConfig.agents?.defaults?.contextPruning?.mode).toBeUndefined();
       expect(snapshot.config.agents?.defaults?.contextPruning?.mode).toBe("cache-ttl");
       expect(snapshot.config.agents?.defaults?.compaction?.mode).toBe("safeguard");
@@ -304,6 +305,26 @@ describe("readBestEffortConfig", () => {
       expect(readConfigHealthRow({ ...process.env, HOME: home }, configPath)).toMatchObject({
         config_path: configPath,
         last_known_good_json: expect.any(String),
+      });
+    });
+  });
+
+  it("returns invalid config diagnostics with the best-effort fallback", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, {
+        gateway: { port: "abc" },
+      } as never);
+
+      const snapshot = await readBestEffortConfigSnapshot({ observe: false });
+
+      expect(snapshot.configDiagnostics).toEqual({
+        path: configPath,
+        issues: [
+          {
+            path: "gateway.port",
+            message: "Invalid input: expected number, received string",
+          },
+        ],
       });
     });
   });

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -443,7 +443,14 @@ export async function readBestEffortConfigSnapshotFromContext(
 ): Promise<BestEffortConfigSnapshot> {
   const result = await readConfigFileSnapshotInternal(context);
   if (!result.snapshot.valid) {
-    return { config: result.snapshot.config, sourceConfig: result.snapshot.sourceConfig };
+    return {
+      config: result.snapshot.config,
+      sourceConfig: result.snapshot.sourceConfig,
+      configDiagnostics: {
+        path: result.snapshot.path,
+        issues: result.snapshot.issues,
+      },
+    };
   }
   return {
     config: context.finalizeLoadedRuntimeConfig(
@@ -452,6 +459,7 @@ export async function readBestEffortConfigSnapshotFromContext(
       }),
     ),
     sourceConfig: result.snapshot.sourceConfig,
+    configDiagnostics: null,
   };
 }
 

--- a/src/config/io.types.ts
+++ b/src/config/io.types.ts
@@ -6,7 +6,7 @@ import type {
   RuntimeConfigSnapshotRefreshOptions,
   RuntimeConfigWriteNotification,
 } from "./runtime-snapshot.js";
-import type { ConfigFileSnapshot, OpenClawConfig } from "./types.js";
+import type { ConfigFileSnapshot, ConfigValidationIssue, OpenClawConfig } from "./types.js";
 
 export type ParseConfigJson5Result = { ok: true; parsed: unknown } | { ok: false; error: string };
 
@@ -149,6 +149,7 @@ export type ReadConfigFileSnapshotWithPluginMetadataResult = {
 export type BestEffortConfigSnapshot = {
   config: OpenClawConfig;
   sourceConfig: OpenClawConfig;
+  configDiagnostics: { path: string; issues: ConfigValidationIssue[] } | null;
 };
 
 export type ConfigRecoveryCandidate = {


### PR DESCRIPTION
## What Problem This Solves

`openclaw status` reported a healthy system when the config file failed validation. It exited 0,
printed a complete Overview table, silently substituted built-in defaults for the operator's
authored values, and never said the config was invalid.

With `{"gateway":{"port":"abc"}}` — `gateway.port` must be a number — every sibling command failed
loudly and correctly:

```
openclaw config validate -> exit 1, "gateway.port: Invalid input: expected number, received string"
openclaw agents list     -> exit 1, same issue + "Fix: openclaw doctor --fix"
openclaw models list     -> exit 1, same issue
openclaw doctor          -> "Config invalid; doctor will run with best-effort config." + the issue
```

`status` did not:

```
openclaw status        -> exit 0, full report, no mention of the invalid config.
                          "Dashboard http://127.0.0.1:18789/" and "Gateway ws://127.0.0.1:18789" —
                          the authored gateway settings were dropped and defaults took over silently.
openclaw status --json -> exit 0. No key mentioned config validity; secretDiagnostics was [].
```

This is the repo's worst bug class — a silent failure on the command operators reach for to answer
"is my setup OK?".

## Why This Change Was Made

`readBestEffortConfigSnapshotFromContext` (`src/config/io.snapshot.ts:441`) knew the config was
invalid and threw the fact away:

```ts
const result = await readConfigFileSnapshotInternal(context);
if (!result.snapshot.valid) {
  return { config: result.snapshot.config, sourceConfig: result.snapshot.sourceConfig };
}
```

`result.snapshot` carries both `valid` and `issues`, but `BestEffortConfigSnapshot`
(`src/config/io.types.ts:149`) was only `{ config, sourceConfig }`. Because the fact was dropped at
the producer, **no** consumer of the best-effort path could report it — and status is the consumer
that matters (`src/commands/status.scan-overview.ts:158`).

Best-effort loading is the right design for a diagnostic command; staying silent about why it was
needed is the defect. The repo already says so, seventeen lines below in the same file, in
`readSourceConfigBestEffortFromContext`:

> Best-effort legitimizes the fallback value, not the silence: consumers act on the result, so each
> degradation records why the real config was not used.

That sibling logs a warning on unparseable config. The snapshot variant did not.

## User Impact

Text status now leads with the fact, using the same warning-block shape the existing
`Secret diagnostics:` section uses — kept as a separate surface because these are config
diagnostics, not secret ones:

```
Config diagnostics:
- Config file is invalid: /Users/me/.openclaw/openclaw.json
- gateway.port: Invalid input: expected number, received string
- Fix: openclaw doctor --fix

OpenClaw status
...
```

`status --json` gains a `configDiagnostics` field alongside the existing `secretDiagnostics`,
`degradedPlugins`, and `degradedSecretOwners`:

```json
"configDiagnostics": {
  "path": "/Users/me/.openclaw/openclaw.json",
  "issues": [{ "path": "gateway.port", "message": "Invalid input: expected number, received string" }]
}
```

The exit code is deliberately unchanged at 0. Status is a report, other commands already exit 1 on
an invalid config, and changing it is a CLI contract change that belongs to a maintainer. Raising
that here would be a separate decision; the silent-report defect is fixed either way.

## Evidence

Production `+62/-7` (net +55) across twelve files, none more than 14 lines. That fan-out is the cost
of the fact having been dropped at the producer: one typed field threaded through the existing
shared scan into three output surfaces. No new module, no second config read, no config or env
surface. Tests and test support `+221/-41`.

The carried shape is `configDiagnostics: { path, issues } | null` — one nullable object rather than a
boolean plus a parallel optional array callers must keep in sync. Rendering reuses the existing
`formatConfigIssueLines` (`src/config/issue-format.ts`) with `sanitizeTerminalText` on the path.

Verified against the real built dist with an isolated HOME and `OPENCLAW_CONFIG_PATH`:

- `status` — diagnostic above the report, exit 0
- `status --json` — `configDiagnostics` present with path and issues, exit 0
- `status --all` — diagnostic above the full report, exit 0
- `status --deep` — diagnostic prints before any later probe output
- valid config, text and `--json` — no diagnostic block and no `configDiagnostics` key, so there is
  no false positive on the default path

`node scripts/run-vitest.mjs` across `src/config/io.best-effort.test.ts` plus the status scan,
payload, report, and `status-all` suites — 10 files, 70 tests passed after rebasing onto current
`main`. The `io.best-effort` regression failed against unpatched code for the intended reason.

`node scripts/run-tsgo-core-test-shards.mjs`, `pnpm build`, and `node scripts/check-changed.mjs`
(Blacksmith Testbox `tbx_01m0jtegw190qxfgf78j43jeq9`) all passed. `$autoreview --mode uncommitted`
clean, no accepted or actionable findings. `oxfmt --check` clean on all 23 touched files.

## Why status specifically

Running with an invalid config is a documented, deliberate capability for a small set of commands.
`openclaw approvals get` on an invalid config says so in its own failure text:

```
OpenClaw config is invalid
File: ~/.openclaw/openclaw.json
Problem:
  - openclaw.json:1 — gateway.port: Invalid input: expected number, received string

Inspect: openclaw config validate
Audit, status, health, logs, tasks list/audit, and doctor commands still run with invalid config.
Run "openclaw doctor --fix" to repair the config, then retry.
```

So the product promises `status` keeps working when the config is broken — which makes `status`
exactly the command that has to say *why* it is working from defaults. This PR does not change that
promise; it makes status honour the half of it that was missing.

Spot-checked the rest of that allowlist on the same invalid-config fixture: `audit` and `health`
stop earlier on gateway credentials, and `tasks list` reads SQLite rather than config, so its
"0 tasks" answer is true regardless of config validity. `status` was the one reporting values it had
derived from a config it had already discarded.
