### PR TITLE
fix(feishu): prevent disallowed env credentials from authenticating requests

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -10,6 +10,12 @@ import {
   resolveFeishuCredentials,
   resolveFeishuRuntimeAccount,
 } from "./accounts.js";
+import {
+  FEISHU_SELECTED_SECRET_ENV,
+  FEISHU_SIBLING_SECRET_ENV,
+  createFeishuSecretRefPolicyConfig,
+  feishuSecretRefPolicyCases,
+} from "./bot.test-support.js";
 import type { FeishuConfig } from "./types.js";
 
 function makeDefaultAndRouterAccounts() {
@@ -190,18 +196,6 @@ describe("resolveFeishuCredentials", () => {
     ).toThrow(/unresolved SecretRef/i);
   });
 
-  it("returns null (without throwing) when unresolved SecretRef is allowed", () => {
-    const creds = resolveFeishuCredentials(
-      asConfig({
-        appId: "cli_123",
-        appSecret: { source: "file", provider: "default", id: "path/to/secret" } as never,
-      }),
-      { allowUnresolvedSecretRef: true },
-    );
-
-    expect(creds).toBeNull();
-  });
-
   it("supports explicit inspect mode for unresolved SecretRefs", () => {
     const creds = resolveFeishuCredentials(
       asConfig({
@@ -221,7 +215,7 @@ describe("resolveFeishuCredentials", () => {
     });
   });
 
-  it("resolves env SecretRef objects when unresolved refs are allowed", () => {
+  it("resolves env SecretRef objects in inspect mode", () => {
     const key = "FEISHU_APP_SECRET_TEST";
     const restore = setTestEnvValue(key, " secret_from_env ");
 
@@ -231,7 +225,7 @@ describe("resolveFeishuCredentials", () => {
           appId: "cli_123",
           appSecret: { source: "env", provider: "default", id: key } as never,
         }),
-        { allowUnresolvedSecretRef: true },
+        { mode: "inspect" },
       );
 
       expect(creds).toEqual({
@@ -246,7 +240,7 @@ describe("resolveFeishuCredentials", () => {
     }
   });
 
-  it("resolves env SecretRef with custom provider alias when unresolved refs are allowed", () => {
+  it("does not resolve an unconfigured custom provider alias", () => {
     const key = "FEISHU_APP_SECRET_CUSTOM_PROVIDER_TEST";
     const restore = setTestEnvValue(key, " secret_from_env_alias ");
 
@@ -256,10 +250,10 @@ describe("resolveFeishuCredentials", () => {
           appId: "cli_123",
           appSecret: { source: "env", provider: "corp-env", id: key } as never,
         }),
-        { allowUnresolvedSecretRef: true },
+        { mode: "inspect" },
       );
 
-      expect(creds?.appSecret).toBe("secret_from_env_alias");
+      expect(creds).toBeNull();
     } finally {
       restore();
     }
@@ -330,6 +324,52 @@ describe("resolveFeishuCredentials", () => {
 });
 
 describe("resolveFeishuAccount", () => {
+  it.each(feishuSecretRefPolicyCases)(
+    "enforces read-only provider policy for $name",
+    (testCase) => {
+      withEnvVar(FEISHU_SELECTED_SECRET_ENV, " selected-secret ", () => {
+        withEnvVar(FEISHU_SIBLING_SECRET_ENV, "sibling-secret", () => {
+          const account = resolveFeishuAccount({
+            cfg: createFeishuSecretRefPolicyConfig(testCase),
+            accountId: "selected",
+          });
+
+          expect(account.accountId).toBe("selected");
+          expect(account.configured).toBe(testCase.configured);
+          expect(account.appId).toBe(testCase.configured ? "selected-app" : undefined);
+          expect(account.appSecret).toBe(testCase.configured ? "selected-secret" : undefined);
+        });
+      });
+    },
+  );
+
+  it("applies the configured default env provider to refs without a provider", () => {
+    withEnvVar(FEISHU_SELECTED_SECRET_ENV, "selected-secret", () => {
+      const account = resolveFeishuAccount({
+        cfg: {
+          secrets: {
+            defaults: { env: "corp-env" },
+            providers: { "corp-env": { source: "env", allowlist: [FEISHU_SELECTED_SECRET_ENV] } },
+          },
+          channels: {
+            feishu: {
+              accounts: {
+                selected: {
+                  appId: "selected-app",
+                  appSecret: { source: "env", id: FEISHU_SELECTED_SECRET_ENV },
+                },
+              },
+            },
+          },
+        } as never,
+        accountId: "selected",
+      });
+
+      expect(account.configured).toBe(true);
+      expect(account.appSecret).toBe("selected-secret");
+    });
+  });
+
   it("uses top-level credentials with configured default account id even without account map entry", () => {
     const cfg = {
       channels: {
@@ -474,6 +514,20 @@ describe("resolveFeishuAccount", () => {
     expect(caught).toBeInstanceOf(FeishuSecretRefUnavailableError);
     expect((caught as Error).message).toMatch(/channels\.feishu\.appSecret: unresolved SecretRef/i);
   });
+
+  it.each(feishuSecretRefPolicyCases.filter((testCase) => testCase.configured))(
+    "does not resolve allowed ambient env refs in strict runtime account snapshots",
+    (testCase) => {
+      withEnvVar(FEISHU_SELECTED_SECRET_ENV, "selected-secret", () => {
+        expect(() =>
+          resolveFeishuRuntimeAccount({
+            cfg: createFeishuSecretRefPolicyConfig(testCase),
+            accountId: "selected",
+          }),
+        ).toThrow(FeishuSecretRefUnavailableError);
+      });
+    },
+  );
 
   it("ignores non-string account names", () => {
     const account = resolveFeishuAccount({

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -211,7 +211,7 @@ function mergeFeishuAccountConfig(cfg: ClawdbotConfig, accountId: string): Feish
  */
 export function resolveFeishuCredentials(
   cfg?: FeishuConfig,
-  options?: { mode?: FeishuCredentialResolutionMode },
+  options?: { mode?: FeishuCredentialResolutionMode; rootConfig?: ClawdbotConfig },
 ): {
   appId: string;
   appSecret: string;
@@ -220,11 +220,11 @@ export function resolveFeishuCredentials(
   domain: FeishuDomain;
 } | null {
   const mode = options?.mode ?? "strict";
-  const base = resolveFeishuBaseCredentials(cfg, mode);
+  const base = resolveFeishuBaseCredentials(cfg, mode, options?.rootConfig);
   if (!base) {
     return null;
   }
-  const eventSecrets = resolveFeishuEventSecrets(cfg, mode);
+  const eventSecrets = resolveFeishuEventSecrets(cfg, mode, options?.rootConfig);
 
   return {
     ...base,
@@ -232,8 +232,8 @@ export function resolveFeishuCredentials(
   };
 }
 
-export function inspectFeishuCredentials(cfg?: FeishuConfig) {
-  return resolveFeishuCredentials(cfg, { mode: "inspect" });
+export function inspectFeishuCredentials(cfg?: FeishuConfig, rootConfig?: ClawdbotConfig) {
+  return resolveFeishuCredentials(cfg, { mode: "inspect", rootConfig });
 }
 
 function buildResolvedFeishuAccount(params: {

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalAccountId,
 } from "openclaw/plugin-sdk/account-resolution";
 import { coerceSecretRef } from "openclaw/plugin-sdk/provider-auth";
+import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/secret-ref-readonly";
 import { normalizeOptionalString as normalizeString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   FeishuConfig,
@@ -54,27 +55,31 @@ export class FeishuSecretRefUnavailableError extends Error {
 }
 
 function resolveFeishuSecretLike(params: {
+  cfg?: ClawdbotConfig;
   value: unknown;
   path: string;
   mode: FeishuCredentialResolutionMode;
-  allowEnvSecretRefRead?: boolean;
 }): string | undefined {
   const asString = normalizeString(params.value);
   if (asString) {
     return asString;
   }
 
-  const ref = coerceSecretRef(params.value);
+  const ref = coerceSecretRef(params.value, params.cfg?.secrets?.defaults);
   if (!ref) {
     return undefined;
   }
 
   if (params.mode === "inspect") {
-    if (params.allowEnvSecretRefRead && ref.source === "env") {
-      const envValue = normalizeString(process.env[ref.id]);
-      if (envValue) {
-        return envValue;
-      }
+    if (
+      ref.source === "env" &&
+      canResolveEnvSecretRefInReadOnlyPath({
+        cfg: params.cfg,
+        provider: ref.provider,
+        id: ref.id,
+      })
+    ) {
+      return normalizeString(process.env[ref.id]);
     }
     return undefined;
   }
@@ -85,22 +90,23 @@ function resolveFeishuSecretLike(params: {
 function resolveFeishuBaseCredentials(
   cfg: FeishuConfig | undefined,
   mode: FeishuCredentialResolutionMode,
+  rootConfig?: ClawdbotConfig,
 ): {
   appId: string;
   appSecret: string;
   domain: FeishuDomain;
 } | null {
   const appId = resolveFeishuSecretLike({
+    cfg: rootConfig,
     value: cfg?.appId,
     path: "channels.feishu.appId",
     mode,
-    allowEnvSecretRefRead: true,
   });
   const appSecret = resolveFeishuSecretLike({
+    cfg: rootConfig,
     value: cfg?.appSecret,
     path: "channels.feishu.appSecret",
     mode,
-    allowEnvSecretRefRead: true,
   });
 
   if (!appId || !appSecret) {
@@ -117,6 +123,7 @@ function resolveFeishuBaseCredentials(
 function resolveFeishuEventSecrets(
   cfg: FeishuConfig | undefined,
   mode: FeishuCredentialResolutionMode,
+  rootConfig?: ClawdbotConfig,
 ): {
   encryptKey?: string;
   verificationToken?: string;
@@ -125,17 +132,17 @@ function resolveFeishuEventSecrets(
     encryptKey:
       (cfg?.connectionMode ?? "websocket") === "webhook"
         ? resolveFeishuSecretLike({
+            cfg: rootConfig,
             value: cfg?.encryptKey,
             path: "channels.feishu.encryptKey",
             mode,
-            allowEnvSecretRefRead: true,
           })
         : normalizeString(cfg?.encryptKey),
     verificationToken: resolveFeishuSecretLike({
+      cfg: rootConfig,
       value: cfg?.verificationToken,
       path: "channels.feishu.verificationToken",
       mode,
-      allowEnvSecretRefRead: true,
     }),
   };
 }
@@ -202,32 +209,9 @@ function mergeFeishuAccountConfig(cfg: ClawdbotConfig, accountId: string): Feish
 /**
  * Resolve Feishu credentials from a config.
  */
-export function resolveFeishuCredentials(cfg?: FeishuConfig): {
-  appId: string;
-  appSecret: string;
-  encryptKey?: string;
-  verificationToken?: string;
-  domain: FeishuDomain;
-} | null;
-export function resolveFeishuCredentials(
-  cfg: FeishuConfig | undefined,
-  options: {
-    mode?: FeishuCredentialResolutionMode;
-    allowUnresolvedSecretRef?: boolean;
-  },
-): {
-  appId: string;
-  appSecret: string;
-  encryptKey?: string;
-  verificationToken?: string;
-  domain: FeishuDomain;
-} | null;
 export function resolveFeishuCredentials(
   cfg?: FeishuConfig,
-  options?: {
-    mode?: FeishuCredentialResolutionMode;
-    allowUnresolvedSecretRef?: boolean;
-  },
+  options?: { mode?: FeishuCredentialResolutionMode },
 ): {
   appId: string;
   appSecret: string;
@@ -235,7 +219,7 @@ export function resolveFeishuCredentials(
   verificationToken?: string;
   domain: FeishuDomain;
 } | null {
-  const mode = options?.mode ?? (options?.allowUnresolvedSecretRef ? "inspect" : "strict");
+  const mode = options?.mode ?? "strict";
   const base = resolveFeishuBaseCredentials(cfg, mode);
   if (!base) {
     return null;
@@ -275,8 +259,8 @@ function buildResolvedFeishuAccount(params: {
   const merged = mergeFeishuAccountConfig(params.cfg, accountId);
   const accountEnabled = merged.enabled !== false;
   const enabled = baseEnabled && accountEnabled;
-  const baseCreds = resolveFeishuBaseCredentials(merged, params.baseMode);
-  const eventSecrets = resolveFeishuEventSecrets(merged, params.eventSecretMode);
+  const baseCreds = resolveFeishuBaseCredentials(merged, params.baseMode, params.cfg);
+  const eventSecrets = resolveFeishuEventSecrets(merged, params.eventSecretMode, params.cfg);
   const accountName = (merged as FeishuAccountConfig).name;
 
   return {

--- a/extensions/feishu/src/bot.test-support.ts
+++ b/extensions/feishu/src/bot.test-support.ts
@@ -18,7 +18,7 @@ type FeishuSecretRefPolicyCase = {
 export const FEISHU_SELECTED_SECRET_ENV = "FEISHU_SECRET_REF_SELECTED_TEST";
 export const FEISHU_SIBLING_SECRET_ENV = "FEISHU_SECRET_REF_SIBLING_TEST";
 
-export const feishuSecretRefPolicyCases = [
+export const feishuSecretRefPolicyCases: FeishuSecretRefPolicyCase[] = [
   {
     name: "unconfigured provider alias",
     provider: "unconfigured",
@@ -43,7 +43,7 @@ export const feishuSecretRefPolicyCases = [
     providers: { "corp-env": { source: "env", allowlist: [FEISHU_SELECTED_SECRET_ENV] } },
     configured: true,
   },
-] satisfies FeishuSecretRefPolicyCase[];
+];
 
 export function createFeishuTestConfig(
   feishu: FeishuConfig,

--- a/extensions/feishu/src/bot.test-support.ts
+++ b/extensions/feishu/src/bot.test-support.ts
@@ -8,6 +8,42 @@ type FeishuSender = FeishuMessageEvent["sender"];
 type TestConfigBase = Record<string, unknown> & {
   channels?: Record<string, unknown>;
 };
+type FeishuSecretRefPolicyCase = {
+  name: string;
+  provider: string;
+  providers: NonNullable<NonNullable<ClawdbotConfig["secrets"]>["providers"]>;
+  configured: boolean;
+};
+
+export const FEISHU_SELECTED_SECRET_ENV = "FEISHU_SECRET_REF_SELECTED_TEST";
+export const FEISHU_SIBLING_SECRET_ENV = "FEISHU_SECRET_REF_SIBLING_TEST";
+
+export const feishuSecretRefPolicyCases = [
+  {
+    name: "unconfigured provider alias",
+    provider: "unconfigured",
+    providers: {},
+    configured: false,
+  },
+  {
+    name: "provider configured with a non-env source",
+    provider: "corp-env",
+    providers: { "corp-env": { source: "file", path: "/unused" } },
+    configured: false,
+  },
+  {
+    name: "provider allowlist excluding the selected credential",
+    provider: "corp-env",
+    providers: { "corp-env": { source: "env", allowlist: [FEISHU_SIBLING_SECRET_ENV] } },
+    configured: false,
+  },
+  {
+    name: "configured env provider allowing the selected credential",
+    provider: "corp-env",
+    providers: { "corp-env": { source: "env", allowlist: [FEISHU_SELECTED_SECRET_ENV] } },
+    configured: true,
+  },
+] satisfies FeishuSecretRefPolicyCase[];
 
 export function createFeishuTestConfig(
   feishu: FeishuConfig,
@@ -17,6 +53,27 @@ export function createFeishuTestConfig(
     ...base,
     channels: { ...base.channels, feishu },
   } as ClawdbotConfig;
+}
+
+export function createFeishuSecretRefPolicyConfig({
+  provider,
+  providers,
+}: FeishuSecretRefPolicyCase): ClawdbotConfig {
+  return createFeishuTestConfig(
+    {
+      accounts: {
+        selected: {
+          appId: "selected-app",
+          appSecret: { source: "env", provider, id: FEISHU_SELECTED_SECRET_ENV },
+        },
+        sibling: {
+          appId: "sibling-app",
+          appSecret: { source: "env", provider: "default", id: FEISHU_SIBLING_SECRET_ENV },
+        },
+      },
+    },
+    { secrets: { providers } },
+  );
 }
 
 export function createFeishuTestEvent(params: {

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -86,9 +86,17 @@ vi.mock("./channel.runtime.js", () => ({
   },
 }));
 
-function getDescribedActions(cfg: OpenClawConfig, accountId?: string): string[] {
-  return [...(feishuPlugin.actions?.describeMessageTool?.({ cfg, accountId })?.actions ?? [])];
+function describeFeishuMessageTool(cfg: OpenClawConfig, accountId?: string) {
+  return feishuPlugin.actions?.describeMessageTool?.({ cfg, accountId });
 }
+
+function getDescribedActions(cfg: OpenClawConfig, accountId?: string): string[] {
+  return [...(describeFeishuMessageTool(cfg, accountId)?.actions ?? [])];
+}
+
+type FeishuSecretProviderConfig = NonNullable<
+  NonNullable<OpenClawConfig["secrets"]>["providers"]
+>[string];
 
 const requireRecord = createRequireRecord("record", "expected-label-capitalized");
 
@@ -307,6 +315,54 @@ describe("feishuPlugin actions", () => {
       "react",
       "reactions",
     ]);
+  });
+
+  it.each([
+    {
+      name: "file-backed default provider",
+      provider: { source: "file", path: "/unused" },
+      allowed: false,
+    },
+    {
+      name: "default provider allowlist exclusion",
+      provider: { source: "env", allowlist: ["OTHER_FEISHU_SECRET"] },
+      allowed: false,
+    },
+    {
+      name: "allowlisted default env provider",
+      provider: { source: "env", allowlist: ["FEISHU_DISCOVERY_SECRET"] },
+      allowed: true,
+    },
+  ] satisfies Array<{
+    name: string;
+    provider: FeishuSecretProviderConfig;
+    allowed: boolean;
+  }>)("enforces root SecretRef policy during discovery: $name", ({ provider, allowed }) => {
+    vi.stubEnv("FEISHU_DISCOVERY_SECRET", "ambient-secret");
+    try {
+      const discovery = describeFeishuMessageTool({
+        secrets: {
+          defaults: { env: "corp-env" },
+          providers: { "corp-env": provider },
+        },
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "cli_main",
+            appSecret: { source: "env", id: "FEISHU_DISCOVERY_SECRET" },
+          },
+        },
+      } as OpenClawConfig);
+
+      expect(discovery?.capabilities).toEqual(allowed ? ["presentation"] : []);
+      if (allowed) {
+        expect(discovery?.actions).toContain("send");
+      } else {
+        expect(discovery?.actions).toEqual([]);
+      }
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("declares native chat IDs as delivery targets for guarded message mutations", () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -354,7 +354,7 @@ function describeFeishuMessageTool({
     enabledAccounts.length > 0 ||
     (!accountId &&
       cfg.channels?.feishu?.enabled !== false &&
-      Boolean(inspectFeishuCredentials(cfg.channels?.feishu as FeishuConfig | undefined)));
+      Boolean(inspectFeishuCredentials(cfg.channels?.feishu as FeishuConfig | undefined, cfg)));
   if (enabledAccounts.length === 0) {
     return {
       actions: [],

--- a/extensions/feishu/src/directory.test.ts
+++ b/extensions/feishu/src/directory.test.ts
@@ -2,6 +2,12 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
+import {
+  FEISHU_SELECTED_SECRET_ENV,
+  FEISHU_SIBLING_SECRET_ENV,
+  createFeishuSecretRefPolicyConfig,
+  feishuSecretRefPolicyCases,
+} from "./bot.test-support.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 
@@ -59,6 +65,51 @@ describe("feishu directory (config-backed)", () => {
   beforeEach(() => {
     createFeishuClientMock.mockReset();
   });
+
+  it.each(feishuSecretRefPolicyCases)(
+    "permits live directory requests only under configured SecretRef policy: $name",
+    async (testCase) => {
+      vi.stubEnv(FEISHU_SELECTED_SECRET_ENV, "selected-secret");
+      vi.stubEnv(FEISHU_SIBLING_SECRET_ENV, "sibling-secret");
+      const listPeers = vi.fn(async () => ({ code: 0, data: { items: [] } }));
+      const listGroups = vi.fn(async () => ({ code: 0, data: { items: [] } }));
+      createFeishuClientMock.mockReturnValue({
+        contact: { user: { list: listPeers } },
+        im: { chat: { list: listGroups } },
+      });
+      const cfg = createFeishuSecretRefPolicyConfig(testCase);
+
+      try {
+        await expect(listFeishuDirectoryPeersLive({ cfg, accountId: "selected" })).resolves.toEqual(
+          [],
+        );
+        await expect(
+          listFeishuDirectoryGroupsLive({ cfg, accountId: "selected" }),
+        ).resolves.toEqual([]);
+
+        if (!testCase.configured) {
+          expect(createFeishuClientMock).not.toHaveBeenCalled();
+          expect(listPeers).not.toHaveBeenCalled();
+          expect(listGroups).not.toHaveBeenCalled();
+          return;
+        }
+
+        expect(createFeishuClientMock).toHaveBeenCalledTimes(2);
+        expect(createFeishuClientMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            accountId: "selected",
+            appId: "selected-app",
+            appSecret: "selected-secret", // pragma: allowlist secret
+            configured: true,
+          }),
+        );
+        expect(listPeers).toHaveBeenCalledOnce();
+        expect(listGroups).toHaveBeenCalledOnce();
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 
   it("merges allowFrom + dms into peer entries", async () => {
     const peers = await listFeishuDirectoryPeers({ cfg: makeStaticCfg(), query: "a" });

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -12,12 +12,22 @@ import {
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
+import {
+  FEISHU_SELECTED_SECRET_ENV,
+  FEISHU_SIBLING_SECRET_ENV,
+  createFeishuSecretRefPolicyConfig,
+  feishuSecretRefPolicyCases,
+} from "./bot.test-support.js";
+import type { FeishuClientCredentials } from "./client.js";
 
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
+const createFeishuClientMock = vi.hoisted(() =>
+  vi.fn((_account: FeishuClientCredentials) => ({ request: vi.fn() })),
+);
 const deliverCommentThreadTextMock = vi.hoisted(() => vi.fn());
 const cleanupAmbientCommentTypingReactionMock = vi.hoisted(() => vi.fn(async () => false));
 const shouldSuppressFeishuTextForVoiceMediaMock = vi.hoisted(
@@ -95,7 +105,7 @@ vi.mock("./runtime.js", () => ({
 }));
 
 vi.mock("./client.js", () => ({
-  createFeishuClient: vi.fn(() => ({ request: vi.fn() })),
+  createFeishuClient: createFeishuClientMock,
 }));
 
 vi.mock("./drive.js", () => ({
@@ -2194,6 +2204,54 @@ describe("feishuOutbound comment-thread routing", () => {
   beforeEach(() => {
     resetOutboundMocks();
   });
+
+  it.each(feishuSecretRefPolicyCases)(
+    "permits document-comment delivery only under configured SecretRef policy: $name",
+    async (testCase) => {
+      vi.stubEnv(FEISHU_SELECTED_SECRET_ENV, "selected-secret");
+      vi.stubEnv(FEISHU_SIBLING_SECRET_ENV, "sibling-secret");
+      createFeishuClientMock.mockImplementationOnce((account) => {
+        if (!account.appId || !account.appSecret) {
+          throw new Error(`Feishu credentials not configured for account "${account.accountId}"`);
+        }
+        return { request: vi.fn() };
+      });
+      const cfg = createFeishuSecretRefPolicyConfig(testCase);
+
+      try {
+        const delivery = sendText({
+          cfg,
+          to: "comment:docx:doxcn123:7623358762119646411",
+          text: "handled in thread",
+          accountId: "selected",
+        });
+
+        if (!testCase.configured) {
+          await expect(delivery).rejects.toThrow(
+            'Feishu credentials not configured for account "selected"',
+          );
+          expect(deliverCommentThreadTextMock).not.toHaveBeenCalled();
+          expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+          expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+          return;
+        }
+
+        expectFeishuResult(await delivery, "reply_msg");
+        expect(createFeishuClientMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            accountId: "selected",
+            appId: "selected-app",
+            appSecret: "selected-secret", // pragma: allowlist secret
+            configured: true,
+          }),
+        );
+        expect(deliverCommentThreadTextMock).toHaveBeenCalledOnce();
+        expect(commentThreadParams()?.content).toBe("handled in thread");
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 
   it("routes comment-thread text through deliverCommentThreadText", async () => {
     const result = await sendText({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu operators using SecretRef provider policy could have a disallowed ambient environment credential treated as configured during account inspection. That inspected credential could then reach authenticated document-comment delivery and live directory lookup paths despite an unconfigured provider alias, a provider with the wrong source, or an allowlist exclusion.

## Why This Change Was Made

Feishu account inspection now delegates provider authorization to the canonical Plugin SDK read-only SecretRef policy seam before reading an environment variable. The repair stays at the account snapshot owner, preserves per-account selection and strict resolved-runtime behavior, and removes the obsolete private relaxed-resolution option rather than adding downstream guards or another credential path.

The same four-case policy matrix covers the account owner, live directory lookup, and authenticated document-comment delivery: unconfigured provider, wrong source, allowlist rejection, and explicitly allowed access. Message-tool discovery also passes the full root config into the same inspection owner, closing the remaining fallback path identified during ClawSweeper review.

AI-assisted: implementation and review used Codex and Claude Code. I reviewed the final code and understand the change.

## User Impact

Feishu requests and capability discovery can no longer authenticate or enable behavior with ambient environment credentials that the configured SecretRef provider policy rejects. Valid literal credentials, configured provider defaults, and explicitly allowed environment references continue to work. Strict runtime snapshots remain fail-closed for unresolved references.

## Evidence

- Pre-fix regression: 10 intended failures demonstrated that denied provider-policy cases configured accounts and reached authenticated directory/comment boundaries.
- Focused native test command before the discovery follow-up:
  - `node scripts/run-vitest.mjs extensions/feishu/src/accounts.test.ts extensions/feishu/src/directory.test.ts extensions/feishu/src/outbound.test.ts -- --reporter=verbose`
  - Result: 3 files passed, 170 tests passed.
- Caller-level discovery regressions now cover a file-backed default provider, allowlist rejection, and explicitly allowed environment access.
- Formatting and whitespace: changed files pass `oxfmt` and `git diff --check`.
- Direct targeted type-aware `oxlint` passed for the initial changed surface.
- Fast guards passed: max-lines ratchet, assertion safety, extension wildcard re-export checks, Plugin SDK wildcard re-export checks, plugin boundary report, coercion helper guard, deprecated API usage, and import-cycle check.
- Independent focused security review: no findings.
- Fresh Codex autoreview after the discovery correction: clean, no accepted/actionable findings; patch correctness confidence 0.99.
- Production LOC: +28/-44 (net -16). Tests and test support: +295/-19 (net +276).
- First exact-head CI run exposed a test-only TypeScript union-inference failure; that was fixed with an explicit case-array annotation.
- ClawSweeper's discovery fallback finding was fixed in exact head `68d6b1e5ab73809496e2e178ca4cf657b01c4683`.
- Exact-head hosted CI is green: https://github.com/openclaw/openclaw/actions/runs/32538652931

Local aggregate wrappers and the post-review focused Vitest attempt were externally terminated with signal 16 / exit 144 without actionable diagnostics. Exact-head hosted CI covers the required test, type, lint, and boundary gates. The native Testbox-backed landing gate remains pending.

Merge gate: explicit Feishu owner acceptance from @m1heng is required on exact head `68d6b1e5ab73809496e2e178ca4cf657b01c4683` before landing.
