### PR TITLE
improve(telegram): reduce rich message planning work

### DIFF
--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -219,18 +219,28 @@ export function buildTelegramRichBlocksPlan(
   };
 }
 
-export function splitTelegramRichMessageTextChunks(params: {
-  text: string;
-  textLimit: number;
-  tableMode?: MarkdownTableMode;
-  skipEntityDetection?: boolean;
-}): TelegramRichTextChunk[] {
+export function splitTelegramRichMessageTextChunks(
+  params:
+    | {
+        text: string;
+        textLimit: number;
+        tableMode?: MarkdownTableMode;
+        skipEntityDetection?: boolean;
+      }
+    | {
+        plan: TelegramRichMessagePlan;
+        textLimit: number;
+      },
+): TelegramRichTextChunk[] {
   // Convert the full markdown document first so fences/tables stay intact, then
   // enforce block/char limits on the typed block list (including oversized pre).
-  const plan = buildTelegramRichMarkdownPlan(params.text, {
-    tableMode: params.tableMode,
-    skipEntityDetection: params.skipEntityDetection,
-  });
+  const plan =
+    "plan" in params
+      ? params.plan
+      : buildTelegramRichMarkdownPlan(params.text, {
+          tableMode: params.tableMode,
+          skipEntityDetection: params.skipEntityDetection,
+        });
   // The render already committed to the document-level linkify decision (a
   // skip anywhere disables our file-ref code-wrapping everywhere), so every
   // chunk must carry the same wire flag; re-deriving per chunk would let
@@ -248,7 +258,7 @@ export function splitTelegramRichMessageTextChunks(params: {
       degradationReasons: index === 0 ? plan.degradationReasons : [],
     };
   });
-  if (chunked.length === 0 && params.text.trim()) {
+  if (chunked.length === 0 && "text" in params && params.text.trim()) {
     // Markdown that projects to zero blocks (e.g. link definitions only) must
     // still send readable source text instead of silently dropping the reply.
     const blocks: InputRichBlock[] = [{ type: "paragraph", text: params.text }];

--- a/extensions/telegram/src/telegram-text-delivery.ts
+++ b/extensions/telegram/src/telegram-text-delivery.ts
@@ -106,18 +106,15 @@ export function planTelegramTextDeliveryPages(
     if (richPlan.richMessage.blocks.length === 0 && params.text.trim()) {
       return [plainPage(params.text)];
     }
-    return splitTelegramRichMessageTextChunks({
-      text: params.text,
-      textLimit: maxChars,
-      tableMode: params.tableMode,
-      skipEntityDetection: params.skipEntityDetection,
-    }).map((chunk) => ({
-      plainText: chunk.plainText,
-      sourceText: chunk.plainText,
-      sourceTextMode: "markdown" as const,
-      richMessage: chunk.richMessage,
-      degradationReasons: chunk.degradationReasons,
-    }));
+    return splitTelegramRichMessageTextChunks({ plan: richPlan, textLimit: maxChars }).map(
+      (chunk) => ({
+        plainText: chunk.plainText,
+        sourceText: chunk.plainText,
+        sourceTextMode: "markdown" as const,
+        richMessage: chunk.richMessage,
+        degradationReasons: chunk.degradationReasons,
+      }),
+    );
   }
   if (params.textMode === "plain") {
     return splitTelegramPlainTextChunks(params.text, maxChars)

--- a/extensions/telegram/src/transport-payload.test.ts
+++ b/extensions/telegram/src/transport-payload.test.ts
@@ -7,7 +7,7 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTelegramCallbackMessageActions } from "./bot-handlers.callback-actions.js";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 import { telegramPlugin } from "./channel.js";
@@ -22,6 +22,21 @@ import type { TelegramRuntime } from "./runtime.types.js";
 import { sendTypingTelegram } from "./send-actions.js";
 import { sendMessageTelegram } from "./send-message.js";
 import { sendPollTelegram } from "./send-special.js";
+
+const richMarkdownProjection = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock("./rich-blocks.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./rich-blocks.js")>();
+  return {
+    ...actual,
+    markdownToTelegramRichBlocks: (
+      ...args: Parameters<typeof actual.markdownToTelegramRichBlocks>
+    ) => {
+      richMarkdownProjection.count += 1;
+      return actual.markdownToTelegramRichBlocks(...args);
+    },
+  };
+});
 
 type CapturedRequest = {
   body: Buffer;
@@ -151,6 +166,7 @@ describe("Telegram topic transport payloads", () => {
 
   beforeEach(() => {
     requests.length = 0;
+    richMarkdownProjection.count = 0;
     resetPluginStateStoreForTests();
     resetTelegramMessageCacheForTest();
     installTelegramStateRuntimeForTest();
@@ -259,6 +275,7 @@ describe("Telegram topic transport payloads", () => {
       direct_messages_topic_id: DIRECT_TOPIC_ID,
     });
     expect(request && parseJsonBody(request)).not.toHaveProperty("message_thread_id");
+    expect(richMarkdownProjection.count).toBe(1);
   });
 
   it("rejects poll and typing for channel Direct Messages without transport", async () => {


### PR DESCRIPTION
## What Problem This Solves

Telegram rich-message delivery projected the same Markdown document twice before sending: once to detect empty rich output and again to split the prepared blocks. Long rich replies therefore paid nearly twice for parsing and block construction.

## Why This Change Was Made

The text-delivery owner now passes its already prepared rich-message plan into the existing splitter. Existing text callers keep the same API and behavior, including zero-block source fallback, document-level entity detection, degradation metadata, chunk ordering, and limits.

A transport-boundary regression exercises `sendMessageTelegram` through grammY and asserts that rich Markdown is projected exactly once while the canonical Bot API payload is still emitted.

## User Impact

Rich Telegram replies require less CPU and allocation before delivery, with no intended payload or formatting change. A 15,040 UTF-16 Markdown fixture improved the real owner path from 24.805 ms to 13.136 ms per interaction (47.0%).

## Evidence

- Red/green owner regression: current main fails with `expected 1, received 2`; this change passes with one projection.
- Telegram owner/sibling suites: 7 files, 517/517 tests passed.
- Latest exact-base focused rerun after dependency refresh: 55/55 passed.
- Exact base/candidate JSON differential across rich send/edit/draft/caption/fallback cases: byte-identical, SHA-256 `30c1eb77b32296173ce5082256f635289cf863af9bf301cf6d5082e2abc7f79d`.
- `node scripts/check-changed.mjs -- extensions/telegram/src/rich-message.ts extensions/telegram/src/telegram-text-delivery.ts extensions/telegram/src/transport-payload.test.ts`: passed.
- `pnpm build`: passed; only existing dependency direct-`eval` warnings.
- Bundled Codex `gpt-5.6-sol`/high review: clean, no actionable P0-P3 findings, correct at 0.96.
- `git diff --check`: passed.

No authenticated live Telegram send was used; this behavior-neutral planning change is covered by exact payload differential and the real grammY serialization boundary with a captured Bot API request.
