### PR TITLE
fix(mac): keep node service aligned with the latest connection mode

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
+++ b/apps/macos/Sources/OpenClaw/NodeServiceManager.swift
@@ -3,48 +3,22 @@ import OSLog
 
 enum NodeServiceManager {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "node.service")
+    private static let lifecycleQueue = LifecycleQueue()
     private static var launchdPlistURL: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/LaunchAgents/\(nodeLaunchdLabel).plist")
     }
 
     static func start(profile: AppProfile = .current) async -> String? {
-        if self.skipUnderProfile(profile, action: "start") { return nil }
-        let result = await self.runServiceCommandResult(
-            ["start"],
-            timeout: 20,
-            quiet: false)
-        if let error = self.errorMessage(from: result, treatNotLoadedAsError: true) {
-            self.logger.error("node service start failed: \(error, privacy: .public)")
-            return error
-        }
-        return nil
+        await self.lifecycleQueue.run("start", profile: profile)
     }
 
     static func stop(profile: AppProfile = .current) async -> String? {
-        if self.skipUnderProfile(profile, action: "stop") { return nil }
-        let result = await self.runServiceCommandResult(
-            ["stop"],
-            timeout: 15,
-            quiet: false)
-        if let error = self.errorMessage(from: result, treatNotLoadedAsError: false) {
-            self.logger.error("node service stop failed: \(error, privacy: .public)")
-            return error
-        }
-        return nil
+        await self.lifecycleQueue.run("stop", profile: profile)
     }
 
     static func restart(profile: AppProfile = .current) async -> String? {
-        if self.skipUnderProfile(profile, action: "restart") { return nil }
-        let result = await self.runServiceCommandResult(
-            ["restart"],
-            timeout: 20,
-            quiet: false)
-        if let error = self.errorMessage(from: result, treatNotLoadedAsError: true) {
-            self.logger.error("node service restart failed: \(error, privacy: .public)")
-            return error
-        }
-        return nil
+        await self.lifecycleQueue.run("restart", profile: profile)
     }
 
     /// Empty means no node LaunchAgent. Nil means the on-disk ownership proof
@@ -82,6 +56,31 @@ enum NodeServiceManager {
 }
 
 extension NodeServiceManager {
+    private actor LifecycleQueue {
+        private var tail: Task<String?, Never>?
+
+        func run(_ action: String, profile: AppProfile) async -> String? {
+            if NodeServiceManager.skipUnderProfile(profile, action: action) { return nil }
+            let predecessor = self.tail
+            let task = Task<String?, Never> {
+                _ = await predecessor?.value
+                let result = await NodeServiceManager.runServiceCommandResult(
+                    [action],
+                    timeout: action == "stop" ? 15 : 20,
+                    quiet: false)
+                guard let error = NodeServiceManager.errorMessage(
+                    from: result,
+                    treatNotLoadedAsError: action != "stop")
+                else { return nil }
+                NodeServiceManager.logger.error(
+                    "node service \(action, privacy: .public) failed: \(error, privacy: .public)")
+                return error
+            }
+            self.tail = task
+            return await task.value
+        }
+    }
+
     private static func skipUnderProfile(_ profile: AppProfile, action: String) -> Bool {
         guard profile.isActive else { return false }
         self.logger.info("node service \(action, privacy: .public) skipped (unavailable under app profile)")

--- a/apps/macos/Tests/OpenClawIPCTests/NodeServiceManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodeServiceManagerTests.swift
@@ -36,6 +36,67 @@ import Testing
         }
     }
 
