### PR TITLE
fix(ui): keep Usage results aligned with active filters

### DIFF
--- a/ui/src/e2e/usage-reconnect.e2e.test.ts
+++ b/ui/src/e2e/usage-reconnect.e2e.test.ts
@@ -53,7 +53,10 @@ function costSummary(cacheStatus?: {
   };
 }
 
-function sessionsUsage(cacheStatus?: ReturnType<typeof costSummary>["cacheStatus"]) {
+function sessionsUsage(
+  cacheStatus?: ReturnType<typeof costSummary>["cacheStatus"],
+  label = "Proxy proof",
+) {
   return {
     updatedAt: Date.now(),
     startDate: today(),
@@ -61,7 +64,7 @@ function sessionsUsage(cacheStatus?: ReturnType<typeof costSummary>["cacheStatus
     sessions: [
       {
         key: "agent:main:proxy-proof",
-        label: "Proxy proof",
+        label,
         agentId: "main",
         modelProvider: "openai",
         model: "gpt-5.5",
@@ -143,6 +146,14 @@ async function captureProof(page: Page, name: string): Promise<void> {
     return;
   }
   await page.screenshot({ fullPage: true, path: path.join(proofDir, name) });
+}
+
+async function captureResultProof(page: Page, name: string, resultLabel: string): Promise<void> {
+  if (!proofDir) {
+    return;
+  }
+  await page.getByText(resultLabel, { exact: true }).scrollIntoViewIfNeeded();
+  await page.screenshot({ path: path.join(proofDir, name) });
 }
 
 async function usageBadges(page: Page): Promise<string[]> {
@@ -230,6 +241,66 @@ suite.define(() => {
       await page.locator(".daily-chart-compact").waitFor({ timeout: 10_000 });
       await expect.poll(() => usageBadges(page)).toEqual(["120 Tokens", "$0.01 Cost", "1 session"]);
       await captureProof(page, "usage-after-interrupted-retry.png");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps results aligned when scope changes during a refresh", async () => {
+    const context = await createContext();
+    const page = await context.newPage();
+    const staleFamilyResult = sessionsUsage(undefined, "Family stale result");
+    const currentInstanceResult = sessionsUsage(undefined, "Current instance result");
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.usage": staleFamilyResult,
+        "usage.cost": costSummary(),
+        "usage.status": { updatedAt: Date.now(), providers: [] },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${suite.server.baseUrl}usage`);
+      expect(response?.status()).toBe(200);
+      await waitForRequestCount(gateway, "sessions.usage", 1);
+      await page.getByText("Family stale result", { exact: true }).waitFor();
+
+      await gateway.deferNext("sessions.usage");
+      await gateway.deferNext("usage.cost");
+      await page
+        .locator("openclaw-usage-page")
+        .getByRole("button", { name: "Refresh", exact: true })
+        .click();
+      await waitForRequestCount(gateway, "sessions.usage", 2);
+      await waitForRequestCount(gateway, "usage.cost", 2);
+
+      await gateway.setMethodResponse("sessions.usage", currentInstanceResult);
+      await page.getByRole("button", { name: "Current instance", exact: true }).click();
+      await gateway.resolveDeferred("sessions.usage", staleFamilyResult);
+      await gateway.resolveDeferred("usage.cost", costSummary());
+      await expect
+        .poll(() =>
+          page
+            .locator("openclaw-usage-page")
+            .getByRole("button", { name: "Refresh", exact: true })
+            .isEnabled(),
+        )
+        .toBe(true);
+      await captureProof(page, "usage-filter-during-refresh.png");
+
+      const requests = await gateway.getRequests("sessions.usage");
+      const currentResult = page.getByText("Current instance result", { exact: true });
+      const staleResult = page.getByText("Family stale result", { exact: true });
+      await expect
+        .poll(async () => (await currentResult.count()) + (await staleResult.count()))
+        .toBe(1);
+      const visibleResultLabel =
+        (await currentResult.count()) === 1 ? "Current instance result" : "Family stale result";
+      await captureResultProof(page, "usage-filter-during-refresh-result.png", visibleResultLabel);
+      expect(requests).toHaveLength(3);
+      expect(requests[2]?.params).toMatchObject({ groupBy: "instance" });
+      expect(await currentResult.count()).toBe(1);
+      expect(await staleResult.count()).toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -366,9 +366,8 @@ class UsagePage extends OpenClawLightDomElement {
       this.refreshPolicy.markLoadDeferred();
       return Promise.resolve();
     }
-    if (this.usageLoading) {
-      return Promise.resolve();
-    }
+    // Filter changes must supersede active work; Task.run fences the old result
+    // so it cannot publish under the newly rendered query controls.
     this.routeDataEnabled = false;
     this.usageLoadStartDate = this.usageStartDate;
     this.usageLoadEndDate = this.usageEndDate;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users changing a server-side Usage filter during an active refresh would see the newly selected controls paired with results from the previous query. For example, selecting **Current instance** while a Historical lineage refresh was pending sent no replacement request and allowed the family result to remain visible.

## Why This Change Was Made

Filter-driven reloads now invoke the existing Lit Task even when prior Usage work is active. `@lit/task` already aborts the superseded run and fences its completion by call ID, so this removes the page-level early return that dropped the newer query without adding another generation or pending-work mechanism. Reconnect coalescing remains owned by the existing refresh policy.

## User Impact

Usage scope, date, timezone, and agent changes can no longer be lost behind an in-flight refresh. The latest query starts immediately, stale completions stay silent, and the visible results remain aligned with the selected controls.

## Evidence

- Authentic pre-fix source-Chromium failure: selecting Current instance during a deferred family refresh left exactly 2 `sessions.usage` requests and rendered `Family stale result`; the regression expected a third instance-scoped request.
- Post-fix source-Chromium proof: 2/2 Usage lifecycle E2Es passed. The replacement request used `groupBy: "instance"`; resolving the older family request afterward did not repaint the row.
- Focused owner proof: 33/33 tests across Usage page, refresh policy, request mapping, and rendering.
- Full changed-file gate passed: format, i18n, core-test/UI types, oxlint, stylelint, dead-export and repository guards.
- Codex autoreview: clean, no accepted/actionable findings, patch correct at 0.95 confidence.
- Production LOC: +2/-3 (net -1). Tests/test support: +73/-2.

**Before — Current instance selected, but the old family aggregate and row remain:**

![Before: Current instance controls with stale family aggregate](https://ampcode.com/user-content/artifacts/6ae38a0de3f7effa614ae2c65fa658fe43bec23a4ab292e742cc6f9d100dc40b-file.png)

![Before: stale Family result row](https://ampcode.com/user-content/artifacts/7b27a2d7a442110007b8a3f4adac4a8d2b830dd50a1bd84957d2dad3cb3073d7-file.png)

**After — Current instance selected and the replacement result remains after the old response resolves:**

![After: Current instance controls with aligned aggregate](https://ampcode.com/user-content/artifacts/2b6acd095e07c0ef2f727f21cc42ed646954e0ad942e76b65a349da1f5a12b97-file.png)

![After: Current instance result row](https://ampcode.com/user-content/artifacts/db2303d002229e5e3d1d4418e095b01beb907500cacca405703d442226ec77d0-file.png)

Provenance: the loading guard was introduced in PR #108726 (`dd58667be879`), authored by @ZengWen-DT and squash-merged by @steipete on 2026-07-16; PR #115131 later carried it into the Lit Task lifecycle. This change preserves the intended reconnect suppression while allowing explicit filter changes to supersede active work.

AI-assisted: yes. The implementation, direct dependency-source inspection, browser reproduction, regression, and validation were completed in one autonomous maintainer workflow.
