### PR TITLE
perf(tui): prepare searchable picker rows once

### DIFF
--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -34,6 +34,12 @@ export interface SearchableSelectItem extends SelectItem {
  */
 export class SearchableSelectList implements Component, Focusable {
   private items: SearchableSelectItem[];
+  private preparedItems?: Array<{
+    item: SearchableSelectItem;
+    label: string;
+    description: string;
+    searchText: string;
+  }>;
   private filteredItems: SearchableSelectItem[];
   private selectedIndex = 0;
   private maxVisible: number;
@@ -103,35 +109,35 @@ export class SearchableSelectList implements Component, Focusable {
     const scoredItems: ScoredItem[] = [];
     const fuzzyCandidates: FuzzyCandidate[] = [];
 
-    for (const item of this.items) {
-      const rawLabel = this.getItemLabel(item);
-      const rawDesc = item.description ?? "";
-      const label = normalizeLowercaseStringOrEmpty(stripAnsi(rawLabel));
-      const desc = normalizeLowercaseStringOrEmpty(stripAnsi(rawDesc));
-
+    // Rows are fixed for the overlay lifetime; defer search projection until it is needed.
+    this.preparedItems ??= this.items.map((item) => {
+      const label = stripAnsi(this.getItemLabel(item));
+      const description = stripAnsi(item.description ?? "");
+      const searchText = stripAnsi(item.searchText ?? "");
+      return {
+        item,
+        label: normalizeLowercaseStringOrEmpty(label),
+        description: normalizeLowercaseStringOrEmpty(description),
+        searchText: normalizeLowercaseStringOrEmpty(
+          [label, description, searchText].filter((value) => value.length > 0).join(" "),
+        ),
+      };
+    });
+    for (const prepared of this.preparedItems) {
       // Tier 1: Exact substring in label
-      const labelIndex = label.indexOf(q);
+      const labelIndex = prepared.label.indexOf(q);
       if (labelIndex !== -1) {
-        scoredItems.push({ item, tier: 0, score: labelIndex });
+        scoredItems.push({ item: prepared.item, tier: 0, score: labelIndex });
         continue;
       }
       // Tier 2: Exact substring in description
-      const descIndex = desc.indexOf(q);
+      const descIndex = prepared.description.indexOf(q);
       if (descIndex !== -1) {
-        scoredItems.push({ item, tier: 1, score: descIndex });
+        scoredItems.push({ item: prepared.item, tier: 1, score: descIndex });
         continue;
       }
       // Tier 3: Fuzzy match
-      const searchText = item.searchText ?? "";
-      fuzzyCandidates.push({
-        item,
-        searchText: normalizeLowercaseStringOrEmpty(
-          [rawLabel, rawDesc, searchText]
-            .map((value) => stripAnsi(value))
-            .filter((value) => value.length > 0)
-            .join(" "),
-        ),
-      });
+      fuzzyCandidates.push(prepared);
     }
 
     scoredItems.sort(this.compareByScore);


### PR DESCRIPTION
## What Problem This Solves

`SearchableSelectList.smartFilter()` stripped ANSI, lowercased labels and descriptions, concatenated search fields, and rebuilt fuzzy-candidate wrappers for every stable row on every search edit. A large model picker therefore repeated the same immutable row projection for every typed character.

## Why This Change Was Made

TUI picker callers construct fresh fixed rows immediately before opening an overlay, and the component has no row-refresh API. The first non-empty query now prepares normalized label, description, and combined fuzzy-search text once; later edits reuse those fields. Preparation stays lazy so opening a picker and selecting without searching pays no search-projection cost.

Filtering still applies the same exact-label, exact-description, and native fuzzy tiers. Tie sorting, ANSI handling, labels/descriptions/search text, active selection, callbacks, and errors are unchanged. Every filter and selection result remains the original item object.

## User Impact

Search interaction in large model/provider lists is faster without changing visible ordering, matches, selection, keyboard behavior, or model routing. There is no provider-auth, catalog-freshness, configuration, protocol, persistence, or public projection change.

## Evidence

Deterministic exact-owner fixture: 2,500 frozen model-like rows, 22 typed characters, constructor + every filter + render, 25 interactions × 7 trials.

- median: 63.454 → 42.092 ms/interaction (-33.7%)
- exact output digest before/after: `261c7a4dfc80464caf71fc3599cc9284b0483f42571ff2c5460a6ba3e9538d49`
- selected/filter results retained the exact original item objects
- the final revision additionally defers all preparation until the first non-empty query

Validation:

- selector component: 39/39 on the revised exact head
- TUI command handlers, Gateway chat, and embedded backend: 267/267
- all TUI components: 183/183
- focused authenticated real PTY picker + `/model`: 2/2 on the revised exact head
- `node scripts/check-changed.mjs -- src/tui/components/searchable-select-list.ts`: passed on the revised exact head
- `pnpm build`: passed; only existing third-party direct-`eval` warnings
- `git diff --check`: passed
- fresh bundled Codex `gpt-5.6-sol`/high autoreview of the revised commit: clean, correct at 0.99
