### PR TITLE
fix(cli): stop approvals --json printing the exec-approvals socket token

### DIFF
--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -170,6 +170,7 @@ function scopeByLabel(label: string, output: Record<string, unknown> = writtenJs
 
 function resetLocalSnapshot() {
   localSnapshot.exists = true;
+  localSnapshot.raw = "{}";
   localSnapshot.hash = "hash-local";
   localSnapshot.file = { version: 1, agents: {} };
 }
@@ -220,6 +221,7 @@ vi.mock("../infra/exec-approvals.js", async () => {
         const next = update(structuredClone(localSnapshot.file));
         if (next !== null) {
           localSnapshot.file = next;
+          localSnapshot.raw = JSON.stringify(next);
           localSnapshot.hash = "hash-local-written";
         }
         return structuredClone(localSnapshot);
@@ -351,6 +353,37 @@ describe("exec approvals CLI", () => {
     const wildcard = requireRecord(agents["*"], "JSON wildcard agent");
     const allowlist = requireArray(wildcard.allowlist, "JSON wildcard allowlist");
     expect(requireRecord(allowlist[0], "JSON allowlist entry").pattern).toBe(pattern);
+  });
+
+  it("redacts the socket token from local get JSON while preserving its path", async () => {
+    localSnapshot.file = {
+      version: 1,
+      socket: { path: "/tmp/local-exec-approvals.sock", token: "fixture-token" },
+      agents: {},
+    };
+
+    await runApprovalsCommand(["approvals", "get", "--json"]);
+
+    const output = writtenJson();
+    const file = requireRecord(output.file, "JSON approvals file");
+    expect(file.socket).toEqual({ path: "/tmp/local-exec-approvals.sock" });
+    expect(JSON.stringify(output)).not.toContain('"token"');
+  });
+
+  it("redacts the socket token from local write JSON while preserving its path", async () => {
+    localSnapshot.file = {
+      version: 1,
+      socket: { path: "/tmp/local-exec-approvals.sock", token: "fixture-token" },
+      agents: {},
+    };
+
+    await runApprovalsCommand(["approvals", "allowlist", "add", "/usr/bin/uname", "--json"]);
+
+    const output = writtenJson();
+    const file = requireRecord(output.file, "JSON approvals file");
+    expect(file.socket).toEqual({ path: "/tmp/local-exec-approvals.sock" });
+    expect(output.raw).toBeUndefined();
+    expect(JSON.stringify(output)).not.toContain('"token"');
   });
 
   it("adds effective policy to json output", async () => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -36,6 +36,7 @@ import {
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
+  redactExecApprovals,
   updateExecApprovals,
   type ExecApprovalsAgent,
   type ExecApprovalsDefaults,
@@ -368,7 +369,7 @@ async function saveSnapshotTargeted(params: SaveSnapshotTargetedParams): Promise
     next = await saveSnapshot(params.opts, params.nodeId, params.file, params.baseHash);
   }
   if (params.opts.json) {
-    defaultRuntime.writeJson(next, 0);
+    defaultRuntime.writeJson(isFileApprovalsSnapshot(next) ? redactExecApprovals(next) : next, 0);
     return;
   }
   defaultRuntime.log(theme.muted(`Target: ${params.targetLabel}`));
@@ -1188,7 +1189,8 @@ export function registerExecApprovalsCli(program: Command) {
           nativePolicy,
         });
         if (opts.json) {
-          defaultRuntime.writeJson({ ...snapshot, effectivePolicy }, 0);
+          const outputSnapshot = fileSnapshot ? redactExecApprovals(fileSnapshot) : snapshot;
+          defaultRuntime.writeJson({ ...outputSnapshot, effectivePolicy }, 0);
           return;
         }
 

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -18,6 +18,7 @@ import {
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
+  redactExecApprovals,
   resolveExecApprovalsFromFile,
   updateExecApprovals,
   type ExecApprovalsFile,
@@ -89,22 +90,9 @@ function respondApprovalsChanged(respond: RespondFn): void {
   );
 }
 
-function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
-  const socketPath = file.socket?.path?.trim();
-  // The socket token/defaults are runtime-only; expose only the path needed by
-  // the editor so GET responses cannot leak connection material.
-  return {
-    ...file,
-    socket: socketPath ? { path: socketPath } : undefined,
-  };
-}
-
 function toExecApprovalsPayload(snapshot: ExecApprovalsSnapshot) {
   return {
-    path: snapshot.path,
-    exists: snapshot.exists,
-    hash: snapshot.hash,
-    file: redactExecApprovals(snapshot.file),
+    ...redactExecApprovals(snapshot),
     resolvedDefaults: resolveExecApprovalsFromFile({ file: snapshot.file }).defaults,
   };
 }

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -5,7 +5,11 @@ import {
   resolveExecApprovalsSocketPath,
 } from "./exec-approvals-config.js";
 import type { ExecApprovalsDefaultOverrides } from "./exec-approvals-contracts.js";
-import type { ExecApprovalsFile, ExecApprovalsResolved } from "./exec-approvals-core.js";
+import type {
+  ExecApprovalsFile,
+  ExecApprovalsResolved,
+  ExecApprovalsSnapshot,
+} from "./exec-approvals-core.js";
 import { resolveExecApprovalsFromFilePrepared } from "./exec-approvals-resolver.js";
 import {
   ensureExecApprovals,
@@ -41,6 +45,21 @@ export {
   updateExecApprovals,
   withAgentExecApprovalsRemoved,
 } from "./exec-approvals-store.js";
+
+export function redactExecApprovals(
+  snapshot: Omit<ExecApprovalsSnapshot, "raw"> & { raw?: ExecApprovalsSnapshot["raw"] },
+): Omit<ExecApprovalsSnapshot, "raw"> {
+  const { raw: _raw, ...rest } = snapshot;
+  const socketPath = snapshot.file.socket?.path?.trim();
+  // Socket connection material is runtime-only; presentation boundaries need only its path.
+  return {
+    ...rest,
+    file: {
+      ...snapshot.file,
+      socket: socketPath ? { path: socketPath } : undefined,
+    },
+  };
+}
 
 export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
   const socketPath = file.socket?.path?.trim();

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -12,6 +12,7 @@ import {
   mergeExecApprovalsSocketDefaults,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
+  redactExecApprovals,
   resolveAllowAlwaysPatternCoverage,
   resolveExecApprovalsFromFile,
   updateExecApprovals,
@@ -272,14 +273,6 @@ function truncateOutput(raw: string, maxChars: number): { text: string; truncate
     return { text: raw, truncated: false };
   }
   return { text: `... (truncated) ${sliceUtf16Safe(raw, raw.length - maxChars)}`, truncated: true };
-}
-
-function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
-  const socketPath = file.socket?.path?.trim();
-  return {
-    ...file,
-    socket: socketPath ? { path: socketPath } : undefined,
-  };
 }
 
 function requireExecApprovalsBaseHash(
@@ -692,10 +685,7 @@ async function dispatchInvoke(
     try {
       const snapshot = await ensureExecApprovalsSnapshot();
       const payload = {
-        path: snapshot.path,
-        exists: snapshot.exists,
-        hash: snapshot.hash,
-        file: redactExecApprovals(snapshot.file),
+        ...redactExecApprovals(snapshot),
         ...(includeResolvedDefaults
           ? { resolvedDefaults: resolveExecApprovalsFromFile({ file: snapshot.file }).defaults }
           : {}),
@@ -758,12 +748,7 @@ async function dispatchInvoke(
       return;
     }
 
-    const payload: ExecApprovalsSnapshot = {
-      path: nextSnapshot.path,
-      exists: nextSnapshot.exists,
-      hash: nextSnapshot.hash,
-      file: redactExecApprovals(nextSnapshot.file),
-    };
+    const payload: ExecApprovalsSnapshot = redactExecApprovals(nextSnapshot);
     await sendJsonPayloadResult(client, frame, payload);
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

`openclaw approvals get --json`, and the `--json` output of every local approvals write
(`approvals allowlist add`, `approvals set`, …), print the exec-approvals **socket token** in clear
text:

```
"file":{"version":1,"socket":{"path":"…/state/exec-approvals.sock","token":"<32-char token>"},…}
```

The human-readable table for the same command shows only the socket **path**
(`src/cli/exec-approvals-cli.ts:909`), so the two views of the same data disagreed about whether the
token is fit to print.

Observed on the real dist CLI with an isolated `HOME` and `OPENCLAW_STATE_DIR`.

## Why This Change Was Made

The token is root key material for two derived authorization tokens:

- `src/gateway/operator-approval-runtime-token.ts` HMACs it to produce
  `getOperatorApprovalRuntimeToken()`, documented as "the token used to authorize local
  operator-approval clients".
- `src/gateway/agent-runtime-identity-token.ts:263` reads it for the agent runtime identity token.

Three surfaces already treat it as secret, and the local CLI JSON path was the only one that did
not:

- `src/gateway/server-methods/exec-approvals.ts:92` — `redactExecApprovals()` on every
  `exec.approvals.get` response, with the comment "The socket token/defaults are runtime-only;
  expose only the path needed by the editor so GET responses cannot leak connection material."
- `src/node-host/invoke.ts:277` — a second, byte-identical copy of the same function for the
  node-host RPC.
- `src/state/openclaw-state-snapshot-sanitizer.ts:61` — `delete sanitized.socket.token` when
  producing state snapshots and backups.

Calibrating the severity honestly: an operator running this command already has filesystem access to
the same SQLite store, so this is not privilege escalation. The realistic harm is exfiltration by
sharing — `--json` piped into a bug report, a CI artifact, a log, or an agent transcript. That is
precisely the risk the backup sanitizer already exists to prevent.

## User Impact

`file.socket` in CLI JSON output now contains only `path`. The socket path, allowlist, defaults,
agents, hash, and every other field are unchanged, as is the human-readable rendering, all exit
codes, token generation, and the store itself.

The redactor also drops the snapshot's `raw` field from presentation output. That field holds the
stored JSON of the same file, so redacting `file` while emitting `raw` would have leaked the token
anyway.

No consumer needed the token from CLI output: every reader — including the macOS app's IPC store —
loads it from the store directly, and both RPC responses were already redacted before reaching a
client.

## Evidence

Production `+29/-35` — net **-6**, because the two duplicate `redactExecApprovals` copies collapse
into one canonical implementation in `src/infra/exec-approvals.ts`, next to the file type and store
it operates on. Both RPC call sites now use it. Tests `+33/-0`.

`node scripts/run-vitest.mjs src/cli/exec-approvals-cli.test.ts src/node-host/invoke.test.ts` —
37 and 28 tests pass. The two new cases assert that `file.socket` equals exactly
`{ path: "…" }` and that the serialized output contains no `"token"` key anywhere, which also
catches `raw` leakage.

Reverting only the production change to `src/cli/exec-approvals-cli.ts` fails exactly those two
cases and passes the other 35, so they are regression tests rather than restatements of current
behaviour.

`oxfmt --check` clean on all five files. `$autoreview --mode uncommitted` clean, no accepted or
actionable findings.

Proof gap, stated plainly: the bug was reproduced against a real built dist, but the **fix** is
proven at unit level rather than by a second dist run. Building inside this linked worktree is not
possible without a dependency install (`pnpm build` fails at `plugins:assets:build` with no
`node_modules`), and the repo guidance is not to reconcile dependencies in a linked checkout just to
keep proof local. The assertions above cover both changed emission points exactly.