+    @Test(arguments: ["start:stop", "stop:start", "restart:stop"])
+    func `node lifecycle commands finish in request order`(_ transition: String) async throws {
+        let actions = transition.split(separator: ":").map(String.init)
+        let previousAction = try #require(actions.first)
+        let nextAction = try #require(actions.last)
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try await TestIsolation.withIsolatedState(
+            env: [
+                "OPENCLAW_NODE_SERVICE_TEST_ROOT": root.path,
+                "OPENCLAW_NODE_SERVICE_DELAYED_ACTION": previousAction,
+            ],
+            defaults: ["openclaw.gatewayProjectRootPath": nil])
+        {
+            CommandResolver.setProjectRoot(root.path)
+            let executable = root.appendingPathComponent("node_modules/.bin/openclaw")
+            try makeExecutableForTests(at: executable)
+            let script = """
+            #!/bin/sh
+            action="$2"
+            : > "$OPENCLAW_NODE_SERVICE_TEST_ROOT/$action.entered"
+            if [ "$action" = "$OPENCLAW_NODE_SERVICE_DELAYED_ACTION" ]; then
+              while [ ! -f "$OPENCLAW_NODE_SERVICE_TEST_ROOT/release" ]; do
+                sleep 0.01
+              done
+            fi
+            if [ "$action" = "stop" ]; then
+              printf stopped > "$OPENCLAW_NODE_SERVICE_TEST_ROOT/state"
+            else
+              printf running > "$OPENCLAW_NODE_SERVICE_TEST_ROOT/state"
+            fi
+            printf '{"ok":true}'
+            """
+            try script.write(to: executable, atomically: false, encoding: .utf8)
+
+            let release = root.appendingPathComponent("release")
+            defer { try? Data().write(to: release) }
+            let profile = AppProfile(environment: [:])
+            let previous = Task { await self.runNodeServiceAction(previousAction, profile: profile) }
+            let previousEntered = root.appendingPathComponent("\(previousAction).entered")
+            for _ in 0..<200 where !FileManager.default.fileExists(atPath: previousEntered.path) {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            try #require(FileManager.default.fileExists(atPath: previousEntered.path))
+
+            let next = Task { await self.runNodeServiceAction(nextAction, profile: profile) }
+            let nextEntered = root.appendingPathComponent("\(nextAction).entered")
+            for _ in 0..<50 where !FileManager.default.fileExists(atPath: nextEntered.path) {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            #expect(!FileManager.default.fileExists(atPath: nextEntered.path))
+
+            try Data().write(to: release)
+            #expect(await previous.value == nil)
+            #expect(await next.value == nil)
+            let observed = try String(contentsOf: root.appendingPathComponent("state"), encoding: .utf8)
+            #expect(observed == (nextAction == "stop" ? "stopped" : "running"))
+        }
+    }
+
     @Test func `reads node service ownership command directly from launchd`() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("openclaw-node-\(UUID().uuidString).plist")
@@ -69,5 +130,18 @@ import Testing
         #expect(!NodeServiceManager._testRuntimeIsRunning(fromJSON: """
         {"service":{"loaded":true,"runtime":{"status":"stopped"}}}
         """))
+    }
+
+    private func runNodeServiceAction(_ action: String, profile: AppProfile) async -> String? {
+        switch action {
+        case "start":
+            await NodeServiceManager.start(profile: profile)
+        case "stop":
+            await NodeServiceManager.stop(profile: profile)
+        case "restart":
+            await NodeServiceManager.restart(profile: profile)
+        default:
+            "Unknown node service action"
+        }
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users who switch between local and remote Gateway modes, or receive an app update during a mode change, can end up with the Mac node service running in local mode or stopped in remote mode. An older node start, stop, or update-triggered restart can finish after the newer requested action and silently leave the persistent service in the wrong state.

## Why This Change Was Made

Connection-mode generation guards protect their callers after each await, but cannot undo an already launched independent service-management subprocess. Make the node-service owner serialize all three mutating operations through one predecessor-task lifecycle actor, matching existing native coordinator patterns. Fold the previously duplicated action execution, timeout, error, and profile policy into that owner. Read-only status polling remains independent; production decreases by one line.

## User Impact

The Mac node now ends in the state requested by the latest local/remote mode transition or app update, even when a previous service command is slow. Named-profile behavior, existing action-specific timeouts, not-loaded handling, and status checks remain unchanged.

## Evidence

- A real-subprocess regression uses a temporary fake OpenClaw CLI, blocks the first command, then races start→stop, stop→start, and restart→stop. Before the fix, all three scenarios fail twice: the newer subprocess starts prematurely and the older subprocess leaves the service in the wrong final state (six failures total).
- After the owner fix, all 159 native macOS tests pass across `NodeServiceManagerTests`, `ConnectionModeCoordinatorTests`, `GatewayProcessManagerTests`, `GatewayEndpointStoreTests`, `DashboardWindowSmokeTests`, and `MenuContentSmokeTests`; the three real fake-CLI subprocess orderings all end in the correct state.
- The subprocess proof executes production command resolution, process launching, JSON parsing, and lifecycle methods while guaranteeing the temporary fake executable is selected; no real operator `launchd` service is touched. Native dashboard smoke tests additionally exercise actual macOS windows.
- SwiftFormat, SwiftLint, `git diff --check`, and independent Codex review all pass. Production: +29/-30 (net -1); tests: +74/-0.
