### PR TITLE
fix(models): scope status alias resolution to the selected agent

### DIFF
--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -379,24 +379,6 @@ export async function modelsStatusCommand(
   const agentFallbacksOverride = agentId
     ? resolveAgentModelFallbacksOverride(cfg, agentId)
     : undefined;
-  const resolvedConfig =
-    agentModelPrimary && agentModelPrimary.length > 0
-      ? {
-          ...cfg,
-          agents: {
-            ...cfg.agents,
-            defaults: {
-              ...cfg.agents?.defaults,
-              model: {
-                ...(typeof cfg.agents?.defaults?.model === "object"
-                  ? cfg.agents.defaults.model
-                  : {}),
-                primary: agentModelPrimary,
-              },
-            },
-          },
-        }
-      : cfg;
   const metadataSnapshot = loadManifestMetadataSnapshot({
     config: cfg,
     workspaceDir,
@@ -452,8 +434,13 @@ export async function modelsStatusCommand(
     env: process.env,
   });
   try {
+    // agentId, not a synthetic config carrying the agent's primary into global
+    // defaults: the canonical resolvers merge per-agent model rows themselves, so
+    // the synthetic route resolved a bare per-agent alias against global defaults
+    // and reported a different provider than runtime selects.
     const resolved = resolveConfiguredModelRef({
-      cfg: resolvedConfig,
+      cfg,
+      agentId,
       defaultProvider: DEFAULT_PROVIDER,
       defaultModel: DEFAULT_MODEL,
       ...DISPLAY_MODEL_PARSE_OPTIONS,
@@ -484,15 +471,6 @@ export async function modelsStatusCommand(
           : utilityModelRef
             ? "provider-default"
             : "none";
-    const aliases = Object.entries(cfg.agents?.defaults?.models ?? {}).reduce<
-      Record<string, string>
-    >((acc, [key, entry]) => {
-      const alias = normalizeOptionalString(entry?.alias);
-      if (alias) {
-        acc[alias] = key;
-      }
-      return acc;
-    }, {});
     const configuredAllowRefs = [
       ...resolveConfiguredModelPolicyAllow({ cfg, agentId: workspaceAgentId }).refs,
     ];
@@ -500,9 +478,19 @@ export async function modelsStatusCommand(
     const modelsPath = path.join(agentDir, "models.json");
     const aliasIndex = buildModelAliasIndex({
       cfg,
+      agentId,
       defaultProvider: DEFAULT_PROVIDER,
       ...DISPLAY_MODEL_PARSE_OPTIONS,
     });
+    // The index is the same effective alias set the resolvers use, so per-agent
+    // rows that replace or empty-disable a default alias are reflected here
+    // instead of being read straight off `agents.defaults.models`.
+    const aliases = Object.fromEntries(
+      [...aliasIndex.byAlias.values()].map((match) => [
+        match.alias,
+        modelKey(match.ref.provider, match.ref.model),
+      ]),
+    );
     const resolveStatusModelRef = (raw: string | undefined) => {
       const modelRef = raw?.trim();
       if (!modelRef) {
@@ -510,6 +498,7 @@ export async function modelsStatusCommand(
       }
       return resolveModelRefFromString({
         cfg,
+        agentId,
         raw: modelRef,
         defaultProvider: DEFAULT_PROVIDER,
         aliasIndex,
@@ -1195,6 +1184,8 @@ export async function modelsStatusCommand(
       .map(
         (raw) =>
           resolveModelRefFromString({
+            cfg,
+            agentId,
             raw: raw ?? "",
             defaultProvider: DEFAULT_PROVIDER,
             aliasIndex,

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -990,6 +990,107 @@ describe("modelsStatusCommand auth overview", () => {
     );
   });
 
+  async function withConfig<T>(cfg: unknown, run: () => Promise<T>): Promise<T> {
+    const original = mocks.loadConfig.getMockImplementation();
+    mocks.loadConfig.mockReturnValue(cfg);
+    try {
+      return await run();
+    } finally {
+      if (original) {
+        mocks.loadConfig.mockImplementation(original);
+      }
+    }
+  }
+
+  it("resolves a selected agent's bare alias from that agent's model scope", async () => {
+    const localRuntime = createRuntime();
+    await withConfig(
+      {
+        agents: {
+          defaults: { model: { primary: "openai/gpt-default", fallbacks: [] } },
+          entries: {
+            jeremiah: {
+              model: { primary: "jeremiah-choice" },
+              models: { "anthropic/claude-sonnet-4-6": { alias: "jeremiah-choice" } },
+            },
+          },
+        },
+      },
+      async () => {
+        await withAgentScopeOverrides({ primary: "jeremiah-choice" }, async () => {
+          await modelsStatusCommand({ json: true, agent: "jeremiah" }, localRuntime as never);
+          const payload = parseFirstJsonLog(localRuntime);
+          expect(payload.defaultModel).toBe("jeremiah-choice");
+          // Resolving the bare alias against global defaults reported
+          // openai/jeremiah-choice while the runtime selected Anthropic, so status,
+          // --check and --probe all inspected the wrong provider route.
+          expect(payload.resolvedDefault).toBe("anthropic/claude-sonnet-4-6");
+          expect(payload.aliases).toMatchObject({
+            "jeremiah-choice": "anthropic/claude-sonnet-4-6",
+          });
+        });
+      },
+    );
+  });
+
+  it("prefers a per-agent alias row over the same alias in defaults", async () => {
+    const localRuntime = createRuntime();
+    await withConfig(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-default", fallbacks: [] },
+            models: { "openai/gpt-shared": { alias: "shared" } },
+          },
+          entries: {
+            jeremiah: {
+              model: { primary: "shared" },
+              models: { "anthropic/claude-sonnet-4-6": { alias: "shared" } },
+            },
+          },
+        },
+      },
+      async () => {
+        await withAgentScopeOverrides({ primary: "shared" }, async () => {
+          await modelsStatusCommand({ json: true, agent: "jeremiah" }, localRuntime as never);
+          const payload = parseFirstJsonLog(localRuntime);
+          // Per-agent rows are applied after defaults, so the agent's row owns
+          // the alias and the displayed target must follow the same precedence.
+          expect(payload.resolvedDefault).toBe("anthropic/claude-sonnet-4-6");
+          expect(payload.aliases).toMatchObject({ shared: "anthropic/claude-sonnet-4-6" });
+        });
+      },
+    );
+  });
+
+  it("keeps unscoped status on global defaults when no agent is selected", async () => {
+    const localRuntime = createRuntime();
+    await withConfig(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "shared", fallbacks: [] },
+            models: { "openai/gpt-shared": { alias: "shared" } },
+          },
+          entries: {
+            jeremiah: {
+              model: { primary: "shared" },
+              models: { "anthropic/claude-sonnet-4-6": { alias: "shared" } },
+            },
+          },
+        },
+      },
+      async () => {
+        await modelsStatusCommand({ json: true }, localRuntime as never);
+        const payload = parseFirstJsonLog(localRuntime);
+        // No --agent still reports unscoped defaults; another agent's rows must
+        // not leak into the global view.
+        expect(payload.resolvedDefault).toBe("openai/gpt-shared");
+        expect(payload.aliases).toMatchObject({ shared: "openai/gpt-shared" });
+      },
+    );
+  });
+
   it("uses system-agent storage without changing unscoped model output", async () => {
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();
     mocks.loadConfig.mockReturnValue({


### PR DESCRIPTION
Fixes #127585.

## What Problem This Solves

`openclaw models status --agent <id>` selected the agent's primary and fallbacks but resolved **aliases** from global defaults only. A bare per-agent alias was therefore displayed and probed as a different provider than the runtime actually selects.

Given global default `openai/gpt-default`, selected agent primary `jeremiah-choice`, and `agents.entries.jeremiah.models["anthropic/claude-sonnet-4-6"].alias = "jeremiah-choice"`, status reported:

```
resolvedDefault: openai/jeremiah-choice     # runtime selects anthropic/claude-sonnet-4-6
```

Because the same unscoped route feeds `--check`, auth diagnostics, provider-use reporting and the raw `--probe` candidate list, every one of those could inspect the wrong provider route and report false missing/auth state while the agent ran fine.

## Why This Change Was Made

The canonical selection helpers — `resolveConfiguredModelRef`, `buildModelAliasIndex`, `resolveModelRefFromString` — already accept an `agentId` and already merge per-agent model rows with inherit/replace semantics. CLI model listing, Gateway listing, runtime directives and the model picker all pass it. Only this command did not.

The command had already resolved the agent id locally; it just never handed it to the resolvers. Instead it built a **synthetic config** that spliced the agent's primary into `agents.defaults.model` — which carried the primary across but left aliases resolving against global defaults, which is precisely the defect.

So the repair is to use the canonical owner rather than to add a branch:

- pass the existing local `agentId` to all four resolver call sites (including the probe-candidate route);
- delete the synthetic global-default config entirely;
- build the displayed `aliases` map from the effective agent-scoped `aliasIndex` instead of reading `agents.defaults.models` by hand, so per-agent rows that replace a default alias are reflected.

**Production LOC: +19 / −28 = net −9.** The fix removes more than it adds; there is no new helper, branch, or fallback.

## User Impact

- `models status --agent` now reports the provider/model the selected agent will actually use.
- `--check`, `--probe`, auth diagnostics and provider-use reporting inspect the same route as runtime, so they stop reporting false missing/auth state for per-agent aliases.
- Displayed aliases reflect per-agent replacement rather than global defaults only.
- **Unscoped `models status` is unchanged** and still reports global defaults — covered by a preservation test.

No config, schema, protocol or persisted-state surface is touched; this is a read-only diagnostic command.

## Evidence

Three tests added to `src/commands/models/list.status.test.ts`. `model-selection-shared.js` is **not** mocked in that file, so these exercise the real canonical resolvers end-to-end through `modelsStatusCommand`.

**Red — production fix stashed, tests in place** (`git stash push src/commands/models/list.status-command.ts`):

```
FAIL > resolves a selected agent's bare alias from that agent's model scope
AssertionError: expected 'openai/jeremiah-choice' to be 'anthropic/claude-sonnet-4-6'

FAIL > prefers a per-agent alias row over the same alias in defaults
AssertionError: expected 'openai/gpt-shared' to be 'anthropic/claude-sonnet-4-6'

Tests  2 failed | 36 passed (38)
```

Both fail with the exact symptom reported in #127585, not an incidental error.

**Green — fix restored:**

```
Test Files  1 passed (1)
      Tests  38 passed (38)
```

Command, both runs: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/models/list.status.test.ts`

The third test ("keeps unscoped status on global defaults when no agent is selected") passes on both sides by design — it is a preservation test guarding the unscoped path against this change, not a regression test, and is labelled as such rather than counted as proof of the fix.

### Real behavior proof — actual CLI, real configuration

#127585's scenario written as a real `openclaw.json` and loaded through the production config path. The schema validator ran and rejected an earlier draft (`agents.entries.worker: Unrecognized key: "id"`), which is what makes this the real loader rather than a hand-built object:

```json
{
  "agents": {
    "ownership": "explicit",
    "defaults": { "model": { "primary": "openai/gpt-default", "fallbacks": [] } },
    "entries": {
      "worker": {
        "model": { "primary": "worker-choice", "fallbacks": [] },
        "models": { "anthropic/claude-sonnet-4-6": { "alias": "worker-choice" } }
      }
    }
  }
}
```

Run off this PR's head `599fb28f79` against an isolated throwaway home (`OPENCLAW_HOME` / `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH` all pointed at a scratch dir; no real install touched):

```
openclaw models status --agent worker --json
```

**After-fix CLI output** (paths redacted, otherwise verbatim; exit code 0):

```json
{
  "agentId": "worker",
  "agentDir": "<redacted>/agents/worker/agent",
  "defaultModel": "worker-choice",
  "resolvedDefault": "anthropic/claude-sonnet-4-6",
  "aliases": {
    "worker-choice": "anthropic/claude-sonnet-4-6"
  },
  "fallbacks": [],
  "modelConfig": {
    "defaultSource": "agent",
    "fallbacksSource": "agent"
  }
}
```

`resolvedDefault` is `anthropic/claude-sonnet-4-6` — the model the agent actually runs — where #127585 records `openai/worker-choice` on current `main`. `aliases` carries the agent-scoped row instead of global defaults, and `modelConfig.defaultSource: "agent"` confirms the selected-agent path is the one being reported.

Stated gap: this is the after-fix half only. The before half is covered by the issue's own recorded output on `main` and by the red Vitest run above failing with that literal value. A paired before-run on the same host is available on request — it is memory-constrained and each CLI invocation spawns a full plugin-compiling process alongside a live service.

Also run:

- `node_modules/.bin/oxfmt --check` on both files — clean.
- `node scripts/run-oxlint.mjs` on both files — exit 0.

Not run locally: `pnpm build` and the full suite. This host is memory-constrained (~1.7 GB available) and a full shard risks an OOM kill against an unrelated live service on it; the change touches no build output, packaging, or dynamic-import boundary. CI on the head SHA is the authority for those lanes.

### Evidence map

| Cell | Where |
|---|---|
| Changed surface | `src/commands/models/list.status-command.ts` |
| Entry point | `modelsStatusCommand` |
| Owner boundary | `src/agents/model-selection-shared.ts` (`buildEffectiveModelAliases` → `listConfiguredModelMaps`, which merges per-agent rows on `agentId`) |
| Caller | `openclaw models status --agent <id>` |
| Callee | `resolveConfiguredModelRef` / `buildModelAliasIndex` / `resolveModelRefFromString` |
| Invariant-sharing siblings | CLI model listing, Gateway listing, runtime directives, model picker — all already pass `agentId`; this command was the sole holdout |
| Existing tests | `src/commands/models/list.status.test.ts` (35 pre-existing tests still pass) |
| Current `main` behavior | Reproduced red above at `69d30923bf` |
