### PR TITLE
fix: preserve message-tool images across gateway restarts

### DIFF
--- a/src/agents/embedded-agent-messaging-extraction.ts
+++ b/src/agents/embedded-agent-messaging-extraction.ts
@@ -74,6 +74,9 @@ export function extractMessagingToolSourceReplyPayload(
   if (idempotencyKey) {
     payload.idempotencyKey = idempotencyKey;
   }
+  if (details.sourceReplyTranscriptOwner === true) {
+    payload.transcriptOwner = true;
+  }
   return Object.keys(payload).length > 0 ? payload : undefined;
 }
 

--- a/src/agents/embedded-agent-messaging.types.ts
+++ b/src/agents/embedded-agent-messaging.types.ts
@@ -29,6 +29,7 @@ export type MessagingToolSourceReplyPayload = Pick<
   | "text"
 > & {
   idempotencyKey?: string;
+  transcriptOwner?: true;
   /** Current-source progress (`false`) or completed reply (`true`). */
   sourceReplyFinal?: boolean;
 };

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -530,6 +530,9 @@ export function buildEmbeddedRunPayloads(params: {
           if (item.sourceReplyMirror.idempotencyKey) {
             sourceReplyTranscriptMirror.idempotencyKey = item.sourceReplyMirror.idempotencyKey;
           }
+          if (item.sourceReplyMirror.transcriptOwner) {
+            sourceReplyTranscriptMirror.transcriptOwner = true;
+          }
           setReplyPayloadMetadata(payload, {
             sourceReplyTranscriptMirror,
           });

--- a/src/agents/embedded-agent-runner/run/source-reply-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/source-reply-payloads.ts
@@ -23,7 +23,7 @@ type EmbeddedRunReplyItem = {
   interactive?: ReplyPayload["interactive"];
   channelData?: Record<string, unknown>;
   nonTerminalToolErrorWarning?: boolean;
-  sourceReplyMirror?: { idempotencyKey?: string };
+  sourceReplyMirror?: { idempotencyKey?: string; transcriptOwner?: true };
 };
 
 /** Builds transcript mirrors and completion evidence for message-tool source replies. */
@@ -70,6 +70,7 @@ export function buildSourceReplyPayloadState(params: {
           idempotencyKey:
             payload.idempotencyKey ??
             (params.runId ? `${params.runId}:internal-source-reply:${index}` : undefined),
+          ...(payload.transcriptOwner ? { transcriptOwner: true as const } : {}),
         },
       },
     ];

--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -5,6 +5,13 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import { buildReplyPayloads } from "../../auto-reply/reply/agent-runner-payloads.js";
+import { mirrorDeliveredReplyToTranscript } from "../../auto-reply/reply/dispatch-from-config.transcript.js";
+import {
+  loadTranscriptEvents,
+  replaceSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import { resolveManagedOutgoingMediaArtifactDownload } from "../../gateway/managed-image-attachments.js";
+import { listManagedImageRecordEntries } from "../../gateway/managed-image-record-store.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { extractMessagingToolSourceReplyPayload } from "../embedded-agent-messaging-extraction.js";
 import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
@@ -27,6 +34,9 @@ function createCurrentSourceMessageTool(params: { workspaceDir?: string } = {}) 
     }),
   });
 }
