### PR TITLE
fix(cron): restore automation failure alerts after clock rollback

### DIFF
--- a/src/cron/service/failure-alerts.persistence.test.ts
+++ b/src/cron/service/failure-alerts.persistence.test.ts
@@ -12,7 +12,7 @@ import { cronStoreKey } from "../store/key.js";
 import type { CronJob, CronRunStatus } from "../types.js";
 import { createCronServiceState } from "./state.js";
 import { finalizeCompletedCronRunOutcomes } from "./timer-outcome-finalization.js";
-import { authorCronRunCompletion } from "./timer.js";
+import { applyJobResult, authorCronRunCompletion } from "./timer.js";
 
 const fixtures = setupCronRegressionFixtures({
   prefix: "cron-failure-alert-persistence-",
@@ -126,6 +126,96 @@ describe("cron failure alert persistence", () => {
       lastFailureNotificationDeliveryStatus: "unknown",
     });
     expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { status: "error", includeSkipped: false },
+    { status: "skipped", includeSkipped: true },
+  ] as const)(
+    "resumes $status alerts after a clock rollback and restores their cooldown",
+    async (testCase) => {
+      const store = fixtures.makeStorePath();
+      const dueAt = Date.parse("2026-08-01T14:52:00.000Z");
+      const job = createAlertJob({
+        id: `${testCase.status}-alert-clock-rollback`,
+        dueAt,
+        includeSkipped: testCase.includeSkipped,
+      });
+      job.state.lastFailureAlertAtMs = dueAt + 3_600_000;
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+      let now = dueAt;
+      const sendCronFailureAlert = vi.fn(async () => undefined);
+      const state = createAlertState({
+        storePath: store.storePath,
+        nowMs: () => now,
+        sendCronFailureAlert,
+      });
+
+      await finalizeAlertOutcome({
+        state,
+        job,
+        status: testCase.status,
+        error: "provider unavailable",
+        startedAt: now,
+        endedAt: now + 10,
+      });
+
+      expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureAlertAtMs).toBe(now);
+
+      now += 30_000;
+      const currentJob = state.store?.jobs[0];
+      if (!currentJob) {
+        throw new Error("expected persisted cron job");
+      }
+      await finalizeAlertOutcome({
+        state,
+        job: currentJob,
+        status: testCase.status,
+        error: "provider still unavailable",
+        startedAt: now,
+        endedAt: now + 10,
+      });
+
+      expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureAlertAtMs).toBe(
+        dueAt,
+      );
+    },
+  );
+
+  it("preserves a newer cooldown when replaying an older finalized failure", () => {
+    const store = fixtures.makeStorePath();
+    const now = Date.parse("2026-08-01T14:54:00.000Z");
+    const replayedAt = now - 30_000;
+    const previousAlertAt = now - 10_000;
+    const job = createAlertJob({ id: "failure-alert-historical-replay", dueAt: replayedAt });
+    job.state.lastFailureAlertAtMs = previousAlertAt;
+
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const state = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => now,
+      sendCronFailureAlert,
+    });
+    const deferredNotifications: Array<() => void> = [];
+
+    applyJobResult(
+      state,
+      job,
+      {
+        status: "error",
+        error: "historical failure",
+        startedAt: replayedAt - 10,
+        endedAt: replayedAt,
+      },
+      { replayFailureAlertAtMs: replayedAt, deferredNotifications },
+    );
+
+    expect(job.state.lastFailureAlertAtMs).toBe(previousAlertAt);
+    expect(deferredNotifications).toEqual([]);
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
   });
 
   it("rolls back the cooldown without delivery when persistence fails", async () => {

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -366,12 +366,15 @@ export function maybeEmitFailureAlert(
   if (params.job.delivery?.bestEffort === true && !params.job.failureAlert) {
     return;
   }
-  const now = params.occurredAtMs ?? state.deps.nowMs();
+  const wallClockNow = state.deps.nowMs();
+  const now = params.occurredAtMs ?? wallClockNow;
   const lastAlert = params.job.state.lastFailureAlertAtMs;
   // Cooldown is stored on job state so process restarts and service reloads do
-  // not spam operators with repeated alerts for the same failing job.
+  // not spam operators. Future timestamps cannot prove a recent prior alert.
   const inCooldown =
-    typeof lastAlert === "number" && now - lastAlert < Math.max(0, alertConfig.cooldownMs);
+    typeof lastAlert === "number" &&
+    lastAlert <= wallClockNow &&
+    now - lastAlert < Math.max(0, alertConfig.cooldownMs);
   if (inCooldown) {
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators of failing scheduled automations stopped receiving failure notifications after the host clock moved behind a previously persisted alert timestamp. Both ordinary execution failures and opted-in skipped-run alerts were silently suppressed until the wall clock caught up, potentially for hours or indefinitely after a larger clock correction.

## Why This Change Was Made

The scheduler treated a negative elapsed time as proof that an earlier alert was still within its cooldown. The shared failure-alert owner now validates that the previous alert is not in the future relative to the actual current wall clock while preserving the separate historical occurrence time required by record-only startup replay. Existing persistence, failure-routing, configuration, thresholds, and cooldown contracts remain unchanged.

Comparing against the historical event time alone was rejected because startup replay can legitimately restore a run older than a more recent valid alert. Clearing timestamps in storage or special-casing each caller was rejected because alert timing belongs to the shared scheduler owner. Production delta: +6/-3, net +3; the additional lines preserve the essential distinction between current wall-clock authority and historical event time.

## User Impact

Automation operators receive the next legitimate failure or opted-in skipped-run notification immediately after a clock rollback. The renewed cooldown still prevents repeated notification floods, and restarting the gateway does not redeliver historical alerts or rewind a newer cooldown.

## Evidence

- Authentic regression-first proof on unchanged production: both persisted execution-failure and skipped-run notification regressions failed because zero alerts were delivered; five existing and historical-replay controls passed.
- After the owner-level repair, all seven failure-alert persistence regressions pass, including durable post-commit delivery, renewed cooldown suppression, and historical record-only replay.
- Focused owner, routing, service, startup-recovery, interrupted-run, and sibling clock-rollback suites: 172 tests passing across seven files.
- Commands:
  - `node scripts/run-vitest.mjs src/cron/service/failure-alerts.persistence.test.ts src/cron/service/failure-alerts.account-routing.test.ts src/cron/service.failure-alert.test.ts src/cron/service/run-recovery.test.ts src/cron/service/ops.test.ts src/cron/session-reaper.test.ts`
  - `node scripts/run-vitest.mjs src/cron/service/startup-run-repair.auto-disable.test.ts`
  - `node --import tsx scripts/check-max-lines-ratchet.mts --base f6b42ea223abf55ab6120fafc83d4fb74c35c72f`
  - `node --import tsx scripts/check-assertion-safety-ratchet.mts --base f6b42ea223abf55ab6120fafc83d4fb74c35c72f`
  - `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/cron/service/failure-alerts.persistence.test.ts src/cron/service/failure-alerts.ts`
  - `node_modules/.bin/oxfmt --check src/cron/service/failure-alerts.ts src/cron/service/failure-alerts.persistence.test.ts`
- Separate independent source review and fresh authenticated full-branch Codex review both found no actionable issues.
- Reviewed head: `6082bf06eb744df953ed2db395186bb4047d74d6`; original baseline: `f6b42ea223abf55ab6120fafc83d4fb74c35c72f`; both touched files were revalidated against current main before publication.
