### PR TITLE
fix(ui): surface newly available account models in picker

### DIFF
--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -364,4 +364,82 @@ suite.define(() => {
       }
     });
   });
+
+  it("refreshes a successful account catalog after the picker cooldown", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const initialTime = new Date("2026-08-21T12:00:00Z");
+      await page.clock.setFixedTime(initialTime);
+      const existingModel = {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        available: true,
+      };
+      const newlyAvailableModel = {
+        id: "gpt-5.6-terra",
+        name: "GPT-5.6 Terra",
+        provider: "openai",
+        available: true,
+      };
+      const gateway = await installMockGateway(page, {
+        models: [existingModel],
+        methodResponses: {
+          "models.list": {
+            sequence: [
+              { models: [existingModel] },
+              { models: [existingModel, newlyAvailableModel] },
+            ],
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+
+      const composer = page.locator(".agent-chat__input");
+      const pickerTrigger = composer.locator('[data-chat-model-select="true"]');
+      await pickerTrigger.click();
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(1);
+      await expect
+        .poll(() => composer.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').isVisible())
+        .toBe(true);
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: `${artifactDir}/01-account-catalog-before-refresh.png`,
+        });
+      }
+
+      await pickerTrigger.click();
+      await page.clock.setFixedTime(new Date(initialTime.getTime() + 60_000 + 1));
+      await pickerTrigger.click();
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(1);
+      await expect
+        .poll(() => composer.locator('[data-chat-model-option="openai/gpt-5.6-terra"]').count())
+        .toBe(0);
+
+      await pickerTrigger.click();
+      await page.clock.setFixedTime(new Date(initialTime.getTime() + 5 * 60_000 + 1));
+      await pickerTrigger.click();
+
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
+      await expect
+        .poll(() => composer.locator('[data-chat-model-option="openai/gpt-5.6-terra"]').isVisible())
+        .toBe(true);
+      if (artifactDir) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: `${artifactDir}/02-account-catalog-after-refresh.png`,
+        });
+      }
+      for (const request of await gateway.getRequests("models.list")) {
+        expect(request.params).toEqual(
+          expect.objectContaining({ agentId: "main", refresh: true, view: "configured" }),
+        );
+      }
+    });
+  });
 });

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -79,7 +79,7 @@ suite.define(() => {
       await model.click();
       await model.click();
       const retry = await gateway.waitForRequest("models.list", { after: beforeRetry });
-      expect(retry.params).toEqual({ agentId: "main", view: "configured" });
+      expect(retry.params).toEqual({ agentId: "main", view: "configured", refresh: true });
       await expect.poll(() => textarea.isEnabled()).toBe(true);
       await expect.poll(() => composer.locator("[data-chat-model-catalog-state]").count()).toBe(0);
       await expect

--- a/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
@@ -115,7 +115,11 @@ suite.define(() => {
       const sessionListCount = (await gateway.getRequests("sessions.list")).length;
       await modelSelect.click();
       const modelsRequest = await gateway.waitForRequest("models.list");
-      expect(modelsRequest.params).toEqual({ view: "configured", agentId: "main" });
+      expect(modelsRequest.params).toEqual({
+        view: "configured",
+        agentId: "main",
+        refresh: true,
+      });
       const refreshedSessionsRequest = await gateway.waitForRequest("sessions.list", {
         after: sessionListCount,
       });

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -175,7 +175,7 @@ describe("chat pane composer controls", () => {
     );
   });
 
-  it("uses the configured server-cache policy when the picker opens", async () => {
+  it("refreshes the configured model catalog when the picker opens", async () => {
     const container = document.createElement("div");
     const request = vi.fn(async () => ({ models: [] }));
     const state = {
@@ -215,6 +215,7 @@ describe("chat pane composer controls", () => {
     expect(request).toHaveBeenCalledWith("models.list", {
       view: "configured",
       agentId: "main",
+      refresh: true,
     });
   });
 });

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -192,6 +192,7 @@ export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promi
   try {
     const models = await loadModels(client, {
       agentId,
+      refreshIfDue: true,
       rejectOnFailure: true,
     });
     if (ownsRequest()) {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -2213,7 +2213,7 @@ describe("refreshChatMetadata", () => {
     const refreshSessions = vi.fn().mockResolvedValue(undefined);
     const request = vi.fn(async (method: string, params?: unknown) => {
       expect(method).toBe("models.list");
-      expect(params).toEqual({ view: "configured", agentId: "work" });
+      expect(params).toEqual({ view: "configured", agentId: "work", refresh: true });
       return {
         models: [
           {

--- a/ui/src/pages/chat/models.test.ts
+++ b/ui/src/pages/chat/models.test.ts
@@ -139,4 +139,82 @@ describe("loadModels", () => {
 
     expect(request).toHaveBeenCalledTimes(2);
   });
+
+  it("joins an active picker refresh instead of returning the cooldown cache", async () => {
+    const initial = [{ id: "initial", name: "Initial", provider: "openai" }];
+    const refreshed = [{ id: "refreshed", name: "Refreshed", provider: "openai" }];
+    let releaseRefresh: (() => void) | undefined;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ models: initial })
+      .mockImplementationOnce(async () => {
+        await refreshGate;
+        return { models: refreshed };
+      });
+    const client = { request } as unknown as GatewayBrowserClient;
+
+    expect(await loadModels(client, { agentId: "main" })).toEqual(initial);
+    const first = loadModels(client, { agentId: "main", refreshIfDue: true });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    const concurrent = loadModels(client, { agentId: "main", refreshIfDue: true });
+    releaseRefresh?.();
+
+    expect(await concurrent).toBe(await first);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes an account catalog once per picker cooldown", async () => {
+    const initial = [{ id: "initial", name: "Initial", provider: "openai" }];
+    const refreshed = [{ id: "refreshed", name: "Refreshed", provider: "openai" }];
+    const later = [{ id: "later", name: "Later", provider: "openai" }];
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ models: initial })
+      .mockResolvedValueOnce({ models: refreshed })
+      .mockResolvedValueOnce({ models: later });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+
+    try {
+      expect(await loadModels(client, { agentId: "main" })).toEqual(initial);
+      expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(refreshed);
+      expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(refreshed);
+      expect(request).toHaveBeenCalledTimes(2);
+
+      now.mockReturnValue(1_000 + 60_000 + 1);
+      expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(refreshed);
+      expect(request).toHaveBeenCalledTimes(2);
+
+      now.mockReturnValue(1_000 + 5 * 60_000 + 1);
+      expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(later);
+      expect(request).toHaveBeenCalledTimes(3);
+      expect(request.mock.calls.slice(1).map((call) => call[1])).toEqual([
+        { view: "configured", agentId: "main", refresh: true },
+        { view: "configured", agentId: "main", refresh: true },
+      ]);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it("keeps a failed account catalog refresh retryable", async () => {
+    const initial = [{ id: "initial", name: "Initial", provider: "openai" }];
+    const recovered = [{ id: "recovered", name: "Recovered", provider: "openai" }];
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ models: initial })
+      .mockRejectedValueOnce(new Error("probe timed out"))
+      .mockResolvedValueOnce({ models: recovered });
+    const client = { request } as unknown as GatewayBrowserClient;
+
+    expect(await loadModels(client, { agentId: "main" })).toEqual(initial);
+    await expect(
+      loadModels(client, { agentId: "main", refreshIfDue: true, rejectOnFailure: true }),
+    ).rejects.toThrow("probe timed out");
+    expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(recovered);
+    expect(request).toHaveBeenCalledTimes(3);
+  });
 });

--- a/ui/src/pages/chat/models.ts
+++ b/ui/src/pages/chat/models.ts
@@ -3,9 +3,12 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelCatalogEntry } from "../../api/types.ts";
 
 const MODEL_CATALOG_CACHE_TTL_MS = 60_000;
+// A picker open is an operator signal to revalidate, but full provider discovery can be slow.
+const MODEL_CATALOG_REFRESH_COOLDOWN_MS = 5 * 60_000;
 
 type ModelCatalogCacheEntry = {
   expiresAt: number;
+  refreshEligibleAt?: number;
   models: ModelCatalogEntry[];
   inFlight?: Promise<ModelCatalogEntry[]>;
   inFlightRefresh?: boolean;
@@ -29,6 +32,7 @@ export async function loadModels(
     agentId: string;
     preparedOnly?: boolean;
     refresh?: boolean;
+    refreshIfDue?: boolean;
     rejectOnFailure?: boolean;
   },
 ): Promise<ModelCatalogEntry[]> {
@@ -39,13 +43,29 @@ export async function loadModels(
   const preparedCacheKey = `${agentId}\0prepared`;
   const cached = cache.get(cacheKey);
   const now = Date.now();
-  if (!opts.refresh && cached?.models && cached.expiresAt > now) {
+  const refresh =
+    opts.refresh === true ||
+    (opts.refreshIfDue === true && (cached?.refreshEligibleAt ?? 0) <= now);
+  const nextRefreshEligibleAt = refresh
+    ? now + MODEL_CATALOG_REFRESH_COOLDOWN_MS
+    : cached?.refreshEligibleAt;
+  const refreshCooldownActive =
+    opts.refreshIfDue === true && (cached?.refreshEligibleAt ?? 0) > now;
+  if (
+    opts.refreshIfDue === true &&
+    cached?.inFlight &&
+    cached.inFlightRefresh === true &&
+    cached.inFlightRejects === rejectOnFailure
+  ) {
+    return cached.inFlight;
+  }
+  if (!refresh && cached?.models && (cached.expiresAt > now || refreshCooldownActive)) {
     return cached.models;
   }
   if (
     cached?.inFlight &&
     cached.inFlightRejects === rejectOnFailure &&
-    (!opts.refresh || cached.inFlightRefresh === true)
+    (!refresh || cached.inFlightRefresh === true)
   ) {
     return cached.inFlight;
   }
@@ -58,14 +78,20 @@ export async function loadModels(
     cached?.models,
     agentId,
     opts.preparedOnly === true,
-    opts.refresh === true,
+    refresh,
     rejectOnFailure,
   )
     .then((result) => {
       const latest = cache.get(cacheKey);
       if (!latest || latest.inFlight === inFlight) {
+        const refreshEligibleAt = refresh
+          ? result.fresh
+            ? Date.now() + MODEL_CATALOG_REFRESH_COOLDOWN_MS
+            : undefined
+          : nextRefreshEligibleAt;
         const entry = {
           expiresAt: result.fresh ? Date.now() + MODEL_CATALOG_CACHE_TTL_MS : 0,
+          ...(refreshEligibleAt ? { refreshEligibleAt } : {}),
           models: result.models,
         };
         cache.set(cacheKey, entry);
@@ -77,6 +103,13 @@ export async function loadModels(
       }
       return result.models;
     })
+    .catch((error: unknown) => {
+      const latest = cache.get(cacheKey);
+      if (refresh && latest?.inFlight === inFlight) {
+        delete latest.refreshEligibleAt;
+      }
+      throw error;
+    })
     .finally(() => {
       const latest = cache.get(cacheKey);
       if (latest?.inFlight === inFlight) {
@@ -85,10 +118,11 @@ export async function loadModels(
     });
   cache.set(cacheKey, {
     expiresAt: cached?.expiresAt ?? 0,
+    ...(nextRefreshEligibleAt ? { refreshEligibleAt: nextRefreshEligibleAt } : {}),
     models: cached?.models ?? [],
     inFlight,
     inFlightRejects: rejectOnFailure,
-    ...(opts.refresh ? { inFlightRefresh: true } : {}),
+    ...(refresh ? { inFlightRefresh: true } : {}),
   });
   return inFlight;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with OpenAI ChatGPT/Codex account models could keep seeing an old model list in the Control UI chat picker after their available account catalog changed. Reopening the picker reused the Gateway's completed catalog indefinitely, while forcing discovery on every open would make a long-running, expensive probe unbounded.

Regression provenance: #125661, merged as `475d20a034739551a821da8125b90a568ddeb5e6`, removed the picker-open `refresh` request while documenting that reopening re-requested the catalog. #127394 separately lets an explicitly selected account model run before catalog refresh; it does not make newly available models appear in the picker.

## Why This Change Was Made

Picker-open discovery now uses a bounded refresh mode: the first open without a recent successful refresh revalidates the account catalog, successful results receive a five-minute per-client/per-agent cooldown, and the next open after that cooldown may refresh again. Repeated opens while discovery is still active join that request instead of returning the stale cooldown cache. Failed discovery remains retryable on reopen, and explicit Refresh controls keep their force-refresh behavior.

The fix stays at the Control UI catalog-cache owner. The OpenAI plugin already performs account-scoped ChatGPT/Codex OAuth discovery and retains its provider-level cache; no provider, auth, model-routing, or Gateway protocol contract changes.

Codex dependency audit: at `openai/codex@d4fcb2873bf23464cfacd804a31d46529db943b0`, app-server `model/list` filters picker-visible account models through [`OnlineIfUncached`](https://github.com/openai/codex/blob/d4fcb2873bf23464cfacd804a31d46529db943b0/codex-rs/app-server/src/models.rs#L13-L24), and the model manager defines a [300-second cache horizon and refresh policies](https://github.com/openai/codex/blob/d4fcb2873bf23464cfacd804a31d46529db943b0/codex-rs/models-manager/src/manager.rs#L26-L60). The UI cooldown preserves that bounded-catalog design instead of probing on every interaction.

AI-assisted: yes. The author reviewed the owner boundary, provider/Codex contracts, regression provenance, tests, and final diff.

## User Impact

Newly available ChatGPT account models can appear in the chat model selector without a page reload or an indefinitely stale catalog. Opening and reopening the picker during ordinary use does not repeatedly launch the expensive full model probe.

## Evidence

### ClawSweeper proof

- **Claim:** The chat model picker requests an account-catalog refresh when no successful picker refresh occurred in the prior five minutes; a repeated open joins an active refresh; completed results are reused inside the cooldown; the next open after the cooldown can surface a newly available model; failed refreshes remain retryable.
- **Exercised surface:** Control UI chat composer model picker -> `loadModels` cache owner -> Gateway `models.list` configured view -> existing OpenAI ChatGPT/Codex OAuth catalog discovery.
- **Scenario/fixture:** Chromium Control UI with a mocked Gateway returns `openai/gpt-5.6-luna` on the first refreshed catalog and adds `openai/gpt-5.6-terra` after the browser clock crosses the five-minute cooldown. The scenario also reopens the picker after one minute and asserts that no second request occurs. Focused cache-owner scenarios prove a concurrent reopen receives the active refresh result and that an unsuccessful discovery retries on the next open. Separate exact-head real behavior proof below uses the existing authenticated Gateway and OpenAI account catalog.
- **Exact command/environment:** Node `v24.19.0`, pnpm `11.15.1`, Linux. `node scripts/run-vitest.mjs ui/src/pages/chat/models.test.ts ui/src/pages/chat/chat-pane-session-controls.test.ts`; `OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/openai-account-model-catalog node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-catalog.e2e.test.ts`; `pnpm check:changed`; `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin /home/rev/openclaw/node_modules/.bin/codex --stream-engine-output`.
- **Observable output:** Pre-fix browser reproduction failed with `expected 1 to be 2` because reopening made no second `models.list` request. Final focused unit lane: 17/17 passed. Final Chromium lanes: 9/9 passed, including the 5/5 catalog scenarios. `pnpm check:changed`: exit 0, including policy, format, dead-code, i18n, core/UI typecheck, and lint lanes. Final structured review: clean, no accepted/actionable findings, correctness confidence 0.99. Exact-head real proof returned and rendered eight official OpenAI account models while immediate reopen kept the request count at one.
- **Artifact/trace:** The committed Chromium scenario is `ui/src/e2e/chat-composer-catalog.e2e.test.ts` and emits `01-account-catalog-before-refresh.png` (Luna only) and `02-account-catalog-after-refresh.png` (Luna plus Terra) when the artifact environment variable is set. Sanitized real Gateway/browser [before](https://raw.githubusercontent.com/jason-allen-oneal/openclaw/cbd21a33b8a1e93e86be11a0deb98f8f8f7f4f4d/pr-127725/real-gateway-before-refresh.png), [after](https://raw.githubusercontent.com/jason-allen-oneal/openclaw/cbd21a33b8a1e93e86be11a0deb98f8f8f7f4f4d/pr-127725/real-gateway-after-refresh.png), and [machine-readable trace](https://raw.githubusercontent.com/jason-allen-oneal/openclaw/cbd21a33b8a1e93e86be11a0deb98f8f8f7f4f4d/pr-127725/real-gateway-trace.json) are pinned to immutable evidence commit `cbd21a33b8a1e93e86be11a0deb98f8f8f7f4f4d`. Exact reviewed head: `8aa2638863fbea3c22d711afe7db43caeea8ce46`. Exact-head GitHub checks: 147 passed, 22 intentionally skipped, 0 failed ([check suite](https://github.com/openclaw/openclaw/pull/127725/checks), [CI run](https://github.com/openclaw/openclaw/actions/runs/32544591314)).
- **Limits:** The deterministic cooldown-boundary browser proof uses the real Control UI with a mocked Gateway response sequence. The separate real proof uses the exact-head Vite Control UI with the existing OpenClaw 2026.8.1 Gateway and authenticated account catalog; the patched build was not installed into or used to restart the live Gateway. The cooldown is browser-client/agent scoped; explicit settings refresh remains forceful.

### Real behavior proof

**HEAD:** `8aa2638863fbea3c22d711afe7db43caeea8ce46`

**Claim:** The exact-head Control UI requests real account-catalog discovery on picker open, renders all official OpenAI account models returned by the existing authenticated Gateway, and does not issue another expensive probe on immediate reopen.

**Exercised surface:** Exact-head Vite Control UI -> production browser `GatewayBrowserClient` WebSocket -> existing OpenClaw 2026.8.1 Gateway -> installed OpenAI ChatGPT/Codex OAuth provider discovery -> production model-picker DOM. No Gateway response or provider discovery was mocked.

**Environment:** Kali Linux x86_64, Node `v24.19.0`, pnpm `11.15.1`, system Chromium, exact clean HEAD above. The live Gateway remained running and unmodified.

**Scenario:** Opened the exact-head chat UI in a fresh Chromium context, authenticated to the existing Gateway without logging credentials, opened the picker, captured only the `models.list` request/response pair, read the rendered model-option DOM, closed and immediately reopened the picker, and compared the filtered request count.

**Exact command:**

```console
pnpm ui:dev
node .artifacts/openai-account-model-catalog/capture-live-proof.mjs
```

**Sanitized real UI before/after:**

| Before the refreshed response | After the refreshed response |
|---|---|
| ![Real model picker before refreshed account discovery](https://raw.githubusercontent.com/jason-allen-oneal/openclaw/cbd21a33b8a1e93e86be11a0deb98f8f8f7f4f4d/pr-127725/real-gateway-before-refresh.png) | ![Real model picker after refreshed account discovery](https://raw.githubusercontent.com/jason-allen-oneal/openclaw/cbd21a33b8a1e93e86be11a0deb98f8f8f7f4f4d/pr-127725/real-gateway-after-refresh.png) |

Both captures are tight crops of the production picker DOM from the same exact-head run. They contain provider/model labels only; credentials, sessions, messages, and workspace content are excluded. The unmodified sanitized [WebSocket/DOM trace is inspectable here](https://raw.githubusercontent.com/jason-allen-oneal/openclaw/cbd21a33b8a1e93e86be11a0deb98f8f8f7f4f4d/pr-127725/real-gateway-trace.json).

**Relevant sanitized output:**

```text
head=8aa2638863fbea3c22d711afe7db43caeea8ce46
ui=patched Vite Control UI
gateway=existing local OpenClaw 2026.8.1 Gateway
browser=system Chromium
request={"view":"configured","agentId":"main","refresh":true}
gateway_openai_models=[gpt-5.6-sol,gpt-5.6-terra,gpt-5.6-luna,gpt-daybreak-blue-latest,gpt-5.5,gpt-5.4,gpt-5.4-mini,gpt-5.3-codex-spark]
rendered_openai_models=[GPT-5.6-Sol,GPT-5.6-Terra,GPT-5.6-Luna,gpt-daybreak-blue-latest,GPT-5.5,GPT-5.4,GPT-5.4-Mini,gpt-5.3-codex-spark]
models_list_requests_after_first_open=1
models_list_requests_after_immediate_reopen=1
immediate_reopen_issued_another_probe=false
result=PASS
```

**Observed result:** The real provider response contained all eight official OpenAI account models and the exact-head picker rendered all eight. Immediate reopen reused the completed result without another `models.list` request.

**Limits:** This proof covers one authenticated Linux/Chromium setup and an immediate cooldown reuse. The deterministic browser test covers the exact five-minute boundary, newly appearing model transition, failed refresh retry, and mocked failure timing. No model execution was started.

### Live read-only observation

Command:

```text
openclaw gateway call models.list --json --params '{"agentId":"main","view":"default","refresh":true}'
```

The existing OpenAI plugin returned eight available account models, including `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, and `gpt-daybreak-blue-latest`. This isolates the defect to picker refresh behavior rather than account discovery or authentication.

Production footprint: +35 net lines across the Control UI catalog cache and picker-open owner. Tests: +161 net lines covering cooldown, in-flight refresh joining, force-refresh compatibility, failure retry, request shape, and the browser-visible catalog transition.
