### PR TITLE
refactor(browser): remove test-only route bypass

### DIFF
--- a/extensions/browser/src/browser/bridge-server.auth.test.ts
+++ b/extensions/browser/src/browser/bridge-server.auth.test.ts
@@ -58,15 +58,14 @@ describe("startBrowserBridgeServer auth", () => {
     const bridge = await startBrowserBridgeServer({
       resolved: buildResolvedConfig(),
       ...authConfig,
-      skipRouteRegistrationForTest: true,
     });
     servers.push({ stop: () => stopBrowserBridgeServer(bridge.server) });
 
-    const unauth = await fetch(`${bridge.baseUrl}/`);
+    const unauth = await fetch(`${bridge.baseUrl}/?profile=__auth_probe_missing__`);
     expect(unauth.status).toBe(401);
 
-    const authed = await fetch(`${bridge.baseUrl}/`, { headers });
-    expect(authed.status).toBe(200);
+    const authed = await fetch(`${bridge.baseUrl}/?profile=__auth_probe_missing__`, { headers });
+    expect(authed.status).toBe(404);
   }
 
   afterEach(async () => {
@@ -114,7 +113,6 @@ describe("startBrowserBridgeServer auth", () => {
           authToken: "secret-token",
           host: "127.0.0.1",
           port: address.port,
-          skipRouteRegistrationForTest: true,
         }),
       ).rejects.toMatchObject({ code: "EADDRINUSE" });
     } finally {
@@ -128,7 +126,6 @@ describe("startBrowserBridgeServer auth", () => {
     const bridge = await startBrowserBridgeServer({
       resolved: buildResolvedConfig(),
       authToken: "secret-token",
-      skipRouteRegistrationForTest: true,
     });
     servers.push({ stop: () => stopBrowserBridgeServer(bridge.server) });
     const close = vi
@@ -197,7 +194,6 @@ describe("startBrowserBridgeServer auth", () => {
     const bridge = await startBrowserBridgeServer({
       resolved: buildResolvedConfig(),
       authToken: "secret-token",
-      skipRouteRegistrationForTest: true,
       resolveSandboxNoVncToken: (token) => {
         resolveCalls += 1;
         if (token !== "valid-token") {

--- a/extensions/browser/src/browser/bridge-server.ts
+++ b/extensions/browser/src/browser/bridge-server.ts
@@ -90,7 +90,6 @@ export async function startBrowserBridgeServer(params: {
   authPassword?: string;
   onEnsureAttachTarget?: (profile: ProfileContext["profile"]) => Promise<void>;
   resolveSandboxNoVncToken?: (token: string) => ResolvedNoVncObserver | null;
-  skipRouteRegistrationForTest?: boolean;
 }): Promise<BrowserBridge> {
   const host = params.host ?? "127.0.0.1";
   if (!isLoopbackHost(host)) {
@@ -139,21 +138,15 @@ export async function startBrowserBridgeServer(params: {
     profiles: new Map(),
   };
 
-  if (params.skipRouteRegistrationForTest) {
-    app.get("/", (_req, res) => {
-      res.status(200).send("OK");
-    });
-  } else {
-    const [{ createBrowserRouteContext }, { registerBrowserRoutes }] = await Promise.all([
-      import("./server-context.js"),
-      import("./routes/index.js"),
-    ]);
-    const ctx = createBrowserRouteContext({
-      getState: () => state,
-      onEnsureAttachTarget: params.onEnsureAttachTarget,
-    });
-    registerBrowserRoutes(app as unknown as BrowserRouteRegistrar, ctx);
-  }
+  const [{ createBrowserRouteContext }, { registerBrowserRoutes }] = await Promise.all([
+    import("./server-context.js"),
+    import("./routes/index.js"),
+  ]);
+  const ctx = createBrowserRouteContext({
+    getState: () => state,
+    onEnsureAttachTarget: params.onEnsureAttachTarget,
+  });
+  registerBrowserRoutes(app as unknown as BrowserRouteRegistrar, ctx);
 
   const server = await listenBrowserHttpServer(app, port, host);
 


### PR DESCRIPTION
## What Problem This Solves

Browser bridge tests could start a production server without registering the production route graph. That test-only startup mode let authentication checks pass against a synthetic root response instead of the real browser route boundary.

## Why This Change Was Made

The bridge now always creates the browser route context and registers the canonical routes. Authentication probes use the real root route with a deliberately missing profile, so unauthenticated requests still return 401 while authenticated requests prove middleware passage through the canonical 404 response. No compatibility alias or fallback remains.

## User Impact

There is no user-visible runtime behavior change. Browser bridge startup now has one production path, and its authentication tests exercise the same route registration used by every production caller.

AI-assisted cleanup; the implementation and proof were inspected locally.

## Evidence

- `node scripts/run-vitest.mjs extensions/browser/src/browser/bridge-server.auth.test.ts` — 7 tests passed.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/server-middleware.test.ts extensions/browser/src/browser/server.auth-token-gates-http.test.ts` — 6 tests passed.
- `pnpm test:changed` — 26 files and 243 tests passed.
- `pnpm check:changed` — formatting, extension production/test types, lint, dependency and architecture guards passed.
- `pnpm build` — full build passed with no ineffective dynamic-import warning.
- `git diff --check` — passed.
- Codex-backed autoreview against `origin/main` — clean, no accepted/actionable findings.
