### PR TITLE
fix(ui): keep Home status clear of Pages editor

### DIFF
--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -691,6 +691,94 @@ suite.define(() => {
     );
   });
 
+  it("moves Home activity clear of the aligned Pages editor", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          methodResponses: {
+            "sessions.list": {
+              count: 1,
+              defaults: {
+                contextTokens: null,
+                model: "gpt-5.5",
+                modelProvider: "openai",
+              },
+              path: "",
+              sessions: [
+                {
+                  hasActiveRun: true,
+                  key: "main",
+                  kind: "direct",
+                  status: "running",
+                  updatedAt: 100,
+                },
+              ],
+              ts: 100,
+            },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const sidebar = page.locator("openclaw-app-sidebar");
+        const home = sidebar.locator(".nav-item--home");
+        await expect.poll(() => home.isVisible()).toBe(true);
+        await sidebar.evaluate(async (element) => {
+          const host = element as HTMLElement & {
+            requestUpdate(): void;
+            updateComplete: Promise<unknown>;
+          };
+          // The shell refreshes this callback whenever its lazy outbox runtime
+          // loads. Keep the warning fixture stable until geometry is measured.
+          Object.defineProperty(host, "outboxAttentionCountForSession", {
+            configurable: true,
+            get: () => () => 1,
+            set: () => undefined,
+          });
+          host.requestUpdate();
+          await host.updateComplete;
+        });
+
+        const activity = home.locator(".sidebar-home-session-states");
+        const editor = sidebar.locator(".sidebar-nav__head-action");
+        await expect.poll(() => activity.locator(".session-run-spinner").count()).toBe(1);
+        await expect.poll(() => activity.locator(".session-row-badge--attention").count()).toBe(1);
+
+        await page.mouse.move(900, 400);
+        const restingActivity = await activity.boundingBox();
+        expect(restingActivity).not.toBeNull();
+        await sidebar.locator(".sidebar-nav").hover();
+        await expect
+          .poll(() => editor.evaluate((element) => getComputedStyle(element).opacity))
+          .toBe("1");
+        await expect
+          .poll(async () => {
+            const [homeBox, activityBox, editorBox] = await Promise.all([
+              home.boundingBox(),
+              activity.boundingBox(),
+              editor.boundingBox(),
+            ]);
+            if (!homeBox || !activityBox || !editorBox || !restingActivity) {
+              return null;
+            }
+            return {
+              activityShift: Math.round(restingActivity.x - activityBox.x),
+              centerDelta: Math.abs(
+                editorBox.y + editorBox.height / 2 - (homeBox.y + homeBox.height / 2),
+              ),
+              gap: Math.round(editorBox.x - (activityBox.x + activityBox.width)),
+            };
+          })
+          .toEqual({ activityShift: 25, centerDelta: 0, gap: 4 });
+        await captureUiProof(page, "07-home-activity-editor.png");
+      },
+    );
+  });
+
   it("keeps mobile attention in the drawer while desktop remains unchanged", async () => {
     await suite.withPage(
       {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3397,12 +3397,12 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-nav__head {
   position: absolute;
   z-index: 1;
-  top: 0;
+  top: 5px;
   right: 0;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  padding: 2px 8px 2px 12px;
+  padding: 0 8px 0 12px;
 }
 
 .sidebar-nav__head-action {
@@ -3435,6 +3435,10 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   .sidebar-nav__head-action {
     opacity: 1;
   }
+
+  .sidebar-home-session-states {
+    transform: translateX(-25px);
+  }
 }
 
 .sidebar-nav__head-action:hover,
@@ -3463,6 +3467,14 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  transition: transform var(--duration-fast) ease;
+}
+
+/* The Pages editor shares Home's row. Move every trailing state together so
+   its hover/focus hitbox never covers progress, warning, or draft status. */
+.sidebar-nav:hover .sidebar-home-session-states,
+.sidebar-nav:focus-within .sidebar-home-session-states {
+  transform: translateX(-25px);
 }
 
 /* Zone 5: product chrome in one slim footer bar. The shell footer's top


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Home activity indicators overlapped the Pages edit control when the sidebar was hovered or focused. The collision obscured the warning state, covered the edit glyph, and left the edit control vertically misaligned.

## Why This Change Was Made

The sidebar now moves Home's complete trailing state group aside when the Pages editor appears, so progress, warning, and draft indicators keep their ordering and remain visible. The editor is vertically centered in the Home row, and touch layouts reserve the same space because the editor is always visible there.

## User Impact

Users can read Home progress and warning state while still seeing and using the Pages edit control. The controls remain separated by a compact 4 px gap instead of overlapping or drifting apart.

## Evidence

### Before

![Before: warning and edit glyphs overlap](https://github.com/user-attachments/assets/538c135d-a382-4d59-afb6-beeb0ad0a9b9)

### After

![After: progress, warning, and edit glyphs are separated and aligned](https://github.com/user-attachments/assets/405aeeee-625f-4471-9380-e44458821fe4)

- Current-head focused browser regression passed:
  `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-customization.e2e.test.ts -t 'moves Home activity clear of the aligned Pages editor'`
- Full sidebar customization E2E passed before the final conflict-free rebase: 7/7 tests.
- Changed-file checks passed for the UI production and test paths before the final conflict-free rebase.
- Current-head branch autoreview: clean, no actionable findings.
- Production delta: +14/-2 lines; test delta: +88/-0 lines.

AI-assisted: yes. I understand the CSS behavior, geometry assertions, and affected sidebar states.
