### PR TITLE
refactor(telegram): remove obsolete action runtime override

### DIFF
--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -23,13 +23,23 @@ describe("telegram actions contract", () => {
     ],
   });
 
-  it("exposes message resource aliases through the registered adapter", () => {
+  it("exposes provider-owned read gates and message resource aliases through the registered adapter", () => {
+    expect(telegramPlugin.actions?.providerOwnedReadGates).toEqual(["react", "edit", "delete"]);
     for (const action of ["react", "edit", "delete"] as const) {
       expect(telegramPlugin.actions?.messageActionTargetAliases?.[action]).toEqual({
         aliases: ["messageId"],
         deliveryTargetAliases: [],
       });
     }
+  });
+
+  it("routes registered message actions through the gateway", () => {
+    expect(telegramPlugin.actions?.resolveExecutionMode?.({ action: "send" as never })).toBe(
+      "gateway",
+    );
+    expect(telegramPlugin.actions?.resolveExecutionMode?.({ action: "read" as never })).toBe(
+      "gateway",
+    );
   });
 
   it.each([

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -72,7 +72,7 @@ function resolveTelegramMessageActionName(action: ChannelMessageActionName) {
   return TELEGRAM_MESSAGE_ACTION_MAP[action as keyof typeof TELEGRAM_MESSAGE_ACTION_MAP];
 }
 
-function prepareTelegramSendPayload({
+async function prepareTelegramSendPayload({
   ctx,
   payload,
 }: Parameters<NonNullable<ChannelMessageActionAdapter["prepareSendPayload"]>>[0]) {
@@ -217,6 +217,7 @@ function describeTelegramMessageTool({
 
 export const telegramMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeTelegramMessageTool,
+  providerOwnedReadGates: ["react", "edit", "delete"],
   resolveExecutionMode: () => "gateway",
   messageActionTargetAliases: {
     react: { aliases: ["messageId"], deliveryTargetAliases: [] },

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -274,15 +274,6 @@ afterEach(async () => {
 });
 
 describe("telegramPlugin gateway startup", () => {
-  it("routes message actions through the gateway", () => {
-    expect(telegramPlugin.actions?.resolveExecutionMode?.({ action: "send" as never })).toBe(
-      "gateway",
-    );
-    expect(telegramPlugin.actions?.resolveExecutionMode?.({ action: "read" as never })).toBe(
-      "gateway",
-    );
-  });
-
   it.each([401, 404] as const)(
     "stops before monitor startup when getMe rejects the token with %s",
     async (status) => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -4,7 +4,6 @@ import {
   buildDmGroupAccountAllowlistAdapter,
   createNestedAllowlistOverrideResolver,
 } from "openclaw/plugin-sdk/allowlist-config-edit";
-import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
 import {
   buildChannelOutboundSessionRoute,
   buildThreadAwareOutboundSessionRoute,
@@ -55,7 +54,7 @@ import {
 } from "./bot-info-cache.js";
 import type { TelegramBotInfo } from "./bot-info.js";
 import { buildTelegramRoutingTarget, type TelegramThreadSpec } from "./bot/helpers.js";
-import { telegramMessageActions as telegramMessageActionsImpl } from "./channel-actions.js";
+import { telegramMessageActions } from "./channel-actions.js";
 import {
   findTelegramTokenOwnerAccountId,
   formatDuplicateTelegramTokenReason,
@@ -88,7 +87,7 @@ import type { TelegramProbe } from "./probe.js";
 import * as probeModule from "./probe.js";
 import { resolveTelegramReactionLevel } from "./reaction-level.js";
 import { resolveTelegramStartupProbeTimeoutMs } from "./request-timeouts.js";
-import { getTelegramRuntime } from "./runtime.js";
+import { getOptionalTelegramRuntime, getTelegramRuntime } from "./runtime.js";
 import { telegramSecurityAdapter } from "./security.js";
 import { loadTelegramSendModule } from "./send-runtime.js";
 import {
@@ -206,14 +205,6 @@ function formatTelegramUnauthorizedTokenError(
   return `Telegram bot token unauthorized for account "${account.accountId}" (getMe returned ${status} from Telegram; source: ${source}). Update ${credentialPath} with the current BotFather token.`;
 }
 
-function getOptionalTelegramRuntime() {
-  try {
-    return getTelegramRuntime();
-  } catch {
-    return null;
-  }
-}
-
 async function resolveTelegramSend(deps?: OutboundSendDeps): Promise<TelegramSendFn> {
   return (
     resolveOutboundSendDep<TelegramSendFn>(deps, "telegram") ??
@@ -282,54 +273,6 @@ const telegramMessageAdapter = createChannelMessageAdapterFromOutbound<OpenClawC
   },
   outbound: telegramChannelOutbound,
 });
-
-const telegramMessageActions: ChannelMessageActionAdapter = {
-  providerOwnedReadGates: ["react", "edit", "delete"],
-  messageActionTargetAliases: telegramMessageActionsImpl.messageActionTargetAliases,
-  resolveExecutionMode: (ctx) =>
-    getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.resolveExecutionMode?.(ctx) ??
-    telegramMessageActionsImpl.resolveExecutionMode?.(ctx) ??
-    "gateway",
-  describeMessageTool: (ctx) =>
-    getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.describeMessageTool?.(ctx) ??
-    telegramMessageActionsImpl.describeMessageTool?.(ctx) ??
-    null,
-  resolveCliActionRequest: (ctx) =>
-    getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.resolveCliActionRequest?.(
-      ctx,
-    ) ??
-    telegramMessageActionsImpl.resolveCliActionRequest?.(ctx) ?? {
-      action: ctx.action,
-      args: ctx.args,
-    },
-  extractToolSend: (ctx) =>
-    getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.extractToolSend?.(ctx) ??
-    telegramMessageActionsImpl.extractToolSend?.(ctx) ??
-    null,
-  isToolDeliveryAction: (ctx) =>
-    getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.isToolDeliveryAction?.(ctx) ??
-    telegramMessageActionsImpl.isToolDeliveryAction?.(ctx) ??
-    false,
-  prepareSendPayload: async (ctx) => {
-    const runtimePrepareSendPayload =
-      getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.prepareSendPayload;
-    if (runtimePrepareSendPayload) {
-      return await runtimePrepareSendPayload(ctx);
-    }
-    return await telegramMessageActionsImpl.prepareSendPayload?.(ctx);
-  },
-  handleAction: async (ctx) => {
-    const runtimeHandleAction =
-      getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.handleAction;
-    if (runtimeHandleAction) {
-      return await runtimeHandleAction(ctx);
-    }
-    if (!telegramMessageActionsImpl.handleAction) {
-      throw new Error("Telegram message actions not available");
-    }
-    return await telegramMessageActionsImpl.handleAction(ctx);
-  },
-};
 
 function normalizeTelegramAcpConversationId(conversationId: string) {
   const parsed = parseTelegramTopicConversation({ conversationId });

--- a/extensions/telegram/src/runtime.types.ts
+++ b/extensions/telegram/src/runtime.types.ts
@@ -1,5 +1,4 @@
 // Telegram type declarations define plugin contracts.
-import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
 import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import type { TelegramMonitorFn } from "./monitor.types.js";
 
@@ -17,7 +16,6 @@ type TelegramChannelRuntime = {
   monitorTelegramProvider?: TelegramMonitorFn;
   sendMessageTelegram?: TelegramSendFn;
   resolveTelegramToken?: TelegramResolveTokenFn;
-  messageActions?: ChannelMessageActionAdapter;
 };
 
 interface TelegramRuntimeChannel extends BasePluginRuntimeChannel {


### PR DESCRIPTION
## What Problem This Solves

Removes a dormant Telegram whole-adapter runtime override that no supported production or test runtime populates. Keeping the unused seam duplicated message-action ownership and made the registered adapter differ from the canonical exported adapter.

## Why This Change Was Made

The canonical Telegram action adapter now owns its provider-read gates and gateway execution mode directly. The channel registers that adapter without a forwarding wrapper, while the active probe, monitor, send, and token runtime overrides remain unchanged.

## User Impact

No user-visible behavior changes. Telegram message actions retain the same execution routing and provider-owned authorization semantics, with less private runtime surface and 58 fewer net production lines.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/channel-actions.contract.test.ts extensions/telegram/src/channel-actions.test.ts extensions/telegram/src/channel.gateway.test.ts` — 3 files, 53 tests passed
- `./node_modules/.bin/oxfmt --check` on all five changed files — passed
- `git diff --check` — passed
- Fresh structured autoreview — no accepted/actionable findings
- Local `check:changed` and the broad build were attempted but externally terminated under host resource pressure before completing; exact-head CI is required before merge

AI-assisted: yes. The change and repository history were manually inspected, and the final diff was independently reviewed.
