### PR TITLE
fix(ui): show agent skill matches while filtering

### DIFF
--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -55,6 +55,30 @@ function createBaseParams(overrides: Partial<Parameters<typeof renderAgentTools>
   };
 }
 
+function createSkill(
+  name: string,
+  options: { source?: string; bundled?: boolean; blockedByAgentFilter?: boolean } = {},
+): SkillStatusEntry {
+  return {
+    name,
+    description: `${name} skill`,
+    source: options.source ?? "openclaw-managed",
+    bundled: options.bundled ?? false,
+    filePath: `/tmp/skills/${name}/SKILL.md`,
+    baseDir: `/tmp/skills/${name}`,
+    skillKey: name,
+    always: false,
+    disabled: false,
+    blockedByAllowlist: false,
+    blockedByAgentFilter: options.blockedByAgentFilter ?? false,
+    eligible: true,
+    requirements: { bins: [], anyBins: [], env: [], config: [], os: [] },
+    missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+    configChecks: [],
+    install: [],
+  };
+}
+
 describe("agents tools panel (browser)", () => {
   it("renders catalog provenance and effective runtime tools", async () => {
     const container = document.createElement("div");
@@ -637,26 +661,58 @@ describe("agents tools panel (browser)", () => {
 });
 
 describe("agents skills panel (browser)", () => {
+  it("shows matches from default-collapsed groups while filtering", async () => {
+    const container = document.createElement("div");
+    const params: Parameters<typeof renderAgentSkills>[0] = {
+      agentId: "main",
+      canPatchConfig: true,
+      canUpdateConfig: true,
+      report: {
+        workspaceDir: "/tmp/workspace",
+        managedSkillsDir: "/tmp/skills",
+        agentId: "main",
+        skills: [
+          createSkill("Unique Built In Match", {
+            source: "openclaw-bundled",
+            bundled: true,
+          }),
+          createSkill("Installed Distractor"),
+        ],
+      },
+      loading: false,
+      error: null,
+      activeAgentId: "main",
+      configForm: { agents: { entries: { main: { default: true } } } },
+      configLoading: false,
+      configSaving: false,
+      configDirty: false,
+      filter: "",
+      onFilterChange: () => undefined,
+      onRefresh: () => undefined,
+      onToggle: () => undefined,
+      onClear: () => undefined,
+      onDisableAll: () => undefined,
+      onConfigReload: () => undefined,
+      onConfigSave: () => undefined,
+    };
+
+    render(renderAgentSkills(params), container);
+    await Promise.resolve();
+    const builtInGroup = container.querySelector<HTMLDetailsElement>(".agent-skills-group");
+    expect(builtInGroup?.open).toBe(false);
+
+    render(renderAgentSkills({ ...params, filter: "Unique Built In Match" }), container);
+    await Promise.resolve();
+    const filteredGroup = container.querySelector<HTMLDetailsElement>(".agent-skills-group");
+    expect(container.textContent).toContain("1 shown");
+    expect(filteredGroup?.open).toBe(true);
+    expect(filteredGroup?.querySelector(".agent-skill-row")?.textContent).toContain(
+      "Unique Built In Match",
+    );
+  });
+
   it("reflects an inherited default skill allowlist", async () => {
     const container = document.createElement("div");
-    const skill = (name: string, blockedByAgentFilter: boolean): SkillStatusEntry => ({
-      name,
-      description: `${name} skill`,
-      source: "openclaw-managed",
-      bundled: false,
-      filePath: `/tmp/skills/${name}/SKILL.md`,
-      baseDir: `/tmp/skills/${name}`,
-      skillKey: name,
-      always: false,
-      disabled: false,
-      blockedByAllowlist: false,
-      blockedByAgentFilter,
-      eligible: true,
-      requirements: { bins: [], anyBins: [], env: [], config: [], os: [] },
-      missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
-      configChecks: [],
-      install: [],
-    });
 
     render(
       renderAgentSkills({
@@ -668,7 +724,7 @@ describe("agents skills panel (browser)", () => {
           managedSkillsDir: "/tmp/skills",
           agentId: "main",
           agentSkillFilter: ["github"],
-          skills: [skill("github", false), skill("weather", true)],
+          skills: [createSkill("github"), createSkill("weather", { blockedByAgentFilter: true })],
         },
         loading: false,
         error: null,

--- a/ui/src/pages/agents/panels-tools-skills.ts
+++ b/ui/src/pages/agents/panels-tools-skills.ts
@@ -841,6 +841,7 @@ export function renderAgentSkills(params: {
                     allowSet,
                     usingAllowlist,
                     editable,
+                    filterActive: Boolean(filter),
                     onToggle: params.onToggle,
                   }),
                 )}
@@ -858,10 +859,12 @@ function renderAgentSkillGroup(
     allowSet: Set<string>;
     usingAllowlist: boolean;
     editable: boolean;
+    filterActive: boolean;
     onToggle: (agentId: string, skillName: string, enabled: boolean) => void;
   },
 ) {
-  const collapsedByDefault = group.id === "workspace" || group.id === "built-in";
+  const collapsedByDefault =
+    !params.filterActive && (group.id === "workspace" || group.id === "built-in");
   return html`
     <details class="agent-skills-group" ?open=${!collapsedByDefault}>
       <summary class="agent-skills-header">


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users filtering an agent's Skills panel would see a nonzero “shown” count while matching Built-In or Workspace skills remained hidden inside their default-collapsed groups.

## Why This Change Was Made

An active normalized filter now opens only the matching grouped disclosures; the existing collapsed-by-default behavior remains unchanged when the filter is empty. The production change is three net lines at the existing group-rendering owner and does not alter skill loading, eligibility, or config mutation behavior.

## User Impact

Agent skill search results are immediately visible, including matches from Built-In and Workspace groups. Users no longer need to guess which collapsed group contains the counted match and manually expand it.

## Evidence

- Authentic pre-fix owner regression failed because the filtered Built-In group remained closed (`expected true, received false`). The same regression now passes and retains an explicit empty-filter collapsed assertion.
- Real source-mode Chromium at 390×844 with touch input and a mocked Gateway reproduced `1 shown` with the result hidden before the fix, then verified the same result is visible after the fix.
- [Before: counted match hidden in collapsed group](https://ampcode.com/user-content/artifacts/9c8a426bde516e0fb92abc3eb51506c0717c8efbe427070f66133767550dfb74-file.png)
- [After: matching group opens and row is visible](https://ampcode.com/user-content/artifacts/5c289e33f21e2953f4e20e154d3f1abacf3ce4fa3cc95ae6fbd34ce1637646d5-file.png)
- 134/134 relevant UI tests passed across skills and agents owners.
- 3/3 source-Chromium sibling E2E tests passed (`agent-config-save`, `skills-owner-selection`).
- `node scripts/check-changed.mjs` passed, including formatting, policy guards, i18n, typecheck, and lint.
- Structured pre-commit autoreview found no actionable issues (0.99 confidence).

The narrow right-edge mobile clipping visible in the screenshots is pre-existing, independently owned UI layout work and is not changed here.