### PR TITLE
fix(memory): respect provenance in automatic context

### DIFF
--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -47,17 +47,18 @@ Five rules shape everything below:
 
 ## The tier model
 
-| Tier         | Surface                                                 | Written by                                          | Injected                           |
-| ------------ | ------------------------------------------------------- | --------------------------------------------------- | ---------------------------------- |
-| Instructions | `AGENTS.md` and workspace instruction files             | Human only                                          | Always, at session start           |
-| Curated core | `MEMORY.md`, `USER.md`                                  | Dreaming consolidation; direct user request         | Always, at session start, budgeted |
-| Episodic     | `memory/YYYY-MM-DD.md` daily notes, session transcripts | Agent during work; memory flush; transcript capture | Never; searchable on demand        |
-| Prospective  | Standing intents (SQLite) and cron jobs                 | `intent` tool; scheduled tasks                      | Only when a trigger fires          |
-| Review       | `DREAMS.md`, dreaming reports                           | Dreaming phases                                     | Never; for human reading           |
+| Tier         | Surface                                                 | Written by                                          | Injected                                               |
+| ------------ | ------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------ |
+| Instructions | `AGENTS.md` and workspace instruction files             | Human only                                          | Always, at session start                               |
+| Curated core | `MEMORY.md`, `USER.md`                                  | Dreaming consolidation; direct user request         | At session start when provenance is eligible; budgeted |
+| Episodic     | `memory/YYYY-MM-DD.md` daily notes, session transcripts | Agent during work; memory flush; transcript capture | Never; searchable on demand                            |
+| Prospective  | Standing intents (SQLite) and cron jobs                 | `intent` tool; scheduled tasks                      | Only when a trigger fires                              |
+| Review       | `DREAMS.md`, dreaming reports                           | Dreaming phases                                     | Never; for human reading                               |
 
 The boundary that matters most is between the **curated core** and the
-**episodic** tier. Curated files are small, always in context, and written
-only through gated consolidation. Episodic files are large, append-friendly,
+**episodic** tier. Curated files are small, normally in context when their
+provenance is eligible, and written only through gated consolidation. Episodic
+files are large, append-friendly,
 and reachable only through explicit search tools or the escalation lane.
 Nothing crosses from episodic to curated without passing the promotion gates
 described below.
@@ -194,8 +195,11 @@ that need it.
 Three mechanisms run on eligible turns with no model involvement:
 
 - **Bootstrap injection.** `MEMORY.md` and `USER.md` load at session start
-  within budgets, and refresh per turn so long-lived sessions pick up
-  consolidation results without restarting.
+  when the selected memory runtime classifies their provenance as eligible.
+  Files with ineligible or unavailable provenance are omitted from automatic
+  context but remain available through explicit memory tools. Eligible files
+  refresh per turn within budgets so long-lived sessions pick up consolidation
+  results without restarting.
 - **Ranked search.** `memory_search` scores hybrid relevance multiplied by
   an exponential recency decay (30-day half-life) and an importance
   multiplier. Importance (1 to 10) is assigned once at write time by

--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -194,12 +194,13 @@ that need it.
 
 Three mechanisms run on eligible turns with no model involvement:
 
-- **Bootstrap injection.** `MEMORY.md` and `USER.md` load at session start
-  when the selected memory runtime classifies their provenance as eligible.
-  Files with ineligible or unavailable provenance are omitted from automatic
-  context but remain available through explicit memory tools. Eligible files
-  refresh per turn within budgets so long-lived sessions pick up consolidation
-  results without restarting.
+- **Bootstrap injection.** When a memory runtime is selected, `MEMORY.md` and
+  `USER.md` load at session start only when that runtime classifies their
+  provenance as eligible. Ineligible, missing, or unsupported classifications
+  are omitted from automatic context but remain available through explicit
+  memory tools. With no selected memory runtime, bootstrap behavior is unchanged.
+  Eligible files refresh per turn within budgets so long-lived sessions pick up
+  consolidation results without restarting.
 - **Ranked search.** `memory_search` scores hybrid relevance multiplied by
   an exponential recency decay (30-day half-life) and an importance
   multiplier. Importance (1 to 10) is assigned once at write time by

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -2111,7 +2111,11 @@ describe("active-memory plugin", () => {
             score: 1,
             snippet: "Prefer aisle seats.",
             source: "memory" as const,
-            originClass: "agent",
+            provenance: {
+              originClass: "agent" as const,
+              sessionKind: "interactive" as const,
+              observedAt: 1,
+            },
             triggers: "booking a flight",
           },
         ]),

--- a/extensions/active-memory/trigger-recall.test.ts
+++ b/extensions/active-memory/trigger-recall.test.ts
@@ -29,6 +29,7 @@ function result(overrides: Partial<MemorySearchResult> = {}): MemorySearchResult
     snippet: "User prefers aisle seats and extra connection time.",
     source: "memory",
     triggers: "when booking a flight; seat preferences",
+    provenance: { originClass: "owner", sessionKind: "interactive", observedAt: 1 },
     ...overrides,
   };
 }
