### PR TITLE
fix: stop a leaked console-routing latch from flaking CLI failure-output tests

### DIFF
--- a/src/entry.run-main.test.ts
+++ b/src/entry.run-main.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { ExpectedCliError } from "./cli/failure-output.js";
 import { runMainOrRootHelp } from "./entry.js";
-import { enableConsoleCapture } from "./logging.js";
 
 describe("entry run-main boundary", () => {
   it("retains JSON console routing through process finalization", async () => {
@@ -26,7 +25,6 @@ describe("entry run-main boundary", () => {
       humanOutput: message,
       machineOutput: message,
     });
-    enableConsoleCapture();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     process.exitCode = undefined;
 

--- a/src/mcp/codex-supervision-tools-serve.test.ts
+++ b/src/mcp/codex-supervision-tools-serve.test.ts
@@ -1,9 +1,8 @@
 // Codex supervision MCP tests cover the retired Supervisor command bridge.
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnyAgentTool } from "../agents/tools/common.js";
-import { loggingState } from "../logging/state.js";
 import {
   createCodexSupervisionToolsMcpServer,
   serveCodexSupervisionToolsMcp,
@@ -49,7 +48,6 @@ const TOOL_NAMES = [
   "codex_session_send",
   "codex_session_interrupt",
 ] as const;
-let originalForceConsoleToStderr = false;
 
 function createTools(): AnyAgentTool[] {
   return TOOL_NAMES.map(
@@ -66,16 +64,11 @@ function createTools(): AnyAgentTool[] {
 
 describe("createCodexSupervisionToolsMcpServer", () => {
   beforeEach(() => {
-    originalForceConsoleToStderr = loggingState.forceConsoleToStderr;
     ensureStandalonePluginToolRegistryLoadedMock.mockClear();
     resolvePluginToolsMock.mockReset();
     resolvePluginToolsMock.mockReturnValue([]);
     connectToolsMcpServerToStdioMock.mockClear();
     disposeRegisteredAgentHarnessesMock.mockClear();
-  });
-
-  afterEach(() => {
-    loggingState.forceConsoleToStderr = originalForceConsoleToStderr;
   });
 
   it("fails closed when the external Codex plugin tools are unavailable", () => {

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -48,6 +48,8 @@ function fixtureFiles(): Record<string, string> {
     path.join(repoRoot, "src", "infra", "agent-run-registry.ts"),
   );
   const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
+  const loggingConsolePath = JSON.stringify(path.join(repoRoot, "src", "logging", "console.ts"));
+  const loggingStatePath = JSON.stringify(path.join(repoRoot, "src", "logging", "state.ts"));
 
   return {
     "01-dep.ts": 'export function flavor(): string {\n  return "real";\n}\n',
@@ -161,6 +163,39 @@ function fixtureFiles(): Record<string, string> {
       "});",
       "",
     ].join("\n"),
+    "06-a-console-routing.test.ts": [
+      `import { enableConsoleCapture, routeLogsToStderr } from ${loggingConsolePath};`,
+      `import { loggingState } from ${loggingStatePath};`,
+      'import { expect, it } from "vitest";',
+      'it("latches console capture and stderr routing", () => {',
+      "  const native = console.error;",
+      "  routeLogsToStderr();",
+      "  enableConsoleCapture();",
+      "  expect(loggingState.forceConsoleToStderr).toBe(true);",
+      "  expect(loggingState.consolePatched).toBe(true);",
+      "  expect(console.error).not.toBe(native);",
+      "});",
+      "",
+    ].join("\n"),
+    // Production never unwinds those latches: a stdio MCP server or a `--json`
+    // one-shot owns the console until the process exits. The next file must still
+    // see its own console.error spy, not the previous file's stderr forwarder.
+    "06-b-console-routing.test.ts": [
+      `import { enableConsoleCapture } from ${loggingConsolePath};`,
+      `import { loggingState } from ${loggingStatePath};`,
+      'import { expect, it, vi } from "vitest";',
+      'it("starts from unrouted, unpatched console state", () => {',
+      "  expect(loggingState.forceConsoleToStderr).toBe(false);",
+      "  expect(loggingState.consolePatched).toBe(false);",
+      "  expect(loggingState.rawConsole).toBeNull();",
+      '  const spy = vi.spyOn(console, "error").mockImplementation(() => {});',
+      "  enableConsoleCapture();",
+      '  console.error("routed line");',
+      '  expect(spy.mock.calls).toEqual([["routed line"]]);',
+      "  spy.mockRestore();",
+      "});",
+      "",
+    ].join("\n"),
   };
 }
 
@@ -216,7 +251,7 @@ it("cleans every shared runner surface between files", async () => {
     // The collection failure is intentional. Every behavior test after it must
     // pass; any leaked surface turns the summary into a second failure.
     expect(output).toContain("synthetic collect failure");
-    expect(output).toContain("1 failed | 9 passed");
+    expect(output).toContain("1 failed | 11 passed");
     expect(output).not.toContain("first-file");
   } finally {
     await fs.rm(root, { recursive: true, force: true });

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { TestRunner, type RunnerTask, type RunnerTestFile, vi } from "vitest";
 import { resetAgentEventsForTest } from "../src/infra/agent-events.js";
+import { loggingState } from "../src/logging/state.js";
 import { clearNamedPluginRuntimeStoresForTest } from "../src/plugin-sdk/runtime-store-registry.js";
 import {
   type CustomElementTracking,
@@ -40,6 +41,17 @@ const DIAGNOSTIC_EVENT_LISTENER_PRESENCE = Symbol.for(
 const SESSION_SUSPENSION_TEST_API = Symbol.for("openclaw.sessionSuspensionTestApi");
 // Shared-worker scoped: the registry lives on the worker global, not in the module graph.
 const CUSTOM_ELEMENT_TRACKING = Symbol.for("openclaw.nonIsolatedCustomElementTracking");
+const nativeConsoleMethods = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+  debug: console.debug,
+  trace: console.trace,
+};
+// loggingState is keyed off globalThis precisely so it survives module reloads,
+// so vi.resetModules() below cannot undo what a file latched into it.
+const baselineLoggingState = { ...loggingState };
 const nativeTimerGlobals = {
   setTimeout: globalThis.setTimeout,
   clearTimeout: globalThis.clearTimeout,
@@ -144,6 +156,19 @@ function restoreRealTimers(): void {
 
 function restoreNativeTimerGlobals(): void {
   Object.assign(globalThis, nativeTimerGlobals);
+}
+
+// enableConsoleCapture() swaps every console method for a forwarder and latches
+// routing that production only unwinds at process exit (stdio MCP servers, `--json`
+// one-shot commands), so a shared worker carries both into the next file. That
+// forwarder writes to process.stderr once forceConsoleToStderr is latched, and the
+// next file's console spy then records nothing.
+function restoreConsoleRoutingState(): void {
+  Object.assign(console, nativeConsoleMethods);
+  // The EPIPE handlers really are attached to the worker's stdout/stderr; resetting
+  // this flag would let the next enableConsoleCapture() stack a second pair.
+  const { streamErrorHandlersInstalled } = loggingState;
+  Object.assign(loggingState, baselineLoggingState, { streamErrorHandlersInstalled });
 }
 
 function restoreMocksThenRealTimers(): void {
@@ -435,6 +460,7 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     // not carry file-scoped timers, stubs, spies, or stale module state
     // forward into the next file.
     restoreMocksThenRealTimers();
+    restoreConsoleRoutingState();
     vi.unstubAllGlobals();
     const testHome = getSharedTestHome();
     vi.unstubAllEnvs();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `src/entry.run-main.test.ts > entry run-main boundary > keeps
expected conditions at exit 1 without crash framing` failed intermittently in CI and
blocked unrelated PRs (seen on #127011 and #127075, always in shard
`core-unit-src-security-2`):

```
AssertionError: expected [] to deeply equal [ Array(1) ]
- [ [ "The `openclaw workboard` command is provided by the \"workboard\" plugin, ..." ] ]
+ []
```

Rerunning the failed job turned the run green, so it was order-dependent, not
deterministic. Maintainers lost time to a red gate on changes that had nothing to do
with CLI failure output.

## Why This Change Was Made

Root cause is a global that no test owned.

`enableConsoleCapture()` (`src/logging/console.ts:253`) replaces every `console.*`
method with a forwarder, and `routeLogsToStderr()` / `--json` one-shot mode latch
`loggingState.forceConsoleToStderr`. Production never unwinds either: a stdio MCP
server (`serveCodexSupervisionToolsMcp` -> `routeLogsToStderr`,
`src/mcp/codex-supervision-tools-serve.ts:107`) and `runMainOrRootHelp`'s
`retainConsoleRoutingUntilProcessExit: true` both own the console until the process
exits. That is correct for a CLI process and wrong for a Vitest worker, which never
exits. `loggingState` is deliberately keyed off `globalThis`
(`src/logging/state.ts:41`) so it survives module reloads, so the runner's existing
`vi.resetModules()` cleanup could not undo it either.

The failing test spies on `console.error`, then `onError` (`src/entry.ts:315`) calls
`enableConsoleCapture()` and writes through the forwarder. When the worker had
already inherited `forceConsoleToStderr = true` from an earlier file,
`writeFormattedConsoleOutput` took its `process.stderr.write` branch
(`src/logging/console.ts:210`) and never called the captured original, so the spy
recorded nothing. Whether the latching file landed in the same worker first was pure
scheduling luck, which is exactly the observed rerun-and-it-passes behavior.

The architectural owner is `OpenClawNonIsolatedRunner.onAfterRunFiles`, whose stated
job is to "mirror the missing cleanup from Vitest isolate mode so shared workers do
not carry file-scoped timers, stubs, spies, or stale module state forward into the
next file". Console routing belongs in that list. The fix restores the worker's
baseline console methods and `loggingState` there, and drops the two consumer-side
workarounds that were compensating downstream:

- `src/entry.run-main.test.ts` no longer needs a pre-emptive `enableConsoleCapture()`
  to make its spy the outermost sink; it exercises the real forwarder path again.
- `src/mcp/codex-supervision-tools-serve.test.ts` no longer hand-rolls a
  save/restore of `forceConsoleToStderr` around a describe block.

`streamErrorHandlersInstalled` is deliberately retained across the reset: those EPIPE
handlers really are attached to the worker's stdout/stderr, and clearing the flag
would let the next `enableConsoleCapture()` stack a second pair on every file.

## User Impact

None at runtime. Test-harness only; production LOC delta is 0.

## Evidence

Failure mechanism, reproduced in the original execution order with the real files
(forced sequencer so `codex-supervision-tools-serve.test.ts` runs first in one
worker):

- Without the runner fix: `FAIL src/entry.run-main.test.ts > keeps expected
  conditions at exit 1 without crash framing`, `AssertionError: expected [] to
  deeply equal [ Array(1) ]` — byte-identical to the CI failure.
- With the runner fix: `Test Files 2 passed (2) / Tests 6 passed (6)`.

Regression coverage lands in `test/non-isolated-runner.test.ts` as a `06-a`/`06-b`
fixture pair (file A latches capture + stderr routing, file B asserts a clean start
and that its own `console.error` spy still receives the line). Against the pre-fix
runner it fails with `expected true to be false` on
`loggingState.forceConsoleToStderr`; with the fix the child run reports
`1 failed | 11 passed` as asserted.

Local proof on this branch (rebased onto `origin/main` @ `41acededbc5`):

- `node scripts/run-vitest.mjs --config test/vitest/vitest.unit-src.config.ts` (full
  project, owns both changed test files) — green.
- `node scripts/run-vitest.mjs src/logging src/mcp test/non-isolated-runner.test.ts`
  — `555 + 60 + 45 + 1` tests passed.
- Shard `core-unit-src-security-2` (146 files, pre-rebase membership that co-located
  the two files) — `145 passed | 1 skipped`.
- `node scripts/check-changed.mjs` — exit 0.
- `autoreview --mode uncommitted` (codex/gpt-5.6-sol) — clean, no accepted findings.

Note on shard membership: the stripe split is content-derived, so the latching file
and `entry.run-main.test.ts` only co-locate in `core-unit-src-security-2` for some
bases. After this rebase they no longer share that shard, which is why the flake
appeared on some PRs and not others.

Unrelated local-only failures, confirmed pre-existing (they reproduce with this
change stashed and on a clean `origin/main`, and `main`'s CI check-runs are green):
`src/infra/system-run-approval-binding.test.ts`, `test/scripts/telegram-user-observer.test.ts`,
and `test/scripts/telegram-mantis-lane.test.ts` all fail on this Mac's Python 3.14
setup. Worth a follow-up to make those tests environment-independent; out of scope
here.
