### PR TITLE
fix(gateway): fail streaming responses when agent runs fail

### DIFF
--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { describeFailoverError, resolveFailoverStatus } from "../agents/failover-error.js";
 // OpenAI-compatible error helpers.
 // Converts OpenClaw failover/sampling errors to OpenAI-style HTTP responses.
@@ -30,6 +31,12 @@ const ERROR_TYPE_BY_REASON = {
   unclassified: undefined,
   unknown: undefined,
 } satisfies Record<FailoverReason, string | undefined>;
+
+/** Resolved agent failures must not become successful OpenAI HTTP responses. */
+export function isFailedOpenAiAgentRun(result: unknown): boolean {
+  const metadata = asOptionalRecord(asOptionalRecord(result)?.meta);
+  return Boolean(metadata?.error) || metadata?.stopReason === "error";
+}
 
 function statusForReason(reason: FailoverReason, status: number | undefined): number {
   if (reason === "server_error") {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2044,7 +2044,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     [
       {
         label: "terminal metadata",
-        meta: { error: { kind: "incomplete_turn", message: "private provider failure" } },
+        meta: { error: { kind: "incomplete_turn" as const, message: "private provider failure" } },
         expectedPhase: "error" as const,
       },
       {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -6,7 +6,12 @@ import path from "node:path";
 import OpenAI from "openai";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  buildAgentRunTerminalOutcome,
+  buildAgentRunTerminalOutcomeFromLifecycleEvent,
+} from "../agents/agent-run-terminal-outcome.js";
 import { createClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
+import { createAgentCommandLifecycle } from "../agents/command/lifecycle.js";
 import {
   createStubSessionHarness,
   emitAssistantTextDelta,
@@ -17,7 +22,11 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
-import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import {
+  emitAgentEvent,
+  getAgentEventLifecycleGeneration,
+  onAgentEvent,
+} from "../infra/agent-events.js";
 import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -2030,6 +2039,101 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     });
     expect(res.status).toBe(500);
   });
+
+  it.each(
+    [
+      {
+        label: "terminal metadata",
+        meta: { error: { kind: "incomplete_turn", message: "private provider failure" } },
+        expectedPhase: "error" as const,
+      },
+      {
+        label: "an error stop reason",
+        meta: { stopReason: "error" },
+        expectedPhase: "end" as const,
+      },
+    ].flatMap((failure) =>
+      [false, true].map((producerTerminal) => ({
+        meta: failure.meta,
+        expectedPhase: failure.expectedPhase,
+        producerTerminal,
+        label: `${failure.label} ${producerTerminal ? "after" : "without"} a producer terminal`,
+      })),
+    ),
+  )(
+    "rejects resolved streaming agent failures from $label",
+    async ({ meta, expectedPhase, producerTerminal }) => {
+      let runId: string | undefined;
+      const terminals: Array<{ phase: "end" | "error"; status: string }> = [];
+      const unsubscribe = onAgentEvent((event) => {
+        if (event.runId === runId && event.stream === "lifecycle") {
+          const phase = event.data?.phase;
+          if (phase === "end" || phase === "error") {
+            terminals.push({
+              phase,
+              status: buildAgentRunTerminalOutcomeFromLifecycleEvent({ phase, data: event.data })
+                .status,
+            });
+          }
+        }
+      });
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (options: unknown) => {
+        runId = (options as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming chat-completion run ID");
+        }
+        const result = {
+          payloads: [{ text: "Command may have changed state", isError: true }],
+          meta: { durationMs: 0, ...meta },
+        };
+        if (producerTerminal) {
+          const lifecycle = createAgentCommandLifecycle({
+            runId,
+            lifecycleGeneration: getAgentEventLifecycleGeneration,
+            startedAt: Date.now(),
+            state: {
+              currentTurnUserMessagePersisted: true,
+              lifecycleFinishing: false,
+              lifecycleEnded: false,
+            },
+          });
+          const terminal = {
+            metadata: {},
+            outcome: buildAgentRunTerminalOutcome({ status: "error", stopReason: "error" }),
+          };
+          if (lifecycle.resolveResultError(result, false)) {
+            lifecycle.emitResultError(result, false, terminal);
+          } else {
+            lifecycle.emitEnd(terminal);
+          }
+        }
+        return result;
+      }) as never);
+
+      try {
+        const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+          stream: true,
+        });
+        const finishReasons: Array<string | null> = [];
+        await expect(async () => {
+          for await (const chunk of stream) {
+            finishReasons.push(...chunk.choices.map((choice) => choice.finish_reason));
+          }
+        }).rejects.toMatchObject({
+          error: { message: "internal error", type: "api_error" },
+        });
+        expect(finishReasons).not.toContain("stop");
+        expect(terminals).toEqual([
+          { phase: producerTerminal ? expectedPhase : "error", status: "error" },
+        ]);
+      } finally {
+        unsubscribe();
+      }
+    },
+  );
 
   it("forwards response_format into streamParams", async () => {
     const port = enabledPort;

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -66,7 +66,11 @@ import {
 } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 import { resolveAgentRunUsage } from "./openai-agent-run-usage.js";
-import { resolveOpenAiCompatError, validateOpenAiSamplingParams } from "./openai-compat-errors.js";
+import {
+  isFailedOpenAiAgentRun,
+  resolveOpenAiCompatError,
+  validateOpenAiSamplingParams,
+} from "./openai-compat-errors.js";
 import {
   isToolChoiceConstraintSatisfied,
   resolveUnsatisfiedToolChoiceMessage,
@@ -1098,7 +1102,7 @@ export async function handleOpenAiHttpRequest(
       }
 
       const meta = (result as { meta?: { error?: unknown; stopReason?: unknown } } | null)?.meta;
-      if (meta?.error || meta?.stopReason === "error") {
+      if (isFailedOpenAiAgentRun(result)) {
         throw new Error("agent run failed");
       }
       const usage = resolveChatCompletionUsage(result);
@@ -1380,6 +1384,12 @@ export async function handleOpenAiHttpRequest(
       resultResolved = true;
 
       if (closed) {
+        return;
+      }
+
+      if (isFailedOpenAiAgentRun(result)) {
+        terminalLifecyclePhase = "error";
+        finishStreamWithError({ message: "internal error", type: "api_error" });
         return;
       }
 

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -6,13 +6,22 @@ import path from "node:path";
 import OpenAI from "openai";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  buildAgentRunTerminalOutcome,
+  buildAgentRunTerminalOutcomeFromLifecycleEvent,
+} from "../agents/agent-run-terminal-outcome.js";
 import { createClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
+import { createAgentCommandLifecycle } from "../agents/command/lifecycle.js";
 import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
-import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import {
+  emitAgentEvent,
+  getAgentEventLifecycleGeneration,
+  onAgentEvent,
+} from "../infra/agent-events.js";
 import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -1831,6 +1840,111 @@ describe("OpenResponses HTTP API (e2e)", () => {
     const res = await postResponses(enabledPort, { model: "openclaw", input: "hi" });
     expect(res.status).toBe(500);
   });
+
+  it.each(
+    [
+      {
+        label: "terminal metadata",
+        meta: { error: { kind: "incomplete_turn", message: "private provider failure" } },
+        expectedPhase: "error" as const,
+      },
+      {
+        label: "an error stop reason",
+        meta: { stopReason: "error" },
+        expectedPhase: "end" as const,
+      },
+    ].flatMap((failure) =>
+      [false, true].map((producerTerminal) => ({
+        meta: failure.meta,
+        expectedPhase: failure.expectedPhase,
+        producerTerminal,
+        label: `${failure.label} ${producerTerminal ? "after" : "without"} a producer terminal`,
+      })),
+    ),
+  )(
+    "fails resolved streaming agent failures from $label",
+    async ({ meta, expectedPhase, producerTerminal }) => {
+      let runId: string | undefined;
+      const terminals: Array<{ phase: "end" | "error"; status: string }> = [];
+      const unsubscribe = onAgentEvent((event) => {
+        if (event.runId === runId && event.stream === "lifecycle") {
+          const phase = event.data?.phase;
+          if (phase === "end" || phase === "error") {
+            terminals.push({
+              phase,
+              status: buildAgentRunTerminalOutcomeFromLifecycleEvent({ phase, data: event.data })
+                .status,
+            });
+          }
+        }
+      });
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (options: unknown) => {
+        runId = (options as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        const result = {
+          payloads: [{ text: "Command may have changed state", isError: true }],
+          meta: {
+            durationMs: 0,
+            agentMeta: { usage: { input: 11, output: 7, total: 18 } },
+            ...meta,
+          },
+        };
+        if (producerTerminal) {
+          const lifecycle = createAgentCommandLifecycle({
+            runId,
+            lifecycleGeneration: getAgentEventLifecycleGeneration,
+            startedAt: Date.now(),
+            state: {
+              currentTurnUserMessagePersisted: true,
+              lifecycleFinishing: false,
+              lifecycleEnded: false,
+            },
+          });
+          const terminal = {
+            metadata: {},
+            outcome: buildAgentRunTerminalOutcome({ status: "error", stopReason: "error" }),
+          };
+          if (lifecycle.resolveResultError(result, false)) {
+            lifecycle.emitResultError(result, false, terminal);
+          } else {
+            lifecycle.emitEnd(terminal);
+          }
+        }
+        return result;
+      }) as never);
+
+      try {
+        const client = new OpenAI({
+          apiKey: "test",
+          baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+          defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+          maxRetries: 0,
+        });
+        const stream = client.responses.stream({ model: "openclaw", input: "hi" });
+        const terminalEvents: string[] = [];
+        stream.on("response.completed", () => terminalEvents.push("response.completed"));
+        stream.on("response.failed", () => terminalEvents.push("response.failed"));
+
+        const response = await stream.finalResponse();
+        expect(response.status).toBe("failed");
+        expect(response.error).toEqual({ code: "api_error", message: "internal error" });
+        expect(response.usage).toMatchObject({
+          input_tokens: 11,
+          output_tokens: 7,
+          total_tokens: 18,
+        });
+        expect(terminalEvents).toEqual(["response.failed"]);
+        expect(terminals).toEqual([
+          { phase: producerTerminal ? expectedPhase : "error", status: "error" },
+        ]);
+      } finally {
+        unsubscribe();
+      }
+    },
+  );
 
   it.each(
     STREAM_FAILURE_CASES.flatMap((failure) =>

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1845,7 +1845,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
     [
       {
         label: "terminal metadata",
-        meta: { error: { kind: "incomplete_turn", message: "private provider failure" } },
+        meta: { error: { kind: "incomplete_turn" as const, message: "private provider failure" } },
         expectedPhase: "error" as const,
       },
       {
@@ -1888,7 +1888,12 @@ describe("OpenResponses HTTP API (e2e)", () => {
           payloads: [{ text: "Command may have changed state", isError: true }],
           meta: {
             durationMs: 0,
-            agentMeta: { usage: { input: 11, output: 7, total: 18 } },
+            agentMeta: {
+              sessionId: "failed-stream-session",
+              provider: "openai",
+              model: "test-model",
+              usage: { input: 11, output: 7, total: 18 },
+            },
             ...meta,
           },
         };

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -77,7 +77,7 @@ import {
   type Usage,
 } from "./open-responses.schema.js";
 import { resolveAgentRunUsage } from "./openai-agent-run-usage.js";
-import { resolveOpenAiCompatError } from "./openai-compat-errors.js";
+import { isFailedOpenAiAgentRun, resolveOpenAiCompatError } from "./openai-compat-errors.js";
 import {
   isToolChoiceConstraintSatisfied,
   resolveUnsatisfiedToolChoiceMessage,
@@ -720,7 +720,7 @@ export async function handleOpenResponsesHttpRequest(
       }
 
       const meta = (result as { meta?: { error?: unknown; stopReason?: unknown } } | null)?.meta;
-      if (meta?.error || meta?.stopReason === "error") {
+      if (isFailedOpenAiAgentRun(result)) {
         throw new Error("agent run failed");
       }
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
@@ -1184,6 +1184,23 @@ export async function handleOpenResponsesHttpRequest(
       if (closed) {
         return;
       }
+
+      if (isFailedOpenAiAgentRun(result)) {
+        terminalLifecyclePhase = "error";
+        rememberResponseSession();
+        finalizeFailedResponse(
+          createResponseResource({
+            id: responseId,
+            model,
+            status: "failed",
+            output: [],
+            error: { code: "api_error", message: "internal error" },
+            usage: extractUsageFromResult(result),
+          }),
+        );
+        return;
+      }
+
       finalUsage = extractUsageFromResult(result);
 
       if (unrepresentableAssistantReplacement) {


### PR DESCRIPTION
Related: #124039

## What Problem This Solves

Fixes an issue where users streaming an agent response through the OpenAI-compatible Chat Completions or Responses API would receive a successful completion even though the resolved agent run failed. This happened when the agent reported its failure in terminal metadata or its error stop reason instead of rejecting the run promise.

## Why This Change Was Made

The earlier repair in #124039 recognized failed agent results only on the non-streaming branches. Move that classification into the existing shared OpenAI compatibility-error owner and apply it consistently across both streaming and non-streaming routes. Each streaming transport uses its existing failure envelope, keeps private provider details redacted, preserves Responses token usage, and respects the agent owner's single authoritative lifecycle terminal, including legitimate end-phase events whose normalized outcome is failure.

## User Impact

OpenAI SDK consumers now observe a real API error or failed response instead of treating an unsuccessful agent turn as a completed answer. Existing successful streams, tool calls, cancellation, lifecycle ownership, authentication, and non-streaming behavior remain unchanged.

## Evidence

- Before the fix, all eight original real-Gateway/official-OpenAI-SDK regression executions failed: Chat Completions silently finished successfully and Responses returned `status: completed`.
- After the fix, the expanded 16-case integration matrix passes for both APIs, both failed-result shapes, and both present/absent producer lifecycle terminals. It verifies one normalized failed lifecycle outcome, no successful chat finish reason, redacted error text, and nonzero Responses usage.
- Full sibling coverage: **250/250 tests passed** across the ordinary and isolated Gateway test projects:
  `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-autoqa-gateway-stream-failure-cache-20260821 PNPM_CONFIG_MODULES_DIR=/Users/steipete/Projects/openclaw/node_modules OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs --configLoader runner src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts`
- Focused formatting and lint passed; assertion-safety, max-lines, and coercion-helper ratchets passed.
- Independent full-source review and fresh authenticated Codex review found no actionable issues.
- Base: `3bb1433b78559a85b96ebbfd21260dfb52bb88e2`; production delta **+34**, justified by one shared failure classifier and the two distinct existing streaming wire contracts; regression tests **+218**.
- No authentication, security, configuration, public API, protocol, storage, or agent lifecycle contract changes.
