### PR TITLE
fix: control UI stays available during GitHub lookup outages

### DIFF
--- a/src/gateway/github-user-identity.test.ts
+++ b/src/gateway/github-user-identity.test.ts
@@ -345,15 +345,7 @@ describe("authenticated GitHub identity sync", () => {
     });
   });
 
-  it.each([
-    {
-      name: "GitHub rate limit",
-      githubResult: githubResponse({ message: "rate limit" }, 403, {
-        "x-ratelimit-remaining": "0",
-      }),
-    },
-    { name: "GitHub network failure", githubError: new Error("network unavailable") },
-  ])("preserves prior identity after a $name", async ({ githubResult, githubError }) => {
+  it("does not reuse an email-linked identity for a different Access account id", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const fetchMock = vi
         .spyOn(globalThis, "fetch")
@@ -366,25 +358,85 @@ describe("authenticated GitHub identity sync", () => {
         )
         .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
       const first = await cloudflareSync({})?.();
-      fetchMock.mockResolvedValueOnce(
-        githubResponse({
-          id: 58493,
-          email: "ada@example.com",
-          idp: { type: "github" },
-        }),
-      );
-      if (githubError) {
-        fetchMock.mockRejectedValueOnce(githubError);
-      } else {
-        fetchMock.mockResolvedValueOnce(githubResult!);
-      }
+      fetchMock
+        .mockResolvedValueOnce(
+          githubResponse({
+            id: 99999,
+            email: "ada@example.com",
+            idp: { type: "github" },
+          }),
+        )
+        .mockRejectedValueOnce(new Error("network unavailable"));
 
-      await expect(cloudflareSync({})?.()).rejects.toThrow();
+      await expect(cloudflareSync({})?.()).rejects.toMatchObject({ statusCode: 502 });
       expect(getUserProfileListItem(first!.profileId).githubIdentity).toMatchObject({
         login: "steipete",
       });
     });
   });
