### PR TITLE
fix(gateway): plugin metadata lifecycle staleness in auth-bypass cache and config reload

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -4507,6 +4507,54 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("forces a plugin reload when signaled metadata leaves config and install records identical", async () => {
+    const activeConfig: OpenClawConfig = {
+      gateway: { reload: {} },
+    };
+    const installRecords = {
+      brave: {
+        source: "npm",
+        spec: "@openclaw/brave",
+        installPath: "/tmp/openclaw/plugins/brave",
+      },
+    } satisfies Record<string, PluginInstallRecord>;
+    const readSnapshot = vi.fn(async () =>
+      makeSnapshot({
+        sourceConfig: activeConfig,
+        runtimeConfig: activeConfig,
+        config: activeConfig,
+        hash: "unchanged-config",
+      }),
+    );
+    const readPluginInstallRecords = vi.fn(async () => ({ ...installRecords }));
+    const harness = createReloaderHarness(readSnapshot, {
+      initialConfig: activeConfig,
+      initialCompareConfig: activeConfig,
+      initialPluginInstallRecords: installRecords,
+      readPluginInstallRecords,
+    });
+
+    harness.reloader.notifyPluginMetadataChanged();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    const [plan, nextConfig] = getOnlyHotReloadCall(harness);
+    expect(plan.changedPaths).toEqual([]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.reloadPlugins).toBe(true);
+    expect(plan.disposeMcpRuntimes).toBe(true);
+    expect(nextConfig).toBe(activeConfig);
+
+    // The refresh is consumed by the committed reload: a later watcher echo of
+    // identical bytes must not replace the plugin runtime generation again.
+    harness.watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(harness.onHotReload).toHaveBeenCalledTimes(1);
+    expect(harness.onRestart).not.toHaveBeenCalled();
+
+    await harness.reloader.stop();
+  });
+
   it("keeps external plugin policy-only writes on the hot reload path", async () => {
     const previousConfig: OpenClawConfig = {
       gateway: { reload: {} },

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -265,6 +265,11 @@ export function startGatewayConfigReloader(opts: {
   const activeReloads = new Set<Promise<void>>();
   let missingConfigRetries = 0;
   let configWriteEpoch = 0;
+  // Signaled metadata changes clear the process snapshot slot before the diff
+  // pass runs; the counters keep that pass honest when config bytes are
+  // unchanged, and stay pending until a plugin reload or restart commits.
+  let pluginMetadataRefreshRequests = 0;
+  let pluginMetadataRefreshApplied = 0;
   let pendingInProcessConfig: InProcessConfigCandidate | null = null;
   let activeInProcessConfig: InProcessConfigCandidate | null = null;
   let watcherIntentCandidate: InProcessConfigCandidate | null = null;
@@ -644,7 +649,16 @@ export function startGatewayConfigReloader(opts: {
       }
       notifyCommitted();
     };
-    if (changedPaths.length === 0) {
+    // A signaled metadata change emptied the process snapshot slot. An
+    // unchanged config diff must still replace the plugin runtime generation so
+    // the slot republishes instead of leaving configless readers cold-scanning
+    // against a registry that diverged from the live runtime owners.
+    const pluginMetadataRefreshToken = pluginMetadataRefreshRequests;
+    const forcePluginMetadataReload = pluginMetadataRefreshToken !== pluginMetadataRefreshApplied;
+    const markPluginMetadataRefreshApplied = () => {
+      pluginMetadataRefreshApplied = pluginMetadataRefreshToken;
+    };
+    if (changedPaths.length === 0 && !forcePluginMetadataReload) {
       let publishedSource: { rollback: () => Promise<void>; commit?: () => void } | undefined;
       let publishedSourceRollback: (() => Promise<void>) | undefined;
       let publishedSourceRolledBack = false;
@@ -681,7 +695,11 @@ export function startGatewayConfigReloader(opts: {
     }
 
     const followUp = resolveConfigWriteFollowUp(afterWrite);
-    opts.log.info(`config change detected; evaluating reload (${changedPaths.join(", ")})`);
+    opts.log.info(
+      changedPaths.length > 0
+        ? `config change detected; evaluating reload (${changedPaths.join(", ")})`
+        : "plugin metadata changed with identical config; replacing plugin runtime generation",
+    );
     if (followUp.mode === "none") {
       opts.log.info(`config reload skipped by writer intent (${followUp.reason})`);
       await commitReloadBaseline({ runtimeApplied: false });
@@ -692,6 +710,12 @@ export function startGatewayConfigReloader(opts: {
       forceChangedPaths: pluginInstallWholeRecordPaths,
       candidateConfig: nextConfig,
     });
+    if (forcePluginMetadataReload && !plan.restartGateway && !plan.reloadPlugins) {
+      // Mirror the `plugins.*` hot rule pairing: a replaced plugin registry
+      // also invalidates MCP runtimes assembled from the previous generation.
+      plan.reloadPlugins = true;
+      plan.disposeMcpRuntimes = true;
+    }
     if (nextSettings.mode === "off") {
       opts.log.info("config reload disabled (gateway.reload.mode=off)");
       await commitReloadBaseline({ runtimeApplied: false });
@@ -716,12 +740,15 @@ export function startGatewayConfigReloader(opts: {
       await opts.onConfigChange?.(restartPlan, nextConfig);
       await prepareRestart(restartPlan, nextConfig, ownership, nextSourceConfig);
       await commitReloadBaseline();
+      // The accepted restart owns snapshot republication at next startup.
+      markPluginMetadataRefreshApplied();
       return;
     }
     if (plan.restartGateway) {
       await opts.onConfigChange?.(plan, nextConfig);
       await prepareRestart(plan, nextConfig, ownership, nextSourceConfig);
       await commitReloadBaseline();
+      markPluginMetadataRefreshApplied();
       return;
     }
 
@@ -735,6 +762,10 @@ export function startGatewayConfigReloader(opts: {
     assertCurrent();
     await appliedRevision.apply(plan, nextConfig, nextConfigRevisionHash);
     await commitReloadBaseline();
+    if (plan.reloadPlugins) {
+      // The committed reload republished the metadata snapshot generation.
+      markPluginMetadataRefreshApplied();
+    }
   };
 
   const promoteAcceptedSnapshot = async (snapshot: ConfigFileSnapshot, reason: string) => {
@@ -1271,6 +1302,7 @@ export function startGatewayConfigReloader(opts: {
     notifyPluginMetadataChanged: () => {
       // The signal carries a metadata change while config bytes stay identical.
       // Clear both metadata and config-echo caches before scheduling the shared diff path.
+      pluginMetadataRefreshRequests += 1;
       clearLoadInstalledPluginIndexInstallRecordsCache();
       clearPluginMetadataLifecycleCaches();
       startupInternalWriteHash = null;

--- a/src/gateway/server-http-plugin-auth.test.ts
+++ b/src/gateway/server-http-plugin-auth.test.ts
@@ -1,0 +1,86 @@
+// Covers plugin gateway auth bypass caching across metadata lifecycle resets.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { getCachedPluginGatewayAuthBypassPaths } from "./server-http-plugin-auth.js";
+
+const resolveBypassPaths = vi.hoisted(() =>
+  vi.fn<(params: { channelId: string; cfg: OpenClawConfig }) => Promise<string[]>>(),
+);
+
+vi.mock("../channels/plugins/gateway-auth-bypass.js", () => ({
+  resolveBundledChannelGatewayAuthBypassPaths: resolveBypassPaths,
+}));
+
+describe("getCachedPluginGatewayAuthBypassPaths", () => {
+  beforeEach(() => {
+    resolveBypassPaths.mockReset();
+    clearPluginMetadataLifecycleCaches();
+  });
+
+  it("caches resolved bypass paths per config identity", async () => {
+    const config: OpenClawConfig = { channels: { telegram: {} } };
+    resolveBypassPaths.mockResolvedValue(["/telegram/webhook"]);
+
+    await expect(getCachedPluginGatewayAuthBypassPaths(config)).resolves.toEqual(
+      new Set(["/telegram/webhook"]),
+    );
+    await getCachedPluginGatewayAuthBypassPaths(config);
+    expect(resolveBypassPaths).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops cached bypass paths on a metadata lifecycle reset despite stable config identity", async () => {
+    const config: OpenClawConfig = { channels: { telegram: {} } };
+    resolveBypassPaths.mockResolvedValueOnce(["/telegram/old-bypass"]);
+    await expect(getCachedPluginGatewayAuthBypassPaths(config)).resolves.toEqual(
+      new Set(["/telegram/old-bypass"]),
+    );
+
+    // Same config object, replaced plugin contract: the reset must invalidate,
+    // or the predecessor's unauthenticated paths keep bypassing gateway auth.
+    clearPluginMetadataLifecycleCaches();
+    resolveBypassPaths.mockResolvedValueOnce(["/telegram/new-bypass"]);
+
+    await expect(getCachedPluginGatewayAuthBypassPaths(config)).resolves.toEqual(
+      new Set(["/telegram/new-bypass"]),
+    );
+  });
+
+  it("retries after a failed resolution instead of caching the rejection", async () => {
+    const config: OpenClawConfig = { channels: { telegram: {} } };
+    resolveBypassPaths.mockRejectedValueOnce(new Error("resolution failed"));
+    await expect(getCachedPluginGatewayAuthBypassPaths(config)).rejects.toThrow(
+      "resolution failed",
+    );
+
+    resolveBypassPaths.mockResolvedValueOnce(["/telegram/webhook"]);
+    await expect(getCachedPluginGatewayAuthBypassPaths(config)).resolves.toEqual(
+      new Set(["/telegram/webhook"]),
+    );
+  });
+
+  it("keeps the fresh generation cached when a stale failed resolution settles late", async () => {
+    const config: OpenClawConfig = { channels: { telegram: {} } };
+    let rejectStale: (error: Error) => void = () => {};
+    resolveBypassPaths.mockReturnValueOnce(
+      new Promise<string[]>((_resolve, reject) => {
+        rejectStale = reject;
+      }),
+    );
+    const stale = getCachedPluginGatewayAuthBypassPaths(config);
+
+    clearPluginMetadataLifecycleCaches();
+    resolveBypassPaths.mockResolvedValue(["/telegram/webhook"]);
+    await expect(getCachedPluginGatewayAuthBypassPaths(config)).resolves.toEqual(
+      new Set(["/telegram/webhook"]),
+    );
+
+    rejectStale(new Error("stale plugin generation failed"));
+    await expect(stale).rejects.toThrow("stale plugin generation failed");
+
+    // The stale rejection evicts from its own generation only; the fresh entry
+    // must stay cached instead of being re-resolved.
+    await getCachedPluginGatewayAuthBypassPaths(config);
+    expect(resolveBypassPaths).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/server-http-plugin-auth.ts
+++ b/src/gateway/server-http-plugin-auth.ts
@@ -1,5 +1,6 @@
 import { resolveBundledChannelGatewayAuthBypassPaths } from "../channels/plugins/gateway-auth-bypass.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugins/plugin-metadata-lifecycle.js";
 import type { AuthorizedGatewayHttpRequest } from "./http-auth-utils.js";
 import type { PluginNodeCapabilitySurface } from "./plugin-node-capability.js";
 import {
@@ -18,10 +19,15 @@ export type ResolvePluginNodeCapabilityRoute = (
   pathContext: PluginRoutePathContext,
 ) => PluginNodeCapabilitySurface | undefined;
 
-const pluginGatewayAuthBypassPathsCache = new WeakMap<
-  OpenClawConfig,
-  Promise<ReadonlySet<string>>
->();
+// Bypass paths come from plugin-declared artifacts, not config bytes alone. A
+// metadata lifecycle reset can replace that contract while the config object
+// identity stays stable, so the cache must roll to a fresh generation on reset
+// or a replaced channel plugin keeps its predecessor's HTTP auth exceptions.
+let pluginGatewayAuthBypassPathsCache = new WeakMap<OpenClawConfig, Promise<ReadonlySet<string>>>();
+
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  pluginGatewayAuthBypassPathsCache = new WeakMap();
+});
 
 async function resolvePluginGatewayAuthBypassPaths(
   configSnapshot: OpenClawConfig,
@@ -45,15 +51,18 @@ async function resolvePluginGatewayAuthBypassPaths(
 export function getCachedPluginGatewayAuthBypassPaths(
   configSnapshot: OpenClawConfig,
 ): Promise<ReadonlySet<string>> {
-  const cached = pluginGatewayAuthBypassPathsCache.get(configSnapshot);
+  const cache = pluginGatewayAuthBypassPathsCache;
+  const cached = cache.get(configSnapshot);
   if (cached) {
     return cached;
   }
   const resolved = resolvePluginGatewayAuthBypassPaths(configSnapshot).catch((error: unknown) => {
-    pluginGatewayAuthBypassPathsCache.delete(configSnapshot);
+    // Evict from the owning generation only; a stale failure settling after a
+    // lifecycle reset must not drop a freshly cached entry.
+    cache.delete(configSnapshot);
     throw error;
   });
-  pluginGatewayAuthBypassPathsCache.set(configSnapshot, resolved);
+  cache.set(configSnapshot, resolved);
   return resolved;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Two lifecycle-staleness defects surfaced by the plugin-metadata cache audit:

1. `src/gateway/server-http-plugin-auth.ts` cached channel-declared HTTP auth-bypass paths in a `WeakMap` keyed only by config object identity, with no tie to the plugin registry/metadata generation. Replacing a channel plugin's declared bypass contract while the config object identity stayed stable (a metadata-only lifecycle reset) preserved the *previous* plugin's unauthenticated HTTP route exceptions.
2. `src/gateway/config-reload.ts`'s `notifyPluginMetadataChanged()` synchronously clears the process plugin-metadata snapshot slot and install-record caches, then schedules the standard config-diff reload pass. When config bytes are unchanged, that pass took its `changedPaths.length === 0` early return, which skips both plugin reload and republishing — leaving the snapshot slot empty so configless readers cold-scan repeatedly and can diverge from the live runtime owners.

## Why This Change Was Made

Both are lifecycle-ownership bugs in the plugin-metadata cache/reload path: a cache invalidation seam that every other plugin-derived process memo participates in (`registerPluginMetadataProcessMemoLifecycleClear`) was missing from the auth-bypass cache, and a signaled metadata-only refresh had no path to actually republish the runtime generation when config bytes matched.

## User Impact

- Gateway HTTP auth: a replaced channel plugin's bypass contract now takes effect immediately instead of leaking the predecessor's unauthenticated route exceptions.
- Config reload: a metadata-only refresh (e.g. after an install/doctor flow that doesn't touch config bytes) now reliably replaces the plugin runtime generation and republishes the metadata snapshot, instead of leaving the process snapshot slot empty.

## Evidence

- New regression tests added; verified they **fail on pre-fix code** by temporarily restoring the `HEAD` versions of both production files and re-running (2 failures), then restoring the fix (green).
- `src/gateway/server-http-plugin-auth.test.ts` (new): 4/4 passing, including a test proving a stale failed resolution settling after a lifecycle reset does not evict the fresh cache generation.
- `src/gateway/config-reload.test.ts`: 388/388 passing, including the new forced-reload test and a follow-up assertion that the token is consumed (a later identical-bytes watcher echo does not re-trigger a plugin reload).
- Sibling coverage green: `src/channels/plugins/gateway-auth-bypass.test.ts`, `src/gateway/server-methods/plugins.test.ts`.
- `node scripts/check-changed.mjs` — format/typecheck/lint/guards — exits 0.
- `autoreview` (Codex, gpt-5.6-sol, high effort) on the full uncommitted diff: clean, 0 accepted/actionable findings, confidence 0.96.
