### PR TITLE
fix(config): match the config directory through symlinks when diagnosing permissions

### DIFF
--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -514,6 +514,30 @@ describe("config mutate helpers", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "diagnoses config lock failures through a symlinked config directory",
+    async () => {
+      const root = await suiteRootTracker.make("lock-permission-symlink");
+      const realConfigDir = path.join(root, "real");
+      const configuredDir = path.join(root, "configured");
+      await fs.mkdir(realConfigDir);
+      await fs.symlink(realConfigDir, configuredDir);
+      const configPath = path.join(configuredDir, "openclaw.json");
+      const lockPath = path.join(realConfigDir, "openclaw.json.lock");
+      const failure = Object.assign(new Error(`EACCES: permission denied, open '${lockPath}'`), {
+        code: "EACCES",
+        path: lockPath,
+      });
+      fileLockMocks.withFileLock.mockRejectedValueOnce(failure);
+      const snapshot = createSnapshot({ hash: "hash-1", path: configPath, sourceConfig: {} });
+
+      await expect(replaceConfigFile({ snapshot, nextConfig: {} })).rejects.toMatchObject({
+        message: `OpenClaw cannot write to the config directory ${configuredDir}. Fix its ownership or permissions, then try again. Underlying error: ${failure.message}`,
+        cause: failure,
+      });
+    },
+  );
+
   it("preserves a permission failure raised outside the config directory", async () => {
     const configDir = await suiteRootTracker.make("lock-unrelated-permission");
     const configPath = path.join(configDir, "openclaw.json");

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -225,10 +225,10 @@ async function withConfigMutationLock<T>(
         async () => await withFileLock(configPath, CONFIG_MUTATION_LOCK_OPTIONS, fn),
       ),
     )
-    .catch((error: unknown) => {
+    .catch(async (error: unknown) => {
       // Only relabel a permission failure on the config directory itself. The caller's mutation
       // runs inside this scope, so an unrelated EACCES from its own work must not be misdiagnosed.
-      if (!isPermissionErrorInDirectory(error, configDir)) {
+      if (!(await isPermissionErrorInDirectory(error, configDir))) {
         throw error;
       }
       throw new Error(
@@ -238,7 +238,7 @@ async function withConfigMutationLock<T>(
     });
 }
 
-function isPermissionErrorInDirectory(error: unknown, directory: string): boolean {
+async function isPermissionErrorInDirectory(error: unknown, directory: string): Promise<boolean> {
   if (
     !isErrno(error) ||
     (error.code !== "EACCES" && error.code !== "EPERM" && error.code !== "EROFS")
@@ -246,7 +246,18 @@ function isPermissionErrorInDirectory(error: unknown, directory: string): boolea
     return false;
   }
   const failedPath = error.path;
-  return typeof failedPath === "string" && path.dirname(path.resolve(failedPath)) === directory;
+  if (typeof failedPath !== "string") {
+    return false;
+  }
+  const failedDir = path.dirname(path.resolve(failedPath));
+  if (failedDir === directory) {
+    return true;
+  }
+  // Node reports the canonical path, so a config directory reached through a symlink (a macOS
+  // /var -> /private/var home, for one) never matches the raw string. Resolve only on mismatch to
+  // keep the successful write path free of an extra syscall.
+  const canonicalDirectory = await fs.realpath(directory).catch(() => undefined);
+  return canonicalDirectory !== undefined && failedDir === canonicalDirectory;
 }
 
 function markActiveConfigMutationPath(configPath: string): void {


### PR DESCRIPTION
## What Problem This Solves

The config-directory permission diagnosis added in #127703 silently does not fire when the config
directory is reached through a symlink. The operator falls back to the raw
`EACCES … openclaw.json.lock` errno that PR set out to replace.

This is a follow-up to my own change: the guard was correct in intent but compared paths too
literally.

## Why This Change Was Made

`isPermissionErrorInDirectory` compared Node's reported errno path against the configured directory
as raw strings:

```ts
return typeof failedPath === "string" && path.dirname(path.resolve(failedPath)) === directory;
```

Node reports the **canonical** path. When the config directory is reached through a symlink the two
never match, so the diagnosis is skipped. This is not exotic on macOS, where `/var` is a symlink to
`/private/var` — the repo already carries a testing note about exactly this asymmetry, since raw
temp-dir path assertions pass on Linux CI and fail on a Mac.

The narrow path check itself is deliberate and stays: the caller's whole mutation runs inside the
locked scope, so an unrelated `EACCES` from the caller's own work must keep propagating rather than
being relabelled as a config-directory permission problem. Only the comparison gets smarter.

## User Impact

An operator whose home or config directory resolves through a symlink now gets the same actionable
message everyone else gets:

```
OpenClaw cannot write to the config directory /Users/me/.openclaw. Fix its ownership or
permissions, then try again. Underlying error: EACCES: permission denied, open
'/Users/me/.openclaw/openclaw.json.lock'
```

Nothing else changes. Non-permission errors, permission errors outside the config directory, and
permission errors with no reported path all propagate exactly as before.

## Evidence

Production `+18/-5`. Tests `+23/-0`.

The `realpath` call happens **only** when the raw comparison already failed, so successful config
writes — the overwhelmingly common path — gain no syscall. It is wrapped in `.catch(() => undefined)`
so a directory that has since disappeared falls through to propagating the original error rather
than throwing a second one.

`node scripts/run-vitest.mjs src/config/mutate.test.ts` — 55/55 pass. Reverting only
`src/config/mutate.ts` to current `main` fails exactly the new symlink case and passes the other 54,
so the test pins the gap rather than restating existing behaviour.

The new case is `it.runIf(process.platform !== "win32")`, since creating a symlink needs privileges
on Windows.

`oxfmt --check` and `git diff --check` clean. `$autoreview --mode uncommitted` clean, no accepted or
actionable findings.
