### PR TITLE
fix(cli): return JSON for invalid status timeouts

### DIFF
--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -200,27 +200,17 @@ function registerSessionsLifecycleCommand(
     });
 }
 
-function parseTimeoutMs(timeout: unknown): number | null | undefined {
-  const parsed = parseStrictPositiveInteger(timeout);
-  if (timeout !== undefined && parsed === undefined) {
-    defaultRuntime.error("--timeout must be a positive integer (milliseconds)");
-    defaultRuntime.exit(1);
-    return null;
-  }
-  return parsed;
-}
-
 async function runWithVerboseAndTimeout(
   opts: { verbose?: boolean; debug?: boolean; timeout?: unknown },
   action: (params: { verbose: boolean; timeoutMs: number | undefined }) => Promise<void>,
 ): Promise<void> {
   const verbose = resolveVerbose(opts);
   setVerbose(verbose);
-  const timeoutMs = parseTimeoutMs(opts.timeout);
-  if (timeoutMs === null) {
-    return;
-  }
   await runCommandWithRuntime(defaultRuntime, async () => {
+    const timeoutMs = parseStrictPositiveInteger(opts.timeout);
+    if (opts.timeout !== undefined && timeoutMs === undefined) {
+      throw new Error("--timeout must be a positive integer (milliseconds)");
+    }
     await action({ verbose, timeoutMs });
   });
 }

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -276,6 +276,61 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it.each([
+    {
+      name: "routed status with JSON before its timeout",
+      args: ["status", "--json", "--timeout", "nope"],
+    },
+    {
+      name: "routed health with JSON after its timeout",
+      args: ["health", "--timeout", "0", "--json"],
+    },
+    {
+      name: "Commander status with JSON after its timeout",
+      args: ["status", "--timeout", "nope", "--json"],
+      commander: true,
+    },
+    {
+      name: "Commander health with JSON before its timeout",
+      args: ["health", "--json", "--timeout", "0"],
+      commander: true,
+    },
+    {
+      name: "routed status through dual-TTY finalization",
+      args: ["status", "--json", "--timeout", "nope"],
+      tty: true,
+    },
+  ])("renders invalid status/health timeouts as canonical JSON for $name", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const preload = `data:text/javascript,${encodeURIComponent(
+          'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true }); Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
+        )}`;
+        const result = runBuiltCli(tempHome, testCase.args, {
+          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+          OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+          OPENCLAW_GATEWAY_PORT: "29791",
+          ...("commander" in testCase ? { OPENCLAW_DISABLE_ROUTE_FIRST: "1" } : {}),
+          ...("tty" in testCase ? { NODE_OPTIONS: `--import=${preload}`, FORCE_COLOR: "1" } : {}),
+        });
+        const message = "--timeout must be a positive integer (milliseconds)";
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stdout, result.stderr).not.toContain("\u001B");
+        expect(result.stdout, result.stderr).not.toContain("\u0007");
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: { type: "cli_error", message },
+        });
+        expect(result.stderr).toContain(message);
+        if ("tty" in testCase) {
+          expect(result.stderr).toContain("\u001B[?25h");
+        }
+      },
+      { prefix: "openclaw-status-health-json-timeout-e2e-" },
+    );
+  });
+
   it("returns one canonical document for a command that previously failed on stderr only", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw status --json` or `openclaw health --json` with an invalid `--timeout` received exit code 1 with empty stdout and only a human stderr message. JSON automation therefore failed with an unrelated parse error instead of receiving the actionable timeout validation failure.

## Why This Change Was Made

Timeout validation now runs inside the existing command runtime boundary shared by status and health. That lets JSON-mode failures reach the canonical root renderer while preserving the existing human diagnostic and terminal cleanup behavior. The obsolete local exit-and-sentinel path is removed rather than adding another JSON-specific branch.

Production delta: +4/-14, net -10 lines. Tests: +55 lines.

AI-assisted: yes. The implementation, ownership boundary, test behavior, and final diff were reviewed and understood.

## User Impact

Invalid status and health timeout values now produce one parseable `cli_error` JSON document in both fast-route and Commander execution, regardless of option order. Human-mode behavior remains unchanged.

## Evidence

- Pre-fix exact-main reproduction: both status and health exited 1 with empty stdout for invalid timeouts.
- Latest-head owner suite: 29/29 passed on `0a704810e4112cd2140e1d3792d8969879c7fa47` after rebase.
- Built-process regression: 5/5 passed on `66c0a23a063908fa5d83d344cebff171c7dea832`, covering status, health, both option orders, fast-route, forced Commander, ANSI-free stdout, and dual-TTY finalization; the subsequent rebase range did not touch either changed file.
- Complete changed-file gate passed on the candidate before the final conflict-free rebase; the rebased main range did not touch either changed file.
- Exact-head CI run 32541394823 on `d14a95ce9f933c4840670b9cd50286bf6aab5774`: green.
- Fresh P1 autoreview: no accepted/actionable findings.
- ClawSweeper: no findings. Its live runner captured the correct canonical JSON after a source build; its compact-substring matcher timed out during that build. The exact-head built-process CI above supplies the merge gate it requested.
- `git diff --check`: passed.
