### PR TITLE
fix(onboard): keep provider credentials with named first agents

### DIFF
--- a/src/commands/auth-choice.apply.api-providers.test.ts
+++ b/src/commands/auth-choice.apply.api-providers.test.ts
@@ -1,16 +1,34 @@
 // API-provider auth-choice tests cover built-in provider config, API keys, and provider plugin setup.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as providerAuthChoices from "../plugins/provider-auth-choices.js";
 import type { ProviderPlugin } from "../plugins/types.js";
 import { normalizeApiKeyTokenProviderAuthChoice } from "./auth-choice.apply.api-providers.js";
+import { prepareAuthChoice } from "./auth-choice.apply.js";
 
 const resolvePluginProviders = vi.hoisted(() =>
   vi.fn<typeof import("../plugins/provider-auth-choice.runtime.js").resolvePluginProviders>(),
 );
 const resolvePluginSetupProvider = vi.hoisted(() => vi.fn(() => undefined));
+const prepareAuthChoiceLoadedPluginProvider = vi.hoisted(() =>
+  vi.fn<
+    typeof import("../plugins/provider-auth-choice.js").prepareAuthChoiceLoadedPluginProvider
+  >(),
+);
+const resolveDeprecatedProviderInstallCatalogEntry = vi.hoisted(() =>
+  vi.fn<
+    typeof import("../plugins/provider-install-catalog.js").resolveDeprecatedProviderInstallCatalogEntry
+  >(),
+);
 
 vi.mock("../plugins/provider-auth-choice.runtime.js", () => ({
   resolvePluginProviders,
   resolvePluginSetupProvider,
+}));
+vi.mock("../plugins/provider-auth-choice.js", () => ({
+  prepareAuthChoiceLoadedPluginProvider,
+}));
+vi.mock("../plugins/provider-install-catalog.js", () => ({
+  resolveDeprecatedProviderInstallCatalogEntry,
 }));
 
 function createProvider(params: {
@@ -39,6 +57,9 @@ function createProvider(params: {
 describe("normalizeApiKeyTokenProviderAuthChoice", () => {
   afterEach(() => {
     resolvePluginProviders.mockReset();
+    prepareAuthChoiceLoadedPluginProvider.mockReset();
+    resolveDeprecatedProviderInstallCatalogEntry.mockReset();
+    vi.restoreAllMocks();
   });
 
   it("maps token provider auth through plugin token methods", () => {
@@ -89,4 +110,94 @@ describe("normalizeApiKeyTokenProviderAuthChoice", () => {
       }),
     ).toBe("token");
   });
+
+  it.each([
+    { authChoice: "apiKey", kind: "api_key" },
+    { authChoice: "token", kind: "token" },
+    { authChoice: "setup-token", kind: "token" },
+  ] as const)(
+    "resolves workspace-only $authChoice providers through interactive setup",
+    async (choice) => {
+      const workspaceDir = "/tmp/selected-agent-workspace";
+      const provider = createProvider({
+        id: "workspace-provider",
+        auth: [{ id: "workspace-auth", kind: choice.kind, choiceId: "workspace-provider-auth" }],
+      });
+      resolvePluginProviders.mockImplementation((params) =>
+        params?.workspaceDir === workspaceDir ? [provider] : [],
+      );
+      prepareAuthChoiceLoadedPluginProvider.mockImplementation(async (params) =>
+        params.authChoice === "workspace-provider-auth"
+          ? {
+              config: params.config,
+              authProfiles: [
+                {
+                  profileId: "workspace-provider:default",
+                  credential: {
+                    type: "api_key",
+                    provider: "workspace-provider",
+                    key: "fixture-workspace-key",
+                  },
+                },
+              ],
+              persistAuthProfiles: async () => {},
+            }
+          : null,
+      );
+
+      const prepared = await prepareAuthChoice({
+        authChoice: choice.authChoice,
+        config: {},
+        workspaceDir,
+        prompter: {} as never,
+        runtime: {} as never,
+        setDefaultModel: false,
+        opts: { tokenProvider: provider.id },
+      });
+
+      expect(prepared.authProfiles).toEqual([
+        {
+          profileId: "workspace-provider:default",
+          credential: {
+            type: "api_key",
+            provider: "workspace-provider",
+            key: "fixture-workspace-key",
+          },
+        },
+      ]);
+    },
+  );
+
+  it.each(["manifest", "install catalog"] as const)(
+    "resolves workspace-only deprecated auth choices from the %s",
+    async (source) => {
+      const workspaceDir = "/tmp/selected-agent-workspace";
+      vi.spyOn(
+        providerAuthChoices,
+        "resolveManifestDeprecatedProviderAuthChoice",
+      ).mockImplementation((_choice, params) =>
+        source === "manifest" && params?.workspaceDir === workspaceDir
+          ? ({ choiceId: "workspace-modern-auth" } as never)
+          : undefined,
+      );
+      resolveDeprecatedProviderInstallCatalogEntry.mockImplementation((_choice, params) =>
+        source === "install catalog" &&
+        params?.workspaceDir === workspaceDir &&
+        params.includeUntrustedWorkspacePlugins === false
+          ? ({ choiceId: "workspace-modern-auth" } as never)
+          : undefined,
+      );
+
+      await expect(
+        prepareAuthChoice({
+          authChoice: "workspace-legacy-auth",
+          config: {},
+          workspaceDir,
+          prompter: {} as never,
+          runtime: {} as never,
+          setDefaultModel: false,
+        }),
+      ).rejects.toThrow('Use "workspace-modern-auth" instead');
+    },
+  );
 });

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -10,7 +10,7 @@ import type { AuthChoice } from "./onboard-types.js";
 
 async function normalizeLegacyChoice(
   authChoice: AuthChoice | undefined,
-  params: Pick<ApplyAuthChoiceParams, "config" | "env">,
+  params: Pick<ApplyAuthChoiceParams, "config" | "env" | "workspaceDir">,
 ): Promise<AuthChoice | undefined> {
   if (authChoice === "oauth") {
     return "setup-token";
@@ -42,31 +42,28 @@ async function normalizeTokenProviderChoice(params: {
     authChoice: params.authChoice,
     tokenProvider: params.source.opts.tokenProvider,
     config: params.source.config,
+    workspaceDir: params.source.workspaceDir,
     env: params.source.env,
   });
 }
 
 async function formatDeprecatedProviderChoiceError(
   authChoice: AuthChoice | undefined,
-  params: Pick<ApplyAuthChoiceParams, "config" | "env">,
+  params: Pick<ApplyAuthChoiceParams, "config" | "env" | "workspaceDir">,
 ): Promise<string | undefined> {
   if (typeof authChoice !== "string") {
     return undefined;
   }
   const { resolveManifestDeprecatedProviderAuthChoice } =
     await import("../plugins/provider-auth-choices.js");
-  const deprecatedChoice = resolveManifestDeprecatedProviderAuthChoice(authChoice, {
-    config: params.config,
-    env: params.env,
-  });
+  const deprecatedChoice = resolveManifestDeprecatedProviderAuthChoice(authChoice, params);
   if (deprecatedChoice) {
     return `Auth choice ${JSON.stringify(authChoice)} is no longer supported. Use ${JSON.stringify(deprecatedChoice.choiceId)} instead, or run ${formatCliCommand("openclaw onboard")} to choose interactively.`;
   }
   const { resolveDeprecatedProviderInstallCatalogEntry } =
     await import("../plugins/provider-install-catalog.js");
   const externalDeprecatedChoice = resolveDeprecatedProviderInstallCatalogEntry(authChoice, {
-    config: params.config,
-    env: params.env,
+    ...params,
     includeUntrustedWorkspacePlugins: false,
   });
   if (!externalDeprecatedChoice) {
@@ -80,10 +77,7 @@ export async function prepareAuthChoice(
   params: ApplyAuthChoiceParams,
 ): Promise<PreparedAuthChoiceResult> {
   const normalizedAuthChoice =
-    (await normalizeLegacyChoice(params.authChoice, {
-      config: params.config,
-      env: params.env,
-    })) ?? params.authChoice;
+    (await normalizeLegacyChoice(params.authChoice, params)) ?? params.authChoice;
   const normalizedProviderAuthChoice = await normalizeTokenProviderChoice({
     authChoice: normalizedAuthChoice,
     source: params,
@@ -99,10 +93,7 @@ export async function prepareAuthChoice(
 
   const deprecatedProviderChoiceError = await formatDeprecatedProviderChoiceError(
     normalizedParams.authChoice,
-    {
-      config: normalizedParams.config,
-      env: normalizedParams.env,
-    },
+    normalizedParams,
   );
   if (deprecatedProviderChoiceError) {
     throw new Error(deprecatedProviderChoiceError);

--- a/src/commands/auth-choice.apply.types.ts
+++ b/src/commands/auth-choice.apply.types.ts
@@ -12,6 +12,7 @@ export type ApplyAuthChoiceParams = {
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
   agentDir?: string;
+  workspaceDir?: string;
   setDefaultModel: boolean;
   preserveExistingDefaultModel?: boolean;
   agentId?: string;

--- a/src/commands/onboard-agent-target.test.ts
+++ b/src/commands/onboard-agent-target.test.ts
@@ -78,19 +78,68 @@ describe("onboarding agent target", () => {
       main: { workspace: "/srv/main" },
       ops: { default: true, workspace: "/srv/ops" },
     };
+    const pendingAgent = { name: "robby", workspaceDir: "/srv/robby" };
 
     expect(
-      resolveOnboardingSetupTarget({
-        agents: {
-          ownership: "explicit",
-          defaults: { systemAgent: { agentId: "main" } },
-          entries,
+      resolveOnboardingSetupTarget(
+        {
+          agents: {
+            ownership: "explicit",
+            defaults: { systemAgent: { agentId: "main" } },
+            entries,
+          },
         },
-      }),
+        pendingAgent,
+      ),
     ).toMatchObject({ agentId: "main", workspaceDir: "/srv/main" });
+    expect(
+      resolveOnboardingSetupTarget(
+        {
+          agents: {
+            ownership: "explicit",
+            defaults: { systemAgent: { agentId: "main" } },
+            entries: { main: { default: true } },
+          },
+        },
+        pendingAgent,
+      ),
+    ).toMatchObject({ agentId: "main" });
     expect(resolveOnboardingSetupTarget({ agents: { entries } })).toMatchObject({
       agentId: "ops",
       workspaceDir: "/srv/ops",
+    });
+  });
+
+  it("resolves a pending first agent without nesting the selected workspace", async () => {
+    const stateDir = tempDirs.make("openclaw-pending-onboard-target-");
+    const workspaceDir = path.join(stateDir, "requested-workspace");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      for (const entries of [undefined, { main: {} }, { main: { default: true } }] as const) {
+        const config = {
+          agents: { defaults: { workspace: workspaceDir }, ...(entries ? { entries } : {}) },
+        };
+
+        expect(resolveOnboardingSetupTarget(config, { name: " Robby! ", workspaceDir })).toEqual({
+          agentId: "robby",
+          agentDir: path.join(stateDir, "agents", "robby", "agent"),
+          workspaceDir,
+        });
+        expect(resolveOnboardingSetupTarget(config)).toMatchObject({
+          agentId: "main",
+          workspaceDir,
+        });
+      }
+      expect(
+        resolveOnboardingSetupTarget({
+          agents: {
+            entries: { main: { default: true, name: "Authored main", workspace: "/srv/main" } },
+          },
+        }),
+      ).toMatchObject({ agentId: "main", workspaceDir: "/srv/main" });
+      expect(
+        resolveOnboardingSetupTarget({ agents: { entries: { main: { default: false } } } }),
+      ).toMatchObject({ agentId: "main" });
     });
   });
 

--- a/src/commands/onboard-agent-target.ts
+++ b/src/commands/onboard-agent-target.ts
@@ -48,11 +48,21 @@ export function resolveSystemAgentOnboardingTarget(config: OpenClawConfig): Onbo
   return resolveOnboardingAgentTarget(config, config.agents?.defaults?.systemAgent?.agentId);
 }
 
-/** Resolve onboarding setup to the system agent only for explicitly owned fleets. */
-export function resolveOnboardingSetupTarget(config: OpenClawConfig): OnboardingAgentTarget {
-  return config.agents?.ownership === "explicit"
-    ? resolveSystemAgentOnboardingTarget(config)
-    : resolveOnboardingAgentTarget(config);
+/** Resolve onboarding setup to its existing or pending first-agent owner. */
+export function resolveOnboardingSetupTarget(
+  config: OpenClawConfig,
+  pendingAgent?: { name: string; workspaceDir: string },
+): OnboardingAgentTarget {
+  if (config.agents?.ownership === "explicit") {
+    return resolveSystemAgentOnboardingTarget(config);
+  }
+  if (pendingAgent) {
+    return {
+      ...resolveOnboardingAgentTarget(config, pendingAgent.name),
+      workspaceDir: pendingAgent.workspaceDir,
+    };
+  }
+  return resolveOnboardingAgentTarget(config);
 }
 
 export async function ensureOnboardingAgentWorkspace(

--- a/src/commands/onboard-non-interactive/local.default-agent.test.ts
+++ b/src/commands/onboard-non-interactive/local.default-agent.test.ts
@@ -198,7 +198,6 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
               robby: {
                 name: "robby",
                 workspace,
-                agentDir: "/tmp/robby-agent",
               },
             },
           },
@@ -215,7 +214,7 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
         mode: "local",
         agentName: "robby",
         workspace,
-        authChoice: "skip",
+        authChoice: "demo-api-key",
         skipHooks: true,
         skipSkills: true,
         skipHealth: true,
@@ -225,6 +224,18 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
       baseConfig: {},
     });
 
+    expect(mocks.applyAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          agentId: "robby",
+          agentDir: expect.stringMatching(/[/\\]agents[/\\]robby[/\\]agent$/),
+          workspaceDir: workspace,
+        }),
+      }),
+    );
+    expect(mocks.applyAuthChoice.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.ensureOnboardingAgent.mock.invocationCallOrder[0]!,
+    );
     expect(mocks.ensureOnboardingAgent).toHaveBeenCalledOnce();
     expect(mocks.ensureOnboardingAgent).toHaveBeenCalledWith(
       expect.objectContaining({ firstAgent: { name: "robby" } }),
@@ -306,8 +317,9 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
       opts: {
         nonInteractive: true,
         mode: "local",
+        agentName: "robby",
         workspace: "/tmp/global-workspace",
-        authChoice: "skip",
+        authChoice: "demo-api-key",
         skipHooks: true,
         skipSkills: true,
         skipHealth: true,
@@ -318,6 +330,15 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
       baseConfig,
     });
 
+    expect(mocks.applyAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          agentId: "ops",
+          agentDir: "/tmp/ops-agent",
+          workspaceDir: "/tmp/ops-workspace",
+        }),
+      }),
+    );
     expect(mocks.commitConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         nextConfig: expect.objectContaining({

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -4,6 +4,7 @@
  * This entrypoint applies config changes, optionally installs the gateway
  * daemon, verifies health, and emits machine-readable setup output.
  */
+import { listAgentEntries } from "../../agents/agent-scope-config.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { resolveGatewayPort } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
@@ -178,7 +179,6 @@ export async function runNonInteractiveLocalSetup(params: {
 }) {
   const { opts, runtime, baseConfig, baseHash } = params;
   const mode = "local" as const;
-  const preCreationAgentId = resolveOnboardingSetupTarget(baseConfig).agentId;
 
   const requestedWorkspaceDir = resolveNonInteractiveWorkspaceDir({
     opts,
@@ -207,7 +207,12 @@ export async function runNonInteractiveLocalSetup(params: {
   }
   // Workspace defaults are already staged above; provider discovery must use
   // that requested owner before first-agent creation is allowed to write.
-  const authTarget = resolveOnboardingAgentTarget(nextConfig, preCreationAgentId);
+  const authTarget = resolveOnboardingSetupTarget(
+    nextConfig,
+    opts.agentName && listAgentEntries(baseConfig).length === 0
+      ? { name: opts.agentName, workspaceDir }
+      : undefined,
+  );
 
   const inferredAuthChoice = opts.authChoice
     ? undefined

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../../../config/model-input.js";
+import * as apiProviderAuthChoices from "../../auth-choice.apply.api-providers.js";
 import { commitNonInteractiveOnboardConfig } from "../config-write.js";
 import { applyNonInteractiveAuthChoice } from "./auth-choice.js";
 
@@ -105,6 +106,34 @@ describe("applyNonInteractiveAuthChoice", () => {
     );
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("resolves generic provider auth from the selected agent workspace", async () => {
+    const runtime = createRuntime();
+    const nextConfig = { agents: { defaults: {} } } as OpenClawConfig;
+    const resolvedConfig = { auth: { profiles: { "demo-provider:default": { mode: "api_key" } } } };
+    applyNonInteractivePluginProviderChoice.mockResolvedValueOnce(resolvedConfig as never);
+    const normalize = vi
+      .spyOn(apiProviderAuthChoices, "normalizeApiKeyTokenProviderAuthChoice")
+      .mockImplementation((params) =>
+        params.workspaceDir === target.workspaceDir ? "demo-provider-api-key" : params.authChoice,
+      );
+
+    try {
+      const result = await applyNonInteractiveAuthChoice({
+        nextConfig,
+        authChoice: "apiKey",
+        opts: { tokenProvider: "demo-provider" },
+        runtime: runtime as never,
+        baseConfig: nextConfig,
+        target,
+      });
+
+      expect(result).toBe(resolvedConfig);
+      expect(runtime.error).not.toHaveBeenCalled();
+    } finally {
+      normalize.mockRestore();
+    }
   });
 
   it("resolves plugin provider auth before builtin custom-provider handling", async () => {

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -50,6 +50,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     authChoice: params.authChoice,
     tokenProvider: opts.tokenProvider,
     config: params.nextConfig,
+    workspaceDir: params.target.workspaceDir,
     env: process.env,
   });
   const nextConfig = params.nextConfig;

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -152,6 +152,43 @@ describe("runSetupModelAuthStep", () => {
     });
   });
 
+  it("stages provider auth on the pending named agent without nesting its workspace", async () => {
+    const workspaceDir = "/tmp/robby-workspace";
+    const config: OpenClawConfig = { agents: { defaults: { workspace: workspaceDir } } };
+    promptAuthChoiceGrouped.mockResolvedValueOnce("anthropic-cli");
+    applyAuthChoice.mockResolvedValueOnce({
+      config,
+      authProfiles: [],
+      persistAuthProfiles: async () => {},
+    });
+
+    await runSetupModelAuthStep({
+      config,
+      opts: {},
+      pendingAgent: { name: "Robby!", workspaceDir },
+      prompter: createPrompter(),
+      runtime: createRuntime(),
+    });
+
+    const agentDir = expect.stringMatching(/[/\\]agents[/\\]robby[/\\]agent$/);
+    expect(ensureAuthProfileStore).toHaveBeenCalledWith(agentDir, {
+      allowKeychainPrompt: false,
+      readOnly: true,
+    });
+    expect(promptAuthChoiceGrouped).toHaveBeenCalledWith(expect.objectContaining({ workspaceDir }));
+    expect(applyAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "robby", agentDir, workspaceDir }),
+    );
+    expect(promptDefaultModel).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "robby", agentDir, workspaceDir }),
+    );
+    expect(warnIfModelConfigLooksOff).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ agentId: "robby", agentDir }),
+    );
+  });
+
   it("targets the system agent when an explicit fleet selects Claude CLI", async () => {
     const config: OpenClawConfig = {
       agents: {

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -126,6 +126,7 @@ export async function runSetupModelAuthStep(params: {
   runtime: RuntimeEnv;
   agentDir?: string;
   stateDir?: string;
+  pendingAgent?: { name: string; workspaceDir: string };
   preserveExistingModelSelection?: boolean;
 }): Promise<SetupModelAuthCandidate> {
   const { opts, prompter, runtime } = params;
@@ -148,6 +149,8 @@ export async function runSetupModelAuthStep(params: {
     | (typeof import("../commands/auth-choice-prompt.js"))["isKeepCurrentAuthChoice"]
     | undefined;
   let detectedProviderIds: ReadonlySet<string> | undefined;
+  const resolveTarget = (config: OpenClawConfig) =>
+    resolveOnboardingSetupTarget(config, params.pendingAgent);
   if (authChoiceFromPrompt) {
     const [
       { ensureAuthProfileStore },
@@ -160,7 +163,7 @@ export async function runSetupModelAuthStep(params: {
     ]);
     promptAuthChoiceGrouped = promptAuthChoice;
     isKeepCurrentAuthChoice = isKeepCurrentChoice;
-    const target = resolveOnboardingSetupTarget(nextConfig);
+    const target = resolveTarget(nextConfig);
     authStore = ensureAuthProfileStore(params.agentDir ?? target.agentDir, {
       allowKeychainPrompt: false,
       readOnly: true,
@@ -173,7 +176,7 @@ export async function runSetupModelAuthStep(params: {
   }
   while (true) {
     if (authChoiceFromPrompt) {
-      const target = resolveOnboardingSetupTarget(nextConfig);
+      const target = resolveTarget(nextConfig);
       authChoice = await promptAuthChoiceGrouped!({
         prompter,
         store: authStore!,
@@ -214,7 +217,7 @@ export async function runSetupModelAuthStep(params: {
       // or run model/auth checks when the caller already chose to skip setup.
       if (authChoiceFromPrompt) {
         const { promptDefaultModel } = await loadModelPickerModule();
-        const target = resolveOnboardingSetupTarget(nextConfig);
+        const target = resolveTarget(nextConfig);
         const modelSelection = await promptDefaultModel({
           config: nextConfig,
           prompter,
@@ -235,7 +238,7 @@ export async function runSetupModelAuthStep(params: {
         }
 
         const { warnIfModelConfigLooksOff } = await loadAuthChoiceModule();
-        const validationTarget = resolveOnboardingSetupTarget(nextConfig);
+        const validationTarget = resolveTarget(nextConfig);
         await warnIfModelConfigLooksOff(nextConfig, prompter, {
           agentId: validationTarget.agentId,
           agentDir: validationTarget.agentDir,
@@ -250,7 +253,7 @@ export async function runSetupModelAuthStep(params: {
       { promptDefaultModel },
     ] = await Promise.all([loadAuthChoiceModule(), loadModelPickerModule()]);
     prompter.disableBackNavigation?.();
-    const target = resolveOnboardingSetupTarget(nextConfig);
+    const target = resolveTarget(nextConfig);
     let authResult: PreparedAuthChoiceResult;
     try {
       authResult = await prepareAuthChoice({
@@ -260,6 +263,7 @@ export async function runSetupModelAuthStep(params: {
         runtime,
         agentId: target.agentId,
         agentDir: params.agentDir ?? target.agentDir,
+        workspaceDir: target.workspaceDir,
         setDefaultModel: true,
         preserveExistingDefaultModel: true,
         env,
@@ -292,7 +296,7 @@ export async function runSetupModelAuthStep(params: {
       break;
     }
     if (authResult.agentModelOverride) {
-      const overrideTarget = resolveOnboardingSetupTarget(nextConfig);
+      const overrideTarget = resolveTarget(nextConfig);
       nextConfig = applyOnboardingPrimaryModel(
         nextConfig,
         overrideTarget,
@@ -300,7 +304,7 @@ export async function runSetupModelAuthStep(params: {
       );
     }
 
-    const updatedTarget = resolveOnboardingSetupTarget(nextConfig);
+    const updatedTarget = resolveTarget(nextConfig);
     const authChoiceModelSelectionPolicy = await resolveAuthChoiceModelSelectionPolicy({
       authChoice,
       config: nextConfig,
@@ -334,7 +338,7 @@ export async function runSetupModelAuthStep(params: {
       }
     }
 
-    const validationTarget = resolveOnboardingSetupTarget(nextConfig);
+    const validationTarget = resolveTarget(nextConfig);
     await warnIfModelConfigLooksOff(nextConfig, prompter, {
       agentId: validationTarget.agentId,
       agentDir: validationTarget.agentDir,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -527,13 +527,13 @@ async function runSetupWizardOnce(
   }
   const preModelAuthConfig = nextConfig;
   let stagedModelAuth: SetupModelAuthCandidate | undefined;
-  const hasExplicitAuthSetup = opts.authChoice !== undefined && opts.authChoice !== "skip";
-  if (!keepExistingModelConfig || hasExplicitAuthSetup) {
+  if (!keepExistingModelConfig || (opts.authChoice !== undefined && opts.authChoice !== "skip")) {
     stagedModelAuth = await runSetupModelAuthStep({
       config: nextConfig,
       opts,
       prompter,
       runtime,
+      pendingAgent: firstAgent && { ...firstAgent, workspaceDir },
       preserveExistingModelSelection: keepExistingModelConfig,
     });
     nextConfig = stagedModelAuth.config;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users onboarding their first agent with `--agent-name` and a provider credential would receive a successful setup result even though the credential was saved under the unrelated `main` agent. The named agent then had no auth profile for its configured model.

Both `openclaw onboard` and `openclaw setup` were affected in interactive and noninteractive flows. The failure reproduces with multiple provider plugins and with both plaintext credentials and SecretRefs.

## Why This Change Was Made

Onboarding prepares provider authentication before creating the first agent, which is required to avoid writing agent state when provider validation fails. Carry the authoritative pending first-agent identity and selected workspace through the existing shared setup-target owner instead of resolving the still-uncreated agent from runtime defaults.

Interactive setup determines first-agent provenance from the pre-migration source roster, so synthetic runtime `main` placeholders cannot steal ownership. Noninteractive setup only supplies a pending identity when the original roster is empty. Existing explicit/system-agent fleets, authored minimal `main` agents, staged provider-profile persistence, and provider workspace discovery keep their existing ownership contracts.

Generic API-key, token, and setup-token provider normalization now retains that same selected workspace in both interactive and noninteractive setup. Interactive legacy-provider aliases and deprecated-provider guidance also resolve against the selected workspace while retaining the existing untrusted-plugin restriction. This addresses both actionable ClawSweeper findings and removes duplicated context construction.

## User Impact

Naming a first agent during onboarding now stores provider credentials in that agent's own SQLite auth-profile database. Setup no longer creates an orphaned `main` credential database, and existing installations retain their configured agent ownership.

## Evidence

- Before: real isolated `openclaw onboard --non-interactive --accept-risk --agent-name robby --auth-choice nvidia-api-key --nvidia-api-key <fixture> ... --json` exited successfully with only `robby` configured, but `nvidia:default` existed only in `agents/main/agent/openclaw-agent.sqlite` and the `robby` auth database did not exist.
- After: the same actual CLI flow stores `nvidia:default` only in `agents/robby/agent/openclaw-agent.sqlite`; the `main` database is absent and the configured/JSON workspace remains the requested workspace.
- Repeated the actual CLI and SQLite proof for both `onboard` and `setup`, NVIDIA and Gemini providers, plaintext and env-backed SecretRef profiles, normalized agent names, the default `main` path, and existing explicit/system-agent fleets.
- Real interactive PTY proof starts with a synthetic runtime `main` roster but forwards the normalized named agent ID, its canonical agent directory, and the exact selected workspace to the real provider-auth owner.
- A genuinely authored minimal `agents.entries.main={}` followed by onboarding with `--agent-name robby` remains owned by `main`, proving runtime placeholders and authored rosters are distinguished by authoritative provenance.
- Existing owner regressions cover pending targets, synthetic/bootstrap roster forms, explicit single-agent fleets, existing legacy fleets, normalized agent IDs, auth-before-agent-creation ordering, provider workspace propagation, and staged interactive profile ownership.
- Actual generic `--auth-choice apiKey --token-provider nvidia` onboarding now forwards the exact selected workspace while persisting its profile only under the named agent. Executable workspace-only provider fixtures cover generic API-key, token, and setup-token choices, plus workspace-scoped legacy/deprecated provider handling.
- Both ClawSweeper rank-up items are addressed: interactive and noninteractive token-provider normalizers retain the target workspace, with focused caller-boundary regressions. The follow-up simplifies the owning production code by eight net lines.
- All eight changed files pass `oxfmt --check`, `oxlint --tsconfig tsconfig.json`, `git diff --check`, and an offline TruffleHog scan. Independent Codex autoreview completed with no actionable findings.

AI-assisted; all source, storage effects, provider ownership, and user-visible behavior were independently reviewed.