+
+  it.each([
+    {
+      name: "GitHub rate limit",
+      githubResult: githubResponse({ message: "rate limit" }, 403, {
+        "x-ratelimit-remaining": "0",
+      }),
+    },
+    { name: "GitHub network failure", githubError: new Error("network unavailable") },
+  ])(
+    "uses prior identity after a $name and retries later",
+    async ({ githubResult, githubError }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const fetchMock = vi
+          .spyOn(globalThis, "fetch")
+          .mockResolvedValueOnce(
+            githubResponse({
+              id: 58493,
+              email: "ada@example.com",
+              idp: { type: "github" },
+            }),
+          )
+          .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
+        const first = await cloudflareSync({})?.();
+        fetchMock.mockResolvedValueOnce(
+          githubResponse({
+            id: 58493,
+            email: "ada@example.com",
+            idp: { type: "github" },
+          }),
+        );
+        if (githubError) {
+          fetchMock.mockRejectedValueOnce(githubError);
+        } else {
+          fetchMock.mockResolvedValueOnce(githubResult!);
+        }
+        fetchMock
+          .mockResolvedValueOnce(
+            githubResponse({
+              id: 58493,
+              email: "ada@example.com",
+              idp: { type: "github" },
+            }),
+          )
+          .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete-renamed" }));
+
+        const recoveringConnection = cloudflareSync({});
+        await expect(recoveringConnection?.()).resolves.toMatchObject({
+          profileId: first!.profileId,
+        });
+        expect(getUserProfileListItem(first!.profileId).githubIdentity).toMatchObject({
+          login: "steipete",
+        });
+
+        await expect(recoveringConnection?.()).resolves.toMatchObject({
+          profileId: first!.profileId,
+        });
+        expect(getUserProfileListItem(first!.profileId).githubIdentity).toMatchObject({
+          login: "steipete-renamed",
+        });
+      });
+    },
+  );
 
   it("redacts the Access assertion from network failures and retries on the same connection", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {

--- a/src/gateway/github-user-identity.ts
+++ b/src/gateway/github-user-identity.ts
@@ -2,6 +2,7 @@ import type { IncomingHttpHeaders } from "node:http";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
+import { resolveStoredGitHubIdentityByAccountId } from "../state/user-profile-github-identity.js";
 import { classifyTailscaleLogin } from "../state/user-profiles-tailscale-login.js";
 import { syncGitHubIdentity } from "../state/user-profiles.js";
 import { normalizeGitHubLogin } from "../utils/github-login.js";
@@ -22,8 +23,11 @@ const ACCESS_ASSERTION_MAX_BYTES = 16 * 1024;
 const ACCESS_IDENTITY_MAX_BYTES = 64 * 1024;
 const JWT_SEGMENT_PATTERN = /^[A-Za-z0-9_-]+$/u;
 
-type ResolvedGitHubUserIdentity = { accountId: number; login: string };
+type ResolvedGitHubUserIdentity = { accountId: number; login: string; retryLookup?: true };
 type AuthenticatedGitHubIdentitySyncResult = { profileId: string; updatedAt: number };
+type AuthenticatedGitHubIdentitySyncAttempt = AuthenticatedGitHubIdentitySyncResult & {
+  retryLookup?: true;
+};
 export type AuthenticatedGitHubIdentitySync = () => Promise<AuthenticatedGitHubIdentitySyncResult>;
 
 function headerValue(value: string | string[] | undefined): string | undefined {
@@ -149,6 +153,12 @@ async function resolveGitHubUserIdentityById(
   try {
     payload = await fetchGitHubJson(`${GITHUB_API_ORIGIN}/user/${accountId}`, fetch, undefined);
   } catch (error) {
+    const storedIdentity = resolveStoredGitHubIdentityByAccountId(accountId);
+    if (storedIdentity) {
+      // Access already verified this immutable account ID. Keep its durable profile usable,
+      // but let a later Profile refresh retry GitHub for a renamed canonical login.
+      return { ...storedIdentity, retryLookup: true };
+    }
     if (error instanceof ControlUiGitHubError) {
       throw error;
     }
@@ -165,7 +175,7 @@ async function resolveGitHubUserIdentityById(
 }
 
 function retryableConnectionSync(
-  sync: () => Promise<AuthenticatedGitHubIdentitySyncResult>,
+  sync: () => Promise<AuthenticatedGitHubIdentitySyncAttempt>,
 ): AuthenticatedGitHubIdentitySync {
   let inFlight: Promise<AuthenticatedGitHubIdentitySyncResult> | undefined;
   let completed: AuthenticatedGitHubIdentitySyncResult | undefined;
@@ -176,8 +186,10 @@ function retryableConnectionSync(
     if (inFlight) {
       return inFlight;
     }
-    const current = sync().then((result) => {
-      completed = result;
+    const current = sync().then(({ retryLookup, ...result }) => {
+      if (!retryLookup) {
+        completed = result;
+      }
       return result;
     });
     inFlight = current;
@@ -252,6 +264,10 @@ export function createAuthenticatedGitHubIdentitySync(params: {
       authenticationAlias: { kind: "email", email: access.principal },
       initialDisplayName: accessIdentity.initialDisplayName,
     });
-    return { profileId: profile.id, updatedAt: profile.updatedAt };
+    return {
+      profileId: profile.id,
+      updatedAt: profile.updatedAt,
+      ...(identity.retryLookup ? { retryLookup: true } : {}),
+    };
   });
 }

--- a/src/state/user-profile-github-identity.ts
+++ b/src/state/user-profile-github-identity.ts
@@ -60,6 +60,28 @@ function selectStoredGitHubIdentities(
   );
 }
 
+export function resolveStoredGitHubIdentityByAccountId(
+  accountId: number,
+  options: OpenClawStateDatabaseOptions = {},
+): StoredGitHubIdentity | undefined {
+  if (!Number.isSafeInteger(accountId) || accountId <= 0) {
+    throw new TypeError("GitHub account id must be a positive safe integer");
+  }
+  const database = openOpenClawStateDatabase(options);
+  ensureUserProfilesSchema(options, database);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    userProfilesDb(database.db)
+      .selectFrom("user_profile_identities")
+      .select(["subject", "canonical_login"])
+      .where("provider", "=", GITHUB_PROVIDER)
+      .where("subject", "=", String(accountId))
+      .where("canonical_login", "is not", null),
+  );
+  const identity = row ? parseStoredGitHubIdentity(row) : null;
+  return identity?.accountId === accountId ? identity : undefined;
+}
+
 function deleteProfileGitHubIdentities(
   db: DatabaseSync,
   profileIds: readonly string[],


### PR DESCRIPTION
A returning shared-Gateway user could lose the entire Profile identity section whenever GitHub's public user lookup was rate-limited, even though OpenClaw had already stored that exact verified account. That blocked profile-dependent Control UI work during a transient external outage.

This PR recovers only the durable identity whose immutable GitHub account ID matches the Cloudflare Access assertion. The connection stays retryable so a later successful lookup can refresh the canonical login. A different account presenting the same email still fails closed.

Related: #126114

## Change breakdown

| Category | Files | Added | Removed |
| --- | ---: | ---: | ---: |
| Implementation | 2 | 43 | 5 |
| Tests | 1 | 74 | 22 |
| Total | 3 | 117 | 27 |

## Proof

Both captures use the same built Control UI, `/profile` route, 1440x900 browser viewport, persisted account ID `58493`, Cloudflare Access identity, and simulated anonymous GitHub `403` rate limit. The direct-base and PR Gateway code are the only changed variable.

**Before: direct base**

![Before: direct base Profile page omits the Identity section during a simulated GitHub rate limit](https://github.com/user-attachments/assets/bd4f252b-1837-4fdb-a5f3-3429a4fbe890)

```text
profileVerified: false
visibleAccount: null
visibleFailure: authenticated profile and Identity section absent
```

**After: PR**

![After: PR Profile page preserves the exact stored verified GitHub account during the same rate limit](https://github.com/user-attachments/assets/08c4678d-29a9-4fde-89c9-9032a5b7d04d)

```text
profileVerified: true
visibleAccount: @steipete
visibleFailure: null
```

## How to verify

1. Seed verified account ID `58493` and login `steipete` for `ada@example.com` in isolated state.
2. Start the Gateway with standard Cloudflare Access headers and make GitHub `/user/58493` return a rate-limit `403`.
3. Open `/profile`. Direct base omits the Identity section; this PR shows the verified `@steipete` account.

The focused regression also proves that a later successful lookup refreshes the login, while an account-ID mismatch remains rejected. There are no schema, config, or dependency changes.

AI-assisted: Codex implemented and validated the change; the author reviewed the result.
