### PR TITLE
fix(gateway): let cloud sessions retry failed worker cleanup

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -50,6 +50,7 @@ export type WorkerDispatchPlacementStore = Pick<
   | "list"
   | "listPendingWorkspaceResults"
   | "markWorkspaceResultPending"
+  | "handoffWorkspaceResultRecovery"
   | "workspaceResultInstanceId"
   | "validateWorkspaceResultClaim"
   | "recordStagedWorkspaceResult"

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -30,6 +30,7 @@ export function createHarness(
   options: {
     failAt?: DispatchStage;
     destroyFails?: boolean;
+    destroyFailureCount?: number;
     claimOnDrain?: boolean;
     reconcileFails?: boolean;
     reconcileFailureCount?: number;
@@ -64,6 +65,7 @@ export function createHarness(
   } = {},
 ) {
   const reconciledManifestRef = MANIFEST_REF.replaceAll("b", "c");
+  let remainingDestroyFailures = options.destroyFailureCount ?? 0;
   let remainingReconcileFailures = options.reconcileFailureCount ?? 0;
   let remainingLeaseFailures = options.leaseFailureCount ?? 0;
   let verifyCalls = 0;
@@ -127,6 +129,7 @@ export function createHarness(
     recordPlacementMoveError: (params) => placementStore.recordPlacementMoveError(params),
     markWorkspaceResultPending: (claim) => placementStore.markWorkspaceResultPending(claim),
     acceptWorkspaceResult: (claim) => placementStore.acceptWorkspaceResult(claim),
+    handoffWorkspaceResultRecovery: (claim) => placementStore.handoffWorkspaceResultRecovery(claim),
     cancelWorkspaceResultAndReleaseTurn: (claim) =>
       placementStore.cancelWorkspaceResultAndReleaseTurn(claim),
     completeWorkspaceResultAndReleaseTurn: (claim) =>
@@ -344,7 +347,10 @@ export function createHarness(
     }),
     destroy: vi.fn(async () => {
       log.push("teardown:destroy");
-      if (options.destroyFails) {
+      if (options.destroyFails || remainingDestroyFailures > 0) {
+        if (remainingDestroyFailures > 0) {
+          remainingDestroyFailures -= 1;
+        }
         if (options.destroyFailureState) {
           currentEnvironment = {
             ...attached,

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -500,18 +500,16 @@ describe("worker placement dispatch", () => {
     expect(harness.placements.current()).toMatchObject({
       state: "draining",
       workspaceBaseManifestRef: harness.reconciledManifestRef,
-      turnClaim: { owner: "worker" },
+      turnClaim: null,
     });
-    expect(placementStore.listPendingWorkspaceResults()).toMatchObject([
-      { workspaceAcceptedAtMs: expect.any(Number) },
-    ]);
+    expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
     expect(harness.log).toContain("placement:draining");
     expect(harness.log).toContain("workspace:resume");
   });
 
-  it("preserves a draining provider destroy failure after teardown owns the stopped tunnel", async () => {
+  it("recovers a failed provider destroy and allows a normal local reclaim", async () => {
     const harness = createTestHarness({
-      destroyFails: true,
+      destroyFailureCount: 1,
       destroyFailureState: "destroying",
       resumeFails: true,
     });
@@ -520,17 +518,18 @@ describe("worker placement dispatch", () => {
     await expect(harness.service.reclaim(REQUEST)).rejects.toThrow("destroy pending");
 
     expect(harness.environments.get(active.environmentId)).toMatchObject({
-      state: "destroying",
-      ownerEpoch: active.activeOwnerEpoch,
+      state: "destroyed",
     });
     expect(harness.placements.current()).toMatchObject({
-      state: "draining",
-      turnClaim: { owner: "worker" },
+      state: "failed",
+      turnClaim: null,
     });
-    expect(placementStore.listPendingWorkspaceResults()).toMatchObject([
-      { workspaceAcceptedAtMs: expect.any(Number) },
-    ]);
+    expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
+    expect(harness.environments.destroy).toHaveBeenCalledTimes(2);
     expect(harness.log).not.toContain("workspace:resume");
+
+    await expect(harness.service.reclaim(REQUEST)).resolves.toMatchObject({ state: "local" });
+    expect(harness.environments.destroy).toHaveBeenCalledTimes(2);
   });
 
   it.each<DispatchStage>([

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -548,6 +548,18 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           await cancelUnstagedFailedReclaim(
             error instanceof WorkerWorkspaceFinalFenceError && error.reclaimDisposition === "retry",
           ).catch(() => undefined);
+          const pendingReclaimResult = placements
+            .listPendingWorkspaceResults()
+            .find(
+              (pending) =>
+                pending.sessionId === reclaimClaim.sessionId &&
+                pending.claimId === reclaimClaim.claimId &&
+                pending.runId === reclaimClaim.runId,
+            );
+          if (pendingReclaimResult && pendingReclaimResult.workspaceAcceptedAtMs !== null) {
+            placements.handoffWorkspaceResultRecovery(reclaimClaim);
+            await recovery.reconcileActive(current.environmentId).catch(() => undefined);
+          }
           throw error;
         }
       },

--- a/src/gateway/worker-environments/placement-force-abandon.test.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.test.ts
@@ -87,32 +87,34 @@ describe("forced worker environment abandonment", () => {
     expect(store.listPendingWorkspaceResults()).toEqual([]);
   });
 
-  it("releases a pending worker claim when its workspace is already gone", async () => {
+  it("releases a pending reclaim claim when its workspace is already gone", async () => {
     const store = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
     const { environmentId } = createDispatchEnvironmentFixtures();
     const active = seedActivePlacement(store, { environmentId, ownerEpoch: 2 });
     if (active.state !== "active") {
       throw new Error("active placement fixture was not active");
     }
-    const claim = store.claimTurn({
+    store.startDrain({
+      sessionId: active.sessionId,
+      environmentId,
+      ownerEpoch: active.activeOwnerEpoch,
+      expectedGeneration: active.generation,
+    });
+    const claim = store.claimReclaimWorkspaceResult({
       ...REQUEST,
-      claimId: "forced-missing-workspace-claim",
-      runId: "forced-missing-workspace-run",
+      claimId: "reclaim-forced-missing-workspace",
+      runId: "reclaim-forced-missing-workspace",
       owner: { kind: "worker", environmentId, ownerEpoch: 2 },
     });
-    store.markWorkspaceResultPending(claim);
     store.recordStagedWorkspaceResult(
       claim,
-      "refs/openclaw/worker-results/forced-missing-workspace-claim",
+      "refs/openclaw/worker-results/reclaim-forced-missing-workspace",
     );
-
-    await forceAbandonWorkerEnvironment({
-      placements: store,
-      environmentId,
-      resolveWorkspacePath: async () => {
-        throw new Error("session-owned managed worktree is missing");
-      },
+    const resolveWorkspacePath = vi.fn(async () => {
+      throw new Error("session-owned managed worktree is missing");
     });
+
+    await forceAbandonWorkerEnvironment({ placements: store, environmentId, resolveWorkspacePath });
 
     expect(store.get(REQUEST.sessionId)).toMatchObject({
       state: "failed",
@@ -120,6 +122,7 @@ describe("forced worker environment abandonment", () => {
       recoveryError: "Worker result abandoned by forced operator teardown",
     });
     expect(store.listPendingWorkspaceResults()).toEqual([]);
+    expect(resolveWorkspacePath).toHaveBeenCalledOnce();
   });
 
   it("deletes a stale journal without replaying it into the current workspace", async () => {

--- a/src/gateway/worker-environments/placement-force-abandon.ts
+++ b/src/gateway/worker-environments/placement-force-abandon.ts
@@ -1,5 +1,6 @@
 import type { WorkerDispatchPlacementStore } from "./placement-dispatch-failure.js";
 import { placementTurnOwner } from "./placement-record.js";
+import { isCurrentWorkerWorkspacePendingResultOwner } from "./placement-workspace-result.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   deleteStagedWorkerWorkspaceResult,
@@ -98,15 +99,7 @@ export async function forceAbandonWorkerEnvironment(params: {
   for (const pending of placements.listPendingWorkspaceResults()) {
     if (pending.environmentId === environmentId) {
       const placement = placements.get(pending.sessionId);
-      if (
-        (placement?.state === "active" || placement?.state === "draining") &&
-        placement.environmentId === pending.environmentId &&
-        placement.activeOwnerEpoch === pending.ownerEpoch &&
-        placement.generation ===
-          (placement.state === "active"
-            ? pending.placementGeneration
-            : pending.placementGeneration + 1)
-      ) {
+      if (isCurrentWorkerWorkspacePendingResultOwner(placement, pending)) {
         const finalRef = pending.stagedResultRef ?? workerWorkspaceResultRef(pending.claimId);
         stagedResultCleanups.push({
           placement,

--- a/src/gateway/worker-environments/placement-pending-failure.ts
+++ b/src/gateway/worker-environments/placement-pending-failure.ts
@@ -1,7 +1,6 @@
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import type { DB as StateDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
-  isCurrentPlacementTurnClaim,
   placementTurnOwner,
   required,
   type WorkerSessionPlacementRecord,
@@ -14,7 +13,10 @@ import {
   clearWorkerTurnToolState,
 } from "./placement-session-tool-operations.js";
 import { signalWorkerTurnClaimClosed } from "./placement-turn-claims.js";
-import type { WorkerWorkspacePendingResult } from "./placement-workspace-result.js";
+import {
+  isCurrentWorkerWorkspacePendingResultOwner,
+  type WorkerWorkspacePendingResult,
+} from "./placement-workspace-result.js";
 import { boundedWorkerError } from "./worker-error.js";
 
 export function createPlacementPendingFailureOps(runtime: PlacementStoreRuntime) {
@@ -28,6 +30,9 @@ export function createPlacementPendingFailureOps(runtime: PlacementStoreRuntime)
       const recoveryError = boundedWorkerError(error);
       const outcome = write((db) => {
         const current = getRequired(db, sessionId);
+        if (!isCurrentWorkerWorkspacePendingResultOwner(current, pending)) {
+          throw new Error(`Session ${sessionId} workspace result owner changed before failure`);
+        }
         const persisted = current.turnClaim;
         const releasedClaim: WorkerSessionTurnClaim | null = persisted
           ? {
@@ -35,31 +40,9 @@ export function createPlacementPendingFailureOps(runtime: PlacementStoreRuntime)
               claimId: persisted.claimId,
               runId: persisted.runId,
               placementGeneration: persisted.generation,
-              owner: placementTurnOwner({
-                executionMode: current.executionMode,
-                environmentId: pending.environmentId,
-                activeOwnerEpoch: pending.ownerEpoch,
-              }),
+              owner: placementTurnOwner(current),
             }
           : null;
-        const exactClaim =
-          releasedClaim === null ||
-          (releasedClaim.claimId === pending.claimId &&
-            releasedClaim.runId === pending.runId &&
-            releasedClaim.placementGeneration === pending.placementGeneration &&
-            isCurrentPlacementTurnClaim(current, releasedClaim));
-        if (
-          (current.state !== "active" && current.state !== "draining") ||
-          current.environmentId !== pending.environmentId ||
-          current.activeOwnerEpoch !== pending.ownerEpoch ||
-          current.generation !==
-            (current.state === "active"
-              ? pending.placementGeneration
-              : pending.placementGeneration + 1) ||
-          !exactClaim
-        ) {
-          throw new Error(`Session ${sessionId} workspace result owner changed before failure`);
-        }
         const pendingQuery =
           getNodeSqliteKysely<Pick<StateDatabase, "worker_workspace_pending_results">>(db);
         const exactPending = executeSqliteQuerySync(

--- a/src/gateway/worker-environments/placement-workspace-result.ts
+++ b/src/gateway/worker-environments/placement-workspace-result.ts
@@ -32,6 +32,35 @@ export type WorkerWorkspacePendingResult = {
   stagedResultRef: string | null;
 };
 
+export function isCurrentWorkerWorkspacePendingResultOwner(
+  placement: WorkerSessionPlacementRecord | undefined,
+  pending: WorkerWorkspacePendingResult,
+): placement is Extract<WorkerSessionPlacementRecord, { state: "active" | "draining" }> {
+  if (
+    (placement?.state !== "active" && placement?.state !== "draining") ||
+    placement.sessionId !== pending.sessionId ||
+    placement.environmentId !== pending.environmentId ||
+    placement.activeOwnerEpoch !== pending.ownerEpoch
+  ) {
+    return false;
+  }
+  if (placement.turnClaim) {
+    // Reclaim claims after drain; worker turns claim before it. The exact live
+    // claim owns either generation shape without weakening claimless recovery.
+    return isCurrentPlacementTurnClaim(placement, {
+      sessionId: pending.sessionId,
+      claimId: pending.claimId,
+      runId: pending.runId,
+      placementGeneration: pending.placementGeneration,
+      owner: placementTurnOwner(placement),
+    });
+  }
+  return (
+    placement.generation ===
+    (placement.state === "active" ? pending.placementGeneration : pending.placementGeneration + 1)
+  );
+}
+
 function matchesWorkspaceResultClaim(
   placement: WorkerSessionPlacementRecord,
   row: StateDatabase["worker_workspace_pending_results"],


### PR DESCRIPTION
Related: #112106

## What Problem This Solves

Fixes an issue where stopping a cloud session could reconcile its workspace successfully but leave the session permanently draining when provider lease cleanup failed. A retry then waited for the abandoned reclaim claim until timeout, forcing operators to stop the provider lease and force-destroy the environment manually.

## Why This Change Was Made

Accepted reclaim results now transfer their exact claim to the existing same-Gateway recovery owner before targeted reconciliation retries provider cleanup. One shared pending-result ownership predicate distinguishes exact live reclaim claims created after drain from claimless restart recovery, and forced teardown uses the same invariant. Unaccepted workspace results remain fenced; delete and reclaim safety guards are unchanged.

Crabbox 0.44.0 and 0.46.0 expose the same stop identifier contract, so this change stays in the Gateway lifecycle owner instead of changing the provider plugin.

## User Impact

A transient cloud-worker provider cleanup failure no longer wedges the session or requires direct Crabbox intervention. Recovery releases the completed claim, retries lease teardown, and lets a normal reclaim finish the session cleanup.

## Evidence

- Regression failed before the fix: 4 failed / 92 passed; the accepted result retained its claim and environment remained destroying.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch.test.ts` — 96 passed.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch-reclaim.test.ts` — 50 passed.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/placement-force-abandon.test.ts src/gateway/worker-environments/placement-store-terminal.test.ts` — 36 passed.
- Recovery/staged-result/worker-turn/provider-reconciliation sibling suite — 164 passed.
- `node scripts/check-changed.mjs -- <touched files>` — passed (core and coreTests lanes).
- Autoreview — no accepted/actionable findings.
- Production LOC: +52/-34 (net +18), after deleting duplicate ownership checks. Tests and test support: +35/-27.
- AI-assisted; implementation and proof were reviewed against the owner modules and Crabbox source contract.

Live proof note: the original failure was reproduced twice through a real Gateway → Crabbox → AWS worker flow, including Crabbox 0.46.0. This PR did not access the production Gateway or start a new cloud worker; its deterministic owner-boundary regression captures the exact persisted state and provider retry sequence.
