### PR TITLE
fix(channels): Matrix attachment delivery and ClickClack recovery

### DIFF
--- a/extensions/clickclack/src/outbound.test.ts
+++ b/extensions/clickclack/src/outbound.test.ts
@@ -658,6 +658,32 @@ describe("reconcileClickClackUnknownSend", () => {
     expect(loadOutboundMediaFromUrl).not.toHaveBeenCalled();
   });
 
+  it("recovers one attachment when legacy and plural URLs describe the same upload", async () => {
+    findUploadByNonce.mockResolvedValueOnce({ id: "upl_existing", filename: "proof.ts" });
+    findMessageByNonce.mockResolvedValueOnce({
+      id: "msg_existing",
+      attachments: [{ id: "upl_existing" }],
+    });
+    const mediaUrl = "/workspace/proof.ts";
+
+    const result = await reconcileClickClackUnknownSend({
+      cfg,
+      queueId: "queue-media",
+      channel: "clickclack",
+      to: "channel:general",
+      enqueuedAt: 1,
+      retryCount: 0,
+      payloads: [{ text: "proof", mediaUrl, mediaUrls: [mediaUrl] }],
+    });
+
+    expect(result.status).toBe("sent");
+    expect(findUploadByNonce).toHaveBeenCalledOnce();
+    expect(findMessageByNonce).toHaveBeenCalledOnce();
+    if (result.status === "sent") {
+      expect(result.receipt.platformMessageIds).toEqual(["msg_existing"]);
+    }
+  });
+
   it("replays normally when uploads exist but messages do not", async () => {
     findUploadByNonce
       .mockResolvedValueOnce({ id: "upl_first", filename: "first.png" })

--- a/extensions/clickclack/src/outbound.ts
+++ b/extensions/clickclack/src/outbound.ts
@@ -13,6 +13,7 @@ import {
   loadOutboundMediaFromUrl,
   type OutboundMediaLoadOptions,
 } from "openclaw/plugin-sdk/outbound-media";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import {
   FormatCapabilityProfile,
   renderMarkdownWithMarkers,
@@ -305,9 +306,7 @@ function collectReconciliationMediaUrls(ctx: ChannelMessageUnknownSendContext): 
     return planned.map((url) => url.trim()).filter(Boolean);
   }
   const payload = ctx.payloads[0];
-  return [payload?.mediaUrl, ...(payload?.mediaUrls ?? [])]
-    .map((url) => url?.trim())
-    .filter((url): url is string => Boolean(url));
+  return payload ? resolveSendableOutboundReplyParts(payload).mediaUrls : [];
 }
 
 /**

--- a/src/auto-reply/reply-payload-parts.ts
+++ b/src/auto-reply/reply-payload-parts.ts
@@ -1,4 +1,4 @@
-import { normalizeStringEntries } from "../../../packages/normalization-core/src/string-normalization.js";
+import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 
 /** Derived sendability facts for text/media outbound payload delivery. */
 export type SendableOutboundReplyParts = {

--- a/src/channels/message/rendered-batch.test.ts
+++ b/src/channels/message/rendered-batch.test.ts
@@ -2,6 +2,32 @@ import { describe, expect, it } from "vitest";
 import { createRenderedMessageBatchPlan } from "./rendered-batch.js";
 
 describe("createRenderedMessageBatchPlan", () => {
+  it.each([
+    {
+      name: "matching legacy and plural attachments",
+      payload: { mediaUrl: " /tmp/image.png ", mediaUrls: [" /tmp/image.png "] },
+      expected: ["/tmp/image.png"],
+    },
+    {
+      name: "plural attachments superseding a legacy attachment",
+      payload: {
+        mediaUrl: "/tmp/obsolete.png",
+        mediaUrls: [" /tmp/first.png ", "", "/tmp/second.png"],
+      },
+      expected: ["/tmp/first.png", "/tmp/second.png"],
+    },
+    {
+      name: "an empty plural attachment list",
+      payload: { mediaUrl: " /tmp/image.png ", mediaUrls: [] },
+      expected: ["/tmp/image.png"],
+    },
+  ])("uses canonical media precedence for $name", ({ payload, expected }) => {
+    const plan = createRenderedMessageBatchPlan([payload]);
+
+    expect(plan.mediaCount).toBe(expected.length);
+    expect(plan.items[0]?.mediaUrls).toEqual(expected);
+  });
+
   it("keeps aggregate media counts aligned with normalized media items", () => {
     const plan = createRenderedMessageBatchPlan([
       {

--- a/src/channels/message/rendered-batch.ts
+++ b/src/channels/message/rendered-batch.ts
@@ -3,6 +3,7 @@
  *
  * Summarizes reply payloads so delivery can pick adapter paths and recovery metadata.
  */
+import { resolveSendableOutboundReplyParts } from "../../auto-reply/reply-payload-parts.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type {
   RenderedMessageBatch,
@@ -11,22 +12,12 @@ import type {
   RenderedMessageBatchPlanKind,
 } from "./types.js";
 
-function countMedia(payload: ReplyPayload): number {
-  return collectMediaUrls(payload).length;
-}
-
-function collectMediaUrls(payload: ReplyPayload): string[] {
-  return [payload.mediaUrl, ...(payload.mediaUrls ?? [])]
-    .map((url) => url?.trim())
-    .filter((url): url is string => Boolean(url));
-}
-
 function createRenderedMessageBatchPlanItem(
   payload: ReplyPayload,
   index: number,
 ): RenderedMessageBatchPlanItem {
   const text = payload.text?.trim();
-  const mediaUrls = collectMediaUrls(payload);
+  const mediaUrls = resolveSendableOutboundReplyParts(payload).mediaUrls;
   const presentationBlockCount = payload.presentation?.blocks?.length ?? 0;
   const kinds: RenderedMessageBatchPlanKind[] = [];
   if (text) {
@@ -62,9 +53,9 @@ export function createRenderedMessageBatchPlan(
 ): RenderedMessageBatchPlan {
   const items = payloads.map(createRenderedMessageBatchPlanItem);
   return payloads.reduce<RenderedMessageBatchPlan>(
-    (plan, payload) => {
+    (plan, payload, index) => {
       const text = payload.text?.trim();
-      const mediaCount = countMedia(payload);
+      const mediaCount = items[index]?.mediaUrls.length ?? 0;
       return {
         payloadCount: plan.payloadCount + 1,
         textCount: plan.textCount + (text ? 1 : 0),

--- a/src/infra/outbound/deliver-queue.exact-reconciliation.integration.test.ts
+++ b/src/infra/outbound/deliver-queue.exact-reconciliation.integration.test.ts
@@ -102,11 +102,18 @@ describe("exact Matrix delivery queue reconciliation", () => {
     },
   );
 
-  it.each(["automatic", "explicit"] as const)(
-    "delivers one normalized attachment with %s exact reconciliation",
-    async (reconciliation) => {
+  it.each([
+    { reconciliation: "automatic", legacyAttachment: "matching" },
+    { reconciliation: "automatic", legacyAttachment: "distinct" },
+    { reconciliation: "explicit", legacyAttachment: "matching" },
+    { reconciliation: "explicit", legacyAttachment: "distinct" },
+  ] as const)(
+    "delivers one attachment with $reconciliation reconciliation and a $legacyAttachment legacy URL",
+    async ({ reconciliation, legacyAttachment }) => {
       process.env.OPENCLAW_STATE_DIR = tmpDir;
       const mediaUrl = "https://example.invalid/image.png";
+      const legacyMediaUrl =
+        legacyAttachment === "distinct" ? "https://example.invalid/obsolete.png" : mediaUrl;
       const sendMedia = vi.fn(async (ctx: ChannelMessageSendMediaContext) => {
         await ctx.onPlatformSendDispatch?.();
         return {
@@ -147,7 +154,7 @@ describe("exact Matrix delivery queue reconciliation", () => {
           cfg: {} as OpenClawConfig,
           channel: "matrix",
           to: "!room:example",
-          payloads: [{ text: "caption", mediaUrl, mediaUrls: [mediaUrl] }],
+          payloads: [{ text: "caption", mediaUrl: legacyMediaUrl, mediaUrls: [mediaUrl] }],
           queuePolicy: "required",
           ...(reconciliation === "explicit" ? { requireUnknownSendReconciliation: true } : {}),
         }),

--- a/src/infra/outbound/deliver-queue.exact-reconciliation.integration.test.ts
+++ b/src/infra/outbound/deliver-queue.exact-reconciliation.integration.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
-import type { ChannelMessageSendTextContext } from "../../channels/message/types.js";
+import type {
+  ChannelMessageSendMediaContext,
+  ChannelMessageSendTextContext,
+} from "../../channels/message/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -96,6 +99,64 @@ describe("exact Matrix delivery queue reconciliation", () => {
       await drainMatrixReconnect({ deliver: recoveryDeliver, stateDir: tmpDir });
       expect(recoveryDeliver).not.toHaveBeenCalled();
       expect(sendText).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["automatic", "explicit"] as const)(
+    "delivers one normalized attachment with %s exact reconciliation",
+    async (reconciliation) => {
+      process.env.OPENCLAW_STATE_DIR = tmpDir;
+      const mediaUrl = "https://example.invalid/image.png";
+      const sendMedia = vi.fn(async (ctx: ChannelMessageSendMediaContext) => {
+        await ctx.onPlatformSendDispatch?.();
+        return {
+          messageId: "media-1",
+          receipt: createMessageReceiptFromOutboundResults({
+            results: [{ channel: "matrix", messageId: "media-1" }],
+            kind: "media",
+          }),
+        };
+      });
+
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "matrix",
+            source: "test",
+            plugin: {
+              ...createOutboundTestPlugin({ id: "matrix", outbound: matrixOutboundForQueueTest }),
+              message: {
+                id: "matrix",
+                durableFinal: {
+                  ...(reconciliation === "automatic"
+                    ? { automaticUnknownSendReconciliation: true }
+                    : {}),
+                  capabilities: { text: true, media: true, reconcileUnknownSend: true },
+                  reconcileUnknownSendKinds: { media: true },
+                  reconcileUnknownSend: async () => ({ status: "not_sent" as const }),
+                },
+                send: { text: vi.fn(), media: sendMedia },
+              },
+            },
+          },
+        ]),
+      );
+
+      await expect(
+        deliverOutboundPayloads({
+          cfg: {} as OpenClawConfig,
+          channel: "matrix",
+          to: "!room:example",
+          payloads: [{ text: "caption", mediaUrl, mediaUrls: [mediaUrl] }],
+          queuePolicy: "required",
+          ...(reconciliation === "explicit" ? { requireUnknownSendReconciliation: true } : {}),
+        }),
+      ).resolves.toMatchObject([{ messageId: "media-1" }]);
+
+      expect(sendMedia).toHaveBeenCalledOnce();
+      expect(sendMedia).toHaveBeenCalledWith(
+        expect.objectContaining({ mediaUrl, deliveryPartIndex: 0, deliveryPartCount: 1 }),
+      );
     },
   );
 });

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -31,6 +31,22 @@ function resolveMirrorProjection(payloads: readonly ReplyPayload[]) {
 }
 
 describe("normalizeReplyPayloadsForDelivery", () => {
+  it("prefers plural attachments over a distinct legacy primary before delivery", () => {
+    const [entry] = createOutboundPayloadPlan([
+      {
+        text: "caption",
+        mediaUrl: "https://x.test/obsolete.png",
+        mediaUrls: ["https://x.test/image.png"],
+      },
+    ]);
+
+    expect(entry?.payload).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: ["https://x.test/image.png"],
+    });
+    expect(entry?.parts.mediaUrls).toEqual(["https://x.test/image.png"]);
+  });
+
   it("parses directives, merges media, and preserves reply metadata", () => {
     expect(
       normalizeReplyPayloadsForDelivery([

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -188,28 +188,6 @@ function isSuppressedRelayStatusText(text: string): boolean {
   return false;
 }
 
-function mergeMediaUrls(...lists: Array<ReadonlyArray<string | undefined> | undefined>): string[] {
-  const seen = new Set<string>();
-  const merged: string[] = [];
-  for (const list of lists) {
-    if (!list) {
-      continue;
-    }
-    for (const entry of list) {
-      const trimmed = entry?.trim();
-      if (!trimmed) {
-        continue;
-      }
-      if (seen.has(trimmed)) {
-        continue;
-      }
-      seen.add(trimmed);
-      merged.push(trimmed);
-    }
-  }
-  return merged;
-}
-
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
   context: Pick<OutboundPayloadPlanContext, "extractMarkdownImages"> = {},
@@ -222,9 +200,13 @@ function createOutboundPayloadPlanEntry(
   });
   const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
   const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrls?.[0];
-  const mergedMedia = mergeMediaUrls(
-    explicitMediaUrls,
-    explicitMediaUrl ? [explicitMediaUrl] : undefined,
+  const mergedMedia = Array.from(
+    new Set(
+      resolveSendableOutboundReplyParts({
+        mediaUrls: explicitMediaUrls,
+        mediaUrl: explicitMediaUrl,
+      }).mediaUrls,
+    ),
   );
   const strippedText = stripUnsupportedCitationControlMarkers(parsed.text ?? "");
   const strippedParsed =
@@ -237,7 +219,8 @@ function createOutboundPayloadPlanEntry(
     return null;
   }
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
-  const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
+  const resolvedMediaUrl =
+    !hasMultipleMedia && explicitMediaUrl?.trim() === mergedMedia[0] ? explicitMediaUrl : undefined;
   const normalizedPayload: ReplyPayload = {
     ...payload,
     text:

--- a/src/media/media-retirement-non-goals.test.ts
+++ b/src/media/media-retirement-non-goals.test.ts
@@ -3,7 +3,7 @@ import { filterMessagingToolMediaDuplicates } from "../auto-reply/reply/reply-pa
 import { createRenderedMessageBatchPlan } from "../channels/message/rendered-batch.js";
 
 describe("media retirement outbound non-goals", () => {
-  it("keeps lowercase ReplyPayload media fields in rendered batch plans", () => {
+  it("keeps canonical lowercase ReplyPayload media fields in rendered batch plans", () => {
     expect(
       createRenderedMessageBatchPlan([
         {
@@ -13,10 +13,10 @@ describe("media retirement outbound non-goals", () => {
         },
       ]),
     ).toMatchObject({
-      mediaCount: 2,
+      mediaCount: 1,
       items: [
         {
-          mediaUrls: ["https://example.test/one.png", "https://example.test/two.png"],
+          mediaUrls: ["https://example.test/two.png"],
         },
       ],
     });

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -1,15 +1,15 @@
 // Reply payload helpers normalize plugin reply targets, text, media, and approval metadata.
 import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-core/src/string-coerce.js";
-import type { ReplyPayload as InternalReplyPayload } from "../auto-reply/reply-payload.js";
-import type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.js";
-import { normalizeOutboundReplyPayloadCore as normalizeCoreOutboundReplyPayload } from "../infra/outbound/reply-payload-normalize.js";
 import {
   countOutboundMedia,
   hasOutboundMedia,
   hasOutboundText,
   resolveOutboundMediaUrls,
   resolveSendableOutboundReplyParts,
-} from "../infra/outbound/reply-payload-parts.js";
+} from "../auto-reply/reply-payload-parts.js";
+import type { ReplyPayload as InternalReplyPayload } from "../auto-reply/reply-payload.js";
+import type { ChannelOutboundAdapter } from "../channels/plugins/outbound.types.js";
+import { normalizeOutboundReplyPayloadCore as normalizeCoreOutboundReplyPayload } from "../infra/outbound/reply-payload-normalize.js";
 import { createReplyToFanout } from "../infra/outbound/reply-policy.js";
 import { hasReplyPayloadContent } from "../interactive/payload.js";
 
@@ -74,7 +74,7 @@ export type ReasoningReplyPayload = {
 };
 
 /** Derived sendability facts for text/media outbound payload delivery. */
-export type { SendableOutboundReplyParts } from "../infra/outbound/reply-payload-parts.js";
+export type { SendableOutboundReplyParts } from "../auto-reply/reply-payload-parts.js";
 export {
   countOutboundMedia,
   hasOutboundMedia,

--- a/src/tts/tts-payload.ts
+++ b/src/tts/tts-payload.ts
@@ -1,3 +1,4 @@
+import { resolveSendableOutboundReplyParts } from "../auto-reply/reply-payload-parts.js";
 import {
   getReplyPayloadMetadata,
   markReplyPayloadAsTtsSupplement,
@@ -6,7 +7,6 @@ import {
 import { getChannelPlugin } from "../channels/plugins/registry.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { isVerbose, logVerbose } from "../globals.js";
-import { resolveSendableOutboundReplyParts } from "../infra/outbound/reply-payload-parts.js";
 import { hasReplyPayloadContent } from "../interactive/payload.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending an attachment to Matrix would receive no message when the normal reply producer populated both the primary attachment and its attachment list. The same mismatch could prevent ClickClack from recognizing an attachment that was already delivered during crash recovery.

## Why This Change Was Made

The reply-payload owner now provides the single canonical attachment-selection rule to rendered-message planning, outbound payload preparation, durable delivery, the existing plugin SDK, text-to-speech, and ClickClack recovery. Nonempty attachment lists supersede the legacy primary field, empty lists retain the existing primary-field fallback, and obsolete infra-owned helpers and duplicate planner/recovery policy are removed without changing the public SDK.

## User Impact

Normalized Matrix attachments are delivered exactly once with both automatic and explicit durable reconciliation, and ClickClack recovers previously uploaded attachments without searching for a nonexistent duplicate. Other channel planners inherit the same attachment order and trimming contract.

## Evidence

- Failing-first planner proof: one producer-normalized attachment was counted twice, and a plural attachment list incorrectly included an unrelated legacy primary attachment.
- Passed 39 focused tests across shared rendered planning, legacy media contract coverage, real SQLite-backed Matrix durable delivery, and ClickClack outbound/crash recovery:
  `node scripts/run-vitest.mjs src/channels/message/rendered-batch.test.ts src/media/media-retirement-non-goals.test.ts src/infra/outbound/deliver-queue.exact-reconciliation.integration.test.ts extensions/clickclack/src/outbound.test.ts`
- Applied the exact-head ClawSweeper finding and both rank-up moves at the outbound payload-plan owner; the strengthened real SQLite-backed Matrix suite passes all six cases, including automatic and explicit reconciliation with distinct legacy and plural attachment URLs:
  `node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/outbound/deliver-queue.exact-reconciliation.integration.test.ts --maxWorkers 1 --no-file-parallelism`
- Passed strict core types:
  `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- Full extension typecheck reported only two existing, unrelated ACPX dependency-contract errors and no ClickClack errors.
- All touched files pass the repository formatter, and the refactor removes 27 production lines while preserving the existing public plugin SDK.
- Real external channel delivery was not attempted because it would require live credentials and sending messages to real users; the durable queue regression runs the actual delivery pipeline against isolated SQLite and a controlled transport boundary.
