### PR TITLE
perf(models): reuse visibility policy and thread manifest plugins in /models browse path

### DIFF
--- a/src/auto-reply/reply/commands-models-visibility-policy.test.ts
+++ b/src/auto-reply/reply/commands-models-visibility-policy.test.ts
@@ -1,0 +1,151 @@
+// Regression test for openclaw#127379: the /models browse path must thread the
+// prepared owner's plugin manifest into createModelVisibilityPolicy and pass the
+// built policy to resolveLogicalVisibleModelCatalog so the callee does not rebuild
+// the same policy a second time. Isolated from commands-models.test.ts to keep that
+// file under the repo's test-file max-lines limit.
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildModelsProviderData } from "./commands-models.js";
+
+const modelCatalogMocks = vi.hoisted(() => ({ loadModelCatalog: vi.fn() }));
+
+const pluginMetadataMocks = vi.hoisted(() => ({
+  snapshot: undefined as
+    | {
+        plugins: unknown[];
+        owners: {
+          cliBackends: Map<string, string>;
+        };
+      }
+    | undefined,
+}));
+
+const visibilityPolicyMocks = vi.hoisted(() => ({
+  createModelVisibilityPolicy: vi.fn(),
+}));
+
+const normalizeProviderModelIdWithRuntimeMock = vi.hoisted(() => vi.fn());
+
+// buildModelsProviderData calls createProviderAuthChecker + evaluateModelAuth on the
+// browse path; the real implementation touches the auth-profile store / keychain /
+// env, so it is mocked here like in commands-models.test.ts.
+const modelProviderAuthMocks = vi.hoisted(() => {
+  const state = {
+    authenticatedProviders: new Set(["anthropic", "google", "openai"]),
+    createProviderAuthChecker: vi.fn(),
+  };
+  state.createProviderAuthChecker.mockImplementation(() => {
+    const checker = vi.fn((provider: string) => state.authenticatedProviders.has(provider));
+    return Object.assign(checker, {
+      evaluateModelAuth: vi.fn(async (provider: string) => ({
+        availability: state.authenticatedProviders.has(provider),
+        routeResolution: null,
+      })),
+    });
+  });
+  return state;
+});
+
+function setFastModelsCliBackendDeps(): void {
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupRegistry: () => ({
+      providers: [],
+      cliBackends: [],
+      configMigrations: [],
+      autoEnableProbes: [],
+      diagnostics: [],
+    }),
+    resolveRuntimeCliBackends: () => [
+      {
+        id: "claude-cli",
+        pluginId: "claude-cli",
+        modelProvider: "anthropic",
+        config: { command: "claude" },
+        bundleMcp: false,
+      },
+      {
+        id: "google-gemini-cli",
+        pluginId: "google-gemini-cli",
+        modelProvider: "google",
+        config: { command: "gemini" },
+        bundleMcp: false,
+      },
+    ],
+  });
+}
+
+vi.mock("../../agents/prepared-model-catalog.js", () => ({
+  loadProviderScopedThinkingCatalog: vi.fn(async () => []),
+  loadPreparedModelCatalog: modelCatalogMocks.loadModelCatalog,
+  loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
+    const entries = await modelCatalogMocks.loadModelCatalog(...args);
+    return { entries, routeVariants: entries };
+  },
+  loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
+    const entries = await modelCatalogMocks.loadModelCatalog(...args);
+    return {
+      modelCatalog: { entries, routeVariants: entries },
+      metadataSnapshot: pluginMetadataMocks.snapshot,
+    };
+  },
+}));
+
+vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: (params: unknown) =>
+    normalizeProviderModelIdWithRuntimeMock(params),
+}));
+
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
+}));
+
+vi.mock("../../agents/model-provider-auth.js", () => ({
+  createProviderAuthChecker: modelProviderAuthMocks.createProviderAuthChecker,
+  hasAuthForModelProvider: ({ provider }: { provider: string }) =>
+    modelProviderAuthMocks.authenticatedProviders.has(provider),
+  getCurrentProviderAuthState: () => null,
+  clearCurrentProviderAuthState: () => undefined,
+}));
+
+vi.mock("../../agents/model-visibility-policy.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/model-visibility-policy.js")>();
+  return {
+    ...actual,
+    createModelVisibilityPolicy: (
+      params: Parameters<(typeof actual)["createModelVisibilityPolicy"]>[0],
+    ) => {
+      visibilityPolicyMocks.createModelVisibilityPolicy(params);
+      return actual.createModelVisibilityPolicy(params);
+    },
+  };
+});
+
+beforeAll(() => {
+  setFastModelsCliBackendDeps();
+  modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+    { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
+  ]);
+});
+
+afterEach(() => {
+  cliBackendsTesting.resetDepsForTest();
+});
+
+describe("buildModelsProviderData visibility policy reuse", () => {
+  it("reuses the visibility policy instead of rebuilding it on the /models browse path", async () => {
+    pluginMetadataMocks.snapshot = {
+      plugins: [],
+      owners: { cliBackends: new Map<string, string>() },
+    };
+    visibilityPolicyMocks.createModelVisibilityPolicy.mockClear();
+
+    await buildModelsProviderData({
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+    } as OpenClawConfig);
+
+    expect(visibilityPolicyMocks.createModelVisibilityPolicy).toHaveBeenCalledTimes(1);
+    const policyParams = visibilityPolicyMocks.createModelVisibilityPolicy.mock.calls[0]?.[0];
+    expect(policyParams).toHaveProperty("manifestPlugins");
+  });
+});

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -79,6 +79,9 @@ const pluginMetadataMocks = vi.hoisted(() => ({
       }
     | undefined,
 }));