@@ -61,23 +62,43 @@ describe("active-memory trigger recall", () => {
   it("limits automatic injection to curated or trusted-origin entries", () => {
     expect(isPromotedTrustedMemoryEntry(result())).toBe(true);
     expect(isPromotedTrustedMemoryEntry(result({ path: "USER.md" }))).toBe(true);
-    expect(isPromotedTrustedMemoryEntry(result({ path: "memory/2026-07-27.md" }))).toBe(false);
+    expect(isPromotedTrustedMemoryEntry(result({ provenance: undefined }))).toBe(false);
+    expect(
+      isPromotedTrustedMemoryEntry({
+        ...result({ path: "memory/2026-07-27.md" }),
+        provenance: undefined,
+      }),
+    ).toBe(false);
     expect(isPromotedTrustedMemoryEntry(result({ source: "sessions" }))).toBe(false);
     expect(
-      isPromotedTrustedMemoryEntry(result({ path: "memory/promoted.md", originClass: "owner" })),
+      isPromotedTrustedMemoryEntry(
+        result({
+          path: "memory/promoted.md",
+          provenance: { originClass: "agent", sessionKind: "interactive", observedAt: 1 },
+        }),
+      ),
     ).toBe(true);
 
     const matches = selectStrongTriggerMatches("when booking a flight", [
       result(),
       result({ path: "USER.md", startLine: 3 }),
-      result({ path: "memory/2026-07-27.md", startLine: 4 }),
+      result({ path: "memory/2026-07-27.md", startLine: 4, provenance: undefined }),
       result({ source: "sessions", path: "session.jsonl", startLine: 5 }),
     ]);
     expect(matches.map((entry) => entry.path)).toEqual(["MEMORY.md", "USER.md"]);
 
     const provenanceMatches = selectStrongTriggerMatches("when booking a flight", [
-      result({ path: "memory/untrusted.md", originClass: "untrusted", score: 1 }),
-      result({ path: "memory/owner.md", originClass: "owner", score: 1 }),
+      result({
+        path: "memory/untrusted.md",
+        provenance: { originClass: "untrusted", sessionKind: "interactive", observedAt: 1 },
+        score: 1,
+      }),
+      result({ path: "memory/missing.md", provenance: undefined, score: 1 }),
+      result({
+        path: "memory/owner.md",
+        provenance: { originClass: "owner", sessionKind: "interactive", observedAt: 1 },
+        score: 1,
+      }),
     ]);
     expect(provenanceMatches.map((entry) => entry.path)).toEqual(["memory/owner.md"]);
   });

--- a/extensions/active-memory/trigger-recall.ts
+++ b/extensions/active-memory/trigger-recall.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
+  isAutomaticMemoryEntryEligible,
   stripMemoryAnnotationCarriers,
   type MemorySearchResult,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -56,7 +57,7 @@ function scoreTriggerPhrase(message: string, phrase: string): number {
 }
 
 export function isPromotedTrustedMemoryEntry(
-  entry: Pick<MemorySearchResult, "path" | "source" | "originClass" | "projectKey">,
+  entry: Pick<MemorySearchResult, "provenance" | "projectKey" | "source">,
   activeProjectKeys: readonly string[] = [],
 ): boolean {
   if (entry.projectKey) {
@@ -77,14 +78,7 @@ export function isPromotedTrustedMemoryEntry(
       return false;
     }
   }
-  if (entry.originClass === "owner" || entry.originClass === "agent") {
-    return true;
-  }
-  if (entry.source !== "memory") {
-    return false;
-  }
-  const normalized = entry.path.replaceAll("\\", "/").replace(/^\.\//u, "").toUpperCase();
-  return normalized === "MEMORY.MD" || normalized === "USER.MD";
+  return entry.source === "memory" && isAutomaticMemoryEntryEligible(entry);
 }
 
 export function scoreTriggerMatch(message: string, entry: MemorySearchResult): number {

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -201,6 +201,16 @@ function createLazyMemoryRuntime(host: MemoryCoreRuntimeHost): MemoryPluginRunti
       }
       return await runtime.authorizeSearchHits(params);
     },
+    async classifyWorkspaceMemoryPaths(params) {
+      const [{ classifyWorkspaceMemoryPaths }, dreamingState] = await Promise.all([
+        import("./src/workspace-path-classifier.js"),
+        import("./src/dreaming-state.js"),
+      ]);
+      if (host.openKeyedStore) {
+        dreamingState.configureMemoryCoreDreamingState(host.openKeyedStore);
+      }
+      return await classifyWorkspaceMemoryPaths(params);
+    },
     resolveMemoryBackendConfig(params) {
       return resolveMemoryBackendConfig(params);
     },

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -18,6 +18,10 @@ import {
 } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { describe, expect, it, vi } from "vitest";
 import {
+  DREAMING_DAILY_PROVENANCE_NAMESPACE,
+  writeMemoryCoreWorkspaceEntry,
+} from "../dreaming-state.js";
+import {
   createManagerIndexFixture,
   type ManagerIndexFixture,
 } from "./manager-index.test-support.js";
@@ -270,8 +274,20 @@ describe("memory index", () => {
       const activeProjectKeys = [projectKey];
       const curated = await manager.listCuratedProjectCandidates({ activeProjectKeys });
       const triggers = await manager.listTriggerCandidates({ activeProjectKeys });
-      expect(curated).toMatchObject([{ projectKey, triggers: "kraken deploy ritual" }]);
-      expect(triggers).toMatchObject([{ projectKey, triggers: "kraken deploy ritual" }]);
+      expect(curated).toMatchObject([
+        {
+          projectKey,
+          triggers: "kraken deploy ritual",
+          provenance: { originClass: "agent" },
+        },
+      ]);
+      expect(triggers).toMatchObject([
+        {
+          projectKey,
+          triggers: "kraken deploy ritual",
+          provenance: { originClass: "agent" },
+        },
+      ]);
 
       const neutral = await manager.search("kraken deploy", {
         minScore: 0,
@@ -291,6 +307,50 @@ describe("memory index", () => {
         throw new Error("expected mixed-case project hit in neutral and active search");
       }
       expect(activeHit.score).toBeGreaterThan(neutralHit.score);
+    } finally {
+      await manager.close?.();
+    }
+  });
+
+  it("keeps quarantined curated memory searchable but out of automatic candidates", async () => {
+    const projectKey = "github.com/openclaw/openclaw";
+    await fs.writeFile(
+      path.join(fixture.paths.workspace, "MEMORY.md"),
+      `- Quarantined release instruction. <!-- trigger: release instruction --> <!-- project: ${projectKey} -->\n`,
+    );
+    await writeMemoryCoreWorkspaceEntry({
+      namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+      workspaceDir: fixture.paths.workspace,
+      key: "MEMORY.md",
+      value: { originClass: "untrusted" },
+    });
+
+    const manager = await getFreshManager(createCfg({ provider: "none" }));
+    try {
+      await manager.sync({ reason: "test", force: true });
+      if (!manager.listCuratedProjectCandidates || !manager.listTriggerCandidates) {
+        throw new Error("expected curated project and trigger candidate listing");
+      }
+      await expect(
+        manager.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
+      ).resolves.toEqual([]);
+      await expect(
+        manager.listTriggerCandidates({ activeProjectKeys: [projectKey] }),
+      ).resolves.toEqual([]);
+
+      const explicit = await manager.search("Quarantined release instruction", {
+        lexicalOnly: true,
+        minScore: 0,
+        maxResults: 10,
+        sources: ["memory"],
+      });
+      expect(explicit).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            provenance: expect.objectContaining({ originClass: "untrusted" }),
+          }),
+        ]),
+      );
     } finally {
       await manager.close?.();
     }

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -6,6 +6,7 @@ import {
   hashText,
   INVALID_PROJECT_ANNOTATION_KEY,
   MEMORY_CHUNKING_VERSION,
+  MEMORY_INDEX_CHUNK_PROVENANCE_TABLE,
   type MemorySessionSyncTarget,
   type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -17,10 +18,6 @@ import {
   openOpenClawAgentDatabase,
 } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { describe, expect, it, vi } from "vitest";
-import {
-  DREAMING_DAILY_PROVENANCE_NAMESPACE,
-  writeMemoryCoreWorkspaceEntry,
-} from "../dreaming-state.js";
 import {
   createManagerIndexFixture,
   type ManagerIndexFixture,
@@ -318,16 +315,17 @@ describe("memory index", () => {
       path.join(fixture.paths.workspace, "MEMORY.md"),
       `- Quarantined release instruction. <!-- trigger: release instruction --> <!-- project: ${projectKey} -->\n`,
     );
-    await writeMemoryCoreWorkspaceEntry({
-      namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
-      workspaceDir: fixture.paths.workspace,
-      key: "MEMORY.md",
-      value: { originClass: "untrusted" },
-    });
-
     const manager = await getFreshManager(createCfg({ provider: "none" }));
     try {
       await manager.sync({ reason: "test", force: true });
+      const db = Reflect.get(manager, "db") as DatabaseSync;
+      db.prepare(
+        `UPDATE ${MEMORY_INDEX_CHUNK_PROVENANCE_TABLE}
+         SET origin_class = 'untrusted'
+         WHERE chunk_id IN (
+           SELECT id FROM memory_index_chunks WHERE path = 'MEMORY.md' AND source = 'memory'
+         )`,
+      ).run();
       if (!manager.listCuratedProjectCandidates || !manager.listTriggerCandidates) {
         throw new Error("expected curated project and trigger candidate listing");
       }
@@ -353,6 +351,98 @@ describe("memory index", () => {
       );
     } finally {
       await manager.close?.();
+    }
+  });
+
+  it("reindexes legacy curated provenance before the first automatic candidate read", async () => {
+    const projectKey = "github.com/openclaw/openclaw";
+    await fs.writeFile(
+      path.join(fixture.paths.workspace, "MEMORY.md"),
+      `- Preserve legacy preference. <!-- trigger: legacy preference --> <!-- project: ${projectKey} -->\n`,
+    );
+    const cfg = createCfg({ provider: "none" });
+    const initialManager = await getFreshManager(cfg);
+    await initialManager.sync({ reason: "test", force: true });
+    const initialDb = Reflect.get(initialManager, "db") as DatabaseSync;
+    initialDb.exec(`DELETE FROM ${MEMORY_INDEX_CHUNK_PROVENANCE_TABLE}`);
+    await initialManager.close();
+
+    const upgradedManager = await getFreshManager(cfg);
+    try {
+      expect(upgradedManager.status().dirty).toBe(true);
+      const upgradedDb = Reflect.get(upgradedManager, "db") as DatabaseSync;
+      expect(
+        upgradedDb
+          .prepare(
+            `SELECT hash FROM memory_index_sources WHERE path = 'MEMORY.md' AND source = 'memory'`,
+          )
+          .get(),
+      ).toEqual({ hash: "" });
+      expect(
+        upgradedDb
+          .prepare(
+            `SELECT DISTINCT origin_class AS originClass
+             FROM ${MEMORY_INDEX_CHUNK_PROVENANCE_TABLE}`,
+          )
+          .all(),
+      ).toEqual([{ originClass: "untrusted" }]);
+      if (!upgradedManager.listCuratedProjectCandidates || !upgradedManager.listTriggerCandidates) {
+        throw new Error("expected curated project and trigger candidate listing");
+      }
+      const syncAdmitted = vi
+        .spyOn(
+          upgradedManager as unknown as {
+            syncAdmitted: (
+              params?: MemorySyncParams,
+              options?: { allowEmbeddingBootstrapFallback?: boolean },
+            ) => Promise<void>;
+          },
+          "syncAdmitted",
+        )
+        .mockRejectedValueOnce(new Error("legacy provenance repair unavailable"));
+      await expect(
+        upgradedManager.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
+      ).resolves.toEqual([]);
+      expect(syncAdmitted).toHaveBeenCalledWith(
+        { reason: "search" },
+        { allowEmbeddingBootstrapFallback: true },
+      );
+      expect(upgradedManager.status().dirty).toBe(true);
+      syncAdmitted.mockRestore();
+
+      const runSync = vi.spyOn(
+        upgradedManager as unknown as { runSync: (params?: MemorySyncParams) => Promise<void> },
+        "runSync",
+      );
+      const [projectCandidates, triggerCandidates] = await Promise.all([
+        upgradedManager.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
+        upgradedManager.listTriggerCandidates({ activeProjectKeys: [projectKey] }),
+      ]);
+      expect(projectCandidates).toMatchObject([
+        {
+          projectKey,
+          triggers: "legacy preference",
+          provenance: { originClass: "agent" },
+        },
+      ]);
+      expect(triggerCandidates).toMatchObject([
+        {
+          projectKey,
+          triggers: "legacy preference",
+          provenance: { originClass: "agent" },
+        },
+      ]);
+      expect(runSync).toHaveBeenCalledTimes(1);
+      expect(upgradedManager.status().dirty).toBe(false);
+      expect(
+        upgradedDb
+          .prepare(
+            `SELECT hash FROM memory_index_sources WHERE path = 'MEMORY.md' AND source = 'memory'`,
+          )
+          .get(),
+      ).toMatchObject({ hash: expect.not.stringMatching(/^$/u) });
+    } finally {
+      await upgradedManager.close();
     }
   });
 

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
@@ -90,7 +90,7 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
     activeProjectKeys?: string[];
   }): Promise<MemorySearchResult[]> {
     const limit = Math.max(1, Math.min(512, Math.floor(opts?.limit ?? 512)));
-    return this.toCuratedMemorySearchResults(
+    return await this.readCuratedMemoryCandidates(() =>
       readCuratedMemoryTriggerCandidates(this.db, limit, opts?.activeProjectKeys),
     );
   }
@@ -100,9 +100,42 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
     limit?: number;
   }): Promise<MemorySearchResult[]> {
     const limit = Math.max(1, Math.min(512, Math.floor(opts.limit ?? 48)));
-    return this.toCuratedMemorySearchResults(
+    return await this.readCuratedMemoryCandidates(() =>
       readCuratedProjectMemoryCandidates(this.db, limit, opts.activeProjectKeys),
     );
+  }
+
+  private async readCuratedMemoryCandidates(
+    read: () => ReturnType<typeof readCuratedMemoryTriggerCandidates>,
+  ): Promise<MemorySearchResult[]> {
+    return await this.withManagerOperation(async () => {
+      if (this.memorySourceProvenanceRepairPending) {
+        const repairPending = () =>
+          this.db
+            .prepare(
+              `SELECT 1 FROM memory_index_sources
+               WHERE source = 'memory' AND hash = '' LIMIT 1`,
+            )
+            .get() !== undefined;
+        try {
+          // Provenance schema adoption invalidates legacy source hashes. Finish that
+          // owner-classified reindex before the first automatic candidate read.
+          if (repairPending()) {
+            await this.syncAdmitted(
+              { reason: "search" },
+              { allowEmbeddingBootstrapFallback: true },
+            );
+          }
+        } catch (err) {
+          log.warn(`memory sync failed (automatic candidates): ${formatErrorMessage(err)}`);
+        }
+        this.memorySourceProvenanceRepairPending = repairPending();
+        if (this.memorySourceProvenanceRepairPending) {
+          return [];
+        }
+      }
+      return this.toCuratedMemorySearchResults(read());
+    });
   }
 
   private toCuratedMemorySearchResults(

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
@@ -126,6 +126,12 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
       if (typeof row.project_key === "string" && row.project_key.trim()) {
         result.projectKey = row.project_key.trim();
       }
+      result.provenance = {
+        originClass: row.origin_class,
+        sessionKind: row.session_kind,
+        observedAt: row.observed_at,
+        ...(typeof row.supersedes_key === "string" ? { supersedesKey: row.supersedes_key } : {}),
+      };
       return result;
     });
   }

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -151,6 +151,7 @@ export abstract class MemoryManagerSyncBase {
   protected memoryWatchPressureStartupTimer: NodeJS.Timeout | null = null;
   protected closed = false;
   protected dirty = false;
+  protected memorySourceProvenanceRepairPending = false;
   // Failed full memory reindexes must retry as full rebuilds, not incremental
   // dirty syncs that can skip unchanged files against the still-live index.
   protected memoryFullRetryDirty = false;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -259,13 +259,14 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
           row.source === "memory" || row.source === "sessions" ? [row.source] : [],
         ),
       );
