### PR TITLE
fix(ui): prevent interrupted model setup from blocking retries

### DIFF
--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -322,7 +322,7 @@ describe("ModelSetupPage catalog icons", () => {
       expect(request).toHaveBeenCalledWith(
         "openclaw.setup.prepare.start",
         { sessionId: expect.any(String), agentId: "main", authChoice: "llama-cpp" },
-        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        { timeoutMs: null },
       );
       expect(page.querySelector("openclaw-modal-dialog")).not.toBeNull();
       expect(page.textContent).toContain("Downloading model: 25%");

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -39,7 +39,7 @@ describe("ModelSetupWizardRunner", () => {
       1,
       "openclaw.setup.auth.start",
       { sessionId: expect.any(String), agentId: "research", authChoice: "openai-oauth" },
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      { timeoutMs: null },
     );
     expect(runner.state).toMatchObject({ phase: "step" });
     const answer = runner.answer(undefined, false);
@@ -119,7 +119,7 @@ describe("ModelSetupWizardRunner", () => {
       1,
       "openclaw.setup.prepare.start",
       { sessionId: expect.any(String), authChoice: "llama-cpp" },
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      { timeoutMs: null },
     );
     expect(runner.state).toMatchObject({
       phase: "step",
@@ -127,6 +127,295 @@ describe("ModelSetupWizardRunner", () => {
       step: { type: "progress" },
     });
   });
+
+  it.each([
+    ["openclaw.setup.auth.start", "cancel"],
+    ["openclaw.setup.auth.start", "settled cancel"],
+    ["openclaw.setup.auth.start", "close"],
+    ["openclaw.setup.prepare.start", "cancel"],
+    ["openclaw.setup.prepare.start", "settled cancel"],
+    ["openclaw.setup.prepare.start", "close"],
+  ] as const)(
+    "releases a late %s session after %s so setup can restart",
+    async (method, action) => {
+      let runningSession: string | null = null;
+      let firstSessionId = "";
+      let resolveFirstStart: () => void = () => {
+        throw new Error("the first setup request did not start");
+      };
+      let startCount = 0;
+      const request = vi.fn(
+        async (
+          requestMethod: string,
+          params?: { sessionId?: string },
+          options?: { signal?: AbortSignal },
+        ) => {
+          if (requestMethod === method) {
+            const sessionId = params?.sessionId;
+            if (!sessionId) {
+              throw new Error("missing setup session");
+            }
+            if (startCount++ === 0) {
+              firstSessionId = sessionId;
+              return await new Promise((resolve, reject) => {
+                options?.signal?.addEventListener(
+                  "abort",
+                  () => reject(new Error("Gateway retired the aborted start request")),
+                  { once: true },
+                );
+                resolveFirstStart = () => {
+                  runningSession = sessionId;
+                  resolve({ sessionId, done: false, status: "running" });
+                };
+              });
+            }
+            if (runningSession) {
+              throw new Error("wizard already running");
+            }
+            return { sessionId, done: true, status: "done" };
+          }
+          if (requestMethod === "wizard.cancel") {
+            if (runningSession !== params?.sessionId) {
+              throw new Error("wizard not found");
+            }
+            runningSession = null;
+            return { status: "cancelled" };
+          }
+          throw new Error(`unexpected request ${requestMethod}`);
+        },
+      );
+      const client = { request } as unknown as GatewayBrowserClient;
+      const runner = new ModelSetupWizardRunner({
+        getClient: () => client,
+        getAgentId: () => null,
+        onChange: () => undefined,
+        requestFailedMessage: () => "failed",
+        cancelledMessage: () => "cancelled",
+        sessionExpiredMessage: () => "expired",
+      });
+
+      const firstStart = runner.start("original", method);
+      if (action === "cancel") {
+        await runner.cancel();
+      } else if (action === "settled cancel") {
+        await runner.cancel({ settleActiveRequest: true });
+      } else {
+        runner.close();
+      }
+      resolveFirstStart();
+      await firstStart;
+
+      expect(runningSession).toBeNull();
+      expect(request).toHaveBeenCalledWith(
+        "wizard.cancel",
+        { sessionId: firstSessionId },
+        { timeoutMs: 30_000 },
+      );
+      await expect(runner.start("replacement", method)).resolves.toEqual({ startMethod: method });
+      expect(runner.state).toEqual({ phase: "done", authChoice: "replacement" });
+    },
+  );
+
+  it.each([
+    ["openclaw.setup.auth.start", false],
+    ["openclaw.setup.prepare.start", false],
+    ["openclaw.setup.auth.start", true],
+    ["openclaw.setup.prepare.start", true],
+  ] as const)(
+    "retains late %s responses after the local deadline (terminal: %s)",
+    async (method, terminal) => {
+      vi.useFakeTimers();
+      try {
+        let runningSession: string | null = null;
+        let firstSessionId = "";
+        let resolveFirstStart: () => void = () => {
+          throw new Error("the first setup request did not start");
+        };
+        let startCount = 0;
+        const request = vi.fn(
+          async (
+            requestMethod: string,
+            params?: { sessionId?: string },
+            options?: { signal?: AbortSignal; timeoutMs?: number | null },
+          ) => {
+            if (requestMethod === method) {
+              const sessionId = params?.sessionId;
+              if (!sessionId) {
+                throw new Error("missing setup session");
+              }
+              if (startCount++ === 0) {
+                firstSessionId = sessionId;
+                return await new Promise((resolve, reject) => {
+                  options?.signal?.addEventListener("abort", () => reject(new Error("aborted")), {
+                    once: true,
+                  });
+                  if (typeof options?.timeoutMs === "number") {
+                    setTimeout(
+                      () => reject(new Error("Gateway retired the timed-out request")),
+                      options.timeoutMs,
+                    );
+                  }
+                  resolveFirstStart = () => {
+                    if (!terminal) {
+                      runningSession = sessionId;
+                    }
+                    resolve({ sessionId, done: terminal, status: terminal ? "done" : "running" });
+                  };
+                });
+              }
+              if (runningSession) {
+                throw new Error("wizard already running");
+              }
+              return { sessionId, done: true, status: "done" };
+            }
+            if (requestMethod === "wizard.cancel") {
+              if (runningSession !== params?.sessionId) {
+                throw new Error("wizard not found");
+              }
+              runningSession = null;
+              return { status: "cancelled" };
+            }
+            throw new Error(`unexpected request ${requestMethod}`);
+          },
+        );
+        const client = { request } as unknown as GatewayBrowserClient;
+        const runner = new ModelSetupWizardRunner({
+          getClient: () => client,
+          getAgentId: () => null,
+          onChange: () => undefined,
+          requestFailedMessage: () => "failed",
+          cancelledMessage: () => "cancelled",
+          sessionExpiredMessage: () => "expired",
+        });
+
+        const timedOutStart = runner.start("original", method);
+        await vi.advanceTimersByTimeAsync(30_000);
+        await timedOutStart;
+        expect(runner.state).toEqual({
+          phase: "error",
+          message: `gateway request timed out after 30000ms: ${method}`,
+        });
+
+        resolveFirstStart();
+        await vi.runAllTimersAsync();
+        expect(runningSession).toBeNull();
+        const cancelCalls = request.mock.calls.filter(
+          ([requestMethod]) => requestMethod === "wizard.cancel",
+        );
+        const lateCancelCalls = cancelCalls.filter(
+          ([, params]) => params?.sessionId === firstSessionId,
+        );
+        expect(lateCancelCalls).toHaveLength(terminal ? 1 : 2);
+
+        await runner.cancel();
+        await expect(runner.start("replacement", method)).resolves.toEqual({ startMethod: method });
+        expect(runner.state).toEqual({ phase: "done", authChoice: "replacement" });
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("cleans the original Gateway session without disturbing a replacement connection", async () => {
+    let originalSessionId = "";
+    let resolveOriginalStart: () => void = () => {
+      throw new Error("the original setup request did not start");
+    };
+    const originalRequest = vi.fn(
+      async (
+        method: string,
+        params?: { sessionId?: string },
+        options?: { signal?: AbortSignal },
+      ) => {
+        if (method === "openclaw.setup.auth.start") {
+          originalSessionId = params?.sessionId ?? "";
+          return await new Promise((resolve, reject) => {
+            options?.signal?.addEventListener("abort", () => reject(new Error("aborted")), {
+              once: true,
+            });
+            resolveOriginalStart = () =>
+              resolve({ sessionId: originalSessionId, done: false, status: "running" });
+          });
+        }
+        return { status: "cancelled" };
+      },
+    );
+    const replacementRequest = vi.fn(async (method: string, params?: { sessionId?: string }) => {
+      if (method === "openclaw.setup.auth.start") {
+        return { sessionId: params?.sessionId, done: false, status: "running" };
+      }
+      if (method === "wizard.next") {
+        return {
+          done: false,
+          status: "running",
+          step: { id: "replacement", type: "text", message: "Replacement setup" },
+        };
+      }
+      throw new Error(`unexpected replacement request ${method}`);
+    });
+    const originalClient = { request: originalRequest } as unknown as GatewayBrowserClient;
+    const replacementClient = { request: replacementRequest } as unknown as GatewayBrowserClient;
+    let currentClient = originalClient;
+    const runner = new ModelSetupWizardRunner({
+      getClient: () => currentClient,
+      getAgentId: () => null,
+      onChange: () => undefined,
+      requestFailedMessage: () => "failed",
+      cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
+    });
+
+    const originalStart = runner.start("original");
+    runner.close();
+    currentClient = replacementClient;
+    await runner.start("replacement");
+    resolveOriginalStart();
+    await originalStart;
+
+    expect(originalRequest).toHaveBeenCalledWith(
+      "wizard.cancel",
+      { sessionId: originalSessionId },
+      { timeoutMs: 30_000 },
+    );
+    expect(replacementRequest.mock.calls.some(([method]) => method === "wizard.cancel")).toBe(
+      false,
+    );
+    expect(runner.state).toMatchObject({ phase: "step", authChoice: "replacement" });
+  });
+
+  it.each(["openclaw.setup.auth.start", "openclaw.setup.prepare.start"] as const)(
+    "does not cancel a terminal %s result after its wizard closes",
+    async (method) => {
+      let resolveStart: () => void = () => {
+        throw new Error("the setup request did not start");
+      };
+      const request = vi.fn(async (requestMethod: string) => {
+        if (requestMethod === method) {
+          return await new Promise((resolve) => {
+            resolveStart = () => resolve({ done: true, status: "done" });
+          });
+        }
+        throw new Error(`unexpected request ${requestMethod}`);
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      const runner = new ModelSetupWizardRunner({
+        getClient: () => client,
+        getAgentId: () => null,
+        onChange: () => undefined,
+        requestFailedMessage: () => "failed",
+        cancelledMessage: () => "cancelled",
+        sessionExpiredMessage: () => "expired",
+      });
+
+      const start = runner.start("original", method);
+      runner.close();
+      resolveStart();
+      await start;
+
+      expect(request.mock.calls.map(([requestMethod]) => requestMethod)).toEqual([method]);
+      expect(runner.state).toEqual({ phase: "idle" });
+    },
+  );
 
   it("clears an expired session and abort without cancelling or replaying the answer", async () => {
     let nextCount = 0;

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -57,16 +57,21 @@ export class ModelSetupWizardRunner {
     this.setState({ phase: "starting", authChoice });
     try {
       const agentId = this.options.getAgentId();
-      const started = await client.request<SystemAgentSetupAuthStartResult>(
+      const request = client.request<SystemAgentSetupAuthStartResult>(
         startMethod,
         {
           sessionId,
           authChoice,
           ...(agentId ? { agentId } : {}),
         },
-        { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS, signal: abortController.signal },
+        { timeoutMs: null },
       );
+      const started = await this.awaitWizardStart(client, request, sessionId, startMethod);
       if (generation !== this.generation) {
+        if (!started.done) {
+          // Admission can finish after cancellation; release only this generation's original session.
+          await this.cancelSession(client, sessionId);
+        }
         return null;
       }
       if (started.done) {
@@ -108,15 +113,7 @@ export class ModelSetupWizardRunner {
     if (!client || !sessionId) {
       return;
     }
-    try {
-      await client.request(
-        "wizard.cancel",
-        { sessionId },
-        { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS },
-      );
-    } catch {
-      // The gateway may have already completed or purged the session.
-    }
+    await this.cancelSession(client, sessionId);
   }
 
   close(): void {
@@ -131,6 +128,40 @@ export class ModelSetupWizardRunner {
     this.sessionId = null;
     this.abortController = null;
     this.setState({ phase: "error", message });
+  }
+
+  private async awaitWizardStart(
+    client: GatewayBrowserClient,
+    request: Promise<SystemAgentSetupAuthStartResult>,
+    sessionId: string,
+    startMethod: ModelSetupWizardStartMethod,
+  ): Promise<SystemAgentSetupAuthStartResult> {
+    let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // Gateway request abort/deadline retirement discards the late session needed for cleanup.
+    const retainedRequest = request.then(async (result) => {
+      if (timedOut && !result.done) {
+        await this.cancelSession(client, sessionId);
+      }
+      return result;
+    });
+    try {
+      return await Promise.race([
+        retainedRequest,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            timedOut = true;
+            reject(
+              new Error(
+                `gateway request timed out after ${MODEL_SETUP_AUTH_START_TIMEOUT_MS}ms: ${startMethod}`,
+              ),
+            );
+          }, MODEL_SETUP_AUTH_START_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private async requestNext(
@@ -202,16 +233,24 @@ export class ModelSetupWizardRunner {
     this.abortController = null;
     const sessionExpired = isWizardNotFoundError(error);
     if (!sessionExpired && client && sessionId) {
-      void client
-        .request("wizard.cancel", { sessionId }, { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS })
-        .catch(() => {
-          // The failed request may have already completed or purged the session.
-        });
+      void this.cancelSession(client, sessionId);
     }
     const message = sessionExpired
       ? this.options.sessionExpiredMessage()
       : formatUiError(error, this.options.requestFailedMessage());
     this.setState({ phase: "error", message });
+  }
+
+  private async cancelSession(client: GatewayBrowserClient, sessionId: string): Promise<void> {
+    try {
+      await client.request(
+        "wizard.cancel",
+        { sessionId },
+        { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS },
+      );
+    } catch {
+      // The Gateway may already have completed or purged the session.
+    }
   }
 
   private setState(state: ModelSetupWizardState): void {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users closing, cancelling, reconnecting, or waiting for a slow model setup wizard would become permanently unable to retry OAuth sign-in or local model preparation because the previous Gateway wizard remained running.

## Why This Change Was Made

The model-setup owner now keeps its original Gateway start response observable while enforcing the same 30-second local deadline, then releases only the exact original nonterminal session if that response arrives after cancellation, replacement, or timeout. Existing next-step cancellation remains abortable, terminal results are never cancelled, and the existing cancellation paths share one owner-owned cleanup policy.

Rejecting late responses, adding retries, or cancelling whichever Gateway connection happens to be current would preserve the leaked server-side admission lock or risk touching an unrelated replacement session. Production grows by 39 net lines because bounded local timeout ownership plus retained late-response custody cannot be represented by the previous transport deadline, which retires the only response identifying the session to clean up.

## User Impact

Operators can close and retry interrupted provider sign-in and model preparation without encountering a persistent "wizard already running" failure. Reconnected or replacement Gateway sessions remain untouched, completed setup is never cancelled, and slow starts still fail visibly after 30 seconds.

## Evidence

- Regression-first proof with a Gateway-contract-aware client: 11 owner checks failed before the lifecycle repair; all 18 pass after it, including auth and prepare starts, default cancel, settled modal cancel, close, replacement connections, and late running versus terminal timeout responses.
- Actual model-setup page, reconnect owner, model wizard owner, and existing channel wizard sibling: 4 suites, 54 tests passed.
- Fresh independent full-source review and authenticated full committed Codex review found no actionable P0/P1 issues.
- Targeted oxlint, formatting, assertion-safety ratchet, maximum-lines ratchet, and diff checks pass.
- Local browser E2E and full UI typechecking could not run because the existing shared dependency installation is missing unrelated `@panzoom/panzoom` and `pako` declarations; browser scenarios executed: 0. Exact-head hosted CI supplies the authoritative browser/build/typecheck evidence.
- Scope: one Control UI production owner (+55/-16, net +39) and two relevant UI regression/integration tests (+292/-3, net +289); no authentication, configuration, persistence, protocol, or public SDK contract changes.
- Frozen base: `3bb1433b78559a85b96ebbfd21260dfb52bb88e2`; reviewed candidate: `832f0eff2221f58905b7481c90ca407507747f80`.
