### PR TITLE
fix: settle terminal transcript projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.
 - **Onboarding migration menu:** group Claude, Codex, Hermes, and plugin-provided imports under a single **Import from another agent** setup choice while preserving detected source hints, manual paths, and Back navigation before import begins. Fixes #126440. Thanks @shakkernerd.

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -1061,12 +1061,17 @@ describe("mirrorCodexAppServerTranscript", () => {
         ),
       ],
       idempotencyScope: "codex-app-server:thread-1",
+      terminalAssistantOwner: {
+        mirrorIdentity: "turn-1:assistant",
+        runId: "openclaw-run-1",
+      },
     });
 
     const updates = publishSessionTranscriptUpdateByIdentityMock.mock.calls.map(
       ([update]) => update as Record<string, unknown> & { update?: Record<string, unknown> },
     );
     expect(updates.map((update) => update.update?.messageSeq)).toEqual([1, 2]);
+    expect(updates.map((update) => update.update?.runId)).toEqual([undefined, "openclaw-run-1"]);
     expect(
       updates.map((update) => {
         const message = update.update?.message as { role?: string } | undefined;

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -134,6 +134,10 @@ async function mirrorBestEffort(params: {
       // identity (not via the scope). Dropping `turnId` from the scope here is
       // what lets a re-emitted prior-turn entry collide with its existing key.
       idempotencyScope: `codex-app-server:${params.threadId}`,
+      terminalAssistantOwner: {
+        mirrorIdentity: `${params.turnId}:assistant`,
+        runId: params.params.runId,
+      },
       config: params.params.config,
     });
     for (const receipt of mirrorResult.userMessageReceipts) {
@@ -323,6 +327,7 @@ async function mirror(params: {
   storePath?: string;
   messages: AgentMessage[];
   idempotencyScope?: string;
+  terminalAssistantOwner?: { mirrorIdentity: string; runId: string };
   config?: SessionTranscriptWriteLockParams["config"];
   skipBeforeMessageWriteHooks?: boolean;
 }): Promise<CodexAppServerTranscriptMirrorResult> {
@@ -498,6 +503,14 @@ async function mirror(params: {
 
   for (const update of appendedUpdates) {
     try {
+      // Commentary and tool rows share the Codex turn but cannot claim terminal run ownership.
+      const terminalOwner = params.terminalAssistantOwner;
+      const terminalRunId =
+        update.message.role === "assistant" &&
+        terminalOwner &&
+        readMirrorIdentity(update.message) === terminalOwner.mirrorIdentity
+          ? terminalOwner.runId
+          : undefined;
       await publishSessionTranscriptUpdateByIdentity({
         ...transcriptTarget,
         update: {
@@ -505,6 +518,7 @@ async function mirror(params: {
           message: update.message,
           messageId: update.messageId,
           ...(update.messageSeq !== undefined ? { messageSeq: update.messageSeq } : {}),
+          ...(terminalRunId ? { runId: terminalRunId } : {}),
           sessionKey: transcriptTarget.sessionKey,
         },
       });

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -294,6 +294,22 @@ suite.define(() => {
         sessionKey: "main",
         state: "delta",
       });
+      const streamingBubble = page.locator(".chat-bubble.streaming", {
+        hasText: "Terminal response paragraph 1.",
+      });
+      await streamingBubble.waitFor();
+      const streamingRow = streamingBubble.locator(
+        "xpath=ancestor::div[contains(@class, 'chat-virtual-row')]",
+      );
+      await streamingRow.waitFor();
+      const steerBubble = page.locator(".chat-group.user", { hasText: steerText }).last();
+      const [steerBounds, streamingBounds] = await Promise.all([
+        steerBubble.boundingBox(),
+        streamingBubble.boundingBox(),
+      ]);
+      expect(steerBounds).not.toBeNull();
+      expect(streamingBounds).not.toBeNull();
+      expect(streamingBounds!.y).toBeGreaterThanOrEqual(steerBounds!.y + steerBounds!.height - 1);
       await gateway.emitGatewayEvent("session.message", {
         activeRunIds: [],
         clientRunId: runId,

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -315,15 +315,16 @@ suite.define(() => {
       expect(steerBounds).not.toBeNull();
       expect(streamingBounds).not.toBeNull();
       expect(streamingBounds!.y).toBeGreaterThanOrEqual(steerBounds!.y + steerBounds!.height - 1);
+      const durableFinalMessage = {
+        role: "assistant",
+        content: [{ text: finalText, type: "text" }],
+        __openclaw: { id: "ui4-final", seq: 5 },
+      };
       await gateway.emitGatewayEvent("session.message", {
-        activeRunIds: [],
+        activeRunIds: [runId],
         clientRunId: runId,
-        hasActiveRun: false,
-        message: {
-          role: "assistant",
-          content: [{ text: finalText, type: "text" }],
-          __openclaw: { id: "ui4-final", seq: 5 },
-        },
+        hasActiveRun: true,
+        message: durableFinalMessage,
         messageId: "ui4-final",
         messageSeq: 5,
         runId,
@@ -344,13 +345,10 @@ suite.define(() => {
             requestAnimationFrame(wait);
           }),
       );
+      await streamingBubble.waitFor({ state: "detached" });
       expect(
-        await page
-          .locator(
-            "[data-virtual-row-key^='stream-run:'] .chat-group.assistant:not(.chat-group--working)",
-          )
-          .count(),
-      ).toBe(0);
+        await page.locator(".chat-thread-inner").getByText(finalText, { exact: true }).count(),
+      ).toBe(1);
       const overlaps = await page.locator(".chat-thread").evaluate((thread) => {
         const rows = Array.from(thread.querySelectorAll<HTMLElement>(".chat-virtual-row"))
           .map((row) => {
@@ -371,6 +369,25 @@ suite.define(() => {
         });
       });
       expect(overlaps).toEqual([]);
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [],
+        clientRunId: runId,
+        hasActiveRun: false,
+        message: durableFinalMessage,
+        messageId: "ui4-final",
+        messageSeq: 5,
+        runId,
+        sessionKey: "main",
+      });
+      await expect
+        .poll(() =>
+          page
+            .locator(
+              "[data-virtual-row-key^='stream-run:'] .chat-group.assistant:not(.chat-group--working)",
+            )
+            .count(),
+        )
+        .toBe(0);
       await gateway.emitChatFinal({ runId, text: finalText });
       await expect
         .poll(() =>

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -277,7 +277,12 @@ suite.define(() => {
         result: "process complete",
         toolCallId: "callProcess",
       });
-      const finalText = "UI4_LONG_BASE UI4_STEER_OK";
+      const finalText = Array.from(
+        { length: 18 },
+        (_, index) =>
+          `Terminal response paragraph ${index + 1}. ` +
+          "The durable reply must replace every transient projection before the browser paints.",
+      ).join("\n\n");
       await gateway.emitGatewayEvent("chat", {
         deltaText: finalText,
         message: {
@@ -290,9 +295,9 @@ suite.define(() => {
         state: "delta",
       });
       await gateway.emitGatewayEvent("session.message", {
-        activeRunIds: [runId],
+        activeRunIds: [],
         clientRunId: runId,
-        hasActiveRun: true,
+        hasActiveRun: false,
         message: {
           role: "assistant",
           content: [{ text: finalText, type: "text" }],
@@ -300,16 +305,51 @@ suite.define(() => {
         },
         messageId: "ui4-final",
         messageSeq: 5,
-        session: {
-          activeRunIds: [runId],
-          hasActiveRun: true,
-          key: "main",
-          kind: "direct",
-          status: "running",
-          updatedAt: Date.now(),
-        },
+        runId,
         sessionKey: "main",
       });
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            let frames = 12;
+            const wait = () => {
+              frames -= 1;
+              if (frames <= 0) {
+                resolve();
+                return;
+              }
+              requestAnimationFrame(wait);
+            };
+            requestAnimationFrame(wait);
+          }),
+      );
+      expect(
+        await page
+          .locator(
+            "[data-virtual-row-key^='stream-run:'] .chat-group.assistant:not(.chat-group--working)",
+          )
+          .count(),
+      ).toBe(0);
+      const overlaps = await page.locator(".chat-thread").evaluate((thread) => {
+        const rows = Array.from(thread.querySelectorAll<HTMLElement>(".chat-virtual-row"))
+          .map((row) => {
+            const rect = row.getBoundingClientRect();
+            return {
+              bottom: rect.bottom,
+              key: row.dataset.virtualRowKey ?? "",
+              top: rect.top,
+            };
+          })
+          .filter((row) => row.bottom > row.top)
+          .toSorted((left, right) => left.top - right.top);
+        return rows.slice(1).flatMap((row, index) => {
+          const previous = rows[index];
+          return previous && row.key !== previous.key && row.top < previous.bottom - 1
+            ? [`${previous.key}->${row.key}`]
+            : [];
+        });
+      });
+      expect(overlaps).toEqual([]);
       await gateway.emitChatFinal({ runId, text: finalText });
       await expect
         .poll(() =>

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -277,6 +277,10 @@ suite.define(() => {
         result: "process complete",
         toolCallId: "callProcess",
       });
+      const workingRowKey = await page
+        .locator("[data-virtual-row-key^='stream-run:']")
+        .last()
+        .getAttribute("data-virtual-row-key");
       const finalText = Array.from(
         { length: 18 },
         (_, index) =>
@@ -302,6 +306,7 @@ suite.define(() => {
         "xpath=ancestor::div[contains(@class, 'chat-virtual-row')]",
       );
       await streamingRow.waitFor();
+      expect(await streamingRow.getAttribute("data-virtual-row-key")).not.toBe(workingRowKey);
       const steerBubble = page.locator(".chat-group.user", { hasText: steerText }).last();
       const [steerBounds, streamingBounds] = await Promise.all([
         steerBubble.boundingBox(),

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -27,6 +27,7 @@ import { buildChatItems } from "./chat-thread-build.ts";
 import { getChatSessionProjection, reduceChatSessionProjection } from "./history-merge.ts";
 import { scheduleControlUiAfterPaint } from "./performance.ts";
 import { applySessionMessagePayload } from "./session-message-apply.ts";
+import { buildToolStreamIdentity } from "./tool-stream-identity.ts";
 
 beforeEach(() => {
   vi.spyOn(assistantIdentity, "loadLocalAssistantIdentity").mockReturnValue({
@@ -177,19 +178,35 @@ describe("canonical session message recovery", () => {
 
   it("retires the complete transient projection when the durable terminal arrives", () => {
     const runId = "active-run";
+    const siblingRunId = "sibling-run";
     const finalText = "The durable terminal reply.";
     const toolMessage = { role: "assistant", runId, toolCallId: "tool-1" };
+    const siblingToolMessage = {
+      role: "assistant",
+      runId: siblingRunId,
+      toolCallId: "tool-2",
+    };
+    const toolIdentity = buildToolStreamIdentity(runId, "tool-1");
+    const siblingToolIdentity = buildToolStreamIdentity(siblingRunId, "tool-2");
     const { state } = createSessionEventState({
       connected: false,
       chatMessages: [],
       chatRunId: runId,
       chatStream: finalText,
       chatStreamStartedAt: 1,
-      chatStreamSegments: [{ text: "Commentary", ts: 1, runId, itemId: "commentary-1" }],
-      chatToolMessages: [toolMessage],
+      chatStreamSegments: [
+        { text: "Commentary", ts: 1, runId, itemId: "commentary-1" },
+        {
+          text: "Sibling commentary",
+          ts: 1,
+          runId: siblingRunId,
+          itemId: "commentary-2",
+        },
+      ],
+      chatToolMessages: [toolMessage, siblingToolMessage],
       toolStreamById: new Map([
         [
-          "tool-1",
+          toolIdentity,
           {
             message: toolMessage,
             name: "exec",
@@ -199,8 +216,28 @@ describe("canonical session message recovery", () => {
             toolCallId: "tool-1",
           },
         ],
+        [
+          siblingToolIdentity,
+          {
+            message: siblingToolMessage,
+            name: "read",
+            receivedAt: 1,
+            runId: siblingRunId,
+            startedAt: 1,
+            toolCallId: "tool-2",
+          },
+        ],
       ]),
-      toolStreamOrder: ["tool-1"],
+      toolStreamOrder: [toolIdentity, siblingToolIdentity],
+      activityEventSeqById: new Map([
+        [`tool:${JSON.stringify([runId, "tool-1"])}:result`, 2],
+        [`tool:${JSON.stringify([siblingRunId, "tool-2"])}:result`, 2],
+      ]),
+      knownAgentRunIds: new Set([runId, siblingRunId]),
+      waitingApprovalStatuses: new Map([
+        ["approval-1", { approvalId: "approval-1", toolCallId: "tool-1", runId }],
+        ["approval-2", { approvalId: "approval-2", toolCallId: "tool-2", runId: siblingRunId }],
+      ]),
     });
 
     applySessionMessagePayload(
@@ -220,12 +257,27 @@ describe("canonical session message recovery", () => {
       { kind: "live", activeRunId: runId },
     );
 
-    expect(renderedTranscript(state)).toEqual([{ role: "assistant", text: finalText }]);
+    expect(state.chatMessages.filter((message) => extractText(message) === finalText)).toHaveLength(
+      1,
+    );
     expect(state.chatStream).toBeNull();
-    expect(state.chatStreamSegments).toEqual([]);
-    expect(state.chatToolMessages).toEqual([]);
-    expect(state.toolStreamById).toEqual(new Map());
-    expect(state.toolStreamOrder).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([
+      {
+        text: "Sibling commentary",
+        ts: 1,
+        runId: siblingRunId,
+        itemId: "commentary-2",
+      },
+    ]);
+    expect(state.chatToolMessages).toEqual([siblingToolMessage]);
+    expect(state.toolStreamById.has(toolIdentity)).toBe(false);
+    expect(state.toolStreamById.has(siblingToolIdentity)).toBe(true);
+    expect(state.toolStreamOrder).toEqual([siblingToolIdentity]);
+    expect(state.knownAgentRunIds).toEqual(new Set([siblingRunId]));
+    expect([...state.waitingApprovalStatuses.keys()]).toEqual(["approval-2"]);
+    expect([...(state.activityEventSeqById?.keys() ?? [])]).toEqual([
+      `tool:${JSON.stringify([siblingRunId, "tool-2"])}:result`,
+    ]);
   });
 
   it("keeps cumulative assistant output split across an authoritative steer", () => {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -24,7 +24,7 @@ import {
 } from "./chat-state-refresh.ts";
 import { resolveChatAvatarUrl, selectedChatSessionRow } from "./chat-state-route.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
-import { getChatSessionProjection } from "./history-merge.ts";
+import { getChatSessionProjection, reduceChatSessionProjection } from "./history-merge.ts";
 import { scheduleControlUiAfterPaint } from "./performance.ts";
 import { applySessionMessagePayload } from "./session-message-apply.ts";
 
@@ -269,6 +269,16 @@ describe("canonical session message recovery", () => {
     ]);
     expect(state.chatRunId).toBe(activeRunId);
     expect(state.chatQueue).toEqual([]);
+    reduceChatSessionProjection(state, {
+      type: "sendPending",
+      runId: steerRunId,
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "Steer prompt" }],
+        timestamp: 50,
+        __openclaw: { idempotencyKey: `${steerRunId}:user` },
+      },
+    });
     state.chatRunId = steerRunId;
 
     const steerEvent = {
@@ -296,6 +306,7 @@ describe("canonical session message recovery", () => {
     handlePageGatewayEvent(state, steerEvent);
     expect(state.chatRunId).toBe(activeRunId);
     const segmentsAfterRequestBoundary = state.chatStreamSegments;
+    expect(segmentsAfterRequestBoundary.at(-1)?.boundaryRunId).toBe(steerRunId);
     expect(state.chatStreamSegments).toBe(segmentsAfterRequestBoundary);
     expect(
       state.chatMessages.filter((message) => extractText(message) === "Steer prompt"),

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -175,6 +175,59 @@ describe("canonical session message recovery", () => {
     expect(renderedTranscript(state)).toEqual([{ role: "assistant", text }]);
   });
 
+  it("retires the complete transient projection when the durable terminal arrives", () => {
+    const runId = "active-run";
+    const finalText = "The durable terminal reply.";
+    const toolMessage = { role: "assistant", runId, toolCallId: "tool-1" };
+    const { state } = createSessionEventState({
+      connected: false,
+      chatMessages: [],
+      chatRunId: runId,
+      chatStream: finalText,
+      chatStreamStartedAt: 1,
+      chatStreamSegments: [{ text: "Commentary", ts: 1, runId, itemId: "commentary-1" }],
+      chatToolMessages: [toolMessage],
+      toolStreamById: new Map([
+        [
+          "tool-1",
+          {
+            message: toolMessage,
+            name: "exec",
+            receivedAt: 1,
+            runId,
+            startedAt: 1,
+            toolCallId: "tool-1",
+          },
+        ],
+      ]),
+      toolStreamOrder: ["tool-1"],
+    });
+
+    applySessionMessagePayload(
+      state,
+      {
+        sessionKey: state.sessionKey,
+        runId,
+        messageId: "terminal-message",
+        messageSeq: 2,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: finalText }],
+          timestamp: 2,
+        },
+      },
+      false,
+      { kind: "live", activeRunId: runId },
+    );
+
+    expect(renderedTranscript(state)).toEqual([{ role: "assistant", text: finalText }]);
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.toolStreamById).toEqual(new Map());
+    expect(state.toolStreamOrder).toEqual([]);
+  });
+
   it("keeps cumulative assistant output split across an authoritative steer", () => {
     const activeRunId = "active-run";
     const steerRunId = "steer-request";

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -714,7 +714,9 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       const liveProgress = resolveProgress();
       const liveStreamItem: ChatItem = {
         kind: "stream",
-        key: liveProgress.key,
+        key: latestBoundaryRunId
+          ? `${liveProgress.key}:after:${latestBoundaryRunId}`
+          : liveProgress.key,
         text: visibleText,
         startedAt: timestampAfterVisibleItems(items, props.streamStartedAt ?? Date.now()),
         isStreaming: true,

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   reconcileStaleChatRunAfterSessionStatePublication,
   replayPendingChatAbort,
 } from "./run-lifecycle.ts";
+import { buildToolStreamIdentity } from "./tool-stream-identity.ts";
 
 type ReconcileHost = Parameters<typeof reconcileChatRunFromCurrentSessionRow>[0];
 type TestRow = {
@@ -346,6 +347,79 @@ describe("reconcileChatRunLifecycle indicators", () => {
     });
 
     expect(host.waitingApprovalStatuses?.has("approval-1")).toBe(true);
+  });
+});
+
+describe("reconcileChatRunFromSessionRow transient projections", () => {
+  it("clears only the terminal run's tool stream", () => {
+    const runId = "r1";
+    const siblingRunId = "r2";
+    const toolIdentity = buildToolStreamIdentity(runId, "tool-1");
+    const siblingToolIdentity = buildToolStreamIdentity(siblingRunId, "tool-2");
+    const toolMessage = { role: "assistant", runId, toolCallId: "tool-1" };
+    const siblingToolMessage = {
+      role: "assistant",
+      runId: siblingRunId,
+      toolCallId: "tool-2",
+    };
+    const host = makeHost({
+      chatRunId: runId,
+      chatStream: "Final reply",
+      chatStreamSegments: [
+        { text: "run one", ts: 1, runId },
+        { text: "run two", ts: 2, runId: siblingRunId },
+      ],
+      chatToolMessages: [toolMessage, siblingToolMessage],
+      toolStreamById: new Map([
+        [
+          toolIdentity,
+          {
+            message: toolMessage,
+            name: "exec",
+            receivedAt: 1,
+            runId,
+            startedAt: 1,
+            toolCallId: "tool-1",
+          },
+        ],
+        [
+          siblingToolIdentity,
+          {
+            message: siblingToolMessage,
+            name: "read",
+            receivedAt: 2,
+            runId: siblingRunId,
+            startedAt: 2,
+            toolCallId: "tool-2",
+          },
+        ],
+      ]),
+      toolStreamOrder: [toolIdentity, siblingToolIdentity],
+      toolStreamSyncTimer: null,
+      knownAgentRunIds: new Set([runId, siblingRunId]),
+      waitingApprovalStatuses: new Map([
+        ["approval-1", { approvalId: "approval-1", toolCallId: "tool-1", runId }],
+        ["approval-2", { approvalId: "approval-2", toolCallId: "tool-2", runId: siblingRunId }],
+      ]),
+    });
+
+    expect(
+      reconcileChatRunFromSessionRow(host, {
+        key: "s1",
+        kind: "direct",
+        updatedAt: 2,
+        hasActiveRun: false,
+        status: "done",
+      }),
+    ).toBe(true);
+
+    expect(host.chatStreamSegments).toEqual([{ text: "run two", ts: 2, runId: siblingRunId }]);
+    expect(host.chatToolMessages).toEqual([siblingToolMessage]);
+    expect(host.toolStreamById?.has(toolIdentity)).toBe(false);
+    expect(host.toolStreamById?.has(siblingToolIdentity)).toBe(true);
+    expect(host.toolStreamOrder).toEqual([siblingToolIdentity]);
+    expect(host.knownAgentRunIds).toEqual(new Set([siblingRunId]));
+    expect([...host.waitingApprovalStatuses!.keys()]).toEqual(["approval-2"]);
   });
 });
 

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -606,6 +606,7 @@ export function reconcileChatRunFromSessionRow(
     sessionKeys: [row.key],
     clearLocalRun: true,
     clearChatStream: true,
+    clearToolStream: true,
     publishRunStatus: options.publishRunStatus,
   });
   return true;

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -24,6 +24,7 @@ import { resetChatInputHistoryNavigation, type ChatInputHistoryState } from "./i
 // Control UI chat module implements run lifecycle behavior.
 import {
   resetToolStream,
+  resetToolStreamRun,
   type CompactionStatus,
   type FallbackStatus,
   type WaitingApprovalStatus,
@@ -83,6 +84,7 @@ type ReconcileOptions = {
   clearChatStream?: boolean;
   clearIndicators?: boolean;
   clearToolStream?: boolean;
+  clearToolStreamForRun?: boolean;
   clearRunStatus?: boolean;
   publishRunStatus?: boolean;
   armLocalTerminalReconcile?: boolean;
@@ -452,8 +454,12 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
   if (options.clearLocalRun) {
     host.chatRunId = null;
   }
-  if (options.clearToolStream && canResetToolStream(host)) {
-    resetToolStream(host);
+  if (canResetToolStream(host)) {
+    if (options.clearToolStream) {
+      resetToolStream(host);
+    } else if (options.clearToolStreamForRun && runId) {
+      resetToolStreamRun(host, runId);
+    }
   }
   if (options.outcome) {
     const status: ChatRunUiStatus = {
@@ -606,7 +612,7 @@ export function reconcileChatRunFromSessionRow(
     sessionKeys: [row.key],
     clearLocalRun: true,
     clearChatStream: true,
-    clearToolStream: true,
+    clearToolStreamForRun: true,
     publishRunStatus: options.publishRunStatus,
   });
   return true;

--- a/ui/src/pages/chat/session-message-apply.ts
+++ b/ui/src/pages/chat/session-message-apply.ts
@@ -12,7 +12,12 @@ import {
   readChatSessionProjectionScope,
   reduceChatSessionProjection,
 } from "./history-merge.ts";
-import { persistedSteerTargetRunId, rolloverChatStream } from "./stream-causal-boundary.ts";
+import {
+  latestPersistedSteerBoundary,
+  latestStreamBoundaryRunId,
+  persistedSteerTargetRunId,
+  rolloverChatStream,
+} from "./stream-causal-boundary.ts";
 import { maybeResetToolStream } from "./stream-reconciliation.ts";
 import { prunePersistedAssistantStreamSegments } from "./stream-segment-pruning.ts";
 
@@ -121,7 +126,6 @@ export function applySessionMessagePayload(
       ...(incoming.sequence !== null ? { seq: incoming.sequence } : {}),
     },
   };
-  const previousMessageCount = state.chatMessages.length;
   const projection = reduceChatSessionProjection(
     state,
     {
@@ -141,13 +145,17 @@ export function applySessionMessagePayload(
   }
   const steerTargetRunId = persistedSteerTargetRunId(message);
   const currentRunId = state.chatRunId;
+  const persistedSteerBoundary = steerTargetRunId
+    ? latestPersistedSteerBoundary(projection.messages, steerTargetRunId)
+    : null;
   if (
     incoming.role === "user" &&
     runActive === true &&
     incoming.runId &&
     steerTargetRunId &&
     (!currentRunId || currentRunId === steerTargetRunId || currentRunId === incoming.runId) &&
-    projection.messages.length > previousMessageCount
+    persistedSteerBoundary?.runId === incoming.runId &&
+    latestStreamBoundaryRunId(state) !== incoming.runId
   ) {
     state.chatRunId = steerTargetRunId;
     rolloverChatStream(state, {

--- a/ui/src/pages/chat/session-message-apply.ts
+++ b/ui/src/pages/chat/session-message-apply.ts
@@ -13,6 +13,7 @@ import {
   reduceChatSessionProjection,
 } from "./history-merge.ts";
 import { persistedSteerTargetRunId, rolloverChatStream } from "./stream-causal-boundary.ts";
+import { maybeResetToolStream } from "./stream-reconciliation.ts";
 import { prunePersistedAssistantStreamSegments } from "./stream-segment-pruning.ts";
 
 type SessionMessageApplySource =
@@ -132,6 +133,11 @@ export function applySessionMessagePayload(
   );
   if (incoming.role === "assistant" && projection.messages.includes(message)) {
     prunePersistedAssistantStreamSegments(state, message);
+    if (assistantOwnerRunId && runActive === false) {
+      state.chatStream = null;
+      state.chatStreamStartedAt = null;
+      maybeResetToolStream(state);
+    }
   }
   const steerTargetRunId = persistedSteerTargetRunId(message);
   const currentRunId = state.chatRunId;

--- a/ui/src/pages/chat/session-message-apply.ts
+++ b/ui/src/pages/chat/session-message-apply.ts
@@ -18,7 +18,10 @@ import {
   persistedSteerTargetRunId,
   rolloverChatStream,
 } from "./stream-causal-boundary.ts";
-import { maybeResetToolStream } from "./stream-reconciliation.ts";
+import {
+  assistantMessageReplacesCurrentStream,
+  maybeResetToolStreamRun,
+} from "./stream-reconciliation.ts";
 import { prunePersistedAssistantStreamSegments } from "./stream-segment-pruning.ts";
 
 type SessionMessageApplySource =
@@ -137,10 +140,17 @@ export function applySessionMessagePayload(
   );
   if (incoming.role === "assistant" && projection.messages.includes(message)) {
     prunePersistedAssistantStreamSegments(state, message);
-    if (assistantOwnerRunId && runActive === false) {
-      state.chatStream = null;
-      state.chatStreamStartedAt = null;
-      maybeResetToolStream(state);
+    if (assistantOwnerRunId) {
+      if (
+        runActive === false ||
+        (state.chatStream !== null && assistantMessageReplacesCurrentStream(state, message))
+      ) {
+        state.chatStream = null;
+        state.chatStreamStartedAt = null;
+      }
+      if (runActive === false) {
+        maybeResetToolStreamRun(state, assistantOwnerRunId);
+      }
     }
   }
   const steerTargetRunId = persistedSteerTargetRunId(message);

--- a/ui/src/pages/chat/stream-causal-boundary.ts
+++ b/ui/src/pages/chat/stream-causal-boundary.ts
@@ -100,7 +100,7 @@ export function indexTurnContinuations<T>(
 }
 
 export function latestPersistedSteerBoundary(
-  messages: unknown[],
+  messages: readonly unknown[],
   activeRunId: string,
 ): { index: number; runId: string } | null {
   for (let index = messages.length - 1; index >= 0; index -= 1) {

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -27,7 +27,7 @@ import {
   resolveLiveToolStreamRefs,
   resolveMatchingLiveToolIdentity,
 } from "./tool-stream-identity.ts";
-import { resetToolStream } from "./tool-stream.ts";
+import { resetToolStream, resetToolStreamRun } from "./tool-stream.ts";
 
 type StreamReconciliationState = StreamCausalBoundaryState & {
   chatStream: string | null;
@@ -64,6 +64,18 @@ type MaterializeVisibleStreamOptions = {
   isHiddenStreamText: StreamVisibility;
 };
 
+function resettableToolStreamHost(
+  state: StreamReconciliationState,
+): Parameters<typeof resetToolStream>[0] | null {
+  const toolHost = state as ToolStreamHost & Partial<Parameters<typeof resetToolStream>[0]>;
+  return toolHost.toolStreamById instanceof Map &&
+    Array.isArray(toolHost.toolStreamOrder) &&
+    Array.isArray(toolHost.chatToolMessages) &&
+    Array.isArray(toolHost.chatStreamSegments)
+    ? (toolHost as Parameters<typeof resetToolStream>[0])
+    : null;
+}
+
 export function currentLiveToolCallIds(state: StreamReconciliationState): string[] {
   const toolHost = state as ToolStreamHost;
   return Array.isArray(toolHost.toolStreamOrder)
@@ -89,20 +101,23 @@ export function maybeResetToolStream(
   state: StreamReconciliationState,
   opts?: { preserveStreamSegments?: boolean },
 ) {
-  const toolHost = state as ToolStreamHost & Partial<Parameters<typeof resetToolStream>[0]>;
-  if (
-    toolHost.toolStreamById instanceof Map &&
-    Array.isArray(toolHost.toolStreamOrder) &&
-    Array.isArray(toolHost.chatToolMessages) &&
-    Array.isArray(toolHost.chatStreamSegments)
-  ) {
-    const preservedStreamSegments = opts?.preserveStreamSegments
-      ? [...toolHost.chatStreamSegments]
-      : null;
-    resetToolStream(toolHost as Parameters<typeof resetToolStream>[0]);
-    if (preservedStreamSegments) {
-      toolHost.chatStreamSegments = preservedStreamSegments;
-    }
+  const toolHost = resettableToolStreamHost(state);
+  if (!toolHost) {
+    return;
+  }
+  const preservedStreamSegments = opts?.preserveStreamSegments
+    ? [...toolHost.chatStreamSegments]
+    : null;
+  resetToolStream(toolHost);
+  if (preservedStreamSegments) {
+    toolHost.chatStreamSegments = preservedStreamSegments;
+  }
+}
+
+export function maybeResetToolStreamRun(state: StreamReconciliationState, runId: string) {
+  const toolHost = resettableToolStreamHost(state);
+  if (toolHost) {
+    resetToolStreamRun(toolHost, runId);
   }
 }
 
@@ -264,6 +279,21 @@ function hasAssistantStreamReplacement(
     const text = extractText(message)?.trim();
     return Boolean(text && (text === expected || text.startsWith(expected)));
   });
+}
+
+export function assistantMessageReplacesCurrentStream(
+  state: StreamReconciliationState,
+  message: unknown,
+): boolean {
+  const currentPart = visibleAssistantStreamParts(state, {
+    includeCurrent: true,
+    isHiddenStreamText: () => false,
+  }).findLast((part) => part.source === "current");
+  return Boolean(
+    currentPart &&
+    (hasAssistantStreamReplacement([message], currentPart.replacementText, () => false, 0) ||
+      hasAssistantStreamReplacement([message], currentPart.text, () => false, 0)),
+  );
 }
 
 function streamFallbackItemId(message: unknown): string | null {

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -330,11 +330,15 @@ function syncToolStreamMessages(host: ToolStreamHost) {
     .filter((msg): msg is Record<string, unknown> => Boolean(msg));
 }
 
-function flushToolStreamSync(host: ToolStreamHost) {
+function cancelToolStreamSync(host: ToolStreamHost) {
   if (host.toolStreamSyncTimer != null) {
     clearTimeout(host.toolStreamSyncTimer);
     host.toolStreamSyncTimer = null;
   }
+}
+
+function flushToolStreamSync(host: ToolStreamHost) {
+  cancelToolStreamSync(host);
   syncToolStreamMessages(host);
 }
 
@@ -354,10 +358,7 @@ function scheduleToolStreamSync(host: ToolStreamHost, force = false) {
 }
 
 export function resetToolStream(host: ToolStreamHost) {
-  if (host.toolStreamSyncTimer != null) {
-    clearTimeout(host.toolStreamSyncTimer);
-    host.toolStreamSyncTimer = null;
-  }
+  cancelToolStreamSync(host);
   host.toolStreamById.clear();
   host.toolStreamOrder = [];
   host.activityEventSeqById?.clear();
@@ -367,6 +368,38 @@ export function resetToolStream(host: ToolStreamHost) {
   host.waitingApprovalStatuses?.clear();
   // Resolution can beat the overlay queue update. Keep tombstones across transient stream resets
   // until snapshot reconciliation observes the approval leaving the queue.
+}
+
+export function resetToolStreamRun(host: ToolStreamHost, runId: string) {
+  cancelToolStreamSync(host);
+  const removedIdentities = new Set<string>();
+  for (const identity of host.toolStreamOrder) {
+    const entry = host.toolStreamById.get(identity);
+    if (entry?.runId !== runId) {
+      continue;
+    }
+    removedIdentities.add(identity);
+  }
+  for (const identity of removedIdentities) {
+    host.toolStreamById.delete(identity);
+  }
+  const activityPrefix = `tool:[${JSON.stringify(runId)},`;
+  for (const sequenceIdentity of host.activityEventSeqById?.keys() ?? []) {
+    if (sequenceIdentity.startsWith(activityPrefix)) {
+      host.activityEventSeqById?.delete(sequenceIdentity);
+    }
+  }
+  host.toolStreamOrder = host.toolStreamOrder.filter(
+    (identity) => !removedIdentities.has(identity),
+  );
+  syncToolStreamMessages(host);
+  host.chatStreamSegments = host.chatStreamSegments.filter((segment) => segment.runId !== runId);
+  host.knownAgentRunIds?.delete(runId);
+  for (const [approvalId, waitingApproval] of host.waitingApprovalStatuses ?? []) {
+    if (waitingApproval.runId === runId) {
+      host.waitingApprovalStatuses?.delete(approvalId);
+    }
+  }
 }
 
 function toolActivityIdentity(runId: string, toolCallId: string): string {


### PR DESCRIPTION
## Summary

- publish the owning OpenClaw run ID with Codex terminal transcript mirrors
- replace the matching live final stream as soon as its durable assistant row arrives
- retire terminal tool, commentary, approval, and run projections only for the completed run
- preserve post-steer transcript ordering and remount the stream row across the causal boundary

Fixes #127209.

## Root cause

Codex persisted the terminal assistant mirror and emitted `session.message` about 50 ms before `chat.final`, while the session still reported `hasActiveRun: true`.

The mirror update omitted the OpenClaw run ID. Its Codex mirror idempotency key was therefore interpreted as assistant run ownership, and the durable final was misclassified as a delayed previous-run row. The Control UI admitted that row beside the still-mounted live stream, allowing both projections to overlap while the virtualized transcript settled.

The first cleanup implementation also reset the shared transient store, which could erase another active run's tools, commentary, known-run state, or pending approval.

## Fix

- the Codex mirror carries the exact OpenClaw run ID only on the matching terminal assistant update; prompt, commentary, tool, and imported mirror rows remain unowned
- a durable assistant row that replaces the current stream retires that stream immediately, independent of the lagging active-state flag
- terminal cleanup removes only state owned by the completed run
- persisted steers create the missing causal boundary even when the optimistic row is promoted in place
- the post-steer stream row receives a new virtual-row identity so stale geometry is not reused

## Verification

- Codex transcript mirror: 38 passed
- Control UI owner suites: 158 passed
- active-follow-up Control UI E2E: 7 passed
- core and extension production/test typechecks: passed
- structured autoreview: clean, no accepted findings
- pre-fix live capture: 10.02 px text overlap
- intermediate exact-head live capture: 11.78 px text overlap, which exposed the missing producer run ID
- final exact-head OCM capture: 277 sampled frames, no overlap, 0 stale streamed assistant rows, exactly 1 final
- Blacksmith Testbox changed-file gate: passed on the final head
- GitHub CI attempt 2: all 138 jobs completed successfully; the initial `SIGKILL` shard passed on retry

## Visual evidence

| Before | After |
| --- | --- |
| ![Terminal final overlapping the live stream](https://github.com/user-attachments/assets/5da53687-993d-4001-b012-dc3fe9d6d55f) | ![Terminal final settled without overlap](https://github.com/user-attachments/assets/ec6c568f-d576-4bc6-9620-776539bb7191) |

### Exact-head live recording

https://github.com/user-attachments/assets/e2e07356-b1eb-4ed3-9f1c-a980601af637
