### PR TITLE
fix(channels): degrade unavailable credential files

### DIFF
--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -170,6 +170,8 @@ describe("ClickClack account resolution", () => {
       requireMention: false,
       systemPrompt: undefined,
       token: "test-token-placeholder",
+      tokenSource: "config",
+      tokenStatus: "available",
       toolsAllow: undefined,
       workspace: "wsp_1",
     });
@@ -219,6 +221,90 @@ describe("ClickClack account resolution", () => {
       expect(listClickClackAccountIds(cfg)).toEqual(["default", "work"]);
       expect(resolveClickClackAccount({ cfg }).token).toBe("file-token");
       expect(resolveClickClackAccount({ cfg, accountId: "work" }).token).toBe("work-token");
+    });
+  });
+
+  it("isolates unavailable root and account token files without falling back", async () => {
+    await withTempDir("clickclack-unavailable-token-", async (tempDir) => {
+      const missingRootFile = path.join(tempDir, "missing-root-token");
+      const missingAccountFile = path.join(tempDir, "missing-account-token");
+      const missingDefaultFile = path.join(tempDir, "missing-default-token");
+      const cfg = {
+        channels: {
+          clickclack: {
+            baseUrl: "https://app.clickclack.chat",
+            workspace: "wsp_1",
+            token: "lower-priority-config-token",
+            tokenFile: missingRootFile,
+            accounts: {
+              default: { tokenFile: missingDefaultFile },
+              inherited: {},
+              work: { tokenFile: missingAccountFile },
+            },
+          },
+        },
+      } satisfies CoreConfig;
+      const env = { CLICKCLACK_BOT_TOKEN: "lower-priority-env-token" };
+
+      for (const [accountId, filePath, configPath] of [
+        ["default", missingDefaultFile, "channels.clickclack.accounts.default.tokenFile"],
+        ["inherited", missingRootFile, "channels.clickclack.tokenFile"],
+        ["work", missingAccountFile, "channels.clickclack.accounts.work.tokenFile"],
+      ] as const) {
+        const account = resolveClickClackAccount({ cfg, accountId, env });
+        expect(account).toMatchObject({
+          configured: true,
+          token: "",
+          tokenSource: "tokenFile",
+          tokenStatus: "configured_unavailable",
+          credentialDiagnostics: [
+            { code: "CREDENTIAL_FILE_UNAVAILABLE", path: configPath, reason: "not-found" },
+          ],
+        });
+        expect(JSON.stringify(account.credentialDiagnostics)).not.toContain(filePath);
+      }
+    });
+  });
+
+  it("degrades empty and unsafe token files without exposing their filesystem paths", async () => {
+    await withTempDir("clickclack-invalid-token-", async (tempDir) => {
+      const emptyFile = path.join(tempDir, "empty-token");
+      fs.writeFileSync(emptyFile, "  \n", "utf8");
+      const invalidFiles: Array<[string, "invalid-path" | "symlink"]> = [
+        [emptyFile, "invalid-path"],
+      ];
+      if (process.platform !== "win32") {
+        const tokenFile = path.join(tempDir, "valid-token");
+        const symlink = path.join(tempDir, "token-link");
+        fs.writeFileSync(tokenFile, "file-token", "utf8");
+        fs.symlinkSync(tokenFile, symlink);
+        invalidFiles.push([symlink, "symlink"]);
+      }
+
+      for (const [selectedFile, reason] of invalidFiles) {
+        const account = resolveClickClackAccount({
+          cfg: {
+            channels: {
+              clickclack: {
+                baseUrl: "https://app.clickclack.chat",
+                workspace: "wsp_1",
+                token: "lower-priority-token",
+                tokenFile: selectedFile,
+              },
+            },
+          },
+        });
+
+        expect(account).toMatchObject({
+          token: "",
+          tokenSource: "tokenFile",
+          tokenStatus: "configured_unavailable",
+          credentialDiagnostics: [
+            { code: "CREDENTIAL_FILE_UNAVAILABLE", path: "channels.clickclack.tokenFile", reason },
+          ],
+        });
+        expect(JSON.stringify(account.credentialDiagnostics)).not.toContain(selectedFile);
+      }
     });
   });
 
@@ -283,6 +369,8 @@ describe("ClickClack account resolution", () => {
       requireMention: false,
       systemPrompt: undefined,
       token: "token-oversized",
+      tokenSource: "config",
+      tokenStatus: "available",
       toolsAllow: ["web_search"],
       workspace: "wsp_1",
     });

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -14,7 +14,6 @@ import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import {
   normalizeSecretInputString,
-  normalizeResolvedSecretInputString,
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -116,18 +115,33 @@ function resolveClickClackToken(params: {
   tokenFile?: string;
   accountId: string;
   env?: NodeJS.ProcessEnv;
-}): string {
+}): Required<Pick<ResolvedClickClackAccount, "token" | "tokenSource" | "tokenStatus">> &
+  Pick<ResolvedClickClackAccount, "credentialDiagnostics"> {
   const tokenFile = params.tokenFile?.trim();
   if (tokenFile) {
-    return (
-      tryReadSecretFileSync(
-        tokenFile,
-        params.accountId === DEFAULT_ACCOUNT_ID
-          ? "channels.clickclack.tokenFile"
-          : `channels.clickclack.accounts.${params.accountId}.tokenFile`,
-        { rejectSymlink: true },
-      ) ?? ""
+    const accountTokenFile = resolveNormalizedAccountEntry(
+      params.cfg.channels?.clickclack?.accounts,
+      params.accountId,
+      normalizeAccountId,
+    )?.tokenFile?.trim();
+    const result = tryReadSecretFileSync(
+      tokenFile,
+      "ClickClack bot token",
+      { rejectSymlink: true },
+      {
+        configPath: accountTokenFile
+          ? `channels.clickclack.accounts.${params.accountId}.tokenFile`
+          : "channels.clickclack.tokenFile",
+      },
     );
+    return result.status === "available"
+      ? { token: result.value, tokenSource: "tokenFile", tokenStatus: "available" }
+      : {
+          token: "",
+          tokenSource: "tokenFile",
+          tokenStatus: "configured_unavailable",
+          credentialDiagnostics: [result.diagnostic],
+        };
   }
   const resolved = resolveSecretInputString({
     value: params.value,
@@ -140,7 +154,10 @@ function resolveClickClackToken(params: {
   });
   if (resolved.status !== "available") {
     if (resolved.status === "missing" && params.accountId === DEFAULT_ACCOUNT_ID) {
-      return normalizeSecretInputString((params.env ?? process.env).CLICKCLACK_BOT_TOKEN) ?? "";
+      const token = normalizeSecretInputString((params.env ?? process.env).CLICKCLACK_BOT_TOKEN);
+      return token
+        ? { token, tokenSource: "env", tokenStatus: "available" }
+        : { token: "", tokenSource: "none", tokenStatus: "missing" };
     }
     if (resolved.status === "configured_unavailable" && resolved.ref.source === "env") {
       const providerConfig = params.cfg.secrets?.providers?.[resolved.ref.provider];
@@ -163,16 +180,20 @@ function resolveClickClackToken(params: {
           `Secret provider "${resolved.ref.provider}" is not configured (ref: env:${resolved.ref.provider}:${resolved.ref.id}).`,
         );
       }
-      return normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]) ?? "";
+      const token = normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]);
+      return {
+        token: token ?? "",
+        tokenSource: "config",
+        tokenStatus: token ? "available" : "configured_unavailable",
+      };
     }
-    return "";
+    return {
+      token: "",
+      tokenSource: resolved.status === "missing" ? "none" : "config",
+      tokenStatus: resolved.status,
+    };
   }
