### PR TITLE
improve(qa): avoid loading agent runtime in OTEL receiver tests

### DIFF
--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -33,10 +33,8 @@ import {
   waitForDiagnosticEventsDrained,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import {
-  runModelCallAndCaptureTraceparent,
-  startLocalOtlpReceiver,
-} from "../../../test/e2e/qa-lab/runtime/otel-test-support.js";
+import { runModelCallAndCaptureTraceparent } from "../../../test/e2e/qa-lab/runtime/otel-model-call.test-support.js";
+import { startLocalOtlpReceiver } from "../../../test/e2e/qa-lab/runtime/otel-test-support.js";
 import { createDiagnosticsOtelService } from "./service.js";
 import {
   createOtelContext,

--- a/test/e2e/qa-lab/runtime/otel-model-call.test-support.ts
+++ b/test/e2e/qa-lab/runtime/otel-model-call.test-support.ts
@@ -1,0 +1,33 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { DiagnosticTraceContext } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { wrapStreamFnWithDiagnosticModelCallEvents } from "../../../../src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.js";
+
+export function runModelCallAndCaptureTraceparent(params: {
+  trace: DiagnosticTraceContext;
+  runId: string;
+  callId: string;
+  provider: string;
+  model: string;
+}): string | undefined {
+  let outboundTraceparent: string | undefined;
+  const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+    ((
+      _model: Parameters<StreamFn>[0],
+      _context: Parameters<StreamFn>[1],
+      options: Parameters<StreamFn>[2],
+    ) => {
+      outboundTraceparent = options?.headers?.traceparent;
+      return undefined as never;
+    }) as StreamFn,
+    {
+      runId: params.runId,
+      provider: params.provider,
+      model: params.model,
+      trace: params.trace,
+      nextCallId: () => params.callId,
+      suppressPluginHooks: true,
+    },
+  );
+  void wrapped({} as never, {} as never);
+  return outboundTraceparent;
+}

--- a/test/e2e/qa-lab/runtime/otel-test-support.ts
+++ b/test/e2e/qa-lab/runtime/otel-test-support.ts
@@ -1,9 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Socket } from "node:net";
 import { gunzipSync } from "node:zlib";
-import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
-import type { DiagnosticTraceContext } from "openclaw/plugin-sdk/diagnostic-runtime";
-import { wrapStreamFnWithDiagnosticModelCallEvents } from "../../../../src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.js";
 
 export type OtlpSignal = "logs" | "metrics" | "traces";
 
@@ -114,36 +111,6 @@ export function createRecentTraceSummary() {
       }));
     },
   };
-}
-
-export function runModelCallAndCaptureTraceparent(params: {
-  trace: DiagnosticTraceContext;
-  runId: string;
-  callId: string;
-  provider: string;
-  model: string;
-}): string | undefined {
-  let outboundTraceparent: string | undefined;
-  const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
-    ((
-      _model: Parameters<StreamFn>[0],
-      _context: Parameters<StreamFn>[1],
-      options: Parameters<StreamFn>[2],
-    ) => {
-      outboundTraceparent = options?.headers?.traceparent;
-      return undefined as never;
-    }) as StreamFn,
-    {
-      runId: params.runId,
-      provider: params.provider,
-      model: params.model,
-      trace: params.trace,
-      nextCallId: () => params.callId,
-      suppressPluginHooks: true,
-    },
-  );
-  void wrapped({} as never, {} as never);
-  return outboundTraceparent;
 }
 
 const OTLP_SIGNAL_PATHS = new Map<string, OtlpSignal>([


### PR DESCRIPTION
## What Problem This Solves

The QA OpenTelemetry trace-summary test and every shared OTLP receiver consumer unnecessarily load the complete embedded-agent diagnostic lifecycle, plugin hooks, and unrelated runtime dependencies. This adds avoidable time and memory to developer and CI test runs.

## Why This Change Was Made

Move the real model-call traceparent helper into its own narrowly scoped, root-owned test-support module and import it only from the diagnostics-plugin test that actually needs it. The shared receiver remains the owner of decoding, capture, configuration bounds, and recent-trace summaries; its production-like model-call coverage still executes the original real diagnostic wrapper. No production API, plugin SDK seam, assertion, scenario, or dependency changes.

## User Impact

Developers and CI get the same realistic OTEL environment, configuration, event, privacy, receiver, and real-SDK trace-propagation coverage with faster tests and substantially lower memory usage. Shipped product behavior does not change.

## Evidence

- Eight interleaved baseline/candidate pairs on one Blacksmith Testbox after excluded warmups, with one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`: mean full-file wall `7.383s -> 5.740s` (`-1.643s`, `-22.25%`).
- Mean Vitest duration `1.703s -> 0.120s`; import time `1.603s -> 0.019s`; test bodies remain `2.25ms -> 2.25ms`; user CPU `7.795s -> 5.928s`; peak RSS `618,927 KiB -> 253,632 KiB` (`-59.02%`).
- Separate uncapped Vitest diagnostics prove the actual import graph shrinks from `518` to `18` modules; embedded-agent lifecycle and global plugin-hook modules disappear while the unchanged trace-summary assertions pass `2/2` in every run.
- Focused QA summary, config watcher, real-SDK OTLP export, restart, and disabled-service sibling tests pass `109/109`; the real local-receiver OTEL smoke independently passes `28/28`, including environment bounds, exporter configuration, malformed protobuf, gzip limits, event correlation, privacy, and socket cleanup.
- Reversible fault injection returned an absent outbound traceparent from the extracted helper; the unchanged real-SDK propagation assertion failed against its actual exported span context, then passed again after restoration.
- Full clean-machine changed gate: https://github.com/openclaw/openclaw/actions/runs/32516872455
- Structured Codex autoreview: clean. Production `+0/-0`; test/test-support-only refactor; no release files, dependencies, baselines, snapshots, protocol, SQLite, live Gateway, or secrets changed.
