### PR TITLE
fix(talk): keep unused speech secrets from blocking startup

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -711,7 +711,7 @@ Use `contracts` only for static capability ownership metadata that OpenClaw can 
 }
 ```
 
-Each list is optional:
+Each list is optional. For `speechProviders` and `realtimeVoiceProviders`, list the canonical provider ID first, followed by any aliases scoped to that capability:
 
 | Field                            | Type       | What it means                                                                                                                        |
 | -------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |

--- a/extensions/elevenlabs/config-compat.test.ts
+++ b/extensions/elevenlabs/config-compat.test.ts
@@ -12,6 +12,7 @@ describe("elevenlabs config compat", () => {
   it("moves legacy talk fields into talk.providers.elevenlabs", () => {
     const result = migrateElevenLabsLegacyTalkConfig({
       talk: {
+        providers: { elevenlabs: { voiceId: "existing-voice" } },
         voiceId: "voice-123",
         modelId: "eleven_v3",
         outputFormat: "pcm_44100",
@@ -26,13 +27,30 @@ describe("elevenlabs config compat", () => {
       talk: {
         providers: {
           elevenlabs: {
-            voiceId: "voice-123",
+            voiceId: "existing-voice",
             modelId: "eleven_v3",
             outputFormat: "pcm_44100",
             apiKey: "secret-key", // pragma: allowlist secret
           },
         },
       },
+    });
+    expect(migrateElevenLabsLegacyTalkConfig(result.config)).toEqual({
+      config: result.config,
+      changes: [],
+    });
+  });
+
+  it("preserves ambiguous legacy Talk fields for actionable doctor guidance", () => {
+    const config = {
+      talk: {
+        providers: { acme: { modelId: "acme-model" }, other: { modelId: "other-model" } },
+        voiceId: "legacy-voice",
+      },
+    };
+    expect(migrateElevenLabsLegacyTalkConfig(config)).toEqual({
+      config,
+      changes: [expect.stringContaining("multiple providers")],
     });
   });
 

--- a/extensions/microsoft/openclaw.plugin.json
+++ b/extensions/microsoft/openclaw.plugin.json
@@ -5,7 +5,7 @@
   },
   "enabledByDefault": true,
   "contracts": {
-    "speechProviders": ["microsoft"]
+    "speechProviders": ["microsoft", "edge"]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/volcengine/openclaw.plugin.json
+++ b/extensions/volcengine/openclaw.plugin.json
@@ -352,7 +352,9 @@
   },
   "contracts": {
     "speechProviders": [
-      "volcengine"
+      "volcengine",
+      "bytedance",
+      "doubao"
     ]
   }
 }

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -197,7 +197,7 @@
     "mediaUnderstandingProviders": ["xai"],
     "speechProviders": ["xai"],
     "realtimeTranscriptionProviders": ["xai"],
-    "realtimeVoiceProviders": ["xai"],
+    "realtimeVoiceProviders": ["xai", "grok-voice", "xai-realtime-voice"],
     "imageGenerationProviders": ["xai"],
     "tools": ["code_execution", "x_search"]
   },

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -99,7 +99,7 @@
     }
   ],
   "contracts": {
-    "speechProviders": ["xiaomi"],
+    "speechProviders": ["xiaomi", "mimo"],
     "usageProviders": ["xiaomi", "xiaomi-token-plan"]
   },
   "providerAuthChoices": [

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -1533,6 +1533,7 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       const result = await resolveCommandSecretRefsViaGateway({
         config: {
           talk: {
+            provider: "gateway",
             providers: {
               gateway: {
                 apiKey: {
@@ -1541,21 +1542,28 @@ describe("resolveCommandSecretRefsViaGateway", () => {
                   id: "GATEWAY_ONLY_TALK_KEY",
                 },
               },
-              local: {
-                apiKey: { source: "env", provider: "default", id: localEnvKey },
+            },
+            realtime: {
+              provider: "local",
+              providers: {
+                local: {
+                  apiKey: { source: "env", provider: "default", id: localEnvKey },
+                },
               },
             },
           },
         } as OpenClawConfig,
         commandName: "reply",
-        targetIds: new Set(["talk.providers.*.apiKey"]),
+        targetIds: new Set(["talk.providers.*.apiKey", "talk.realtime.providers.*.apiKey"]),
       });
 
       expect(result.resolvedConfig.talk?.providers?.gateway?.apiKey).toBe("gateway-owned-key");
-      expect(result.resolvedConfig.talk?.providers?.local?.apiKey).toBe("local-fallback-key");
+      expect(result.resolvedConfig.talk?.realtime?.providers?.local?.apiKey).toBe(
+        "local-fallback-key",
+      );
       expect(result.targetStatesByPath).toMatchObject({
         "talk.providers.gateway.apiKey": "resolved_gateway",
-        "talk.providers.local.apiKey": "resolved_local",
+        "talk.realtime.providers.local.apiKey": "resolved_local",
       });
       expect(
         result.diagnostics.some((entry) => entry.includes("gateway secrets.resolve unavailable")),

--- a/src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts
@@ -29,6 +29,7 @@ describe("legacy migrate provider-shaped config", () => {
       {
         talk: {
           provider: "openai",
+          voiceId: "legacy-voice",
           providers: {
             openai: {
               apiKey: "test-key",
@@ -40,6 +41,7 @@ describe("legacy migrate provider-shaped config", () => {
           brain: "agent-consult",
           model: "gpt-realtime",
           voice: "alloy",
+          unknown: "discarded",
         } as never,
       },
       changes,
@@ -51,6 +53,7 @@ describe("legacy migrate provider-shaped config", () => {
     ]);
     expect(migrated.talk).toEqual({
       provider: "openai",
+      voiceId: "legacy-voice",
       providers: {
         openai: {
           apiKey: "test-key",
@@ -72,6 +75,12 @@ describe("legacy migrate provider-shaped config", () => {
         speakerVoice: "alloy",
       },
     });
+    const conflicting = {
+      ...migrated,
+      talk: { ...migrated.talk, model: "obsolete", voice: "obsolete" },
+    } as OpenClawConfig;
+    expect(normalizeLegacyTalkConfig(conflicting, [])).toEqual(migrated);
+    expect(normalizeLegacyTalkConfig(migrated, [])).toBe(migrated);
   });
 
   it("does not copy plain Talk speech provider config into talk.realtime", () => {

--- a/src/commands/doctor/shared/legacy-talk-config-normalizer.ts
+++ b/src/commands/doctor/shared/legacy-talk-config-normalizer.ts
@@ -1,25 +1,13 @@
-// Legacy Talk config normalizer for provider scalar fields and realtime aliases.
+// Legacy Talk config normalizer for provider shape and generic realtime aliases.
 import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeTalkSection } from "../../../config/talk.js";
 import type { OpenClawConfig } from "../../../config/types.js";
 
-function buildLegacyTalkProviderCompat(
-  talk: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  const compat: Record<string, unknown> = {};
-  for (const key of ["voiceId", "voiceAliases", "modelId", "outputFormat", "apiKey"] as const) {
-    if (talk[key] !== undefined) {
-      compat[key] = talk[key];
-    }
-  }
-  return Object.keys(compat).length > 0 ? compat : undefined;
-}
-
 function buildLegacyRealtimeTalkCompat(
   talk: Record<string, unknown>,
   normalizedTalk: NonNullable<OpenClawConfig["talk"]>,
-): Record<string, unknown> | undefined {
+): NonNullable<OpenClawConfig["talk"]>["realtime"] {
   if (talk.realtime !== undefined) {
     return undefined;
   }
@@ -44,30 +32,23 @@ function buildLegacyRealtimeTalkCompat(
   return normalizeTalkSection({ realtime: compat } as OpenClawConfig["talk"])?.realtime;
 }
 
-/** Normalize legacy Talk provider/realtime fields into current talk.providers and talk.realtime. */
+/** Normalize Talk provider shape and move only core-owned legacy realtime fields. */
 export function normalizeLegacyTalkConfig(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
-  const rawTalk = cfg.talk;
+  const rawTalk: unknown = cfg.talk;
   if (!isRecord(rawTalk)) {
     return cfg;
   }
 
-  const normalizedTalk = normalizeTalkSection(rawTalk as OpenClawConfig["talk"]) ?? {};
-  const legacyProviderCompat = buildLegacyTalkProviderCompat(rawTalk);
-  if (legacyProviderCompat) {
-    normalizedTalk.providers = {
-      ...normalizedTalk.providers,
-      elevenlabs: {
-        ...legacyProviderCompat,
-        ...normalizedTalk.providers?.elevenlabs,
-      },
-    };
+  const normalizedTalk: Record<string, unknown> & NonNullable<OpenClawConfig["talk"]> =
+    normalizeTalkSection(rawTalk as OpenClawConfig["talk"]) ?? {};
+  for (const key of ["voiceId", "voiceAliases", "modelId", "outputFormat", "apiKey"] as const) {
+    if (rawTalk[key] !== undefined) {
+      normalizedTalk[key] = rawTalk[key];
+    }
   }
   const legacyRealtimeCompat = buildLegacyRealtimeTalkCompat(rawTalk, normalizedTalk);
   if (legacyRealtimeCompat) {
-    normalizedTalk.realtime = {
-      ...legacyRealtimeCompat,
-      ...normalizedTalk.realtime,
-    };
+    normalizedTalk.realtime = legacyRealtimeCompat;
   }
   if (Object.keys(normalizedTalk).length === 0 || isDeepStrictEqual(normalizedTalk, rawTalk)) {
     return cfg;

--- a/src/config/config.legacy-config-provider-shapes.test.ts
+++ b/src/config/config.legacy-config-provider-shapes.test.ts
@@ -5,7 +5,7 @@ import type { OpenClawConfig } from "./types.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 describe("legacy provider-shaped config snapshots", () => {
-  it("accepts a string map of voice aliases while still flagging legacy talk config", () => {
+  it("preserves provider-owned legacy Talk fields for the provider doctor migration", () => {
     const raw = {
       talk: {
         voiceAliases: {
@@ -17,22 +17,8 @@ describe("legacy provider-shaped config snapshots", () => {
     const changes: string[] = [];
     const migrated = normalizeLegacyTalkConfig(raw as unknown as OpenClawConfig, changes);
 
-    expect(changes).toContain(
-      "Normalized talk.provider/providers shape (trimmed provider ids and merged missing compatibility fields).",
-    );
-    const next = migrated as {
-      talk?: {
-        providers?: {
-          elevenlabs?: {
-            voiceAliases?: Record<string, string>;
-          };
-        };
-      };
-    };
-    expect(next?.talk?.providers?.elevenlabs?.voiceAliases).toEqual({
-      Clawd: "VoiceAlias1234567890",
-      Roger: "CwhRBWXzGAHq8TQ4Fs17",
-    });
+    expect(changes).toEqual([]);
+    expect(migrated).toEqual(raw);
   });
 
   it("rejects non-string voice alias values", () => {

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -270,30 +270,43 @@ describe("applyPluginAutoEnable core", () => {
     ).toBe("google auth configured");
   });
 
-  it("auto-enables external speech providers selected by TTS config", () => {
-    const result = applyPluginAutoEnable({
-      config: {
-        tts: { provider: "gradium" },
-        plugins: { allow: ["telegram"] },
-      },
-      env,
-      manifestRegistry: makeRegistry([
-        {
-          id: "gradium",
-          channels: [],
-          contracts: { speechProviders: ["gradium"] },
-          origin: "global",
+  it.each([
+    ["TTS", { tts: { provider: "gradium" } }, "gradium", "gradium", "speechProviders"],
+    [
+      "sole Talk speech alias",
+      { talk: { providers: { "gradium-voice": {} } } },
+      "gradium-voice",
+      "gradium",
+      "speechProviders",
+    ],
+    [
+      "Talk realtime alias",
+      { talk: { realtime: { provider: "grok-voice", providers: { "grok-voice": {} } } } },
+      "grok-voice",
+      "xai",
+      "realtimeVoiceProviders",
+    ],
+  ] as const)(
+    "auto-enables the manifest owner selected by %s",
+    (_surface, config, id, owner, key) => {
+      const result = applyPluginAutoEnable({
+        config: {
+          ...config,
+          plugins: { allow: ["telegram"] },
         },
-      ]),
-    });
+        env,
+        manifestRegistry: makeRegistry([
+          { id: owner, channels: [], contracts: { [key]: [owner, id] }, origin: "global" },
+        ]),
+      });
 
-    expect(result.config.plugins?.allow).toEqual(["telegram", "gradium"]);
-    expect(result.config.plugins?.entries?.gradium).toEqual({ enabled: true });
-    expect(result.autoEnabledReasons).toEqual({
-      gradium: ["gradium speech provider selected"],
-    });
-    expect(result.changes).toContain("gradium speech provider selected, enabled automatically.");
-  });
+      const reason = `${id} ${key === "speechProviders" ? "speech" : "realtime voice"} provider selected`;
+      expect(result.config.plugins?.allow).toEqual(["telegram", owner]);
+      expect(result.config.plugins?.entries?.[owner]).toEqual({ enabled: true });
+      expect(result.autoEnabledReasons).toEqual({ [owner]: [reason] });
+      expect(result.changes).toContain(`${reason}, enabled automatically.`);
+    },
+  );
 
   it("treats an undefined config as empty", () => {
     const result = applyPluginAutoEnable({

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -40,6 +40,7 @@ import type {
   PluginAutoEnableResult,
 } from "./plugin-auto-enable.types.js";
 import { ensurePluginAllowlisted } from "./plugins-allowlist.js";
+import { resolveConfiguredTalkRealtimeProviderId } from "./talk.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 const EMPTY_PLUGIN_MANIFEST_REGISTRY: PluginManifestRegistry = {
@@ -353,8 +354,10 @@ function hasConfiguredWebSearchProviderSelection(cfg: OpenClawConfig): boolean {
   );
 }
 
-function hasConfiguredSpeechProviderSelection(cfg: OpenClawConfig): boolean {
-  return collectConfiguredSpeechProviderIds(cfg).size > 0;
+function hasConfiguredVoiceProviderSelection(cfg: OpenClawConfig): boolean {
+  return Boolean(
+    collectConfiguredSpeechProviderIds(cfg).size || resolveConfiguredTalkRealtimeProviderId(cfg),
+  );
 }
 
 function hasConfiguredPluginConfigEntry(
@@ -533,7 +536,7 @@ function configMayNeedPluginManifestRegistry(cfg: OpenClawConfig, env: NodeJS.Pr
   if (hasConfiguredProviderModelOrHarness(cfg, env)) {
     return true;
   }
-  if (hasConfiguredSpeechProviderSelection(cfg)) {
+  if (hasConfiguredVoiceProviderSelection(cfg)) {
     return true;
   }
   if (collectConfiguredWorkerProviderIds(cfg).length > 0) {
@@ -584,7 +587,7 @@ export function resolvePluginAutoEnableReadiness(
   if (hasConfiguredProviderModelOrHarness(cfg, env)) {
     return { mayNeedAutoEnable: true, configuredChannelIds };
   }
-  if (hasConfiguredSpeechProviderSelection(cfg)) {
+  if (hasConfiguredVoiceProviderSelection(cfg)) {
     return { mayNeedAutoEnable: true, configuredChannelIds };
   }
   if (collectConfiguredWorkerProviderIds(cfg).length > 0) {
@@ -694,6 +697,20 @@ export function resolveConfiguredPluginAutoEnableCandidates(params: {
         pluginId,
         kind: "speech-provider-selected",
         providerId,
+      });
+    }
+  }
+
+  const realtimeProviderId = resolveConfiguredTalkRealtimeProviderId(params.config);
+  if (realtimeProviderId) {
+    for (const plugin of params.registry.plugins) {
+      if (!plugin.contracts?.realtimeVoiceProviders?.includes(realtimeProviderId.toLowerCase())) {
+        continue;
+      }
+      changes.push({
+        pluginId: plugin.id,
+        kind: "setup-auto-enable",
+        reason: `${realtimeProviderId} realtime voice provider selected`,
       });
     }
   }

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -1,10 +1,12 @@
 // Normalizes talk-mode config for voice and channel interactions.
+import { findNormalizedProviderKey } from "@openclaw/model-catalog-core/provider-id";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeFastMode,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { normalizeThinkLevel } from "../auto-reply/thinking.js";
-import { isRecord } from "../utils.js";
+import { normalizeThinkLevel } from "../auto-reply/thinking.shared.js";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import type {
   ResolvedTalkConfig,
   TalkConfig,
@@ -71,7 +73,7 @@ function normalizeTalkProviderConfig(value: unknown): TalkProviderConfig | undef
     provider[key] = raw;
   }
 
-  return Object.keys(provider).length > 0 ? provider : undefined;
+  return provider;
 }
 
 function normalizeTalkProviders(value: unknown): Record<string, TalkProviderConfig> | undefined {
@@ -171,16 +173,28 @@ function normalizeTalkRealtimeConfig(value: unknown): TalkRealtimeConfig | undef
 }
 
 function activeProviderFromTalk(talk: TalkConfig): string | undefined {
-  const provider = normalizeOptionalString(talk.provider);
-  const providers = talk.providers;
-  if (provider) {
-    if (providers && !Object.hasOwn(providers, provider)) {
-      return undefined;
-    }
-    return provider;
+  const providerIds = Object.keys(talk.providers ?? {});
+  const provider = normalizeOptionalString(
+    talk.provider ?? (providerIds.length === 1 ? providerIds[0] : undefined),
+  );
+  if (!provider || isBlockedObjectKey(provider.toLowerCase())) {
+    return undefined;
   }
-  const providerIds = providers ? Object.keys(providers) : [];
-  return providerIds.length === 1 ? providerIds[0] : undefined;
+  return talk.providers ? findNormalizedProviderKey(talk.providers, provider) : provider;
+}
+
+/** Resolve the explicitly selected or sole authored Talk speech provider. */
+export function resolveConfiguredTalkSpeechProviderId(
+  config: Pick<OpenClawConfig, "talk">,
+): string | undefined {
+  return config.talk ? activeProviderFromTalk(config.talk) : undefined;
+}
+
+/** Resolve the explicitly selected or sole authored Talk realtime provider. */
+export function resolveConfiguredTalkRealtimeProviderId(
+  config: Pick<OpenClawConfig, "talk">,
+): string | undefined {
+  return config.talk?.realtime ? activeProviderFromTalk(config.talk.realtime) : undefined;
 }
 
 /**
@@ -261,17 +275,16 @@ export function normalizeTalkConfig(config: OpenClawConfig): OpenClawConfig {
 export function resolveActiveTalkProviderConfig(
   talk: TalkConfig | undefined,
 ): ResolvedTalkConfig | undefined {
+  const selectedProvider = resolveConfiguredTalkSpeechProviderId({ talk });
+  if (!selectedProvider || !talk) {
+    return undefined;
+  }
   const normalizedTalk = normalizeTalkSection(talk);
-  if (!normalizedTalk) {
-    return undefined;
-  }
-  const provider = activeProviderFromTalk(normalizedTalk);
-  if (!provider) {
-    return undefined;
-  }
+  const provider =
+    findNormalizedProviderKey(normalizedTalk?.providers, selectedProvider) ?? selectedProvider;
   return {
     provider,
-    config: normalizedTalk.providers?.[provider] ?? {},
+    config: normalizedTalk?.providers?.[provider] ?? {},
   };
 }
 

--- a/src/gateway/config-diff.ts
+++ b/src/gateway/config-diff.ts
@@ -1,5 +1,6 @@
 // Config path diff helper used by gateway mutation diagnostics.
 import { isDeepStrictEqual } from "node:util";
+import * as talk from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPlainObject } from "../utils.js";
 
@@ -46,6 +47,10 @@ function projectGatewayReloadBoundaries(config: OpenClawConfig) {
     session: {
       scope: config.session?.scope,
       store: config.session?.store,
+    },
+    talk: {
+      provider: talk.resolveConfiguredTalkSpeechProviderId(config),
+      realtime: { provider: talk.resolveConfiguredTalkRealtimeProviderId(config) },
     },
   };
 }

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -141,6 +141,9 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "secrets.egressProxy", kind: "restart" },
   { prefix: "plugins.load", kind: "restart" },
   { prefix: "plugins.installs", kind: "restart" },
+  // Capability ownership changes must replace the plugin generation that owns its routes.
+  { prefix: "talk.provider", kind: "hot", actions: ["reload-plugins"] },
+  { prefix: "talk.realtime.provider", kind: "hot", actions: ["reload-plugins"] },
 ];
 
 const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -160,6 +160,22 @@ describe("diffConfigPaths", () => {
     expect(buildGatewayReloadPlan(changedPaths).restartReasons).toContain("mcp.apps");
   });
 
+  it.each(["speech", "realtime"] as const)("reloads only changed Talk %s owners", (surface) => {
+    const configure = (provider: string, model?: string) => ({
+      talk:
+        surface === "speech"
+          ? { providers: { [provider]: { model } } }
+          : { realtime: { providers: { [provider]: { model } } } },
+    });
+    for (const [prev, next, reload] of [
+      [{}, configure("first"), true],
+      [configure("first"), configure("second"), true],
+      [configure("first", "before"), configure("first", "after"), false],
+    ] as const) {
+      expect(buildGatewayReloadPlan(diffGatewayReloadPaths(prev, next)).reloadPlugins).toBe(reload);
+    }
+  });
+
   it.each([
     {
       name: "adds agents",
@@ -406,6 +422,8 @@ describe("buildGatewayReloadPlan", () => {
       path: "plugins.entries.lossless-claw.config.mode",
       expected: { reloadPlugins: true, disposeMcpRuntimes: true },
     },
+    { path: "talk.provider", expected: { reloadPlugins: true } },
+    { path: "talk.realtime.provider", expected: { reloadPlugins: true } },
   ])("keeps hot-reload actions for $path", ({ path, expected }) => {
     const plan = buildGatewayReloadPlan([path]);
 

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { AgentSelectionRequiredError, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { buildAgentMainSessionKey } from "../../routing/session-key.js";
+import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
@@ -195,16 +196,15 @@ export const talkClientHandlers: GatewayRequestHandlers = {
         defaults: realtimeConfig,
       });
       const requestedAgentId = resolveTalkSessionAgentId(runtimeConfig, typedParams.sessionKey);
+      assertSecretOwnerAvailable("capability", "talk:realtime");
       const resolution = resolveConfiguredRealtimeVoiceProvider({
         configuredProviderId: realtimeConfig.provider,
         providerConfigs: realtimeConfig.providers,
         ...(launchOptions.model ? { providerConfigOverrides: { model: launchOptions.model } } : {}),
         cfg: runtimeConfig,
-        cfgForResolve: runtimeConfig,
         agentId: requestedAgentId,
         defaultModel: realtimeConfig.model,
         surface: "browser-session",
-        noRegisteredProviderMessage: "No realtime voice provider registered",
       });
       const providerCapabilities = resolveRealtimeVoiceProviderCapabilities({
         provider: resolution.provider,

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { AgentSelectionRequiredError } from "../../agents/agent-scope.js";
 import { buildAgentMainSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
+import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
 import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
@@ -260,6 +261,7 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           requestedOwner?.agentId ??
           bareTalkAgentId ??
           resolveTalkSessionAgentId(runtimeConfig, requestedSessionKey);
+        assertSecretOwnerAvailable("capability", "talk:realtime");
         const resolution = resolveConfiguredRealtimeVoiceProvider({
           configuredProviderId: realtimeConfig.provider,
           providerConfigs: realtimeConfig.providers,

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -8,6 +8,7 @@ import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../talk/describe-view-tool.js";
 import { buildTalkRealtimeConfig } from "./talk-shared.js";
 import { talkHandlers } from "./talk.js";
@@ -105,6 +106,8 @@ vi.mock("../../tts/tts.js", () => ({
   resolveTtsConfig: mocks.resolveTtsConfig,
   synthesizeSpeech: mocks.synthesizeSpeech,
 }));
+
+vi.mock("../../tts/tts-synthesis.js", () => ({ synthesizeTalkSpeech: mocks.synthesizeSpeech }));
 
 vi.mock("../../talk/provider-registry.js", () => ({
   canonicalizeRealtimeVoiceProviderId: mocks.canonicalizeRealtimeVoiceProviderId,
@@ -303,6 +306,7 @@ function expectRespondError(mock: ReturnType<typeof vi.fn>, expected: Record<str
 }
 
 beforeEach(() => {
+  setActiveDegradedSecretOwners([]);
   mocks.getRealtimeTranscriptionProvider.mockImplementation((providerId: string | undefined) => {
     const normalized = providerId?.trim().toLowerCase();
     const providers = mocks.listRealtimeTranscriptionProviders() as Array<{
@@ -317,6 +321,19 @@ beforeEach(() => {
   });
 });
 
+function markTalkOwnerCold(ownerId: string): void {
+  setActiveDegradedSecretOwners([
+    {
+      ownerKind: "capability",
+      ownerId,
+      state: "unavailable",
+      paths: [],
+      refKeys: [],
+      reason: "secret reference was not found",
+    },
+  ]);
+}
+
 describe("talk.catalog handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -325,6 +342,36 @@ describe("talk.catalog handler", () => {
     mocks.listRealtimeVoiceProviders.mockReturnValue([]);
     mocks.getResolvedSpeechProviderConfig.mockReturnValue({});
     mocks.resolveTtsConfig.mockReturnValue({ timeoutMs: 30_000 });
+  });
+
+  it.each([
+    ["talk.catalog", {}],
+    ["talk.client.create", { provider: "openai" }],
+    ["talk.session.create", { mode: "realtime", transport: "gateway-relay", provider: "openai" }],
+  ] as const)("isolates a cold realtime owner for %s", async (method, params) => {
+    markTalkOwnerCold("talk:realtime");
+    mocks.listRealtimeVoiceProviders.mockReturnValue([
+      {
+        id: "openai",
+        label: "Realtime",
+        resolveConfig: () => {
+          throw new Error("cold SecretRef");
+        },
+      },
+    ] as never);
+    const respond = vi.fn();
+    await callTalkHandler(method, {
+      params,
+      respond,
+      context: { getRuntimeConfig: () => ({ talk: { realtime: { provider: "openai" } } }) },
+    });
+    if (method === "talk.catalog") {
+      expect(expectRespondOk(respond)).toMatchObject({
+        realtime: { ready: false, providers: [{ configured: false }] },
+      });
+    } else {
+      expectRespondError(respond, { code: ErrorCodes.UNAVAILABLE });
+    }
   });
 
   it("returns safe speech, transcription, and realtime catalogs without provider secrets", async () => {
@@ -927,111 +974,149 @@ describe("talk.speak handler", () => {
     vi.clearAllMocks();
   });
 
-  it("uses the active runtime config snapshot instead of the raw config snapshot", async () => {
-    const runtimeConfig = createTalkConfig("env-acme-key");
-    runtimeConfig.talk = {
-      provider: "acme",
-      providers: {
-        acme: {
-          apiKey: "env-acme-key",
-          speakerVoice: "talk-speaker",
-          speakerVoiceId: "talk-speaker-id",
-          voice: "explicit-talk-voice",
-          voiceId: "explicit-talk-voice-id",
+  it.each(["talk:speech", "tts"])(
+    "uses the runtime snapshot with cold owner %s",
+    async (coldOwnerId) => {
+      markTalkOwnerCold(coldOwnerId);
+      const runtimeConfig = createTalkConfig("env-acme-key");
+      runtimeConfig.talk = {
+        provider: "acme",
+        providers: {
+          acme: {
+            apiKey: "env-acme-key",
+            speakerVoice: "talk-speaker",
+            speakerVoiceId: "talk-speaker-id",
+            voice: "explicit-talk-voice",
+            voiceId: "explicit-talk-voice-id",
+          },
         },
-      },
-    };
-    runtimeConfig.tts = {
-      providers: {
-        acme: {
-          speakerVoice: "marin",
-          speakerVoiceId: "voice-123",
+      };
+      runtimeConfig.tts = {
+        providers: {
+          acme: {
+            apiKey: { source: "env", provider: "default", id: "MISSING" },
+            speakerVoice: "marin",
+            speakerVoiceId: "voice-123",
+          },
         },
-      },
-    };
-    const diskConfig = createTalkConfig({
-      source: "env",
-      provider: "default",
-      id: "ACME_SPEECH_API_KEY",
-    });
+      };
+      const diskConfig = createTalkConfig({
+        source: "env",
+        provider: "default",
+        id: "ACME_SPEECH_API_KEY",
+      });
 
-    mocks.getRuntimeConfig.mockReturnValue(runtimeConfig);
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      path: "/tmp/openclaw.json",
-      hash: "test-hash",
-      valid: true,
-      config: diskConfig,
-    });
-    mocks.getSpeechProvider.mockReturnValue({
-      id: "acme",
-      label: "Acme Speech",
-      resolveTalkConfig: ({
-        baseTtsConfig,
-        talkProviderConfig,
-      }: {
-        baseTtsConfig: Record<string, unknown>;
-        talkProviderConfig: Record<string, unknown>;
-      }) => {
-        expectRecordFields(talkProviderConfig, {
-          speakerVoice: "talk-speaker",
-          voice: "explicit-talk-voice",
-          voiceName: "talk-speaker",
-          speakerVoiceId: "talk-speaker-id",
-          voiceId: "explicit-talk-voice-id",
-        });
-        expectRecordFields(expectRecordFields(baseTtsConfig.providers, {}).acme, {
-          speakerVoice: "marin",
-          voice: "marin",
-          voiceName: "marin",
-          speakerVoiceId: "voice-123",
-          voiceId: "voice-123",
-        });
-        return talkProviderConfig;
-      },
-    });
-    mocks.synthesizeSpeech.mockImplementation(
-      async ({ cfg }: { cfg: OpenClawConfig; text: string; disableFallback: boolean }) => {
-        expect(cfg.tts?.provider).toBe("acme");
-        expect(cfg.tts?.providers?.acme?.apiKey).toBe("env-acme-key");
-        return {
-          success: true,
-          provider: "acme",
-          audioBuffer: Buffer.from([1, 2, 3]),
-          outputFormat: "mp3",
-          voiceCompatible: false,
-          fileExtension: ".mp3",
-        };
-      },
-    );
+      mocks.getRuntimeConfig.mockReturnValue(runtimeConfig);
+      mocks.readConfigFileSnapshot.mockResolvedValue({
+        path: "/tmp/openclaw.json",
+        hash: "test-hash",
+        valid: true,
+        config: diskConfig,
+      });
+      mocks.getSpeechProvider.mockReturnValue({
+        id: "acme",
+        label: "Acme Speech",
+        resolveTalkConfig: ({
+          baseTtsConfig,
+          talkProviderConfig,
+        }: {
+          baseTtsConfig: Record<string, unknown>;
+          talkProviderConfig: Record<string, unknown>;
+        }) => {
+          expectRecordFields(talkProviderConfig, {
+            speakerVoice: "talk-speaker",
+            voice: "explicit-talk-voice",
+            voiceName: "talk-speaker",
+            speakerVoiceId: "talk-speaker-id",
+            voiceId: "explicit-talk-voice-id",
+          });
+          expectRecordFields(expectRecordFields(baseTtsConfig.providers, {}).acme, {
+            apiKey: "env-acme-key",
+            speakerVoice: "marin",
+            voice: "marin",
+            voiceName: "marin",
+            speakerVoiceId: "voice-123",
+            voiceId: "voice-123",
+          });
+          return talkProviderConfig;
+        },
+      });
+      mocks.synthesizeSpeech.mockImplementation(
+        async ({ cfg }: { cfg: OpenClawConfig; text: string; disableFallback: boolean }) => {
+          expect(cfg.tts?.provider).toBe("acme");
+          expect(cfg.tts?.providers?.acme?.apiKey).toBe("env-acme-key");
+          return {
+            success: true,
+            provider: "acme",
+            audioBuffer: Buffer.from([1, 2, 3]),
+            outputFormat: "mp3",
+            voiceCompatible: false,
+            fileExtension: ".mp3",
+          };
+        },
+      );
 
-    const respond = vi.fn();
-    await callTalkHandler("talk.speak", {
-      params: { text: "Hello from talk mode." },
-      client: null,
-      respond,
-      context: { getRuntimeConfig: () => runtimeConfig },
-    });
+      const respond = vi.fn();
+      await callTalkHandler("talk.speak", {
+        params: { text: "Hello from talk mode." },
+        client: null,
+        respond,
+        context: { getRuntimeConfig: () => runtimeConfig },
+      });
 
-    expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
-    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
-    expectRecordFields(mockCallArg(mocks.synthesizeSpeech), {
-      text: "Hello from talk mode.",
-      disableFallback: true,
-    });
-    expectRespondOk(respond, {
-      provider: "acme",
-      audioBase64: Buffer.from([1, 2, 3]).toString("base64"),
-      outputFormat: "mp3",
-      mimeType: "audio/mpeg",
-      fileExtension: ".mp3",
-    });
-  });
+      if (coldOwnerId === "talk:speech") {
+        expectRespondError(respond, { code: ErrorCodes.UNAVAILABLE });
+        return;
+      }
+      expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+      expectRecordFields(mockCallArg(mocks.synthesizeSpeech), {
+        text: "Hello from talk mode.",
+        disableFallback: true,
+      });
+      expectRespondOk(respond, {
+        provider: "acme",
+        audioBase64: Buffer.from([1, 2, 3]).toString("base64"),
+        outputFormat: "mp3",
+        mimeType: "audio/mpeg",
+        fileExtension: ".mp3",
+      });
+    },
+  );
 });
 
 describe("talk.config handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  it.each([
+    ["talk:speech", false, true],
+    ["talk:speech", true, false],
+    ["tts", true, true],
+  ] as const)(
+    "projects speech for owner=%s includeSecrets=%s",
+    async (coldOwnerId, includeSecrets, ok) => {
+      markTalkOwnerCold(coldOwnerId);
+      const runtimeConfig = createTalkConfig(
+        coldOwnerId === "tts"
+          ? "healthy-talk-key"
+          : { source: "env", provider: "default", id: "MISSING" },
+      );
+      mocks.getSpeechProvider.mockReturnValue({ id: "acme" });
+      mocks.readConfigFileSnapshot.mockResolvedValue({ config: runtimeConfig });
+      const respond = vi.fn();
+
+      await callTalkHandler("talk.config", {
+        params: { includeSecrets },
+        client: { connect: { scopes: ["operator.read", "operator.talk.secrets"] } },
+        respond,
+        context: { getRuntimeConfig: () => runtimeConfig },
+      });
+
+      expect(respond.mock.calls[0]?.[0]).toBe(ok);
+    },
+  );
 
   it("projects the runtime realtime transport when source config is invalid", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -31,6 +31,10 @@ import type {
 import type { OpenClawConfig, TtsConfig, TtsProviderConfigMap } from "../../config/types.js";
 import { resolveProviderRawConfig } from "../../plugin-sdk/provider-selection-runtime.js";
 import { canonicalizeRealtimeTranscriptionProviderId } from "../../realtime-transcription/provider-registry.js";
+import {
+  assertSecretOwnerAvailable,
+  isSecretOwnerAvailable,
+} from "../../secrets/runtime-degraded-state.js";
 import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import {
   canonicalizeRealtimeVoiceProviderId,
@@ -51,15 +55,14 @@ import {
   withSpeakerSelectionFallbackCompat,
 } from "../../tts/speaker.js";
 import { CODE_HEAVY_SPOKEN_FALLBACK, isCodeHeavySpeechText } from "../../tts/speech-text.js";
+import { synthesizeTalkSpeech } from "../../tts/tts-synthesis.js";
 import {
   getResolvedSpeechProviderConfig,
   resolveTtsConfig,
-  synthesizeSpeech,
   type TtsDirectiveOverrides,
 } from "../../tts/tts.js";
-import { getVoiceProviderConfig } from "../../tts/voice-models.js";
+import { getVoiceProviderConfig, providerMatchesId } from "../../tts/voice-models.js";
 import { ADMIN_SCOPE, READ_SCOPE, TALK_SECRETS_SCOPE } from "../operator-scopes.js";
-import { resolveConfiguredSecretInputString } from "../resolve-configured-secret-input-string.js";
 import { formatForLog } from "../ws-log.js";
 import { inferSpeechMimeType } from "./speech-mime.js";
 import { talkClientHandlers } from "./talk-client.js";
@@ -150,15 +153,24 @@ function resolveTalkVoiceId(
 
 function withTalkBaseTtsSpeakerSelectionCompat(
   baseTts: Record<string, unknown>,
+  talkProvider?: { provider: { id: string; aliases?: readonly string[] }; apiKey?: unknown },
 ): Record<string, unknown> {
   const next = withSpeakerSelectionCompat(baseTts);
   const providers = asOptionalRecord(baseTts.providers);
   if (providers) {
     next.providers = Object.fromEntries(
-      Object.entries(providers).map(([providerId, providerConfig]) => [
-        providerId,
-        withSpeakerSelectionCompat(asOptionalRecord(providerConfig) ?? {}),
-      ]),
+      Object.entries(providers).map(([providerId, providerConfig]) => {
+        const normalized = withSpeakerSelectionCompat(asOptionalRecord(providerConfig) ?? {});
+        // Talk-owned overrides must shield provider normalization from a cold global TTS ref.
+        if (
+          typeof talkProvider?.apiKey === "string" &&
+          providerMatchesId(talkProvider.provider, providerId) &&
+          typeof normalized.apiKey === "object"
+        ) {
+          normalized.apiKey = talkProvider.apiKey;
+        }
+        return [providerId, normalized];
+      }),
     );
   }
   for (const [key, value] of Object.entries(baseTts)) {
@@ -186,6 +198,7 @@ function buildTalkTtsConfig(
       reason: "talk_unconfigured",
     };
   }
+  assertSecretOwnerAvailable("capability", "talk:speech");
 
   const speechProvider = getSpeechProvider(provider, config);
   if (!speechProvider) {
@@ -195,10 +208,11 @@ function buildTalkTtsConfig(
     };
   }
 
-  const baseTts = withTalkBaseTtsSpeakerSelectionCompat(
-    asOptionalRecord(config.tts) ?? {},
-  ) as TtsConfig;
   const providerConfig = withSpeakerSelectionFallbackCompat(resolved.config);
+  const baseTts = withTalkBaseTtsSpeakerSelectionCompat(asOptionalRecord(config.tts) ?? {}, {
+    provider: speechProvider,
+    apiKey: providerConfig.apiKey,
+  }) as TtsConfig;
   const resolvedProviderConfig =
     speechProvider.resolveTalkConfig?.({
       cfg: config,
@@ -227,7 +241,6 @@ function buildTalkTtsConfig(
 }
 
 function buildTalkCatalog(config: OpenClawConfig) {
-  const ttsConfig = resolveTtsConfig(config);
   const talkResolved = resolveActiveTalkProviderConfig(config.talk);
   const activeSpeechProvider = canonicalizeSpeechProviderId(talkResolved?.provider, config);
   const transcriptionConfig = buildTalkTranscriptionConfig(config);
@@ -254,8 +267,9 @@ function buildTalkCatalog(config: OpenClawConfig) {
     : {};
   const realtimeSelection = resolveCatalogProviderSelection(
     canonicalizeRealtimeVoiceProviderId(realtimeConfig.provider, config),
-    () =>
-      resolveConfiguredRealtimeVoiceProvider({
+    () => {
+      assertSecretOwnerAvailable("capability", "talk:realtime");
+      return resolveConfiguredRealtimeVoiceProvider({
         cfg: config,
         configuredProviderId: realtimeConfig.provider,
         providerConfigs: realtimeConfig.providers,
@@ -263,9 +277,11 @@ function buildTalkCatalog(config: OpenClawConfig) {
         agentId: realtimeAgentId,
         defaultModel: realtimeConfig.model,
         surface: realtimeSurface,
-      }).provider.id,
+      }).provider.id;
+    },
   );
   const activeRealtimeProvider = realtimeSelection.activeProvider;
+  const speechAvailable = isSecretOwnerAvailable("capability", "talk:speech");
 
   return {
     modes: ["realtime", "stt-tts", "transcription"],
@@ -277,13 +293,23 @@ function buildTalkCatalog(config: OpenClawConfig) {
         const entry: Record<string, unknown> = {
           id: provider.id,
           label: provider.label,
-          configured: configuredOrFalse(() =>
-            provider.isConfigured({
-              cfg: config,
-              providerConfig: getResolvedSpeechProviderConfig(ttsConfig, provider.id, config),
-              timeoutMs: ttsConfig.timeoutMs,
+          configured:
+            speechAvailable &&
+            configuredOrFalse(() => {
+              const setup =
+                provider.id === activeSpeechProvider ? buildTalkTtsConfig(config) : undefined;
+              const speechConfig = setup && !("error" in setup) ? setup.cfg : config;
+              const effectiveTts = resolveTtsConfig(speechConfig);
+              return provider.isConfigured({
+                cfg: speechConfig,
+                providerConfig: getResolvedSpeechProviderConfig(
+                  effectiveTts,
+                  provider.id,
+                  speechConfig,
+                ),
+                timeoutMs: effectiveTts.timeoutMs,
+              });
             }),
-          ),
           modes: ["stt-tts"],
           brains: ["agent-consult"],
         };
@@ -346,6 +372,7 @@ function buildTalkCatalog(config: OpenClawConfig) {
       ready: realtimeSelection.ready,
       ...(activeRealtimeProvider ? { activeProvider: activeRealtimeProvider } : {}),
       providers: listRealtimeVoiceProviders(config).map((provider) => {
+        const available = isSecretOwnerAvailable("capability", "talk:realtime");
         const rawConfig = resolveProviderRawConfig({
           providerConfigs: realtimeConfig.providers ?? {},
           providerId: provider.id,
@@ -357,28 +384,33 @@ function buildTalkCatalog(config: OpenClawConfig) {
         const rawConfigWithModel = realtimeConfig.model
           ? { ...rawConfig, model: realtimeConfig.model }
           : rawConfig;
-        const providerConfig =
-          provider.resolveConfig?.({ cfg: config, rawConfig: rawConfigWithModel }) ??
-          rawConfigWithModel;
-        const capabilities = resolveRealtimeVoiceProviderCapabilities({
-          provider,
-          providerConfig,
-          cfg: config,
-          agentId: realtimeAgentId,
-          surface: realtimeSurface,
-        });
+        const providerConfig = available
+          ? (provider.resolveConfig?.({ cfg: config, rawConfig: rawConfigWithModel }) ??
+            rawConfigWithModel)
+          : rawConfigWithModel;
+        const capabilities: ReturnType<typeof resolveRealtimeVoiceProviderCapabilities> = available
+          ? resolveRealtimeVoiceProviderCapabilities({
+              provider,
+              providerConfig,
+              cfg: config,
+              agentId: realtimeAgentId,
+              surface: realtimeSurface,
+            })
+          : provider.capabilities;
         const entry: Record<string, unknown> = {
           id: provider.id,
           label: provider.label,
-          configured: configuredOrFalse(() =>
-            isRealtimeVoiceProviderConfigured({
-              provider,
-              cfg: config,
-              providerConfig,
-              agentId: realtimeAgentId,
-              surface: realtimeSurface,
-            }),
-          ),
+          configured:
+            available &&
+            configuredOrFalse(() =>
+              isRealtimeVoiceProviderConfigured({
+                provider,
+                cfg: config,
+                providerConfig,
+                agentId: realtimeAgentId,
+                surface: realtimeSurface,
+              }),
+            ),
           modes: ["realtime"],
           brains:
             capabilities?.supportsToolCalls === false && capabilities.handlesAgentConsult !== true
@@ -493,11 +525,11 @@ function buildTalkSpeakOverrides(
   };
 }
 
-async function resolveTalkResponseFromConfig(params: {
+function resolveTalkResponseFromConfig(params: {
   includeSecrets: boolean;
   sourceConfig: OpenClawConfig;
   runtimeConfig: OpenClawConfig;
-}): Promise<TalkConfigResponse | undefined> {
+}): TalkConfigResponse | undefined {
   // Normalize once at the Gateway boundary. Legacy flat provider fields belong to doctor
   // migration and must not leak into steady-state response construction.
   const normalizedTalk = normalizeTalkSection(params.sourceConfig.talk);
@@ -544,11 +576,17 @@ async function resolveTalkResponseFromConfig(params: {
     ? projectTalkSourcePayloadForSecrets(sourcePayload)
     : sourcePayload;
 
-  const sourceResolved = resolveActiveTalkProviderConfig(normalizedTalk);
+  const sourceResolved = configuredPayload?.resolved;
   const runtimeResolved = resolveActiveTalkProviderConfig(params.runtimeConfig.talk);
   const activeProviderId = sourceResolved?.provider ?? runtimeResolved?.provider;
   const provider = canonicalizeSpeechProviderId(activeProviderId, params.runtimeConfig);
   if (!provider) {
+    return payload;
+  }
+  if (params.includeSecrets) {
+    assertSecretOwnerAvailable("capability", "talk:speech");
+  } else if (!isSecretOwnerAvailable("capability", "talk:speech")) {
+    // A readable redacted projection must not normalize a cold ref into provider/env fallback.
     return payload;
   }
 
@@ -556,27 +594,19 @@ async function resolveTalkResponseFromConfig(params: {
   const sourceBaseTts = withTalkBaseTtsSpeakerSelectionCompat(
     asOptionalRecord(params.sourceConfig.tts) ?? {},
   );
-  const runtimeBaseTts = withTalkBaseTtsSpeakerSelectionCompat(
-    asOptionalRecord(params.runtimeConfig.tts) ?? {},
-  );
   const sourceProviderConfig = withSpeakerSelectionFallbackCompat(sourceResolved?.config);
   const runtimeProviderConfig = withSpeakerSelectionFallbackCompat(runtimeResolved?.config);
+  const providerInputConfig = stripUnresolvedSecretApiKey(
+    Object.keys(runtimeProviderConfig).length > 0 ? runtimeProviderConfig : sourceProviderConfig,
+  );
+  const runtimeBaseTts = withTalkBaseTtsSpeakerSelectionCompat(
+    asOptionalRecord(params.runtimeConfig.tts) ?? {},
+    { provider: speechProvider ?? { id: provider }, apiKey: providerInputConfig.apiKey },
+  );
   const selectedBaseTts =
     Object.keys(runtimeBaseTts).length > 0
       ? runtimeBaseTts
       : stripUnresolvedSecretApiKeysFromBaseTtsProviders(sourceBaseTts);
-  // Prefer runtime-resolved provider config and fall back to source. Provider
-  // plugins (ElevenLabs/OpenAI) call strict secret helpers that throw on
-  // unresolved wrappers, so only the already-authorized includeSecrets path may
-  // materialize SecretRef apiKey values before provider resolution. Read-scope
-  // calls keep the old strip/redact behavior.
-  const providerInputConfig = await resolveTalkProviderInputConfig({
-    includeSecrets: params.includeSecrets,
-    config: params.runtimeConfig,
-    providerConfig:
-      Object.keys(runtimeProviderConfig).length > 0 ? runtimeProviderConfig : sourceProviderConfig,
-    provider,
-  });
   const resolvedConfig =
     speechProvider?.resolveTalkConfig?.({
       cfg: params.runtimeConfig,
@@ -657,27 +687,6 @@ function projectTalkSourcePayloadForSecrets(payload: TalkConfigResponse): TalkCo
     projected.realtime = projectTalkRealtimeForSecrets(payload.realtime);
   }
   return projected;
-}
-
-async function resolveTalkProviderInputConfig(params: {
-  includeSecrets: boolean;
-  config: OpenClawConfig;
-  providerConfig: TalkProviderConfig;
-  provider: string;
-}): Promise<TalkProviderConfig> {
-  const strippedConfig = stripUnresolvedSecretApiKey(params.providerConfig);
-  if (!params.includeSecrets || params.providerConfig.apiKey === undefined) {
-    return strippedConfig;
-  }
-  const resolved = await resolveConfiguredSecretInputString({
-    config: params.config,
-    env: process.env,
-    value: params.providerConfig.apiKey,
-    path: `talk.providers.${params.provider}.apiKey`,
-  });
-  return resolved.value === undefined
-    ? strippedConfig
-    : { ...params.providerConfig, apiKey: resolved.value };
 }
 
 function stripUnresolvedSecretApiKey(config: TalkProviderConfig): TalkProviderConfig {
@@ -773,11 +782,17 @@ export const talkHandlers: GatewayRequestHandlers = {
     const runtimeConfig = context.getRuntimeConfig();
     const configPayload: Record<string, unknown> = {};
 
-    const talk = await resolveTalkResponseFromConfig({
-      includeSecrets,
-      sourceConfig: snapshot.config,
-      runtimeConfig,
-    });
+    let talk: TalkConfigResponse | undefined;
+    try {
+      talk = resolveTalkResponseFromConfig({
+        includeSecrets,
+        sourceConfig: snapshot.config,
+        runtimeConfig,
+      });
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+      return;
+    }
     if (talk) {
       configPayload.talk = includeSecrets ? talk : redactConfigObject(talk);
     }
@@ -837,7 +852,7 @@ export const talkHandlers: GatewayRequestHandlers = {
         typedParams,
       );
       const speechText = isCodeHeavySpeechText(text) ? CODE_HEAVY_SPOKEN_FALLBACK : text;
-      const result = await synthesizeSpeech({
+      const result = await synthesizeTalkSpeech({
         text: speechText,
         cfg: setup.cfg,
         overrides,

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -192,7 +192,16 @@ async function expectTalkSecretsConfig(
   await withTalkConfigConnection(
     ["operator.read", "operator.write", "operator.talk.secrets"],
     async (ws) => {
-      const res = await fetchOkTalkConfig(ws, { includeSecrets: true });
+      const secrets = await import("../secrets/runtime.js");
+      const snapshot = await secrets.prepareSecretsRuntimeSnapshot({
+        config: (await (await import("../config/config.js")).readConfigFileSnapshot()).config,
+        env: process.env,
+        includeAuthStoreRefs: false,
+        loadablePluginOrigins: new Map(),
+      });
+      const response = fetchOkTalkConfig(ws, { includeSecrets: true });
+      secrets.activateSecretsRuntimeSnapshot(snapshot);
+      const res = await response;
       expect(validateTalkConfigResult(res.payload)).toBe(true);
       expectTalkConfig(res.payload?.config?.talk, {
         provider: GENERIC_TALK_PROVIDER_ID,

--- a/src/gateway/server.talk-runtime.test.ts
+++ b/src/gateway/server.talk-runtime.test.ts
@@ -24,6 +24,8 @@ vi.mock("../tts/tts.js", () => ({
   synthesizeSpeech: synthesizeSpeechMock,
 }));
 
+vi.mock("../tts/tts-synthesis.js", () => ({ synthesizeTalkSpeech: synthesizeSpeechMock }));
+
 type SpeechProvider = Parameters<typeof withSpeechProviders>[0][number]["provider"];
 
 const ALIAS_STUB_VOICE_ID = "VoiceAlias1234567890";

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -83,7 +83,7 @@ export const pluginRegistrationContractCases = {
   },
   microsoft: {
     pluginId: "microsoft",
-    speechProviderIds: ["microsoft"],
+    speechProviderIds: ["microsoft", "edge"],
   },
   minimax: {
     pluginId: "minimax",

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -1007,29 +1007,33 @@ describe("resolvePluginCapabilityProviders", () => {
     expectActiveRegistryLookup(["openai"]);
   });
 
-  it("loads a voiceModel provider that is missing from an active speech registry", () => {
+  it.each([
+    ["voice model", "speechProviders", { agents: { defaults: { voiceModel: "openai/model" } } }],
+    ["sole Talk speech", "speechProviders", { talk: { providers: { openai: {} } } }],
+    [
+      "Talk speech alias",
+      "speechProviders",
+      { talk: { provider: "voice-alias", providers: { "voice-alias": {} } } },
+    ],
+    [
+      "Talk realtime alias",
+      "realtimeVoiceProviders",
+      { talk: { realtime: { provider: "voice-alias", providers: { "voice-alias": {} } } } },
+    ],
+  ] as const)("loads a missing provider requested by %s", (_source, key, cfg) => {
     const active = createEmptyPluginRegistry();
-    addSpeechProvider(active, "google", { pluginName: "Google", label: "Google" });
+    addCapabilityProvider(active, key, { id: "google" });
     const loaded = createEmptyPluginRegistry();
-    addSpeechProvider(loaded, "openai", { pluginName: "OpenAI", label: "OpenAI" });
+    addCapabilityProvider(loaded, key, { id: "openai", provider: { aliases: ["voice-alias"] } });
     setCapabilityManifestPlugins([
-      { id: "google", contracts: { speechProviders: ["google"] } },
-      { id: "openai", contracts: { speechProviders: ["openai"] } },
+      { id: "google", contracts: { [key]: ["google"] } },
+      { id: "openai", contracts: { [key]: ["openai", "voice-alias"] } },
     ]);
     mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
       params === undefined ? active : loaded,
     );
 
-    const providers = resolvePluginCapabilityProviders({
-      key: "speechProviders",
-      cfg: {
-        agents: {
-          defaults: {
-            voiceModel: { primary: "openai/gpt-4o-mini-tts" },
-          },
-        },
-      } as OpenClawConfig,
-    });
+    const providers = resolvePluginCapabilityProviders({ key, cfg: cfg as OpenClawConfig });
 
     expectResolvedCapabilityProviderIds(providers, ["google", "openai"]);
     expectActiveRegistryLookup(["openai"]);

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import * as talk from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveVoiceModelRefs } from "../tts/voice-models.js";
 import {
@@ -267,6 +268,7 @@ function collectRequestedSpeechProviderIds(
       : undefined;
   addStringValue(requested, tts?.provider);
   addObjectKeys(requested, tts?.providers);
+  addStringValue(requested, cfg && talk.resolveConfiguredTalkSpeechProviderId(cfg));
   if (options.includeVoiceModel) {
     addModelConfigProviderIds(requested, cfg?.agents?.defaults?.voiceModel);
   }
@@ -311,10 +313,16 @@ function collectRequestedCapabilityProviderIds(params: {
         includeVoiceModel: params.includeVoiceModel ?? false,
       });
     case "realtimeTranscriptionProviders":
-    case "realtimeVoiceProviders":
       return params.includeVoiceModel
         ? collectRequestedVoiceModelProviderIds(params.cfg)
         : undefined;
+    case "realtimeVoiceProviders": {
+      const requested = params.includeVoiceModel
+        ? collectRequestedVoiceModelProviderIds(params.cfg)
+        : new Set<string>();
+      addStringValue(requested, talk.resolveConfiguredTalkRealtimeProviderId(params.cfg ?? {}));
+      return requested.size > 0 ? requested : undefined;
+    }
     case "mediaUnderstandingProviders":
       return collectRequestedMediaUnderstandingProviderIds(params.cfg);
     default:

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -115,7 +115,7 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
     {
       id: "microsoft",
       enabledByDefault: true,
-      contracts: { speechProviders: ["microsoft"] },
+      contracts: { speechProviders: ["microsoft", "edge"] },
     },
     {
       id: "tts-local-cli",
@@ -143,6 +143,11 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         videoGenerationProviders: ["openai"],
         embeddingProviders: ["openai"],
       },
+    },
+    {
+      id: "xai",
+      enabledByDefault: true,
+      contracts: { realtimeVoiceProviders: ["xai", "grok-voice"] },
     },
     {
       id: "ollama",
@@ -589,6 +594,16 @@ describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
         tts: { provider: "microsoft" },
       } as OpenClawConfig,
       ["browser", "microsoft", "memory-core"],
+    ],
+    [
+      "activates the sole Talk speech provider from its capability alias",
+      { channels: {}, talk: { providers: { edge: {} } } } as OpenClawConfig,
+      ["browser", "microsoft", "memory-core"],
+    ],
+    [
+      "activates the selected Talk realtime capability alias",
+      { channels: {}, talk: { realtime: { provider: "grok-voice" } } } as OpenClawConfig,
+      ["browser", "xai", "memory-core"],
     ],
     [
       "includes bundled speech providers configured by provider block",

--- a/src/plugins/contracts/registry.contract.test.ts
+++ b/src/plugins/contracts/registry.contract.test.ts
@@ -129,6 +129,19 @@ describe("plugin contract registry", () => {
     expectUniqueIds(pluginRegistrationContractRegistry.flatMap((entry) => entry.speechProviderIds));
   });
 
+  it.each([
+    ["azure-speech", "speechProviderIds", ["azure-speech", "azure"]],
+    ["microsoft", "speechProviderIds", ["microsoft", "edge"]],
+    ["tts-local-cli", "speechProviderIds", ["tts-local-cli", "cli"]],
+    ["volcengine", "speechProviderIds", ["volcengine", "bytedance", "doubao"]],
+    ["xiaomi", "speechProviderIds", ["xiaomi", "mimo"]],
+    ["xai", "realtimeVoiceProviderIds", ["xai", "grok-voice", "xai-realtime-voice"]],
+  ] as const)("declares canonical-first %s %s aliases", (pluginId, contract, providerIds) => {
+    expect(
+      pluginRegistrationContractRegistry.find((entry) => entry.pluginId === pluginId)?.[contract],
+    ).toEqual(providerIds);
+  });
+
   it("covers every bundled worker provider plugin discovered from manifests", () => {
     expectRegistryPluginIds({
       actualPluginIds: pluginRegistrationContractRegistry

--- a/src/plugins/gateway-startup-plugin-providers.ts
+++ b/src/plugins/gateway-startup-plugin-providers.ts
@@ -11,6 +11,7 @@ import {
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
+import { resolveConfiguredTalkRealtimeProviderId } from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { planEffectiveModelCatalogRows } from "../model-catalog/index.js";
 import { resolveConfiguredGenericEmbeddingProviderId } from "./embedding-provider-config.js";
@@ -19,7 +20,6 @@ import type {
   ConfiguredGenerationProviderIds,
   ConfiguredVoiceProviderIds,
 } from "./gateway-startup-plugin-contracts.js";
-import { normalizeConfiguredSpeechProviderIdForStartup } from "./gateway-startup-speech-providers.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import { CORE_BUILT_IN_MODEL_APIS } from "./provider-config-owner.js";
 import type { PluginRegistry } from "./registry-types.js";
@@ -32,7 +32,7 @@ export function manifestOwnsConfiguredSpeechProvider(params: {
     return false;
   }
   return (params.manifest?.contracts?.speechProviders ?? []).some((providerId) => {
-    const normalized = normalizeConfiguredSpeechProviderIdForStartup(providerId);
+    const normalized = normalizeOptionalLowercaseString(providerId);
     return normalized ? params.configuredSpeechProviderIds.has(normalized) : false;
   });
 }
@@ -216,10 +216,15 @@ export function collectConfiguredVoiceProviderIds(
   config: OpenClawConfig,
 ): ConfiguredVoiceProviderIds {
   const providerIds = collectModelProviderIds(config.agents?.defaults?.voiceModel);
+  const realtimeProviderIds = new Set(providerIds);
+  const talkRealtimeProviderId = resolveConfiguredTalkRealtimeProviderId(config);
+  if (talkRealtimeProviderId) {
+    realtimeProviderIds.add(talkRealtimeProviderId.toLowerCase());
+  }
   return {
     speechProviders: providerIds,
     realtimeTranscriptionProviders: providerIds,
-    realtimeVoiceProviders: providerIds,
+    realtimeVoiceProviders: realtimeProviderIds,
   };
 }
 

--- a/src/plugins/gateway-startup-speech-providers.ts
+++ b/src/plugins/gateway-startup-speech-providers.ts
@@ -2,6 +2,7 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
+import { resolveConfiguredTalkSpeechProviderId } from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveEffectiveTtsConfig } from "../tts/tts-config.js";
 
@@ -32,14 +33,8 @@ function isConfigActivationValueEnabled(value: unknown): boolean {
 }
 
 /** Normalizes configured TTS provider ids for startup plugin selection. */
-export function normalizeConfiguredSpeechProviderIdForStartup(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
+function normalizeConfiguredSpeechProviderIdForStartup(value: unknown): string | undefined {
   const normalized = normalizeOptionalLowercaseString(value);
-  if (!normalized) {
-    return undefined;
-  }
   return normalized === "edge" ? "microsoft" : normalized;
 }
 
@@ -142,10 +137,14 @@ function addConfiguredTtsProviderIds(target: Set<string>, value: unknown): void 
   }
 }
 
-/** Collects TTS provider ids referenced by root, agent, channel, account, and plugin config. */
+/** Collects active Talk and TTS provider ids across root, agent, channel, and plugin config. */
 export function collectConfiguredSpeechProviderIds(config: OpenClawConfig): ReadonlySet<string> {
   const configured = new Set<string>();
   addConfiguredTtsProviderIds(configured, resolveEffectiveTtsConfig(config));
+  const talkProviderId = resolveConfiguredTalkSpeechProviderId(config);
+  if (talkProviderId) {
+    configured.add(talkProviderId.toLowerCase());
+  }
 
   for (const agent of listAgentEntries(config)) {
     addConfiguredTtsProviderIds(

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -291,6 +291,32 @@ describe("secrets audit", () => {
     expectFindingCode(report, "PLAINTEXT_FOUND");
   });
 
+  it("audits inactive Talk speech and realtime provider references independently", async () => {
+    const activeKey = { source: "env", provider: "default", id: OPENAI_API_KEY_MARKER };
+    const providerSelection = (missingKey: string) => ({
+      provider: "openai",
+      providers: {
+        openai: { apiKey: activeKey },
+        inactive: { apiKey: { source: "env", provider: "default", id: missingKey } },
+      },
+    });
+    await writeJsonFile(fixture.configPath, {
+      talk: {
+        ...providerSelection("MISSING_TALK_SPEECH_KEY"),
+        realtime: providerSelection("MISSING_TALK_REALTIME_KEY"),
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(
+      report.findings
+        .filter((finding) => finding.code === "REF_UNRESOLVED")
+        .map((finding) => finding.jsonPath)
+        .toSorted(),
+    ).toEqual(["talk.providers.inactive.apiKey", "talk.realtime.providers.inactive.apiKey"]);
+  });
+
   it("reports plaintext that duplicates the store while resolving store refs", async () => {
     writeSecretStoreEntry({
       scope: { kind: "team" },

--- a/src/secrets/runtime-config-collectors-core.ts
+++ b/src/secrets/runtime-config-collectors-core.ts
@@ -1,6 +1,11 @@
 /** Collects core config secret refs during runtime preparation. */
+import { findNormalizedProviderKey } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentEntriesWithSource } from "../agents/agent-scope-config.js";
+import {
+  resolveConfiguredTalkRealtimeProviderId,
+  resolveConfiguredTalkSpeechProviderId,
+} from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { MediaUnderstandingModelConfig } from "../config/types.tools.js";
 import {
@@ -8,6 +13,7 @@ import {
   resolveEffectiveMediaEntryCapabilities,
 } from "../media-understanding/entry-capabilities.js";
 import { buildMediaUnderstandingCapabilityRegistry } from "../media-understanding/provider-capability-registry.js";
+import { resolveVoiceModelRefs } from "../tts/voice-models.js";
 import { collectAgentMemorySearchAssignments } from "./runtime-config-collectors-memory.js";
 import { collectAgentSandboxAssignments } from "./runtime-config-collectors-sandbox.js";
 import { collectTtsApiKeyAssignments } from "./runtime-config-collectors-tts.js";
@@ -136,6 +142,15 @@ function collectSkillAssignments(params: {
   }
 }
 
+function findTalkProviderConfig(providers: unknown, providerId: string) {
+  if (!isRecord(providers)) {
+    return undefined;
+  }
+  const id = findNormalizedProviderKey(providers, providerId);
+  const config = id ? providers[id] : undefined;
+  return id && isRecord(config) ? { id, config } : undefined;
+}
+
 function collectTalkAssignments(params: {
   config: OpenClawConfig;
   defaults: SecretDefaults | undefined;
@@ -145,54 +160,119 @@ function collectTalkAssignments(params: {
   if (!isRecord(talk)) {
     return;
   }
-  collectSecretInputAssignment({
-    value: talk.apiKey,
-    path: "talk.apiKey",
-    expected: "string",
-    defaults: params.defaults,
-    context: params.context,
-    apply: (value) => {
-      talk.apiKey = value;
-    },
-  });
-  collectTalkProviderApiKeyAssignments({
-    providers: talk.providers,
-    pathPrefix: "talk.providers",
-    defaults: params.defaults,
-    context: params.context,
-  });
-  const realtime = isRecord(talk.realtime) ? talk.realtime : undefined;
-  collectTalkProviderApiKeyAssignments({
-    providers: realtime?.providers,
-    pathPrefix: "talk.realtime.providers",
-    defaults: params.defaults,
-    context: params.context,
-  });
-}
-
-function collectTalkProviderApiKeyAssignments(params: {
-  providers: unknown;
-  pathPrefix: string;
-  defaults: SecretDefaults | undefined;
-  context: ResolverContext;
-}): void {
-  if (!isRecord(params.providers)) {
-    return;
-  }
-  for (const [providerId, providerConfig] of Object.entries(params.providers)) {
-    if (!isRecord(providerConfig)) {
+  for (const surface of ["speech", "realtime"] as const) {
+    const section =
+      surface === "speech" ? talk : isRecord(talk.realtime) ? talk.realtime : undefined;
+    if (!section) {
       continue;
     }
-    collectSecretInputAssignment({
-      value: providerConfig.apiKey,
-      path: `${params.pathPrefix}.${providerId}.apiKey`,
-      expected: "string",
-      defaults: params.defaults,
-      context: params.context,
-      apply: (value) => {
-        providerConfig.apiKey = value;
-      },
-    });
+    const configuredId =
+      surface === "speech"
+        ? resolveConfiguredTalkSpeechProviderId(params.config)
+        : resolveConfiguredTalkRealtimeProviderId(params.config);
+    const normalizedConfiguredId = normalizeOptionalLowercaseString(configuredId);
+    const capability = surface === "speech" ? "speechProviders" : "realtimeVoiceProviders";
+    const providerIds = normalizedConfiguredId
+      ? params.context.manifestRegistry
+        ? params.context.manifestRegistry.plugins
+            .map((manifest) => manifest.contracts?.[capability])
+            .find((ids) =>
+              ids?.some((id) => normalizeOptionalLowercaseString(id) === normalizedConfiguredId),
+            )
+        : [normalizedConfiguredId]
+      : undefined;
+    const normalizedProviderIds = providerIds?.map(
+      (id) => normalizeOptionalLowercaseString(id) ?? id,
+    );
+    const providerId = normalizedProviderIds?.[0];
+    const selected = configuredId
+      ? findTalkProviderConfig(section.providers, configuredId)
+      : undefined;
+    const inherited =
+      surface === "speech" && providerId
+        ? normalizedProviderIds
+            .map((id) => findTalkProviderConfig(params.config.tts?.providers, id))
+            .find((entry) => entry !== undefined)
+        : undefined;
+    const explicitModel =
+      surface === "realtime"
+        ? section.model
+        : (selected?.config.model ??
+          selected?.config.modelId ??
+          inherited?.config.model ??
+          inherited?.config.modelId);
+    const voiceModel =
+      explicitModel === undefined
+        ? resolveVoiceModelRefs(params.config.agents?.defaults?.voiceModel).find((ref) =>
+            normalizedProviderIds?.includes(ref.provider.toLowerCase()),
+          )
+        : undefined;
+    const { providers: _providers, provider: _provider, ...realtimeDefaults } = section;
+    const inheritedConfig =
+      inherited && selected?.config.apiKey !== undefined
+        ? Object.fromEntries(Object.entries(inherited.config).filter(([key]) => key !== "apiKey"))
+        : inherited?.config;
+    const owner = providerId
+      ? ({
+          ownerKind: "capability",
+          ownerId: `talk:${surface}`,
+          requiredForGateway: false,
+          disposition: "isolate",
+          contract: {
+            provider: providerId,
+            selectedProvider: configuredId,
+            providerConfig: selected?.config,
+            voiceModel,
+            ...(surface === "realtime"
+              ? {
+                  ...realtimeDefaults,
+                  canonicalProviderConfig: findTalkProviderConfig(section.providers, providerId)
+                    ?.config,
+                }
+              : {
+                  inheritedProviderConfig: inheritedConfig,
+                  timeoutMs: params.config.tts?.timeoutMs,
+                  maxTextLength: params.config.tts?.maxTextLength,
+                }),
+          },
+        } satisfies SecretAssignmentOwner)
+      : undefined;
+    const inheritedKey =
+      surface === "speech" && inherited && selected?.config.apiKey === undefined
+        ? inherited
+        : undefined;
+    const entries = Object.entries(isRecord(section.providers) ? section.providers : {});
+    if (inheritedKey && selected) {
+      entries.push([inheritedKey.id, inheritedKey.config]);
+    }
+    for (const [id, config] of entries) {
+      if (!isRecord(config)) {
+        continue;
+      }
+      const isInherited = config === inheritedKey?.config;
+      const destination = isInherited && selected ? selected.config : config;
+      const normalized = normalizeOptionalLowercaseString(id);
+      collectRuntimeSecretInputAssignment({
+        value: config.apiKey,
+        path: isInherited
+          ? `tts.providers.${id}.apiKey`
+          : `talk.${surface === "realtime" ? "realtime." : ""}providers.${id}.apiKey`,
+        expected: "string",
+        defaults: params.defaults,
+        context: params.context,
+        active: Boolean(
+          isInherited ||
+          (providerId &&
+            (normalized === normalizedConfiguredId ||
+              (surface === "realtime" && normalized === providerId))),
+        ),
+        inactiveReason: "Talk provider is not selected.",
+        owner,
+        apply: (resolved) => {
+          destination.apiKey = resolved;
+        },
+      });
+    }
   }
 }
 

--- a/src/secrets/runtime-talk-secret-owners.test.ts
+++ b/src/secrets/runtime-talk-secret-owners.test.ts
@@ -1,0 +1,189 @@
+/** Tests owner-isolated Talk speech and realtime SecretRefs in runtime snapshots. */
+import { describe, expect, it } from "vitest";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { activateSecretsRuntimeSnapshotState } from "./runtime-state.js";
+import { asConfig, setupSecretsRuntimeSnapshotTestHooks } from "./runtime.test-support.ts";
+
+const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
+const ref = (id: string) => ({ source: "env" as const, provider: "default", id });
+
+function prepare(config: unknown, env: NodeJS.ProcessEnv = {}, manifests?: PluginManifestRecord[]) {
+  return prepareSecretsRuntimeSnapshot({
+    config: asConfig(config),
+    env,
+    includeAuthStoreRefs: false,
+    allowUnavailableSecretOwners: true,
+    loadablePluginOrigins: new Map(),
+    ...(manifests ? { manifestRegistry: { plugins: manifests } } : {}),
+  });
+}
+
+async function activate(config: unknown, env: NodeJS.ProcessEnv) {
+  const snapshot = await prepare(config, env);
+  activateSecretsRuntimeSnapshotState({ snapshot, refreshContext: null, refreshHandler: null });
+}
+
+function manifest(canonical: string, ...aliases: string[]): PluginManifestRecord {
+  return {
+    id: `${canonical}-plugin`,
+    channels: [],
+    providers: [canonical],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    origin: "bundled",
+    rootDir: `/tmp/${canonical}`,
+    source: `/tmp/${canonical}/index.ts`,
+    manifestPath: `/tmp/${canonical}/openclaw.plugin.json`,
+    contracts: {
+      speechProviders: [canonical, ...aliases],
+      realtimeVoiceProviders: [canonical, ...aliases],
+    },
+  };
+}
+
+describe("secrets runtime Talk capability owners", () => {
+  it.each(["speech", "realtime"] as const)(
+    "resolves selected %s refs and ignores inactive refs",
+    async (surface) => {
+      const providers = {
+        openai: { apiKey: ref("READY_KEY") },
+        unused: { apiKey: ref("UNUSED_KEY") },
+      };
+      const selected = { provider: "openai", providers };
+      const snapshot = await prepare(
+        { talk: surface === "speech" ? selected : { realtime: selected } },
+        { READY_KEY: "ready" },
+      );
+      const prefix = `talk.${surface === "realtime" ? "realtime." : ""}providers`;
+      expect(snapshot.degradedOwners).toEqual([]);
+      expect(snapshot.warnings).toContainEqual(
+        expect.objectContaining({ path: `${prefix}.unused.apiKey` }),
+      );
+      const runtime = surface === "speech" ? snapshot.config.talk : snapshot.config.talk?.realtime;
+      expect(runtime?.providers?.openai?.apiKey).toBe("ready");
+    },
+  );
+
+  it.each([
+    { surface: "speech", canonical: "volcengine", alias: "bytedance", source: "tts" },
+    { surface: "realtime", canonical: "xai", alias: "grok-voice", source: "talk.realtime" },
+  ] as const)(
+    "resolves $surface aliases from capability contracts, not plugin ids",
+    async ({ surface, canonical, alias, source }) => {
+      const providers =
+        surface === "speech"
+          ? { [alias]: {} }
+          : { [canonical]: { apiKey: ref("MISSING_KEY") }, [alias]: { model: "voice" } };
+      const selection = { provider: alias, providers };
+      const tts =
+        surface === "speech"
+          ? { providers: { [canonical]: { apiKey: ref("MISSING_KEY") } } }
+          : undefined;
+      const talk = surface === "speech" ? selection : { realtime: selection };
+      const snapshot = await prepare({ tts, talk }, {}, [manifest(canonical, alias)]);
+      const owner = snapshot.degradedOwners?.find(({ ownerId }) => ownerId === `talk:${surface}`);
+      expect(owner?.paths).toEqual([`${source}.providers.${canonical}.apiKey`]);
+    },
+  );
+
+  it.each([false, true])(
+    "inherits the global TTS key only without a Talk override (%s)",
+    async (override) => {
+      const snapshot = await prepare(
+        {
+          tts: { providers: { openai: { apiKey: ref("MISSING_GLOBAL_KEY") } } },
+          talk: {
+            provider: "openai",
+            providers: { openai: override ? { apiKey: ref("TALK_KEY") } : {} },
+          },
+        },
+        override ? { TALK_KEY: "healthy" } : {},
+      );
+      expect(snapshot.degradedOwners?.map(({ ownerId }) => ownerId)).toEqual(
+        override ? ["tts"] : ["talk:speech", "tts"],
+      );
+      expect(snapshot.config.talk?.providers?.openai?.apiKey).toEqual(
+        override ? "healthy" : ref("MISSING_GLOBAL_KEY"),
+      );
+    },
+  );
+
+  it.each([
+    { changedOwner: "talk", tts: "stale", talk: "cold" },
+    { changedOwner: "tts", tts: "cold", talk: "stale" },
+  ] as const)(
+    "keeps shared-source $changedOwner transitions in independent runtime destinations",
+    async ({ changedOwner, tts, talk }) => {
+      const config = (changed: boolean) => ({
+        tts: {
+          providers: {
+            openai: { apiKey: ref("SHARED_KEY") },
+            dormant: { model: changed && changedOwner === "tts" ? "new" : "old" },
+          },
+        },
+        talk: {
+          provider: "openai",
+          providers: {
+            openai: { model: changed && changedOwner === "talk" ? "new" : "old" },
+          },
+        },
+      });
+      await activate(config(false), { SHARED_KEY: "last-known-good" });
+      const snapshot = await prepare(config(true));
+      expect(snapshot.degradedOwners).toMatchObject([
+        { ownerId: "talk:speech", degradationState: talk },
+        { ownerId: "tts", degradationState: tts },
+      ]);
+      expect(snapshot.config.tts?.providers?.openai?.apiKey).toEqual(
+        tts === "stale" ? "last-known-good" : ref("SHARED_KEY"),
+      );
+      expect(snapshot.config.talk?.providers?.openai?.apiKey).toEqual(
+        talk === "stale" ? "last-known-good" : ref("SHARED_KEY"),
+      );
+    },
+  );
+
+  it.each([
+    { surface: "speech", change: "unchanged", state: "stale" },
+    { surface: "realtime", change: "dormant", state: "stale" },
+    { surface: "speech", change: "model", state: "cold" },
+    { surface: "realtime", change: "endpoint", state: "cold" },
+    { surface: "speech", change: "inherited-endpoint", state: "cold" },
+    { surface: "realtime", change: "voice-model", state: "cold" },
+  ] as const)(
+    "classifies $surface owner as $state after $change changes",
+    async ({ surface, change, state }) => {
+      const config = (candidate: boolean) => {
+        const current = candidate ? "changed" : "current";
+        const voiceModel = change === "voice-model";
+        const selection = {
+          provider: "openai",
+          providers: {
+            openai: {
+              apiKey: ref("CURRENT_KEY"),
+              ...(voiceModel ? {} : { model: change === "model" ? current : "current" }),
+              baseUrl: change === "endpoint" ? current : "current",
+            },
+            dormant: { model: change === "dormant" ? current : "current" },
+          },
+        };
+        const agents = voiceModel
+          ? { defaults: { voiceModel: { primary: `openai/${current}` } } }
+          : undefined;
+        const baseUrl = change === "inherited-endpoint" ? current : "current";
+        const tts = surface === "speech" ? { providers: { openai: { baseUrl } } } : undefined;
+        return { agents, tts, talk: surface === "speech" ? selection : { realtime: selection } };
+      };
+      await activate(config(false), { CURRENT_KEY: "last-known-good" });
+      const snapshot = await prepare(config(true));
+      expect(snapshot.degradedOwners).toMatchObject([
+        { ownerId: `talk:${surface}`, degradationState: state },
+      ]);
+      const runtime = surface === "speech" ? snapshot.config.talk : snapshot.config.talk?.realtime;
+      expect(runtime?.providers?.openai?.apiKey).toEqual(
+        state === "stale" ? "last-known-good" : ref("CURRENT_KEY"),
+      );
+    },
+  );
+});

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -368,7 +368,10 @@ describe("secrets runtime snapshot", () => {
       config: asConfig({
         ...explicitMainRoster(),
         talk: {
-          apiKey: { source: "env", provider: "default", id: "TALK_API_KEY" },
+          provider: "example",
+          providers: {
+            example: { apiKey: { source: "env", provider: "default", id: "TALK_API_KEY" } },
+          },
         },
       }),
       env: { TALK_API_KEY: secret },
@@ -914,7 +917,10 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           ...explicitMainRoster(),
           talk: {
-            apiKey: { source: "exec", provider: "vault", id: "a/../b" },
+            provider: "example",
+            providers: {
+              example: { apiKey: { source: "exec", provider: "vault", id: "a/../b" } },
+            },
           },
           secrets: {
             providers: {

--- a/src/tts/tts-synthesis.ts
+++ b/src/tts/tts-synthesis.ts
@@ -2,6 +2,7 @@ import { resolveChannelTtsVoiceDelivery } from "../channels/plugins/tts-capabili
 import type { OpenClawConfig } from "../config/types.js";
 import { logVerbose } from "../globals.js";
 import { transcodeAudioBuffer } from "../media/media-services.js";
+import { assertSecretOwnerAvailable } from "../secrets/runtime-degraded-state.js";
 import type { TtsDirectiveOverrides } from "./provider-types.js";
 import { assertSpeechRuntimeAvailable } from "./runtime-availability.js";
 import { normalizeSpeechText } from "./speech-text.js";
@@ -204,7 +205,7 @@ async function maybePreTranscodeForVoiceDelivery(params: {
   };
 }
 
-export async function synthesizeSpeech(params: {
+type SpeechSynthesisParams = {
   text: string;
   cfg: OpenClawConfig;
   prefsPath?: string;
@@ -214,8 +215,24 @@ export async function synthesizeSpeech(params: {
   timeoutMs?: number;
   agentId?: string;
   accountId?: string;
-}): Promise<TtsSynthesisResult> {
+};
+
+export async function synthesizeSpeech(params: SpeechSynthesisParams): Promise<TtsSynthesisResult> {
   assertSpeechRuntimeAvailable();
+  return synthesizeSpeechInternal(params);
+}
+
+/** Host-only Talk synthesis retains its own capability boundary instead of bypassing public TTS. */
+export async function synthesizeTalkSpeech(
+  params: SpeechSynthesisParams,
+): Promise<TtsSynthesisResult> {
+  assertSecretOwnerAvailable("capability", "talk:speech");
+  return synthesizeSpeechInternal(params);
+}
+
+async function synthesizeSpeechInternal(
+  params: SpeechSynthesisParams,
+): Promise<TtsSynthesisResult> {
   const setup = resolveTtsRequestSetup({
     text: params.text,
     cfg: params.cfg,
@@ -232,7 +249,7 @@ export async function synthesizeSpeech(params: {
 
   const { cfg, config, persona, providers } = setup;
   const target = resolveTtsSynthesisTarget(params.channel);
-  return await executeTtsProviderAttempts({
+  return executeTtsProviderAttempts({
     cfg,
     config,
     persona,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where configuring multiple Talk speech or realtime providers could make an unused or unavailable SecretRef abort Gateway startup. Selected credential failures were also attributed to an unknown owner, so the Gateway could not degrade only the affected Talk capability.

## Why This Change Was Made

Talk now selects the explicit or sole provider before collecting runtime secrets. Only the effective provider is active; unused references remain diagnostic. Speech and realtime use independent capability owners, inherited speech credentials materialize into Talk's runtime provider block, and provider aliases reuse the existing canonical-first plugin capability contracts.

The repair also removes runtime handling of retired `talk.apiKey`, leaves provider-specific legacy migration with the ElevenLabs plugin, reloads plugins only when effective provider ownership changes, and keeps unrelated Gateway capabilities running.

## User Impact

Gateways can start when an unused Talk provider has a broken credential. If the selected speech or realtime credential is unavailable, only that Talk capability reports configured-unavailable while other Gateway functionality remains operational. Credential rotation and model/voice changes no longer reload the entire plugin generation unless provider ownership changes.

## Evidence

- Pre-fix direct reproduction: selected and unused speech/realtime missing refs all aborted runtime snapshot preparation despite owner isolation.
- Post-fix cold-start reproduction:
  - `edge` selects canonical `microsoft`; the inherited credential is attributed independently to `capability:talk:speech` and `capability:tts`.
  - `grok-voice` selects canonical `xai`; the canonical realtime key resolves with no active plugin registry.
- Focused regression suite passed before the conflict-free rebase: 808 tests across Talk owners, Gateway RPCs, reload, plugin activation, migration, status/audit, and provider contracts.
- Exact-head required CI passed: https://github.com/openclaw/openclaw/actions/runs/32537975423
- Fresh structured autoreview reported no actionable findings for both the implementation and the CI test repairs.
- Production LOC: +351/-204 (net +147). Tests: +560/-159 (net +401).
- Local post-rebase Vitest/build wrappers were terminated by an external host `SIGURG`; exact-head CI is the authoritative rebased-head proof.

AI-assisted; the complete diff and tests were reviewed by the author.