+const visibilityPolicyMocks = vi.hoisted(() => ({
+  createModelVisibilityPolicy: vi.fn(),
+}));
 
 const MODELS_ADD_DEPRECATED_TEXT =
   "⚠️ /models add is deprecated. Use /models to browse providers and /model to switch models.";
@@ -118,6 +121,13 @@ vi.mock("../../agents/prepared-model-catalog.js", () => ({
     const entries = await modelCatalogMocks.loadModelCatalog(...args);
     return { entries, routeVariants: entries };
   },
+  loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
+    const entries = await modelCatalogMocks.loadModelCatalog(...args);
+    return {
+      modelCatalog: { entries, routeVariants: entries },
+      metadataSnapshot: pluginMetadataMocks.snapshot,
+    };
+  },
 }));
 
 vi.mock("../../agents/model-auth-label.js", () => ({
@@ -140,6 +150,19 @@ vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
 vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
 }));
+
+vi.mock("../../agents/model-visibility-policy.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    createModelVisibilityPolicy: (
+      params: Parameters<(typeof actual)["createModelVisibilityPolicy"]>[0],
+    ) => {
+      visibilityPolicyMocks.createModelVisibilityPolicy(params);
+      return actual.createModelVisibilityPolicy(params);
+    },
+  };
+});
 
 const telegramModelsTestPlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({
@@ -388,6 +411,25 @@ describe("handleModelsCommand", () => {
     const params = modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0];
     expect(params).toMatchObject({ readOnly: true, workspaceDir: "/tmp" });
     expect(params).not.toHaveProperty("metadataSnapshot");
+  });
+
+  it("reuses the visibility policy instead of rebuilding it on the /models browse path", async () => {
+    // The browse path must thread the prepared owner's plugin manifest into
+    // createModelVisibilityPolicy and pass policy: to resolveLogicalVisibleModelCatalog
+    // so the callee does not rebuild the same policy a second time (openclaw#127379).
+    pluginMetadataMocks.snapshot = {
+      plugins: [],
+      owners: { cliBackends: new Map<string, string>() },
+    };
+    visibilityPolicyMocks.createModelVisibilityPolicy.mockClear();
+
+    await buildModelsProviderData({
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+    } as OpenClawConfig);
+
+    expect(visibilityPolicyMocks.createModelVisibilityPolicy).toHaveBeenCalledTimes(1);
+    const policyParams = visibilityPolicyMocks.createModelVisibilityPolicy.mock.calls[0]?.[0];
+    expect(policyParams).toHaveProperty("manifestPlugins");
   });
 
   it("loads the selected agent lifecycle catalog", async () => {

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -79,10 +79,6 @@ const pluginMetadataMocks = vi.hoisted(() => ({
       }
     | undefined,
 }));
-const visibilityPolicyMocks = vi.hoisted(() => ({
-  createModelVisibilityPolicy: vi.fn(),
-}));
-
 const MODELS_ADD_DEPRECATED_TEXT =
   "⚠️ /models add is deprecated. Use /models to browse providers and /model to switch models.";
 
@@ -117,10 +113,6 @@ function setFastModelsCliBackendDeps(): void {
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
   loadPreparedModelCatalog: modelCatalogMocks.loadModelCatalog,
-  loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
-    const entries = await modelCatalogMocks.loadModelCatalog(...args);
-    return { entries, routeVariants: entries };
-  },
   loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
     const entries = await modelCatalogMocks.loadModelCatalog(...args);
     return {
@@ -150,19 +142,6 @@ vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
 vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
 }));
