### PR TITLE
fix(config): diagnose an unwritable config directory instead of leaking EACCES

### DIFF
--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -3,6 +3,7 @@ import fsNode from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FILE_LOCK_TIMEOUT_ERROR_CODE } from "../infra/file-lock.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { initializePublishedConfigRuntimeEnv, prepareConfigRuntimeEnv } from "./config-env-vars.js";
 import { hashConfigIncludeRaw } from "./includes.js";
@@ -59,6 +60,9 @@ const validationMocks = vi.hoisted(() => ({
 const backupMocks = vi.hoisted(() => ({
   maintainConfigBackups: vi.fn<typeof import("./backup-rotation.js").maintainConfigBackups>(),
 }));
+const fileLockMocks = vi.hoisted(() => ({
+  withFileLock: vi.fn<typeof import("../infra/file-lock.js").withFileLock>(),
+}));
 
 vi.mock("./io.js", async () => ({
   ...(await vi.importActual<typeof import("./io.js")>("./io.js")),
@@ -73,6 +77,10 @@ vi.mock("./backup-rotation.js", async (importOriginal) => {
     maintainConfigBackups: backupMocks.maintainConfigBackups,
   };
 });
+vi.mock("../infra/file-lock.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/file-lock.js")>()),
+  withFileLock: fileLockMocks.withFileLock,
+}));
 
 function createSnapshot(params: {
   hash: string;
@@ -168,6 +176,7 @@ describe("config mutate helpers", () => {
     ioMocks.resolveConfigSnapshotHash.mockImplementation(
       (snapshot: { hash?: string }) => snapshot.hash ?? null,
     );
+    fileLockMocks.withFileLock.mockImplementation(async (_filePath, _options, fn) => await fn());
     delete process.env.OPENCLAW_NIX_MODE;
   });
 
@@ -482,6 +491,61 @@ describe("config mutate helpers", () => {
     expect(result.result).toBe("created");
     expect(ioMocks.readConfigFileSnapshotForWrite).toHaveBeenCalledTimes(2);
     expect(ioMocks.writeConfigFile).toHaveBeenCalledOnce();
+  });
+
+  it.each(["EACCES", "EPERM", "EROFS"] as const)(
+    "diagnoses %s config lock failures at the config directory",
+    async (code) => {
+      const configDir = await suiteRootTracker.make(`lock-permission-${code.toLowerCase()}`);
+      const configPath = path.join(configDir, "openclaw.json");
+      const lockPath = `${configPath}.lock`;
+      const failure = Object.assign(new Error(`${code}: permission denied, open '${lockPath}'`), {
+        code,
+        path: lockPath,
+      });
+      fileLockMocks.withFileLock.mockRejectedValueOnce(failure);
+      const snapshot = createSnapshot({ hash: "hash-1", path: configPath, sourceConfig: {} });
+
+      await expect(replaceConfigFile({ snapshot, nextConfig: {} })).rejects.toMatchObject({
+        name: "Error",
+        message: `OpenClaw cannot write to the config directory ${configDir}. Fix its ownership or permissions, then try again. Underlying error: ${failure.message}`,
+        cause: failure,
+      });
+    },
+  );
+
+  it("preserves a permission failure raised outside the config directory", async () => {
+    const configDir = await suiteRootTracker.make("lock-unrelated-permission");
+    const configPath = path.join(configDir, "openclaw.json");
+    // The caller's mutation runs inside the lock scope, so its own EACCES must not be
+    // relabelled as a config-directory permission problem.
+    const failure = Object.assign(
+      new Error("EACCES: permission denied, open '/elsewhere/secret'"),
+      {
+        code: "EACCES",
+        path: "/elsewhere/secret",
+      },
+    );
+    fileLockMocks.withFileLock.mockRejectedValueOnce(failure);
+    const snapshot = createSnapshot({ hash: "hash-1", path: configPath, sourceConfig: {} });
+
+    await expect(replaceConfigFile({ snapshot, nextConfig: {} })).rejects.toBe(failure);
+  });
+
+  it.each([
+    new ConfigMutationConflictError("stale"),
+    Object.assign(new Error("lock timed out"), {
+      code: FILE_LOCK_TIMEOUT_ERROR_CODE,
+      lockPath: "/tmp/openclaw.json.lock",
+    }),
+    new Error("unexpected lock failure"),
+  ])("preserves non-permission config lock failures", async (failure) => {
+    const configDir = await suiteRootTracker.make("lock-error");
+    const configPath = path.join(configDir, "openclaw.json");
+    fileLockMocks.withFileLock.mockRejectedValueOnce(failure);
+    const snapshot = createSnapshot({ hash: "hash-1", path: configPath, sourceConfig: {} });
+
+    await expect(replaceConfigFile({ snapshot, nextConfig: {} })).rejects.toBe(failure);
   });
 
   it("rejects stale replace attempts when the base hash changed", async () => {

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { expectDefined } from "@openclaw/normalization-core";
-import { formatErrorMessage, isMissingPathError } from "../infra/errors.js";
+import { formatErrorMessage, isErrno, isMissingPathError } from "../infra/errors.js";
 import { withFileLock } from "../infra/file-lock.js";
 import { root as createFsRoot, type Root as FsSafeRoot } from "../infra/fs-safe.js";
 import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
@@ -213,16 +213,40 @@ async function withConfigMutationLock<T>(
     return await fn();
   }
   assertConfigWriteAllowedInCurrentMode({ configPath });
-  await fs.mkdir(path.dirname(configPath), { recursive: true, mode: 0o700 });
+  const configDir = path.dirname(configPath);
+  await fs.mkdir(configDir, { recursive: true, mode: 0o700 });
 
   const nextActiveLocks = new Set(activeLocks ?? []);
   nextActiveLocks.add(configPath);
-  return await configMutationQueue.enqueue(configPath, () =>
-    activeConfigMutationLocks.run(
-      nextActiveLocks,
-      async () => await withFileLock(configPath, CONFIG_MUTATION_LOCK_OPTIONS, fn),
-    ),
-  );
+  return await configMutationQueue
+    .enqueue(configPath, () =>
+      activeConfigMutationLocks.run(
+        nextActiveLocks,
+        async () => await withFileLock(configPath, CONFIG_MUTATION_LOCK_OPTIONS, fn),
+      ),
+    )
+    .catch((error: unknown) => {
+      // Only relabel a permission failure on the config directory itself. The caller's mutation
+      // runs inside this scope, so an unrelated EACCES from its own work must not be misdiagnosed.
+      if (!isPermissionErrorInDirectory(error, configDir)) {
+        throw error;
+      }
+      throw new Error(
+        `OpenClaw cannot write to the config directory ${configDir}. Fix its ownership or permissions, then try again. Underlying error: ${formatErrorMessage(error)}`,
+        { cause: error },
+      );
+    });
+}
+
+function isPermissionErrorInDirectory(error: unknown, directory: string): boolean {
+  if (
+    !isErrno(error) ||
+    (error.code !== "EACCES" && error.code !== "EPERM" && error.code !== "EROFS")
+  ) {
+    return false;
+  }
+  const failedPath = error.path;
+  return typeof failedPath === "string" && path.dirname(path.resolve(failedPath)) === directory;
 }
 
 function markActiveConfigMutationPath(configPath: string): void {


### PR DESCRIPTION
## What Problem This Solves

When the OpenClaw config directory is not writable, every config write fails with a raw Node errno
that names the **lock file** — an internal artifact — instead of the directory whose permissions are
the actual problem.

Reproduced on the real dist CLI with an isolated HOME and `chmod 555` on the config directory:

```
openclaw onboard --non-interactive --accept-risk --auth-choice skip --gateway-port 18997 --skip-health
```

```
Workspace OK: …/state/workspace
Sessions OK: …/state/agents/main/sessions
EACCES: permission denied, open '…/.openclaw/openclaw.json.lock'
[openclaw] Reason: EACCES: permission denied, open '…/.openclaw/openclaw.json.lock'
[openclaw] Try: openclaw doctor
```

`--json` emits the same raw text inside its `cli_error` envelope.

Two successes are reported, then a bare errno pointing at `openclaw.json.lock`. An operator reading
that will investigate or delete the lock file, which changes nothing.

This is not onboarding-specific. `withConfigMutationLock` is the choke point for **every** config
write, so `config set`, `doctor --fix`, `hooks enable`, and everything else that persists config
failed the same unhelpful way.

## Why This Change Was Made

`withConfigMutationLock` (`src/config/mutate.ts`) prepares the directory and then takes the
cross-process lock:

```ts
await fs.mkdir(path.dirname(configPath), { recursive: true, mode: 0o700 });
…
await withFileLock(configPath, CONFIG_MUTATION_LOCK_OPTIONS, fn)
```

`mkdir` is a no-op when the directory already exists, so an existing-but-unwritable directory sails
past it and the failure lands inside `withFileLock`. Nothing in the lock stack
(`src/plugin-sdk/file-lock.ts`, `src/infra/file-lock*.ts`) has permission-specific handling, so the
raw errno reaches the CLI's generic error printer.

Every neighbouring failure class in this product diagnoses itself: an invalid config prints
File / Problem / Inspect / Fix, and a gateway health failure prints Classification / Last probe /
Fix. A permission failure on the config directory got none of that. Fixing it at the choke point
means one diagnosis serves every config writer, rather than a consumer-side guard in onboarding.

## User Impact

```
OpenClaw cannot write to the config directory /Users/me/.openclaw. Fix its ownership or
permissions, then try again. Underlying error: EACCES: permission denied, open
'/Users/me/.openclaw/openclaw.json.lock'
```

The underlying errno is preserved so the original cause stays greppable and is attached as `cause`.
The message names the directory and does not guess an account name for a `chown` suggestion, since
the common cause — a stray `sudo` run leaving root-owned files — varies by environment.

Nothing else changes: no control-flow, retry, lock-semantics, or lock-layout changes, and no new
exported error type.

## Evidence

Production `+32/-8` (net +24, most of it the guard helper and its comment). Tests `+64/-0`.

The translation is deliberately narrow. Only `EACCES`, `EPERM`, and `EROFS` are relabelled, and only
when the errno's reported `path` resolves to a file directly inside the config directory. This
matters because the caller's entire mutation runs inside the locked scope: a first cut caught the
whole `enqueue`, which would have relabelled an unrelated `EACCES` raised by the caller's own work
as a config-directory permission problem. Verified against real Node behaviour that `fs` errors
carry `.path` for this failure before relying on it.

`node scripts/run-vitest.mjs src/config/mutate.test.ts` — 54/54 pass. Coverage:

- each of `EACCES`, `EPERM`, `EROFS` on the lock path produces the new message with the errno
  preserved and set as `cause`;
- a permission failure raised **outside** the config directory propagates untouched — reverting the
  path check to `return true` fails exactly this case and passes the other 53;
- `ConfigMutationConflictError`, the file-lock timeout error (`FILE_LOCK_TIMEOUT_ERROR_CODE`), and a
  generic error all propagate by identity (`rejects.toBe(failure)`), since callers match on them.

Failures are injected through the existing `withFileLock` seam rather than by chmod-ing real
directories, so the suite stays deterministic on CI and does not depend on the runner being
non-root.

`oxfmt --check` and `git diff --check` clean. `$autoreview --mode uncommitted` clean, no accepted or
actionable findings.
