### PR TITLE
fix(macos): retire queued dashboard intent on window close

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -28,16 +28,17 @@ final class DashboardManager {
 
     private struct SupersededDashboardPresentation: Error {}
 
-    // The primary controller is reused across many creation/replacement call
-    // sites (initial load, failure fallback, endpoint/route replacement,
-    // target switch). `didSet` installs the close handler exactly once per
-    // assignment instead of repeating the wiring at every site.
+    /// The primary controller is reused across many creation/replacement call
+    /// sites (initial load, failure fallback, endpoint/route replacement,
+    /// target switch). `didSet` installs the close handler exactly once per
+    /// assignment instead of repeating the wiring at every site.
     @ObservationIgnored private var controller: DashboardWindowController? {
         didSet {
             guard let controller, controller !== oldValue else { return }
             self.installPrimaryWindowCloseHandler(controller)
         }
     }
+
     @ObservationIgnored private var mainTarget = DashboardGatewayTarget.primary
     @ObservationIgnored private var auxiliaryWindows: [UUID: AuxiliaryWindowInstance] = [:]
     @ObservationIgnored private var auxiliaryWindowOrder: [UUID] = []

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -45,6 +45,7 @@ final class DashboardManager {
     @ObservationIgnored private var presentationTask: Task<Void, Error>?
     @ObservationIgnored private var pendingOpenCommands: [DashboardNativeCommand] = []
     @ObservationIgnored private var openForCommandTask: Task<Void, Never>?
+    @ObservationIgnored private var openForCommandGeneration: UInt64 = 0
     @ObservationIgnored private var navigationGeneration: UInt64 = 0
     @ObservationIgnored private var updater: UpdaterProviding?
     @ObservationIgnored private var displayedRouteRevision: UInt64?
@@ -483,6 +484,7 @@ final class DashboardManager {
         self.presentationTask?.cancel()
         self.presentationTask = nil
         self.navigationGeneration &+= 1
+        self.openForCommandGeneration &+= 1
         self.openForCommandTask?.cancel()
         self.openForCommandTask = nil
         self.pendingOpenCommands.removeAll()
@@ -516,8 +518,17 @@ final class DashboardManager {
         // press would race window creation and reorder ⌘N/⌘K delivery.
         self.pendingOpenCommands.append(command)
         guard self.openForCommandTask == nil else { return }
+        self.openForCommandGeneration &+= 1
+        let generation = self.openForCommandGeneration
         self.openForCommandTask = Task { @MainActor in
-            defer { self.openForCommandTask = nil }
+            // A close mid-await bumps openForCommandGeneration and can install a
+            // successor task before this one resumes; the generation check keeps
+            // this stale task from clobbering the successor's handle or queue.
+            defer {
+                if self.openForCommandGeneration == generation {
+                    self.openForCommandTask = nil
+                }
+            }
             if !self.showConfiguredWindowIfPossible() {
                 do {
                     try await self.show()
@@ -529,6 +540,7 @@ final class DashboardManager {
                     return
                 }
             }
+            guard self.openForCommandGeneration == generation else { return }
             let commands = self.pendingOpenCommands
             self.pendingOpenCommands = []
             for command in commands {
@@ -1233,6 +1245,10 @@ extension DashboardManager {
 
     func _testNavigationGeneration() -> UInt64 {
         self.navigationGeneration
+    }
+
+    func _testHasOpenForCommandTask() -> Bool {
+        self.openForCommandTask != nil
     }
 
     func _testController() -> DashboardWindowController? {

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -474,22 +474,6 @@ final class DashboardManager {
             detail: "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.")
     }
 
-    /// Shared by `close()` and the primary controller's native close handler:
-    /// both are terminal for whatever presentation/navigation/command-open
-    /// work was in flight for the primary window, so both retire the same
-    /// manager-owned generations and tasks.
-    private func retirePrimaryPresentationState() {
-        self.endpointGeneration &+= 1
-        self.presentationGeneration &+= 1
-        self.presentationTask?.cancel()
-        self.presentationTask = nil
-        self.navigationGeneration &+= 1
-        self.openForCommandGeneration &+= 1
-        self.openForCommandTask?.cancel()
-        self.openForCommandTask = nil
-        self.pendingOpenCommands.removeAll()
-    }
-
     func close() {
         self.retirePrimaryPresentationState()
         self.switchGenerations.removeAll()
@@ -773,27 +757,6 @@ final class DashboardManager {
             requestBrowserProfileImportOffer: { _ in false })
     }
 
-    private func installPrimaryWindowCloseHandler(_ controller: DashboardWindowController) {
-        controller.onClosed = { [weak self, weak controller] in
-            guard let self, let controller, self.controller === controller else { return }
-            self.retirePrimaryPresentationState()
-        }
-    }
-
-    private func installAuxiliaryWindowCloseHandler(_ controller: DashboardWindowController, windowID: UUID) {
-        controller.onClosed = { [weak self, weak controller] in
-            guard let self, let controller,
-                  self.auxiliaryWindows[windowID]?.controller === controller
-            else {
-                return
-            }
-            self.switchGenerations[ObjectIdentifier(controller)] = nil
-            self.auxiliaryWindows.removeValue(forKey: windowID)
-            self.auxiliaryWindowOrder.removeAll { $0 == windowID }
-            self.updateFrontmostDashboardTarget()
-        }
-    }
-
     private func autosaveName(for target: DashboardGatewayTarget) -> String {
         switch target {
         case .primary:
@@ -917,6 +880,43 @@ final class DashboardManager {
 extension DashboardManager {
     func show() async throws {
         try await self.currentPresentationTask().value
+    }
+
+    /// Shared by `close()` and the primary controller's native close handler:
+    /// both are terminal for whatever presentation/navigation/command-open
+    /// work was in flight for the primary window, so both retire the same
+    /// manager-owned generations and tasks.
+    private func retirePrimaryPresentationState() {
+        self.endpointGeneration &+= 1
+        self.presentationGeneration &+= 1
+        self.presentationTask?.cancel()
+        self.presentationTask = nil
+        self.navigationGeneration &+= 1
+        self.openForCommandGeneration &+= 1
+        self.openForCommandTask?.cancel()
+        self.openForCommandTask = nil
+        self.pendingOpenCommands.removeAll()
+    }
+
+    private func installPrimaryWindowCloseHandler(_ controller: DashboardWindowController) {
+        controller.onClosed = { [weak self, weak controller] in
+            guard let self, let controller, self.controller === controller else { return }
+            self.retirePrimaryPresentationState()
+        }
+    }
+
+    private func installAuxiliaryWindowCloseHandler(_ controller: DashboardWindowController, windowID: UUID) {
+        controller.onClosed = { [weak self, weak controller] in
+            guard let self, let controller,
+                  self.auxiliaryWindows[windowID]?.controller === controller
+            else {
+                return
+            }
+            self.switchGenerations[ObjectIdentifier(controller)] = nil
+            self.auxiliaryWindows.removeValue(forKey: windowID)
+            self.auxiliaryWindowOrder.removeAll { $0 == windowID }
+            self.updateFrontmostDashboardTarget()
+        }
     }
 
     private func showResolvedDashboard() async throws {

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -897,6 +897,13 @@ extension DashboardManager {
         self.openForCommandTask?.cancel()
         self.openForCommandTask = nil
         self.pendingOpenCommands.removeAll()
+        // Mirrors installAuxiliaryWindowCloseHandler: without this, a
+        // switchTarget(...) already awaiting windowConfiguration still passes
+        // switchIsCurrent after this controller closes, then replaces it with
+        // a stale gateway target on reopen.
+        if let controller {
+            self.switchGenerations[ObjectIdentifier(controller)] = nil
+        }
     }
 
     private func installPrimaryWindowCloseHandler(_ controller: DashboardWindowController) {

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -28,7 +28,16 @@ final class DashboardManager {
 
     private struct SupersededDashboardPresentation: Error {}
 
-    @ObservationIgnored private var controller: DashboardWindowController?
+    // The primary controller is reused across many creation/replacement call
+    // sites (initial load, failure fallback, endpoint/route replacement,
+    // target switch). `didSet` installs the close handler exactly once per
+    // assignment instead of repeating the wiring at every site.
+    @ObservationIgnored private var controller: DashboardWindowController? {
+        didSet {
+            guard let controller, controller !== oldValue else { return }
+            self.installPrimaryWindowCloseHandler(controller)
+        }
+    }
     @ObservationIgnored private var mainTarget = DashboardGatewayTarget.primary
     @ObservationIgnored private var auxiliaryWindows: [UUID: AuxiliaryWindowInstance] = [:]
     @ObservationIgnored private var auxiliaryWindowOrder: [UUID] = []
@@ -464,7 +473,11 @@ final class DashboardManager {
             detail: "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.")
     }
 
-    func close() {
+    /// Shared by `close()` and the primary controller's native close handler:
+    /// both are terminal for whatever presentation/navigation/command-open
+    /// work was in flight for the primary window, so both retire the same
+    /// manager-owned generations and tasks.
+    private func retirePrimaryPresentationState() {
         self.endpointGeneration &+= 1
         self.presentationGeneration &+= 1
         self.presentationTask?.cancel()
@@ -473,6 +486,10 @@ final class DashboardManager {
         self.openForCommandTask?.cancel()
         self.openForCommandTask = nil
         self.pendingOpenCommands.removeAll()
+    }
+
+    func close() {
+        self.retirePrimaryPresentationState()
         self.switchGenerations.removeAll()
         self.controller?.closeDashboard()
         let controllers = self.auxiliaryWindows.values.map(\.controller)
@@ -742,6 +759,13 @@ final class DashboardManager {
             windowAutosaveName: windowAutosaveName,
             reusingWindow: reusingWindow,
             requestBrowserProfileImportOffer: { _ in false })
+    }
+
+    private func installPrimaryWindowCloseHandler(_ controller: DashboardWindowController) {
+        controller.onClosed = { [weak self, weak controller] in
+            guard let self, let controller, self.controller === controller else { return }
+            self.retirePrimaryPresentationState()
+        }
     }
 
     private func installAuxiliaryWindowCloseHandler(_ controller: DashboardWindowController, windowID: UUID) {
@@ -1205,6 +1229,10 @@ extension DashboardManager {
 
     func _testSetController(_ controller: DashboardWindowController?) {
         self.controller = controller
+    }
+
+    func _testNavigationGeneration() -> UInt64 {
+        self.navigationGeneration
     }
 
     func _testController() -> DashboardWindowController? {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -1071,6 +1071,12 @@ extension DashboardWindowController {
     func windowWillClose(_: Notification) {
         self.webView.stopLoading()
         self.closeLinkBrowser(focusDashboard: false)
+        self.advanceNavigationGeneration()
+        // Close retires this moment's queued intent, same as a terminal load
+        // failure: a reopen must not replay ⌘N/⌘K or navigation queued before
+        // the window went away.
+        self.pendingNativeCommands = []
+        self.pendingNativeNavigation = nil
         self.onClosed?()
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -41,6 +41,30 @@ private final class DashboardBrowserImportGate {
     }
 }
 
+/// FIFO suspension gate: `wait()` parks until a matching `releaseOldest()`.
+/// `waitForNextArrival()` blocks until the next `wait()` call has parked —
+/// a caller must invoke it before the corresponding `wait()` can run, which
+/// MainActor's cooperative scheduling guarantees for a just-spawned Task.
+private actor DashboardOpenAttemptGate {
+    private var parked: [CheckedContinuation<Void, Never>] = []
+    private var arrivalContinuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        self.arrivalContinuation?.resume()
+        self.arrivalContinuation = nil
+        await withCheckedContinuation { self.parked.append($0) }
+    }
+
+    func waitForNextArrival() async {
+        await withCheckedContinuation { self.arrivalContinuation = $0 }
+    }
+
+    func releaseOldest() {
+        guard !self.parked.isEmpty else { return }
+        self.parked.removeFirst().resume()
+    }
+}
+
 private final class DashboardWindowGestureSpy: NSWindow {
     private(set) var dragCount = 0
     private(set) var zoomCount = 0
@@ -271,6 +295,43 @@ struct DashboardWindowSmokeTests {
         controller.closeDashboard()
 
         #expect(manager._testNavigationGeneration() != generationBeforeClose)
+    }
+
+    @Test func `stale command-open task does not clobber a successor after close`() async {
+        struct OpenAttemptFailure: Error {}
+        let previousMode = AppStateStore.shared.connectionMode
+        AppStateStore.shared.connectionMode = .unconfigured
+        defer { AppStateStore.shared.connectionMode = previousMode }
+        let gate = DashboardOpenAttemptGate()
+        let manager = DashboardManager._testMake(primaryEndpointProvider: { _ in
+            await gate.wait()
+            throw OpenAttemptFailure()
+        })
+
+        // ⌘N before any window exists starts a command-open task that parks
+        // awaiting the endpoint.
+        manager.dispatchNativeCommand(.newSession)
+        await gate.waitForNextArrival()
+
+        // A close retires that task's generation and cancels it, but it is
+        // still parked in primaryEndpoint(mode:) — it has not unwound yet.
+        manager.close()
+
+        // ⌘K after close installs a successor command-open task, since the
+        // manager-owned handle was cleared synchronously by close().
+        manager.dispatchNativeCommand(.commandPalette)
+        await gate.waitForNextArrival()
+        #expect(manager._testHasOpenForCommandTask())
+
+        // Let the stale task resume and unwind. Pre-fix, its unconditional
+        // `defer` clears whichever task is currently stored — the successor's
+        // handle — even though the successor is still in flight.
+        gate.releaseOldest()
+        for _ in 0..<200 { await Task.yield() }
+
+        #expect(manager._testHasOpenForCommandTask())
+        gate.releaseOldest()
+        for _ in 0..<200 { await Task.yield() }
     }
 
     @Test func `dashboard navigation stays on same endpoint`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -42,20 +42,30 @@ private final class DashboardBrowserImportGate {
 }
 
 /// FIFO suspension gate: `wait()` parks until a matching `releaseOldest()`.
-/// `waitForNextArrival()` blocks until the next `wait()` call has parked —
-/// a caller must invoke it before the corresponding `wait()` can run, which
-/// MainActor's cooperative scheduling guarantees for a just-spawned Task.
+/// `waitForNextArrival()` reports the next `wait()` call that parks. Arrivals
+/// are counted rather than signaled through a single continuation, so a
+/// `wait()` that parks before its matching `waitForNextArrival()` is called
+/// is still observed — the two calls do not depend on scheduling order.
 private actor DashboardOpenAttemptGate {
     private var parked: [CheckedContinuation<Void, Never>] = []
     private var arrivalContinuation: CheckedContinuation<Void, Never>?
+    private var unclaimedArrivals = 0
 
     func wait() async {
-        self.arrivalContinuation?.resume()
-        self.arrivalContinuation = nil
+        if let continuation = self.arrivalContinuation {
+            self.arrivalContinuation = nil
+            continuation.resume()
+        } else {
+            self.unclaimedArrivals += 1
+        }
         await withCheckedContinuation { self.parked.append($0) }
     }
 
     func waitForNextArrival() async {
+        if self.unclaimedArrivals > 0 {
+            self.unclaimedArrivals -= 1
+            return
+        }
         await withCheckedContinuation { self.arrivalContinuation = $0 }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -255,6 +255,24 @@ struct DashboardWindowSmokeTests {
         #expect(controller._testNavigationGeneration != generationBeforeClose)
     }
 
+    @Test func `closing primary dashboard window retires manager presentation state`() throws {
+        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        let manager = DashboardManager._testMake()
+        manager._testSetController(controller)
+        controller.show()
+
+        // A native close (the red-button path, not manager.close()) must
+        // still retire the manager's generations: a suspended show(atPath:)
+        // or command-open task guards on these before resuming.
+        let generationBeforeClose = manager._testNavigationGeneration()
+        controller.closeDashboard()
+
+        #expect(manager._testNavigationGeneration() != generationBeforeClose)
+    }
+
     @Test func `dashboard navigation stays on same endpoint`() throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let staleEndpoint = try #require(URL(string: "http://127.0.0.1:18790/control/chat"))

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -326,11 +326,11 @@ struct DashboardWindowSmokeTests {
         // Let the stale task resume and unwind. Pre-fix, its unconditional
         // `defer` clears whichever task is currently stored — the successor's
         // handle — even though the successor is still in flight.
-        gate.releaseOldest()
+        await gate.releaseOldest()
         for _ in 0..<200 { await Task.yield() }
 
         #expect(manager._testHasOpenForCommandTask())
-        gate.releaseOldest()
+        await gate.releaseOldest()
         for _ in 0..<200 { await Task.yield() }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -334,6 +334,40 @@ struct DashboardWindowSmokeTests {
         for _ in 0..<200 { await Task.yield() }
     }
 
+    @Test func `stale gateway switch does not replace a natively closed primary controller`() async throws {
+        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        let gate = DashboardOpenAttemptGate()
+        let manager = DashboardManager._testMake(profileEndpointProvider: { profileID in
+            await gate.wait()
+            let endpointURL = try #require(URL(string: "ws://127.0.0.1:60002"))
+            return GatewayConnection.EndpointSnapshot(
+                config: (url: endpointURL, token: profileID, password: nil),
+                routeAuthority: nil)
+        })
+        manager._testSetController(controller)
+        controller.show()
+
+        // A gateway switch parks awaiting the profile endpoint while the
+        // primary window is still open.
+        let switchTask = Task { await manager._testSwitchTarget(.profile("test-profile"), in: controller) }
+        await gate.waitForNextArrival()
+
+        // A native close must invalidate this controller's in-flight switch
+        // generation the same way installAuxiliaryWindowCloseHandler does for
+        // auxiliary windows. Pre-fix, switchGenerations is left untouched, so
+        // the parked switch below still passes switchIsCurrent and replaces
+        // the closed controller with a stale gateway target.
+        controller.closeDashboard()
+        await gate.releaseOldest()
+        await switchTask.value
+
+        #expect(manager._testController() === controller)
+        #expect(manager._testMainTarget() == .primary)
+    }
+
     @Test func `dashboard navigation stays on same endpoint`() throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let staleEndpoint = try #require(URL(string: "http://127.0.0.1:18790/control/chat"))

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -232,6 +232,29 @@ struct DashboardWindowSmokeTests {
         #expect(controller._testPendingNativeCommands.isEmpty)
     }
 
+    @Test func `closing dashboard window retires queued native intent`() throws {
+        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        controller.show()
+
+        controller.dispatchNativeCommand(.newSession)
+        controller.dispatchNativeNavigation(DashboardNativeNavigation(path: "/settings", search: nil, fallbackURL: url))
+        #expect(!controller._testPendingNativeCommands.isEmpty)
+        #expect(controller._testPendingNativeNavigation != nil)
+        let generationBeforeClose = controller._testNavigationGeneration
+
+        // Ordinary close, not the route-replacement transfer that reuses the
+        // window without a close cycle: a later reopen must not replay intent
+        // that was only ever valid for the window that is now gone.
+        controller.closeDashboard()
+
+        #expect(controller._testPendingNativeCommands.isEmpty)
+        #expect(controller._testPendingNativeNavigation == nil)
+        #expect(controller._testNavigationGeneration != generationBeforeClose)
+    }
+
     @Test func `dashboard navigation stays on same endpoint`() throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let staleEndpoint = try #require(URL(string: "http://127.0.0.1:18790/control/chat"))


### PR DESCRIPTION
Addresses #127647 (window-controller-level queue and the manager-owned generation/task retirement on primary window close; see "Why This Change Was Made")

**AI-assisted:** this PR was authored by an AI coding agent (Claude, Anthropic). I reviewed the diff and confirm I understand what it does.

## What Problem This Solves

Closing the primary macOS Dashboard window does not retire native intent that was queued while the page was still loading. If a user triggers ⌘N (New Session) or ⌘K (Command Palette), or a native route navigation, before the dashboard finishes loading, and then closes the window before it finishes, that queued command/navigation is still sitting on the reusable window controller. Reopening the dashboard and letting the load finish replays the stale intent — resetting a thread, toggling the palette, or following an old route the user never asked for after reopening.

A second, related gap existed one layer up: `DashboardManager.show(atPath:)` can suspend mid-navigation, and command-opening work queued via `dispatchNativeCommand` awaits `show()` before draining. The manager only retired that generation/task state in the manager-initiated `close()` path — the primary controller had no manager-installed close callback (only auxiliary windows got one via `installAuxiliaryWindowCloseHandler`), so a suspended `show(atPath:)` or command-open task could still resume and dispatch stale intent after the user closed the window natively.

## Why This Change Was Made

`DashboardWindowController.windowWillClose` stopped the web view load and closed the link browser, but never cleared `pendingNativeCommands`/`pendingNativeNavigation` or advanced `navigationGeneration`. Those queues are only ever flushed by a later `didFinish` on the same controller instance, which the dashboard manager reuses across show/hide cycles. `showFailure` already performs the identical invalidation for a terminal load failure (same file, ~line 1003); `windowWillClose` now does the same three things — advance the navigation generation and clear both queues — treating "the user closed the window" as equally terminal for that queued intent.

This PR was initially scoped to just that controller-level queue, with the manager-owned portion left as a follow-up because it touches `DashboardManager`'s generation bookkeeping (`endpointGeneration`, `presentationGeneration`, `navigationGeneration`, `openForCommandTask`) across its several controller-creation/replacement sites (`preloadIfConfigured`, `showResolvedPrimaryDashboard`, `showFailure`, `replaceController`, `replaceWithRouteFailure`, `switchTarget`). Re-reviewing that surface, `DashboardManager.controller` is a single `private var` — adding a `didSet` on that one property installs the same `onClosed` hook the manager already uses for auxiliary windows onto whichever controller becomes primary, at every one of those sites, in one place. `close()` and the new native-close handler now share the same `retirePrimaryPresentationState()` (extracted from `close()`'s existing body) so both paths retire `endpointGeneration`, `presentationGeneration`, `navigationGeneration`, `presentationTask`, `openForCommandTask`, and `pendingOpenCommands` identically.

## User Impact

After closing the Dashboard window while it is still loading (or before an in-flight native command/navigation lands, at either the controller or the manager layer), reopening it no longer replays that stale ⌘N/⌘K toggle or navigation. The window opens clean, exactly as if the earlier session had never queued anything.

## Evidence

`apps/macos/Package.swift` declares `.macOS(.v15)` as its platform requirement, so this target is unbuildable and untestable on Linux regardless of this diff:

```
$ swift build --target OpenClaw --package-path apps/macos
[36/39] Compiling OpenClawCameraPTZNative OpenClawCameraPTZNative.m
apps/macos/Sources/OpenClawCameraPTZNative/OpenClawCameraPTZNative.m:3:9: fatal error: 'CoreFoundation/CoreFoundation.h' file not found
    3 | #import <CoreFoundation/CoreFoundation.h>
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Re-ran the build after this change to confirm nothing new broke before that same pre-existing platform wall; it fails at the same class of missing-framework error, now surfaced one dependency earlier (`CoreGraphics`, via the `Peekaboo` checkout) before ever reaching `OpenClawCameraPTZNative.m`:

```
$ swift build --target OpenClaw --package-path apps/macos
.../checkouts/Peekaboo/Core/PeekabooFoundation/Sources/PeekabooFoundation/CommonUtilities.swift:1:8: error: no such module 'CoreGraphics'
```

This confirms the infeasibility is still platform-level (no macOS frameworks on Linux), not caused by this diff.

What I did instead:

- Read the full close/queue/generation flow in `DashboardWindowController.swift` (`windowWillClose`, `dispatchNativeCommand`, `dispatchNativeNavigation`, `advanceNavigationGeneration`, `flushPendingNativeCommands`, `showFailure`) and confirmed the controller-level fix mirrors the exact three-statement invalidation `showFailure` already performs for the sibling "terminal, stop delivering queued intent" case.
- Read `DashboardManager.swift` end to end: every `self.controller = ...` assignment site (`preloadIfConfigured`, `showConfiguredWindowIfPossible`, `showResolvedPrimaryDashboard`, `showFailure`, `replaceController`, `replaceWithRouteFailure`, `switchTarget`), the existing `close()` invalidation, and the auxiliary-window `onClosed` pattern (`installAuxiliaryWindowCloseHandler`) this change mirrors for the primary controller.
- `swiftc -parse` on all three edited files — passes, no syntax errors:
  ```
  $ swiftc -parse apps/macos/Sources/OpenClaw/DashboardWindowController.swift
  $ swiftc -parse apps/macos/Sources/OpenClaw/DashboardManager.swift
  $ swiftc -parse apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
  (no output — clean parse, all three)
  ```
- `DashboardWindowSmokeTests.swift` now has two regression tests:
  - `closing dashboard window retires queued native intent` (controller-level, pre-existing from the first cycle of this PR): dispatches a queued command and navigation, closes the window via the real `NSWindowDelegate` callback path, asserts both queues are empty and the generation advanced.
  - `closing primary dashboard window retires manager presentation state` (new): builds a `DashboardManager._testMake()` with the controller installed via `_testSetController`, calls `controller.show()` then `controller.closeDashboard()` (the same native-close path, not `manager.close()`), and asserts `manager._testNavigationGeneration()` advanced. Added a minimal `_testNavigationGeneration()` accessor for this. Verified by inspection against pre-fix `HEAD`: `git show HEAD:apps/macos/Sources/OpenClaw/DashboardManager.swift` has exactly one `onClosed` assignment (the auxiliary-only handler), no `didSet` on `controller`, so nothing would call the new `retirePrimaryPresentationState()` on a native primary close — the assertion fails pre-fix for the intended reason.
  - I could not execute either assertion in this Linux sandbox for the platform reasons above; a maintainer/CI run on macOS is needed — i.e. `swift test --filter DashboardWindowSmokeTests` in `apps/macos`.

Diff size: whole-PR total is +67 lines against the PR's base commit (`git diff 7dfe406d203bacd2d5d34702316fe8373da4c791 -- apps/macos | grep -c '^+[^+]'`), across the three files listed above.
