### PR TITLE
fix(ui): align Activity sessions across viewports

### DIFF
--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -284,6 +284,12 @@ suite.define(() => {
         expect(await inspectRun.getAttribute("href")).toBe(
           "/activity?view=run&run=mock%20run%3Aa%2Fb",
         );
+        const timeFilter = activityPage.locator(".activity-feed__time-filter");
+        expect(
+          await timeFilter
+            .locator(".settings-segmented__btn")
+            .evaluateAll((buttons) => buttons.map((button) => button.textContent?.trim())),
+        ).toEqual(["Last 24 hours", "Last 7 days", "Last 30 days", "All time"]);
         await page.screenshot({
           animations: "disabled",
           path: path.join(outputDir, "05-global-activity.png"),
@@ -304,6 +310,47 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           path: path.join(outputDir, "06-person-activity.png"),
+        });
+
+        await activityPage.locator(".activity-feed__people-clear").click();
+        await expect.poll(() => new URL(page.url()).searchParams.get("person")).toBeNull();
+        await page.setViewportSize({ height: 844, width: 390 });
+
+        const peopleControl = activityPage.locator(".activity-feed__people-control");
+        const timeButtonTops = await timeFilter
+          .locator(".settings-segmented__btn")
+          .evaluateAll((buttons) =>
+            buttons.map((button) => Math.round(button.getBoundingClientRect().top)),
+          );
+        const [timeFilterBox, peopleControlBox] = await Promise.all([
+          timeFilter.boundingBox(),
+          peopleControl.boundingBox(),
+        ]);
+        expect(new Set(timeButtonTops)).toHaveLength(1);
+        expect(timeFilterBox).not.toBeNull();
+        expect(peopleControlBox).not.toBeNull();
+        expect(Math.abs(timeFilterBox!.y - peopleControlBox!.y)).toBeLessThan(2);
+        const automationGroupChildTops = await automationGroup
+          .locator(":scope > *")
+          .evaluateAll((children) =>
+            children.map((child) => Math.round(child.getBoundingClientRect().top)),
+          );
+        expect(
+          Math.max(...automationGroupChildTops) - Math.min(...automationGroupChildTops),
+        ).toBeLessThan(3);
+        expect(
+          await activityFeed.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+              backgroundColor: style.backgroundColor,
+              borderTopWidth: style.borderTopWidth,
+            };
+          }),
+        ).toEqual({ backgroundColor: "rgba(0, 0, 0, 0)", borderTopWidth: "0px" });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(outputDir, "07-global-activity-mobile.png"),
         });
       },
     );

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -447,6 +447,8 @@ export function renderSessionActivityView(props: SessionActivityViewProps) {
               class="settings-segmented__btn ${props.filters.time === time
                 ? "settings-segmented__btn--active"
                 : ""}"
+              data-compact-label=${time === "all" ? t(TIME_LABELS[time]) : time}
+              aria-label=${t(TIME_LABELS[time])}
               aria-pressed=${String(props.filters.time === time)}
               @click=${() => props.onFiltersChange({ ...props.filters, time })}
             >

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -61,9 +61,6 @@ openclaw-activity-page {
   height: 100%;
   min-height: 0;
   overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--card);
 }
 
 .activity-feed__toolbar {
@@ -72,8 +69,6 @@ openclaw-activity-page {
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-3) var(--space-4);
-  border-bottom: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg-elevated) 58%, transparent);
 }
 
 .activity-feed__search {
@@ -102,12 +97,14 @@ openclaw-activity-page {
 
 .activity-feed__time-filter {
   flex: 0 0 auto;
+  flex-wrap: nowrap;
 }
 
 .activity-feed__people-control {
   position: relative;
   display: flex;
   align-items: center;
+  margin-left: auto;
 }
 
 .activity-feed__people-trigger,
@@ -118,7 +115,7 @@ openclaw-activity-page {
 
 .activity-feed__people-trigger {
   min-width: 64px;
-  max-width: 220px;
+  max-width: min(220px, 30vw);
   padding: 3px 10px;
 }
 
@@ -784,6 +781,15 @@ openclaw-activity-page {
     order: -1;
   }
 
+  .activity-feed__time-filter .settings-segmented__btn {
+    font-size: 0;
+  }
+
+  .activity-feed__time-filter .settings-segmented__btn::after {
+    content: attr(data-compact-label);
+    font-size: var(--control-ui-text-sm);
+  }
+
   .activity-feed__main {
     overflow: visible;
     padding: var(--space-4);
@@ -791,6 +797,10 @@ openclaw-activity-page {
 
   .activity-feed__session {
     grid-template-columns: 28px minmax(0, 1fr);
+  }
+
+  .activity-feed__automation-group {
+    grid-template-columns: 28px minmax(0, 1fr) auto;
   }
 
   .activity-feed__session-time {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Activity → Sessions looked visually inconsistent with Automations: the feed added a second full-page card, and its mobile filters and automation disclosure wrapped into awkward extra rows.

## Why This Change Was Made

The Activity workspace now owns the page surface directly, keeps full localized time labels on desktop, switches to compact tokens on narrow screens, and preserves a single aligned mobile filter row and automation disclosure. This is AI-assisted; the implementation and rendered evidence were reviewed directly.

## User Impact

Activity sessions now use the same flatter hierarchy as Automations. Desktop users retain descriptive time labels, while mobile users get a compact, readable layout without losing filter, person-selection, session, or run-inspection behavior.

## Evidence

### Before

Desktop:
![Activity Sessions before — desktop](https://github.com/user-attachments/assets/7625086d-26f9-47cc-bfa3-eae1d26ec7cc)

Mobile:
![Activity Sessions before — mobile](https://github.com/user-attachments/assets/3320b9d3-1315-4f09-8d23-5213646b6563)

### After

Desktop:
![Activity Sessions after — desktop](https://github.com/user-attachments/assets/5f5f81b5-5abc-450c-a48e-fd8838a989a0)

Mobile:
![Activity Sessions after — mobile](https://github.com/user-attachments/assets/3e5a051a-5c5e-4fc8-81d4-f13488924e3c)

Validation:

- `node scripts/run-vitest.mjs ui/src/pages/activity/session-activity-view.test.ts ui/src/pages/activity/session-activity.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/activity-session-feed.capture.e2e.test.ts`
- `node scripts/check-changed.mjs`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/check-changed.mjs" --stream-engine-output` — clean, no accepted/actionable findings

Production LOC: +18/-6 (net +12) | Tests: +49/-0. The production growth is the responsive-label and mobile-alignment behavior; the obsolete nested-card styling was removed.
