### PR TITLE
chore: trim duplicate core test assertions

### DIFF
--- a/src/agents/cli-runner/reseed-envelope.test.ts
+++ b/src/agents/cli-runner/reseed-envelope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hashCliReseedPrompt, parseCliReseedPrompt } from "./reseed-envelope.js";
+import { parseCliReseedPrompt } from "./reseed-envelope.js";
 
 const LEGACY_RESEED_PROMPT = [
   "Continue this conversation using the OpenClaw transcript below as prior session history.",
@@ -15,13 +15,11 @@ const LEGACY_RESEED_PROMPT = [
 ].join("\n");
 
 describe("CLI reseed envelope", () => {
-  it("recognizes exact legacy prompts and stable prompt hashes", () => {
+  it("recognizes exact legacy prompts", () => {
     expect(parseCliReseedPrompt(LEGACY_RESEED_PROMPT)).toEqual({
       kind: "legacy",
       userMessage: "current",
     });
-    expect(hashCliReseedPrompt("same")).toBe(hashCliReseedPrompt("same"));
-    expect(hashCliReseedPrompt("same")).not.toBe(hashCliReseedPrompt("different"));
   });
 
   it("keeps suffixes outside the recovered legacy user message", () => {

--- a/src/agents/embedded-agent-runner/run/idle-timeout-breaker.test.ts
+++ b/src/agents/embedded-agent-runner/run/idle-timeout-breaker.test.ts
@@ -1,11 +1,7 @@
 // Idle-timeout breaker tests cover the outer run-loop guard that stops
 // repeated silent provider attempts from spinning forever.
 import { describe, expect, it } from "vitest";
-import {
-  MAX_CONSECUTIVE_IDLE_TIMEOUTS_BEFORE_OUTPUT,
-  createIdleTimeoutBreakerState,
-  stepIdleTimeoutBreaker,
-} from "./idle-timeout-breaker.js";
+import { createIdleTimeoutBreakerState, stepIdleTimeoutBreaker } from "./idle-timeout-breaker.js";
 
 // Issue #76293. The wedge: a stalled provider returns from each LLM call
 // with idleTimedOut=true and no completed model progress. Without this
@@ -36,10 +32,6 @@ describe("stepIdleTimeoutBreaker (#76293)", () => {
     }
     return steps;
   }
-
-  it("default cap matches the constant the run loop reads from", () => {
-    expect(MAX_CONSECUTIVE_IDLE_TIMEOUTS_BEFORE_OUTPUT).toBe(5);
-  });
 
   it("does not trip on a single wedged attempt", () => {
     const steps = drive([{ idleTimedOut: true, completedModelProgress: false }]);

--- a/src/agents/mcp-connection-resolver.test.ts
+++ b/src/agents/mcp-connection-resolver.test.ts
@@ -340,7 +340,6 @@ describe("mcp connection resolver helpers", () => {
       };
       const reloadLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
       const requestRecoveryRestart = vi.fn(() => ({ status: "failed" as const }));
-      const pruneInactiveChannelAccountState = vi.fn();
       const nextConfig: OpenClawConfig = {
         plugins: {
           entries: {
@@ -366,7 +365,7 @@ describe("mcp connection resolver helpers", () => {
         },
         async startChannel() {},
         async stopChannel() {},
-        pruneInactiveChannelAccountState,
+        pruneInactiveChannelAccountState() {},
         async reloadPlugins({ beforeReplace, commitRuntime }) {
           await beforeReplace(new Set());
           await commitRuntime();
@@ -394,7 +393,6 @@ describe("mcp connection resolver helpers", () => {
       });
       expect(refreshContextWindowCache).toHaveBeenCalledWith(nextConfig);
       expect(requestRecoveryRestart).not.toHaveBeenCalled();
-      expect(pruneInactiveChannelAccountState).toHaveBeenCalledExactlyOnceWith(new Set());
       expect(isPluginRegistryRetired(previous.registry)).toBe(true);
       expect(peekSessionMcpRuntime({ sessionId })).toBeUndefined();
 


### PR DESCRIPTION
## What Problem This Solves

Removes three low-value core test assertions that duplicate stronger behavior and owner-boundary coverage, reducing maintenance coupling without changing production behavior.

## Why This Change Was Made

This focused test-audit batch removes an MCP channel-state spy duplicated by Gateway publication/pruning tests, SHA-256 self-comparisons superseded by durable reseed receipt tests, and a constant-literal assertion superseded by the default five-attempt breaker behavior test. MCP credential/runtime revocation, reseed parsing and persistence boundaries, and idle-timeout behavior remain covered.

## User Impact

No user-visible behavior changes. The test suite is smaller and less coupled to implementation details while retaining the product contracts at their owning boundaries.

## Evidence

- `node scripts/run-vitest.mjs src/agents/mcp-connection-resolver.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server-channels.test.ts` — 652 tests passed.
- `node scripts/run-vitest.mjs src/agents/cli-runner/reseed-envelope.test.ts src/agents/cli-runner.reliability.test.ts src/gateway/cli-session-history.test.ts` — 202 tests passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/idle-timeout-breaker.test.ts src/agents/embedded-agent-runner/run/attempt-result.test.ts` — 17 tests passed after final formatting.
- `pnpm test:changed` — 28 tests passed.
- `pnpm check:changed` — passed.
- `git diff --check` — passed.
- Codex-backed autoreview against `origin/main` — clean, no accepted/actionable findings.

Production LOC: +0/-0. Test support LOC: +0/-0. Tests: +4/-16.
