### PR TITLE
fix: explicit session resets clear prior context

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files-reset-revision.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files-reset-revision.test.ts
@@ -88,7 +88,7 @@ describe("SQLite session reset content revision", () => {
         sessionId,
         updatedAt: 2,
       }),
-      resetBoundaryReason: "reset",
+      resetBoundary: { context: "preserve-tail", reason: "reset" },
       storePath,
       target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
     });

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3741,62 +3741,66 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     expect(result.isNewSession).toBe(false);
     expect(result.sessionId).toBe(existingSessionId);
   });
-  it("retains the transcript in place on /new", async () => {
-    const storePath = await createStorePath("openclaw-archive-old-");
-    const sessionKey = "agent:main:telegram:dm:user-archive";
-    const existingSessionId = "existing-session-archive";
-    await seedSessionStoreWithOverrides({
-      storePath,
-      sessionKey,
-      sessionId: existingSessionId,
-      overrides: { verboseLevel: "on" },
-    });
-    await appendTranscriptMessage(
-      { agentId: "main", sessionId: existingSessionId, sessionKey, storePath },
-      { message: { role: "user", content: "kept question" } },
-    );
-    await appendTranscriptMessage(
-      { agentId: "main", sessionId: existingSessionId, sessionKey, storePath },
-      { message: { role: "assistant", content: "kept answer" } },
-    );
+  it.each(["/new", "/reset"] as const)(
+    "retains the transcript but clears prior context on %s",
+    async (command) => {
+      const slug = command.slice(1);
+      const storePath = await createStorePath(`openclaw-archive-old-${slug}-`);
+      const sessionKey = `agent:main:telegram:dm:user-archive-${slug}`;
+      const existingSessionId = `existing-session-archive-${slug}`;
+      await seedSessionStoreWithOverrides({
+        storePath,
+        sessionKey,
+        sessionId: existingSessionId,
+        overrides: { verboseLevel: "on" },
+      });
+      await appendTranscriptMessage(
+        { agentId: "main", sessionId: existingSessionId, sessionKey, storePath },
+        { message: { role: "user", content: "kept question" } },
+      );
+      await appendTranscriptMessage(
+        { agentId: "main", sessionId: existingSessionId, sessionKey, storePath },
+        { message: { role: "assistant", content: "kept answer" } },
+      );
 
-    const cfg = {
-      session: { store: storePath, idleMinutes: 999 },
-    } as OpenClawConfig;
+      const cfg = {
+        session: { store: storePath, idleMinutes: 999 },
+      } as OpenClawConfig;
 
-    const result = await initSessionState({
-      ctx: {
-        Body: "/new",
-        RawBody: "/new",
-        CommandBody: "/new",
-        From: "user-archive",
-        To: "bot",
-        ChatType: "direct",
-        SessionKey: sessionKey,
-        Provider: "telegram",
-        Surface: "telegram",
-      },
-      cfg,
-    });
+      const result = await initSessionState({
+        ctx: {
+          Body: command,
+          RawBody: command,
+          CommandBody: command,
+          From: "user-archive",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+      });
 
-    expect(result.isNewSession).toBe(true);
-    expect(result.resetTriggered).toBe(true);
-    expect(result.sessionId).toBe(existingSessionId);
-    const events = await loadTranscriptEvents({
-      agentId: "main",
-      sessionId: existingSessionId,
-      sessionKey,
-      storePath,
-    });
-    expect(events.map((event) => (event as { type?: unknown }).type)).toContain("reset");
-    expect(
-      events.findLast((event) => (event as { type?: unknown }).type === "reset"),
-    ).toMatchObject({ reason: "new", firstKeptEntryId: expect.any(String) });
-    const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
-      entry.startsWith(`${existingSessionId}.jsonl.reset.`),
-    );
-    expect(archived).toHaveLength(0);
-  });
+      expect(result.isNewSession).toBe(true);
+      expect(result.resetTriggered).toBe(true);
+      expect(result.sessionId).toBe(existingSessionId);
+      const events = await loadTranscriptEvents({
+        agentId: "main",
+        sessionId: existingSessionId,
+        sessionKey,
+        storePath,
+      });
+      expect(events.map((event) => (event as { type?: unknown }).type)).toContain("reset");
+      const resetEvent = events.findLast((event) => (event as { type?: unknown }).type === "reset");
+      expect(resetEvent).toMatchObject({ reason: slug });
+      expect(resetEvent).not.toHaveProperty("firstKeptEntryId");
+      const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
+        entry.startsWith(`${existingSessionId}.jsonl.reset.`),
+      );
+      expect(archived).toHaveLength(0);
+    },
+  );
 
   it("drains foreign work before appending a reply reset boundary", async () => {
     const storePath = await createStorePath("openclaw-rollover-admission-");
@@ -4125,7 +4129,9 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     vi.useFakeTimers();
     try {
       // Simulate: it is 5am, session was last active at 3am (before 4am daily boundary)
-      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const now = new Date(2026, 0, 18, 5, 0, 0);
+      const sessionStart = new Date(2026, 0, 18, 3, 0, 0);
+      vi.setSystemTime(now);
       const storePath = await createStorePath("openclaw-stale-archive-");
       const sessionKey = "agent:main:telegram:dm:archive-stale-user";
       const existingSessionId = "stale-session-to-be-archived";
@@ -4134,10 +4140,26 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       await writeSessionStoreFast(storePath, {
         [sessionKey]: {
           sessionId: existingSessionId,
-          updatedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+          updatedAt: sessionStart.getTime(),
         },
       });
       await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf8");
+      vi.setSystemTime(sessionStart);
+      await appendTranscriptMessage(
+        { agentId: "main", sessionId: existingSessionId, sessionKey, storePath },
+        { message: { role: "user", content: "question before daily rollover" } },
+      );
+      await appendTranscriptMessage(
+        { agentId: "main", sessionId: existingSessionId, sessionKey, storePath },
+        { message: { role: "assistant", content: "answer before daily rollover" } },
+      );
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: sessionStart.getTime(),
+        },
+      });
+      vi.setSystemTime(now);
 
       const cfg = {
         session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
@@ -4165,6 +4187,15 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         entry.startsWith(`${existingSessionId}.jsonl.reset.`),
       );
       expect(archived).toHaveLength(0);
