### PR TITLE
fix: owner filter resets when gateway reconnects

### DIFF
--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -183,6 +183,23 @@ suite.define(() => {
         ),
       )
       .toBe(true);
+
+    const initialConnections = (await gateway.getRequests("connect")).length;
+    await gateway.closeLatest(1012, "owner filter reconnect proof");
+    await expect
+      .poll(async () => (await gateway.getRequests("connect")).length)
+      .toBeGreaterThan(initialConnections);
+    await expect
+      .poll(async () => (await gateway.getRequests("sessions.list")).at(-1)?.params)
+      .toMatchObject({ ownerId: "profile-ada" });
+    await expect
+      .poll(() => currentPage.locator('[data-session-key="agent:main:bob"]').count())
+      .toBe(0);
+    const reconnectedMenu = await openSidebarSortMenu(currentPage);
+    await expectBrowser(reconnectedMenu.locator('[value="owner:profile-ada"]')).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
   });
 
   it("renders zero ownership chrome for a single owner", async () => {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -387,6 +387,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
             ? scopedAgentListParamsForSession(gateway.snapshot, sessionKey)
             : { agentId: resolveUiSelectedGlobalAgentId(gateway.snapshot) };
           await roster.refresh({
+            ...roster.lastOptions(), // Keep visible roster filters through reconnect hydration.
             ...agentScope,
             includeDerivedTitles: true,
             includeLastMessage: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who filter the session sidebar to one owner would lose that filter whenever the Gateway disconnected and reconnected.

## Why This Change Was Made

Reconnect hydration now starts from the roster's last list options, then applies the current agent scope and required hydration flags. This keeps the existing owner, status, sort, and visibility choices without preserving stale route scope.

The existing session-ownership browser scenario now forces a same-client Gateway reconnect and verifies both the next `sessions.list` request and the visible owner selection.

## User Impact

The selected owner filter remains active across Gateway restarts and reconnects, so the sidebar does not unexpectedly return to all sessions.

## Evidence

- Pre-fix browser reproduction: after selecting Ada and reconnecting, the replacement `sessions.list` request omitted the selected owner filter.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-ownership.e2e.test.ts --reporter=verbose` — 11/11 passed.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/ui.tsbuildinfo` — passed.
- `node scripts/run-oxlint.mjs ui/src/lib/sessions/index.ts ui/src/e2e/session-ownership.e2e.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- Visual proof: focused Playwright browser flow against the mocked Gateway.

Before reconnect: owner sorting and choices are active.

![Owner filter before reconnect](https://github.com/user-attachments/assets/77219281-024a-4c73-833a-40e760b1b312)

After reconnect: Ada remains selected and Bob remains filtered out.

![Ada owner filter retained after reconnect](https://github.com/user-attachments/assets/80873317-4a9a-4e7c-82f5-cb0f9a6377de)

AI-assisted: yes. I inspected the owner boundary, reproduction, test assertions, and final diff.
