### PR TITLE
fix(ui): prevent settings save action from overlapping build info

### DIFF
--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -111,6 +111,21 @@ function settingsRow(page: Page, title: string): Locator {
   });
 }
 
+function overlapArea(
+  first: { x: number; y: number; width: number; height: number },
+  second: { x: number; y: number; width: number; height: number },
+): number {
+  const width = Math.max(
+    0,
+    Math.min(first.x + first.width, second.x + second.width) - Math.max(first.x, second.x),
+  );
+  const height = Math.max(
+    0,
+    Math.min(first.y + first.height, second.y + second.height) - Math.max(first.y, second.y),
+  );
+  return width * height;
+}
+
 async function capture(page: Page, name: string): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
@@ -440,10 +455,40 @@ suite.define(() => {
         await expect
           .poll(() => saveIndicator.textContent())
           .toContain("Autosave paused after reconnect");
+        const saveButton = saveIndicator.getByRole("button", { name: "Save", exact: true });
+        const buildLink = page.locator(".settings-sidebar__footer .sidebar-footer-build");
+        await saveButton.focus();
+        await expect
+          .poll(() => saveButton.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+        const [saveBounds, buildBounds] = await Promise.all([
+          saveButton.boundingBox(),
+          buildLink.boundingBox(),
+        ]);
+        expect(saveBounds).not.toBeNull();
+        expect(buildBounds).not.toBeNull();
+        if (!saveBounds || !buildBounds) {
+          throw new Error("Expected visible settings footer controls");
+        }
+        expect(overlapArea(saveBounds, buildBounds)).toBe(0);
+        expect(await buildLink.textContent()).not.toBe("");
         await capture(page, "07-opaque-revision-reconnect.png");
 
+        await page.setViewportSize({ height: 900, width: 1280 });
+        const [narrowSaveBounds, narrowBuildBounds] = await Promise.all([
+          saveButton.boundingBox(),
+          buildLink.boundingBox(),
+        ]);
+        expect(narrowSaveBounds).not.toBeNull();
+        expect(narrowBuildBounds).not.toBeNull();
+        if (!narrowSaveBounds || !narrowBuildBounds) {
+          throw new Error("Expected visible settings footer controls at 1280px");
+        }
+        expect(overlapArea(narrowSaveBounds, narrowBuildBounds)).toBe(0);
+        await capture(page, "07-opaque-revision-reconnect-1280.png");
+
         await gateway.deferNext("config.set");
-        await saveIndicator.getByRole("button", { name: "Save", exact: true }).click();
+        await saveButton.click();
         const save = mutationParams(await gateway.waitForRequest("config.set"));
         expect(save.baseHash).toBe("hmac-sha256:v1:opaque-current");
         expect(JSON.parse(String(save.raw))).toMatchObject({

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -616,7 +616,8 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
 .settings-sidebar__footer {
   flex-shrink: 0;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 8px;
   padding: 12px 21px;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
@@ -626,6 +627,10 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
 
 openclaw-settings-save-indicator {
   min-width: 0;
+}
+
+openclaw-settings-save-indicator:empty {
+  display: none;
 }
 
 .settings-save-indicator {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with a dirty Settings draft after reconnect could see the focused Save action overlap the non-shrinking build provenance link in the sidebar footer. The overlap obscured both controls at supported desktop sizes.

## Why This Change Was Made

The shared Settings footer now gives mutation status/actions and build provenance separate rows. Empty save-indicator hosts are removed from layout so the idle footer keeps its existing height. Config revision, reconnect, and save ownership remain unchanged.

Production LOC: +6/-1 (net +5) | Tests: +46/-1

## User Impact

Save remains fully visible and keyboard-focusable after reconnect, while the version and git provenance link stays readable and clickable below it.

## Evidence

- Authentic pre-fix source-Chromium regression failed with exactly `140.370361328125 px²` of Save/build-link intersection.
- The same mocked-Gateway reconnect path now asserts keyboard focus, zero intersection at 1440×1000 and 1280×900, and the exact opaque revision used by the subsequent `config.set`.
- Focused source-Chromium E2E: 1/1 passed after rebasing current main.
- Full Config safe-write source-Chromium E2E: 4/4 passed.
- Settings sidebar/save-indicator/style owner tests: 22/22 passed.
- `node scripts/check-changed.mjs`: passed, including core/UI typechecks, lint, formatting, dead-code and policy gates.
- Fresh structured autoreview: clean, confidence 0.99.

Before — focused Save overlaps build provenance:

https://ampcode.com/user-content/attachments/5b0abfec4fbaa9f726c6bc5cc3e94300bb9980eeb9851e717291494529c9a30f-file.png

After — separate rows at 1280×900:

https://ampcode.com/user-content/artifacts/b6b65bd933b58612bf2527bbf95f3ec61401d498bdcf5c8f1a32f2092b4e1654-file.png
