### PR TITLE
fix(ui): surface session owner assignment failures

### DIFF
--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -395,8 +395,8 @@ export async function renameSession(
 }
 
 export async function assignSessionOwner(
-  host: SessionOrganizerControllerHost,
-  session: SidebarRecentSession,
+  host: SessionActionHost,
+  session: Pick<SidebarRecentSession, "key">,
   owner: Pick<SessionOwnerOption, "type" | "id">,
   scope: SidebarSessionMutationScope,
 ): Promise<void> {
@@ -409,9 +409,16 @@ export async function assignSessionOwner(
   ) {
     return;
   }
-  await scope.sessions.assignOwner(session.key, owner, {
+  const assigned = await scope.sessions.assignOwner(session.key, owner, {
     agentId: parseAgentSessionKey(session.key)?.agentId ?? scope.selectedAgentId,
   });
+  if (
+    host.sessionData.isSessionMutationScopeCurrent(scope) &&
+    !assigned &&
+    scope.sessions.state.error
+  ) {
+    host.sessionData.publishSessionMutationError(scope, scope.sessions.state.error);
+  }
 }
 
 export async function createSessionGroup(

--- a/ui/src/components/session-organizer-owner-assignment.test.ts
+++ b/ui/src/components/session-organizer-owner-assignment.test.ts
@@ -1,0 +1,99 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ApplicationGatewaySnapshot } from "../app/gateway.ts";
+import type { SessionCapability } from "../lib/sessions/index.ts";
+import { gatewayHelloForMethods } from "../test-helpers/gateway-methods.ts";
+import type { SidebarSessionMutationScope } from "./app-sidebar-session-types.ts";
+import type { SessionActionHost } from "./session-organizer-batch-mutations.ts";
+import { assignSessionOwner } from "./session-organizer-operations.runtime.ts";
+
+function createHarness() {
+  let current = true;
+  let sessionError: string | null = null;
+  let settleAssignment: ((result: null) => void) | undefined;
+  const assignOwner = vi.fn(
+    () =>
+      new Promise<null>((resolve) => {
+        settleAssignment = resolve;
+      }),
+  );
+  const publishSessionMutationError = vi.fn();
+  const snapshot = {
+    client: {},
+    phase: "connected",
+    hello: gatewayHelloForMethods(["sessions.assignOwner"], ["operator.write"]),
+  } as ApplicationGatewaySnapshot;
+  const scope = {
+    gateway: { snapshot },
+    sessions: {
+      assignOwner,
+      get state() {
+        return { error: sessionError };
+      },
+    } as unknown as SessionCapability,
+    selectedAgentId: "main",
+  } as SidebarSessionMutationScope;
+  const host = {
+    sessionData: {
+      isSessionMutationScopeCurrent: vi.fn(() => current),
+      publishSessionMutationError,
+    },
+  } as unknown as SessionActionHost;
+  const session = {
+    key: "agent:main:owner-proof",
+  };
+  return {
+    assignOwner,
+    host,
+    publishSessionMutationError,
+    retire: () => {
+      current = false;
+    },
+    scope,
+    session,
+    setError: (error: string) => {
+      sessionError = error;
+    },
+    settle: () => settleAssignment?.(null),
+  };
+}
+
+describe("assignSessionOwner", () => {
+  it("publishes a current capability rejection at the action surface", async () => {
+    const harness = createHarness();
+    const pending = assignSessionOwner(
+      harness.host,
+      harness.session,
+      { type: "human", id: "profile-ada" },
+      harness.scope,
+    );
+
+    harness.setError("Owner assignment rejected.");
+    harness.settle();
+    await pending;
+
+    expect(harness.publishSessionMutationError).toHaveBeenCalledWith(
+      harness.scope,
+      "Owner assignment rejected.",
+    );
+  });
+
+  it("keeps a retired assignment rejection silent", async () => {
+    const harness = createHarness();
+    const pending = assignSessionOwner(
+      harness.host,
+      harness.session,
+      { type: "human", id: "profile-ada" },
+      harness.scope,
+    );
+
+    harness.setError("Retired assignment rejection.");
+    harness.retire();
+    harness.settle();
+    await pending;
+
+    expect(harness.assignOwner).toHaveBeenCalledOnce();
+    expect(harness.publishSessionMutationError).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -1,0 +1,156 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect as expectBrowser } from "playwright/test";
+import { expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI session owner assignment mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+});
+const sessionKey = "agent:main:owner-outcome";
+const proofPhase = process.env.OPENCLAW_OWNER_ASSIGNMENT_PROOF_PHASE;
+const proofDir = path.resolve(".artifacts/control-ui-e2e/session-owner-assignment");
+
+function sessionsListResponse() {
+  return {
+    count: 2,
+    owners: [
+      { type: "human" as const, id: "profile-ada", label: "Ada" },
+      { type: "human" as const, id: "profile-bob", label: "Bob" },
+    ],
+    defaults: { contextTokens: null, model: null, modelProvider: null },
+    path: "",
+    sessions: [
+      {
+        key: "agent:main:ada-research",
+        kind: "direct",
+        label: "Ada research",
+        createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+        owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
+        updatedAt: 2,
+      },
+      {
+        key: sessionKey,
+        kind: "direct",
+        label: "Owner outcome",
+        createdActor: { type: "human", id: "profile-bob", label: "Bob" },
+        owner: { actor: { type: "human", id: "profile-bob", label: "Bob" } },
+        updatedAt: 1,
+      },
+    ],
+    ts: 1,
+  };
+}
+
+async function installOwnerGateway(page: Page) {
+  const gateway = await installMockGateway(page, {
+    featureMethods: ["chat.startup", "sessions.assignOwner"],
+    historyMessages: [{ role: "assistant", content: "Owner assignment outcome proof." }],
+    methodResponses: { "sessions.list": sessionsListResponse() },
+    operatorScopes: ["operator.read", "operator.write"],
+    presenceUsers: [{ self: true, id: "profile-ada", name: "Ada" }],
+    sessionKey,
+  });
+  await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+  await page.getByText("Owner assignment outcome proof.", { exact: true }).waitFor();
+  await gateway.deferNext("sessions.assignOwner");
+  return gateway;
+}
+
+async function expectAssignmentRequest(
+  gateway: Awaited<ReturnType<typeof installOwnerGateway>>,
+): Promise<void> {
+  const request = await gateway.waitForRequest("sessions.assignOwner");
+  expect(request.params).toEqual({
+    agentId: "main",
+    key: sessionKey,
+    owner: { type: "human", id: "profile-ada" },
+  });
+}
+
+async function captureProof(page: Page, surface: string): Promise<void> {
+  if (!proofPhase) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(proofDir, `${surface}-${proofPhase}.png`),
+  });
+}
+
+async function chooseAssignToMe(page: Page): Promise<void> {
+  const action = page.locator('wa-dropdown-item[value="assign-owner:human:profile-ada"]:visible');
+  await action.waitFor({ state: "visible" });
+  await action.click();
+}
+
+suite.define(() => {
+  it("keeps a rejected header owner assignment visible", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installOwnerGateway(page);
+        const activePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
+        const menuTrigger = activePane.getByRole("button", { name: "Actions for Owner outcome" });
+        await menuTrigger.press("Enter");
+        await chooseAssignToMe(page);
+        await expectAssignmentRequest(gateway);
+
+        const message = "Owner assignment rejected for visible outcome proof.";
+        await gateway.rejectDeferred("sessions.assignOwner", {
+          code: "INVALID_REQUEST",
+          message,
+        });
+        await captureProof(page, "header");
+
+        await expectBrowser(
+          activePane.getByRole("alert").filter({ hasText: message }),
+        ).toBeVisible();
+        await expectBrowser(
+          activePane.getByRole("img", { name: "Created by Bob", exact: true }),
+        ).toHaveCount(1);
+      },
+    );
+  });
+
+  it("keeps a rejected sidebar owner assignment visible", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installOwnerGateway(page);
+        const row = page.locator(`[data-session-key="${sessionKey}"]`);
+        await row.hover();
+        await row
+          .getByRole("button", { name: "Open session menu: Owner outcome", exact: true })
+          .click();
+        await chooseAssignToMe(page);
+        await expectAssignmentRequest(gateway);
+
+        const message = "Sidebar owner assignment rejected for visible outcome proof.";
+        await gateway.rejectDeferred("sessions.assignOwner", {
+          code: "INVALID_REQUEST",
+          message,
+        });
+
+        await expectBrowser(page.getByRole("alert").filter({ hasText: message })).toBeVisible();
+        await expectBrowser(
+          row.getByRole("img", { name: "Created by Bob", exact: true }),
+        ).toHaveCount(1);
+      },
+    );
+  });
+});

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -113,9 +113,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       };
       switch (action.kind) {
         case "assign-owner":
-          await scope.sessions.assignOwner(row.key, action.owner, {
-            agentId: parseAgentSessionKey(row.key)?.agentId ?? scope.selectedAgentId,
-          });
+          await operations.assignSessionOwner(host, session, action.owner, scope);
           break;
         case "fork":
           await operations.forkSession(host, session, scope);


### PR DESCRIPTION
## Summary

- surface rejected owner assignments in both the chat-header and sidebar action owners
- route the chat-header action through the existing shared session-organizer operation
- preserve current-scope ownership so reconnects/navigation keep retired failures silent

## Root cause

`SessionCapability.assignOwner()` intentionally converts a current Gateway rejection into a nullable result while retaining the formatted error in session capability state. The sidebar organizer wrapper discarded that nullable result, and the chat header bypassed the wrapper entirely. Both visible action surfaces therefore closed their menus after dispatch but never published the retained failure to their existing error owner.

The shared operation now follows the same contract as its `patchSession` sibling: after the assignment settles, it rechecks the captured mutation scope and publishes the capability error only for a current failed result. The chat header now calls that canonical operation instead of duplicating the raw capability call.

## User proof

Authentic pre-fix source-Chromium tests issued the exact `sessions.assignOwner` request from both **Assign to me** controls and failed because neither surface exposed the rejected message as an alert. The focused owner regression likewise failed because a current nullable rejection produced zero publications; its retired-scope sibling already stayed silent.

Post-fix, both routes retain the selected session and Bob attribution while rendering the exact rejection in the owning dismissible alert. No session mutation is inferred from the failed response.

| Before | After |
| --- | --- |
| ![Rejected owner assignment has no feedback](https://ampcode.com/user-content/artifacts/226ac2977d0da479f3f316fbea5187bd187a69b36f483ef004ab24fa7d8f58a1-file.png) | ![Rejected owner assignment is visible in a dismissible alert](https://ampcode.com/user-content/artifacts/1f19ac650a3e23a417d5005c8eb271aa219eaeaf0dad08bf3c3b522c308edef6-file.png) |

## Validation

- `node ../scripts/run-vitest.mjs run --config vitest.config.ts --configLoader runner src/components/app-sidebar.test.ts src/pages/chat/components/chat-header-session-menu.test.ts src/components/session-organizer-owner-assignment.test.ts` — **296/296 passed**
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=… node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-ownership.e2e.test.ts ui/src/e2e/chat-header-session-outcomes.e2e.test.ts ui/src/e2e/session-owner-assignment.e2e.test.ts` — **17/17 passed** in real source Chromium
- `node scripts/check-changed.mjs` — passed in full
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, patch correct at **0.99**
- three fresh open issue/PR duplicate searches — no exact match

## Risk

Low. Production changes are limited to one existing action wrapper and replacement of one duplicate direct call. No protocol, persistence, configuration, authorization, success-state, or mutation behavior changes. The regression explicitly covers current rejection publication and retired-scope silence.