+
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9ZQmcAAAAASUVORK5CYII=";
 
 describe("WebChat message tool internal source reply", () => {
   it("projects a real targetless send and preserves the automatic final reply", async () => {
@@ -129,6 +139,121 @@ describe("WebChat message tool internal source reply", () => {
             media: outsidePath,
           }),
         ).rejects.toThrow(/could not be staged|allowed directory/i);
+      },
+    );
+  });
+
+  it("persists one managed image for overlapping internal source replies", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-internal-source-reply-" },
+      async (state) => {
+        const stateDir = state.stateDir;
+        const workspaceDir = state.workspaceDir;
+        const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+        const sessionKey = "agent:main:webchat:dm:restart-proof";
+        const sessionId = "restart-proof-session";
+        const imagePath = path.join(workspaceDir, "restart-proof.png");
+        await fs.mkdir(workspaceDir, { recursive: true });
+        await fs.writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+
+        await replaceSessionEntry(
+          { agentId: "main", sessionKey, storePath },
+          { sessionId, chatType: "direct", updatedAt: 1 },
+        );
+        const config = {
+          agents: {
+            entries: {
+              main: { default: true, workspace: workspaceDir },
+            },
+          },
+        };
+        const tool = createMessageTool({
+          config,
+          currentChannelProvider: "webchat",
+          agentSessionKey: sessionKey,
+          runSessionKey: sessionKey,
+          sessionId,
+          agentId: "main",
+          runId: "restart-proof-run",
+          getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
+          resolveCommandSecretRefsViaGateway: async () => ({
+            resolvedConfig: config,
+            diagnostics: [],
+            targetStatesByPath: {},
+            hadUnresolvedTargets: false,
+          }),
+        });
+
+        const sendParams = {
+          action: "send" as const,
+          message: "Durable image reply",
+          media: imagePath,
+        };
+        const [toolResult, overlappingResult] = await Promise.all([
+          tool.execute("restart-proof-call", sendParams),
+          tool.execute("restart-proof-call", sendParams),
+        ]);
+        const sourceReply = extractMessagingToolSourceReplyPayload(toolResult);
+        expect(sourceReply).toMatchObject({ transcriptOwner: true });
+        expect(overlappingResult.details).toMatchObject({
+          idempotencyKey: sourceReply?.idempotencyKey,
+          sourceReplyTranscriptOwner: true,
+        });
+        const sourcePayloads = buildEmbeddedRunPayloads({
+          assistantTexts: [],
+          lastAssistant: undefined,
+          currentAssistant: undefined,
+          sessionKey,
+          agentId: "main",
+          sourceReplyDeliveryMode: "message_tool_only",
+          messagingToolSourceReplyPayloads: sourceReply ? [sourceReply] : [],
+          runId: "restart-proof-run",
+          verboseLevel: "off",
+          reasoningLevel: "off",
+          toolResultFormat: "plain",
+        });
+        const mirror = getReplyPayloadMetadata(
+          sourcePayloads[0] as object,
+        )?.sourceReplyTranscriptMirror;
+        expect(mirror).toMatchObject({ transcriptOwner: true });
+        await mirrorDeliveredReplyToTranscript({
+          metadata: mirror ? { ...mirror, expectedSessionId: sessionId, storePath } : undefined,
+          cfg: config,
+        });
+        const events = await loadTranscriptEvents({
+          agentId: "main",
+          sessionId,
+          sessionKey,
+          storePath,
+        });
+        const assistants = events
+          .map((event) => (event as { message?: Record<string, unknown> }).message)
+          .filter((message) => message?.role === "assistant");
+        expect(assistants).toHaveLength(1);
+        const assistant = assistants[0];
+        const content = Array.isArray(assistant?.content)
+          ? (assistant.content as Array<Record<string, unknown>>)
+          : [];
+        const image = content.find((block) => block.type === "image");
+        expect(toolResult.details).toMatchObject({
+          sourceReplySink: "internal-ui",
+          idempotencyKey: expect.any(String),
+        });
+        expect(content[0]).toEqual({ type: "text", text: "Durable image reply" });
+        expect(image).toMatchObject({
+          type: "image",
+          artifactId: expect.stringMatching(/^artifact_managed_image_/u),
+        });
+        expect(JSON.stringify(assistant)).not.toContain(imagePath);
+        expect(listManagedImageRecordEntries({ stateDir, sessionKey })).toHaveLength(1);
+        await expect(
+          resolveManagedOutgoingMediaArtifactDownload({
+            sessionKey,
+            agentId: "main",
+            artifactId: String(image?.artifactId),
+            stateDir,
+          }),
+        ).resolves.toMatchObject({ type: "image" });
       },
     );
   });

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -294,6 +294,8 @@ export type ReplyPayloadMetadata = {
     expectedSessionId?: string;
     /** Delivery stays live, but neither side may be appended to a transcript. */
     transcriptWriteBlocked?: boolean;
+    /** The visible reply already owns its durable transcript row. */
+    transcriptOwner?: boolean;
     text?: string;
     mediaUrls?: string[];
     idempotencyKey?: string;

--- a/src/auto-reply/reply/dispatch-from-config.transcript.ts
+++ b/src/auto-reply/reply/dispatch-from-config.transcript.ts
@@ -30,7 +30,7 @@ export async function mirrorDeliveredReplyToTranscript(params: {
   cfg: OpenClawConfig;
 }): Promise<void> {
   const mirror = params.metadata;
-  if (!mirror) {
+  if (!mirror || mirror.transcriptOwner) {
     return;
   }
   try {

--- a/src/gateway/internal-source-reply-persistence.ts
+++ b/src/gateway/internal-source-reply-persistence.ts
@@ -1,0 +1,149 @@
+import type { ReplyPayload } from "../auto-reply/reply-payload.js";
+import { appendAssistantMessageToSessionTranscript } from "../config/sessions.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import {
+  findTranscriptEvent,
+  readTranscriptEventMessage,
+} from "../config/sessions/session-accessor.sqlite-read.js";
+import { getOwnedSessionTranscriptWriterFence } from "../config/sessions/transcript-write-context.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getAgentScopedMediaLocalRootsForSources } from "../media/local-roots.js";
+import { createKeyedFifoLeaseRegistry } from "../shared/keyed-fifo-lease.js";
+import { isOpenClawDeliveryMirrorAssistantMessage } from "../shared/transcript-only-openclaw-assistant.js";
+import {
+  attachManagedOutgoingMediaToMessage,
+  createManagedOutgoingMediaBlocks,
+} from "./managed-image-attachments.js";
+import { prepareGatewayInjectedAssistantContent } from "./server-methods/chat-transcript-inject.js";
+
+const internalSourceReplyPersistenceLeases = createKeyedFifoLeaseRegistry(
+  Symbol.for("openclaw.internalSourceReplyPersistenceLeases"),
+);
+
+function collectSourceReplyMediaUrls(payload: ReplyPayload): string[] {
+  return Array.from(
+    new Set([...(payload.mediaUrl ? [payload.mediaUrl] : []), ...(payload.mediaUrls ?? [])]),
+  ).filter((value) => value.trim().length > 0);
+}
+
+async function hasPersistedInternalSourceReply(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  expectedSessionId?: string;
+  agentId?: string;
+  idempotencyKey?: string;
+}): Promise<boolean> {
+  if (!params.expectedSessionId || !params.idempotencyKey) {
+    return false;
+  }
+  const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+    agentId: params.agentId,
+  });
+  const found = await findTranscriptEvent(
+    {
+      agentId: params.agentId,
+      sessionId: params.expectedSessionId,
+      sessionKey: params.sessionKey,
+      storePath,
+    },
+    (event) => {
+      const message = readTranscriptEventMessage(event);
+      return (
+        message?.idempotencyKey === params.idempotencyKey &&
+        isOpenClawDeliveryMirrorAssistantMessage(message)
+      );
+    },
+  );
+  return found !== undefined;
+}
+
+function resolveInternalSourceReplyPersistenceLeaseKey(params: {
+  sessionKey: string;
+  expectedSessionId?: string;
+  agentId?: string;
+  idempotencyKey?: string;
+}): string | undefined {
+  if (!params.idempotencyKey) {
+    return undefined;
+  }
+  return JSON.stringify([
+    params.agentId ?? "",
+    params.sessionKey,
+    params.expectedSessionId ?? "",
+    params.idempotencyKey,
+  ]);
+}
+
+/** Persist the private WebChat source reply before its successful tool result becomes visible. */
+export async function persistInternalSourceReply(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  expectedSessionId?: string;
+  agentId?: string;
+  payload: ReplyPayload;
+  idempotencyKey?: string;
+  sourceReplyFinal?: boolean;
+  toolCallId?: string;
+  sourceTurnId?: string;
+}): Promise<void> {
+  const leaseKey = resolveInternalSourceReplyPersistenceLeaseKey(params);
+  const lease = leaseKey ? internalSourceReplyPersistenceLeases.reserve([leaseKey]) : undefined;
+  await lease?.wait();
+  try {
+    if (await hasPersistedInternalSourceReply(params)) {
+      return;
+    }
+    const mediaUrls = collectSourceReplyMediaUrls(params.payload);
+    const mediaBlocks = await createManagedOutgoingMediaBlocks({
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      mediaUrls,
+      localRoots: getAgentScopedMediaLocalRootsForSources({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        mediaSources: mediaUrls,
+      }),
+    });
+    const content: Array<Record<string, unknown>> = [
+      ...(params.payload.text ? [{ type: "text", text: params.payload.text }] : []),
+      ...mediaBlocks,
+    ];
+    const writerFence = getOwnedSessionTranscriptWriterFence();
+    const appended = await appendAssistantMessageToSessionTranscript({
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      ...(params.expectedSessionId ? { expectedSessionId: params.expectedSessionId } : {}),
+      ...(writerFence?.expectedLifecycleRevision !== undefined
+        ? { expectedLifecycleRevision: writerFence.expectedLifecycleRevision }
+        : {}),
+      ...(writerFence ? { expectedWriterRunId: writerFence.expectedWriterRunId } : {}),
+      content: prepareGatewayInjectedAssistantContent(content),
+      idempotencyKey: params.idempotencyKey,
+      ...(params.sourceReplyFinal !== undefined
+        ? {
+            deliveryMirror: {
+              kind: "message-tool-source-reply" as const,
+              final: params.sourceReplyFinal,
+              ...(params.toolCallId ? { toolCallId: params.toolCallId } : {}),
+              ...(params.sourceTurnId ? { sourceTurnId: params.sourceTurnId } : {}),
+            },
+          }
+        : {}),
+      config: params.cfg,
+    });
+    if (!appended.ok) {
+      throw new Error(`Internal source reply persistence failed: ${appended.reason}`);
+    }
+    if (
+      mediaBlocks.length > 0 &&
+      !attachManagedOutgoingMediaToMessage({
+        messageId: appended.messageId,
+        blocks: mediaBlocks,
+      })
+    ) {
+      throw new Error("Internal source reply media ownership could not be persisted");
+    }
+  } finally {
+    lease?.release();
+  }
+}

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -14,6 +14,7 @@ import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import { hasPollCreationParams } from "../../poll-params.js";
+import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
@@ -48,6 +49,10 @@ import {
   resolveEffectiveMessageToolsConfig,
 } from "./outbound-policy.js";
 import { getRuntimeVisibleChannelPlugin } from "./runtime-visible-channels.js";
