### PR TITLE
improve: speed up browser extension security test suites

### DIFF
--- a/extensions/browser/chrome-extension/background.test-harness.ts
+++ b/extensions/browser/chrome-extension/background.test-harness.ts
@@ -16,6 +16,10 @@ const PAIRING_CONFIG_KEYS = ["relayUrl", "token", "pairingStatus"];
 const RETIRED_CUSTODY_BLOCKED_KEY = "retiredCopilotCustodyBlockedV1";
 const backgroundCleanups = new Set<() => Promise<void>>();
 
+function waitForBackgroundState<T>(assertion: () => T | Promise<T>): Promise<T> {
+  return vi.waitFor(assertion, { interval: 1 });
+}
+
 export async function cleanupBackgroundHarnesses(): Promise<void> {
   await Promise.all([...backgroundCleanups].map(async (cleanup) => await cleanup()));
 }
@@ -388,7 +392,7 @@ export async function loadBackground({
   const backgroundModulePath = "./background.js";
   await import(backgroundModulePath);
   if (!deferRetiredStatePreparation) {
-    await vi.waitFor(() => {
+    await waitForBackgroundState(() => {
       const pairingReads = storageGet.mock.calls.filter(([keys]) =>
         PAIRING_CONFIG_KEYS.every((key) => keys.includes(key)),
       );
@@ -396,7 +400,7 @@ export async function loadBackground({
     });
   }
   if (!deferTabAccessInitialization && !deferRetiredStatePreparation) {
-    await vi.waitFor(() => {
+    await waitForBackgroundState(() => {
       const pairingWasCleared = storageRemove.mock.calls.some(([keys]) =>
         keys.includes("relayUrl"),
       );
@@ -482,7 +486,7 @@ export async function loadBackground({
       if (socket.readyState !== FakeWebSocket.OPEN) {
         socket.open();
       }
-      await vi.waitFor(() => expect(socket.send).toHaveBeenCalled());
+      await waitForBackgroundState(() => expect(socket.send).toHaveBeenCalled());
       const helloRaw = socket.send.mock.calls.find(
         ([raw]) => JSON.parse(raw).type === "auth.hello",
       )?.[0];
@@ -511,7 +515,7 @@ export async function loadBackground({
         ...fields,
         serverProof: await computeRelayAuthProof(String(storageValues.token), "server", fields),
       });
-      await vi.waitFor(() => {
+      await waitForBackgroundState(() => {
         expect(
           socket.send.mock.calls.some(([raw]) => JSON.parse(raw).type === "auth.response"),
         ).toBe(true);
@@ -534,7 +538,7 @@ export async function loadBackground({
           response.clientProof,
         ),
       });
-      await vi.waitFor(() => {
+      await waitForBackgroundState(() => {
         expect(socket.send.mock.calls.some(([raw]) => JSON.parse(raw).type === "hello")).toBe(true);
       });
     },


### PR DESCRIPTION
## What Problem This Solves

Browser-extension access-mode and background security tests spend about half of their wall time waiting for Vitest's default 50 ms observation interval after real asynchronous relay authentication and extension initialization have already completed.

## Why This Change Was Made

Keep completion observation in the shared browser-extension test harness, preserve Vitest's existing timeout and every security assertion, and observe the same state at a 1 ms interval. No production code, extension lifecycle, relay protocol, authentication, access-control behavior, or test coverage changes.

## User Impact

No shipped behavior changes. Developers and CI receive the same browser-extension security and lifecycle proof approximately 6.7 seconds sooner per serial run.

## Evidence

Measured on the same Blacksmith Testbox, using one Vitest worker, one excluded warmup per condition, two retained samples per condition, separate filesystem module-cache paths, import-duration diagnostics, and `/usr/bin/time -v`:

| Condition | Retained wall samples | Mean wall | Test count | Import count |
| --- | --- | --- | --- | --- |
| Before | 13.50 s, 13.27 s | 13.385 s | 56 | 20 |
| After | 6.67 s, 6.72 s | 6.695 s | 56 | 20 |

That is a stable **6.690 s / 49.98% reduction**. Baseline Vitest test bodies took 9.84 s and 9.80 s; the measured after sample took 3.08 s. Mean maximum RSS changed from 524,786 KiB to 516,596 KiB, while user/system CPU and the import graph remained effectively unchanged.

The seven directly relevant browser-extension access, lifecycle, HMAC authentication, tab-access, native-bootstrap, and command-handler suites pass **126 tests**. Reversible mutation proof changed the relay challenge proof from the server key to the client key: the authority-revocation test failed at the original authentication assertion; restoring the server proof made the same test pass again. The complete changed-file gate passes, and fresh structured review found no actionable issues.

Production LOC: +0/-0. Test-support LOC: +9/-5. The default 1,000 ms timeout and all existing tests/assertions remain unchanged.
