### PR TITLE
fix(ui): Model Setup stuck on "Checking this Gateway" for fresh clients

### DIFF
--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -1,5 +1,5 @@
 import { consume } from "@lit/context";
-import { initialState, Task } from "@lit/task";
+import { initialState, Task, TaskStatus } from "@lit/task";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -305,15 +305,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     };
     if (!this.observedConnection) {
       this.observedConnection = connection;
-      if (
-        connection.connected &&
-        this.routeData &&
-        (this.routeData.connection.client !== connection.client ||
-          this.routeData.connection.hello !== connection.hello ||
-          this.routeData.connection.agentId !== connection.agentId)
-      ) {
-        void this.detect();
-      }
+      this.ensureRouteSettledDetection();
       return;
     }
     if (
@@ -322,6 +314,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       connection.agentId === this.observedConnection.agentId &&
       connection.connected === this.observedConnection.connected
     ) {
+      this.ensureRouteSettledDetection();
       return;
     }
     this.observedConnection = connection;
@@ -340,6 +333,24 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       return;
     }
     if (this.canUseSetup(connection.client)) {
+      void this.detect();
+    }
+  }
+
+  // Route data can settle after mount and be discarded as another
+  // connection's result. Nothing else re-arms detection then, so a loading
+  // page with a connected, capable Gateway self-heals here instead of
+  // dead-ending silently.
+  private ensureRouteSettledDetection(): void {
+    if (
+      !this.hasUpdated ||
+      !this.routeData ||
+      this.pageState.phase !== "loading" ||
+      this.detectTask.status !== TaskStatus.INITIAL
+    ) {
+      return;
+    }
+    if (this.canUseSetup(this.context.gateway.snapshot.client)) {
       void this.detect();
     }
   }

--- a/ui/src/pages/model-setup/model-setup-reconnect.test.ts
+++ b/ui/src/pages/model-setup/model-setup-reconnect.test.ts
@@ -122,6 +122,35 @@ describe("ModelSetupPage Gateway reconnect ownership", () => {
     vi.restoreAllMocks();
   });
 
+  it("recovers when stale route data settles after mounting under a connected gateway", async () => {
+    const { context, request, runtimeConfig } = createFixture();
+    request.mockImplementation(async (method) =>
+      method === "openclaw.setup.detect" ? detection : {},
+    );
+    const provider = createApplicationContextProvider(context);
+    const page = document.createElement("openclaw-model-setup-page") as TestModelSetupPage;
+    provider.append(page);
+    document.body.append(provider);
+    await page.updateComplete;
+
+    expect(request).not.toHaveBeenCalled();
+
+    page.routeData = {
+      state: { phase: "loading" },
+      connection: { client: null, hello: null, agentId: null },
+      firstRun: false,
+    };
+    await page.updateComplete;
+
+    await vi.waitFor(() => {
+      expect(
+        request.mock.calls.filter(([method]) => method === "openclaw.setup.detect"),
+      ).toHaveLength(1);
+      expect(page.querySelector('[data-auth-choice="provider-auth"]')).not.toBeNull();
+    });
+    runtimeConfig.dispose();
+  });
+
   it("does not expose stale route data when the page mounts during reconnect", async () => {
     const { client, context, request, runtimeConfig, setGatewayPhase } = createFixture();
     request.mockImplementation(async (method) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **Settings → Models (Model Setup)** would see "Checking this Gateway for available AI access…" forever, even though the Gateway answered `openclaw.setup.detect` within seconds. Fresh browser clients (first visit, cleared storage, automation/webviews) hit the stall near-100%; warm tabs usually escaped it. The affected surface is the Control UI Model Setup page — the default first-run path for connecting a model, so a silent dead-end here blocks new operators from finishing setup.

## Why This Change Was Made

Root cause is a mount-ordering race between the route loader and the lazy page module. On a fresh client the loader runs before the Gateway websocket connects and instantly returns `{state: "loading", connection: {client: null}}`. The lazy page module finishes importing after hello, and the router publishes the active match with `data` still undefined — so the page mounts with `routeData === undefined` under an already-connected Gateway, and `synchronizeGateway`'s mount branch skips detection. When the stale loader result settles a microtask later, `willUpdate` correctly discards it, but the follow-up `synchronizeGateway` takes the identity-equality early return. The connection never changes again, so nothing ever arms `detectTask` (it stays INITIAL forever). Warm tabs recover only by accident: their cached module mounts before hello, so connect arrives as an identity change that resets and re-detects.

The fix replaces the mount-branch routeData-connection comparison with one self-healing invariant, `ensureRouteSettledDetection()`, also called from the identity-equality early return: once route data has settled, a page still holding phase `"loading"` with an idle detect task and a connected, capable Gateway starts detection itself. Two guards keep the normal path duplicate-free: `routeData` unset means the loader's own detect is still in flight, and `hasUpdated` defers to `willUpdate`'s seeding because subscriptions fire before the first render. Model Setup is the only route using this loader-seed pattern, so the fix is complete at its owner.

## User Impact

New and automation-driven clients reliably reach the Model Setup results instead of an indefinite spinner. No behavior change for the normal warm path: exactly one detect request is issued per settle (verified in the live probe below).

## Evidence

- Regression test (`ui/src/pages/model-setup/model-setup-reconnect.test.ts`, "recovers when stale route data settles after mounting under a connected gateway") reproduces the exact sequence and **fails on pre-fix code** with zero detect calls / stuck loading; passes with the fix. All 109 model-setup tests pass (`node scripts/run-vitest.mjs ui/src/pages/model-setup`).
- Live proof against a dev gateway (`gateway run --port 19807 --auth token --allow-unconfigured`, isolated state dir) with a fresh headless Playwright client: pre-fix build stalls past 45s with `detectTask.status === INITIAL` despite a connected, operator-admin snapshot; fixed build sends exactly one `openclaw.setup.detect` (`agentId: "main"`) and reaches `phase: "ready"` in ~5s.
- `node scripts/check-changed.mjs` green (typecheck, lint, format, ratchets); autoreview clean.
- Production LOC: +21/-10 (net +11, the self-heal owner method that absorbs the old ad-hoc mismatch conditional) | Tests: +29/-0.

### Before (pre-fix bundle, 20s after load — stuck)

![Model Setup stuck at Checking this Gateway](https://github.com/user-attachments/assets/bca7d29a-62bd-4dc7-964e-2e6e0a84e26b)

### After (fixed bundle, same fresh-client conditions — ready)

![Model Setup showing detection results](https://github.com/user-attachments/assets/24004dd7-2f6b-48e6-9038-58d94b4da724)
