### PR TITLE
fix(channels): stop false no-payload warnings for queued replies

### DIFF
--- a/src/channels/turn/execution.ts
+++ b/src/channels/turn/execution.ts
@@ -9,7 +9,7 @@ import { isRecentOutboundMessageIdentity } from "../message/outbound-echo.js";
 import { recordChannelBotPairLoopAndCheckSuppression } from "./bot-loop-protection.js";
 import {
   EMPTY_CHANNEL_TURN_DISPATCH_COUNTS,
-  hasVisibleChannelTurnDispatchFromReceipt as hasVisibleChannelTurnDispatch,
+  hasVisibleChannelTurnDispatch,
   type ChannelTurnDispatchResultLike,
   type ChannelTurnVisibleDeliverySignals,
 } from "./dispatch-result.js";

--- a/src/channels/turn/run-channel-turn.pipeline.test.ts
+++ b/src/channels/turn/run-channel-turn.pipeline.test.ts
@@ -945,6 +945,43 @@ describe("channel turn pipeline", () => {
     ]);
   });
 
+  it.each([
+    {
+      name: "accepts compatibility counters when no receipt exists",
+      dispatchResult: { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } },
+      warns: false,
+    },
+    {
+      name: "keeps a non-visible settled receipt authoritative",
+      dispatchResult: {
+        queuedFinal: true,
+        counts: { tool: 0, block: 0, final: 1 },
+        settledReceipt: {
+          anyVisibleDelivered: false,
+          counts: { final: { delivered: 0, failedAfterSend: 0 } },
+        },
+      },
+      warns: true,
+    },
+  ])("$name", async ({ dispatchResult, warns }) => {
+    const log = vi.fn();
+
+    await runPreparedChannelTurn({
+      channel: "test",
+      routeSessionKey: "agent:main:test:peer",
+      storePath: "/tmp/sessions.json",
+      ctxPayload: createCtx(),
+      recordInboundSession: createRecordInboundSession(),
+      runDispatch: vi.fn(async () => dispatchResult),
+      log,
+      messageId: "msg-compat",
+    });
+
+    expect(log.mock.calls.some(([event]) => event.reason === "zero-count-visible-dispatch")).toBe(
+      warns,
+    );
+  });
+
   it("does not warn for observed-path deliveries with zero queued counts", async () => {
     const events: string[] = [];
     const log = vi.fn();


### PR DESCRIPTION
Related: #107902

AI-assisted with Codex. I reviewed the generated change and understand the behavior and compatibility boundary it modifies.

## What Problem This Solves

Fixes an issue where a queued channel reply could emit `visible channel turn dispatched with no queued reply payloads` when its compatibility dispatcher returned queued-reply counters without a settled receipt. The warning looks like message loss and can send incident triage toward unrelated failures.

## Root Cause and Fix

#124773 changed the channel-turn sentinel from the canonical `hasVisibleChannelTurnDispatch` helper to the receipt-only `hasVisibleChannelTurnDispatchFromReceipt` helper. That bypassed the existing no-receipt compatibility contract even though `runPreparedInboundReply` still accepts generic dispatch results.

The sentinel now uses the canonical helper again. Settled receipts remain authoritative when present; only results without a receipt fall back to `queuedFinal`, legacy counts, or existing observed-delivery signals. No delivery behavior or public contract changes.

This is distinct from #116486. That PR attests plugin-bound routed deliveries that bypass queued counters. This change restores the supported no-receipt compatibility path at the sentinel itself.

## User Impact

Operators no longer receive a false no-payload warning for no-receipt compatibility results that report a queued reply. Genuine zero-payload turns and settled receipts that prove no visible delivery still warn as before.

## Evidence

Head: `36f851f13a2bc2b258ed2c1826c97baa07c03f15`

- Regression red: with the receipt-only import restored locally, `pnpm exec vitest run src/channels/turn/run-channel-turn.pipeline.test.ts -t 'accepts compatibility counters' --maxWorkers=1` fails because the warning is observed (`expected true to be false`).
- Owner-boundary green: one grouped `src/channels/turn/*.test.ts` Vitest run passes 12 files / 102 tests.
- Type safety: `pnpm tsgo` and `pnpm check:test-types` pass.
- Static checks: targeted `oxfmt --check`, targeted core `oxlint`, and `git diff --check` pass.
- Production compatibility boundary (`runPreparedInboundReply`, synthetic closed fixtures):
  - no receipt + `queuedFinal: true` + `counts.final: 1` => `dispatched: true`, `warningObserved: false`;
  - identical compatibility counters + explicit non-visible settled receipt => `dispatched: true`, `warningObserved: true`.
- Production LOC: `+1/-1` (net 0). Test LOC: `+37/-0`.

Redacted exact-head compatibility-dispatcher output:

```json
[
  {
    "mode": "synthetic-compatibility",
    "boundary": "runPreparedInboundReply",
    "dispatchResult": {
      "queuedFinal": true,
      "counts": { "tool": 0, "block": 0, "final": 1 }
    },
    "dispatched": true,
    "warningObserved": false,
    "warningEvents": []
  },
  {
    "mode": "synthetic-compatibility",
    "boundary": "runPreparedInboundReply",
    "dispatchResult": {
      "queuedFinal": true,
      "counts": { "tool": 0, "block": 0, "final": 1 },
      "settledReceipt": {
        "anyVisibleDelivered": false,
        "counts": { "final": { "delivered": 0, "failedAfterSend": 0 } }
      }
    },
    "dispatched": true,
    "warningObserved": true,
    "warningEvents": [
      {
        "stage": "dispatch",
        "event": "warning",
        "messageId": "telegram-e2e-channel-turn-dispatch-result",
        "sessionKey": "agent:main:telegram-e2e:channel-turn-dispatch-result",
        "admission": "dispatch",
        "reason": "zero-count-visible-dispatch",
        "channel": "telegram-e2e"
      }
    ]
  }
]
```

The regression test covers both sides of the gate at the prepared-turn owner boundary. The change introduces no state, concurrency behavior, callback binding, documentation instruction, config surface, or renamed API.

## Why This Proof Uses the Prepared Boundary

An ephemeral Telegram/core gateway cannot naturally produce the changed no-receipt shape. Telegram enters through `runChannelInboundEvent` (`extensions/telegram/src/bot-message-dispatch-turn.ts:100`), the assembled lifecycle uses the core/routed dispatcher (`src/channels/turn/lifecycle.ts:438`), the current reply dispatcher declares `supportsSettledReceipt: true` and returns a receipt from `waitForIdle` (`src/auto-reply/reply/reply-dispatcher.ts:615-626`), and inbound dispatch attaches that receipt (`src/auto-reply/dispatch.ts:239-266`). Such a gateway run exercises the unchanged receipt path.

The supported no-receipt owner is instead the generic public `runPreparedInboundReply<TDispatchResult>` boundary (`src/plugin-sdk/channel-inbound.ts:201-228`), backed by the legacy direct prepared runner whose lifecycle remains optional (`src/channels/turn/types.ts:363-377`). The attached trace executes that production boundary. Forcing a gateway to omit its real receipt would require a fake production dispatcher seam and would not improve changed-path evidence.

## Real Plugin / Gateway Harness

An ephemeral OpenClaw Gateway loaded a bundled startup proof plugin. An authenticated operator Gateway client invoked the plugin RPC twice; the plugin called the public `runPreparedInboundReply` boundary with each closed result. The temporary fixture was removed after the run.

Command:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/channel-turn-dispatch-result-plugin-proof.e2e.test.ts --maxWorkers=1
```

Result: `1 file passed, 1 test passed`; OpenClaw `2026.8.1 (36f851f)`.

Redacted Gateway RPC results:

```json
[
  {
    "boundary": "runPreparedInboundReply",
    "dispatchResult": {
      "queuedFinal": true,
      "counts": { "tool": 0, "block": 0, "final": 1 }
    },
    "dispatched": true,
    "warningObserved": false
  },
  {
    "boundary": "runPreparedInboundReply",
    "dispatchResult": {
      "queuedFinal": true,
      "counts": { "tool": 0, "block": 0, "final": 1 },
      "settledReceipt": {
        "anyVisibleDelivered": false,
        "counts": { "final": { "delivered": 0, "failedAfterSend": 0 } }
      }
    },
    "dispatched": true,
    "warningObserved": true
  }
]
```

## Telegram User E2E

The final exact-head run used the reusable `telegram-e2e-userbot` scenario `channel-turn-dispatch-result-fixed.json`. A leased real Telegram user sent `Please answer with OPENCLAW_E2E_OK only.` to `@foremanclawbot`; the SUT produced two typing events and one `OPENCLAW_E2E_OK` reply through the ephemeral Gateway and mock provider (`1` request / `1` response).

The same recorded run then exercised the changed production `runPreparedInboundReply` boundary:

- no receipt + `queuedFinal: true` + `counts.final: 1`: completed, dispatched, no warning;
- explicit non-visible settled receipt with identical counters: completed, dispatched, warning observed.

Recorder result: complete; `1` user action, `2` messages, `2` SUT typing events; both changed-path assertions `ok: true`. The harness labels these closed compatibility fixtures `mode: synthetic-compatibility`, because the current Telegram dispatcher always supplies a settled receipt.

## ClawSweeper Rank-up Move

Skipped the optional branch-refresh move. The branch is cleanly `MERGEABLE`; OpenClaw fast-lane drift policy says `BEHIND` merges and to rebase only when `CONFLICTING`. Refreshing a fast-moving base would churn an already exact-head-green patch without changing the fix.
