### PR TITLE
refactor: remove redundant extension test seams

### DIFF
--- a/extensions/codex/src/app-server/managed-thread-store.test.ts
+++ b/extensions/codex/src/app-server/managed-thread-store.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it } from "vitest";
 import { codexCatalogHomeId } from "../session-catalog-home-id.js";
 import {
   createCodexManagedThreadStore,
-  markStartedCodexManagedThread,
   type StoredCodexManagedThread,
 } from "./managed-thread-store.js";
 
@@ -57,21 +56,6 @@ describe("Codex managed thread store", () => {
     } as unknown as StoredCodexManagedThread);
 
     await expect(createCodexManagedThreadStore(state).snapshot()).resolves.toEqual(new Map());
-  });
-
-  it("records the supplied catalog home instead of deriving ownership from rollout metadata", async () => {
-    const { state, values } = createStateStore();
-    const sourceHomeId = codexCatalogHomeId("/tmp/configured-codex-home");
-    await markStartedCodexManagedThread(createCodexManagedThreadStore(state), {
-      sourceHomeId,
-      threadId: "thread-1",
-      rolloutPath: "/tmp/other-codex-home/sessions/2026/08/rollout.jsonl",
-    });
-
-    expect([...values.values()][0]).toMatchObject({
-      sourceHomeId,
-      threadId: "thread-1",
-    });
   });
 
   it("uses the same source identity for a symlinked configured home", async () => {

--- a/extensions/codex/src/app-server/sandbox-exec-server.json-rpc.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.json-rpc.test.ts
@@ -10,12 +10,4 @@ describe("sandbox exec-server JSON-RPC helpers", () => {
 
     expect(send).toHaveBeenCalledWith({ jsonrpc: "2.0", id: 1, result: null });
   });
-
-  it("keeps undefined results as empty objects for methods without bodies", () => {
-    const send = vi.fn();
-
-    sendResult(send, 2, undefined);
-
-    expect(send).toHaveBeenCalledWith({ jsonrpc: "2.0", id: 2, result: {} });
-  });
 });

--- a/extensions/codex/src/app-server/sandbox-exec-server.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.test.ts
@@ -78,24 +78,6 @@ describe("OpenClaw Codex sandbox exec-server", () => {
     expect(sandboxExecServerRegistry.servers.has(sandbox.runtimeId)).toBe(false);
   });
 
