### PR TITLE
fix(macos): prevent stale mode switches from stopping a new Gateway

### DIFF
--- a/apps/macos/Sources/OpenClaw/ConnectionModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/ConnectionModeCoordinator.swift
@@ -5,67 +5,51 @@ import OSLog
 final class ConnectionModeCoordinator {
     static let shared = ConnectionModeCoordinator()
 
+    struct Transition {
+        private(set) var generation: UInt64 = 0
+        private(set) var mode: AppState.ConnectionMode?
+
+        mutating func begin(_ mode: AppState.ConnectionMode) -> UInt64 {
+            self.generation &+= 1
+            self.mode = mode
+            return self.generation
+        }
+
+        func isCurrent(_ generation: UInt64, mode: AppState.ConnectionMode) -> Bool {
+            self.generation == generation && self.mode == mode
+        }
+    }
+
     private let logger = Logger(subsystem: "ai.openclaw", category: "connection")
-    private var lastMode: AppState.ConnectionMode?
-    private var applyGeneration: UInt64 = 0
+    private var transition = Transition()
 
     /// Apply the requested connection mode by starting/stopping local gateway,
     /// managing the control-channel SSH tunnel, and cleaning up chat windows/panels.
     func apply(mode: AppState.ConnectionMode, paused: Bool) async {
-        self.applyGeneration &+= 1
-        let applyGeneration = self.applyGeneration
-        if let lastMode = self.lastMode, lastMode != mode {
+        let previousMode = self.transition.mode
+        let applyGeneration = self.transition.begin(mode)
+        if let previousMode, previousMode != mode {
             GatewayProcessManager.shared.clearLastFailure()
             NodesStore.shared.lastError = nil
         }
-        self.lastMode = mode
+        if mode != .remote {
+            _ = await NodeServiceManager.stop()
+            guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
+            NodesStore.shared.lastError = nil
+            await RemoteTunnelManager.shared.stopAll()
+            guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
+            WebChatManager.shared.resetTunnels()
+        }
+
         switch mode {
         case .unconfigured:
-            _ = await NodeServiceManager.stop()
-            NodesStore.shared.lastError = nil
-            await RemoteTunnelManager.shared.stopAll()
-            WebChatManager.shared.resetTunnels()
             GatewayProcessManager.shared.stop()
-            await GatewayConnection.shared.shutdown()
             await ControlChannel.shared.disconnect()
-            Task.detached { await PortGuardian.shared.sweep(mode: .unconfigured) }
+            guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
 
         case .local:
-            _ = await NodeServiceManager.stop()
-            guard self.applyGeneration == applyGeneration else { return }
-            NodesStore.shared.lastError = nil
-            await RemoteTunnelManager.shared.stopAll()
-            guard self.applyGeneration == applyGeneration else { return }
-            WebChatManager.shared.resetTunnels()
-            let shouldStart = GatewayAutostartPolicy.shouldStartGateway(mode: .local, paused: paused)
-            if shouldStart {
-                GatewayProcessManager.shared.setActive(true)
-                await GatewayProcessManager.shared.waitForStartupAttempt()
-                guard self.applyGeneration == applyGeneration else { return }
-                var launchAgentInstalled = false
-                if GatewayAutostartPolicy.shouldEnsureLaunchAgent(
-                    mode: .local,
-                    paused: paused)
-                {
-                    launchAgentInstalled = await GatewayProcessManager.shared.ensureLaunchAgentEnabledIfNeeded()
-                }
-                guard self.applyGeneration == applyGeneration else { return }
-                // Always finish the generation-aware health audit after persistence work. A newer
-                // inactive lifecycle makes this return false without touching its repair marker.
-                _ = await GatewayProcessManager.shared.waitForGatewayReady(
-                    launchAgentInstalled: launchAgentInstalled)
-                guard self.applyGeneration == applyGeneration else { return }
-            } else {
-                GatewayProcessManager.shared.stop()
-            }
-            do {
-                try await ControlChannel.shared.configure(mode: .local)
-            } catch {
-                // Control channel will mark itself degraded; nothing else to do here.
-                self.logger.error(
-                    "control channel local configure failed: \(error.localizedDescription, privacy: .public)")
-            }
-            Task.detached { await PortGuardian.shared.sweep(mode: .local) }
+            await self.applyLocalMode(paused: paused, generation: applyGeneration)
+            guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
 
         case .remote:
             // Never run a local gateway in remote mode.
@@ -74,19 +58,51 @@ final class ConnectionModeCoordinator {
 
             do {
                 NodesStore.shared.lastError = nil
-                if let error = await NodeServiceManager.start() {
+                let nodeError = await NodeServiceManager.start()
+                guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
+                if let error = nodeError {
                     NodesStore.shared.lastError = "Node service start failed: \(error)"
                 }
                 _ = try await GatewayEndpointStore.shared.ensureRemoteControlTunnel()
+                guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
                 let settings = CommandResolver.connectionSettings()
                 try await ControlChannel.shared.configure(mode: .remote(
                     target: settings.target,
                     identity: settings.identity))
+                guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
             } catch {
+                guard self.transition.isCurrent(applyGeneration, mode: mode) else { return }
                 self.logger.error("remote tunnel/configure failed: \(error.localizedDescription, privacy: .public)")
             }
+        }
 
-            Task.detached { await PortGuardian.shared.sweep(mode: .remote) }
+        Task.detached { await PortGuardian.shared.sweep(mode: mode) }
+    }
+
+    private func applyLocalMode(paused: Bool, generation: UInt64) async {
+        if GatewayAutostartPolicy.shouldStartGateway(mode: .local, paused: paused) {
+            GatewayProcessManager.shared.setActive(true)
+            await GatewayProcessManager.shared.waitForStartupAttempt()
+            guard self.transition.isCurrent(generation, mode: .local) else { return }
+            var launchAgentInstalled = false
+            if GatewayAutostartPolicy.shouldEnsureLaunchAgent(mode: .local, paused: paused) {
+                launchAgentInstalled = await GatewayProcessManager.shared.ensureLaunchAgentEnabledIfNeeded()
+            }
+            guard self.transition.isCurrent(generation, mode: .local) else { return }
+            // Finish persistence before readiness so a newer lifecycle cannot clear its repair marker.
+            _ = await GatewayProcessManager.shared.waitForGatewayReady(
+                launchAgentInstalled: launchAgentInstalled)
+            guard self.transition.isCurrent(generation, mode: .local) else { return }
+        } else {
+            GatewayProcessManager.shared.stop()
+        }
+
+        do {
+            try await ControlChannel.shared.configure(mode: .local)
+        } catch {
+            guard self.transition.isCurrent(generation, mode: .local) else { return }
+            self.logger.error(
+                "control channel local configure failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -217,10 +217,8 @@ final class ControlChannel {
     }
 
     func disconnect() async {
-        await GatewayConnection.shared.shutdown()
         self.setStateThrottled(.disconnected)
-        self.lastPingMs = nil
-        self.authSourceLabel = nil
+        await GatewayConnection.shared.shutdown()
     }
 
     func health(timeout: TimeInterval? = nil) async throws -> Data {

--- a/apps/macos/Sources/OpenClaw/DebugActions.swift
+++ b/apps/macos/Sources/OpenClaw/DebugActions.swift
@@ -108,7 +108,6 @@ enum DebugActions {
                 }
 
             case .unconfigured:
-                await GatewayConnection.shared.shutdown()
                 await ControlChannel.shared.disconnect()
             }
         }

--- a/apps/macos/Tests/OpenClawIPCTests/ConnectionModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConnectionModeCoordinatorTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct ConnectionModeCoordinatorTests {
+    @Test(arguments: [
+        (AppState.ConnectionMode.unconfigured, AppState.ConnectionMode.local),
+        (AppState.ConnectionMode.remote, AppState.ConnectionMode.local),
+        (AppState.ConnectionMode.local, AppState.ConnectionMode.remote),
+    ])
+    func `newer connection mode owns transition side effects`(
+        previousMode: AppState.ConnectionMode,
+        nextMode: AppState.ConnectionMode)
+    {
+        var transition = ConnectionModeCoordinator.Transition()
+        let previousGeneration = transition.begin(previousMode)
+        let currentGeneration = transition.begin(nextMode)
+
+        #expect(!transition.isCurrent(previousGeneration, mode: previousMode))
+        #expect(transition.isCurrent(currentGeneration, mode: nextMode))
+    }
+
+    @Test func `reselecting the same mode invalidates its prior transition`() {
+        var transition = ConnectionModeCoordinator.Transition()
+        let previousGeneration = transition.begin(.remote)
+        let currentGeneration = transition.begin(.remote)
+
+        #expect(!transition.isCurrent(previousGeneration, mode: .remote))
+        #expect(transition.isCurrent(currentGeneration, mode: .remote))
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rapidly switching between Configure Later, This Mac, and a remote Gateway can allow an older connection-mode transition to uninstall the newly selected local Gateway, recreate an outdated remote tunnel, overwrite connection status, or run a stale port sweep.

## Why This Change Was Made

Move transition identity and generation into one lifecycle owner, require every connection mode to retain that ownership after asynchronous work, and share the common local/unconfigured teardown path. Publish control-channel disconnection before its asynchronous shutdown, and remove duplicate Gateway shutdown calls from both affected owners.

## User Impact

Changing Gateway modes reliably preserves the most recently selected connection instead of letting a delayed older transition stop its Gateway, disconnect the app, or display outdated node-service errors.

## Evidence

- Pre-fix production-owner regressions fail for stale unconfigured-to-local, remote-to-local, and repeated-remote transitions; the existing local-mode case passes, proving the previous asymmetry.
- Post-fix: **95 tests across 7 macOS suites passed**, including connection-mode ownership, Gateway startup/readiness, node-service isolation, control-channel debouncing and diagnostics, onboarding, and launch policy.
- SwiftFormat and SwiftLint pass, including the coordinator complexity limit.
- Independent Codex review and secret scan pass with no actionable findings.
- The regression exercises the real production transition-owner state machine without starting launchd services, touching the host-global port-guardian database, or modifying the running operator Gateway.
- Production: +64/-51 (net +13), justified by explicit lifecycle-generation ownership across all three connection modes and the nested control-channel teardown boundary; tests: +31/-0.
- Existing node-service shell commands can themselves finish out of order across process boundaries; service-level serialization is a separately owned follow-up, not masked by coordinator retries.
