### PR TITLE
fix(codex): accept bounded upstream prompt provenance

### DIFF
--- a/extensions/codex/src/app-server/settled-turn-projection.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { describe, expect, it } from "vitest";
 import { projectSettledCodexMessages } from "./settled-turn-projection.js";
+import { attachUpstreamUserText } from "./upstream-prompt-provenance.js";
 
 function message(value: unknown): AgentMessage {
   return value as AgentMessage;
@@ -194,6 +195,53 @@ describe("projectSettledCodexMessages", () => {
       role: "user",
       content: [{ type: "input_text", text: "Send the Aurora notice to Erin." }],
     });
+  });
+
+  it("preserves upstream user text above the ordinary message limit", () => {
+    const upstreamUserText = "x".repeat(64 * 1024 + 1);
+
+    expect(
+      projectSettledCodexMessages([
+        attachUpstreamUserText(
+          message({ role: "user", content: "[Telegram metadata] decorated prompt" }),
+          upstreamUserText,
+        ),
+        toolCall(),
+        toolResult(),
+      ])[0],
+    ).toEqual({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: upstreamUserText }],
+    });
+  });
+
+  it("rejects upstream user text above the projection limit", () => {
+    expect(() =>
+      projectSettledCodexMessages([
+        attachUpstreamUserText(
+          message({ role: "user", content: "[Telegram metadata] decorated prompt" }),
+          "x".repeat(512 * 1024 + 1),
+        ),
+        toolCall(),
+        toolResult(),
+      ]),
+    ).toThrow("oversized upstream user text");
+  });
+
+  it("charges upstream user text against the aggregate byte limit", () => {
+    expect(() =>
+      projectSettledCodexMessages([
+        attachUpstreamUserText(
+          message({ role: "user", content: "decorated" }),
+          "x".repeat(400 * 1024),
+        ),
+        message({ role: "user", content: "x".repeat(60 * 1024) }),
+        message({ role: "user", content: "x".repeat(60 * 1024) }),
+        toolCall(),
+        toolResult(),
+      ]),
+    ).toThrow("exceeds the byte limit");
   });
 
   it("does not let provenance hide non-text user content", () => {

--- a/extensions/codex/src/app-server/settled-turn-projection.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.ts
@@ -93,7 +93,10 @@ function projectUserMessage(message: Extract<AgentMessage, { role: "user" }>): J
         type: "message",
         role: "user",
         content: [
-          { type: "input_text", text: requireBoundedText(upstreamUserText, "upstream user text") },
+          {
+            type: "input_text",
+            text: requireBoundedText(upstreamUserText, "upstream user text", MAX_PROJECTION_BYTES),
+          },
         ],
       },
     ];


### PR DESCRIPTION
Related to #125254.

AI-assisted with Codex. I reviewed the generated change and understand the behavior and compatibility boundary it modifies.

## What Problem This Solves

Codex settled-turn finalization rejects exact `upstreamUserText` provenance above 64 KiB before applying the existing 512 KiB complete-projection budget. OpenClaw can legitimately persist a larger exact prompt. The isolated finalizer then aborts before `thread/inject_items`, leaving the Telegram turn without its final answer.

This fixes only that secondary finalizer contradiction. It does **not** remove the degraded-engine whole-history continuity producer and must not close #125254.

## Root cause and fix

`projectSettledCodexMessages` applied the ordinary-message 64 KiB field bound to exact prompt provenance. Exact provenance is a distinct contract: adopted-session activity detection exact-matches it against Codex user input, so truncation or substitution would corrupt ownership detection.

The projector now admits exact provenance up to the existing 512 KiB projection budget. Ordinary user, assistant, tool-result, and tool-argument text remains capped at 64 KiB. Serialized response items are still charged to the aggregate 512 KiB limit and fail closed above it.

## Evidence

Exact head: `8596e8ca443741f6481a8e611af60095d86d1e1f`.

- Current-main real Telegram reproduction (`6cb08cb8ee9ee6235c7bd1f5f3fd7b85b8673ce7`): one real-user DM exercised the deterministic tool-only settled-finalizer path with a 68,884-byte prompt. Gateway result: `Codex settled-turn projection found oversized upstream user text`; Telegram showed the visible agent-failure warning. Verdict: `actual=affected`, `toolOnlyTurnCompleted=true`, `finalizerStarted=false`, `injectedHistoryBytes=0`, `finalAnswerObserved=false`.
- Stock owner-boundary control: 65,537-byte exact provenance throws `Codex settled-turn projection found oversized upstream user text` on current main.
- Patched focused suite: `node scripts/run-vitest.mjs extensions/codex/src/app-server/settled-turn-projection.test.ts extensions/codex/src/app-server/settled-turn-context.test.ts extensions/codex/src/app-server/settled-turn-finalizer.test.ts extensions/codex/src/app-server/bounded-turn.test.ts` — 64/64 pass.
- Boundary coverage: 65,537-byte exact provenance is preserved; 512 KiB + 1 is rejected; mixed 400 KiB provenance plus ordinary content is rejected by aggregate accounting.
- `pnpm exec oxfmt --check` on both touched files — pass.
- `pnpm exec oxlint` on both touched files — pass.
- `pnpm tsgo` — pass.
- `pnpm check:test-types` — pass.
- `git diff --check origin/main...HEAD` — pass.
- Distill audit: exact provenance and ordinary transcript content are genuinely distinct contracts; the patch reuses the canonical projection path and adds no fallback or parallel implementation.
- Greybeard audit: 50 projections with 512,000 bytes of provenance averaged 0.595 ms each; work remains linear and bounded by the existing aggregate limit.

## Pinned Codex contract

Directly verified against `openai/codex` tag `rust-v0.148.0` (`3ba0f711642a888aec92a611a3f3b2211157ff89`), matching `extensions/codex/package.json`:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`: `ThreadInjectItemsParams.items` is raw `Vec<JsonValue>` with no protocol text-size cap.
- `codex-rs/app-server/src/request_processors/turn_processor.rs`: `thread_inject_items_response_inner` deserializes each item as `ResponseItem`, validates image URLs, and injects the items; it adds no text-size cap.
- `codex-rs/app-server/tests/suite/v2/thread_inject_items.rs`: injected response items are retained in model-visible rollout history.

The final real-Telegram repaired-path verdict will be added after the exact-head local ClawSweeper gate.

## Final real-Telegram repaired-path proof

A real Telegram user DM exercised the changed path on exact head `8596e8ca443741f6481a8e611af60095d86d1e1f` with the retained oversized-provenance fixture:

```json
{
  "actual": "repaired",
  "promptBytes": 68884,
  "toolOnlyTurnCompleted": true,
  "finalizerStarted": true,
  "injectedHistoryBytes": 68884,
  "oversizedProvenanceRejected": false,
  "finalAnswerObserved": true
}
```

The redacted app-server trace records the first tool-only turn, then an isolated process calling `thread/inject_items` with six items (largest exact input text: 68,884 bytes) before `turn/start`. Telegram observed typing plus one SUT answer containing `CODEX_SETTLED_FINALIZATION_OK`. This is the same deterministic flow that failed on current main before finalizer startup.