+      this.memorySourceProvenanceRepairPending =
+        this.sources.has("memory") && invalidatedSources.has("memory");
       this.dirty =
         resolveInitialMemoryDirty({
           hasMemorySource: this.sources.has("memory"),
           statusOnly: params.purpose === "status",
           hasIndexedMeta: Boolean(meta),
-        }) ||
-        (this.sources.has("memory") && invalidatedSources.has("memory"));
+        }) || this.memorySourceProvenanceRepairPending;
       if (this.sources.has("sessions") && invalidatedSources.has("sessions")) {
         // Migration cannot map a durable session source path back to one live
         // transcript file. Carry a full-session retry so unchanged and deleted

--- a/extensions/memory-core/src/memory/memory-path-provenance.test.ts
+++ b/extensions/memory-core/src/memory/memory-path-provenance.test.ts
@@ -95,4 +95,24 @@ describe("memory path provenance", () => {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });
+
+  it("fails closed for malformed recorded provenance", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-path-invalid-origin-"));
+    try {
+      const absolutePath = path.join(workspaceDir, "USER.md");
+      await fs.writeFile(absolutePath, "profile", "utf8");
+      await writeMemoryCoreWorkspaceEntry({
+        namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+        workspaceDir,
+        key: "USER.md",
+        value: { originClass: "invalid" },
+      });
+
+      await expect(
+        resolveMemoryPathClassification({ absolutePath, source: "memory", workspaceDir }),
+      ).resolves.toEqual({ curatedRoot: true, originClass: "untrusted" });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/extensions/memory-core/src/memory/memory-path-provenance.test.ts
+++ b/extensions/memory-core/src/memory/memory-path-provenance.test.ts
@@ -1,8 +1,8 @@
 // Memory Core tests cover workspace path provenance classification.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { readMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMemoryCoreTestHarness } from "../test-helpers.js";
 import { resolveMemoryPathClassification } from "./memory-path-provenance.js";
@@ -10,6 +10,7 @@ import { resolveMemoryPathClassification } from "./memory-path-provenance.js";
 vi.mock("openclaw/plugin-sdk/memory-core-host-runtime-core", { spy: true });
 
 createMemoryCoreTestHarness();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -17,7 +18,7 @@ afterEach(() => {
 
 describe("memory path provenance", () => {
   it("trusts canonical workspace memory while excluding system and lookalike paths", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "memory-path-provenance-"));
+    const root = tempDirs.make("memory-path-provenance-");
     const workspaceDir = path.join(root, "workspace");
     const outsideDir = path.join(root, "outside");
     await fs.mkdir(path.join(workspaceDir, "memory", "projects"), { recursive: true });
@@ -78,41 +79,18 @@ describe("memory path provenance", () => {
   });
 
   it("honors sticky untrusted provenance for runtime-written memory files", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-path-runtime-taint-"));
-    try {
-      const absolutePath = path.join(workspaceDir, "MEMORY.md");
-      await fs.writeFile(absolutePath, "network-authored memory", "utf8");
-      vi.mocked(readMemoryArtifactProvenance).mockResolvedValueOnce({
-        fileHash: "0".repeat(64),
-        originClass: "untrusted",
-        observedAt: 1,
-      });
+    const workspaceDir = tempDirs.make("memory-path-runtime-taint-");
+    const absolutePath = path.join(workspaceDir, "MEMORY.md");
+    await fs.writeFile(absolutePath, "network-authored memory", "utf8");
+    vi.mocked(readMemoryArtifactProvenance).mockResolvedValueOnce({
+      fileHash: "0".repeat(64),
+      originClass: "untrusted",
+      observedAt: 1,
+    });
 
-      await expect(
-        resolveMemoryPathClassification({ absolutePath, source: "memory", workspaceDir }),
-      ).resolves.toEqual({ curatedRoot: true, originClass: "untrusted" });
-    } finally {
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
+    await expect(
+      resolveMemoryPathClassification({ absolutePath, source: "memory", workspaceDir }),
+    ).resolves.toEqual({ curatedRoot: true, originClass: "untrusted" });
   });
 
-  it("fails closed for malformed recorded provenance", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-path-invalid-origin-"));
-    try {
-      const absolutePath = path.join(workspaceDir, "USER.md");
-      await fs.writeFile(absolutePath, "profile", "utf8");
-      await writeMemoryCoreWorkspaceEntry({
-        namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
-        workspaceDir,
-        key: "USER.md",
-        value: { originClass: "invalid" },
-      });
-
-      await expect(
-        resolveMemoryPathClassification({ absolutePath, source: "memory", workspaceDir }),
-      ).resolves.toEqual({ curatedRoot: true, originClass: "untrusted" });
-    } finally {
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
-  });
 });

--- a/extensions/memory-core/src/memory/memory-path-provenance.test.ts
+++ b/extensions/memory-core/src/memory/memory-path-provenance.test.ts
@@ -92,5 +92,4 @@ describe("memory path provenance", () => {
       resolveMemoryPathClassification({ absolutePath, source: "memory", workspaceDir }),
     ).resolves.toEqual({ curatedRoot: true, originClass: "untrusted" });
   });
-
 });

--- a/extensions/memory-core/src/memory/memory-path-provenance.ts
+++ b/extensions/memory-core/src/memory/memory-path-provenance.ts
@@ -54,8 +54,8 @@ export async function resolveMemoryPathClassification(params: {
         relativePath: normalizedRelativePath,
       })
     : undefined;
-  if (recorded?.originClass === "untrusted") {
-    return { curatedRoot, originClass: "untrusted" };
+  if (recorded) {
+    return { curatedRoot, originClass: recorded.originClass };
   }
   // Workspace memory Markdown is owner-controlled. Flush-recorded provenance
   // still downgrades machine-written untrusted material during ingestion; the

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -8,6 +8,7 @@ import {
   getMemorySearchManager,
 } from "./memory/index.js";
 import type { MemoryCoreRuntimeHost } from "./memory/runtime-host.js";
+import { classifyWorkspaceMemoryPaths } from "./workspace-path-classifier.js";
 
 export function createMemoryRuntime(host: MemoryCoreRuntimeHost = {}): MemoryPluginRuntime {
   if (host.openKeyedStore) {
@@ -34,6 +35,7 @@ export function createMemoryRuntime(host: MemoryCoreRuntimeHost = {}): MemoryPlu
         await import("./session-search-visibility.js");
       return await filterMemorySearchHitsBySessionVisibility(params);
     },
+    classifyWorkspaceMemoryPaths,
     async closeAllMemorySearchManagers() {
       await closeAllMemorySearchManagers();
     },

--- a/extensions/memory-core/src/workspace-path-classifier.ts
+++ b/extensions/memory-core/src/workspace-path-classifier.ts
@@ -1,0 +1,20 @@
+// Memory Core classifies automatic workspace context without loading the search manager.
+import path from "node:path";
+import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { resolveMemoryPathClassification } from "./memory/memory-path-provenance.js";
+
+type ClassifyWorkspaceMemoryPaths = NonNullable<
+  MemoryPluginRuntime["classifyWorkspaceMemoryPaths"]
+>;
+
+export const classifyWorkspaceMemoryPaths: ClassifyWorkspaceMemoryPaths = async (params) =>
+  await Promise.all(
+    params.relativePaths.map(async (relativePath) => {
+      const classification = await resolveMemoryPathClassification({
+        absolutePath: path.resolve(params.workspaceDir, relativePath),
+        source: "memory",
+        workspaceDir: params.workspaceDir,
+      });
+      return { relativePath, originClass: classification.originClass };
+    }),
+  );

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -37,7 +37,11 @@ export {
   type MemoryReadResult,
 } from "./host/read-file-shared.js";
 export { resolveMemoryBackendConfig } from "./host/backend-config.js";
-export { resolveMemorySearchStaleness } from "./host/types.js";
+export {
+  isAutomaticMemoryEntryEligible,
+  isMemoryOriginEligibleForAutomaticInjection,
+  resolveMemorySearchStaleness,
+} from "./host/types.js";
 export type { ResolvedMemoryBackendConfig } from "./host/backend-config.js";
 export type {
   MemoryEmbeddingProbeResult,

--- a/packages/memory-host-sdk/src/host/memory-recall-metadata.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-recall-metadata.test.ts
@@ -5,6 +5,7 @@ import {
   readCuratedMemoryTriggerCandidates,
   readMemoryRecallMetadata,
 } from "./memory-recall-metadata.js";
+import { MEMORY_INDEX_CHUNK_PROVENANCE_TABLE } from "./memory-schema-provenance.js";
 import {
   ensureMemoryRecallMetadataSchema,
   MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE,
@@ -59,8 +60,14 @@ describe("memory recall metadata", () => {
         `INSERT INTO ${MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE}
          (chunk_id, importance, triggers, project_key) VALUES (?, ?, ?, ?)`,
       );
+      const insertProvenance = db.prepare(
+        `INSERT INTO ${MEMORY_INDEX_CHUNK_PROVENANCE_TABLE}
+         (chunk_id, origin_class, session_kind, observed_at)
+         VALUES (?, ?, 'interactive', 2)`,
+      );
 
       insertChunk.run("good", "MEMORY.md", 1, 1, "h", "t");
+      insertProvenance.run("good", "owner");
       insertChunk.run("neutral", "MEMORY.md", 2, 2, "neutral", "neutral");
       expect(readMemoryRecallMetadata(db, ["neutral"]).get("neutral")).toEqual({
         id: "neutral",
@@ -87,6 +94,10 @@ describe("memory recall metadata", () => {
           importance: 9,
           triggers: "when flying",
           project_key: "github.com/openclaw/openclaw",
+          origin_class: "owner",
+          session_kind: "interactive",
+          observed_at: 2,
+          supersedes_key: null,
         },
       ]);
 
@@ -109,6 +120,7 @@ describe("memory recall metadata", () => {
       for (let index = 0; index < 64; index += 1) {
         const id = `bootstrap-low-${String(index).padStart(3, "0")}`;
         insertChunk.run(id, "MEMORY.md", index + 2, index + 2, id, "low");
+        insertProvenance.run(id, "agent");
         insertMetadata.run(id, 1, null, "github.com/openclaw/openclaw");
       }
       insertChunk.run(
@@ -119,12 +131,14 @@ describe("memory recall metadata", () => {
         "bootstrap-high",
         "high-priority bootstrap fact",
       );
+      insertProvenance.run("bootstrap-high", "agent");
       insertMetadata.run("bootstrap-high", 10, null, "github.com/openclaw/openclaw");
       expect(readCuratedProjectMemoryCandidates(db, 48, ["github.com/openclaw/openclaw"])).toEqual(
         expect.arrayContaining([expect.objectContaining({ id: "bootstrap-high", importance: 10 })]),
       );
 
       insertChunk.run("a-foreign", "MEMORY.md", 2, 2, "h2", "foreign");
+      insertProvenance.run("a-foreign", "agent");
       insertMetadata.run("a-foreign", 9, "when flying", "github.com/example/other");
       expect(readCuratedMemoryTriggerCandidates(db, 1, ["github.com/openclaw/openclaw"])).toEqual([
         expect.objectContaining({ id: "good" }),
@@ -132,6 +146,7 @@ describe("memory recall metadata", () => {
       expect(readCuratedMemoryTriggerCandidates(db, 1, [])).toEqual([]);
 
       insertChunk.run("a-fourth", "MEMORY.md", 3, 3, "h3", "fourth");
+      insertProvenance.run("a-fourth", "agent");
       insertMetadata.run("a-fourth", 8, "when flying", "project/d");
       expect(
         readCuratedMemoryTriggerCandidates(db, 1, [
@@ -141,6 +156,20 @@ describe("memory recall metadata", () => {
           "project/d",
         ])[0],
       ).toMatchObject({ id: "a-fourth", project_key: "project/d" });
+
+      insertChunk.run("untrusted", "MEMORY.md", 4, 4, "h4", "untrusted");
+      insertProvenance.run("untrusted", "untrusted");
+      insertMetadata.run("untrusted", 10, "when flying", "github.com/openclaw/openclaw");
+      insertChunk.run("missing", "MEMORY.md", 5, 5, "h5", "missing");
+      insertMetadata.run("missing", 10, "when flying", "github.com/openclaw/openclaw");
+      const triggerIds = readCuratedMemoryTriggerCandidates(db, 10).map((entry) => entry.id);
+      const projectIds = readCuratedProjectMemoryCandidates(db, 10, [
+        "github.com/openclaw/openclaw",
+      ]).map((entry) => entry.id);
+      for (const id of ["untrusted", "missing"]) {
+        expect(triggerIds).not.toContain(id);
+        expect(projectIds).not.toContain(id);
+      }
     } finally {
       db.close();
     }

--- a/packages/memory-host-sdk/src/host/memory-recall-metadata.ts
+++ b/packages/memory-host-sdk/src/host/memory-recall-metadata.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { INVALID_PROJECT_ANNOTATION_KEY } from "./internal.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./openclaw-runtime-kysely.js";
+import type { MemoryOriginClass, MemorySessionKind } from "./types.js";
 
 type MemoryRecallMetadataDatabase = {
   memory_index_chunks: {
@@ -16,6 +17,13 @@ type MemoryRecallMetadataDatabase = {
     importance: number | null;
     triggers: string | null;
     project_key: string | null;
+  };
+  memory_index_chunk_provenance: {
+    chunk_id: string;
+    origin_class: MemoryOriginClass;
+    session_kind: MemorySessionKind;
+    observed_at: number;
+    supersedes_key: string | null;
   };
 };
 
@@ -137,6 +145,7 @@ function readCuratedCandidateBatch(params: {
   let query = getNodeSqliteKysely<MemoryRecallMetadataDatabase>(params.db)
     .selectFrom("memory_index_chunks as chunk")
     .leftJoin("memory_index_chunk_recall_metadata as metadata", "metadata.chunk_id", "chunk.id")
+    .innerJoin("memory_index_chunk_provenance as provenance", "provenance.chunk_id", "chunk.id")
     .select([
       "chunk.id as id",
       "chunk.path as path",
@@ -147,9 +156,14 @@ function readCuratedCandidateBatch(params: {
       "metadata.importance as importance",
       "metadata.triggers as triggers",
       "metadata.project_key as project_key",
+      "provenance.origin_class as origin_class",
+      "provenance.session_kind as session_kind",
+      "provenance.observed_at as observed_at",
+      "provenance.supersedes_key as supersedes_key",
     ])
     .where("chunk.source", "=", "memory")
-    .where("chunk.path", "in", ["MEMORY.md", "USER.md"]);
+    .where("chunk.path", "in", ["MEMORY.md", "USER.md"])
+    .where("provenance.origin_class", "in", ["owner", "agent"]);
   if (params.requireProject) {
     query = query.where("metadata.project_key", "is not", null);
   }

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -29,11 +29,22 @@ export type MemorySearchResult = {
   triggers?: string;
   /** Semicolon-separated stable repository identities lifted from inline annotations. */
   projectKey?: string;
-  /** Future provenance column supplied by the promoted-memory workstream. */
-  originClass?: string;
   citation?: string;
   provenance?: MemoryEntryProvenance;
 };
+
+/** Automatic prompt injection is reserved for content with authoritative trusted provenance. */
+export function isMemoryOriginEligibleForAutomaticInjection(
+  originClass: unknown,
+): originClass is "owner" | "agent" {
+  return originClass === "owner" || originClass === "agent";
+}
+
+export function isAutomaticMemoryEntryEligible(
+  entry: Pick<MemorySearchResult, "provenance">,
+): boolean {
+  return isMemoryOriginEligibleForAutomaticInjection(entry.provenance?.originClass);
+}
 
 /** Cached/probed embedding availability status. */
 export type MemoryEmbeddingProbeResult = {

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -29,6 +29,8 @@ export type MemorySearchResult = {
   triggers?: string;
   /** Semicolon-separated stable repository identities lifted from inline annotations. */
   projectKey?: string;
+  /** @deprecated Use provenance.originClass. This field is not authoritative for automatic injection. */
+  originClass?: string;
   citation?: string;
   provenance?: MemoryEntryProvenance;
 };

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -216,7 +216,9 @@ describe("resolveBootstrapFilesForRun", () => {
   beforeEach(async () => {
     clearInternalHooks();
     resetLegacyWorkspaceStateCheckForTest();
-    memoryRuntimeMocks.classifyWorkspacePaths.mockReset().mockResolvedValue(undefined);
+    memoryRuntimeMocks.classifyWorkspacePaths
+      .mockReset()
+      .mockResolvedValue({ status: "unavailable" });
     testState = await createOpenClawTestState({
       layout: "state-only",
       prefix: "openclaw-bootstrap-state-",
@@ -228,10 +230,13 @@ describe("resolveBootstrapFilesForRun", () => {
     await fs.writeFile(path.join(workspaceDir, DEFAULT_MEMORY_FILENAME), "tainted memory", "utf8");
     await fs.writeFile(path.join(workspaceDir, DEFAULT_USER_FILENAME), "trusted user", "utf8");
     registerNamedBootstrapFileHook(DEFAULT_MEMORY_FILENAME);
-    memoryRuntimeMocks.classifyWorkspacePaths.mockResolvedValue([
-      { relativePath: DEFAULT_MEMORY_FILENAME, originClass: "untrusted" },
-      { relativePath: DEFAULT_USER_FILENAME, originClass: "owner" },
-    ]);
+    memoryRuntimeMocks.classifyWorkspacePaths.mockResolvedValue({
+      status: "classified",
+      classifications: [
+        { relativePath: DEFAULT_MEMORY_FILENAME, originClass: "untrusted" },
+        { relativePath: DEFAULT_USER_FILENAME, originClass: "owner" },
+      ],
+    });
 
     const files = await resolveBootstrapFilesForRun({
       workspaceDir,
@@ -247,9 +252,10 @@ describe("resolveBootstrapFilesForRun", () => {
     const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-missing-provenance-");
     await fs.writeFile(path.join(workspaceDir, DEFAULT_MEMORY_FILENAME), "memory", "utf8");
     await fs.writeFile(path.join(workspaceDir, DEFAULT_USER_FILENAME), "user", "utf8");
-    memoryRuntimeMocks.classifyWorkspacePaths.mockResolvedValue([
-      { relativePath: DEFAULT_MEMORY_FILENAME, originClass: "agent" },
-    ]);
+    memoryRuntimeMocks.classifyWorkspacePaths.mockResolvedValue({
+      status: "classified",
+      classifications: [{ relativePath: DEFAULT_MEMORY_FILENAME, originClass: "agent" }],
+    });
 
     const files = await resolveBootstrapFilesForRun({
       workspaceDir,
@@ -259,6 +265,27 @@ describe("resolveBootstrapFilesForRun", () => {
 
     expect(files.map((file) => file.name)).toContain(DEFAULT_MEMORY_FILENAME);
     expect(files.map((file) => file.name)).not.toContain(DEFAULT_USER_FILENAME);
+  });
+
+  it("excludes root memory for a selected runtime without provenance support", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-unsupported-provenance-");
+    await fs.writeFile(path.join(workspaceDir, DEFAULT_MEMORY_FILENAME), "memory", "utf8");
+    await fs.writeFile(path.join(workspaceDir, DEFAULT_USER_FILENAME), "user", "utf8");
+    memoryRuntimeMocks.classifyWorkspacePaths.mockResolvedValue({ status: "unsupported" });
+    const warnings: string[] = [];
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: {},
+      agentId: "main",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(files.map((file) => file.name)).not.toContain(DEFAULT_MEMORY_FILENAME);
+    expect(files.map((file) => file.name)).not.toContain(DEFAULT_USER_FILENAME);
+    expect(warnings).toContain(
+      "excluding automatic memory context: selected memory runtime does not support provenance classification",
+    );
   });
   afterEach(async () => {
     clearInternalHooks();

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   upsertSessionEntryCore,
   type SessionTranscriptRuntimeTarget,
@@ -34,9 +34,17 @@ import { resetLegacyWorkspaceStateCheckForTest } from "./workspace-legacy-state.
 import { mergeWorkspaceSetupState } from "./workspace-state-store.js";
 import {
   DEFAULT_MEMORY_FILENAME,
+  DEFAULT_USER_FILENAME,
   loadExtraBootstrapFilesWithDiagnostics,
   type WorkspaceBootstrapFile,
 } from "./workspace.js";
+
+const memoryRuntimeMocks = vi.hoisted(() => ({ classifyWorkspacePaths: vi.fn() }));
+
+vi.mock("../plugins/memory-runtime.js", () => ({
+  classifyActiveMemoryWorkspacePaths: (...args: unknown[]) =>
+    memoryRuntimeMocks.classifyWorkspacePaths(...args),
+}));
 
 let testState: OpenClawTestState | undefined;
 
@@ -208,10 +216,49 @@ describe("resolveBootstrapFilesForRun", () => {
   beforeEach(async () => {
     clearInternalHooks();
     resetLegacyWorkspaceStateCheckForTest();
+    memoryRuntimeMocks.classifyWorkspacePaths.mockReset().mockResolvedValue(undefined);
     testState = await createOpenClawTestState({
       layout: "state-only",
       prefix: "openclaw-bootstrap-state-",
     });
+  });
+
+  it("excludes lower-trust root memory before hooks while preserving trusted user context", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-memory-provenance-");
+    await fs.writeFile(path.join(workspaceDir, DEFAULT_MEMORY_FILENAME), "tainted memory", "utf8");
+    await fs.writeFile(path.join(workspaceDir, DEFAULT_USER_FILENAME), "trusted user", "utf8");
+    registerNamedBootstrapFileHook(DEFAULT_MEMORY_FILENAME);
+    memoryRuntimeMocks.classifyWorkspacePaths.mockResolvedValue([
+      { relativePath: DEFAULT_MEMORY_FILENAME, originClass: "untrusted" },
+      { relativePath: DEFAULT_USER_FILENAME, originClass: "owner" },
+    ]);
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: {},
+      agentId: "main",
+    });
+
+    expect(files.map((file) => file.name)).not.toContain(DEFAULT_MEMORY_FILENAME);
+    expect(files.map((file) => file.name)).toContain(DEFAULT_USER_FILENAME);
+  });
+
+  it("fails closed when the memory runtime omits a requested root classification", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-missing-provenance-");
+    await fs.writeFile(path.join(workspaceDir, DEFAULT_MEMORY_FILENAME), "memory", "utf8");
+    await fs.writeFile(path.join(workspaceDir, DEFAULT_USER_FILENAME), "user", "utf8");
+    memoryRuntimeMocks.classifyWorkspacePaths.mockResolvedValue([
+      { relativePath: DEFAULT_MEMORY_FILENAME, originClass: "agent" },
+    ]);
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: {},
+      agentId: "main",
+    });
+
+    expect(files.map((file) => file.name)).toContain(DEFAULT_MEMORY_FILENAME);
+    expect(files.map((file) => file.name)).not.toContain(DEFAULT_USER_FILENAME);
   });
   afterEach(async () => {
     clearInternalHooks();

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -259,9 +259,9 @@ async function resolveIneligibleAutomaticMemoryFiles(params: {
   const relativePaths = candidates.map((file) =>
     path.relative(resolveUserPath(params.workspaceDir), file.path).replaceAll(path.sep, "/"),
   );
-  let classifications: Array<{ relativePath: string; originClass: string }> | undefined;
+  let classificationResult: Awaited<ReturnType<typeof classifyActiveMemoryWorkspacePaths>>;
   try {
-    classifications = await classifyActiveMemoryWorkspacePaths({
+    classificationResult = await classifyActiveMemoryWorkspacePaths({
       cfg: params.config,
       agentId,
       workspaceDir: params.workspaceDir,
@@ -271,10 +271,18 @@ async function resolveIneligibleAutomaticMemoryFiles(params: {
     params.warn?.(`excluding automatic memory context: ${String(error)}`);
     return candidates;
   }
-  if (!classifications) {
+  if (classificationResult.status === "unavailable") {
     return [];
   }
-  const origins = new Map(classifications.map((entry) => [entry.relativePath, entry.originClass]));
+  if (classificationResult.status === "unsupported") {
+    params.warn?.(
+      "excluding automatic memory context: selected memory runtime does not support provenance classification",
+    );
+    return candidates;
+  }
+  const origins = new Map(
+    classificationResult.classifications.map((entry) => [entry.relativePath, entry.originClass]),
+  );
   return candidates.filter(
     (_file, index) =>
       !isMemoryOriginEligibleForAutomaticInjection(origins.get(relativePaths[index]!)),

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -8,8 +8,10 @@ import type { ChatType } from "../channels/chat-type.js";
 import { readRecentSessionTranscriptActiveEvents } from "../config/sessions/session-accessor.js";
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isMemoryOriginEligibleForAutomaticInjection } from "../memory-host-sdk/host/types.js";
+import { classifyActiveMemoryWorkspacePaths } from "../plugins/memory-runtime.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import type { BootstrapContextRunKind } from "./bootstrap-mode.js";
@@ -23,6 +25,7 @@ import type { AgentRunSessionTarget } from "./run-session-target.js";
 import {
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_MEMORY_FILENAME,
+  DEFAULT_USER_FILENAME,
   filterBootstrapFilesForSession,
   isWorkspaceSetupCompleted,
   loadWorkspaceBootstrapFiles,
@@ -207,16 +210,75 @@ function filterBootstrapFilesAfterHooks(params: {
     chatType?: ChatType;
     workspaceDir: string;
   };
-  protectedRootMemoryFile?: WorkspaceBootstrapFile;
+  protectedFiles?: WorkspaceBootstrapFile[];
 }): WorkspaceBootstrapFile[] {
   const sessionFiltered = filterBootstrapFilesForSession(params.files, params.session);
-  const rootMemoryFile = params.protectedRootMemoryFile;
-  if (!rootMemoryFile) {
+  const protectedFiles = params.protectedFiles ?? [];
+  if (protectedFiles.length === 0) {
     return sessionFiltered;
   }
   // Hooks can relabel or alias loader-produced records. Reapply lexical/session
-  // policy first, then enforce the root-memory source captured by the pinned open.
-  return sessionFiltered.filter((file) => !workspaceFilesShareSourceIdentity(file, rootMemoryFile));
+  // policy first, then enforce protected sources captured by the pinned opens.
+  return sessionFiltered.filter(
+    (file) =>
+      !protectedFiles.some((protectedFile) => {
+        if (workspaceFilesShareSourceIdentity(file, protectedFile)) {
+          return true;
+        }
+        const filePath = normalizeOptionalString(file.path);
+        const protectedPath = normalizeOptionalString(protectedFile.path);
+        return Boolean(
+          filePath && protectedPath && path.resolve(filePath) === path.resolve(protectedPath),
+        );
+      }),
+  );
+}
+
+async function resolveIneligibleAutomaticMemoryFiles(params: {
+  files: WorkspaceBootstrapFile[];
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  warn?: (message: string) => void;
+}): Promise<WorkspaceBootstrapFile[]> {
+  const candidates = params.files.filter(
+    (file) =>
+      !file.missing &&
+      (file.name === DEFAULT_MEMORY_FILENAME || file.name === DEFAULT_USER_FILENAME),
+  );
+  if (candidates.length === 0 || !params.config) {
+    return [];
+  }
+  let agentId: string;
+  try {
+    agentId = params.agentId ?? resolveDefaultAgentId(params.config);
+  } catch (error) {
+    params.warn?.(`excluding automatic memory context: ${String(error)}`);
+    return candidates;
+  }
+  const relativePaths = candidates.map((file) =>
+    path.relative(resolveUserPath(params.workspaceDir), file.path).replaceAll(path.sep, "/"),
+  );
+  let classifications: Array<{ relativePath: string; originClass: string }> | undefined;
+  try {
+    classifications = await classifyActiveMemoryWorkspacePaths({
+      cfg: params.config,
+      agentId,
+      workspaceDir: params.workspaceDir,
+      relativePaths,
+    });
+  } catch (error) {
+    params.warn?.(`excluding automatic memory context: ${String(error)}`);
+    return candidates;
+  }
+  if (!classifications) {
+    return [];
+  }
+  const origins = new Map(classifications.map((entry) => [entry.relativePath, entry.originClass]));
+  return candidates.filter(
+    (_file, index) =>
+      !isMemoryOriginEligibleForAutomaticInjection(origins.get(relativePaths[index]!)),
+  );
 }
 
 /** Resolves hook-adjusted, session-filtered bootstrap files for a run. */
@@ -248,6 +310,13 @@ export async function resolveBootstrapFilesForRun(params: {
         sessionKey: params.sessionKey,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+  const ineligibleAutomaticMemoryFiles = await resolveIneligibleAutomaticMemoryFiles({
+    files: rawFiles,
+    workspaceDir: params.workspaceDir,
+    config: params.config,
+    agentId: params.agentId,
+    warn: params.warn,
+  });
   const rootMemoryFile = rawFiles.find(
     (file) => file.name === DEFAULT_MEMORY_FILENAME && !file.missing,
   );
@@ -255,9 +324,18 @@ export async function resolveBootstrapFilesForRun(params: {
     rootMemoryFile && filterBootstrapFilesForSession([rootMemoryFile], session).length === 0
       ? rootMemoryFile
       : undefined;
+  const protectedFiles = [
+    ...(protectedRootMemoryFile ? [protectedRootMemoryFile] : []),
+    ...ineligibleAutomaticMemoryFiles,
+  ];
   const bootstrapFiles = applyContextModeFilter({
     files: filterCompletedWorkspaceBootstrapFile(
-      filterBootstrapFilesForSession(rawFiles, session),
+      filterBootstrapFilesForSession(rawFiles, session).filter(
+        (file) =>
+          !ineligibleAutomaticMemoryFiles.some((ineligible) =>
+            workspaceFilesShareSourceIdentity(file, ineligible),
+          ),
+      ),
       workspaceSetupCompleted,
       params.workspaceDir,
     ),
@@ -277,7 +355,7 @@ export async function resolveBootstrapFilesForRun(params: {
     filterBootstrapFilesAfterHooks({
       files: updated,
       session,
-      protectedRootMemoryFile,
+      protectedFiles,
     }),
     workspaceSetupCompleted,
     params.workspaceDir,

--- a/src/agents/project-memory-bootstrap.test.ts
+++ b/src/agents/project-memory-bootstrap.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MemorySearchResult } from "../memory-host-sdk/host/types.js";
 import {
   buildProjectMemoryWriteInstruction,
   filterProjectScopedCuratedContextFiles,
@@ -22,7 +23,7 @@ describe("project memory bootstrap", () => {
     runtimeMocks.search.mockReset();
   });
 
-  const entries = [
+  const entries: MemorySearchResult[] = [
     {
       path: "MEMORY.md",
       startLine: 2,
@@ -33,6 +34,11 @@ describe("project memory bootstrap", () => {
       source: "memory" as const,
       projectKey: "github.com/OpenClaw/OpenClaw",
       importance: 8,
+      provenance: {
+        originClass: "owner" as const,
+        sessionKind: "interactive" as const,
+        observedAt: 1,
+      },
     },
     {
       path: "MEMORY.md",
@@ -43,6 +49,11 @@ describe("project memory bootstrap", () => {
       source: "memory" as const,
       projectKey: "github.com/example/other",
       importance: 10,
+      provenance: {
+        originClass: "owner" as const,
+        sessionKind: "interactive" as const,
+        observedAt: 1,
+      },
     },
   ];
 
@@ -58,10 +69,30 @@ describe("project memory bootstrap", () => {
   }
 
   it("includes only active-project entries and stays inside its budget", async () => {
-    const lines = await prepareEntries(entries);
+    const lines = await prepareEntries([
+      ...entries,
+      {
+        ...entries[0]!,
+        startLine: 4,
+        snippet: "Untrusted project instruction.",
+        provenance: {
+          originClass: "untrusted",
+          sessionKind: "interactive",
+          observedAt: 1,
+        },
+      },
+      {
+        ...entries[0]!,
+        startLine: 5,
+        snippet: "Missing-provenance project instruction.",
+        provenance: undefined,
+      },
+    ]);
     const rendered = lines.join("\n");
     expect(rendered).toContain("Use the release helper.");
     expect(rendered).not.toContain("Foreign fact");
+    expect(rendered).not.toContain("Untrusted project instruction");
+    expect(rendered).not.toContain("Missing-provenance project instruction");
     expect(rendered).not.toContain("<!--");
     expect(rendered.length).toBeLessThanOrEqual(2_000);
   });

--- a/src/agents/project-memory-bootstrap.ts
+++ b/src/agents/project-memory-bootstrap.ts
@@ -5,7 +5,10 @@ import {
   stripMemoryAnnotationCarriers,
 } from "../../packages/memory-host-sdk/src/engine-storage.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { MemorySearchResult } from "../memory-host-sdk/host/types.js";
+import {
+  isAutomaticMemoryEntryEligible,
+  type MemorySearchResult,
+} from "../memory-host-sdk/host/types.js";
 import { getMemoryRuntime } from "../plugins/memory-state.js";
 import type { EmbeddedContextFile } from "./embedded-agent-helpers.js";
 
@@ -76,6 +79,7 @@ function buildProjectMemoryBootstrap(params: {
         .map((key) => key.trim())
         .filter(Boolean);
       return (
+        isAutomaticMemoryEntryEligible(entry) &&
         storedProjectKeys !== undefined &&
         storedProjectKeys.length > 0 &&
         storedProjectKeys.every((key) => active.has(key)) &&

--- a/src/auto-reply/reply/commands-system-prompt.test.ts
+++ b/src/auto-reply/reply/commands-system-prompt.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { createOpenClawCodingTools } from "../../agents/agent-tools.js";
-import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
+import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import {
   ensureSandboxWorkspaceForSession,
   resolveSandboxRuntimeStatus,
@@ -16,11 +16,18 @@ import { resolveReusableWorkspaceSkillSnapshot } from "../../skills/runtime/sess
 import { resolveCommandsSystemPromptBundle } from "./commands-system-prompt.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
-const { createOpenClawCodingToolsMock } = vi.hoisted(() => ({
+const { createOpenClawCodingToolsMock, logWarnMock, makeBootstrapWarnMock } = vi.hoisted(() => ({
   createOpenClawCodingToolsMock: vi.fn(() => []),
+  logWarnMock: vi.fn(),
+  makeBootstrapWarnMock: vi.fn((params: { warn?: (message: string) => void }) => params.warn),
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({ warn: logWarnMock })),
 }));
 
 vi.mock("../../agents/bootstrap-files.js", () => ({
+  makeBootstrapWarn: makeBootstrapWarnMock,
   resolveBootstrapContextForRun: vi.fn(async () => ({
     bootstrapFiles: [],
     contextFiles: [],
@@ -201,6 +208,26 @@ describe("resolveCommandsSystemPromptBundle", () => {
       "resolveBootstrapContextForRun",
     );
     expect(bootstrapParams.agentId).toBe("target");
+  });
+
+  it("records bootstrap exclusions for generated command prompts", async () => {
+    const params = makeParams();
+
+    await resolveCommandsSystemPromptBundle(params);
+
+    expect(vi.mocked(makeBootstrapWarn)).toHaveBeenCalledWith({
+      sessionLabel: "agent:main:default",
+      workspaceDir: "/tmp/workspace",
+      warn: expect.any(Function),
+    });
+    const bootstrapParams = requireFirstArg(
+      vi.mocked(resolveBootstrapContextForRun),
+      "resolveBootstrapContextForRun",
+    );
+    const warn = bootstrapParams.warn as ((message: string) => void) | undefined;
+    expect(warn).toEqual(expect.any(Function));
+    warn?.("excluding automatic memory context");
+    expect(logWarnMock).toHaveBeenCalledWith("excluding automatic memory context");
   });
 
   it("prefers the target session entry for bootstrap and tool metadata", async () => {

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -2,7 +2,7 @@
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { createOpenClawCodingTools } from "../../agents/agent-tools.js";
-import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
+import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import type { EmbeddedContextFile } from "../../agents/embedded-agent-helpers.js";
 import { resolveEmbeddedFullAccessState } from "../../agents/embedded-agent-runner/sandbox-info.js";
 import {
@@ -20,6 +20,7 @@ import {
 import { buildConfiguredAgentSystemPrompt } from "../../agents/system-prompt-config.js";
 import { buildSystemPromptParams } from "../../agents/system-prompt-params.js";
 import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
 import { resolveSkillsPrompt } from "../../skills/loading/workspace-skill-prompt.js";
 import { resolveEmbeddedRunSkillEntries } from "../../skills/runtime/embedded-run-entries.js";
@@ -28,6 +29,8 @@ import { resolveReusableWorkspaceSkillSnapshot } from "../../skills/runtime/sess
 import type { SkillEligibilityContext } from "../../skills/types.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
+
+const log = createSubsystemLogger("auto-reply/commands-system-prompt");
 
 type CommandsSystemPromptBundle = {
   systemPrompt: string;
@@ -176,6 +179,11 @@ export async function resolveCommandsSystemPromptBundle(
     sessionId: targetSessionEntry?.sessionId,
     chatType: targetSessionEntry?.chatType,
     agentId: sessionAgentId,
+    warn: makeBootstrapWarn({
+      sessionLabel: params.sessionKey,
+      workspaceDir,
+      warn: (message) => log.warn(message),
+    }),
   });
   const toolPolicySessionKey = resolveRuntimePolicySessionKey({
     agentId: sessionAgentId,

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -21,6 +21,8 @@ export {
   ensureMemoryPathFtsTriggers,
   hashText,
   INVALID_PROJECT_ANNOTATION_KEY,
+  isAutomaticMemoryEntryEligible,
+  isMemoryOriginEligibleForAutomaticInjection,
   isFileMissingError,
   isTransientMemoryReadError,
   listMemoryFiles,

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -413,10 +413,32 @@ describe("memory runtime handles", () => {
         workspaceDir: "/workspace/main",
         relativePaths: ["MEMORY.md", "USER.md"],
       }),
-    ).resolves.toEqual([
-      { relativePath: "MEMORY.md", originClass: "untrusted" },
-      { relativePath: "USER.md", originClass: "owner" },
-    ]);
+    ).resolves.toEqual({
+      status: "classified",
+      classifications: [
+        { relativePath: "MEMORY.md", originClass: "untrusted" },
+        { relativePath: "USER.md", originClass: "owner" },
+      ],
+    });
+  });
+
+  it("distinguishes a selected runtime without workspace provenance support", async () => {
+    const runtimeWithoutClassifier = {
+      getMemorySearchManager: vi.fn(async () => ({ manager: null, error: "no index" })),
+      resolveMemoryBackendConfig: vi.fn(() => ({ backend: "builtin" as const })),
+    } satisfies MemoryPluginRuntime;
+    mocks.loadPluginRegistryHandle.mockReturnValue(
+      createRegistry(runtimeWithoutClassifier).registry,
+    );
+
+    await expect(
+      classifyActiveMemoryWorkspacePaths({
+        cfg: memoryConfig,
+        agentId: "main",
+        workspaceDir: "/workspace/main",
+        relativePaths: ["MEMORY.md", "USER.md"],
+      }),
+    ).resolves.toEqual({ status: "unsupported" });
   });
 
   it("fails closed on session hits when a memory runtime has no authorizer", async () => {

--- a/src/plugins/memory-runtime.test.ts
+++ b/src/plugins/memory-runtime.test.ts
@@ -14,6 +14,9 @@ import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
 
 type AuthorizeSearchHits = NonNullable<MemoryPluginRuntime["authorizeSearchHits"]>;
+type ClassifyWorkspaceMemoryPaths = NonNullable<
+  MemoryPluginRuntime["classifyWorkspaceMemoryPaths"]
+>;
 
 const mocks = vi.hoisted(() => ({
   getMemoryRuntime: vi.fn(),
@@ -38,6 +41,7 @@ vi.mock("./memory-state.js", async (importOriginal) => {
 
 import {
   authorizeActiveMemorySearchHits,
+  classifyActiveMemoryWorkspacePaths,
   closeActiveMemorySearchManagerCore,
   closeActiveMemorySearchManagersCore,
   getActiveMemorySearchManagerCore,
@@ -49,6 +53,9 @@ import { hasMemoryRuntime } from "./memory-state.js";
 function createRuntime() {
   return {
     authorizeSearchHits: vi.fn<AuthorizeSearchHits>(async ({ hits }) => hits),
+    classifyWorkspaceMemoryPaths: vi.fn<ClassifyWorkspaceMemoryPaths>(async ({ relativePaths }) =>
+      relativePaths.map((relativePath) => ({ relativePath, originClass: "agent" as const })),
+    ),
     getMemorySearchManager: vi.fn(async () => ({ manager: null, error: "no index" })),
     resolveMemoryBackendConfig: vi.fn(() => ({ backend: "builtin" as const })),
     closeMemorySearchManager: vi.fn(async () => {}),
@@ -386,6 +393,30 @@ describe("memory runtime handles", () => {
         hits,
       }),
     ).resolves.toEqual([hits[0]]);
+  });
+
+  it("classifies workspace paths inside the selected plugin runtime scope", async () => {
+    const { registry, runtime } = createRegistry();
+    runtime.classifyWorkspaceMemoryPaths.mockImplementationOnce(async ({ relativePaths }) => {
+      expect(getPluginRuntimeGatewayRequestScope()?.pluginRegistry).toBe(registry);
+      return relativePaths.map((relativePath) => ({
+        relativePath,
+        originClass: relativePath === "MEMORY.md" ? "untrusted" : "owner",
+      }));
+    });
+    mocks.loadPluginRegistryHandle.mockReturnValue(registry);
+
+    await expect(
+      classifyActiveMemoryWorkspacePaths({
+        cfg: memoryConfig,
+        agentId: "main",
+        workspaceDir: "/workspace/main",
+        relativePaths: ["MEMORY.md", "USER.md"],
+      }),
+    ).resolves.toEqual([
+      { relativePath: "MEMORY.md", originClass: "untrusted" },
+      { relativePath: "USER.md", originClass: "owner" },
+    ]);
   });
 
   it("fails closed on session hits when a memory runtime has no authorizer", async () => {

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -215,15 +215,26 @@ export async function authorizeActiveMemorySearchHits(
 /** Classifies workspace memory paths through the selected memory plugin's provenance owner. */
 export async function classifyActiveMemoryWorkspacePaths(
   params: WorkspaceMemoryPathClassification,
-): Promise<Array<{ relativePath: string; originClass: string }> | undefined> {
+): Promise<
+  | { status: "unavailable" }
+  | { status: "unsupported" }
+  | {
+      status: "classified";
+      classifications: Array<{ relativePath: string; originClass: string }>;
+    }
+> {
   const owner = ensureMemoryRuntime(params);
-  if (!owner?.runtime.classifyWorkspaceMemoryPaths) {
-    return undefined;
+  if (!owner) {
+    return { status: "unavailable" };
   }
-  return await withMemoryRuntimeOwner(
+  if (!owner.runtime.classifyWorkspaceMemoryPaths) {
+    return { status: "unsupported" };
+  }
+  const classifications = await withMemoryRuntimeOwner(
     owner,
     async (runtime) => await runtime.classifyWorkspaceMemoryPaths!(params),
   );
+  return { status: "classified", classifications };
 }
 
 /** Resolves current memory backend config without constructing a manager. */

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -27,6 +27,9 @@ type MemoryRuntime = NonNullable<
 type MemorySearchAuthorization = Parameters<
   NonNullable<MemoryPluginRuntime["authorizeSearchHits"]>
 >[0];
+type WorkspaceMemoryPathClassification = Parameters<
+  NonNullable<MemoryPluginRuntime["classifyWorkspaceMemoryPaths"]>
+>[0];
 type MemoryRuntimeOwner = { runtime: MemoryRuntime; registry?: PluginRegistry };
 let standaloneMemoryRegistrySlot:
   | { key: string; registry: PluginRegistry; retiredRuntimes: Map<MemoryRuntime, PluginRegistry> }
@@ -207,6 +210,20 @@ export async function authorizeActiveMemorySearchHits(
     }
     return await runtime.authorizeSearchHits(params);
   });
+}
+
+/** Classifies workspace memory paths through the selected memory plugin's provenance owner. */
+export async function classifyActiveMemoryWorkspacePaths(
+  params: WorkspaceMemoryPathClassification,
+): Promise<Array<{ relativePath: string; originClass: string }> | undefined> {
+  const owner = ensureMemoryRuntime(params);
+  if (!owner?.runtime.classifyWorkspaceMemoryPaths) {
+    return undefined;
+  }
+  return await withMemoryRuntimeOwner(
+    owner,
+    async (runtime) => await runtime.classifyWorkspaceMemoryPaths!(params),
+  );
 }
 
 /** Resolves current memory backend config without constructing a manager. */

--- a/src/plugins/registry-contribution-types.ts
+++ b/src/plugins/registry-contribution-types.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngine } from "../context-engine/types.js";
 import type {
   LegacyMemoryReadResult,
+  MemoryOriginClass,
   MemoryReadResult,
   MemorySearchManager,
   MemorySearchResult,
@@ -279,6 +280,12 @@ export type MemoryPluginRuntime = {
     sandboxed: boolean;
     hits: MemorySearchResult[];
   }): Promise<MemorySearchResult[]>;
+  classifyWorkspaceMemoryPaths?(params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    workspaceDir: string;
+    relativePaths: string[];
+  }): Promise<Array<{ relativePath: string; originClass: MemoryOriginClass }>>;
   closeMemorySearchManager?(params: { cfg: OpenClawConfig; agentId: string }): Promise<void>;
   closeAllMemorySearchManagers?(): Promise<void>;
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where automatic memory context could include content even after the memory provenance owner had classified that content as untrusted.

The affected paths included raw workspace memory bootstrap, project-scoped curated memory, and trigger-based Active Memory recall.

## Why This Change Was Made

Automatic prompt injection now uses one owner/agent provenance eligibility rule. Memory Core supplies authoritative workspace-path classifications through the selected memory runtime, curated database reads retain and enforce chunk provenance, and each automatic consumer applies the shared rule at its boundary.

The shared bootstrap boundary covers normal agent turns and sibling consumers such as prepared compaction, Copilot, Codex, and realtime user context. Explicit memory search remains available for content that is not eligible for automatic injection.

## User Impact

Memory recorded as untrusted or system-originated is no longer inserted automatically into prompts. Owner-authored and agent-authored trusted memory continues to load through the existing automatic context paths.

## Evidence

- Added pre-fix regression coverage for provenance loss in project bootstrap and Active Memory recall.
- 150 focused tests passed across agent bootstrap, plugin runtime selection, Active Memory, Memory Core, and memory-host database contracts.
- `pnpm check:changed` passed, including core and extension typechecks, lint, SDK surface checks, database guards, and runtime import-cycle checks.
- `pnpm build` passed.
- Memory Core extension import/memory profiling passed.
- Structured autoreview reported no accepted or actionable findings.

The focused integration coverage also verifies that explicitly searching quarantined memory still returns it while both automatic candidate APIs exclude it.

### Real behavior proof

An exact-head clean-machine run exercised the production `openclaw agent --local` entry point, real `web_fetch` and `write` tools, Memory Core persistence/indexing, final provider-request construction, and the public memory-search CLI. A controlled OpenAI-compatible capture endpoint observed the outbound request; it did not replace the bootstrap, provenance, tool, indexing, or prompt-building paths under test.

- Exact head: `8095fc17c7b54e62f9aabf3867aa6749e0ed5511`
- Environment: direct AWS Crabbox, Node 24, ephemeral OpenClaw state/workspace
- Run: [Crabbox clean-machine proof](https://crabbox.openclaw.ai/portal/runs/run_ff8ecba2f61a)
- Result: exit `0`; lease stopped after completion

```text
HEAD=8095fc17c7b54e62f9aabf3867aa6749e0ed5511
trusted_root_memory_in_final_provider_request=true
recorded_root_memory_origin=untrusted
quarantined_root_memory_in_final_provider_request=false
quarantined_root_memory_found_by_explicit_search=true
RESULT=PASS
```

This directly demonstrates the changed user-visible boundary: trusted root memory still reaches the model request, quarantined root memory does not, and quarantine does not delete or hide the memory from an explicit operator search.