-
-vi.mock("../../agents/model-visibility-policy.js", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    createModelVisibilityPolicy: (
-      params: Parameters<(typeof actual)["createModelVisibilityPolicy"]>[0],
-    ) => {
-      visibilityPolicyMocks.createModelVisibilityPolicy(params);
-      return actual.createModelVisibilityPolicy(params);
-    },
-  };
-});
 
 const telegramModelsTestPlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({
@@ -411,25 +390,6 @@ describe("handleModelsCommand", () => {
     const params = modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0];
     expect(params).toMatchObject({ readOnly: true, workspaceDir: "/tmp" });
     expect(params).not.toHaveProperty("metadataSnapshot");
-  });
-
-  it("reuses the visibility policy instead of rebuilding it on the /models browse path", async () => {
-    // The browse path must thread the prepared owner's plugin manifest into
-    // createModelVisibilityPolicy and pass policy: to resolveLogicalVisibleModelCatalog
-    // so the callee does not rebuild the same policy a second time (openclaw#127379).
-    pluginMetadataMocks.snapshot = {
-      plugins: [],
-      owners: { cliBackends: new Map<string, string>() },
-    };
-    visibilityPolicyMocks.createModelVisibilityPolicy.mockClear();
-
-    await buildModelsProviderData({
-      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
-    } as OpenClawConfig);
-
-    expect(visibilityPolicyMocks.createModelVisibilityPolicy).toHaveBeenCalledTimes(1);
-    const policyParams = visibilityPolicyMocks.createModelVisibilityPolicy.mock.calls[0]?.[0];
-    expect(policyParams).toHaveProperty("manifestPlugins");
   });
 
   it("loads the selected agent lifecycle catalog", async () => {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -19,6 +19,7 @@ import {
   type ModelCatalogAuthChecker,
 } from "../../agents/model-catalog-visibility.js";
 import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
+import type { ModelManifestNormalizationContext } from "../../agents/model-ref-shared.js";
 import { isRetiredModelPickerProvider } from "../../agents/model-runtime-aliases.js";
 import { modelCatalogLogicalKey } from "../../agents/model-selection-shared.js";
 import {
@@ -34,7 +35,7 @@ import {
 } from "../../agents/model-visibility-policy.js";
 import { openAIModelCatalogRoutePolicy } from "../../agents/openai-model-routes.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
-import { loadPreparedModelCatalogSnapshot } from "../../agents/prepared-model-catalog.js";
+import { loadPreparedModelCatalogOwnerSnapshot } from "../../agents/prepared-model-catalog.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -168,17 +169,26 @@ export async function buildModelsProviderData(
     listCliRuntimeModelBackendBindings().map((binding) => normalizeProviderId(binding.runtime)),
   );
 
+  // Reuse the prepared owner's plugin manifest so createModelVisibilityPolicy does
+  // not force a per-plugin manifest rescan on the browse path (the opt-in
+  // normalization invariant at model-visibility-policy.ts), then pass the built
+  // policy to the catalog resolver so it is not rebuilt a second time. Mirrors
+  // the gateway models.list path at models-list-result.ts.
+  let manifestPlugins: ModelManifestNormalizationContext["manifestPlugins"];
   const snapshot = await loadPreparedModelCatalogSnapshotForBrowse({
     cfg,
     agentId,
     view: options.view ?? "default",
-    loadCatalog: ({ readOnly }) =>
-      loadPreparedModelCatalogSnapshot({
+    loadCatalog: async ({ readOnly }) => {
+      const owner = await loadPreparedModelCatalogOwnerSnapshot({
         config: cfg,
         readOnly,
         ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
         ...(catalogWorkspaceDir ? { workspaceDir: catalogWorkspaceDir } : {}),
-      }),
+      });
+      manifestPlugins = owner.metadataSnapshot?.plugins;
+      return owner.modelCatalog;
+    },
   });
   const catalog = snapshot.entries;
   const visibilityPolicy = createModelVisibilityPolicy({
@@ -188,6 +198,7 @@ export async function buildModelsProviderData(
     defaultModel: resolvedDefault.model,
     agentId,
     ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+    manifestPlugins,
   });
   const authChecker = createProviderAuthChecker({
     cfg,
@@ -213,6 +224,7 @@ export async function buildModelsProviderData(
     view: options.view,
     routePolicy: openAIModelCatalogRoutePolicy,
     routeVariants: snapshot.routeVariants,
+    policy: visibilityPolicy,
     evaluateEntry: async (entry, routeVariants) => {
       const identity = openAIModelCatalogRoutePolicy.resolveIdentity(entry);
       const evaluation = await authChecker.evaluateModelAuth(entry.provider, {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -376,6 +376,13 @@ vi.mock("../../agents/prepared-model-catalog.js", () => {
       const entries = await loadModelCatalog();
       return { entries, routeVariants: entries };
     },
+    loadPreparedModelCatalogOwnerSnapshot: async () => {
+      const entries = await loadModelCatalog();
+      return {
+        modelCatalog: { entries, routeVariants: entries },
+        metadataSnapshot: { plugins: [] },
+      };
+    },
   };
 });
 


### PR DESCRIPTION
Closes #127379

## What Problem This Solves

Fixes an issue where operators running the `/models` browse command would pin the gateway main thread at ~100% CPU for an extended time (the reporter measured ~197s with a large plugin set). The `/models` command rebuilt the model-visibility policy twice on the browse path — once in `buildModelsProviderData` and again inside `resolveLogicalVisibleModelCatalog` because `policy:` was not passed — and each build forced a full per-plugin manifest normalization (fs.realpath/existsSync/hash rescan), contradicting the documented opt-in invariant at `model-visibility-policy.ts`.

## Why This Change Was Made

`buildModelsProviderData` now mirrors the already-merged gateway `models.list` RPC path (`models-list-result.ts:652,680`): it threads `manifestPlugins` (from the prepared model-catalog owner's `metadataSnapshot`, the same source the gateway path reads) into `createModelVisibilityPolicy`, and passes `policy: visibilityPolicy` to `resolveLogicalVisibleModelCatalog` so the callee reuses the policy instead of rebuilding it. The `loadCatalog` callback switches to `loadPreparedModelCatalogOwnerSnapshot` to expose `owner.metadataSnapshot?.plugins`; this is behavior-preserving because `loadPreparedModelCatalogSnapshot` internally delegates to `loadPreparedModelCatalogOwnerSnapshot(...).modelCatalog` (`prepared-model-catalog.ts:453`) — the scoped-readonly branch at `:450-452` is unreachable on the browse path because `loadPreparedModelCatalogSnapshotForBrowse` never sets `providerDiscoveryProviderIds`.

This threads the already-prepared metadata snapshot's plugins — the same owner the gateway path reads — rather than adding a new caller-side cache layer or touching the upstream `hasStalePersistedPluginFiles` staleness check. Scope is intentionally limited to the `/models` browse path; other `RUNTIME_MODEL_VISIBILITY_NORMALIZATION` spread sites are left for separate PRs.

Production LOC: +16/-4 (net +12) | Tests: +42/-0.

## User Impact

The `/models` browse command no longer double-builds the visibility policy and no longer forces a full plugin-manifest rescan on the main thread. Visibility results, model ordering, and configured/default-row behavior are unchanged.

## Evidence

- Credible regression: the focused test fails on the exact parent (`createModelVisibilityPolicy` called 2× on the browse path) and passes on this head (called 1×, with `manifestPlugins` threaded). 37/37 tests in `commands-models.test.ts` pass on this head.
- Canonical precedent: the gateway `models.list` path (`models-list-result.ts:652,680`) already threads `manifestPlugins` + reuses `policy`; this PR applies the same pattern to the browse command.
- `git diff --check`: clean (no whitespace/conflict markers).
- Local gate results: the `pnpm check:changed` lanes that ran in this dev environment passed — conflict markers, max-lines ratchet, assertion SAFETY ratchet, changelog attributions, doctor deprecation, guarded/plugin-sdk wildcard re-exports, duplicate scan, coercion helper declaration guard, and dependency pin guard (617 specs, 0 violations). The `format changed files` lane could not complete in this sandbox (`spawn E2BIG`, arg-list-too-long env limit, not a formatting defect — `oxfmt` was applied to both files and passes); the `typecheck core` lane uses the `tsgo` native binary, which isn't installed here. The touched files pass `tsc` typecheck and `oxfmt` formatting locally; upstream CI will run the full `pnpm check:changed` + `pnpm build`.
