### PR TITLE
fix(onboard): stop printing two contradictory Fix lines for one failure

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -41,6 +41,72 @@ import type {
   OnboardGatewayHealthCall,
   OnboardHealthCommandCall,
 } from "./onboard-non-interactive.test-helpers.js";
+import { logNonInteractiveOnboardingFailure } from "./onboard-non-interactive/local/output.js";
+
+describe("logNonInteractiveOnboardingFailure", () => {
+  const callerFix = "Fix: use the phase-specific recovery path.";
+  const failure = {
+    mode: "local" as const,
+    phase: "gateway-health",
+    message: "Gateway did not become reachable.",
+    detail: "connect ECONNREFUSED 127.0.0.1:18997",
+    hints: ["Phase-specific context.", callerFix],
+  };
+
+  it("uses a caller-supplied Fix hint in human and JSON output", () => {
+    const error = vi.fn();
+    logNonInteractiveOnboardingFailure({
+      ...failure,
+      opts: {},
+      runtime: { ...runtime, error },
+    });
+
+    const humanLines = String(error.mock.calls[0]?.[0]).split("\n");
+    expect(humanLines.filter((line) => line.startsWith("Fix:"))).toEqual([callerFix]);
+
+    const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
+    logNonInteractiveOnboardingFailure({
+      ...failure,
+      opts: { json: true },
+      runtime: runtimeWithCapture,
+    });
+
+    const parsed = JSON.parse(readCapturedJson()) as { hints: string[] };
+    expect(parsed.hints.filter((hint) => hint.startsWith("Fix:"))).toEqual([callerFix]);
+  });
+
+  it("keeps the classification recovery hint when the caller supplies no hints", () => {
+    const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
+    logNonInteractiveOnboardingFailure({
+      ...failure,
+      hints: undefined,
+      opts: { json: true },
+      runtime: runtimeWithCapture,
+    });
+
+    const parsed = JSON.parse(readCapturedJson()) as { hints: string[] };
+    expect(parsed.hints).toEqual([
+      "Fix: start `openclaw gateway run`, or run `openclaw gateway restart` for a managed gateway.",
+    ]);
+  });
+
+  it("leaves hints for a non-gateway-health phase unchanged", () => {
+    const hints = [callerFix, "Keep the configured environment available."];
+    const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
+    logNonInteractiveOnboardingFailure({
+      opts: { json: true },
+      runtime: runtimeWithCapture,
+      mode: "local",
+      phase: "daemon-install",
+      message: "Gateway service install did not complete successfully.",
+      hints,
+    });
+
+    const parsed = JSON.parse(readCapturedJson()) as { classification?: string; hints: string[] };
+    expect(parsed.classification).toBeUndefined();
+    expect(parsed.hints).toEqual(hints);
+  });
+});
 
 describe("onboard (non-interactive): gateway and remote auth", () => {
   let envSnapshot: ReturnType<typeof prepareOnboardGatewayTestEnv>;

--- a/src/commands/onboard-non-interactive/local/output.ts
+++ b/src/commands/onboard-non-interactive/local/output.ts
@@ -196,8 +196,12 @@ export function logNonInteractiveOnboardingFailure(params: {
     detail: params.detail,
     diagnostics: params.diagnostics,
   });
-  const recoveryHint = recoveryHintForGatewayHealthFailure(classification);
-  const hints = [...(recoveryHint ? [recoveryHint] : []), ...(params.hints?.filter(Boolean) ?? [])];
+  const callerHints = params.hints?.filter(Boolean) ?? [];
+  // A caller-supplied Fix has phase context that the generic classification cannot know.
+  const recoveryHint = callerHints.some((hint) => hint.startsWith("Fix:"))
+    ? undefined
+    : recoveryHintForGatewayHealthFailure(classification);
+  const hints = [...(recoveryHint ? [recoveryHint] : []), ...callerHints];
   const output = redactSecrets({
     message: params.message,
     detail: params.detail,


### PR DESCRIPTION
## What Problem This Solves

When non-interactive onboarding fails its gateway health check, it prints **two different `Fix:`
lines for the same failure**, and the first one contradicts the line printed immediately after it.

Reproduced on the real dist CLI with an isolated HOME and `OPENCLAW_STATE_DIR`:

```
openclaw onboard --non-interactive --accept-risk --auth-choice skip --gateway-port 18997
```

```
Gateway did not become reachable at ws://127.0.0.1:18997.
Classification: not-listening
Last probe: connect ECONNREFUSED 127.0.0.1:18997
Fix: start `openclaw gateway run`, or run `openclaw gateway restart` for a managed gateway.
Non-interactive local setup only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`.
Fix: start `openclaw gateway run`, re-run `openclaw onboard --install-daemon`, or use `openclaw onboard --skip-health`.
```

`--json` carries the same three entries in `hints`:

```
hint[0]: Fix: start `openclaw gateway run`, or run `openclaw gateway restart` for a managed gateway.
hint[1]: Non-interactive local setup only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`.
hint[2]: Fix: start `openclaw gateway run`, re-run `openclaw onboard --install-daemon`, or use `openclaw onboard --skip-health`.
```

The most prominent remediation points at restarting a *managed gateway* that, as the very next line
states, was never installed. The accurate advice is printed last.

## Why This Change Was Made

`logNonInteractiveOnboardingFailure` (`src/commands/onboard-non-interactive/local/output.ts`)
unconditionally prepended the classification-derived hint to whatever the caller supplied:

```ts
const recoveryHint = recoveryHintForGatewayHealthFailure(classification);
const hints = [...(recoveryHint ? [recoveryHint] : []), ...(params.hints?.filter(Boolean) ?? [])];
```

The caller at `src/commands/onboard-non-interactive/local.ts` already passes a more specific `Fix:`
for exactly this case, because it knows something the classifier cannot: whether `--install-daemon`
was requested. The generic hint is correct when the caller has nothing better; printing it *in
addition to* a caller-supplied one for the same failure is what produced the contradiction.

Fixing it in the output helper keeps the human text and the `--json` `hints` array consistent by
construction — they are built from the same list.

## User Impact

The same failure now ends with a single, accurate remediation:

```
Gateway did not become reachable at ws://127.0.0.1:18997.
Classification: not-listening
Last probe: connect ECONNREFUSED 127.0.0.1:18997
Non-interactive local setup only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`.
Fix: start `openclaw gateway run`, re-run `openclaw onboard --install-daemon`, or use `openclaw onboard --skip-health`.
```

Callers that supply no hints keep the classification hint exactly as before — verified across every
caller of the helper: daemon-install failure unchanged, installed-daemon gateway failure unchanged,
reachable-gateway health-command failure unchanged, and remote onboarding does not use this helper
at all. Classification strings, the `Classification:` line, hint order, wording, and exit codes are
untouched.

## Evidence

Production `+6/-2` (net +4). Tests `+66/-0`.

`node scripts/run-vitest.mjs src/commands/onboard-non-interactive.gateway.test.ts` — 24/24 pass.
Reverting only the production change fails the new case and passes the other 23, so it is a
regression test rather than a restatement.

New coverage asserts *exactly* one `Fix:` line — `toEqual([callerFix])`, not a count — in both the
human lines and the JSON `hints` array; that the classification hint still appears when the caller
supplies no hints; and that non-gateway-health phases are unaffected.

`node scripts/check-changed.mjs -- <both files>` passed on Blacksmith Testbox
`tbx_01m0kbc9zyge9x4hmq9471x5qn`. `oxfmt --check` and `git diff --check` clean.
`$autoreview --mode uncommitted` clean, no accepted or actionable findings.

The detection rule is "a caller hint that already starts with `Fix:`", chosen over a new parameter
because `Fix:` is already the established remediation convention in this output path. An inline
comment records why the generic hint is suppressed so the behaviour reads as deliberate.