+
+const loadInternalSourceReplyPersistence = createLazyRuntimeModule(
+  () => import("../../gateway/internal-source-reply-persistence.js"),
+);
 
 export function getToolResult(result: MessageActionResult): AgentToolResult<unknown> | undefined {
   return "toolResult" in result ? result.toolResult : undefined;
@@ -294,12 +299,37 @@ async function handleInternalSourceReplySendAction(
   }
   const sourceReplyMediaUrls = resolveSendableOutboundReplyParts(sourceReplyPayload).mediaUrls;
   const sourceReplyMessage = sourceReplyPayload.text ?? sourceReply.message;
+  const idempotencyKey = normalizeOptionalString(params.idempotencyKey);
+  let persistedIdempotencyKey: string | undefined;
+  let persistedTranscriptOwner = false;
+  if (!dryRun && input.sessionId) {
+    const sessionKey = input.sourceReplySessionKey ?? input.sessionKey;
+    if (!sessionKey) {
+      throw new Error("Internal source reply requires a session key");
+    }
+    const { persistInternalSourceReply } = await loadInternalSourceReplyPersistence();
+    await persistInternalSourceReply({
+      cfg: input.cfg,
+      sessionKey,
+      expectedSessionId: input.sessionId,
+      agentId: input.agentId ?? resolveSessionAgentId({ sessionKey, config: input.cfg }),
+      payload: sourceReplyPayload,
+      idempotencyKey,
+      sourceReplyFinal: input.sourceReplyFinal,
+      toolCallId: input.sourceReplyToolCallId,
+      sourceTurnId: input.messageActionAuthorization?.toolContext?.currentSourceTurnId,
+    });
+    persistedIdempotencyKey = idempotencyKey;
+    persistedTranscriptOwner = true;
+  }
   const payload = {
     status: "ok",
     deliveryStatus: dryRun ? "dry_run" : "sent",
     channel: INTERNAL_MESSAGE_CHANNEL,
     target: "current-run",
     sourceReplyDeliveryMode: input.sourceReplyDeliveryMode,
+    ...(persistedIdempotencyKey ? { idempotencyKey: persistedIdempotencyKey } : {}),
+    ...(persistedTranscriptOwner ? { sourceReplyTranscriptOwner: true as const } : {}),
     ...(dryRun ? {} : { sourceReplySink: "internal-ui" as const }),
     sourceReply: sourceReplyPayload,
     ...(sourceReplyMessage ? { message: sourceReplyMessage } : {}),
@@ -328,6 +358,8 @@ function buildInternalSourceReplyToolResult(payload: {
   channel: ChannelId;
   target: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  idempotencyKey?: string;
+  sourceReplyTranscriptOwner?: true;
   sourceReplySink?: "internal-ui";
   sourceReply: ReplyPayload;
   message?: string;
@@ -340,6 +372,8 @@ function buildInternalSourceReplyToolResult(payload: {
   channel: ChannelId;
   target: string;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  idempotencyKey?: string;
+  sourceReplyTranscriptOwner?: true;
   sourceReplySink?: "internal-ui";
   sourceReply: ReplyPayload;
   message?: string;
@@ -364,6 +398,8 @@ function buildInternalSourceReplyToolResult(payload: {
       ...(payload.sourceReplyDeliveryMode
         ? { sourceReplyDeliveryMode: payload.sourceReplyDeliveryMode }
         : {}),
+      ...(payload.idempotencyKey ? { idempotencyKey: payload.idempotencyKey } : {}),
+      ...(payload.sourceReplyTranscriptOwner ? { sourceReplyTranscriptOwner: true as const } : {}),
       ...(payload.sourceReplySink ? { sourceReplySink: payload.sourceReplySink } : {}),
       sourceReply: payload.sourceReply,
       ...(payload.message ? { message: payload.message } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing an internal WebChat message-tool reply with image attachments would lose those images after the Gateway restarted and the session was continued.

The live tool result was visible immediately, but durable media/transcript ownership was deferred until end-of-turn finalization. A restart in that window left only transient tool metadata, so reconstructed chat history had no image artifact to render.

## Why This Change Was Made

Internal source replies now stage allowed media, materialize managed artifacts, and append the idempotent delivery mirror before the message tool reports a successful send. That pre-acknowledgement row is marked as the canonical transcript owner, so completed-run finalization does not append a competing mirror.

Same-key retries share a session-scoped FIFO lease across the media-create and transcript-admission boundary. Sequential and overlapping retries therefore resolve the existing transcript entry before another managed artifact can be created, leaving one transcript row and one managed-media record.

The append remains fenced to the exact session identity and active transcript writer. Synthetic/direct tool invocations without a durable session ID keep their existing behavior.

## User Impact

Images sent through the message tool in WebChat remain available when the Gateway restarts and the session is resumed. The successful tool result now means the visible reply already has durable transcript and media ownership.

## Evidence

- **Original pre-fix regression:** `node scripts/run-vitest.mjs src/agents/tools/message-tool.internal-source-reply.integration.test.ts` failed because the tool returned success without an idempotency key or durable assistant/media transcript entry.
- **Concurrent pre-fix regression:** two overlapping same-key sends created two managed-media records (`expected length 1, received 2`) before the keyed lease repair.
- **Post-fix regression:** the same command passes 4/4 tests and verifies durable managed-media resolution, finalization ownership, overlapping same-key replay deduplication, one transcript row, and one managed image record.
- **Changed-surface gates:** `node scripts/check-changed.mjs -- <nine changed files>` passed, followed by a focused rerun for the concurrent-retry repair; formatting, core/core-test typechecks, lint, database/media guards, and import-cycle checks all passed.
- **Fresh review:** repository autoreview reported no actionable findings at head `c292494e0d4b4752db8c99ec73a22412eac90f70` (0.98 confidence).
- **Codex contract:** inspected sibling Codex commit `66919805ea080053d1933b6b43afeb0d8bf70c91`; `codex-rs/app-server/src/bespoke_event_handling.rs:1435-1443` publishes each completed tool item independently, while turn completion is published separately at `bespoke_event_handling.rs:1301`. This confirms that a tool result can be visible before turn finalization.

### Restart visual proof

The isolated session was seeded through the production message-tool path, loaded in the real Control UI, the owned Gateway process was stopped and restarted against the same state directory, and the same session was loaded again.

| Before Gateway restart | After Gateway restart |
| --- | --- |
| ![Image visible before restart](https://raw.githubusercontent.com/openclaw/openclaw/2b5ae286e17a97af10e038eb29a09758b73ddbc2/evidence/pr-127729/before-restart.png) | ![Image still visible after restart](https://raw.githubusercontent.com/openclaw/openclaw/2b5ae286e17a97af10e038eb29a09758b73ddbc2/evidence/pr-127729/after-restart.png) |

Both captures render the managed 300×113 attachment and caption. The PNG captures are byte-identical (Git blob `71620257608400658f9947719f3d81c34b2362fe`). The post-restart Playwright assertion also verifies the attachment completed with natural dimensions 300×113.

## Implementation notes

- Architectural owner: the internal source-reply acknowledgement boundary.
- Production delta: +197/-2 lines across eight source files, establishing staged-media validation, durable managed-media ownership, transcript fencing, finalization ownership, and serialized idempotent admission before acknowledgement.
- Test delta: +125 lines of boundary regression coverage.
- No schema, protocol, configuration, dependency, or migration changes.

AI-assisted: yes. The change and validation evidence were reviewed directly against current OpenClaw and sibling Codex source.
