### PR TITLE
fix(gateway): prevent sessions from using unconfigured agents

### DIFF
--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -33,7 +33,6 @@ import {
   resolveSessionCreateModelSelection as resolveCreateTitleEntry,
 } from "../session-create-service.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
-import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { readSessionMessageCountAsync } from "../session-transcript-readers.js";
 import {
   loadGatewaySessionEntryReadOnly,
@@ -104,8 +103,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
     const explicitlyRequestedAgent = resolveRequestedGlobalAgentId(
       cfg,
       agentSelectionKey,
-      explicitlyRequestedAgentId,
-      { allowUnconfiguredExplicitAgent: true },
+      p.agentId ?? parseAgentSessionKey(explicitlyRequestedKey)?.agentId,
     );
     if (!explicitlyRequestedAgent.ok) {
       respond(false, undefined, explicitlyRequestedAgent.error);
@@ -224,7 +222,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       return;
     }
     const explicitSessionLabel = normalizeOptionalString(p.label);
-    const titleAgentId = normalizeAgentId(explicitlyRequestedAgent.agentId);
+    const titleAgentId = explicitlyRequestedAgent.agentId;
     const shouldPrepareWorktreeTitle =
       p.worktree === true && !requestedWorktreeName && !explicitSessionLabel;
     const deferWorktreeTitle =
@@ -280,11 +278,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       }
     }
     let sessionKey = p.key;
-    let sessionAgentId =
-      catalogAgentId ??
-      explicitlyRequestedAgent.agentId ??
-      p.agentId ??
-      parseAgentSessionKey(explicitlyRequestedKey)?.agentId;
+    let sessionAgentId = catalogAgentId ?? explicitlyRequestedAgent.agentId;
     let sessionWorktree: Awaited<ReturnType<typeof managedWorktrees.create>> | undefined;
     const sessionExecCwd = requestedExecNode ? requestedCwd : undefined;
     let sessionCwd = requestedExecNode ? undefined : (projectRoot ?? requestedCwd);
@@ -298,11 +292,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       requestedProjectId,
       sessionCwd,
       sessionKey,
-      targetAgentId: normalizeAgentId(
-        sessionAgentId ??
-          parseAgentSessionKey(sessionKey ?? "")?.agentId ??
-          explicitlyRequestedAgent.agentId,
-      ),
+      targetAgentId: sessionAgentId,
     });
     if (!preparedRoot.ok) {
       respond(false, undefined, preparedRoot.error);
@@ -314,11 +304,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       // Workspace-contained cwd and registry-authorized projects stay at operator.write;
       // arbitrary host paths still require operator.admin before reaching this block.
       const explicitKey = explicitlyRequestedKey;
-      const agentId = normalizeAgentId(
-        explicitlyRequestedAgent.agentId ??
-          normalizeOptionalString(p.agentId) ??
-          parseAgentSessionKey(explicitKey)?.agentId,
-      );
+      const agentId = explicitlyRequestedAgent.agentId;
       let targetKey = explicitKey;
       let preservesUnspecifiedKey = false;
       if (
@@ -336,9 +322,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
         const parent = loadGatewaySessionEntryReadOnly(parentSessionKey, {
           agentId: parentRequestedAgent.agentId,
         });
-        const parentAgentId = normalizeAgentId(
-          parentRequestedAgent.agentId ?? resolveSessionStoreAgentId(cfg, parent.canonicalKey),
-        );
+        const parentAgentId = parentRequestedAgent.agentId;
         if (
           parent.entry?.sessionId &&
           parent.canonicalKey === resolveAgentMainSessionKey({ cfg, agentId: parentAgentId })
@@ -518,11 +502,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       ADMIN_SCOPE,
       clientScopes,
     ).allowed;
-    const modelCatalogAgentId = normalizeAgentId(
-      sessionAgentId ??
-        parseAgentSessionKey(sessionKey ?? "")?.agentId ??
-        explicitlyRequestedAgent.agentId,
-    );
+    const modelCatalogAgentId = sessionAgentId;
     if (!authority.ensureActive()) {
       return;
     }

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -748,6 +748,30 @@ test("incognito webchat rejects a vanished non-default-agent session before disp
   }
 });
 
