### PR TITLE
fix(qa): replace Linux-only /proc probes in the Telegram proof harness

### DIFF
--- a/scripts/e2e/telegram-mantis-lane.ts
+++ b/scripts/e2e/telegram-mantis-lane.ts
@@ -234,6 +234,16 @@ function publicRelativePath(root: string, file: string, label: string): string {
   if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
     throw new Error(`${label} must be inside the Mantis output directory.`);
   }
+  // Node has no openat(2), so containment is re-proven component by component: a directory
+  // swapped for a symlink after the caller resolved the path would otherwise route an
+  // already-open descriptor outside the root, which O_NOFOLLOW only prevents for the leaf.
+  let cursor = resolvedRoot;
+  for (const segment of relative.split(path.sep)) {
+    cursor = path.join(cursor, segment);
+    if (fs.lstatSync(cursor).isSymbolicLink()) {
+      throw new Error(`${label} must be inside the Mantis output directory.`);
+    }
+  }
   return relative;
 }
 
@@ -244,11 +254,11 @@ function readPublicFile(
   maxBytes: number,
 ): { relative: string; text: string } {
   const resolved = fs.realpathSync(input);
-  publicRelativePath(root, resolved, label);
   const descriptor = fs.openSync(resolved, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
   try {
-    const opened = fs.realpathSync(`/proc/self/fd/${descriptor}`);
-    const relative = publicRelativePath(root, opened, label);
+    // Containment is checked after the open so the descriptor being read is the file the
+    // check accepted, not one a concurrent swap redirected it to.
+    const relative = publicRelativePath(root, resolved, label);
     const stat = fs.fstatSync(descriptor);
     if (!stat.isFile() || stat.size > maxBytes) {
       throw new Error(`${label} must be a regular file no larger than ${maxBytes} bytes.`);
@@ -297,6 +307,16 @@ function saveActive(sessionRoot: string, state: ActiveSession): void {
   writeJsonAtomic(activeFile(sessionRoot, state.lane), state);
 }
 
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the pid exists under another user; only ESRCH proves the lock owner is gone.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
 function acquireHarnessLock(sessionRoot: string): () => void {
   const lock = path.join(sessionRoot, "harness.lock");
   for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -314,7 +334,7 @@ function acquireHarnessLock(sessionRoot: string): () => void {
         throw error;
       }
       const owner = Number(fs.readFileSync(lock, "utf8").trim());
-      if (Number.isInteger(owner) && owner > 0 && fs.existsSync(`/proc/${owner}`)) {
+      if (Number.isInteger(owner) && owner > 0 && processIsAlive(owner)) {
         throw new Error("The shared Telegram harness already has a command in progress.", {
           cause: error,
         });

--- a/scripts/e2e/telegram-user-driver.py
+++ b/scripts/e2e/telegram-user-driver.py
@@ -34,6 +34,22 @@ def read_json(path):
         return {}
 
 
+def open_contained_file(root, relative):
+    """Opens a file under root, descending one component at a time from an open directory
+    descriptor so no symlink can be traversed and no directory can be swapped mid-walk.
+    Anchoring on descriptors is what keeps containment true without Linux-only /proc paths."""
+    parent = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        *directories, name = relative.parts
+        for directory in directories:
+            child = os.open(directory, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=parent)
+            os.close(parent)
+            parent = child
+        return os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=parent)
+    finally:
+        os.close(parent)
+
+
 def write_json_private(path, data):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.parent.chmod(stat.S_IRWXU)
@@ -764,24 +780,18 @@ class UserObserver:
 
     def resolve_media(self, value):
         relative = Path(value)
-        if relative.is_absolute() or ".." in relative.parts:
+        if relative.is_absolute() or not relative.parts or ".." in relative.parts:
             raise DriverError("Media must be inside the Mantis output directory.")
-        media = self.media_root / relative
         try:
-            descriptor = os.open(media, os.O_RDONLY | os.O_NOFOLLOW)
+            descriptor = open_contained_file(self.media_root, relative)
         except OSError as error:
             raise DriverError("Media must be a regular file inside the Mantis output directory.") from error
         try:
-            opened = Path(os.path.realpath(f"/proc/self/fd/{descriptor}"))
-            try:
-                opened.relative_to(self.media_root)
-            except ValueError as error:
-                raise DriverError("Media must be inside the Mantis output directory.") from error
             if not stat.S_ISREG(os.fstat(descriptor).st_mode):
                 raise DriverError("Media must be a regular file no larger than 20 MiB.")
             staging_dir = self.media_staging / f"upload-{secrets.token_hex(8)}"
             staging_dir.mkdir(mode=0o700)
-            target = staging_dir / opened.name
+            target = staging_dir / relative.name
             target_descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
             try:
                 copied = 0
@@ -972,6 +982,22 @@ def command_serve(args):
         pid_path.unlink(missing_ok=True)
 
 
+def running_process_command_line(pid):
+    """Returns the argv pid is running under, or None once it is gone, so pid reuse cannot
+    redirect cleanup at an unrelated process group. Zombies hold their table entry until
+    they are reaped, so their pid cannot be reused and they count as already gone."""
+    result = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "state=", "-o", "args="],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    state, _, command_line = result.stdout.strip().partition(" ")
+    if result.returncode != 0 or not state or state.startswith("Z"):
+        return None
+    return command_line.strip()
+
+
 def command_terminate_observer(args):
     pid_path = Path(args.pid_file)
     try:
@@ -990,32 +1016,20 @@ def command_terminate_observer(args):
     pgid = int(value.get("pgid") or 0)
     if value.get("socket") != args.socket or pid <= 0 or pgid <= 0 or pgid == os.getpgrp():
         raise DriverError("Telegram observer pid file is invalid.")
-    process_stat = Path(f"/proc/{pid}/stat")
-
-    def running():
-        try:
-            return process_stat.read_text().rsplit(")", 1)[1].split()[0] not in {"X", "Z"}
-        except FileNotFoundError:
-            return False
-
-    try:
-        command_line = Path(f"/proc/{pid}/cmdline").read_bytes()
-    except FileNotFoundError:
-        command_line = b""
-    # Zombies retain their proc entry with an empty command line; they are not reused PIDs.
-    if not running():
+    command_line = running_process_command_line(pid)
+    if command_line is None:
         pid_path.unlink(missing_ok=True)
         return
-    if b"telegram-user-driver" not in command_line or args.socket.encode() not in command_line or b"serve" not in command_line:
+    if "telegram-user-driver" not in command_line or args.socket not in command_line or "serve" not in command_line:
         raise DriverError("Telegram observer process identity changed before cleanup.")
     try:
         os.killpg(pgid, signal.SIGTERM)
     except ProcessLookupError:
         pass
     deadline = time.monotonic() + 2
-    while running() and time.monotonic() < deadline:
+    while running_process_command_line(pid) is not None and time.monotonic() < deadline:
         time.sleep(0.05)
-    if running():
+    if running_process_command_line(pid) is not None:
         try:
             os.killpg(pgid, signal.SIGKILL)
         except ProcessLookupError:

--- a/src/infra/system-run-approval-binding.test.ts
+++ b/src/infra/system-run-approval-binding.test.ts
@@ -335,7 +335,9 @@ describe("missingSystemRunApprovalBinding", () => {
 
 describe("mutable file operand binding", () => {
   it("binds every script in a compound command and detects drift", async () => {
-    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-binding-"));
+    const cwd = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-system-run-binding-")),
+    );
     const first = path.join(cwd, "first.sh");
     const second = path.join(cwd, "second.py");
     try {
@@ -344,7 +346,14 @@ describe("mutable file operand binding", () => {
       const command = { kind: "shell" as const, text: "sh first.sh && python3 second.py" };
       const prepared = expectOk(await prepareSystemRunMutableFileBinding({ command, cwd }));
 
-      expect(prepared.binding.operands).toHaveLength(2);
+      // Assert the script operands by path: a host whose interpreters live in a writable
+      // prefix (Homebrew, asdf, nix profiles) also binds those executables, so an operand
+      // count would only describe the host that ran the test.
+      expect(
+        prepared.binding.operands
+          .filter((operand) => !operand.executable)
+          .map((operand) => operand.snapshot.path),
+      ).toEqual([first, second]);
       await expect(
         revalidateSystemRunMutableFileBinding({ binding: prepared.binding, cwd }),
       ).resolves.toEqual({ ok: true });

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -1001,7 +1001,7 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(sutScript).not.toContain("...process.env,\n    MOCK_PORT");
     expect(laneScript).toContain("function commandEnv()");
     expect(laneScript).toContain("fs.constants.O_NOFOLLOW");
-    expect(laneScript).toContain("/proc/self/fd/${descriptor}");
+    expect(laneScript).toContain("isSymbolicLink()");
     expect(laneScript).not.toContain("readRecorderSession");
     expect(laneScript).toContain('"artifacts"');
     expect(laneScript).toContain(

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -340,6 +340,37 @@ describe("Telegram Mantis free-form lane", () => {
     }
   });
 
+  it("reads nested public files but refuses symlinked directory components", async () => {
+    const harness = await setupHarness();
+    const outside = path.join(path.dirname(harness.outputRoot), "outside.txt");
+    fs.writeFileSync(outside, "not allowed");
+    fs.mkdirSync(path.join(harness.outputRoot, "nested"));
+    fs.writeFileSync(path.join(harness.outputRoot, "nested", "body.txt"), "nested body");
+    fs.symlinkSync(path.dirname(harness.outputRoot), path.join(harness.outputRoot, "escape"));
+    try {
+      await runLane(harness.env, [
+        "send",
+        "--lane",
+        "candidate",
+        "--text-file",
+        path.join(harness.outputRoot, "nested", "body.txt"),
+      ]);
+      expect(harness.requests).toEqual([{ command: "send", text: "nested body" }]);
+      await expect(
+        runLane(harness.env, [
+          "send",
+          "--lane",
+          "candidate",
+          "--text-file",
+          path.join(harness.outputRoot, "escape", "outside.txt"),
+        ]),
+      ).rejects.toThrow("--text-file must be inside the Mantis output directory");
+      expect(harness.requests).toEqual([{ command: "send", text: "nested body" }]);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("runs scenario-authored actions inside the ephemeral desktop", async () => {
     const harness = await setupHarness();
     const actions = path.join(harness.outputRoot, "click-picker.json");

--- a/test/scripts/telegram-user-observer.test.ts
+++ b/test/scripts/telegram-user-observer.test.ts
@@ -66,6 +66,12 @@ with tempfile.TemporaryDirectory() as root:
         media_error = ""
     except module.DriverError as error:
         media_error = str(error)
+    (public / "escape").symlink_to(private)
+    try:
+        observer.resolve_media("escape/credential.txt")
+        directory_escape_error = ""
+    except module.DriverError as error:
+        directory_escape_error = str(error)
     observer.ingest({
         "@type": "updateNewMessage",
         "message": {
@@ -216,6 +222,7 @@ with tempfile.TemporaryDirectory() as root:
     print(json.dumps({
         "bystanderError": bystander_error,
         "deleted": deleted,
+        "directoryEscapeError": directory_escape_error,
         "documentContent": module.UserDriver.document_content(None, "/tmp/proof.txt", "proof"),
         "events": observer.events,
         "foreignAlive": foreign_alive,
@@ -272,6 +279,9 @@ describe("Telegram user observer", () => {
     expect(value.foreignError).toBe("Telegram observer process identity changed before cleanup.");
     expect(value.bystanderError).toBe("Message 125 was not observed in this session.");
     expect(value.mediaError).toBe(
+      "Media must be a regular file inside the Mantis output directory.",
+    );
+    expect(value.directoryEscapeError).toBe(
       "Media must be a regular file inside the Mantis output directory.",
     );
     expect(value.documentContent).toEqual({


### PR DESCRIPTION
## What Problem This Solves

Three tests failed on a macOS developer host while `main`'s CI check-runs were green, because the Telegram proof harness and one approval-binding assertion encode host assumptions that only hold on the Linux CI runner.

**`scripts/e2e/telegram-user-driver.py`** — `resolve_media` opened the file with `O_NOFOLLOW`, then re-derived the opened path with `os.path.realpath("/proc/self/fd/N")` and checked that against `media_root`. Off Linux there is no `/proc`, `realpath` returns the literal string, and containment fails for every file:

```
ValueError: '/proc/self/fd/4' is not in the subpath of '<tmp>/public'
→ DriverError: Media must be inside the Mantis output directory.
```

`command_terminate_observer` had the same problem in a worse shape: `/proc/<pid>/stat` and `/proc/<pid>/cmdline` are the liveness and identity probes, and off Linux both raise `FileNotFoundError`, so `running()` returns `False`. Cleanup then deletes the observer pid file and returns **without ever signalling the process** — a silent no-op, not a visible failure. This was masked until now because `resolve_media` aborted the test first.

**`scripts/e2e/telegram-mantis-lane.ts`** — `readPublicFile` used the same `/proc/self/fd` re-resolution (`fs.realpathSync` throws `ENOENT: lstat '/proc'`), and `acquireHarnessLock` probed `fs.existsSync("/proc/<owner>")` to decide whether a lock owner was still alive. Off Linux every owner reads as dead, so the "shared Telegram harness already has a command in progress" guard silently steals a held lock. Five of this file's eighteen tests failed, not the three originally reported — the other two are `--actions-file`/lock-guard cases that fail for the same two causes.

**`src/infra/system-run-approval-binding.test.ts`** — `sh first.sh && python3 second.py` asserted `operands` had length 2. The production resolver is right: `prepareMutableFileBindingsForSegments` also binds a resolved executable whose path `pathLooksMutableForShellPayloadSync` considers writable, and a Homebrew `python3` (`/opt/homebrew/Cellar/python@3.14/...`) is user-writable, so it correctly binds as a third `executable: true` operand. `/bin/sh` is root-owned and does not. The count only ever described a host whose interpreters live in a root-owned prefix.

## Why This Change Was Made

Each fix uses the strongest construct the runtime actually offers, rather than dropping the guarantee to gain portability.

**Python gets a strictly stronger check.** `open_contained_file` descends the media path one component at a time from an open directory descriptor (`O_DIRECTORY | O_NOFOLLOW` with `dir_fd=`). Because every component is opened relative to an already-pinned parent, no symlink can be traversed and no directory can be swapped mid-walk. That is race-free, and it covers the intermediate directories the old code never protected — `/proc/self/fd` caught an escape after the fact, but the open itself only had `O_NOFOLLOW` on the leaf.

**Node has no `openat(2)`**, so `publicRelativePath` re-walks the resolved components after the descriptor is open and refuses any that became a symlink; `readPublicFile` now runs containment *after* the open for that ordering to mean something. Statically this matches the old behaviour (a symlink planted in the public dir is refused either way); against an active racer it catches "swap a directory component, leave it swapped", which is the case `/proc` covered. The named residual is a swap-and-restore inside the window between `realpathSync` and `openSync`, which cannot be closed in Node without `openat`. One deliberate narrowing: a symlink pointing *back inside* the root used to be accepted and is now refused, on both sides. Nothing in the harness relies on that.

**Liveness probes** move to `process.kill(pid, 0)` (EPERM means alive under another user, only ESRCH proves gone) and to `ps -p <pid> -o state= -o args=`, which preserves both properties the `/proc` reads had: zombies count as gone because they hold their table entry until reaped and their pid cannot be reused, and argv is still checked so a recycled pid cannot redirect `killpg` at an unrelated process group.

`scripts/vitest-process-group.mts` also reads `/proc`, but it is explicitly `inspectLinuxVitestProcessGroup`, try/catch-wrapped, and degrades to `"unavailable"` — correctly designed and left alone.

## User Impact

No user-visible behaviour change; this is QA harness and test-only. Operator-visible effects for anyone running the harness off Linux: media resolution and public-file reads work, the harness lock is no longer stolen from a live owner, and observer cleanup actually terminates the process instead of silently deleting its pid file.

Production LOC: `+34 / −30` across the two scripts (net +4 excluding the invariant comments and docstrings the descriptor walk and the `ps` contract require). The growth is the security-invariant replacement itself; there is no smaller shape that keeps containment and pid-reuse handling.

## Evidence

Reproduced on macOS 27.0 / Homebrew Python 3.14.7 against clean `origin/main` before any change:

- `src/infra/system-run-approval-binding.test.ts` — `expected [...] to have a length of 2 but got 3`; probe confirmed the third operand is `/opt/homebrew/Cellar/python@3.14/3.14.7/.../bin/python3.14` with `executable: true`.
- `test/scripts/telegram-user-observer.test.ts` — 1 failed, the `/proc/self/fd/4` `ValueError` above.
- `test/scripts/telegram-mantis-lane.test.ts` — 5 of 18 failed (`ENOENT: lstat '/proc'` ×3, plus the `--actions-file` and lock-guard knock-ons).

After:

```
node scripts/run-vitest.mjs \
  test/scripts/telegram-mantis-lane.test.ts \
  test/scripts/mantis-telegram-desktop-proof-workflow.test.ts \
  test/scripts/telegram-user-crabbox-proof.test.ts \
  test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts \
  test/scripts/telegram-user-observer.test.ts \
  src/infra/system-run-approval-binding.test.ts
→ 3 shards passed, 143 tests
```

`node scripts/check-changed.mjs` — exit 0 (format, `tsgo:core:test` / `tsgo:scripts` / `tsgo:test:root`, oxlint, `lint:scripts`, script-erasability, and the repo guards).

Direct probe of the new Python walk (nested legit file opens; directory-symlink escape and leaf symlink both refused):

```
sub/ok.txt        -> OPENED b'ok'
escape/secret.txt -> refused NotADirectoryError 20
leaf              -> refused OSError 62 (ELOOP)
```

Added coverage, both of which fail pre-fix on this host:

- `telegram-user-observer.test.ts` — `resolve_media("escape/credential.txt")` through a directory symlink is refused. The existing case only covered a leaf symlink.
- `telegram-mantis-lane.test.ts` — a nested public file (`public/nested/body.txt`) reads through the new component walk, and a file reached through a symlinked directory component is refused. Nested reads were previously untested and are the false-rejection risk the walk introduces.
- `mantis-telegram-desktop-proof-workflow.test.ts` — the mechanism grep moves from `/proc/self/fd/${descriptor}` to `isSymbolicLink()`.

Proof gap, stated plainly: the pre-fix failure for the two harness scripts is host-conditioned. On Linux the `/proc` paths were correct, so no portable test can fail against pre-fix code there — the reproduction *is* the macOS run above. The Node component walk is TOCTOU hardening and is not statically observable; the new lane test pins the behaviour it must not break rather than claiming to prove the race.

`$autoreview` (codex / gpt-5.6-sol, xhigh): clean, no accepted or actionable findings.
