### PR TITLE
fix(cli): return JSON for model list failures

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -398,6 +398,51 @@ describe("rejected CLI process state isolation", () => {
   });
 });
 
+describe("models list JSON failure process output", () => {
+  it.each(
+    [
+      {
+        provider: "Moonshot AI",
+        message:
+          'Invalid provider filter "Moonshot AI". Use a provider id such as "moonshot", not a display label.',
+      },
+      {
+        provider: "autoqa-no-such-provider",
+        message:
+          'Unknown provider filter "autoqa-no-such-provider" for this installation. Run openclaw plugins list --json to see installed providers, or configure it under models.providers.',
+      },
+    ].flatMap(({ provider, message }) => [
+      {
+        name: `routed ${provider}`,
+        provider,
+        message,
+        env: { OPENCLAW_DISABLE_ROUTE_FIRST: undefined },
+      },
+      {
+        name: `Commander ${provider}`,
+        provider,
+        message,
+        env: { OPENCLAW_DISABLE_ROUTE_FIRST: "1" },
+      },
+    ]),
+  )("renders $name as one clean canonical JSON document", async ({ provider, message, env }) => {
+    const result = await runCliProcess({
+      args: ["models", "list", "--provider", provider, "--json"],
+      config: {},
+      env,
+      expectedExitCode: 1,
+    });
+
+    expect(result.stdout).not.toContain("\u001B");
+    expect(result.stdout).not.toContain("\u0007");
+    expect(JSON.parse(result.stdout)).toEqual({
+      ok: false,
+      error: { type: "cli_error", message },
+    });
+    expect(result.stderr).toContain(message);
+  });
+});
+
 describe("message broadcast process exit", () => {
   it("exits nonzero after a structured target failure", async () => {
     const root = tempDirs.make("openclaw-message-broadcast-exit-");

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -98,7 +98,6 @@ function createMockModelRegistry() {
   })();
 }
 
-let previousExitCode: typeof process.exitCode;
 let previousOpenAiApiKey: string | undefined;
 
 vi.mock("./models/load-config.js", () => ({
@@ -233,26 +232,6 @@ function runtimeLogText(runtime: ReturnType<typeof makeRuntime>): string {
   return value;
 }
 
-function runtimeErrorText(runtime: ReturnType<typeof makeRuntime>): string {
-  const value = firstMockArg(runtime.error, "runtime.error");
-  if (typeof value !== "string") {
-    throw new Error("Expected runtime.error text");
-  }
-  return value;
-}
-
-function expectModelRegistryUnavailable(
-  runtime: ReturnType<typeof makeRuntime>,
-  expectedDetail: string,
-) {
-  expect(runtime.error).toHaveBeenCalledTimes(1);
-  const errorText = runtimeErrorText(runtime);
-  expect(errorText).toContain("Model registry unavailable:");
-  expect(errorText).toContain(expectedDetail);
-  expect(runtime.log).not.toHaveBeenCalled();
-  expect(process.exitCode).toBe(1);
-}
-
 async function loadSourceConfigSnapshotForTest(fallback: unknown): Promise<unknown> {
   try {
     const { snapshot } = await readConfigFileSnapshotForWrite();
@@ -266,8 +245,6 @@ async function loadSourceConfigSnapshotForTest(fallback: unknown): Promise<unkno
 }
 
 beforeEach(() => {
-  previousExitCode = process.exitCode;
-  process.exitCode = undefined;
   previousOpenAiApiKey = process.env.OPENAI_API_KEY;
   delete process.env.OPENAI_API_KEY;
   modelRegistryState.models = [];
@@ -292,7 +269,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.exitCode = previousExitCode;
   if (previousOpenAiApiKey === undefined) {
     delete process.env.OPENAI_API_KEY;
   } else {
@@ -704,15 +680,21 @@ describe("models list/status", () => {
   it("models list rejects provider display labels", async () => {
     setDefaultZaiRegistry({ available: false });
     const runtime = makeRuntime();
+    const message =
+      'Invalid provider filter "Moonshot AI". Use a provider id such as "moonshot", not a display label.';
 
-    await modelsListCommand({ all: true, provider: "Moonshot AI", json: true }, runtime);
+    await expect(
+      modelsListCommand({ all: true, provider: "Moonshot AI", json: true }, runtime),
+    ).rejects.toMatchObject({
+      name: "ExpectedCliError",
+      message,
+      humanOutput: message,
+      machineOutput: message,
+    });
 
-    expect(runtime.error).toHaveBeenCalledWith(
-      'Invalid provider filter "Moonshot AI". Use a provider id such as "moonshot", not a display label.',
-    );
+    expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.log).not.toHaveBeenCalled();
     expect(loadModelCatalog).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
   });
 
   it("models list all local skips unauthenticated provider catalog rows", async () => {
@@ -755,9 +737,17 @@ describe("models list/status", () => {
 
     modelRegistryState.models = [];
     modelRegistryState.available = [];
-    await modelsListCommand({ local: true, json: true }, runtime);
+    await expect(modelsListCommand({ local: true, json: true }, runtime)).rejects.toMatchObject({
+      name: "ExpectedCliError",
+      message: "Model registry unavailable: model discovery unavailable",
+      humanOutput: expect.stringContaining(
+        "Model registry unavailable:\nError: model discovery unavailable",
+      ),
+      machineOutput: "Model registry unavailable: model discovery unavailable",
+    });
 
-    expectModelRegistryUnavailable(runtime, "model discovery unavailable");
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
   });
 
   it("loadModelRegistry throws when model discovery is unavailable", async () => {

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -433,24 +433,16 @@ describe("modelsListCommand forward-compat", () => {
 
   it("rejects unknown provider filters before loading the model registry", async () => {
     const runtime = createRuntime();
-    const previousExitCode = process.exitCode;
-    process.exitCode = undefined;
-    let observedExitCode: number | undefined;
 
-    try {
-      await modelsListCommand(
-        { provider: "autoqa-no-such-provider", json: true },
-        runtime as never,
-      );
-      observedExitCode = process.exitCode;
-    } finally {
-      process.exitCode = previousExitCode;
-    }
+    await expect(
+      modelsListCommand({ provider: "autoqa-no-such-provider", json: true }, runtime as never),
+    ).rejects.toMatchObject({
+      name: "ExpectedCliError",
+      humanOutput: expect.stringContaining('Unknown provider filter "autoqa-no-such-provider"'),
+      machineOutput: expect.stringContaining('Unknown provider filter "autoqa-no-such-provider"'),
+    });
 
-    expect(runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining('Unknown provider filter "autoqa-no-such-provider"'),
-    );
-    expect(observedExitCode).toBe(1);
+    expect(runtime.error).not.toHaveBeenCalled();
     expect(mocks.loadModelRegistry).not.toHaveBeenCalled();
     expect(mocks.loadModelCatalog).not.toHaveBeenCalled();
     expect(mocks.printModelTable).not.toHaveBeenCalled();
@@ -504,9 +496,14 @@ describe("modelsListCommand forward-compat", () => {
       mocks.loadModelRegistry.mockRejectedValueOnce(new Error("registry failed"));
       const runtime = createRuntime();
 
-      await modelsListCommand({ all: true }, runtime as never);
+      await expect(modelsListCommand({ all: true }, runtime as never)).rejects.toMatchObject({
+        name: "ExpectedCliError",
+        message: "Model registry unavailable: registry failed",
+        humanOutput: expect.stringContaining("Model registry unavailable:\nError: registry failed"),
+        machineOutput: "Model registry unavailable: registry failed",
+      });
 
-      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("registry failed"));
+      expect(runtime.error).not.toHaveBeenCalled();
       expect(mocks.startPromotionsFeedRefresh).not.toHaveBeenCalled();
       expect(mocks.printAvailablePromotionsSection).not.toHaveBeenCalled();
     });

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -4,6 +4,7 @@ import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-t
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { parseModelRef } from "../../agents/model-selection-normalize.js";
 import { formatCliCommand } from "../../cli/command-format.js";
+import { ExpectedCliError } from "../../cli/failure-output.js";
 import { requestExitAfterOneShotOutput } from "../../cli/one-shot-exit.js";
 import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
@@ -63,11 +64,8 @@ export async function modelsListCommand(
       return undefined;
     }
     if (/\s/u.test(rawProviderFilter)) {
-      runtime.error(
-        `Invalid provider filter "${sanitizeTerminalText(rawProviderFilter)}". Use a provider id such as "moonshot", not a display label.`,
-      );
-      process.exitCode = 1;
-      return null;
+      const message = `Invalid provider filter "${sanitizeTerminalText(rawProviderFilter)}". Use a provider id such as "moonshot", not a display label.`;
+      throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
     }
     const parsed = parseModelRef(
       `${rawProviderFilter}/_`,
@@ -76,9 +74,6 @@ export async function modelsListCommand(
     );
     return parsed?.provider ?? normalizeLowercaseStringOrEmpty(rawProviderFilter);
   })();
-  if (parsedProviderFilter === null) {
-    return;
-  }
   const humanReadable = !opts.json && !opts.plain;
   const [
     { loadAuthProfileStoreWithoutExternalProfiles },
@@ -120,11 +115,8 @@ export async function modelsListCommand(
       ].map((providerId) => providerAliasCanonicalizer.provider(providerId)),
     );
     if (!knownProviderIds.has(providerFilter)) {
-      runtime.error(
-        `Unknown provider filter "${sanitizeTerminalText(rawProviderFilter ?? providerFilter)}" for this installation. Run ${formatCliCommand("openclaw plugins list --json")} to see installed providers, or configure it under models.providers.`,
-      );
-      process.exitCode = 1;
-      return;
+      const message = `Unknown provider filter "${sanitizeTerminalText(rawProviderFilter ?? providerFilter)}" for this installation. Run ${formatCliCommand("openclaw plugins list --json")} to see installed providers, or configure it under models.providers.`;
+      throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
     }
   }
   const authStore = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
@@ -207,9 +199,13 @@ export async function modelsListCommand(
       availableKeys = loaded.availableKeys;
     }
   } catch (err) {
-    runtime.error(`Model registry unavailable:\n${formatErrorWithStack(err)}`);
-    process.exitCode = 1;
-    return;
+    const detail = err instanceof Error ? err.message : String(err);
+    const message = `Model registry unavailable: ${detail}`;
+    throw new ExpectedCliError({
+      message,
+      humanOutput: `Model registry unavailable:\n${formatErrorWithStack(err)}`,
+      machineOutput: message,
+    });
   }
   const promotionsModulePromise = humanReadable ? promotionsModuleLoader.load() : undefined;
   const promotionsRefreshPromise = promotionsModulePromise


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw models list --json` returned exit code 1 with empty stdout for invalid provider labels, unknown providers, or model-registry loading failures. Automation then encountered an unrelated JSON parse error instead of the actionable model-list failure.

## Why This Change Was Made

The shared `modelsListCommand` owner now throws canonical expected CLI failures instead of writing directly to stderr, mutating `process.exitCode`, and returning. Human mode keeps its existing provider guidance and detailed registry stack output; machine mode receives a concise canonical error document. Fast-route and Commander callers use the same owner path.

Production delta: +12/-16, net -4 lines. Tests: +83/-51, net +32 lines.

AI-assisted: yes. The implementation, failure ownership, human/machine output split, and tests were reviewed and understood.

## User Impact

Model-list JSON consumers now receive exactly one parseable `cli_error` document for handled provider and registry failures. Successful JSON and human-readable output are unchanged.

## Evidence

- Pre-fix exact-main reproduction: display-label and unknown-provider failures exited 1 with empty stdout in both fast-route and Commander execution.
- Owner/sibling proof: 44 forward-compat tests and 22 models list/status tests passed.
- Process proof: four provider/routing combinations passed, asserting exit 1, canonical JSON, ANSI-free stdout, and preserved stderr guidance; the same four cases passed again after the final rebase onto `0382ca218a8`.
- Complete changed-file guards passed except core-test typechecking initially observed an incomplete shared workspace dependency tree. After an isolated full `pnpm install`, the exact failed core-test typecheck passed. All other guards passed in both runs.
- Exact-head CI run 32542129764 on `df1f4adf63fcd36569a7304168f964ecfeb55561`: green.
- Fresh P1 autoreview: no accepted/actionable findings.
- ClawSweeper: no findings; its only optional rank-up was exact-head CI, now complete. Its live runner also visibly produced the correct JSON after building, although its compact-substring matcher timed out during the build.
- The main range rebased after the broad proof did not touch any changed file.
- `git diff --check`: passed.
