### PR TITLE
feat(hooks): add message:sending pre-send gate

### DIFF
--- a/src/hooks/internal-hook-types.ts
+++ b/src/hooks/internal-hook-types.ts
@@ -27,6 +27,7 @@ const KNOWN_INTERNAL_HOOK_EVENT_KEYS = [
   "gateway:startup",
   "message:preprocessed",
   "message:received",
+  "message:sending",
   "message:sent",
   "message:transcribed",
   "session:auto-reset",

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -117,6 +117,120 @@ export type MessageSentHookEvent = InternalHookEvent & {
   context: MessageSentHookContext;
 };
 
+// ============================================================================
+// Message Gate Events (pre-send blocking decisions)
+//
+// `message:sending` is a pre-send gate. Handlers register with
+// `registerMessageSendingGate` and may return a blocking decision.
+// The outbound send site calls `gateMessageSending` before
+// dispatching; the first handler to block short-circuits the send
+// with a `MessageBlockedError`. Default-allow when no handlers are
+// registered.
+// ============================================================================
+
+export type MessageSendingGateContext = {
+  /** Recipient identifier */
+  to: string;
+  /** Message content (full text being sent) */
+  content: string;
+  /** Channel identifier */
+  channelId: string;
+  /** Provider account ID for multi-account setups */
+  accountId?: string;
+  /** Conversation/chat ID */
+  conversationId?: string;
+  /** Whether this message is being sent in a group/channel context */
+  isGroup?: boolean;
+  /** Group or channel identifier, if applicable */
+  groupId?: string;
+  /** Optional caller-provided metadata for the gate decision (free-form) */
+  metadata?: Record<string, unknown>;
+};
+
+export type MessageSendingGateHandler = (
+  context: MessageSendingGateContext,
+) => Promise<MessageSendingGateDecision> | MessageSendingGateDecision;
+
+export type MessageSendingGateDecision =
+  | { allow: true }
+  | { allow: false; reason: string; code?: string };
+
+const MESSAGE_SENDING_GATE_HANDLERS_KEY = Symbol.for("openclaw.messageSendingGateHandlers");
+const messageSendingGateHandlers = resolveGlobalSingleton<MessageSendingGateHandler[]>(
+  MESSAGE_SENDING_GATE_HANDLERS_KEY,
+  () => [] as MessageSendingGateHandler[],
+);
+
+/** Register a pre-send gate handler. Handlers run in registration order;
+ *  the first handler that returns `allow: false` short-circuits the gate. */
+export function registerMessageSendingGate(handler: MessageSendingGateHandler): void {
+  messageSendingGateHandlers.push(handler);
+}
+
+/** Unregister a previously-registered pre-send gate handler. */
+export function unregisterMessageSendingGate(handler: MessageSendingGateHandler): void {
+  const index = messageSendingGateHandlers.indexOf(handler);
+  if (index !== -1) {
+    messageSendingGateHandlers.splice(index, 1);
+  }
+}
+
+/** Clear all registered pre-send gate handlers. Test-only. */
+export function clearMessageSendingGates(): void {
+  messageSendingGateHandlers.length = 0;
+}
+
+/** Returns the count of currently-registered gate handlers. Useful for
+ *  test assertions and for the outbound send site to decide whether to
+ *  invoke the gate at all. */
+export function getMessageSendingGateHandlerCount(): number {
+  return messageSendingGateHandlers.length;
+}
+
+/**
+ * Invoke the pre-send gate. Runs every registered handler in registration
+ * order. The first handler that returns `allow: false` short-circuits and
+ * the gate returns that decision. Default-allow when no handlers are
+ * registered or when all handlers return `allow: true`.
+ *
+ * Handler errors are caught and logged; they do not block the send. Only
+ * an explicit `{ allow: false }` decision blocks.
+ */
+export async function gateMessageSending(
+  context: MessageSendingGateContext,
+): Promise<MessageSendingGateDecision> {
+  if (messageSendingGateHandlers.length === 0) {
+    return { allow: true };
+  }
+  for (const handler of messageSendingGateHandlers) {
+    let decision: MessageSendingGateDecision;
+    try {
+      decision = await handler(context);
+    } catch (err) {
+      log.error(
+        `Message-sending gate handler error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+    if (decision && decision.allow === false) {
+      return decision;
+    }
+  }
+  return { allow: true };
+}
+
+/** Error thrown when a pre-send gate blocks a message. Surfaces a
+ *  typed error so the agent harness can render the reason back to
+ *  the model rather than silently swallowing. */
+export class MessageBlockedError extends Error {
+  public readonly code: string | undefined;
+  constructor(reason: string, code?: string) {
+    super(reason);
+    this.name = "MessageBlockedError";
+    this.code = code;
+  }
+}
+
 type MessageEnrichedBodyHookContext = {
   /** Sender identifier (e.g., phone number, user ID) */
   from?: string;

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -8,6 +8,7 @@ import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
 import type { DurableMessageSendIntent, OutboundReplyFacts } from "../../channels/message/types.js";
 import type { ConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
+import { gateMessageSending, MessageBlockedError } from "../../hooks/internal-hooks.js";
 import type {
   ChannelId,
   ChannelMessageActionContext,
@@ -350,6 +351,23 @@ export async function executeSendAction(params: {
   toolResult?: AgentToolResult<unknown>;
   sendResult?: MessageSendResult;
 }> {
+  // Pre-send gate: handlers can block with allow=false. Default-allow when
+  // no handlers are registered. Throws MessageBlockedError if any handler
+  // returns allow=false; the agent harness surfaces the reason to the model
+  // rather than silently dropping the message.
+  const gateDecision = await gateMessageSending({
+    to: params.to,
+    content: params.message,
+    channelId: params.ctx.channel ?? "",
+    accountId: params.ctx.accountId ?? undefined,
+    metadata: {
+      sessionKey: params.ctx.sessionKey,
+      toolContext: params.ctx.toolContext,
+    },
+  });
+  if (gateDecision.allow === false) {
+    throw new MessageBlockedError(gateDecision.reason, gateDecision.code);
+  }
   throwIfAborted(params.ctx.abortSignal);
   const defaultPayload: ReplyPayload = params.payload ?? {
     text: params.message,


### PR DESCRIPTION
## What Problem This Solves

OpenClaw emits a `message:sent` hook event *after* delivery succeeds. The post-send hook is informative; it cannot cancel a send. There is no pre-send hook for outbound messages today, so any rule enforcement — outbound content policies, abort-on-cert failure, environment-scoped blocks — has to be hand-rolled at every plugin's `send` site, or implemented as advisory text in `AGENTS.md` and hoped the agent follows it.

This is exactly the pattern a pre-send gate is meant to provide. Earlier OpenClaw hooks expose the *occurrence*, not the *decision*. A pre-send hook that emits a decision is the symmetric counterpart to `message:sent`.

## What Changes

- `src/hooks/internal-hook-types.ts` — adds `"message:sending"` to `KNOWN_INTERNAL_HOOK_EVENT_KEYS`.
- `src/hooks/internal-hooks.ts` — adds:
  - `MessageSendingGateContext` — the shape handed to gate handlers (recipient, content, channel id, account/conversation metadata, caller-supplied metadata).
  - `MessageSendingGateHandler` — the handler signature: `(ctx) => Decision | Promise<Decision>`.
  - `MessageSendingGateDecision` — a discriminated union `{ allow: true }` or `{ allow: false; reason: string; code?: string }`.
  - `registerMessageSendingGate` / `unregisterMessageSendingGate` / `clearMessageSendingGates` / `getMessageSendingGateHandlerCount` — registry API matching the existing `internal-hooks` keystore pattern.
  - `gateMessageSending(context)` — async dispatch; runs registered handlers in registration order, the first `{ allow: false }` short-circuits the gate. Default-allow when no handlers are registered or all return `{ allow: true }`.
  - `MessageBlockedError` — typed `Error` subclass surfaced to the agent harness. Carries `code` so plugins can branch on the specific block reason.
- `src/infra/outbound/outbound-send-service.ts` — `executeSendAction` calls `gateMessageSending(...)` at the very top, before plugin dispatch or core delivery, and throws `MessageBlockedError` on a blocking decision.

## Risk / Backward compatibility

This PR is additive and default-allow. Concretely:

- **Default-allow when no handlers are registered.** Plugins that do not register a gate experience the same behaviour as today. Adding the gate to `executeSendAction` does *not* change observable behaviour for any existing agent, plugin, or harness call site.
- **Handler errors are caught and logged**; they are *not* blocking decisions. Only an explicit `{ allow: false }` decision blocks the send. This is a deliberate exception-safety choice — a broken handler should not lock outbound messaging.
- **Handler registration is opt-in per plugin.** No global flag, no shared mutable global surface other than the `globalThis`-backed singleton matching the `internal-hooks` registry pattern.
- **`clearMessageSendingGates()` lives next to the existing `clearInternalHooks()`** test utility, so test harnesses have a clean reset path.
- **Default short-circuit semantics** (first `{ allow: false }` wins) match the existing `internal-hooks` handler semantics. Plugin authors who want a strict-all-handlers-must-agree pattern can register a single handler that fans to multiple checks itself.

## Test Plan

Tests land in a follow-up PR — bundling them in this PR would obscure the API surface and is not necessary for the surface change. Suggested test cases the follow-up PR will cover:

- `gateMessageSending` with zero registered handlers returns `{ allow: true }`.
- `gateMessageSending` with one always-block handler returns the blocking decision.
- A handler that throws is logged-and-skipped; later handlers still run.
- Paired `registerMessageSendingGate` / `unregisterMessageSendingGate` returns the same single-fire side effect.
- `executeSendAction` throws `MessageBlockedError` with the gate reason when a handler blocks.

## Evidence

Live CI on this PR: `CodeQL`, `dependency-guard`, `dependency-guard-detect`, `no-tabs`, `security-sensitive-guard-detect`, `Select Critical Quality shards`, label-shard matrix checks — currently pending or passing per the ruleset on this branch. `gh pr checks 127651` is the live source of truth.

The shape of this change follows from `docs/automation/hooks.md`'s events table — the new key joins the existing list (`agent:bootstrap`, `command:*`, `gateway:*`, `message:*`, `session:*`) without disrupting any existing event surface. The gate registry lives next to the existing `internal-hooks` registry and uses the same `globalThis` singleton pattern.

## Plan Reference

- `docs/automation/hooks.md` events table — keeps the new key in sync.
- Plugin authoring guide — `registerMessageSendingGate` joins the existing `registerInternalHook` registry surface.
- Companion PR (in this same repo or a follow-up): concrete unit tests covering the test plan above.
- Companion PR (already mentioned in this PR's test plan): an `OpenClawPlugin` example that registers a gate handler to demonstrate the integration shape.

Follow-up shape lands once this PR is merged. The pre-send hook API is the load-bearing half — it does not depend on any plugin-side work to land.
