### PR TITLE
fix(secrets): preserve authored env shorthand provenance

### DIFF
--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -7,7 +7,8 @@ import {
   getRuntimeConfigSourceSnapshot,
   hashRuntimeConfigValue,
 } from "../config/config.js";
-import { resolveMergedModelProviderConfig } from "../config/model-provider-config.js";
+import { resolveMergedModelProviderEntry } from "../config/model-provider-config.js";
+import { resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
@@ -79,7 +80,23 @@ export function resolveProviderConfig(
   cfg: OpenClawConfig | undefined,
   provider: string,
 ): ModelProviderConfig | undefined {
-  return resolveMergedModelProviderConfig(cfg, provider);
+  return resolveMergedModelProviderEntry(cfg, provider)?.providerConfig;
+}
+
+function resolveProviderConfigSecretInput(cfg: OpenClawConfig | undefined, provider: string) {
+  const entry = resolveMergedModelProviderEntry(cfg, provider);
+  const providerConfig = entry?.providerConfig;
+  return {
+    providerConfig,
+    ref: entry
+      ? resolveConfigSecretRef({
+          config: cfg,
+          path: `models.providers.${entry.providerKey}.apiKey`,
+          value: providerConfig?.apiKey,
+          defaults: cfg?.secrets?.defaults,
+        })
+      : null,
+  };
 }
 
 /** Reads a literal or env-secret marker for a custom provider entry. */
@@ -87,14 +104,9 @@ export function getCustomProviderApiKey(
   cfg: OpenClawConfig | undefined,
   provider: string,
 ): string | undefined {
-  const entry = resolveProviderConfig(cfg, provider);
-  const literal = normalizeOptionalSecretInput(entry?.apiKey);
-  if (literal) {
-    return literal;
-  }
-  const ref = coerceSecretRef(entry?.apiKey);
+  const { providerConfig, ref } = resolveProviderConfigSecretInput(cfg, provider);
   if (!ref) {
-    return undefined;
+    return normalizeOptionalSecretInput(providerConfig?.apiKey);
   }
   if (ref.source === "env") {
     const envId = ref.id.trim();
@@ -115,8 +127,10 @@ export function resolveUsableCustomProviderApiKey(params: {
   env?: NodeJS.ProcessEnv;
   secretSentinels?: boolean;
 }): ResolvedCustomProviderApiKey | null {
-  const customProviderConfig = resolveProviderConfig(params.cfg, params.provider);
-  const apiKeyRef = coerceSecretRef(customProviderConfig?.apiKey);
+  const { providerConfig: customProviderConfig, ref: apiKeyRef } = resolveProviderConfigSecretInput(
+    params.cfg,
+    params.provider,
+  );
   if (apiKeyRef) {
     if (apiKeyRef.source !== "env") {
       return null;
@@ -151,7 +165,7 @@ export function resolveUsableCustomProviderApiKey(params: {
     };
   }
 
-  const customKey = getCustomProviderApiKey(params.cfg, params.provider);
+  const customKey = normalizeOptionalSecretInput(customProviderConfig?.apiKey);
   if (!customKey) {
     return null;
   }
@@ -392,8 +406,8 @@ export function resolveProviderEntryApiKeyProfileReference(params: {
   provider: string;
   store: AuthProfileStore;
 }): ProviderEntryApiKeyProfileReference {
-  const providerConfig = resolveProviderConfig(params.cfg, params.provider);
-  if (coerceSecretRef(providerConfig?.apiKey)) {
+  const { providerConfig, ref } = resolveProviderConfigSecretInput(params.cfg, params.provider);
+  if (ref) {
     return { kind: "none" };
   }
   const perEntryRawKey = normalizeOptionalSecretInput(providerConfig?.apiKey);
@@ -599,8 +613,9 @@ export function hasSecretRefProviderApiKey(
   cfg: OpenClawConfig | undefined,
   provider: string,
 ): boolean {
-  const apiKey = resolveProviderConfig(cfg, provider)?.apiKey;
-  if (coerceSecretRef(apiKey)) {
+  const { providerConfig, ref } = resolveProviderConfigSecretInput(cfg, provider);
+  const apiKey = providerConfig?.apiKey;
+  if (ref) {
     return true;
   }
   return (
@@ -666,9 +681,8 @@ export function resolveLiteralProviderConfigApiKeyAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
 }): ResolvedProviderAuth | undefined {
-  const apiKey = normalizeOptionalSecretInput(
-    resolveProviderConfig(params.cfg, params.provider)?.apiKey,
-  );
+  const { providerConfig, ref } = resolveProviderConfigSecretInput(params.cfg, params.provider);
+  const apiKey = ref ? undefined : normalizeOptionalSecretInput(providerConfig?.apiKey);
   if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
     return undefined;
   }

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -540,6 +540,49 @@ describe("resolveUsableCustomProviderApiKey", () => {
     });
   });
 
+  it.each([
+    { name: "unresolved bare shorthand", authored: "$MISSING", env: {}, expected: null },
+    { name: "unresolved braced shorthand", authored: "${MISSING}", env: {}, expected: null },
+    {
+      name: "substituted template-looking literal",
+      authored: "${SOURCE}",
+      env: { SOURCE: "${OTHER}" },
+      expected: "${OTHER}",
+    },
+  ])(
+    "preserves authored custom-provider credentials: $name",
+    async ({ authored, env, expected }) => {
+      const [{ resolveConfigForRead }, { setConfigResolutionFacts }] = await Promise.all([
+        import("../config/io.read-helpers.js"),
+        import("../config/resolution-facts.js"),
+      ]);
+      const read = resolveConfigForRead(
+        {
+          models: {
+            providers: {
+              custom: {
+                baseUrl: "https://example.com/v1",
+                apiKey: authored,
+                models: [],
+              },
+            },
+          },
+        },
+        env,
+      );
+      const cfg = read.resolvedConfigRaw as NonNullable<
+        Parameters<typeof resolveUsableCustomProviderApiKey>[0]["cfg"]
+      >;
+      setConfigResolutionFacts(cfg, read.resolutionFacts);
+
+      const resolved = resolveUsableCustomProviderApiKey({ cfg, provider: "custom", env: {} });
+
+      expect(resolved).toEqual(
+        expected === null ? null : { apiKey: expected, source: "models.json" },
+      );
+    },
+  );
+
   it("does not treat non-env markers as usable credentials", () => {
     const resolved = resolveUsableCustomProviderApiKey({
       cfg: {

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -4,6 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveConfigForRead } from "../config/io.read-helpers.js";
+import {
+  getAuthoredConfigSecretRef,
+  setConfigResolutionFacts,
+} from "../config/resolution-facts.js";
 import { collectConfigAssignments as collectRuntimeConfigAssignments } from "../secrets/runtime-config-collectors.js";
 import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -336,6 +341,39 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     });
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("sk-live");
   });
+
+  it.each(["$OTHER", "${OTHER}"])(
+    "preserves source provenance while gateway assignments materialize literal %s",
+    async (resolvedLiteral) => {
+      const read = resolveConfigForRead(buildTalkTestProviderConfig("$SOURCE"), {});
+      const config = read.resolvedConfigRaw as OpenClawConfig;
+      setConfigResolutionFacts(config, read.resolutionFacts);
+      callGateway.mockResolvedValueOnce({
+        assignments: [
+          {
+            path: TALK_TEST_PROVIDER_API_KEY_PATH,
+            pathSegments: [...TALK_TEST_PROVIDER_API_KEY_PATH_SEGMENTS],
+            value: resolvedLiteral,
+          },
+        ],
+      });
+
+      const result = await resolveCommandSecretRefsViaGateway({
+        config,
+        commandName: "memory status",
+        targetIds: new Set(["talk.providers.*.apiKey"]),
+      });
+
+      expect(readTalkProviderApiKey(result.resolvedConfig)).toBe(resolvedLiteral);
+      expect(getAuthoredConfigSecretRef(config, TALK_TEST_PROVIDER_API_KEY_PATH)?.id).toBe(
+        "SOURCE",
+      );
+      expect(
+        getAuthoredConfigSecretRef(result.resolvedConfig, TALK_TEST_PROVIDER_API_KEY_PATH),
+      ).toBeNull();
+      expect(result.hadUnresolvedTargets).toBe(false);
+    },
+  );
 
   it("uses the explicit agent owner during channels resolve secret preflight", async () => {
     const channelPath = "channels.telegram.botToken";

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -5,6 +5,11 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { validateSecretsResolveResult } from "../../packages/gateway-protocol/src/index.js";
+import {
+  cloneConfigWithResolutionFacts,
+  copyConfigResolutionFactsExcept,
+  resolveConfigSecretRef,
+} from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { callGateway } from "../gateway/call.js";
@@ -276,7 +281,12 @@ function collectConfiguredTargetRefPaths(params: {
       continue;
     }
     const { ref } = resolveSecretInputRef({
-      value: target.value,
+      value: resolveConfigSecretRef({
+        config: params.config,
+        path: target.path,
+        value: target.value,
+        defaults,
+      }),
       refValue: target.refValue,
       defaults,
     });
@@ -310,7 +320,7 @@ function classifyConfiguredTargetRefs(params: {
     env: process.env,
   });
   commandSecretGatewayDeps.collectConfigAssignments({
-    config: structuredClone(params.config),
+    config: cloneConfigWithResolutionFacts(params.config),
     context,
     agentId: params.agentId,
   });
@@ -554,7 +564,7 @@ async function resolveCommandSecretRefsLocally(params: {
   resolutionPolicy: CommandSecretResolutionPolicy;
 }): Promise<ResolveCommandSecretsResult> {
   const sourceConfig = params.config;
-  const resolvedConfig = structuredClone(params.config);
+  const resolvedConfig = cloneConfigWithResolutionFacts(params.config);
   const context = createResolverContext({
     sourceConfig,
     env: process.env,
@@ -567,7 +577,7 @@ async function resolveCommandSecretRefsLocally(params: {
     targetsRuntimeWebPath(target.path),
   );
   commandSecretGatewayDeps.collectConfigAssignments({
-    config: structuredClone(params.config),
+    config: cloneConfigWithResolutionFacts(params.config),
     context,
     agentId: params.agentId,
   });
@@ -783,7 +793,12 @@ async function resolveTargetSecretLocally(params: {
 }): Promise<void> {
   const defaults = params.sourceConfig.secrets?.defaults;
   const { ref } = resolveSecretInputRef({
-    value: params.target.value,
+    value: resolveConfigSecretRef({
+      config: params.sourceConfig,
+      path: params.target.path,
+      value: params.target.value,
+      defaults,
+    }),
     refValue: params.target.refValue,
     defaults,
   });
@@ -821,6 +836,9 @@ async function resolveTargetSecretLocally(params: {
           : `${params.target.path} resolved to an unsupported value type.`,
     });
     setPathExistingStrict(params.resolvedConfig, params.target.pathSegments, resolved);
+    copyConfigResolutionFactsExcept(params.resolvedConfig, params.resolvedConfig, [
+      params.target.path,
+    ]);
   } catch (error) {
     if (!enforcesResolvedSecrets(params.mode)) {
       params.localResolutionDiagnostics.push(
@@ -983,28 +1001,31 @@ export async function resolveCommandSecretRefsViaGateway(params: {
   const gatewayInactiveRefPaths = params.allowedPaths
     ? parsed.inactiveRefPaths.filter((path) => params.allowedPaths?.has(path))
     : parsed.inactiveRefPaths;
-  const resolvedConfig = structuredClone(params.config);
+  const resolvedConfig = cloneConfigWithResolutionFacts(params.config);
   const assignments = params.allowedPaths
     ? parsed.assignments.filter((assignment) => {
         const path = assignment.path ?? assignment.pathSegments.join(".");
         return params.allowedPaths?.has(path);
       })
     : parsed.assignments;
+  const resolvedAssignmentPaths: string[] = [];
   for (const assignment of assignments) {
     const pathSegments = assignment.pathSegments.filter((segment) => segment.length > 0);
     if (pathSegments.length === 0) {
       continue;
     }
+    const path = pathSegments.join(".");
     try {
       setPathExistingStrict(resolvedConfig, pathSegments, assignment.value);
+      resolvedAssignmentPaths.push(path);
     } catch (err) {
-      const path = pathSegments.join(".");
       throw new Error(
         `${params.commandName}: failed to apply resolved secret assignment at ${path} (${formatErrorMessage(err)}).`,
         { cause: err },
       );
     }
   }
+  copyConfigResolutionFactsExcept(resolvedConfig, resolvedConfig, resolvedAssignmentPaths);
   const inactiveRefPaths = new Set(
     gatewayInactiveRefPaths.length > 0
       ? gatewayInactiveRefPaths
@@ -1080,6 +1101,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         handledPaths.add(unresolved.path);
         locallyResolvedPaths.add(unresolved.path);
       }
+      copyConfigResolutionFactsExcept(resolvedConfig, resolvedConfig, [...locallyResolvedPaths]);
       diagnostics = dedupeDiagnostics([...diagnostics, ...localFallback.diagnostics]);
       const stillUnresolved = analyzed.unresolved.filter((entry) => !handledPaths.has(entry.path));
       if (stillUnresolved.length > 0) {

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -109,10 +109,16 @@ vi.mock("../../config/paths.js", () => ({
   resolveIsNixMode: resolveIsNixModeMock,
 }));
 
-vi.mock("../../config/types.secrets.js", () => ({
-  hasConfiguredSecretInput: hasConfiguredSecretInputMock,
-  resolveSecretInputRef: resolveSecretInputRefMock,
-}));
+vi.mock("../../config/types.secrets.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/types.secrets.js")>();
+  return {
+    ...actual,
+    coerceSecretRef: (value: unknown, defaults?: unknown) =>
+      resolveSecretInputRefMock({ value, defaults })?.ref ?? null,
+    hasConfiguredSecretInput: hasConfiguredSecretInputMock,
+    resolveSecretInputRef: resolveSecretInputRefMock,
+  };
+});
 
 vi.mock("../../gateway/auth.js", () => ({
   resolveGatewayAuth: resolveGatewayAuthMock,

--- a/src/commands/models/list.probe.targets.test.ts
+++ b/src/commands/models/list.probe.targets.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveConfigForRead } from "../../config/io.read-helpers.js";
+import { setConfigResolutionFacts } from "../../config/resolution-facts.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 
 let mockStore: AuthProfileStore;
@@ -445,6 +447,49 @@ describe("buildProbeTargets reason codes", () => {
       }),
     );
   });
+
+  it.each([
+    ["missing bare with authored provider spelling", "$MISSING", undefined, null, "AnThRoPiC"],
+    ["missing braced", "${MISSING}", undefined, null, "anthropic"],
+    ["ordinary substitution", "${SOURCE}", "resolved-secret", "resolved-secret", "anthropic"],
+    ["bare-looking literal", "${SOURCE}", "$OTHER", "$OTHER", "anthropic"],
+    ["braced-looking literal", "${SOURCE}", "${OTHER}", "${OTHER}", "anthropic"],
+    ["escaped template literal", "$${OTHER}", undefined, "${OTHER}", "anthropic"],
+  ] as const)(
+    "preserves authored credential provenance: %s",
+    async (_name, authored, sourceValue, expected, providerKey) => {
+      mockStore = { version: 1, profiles: {}, order: {} };
+      resolveSecretRefStringMock.mockRejectedValue(new Error("missing secret"));
+      const providerConfig = {
+        baseUrl: "https://api.anthropic.com/v1",
+        apiKey: authored,
+        models: [],
+      };
+      const read = resolveConfigForRead(
+        { models: { providers: { [providerKey]: providerConfig } } },
+        sourceValue === undefined ? {} : { SOURCE: sourceValue },
+      );
+      const cfg = read.resolvedConfigRaw as OpenClawConfig;
+      setConfigResolutionFacts(cfg, read.resolutionFacts);
+
+      const plan = await withClearedAnthropicEnv(async () =>
+        buildProbeTargets({
+          cfg,
+          providers: ["anthropic"],
+          modelCandidates: ["anthropic/claude-sonnet-4-6"],
+          options: { includeDirectKeys: true, timeoutMs: 5_000, concurrency: 1, maxTokens: 16 },
+        }),
+      );
+
+      if (expected === null) {
+        expect(plan.targets).toEqual([]);
+        expect(plan.results[0]).toMatchObject({ label: "config", reasonCode: "unresolved_ref" });
+        return;
+      }
+      expect(plan.results).toEqual([]);
+      expect(plan.targets[0]).toMatchObject({ label: "config", boundValue: expected });
+    },
+  );
 
   it("deduplicates matching config and environment credentials", async () => {
     mockStore = { version: 1, profiles: {}, order: {} };

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -49,6 +49,12 @@ import { loadPreparedModelCatalog } from "../../agents/prepared-model-catalog.js
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
+import { resolveMergedModelProviderEntry } from "../../config/model-provider-config.js";
+import {
+  copyConfigResolutionFacts,
+  copyConfigResolutionFactsExcept,
+  resolveConfigSecretRef,
+} from "../../config/resolution-facts.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -258,14 +264,14 @@ function withDirectCredential(
   mode: string | undefined,
 ): OpenClawConfig {
   const providers = cfg.models?.providers ?? {};
-  const configKey =
-    Object.keys(providers).find((key) => normalizeProviderId(key) === provider) ?? provider;
-  const configured = providers[configKey];
+  const configuredEntry = resolveMergedModelProviderEntry(cfg, provider);
+  const configKey = configuredEntry?.providerKey ?? provider;
+  const configured = configuredEntry?.providerConfig;
   if (!configured) {
     return withoutProfileFallback(cfg, provider);
   }
   const auth = mode === "oauth" || mode === "token" ? mode : "api-key";
-  return {
+  const next: OpenClawConfig = {
     ...cfg,
     models: {
       ...cfg.models,
@@ -286,10 +292,12 @@ function withDirectCredential(
       },
     },
   };
+  copyConfigResolutionFactsExcept(cfg, next, [`models.providers.${configKey}.apiKey`]);
+  return next;
 }
 
 function withoutProfileFallback(cfg: OpenClawConfig, provider: string): OpenClawConfig {
-  return {
+  const next: OpenClawConfig = {
     ...cfg,
     auth: {
       ...cfg.auth,
@@ -299,20 +307,24 @@ function withoutProfileFallback(cfg: OpenClawConfig, provider: string): OpenClaw
       },
     },
   };
+  copyConfigResolutionFacts(cfg, next);
+  return next;
 }
 
 async function resolveConfiguredProbeCredential(params: {
   cfg: OpenClawConfig;
   input: unknown;
+  path: string;
   cache: SecretRefResolveCache;
 }): Promise<string | null> {
-  const literal = normalizeSecretInputString(params.input);
-  if (literal !== undefined) {
-    return literal;
-  }
-  const ref = coerceSecretRef(params.input, params.cfg.secrets?.defaults);
+  const ref = resolveConfigSecretRef({
+    config: params.cfg,
+    path: params.path,
+    value: params.input,
+    defaults: params.cfg.secrets?.defaults,
+  });
   if (!ref) {
-    return null;
+    return normalizeSecretInputString(params.input) ?? null;
   }
   try {
     return await resolveSecretRefString(ref, {
@@ -404,7 +416,8 @@ export async function buildProbeTargets(params: {
       candidates,
       catalog,
     });
-    const configuredProvider = findNormalizedProviderValue(cfg.models?.providers, providerKey);
+    const configuredProviderEntry = resolveMergedModelProviderEntry(cfg, providerKey);
+    const configuredProvider = configuredProviderEntry?.providerConfig;
     const includeDirectKeys = options.includeDirectKeys === true && profileFilter.size === 0;
     const includeConfigKey =
       includeDirectKeys &&
@@ -435,6 +448,7 @@ export async function buildProbeTargets(params: {
           })
         : null;
     const configuredValue =
+      configuredProviderEntry &&
       includeConfigKey &&
       configuredReference.kind !== "profile" &&
       configuredReference.kind !== "profile-incompatible"
@@ -447,6 +461,7 @@ export async function buildProbeTargets(params: {
           : await resolveConfiguredProbeCredential({
               cfg,
               input: configuredProvider?.apiKey,
+              path: `models.providers.${configuredProviderEntry.providerKey}.apiKey`,
               cache: refResolveCache,
             })
         : null;

--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -23,6 +23,7 @@
 // Pattern for valid uppercase env var names: starts with letter or underscore,
 // followed by letters, numbers, or underscores (all uppercase)
 import { isPlainObject } from "../utils.js";
+import { parseEnvTemplateSecretRef } from "./types.secrets.js";
 
 const ENV_VAR_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
@@ -86,6 +87,8 @@ export type EnvSubstitutionWarning = {
 type SubstituteOptions = {
   /** When set, missing vars call this instead of throwing and the original placeholder is preserved. */
   onMissing?: (warning: EnvSubstitutionWarning) => void;
+  /** Records exact env SecretRef shorthand that substitution did not materialize. */
+  onPendingEnvSecretRef?: (id: string, configPath: string) => void;
 };
 
 function substituteString(
@@ -98,6 +101,10 @@ function substituteString(
     return value;
   }
 
+  const authoredRef = parseEnvTemplateSecretRef(value);
+  if (authoredRef && !containsEnvVarReference(value)) {
+    opts?.onPendingEnvSecretRef?.(authoredRef.id, configPath);
+  }
   const chunks: string[] = [];
 
   for (let i = 0; i < value.length; i += 1) {
@@ -118,6 +125,9 @@ function substituteString(
       if (envValue === undefined || envValue === "") {
         if (opts?.onMissing) {
           opts.onMissing({ varName: token.name, configPath });
+          if (authoredRef?.id === token.name) {
+            opts.onPendingEnvSecretRef?.(token.name, configPath);
+          }
           // Preserve the original placeholder so the value is visibly unresolved.
           chunks.push(`\${${token.name}}`);
           i = token.end;

--- a/src/config/io.read-helpers.ts
+++ b/src/config/io.read-helpers.ts
@@ -310,14 +310,20 @@ export function resolveConfigForRead(
     applyConfigEnvVars(resolvedIncludes as OpenClawConfig, env, { lowerPrecedenceEnv });
   }
   const envWarnings: EnvSubstitutionWarning[] = [];
+  const pendingEnvSecretRefs = new Map<string, string>();
   const resolvedConfigRaw = resolveConfigEnvVars(resolvedIncludes, env, {
     onMissing: (warning) => envWarnings.push(warning),
+    onPendingEnvSecretRef: (id, configPath) => pendingEnvSecretRefs.set(configPath, id),
   });
   return {
     resolvedConfigRaw,
     envSnapshotForRestore: { ...env } as Record<string, string | undefined>,
     envWarnings,
-    resolutionFacts: createConfigResolutionFacts(envWarnings),
+    resolutionFacts: createConfigResolutionFacts(
+      envWarnings,
+      pendingEnvSecretRefs,
+      coerceConfig(resolvedConfigRaw).secrets?.defaults?.env,
+    ),
   };
 }
 

--- a/src/config/io.snapshot.test.ts
+++ b/src/config/io.snapshot.test.ts
@@ -9,7 +9,11 @@ import {
   readConfigFileSnapshotFromContext,
   readConfigFileSnapshotWithPluginMetadataFromContext,
 } from "./io.snapshot.js";
-import { getConfigResolutionFacts } from "./resolution-facts.js";
+import {
+  cloneConfigWithResolutionFacts,
+  getAuthoredConfigSecretRef,
+  getConfigResolutionFacts,
+} from "./resolution-facts.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -52,6 +56,7 @@ describe("config snapshot plugin metadata", () => {
           },
           remote: { token: "${GATEWAY_TOKEN}", password: "literal-${" },
         },
+        hooks: { token: "$MISSING_HOOK_TOKEN" },
       }),
       "utf8",
     );
@@ -64,6 +69,20 @@ describe("config snapshot plugin metadata", () => {
     expect(snapshot.config.gateway?.auth?.token).toBe("${ESCAPED_GATEWAY_TOKEN}");
     expect(snapshot.config.gateway?.remote?.token).toBe("${ENV_LITERAL_GATEWAY_TOKEN}");
     expect(snapshot.config.gateway?.remote?.password).toBe("literal-${");
+    expect(getAuthoredConfigSecretRef(snapshot.config, "hooks.token")).toEqual({
+      source: "env",
+      provider: "default",
+      id: "MISSING_HOOK_TOKEN",
+    });
+    expect(getAuthoredConfigSecretRef(snapshot.config, "gateway.auth.password")?.id).toBe(
+      "MISSING_GATEWAY_PASSWORD",
+    );
+    expect(getAuthoredConfigSecretRef(snapshot.config, "gateway.auth.token")).toBeNull();
+    expect(getAuthoredConfigSecretRef(snapshot.config, "gateway.remote.token")).toBeNull();
+    expect(
+      getAuthoredConfigSecretRef(cloneConfigWithResolutionFacts(snapshot.config), "hooks.token")
+        ?.id,
+    ).toBe("MISSING_HOOK_TOKEN");
     expect(JSON.stringify(snapshot)).not.toContain("resolutionFacts");
   });
 

--- a/src/config/resolution-facts.ts
+++ b/src/config/resolution-facts.ts
@@ -1,13 +1,34 @@
 import type { EnvSubstitutionWarning } from "./env-substitution.js";
+import { coerceSecretRef, DEFAULT_SECRET_PROVIDER_ALIAS, type SecretRef } from "./types.secrets.js";
+
 /** `null` means this value has not passed through authoritative config env substitution. */
 export type ConfigResolutionFacts = ReadonlySet<string> | null;
 
 const configResolutionFacts = new WeakMap<object, ReadonlySet<string>>();
+const authoredSecretRefsByFacts = new WeakMap<
+  ReadonlySet<string>,
+  ReadonlyMap<string, SecretRef>
+>();
 
 export function createConfigResolutionFacts(
   warnings: readonly EnvSubstitutionWarning[],
+  pendingEnvSecretRefs: ReadonlyMap<string, string> = new Map(),
+  envProvider: string | undefined = DEFAULT_SECRET_PROVIDER_ALIAS,
 ): ReadonlySet<string> {
-  return new Set(warnings.map(({ configPath }) => configPath));
+  const facts = new Set(warnings.map(({ configPath }) => configPath));
+  if (pendingEnvSecretRefs.size > 0) {
+    const provider = envProvider?.trim() || DEFAULT_SECRET_PROVIDER_ALIAS;
+    authoredSecretRefsByFacts.set(
+      facts,
+      new Map(
+        [...pendingEnvSecretRefs].map(([path, id]) => [
+          path,
+          { source: "env", provider, id } satisfies SecretRef,
+        ]),
+      ),
+    );
+  }
+  return facts;
 }
 
 export function setConfigResolutionFacts(target: unknown, facts: ConfigResolutionFacts): void {
@@ -45,13 +66,46 @@ export function copyConfigResolutionFactsExcept(
     setConfigResolutionFacts(target, null);
     return;
   }
+  const authoredSecretRefs = authoredSecretRefsByFacts.get(facts);
+  if (
+    paths.length === 0 ||
+    !paths.some((path) => facts.has(path) || authoredSecretRefs?.has(path) === true)
+  ) {
+    setConfigResolutionFacts(target, facts);
+    return;
+  }
   const remaining = new Set(facts);
   paths.forEach((path) => remaining.delete(path));
-  setConfigResolutionFacts(target, remaining.size === facts.size ? facts : remaining);
+  if (authoredSecretRefs) {
+    const remainingAuthoredSecretRefs = new Map(authoredSecretRefs);
+    paths.forEach((path) => remainingAuthoredSecretRefs.delete(path));
+    if (remainingAuthoredSecretRefs.size > 0) {
+      authoredSecretRefsByFacts.set(remaining, remainingAuthoredSecretRefs);
+    }
+  }
+  setConfigResolutionFacts(target, remaining);
 }
 
 export function hasUnresolvedConfigPath(target: unknown, path: string): boolean {
   return getConfigResolutionFacts(target)?.has(path) === true;
+}
+
+/** Returns only a still-pending reference recorded from the authored config source. */
+export function getAuthoredConfigSecretRef(target: unknown, path: string): SecretRef | null {
+  const facts = getConfigResolutionFacts(target);
+  return facts ? (authoredSecretRefsByFacts.get(facts)?.get(path) ?? null) : null;
+}
+
+/** Reads inline references from authored facts and structured references from their values. */
+export function resolveConfigSecretRef(params: {
+  config: unknown;
+  path: string;
+  value: unknown;
+  defaults?: Parameters<typeof coerceSecretRef>[1];
+}): SecretRef | null {
+  return typeof params.value === "string" && getConfigResolutionFacts(params.config) !== null
+    ? getAuthoredConfigSecretRef(params.config, params.path)
+    : coerceSecretRef(params.value, params.defaults);
 }
 
 export function hasUnresolvedConfigPathInSubtree(target: unknown, path: string): boolean {

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -1,6 +1,11 @@
 // Verifies runtime config snapshots preserve normalized public settings.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getConfigResolutionFacts, setConfigResolutionFacts } from "./resolution-facts.js";
+import {
+  createConfigResolutionFacts,
+  getAuthoredConfigSecretRef,
+  getConfigResolutionFacts,
+  setConfigResolutionFacts,
+} from "./resolution-facts.js";
 import {
   finalizeRuntimeSnapshotWrite,
   getRuntimeConfigAppliedHash,
@@ -87,14 +92,23 @@ describe("runtime snapshot state", () => {
       gateway: { auth: { mode: "token", token: "${GATEWAY_TOKEN}" } },
     };
     const unresolvedSource = structuredClone(runtimeConfig);
-    setConfigResolutionFacts(unresolvedSource, new Set(["gateway.auth.token"]));
+    setConfigResolutionFacts(
+      unresolvedSource,
+      createConfigResolutionFacts(
+        [{ configPath: "gateway.auth.token", varName: "GATEWAY_TOKEN" }],
+        new Map([["gateway.auth.token", "GATEWAY_TOKEN"]]),
+      ),
+    );
     setRuntimeConfigSnapshot(runtimeConfig, unresolvedSource);
     expect([...(getConfigResolutionFacts(getRuntimeConfigSnapshot()) ?? [])]).toEqual([
       "gateway.auth.token",
     ]);
+    expect(getAuthoredConfigSecretRef(getRuntimeConfigSnapshot(), "gateway.auth.token")?.id).toBe(
+      "GATEWAY_TOKEN",
+    );
 
     const literalSource = structuredClone(runtimeConfig);
-    setConfigResolutionFacts(literalSource, new Set());
+    setConfigResolutionFacts(literalSource, createConfigResolutionFacts([]));
     expect(
       setRuntimeConfigSourceSnapshotIfCurrent({
         expectedRevision: getRuntimeConfigSnapshotMetadata()?.revision ?? -1,
@@ -102,6 +116,7 @@ describe("runtime snapshot state", () => {
       }),
     ).toBe(true);
     expect(getConfigResolutionFacts(getRuntimeConfigSnapshot())?.size).toBe(0);
+    expect(getAuthoredConfigSecretRef(getRuntimeConfigSnapshot(), "gateway.auth.token")).toBeNull();
   });
 
   it("tracks snapshot metadata and cache keys across runtime refreshes", () => {

--- a/src/gateway/auth-token-resolution.ts
+++ b/src/gateway/auth-token-resolution.ts
@@ -1,7 +1,7 @@
 // Gateway auth token resolution applies explicit/config/SecretRef/env
 // precedence with caller-controlled env fallback behavior.
+import { resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { trimToUndefined } from "./credentials.js";
 import {
   resolveConfiguredSecretInputString,
@@ -36,10 +36,12 @@ export async function resolveGatewayAuthToken(params: {
   }
 
   const tokenInput = params.cfg.gateway?.auth?.token;
-  const tokenRef = resolveSecretInputRef({
+  const tokenRef = resolveConfigSecretRef({
+    config: params.cfg,
+    path: "gateway.auth.token",
     value: tokenInput,
     defaults: params.cfg.secrets?.defaults,
-  }).ref;
+  });
   const envFallback = params.envFallback ?? "always";
   const envToken = trimToUndefined(params.env.OPENCLAW_GATEWAY_TOKEN);
 

--- a/src/gateway/client-bootstrap.auth.test.ts
+++ b/src/gateway/client-bootstrap.auth.test.ts
@@ -68,6 +68,38 @@ describe("resolveGatewayClientBootstrap interactive auth policy", () => {
     expect(result.auth).toEqual({ token: "${LITERAL_TOKEN}", password: undefined });
   });
 
+  it("preserves a substituted template-looking literal through interactive client auth", async () => {
+    const root = tempDirs.make("openclaw-client-bootstrap-resolved-literal-");
+    const configPath = path.join(root, "openclaw.json");
+    const env: NodeJS.ProcessEnv = {
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+      SOURCE: "${OTHER}",
+      VITEST: "true",
+    };
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "local", auth: { mode: "token", token: "${SOURCE}" } },
+      }),
+      "utf8",
+    );
+    const context = createConfigIoContext({
+      configPath,
+      env,
+      homedir: () => root,
+      observe: false,
+    });
+
+    const snapshot = await readConfigFileSnapshotFromContext(context);
+    const result = await resolveGatewayClientBootstrap({ config: snapshot.config, env: {} });
+
+    expect(result.auth).toEqual({ token: "${OTHER}", password: undefined });
+  });
+
   it("keeps configured local password ahead of OPENCLAW_GATEWAY_PASSWORD", async () => {
     await expectInteractiveAuth(
       {

--- a/src/gateway/credential-planner.ts
+++ b/src/gateway/credential-planner.ts
@@ -2,7 +2,11 @@
 // Classifies local/remote auth inputs before SecretRef resolution.
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { containsEnvVarReference } from "../config/env-substitution.js";
-import { getConfigResolutionFacts, hasUnresolvedConfigPath } from "../config/resolution-facts.js";
+import {
+  getAuthoredConfigSecretRef,
+  getConfigResolutionFacts,
+  hasUnresolvedConfigPath,
+} from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasConfiguredSecretInput, resolveSecretInputRef } from "../config/types.secrets.js";
 
@@ -73,7 +77,10 @@ function resolveConfiguredGatewayCredentialInput(params: {
   path: GatewayCredentialInputPath;
 }): GatewayConfiguredCredentialInput {
   const resolutionFacts = getConfigResolutionFacts(params.config);
-  if (hasUnresolvedConfigPath(params.config, params.path)) {
+  if (
+    hasUnresolvedConfigPath(params.config, params.path) ||
+    getAuthoredConfigSecretRef(params.config, params.path)
+  ) {
     return {
       path: params.path,
       configured: true,

--- a/src/gateway/credentials-secret-inputs.test.ts
+++ b/src/gateway/credentials-secret-inputs.test.ts
@@ -2,6 +2,7 @@
 // remote, CLI override, env override, and config-secret connection flows.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveConfigForRead } from "../config/io.read-helpers.js";
 import { setConfigResolutionFacts } from "../config/resolution-facts.js";
 import { resolveGatewayCredentialsWithSecretInputs } from "./credentials-secret-inputs.js";
 
@@ -211,6 +212,35 @@ describe("resolveGatewayCredentialsWithSecretInputs", () => {
       }),
     ).resolves.toEqual({ token: "env-token", password: undefined });
   });
+
+  it.each([
+    {
+      name: "pending bare shorthand",
+      authored: "$SOURCE",
+      readEnv: {},
+      runtimeEnv: { SOURCE: "${OTHER}" },
+    },
+    {
+      name: "substituted template-looking literal",
+      authored: "${SOURCE}",
+      readEnv: { SOURCE: "${OTHER}" },
+      runtimeEnv: {},
+    },
+  ])(
+    "materializes authored provenance atomically: $name",
+    async ({ authored, readEnv, runtimeEnv }) => {
+      const read = resolveConfigForRead(
+        { gateway: { mode: "local", auth: { mode: "token", token: authored } } },
+        readEnv,
+      );
+      const config = cfg(read.resolvedConfigRaw as OpenClawConfig);
+      setConfigResolutionFacts(config, read.resolutionFacts);
+
+      await expect(
+        resolveGatewayCredentialsWithSecretInputs({ config, env: runtimeEnv }),
+      ).resolves.toEqual({ token: "${OTHER}", password: undefined });
+    },
+  );
 
   it("preserves escaped literal credentials through async resolution clones", async () => {
     const config = cfg({

--- a/src/gateway/credentials-secret-inputs.ts
+++ b/src/gateway/credentials-secret-inputs.ts
@@ -1,8 +1,10 @@
 // Gateway credential secret-input resolver.
 // Resolves SecretRefs before applying Gateway credential precedence rules.
-import { cloneConfigWithResolutionFacts } from "../config/resolution-facts.js";
+import {
+  cloneConfigWithResolutionFacts,
+  resolveConfigSecretRef,
+} from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { materializeSecretInput } from "../secrets/resolve-secret-input-string.js";
 import {
   GatewaySecretRefUnavailableError,
@@ -52,9 +54,15 @@ async function resolveGatewaySecretInputString(params: {
   path: string;
   env: NodeJS.ProcessEnv;
 }): Promise<string | undefined> {
+  const ref = resolveConfigSecretRef({
+    config: params.config,
+    path: params.path,
+    value: params.value,
+    defaults: params.config.secrets?.defaults,
+  });
   const value = await materializeSecretInput({
     config: params.config,
-    value: params.value,
+    value: ref ?? params.value,
     env: params.env,
     normalize: trimToUndefined,
     onResolveRefError: () => {
@@ -72,10 +80,12 @@ function hasConfiguredGatewaySecretRef(
   path: SupportedGatewaySecretInputPath,
 ): boolean {
   return Boolean(
-    resolveSecretInputRef({
+    resolveConfigSecretRef({
+      config,
+      path,
       value: readGatewaySecretInputValue(config, path),
       defaults: config.secrets?.defaults,
-    }).ref,
+    }),
   );
 }
 

--- a/src/gateway/credentials.test.ts
+++ b/src/gateway/credentials.test.ts
@@ -2,6 +2,7 @@
 // remote gateway auth values.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveConfigForRead } from "../config/io.read-helpers.js";
 import { setConfigResolutionFacts } from "../config/resolution-facts.js";
 import {
   resolveGatewayCredentialsFromConfig,
@@ -521,6 +522,37 @@ describe("resolveGatewayCredentialsFromConfig", () => {
       password: undefined,
     });
   });
+
+  it.each([
+    { name: "unresolved bare shorthand", authored: "$MISSING", env: {}, expected: null },
+    { name: "unresolved braced shorthand", authored: "${MISSING}", env: {}, expected: null },
+    {
+      name: "substituted braced-looking literal",
+      authored: "${SOURCE}",
+      env: { SOURCE: "${OTHER}" },
+      expected: "${OTHER}",
+    },
+    { name: "escaped template literal", authored: "$${OTHER}", env: {}, expected: "${OTHER}" },
+  ])(
+    "classifies gateway credentials from authored provenance: $name",
+    ({ authored, env, expected }) => {
+      const read = resolveConfigForRead(
+        { gateway: { auth: { mode: "token", token: authored } } },
+        env,
+      );
+      const config = read.resolvedConfigRaw as OpenClawConfig;
+      setConfigResolutionFacts(config, read.resolutionFacts);
+
+      if (expected === null) {
+        expect(() => resolveGatewayCredentialsWithEmptyEnv(config)).toThrow("gateway.auth.token");
+        return;
+      }
+      expect(resolveGatewayCredentialsWithEmptyEnv(config)).toEqual({
+        token: expected,
+        password: undefined,
+      });
+    },
+  );
 });
 
 describe("resolveGatewayCredentialsFromValues", () => {

--- a/src/gateway/probe-auth.test.ts
+++ b/src/gateway/probe-auth.test.ts
@@ -2,6 +2,8 @@
 // local/remote target selection, and redacted auth payload handling.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveConfigForRead } from "../config/io.read-helpers.js";
+import { setConfigResolutionFacts } from "../config/resolution-facts.js";
 import {
   resolveGatewayProbeAuthSafe,
   resolveGatewayProbeAuthSafeWithSecretInputs,
@@ -34,6 +36,13 @@ function configWithDefaultEnvProvider(gateway: NonNullable<OpenClawConfig["gatew
       },
     },
   } as OpenClawConfig;
+}
+
+function configFromAuthoredToken(token: string, env: NodeJS.ProcessEnv): OpenClawConfig {
+  const read = resolveConfigForRead({ gateway: { auth: { mode: "token", token } } }, env);
+  const config = read.resolvedConfigRaw as OpenClawConfig;
+  setConfigResolutionFacts(config, read.resolutionFacts);
+  return config;
 }
 
 function resolveSafeProbeAuth(cfg: OpenClawConfig, mode: "local" | "remote" = "local") {
@@ -176,6 +185,33 @@ describe("resolveGatewayProbeAuthSafeWithSecretInputs", () => {
       password: undefined,
     });
   });
+
+  it("preserves a substituted template-looking literal for probe auth", async () => {
+    const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+      cfg: configFromAuthoredToken("${SOURCE}", { SOURCE: "${OTHER}" }),
+      mode: "local",
+      env: {},
+    });
+
+    expect(result).toEqual({
+      auth: { token: "${OTHER}", password: undefined },
+    });
+  });
+
+  it.each(["$MISSING", "${MISSING}"])(
+    "keeps unresolved authored shorthand unavailable: %s",
+    async (authored) => {
+      const result = await resolveGatewayProbeAuthSafeWithSecretInputs({
+        cfg: configFromAuthoredToken(authored, {}),
+        mode: "local",
+        env: {},
+      });
+
+      expect(result.auth).toStrictEqual({});
+      expect(result.warning).toContain("gateway.auth.token");
+      expect(result.warning).toContain("unresolved");
+    },
+  );
 
   it("returns empty auth without warning for gateway.remote SecretRefs in local probes", async () => {
     const result = await resolveGatewayProbeAuthSafeWithSecretInputs({

--- a/src/gateway/resolve-configured-secret-input-string.ts
+++ b/src/gateway/resolve-configured-secret-input-string.ts
@@ -1,8 +1,8 @@
 // SecretRef-aware Gateway config string resolver.
 // Resolves configured secret inputs and fallback values without leaking values.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSecretInputRef } from "../config/types.secrets.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { secretRefKey } from "../secrets/ref-contract.js";
 import {
@@ -44,7 +44,9 @@ export async function resolveConfiguredSecretInputString(params: {
   unresolvedReasonStyle?: SecretInputUnresolvedReasonStyle;
 }): Promise<{ value?: string; unresolvedRefReason?: string }> {
   const style = params.unresolvedReasonStyle ?? "generic";
-  const { ref } = resolveSecretInputRef({
+  const ref = resolveConfigSecretRef({
+    config: params.config,
+    path: params.path,
     value: params.value,
     defaults: params.config.secrets?.defaults,
   });
@@ -110,7 +112,9 @@ async function resolveConfiguredSecretRefOnlyInputString(params: {
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
   unresolvedReasonStyle?: SecretInputUnresolvedReasonStyle;
 }): Promise<{ refConfigured: boolean; value?: string; unresolvedRefReason?: string }> {
-  const { ref } = resolveSecretInputRef({
+  const ref = resolveConfigSecretRef({
+    config: params.config,
+    path: params.path,
     value: params.value,
     defaults: params.config.secrets?.defaults,
   });

--- a/src/gateway/resolve-configured-secret-input-string.ts
+++ b/src/gateway/resolve-configured-secret-input-string.ts
@@ -1,8 +1,8 @@
 // SecretRef-aware Gateway config string resolver.
 // Resolves configured secret inputs and fallback values without leaking values.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSecretInputRef } from "../config/types.secrets.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { secretRefKey } from "../secrets/ref-contract.js";
 import {
@@ -44,9 +44,7 @@ export async function resolveConfiguredSecretInputString(params: {
   unresolvedReasonStyle?: SecretInputUnresolvedReasonStyle;
 }): Promise<{ value?: string; unresolvedRefReason?: string }> {
   const style = params.unresolvedReasonStyle ?? "generic";
-  const ref = resolveConfigSecretRef({
-    config: params.config,
-    path: params.path,
+  const { ref } = resolveSecretInputRef({
     value: params.value,
     defaults: params.config.secrets?.defaults,
   });
@@ -112,9 +110,7 @@ async function resolveConfiguredSecretRefOnlyInputString(params: {
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
   unresolvedReasonStyle?: SecretInputUnresolvedReasonStyle;
 }): Promise<{ refConfigured: boolean; value?: string; unresolvedRefReason?: string }> {
-  const ref = resolveConfigSecretRef({
-    config: params.config,
-    path: params.path,
+  const { ref } = resolveSecretInputRef({
     value: params.value,
     defaults: params.config.secrets?.defaults,
   });

--- a/src/gateway/secret-input-paths.ts
+++ b/src/gateway/secret-input-paths.ts
@@ -1,5 +1,6 @@
 // Gateway secret-input path helpers.
 // Lists config locations that may contain plaintext values or SecretRefs.
+import { copyConfigResolutionFactsExcept } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 /** Canonical Gateway config paths whose values may be plaintext or secret refs. */
@@ -41,33 +42,35 @@ export function readGatewaySecretInputValue(
   return config.gateway?.remote?.password;
 }
 
-/** Replace one Gateway secret input with its resolved plaintext value on a cloned config. */
+/** Replace one Gateway secret input and consume its pending authored provenance atomically. */
 export function assignResolvedGatewaySecretInput(params: {
   config: OpenClawConfig;
   path: SupportedGatewaySecretInputPath;
   value: string | undefined;
 }): void {
   const { config, path, value } = params;
+  let assigned = false;
   if (path === "gateway.auth.token") {
     if (config.gateway?.auth) {
       config.gateway.auth.token = value;
+      assigned = true;
     }
-    return;
-  }
-  if (path === "gateway.auth.password") {
+  } else if (path === "gateway.auth.password") {
     if (config.gateway?.auth) {
       config.gateway.auth.password = value;
+      assigned = true;
     }
-    return;
-  }
-  if (path === "gateway.remote.token") {
+  } else if (path === "gateway.remote.token") {
     if (config.gateway?.remote) {
       config.gateway.remote.token = value;
+      assigned = true;
     }
-    return;
-  }
-  if (config.gateway?.remote) {
+  } else if (config.gateway?.remote) {
     config.gateway.remote.password = value;
+    assigned = true;
+  }
+  if (assigned) {
+    copyConfigResolutionFactsExcept(config, config, [path]);
   }
 }
 

--- a/src/secrets/command-config.test.ts
+++ b/src/secrets/command-config.test.ts
@@ -1,6 +1,12 @@
 /** Tests command-specific secret assignment collection from config snapshots. */
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveConfigForRead } from "../config/io.read-helpers.js";
+import {
+  cloneConfigWithResolutionFacts,
+  copyConfigResolutionFactsExcept,
+  setConfigResolutionFacts,
+} from "../config/resolution-facts.js";
 import {
   buildTalkTestProviderConfig,
   TALK_TEST_PROVIDER_API_KEY_PATH,
@@ -51,6 +57,62 @@ describe("analyzeCommandSecretAssignmentsFromSnapshot", () => {
         path: TALK_TEST_PROVIDER_API_KEY_PATH,
         pathSegments: [...TALK_TEST_PROVIDER_API_KEY_PATH_SEGMENTS],
       },
+    ]);
+  });
+
+  it.each([
+    { name: "unresolved bare shorthand", authored: "$MISSING", env: {}, expected: null },
+    { name: "unresolved braced shorthand", authored: "${MISSING}", env: {}, expected: null },
+    {
+      name: "substituted braced-looking literal",
+      authored: "${SOURCE}",
+      env: { SOURCE: "${OTHER}" },
+      expected: "${OTHER}",
+    },
+    { name: "escaped template literal", authored: "$${OTHER}", env: {}, expected: "${OTHER}" },
+  ])("keeps command assignments source-authoritative: $name", ({ authored, env, expected }) => {
+    const read = resolveConfigForRead(buildTalkTestProviderConfig(authored), env);
+    const sourceConfig = read.resolvedConfigRaw as OpenClawConfig;
+    setConfigResolutionFacts(sourceConfig, read.resolutionFacts);
+    const resolvedConfig = cloneConfigWithResolutionFacts(sourceConfig);
+
+    const result = analyzeCommandSecretAssignmentsFromSnapshot({
+      sourceConfig,
+      resolvedConfig,
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+    });
+
+    expect(result.assignments).toEqual([]);
+    expect(result.unresolved).toEqual(
+      expected === null
+        ? [
+            {
+              path: TALK_TEST_PROVIDER_API_KEY_PATH,
+              pathSegments: [...TALK_TEST_PROVIDER_API_KEY_PATH_SEGMENTS],
+            },
+          ]
+        : [],
+    );
+  });
+
+  it("accepts a materialized shorthand whose literal still resembles a reference", () => {
+    const read = resolveConfigForRead(buildTalkTestProviderConfig("$SOURCE"), {});
+    const sourceConfig = read.resolvedConfigRaw as OpenClawConfig;
+    setConfigResolutionFacts(sourceConfig, read.resolutionFacts);
+    const resolvedConfig = buildTalkTestProviderConfig("${OTHER}");
+    copyConfigResolutionFactsExcept(sourceConfig, resolvedConfig, [
+      TALK_TEST_PROVIDER_API_KEY_PATH,
+    ]);
+
+    const result = analyzeCommandSecretAssignmentsFromSnapshot({
+      sourceConfig,
+      resolvedConfig,
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+    });
+
+    expect(result.unresolved).toEqual([]);
+    expect(result.assignments).toEqual([
+      expect.objectContaining({ path: TALK_TEST_PROVIDER_API_KEY_PATH, value: "${OTHER}" }),
     ]);
   });
 

--- a/src/secrets/command-config.ts
+++ b/src/secrets/command-config.ts
@@ -1,6 +1,7 @@
 /** Collects and analyzes command-scoped secret assignments from OpenClaw config. */
+import { getAuthoredConfigSecretRef, resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
+import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { getPath } from "./path-utils.js";
 import { isExpectedResolvedSecretValue } from "./secret-value.js";
 import { discoverConfigSecretTargetsByIds } from "./target-registry.js";
@@ -48,18 +49,26 @@ export function analyzeCommandSecretAssignmentsFromSnapshot(params: {
     if (params.allowedPaths && !params.allowedPaths.has(target.path)) {
       continue;
     }
-    const { explicitRef, ref } = resolveSecretInputRef({
+    const inlineCandidateRef = resolveConfigSecretRef({
+      config: params.sourceConfig,
+      path: target.path,
       value: target.value,
+      defaults,
+    });
+    const { explicitRef, ref } = resolveSecretInputRef({
+      value: inlineCandidateRef,
       refValue: target.refValue,
       defaults,
     });
-    const inlineCandidateRef = explicitRef ? coerceSecretRef(target.value, defaults) : null;
     if (!ref) {
       continue;
     }
 
     const resolved = getPath(params.resolvedConfig, target.pathSegments);
-    if (!isExpectedResolvedSecretValue(resolved, target.entry.expectedResolvedValue)) {
+    if (
+      getAuthoredConfigSecretRef(params.resolvedConfig, target.path) ||
+      !isExpectedResolvedSecretValue(resolved, target.entry.expectedResolvedValue)
+    ) {
       // Inactive surfaces are diagnostics, not hard failures; active unresolved refs block the
       // command because the runtime snapshot promised that target was usable.
       if (params.inactiveRefPaths?.has(target.path)) {

--- a/src/secrets/runtime-command-secrets.ts
+++ b/src/secrets/runtime-command-secrets.ts
@@ -1,6 +1,7 @@
 /** Resolves command-scoped secrets, including web provider override credentials. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { cloneConfigWithResolutionFacts } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry.js";
@@ -43,7 +44,7 @@ function applyProviderOverridesToConfig(
   if (!hasProviderOverrides(overrides)) {
     return config;
   }
-  const next = structuredClone(config);
+  const next = cloneConfigWithResolutionFacts(config);
   const tools = (next.tools ??= {}) as Record<string, unknown>;
   const web = (tools.web ??= {}) as Record<string, unknown>;
   const webSearch = normalizeOptionalString(overrides?.webSearch);

--- a/src/secrets/runtime-core-snapshots.test.ts
+++ b/src/secrets/runtime-core-snapshots.test.ts
@@ -6,6 +6,11 @@ import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
 } from "../config/config.js";
+import { resolveConfigForRead } from "../config/io.read-helpers.js";
+import {
+  getAuthoredConfigSecretRef,
+  setConfigResolutionFacts,
+} from "../config/resolution-facts.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
@@ -155,6 +160,85 @@ describe("secrets runtime snapshot core lanes", () => {
     );
     expect(snapshot.config.skills?.entries?.["review-pr"]?.apiKey).toBe("sk-skill-ref");
   });
+
+  it.each([
+    {
+      name: "bare source resolves to a bare-looking literal",
+      authored: "$SOURCE",
+      sourceEnv: {},
+      runtimeEnv: { SOURCE: "$OTHER" },
+      expected: "$OTHER",
+      pendingSourceRef: true,
+    },
+    {
+      name: "bare source resolves to a braced-looking literal",
+      authored: "$SOURCE",
+      sourceEnv: {},
+      runtimeEnv: { SOURCE: "${OTHER}" },
+      expected: "${OTHER}",
+      pendingSourceRef: true,
+    },
+    {
+      name: "substitution resolves to a bare-looking literal",
+      authored: "${SOURCE}",
+      sourceEnv: { SOURCE: "$OTHER" },
+      runtimeEnv: {},
+      expected: "$OTHER",
+      pendingSourceRef: false,
+    },
+    {
+      name: "substitution resolves to a braced-looking literal",
+      authored: "${SOURCE}",
+      sourceEnv: { SOURCE: "${OTHER}" },
+      runtimeEnv: {},
+      expected: "${OTHER}",
+      pendingSourceRef: false,
+    },
+    {
+      name: "escaped source remains a braced-looking literal",
+      authored: "$${OTHER}",
+      sourceEnv: {},
+      runtimeEnv: {},
+      expected: "${OTHER}",
+      pendingSourceRef: false,
+    },
+  ])(
+    "materializes authored provider credentials without reinterpreting literals: $name",
+    async ({ authored, sourceEnv, runtimeEnv, expected, pendingSourceRef }) => {
+      const read = resolveConfigForRead(
+        {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: authored,
+                models: [],
+              },
+            },
+          },
+        },
+        sourceEnv,
+      );
+      const config = asConfig(read.resolvedConfigRaw);
+      setConfigResolutionFacts(config, read.resolutionFacts);
+
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config,
+        env: runtimeEnv,
+        includeAuthStoreRefs: false,
+        loadablePluginOrigins: new Map(),
+      });
+
+      expect(snapshot.config.models?.providers?.openai?.apiKey).toBe(expected);
+      expect(
+        getAuthoredConfigSecretRef(snapshot.sourceConfig, "models.providers.openai.apiKey") !==
+          null,
+      ).toBe(pendingSourceRef);
+      expect(
+        getAuthoredConfigSecretRef(snapshot.config, "models.providers.openai.apiKey"),
+      ).toBeNull();
+    },
+  );
 
   it("resolves env refs for memory, talk, and gateway surfaces", async () => {
     const snapshot = await prepareSecretsRuntimeSnapshot({

--- a/src/secrets/runtime-shared.ts
+++ b/src/secrets/runtime-shared.ts
@@ -1,6 +1,7 @@
 /** Shared secrets runtime resolver context, assignments, and warning helpers. */
+import { resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { coerceSecretRef, type SecretRef } from "../config/types.secrets.js";
+import type { SecretRef } from "../config/types.secrets.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { secretRefKey } from "./ref-contract.js";
 import type { SecretRefResolveCache } from "./resolve-types.js";
@@ -180,7 +181,12 @@ export function collectRuntimeSecretInputAssignment(params: {
   apply: (value: unknown) => void;
   applyUnavailable?: () => void;
 }): void {
-  const ref = coerceSecretRef(params.value, params.defaults);
+  const ref = resolveConfigSecretRef({
+    config: params.context.sourceConfig,
+    path: params.path,
+    value: params.value,
+    defaults: params.defaults,
+  });
   if (!ref) {
     return;
   }

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -16,7 +16,12 @@ import {
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import { getConfigResolutionFacts, setConfigResolutionFacts } from "../config/resolution-facts.js";
+import {
+  createConfigResolutionFacts,
+  getAuthoredConfigSecretRef,
+  getConfigResolutionFacts,
+  setConfigResolutionFacts,
+} from "../config/resolution-facts.js";
 import {
   getRuntimeConfigSnapshotMetadata,
   getRuntimeConfigSourceSnapshot,
@@ -324,8 +329,14 @@ describe("secrets runtime state", () => {
   it("restores source-only ownership through a scoped descendant", () => {
     const initialSource = { logging: { level: "info" as const } };
     const nextSource = { logging: { level: "debug" as const } };
-    setConfigResolutionFacts(initialSource, new Set(["gateway.auth.token"]));
-    setConfigResolutionFacts(nextSource, new Set());
+    setConfigResolutionFacts(
+      initialSource,
+      createConfigResolutionFacts(
+        [{ configPath: "gateway.auth.token", varName: "GATEWAY_TOKEN" }],
+        new Map([["gateway.auth.token", "GATEWAY_TOKEN"]]),
+      ),
+    );
+    setConfigResolutionFacts(nextSource, createConfigResolutionFacts([]));
     const runtimeConfig = {
       models: {
         providers: {
@@ -379,6 +390,12 @@ describe("secrets runtime state", () => {
         "gateway.auth.token",
       ),
     ).toBe(true);
+    expect(
+      getAuthoredConfigSecretRef(
+        getActiveSecretsRuntimeConfigSnapshot()?.config,
+        "gateway.auth.token",
+      )?.id,
+    ).toBe("GATEWAY_TOKEN");
     expect(getActiveSecretsRuntimeSnapshotState()?.sourceConfig).toEqual(initialSource);
     expect(getActiveSecretsRuntimeSnapshotState()?.config.models?.providers?.openai?.baseUrl).toBe(
       "https://refreshed.example.invalid/v1",

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -13,7 +13,10 @@ import {
 } from "../agents/auth-profiles/legacy-source-diagnostic.js";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import { cloneConfigWithResolutionFacts } from "../config/resolution-facts.js";
+import {
+  cloneConfigWithResolutionFacts,
+  copyConfigResolutionFactsExcept,
+} from "../config/resolution-facts.js";
 import {
   getRuntimeConfigSourceSnapshot,
   getRuntimeConfigSnapshotMetadata,
@@ -27,6 +30,7 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { isRecord, resolveUserPath } from "../utils.js";
+import { secretRefKey } from "./ref-contract.js";
 import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
 import type { DegradedSecretOwner } from "./runtime-degraded-state.js";
 import {
@@ -304,6 +308,13 @@ export async function prepareSecretsRuntimeSnapshot(params: {
           forceColdRefKeys: params.forceColdRefKeys,
         })
       : { degradedOwners: [], resolvedValues: new Map<string, unknown>() };
+  copyConfigResolutionFactsExcept(
+    assignmentSourceConfig,
+    resolvedConfig,
+    context.assignments
+      .filter((assignment) => assignmentResolution.resolvedValues.has(secretRefKey(assignment.ref)))
+      .map((assignment) => assignment.path),
+  );
   const assignmentSecretOwners = listSecretAssignmentOwners(
     context.assignments,
     assignmentResolution.resolvedValues,


### PR DESCRIPTION
Closes #127684

AI-assisted: yes. I understand and reviewed the implementation and its ownership boundaries.

## What Problem This Solves

Fixes an issue where operators using inline env SecretRef shorthand could have unresolved `$NAME` or `${NAME}` text treated as a literal credential by command/read-only consumers. The inverse compatibility failure also occurred: a successfully resolved secret whose literal value was `$OTHER` or `${OTHER}` could be reinterpreted as another SecretRef and reported unavailable.

## Why This Change Was Made

Config env substitution now records a narrow, path-indexed fact only when exact env shorthand remains pending. That fact is preserved through config snapshots, clones, and reloads, consumed atomically when materialization replaces the value, and read by Gateway, command-secret, model-auth, and model-probe boundaries instead of guessing provenance from the resolved string.

The model-provider path uses the canonical merged provider entry so provider key normalization and provenance cannot select different entries. No new config option, environment variable, dependency, database state, compatibility fallback, or process-global state is introduced.

Production LOC: +246/-72 (net +174) | Tests: +470/-11 (net +459)

The positive production delta establishes an authoritative source-vs-resolved ownership boundary that did not previously exist and carries it through the real materialization and read-only credential consumers. A smaller downstream-only guard would leave sibling consumers unable to distinguish the two valid states.

## User Impact

Unresolved inline env shorthand no longer crosses an outbound provider or Gateway authentication boundary as literal credential text. Successfully resolved credentials remain compatible even when their exact literal value resembles env-template syntax.

## Evidence

Pre-fix regression: `src/commands/models/list.probe.targets.test.ts` failed because unresolved `$MISSING` and `${MISSING}` values were emitted as configured probe credentials.

Focused local proof after the repair:

- Config/env substitution and snapshots: 34 tests passed.
- Gateway planning/materialization and probe auth: 73 tests passed.
- Interactive Gateway client bootstrap: 11 tests passed.
- Secret runtime/command snapshots: 82 tests passed.
- CLI command-secret resolution: 40 tests passed.
- Model auth: 84 tests passed.
- Model probe targets: 27 tests passed.
- Daemon install regression after the CI scope correction: 37 tests passed.
- Total focused provenance proof: 351 tests passed.
- Core source typecheck passed with `tsgo -p tsconfig.core.json --noEmit --declaration false`.
- Affected test typecheck shards passed: config/CLI, commands, Gateway root, agents root, and services.
- `oxfmt --check`, focused Oxlint, and `git diff --check` passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Exact-head CI is green: https://github.com/openclaw/openclaw/actions/runs/32539375363

The local `check-changed` and type-aware Oxlint wrappers were repeatedly canceled by a separately owned shared host orchestration session before completion. Exact-head CI covers the changed gates; the repository-native Testbox prepare gate remains mandatory before merge.