-  return (
-    normalizeResolvedSecretInputString({
-      value: resolved.value,
-      path: "channels.clickclack.token",
-    }) ?? ""
-  );
+  return { token: resolved.value, tokenSource: "config", tokenStatus: "available" };
 }
 
 /**
@@ -203,10 +224,10 @@ export function resolveClickClackAccount(params: {
   return {
     accountId,
     enabled,
-    configured: Boolean(baseUrl && token && workspace),
+    configured: Boolean(baseUrl && token.tokenStatus !== "missing" && workspace),
     name: normalizeOptionalString(merged.name),
     baseUrl,
-    token,
+    ...token,
     workspace,
     botUserId: normalizeOptionalString(merged.botUserId),
     agentId: normalizeOptionalString(merged.agentId),

--- a/extensions/clickclack/src/channel.test.ts
+++ b/extensions/clickclack/src/channel.test.ts
@@ -10,4 +10,26 @@ describe("ClickClack channel capabilities", () => {
       blockStreaming: true,
     });
   });
+
+  it("projects credential source and status without exposing tokens or diagnostics", async () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          tokenFile: "/private/clickclack-unavailable-token",
+        },
+      },
+    };
+    const account = clickClackPlugin.config.resolveAccount(cfg, "default");
+    const snapshot = await clickClackPlugin.status?.buildAccountSnapshot?.({ account, cfg });
+
+    expect(snapshot).toMatchObject({
+      configured: true,
+      tokenSource: "tokenFile",
+      tokenStatus: "configured_unavailable",
+    });
+    expect(snapshot).not.toHaveProperty("token");
+    expect(snapshot).not.toHaveProperty("credentialDiagnostics");
+  });
 });

--- a/extensions/clickclack/src/channel.ts
+++ b/extensions/clickclack/src/channel.ts
@@ -200,7 +200,11 @@ export const clickClackPlugin: ChannelPlugin<ResolvedClickClackAccount> = create
         name: account.name,
         enabled: account.enabled,
         configured: account.configured,
-        baseUrl: account.baseUrl,
+        extra: {
+          baseUrl: account.baseUrl,
+          tokenSource: account.tokenSource,
+          tokenStatus: account.tokenStatus,
+        },
       }),
     }),
     gateway: {

--- a/extensions/clickclack/src/types.ts
+++ b/extensions/clickclack/src/types.ts
@@ -5,6 +5,7 @@ import type {
   ChannelBotLoopProtectionConfig,
   OpenClawConfig,
 } from "openclaw/plugin-sdk/config-contracts";
+import type { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 
 /** Session-linked ClickClack discussion settings for one account. */
 type ClickClackDiscussionsConfig = {
@@ -82,6 +83,12 @@ export type ResolvedClickClackAccount = {
   baseUrl: string;
   apiEndpoint: string;
   token: string;
+  tokenSource?: "env" | "tokenFile" | "config" | "none";
+  tokenStatus?: "available" | "configured_unavailable" | "missing";
+  credentialDiagnostics?: Extract<
+    ReturnType<typeof tryReadSecretFileSync>,
+    { status: "configured_unavailable" }
+  >["diagnostic"][];
   workspace: string;
   botUserId?: string;
   botHandle?: string;

--- a/extensions/msteams/src/channel-config.ts
+++ b/extensions/msteams/src/channel-config.ts
@@ -1,12 +1,18 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { createTopLevelChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
+import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { resolveMSTeamsCredentials } from "./token.js";
 
 export type ResolvedMSTeamsAccount = {
   accountId: string;
   enabled: boolean;
   configured: boolean;
+  tokenStatus: "available" | "configured_unavailable" | "missing";
+  credentialDiagnostics?: Extract<
+    ReturnType<typeof tryReadSecretFileSync>,
+    { status: "configured_unavailable" }
+  >["diagnostic"][];
 };
 
 export const msteamsMeta = {
@@ -28,11 +34,29 @@ export const msteamsConfigAdapter = createTopLevelChannelConfigAdapter<
   }
 >({
   sectionKey: "msteams",
-  resolveAccount: (cfg) => ({
-    accountId: DEFAULT_ACCOUNT_ID,
-    enabled: cfg.channels?.msteams?.enabled !== false,
-    configured: Boolean(resolveMSTeamsCredentials(cfg.channels?.msteams)),
-  }),
+  resolveAccount: (cfg) => {
+    const config = cfg.channels?.msteams;
+    const credentials = resolveMSTeamsCredentials(config);
+    const certificatePath =
+      credentials?.type === "federated" && !credentials.useManagedIdentity
+        ? credentials.certificatePath
+        : undefined;
+    const certificate = certificatePath
+      ? tryReadSecretFileSync(certificatePath, "Microsoft Teams certificate", undefined, {
+          configPath: config?.certificatePath?.trim()
+            ? "channels.msteams.certificatePath"
+            : "env.MSTEAMS_CERTIFICATE_PATH",
+        })
+      : undefined;
+    const unavailable = certificate?.status === "configured_unavailable";
+    return {
+      accountId: DEFAULT_ACCOUNT_ID,
+      enabled: config?.enabled !== false,
+      configured: Boolean(credentials),
+      tokenStatus: !credentials ? "missing" : unavailable ? "configured_unavailable" : "available",
+      ...(unavailable ? { credentialDiagnostics: [certificate.diagnostic] } : {}),
+    };
+  },
   resolveAccessorAccount: ({ cfg }) => ({
     allowFrom: cfg.channels?.msteams?.allowFrom,
     defaultTo: cfg.channels?.msteams?.defaultTo,

--- a/extensions/msteams/src/channel-config.ts
+++ b/extensions/msteams/src/channel-config.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { createTopLevelChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { resolveMSTeamsCredentials } from "./token.js";
 
@@ -26,6 +27,30 @@ export const msteamsMeta = {
   order: 60,
 } as const;
 
+export function resolveMSTeamsAccount(cfg: OpenClawConfig): ResolvedMSTeamsAccount {
+  const config = cfg.channels?.msteams;
+  const credentials = resolveMSTeamsCredentials(config);
+  const certificatePath =
+    credentials?.type === "federated" && !credentials.useManagedIdentity
+      ? credentials.certificatePath
+      : undefined;
+  const certificate = certificatePath
+    ? tryReadSecretFileSync(certificatePath, "Microsoft Teams certificate", undefined, {
+        configPath: config?.certificatePath?.trim()
+          ? "channels.msteams.certificatePath"
+          : "env.MSTEAMS_CERTIFICATE_PATH",
+      })
+    : undefined;
+  const unavailable = certificate?.status === "configured_unavailable";
+  return {
+    accountId: DEFAULT_ACCOUNT_ID,
+    enabled: config?.enabled !== false,
+    configured: Boolean(credentials),
+    tokenStatus: !credentials ? "missing" : unavailable ? "configured_unavailable" : "available",
+    ...(unavailable ? { credentialDiagnostics: [certificate.diagnostic] } : {}),
+  };
+}
+
 export const msteamsConfigAdapter = createTopLevelChannelConfigAdapter<
   ResolvedMSTeamsAccount,
   {
@@ -34,29 +59,7 @@ export const msteamsConfigAdapter = createTopLevelChannelConfigAdapter<
   }
 >({
   sectionKey: "msteams",
-  resolveAccount: (cfg) => {
-    const config = cfg.channels?.msteams;
-    const credentials = resolveMSTeamsCredentials(config);
-    const certificatePath =
-      credentials?.type === "federated" && !credentials.useManagedIdentity
-        ? credentials.certificatePath
-        : undefined;
-    const certificate = certificatePath
-      ? tryReadSecretFileSync(certificatePath, "Microsoft Teams certificate", undefined, {
-          configPath: config?.certificatePath?.trim()
-            ? "channels.msteams.certificatePath"
-            : "env.MSTEAMS_CERTIFICATE_PATH",
-        })
-      : undefined;
-    const unavailable = certificate?.status === "configured_unavailable";
-    return {
-      accountId: DEFAULT_ACCOUNT_ID,
-      enabled: config?.enabled !== false,
-      configured: Boolean(credentials),
-      tokenStatus: !credentials ? "missing" : unavailable ? "configured_unavailable" : "available",
-      ...(unavailable ? { credentialDiagnostics: [certificate.diagnostic] } : {}),
-    };
-  },
+  resolveAccount: resolveMSTeamsAccount,
   resolveAccessorAccount: ({ cfg }) => ({
     allowFrom: cfg.channels?.msteams?.allowFrom,
     defaultTo: cfg.channels?.msteams?.defaultTo,

--- a/extensions/msteams/src/channel.actions.test.ts
+++ b/extensions/msteams/src/channel.actions.test.ts
@@ -599,6 +599,41 @@ describe("msteamsPlugin message actions", () => {
     ).toContain("upload-file");
   });
 
+  it("hides message actions when the selected certificate is unavailable", () => {
+    const discovery = msteamsPlugin.actions?.describeMessageTool?.({
+      cfg: {
+        channels: {
+          msteams: {
+            appId: "app-id",
+            tenantId: "tenant-id",
+            authType: "federated",
+            certificatePath: "/private/openclaw-msteams-unavailable-actions.pem",
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(discovery).toEqual({ actions: [], capabilities: [], schema: null });
+  });
+
+  it("keeps message actions available when managed identity owns federated auth", () => {
+    expect(
+      msteamsPlugin.actions?.describeMessageTool?.({
+        cfg: {
+          channels: {
+            msteams: {
+              appId: "app-id",
+              tenantId: "tenant-id",
+              authType: "federated",
+              certificatePath: "/private/openclaw-msteams-unused-certificate.pem",
+              useManagedIdentity: true,
+            },
+          },
+        } as OpenClawConfig,
+      })?.actions,
+    ).toContain("upload-file");
+  });
+
   it("routes upload-file through sendMessageMSTeams with filename override", async () => {
     const mediaReadFile = vi.fn(async () => Buffer.from("pdf"));
     const mediaAccess = {

--- a/extensions/msteams/src/channel.setup.ts
+++ b/extensions/msteams/src/channel.setup.ts
@@ -9,7 +9,6 @@ import {
 import { MSTeamsChannelConfigSchema } from "./config-schema.js";
 import { msteamsSetupContract } from "./setup-core.js";
 import { msteamsSetupWizard } from "./setup-surface.js";
-import { resolveMSTeamsCredentials } from "./token.js";
 
 export const msteamsSetupPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
   id: "msteams",
@@ -28,11 +27,12 @@ export const msteamsSetupPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
   configSchema: MSTeamsChannelConfigSchema,
   config: {
     ...msteamsConfigAdapter,
-    isConfigured: (_account, cfg) => Boolean(resolveMSTeamsCredentials(cfg.channels?.msteams)),
+    isConfigured: (account) => account.configured,
     describeAccount: (account) =>
       describeAccountSnapshot({
         account,
         configured: account.configured,
+        extra: { tokenStatus: account.tokenStatus },
       }),
   },
   setupWizard: msteamsSetupWizard,

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -1,6 +1,9 @@
 // Msteams tests cover channel plugin behavior.
+import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MSTeamsConfigSchema } from "../config-api.js";
 import { msteamsDirectoryContractPlugin } from "../directory-contract-api.js";
 import { msTeamsApprovalAuth } from "./approval-auth.js";
@@ -20,6 +23,8 @@ function createConfiguredMSTeamsCfg(): OpenClawConfig {
 }
 
 describe("msteamsPlugin", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
   it("distinguishes users from channel and group conversations", () => {
     const infer = msteamsPlugin.messaging?.inferTargetChatType;
     const ownerId = "00000000-0000-0000-0000-000000000001";
@@ -85,6 +90,7 @@ describe("msteamsPlugin", () => {
         accountId: "default",
         enabled: true,
         configured: true,
+        tokenStatus: "available",
       });
       expect(plugin.config.resolveAllowFrom?.({ cfg, accountId: "default" })).toEqual([
         "OWNER",
@@ -102,6 +108,138 @@ describe("msteamsPlugin", () => {
       );
     }
   });
+
+  it.each([
+    {
+      label: "configured certificate",
+      configuredPath: "/private/msteams-unavailable-configured.pem",
+      envPath: undefined,
+      diagnosticPath: "channels.msteams.certificatePath",
+    },
+    {
+      label: "environment certificate",
+      configuredPath: "   ",
+      envPath: "/private/msteams-unavailable-env.pem",
+      diagnosticPath: "env.MSTEAMS_CERTIFICATE_PATH",
+    },
+  ])("degrades an unavailable $label without exposing its filesystem path", async (selection) => {
+    if (selection.envPath) {
+      vi.stubEnv("MSTEAMS_CERTIFICATE_PATH", selection.envPath);
+    }
+    const cfg: OpenClawConfig = {
+      channels: {
+        msteams: {
+          appId: "app-id",
+          tenantId: "tenant-id",
+          authType: "federated",
+          certificatePath: selection.configuredPath,
+        },
+      },
+    };
+
+    for (const plugin of [msteamsPlugin, msteamsSetupPlugin]) {
+      const account = plugin.config.resolveAccount(cfg, "default");
+      expect(account).toMatchObject({
+        configured: true,
+        tokenStatus: "configured_unavailable",
+        credentialDiagnostics: [
+          {
+            code: "CREDENTIAL_FILE_UNAVAILABLE",
+            path: selection.diagnosticPath,
+            reason: "not-found",
+          },
+        ],
+      });
+      expect(JSON.stringify(account.credentialDiagnostics)).not.toContain(
+        selection.envPath ?? selection.configuredPath,
+      );
+      expect(plugin.config.isConfigured?.(account, cfg)).toBe(true);
+      expect(plugin.config.describeAccount?.(account, cfg)).toMatchObject({
+        configured: true,
+        tokenStatus: "configured_unavailable",
+      });
+    }
+
+    const account = msteamsPlugin.config.resolveAccount(cfg, "default");
+    expect(await msteamsPlugin.status?.buildAccountSnapshot?.({ account, cfg })).toMatchObject({
+      configured: true,
+      tokenStatus: "configured_unavailable",
+    });
+  });
+
+  it("does not fall back from a selected unavailable configured certificate to an env file", async () => {
+    await withTempDir("msteams-certificate-precedence-", async (tempDir) => {
+      const envCertificate = path.join(tempDir, "env-cert.pem");
+      fs.writeFileSync(envCertificate, "available-certificate", "utf8");
+      vi.stubEnv("MSTEAMS_CERTIFICATE_PATH", envCertificate);
+      const cfg: OpenClawConfig = {
+        channels: {
+          msteams: {
+            appId: "app-id",
+            tenantId: "tenant-id",
+            authType: "federated",
+            certificatePath: "/private/msteams-selected-missing.pem",
+          },
+        },
+      };
+
+      expect(msteamsPlugin.config.resolveAccount(cfg, "default")).toMatchObject({
+        configured: true,
+        tokenStatus: "configured_unavailable",
+        credentialDiagnostics: [
+          { code: "CREDENTIAL_FILE_UNAVAILABLE", path: "channels.msteams.certificatePath" },
+        ],
+      });
+    });
+  });
+
+  it("does not inspect an unavailable certificate when managed identity is selected", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        msteams: {
+          appId: "app-id",
+          tenantId: "tenant-id",
+          authType: "federated",
+          certificatePath: "/private/msteams-unused-missing-certificate.pem",
+          useManagedIdentity: true,
+        },
+      },
+    };
+
+    expect(msteamsPlugin.config.resolveAccount(cfg, "default")).toEqual({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      tokenStatus: "available",
+    });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "preserves the existing symlink-friendly certificate file policy",
+    async () => {
+      await withTempDir("msteams-certificate-symlink-", async (tempDir) => {
+        const certificate = path.join(tempDir, "certificate.pem");
+        const symlink = path.join(tempDir, "certificate-link.pem");
+        fs.writeFileSync(certificate, "available-certificate", "utf8");
+        fs.symlinkSync(certificate, symlink);
+        const cfg: OpenClawConfig = {
+          channels: {
+            msteams: {
+              appId: "app-id",
+              tenantId: "tenant-id",
+              authType: "federated",
+              certificatePath: symlink,
+            },
+          },
+        };
+
+        expect(msteamsPlugin.config.resolveAccount(cfg, "default")).toMatchObject({
+          configured: true,
+          tokenStatus: "available",
+        });
+      });
+    },
+  );
 
   it("exposes approval auth through approvalCapability", () => {
     expect(msteamsPlugin.approvalCapability).toBe(msTeamsApprovalAuth);

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -46,7 +46,7 @@ import {
   resolveMSTeamsAutoThreadId,
 } from "./action-threading.js";
 import { msTeamsApprovalAuth } from "./approval-auth.js";
-import type { ResolvedMSTeamsAccount } from "./channel-config.js";
+import { resolveMSTeamsAccount, type ResolvedMSTeamsAccount } from "./channel-config.js";
 import { msteamsSetupPlugin } from "./channel.setup.js";
 import { collectMSTeamsMutableAllowlistWarnings } from "./doctor.js";
 import { resolveMSTeamsGroupToolPolicy } from "./policy.js";
@@ -67,7 +67,6 @@ import {
   resolveMSTeamsUserAllowlist,
 } from "./resolve-allowlist.js";
 import { inferMSTeamsTargetChatType, resolveMSTeamsOutboundSessionRoute } from "./session-route.js";
-import { resolveMSTeamsCredentials } from "./token.js";
 
 const TEAMS_GRAPH_PERMISSION_HINTS: Record<string, string> = {
   "ChannelMessage.Read.All": "channel history",
@@ -323,9 +322,8 @@ function describeMSTeamsMessageTool({
 }: Parameters<
   NonNullable<ChannelMessageActionAdapter["describeMessageTool"]>
 >[0]): ChannelMessageToolDiscovery {
-  const enabled =
-    cfg.channels?.msteams?.enabled !== false &&
-    Boolean(resolveMSTeamsCredentials(cfg.channels?.msteams));
+  const account = resolveMSTeamsAccount(cfg);
+  const enabled = account.enabled && account.configured && account.tokenStatus === "available";
   return {
     actions: enabled
       ? ([

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1056,6 +1056,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           configured: account.configured,
           extra: {
             port: runtime?.port ?? null,
+            tokenStatus: account.tokenStatus,
           },
         }),
       }),

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -229,17 +229,58 @@ describe("createMSTeamsApp", () => {
     expect(readSecretFile).toHaveBeenCalledWith("/path/to/cert.pem", "Microsoft Teams certificate");
   });
 
+  it.each([
+    {
+      label: "certificate",
+      credentials: {
+        type: "federated" as const,
+        appId: "test-app-id",
+        tenantId: "test-tenant",
+        certificatePath: "/path/to/cert.pem",
+      },
+      expected: { clientId: "test-app-id", token: expect.any(Function) },
+    },
+    {
+      label: "managed identity",
+      credentials: {
+        type: "federated" as const,
+        appId: "test-app-id",
+        tenantId: "test-tenant",
+        useManagedIdentity: true,
+      },
+      expected: {
+        clientId: "test-app-id",
+        managedIdentityClientId: "system",
+        managedIdentityType: "system",
+      },
+    },
+  ])("prevents ambient CLIENT_SECRET from overriding $label authentication", async (mode) => {
+    vi.stubEnv("CLIENT_SECRET", "ambient-secret-must-not-win");
+
+    const app = await createMSTeamsApp(mode.credentials);
+    const credentials = (app as unknown as { credentials?: Record<string, unknown> }).credentials;
+
+    expect(credentials).toMatchObject(mode.expected);
+    expect(credentials).not.toHaveProperty("clientSecret");
+  });
+
   it("throws when certificate file is missing", async () => {
-    readSecretFile.mockRejectedValue(new Error("ENOENT: no such file"));
+    const certificatePath = "/private/msteams-race-sensitive-certificate.pem";
+    readSecretFile.mockRejectedValue(new Error(`ENOENT: no such file, open '${certificatePath}'`));
 
     const creds: MSTeamsFederatedCredentials = {
       type: "federated",
       appId: "test-app-id",
       tenantId: "test-tenant",
-      certificatePath: "/bad/path.pem",
+      certificatePath,
     };
 
-    await expect(createMSTeamsApp(creds)).rejects.toThrow("Failed to read certificate file");
+    const error = await createMSTeamsApp(creds).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    if (error instanceof Error) {
+      expect(error.message).toContain("Failed to read certificate file");
+      expect(error.message).not.toContain(certificatePath);
+    }
   });
 
   it("creates app with managed identity credentials", async () => {

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -1,5 +1,4 @@
 // Msteams plugin module implements sdk behavior.
-import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { readSecretFile } from "openclaw/plugin-sdk/secret-file";
 import { normalizeBotFrameworkServiceUrl } from "./bot-framework-service-url.js";
@@ -298,7 +297,8 @@ async function createMSTeamsApp(
   };
 
   if (creds.type === "federated") {
-    return await createFederatedApp(creds, App, appOptions);
+    // Teams SDK otherwise lets ambient CLIENT_SECRET override both federated modes.
+    return await createFederatedApp(creds, App, { clientSecret: "", ...appOptions });
   }
   return new App({
     clientId: creds.appId,
@@ -333,11 +333,8 @@ async function createFederatedApp(
   let privateKey: string;
   try {
     privateKey = await readSecretFile(creds.certificatePath, "Microsoft Teams certificate");
-  } catch (err: unknown) {
-    const msg = coerceErrorMessage(err);
-    throw new Error(`Failed to read certificate file at '${creds.certificatePath}': ${msg}`, {
-      cause: err,
-    });
+  } catch {
+    throw new Error("Failed to read certificate file: the configured credential is unavailable.");
   }
 
   return createCertificateApp(creds, privateKey, App, appOptions);

--- a/extensions/msteams/src/send-context.test.ts
+++ b/extensions/msteams/src/send-context.test.ts
@@ -100,6 +100,34 @@ beforeEach(() => {
 });
 
 describe("resolveMSTeamsSendContext", () => {
+  it("rejects an unavailable selected certificate before reading conversation state", async () => {
+    const certificatePath = "/private/openclaw-msteams-unavailable-send.pem";
+    const cfg = {
+      channels: {
+        msteams: {
+          enabled: true,
+          appId: "app-id",
+          tenantId: "tenant-id",
+          authType: "federated",
+          certificatePath,
+        },
+      },
+    } as OpenClawConfig;
+
+    const error = await resolveMSTeamsSendContext({
+      cfg,
+      to: "conversation:19:channel@thread.tacv2",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    if (error instanceof Error) {
+      expect(error.message).toBe("msteams credential file is configured but unavailable");
+      expect(error.message).not.toContain(certificatePath);
+    }
+    expect(sendContextMockState.store.get).not.toHaveBeenCalled();
+    expect(sendContextMockState.loadMSTeamsSdkWithAuth).not.toHaveBeenCalled();
+  });
+
   it("ignores ambient SERVICE_URL for default public-cloud proactive sends", async () => {
     vi.stubEnv("SERVICE_URL", "https://bot.example.com/api/messages");
     sendContextMockState.store.get.mockResolvedValue(

--- a/extensions/msteams/src/send-context.ts
+++ b/extensions/msteams/src/send-context.ts
@@ -12,6 +12,7 @@ import {
   isAllowedBotFrameworkServiceUrl,
   normalizeBotFrameworkServiceUrl,
 } from "./bot-framework-service-url.js";
+import { resolveMSTeamsAccount } from "./channel-config.js";
 import {
   resolveMSTeamsSdkCloudOptions,
   validateMSTeamsProactiveServiceUrlBoundary,
@@ -168,6 +169,13 @@ export async function resolveMSTeamsSendContext(params: {
     throw new Error("msteams provider is not enabled");
   }
 
+  const account = resolveMSTeamsAccount(params.cfg);
+  if (account.tokenStatus === "configured_unavailable") {
+    throw new Error("msteams credential file is configured but unavailable");
+  }
+  if (!account.configured) {
+    throw new Error("msteams credentials not configured");
+  }
   const creds = resolveMSTeamsCredentials(msteamsCfg);
   if (!creds) {
     throw new Error("msteams credentials not configured");

--- a/extensions/zalo/src/accounts.test.ts
+++ b/extensions/zalo/src/accounts.test.ts
@@ -93,6 +93,35 @@ describe("resolveZaloAccount", () => {
     expect(resolveDefaultZaloAccountId(cfg)).toBe("default");
     expect(resolveZaloAccount({ cfg, accountId: "default" }).enabled).toBe(true);
   });
+
+  it("carries account-owned unavailable credential diagnostics into the resolved account", () => {
+    const tokenFile = "/private/zalo-resolved-account-token";
+    const resolved = resolveZaloAccount({
+      cfg: {
+        channels: {
+          zalo: {
+            botToken: "lower-priority-token",
+            accounts: { work: { tokenFile } },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(resolved).toMatchObject({
+      token: "",
+      tokenSource: "configFile",
+      tokenStatus: "configured_unavailable",
+      credentialDiagnostics: [
+        {
+          code: "CREDENTIAL_FILE_UNAVAILABLE",
+          path: "channels.zalo.accounts.work.tokenFile",
+          reason: "not-found",
+        },
+      ],
+    });
+    expect(JSON.stringify(resolved.credentialDiagnostics)).not.toContain(tokenFile);
+  });
 });
 
 describe("Zalo account SecretRef inspection", () => {

--- a/extensions/zalo/src/accounts.ts
+++ b/extensions/zalo/src/accounts.ts
@@ -47,6 +47,9 @@ function resolveZaloAccountWithMode(params: {
     token: tokenResolution.token,
     tokenSource: tokenResolution.source,
     tokenStatus: tokenResolution.status,
+    ...(tokenResolution.credentialDiagnostics
+      ? { credentialDiagnostics: tokenResolution.credentialDiagnostics }
+      : {}),
     config: merged,
   };
 }

--- a/extensions/zalo/src/secret-contract.test.ts
+++ b/extensions/zalo/src/secret-contract.test.ts
@@ -1,0 +1,52 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createResolverContext } from "openclaw/plugin-sdk/secret-ref-runtime";
+import { describe, expect, it } from "vitest";
+import { collectRuntimeConfigAssignments } from "./secret-contract.js";
+
+describe("Zalo secret contract", () => {
+  it.each([
+    { label: "only a file-backed account", inherited: false, owners: [] },
+    { label: "another eligible account", inherited: true, owners: ["zalo:inherited"] },
+  ])("does not assign an inherited botToken to a file-backed account with $label", (scenario) => {
+    const sourceConfig = {
+      channels: {
+        zalo: {
+          botToken: { source: "env", provider: "default", id: "ZALO_SHARED_TOKEN" },
+          accounts: {
+            file: { tokenFile: "/run/secrets/zalo-file-token" },
+            ...(scenario.inherited ? { inherited: {} } : {}),
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const context = createResolverContext({ sourceConfig, env: {} });
+
+    collectRuntimeConfigAssignments({ config: structuredClone(sourceConfig), context });
+
+    expect(context.assignments.map(({ path, ownerId }) => ({ path, ownerId }))).toEqual(
+      scenario.owners.map((ownerId) => ({ path: "channels.zalo.botToken", ownerId })),
+    );
+  });
+
+  it("keeps an account-owned botToken active ahead of its same-scope tokenFile", () => {
+    const sourceConfig = {
+      channels: {
+        zalo: {
+          accounts: {
+            work: {
+              botToken: { source: "env", provider: "default", id: "ZALO_WORK_TOKEN" },
+              tokenFile: "/run/secrets/zalo-work-token",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const context = createResolverContext({ sourceConfig, env: {} });
+
+    collectRuntimeConfigAssignments({ config: structuredClone(sourceConfig), context });
+
+    expect(context.assignments).toMatchObject([
+      { path: "channels.zalo.accounts.work.botToken", ownerId: "zalo:work" },
+    ]);
+  });
+});

--- a/extensions/zalo/src/secret-contract.ts
+++ b/extensions/zalo/src/secret-contract.ts
@@ -4,6 +4,7 @@ import {
   createChannelSecretTargetRegistryEntries,
   getChannelSurface,
   hasOwnProperty,
+  normalizeSecretStringValue,
   type ResolverContext,
   type SecretDefaults,
 } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
@@ -33,7 +34,9 @@ export function collectRuntimeConfigAssignments(params: {
     context: params.context,
     topLevelActiveWithoutAccounts: true,
     topLevelInheritedAccountActive: ({ account, enabled }) =>
-      enabled && !hasOwnProperty(account, "botToken"),
+      enabled &&
+      !hasOwnProperty(account, "botToken") &&
+      !normalizeSecretStringValue(account.tokenFile),
     accountActive: ({ enabled }) => enabled,
     topInactiveReason: "no enabled Zalo surface inherits this top-level botToken.",
     accountInactiveReason: "Zalo account is disabled.",

--- a/extensions/zalo/src/token.test.ts
+++ b/extensions/zalo/src/token.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveZaloToken } from "./token.js";
 import type { ZaloConfig } from "./types.js";
 
@@ -19,6 +19,8 @@ function createSymlinkedFile(targetPath: string, linkPath: string): boolean {
 }
 
 describe("resolveZaloToken", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
   it("falls back to top-level token for non-default accounts without overrides", () => {
     const cfg = {
       botToken: "top-level-token",
@@ -87,6 +89,71 @@ describe("resolveZaloToken", () => {
     expect(res.source).toBe("config");
   });
 
+  it("does not fall back from an unavailable top-level token file to the environment", () => {
+    const tokenFile = "/private/zalo-missing-root-token";
+    vi.stubEnv("ZALO_BOT_TOKEN", "lower-priority-env-token");
+
+    const result = resolveZaloToken({ tokenFile });
+
+    expect(result).toMatchObject({
+      token: "",
+      source: "configFile",
+      status: "configured_unavailable",
+      credentialDiagnostics: [
+        {
+          code: "CREDENTIAL_FILE_UNAVAILABLE",
+          path: "channels.zalo.tokenFile",
+          reason: "not-found",
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain(tokenFile);
+  });
+
+  it("does not inherit a top-level token when an account token file is unavailable", () => {
+    const tokenFile = "/private/zalo-missing-work-token";
+    const result = resolveZaloToken(
+      {
+        botToken: "lower-priority-top-level-token",
+        accounts: { work: { tokenFile } },
+      },
+      "work",
+    );
+
+    expect(result).toMatchObject({
+      token: "",
+      source: "configFile",
+      status: "configured_unavailable",
+      credentialDiagnostics: [
+        {
+          code: "CREDENTIAL_FILE_UNAVAILABLE",
+          path: "channels.zalo.accounts.work.tokenFile",
+          reason: "not-found",
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain(tokenFile);
+  });
+
+  it("honors an unavailable account token file after an explicitly blank account bot token", () => {
+    const result = resolveZaloToken(
+      {
+        botToken: "lower-priority-top-level-token",
+        accounts: { work: { botToken: "", tokenFile: "/private/zalo-blank-account-token" } },
+      },
+      "work",
+    );
+
+    expect(result).toMatchObject({
+      token: "",
+      source: "configFile",
+      status: "configured_unavailable",
+      credentialDiagnostics: [
+        { code: "CREDENTIAL_FILE_UNAVAILABLE", path: "channels.zalo.accounts.work.tokenFile" },
+      ],
+    });
+  });
+
   it("rejects symlinked token files", ({ skip }) => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-zalo-token-"));
     try {
@@ -99,7 +166,20 @@ describe("resolveZaloToken", () => {
       const cfg = {
         tokenFile: tokenLink,
       } as ZaloConfig;
-      expect(() => resolveZaloToken(cfg)).toThrow(/Zalo token file.*must not be a symlink/);
+      const result = resolveZaloToken(cfg);
+      expect(result).toMatchObject({
+        token: "",
+        source: "configFile",
+        status: "configured_unavailable",
+        credentialDiagnostics: [
+          {
+            code: "CREDENTIAL_FILE_UNAVAILABLE",
+            path: "channels.zalo.tokenFile",
+            reason: "symlink",
+          },
+        ],
+      });
+      expect(JSON.stringify(result)).not.toContain(tokenLink);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/extensions/zalo/src/token.ts
+++ b/extensions/zalo/src/token.ts
@@ -1,18 +1,34 @@
 // Zalo plugin module implements token behavior.
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { BaseTokenResolution } from "openclaw/plugin-sdk/channel-contract";
-import { tryReadSecretFileSync } from "openclaw/plugin-sdk/core";
 import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
+import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { resolveSecretInputString, type SecretInputStringResolutionMode } from "./secret-input.js";
-import type { ZaloConfig, ZaloTokenStatus } from "./types.js";
+import type { ResolvedZaloAccount, ZaloConfig, ZaloTokenStatus } from "./types.js";
 
 type ZaloTokenResolution = BaseTokenResolution & {
   source: "env" | "config" | "configFile" | "none";
   status: ZaloTokenStatus;
+  credentialDiagnostics?: ResolvedZaloAccount["credentialDiagnostics"];
 };
 
-function readTokenFromFile(tokenFile: string | undefined): string {
-  return tryReadSecretFileSync(tokenFile, "Zalo token file", { rejectSymlink: true }) ?? "";
+function readTokenFromFile(tokenFile: string, configPath: string): ZaloTokenResolution {
+  const result = tryReadSecretFileSync(
+    tokenFile,
+    "Zalo token file",
+    { rejectSymlink: true },
+    {
+      configPath,
+    },
+  );
+  return result.status === "available"
+    ? { token: result.value, source: "configFile", status: "available" }
+    : {
+        token: "",
+        source: "configFile",
+        status: "configured_unavailable",
+        credentialDiagnostics: [result.diagnostic],
+      };
 }
 
 export function resolveZaloToken(
@@ -41,17 +57,13 @@ export function resolveZaloToken(
     if (token.status === "configured_unavailable") {
       return { token: "", source: "config", status: "configured_unavailable" };
     }
-    const fileToken = readTokenFromFile(accountConfig.tokenFile);
-    if (fileToken) {
-      return { token: fileToken, source: "configFile", status: "available" };
-    }
   }
 
-  if (!accountHasBotToken) {
-    const fileToken = readTokenFromFile(accountConfig?.tokenFile);
-    if (fileToken) {
-      return { token: fileToken, source: "configFile", status: "available" };
-    }
+  if (accountConfig?.tokenFile?.trim()) {
+    return readTokenFromFile(
+      accountConfig.tokenFile,
+      `channels.zalo.accounts.${resolvedAccountId}.tokenFile`,
+    );
   }
 
   if (!accountHasBotToken) {
@@ -66,9 +78,8 @@ export function resolveZaloToken(
     if (token.status === "configured_unavailable") {
       return { token: "", source: "config", status: "configured_unavailable" };
     }
-    const fileToken = readTokenFromFile(baseConfig?.tokenFile);
-    if (fileToken) {
-      return { token: fileToken, source: "configFile", status: "available" };
+    if (baseConfig?.tokenFile?.trim()) {
+      return readTokenFromFile(baseConfig.tokenFile, "channels.zalo.tokenFile");
     }
   }
 

--- a/extensions/zalo/src/types.ts
+++ b/extensions/zalo/src/types.ts
@@ -1,4 +1,5 @@
 // Zalo type declarations define plugin contracts.
+import type { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
 
 export type ZaloAccountConfig = {
@@ -49,5 +50,9 @@ export type ResolvedZaloAccount = {
   token: string;
   tokenSource: ZaloTokenSource;
   tokenStatus?: ZaloTokenStatus;
+  credentialDiagnostics?: Extract<
+    ReturnType<typeof tryReadSecretFileSync>,
+    { status: "configured_unavailable" }
+  >["diagnostic"][];
   config: ZaloAccountConfig;
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClickClack, Zalo, and Microsoft Teams accounts using a missing or unsafe selected credential file could fall through to a lower-priority credential, appear unconfigured, or fail late while exposing raw filesystem paths. Their direct credential-file owners skipped the generic `CREDENTIAL_FILE_UNAVAILABLE` account lifecycle, so one unavailable credential was not consistently isolated from healthy sibling accounts.

## Why This Change Was Made

Emit typed, plugin-owned, config-path diagnostics during account resolution; preserve credential precedence and managed identity; prevent lower-priority fallback; and reuse the generic Gateway exact-account degradation flow without introducing core channel branches. Microsoft Teams federated authentication also explicitly prevents an ambient `CLIENT_SECRET` from overriding certificate or managed-identity authentication.

The resolved Microsoft Teams account is now also the canonical eligibility source for model-facing message actions and proactive outbound sends. An unavailable selected certificate hides those actions and fails proactive delivery before conversation state or the SDK is touched, while managed identity remains available even when an unused certificate path is stale.

Best-fix rationale: repair the credential producer at its plugin owner boundary through the existing Plugin SDK diagnostic seam, then have account consumers use that same resolved state. Rejected alternatives were channel-specific branches in core, late SDK catch-only behavior, and falling back to lower-priority credentials, because each either loses exact-account lifecycle ownership, fails after startup, or changes the selected authentication identity.

## User Impact

An affected account remains configured but unavailable and stays cold while healthy sibling accounts continue running. Repairing its credential file and reloading or restarting that exact account recovers it without restarting healthy siblings. Diagnostics identify the configuration field while keeping filesystem paths and credential values redacted. Microsoft Teams tools are not offered while their selected certificate is unavailable.

## Evidence

- Pre-fix focused regressions failed for the intended credential availability, precedence, redaction, federated-authentication, action-discovery, and proactive-outbound assertions.
- Post-fix validation passed the original 124 plugin regressions plus two generic Gateway account-lifecycle tests.
- The ClawSweeper follow-up passed 170 focused Microsoft Teams tests across action discovery, proactive send context, account resolution, SDK authentication, and token selection.
- `node scripts/check-changed.mjs` passed for the original plugin repair. The follow-up changed-check wrapper was externally terminated while another repository build owned the shared type-artifact generator; focused tests, formatting, diff checks, autoreview, and exact-head CI cover the pushed follow-up.
- `pnpm build` passed for the original head.
- All three plugin memory profiles loaded successfully.
- Structured autoreview completed cleanly on both the original patch and the action/outbound follow-up.
- Direct inspection of pinned `@microsoft/teams.apps` 2.0.14 proves `clientSecret ?? process.env.CLIENT_SECRET` is evaluated before custom token and managed-identity branches; passing an explicit empty client secret preserves the selected federated mode.
- No live authenticated channel proof was needed: the failure is a deterministic local credential-file preflight before any channel API connection.
- Production LOC: +143/-58 (net +85). Tests: +519/-6 (net +513). Production growth is required for three plugin-owned diagnostic producers, status/account propagation, canonical Teams consumer gating, and the Microsoft Teams federated-auth invariant; core remains unchanged.
- No `CHANGELOG.md` edit: normal pull requests do not update the release-generated changelog under repository policy.
- AI-assisted; changes and their account-lifecycle and authentication behavior were reviewed and understood.
