### PR TITLE
perf(slack): reuse prepared outbound payload

### DIFF
--- a/extensions/slack/src/client-delivery.payload.test.ts
+++ b/extensions/slack/src/client-delivery.payload.test.ts
@@ -1,0 +1,40 @@
+// Slack tests cover final Web API payload handoff behavior.
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+
+const payloadState = vi.hoisted(() => ({
+  basePayload: {
+    channel: "C123",
+    text: "Deploy ✅",
+    blocks: [{ type: "divider" }],
+    metadata: { event_type: "deploy", event_payload: { status: "ready" } },
+    thread_ts: "1712345678.123456",
+    reply_broadcast: true as const,
+    unfurl_links: false,
+  },
+}));
+
+vi.mock("./post-message-payload.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./post-message-payload.js")>();
+  return {
+    ...actual,
+    buildSlackPostMessagePayload: vi.fn(() => payloadState.basePayload),
+  };
+});
+
+const { postSlackMessageBestEffort } = await import("./client-delivery.js");
+
+describe("postSlackMessageBestEffort", () => {
+  it("passes the prepared payload directly when no identity is requested", async () => {
+    const postMessage = vi.fn(async (_payload: unknown) => ({
+      ok: true,
+      ts: "1712345678.123456",
+    }));
+    const client = { chat: { postMessage } } as unknown as WebClient;
+
+    await postSlackMessageBestEffort({ client, channelId: "C123", text: "Deploy ✅" });
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage.mock.calls[0]?.[0]).toBe(payloadState.basePayload);
+  });
+});

--- a/extensions/slack/src/post-message-identity.ts
+++ b/extensions/slack/src/post-message-identity.ts
@@ -71,6 +71,9 @@ export async function postSlackMessageWithIdentityFallback<T>(params: {
 }): Promise<T> {
   const { basePayload, identity, post } = params;
   try {
+    if (!identity) {
+      return await post(basePayload);
+    }
     if (identity?.iconUrl) {
       return await post(
         {


### PR DESCRIPTION
## What Problem This Solves

Ordinary Slack sends build one canonical `chat.postMessage` payload, then the custom-identity helper shallow-copies every field even when no identity is requested. Slack Web API 8.0.0 immediately projects the options into its own request object, so the OpenClaw copy only adds request-time allocation.

## Why This Change Was Made

The identity helper now passes the prepared payload directly on the no-identity path. Custom username/icon construction and every identity rejection/fallback branch remain unchanged. A regression through the real `postSlackMessageBestEffort` owner proves that OpenClaw hands the exact prepared object to `chat.postMessage`.

## User Impact

Slack message bytes, field ordering, retries, errors, and identity fallback behavior are unchanged. The real outbound-owner benchmark improved from 1,253.985 to 1,217.297 ms over 300,000 iterations (2.93% lower median); the isolated identity helper improved 14.41%.

## Evidence

- Pre-fix owner regression: failed on reference identity while serializing to the same payload; candidate: 1/1 passed.
- Current-main Slack extension: 137 files, 2,432/2,432 tests passed.
- Focused identity/unfurl/payload siblings: 35/35 passed.
- Real Slack SDK raw-body differential: 12 cases / 13 requests byte-identical; SHA-256 `377446c553f1a3db6feed526acae80ba236400da391b544db3dc9a6a53e79c5b`.
- `node scripts/check-changed.mjs -- extensions/slack/src/post-message-identity.ts extensions/slack/src/client-delivery.payload.test.ts`: passed.
- `pnpm build`: passed with existing dependency direct-`eval` warnings only.
- Final exact-head bundled Codex `gpt-5.6-sol`/high autoreview: TruffleHog clean, no actionable P0-P3 findings, correct at 0.94.
- Replayed against the source frozen base, the recreated current diff produced exact reviewed source tree `621591720ba97416566fd2c09f5d555d4178c5cb`.
