### PR TITLE
fix(macos): suppress SIGPIPE on process pipe write ends

### DIFF
--- a/apps/macos/Sources/OpenClaw/FileHandle+SafeRead.swift
+++ b/apps/macos/Sources/OpenClaw/FileHandle+SafeRead.swift
@@ -1,6 +1,15 @@
+import Darwin
 import Foundation
 
 extension FileHandle {
+    /// Marks a pipe/socket write end so a vanished reader fails the write with a
+    /// thrown EPIPE instead of raising SIGPIPE, which kills the whole process.
+    /// Required on every write end whose reader is another process that can exit.
+    @discardableResult
+    func disableSIGPIPE() -> Bool {
+        fcntl(self.fileDescriptor, F_SETNOSIGPIPE, 1) != -1
+    }
+
     /// Reads until EOF using the throwing FileHandle API and returns empty `Data` on failure.
     ///
     /// Important: Avoid legacy, non-throwing FileHandle read APIs (e.g. `readDataToEndOfFile()` and

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalogClient.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalogClient.swift
@@ -62,6 +62,9 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
         var requestData: Data?
         var continuation: CheckedContinuation<Data, Error>?
         var timer: DispatchSourceTimer?
+        /// One requeue budget for the child-exit race: a failed stdin write was
+        /// never delivered, so a single retry on a fresh child cannot duplicate.
+        var redelivered = false
 
         init(
             token: UUID,
@@ -105,6 +108,9 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
         {
             self.invocation = invocation
             self.initializeRequestID = initializeRequestID
+            // The App Server child can exit between requests; without this an
+            // in-flight stdin write raises SIGPIPE and kills the app.
+            self.stdinPipe.fileHandleForWriting.disableSIGPIPE()
         }
     }
 
@@ -351,9 +357,19 @@ final class CodexAppServerThreadClient: @unchecked Sendable {
             }
             try self.write(requestData, over: connection)
         } catch {
-            self.finishActive(
-                .failure(MacNodeCodexThreadCatalog.CatalogError.appServerUnavailable),
-                restartConnection: true)
+            // A warm connection can outlive its child; the exit race surfaces
+            // here as EPIPE before termination is observed. The frame was never
+            // delivered, so requeue once onto a fresh child instead of failing.
+            guard !active.redelivered else {
+                self.finishActive(
+                    .failure(MacNodeCodexThreadCatalog.CatalogError.appServerUnavailable),
+                    restartConnection: true)
+                return
+            }
+            active.redelivered = true
+            self.active = nil
+            self.pending.insert(active, at: 0)
+            self.stopConnection(abortive: true)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -350,7 +350,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         let stdinPipe = Pipe()
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
-        guard fcntl(stdinPipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1) != -1 else {
+        guard stdinPipe.fileHandleForWriting.disableSIGPIPE() else {
             self.finishStartLocked(.failure(WorkerError.unavailable("could not protect worker input pipe")))
             return
         }

--- a/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
+++ b/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
@@ -642,6 +642,9 @@ private actor ProcessMLXTTSTransport: MLXTTSTransport {
     {
         let inputPipe = Pipe()
         let outputPipe = Pipe()
+        // The helper child can exit at any time; without this a racing
+        // send() to its stdin raises SIGPIPE and kills the app.
+        inputPipe.fileHandleForWriting.disableSIGPIPE()
 
         let output = outputPipe.fileHandleForReading
         let (stream, continuation) = AsyncStream<Data>.makeStream()

--- a/apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
@@ -423,6 +423,10 @@ struct CuaDriverHostCoordinatorTests {
         driver diagnostic
 
         """
+        // The relay's readability handler calls stop() on any empty read, which
+        // closes the pipe's read end; without suppression a racing stop turns
+        // this write into a harness-killing SIGPIPE.
+        try TestProcessSupport.suppressSIGPIPE(relay.pipe.fileHandleForWriting)
         try relay.pipe.fileHandleForWriting.write(contentsOf: Data(driverOutput.utf8))
         try relay.pipe.fileHandleForWriting.close()
         for _ in 0..<1000 where probe.events.count < 2 {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -197,9 +197,13 @@ struct MacNodeCodexThreadCatalogTests {
     }
 
     private func openFIFOForWriting(_ url: URL) async throws -> FileHandle {
-        try await Task.detached {
+        let handle = try await Task.detached {
             try FileHandle(forWritingTo: url)
         }.value
+        // The FIFO reader is a spawned fake child; if it exits before the exit
+        // gate write, an unsuppressed SIGPIPE kills the whole test harness.
+        try TestProcessSupport.suppressSIGPIPE(handle)
+        return handle
     }
 
     private func requestEmptyList(

--- a/apps/macos/Tests/OpenClawIPCTests/TestProcessSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TestProcessSupport.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import Testing
+@testable import OpenClaw
 
 enum TestProcessSupport {
     static func pollPID(in file: URL) -> pid_t? {
@@ -32,6 +33,15 @@ enum TestProcessSupport {
             try? await Task.sleep(for: .milliseconds(10))
         }
         return self.processIsGone(pid)
+    }
+
+    /// SIGPIPE from a write whose reader already exited kills the entire test
+    /// process (swiftpm-testing-helper dies with signal 13, blaming whatever
+    /// test happens to be running). Mirror the production F_SETNOSIGPIPE guard
+    /// (MacNodeHostWorker) so a racing reader exit surfaces as a thrown EPIPE
+    /// on that one write instead.
+    static func suppressSIGPIPE(_ writeEnd: FileHandle) throws {
+        try #require(writeEnd.disableSIGPIPE())
     }
 
     static func killLeakedProcesses(in files: [URL]) {

--- a/apps/macos/Tests/OpenClawIPCTests/TestProcessSupportPipeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TestProcessSupportPipeTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Testing
+
+struct TestProcessSupportPipeTests {
+    @Test func `suppressed write end reports EPIPE instead of killing the harness`() throws {
+        let pipe = Pipe()
+        try TestProcessSupport.suppressSIGPIPE(pipe.fileHandleForWriting)
+        try pipe.fileHandleForReading.close()
+
+        // Without suppression this write would raise SIGPIPE and take down the
+        // whole swiftpm-testing-helper process instead of throwing.
+        #expect(throws: Error.self) {
+            try pipe.fileHandleForWriting.write(contentsOf: Data("x".utf8))
+        }
+        try pipe.fileHandleForWriting.close()
+    }
+}


### PR DESCRIPTION
<!-- No linked issue; discovered via macos-swift CI lane triage (intermittent signal-13 crashes, e.g. PR #126559, run 32341197738 job 96340683947). -->

## What Problem This Solves

The macOS app can be killed by SIGPIPE when a spawned child process (the Codex App
Server, or the MLX text-to-speech helper) exits while OpenClaw is still writing to
its stdin pipe. This is a real crash risk in production, and in CI it manifests as
the `macos-swift` lane intermittently dying mid-run with `swiftpm-testing-helper
... exited with unexpected signal code 13`, with the crash blamed on whatever
unrelated test happens to be running at the time.

## Why This Change Was Made

`MacNodeHostWorker` already protected its worker stdin pipe with `F_SETNOSIGPIPE`,
but `MacNodeCodexThreadCatalogClient` (the Codex App Server JSON-RPC client) and
`TalkMLXSpeechSynthesizer`'s helper transport did not, so a child exiting between
requests could raise SIGPIPE and kill the whole app instead of throwing. This adds
a canonical `FileHandle.disableSIGPIPE()` helper and applies it at every process
write-end creation site, including the one already-guarded call site, so the
policy is expressed once. Suppressing the signal exposed a second bug: an
undelivered App Server request write was reported to the caller as
`appServerUnavailable` even though the frame was provably never sent, so a request
racing a client exit is now requeued once onto a fresh child instead of failing.

Test-side pipe write ends whose readers are spawned children or an internal
readability handler that can close the pipe mid-test get the same
`disableSIGPIPE()` treatment, so a racing reader exit fails the assertion instead
of taking down the whole test harness.

## User Impact

The macOS app can no longer be crashed by a child process exiting mid-write on its
stdin (Codex App Server restarts, TTS helper restarts). No user-visible behavior
change on the happy path; a request that races a Codex App Server child exit now
transparently retries once instead of surfacing a spurious `appServerUnavailable`
error.

## Evidence

- Reproduced the CI crash locally: `swift test --package-path apps/macos --filter
  CuaDriverHostCoordinatorTests\|MacNodeCodexThreadCatalogTests\|MacNodeHostWorkerPipeTests`
  died with `exited with unexpected signal code 13` on the first run before the
  fix.
- After the fix: the same filtered suite (61 tests) passed 5/5 consecutive runs.
- Full `apps/macos` suite (1707 tests, `--parallel`) passed with zero signal
  crashes; the one unrelated failure (`OnboardingAISetupTests`, a wizard
  progress-percentage timing assertion) passed 94/94 twice in isolation — a
  pre-existing load-timing flake, not caused by this change.
- `scripts/lint-swift.sh macos` / `scripts/format-swift.sh macos`: clean.
- `swift build --package-path apps/macos --configuration release`: succeeds.
- Fresh Codex autoreview (`gpt-5.6-sol`, high reasoning) on the local diff:
  `autoreview clean: no accepted/actionable findings reported`.
