### PR TITLE
fix(ui): explain blocked Talk microphone access

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -1014,6 +1014,44 @@ suite.define(() => {
     });
   });
 
+  it("shows actionable guidance when Talk microphone permission is blocked", async () => {
+    await suite.withPage(undefined, async ({ page }) => {
+      const relaySessionId = "relay-blocked-microphone-e2e";
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "talk.client.create": {
+            provider: "openai",
+            transport: "gateway-relay",
+            relaySessionId,
+            audio: {
+              inputEncoding: "pcm16",
+              inputSampleRateHz: 16_000,
+              outputEncoding: "pcm16",
+              outputSampleRateHz: 24_000,
+            },
+          },
+          "talk.session.close": {},
+        },
+      });
+      await installBlockedMicrophoneFixture(page);
+
+      await page.setViewportSize({ width: 320, height: 720 });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByRole("button", { name: "Start voice input" }).click();
+      await gateway.waitForRequest("talk.client.create");
+
+      await expect
+        .poll(() => page.getByRole("alert").locator(".agent-chat__talk-status-text").textContent())
+        .toBe("Microphone access is blocked. Allow it in browser site settings to list inputs.");
+      await expect
+        .poll(() => gateway.getRequests("talk.session.close").then((requests) => requests.length))
+        .toBe(1);
+      await expect
+        .poll(() => page.getByRole("button", { name: "Start voice input" }).isVisible())
+        .toBe(true);
+    });
+  });
+
   it("keeps blocked microphone guidance readable in a narrow viewport", async () => {
     await suite.withPage(undefined, async ({ page }) => {
       await installMockGateway(page);

--- a/ui/src/pages/chat/realtime-talk-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test.ts
@@ -134,6 +134,15 @@ describe("realtime Talk microphone inputs", () => {
     });
   });
 
+  it("reports microphone permission denial with actionable guidance", async () => {
+    const getUserMedia = vi.fn().mockRejectedValue(new DOMException("denied", "NotAllowedError"));
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    await expect(openRealtimeTalkInput(undefined)).rejects.toThrow(
+      "Microphone access is blocked. Allow it in browser site settings to list inputs.",
+    );
+  });
+
   it("does not silently fall back when the selected microphone is unavailable", async () => {
     const getUserMedia = vi.fn(async () => {
       throw new DOMException("missing", "OverconstrainedError");

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -221,15 +221,17 @@ export async function openRealtimeTalkInput(
   if (!devices?.getUserMedia) {
     throw new Error(t("chat.composer.realtimeTalkRequiresMicrophone"));
   }
-  let audio: MediaStream;
+  let acquisition: { stream: MediaStream } | { failure: string };
   try {
-    audio = await awaitRealtimeTalkMediaRequest(
-      () =>
-        devices.getUserMedia({
-          audio: realtimeTalkAudioConstraints(inputDeviceId),
-        }),
-      options.signal,
-    );
+    acquisition = {
+      stream: await awaitRealtimeTalkMediaRequest(
+        () =>
+          devices.getUserMedia({
+            audio: realtimeTalkAudioConstraints(inputDeviceId),
+          }),
+        options.signal,
+      ),
+    };
   } catch (error) {
     if (
       inputDeviceId?.trim() &&
@@ -238,8 +240,16 @@ export async function openRealtimeTalkInput(
     ) {
       throw new Error(t("chat.composer.selectedMicrophoneUnavailable"), { cause: error });
     }
-    throw error;
+    if (error instanceof DOMException && error.name !== "AbortError") {
+      acquisition = { failure: describeRealtimeTalkInputError(error) };
+    } else {
+      throw error;
+    }
   }
+  if ("failure" in acquisition) {
+    throw new Error(acquisition.failure);
+  }
+  const { stream: audio } = acquisition;
   if (options.signal?.aborted) {
     audio.getTracks().forEach((track) => track.stop());
     throw realtimeTalkAbortReason(options.signal);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting Talk from Chat after blocking microphone permission would see only raw browser text such as “Permission denied,” with no guidance on how to recover.

## Why This Change Was Made

The shared microphone-acquisition owner now routes non-cancellation browser media errors through its existing localized input-error description. The mapped public error intentionally omits the browser exception cause because Chat formats causes into its visible alert. Selected-device `OverconstrainedError` guidance and `AbortError` lifecycle cancellation remain unchanged; no Gateway, provider, config, permission, or session contract changes.

## User Impact

When browser microphone access is blocked, Chat now shows only actionable browser-settings guidance. The failed Talk allocation still closes, and the Start voice input action becomes available again.

## Evidence

- Authentic pre-fix owner regression failed with raw `denied` instead of the existing localized recovery copy.
- Real source-mode Chromium at 320×720 with a mocked Gateway reproduced the direct Chat path. The same relay allocation closes after acquisition fails, and the Start voice input action recovers.
- [Before: raw “Permission denied”](https://ampcode.com/user-content/artifacts/b8104720da66818811c8f17f6dcc85ced594d2dabc58f07073815a549c3f4bbf-file.png)
- [Final after: exact actionable guidance, no browser suffix](https://ampcode.com/user-content/artifacts/d2f711aafebd262b8a66340960ba3fe4b2534299566f38e281f095a507cc398c-file.png)
- 320/320 relevant Chat/Realtime Talk unit and browser tests passed across 20 files.
- Final owner tests passed 23/23 and the full source-Chromium Talk E2E passed 10/10, covering ordinary start/stop, camera, relay, transcript, backpressure, race cleanup, blocked microphone, and Settings discovery paths.
- The blocked-microphone E2E now requires the rendered status text to equal the localized guidance exactly.
- The changed gate passed formatting, policy guards, i18n, core/UI typecheck, and focused final lint.
- Final structured Codex autoreview found no actionable issues (0.96 confidence).
- Four fresh open issue/PR searches found no exact duplicate.

The existing canonical helper was introduced for dictation and device discovery, but the direct Talk acquisition catch still rethrew browser `DOMException` text. This patch completes that owner boundary with four production lines and adds one owner regression plus one user-path E2E. It also incorporates both ClawSweeper rank-up moves: remove the causal browser exception from the mapped public error and assert exact browser-visible text.