+test("createGatewaySession rejects explicit and key-derived unconfigured creation owners", async () => {
+  const { createGatewaySession } = await import("./session-create-service.js");
+  const cfg = { agents: { entries: { ops: { default: true } } } };
+  const prepareLifecycle = vi.fn();
+
+  for (const { owner, message } of [
+    { owner: { agentId: "main" }, message: 'Unknown agent id "main"' },
+    {
+      owner: { key: "agent:main:dashboard:unconfigured-owner" },
+      message: 'Unknown agent id "main"',
+    },
+    { owner: { agentId: "   " }, message: 'Unknown agent id "   "' },
+  ]) {
+    await expect(
+      createGatewaySession({ cfg, ...owner, commandSource: "test", prepareLifecycle }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST", message },
+    });
+  }
+
+  expect(prepareLifecycle).not.toHaveBeenCalled();
+});
+
 test("createGatewaySession rechecks admin scope after incognito inheritance resolves", async () => {
   await createSessionStoreDir();
   try {
@@ -2879,6 +2903,7 @@ test("sessions.create rejects worktrees for agent workspaces without a commit", 
 
 test("sessions.create stores dashboard model, thinking, and parent linkage, and creates a transcript", async () => {
   const { storePath } = await createSessionStoreDir();
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "ops" }] };
   agentDiscoveryMock.enabled = true;
   agentDiscoveryMock.models = [{ id: "gpt-test-a", name: "A", provider: "openai" }];
   await writeSessionStore({
@@ -3737,6 +3762,7 @@ test("sessions.create resolves the current default instead of inherited runtime 
 
 test("sessions.create accepts an explicit key for persistent dashboard sessions", async () => {
   await createSessionStoreDir();
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "ops-agent" }] };
 
   const key = "agent:ops-agent:dashboard:direct:subagent-orchestrator";
   const created = await directSessionReq<{
@@ -4120,6 +4146,8 @@ test("sessions.create adopting an existing key does not restamp node provenance"
 
 test("sessions.create scopes the main alias to the requested agent", async () => {
   const { storePath } = await createSessionStoreDir();
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "longmemeval" }] };
+  testState.agentConfig = { sessionStore: { agentId: "longmemeval" } };
 
   const created = await directSessionReq<{
     key?: string;
@@ -4132,7 +4160,7 @@ test("sessions.create scopes the main alias to the requested agent", async () =>
     agentId: "longmemeval",
   });
 
-  expect(created.ok).toBe(true);
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
   expect(created.payload?.key).toBe("agent:longmemeval:main");
   expect(created.payload?.entry).not.toHaveProperty("sessionFile");
 
@@ -4197,6 +4225,8 @@ test("sessions.create replaces a dead main entry with a fresh session id", async
 
 test("sessions.create preserves global and unknown sentinel keys", async () => {
   const { storePath } = await createSessionStoreDir();
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "longmemeval" }] };
+  testState.agentConfig = { sessionStore: { agentId: "longmemeval" } };
 
   const globalCreated = await directSessionReq<{
     key?: string;
@@ -4209,7 +4239,7 @@ test("sessions.create preserves global and unknown sentinel keys", async () => {
     agentId: "longmemeval",
   });
 
-  expect(globalCreated.ok).toBe(true);
+  expect(globalCreated.ok, JSON.stringify(globalCreated.error)).toBe(true);
   expect(globalCreated.payload?.key).toBe("global");
   expect(globalCreated.payload?.entry).not.toHaveProperty("sessionFile");
 
@@ -4646,6 +4676,7 @@ test("sessions.create allows plugin runtimes to link their own parent session", 
 
 test("sessions.create rejects unknown parentSessionKey", async () => {
   await createSessionStoreDir();
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "ops" }] };
 
   const created = await directSessionReq("sessions.create", {
     agentId: "ops",

--- a/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
@@ -53,6 +53,75 @@ async function initializeRemoteBackedGitWorkspace(root: string): Promise<string>
   return await fs.realpath(workspace);
 }
 
+test("sessions.create only allocates worktrees for lifecycle-manageable agent owners", async () => {
+  const openClawState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-create-worktree-agent-owner-",
+  });
+  const workspace = await initializeRemoteBackedGitWorkspace(openClawState.root);
+  closeOpenClawStateDatabaseForTest();
+  testState.agentConfig = { workspace };
+  testState.agentsConfig = { list: [{ id: "ops", default: true }] };
+  const { storePath } = await createSessionStoreDir();
+  const adminClient = { connect: { scopes: ["operator.admin"] } } as never;
+  const allocatedWorktreeIds = new Set<string>();
+  const createWorktree = vi.spyOn(managedWorktrees, "create");
+  try {
+    for (const owner of [{ agentId: "main" }, { key: "agent:main:dashboard:unconfigured-owner" }]) {
+      const created = await directSessionReq<{
+        key: string;
+        worktree: { id: string };
+      }>("sessions.create", { ...owner, worktree: true }, { client: adminClient });
+      if (created.payload?.worktree.id) {
+        allocatedWorktreeIds.add(created.payload.worktree.id);
+      }
+
+      expect(created).toMatchObject({
+        ok: false,
+        error: { code: "INVALID_REQUEST", message: 'Unknown agent id "main"' },
+      });
+      if (owner.key) {
+        expect(
+          loadSessionEntry({ agentId: "main", sessionKey: owner.key, storePath }),
+        ).toBeUndefined();
+      }
+      expect(createWorktree).not.toHaveBeenCalled();
+    }
+
+    for (const owner of [{ agentId: "ops" }, {}]) {
+      const created = await directSessionReq<{
+        key: string;
+        worktree: { id: string; path: string };
+      }>("sessions.create", { ...owner, worktree: true }, { client: adminClient });
+      if (created.payload?.worktree.id) {
+        allocatedWorktreeIds.add(created.payload.worktree.id);
+      }
+      expect(created).toMatchObject({
+        ok: true,
+        payload: { key: expect.stringMatching(/^agent:ops:/) },
+      });
+
+      const worktree = created.payload!.worktree;
+      await expect(
+        directSessionReq("sessions.delete", { key: created.payload!.key, agentId: "ops" }),
+      ).resolves.toMatchObject({ ok: true, payload: { deleted: true } });
+      await expect(fs.access(worktree.path)).rejects.toThrow();
+      allocatedWorktreeIds.delete(worktree.id);
+    }
+  } finally {
+    createWorktree.mockRestore();
+    for (const id of allocatedWorktreeIds) {
+      if (getRegistryWorktree(process.env, id)?.removedAt === undefined) {
+        await managedWorktrees.remove({ id, reason: "test-cleanup", allowSnapshotLoss: true });
+      }
+    }
+    closeOpenClawStateDatabaseForTest();
+    testState.agentConfig = undefined;
+    testState.agentsConfig = undefined;
+    await openClawState.cleanup();
+  }
+});
+
 test("sessions.delete snapshots and removes session worktrees", async () => {
   const openClawState = await createOpenClawTestState({
     layout: "state-only",

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -345,44 +345,21 @@ export async function createGatewaySession(params: {
   const requestedKey = normalizeOptionalString(params.key);
   const parentSessionKey = normalizeOptionalString(params.parentSessionKey);
   const projectId = normalizeOptionalString(params.projectId);
-  const explicitAgentId = normalizeOptionalString(params.agentId);
+  const explicitAgentId = params.agentId;
+  const normalizedExplicitAgentId = normalizeOptionalString(explicitAgentId);
   const explicitKeyAgentId = parseAgentSessionKey(requestedKey)?.agentId;
-  if (
-    explicitAgentId &&
-    explicitKeyAgentId &&
-    normalizeAgentId(explicitKeyAgentId) !== normalizeAgentId(explicitAgentId)
-  ) {
-    return {
-      ok: false,
-      error: errorShape(
-        ErrorCodes.INVALID_REQUEST,
-        `sessions.create key agent (${explicitKeyAgentId}) does not match agentId (${normalizeAgentId(explicitAgentId)})`,
-      ),
-    };
-  }
-  const requestedKeyAgent = requestedKey
-    ? resolveRequestedSessionAgentId(params.cfg, requestedKey, explicitAgentId, {
-        allowUnconfiguredExplicitAgent: true,
-      })
-    : undefined;
-  if (requestedKeyAgent && !requestedKeyAgent.ok) {
-    return requestedKeyAgent;
-  }
-  // Resolve the main alias under an explicit selection before compatibility ownership.
-  const implicitSelectionKey = explicitAgentId
-    ? `agent:${normalizeAgentId(explicitAgentId)}:main`
-    : "main";
-  const implicitAgent = requestedKeyAgent
-    ? undefined
-    : resolveRequestedSessionAgentId(params.cfg, implicitSelectionKey, explicitAgentId, {
-        allowUnconfiguredExplicitAgent: true,
-      });
-  if (implicitAgent && !implicitAgent.ok) {
-    return implicitAgent;
-  }
-  const agentId = normalizeAgentId(
-    explicitAgentId ?? requestedKeyAgent?.agentId ?? implicitAgent?.agentId,
+  const selectedAgent = resolveRequestedSessionAgentId(
+    params.cfg,
+    requestedKey ??
+      (normalizedExplicitAgentId
+        ? `agent:${normalizeAgentId(normalizedExplicitAgentId)}:main`
+        : "main"),
+    explicitAgentId ?? explicitKeyAgentId,
   );
+  if (!selectedAgent.ok) {
+    return selectedAgent;
+  }
+  const agentId = selectedAgent.agentId;
   const catalogModel = normalizeOptionalString(params.catalogTarget?.model);
   const catalogAgentRuntime = normalizeOptionalAgentRuntimeId(params.catalogTarget?.agentRuntime);
   const catalogPluginOwnerId = normalizeOptionalString(params.catalogTarget?.pluginOwnerId);

--- a/src/gateway/session-request-agent.ts
+++ b/src/gateway/session-request-agent.ts
@@ -36,7 +36,6 @@ export function resolveRequestedSessionAgentId(
   cfg: OpenClawConfig,
   key: string,
   explicitAgentId?: string,
-  options?: { allowUnconfiguredExplicitAgent?: boolean },
 ): RequestedSessionAgentIdResolution {
   const parsed = parseAgentSessionKey(key.trim());
   const configuredAgentIds = listAgentIds(cfg);
@@ -49,11 +48,7 @@ export function resolveRequestedSessionAgentId(
     };
   }
   const normalizedRequestedAgentId = normalizedRequest?.value;
-  if (
-    normalizedRequestedAgentId &&
-    !options?.allowUnconfiguredExplicitAgent &&
-    !configuredAgentIds.includes(normalizedRequestedAgentId)
-  ) {
+  if (normalizedRequestedAgentId && !configuredAgentIds.includes(normalizedRequestedAgentId)) {
     return {
       ok: false,
       error: errorShape(ErrorCodes.INVALID_REQUEST, `Unknown agent id "${explicitAgentId}"`),
@@ -64,11 +59,7 @@ export function resolveRequestedSessionAgentId(
     const keyIsGlobalMainAlias =
       cfg.session?.scope === "global" &&
       (parsed.rest === "main" || parsed.rest === normalizeMainKey(cfg.session?.mainKey));
-    if (
-      keyIsGlobalMainAlias &&
-      !options?.allowUnconfiguredExplicitAgent &&
-      !configuredAgentIds.includes(keyAgentId)
-    ) {
+    if (keyIsGlobalMainAlias && !configuredAgentIds.includes(keyAgentId)) {
       return {
         ok: false,
         error: errorShape(ErrorCodes.INVALID_REQUEST, `Unknown agent id "${parsed.agentId}"`),


### PR DESCRIPTION
Closes #127659

## What Problem This Solves

Fixes an issue where creating a dashboard session with a stale or otherwise unconfigured explicit agent selection could succeed, but later dispatch, reclaim, and delete operations rejected that same session as owned by an unknown agent. Managed-worktree sessions could therefore become impossible to continue or clean up through the normal lifecycle.

## Why This Change Was Made

Session creation now uses the same configured-agent ownership policy as the rest of the lifecycle and validates the canonical owner before filesystem, session-store, or managed-worktree side effects. Agent-qualified creation keys count as explicit ownership, while the separate historical-read contract for sessions whose agent was later removed remains intact.

The creation-only permissive resolver option and duplicate selection branches were removed. Production code is net negative: +22/-74 lines (net -52).

## User Impact

Operators can no longer create sessions under an unconfigured agent owner. Invalid requests fail immediately with `Unknown agent id`, while configured explicit owners and valid implicit owner selection remain fully manageable through create, dispatch, reclaim, and delete.

## Evidence

Pre-fix regression proof: the new worktree lifecycle test received `ok: true` and allocated an `agent:main:dashboard:*` worktree where `INVALID_REQUEST` was expected.

Post-fix validation:

- `node scripts/run-vitest.mjs src/gateway/session-request-agent.test.ts` — 20 passed
- `node scripts/run-vitest.mjs src/gateway/server.sessions.delete-worktree-lifecycle.test.ts` — 16 passed
- `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts` — 224 passed
- `node scripts/check-changed.mjs -- src/gateway/session-request-agent.ts src/gateway/server-methods/sessions-create.ts src/gateway/session-create-service.ts src/gateway/server.sessions.delete-worktree-lifecycle.test.ts src/gateway/server.sessions.create.test.ts` — passed
- `git diff --check` — passed
- Codex-backed autoreview — no accepted/actionable findings

This change was AI-assisted and reviewed. The implementation and owner boundary were inspected directly, and the regression test was demonstrated failing before the production fix.