+      const events = await loadTranscriptEvents({
+        agentId: "main",
+        sessionId: existingSessionId,
+        sessionKey,
+        storePath,
+      });
+      expect(
+        events.findLast((event) => (event as { type?: unknown }).type === "reset"),
+      ).toMatchObject({ reason: "daily", firstKeptEntryId: expect.any(String) });
     } finally {
       vi.useRealTimers();
     }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -41,6 +41,7 @@ import {
   type SessionCreatedActor,
 } from "../../config/sessions/session-entry-provenance.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
+import type { SessionResetBoundaryRequest } from "../../config/sessions/session-reset-boundary-event.js";
 import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import { runExclusiveSessionStoreWrite } from "../../config/sessions/store-writer.js";
@@ -140,7 +141,9 @@ type ReplySessionEndReason = Extract<
   "new" | "reset" | "idle" | "daily" | "unknown"
 >;
 
-function resolveExplicitSessionEndReason(matchedResetTriggerLower?: string): ReplySessionEndReason {
+function resolveExplicitSessionEndReason(
+  matchedResetTriggerLower?: string,
+): Extract<ReplySessionEndReason, "new" | "reset"> {
   return matchedResetTriggerLower === "/reset" ? "reset" : "new";
 }
 
@@ -973,14 +976,16 @@ async function initSessionStateAttemptLocked(
     // snapshot through /new; the next turn must rebuild the visible skill list.
     sessionEntry.skillsSnapshot = undefined;
   }
-  const resetReason =
-    previousSessionEndReason === "new" ||
-    previousSessionEndReason === "reset" ||
-    previousSessionEndReason === "idle" ||
-    previousSessionEndReason === "daily"
+  const continuityReason =
+    previousSessionEndReason === "idle" || previousSessionEndReason === "daily"
       ? previousSessionEndReason
       : "reset";
-  const resetBoundaryAppended = previousSessionEntry !== undefined;
+  const resetBoundary: SessionResetBoundaryRequest | undefined = previousSessionEntry
+    ? resetTriggered
+      ? { context: "clear", reason: resolveExplicitSessionEndReason(matchedResetTriggerLower) }
+      : { context: "preserve-tail", reason: continuityReason }
+    : undefined;
+  const resetBoundaryAppended = resetBoundary !== undefined;
   const committed = await commitReplySessionInitialization({
     activeSessionKey: sessionKey,
     agentId,
@@ -1015,7 +1020,7 @@ async function initSessionStateAttemptLocked(
         warn: (message) => log.warn(message),
       });
     },
-    ...(previousSessionEntry ? { resetBoundaryReason: resetReason } : {}),
+    ...(resetBoundary ? { resetBoundary } : {}),
     beforeEntryMutation: ({ currentEntry, sessionEntry: entryToCommit }) => {
       if (!previousSessionEntry || !currentEntry) {
         return;

--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../types.openclaw.js";
 import type { ConversationRouteContext } from "./conversation-route-context.js";
 import type { SessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.types.js";
-import type { SessionResetBoundaryReason } from "./session-reset-boundary-event.js";
+import type { SessionResetBoundaryRequest } from "./session-reset-boundary-event.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 export type SessionLifecycleArtifactCleanupParams = {
@@ -60,7 +60,7 @@ export type ResetSessionEntryLifecycleParams = {
     primaryKey: string;
   }) => Promise<SessionEntry> | SessionEntry;
   /** Atomically append this boundary with the reset entry mutation. */
-  resetBoundaryReason?: SessionResetBoundaryReason;
+  resetBoundary?: SessionResetBoundaryRequest;
   /** Explicit store target for SQLite session ownership. */
   storePath: string;
   /** Canonical key plus aliases that identify the logical entry. */
@@ -140,9 +140,9 @@ export class SessionEntryLifecycleUpsertConflictError extends Error {
 
 export type SessionEntryLifecycleUpsert = {
   sessionKey: string;
-  resetBoundaryReason?: SessionResetBoundaryReason;
   /** Authoritative route observation for this write; omitted writes preserve valid evidence. */
   routeContext?: ConversationRouteContext | null;
+  resetBoundary?: SessionResetBoundaryRequest;
 } & (
   | {
       entry: SessionEntry;

--- a/src/config/sessions/session-accessor.reset-boundary-race.test.ts
+++ b/src/config/sessions/session-accessor.reset-boundary-race.test.ts
@@ -54,7 +54,7 @@ describe("reset boundary concurrency", () => {
       reset: async (scope: { sessionId: string; sessionKey: string; storePath: string }) =>
         resetSessionEntryLifecycle({
           buildNextEntry: () => ({ sessionId: "next-single", updatedAt: 20 }),
-          resetBoundaryReason: "reset",
+          resetBoundary: { context: "preserve-tail", reason: "reset" },
           storePath: scope.storePath,
           target: { canonicalKey: scope.sessionKey, storeKeys: [scope.sessionKey] },
         }),
@@ -68,7 +68,7 @@ describe("reset boundary concurrency", () => {
           upserts: [
             {
               entry: { sessionId: "next-bulk", updatedAt: 20 },
-              resetBoundaryReason: "reset",
+              resetBoundary: { context: "preserve-tail", reason: "reset" },
               sessionKey: scope.sessionKey,
             },
           ],

--- a/src/config/sessions/session-accessor.reset.ts
+++ b/src/config/sessions/session-accessor.reset.ts
@@ -28,6 +28,7 @@ import type {
   ReplySessionInitializationCommitContext,
   ReplySessionInitializationCommitResult,
 } from "./session-accessor.types.js";
+import type { SessionResetBoundaryRequest } from "./session-reset-boundary-event.js";
 import { resolveSessionStorePathForScope } from "./session-store-path.js";
 import type {
   ResolvedSessionMaintenanceConfig,
@@ -87,7 +88,7 @@ export async function persistSessionResetLifecycle(params: {
       {
         sessionKey: params.sessionKey,
         entry: params.nextEntry,
-        resetBoundaryReason: "reset",
+        resetBoundary: { context: "preserve-tail", reason: "reset" },
       },
     ],
     skipMaintenance: true,
@@ -156,9 +157,9 @@ export async function commitReplySessionInitialization(params: {
   prepareSessionEntry?: (
     context: ReplySessionInitializationCommitContext,
   ) => Promise<SessionEntry> | SessionEntry;
-  resetBoundaryReason?: import("./session-reset-boundary-event.js").SessionResetBoundaryReason;
   /** Authoritative contextual route facts observed by the admitted inbound turn. */
   routeContext?: ConversationRouteContext | null;
+  resetBoundary?: SessionResetBoundaryRequest;
   previousEntry?: SessionEntry;
   retiredEntry?: SessionEntryRetirement;
   sessionEntry: SessionEntry;
@@ -211,7 +212,7 @@ export async function commitReplySessionInitialization(params: {
     {
       sessionKey: resolved.normalizedKey,
       ...(params.routeContext !== undefined ? { routeContext: params.routeContext } : {}),
-      ...(params.resetBoundaryReason ? { resetBoundaryReason: params.resetBoundaryReason } : {}),
+      ...(params.resetBoundary ? { resetBoundary: params.resetBoundary } : {}),
       buildEntry: async ({ store: currentStore }) => {
         const commitResolved = resolveSessionEntryFromStore({
           store: currentStore,

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -373,7 +373,7 @@ export async function projectSessionEntryLifecycleMutation(
       continue;
     }
     const expectedEntry = store[sessionKey] ? cloneSessionEntry(store[sessionKey]) : undefined;
-    if (upsert.resetBoundaryReason && !expectedEntry) {
+    if (upsert.resetBoundary && !expectedEntry) {
       throw new Error(
         `Cannot append reset boundary without an existing session row: ${sessionKey}`,
       );
@@ -397,7 +397,7 @@ export async function projectSessionEntryLifecycleMutation(
       sessionKey,
       entry: cloned,
       ...(upsert.routeContext !== undefined ? { routeContext: upsert.routeContext } : {}),
-      ...(upsert.resetBoundaryReason ? { resetBoundaryReason: upsert.resetBoundaryReason } : {}),
+      ...(upsert.resetBoundary ? { resetBoundary: upsert.resetBoundary } : {}),
     });
   }
   const referencedSessionIds = collectProjectedReferencedSessionIds({

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
@@ -2,7 +2,7 @@ import type { ConversationRouteContext } from "./conversation-route-context.js";
 import type { SessionLifecycleArchivedTranscript } from "./session-accessor.lifecycle-types.js";
 import type { SessionStateDeletePlan } from "./session-accessor.sqlite-archive.js";
 import type { SessionEntryLifecycleRemoval } from "./session-accessor.sqlite-contract.js";
-import type { SessionResetBoundaryReason } from "./session-reset-boundary-event.js";
+import type { SessionResetBoundaryRequest } from "./session-reset-boundary-event.js";
 import type { SessionEntry } from "./types.js";
 
 // Shared plan shapes only. Runtime ownership stays in maintenance and lifecycle-state.
@@ -40,7 +40,7 @@ export type ProjectedLifecycleMutation = {
     entry: SessionEntry;
     expectedEntry: SessionEntry | undefined;
     routeContext?: ConversationRouteContext | null;
-    resetBoundaryReason?: SessionResetBoundaryReason;
+    resetBoundary?: SessionResetBoundaryRequest;
     sessionKey: string;
   }>;
 };

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -212,7 +212,7 @@ export async function resetSessionEntryLifecycle(
         deletedEntries: deletedOwners,
         commit: async () => {
           const shouldAppendResetBoundary =
-            params.resetBoundaryReason &&
+            params.resetBoundary &&
             current?.entry.sessionId &&
             !sqliteSessionEntriesEqual(current.entry, nextEntry);
           const mutation: ResetSessionEntryLifecycleMutation = {
@@ -222,14 +222,10 @@ export async function resetSessionEntryLifecycle(
           };
           runOpenClawAgentWriteTransaction((transactionDb) => {
             assertLifecycleTargetUnchanged(transactionDb, params.target, current?.entry, "reset");
-            if (
-              shouldAppendResetBoundary &&
-              current?.entry.sessionId &&
-              params.resetBoundaryReason
-            ) {
+            if (shouldAppendResetBoundary && current?.entry.sessionId && params.resetBoundary) {
               const event = buildSessionResetBoundaryEvent({
                 events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId),
-                reason: params.resetBoundaryReason,
+                ...params.resetBoundary,
               });
               const appended = appendTranscriptEventsInTransaction(
                 transactionDb,

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -371,7 +371,7 @@ export async function applySessionEntryLifecycleMutation(params: {
         entry,
         expectedEntry,
         routeContext,
-        resetBoundaryReason,
+        resetBoundary,
       } of projected.upsertedEntries) {
         const sameKeyRemoval = validatedRemovals.find(
           (removal) => removal.sessionKey === sessionKey,
@@ -394,10 +394,10 @@ export async function applySessionEntryLifecycleMutation(params: {
         if (sameKeyRemoval && !shouldRemoveSessionEntry(currentEntry, sameKeyRemoval.removal)) {
           throw new Error(`SQLite session entry has stale lifecycle state for ${sessionKey}`);
         }
-        if (resetBoundaryReason && expectedEntry?.sessionId) {
+        if (resetBoundary && expectedEntry?.sessionId) {
           const event = buildSessionResetBoundaryEvent({
             events: loadTranscriptEventsFromDatabase(transactionDb, expectedEntry.sessionId),
-            reason: resetBoundaryReason,
+            ...resetBoundary,
           });
           const appended = appendTranscriptEventsInTransaction(
             transactionDb,

--- a/src/config/sessions/session-reset-boundary-event.test.ts
+++ b/src/config/sessions/session-reset-boundary-event.test.ts
@@ -18,7 +18,36 @@ function message(params: {
 }
 
 describe("reset boundary planning", () => {
-  it("selects repeated reset tails from the current logical window", async () => {
+  it.each(["new", "reset"] as const)(
+    "cuts prior conversation context for explicit %s boundaries",
+    async (reason) => {
+      const user = message({
+        id: "prior-user",
+        parentId: null,
+        role: "user",
+        content: "discarded",
+        second: 1,
+      });
+      const assistant = message({
+        id: "prior-assistant",
+        parentId: user.id,
+        role: "assistant",
+        content: "discarded answer",
+        second: 2,
+      });
+
+      const event = buildSessionResetBoundaryEvent({
+        context: "clear",
+        events: [user, assistant],
+        reason,
+      });
+
+      expect(event).toMatchObject({ parentId: assistant.id, reason });
+      expect(event).not.toHaveProperty("firstKeptEntryId");
+    },
+  );
+
+  it("retains repeated reset tails for automatic recovery", async () => {
     const oldUser = message({
       id: "old-user",
       parentId: null,
@@ -58,12 +87,14 @@ describe("reset boundary planning", () => {
 
     expect(
       buildSessionResetBoundaryEvent({
+        context: "preserve-tail",
         events: [oldUser, oldAssistant, keptUser, keptAssistant, firstReset],
         reason: "reset",
       }),
     ).toMatchObject({
       parentId: firstReset.id,
       firstKeptEntryId: keptUser.id,
+      reason: "reset",
     });
   });
 
@@ -101,12 +132,14 @@ describe("reset boundary planning", () => {
 
     expect(
       buildSessionResetBoundaryEvent({
+        context: "preserve-tail",
         events: [discarded, keptUser, keptAssistant, compaction],
-        reason: "new",
+        reason: "daily",
       }),
     ).toMatchObject({
       parentId: compaction.id,
       firstKeptEntryId: keptUser.id,
+      reason: "daily",
     });
   });
 });

--- a/src/config/sessions/session-reset-boundary-event.ts
+++ b/src/config/sessions/session-reset-boundary-event.ts
@@ -2,7 +2,14 @@ import { randomUUID } from "node:crypto";
 import { selectRecentUserAssistantReplayRecords } from "./transcript-replay.js";
 import { selectSessionTranscriptLeafControlledPath } from "./transcript-tree.js";
 
-export type SessionResetBoundaryReason = "new" | "reset" | "idle" | "daily" | "cron-stale";
+type SessionResetBoundaryReason = "new" | "reset" | "idle" | "daily" | "cron-stale";
+
+export type SessionResetBoundaryRequest =
+  | { context: "clear"; reason: Extract<SessionResetBoundaryReason, "new" | "reset"> }
+  | {
+      context: "preserve-tail";
+      reason: Extract<SessionResetBoundaryReason, "reset" | "idle" | "daily" | "cron-stale">;
+    };
 
 type SessionResetBoundaryEvent = {
   type: "reset";
@@ -62,10 +69,11 @@ function projectLatestBoundaryWindow(entries: readonly unknown[]): unknown[] {
   return [...kept, ...entries.slice(boundaryIndex + 1)];
 }
 
-export function buildSessionResetBoundaryEvent(params: {
-  events: readonly unknown[];
-  reason: SessionResetBoundaryReason;
-}): SessionResetBoundaryEvent {
+export function buildSessionResetBoundaryEvent(
+  params: {
+    events: readonly unknown[];
+  } & SessionResetBoundaryRequest,
+): SessionResetBoundaryEvent {
   const entries = params.events.filter(
     (event) =>
       event !== null &&
@@ -74,9 +82,10 @@ export function buildSessionResetBoundaryEvent(params: {
       (event as { type?: unknown }).type !== "session",
   );
   const activeEntries = selectSessionTranscriptLeafControlledPath(entries) ?? entries;
-  const keptEntries = selectRecentUserAssistantReplayRecords(
-    projectLatestBoundaryWindow(activeEntries),
-  );
+  const keptEntries =
+    params.context === "preserve-tail"
+      ? selectRecentUserAssistantReplayRecords(projectLatestBoundaryWindow(activeEntries))
+      : [];
   const firstKeptEntryId = recordId(keptEntries[0]);
   return {
     type: "reset",

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -293,7 +293,7 @@ export async function prepareCronRunContext(params: {
           upserts: [
             {
               sessionKey,
-              resetBoundaryReason,
+              resetBoundary: { context: "preserve-tail", reason: resetBoundaryReason },
               buildEntry: ({ currentEntry }) => update(currentEntry),
             },
           ],

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -650,14 +650,13 @@ test("lists and patches session store via sessions.* RPC", async () => {
   const entryAfterReset = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
   expect(deliveryContextFromSession(entryAfterReset)?.accountId).toBe("work");
   expect(deliveryContextFromSession(entryAfterReset)?.threadId).toBe("1737500000.123456");
-  // Retained history stays in the same SQLite transcript behind the reset boundary.
   const resetTranscript = await loadTranscriptRows({
     sessionId: "sess-main",
     sessionKey: "agent:main:main",
     storePath,
   });
-  expect(resetTranscript).toHaveLength(4);
   expect(resetTranscript.at(-1)).toMatchObject({ type: "reset", reason: "reset" });
+  expect(resetTranscript.at(-1)).not.toHaveProperty("firstKeptEntryId");
 
   const badThinking = await directSessionReq("sessions.patch", {
     key: "agent:main:main",

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -1483,7 +1483,7 @@ export async function performGatewaySessionReset(params: {
       const lifecyclePromise = resetSessionEntryLifecycle({
         archivePreviousTranscript: false,
         agentId: target.agentId,
-        resetBoundaryReason: boundaryEntry ? params.reason : undefined,
+        resetBoundary: boundaryEntry ? { context: "clear", reason: params.reason } : undefined,
         storePath,
         target: {
           canonicalKey: target.canonicalKey,


### PR DESCRIPTION
Closes #127513

## Problem

Explicit `/new`, hard `/reset`, and Gateway resets kept a bounded pre-reset message tail in the next model request. Users could ask for a fresh context and still send old work to the model.

## Root cause

Every reset boundary carried only a reason. Boundary construction always selected a replay tail and wrote `firstKeptEntryId`, including for explicit resets.

## Fix

Reset producers now send one closed context request:

- explicit `/new`, hard `/reset`, and Gateway resets use `context: "clear"`;
- automatic role-order recovery, idle or daily rollover, and cron-stale reset use `context: "preserve-tail"`.

The reset-boundary owner selects a tail only for `preserve-tail`. The durable session ID, raw transcript, cursor continuity, route context, and automatic recovery behavior stay unchanged. The old reason-only request is removed.

## Exact-head proof

Head: `e832611107abe7971f0c1646e5dccd40fd9302b7`

- Focused reset and lifecycle tests passed on this head, including both explicit commands, Gateway reset, daily rollover, automatic recovery, cron-stale reset, and memory recall.
- `openclaw/ci-gate` passed on this head.
- Local ClawSweeper passed with `patch is correct`, zero findings, security cleared, no maintainer decision, and zero Rank-up moves.
- Production diff: 49 additions and 38 deletions, net +11.
- Test diff: 125 additions and 62 deletions, net +63.

## Telegram proof

The canonical leased-user Telegram runner started a fresh source-built Gateway from this head and a loopback mock OpenAI Responses provider.

Recorded action sequence:

1. Send a pre-reset marker turn and receive `OPENCLAW_E2E_OK`.
2. Send `/new` and receive `✅ New session started.`.
3. Send a post-reset turn and receive `OPENCLAW_E2E_OK`.

Provider evidence:

- Request 1 contained the pre-reset marker.
- Request 2 contained the post-reset turn and did not contain the marker or any pre-reset user or assistant message.
- Both requests used `POST /v1/responses` and returned HTTP 200.
- Telegram delivery succeeded for the post-reset reply.
- The SUT had no webhook, no pending Bot API updates, and no `401 Unauthorized` or public OpenAI endpoint request.

Message, chat, user, bot, local path, and machine identifiers are redacted. The retained private proof bundle contains the sent actions, TDLib event stream, summary, scoped Gateway log, SUT config, and provider request log.

## Compatibility

The retained-tail behavior appeared only in beta releases. Stable releases do not establish a compatibility requirement for it. Public docs already say `/new` and `/reset` clear conversation context.

AI-assisted: yes. Codex implemented and reviewed the owner-boundary repair. The contributor reviewed the behavior and non-goals.
