### PR TITLE
fix(macos): preserve remote tunnels when switching connection modes

### DIFF
--- a/apps/macos/Sources/OpenClaw/ConnectionModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/ConnectionModeCoordinator.swift
@@ -22,10 +22,12 @@ final class ConnectionModeCoordinator {
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "connection")
     private var transition = Transition()
+    private var portSweepTask: Task<Void, Never>?
 
     /// Apply the requested connection mode by starting/stopping local gateway,
     /// managing the control-channel SSH tunnel, and cleaning up chat windows/panels.
     func apply(mode: AppState.ConnectionMode, paused: Bool) async {
+        self.portSweepTask?.cancel()
         let previousMode = self.transition.mode
         let applyGeneration = self.transition.begin(mode)
         if let previousMode, previousMode != mode {
@@ -76,7 +78,7 @@ final class ConnectionModeCoordinator {
             }
         }
 
-        Task.detached { await PortGuardian.shared.sweep(mode: mode) }
+        self.portSweepTask = Task { await PortGuardian.shared.sweep(mode: mode) }
     }
 
     private func applyLocalMode(paused: Bool, generation: UInt64) async {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -652,7 +652,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         Task { PresenceReporter.shared.start() }
         Task { await HealthStore.shared.refresh(onDemand: true) }
-        Task { await PortGuardian.shared.sweep(mode: AppStateStore.shared.connectionMode) }
+        Task { await PortGuardian.shared.reapOrphanedTunnels() }
         AppStateStore.shared.applyComputerControlHostState()
         if launchPlan.allowsAutomaticPresentation {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -60,10 +60,12 @@ actor PortGuardian {
     }
 
     func sweep(mode: AppState.ConnectionMode) async {
+        guard !Task.isCancelled else { return }
         self.logger.info("port sweep starting (mode=\(mode.rawValue, privacy: .public))")
         // Reap before the port scan and in every mode: orphans come from earlier
         // remote sessions and must die even after the user switched modes.
         await self.reapOrphanedTunnels()
+        guard !Task.isCancelled else { return }
         guard mode != .unconfigured else {
             self.logger.info("port sweep skipped (mode=unconfigured)")
             return
@@ -72,9 +74,11 @@ actor PortGuardian {
         // Capture the listener before launchd status. If its process exits and the
         // PID is reused, the newer status snapshot cannot bless the replacement.
         let listeners = await self.listeners(on: port)
+        guard !Task.isCancelled else { return }
         let managedGatewayPID = mode == .local
             ? await GatewayLaunchAgentManager.runningGatewayPID()
             : nil
+        guard !Task.isCancelled else { return }
         for listener in listeners {
             if Self.isExpected(
                 listener,
@@ -103,6 +107,7 @@ actor PortGuardian {
                         "(pid \(listener.pid, privacy: .public)); preserving conflict")
                 continue
             }
+            guard !Task.isCancelled else { return }
             if await Self.terminateProcess(listener.pid) {
                 let message = """
                 port \(port) was held by \(listener.command)
@@ -330,9 +335,10 @@ actor PortGuardian {
     /// forget a still-running tunnel (the record is its only retry path).
     private static func terminateProcess(_ pid: Int32) async -> Bool {
         #if canImport(Darwin)
-        guard pid > 0 else { return false }
+        guard !Task.isCancelled, pid > 0 else { return false }
         _ = Darwin.kill(pid, SIGTERM)
         if await self.waitForProcessExit(pid: pid) { return true }
+        guard !Task.isCancelled else { return false }
         _ = Darwin.kill(pid, SIGKILL)
         return await self.waitForProcessExit(pid: pid)
         #else
@@ -343,7 +349,7 @@ actor PortGuardian {
     private static func waitForProcessExit(pid: Int32, timeout: TimeInterval = 1.0) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while self.tunnelProcessInfo(pid: pid) != nil {
-            guard Date() < deadline else { return false }
+            guard !Task.isCancelled, Date() < deadline else { return false }
             try? await Task.sleep(nanoseconds: 50_000_000)
         }
         return true

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -123,6 +123,42 @@ struct PortGuardianRecordStoreTests {
     }
 
     @Test
+    func `cancelled port sweep never touches its durable tunnel records`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        let orphan = Self.record(pid: 2_000_000_000, port: 18789, timestamp: 1)
+        try store.upsert(orphan)
+        let guardian = PortGuardian(recordStoreFactory: {
+            try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        })
+
+        let sweep = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            await guardian.sweep(mode: .unconfigured)
+        }
+        await sweep.value
+
+        #expect(try store.records() == [orphan])
+    }
+
+    @Test
+    func `uncancelled unconfigured sweep still reaps orphaned tunnel records`() async throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+        let store = try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        let orphan = Self.record(pid: 2_000_000_000, port: 18789, timestamp: 1)
+        try store.upsert(orphan)
+        let guardian = PortGuardian(recordStoreFactory: {
+            try PortGuardianRecordStore(databaseURL: fixture.databaseURL)
+        })
+
+        await guardian.sweep(mode: .unconfigured)
+
+        #expect(try store.records().isEmpty)
+    }
+
+    @Test
     func `failed receipt deletion relinquishes ownership for sweep retry`() async throws {
         let fixture = try Self.fixture()
         defer { fixture.cleanup() }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users switching from a local Gateway to a remote Gateway could have a stale local port-cleanup task terminate their newly established SSH tunnel. This resolves the remaining actionable review finding on #127609.

## Why This Change Was Made

Connection-mode transitions now own and cancel their pending port sweep before the next transition starts. PortGuardian checks cancellation after every asynchronous boundary and immediately before sending termination signals. Startup retains its necessary orphan-tunnel cleanup without independently running a destructive, stale-mode listener sweep.

## User Impact

Remote Gateway connections remain available when connection modes change quickly. Crashed SSH tunnels are still cleaned up at startup, ordinary unconfigured sweeps still reap orphan records, and named-profile listener protections remain unchanged.

## Evidence

- Before the fix, the new cancelled-sweep regression fails because PortGuardian still opens its isolated SQLite ledger and deletes a stale tunnel receipt.
- After the fix, 43 tests across PortGuardianRecordStoreTests, PortGuardianIsExpectedTests, ConnectionModeCoordinatorTests, and MenuContentSmokeTests pass.
- The uncancelled unconfigured sibling regression confirms legitimate orphan cleanup remains intact.
- SwiftFormat, SwiftLint, and independent Codex review pass.
- No real Gateway, user-owned SSH tunnel, global state database, or launchd service is touched by the isolated regression.
- Exact-head hosted macOS Swift and Node checks, native localization, security checks, and the required CI gate all passed.
- Remaining risk: an interactive rapid local-to-remote transition was not run against a real user-owned SSH tunnel because reproducing the old behavior could terminate the operator's active Gateway connection; isolated production-owner regressions prove the cancellation boundary instead.
- Production delta: +12/-4; tests: +36/-0. The added production lines establish the missing cancellable lifecycle ownership and signal-safety boundary.
