### PR TITLE
fix(cli): tell operators a racing config set changed nothing

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -365,7 +365,7 @@ openclaw config set channels.discord.token \
     - `checks.resolvabilityComplete`: whether resolvability checks ran to completion (false when exec refs are skipped)
     - `refsChecked`: number of refs actually resolved during dry-run
     - `skippedExecRefs`: number of exec refs skipped because `--allow-exec` was not set
-    - `errors`: structured missing-path, schema, or resolvability failures when `ok=false`
+    - `errors`: structured failures when `ok=false`; each carries a `kind` of `missing-path`, `schema`, `resolvability`, `model`, or `conflict` (`conflict` means the config file changed while the command was writing, so nothing was changed — re-run to pick up the new file)
 
   </Accordion>
 </AccordionGroup>

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -3,6 +3,7 @@ import { uniqueValues } from "@openclaw/normalization-core/string-normalization"
 import { replaceConfigFile } from "../config/config.js";
 import { AUTO_MANAGED_CONFIG_META_PATHS } from "../config/io.meta.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
+import { ConfigMutationConflictError } from "../config/mutation-conflict.js";
 import { resolveConfigPath } from "../config/paths.js";
 import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -513,7 +514,11 @@ export function handleConfigMutationError(params: {
   runtime: RuntimeEnv;
   options: ConfigMutationOptions;
 }) {
-  const message = formatErrorMessage(params.err);
+  const isConflict = params.err instanceof ConfigMutationConflictError;
+  const detail = formatErrorMessage(params.err);
+  const message = isConflict
+    ? `The config file changed while this command was writing (${detail}), so nothing was changed. Re-run the same command to pick up the new file and try again.`
+    : detail;
   if (params.options.dryRun && params.options.json) {
     if (params.err instanceof ConfigSetDryRunValidationError) {
       writeRuntimeJson(params.runtime, params.err.result);
@@ -528,7 +533,7 @@ export function handleConfigMutationError(params: {
       checks: { schema: false, resolvability: false, resolvabilityComplete: false },
       refsChecked: 0,
       skippedExecRefs: 0,
-      errors: [{ kind: "schema", message }],
+      errors: [{ kind: isConflict ? "conflict" : "schema", message }],
     };
     writeRuntimeJson(params.runtime, result);
     params.runtime.error(danger(message));

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -5,6 +5,7 @@ import { Command } from "commander";
 // Config CLI tests cover config command registration, reads, writes, and output modes.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfigMutationConflictError } from "../config/mutation-conflict.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -3371,6 +3372,53 @@ describe("config cli", () => {
       ).rejects.toThrow(ExitError);
 
       expectErrorIncludes("Dry run failed: 1 SecretRef assignment(s) could not be resolved.");
+    });
+
+    it("explains config mutation conflicts without changing the exit code", async () => {
+      mockWriteConfigFile.mockRejectedValueOnce(
+        new ConfigMutationConflictError("included config changed since last load"),
+      );
+
+      await expect(runConfigSet("gateway.port", "19000")).rejects.toThrow(ExitError);
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expectErrorIncludes(
+        "The config file changed while this command was writing (included config changed since last load), so nothing was changed. Re-run the same command to pick up the new file and try again.",
+      );
+    });
+
+    it("reports config mutation conflicts accurately in dry-run JSON", async () => {
+      mockReadConfigFileSnapshot.mockRejectedValueOnce(
+        new ConfigMutationConflictError("config changed since last load"),
+      );
+
+      await expect(
+        runConfigCommand(["config", "set", "gateway.port", "19000", "--dry-run", "--json"]),
+      ).rejects.toThrow(ExitError);
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(parseLastLogPayload()).toMatchObject({
+        ok: false,
+        errors: [
+          {
+            kind: "conflict",
+            message:
+              "The config file changed while this command was writing (config changed since last load), so nothing was changed. Re-run the same command to pick up the new file and try again.",
+          },
+        ],
+      });
+    });
+
+    it("preserves non-conflict config mutation errors", async () => {
+      mockWriteConfigFile.mockRejectedValueOnce(new Error("permission denied"));
+
+      await expect(runConfigSet("gateway.port", "19000")).rejects.toThrow(ExitError);
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expectErrorIncludes("permission denied");
+      expect(mockError.mock.calls.flat().join("\n")).not.toContain(
+        "The config file changed while this command was writing",
+      );
     });
 
     it("emits structured JSON for --dry-run --json success", async () => {

--- a/src/cli/config-set-dryrun.ts
+++ b/src/cli/config-set-dryrun.ts
@@ -4,7 +4,7 @@ export type ConfigSetDryRunInputMode = "value" | "json" | "builder" | "unset";
 
 /** One validation error found during config-set dry-run processing. */
 export type ConfigSetDryRunError = {
-  kind: "missing-path" | "schema" | "resolvability" | "model";
+  kind: "missing-path" | "schema" | "resolvability" | "model" | "conflict";
   message: string;
   ref?: string;
 };


### PR DESCRIPTION
## What Problem This Solves

When two `openclaw config set` calls race, the loser fails with a bare, unactionable line. This is
the entire stderr output, exit 1:

```
config changed since last load
```

The operator is not told that nothing was written, that the failure is transient, or that re-running
resolves it.

Reproduced on the real dist CLI with an isolated HOME and `OPENCLAW_CONFIG_PATH` — six concurrent
`openclaw config set skills.entries.probe-N.enabled true` against one config file:

```
w1 exit=1 :: config changed since last load
w2 exit=0 :: Updated skills.entries.probe-2.enabled. No gateway restart needed.
w3 exit=1 :: config changed since last load
w4 exit=1 :: config changed since last load
w5 exit=1 :: config changed since last load
w6 exit=1 :: config changed since last load

resulting keys: ['probe-2']  (1 of 6)
```

## Why This Change Was Made

The concurrency control is correct and is not touched here: exactly one writer won, five failed
loudly, and no update was silently lost. Only the operator-facing message was the defect.

The gateway path already gets the wording right. `src/gateway/server-methods/config.ts:139` throws
`"config changed since last load; re-run config.get and retry"`. The local CLI path does not —
`src/config/mutate.ts:187` and `src/config/io.write-safety.ts:43` throw the bare
`ConfigMutationConflictError("config changed since last load")`, which the CLI surfaces verbatim.

It was also the odd one out among its immediate neighbours, all of which name a next step:

- `config unset <missing>` → "Config path not found: X. **Nothing was changed.** Run
  `openclaw config get <path>` first if you are unsure of the path."
- `config set <bad value>` → "Config validation failed: gateway.port: Invalid input: expected
  number, received string"
- `config get` → names either the unset path or `openclaw config schema` (#127369)

The retry loop deliberately cannot rescue this caller, so retrying harder was not the fix.
`transformConfigFileWithRetry` (`src/config/mutate.ts:1163`) retries up to five times, but every
attempt re-checks the caller-supplied `params.baseHash` (`mutate.ts:1111`), and
`src/cli/config-cli.ts:310` pins `baseHash: snapshot.hash`. That pin is the point of optimistic
concurrency — apply only if the file is still what I read. The right fix is to explain the outcome,
not to weaken the precondition.

## User Impact

```
The config file changed while this command was writing (config changed since last load), so nothing
was changed. Re-run the same command to pick up the new file and try again.
```

The parenthesised detail preserves the underlying variant, so the `included config changed since
last load` cases (`mutate.ts:681/696/708/720`) stay distinguishable — those name a different file.

`config set --dry-run --json` now reports `kind: "conflict"` for this failure. It previously
mislabelled a concurrency conflict as `kind: "schema"`, which is wrong for a scripted consumer
deciding whether to retry: a schema error never succeeds on retry, a conflict usually does. The
`ConfigSetDryRunError` union gains `conflict`; the addition is additive and `docs/cli/config.md` is
updated to enumerate every kind (it previously listed only three of the four that already existed,
omitting `model`).

Exit code stays 1. `baseHash` pinning, the retry loop, and every throw site outside the CLI boundary
are unchanged.

## Evidence

Production `+8/-3` (net +5), docs `+1/-1`, tests `+48/-0`.

`node scripts/run-vitest.mjs src/cli/config-cli.test.ts`
- Before the fix: 196 passed, the 2 new cases failed as intended.
- After: 198/198 passed.

New coverage: the conflict surfaced through the text path produces the new message and exit 1; the
same through `--dry-run --json` produces `kind: "conflict"`; the `included config changed` detail is
preserved; and non-conflict errors are unchanged.

Re-ran the six-way race against a freshly built dist: one writer succeeded, five exited 1 with the
new message, and re-running a loser then succeeded with `config get` returning `true` — confirming
the advice the message now gives is actually correct.

`node scripts/check-changed.mjs -- src/cli/config-cli-runner.ts src/cli/config-set-dryrun.ts src/cli/config-cli.test.ts`
passed on Blacksmith Testbox `tbx_01m0k034p25jy2yc9jaxgstwg3`. `pnpm build` passed.
`$autoreview --mode uncommitted` clean, no accepted or actionable findings. `oxfmt --check` clean.
