### PR TITLE
fix(cli): render plugin search JSON failures

### DIFF
--- a/src/cli/plugins-search-command.test.ts
+++ b/src/cli/plugins-search-command.test.ts
@@ -111,6 +111,26 @@ describe("plugins search command", () => {
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith({ results: [] }, 2);
   });
 
+  it("leaves missing-query JSON failures to the root renderer", async () => {
+    await expect(runPluginsSearchCommand([], { json: true }, mocks.runtime)).rejects.toThrow(
+      "Usage: openclaw plugins search <query>",
+    );
+
+    expect(mocks.runtime.error).not.toHaveBeenCalled();
+    expect(mocks.runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("leaves ClawHub JSON failures to the root renderer", async () => {
+    mocks.searchClawHubPackages.mockRejectedValueOnce(new Error("offline fixture"));
+
+    await expect(
+      runPluginsSearchCommand("calendar", { json: true }, mocks.runtime),
+    ).rejects.toThrow("offline fixture");
+
+    expect(mocks.runtime.error).not.toHaveBeenCalled();
+    expect(mocks.runtime.exit).not.toHaveBeenCalled();
+  });
+
   it("rejects partial numeric search limits", async () => {
     const program = new Command();
     program.exitOverride();

--- a/src/cli/plugins-search-command.ts
+++ b/src/cli/plugins-search-command.ts
@@ -5,6 +5,7 @@ import type { ClawHubPackageSearchResult } from "../infra/clawhub-packages.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { searchInstallablePluginPackages } from "../plugins/catalog-search.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
+import { ExpectedCliError } from "./failure-output.js";
 
 /** Options accepted by `openclaw plugins search`. */
 type PluginsSearchOptions = {
@@ -34,8 +35,8 @@ export async function runPluginsSearchCommand(
     Array.isArray(queryParts) ? queryParts.join(" ") : queryParts,
   );
   if (!query) {
-    runtime.error("Usage: openclaw plugins search <query>");
-    return runtime.exit(1);
+    const message = "Usage: openclaw plugins search <query>";
+    throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
   }
 
   try {
@@ -52,6 +53,9 @@ export async function runPluginsSearchCommand(
     runtime.log(`${theme.heading("ClawHub plugins")} ${theme.muted(`(${results.length})`)}`);
     runtime.log(results.map(formatPackageSearchLine).join("\n"));
   } catch (error) {
+    if (opts.json) {
+      throw error;
+    }
     runtime.error(formatErrorMessage(error));
     runtime.exit(1);
   }

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -476,6 +476,74 @@ describe("cli json stdout contract", () => {
 
   it.each([
     {
+      name: "the search query is missing",
+      args: ["plugins", "search", "--json"],
+      message: "Usage: openclaw plugins search <query>",
+    },
+    {
+      name: "ClawHub transport fails",
+      args: ["plugins", "search", "fixture", "--json"],
+      message: "offline fixture",
+    },
+  ])("returns one canonical JSON document when plugins $name", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const preload = `data:text/javascript,${encodeURIComponent(
+          'globalThis.fetch = async () => { throw new Error("offline fixture"); };',
+        )}`;
+        const result = runBuiltCli(tempHome, testCase.args, {
+          NODE_OPTIONS: `--import=${preload}`,
+          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+          OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+          CLAWHUB_CONFIG_PATH: path.join(tempHome, "missing-clawhub.json"),
+          CLAWHUB_TOKEN: "",
+          CLAWHUB_AUTH_TOKEN: "",
+        });
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stdout, result.stderr).not.toBe("");
+        expect(result.stdout).not.toMatch(/[\u001B\u0007]/u);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: testCase.message,
+          },
+        });
+        expect(result.stderr).toContain(testCase.message);
+      },
+      { prefix: "openclaw-plugins-json-failure-e2e-" },
+    );
+  });
+
+  it("keeps plugins search JSON failures clean through dual-TTY finalization", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const preload = `data:text/javascript,${encodeURIComponent(
+          'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true }); Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
+        )}`;
+        const result = runBuiltCli(tempHome, ["plugins", "search", "--json"], {
+          NODE_OPTIONS: `--import=${preload}`,
+        });
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: "Usage: openclaw plugins search <query>",
+          },
+        });
+        expect(result.stdout).not.toMatch(/[\u001B\u0007]/u);
+        expect(result.stderr).toContain("Usage: openclaw plugins search <query>");
+        expect(result.stderr).toContain("\u001B[?25h");
+      },
+      { prefix: "openclaw-plugins-json-tty-failure-e2e-" },
+    );
+  });
+
+  it.each([
+    {
       name: "search with a leaf JSON flag",
       args: ["skills", "search", "fixture", "--json"],
       message: "ClawHub /api/v1/search failed (400): offline fixture",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw plugins search --json` failures exited with empty stdout and human-only stderr. This affected both a missing search query and ClawHub transport failures, leaving scripts and agents without a parseable result.

## Why This Change Was Made

The plugin-search owner was consuming failures locally and terminating before the shared CLI failure renderer and finalizers could run. Missing-query failures now use the existing expected CLI error contract, while ClawHub errors escape to the root renderer only in JSON mode. Human-mode ClawHub errors and all success/no-results behavior remain unchanged.

## User Impact

Automation can reliably parse plugin-search failures as one canonical JSON document. Human users retain the existing actionable usage and transport diagnostics.

## Evidence

- Pre-fix owner regressions failed for the intended reason: both JSON cases threw the mocked `__exit__:1` instead of propagating the usage or transport error.
- Post-fix `src/cli/plugins-search-command.test.ts` — 5/5 passed, including both propagation regressions, successful JSON, result rendering, and limit validation.
- Built-process regressions cover missing query, deterministic ClawHub failure, exact canonical envelopes, exit 1, stderr guidance, ANSI-free stdout, and dual-TTY finalization.
- Targeted formatting and `git diff --check` passed.
- Fresh final-branch structured autoreview reported no accepted P0/P1 findings.
- Production delta: +6/-2, net +4. Tests: +88/-0.

Known local proof boundary: the host repeatedly terminated the repository build runner before it produced E2E runtime artifacts during concurrent owner work. Exact-head CI must run the built-process regressions before landing.

AI-assisted: yes. I reviewed the implementation and validation results.
