### PR TITLE
fix(macos): prevent duplicate New Chat sessions and stale navigation

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -40394,10 +40394,6 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift"
-        },
-        {
-          "kind": "ui-localized-call",
-          "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift"
         }
       ]
     },

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -35,11 +35,10 @@ extension OpenClawChatViewModel {
         worktreeBaseRef: String? = nil,
         routeLease: OpenClawChatNewSessionRouteLease? = nil) async -> Bool
     {
-        guard !self.blocksAttachmentOwnerChange else {
-            self.errorText = String(
-                localized: "Remove attachments or wait for delivery to resolve before starting a new chat.")
-            return false
-        }
+        guard !self.isCreatingSession, self.canCreateSessionForImmediateSwitch() else { return false }
+        self.isCreatingSession = true
+        defer { self.isCreatingSession = false }
+        let initiatingSession = self.currentSessionSnapshot()
         let normalizedAgentID = agentID?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
@@ -77,6 +76,7 @@ extension OpenClawChatViewModel {
             let createdKey = created.key.trimmingCharacters(in: .whitespacesAndNewlines)
             next = createdKey.isEmpty ? requested : createdKey
         } catch {
+            guard self.isCurrentSession(initiatingSession) else { return false }
             if Self.isUnsupportedCreateSessionError(error) {
                 // Reset only mimics a plain new chat; agent/worktree selections were
                 // not honored, so advanced requests surface the error instead of
@@ -86,17 +86,17 @@ extension OpenClawChatViewModel {
                     self.errorText = error.localizedDescription
                     return false
                 }
+                guard self.canCreateSessionForImmediateSwitch() else { return false }
                 chatUILogger.info("sessions.create unsupported; falling back to sessions.reset")
                 await self.performReset()
-                return true
+                return self.isCurrentSession(initiatingSession)
             }
             chatUILogger.error("sessions.create failed \(error.localizedDescription, privacy: .public)")
             self.errorText = error.localizedDescription
             return false
         }
-        guard !self.blocksAttachmentOwnerChange else {
-            self.errorText = String(
-                localized: "Remove attachments or wait for delivery to resolve before starting a new chat.")
+        guard self.isCurrentSession(initiatingSession), self.canCreateSessionForImmediateSwitch() else {
+            if !self.sessions.contains(where: { $0.key == next }) { self.refreshSessions() }
             return false
         }
         self.adoptCreatedSession(next)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -71,6 +71,8 @@ public final class OpenClawChatViewModel {
     private var deferredExternalSessionKey: String?
     private var deferredDeliveryIdentity: DeferredDeliveryIdentity?
     var isSubmittingDraft = false
+    @ObservationIgnored
+    var isCreatingSession = false
     var attachmentStagingCount = 0
     public private(set) var isAborting = false
     public var errorText: String?
@@ -1273,18 +1275,21 @@ extension OpenClawChatViewModel {
     }
 
     func performReset() async {
+        let session = self.currentSessionSnapshot()
         self.isLoading = true
         self.errorText = nil
 
         do {
-            try await self.transport.resetSession(sessionKey: self.sessionKey)
+            try await self.transport.resetSession(sessionKey: session.key)
         } catch {
+            guard self.isCurrentSession(session) else { return }
             self.isLoading = false
             self.errorText = error.localizedDescription
             chatUILogger.error("session reset failed \(error.localizedDescription, privacy: .public)")
             return
         }
 
+        guard self.isCurrentSession(session) else { return }
         self.replyTarget = nil
         self.runMessageScopesByRunID.removeAll()
         self.provisionalFinalMessagesByID.removeAll()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -79,8 +79,11 @@ private actor SessionActionTransportState {
     var patchIdentities: [(key: String, expectedSessionID: String?)] = []
     var deletedKeys: [String] = []
     var groupPuts: [[String]] = []
+    var createdKeys: [String] = []
     var createdAgentIDs: [String?] = []
     var createdParentKeys: [String?] = []
+    var resetSessionKeys: [String] = []
+    var sessionListRequestCount = 0
 
     func recordFork(_ key: String, fromLastCompleted: Bool) {
         self.forkedParentKeys.append(key)
@@ -128,9 +131,20 @@ private actor SessionActionTransportState {
         self.deletedKeys.append(key)
     }
 
-    func recordCreate(agentID: String?, parentKey: String?) {
+    func recordCreate(key: String, agentID: String?, parentKey: String?) -> Int {
+        let index = self.createdKeys.count
+        self.createdKeys.append(key)
         self.createdAgentIDs.append(agentID)
         self.createdParentKeys.append(parentKey)
+        return index
+    }
+
+    func recordReset(_ sessionKey: String) {
+        self.resetSessionKeys.append(sessionKey)
+    }
+
+    func recordSessionListRequest() {
+        self.sessionListRequestCount += 1
     }
 }
 
@@ -169,6 +183,9 @@ private struct SessionActionCompletionGate: Sendable {
 
 private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTransport {
     private let state = SessionActionTransportState()
+    private let createGate: SessionActionCompletionGate?
+    private let resetGate: SessionActionCompletionGate?
+    private let createIsUnsupported: Bool
     private let forkGate: SessionActionCompletionGate?
     private let rewindGate: SessionActionCompletionGate?
     private let forkAtMessageGate: SessionActionCompletionGate?
@@ -187,6 +204,9 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
     private let sendSucceeds: Bool
 
     init(
+        createGate: SessionActionCompletionGate? = nil,
+        resetGate: SessionActionCompletionGate? = nil,
+        createIsUnsupported: Bool = false,
         forkGate: SessionActionCompletionGate? = nil,
         rewindGate: SessionActionCompletionGate? = nil,
         forkAtMessageGate: SessionActionCompletionGate? = nil,
@@ -204,6 +224,9 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         historyFailureIndices: Set<Int> = [],
         sendSucceeds: Bool = false)
     {
+        self.createGate = createGate
+        self.resetGate = resetGate
+        self.createIsUnsupported = createIsUnsupported
         self.forkGate = forkGate
         self.rewindGate = rewindGate
         self.forkAtMessageGate = forkAtMessageGate
@@ -342,6 +365,8 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
 
     func acquireNewSessionRouteLease() async -> OpenClawChatNewSessionRouteLease? {
         let state = self.state
+        let createGate = self.createGate
+        let createIsUnsupported = self.createIsUnsupported
         return OpenClawChatNewSessionRouteLease(
             listAgents: {
                 OpenClawChatAgentsListResponse(
@@ -349,9 +374,35 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
                     agents: [OpenClawChatAgentChoice(id: "worker", workspaceGit: true)])
             },
             createSession: { key, _, agentID, parentKey, _, _ in
-                await state.recordCreate(agentID: agentID, parentKey: parentKey)
+                let index = await state.recordCreate(key: key, agentID: agentID, parentKey: parentKey)
+                if index == 0 {
+                    await createGate?.suspendCompletion()
+                }
+                if createIsUnsupported {
+                    throw NSError(
+                        domain: "OpenClawChatTransport",
+                        code: 0,
+                        userInfo: [NSLocalizedDescriptionKey: "sessions.create not supported by this transport"])
+                }
                 return OpenClawChatCreateSessionResponse(ok: true, key: key, sessionId: nil)
             })
+    }
+
+    func resetSession(sessionKey: String) async throws {
+        await self.state.recordReset(sessionKey)
+        await self.resetGate?.suspendCompletion()
+    }
+
+    func listSessions(
+        limit _: Int?,
+        search _: String?,
+        archived _: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
+        await self.state.recordSessionListRequest()
+        throw NSError(
+            domain: "OpenClawChatTransport",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "sessions.list not supported by this transport"])
     }
 
     func deleteSession(key: String) async throws {
@@ -418,8 +469,20 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
         await self.state.createdAgentIDs
     }
 
+    func createdKeys() async -> [String] {
+        await self.state.createdKeys
+    }
+
     func createdParentKeys() async -> [String?] {
         await self.state.createdParentKeys
+    }
+
+    func resetSessionKeys() async -> [String] {
+        await self.state.resetSessionKeys
+    }
+
+    func sessionListRequestCount() async -> Int {
+        await self.state.sessionListRequestCount
     }
 }
 
@@ -554,6 +617,137 @@ struct ChatViewModelSessionActionTests {
             using: lease)
 
         #expect(await transport.createdAgentIDs() == ["worker"])
+    }
+
+    @Test func `new session creation rejects a duplicate while its gateway mutation is in flight`() async throws {
+        let createGate = SessionActionCompletionGate()
+        let transport = SessionActionTransport(createGate: createGate)
+        var observedSelections: [String] = []
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: transport,
+            onSessionChanged: { observedSelections.append($0) })
+        let lease = try await viewModel.newSessionRouteLease()
+
+        let firstCreate = Task {
+            await viewModel.startNewSession(agentID: "", worktree: false, worktreeBaseRef: nil, using: lease)
+        }
+        guard await self.waitForForkStart(createGate) else {
+            createGate.release()
+            firstCreate.cancel()
+            Issue.record("timed out waiting for session creation start signal")
+            return
+        }
+
+        let duplicateCreated = await viewModel.startNewSession(
+            agentID: "",
+            worktree: false,
+            worktreeBaseRef: nil,
+            using: lease)
+
+        #expect(duplicateCreated == false)
+        #expect(await transport.createdKeys().count == 1)
+        createGate.release()
+        #expect(await firstCreate.value)
+        #expect(await viewModel.sessionKey == (transport.createdKeys()).first)
+        #expect(observedSelections == [viewModel.sessionKey])
+    }
+
+    @Test(arguments: [false, true])
+    func `stale new session completion cannot replace or reset newer navigation`(
+        createIsUnsupported: Bool) async throws
+    {
+        let createGate = SessionActionCompletionGate()
+        let transport = SessionActionTransport(
+            createGate: createGate,
+            createIsUnsupported: createIsUnsupported)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        let lease = try await viewModel.newSessionRouteLease()
+
+        let create = Task {
+            await viewModel.startNewSession(agentID: "", worktree: false, worktreeBaseRef: nil, using: lease)
+        }
+        guard await self.waitForForkStart(createGate) else {
+            createGate.release()
+            create.cancel()
+            Issue.record("timed out waiting for session creation start signal")
+            return
+        }
+        viewModel.switchSession(to: "other")
+        let newerSession = viewModel.currentSessionSnapshot()
+        let newerHistoryGeneration = viewModel.lastIssuedHistoryRequestID
+
+        createGate.release()
+        let created = await create.value
+
+        #expect(created == false)
+        #expect(viewModel.currentSessionSnapshot() == newerSession)
+        #expect(viewModel.lastIssuedHistoryRequestID == newerHistoryGeneration)
+        #expect(viewModel.errorText == nil)
+        #expect(await transport.createdKeys().count == 1)
+        #expect(await transport.resetSessionKeys().isEmpty)
+    }
+
+    @Test(arguments: [false, true])
+    func `new session completion preserves attachment ownership acquired during creation`(
+        createIsUnsupported: Bool) async throws
+    {
+        let createGate = SessionActionCompletionGate()
+        let transport = SessionActionTransport(
+            createGate: createGate,
+            createIsUnsupported: createIsUnsupported)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        let lease = try await viewModel.newSessionRouteLease()
+
+        let create = Task {
+            await viewModel.startNewSession(agentID: "", worktree: false, worktreeBaseRef: nil, using: lease)
+        }
+        #expect(await self.waitForForkStart(createGate))
+        viewModel.beginAttachmentStaging()
+        defer { viewModel.endAttachmentStaging() }
+
+        createGate.release()
+        #expect(await create.value == false)
+        #expect(viewModel.sessionKey == "main" && viewModel.isAttachmentOwnerPinned)
+        #expect(viewModel.errorText ==
+            "Remove attachments or wait for delivery to resolve before starting a new chat.")
+        #expect(await transport.createdKeys().count == 1)
+        #expect(await transport.resetSessionKeys().isEmpty)
+
+        if !createIsUnsupported {
+            try await waitUntil("committed session is discoverable after attachment ownership changes") {
+                await transport.sessionListRequestCount() == 1
+            }
+        }
+    }
+
+    @Test func `navigation during unsupported new session reset preserves the newer selection`() async throws {
+        let resetGate = SessionActionCompletionGate()
+        let transport = SessionActionTransport(resetGate: resetGate, createIsUnsupported: true)
+        let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        let lease = try await viewModel.newSessionRouteLease()
+
+        let create = Task {
+            await viewModel.startNewSession(agentID: "", worktree: false, worktreeBaseRef: nil, using: lease)
+        }
+        guard await self.waitForForkStart(resetGate) else {
+            resetGate.release()
+            create.cancel()
+            Issue.record("timed out waiting for fallback reset start signal")
+            return
+        }
+        viewModel.switchSession(to: "other")
+        let newerSession = viewModel.currentSessionSnapshot()
+        let newerHistoryGeneration = viewModel.lastIssuedHistoryRequestID
+
+        resetGate.release()
+        let created = await create.value
+
+        #expect(created == false)
+        #expect(viewModel.currentSessionSnapshot() == newerSession)
+        #expect(viewModel.lastIssuedHistoryRequestID == newerHistoryGeneration)
+        #expect(viewModel.errorText == nil)
+        #expect(await transport.resetSessionKeys() == ["main"])
     }
 
     @Test func `unsupported create with advanced options fails without resetting`() async {


### PR DESCRIPTION
Closes #127692

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening New Chat in the macOS or iOS native app could create duplicate sessions when actions overlapped, or have a delayed create/reset response replace a newer chat selection. Attachment ownership could also change while session creation awaited the Gateway, allowing unsupported-create fallback to cross in-progress attachment work or leaving a successfully created session undiscoverable.

## Why This Change Was Made

All Apple entry points converge on the shared chat view model, so the repair establishes one MainActor-owned create in flight and fences every delayed completion against its exact initiating `SessionSnapshot`. It revalidates attachment eligibility before fallback reset and adoption, and refreshes session discovery when a successful create commits but can no longer be safely selected. Android already owns the equivalent single-flight and initiating-history-generation invariant.

## User Impact

Rapid New Chat actions create only one session. Navigating to another conversation while creation or fallback reset is pending no longer changes that newer selection; in-progress attachment work keeps ownership and its actionable error; successfully committed sessions remain discoverable even when they cannot be adopted immediately. Existing normal creation, worktree creation/fallback, slash `/new`, agent ownership, routing, history bootstrap, and macOS/iOS callers retain their behavior.

## Evidence

- Frozen-main reproduction at `74c1900e630f241b8b9a9dc93c56556bc06bf0da`: **11 pre-fix failures** across duplicate creation, stale success, unsupported-create fallback, and delayed reset.
- The first independent autoreview identified **two P1 attachment-ownership edges**; both additional deterministic regressions failed against the intermediate diff before being repaired. Final independent autoreview: **zero actionable findings**.
- Focused shared session-action owner suite: **41/41 tests passing**.
- Full shared Apple package: **1,391 Swift Testing tests**, plus **7 native-state tests** and **56 XCTest cases**, all passing.
- Relevant macOS transport/SwiftUI coverage: **28/28 tests passing**.
- Swift format/lint across **358 Swift files**, focused touched-file format/lint, and `git diff --check`: clean.
- Native source-inventory PR gate: `pnpm native:i18n:verify` **passes** after refreshing the canonical generated inventory; focused generated-only autoreview: **zero actionable findings**. The broader `native:i18n:check` separately exposes pre-existing locale-artifact drift and is not the PR gate's source-verification contract; full locale parity is not claimed.
- Four files: production **+14/-9 effective (net +5)**; raw production Git numstat is +15/-10 because it also counts a one-for-one reset-key rewrite. Tests: **+196/-2 (net +194)**. Generated source inventory: **+0/-4**.

**Signed-build fixture evidence:** matching Developer ID-signed, task-isolated macOS app displaying synthetic fixture data only. This is **not** behavioral evidence, live-Gateway evidence, or before/after proof.

![Signed-build fixture evidence: synthetic macOS chat data only; not behavioral, live-Gateway, or before/after proof](https://github.com/user-attachments/assets/dfd138ed-1b43-4750-8a1b-6095ed275f6f)

**Proof gap:** the exact-source macOS app was built at a stable task-owned path and signed with the matching Developer ID, but interactive delayed-Gateway before/after proof could not be completed: the isolated signed app hit a confirmed macOS login-Keychain deadlock before establishing a Gateway connection. The screenshot contains synthetic fixture data only, and no physical iOS device was available.

**Risk:** low; shared Apple UI/session lifecycle only. No Gateway protocol, configuration, persistence, security/authentication, dependency, or product-default change.

**Release-note context:** Apple chat now prevents duplicate New Chat sessions and stale navigation while preserving in-progress attachments and newly created session discovery.

AI-assisted implementation and review; all reported reproductions, test results, and proof gaps were independently verified.
