### PR TITLE
test(msteams): pin reply threading and reaction routing across conversation kinds

### DIFF
--- a/extensions/msteams/src/channel.actions.test.ts
+++ b/extensions/msteams/src/channel.actions.test.ts
@@ -81,7 +81,6 @@ const currentChannelId = "conversation:19:ctx@thread.tacv2";
 const graphTeamId = "11111111-1111-1111-1111-111111111111";
 const graphChannelId = "19:channel-1@thread.tacv2";
 const graphChannelTarget = `${graphTeamId}/${graphChannelId}`;
-const reactChannelId = "conversation:19:react@thread.tacv2";
 const targetChannelId = "conversation:19:target@thread.tacv2";
 const editedConversationId = "19:edited@thread.tacv2";
 const editedMessageId = "msg-edit-1";
@@ -1056,37 +1055,61 @@ describe("msteamsPlugin message actions", () => {
     expect(properties).toHaveProperty("pinnedMessageId");
   });
 
-  it("reuses currentChannelId fallback for react actions", async () => {
-    await expectSuccessfulAction({
-      mockFn: reactMessageMSTeamsMock,
-      mockResult: { ok: true },
-      action: "react",
-      cfg: unrestrictedReadCfg,
-      accountId: "default",
-      requesterAccountId: "default",
-      actionParams: {
-        messageId: padded("msg-3"),
-        emoji: padded(reactionType),
-      },
-      toolContext: {
-        currentChannelId: padded(reactChannelId),
-      },
-      runtimeParams: {
-        to: reactChannelId,
-        messageId: "msg-3",
-        reactionType,
-      },
-      details: okMSTeamsActionDetails("react", {
-        reactionType,
-      }),
-      contentDetails: {
-        channel: "msteams",
+  it.each([
+    {
+      chatType: "channel",
+      conversationTarget: "conversation:19:c@thread.tacv2",
+      currentMessagingTarget: "team-1/19:c@thread.tacv2",
+      expectedTarget: "team-1/19:c@thread.tacv2",
+    },
+    {
+      chatType: "group",
+      conversationTarget: "conversation:19:g@thread.v2",
+      currentMessagingTarget: undefined,
+      expectedTarget: "conversation:19:g@thread.v2",
+    },
+    {
+      chatType: "direct",
+      conversationTarget: "conversation:a:dm",
+      currentMessagingTarget: undefined,
+      expectedTarget: "conversation:a:dm",
+    },
+  ] as const)(
+    "routes agent react actions and preserves their result shape for $chatType turns",
+    async ({ chatType, conversationTarget, currentMessagingTarget, expectedTarget }) => {
+      await expectSuccessfulAction({
+        mockFn: reactMessageMSTeamsMock,
+        mockResult: { ok: true },
         action: "react",
-        reactionType,
-        ok: true,
-      },
-    });
-  });
+        cfg: unrestrictedReadCfg,
+        accountId: "default",
+        requesterAccountId: "default",
+        actionParams: {
+          ...(chatType === "channel" ? { target: conversationTarget } : {}),
+          messageId: padded("msg-react"),
+          emoji: padded(reactionType),
+        },
+        toolContext: {
+          currentChannelProvider: "msteams",
+          currentChannelId: padded(conversationTarget),
+          currentChatType: chatType,
+          ...(currentMessagingTarget ? { currentMessagingTarget } : {}),
+        },
+        runtimeParams: {
+          to: expectedTarget,
+          messageId: "msg-react",
+          reactionType,
+        },
+        details: okMSTeamsActionDetails("react", { reactionType }),
+        contentDetails: {
+          channel: "msteams",
+          action: "react",
+          reactionType,
+          ok: true,
+        },
+      });
+    },
+  );
 
   it("shares the missing target and messageId validation across actions", async () => {
     await expectActionParamError("delete", {}, deleteMissingTargetError);
@@ -1309,46 +1332,6 @@ describe("msteamsPlugin message actions", () => {
     expect(testCase.runtimeMock).not.toHaveBeenCalled();
   });
 
-  it("restores the Graph route from a core-materialized channel target", async () => {
-    // Core materializes an omitted target from currentChannelId before plugin
-    // dispatch. Teams must restore the prepared Graph target for channel turns.
-    const teamChannelTarget = "team-1/19:channel-abc@thread.tacv2";
-    const conversationTarget = "conversation:19:channel-abc@thread.tacv2";
-    await expectSuccessfulAction({
-      mockFn: reactMessageMSTeamsMock,
-      mockResult: { ok: true },
-      action: "react",
-      cfg: unrestrictedReadCfg,
-      accountId: "default",
-      requesterAccountId: "default",
-      actionParams: {
-        target: conversationTarget,
-        messageId: "msg-channel-react",
-        emoji: reactionType,
-      },
-      toolContext: {
-        currentChannelProvider: "msteams",
-        currentChannelId: conversationTarget,
-        currentChatType: "channel",
-        currentMessagingTarget: teamChannelTarget,
-      },
-      runtimeParams: {
-        to: teamChannelTarget,
-        messageId: "msg-channel-react",
-        reactionType,
-      },
-      details: okMSTeamsActionDetails("react", {
-        reactionType,
-      }),
-      contentDetails: {
-        channel: "msteams",
-        action: "react",
-        reactionType,
-        ok: true,
-      },
-    });
-  });
-
   it("preserves explicit teamId/channelId target over toolContext fallback", async () => {
     // Even in a channel context with a compound currentChannelId, an
     // explicit `target` param must take precedence.
@@ -1371,41 +1354,6 @@ describe("msteamsPlugin message actions", () => {
       runtimeParams: {
         to: explicitTarget,
         messageId: "msg-explicit",
-        reactionType,
-      },
-      details: okMSTeamsActionDetails("react", {
-        reactionType,
-      }),
-      contentDetails: {
-        channel: "msteams",
-        action: "react",
-        reactionType,
-        ok: true,
-      },
-    });
-  });
-
-  it("keeps chat conversation fallback targets as-is for DM react actions", async () => {
-    // DM/group-chat turns continue to set currentChannelId to a
-    // `conversation:<id>` string (no `teamId/` prefix), which the runtime
-    // will resolve through `/chats/{id}`.
-    const dmFallback = "conversation:19:chat-dm@thread.skype";
-    await expectSuccessfulAction({
-      mockFn: reactMessageMSTeamsMock,
-      mockResult: { ok: true },
-      action: "react",
-      cfg: unrestrictedReadCfg,
-      actionParams: {
-        messageId: "msg-dm-react",
-        emoji: reactionType,
-      },
-      toolContext: {
-        currentChannelId: dmFallback,
-        currentChatType: "direct",
-      },
-      runtimeParams: {
-        to: dmFallback,
-        messageId: "msg-dm-react",
         reactionType,
       },
       details: okMSTeamsActionDetails("react", {

--- a/extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts
@@ -224,14 +224,14 @@ describe("msteams thread parent context injection", () => {
     expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it("does not fetch parent for DM replyToId", async () => {
+  it("keeps inbound DM reply targets flat under threaded reply configuration", async () => {
     fetchChannelMessageMock.mockResolvedValue({
       id: "x",
       from: { user: { displayName: "Alice" } },
       body: { content: "should-not-happen", contentType: "text" },
     });
-    const { deps, enqueueSystemEvent } = createMessageHandlerDeps({
-      channels: { msteams: { allowFrom: ["*"] } },
+    const { conversationStore, deps, enqueueSystemEvent } = createMessageHandlerDeps({
+      channels: { msteams: { allowFrom: ["*"], replyStyle: "thread" } },
     } as OpenClawConfig);
     const handler = createMSTeamsMessageHandler(deps);
 
@@ -248,6 +248,26 @@ describe("msteams thread parent context injection", () => {
 
     expect(fetchChannelMessageMock).not.toHaveBeenCalled();
     expect(findParentSystemEventCall(enqueueSystemEvent)).toBeUndefined();
+    expect(conversationStore.upsert).toHaveBeenCalledWith(
+      "a:dm-conversation",
+      expect.objectContaining({
+        conversation: expect.objectContaining({
+          id: "a:dm-conversation",
+          conversationType: "personal",
+        }),
+      }),
+    );
+    expect(conversationStore.upsert).not.toHaveBeenCalledWith(
+      "a:dm-conversation",
+      expect.objectContaining({ threadId: expect.any(String) }),
+    );
+    const dispatchContext =
+      runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mock.calls[0]?.[0].ctx;
+    expect(dispatchContext).toMatchObject({
+      To: "user:user-aad",
+      OriginatingTo: "conversation:a:dm-conversation",
+    });
+    expect(dispatchContext?.MessageThreadId).toBeUndefined();
   });
 
   it("does not fetch parent for top-level channel messages without replyToId", async () => {

--- a/extensions/msteams/src/monitor-handler/reaction-handler.test.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.test.ts
@@ -57,7 +57,7 @@ function createReactionTestHarness() {
   setMSTeamsRuntime(mockRuntime);
 
   const cfg: OpenClawConfig = {
-    channels: { msteams: { allowFrom: ["allowed-aad"] } },
+    channels: { msteams: { allowFrom: ["allowed-aad"], groupPolicy: "open" } },
   } as OpenClawConfig;
 
   const deps = buildDeps(cfg, mockRuntime);
@@ -81,14 +81,6 @@ function firstEnqueueLabel(enqueue: ReturnType<typeof vi.fn>): string {
     throw new Error("Expected enqueueSystemEvent label");
   }
   return label;
-}
-
-function firstEnqueueMeta(enqueue: ReturnType<typeof vi.fn>): Record<string, unknown> {
-  const [, meta] = firstEnqueueCall(enqueue);
-  if (!meta || typeof meta !== "object") {
-    throw new Error("Expected enqueueSystemEvent metadata");
-  }
-  return meta as Record<string, unknown>;
 }
 
 async function invokeReactionEvent(
@@ -190,25 +182,34 @@ describe("createMSTeamsReactionHandler", () => {
   });
 
   describe("inbound reaction events", () => {
-    it("enqueues system event for reactionsAdded", async () => {
-      const { handler, enqueue } = createReactionTestHarness();
-      await invokeReactionEvent(
-        handler,
-        {
-          reactionsAdded: [{ type: "like" }],
-          from: { id: "u1", aadObjectId: "allowed-aad", name: "User" },
-          replyToId: "msg-1",
-        },
-        "added",
-      );
+    it.each([
+      { conversationType: "personal", conversationId: "a:dm" },
+      { conversationType: "groupChat", conversationId: "19:g@thread.v2" },
+      { conversationType: "channel", conversationId: "19:c@thread.tacv2" },
+    ] as const)(
+      "enqueues the exact inbound reaction event label for $conversationType conversations",
+      async ({ conversationType, conversationId }) => {
+        const { handler, enqueue } = createReactionTestHarness();
+        await invokeReactionEvent(
+          handler,
+          {
+            reactionsAdded: [{ type: "like" }],
+            from: { id: "u1", aadObjectId: "allowed-aad", name: "User" },
+            conversation: { id: conversationId, conversationType },
+            replyToId: "msg-1",
+          },
+          "added",
+        );
 
-      expect(enqueue).toHaveBeenCalledOnce();
-      const label = firstEnqueueLabel(enqueue);
-      const meta = firstEnqueueMeta(enqueue);
-      expect(label).toContain("added");
-      expect(meta.sessionKey).toBe("test-session");
-      expect(meta.contextKey).toContain("added");
-    });
+        expect(enqueue).toHaveBeenCalledExactlyOnceWith(
+          "Teams reaction 👍 added by User on message msg-1",
+          {
+            sessionKey: "test-session",
+            contextKey: `msteams:reaction:${conversationId}:msg-1:allowed-aad:like:added`,
+          },
+        );
+      },
+    );
 
     it("enqueues system event for reactionsRemoved", async () => {
       const { handler, enqueue } = createReactionTestHarness();

--- a/extensions/msteams/src/send-context.test.ts
+++ b/extensions/msteams/src/send-context.test.ts
@@ -3,9 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MSTeamsConfig, OpenClawConfig } from "../runtime-api.js";
 import type { StoredConversationReference } from "./conversation-store.js";
 import { resolveMSTeamsSendContext } from "./send-context.js";
+import { sendMessageMSTeams } from "./send.js";
 
 const sendContextMockState = vi.hoisted(() => {
   const getAccessToken = vi.fn();
+  const createActivity = vi.fn(async () => ({ id: "message-1" }));
+  const getActivities = vi.fn(() => ({ create: createActivity }));
   const store = {
     upsert: vi.fn(),
     get: vi.fn(),
@@ -15,9 +18,20 @@ const sendContextMockState = vi.hoisted(() => {
   };
   return {
     store,
-    loadMSTeamsSdkWithAuth: vi.fn(async () => ({ app: { id: "mock-app" } })),
+    loadMSTeamsSdkWithAuth: vi.fn(async () => ({
+      app: {
+        id: "mock-app",
+        api: {
+          serviceUrl: "https://smba.trafficmanager.net/amer/",
+          conversations: { activities: getActivities },
+        },
+      },
+    })),
     createMSTeamsTokenProvider: vi.fn(() => ({ getAccessToken })),
+    createActivity,
+    getActivities,
     getAccessToken,
+    logInfo: vi.fn(),
     logWarn: vi.fn(),
   };
 });
@@ -29,7 +43,10 @@ vi.mock("./conversation-store-state.js", () => ({
 vi.mock("./runtime.js", () => ({
   getMSTeamsRuntime: () => ({
     logging: {
-      getChildLogger: () => ({ warn: sendContextMockState.logWarn }),
+      getChildLogger: () => ({
+        info: sendContextMockState.logInfo,
+        warn: sendContextMockState.logWarn,
+      }),
     },
   }),
 }));
@@ -94,7 +111,10 @@ beforeEach(() => {
   sendContextMockState.store.findPreferredDmByUserId.mockReset();
   sendContextMockState.loadMSTeamsSdkWithAuth.mockClear();
   sendContextMockState.createMSTeamsTokenProvider.mockClear();
+  sendContextMockState.createActivity.mockClear();
+  sendContextMockState.getActivities.mockClear();
   sendContextMockState.getAccessToken.mockReset();
+  sendContextMockState.logInfo.mockReset();
   sendContextMockState.logWarn.mockReset();
   vi.unstubAllEnvs();
 });
@@ -161,6 +181,56 @@ describe("resolveMSTeamsSendContext", () => {
     });
     expect(sendContextMockState.store.get).toHaveBeenCalledWith("19:channel@thread.tacv2");
   });
+
+  it.each([
+    { conversationType: "personal", conversationId: "a:dm", expectedSuffix: "" },
+    { conversationType: "groupChat", conversationId: "19:g@thread.v2", expectedSuffix: "" },
+    {
+      conversationType: "channel",
+      conversationId: "19:c@thread.tacv2",
+      expectedSuffix: ";messageid=root-1",
+    },
+  ] as const)(
+    "sends explicit threaded $conversationType targets to the correct SDK conversation",
+    async ({ conversationType, conversationId, expectedSuffix }) => {
+      sendContextMockState.store.get.mockResolvedValue(
+        channelRef({
+          serviceUrl: "https://smba.trafficmanager.net/amer/",
+          threadId: "root-1",
+          conversation: { id: conversationId, conversationType },
+        }),
+      );
+
+      await sendMessageMSTeams({
+        cfg: {
+          channels: {
+            msteams: {
+              enabled: true,
+              appId: "app-id",
+              appPassword: "app-password",
+              tenantId: "tenant-id",
+              replyStyle: "thread",
+            },
+          },
+        } as OpenClawConfig,
+        to: `conversation:${conversationId};messageid=root-1`,
+        text: "parity proof",
+      });
+
+      expect(sendContextMockState.store.get).toHaveBeenCalledWith(conversationId);
+      expect(sendContextMockState.getActivities).toHaveBeenCalledExactlyOnceWith(
+        `${conversationId}${expectedSuffix}`,
+      );
+      expect(sendContextMockState.createActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: `${conversationId}${expectedSuffix}`,
+            conversationType,
+          }),
+        }),
+      );
+    },
+  );
 
   it("resolves Graph team/channel targets through the stored channel conversation", async () => {
     sendContextMockState.store.get.mockResolvedValue(


### PR DESCRIPTION
## What Problem This Solves

Microsoft's Lobster fork carries two Teams patches whose upstream status was unproven: 0038 (personal-chat replies must never get a Teams thread suffix) and 0026 (agent reaction targeting across conversation kinds). Main appeared to cover both, but no single regression pinned the contracts per conversation kind — so the carries survived on uncertainty.

## Why This Change Was Made

Table-driven regressions settle both with evidence instead of negotiation: for personal|groupChat|channel with both a stored thread ref and an explicit `;messageid=` recipient, the conversation id handed to the SDK stays bare for personal/group and keeps the suffix only for channel (plus an inbound DM turn with `replyStyle: "thread"` producing no suffix); agent react actions route to the prepared Graph target per kind with exact result payloads, and inbound reaction events produce exact labels and context keys. Two older react tests were consolidated into the table (their invariants are rows); substring assertions upgraded to exact strings.

## User Impact

None at runtime — test-only. Teams threading and reaction routing contracts are now pinned per conversation kind.

## Evidence

Parity proven for both patches (each new test verified to fail credibly under contract-breaking mutation); full msteams suite green (1,438 tests) post-rebase; `check:changed` green; autoreview clean (0.99). Production LOC 0; tests +177/−138.

Parity proof for Microsoft Lobster patches 0038/0026 via giodl73-repo/lobster-plugins-and-patches.
