### PR TITLE
fix(ui): align narrow chat composer spacing

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2067,6 +2067,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
   it.each([
     [393, 852],
+    [900, 500],
     [1366, 900],
     [1920, 1080],
   ] as const)("uses compact radii and optical chat-box insets at %sx%s", async (width, height) => {
@@ -2118,14 +2119,17 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(geometry.assistantBubble?.paddingRight).toBe(0);
       expect(geometry.composer?.borderRadius).toBe(mediumRadius);
 
-      const composerInset = width <= 768 ? 4 : 8;
-      const textareaBlockInset = width <= 768 ? 10 : composerInset;
+      const usesCompactComposer = width <= 768 || (width <= 932 && height <= 500 && width > height);
+      const composerInset = usesCompactComposer ? 4 : 8;
+      const textareaBlockInset = usesCompactComposer ? 10 : composerInset;
       expect(geometry.textarea?.paddingTop).toBe(textareaBlockInset);
       expect(geometry.textarea?.paddingRight).toBe(composerInset);
       expect(geometry.textarea?.paddingBottom).toBe(textareaBlockInset);
-      expect(geometry.textarea?.paddingLeft).toBe(width <= 768 ? composerInset : composerInset - 4);
-      expect(geometry.footer?.paddingLeft).toBe(width <= 768 ? composerInset * 2 : composerInset);
-      expect(geometry.footer?.paddingRight).toBe(width <= 768 ? composerInset * 2 : composerInset);
+      expect(geometry.textarea?.paddingLeft).toBe(
+        usesCompactComposer ? composerInset : composerInset - 4,
+      );
+      expect(geometry.footer?.paddingLeft).toBe(8);
+      expect(geometry.footer?.paddingRight).toBe(8);
       // #105866 splits the block inset evenly around the footer so the
       // settings chip centers between the divider and the card edge.
       expect(geometry.footer?.paddingTop).toBe(composerInset / 2);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2123,9 +2123,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(geometry.textarea?.paddingTop).toBe(textareaBlockInset);
       expect(geometry.textarea?.paddingRight).toBe(composerInset);
       expect(geometry.textarea?.paddingBottom).toBe(textareaBlockInset);
-      expect(geometry.textarea?.paddingLeft).toBe(composerInset - 4);
-      expect(geometry.footer?.paddingLeft).toBe(composerInset);
-      expect(geometry.footer?.paddingRight).toBe(composerInset);
+      expect(geometry.textarea?.paddingLeft).toBe(width <= 768 ? composerInset : composerInset - 4);
+      expect(geometry.footer?.paddingLeft).toBe(width <= 768 ? composerInset * 2 : composerInset);
+      expect(geometry.footer?.paddingRight).toBe(width <= 768 ? composerInset * 2 : composerInset);
       // #105866 splits the block inset evenly around the footer so the
       // settings chip centers between the divider and the card edge.
       expect(geometry.footer?.paddingTop).toBe(composerInset / 2);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4120,7 +4120,12 @@ button.chat-pr__diff {
     max-height: calc(7em + var(--chat-box-inset) + var(--chat-box-inset));
     padding-top: 10px;
     padding-bottom: 10px;
+    padding-left: var(--chat-box-inset);
     font-size: var(--control-ui-input-text-size);
+  }
+
+  .agent-chat__composer-footer {
+    padding-inline: calc(var(--chat-box-inset) * 2);
   }
 
   .agent-chat__composer-actions {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3098,7 +3098,7 @@ button.chat-pr__diff {
   border-top: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
   /* Split the inset evenly so the settings chip sits centered between the
      divider and the card edge instead of hugging the divider. */
-  padding: calc(var(--chat-box-inset) / 2) var(--chat-box-inset);
+  padding: calc(var(--chat-box-inset) / 2) max(var(--chat-box-inset), 8px);
 }
 
 .agent-chat__composer-meta,
@@ -4122,10 +4122,6 @@ button.chat-pr__diff {
     padding-bottom: 10px;
     padding-left: var(--chat-box-inset);
     font-size: var(--control-ui-input-text-size);
-  }
-
-  .agent-chat__composer-footer {
-    padding-inline: calc(var(--chat-box-inset) * 2);
   }
 
   .agent-chat__composer-actions {


### PR DESCRIPTION
## Summary

- restore the mobile textarea’s 4px leading inset instead of collapsing it to zero
- increase the narrow composer footer’s inline inset from 4px to 8px so its controls align with the input row
- preserve the existing composer structure, visible controls, wrapping, and 44px touch targets

## Root cause

The mobile composer reduced `--chat-box-inset` to 4px but inherited the desktop optical subtraction for the textarea, leaving its leading padding at 0px. The footer also kept the tighter 4px inline inset, so the two rows did not read as one aligned surface at narrow widths.

The responsive composer stylesheet owns both values; this change corrects them there without introducing a parallel layout.

## Screenshots

Same production-backed fixture and state at a 320px viewport.

| Before | After |
| --- | --- |
| ![Before: narrow composer with zero leading text inset and tighter footer padding](https://raw.githubusercontent.com/openclaw/openclaw/cd68808ced8781b34a44c4158b48ae9fc2b73aa1/before.png) | ![After: narrow composer with aligned text and footer insets](https://raw.githubusercontent.com/openclaw/openclaw/cd68808ced8781b34a44c4158b48ae9fc2b73aa1/after.png) |

## Validation

- pre-fix responsive regression: 3 expected failures at 320×568, 393×852, and 568×320
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/pages/chat/chat-responsive.browser.test.ts` — 89/89 passed, including 900×500 short landscape
- `pnpm exec oxfmt --check ui/src/styles/chat/layout.css ui/src/pages/chat/chat-responsive.browser.test.ts` — passed
- `pnpm lint:ui:styles` — passed
- `pnpm exec oxlint ui/src/pages/chat/chat-responsive.browser.test.ts` — passed
- `pnpm tsgo:ui` — passed
- production screenshot metrics at 320px: no horizontal overflow; send target remains 44×44px

Production delta: +1 line. The footer correction is folded into its existing canonical padding declaration; test expectations cover portrait, short landscape, and desktop.
