### PR TITLE
improve(test): speed up model-provider recovery observations

### DIFF
--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -250,7 +250,7 @@ describe("ModelProvidersPage agent scope", () => {
         page.routeData = routeData;
       }
       document.body.append(page);
-      await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: false }));
+      await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: false }));
       const previousCalls = requestCount(request, "usage.status");
       providerUnavailable = false;
 
@@ -259,7 +259,7 @@ describe("ModelProvidersPage agent scope", () => {
       await vi.waitFor(() => {
         expect(requestCount(request, "usage.status")).toBe(previousCalls + 1);
       });
-      await vi.waitFor(() =>
+      await waitForFast(() =>
         expect(page.data?.providerUsage).toEqual({
           ok: true,
           value: { updatedAt: 1, providers: [] },
@@ -293,7 +293,7 @@ describe("ModelProvidersPage agent scope", () => {
         };
       }
       document.body.append(page);
-      await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
+      await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
       const previousCalls = requestCount(request, "usage.status");
 
       window.dispatchEvent(new Event("focus"));
@@ -321,14 +321,14 @@ describe("ModelProvidersPage agent scope", () => {
       return originalRequest(method);
     });
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: false }));
+    await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: false }));
     providerUnavailable = false;
 
     source.publish({ ...snapshot, phase: "reconnecting" });
     source.publish({ ...snapshot, phase: "connected" });
 
     await vi.waitFor(() => expect(requestCount(request, "usage.status")).toBe(2));
-    await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
+    await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
   });
 
   it("defers failed provider usage recovery while hidden until page activation", async () => {
@@ -346,7 +346,7 @@ describe("ModelProvidersPage agent scope", () => {
       return originalRequest(method);
     });
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: false }));
+    await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: false }));
     providerUnavailable = false;
 
     source.publish({ ...snapshot, phase: "reconnecting" });
@@ -357,7 +357,7 @@ describe("ModelProvidersPage agent scope", () => {
     document.dispatchEvent(new Event("visibilitychange"));
 
     await vi.waitFor(() => expect(requestCount(request, "usage.status")).toBe(2));
-    await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
+    await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
   });
 
   it("supersedes a hung load on disconnect so reconnect can replace it", async () => {
@@ -367,7 +367,7 @@ describe("ModelProvidersPage agent scope", () => {
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
+    await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
     deferNextAuthStatus();
     void page.refresh({ force: true });
     await vi.waitFor(() => expect(requestCount(request, "models.authStatus")).toBe(2));
@@ -376,7 +376,7 @@ describe("ModelProvidersPage agent scope", () => {
     source.publish({ ...snapshot, phase: "connected" });
 
     await vi.waitFor(() => expect(requestCount(request, "models.authStatus")).toBe(3));
-    await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
+    await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
   });
 
   it("keeps direct data visible while a same-client reconnect replaces it", async () => {
@@ -386,7 +386,7 @@ describe("ModelProvidersPage agent scope", () => {
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
     const page = appendPage(context);
-    await vi.waitFor(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
+    await waitForFast(() => expect(page.data?.providerUsage).toMatchObject({ ok: true }));
     const previousData = page.data;
     const originalRequest = request.getMockImplementation()!;
     request.mockImplementation(async (method: string) => {
@@ -406,7 +406,7 @@ describe("ModelProvidersPage agent scope", () => {
     expect(page.data).toBe(previousData);
 
     release();
-    await vi.waitFor(() =>
+    await waitForFast(() =>
       expect(page.data?.config).toEqual({
         agents: { defaults: { model: "openai/replacement-model" } },
       }),


### PR DESCRIPTION
## What Problem This Solves

The Control UI model-provider recovery regression suite unnecessarily waits for Vitest's default polling interval when observing already-owned provider usage and replacement data. These incidental waits slow maintainer and CI feedback after the provider-usage recovery coverage added in #120301.

## Why This Change Was Made

Reuse the existing Control UI fast-polling helper at the eleven previously benchmarked owner-state observation sites. Preserve all request-admission, request-count, reconnect-order, catalog/config-load, agent-switch, mutation, cancellation, and ownership-generation synchronization barriers; assertions, deadlines, imports, test inventory, helper implementation, and production code are unchanged.

## User Impact

No user-visible or production behavior changes. Developers receive faster feedback from the existing model-provider recovery regression suite while retaining its complete coverage.

## Evidence

- Maintainer-requested test-performance follow-up to #127085 and #120301; exactly one test file changed, with production LOC +0/-0 and test LOC +11/-11.
- Eight retained, interleaved, order-balanced baseline/candidate pairs on the same Blacksmith Testbox, with excluded warmups, one worker, isolated module caches, and identical commands: median scoped wall time **2.240 s -> 1.720 s**, a **0.520 s / 23.2% improvement**; paired median improvement **0.525 s**.
- Every benchmark sample passed all **30/30** existing owner tests and retained **10/10** import diagnostics. Vitest's **1,000 ms** default deadline and all assertions were unchanged; only the existing helper's **1 ms** polling interval replaces the default **50 ms** interval at incidental observations.
- Classification: **31** fast owner-state observations and **23** deliberately retained semantic `vi.waitFor` barriers, preserving all **54** existing wait sites. The six newly introduced request/reconnect barriers remain untouched, as do all seventeen pre-existing mutation, agent ownership, cancellation, and request-order barriers.
- Reversible fault injection against the owner on a disposable Testbox prevented successful provider-usage adoption: the unchanged existing recovery assertion failed (`exit=1`), then passed after the owner was restored exactly (`exit=0`). No production mutation was retained or published.
- Current-head focused owner/sibling proof: **145/145 tests across 11 files passed**, covering the model-provider page, loader, data, mutations, view, usage refresh policy/page, Gateway page controller, Gateway connection lifecycle, provider-usage request owner, and Gateway-source replacement.
- Current-head complete changed gate, targeted formatting, and `git diff --check`: passed.
- Fresh structured autoreview: clean, with no accepted or actionable findings.
- Established controlled benchmark workflow: https://github.com/openclaw/openclaw/actions/runs/32523567737
