### PR TITLE
perf(onboarding): avoid broad provider-auth runtime imports

### DIFF
--- a/src/commands/auth-choice.apply.api-providers.ts
+++ b/src/commands/auth-choice.apply.api-providers.ts
@@ -1,7 +1,7 @@
 // Token-provider normalization hooks for provider-backed auth choices.
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveProviderMatch } from "../plugins/provider-auth-choice-helpers.js";
 import { resolvePluginProviders } from "../plugins/provider-auth-choice.runtime.js";
-import { normalizeTokenProviderInput } from "../plugins/provider-auth-input.js";
 import type { ProviderAuthKind } from "../plugins/types.js";
 import type { ApplyAuthChoiceParams } from "./auth-choice.apply.types.js";
 import type { AuthChoice } from "./onboard-types.js";
@@ -37,7 +37,7 @@ export function normalizeApiKeyTokenProviderAuthChoice(params: {
   if (!params.tokenProvider) {
     return params.authChoice;
   }
-  const normalizedTokenProvider = normalizeTokenProviderInput(params.tokenProvider);
+  const normalizedTokenProvider = normalizeOptionalLowercaseString(params.tokenProvider);
   if (!normalizedTokenProvider) {
     return params.authChoice;
   }

--- a/src/plugins/provider-auth-choice-helpers.ts
+++ b/src/plugins/provider-auth-choice-helpers.ts
@@ -1,4 +1,5 @@
 // Normalizes provider auth choice metadata from plugin setup surfaces.
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -11,7 +12,6 @@ import {
   toAgentEntriesRecord,
 } from "../agents/agent-scope-config.js";
 import { normalizeConfiguredProviderCatalogModelId } from "../agents/model-ref-shared.js";
-import { normalizeProviderId } from "../agents/model-selection.js";
 import {
   normalizeAgentModelMapForConfig,
   normalizeAgentModelRefForConfig,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Onboarding provider authentication loaded the complete agent model-selection and provider-credential runtime merely to lowercase provider selectors. The focused eight-case onboarding suite imported 1,344 modules for roughly 15 ms of actual test execution; the same accidental dependency edges also inflated production auth-choice loading.

## Why This Change Was Made

Use the existing canonical model-catalog provider-ID normalizer and existing canonical string normalizer directly at their actual consumers. Both previous wrappers delegate to those exact implementations, so provider aliases, selected-agent workspace ownership, manifest/catalog routing, public onboarding flags, profile persistence, and plugin boundaries remain unchanged. No mocks, test seams, dependencies, configuration, or production lines were added.

## User Impact

Onboarding provider-auth choice preparation avoids loading unrelated model-selection, runtime registry, plugin loader, session, and credential graphs. Provider selection and observable CLI/configuration behavior are unchanged.

## Evidence

Eight interleaved, order-balanced baseline/candidate pairs on the same Blacksmith Testbox, after excluded warmups; one Vitest worker, distinct filesystem module-cache paths, complete import-duration reporting, and `/usr/bin/time -v`:

| Pair | Baseline wall | Candidate wall | Improvement |
| --- | ---: | ---: | ---: |
| 1 | 7.23s | 4.31s | 2.92s |
| 2 | 7.10s | 4.47s | 2.63s |
| 3 | 6.94s | 4.37s | 2.57s |
| 4 | 7.14s | 4.47s | 2.67s |
| 5 | 7.30s | 4.32s | 2.98s |
| 6 | 7.13s | 4.46s | 2.67s |
| 7 | 7.21s | 4.42s | 2.79s |
| 8 | 7.01s | 4.38s | 2.63s |
| Mean | **7.13s** | **4.40s** | **2.73s / 38.3%** |

- Import phase: **3.36s → 0.70s** (79.1% faster); loaded modules: **1,344 → 404** (940 fewer).
- Peak RSS: **587,733 → 511,887 KiB** (12.9% lower).
- All eight original onboarding cases remain unchanged. Reversible fault injection removing selected-workspace forwarding failed the three corresponding API-key/token cases; weakening untrusted-workspace filtering failed the install-catalog case.
- Focused owner/sibling/package/provider proof: **142 tests across seven Vitest shards**, including interactive and non-interactive onboarding, provider-auth configuration, manifest trust policy, normalization contracts, OpenAI, and GitHub Copilot.
- Changed Vitest routing: **29 tests across two owner shards**.
- Complete `pnpm check:changed`, `pnpm build`, targeted formatting, `git diff --check`, and fresh structured autoreview.
- Production LOC: `+3/-3` (net zero). Tests: unchanged.
- Benchmark Testbox: `tbx_01m0k7mptwgqvanadkxwcvhh01`.

AI-assisted; no agent transcript.
