### PR TITLE
fix: onboarding resumes after plugin gateway restart

### DIFF
--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -1,6 +1,9 @@
 /* @vitest-environment jsdom */
 
-import { buildSystemAgentSessionInvalidatedErrorDetails } from "@openclaw/gateway-protocol";
+import {
+  buildSystemAgentInferenceUnavailableErrorDetails,
+  buildSystemAgentSessionInvalidatedErrorDetails,
+} from "@openclaw/gateway-protocol";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import { installSafeLocalStorageForTesting } from "../../test-helpers/storage.ts";
@@ -276,8 +279,63 @@ describe("CustodianSessionStore", () => {
     expect(store.abandonedTurnOutcomeUnknown).toBe(false);
     expect(store.wizardInputPending).toBe(true);
     expect(store.messages.some((message) => message.text === "Repair complete")).toBe(true);
-    expect(reconnectRequest.mock.calls.some(([method]) => method === "openclaw.chat")).toBe(true);
+    const rejoinParams = reconnectRequest.mock.calls.find(
+      ([method]) => method === "openclaw.chat",
+    )?.[1];
+    expect(rejoinParams).toBeDefined();
+    expect(rejoinParams).not.toHaveProperty("message");
   });
+
+  it.each(["replacement", "reconnect"] as const)(
+    "retries an input-free onboarding handoff after a Gateway client %s",
+    async (transition) => {
+      const initialRequest = vi.fn().mockRejectedValue(
+        new GatewayRequestError({
+          code: "UNAVAILABLE",
+          message: "OpenClaw could not reach working inference",
+          details: buildSystemAgentInferenceUnavailableErrorDetails(),
+        }),
+      );
+      const { context, setGatewaySnapshot } = createContext(initialRequest);
+      const store = new CustodianSessionStore();
+
+      store.connect(context, "onboarding");
+      await waitForFast(() => expect(store.sending).toBe(false));
+      expect(store.error).toContain("OpenClaw could not reach working inference");
+      expect(store.setupRequired).toBe(true);
+      expect(store.canRetry()).toBe(true);
+      const sessionId = initialRequest.mock.calls[0]?.[1].sessionId;
+
+      if (transition === "reconnect") {
+        setGatewaySnapshot({ phase: "reconnecting", client: null });
+      }
+      const reconnectRequest = vi.fn((method: string, params: { sessionId?: string }) => {
+        if (method !== "openclaw.chat") {
+          throw new Error(`Unexpected reconnect method: ${method}`);
+        }
+        return Promise.resolve({
+          sessionId: params.sessionId,
+          reply: "Ready after restart.",
+          action: "none",
+        });
+      });
+      setGatewaySnapshot({
+        phase: "connected",
+        client: { request: reconnectRequest } as unknown as GatewayBrowserClient,
+      });
+
+      await waitForFast(() => expect(store.messages.at(-1)?.text).toBe("Ready after restart."));
+      expect(reconnectRequest).toHaveBeenCalledWith(
+        "openclaw.chat",
+        expect.objectContaining({ sessionId, welcomeVariant: "onboarding" }),
+        expect.anything(),
+      );
+      expect(reconnectRequest.mock.calls[0]?.[1]).not.toHaveProperty("message");
+      expect(store.error).toBeNull();
+      expect(store.setupRequired).toBe(false);
+      expect(store.canRetry()).toBe(false);
+    },
+  );
 
   it("reconciles racing history even when the rejoin projects a live wizard", async () => {
     const step = { id: "live-step", type: "text", message: "Continue setup" };

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -515,6 +515,8 @@ export class CustodianSessionStore {
       this.requestAbort = null;
       this.sessionClient = client;
       this.sessionOwnershipKey = ownershipKey;
+      const replayableParams =
+        this.retryParams && !hasCustodianUserInput(this.retryParams) ? this.retryParams : null;
       if (this.questionReplyUncertain || this.abandonedTurnOutcomeUnknown) {
         // A SUBMITTED reply with an unknown outcome blocks the idle refresh by
         // design; only a full rejoin can settle it — the Gateway session owns
@@ -531,6 +533,13 @@ export class CustodianSessionStore {
           sessionId: this.sessionId,
           ...custodianChatParams(this.variant),
         });
+      } else if (replayableParams) {
+        // Input-free welcome/rejoin requests are safe to replay. Plugin
+        // installation can restart the Gateway immediately after activation;
+        // retry the retained handoff on the replacement client instead of
+        // leaving a working setup behind a transient UNAVAILABLE error.
+        this.rejoinBarrierPending = true;
+        void this.initializeSession(client, replayableParams);
       } else {
         void this.refreshTranscriptIfIdle();
       }


### PR DESCRIPTION
Closes #127689

## What Problem This Solves

Fixes an issue where macOS onboarding could report that inference failed after activating an external plugin when the required Gateway restart briefly interrupted the Custodian handoff.

## Why This Change Was Made

The Custodian session now replays a retained input-free welcome or rejoin request on the replacement Gateway client. User-authored messages, wizard answers, and wizard cancellations remain non-replayable, so reconnect recovery cannot duplicate user actions.

## User Impact

Onboarding resumes automatically after a plugin-triggered Gateway restart instead of leaving a working provider route behind a transient `UNAVAILABLE` error.

## Evidence

- `pnpm --dir ui exec vitest run --config vitest.config.ts src/pages/custodian/custodian-session-store.test.ts` — 18 tests passed, including direct client replacement and disconnect/reconnect coverage.
- `pnpm exec tsgo -p tsconfig.ui.json --noEmit` — passed.
- `pnpm lint:ui:no-raw-window-open` — passed.
- `pnpm ui:build` — passed.
- `pnpm exec oxfmt --check ui/src/pages/custodian/custodian-session-store.ts ui/src/pages/custodian/custodian-session-store.test.ts` — passed.
- RooClaw `review-code` — no actionable findings.
- `pnpm --dir ui test` — 720/721 files passed (10,352 passed, 1 skipped); the sole failure was the unchanged `chat-responsive.browser.test.ts` mobile label-width assertion (`82 <= 80`), reproduced identically on an isolated `origin/main` snapshot.
