### PR TITLE
fix(mac): keep remote Gateway connected after a delayed local failure

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -448,11 +448,9 @@ actor GatewayEndpointStore {
         self.state
     }
 
-    func setLocalUnavailableReason(_ reason: String?) {
+    func setLocalUnavailableReason(_ reason: String?) async {
         self.localUnavailableReason = reason
-        if let reason {
-            self.setState(.unavailable(mode: .local, reason: reason))
-        }
+        await self.refresh()
     }
 
     func refresh() async {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -315,6 +315,60 @@ struct GatewayEndpointStoreTests {
         }
     }
 
+    @Test func `stale local conflict cannot replace a healthy remote endpoint`() async throws {
+        try await TestIsolation.withUserDefaultsValues([connectionModeKey: "unconfigured"]) {
+            let remoteURL = try #require(URL(string: "ws://192.168.1.20:18789"))
+            let localSource = self.source(mode: .local, token: "local-token")
+            let remoteSource = self.source(
+                mode: .remote,
+                token: "remote-token",
+                transport: .direct,
+                directURL: remoteURL)
+            let sourceGate = GatewayEndpointSourceGate(localSource)
+            let store = self.makeStore(sourceSnapshot: { await sourceGate.snapshot() })
+            _ = try await store.requireEndpoint()
+
+            await sourceGate.update(remoteSource)
+            let remote = try await store.requireEndpoint()
+            await store.setLocalUnavailableReason("Profile port conflict")
+
+            #expect(try await store.currentState() == .ready(
+                mode: .remote,
+                url: remoteURL,
+                token: "remote-token",
+                password: nil,
+                routeRevision: #require(remote.revision)))
+            #expect(try await store.requireEndpoint().revision == remote.revision)
+
+            await sourceGate.update(localSource)
+            await store.refresh()
+            #expect(await store.currentState() == .unavailable(
+                mode: .local,
+                reason: "Profile port conflict"))
+
+            await store.setLocalUnavailableReason(nil)
+            #expect(try await store.currentState() == .ready(
+                mode: .local,
+                url: #require(URL(string: "ws://127.0.0.1:18789")),
+                token: "local-token",
+                password: nil,
+                routeRevision: #require(try await store.requireEndpoint().revision)))
+        }
+    }
+
+    @Test func `local conflict does not claim an unconfigured endpoint`() async {
+        await TestIsolation.withUserDefaultsValues([connectionModeKey: "unconfigured"]) {
+            let source = self.source(mode: .unconfigured)
+            let store = self.makeStore(sourceSnapshot: { source })
+
+            await store.setLocalUnavailableReason("Profile port conflict")
+
+            #expect(await store.currentState() == .unavailable(
+                mode: .unconfigured,
+                reason: "Gateway not configured"))
+        }
+    }
+
     private func dashboardURL(
         _ endpoint: String,
         mode: AppState.ConnectionMode,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users who switch from a conflicting local Gateway to a healthy remote Gateway can have the remote dashboard and Mac node disconnected when the earlier local failure arrives late. The same stale failure also incorrectly changes an unconfigured connection into a local-connection error.

## Why This Change Was Made

The endpoint store already owns a generation-fenced, route-aware refresh pipeline, but local failure updates bypassed it and unconditionally published a local unavailable state. Route those updates through the existing canonical refresh instead: the currently selected connection remains authoritative, a local conflict stays recorded until local mode is selected again, and clearing the conflict immediately restores the local endpoint. This removes two production lines and avoids adding a second mode guard or downstream dashboard/node workaround.

## User Impact

A healthy remote Gateway, open dashboard, and connected Mac node survive delayed local startup failures. Unconfigured connections keep their correct status, and local Gateway connections recover immediately after a port conflict clears.

## Evidence

- Two owner-boundary regressions fail against the original code with four observed failures: remote endpoint replacement, changed remote route revision, missing immediate local recovery, and an unconfigured connection incorrectly reported as local.
- After the owner fix, all 154 native macOS tests pass across `GatewayEndpointStoreTests`, `GatewayProcessManagerTests`, `ConnectionModeCoordinatorTests`, `DashboardWindowSmokeTests`, and `MenuContentSmokeTests`.
- The dashboard smoke suite exercises real native dashboard windows and verifies endpoint unavailability, route changes, and credential isolation. A full live remote-to-local collision reproduction would require replacing the operator's active Gateway/remote configuration and intentionally colliding with its live port, so it was not safe to run against the existing user session.
- SwiftFormat, SwiftLint, `git diff --check`, and independent Codex review all pass. Production: +2/-4 (net -2); tests: +54/-0.