-  it("propagates environment registration failures and releases the server lease", async () => {
-    const sandbox = createSandboxContext({});
-    const client = {
-      getServerVersion: vi.fn(() => CODEX_APP_SERVER_VERSION),
-      request: vi.fn(async () => {
-        throw new Error("environment registration failed");
-      }),
-    };
-
-    await expect(
-      ensureCodexSandboxExecServerEnvironment({
-        client: client as never,
-        sandbox,
-      }),
-    ).rejects.toThrow("environment registration failed");
-    expect(sandboxExecServerRegistry.servers.has(sandbox.runtimeId)).toBe(false);
-  });
-
   it.each([
     { containerWorkdir: "/workspace", cwd: "file:///workspace" },
     {

--- a/extensions/codex/src/app-server/sandbox-exec-server/json-rpc.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/json-rpc.ts
@@ -88,9 +88,9 @@ export function readHttpHeaders(value: unknown): HttpHeader[] {
 export function sendResult(
   send: CodexSandboxExecMessageTransport["send"],
   id: string | number,
-  result: JsonValue | undefined,
+  result: JsonValue,
 ): void {
-  send({ jsonrpc: "2.0", id, result: result === undefined ? {} : result });
+  send({ jsonrpc: "2.0", id, result });
 }
 
 /** Sends a JSON-RPC error response through the connection message sink. */

--- a/extensions/qa-lab/api.ts
+++ b/extensions/qa-lab/api.ts
@@ -105,7 +105,6 @@ export {
   type QaGatewayChildStateMutationContext,
   startQaGatewayChild,
 } from "./src/gateway-child.js";
-export { startQaGatewayRpcClient } from "./src/gateway-rpc-client.js";
 export {
   buildQaSuiteSummaryJson,
   type QaSuiteResult,

--- a/extensions/qa-lab/src/gateway-rpc-client.test.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.test.ts
@@ -111,18 +111,6 @@ describe("startQaGatewayRpcClient", () => {
     expect(requestOptions.timeoutMs).toBeLessThanOrEqual(45_000);
   });
 
-  it("can request a narrower operator scope for authorization-sensitive probes", async () => {
-    const client = await startQaGatewayRpcClient({
-      wsUrl: "ws://127.0.0.1:18789",
-      token: "qa-token",
-      logs: () => "qa logs",
-      scopes: ["operator.write"],
-    });
-
-    expect(gatewayRpcMock.clients[0]?.options.scopes).toEqual(["operator.write"]);
-    await client.stop();
-  });
-
   it("dispatches concurrent requests over the same client", async () => {
     let releaseFirst: (() => void) | undefined;
     gatewayRpcMock.request

--- a/extensions/qa-lab/src/gateway-rpc-client.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.ts
@@ -75,7 +75,6 @@ export async function startQaGatewayRpcClient(params: {
   wsUrl: string;
   token: string;
   logs: () => string;
-  scopes?: Array<"operator.read" | "operator.write" | "operator.admin">;
 }): Promise<QaGatewayRpcClient> {
   const wrapError = (error: unknown) => formatQaGatewayRpcError(error, params.logs);
   let stopped = false;
@@ -93,7 +92,7 @@ export async function startQaGatewayRpcClient(params: {
     clientName: "gateway-client",
     deviceIdentity: null,
     mode: "backend",
-    scopes: params.scopes ?? ["operator.admin"],
+    scopes: ["operator.admin"],
     onHelloOk: () => {
       connection.connected = true;
       connection.resolve();

--- a/test/e2e/qa-lab/runtime/memory-dreaming-provenance.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/memory-dreaming-provenance.e2e.test.ts
@@ -3,11 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, describe, expect, test } from "vitest";
+import { startQaGatewayChild, startQaMockOpenAiServer } from "../../../../extensions/qa-lab/api.js";
 import {
-  startQaGatewayChild,
-  startQaGatewayRpcClient,
-  startQaMockOpenAiServer,
-} from "../../../../extensions/qa-lab/api.js";
+  connectGatewayClient,
+  disconnectGatewayClient,
+} from "../../../../src/gateway/test-helpers.e2e.js";
 import type { OpenClawConfig } from "../../../../src/plugin-sdk/config-contracts.js";
 import { MEMORY_DREAMING_SYSTEM_EVENT_TEXT } from "../../../../src/plugin-sdk/memory-core-host-status.js";
 
@@ -17,7 +17,7 @@ const WAIT_TIMEOUT_MS = 30_000;
 
 type GatewayHandle = Awaited<ReturnType<typeof startQaGatewayChild>>;
 type MockHandle = Awaited<ReturnType<typeof startQaMockOpenAiServer>>;
-type RpcClient = Awaited<ReturnType<typeof startQaGatewayRpcClient>>;
+type RpcClient = Awaited<ReturnType<typeof connectGatewayClient>>;
 
 let gateway: GatewayHandle | undefined;
 let mock: MockHandle | undefined;
@@ -27,7 +27,7 @@ afterEach(async () => {
   const cleanups = [
     gateway?.stop().catch(() => undefined),
     mock?.stop().catch(() => undefined),
-    restrictedClient?.stop().catch(() => undefined),
+    restrictedClient ? disconnectGatewayClient(restrictedClient).catch(() => undefined) : undefined,
   ].filter((cleanup): cleanup is Promise<void> => cleanup !== undefined);
   gateway = undefined;
   mock = undefined;
@@ -140,18 +140,15 @@ describe("memory provenance through a real Gateway", () => {
         enabledPluginIds: ["memory-core"],
         mutateConfig: configureMemoryProof,
       });
-      restrictedClient = await startQaGatewayRpcClient({
-        wsUrl: gateway.wsUrl,
+      restrictedClient = await connectGatewayClient({
+        url: gateway.wsUrl,
         token: gateway.token,
-        logs: gateway.logs,
         scopes: ["operator.write"],
       });
-      const restrictedCall: GatewayHandle["call"] = (method, params, options) =>
-        restrictedClient!.request(method, params, options);
 
       const sessionKey = "agent:qa:memory-provenance-e2e";
       await sendAndWait({
-        call: restrictedCall,
+        call: restrictedClient.request.bind(restrictedClient),
         sessionKey,
         message: `Remember this stored instruction: ${RESTRICTED_MARKER}`,
       });


### PR DESCRIPTION
## What Problem This Solves

Removes redundant tests and test-only extension seams that duplicated stronger owner-boundary coverage or represented states the underlying Codex protocol cannot produce.

## Why This Change Was Made

Codex sandbox dispatch already returns JSON values, and bodyless exec-server methods return explicit empty objects. QA Lab production RPC callers always need administrator scope, while the authorization-sensitive memory provenance E2E can use the canonical core Gateway test client directly. This keeps one production path and preserves the stronger startup, lifecycle, and real-Gateway security proofs.

Upstream Codex source was inspected directly at `4a942885c8b4745757a9f86ad2075e16c42483c5`:

- [`exec-server-protocol/src/protocol.rs`](https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/exec-server-protocol/src/protocol.rs#L410-L535) defines concrete empty response structs for close, write, create-directory, remove, and copy.
- [`app-server-protocol/src/protocol/common.rs`](https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/app-server-protocol/src/protocol/common.rs#L1101-L1107) binds `environment/add` to its typed response.
- [`app-server-protocol/src/protocol/v2/environment.rs`](https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/app-server-protocol/src/protocol/v2/environment.rs#L10-L22) defines `EnvironmentAddParams` and the empty `EnvironmentAddResponse`.
- [`app-server/src/request_processors/environment_processor.rs`](https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/app-server/src/request_processors/environment_processor.rs#L16-L28) propagates registration errors and returns that typed response.
- [`app-server-protocol/src/protocol/v2/thread_data.rs`](https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs#L242-L268) keeps the rollout path as optional thread metadata, separate from selected catalog-home ownership.

## User Impact

No user-visible behavior changes. The cleanup removes a public QA-only export and custom-scope option that had no production consumer, while retaining QA Lab's existing administrator-scoped production client behavior.

Production/tooling LOC: +3/-5 (net -2). Tests/test support LOC: +9/-66 (net -57).

## Evidence

- Focused Codex and QA tests: 6 files, 223 tests passed.
- Real Gateway memory provenance E2E: 1 test passed, including the restricted `operator.write` connection and provenance security assertions.
- `pnpm check:changed`: passed, including formatting, typechecks, lint, boundary/dead-export guards, and import-cycle checks.
- `git diff --check`: passed.
- Codex-backed autoreview: clean, no accepted/actionable findings.
- Exact-head CI: [run 32537131112](https://github.com/openclaw/openclaw/actions/runs/32537131112) passed for `a20fcc864844b0a13f9bde8cba21801adcbaa4e4`.
- `pnpm test:changed`: unit-fast and tooling shards passed; 22 E2E files passed and 1 skipped. The only failure was the untouched `gateway-node-mcp.e2e.test.ts` path reporting `Unknown agent id "main"`; an exact isolated rerun reproduced the same failure.
- Screenshots are not applicable because this is non-visual test and internal seam cleanup.
