### PR TITLE
fix(qa): retain failed isolated scenarios in fail-fast results

### DIFF
--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -97,6 +97,43 @@ describe("isolated QA suite transport cleanup", () => {
     mocks.disposeRegisteredAgentHarnesses.mockResolvedValue(undefined);
   });
 
+  it("records a rejected dispatched worker and leaves the fail-fast tail unstarted", async () => {
+    const lab = createCleanupTestLab();
+    const context = createCleanupTestContext();
+    context.selectedScenarios.push(makeQaSuiteTestScenario("never-started"));
+    const runChild = vi
+      .fn<QaSuiteRunner>()
+      .mockRejectedValueOnce(new Error("isolated worker gateway failed"));
+
+    const result = await runQaFlowSuiteIsolated(
+      { failFast: true, lab, startLab: async () => lab },
+      context,
+      runChild,
+    );
+
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(result.startedScenarioIds).toEqual(["leased-channel-scenario"]);
+    expect(result.scenarios).toEqual([
+      expect.objectContaining({
+        name: "leased-channel-scenario",
+        status: "fail",
+        details: "isolated worker gateway failed",
+      }),
+    ]);
+    expect(lab.setScenarioRun).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: "completed",
+        scenarios: [
+          expect.objectContaining({ id: "leased-channel-scenario", status: "fail" }),
+          expect.objectContaining({ id: "never-started", status: "pending" }),
+        ],
+      }),
+    );
+    expect(mocks.writeQaSuiteArtifacts).toHaveBeenLastCalledWith(
+      expect.objectContaining({ scenarios: result.scenarios }),
+    );
+  });
+
   it("leaves only running progress when parent cleanup fails after worker completion", async () => {
     const lab = createCleanupTestLab();
     const release = vi.fn(async () => {});

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -170,24 +170,24 @@ export async function runQaFlowSuiteIsolated(
         updateScenarioRun();
         try {
           const scenarioOutputDir = path.join(outputDir, "scenarios", scenario.id);
-          const childSuiteResult: QaSuiteResult = await runQaFlowSuite(
-            markQaSuiteNestedRun(
-              buildQaIsolatedScenarioWorkerParams({
-                repoRoot,
-                outputDir: scenarioOutputDir,
-                providerMode,
-                transportId,
-                channelDriver: params?.channelDriver,
-                channelDriverSelection: params?.channelDriverSelection,
-                primaryModel,
-                alternateModel,
-                fastMode,
-                startLab,
-                scenario,
-                input: params,
-              }),
-            ),
+          const workerParams = markQaSuiteNestedRun(
+            buildQaIsolatedScenarioWorkerParams({
+              repoRoot,
+              outputDir: scenarioOutputDir,
+              providerMode,
+              transportId,
+              channelDriver: params?.channelDriver,
+              channelDriverSelection: params?.channelDriverSelection,
+              primaryModel,
+              alternateModel,
+              fastMode,
+              startLab,
+              scenario,
+              input: params,
+            }),
           );
+          startedScenarioIds.add(scenario.id);
+          const childSuiteResult: QaSuiteResult = await runQaFlowSuite(workerParams);
           for (const scenarioId of childSuiteResult.startedScenarioIds) {
             startedScenarioIds.add(scenarioId);
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running QA Lab scenarios with fail-fast enabled could receive incomplete or misleading evidence after an isolated scenario worker failed before returning its own result. The scenario really started and failed, but the unified suite treated it as unstarted, discarded its failure evidence, and could report the run without its actual failing scenario.

## Why This Change Was Made

The isolated-suite owner now records the scenario as started immediately before dispatching its fully prepared child worker, matching the existing standard-suite lifecycle. This preserves rejected-worker failures through unified fail-fast result, evidence, and progress accounting while leaving genuinely unstarted tail scenarios pending. Recording starts downstream or inventing fallback results would mask the owning lifecycle defect.

## User Impact

QA Lab fail-fast runs now preserve and report the scenario that actually failed, including its failure details and generated evidence, without starting later scenarios after that failure.

## Evidence

- Authentic pre-fix regression failed because a dispatched rejected worker returned an empty started-scenario list.
- After the owner-boundary repair, 131 focused QA owner and sibling tests passed, including the new rejection/fail-fast regression and unchanged pending-tail, progress, and artifact behavior.
- Regression verifies one child dispatch, the exact failed scenario ID and error, a pending unstarted scenario, completed lab progress, and matching final artifacts.
- Production delta: +17/-17 (net zero); regression test delta: +37/-0.
- Both final source files were verified unchanged on current main before publication; no public API, configuration, dependency, protocol, authentication, or persistent-state changes.
- Independent source review and authenticated full committed-branch Codex autoreview returned no actionable findings.
- Reviewed commit: 0096db6df0b73c7d10ab2c47110b94946190d520.
