### PR TITLE
fix(telegram): preserve exact inline callback action values

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-router-controls.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router-controls.ts
@@ -617,18 +617,15 @@ export async function handleTelegramInteractiveCallback(params: {
     return true;
   }
 
-  const managedSelectCallback = parseTelegramManagedSelectCallback(data);
-  if (!managedSelectCallback) {
+  const selectCallback = parseTelegramManagedSelectCallback(callback.data?.trimStart() ?? data);
+  if (!selectCallback) {
     return false;
   }
-  if (
-    managedSelectCallback.type === "multi-toggle" ||
-    managedSelectCallback.type === "multi-clear"
-  ) {
+  if (selectCallback.type === "multi-toggle" || selectCallback.type === "multi-clear") {
     const buttons = updateMultiSelectKeyboard(
       callbackMessage,
-      managedSelectCallback.type === "multi-clear" ? "clear" : "toggle",
-      managedSelectCallback.type === "multi-toggle" ? managedSelectCallback.value : "",
+      selectCallback.type === "multi-clear" ? "clear" : "toggle",
+      selectCallback.type === "multi-toggle" ? selectCallback.value : "",
     );
     if (buttons.length > 0) {
       try {
@@ -643,7 +640,7 @@ export async function handleTelegramInteractiveCallback(params: {
   }
 
   let text: string;
-  if (managedSelectCallback.type === "multi-submit") {
+  if (selectCallback.type === "multi-submit") {
     const selected = resolveMultiSelectedValues(cloneInlineKeyboardButtons(callbackMessage));
     text = `Multi-select submitted: ${selected.length > 0 ? selected.join(", ") : "none"}`;
   } else {
@@ -658,7 +655,7 @@ export async function handleTelegramInteractiveCallback(params: {
         throw new TelegramRetryableCallbackError(editErr);
       }
     }
-    text = `Single-select submitted: ${managedSelectCallback.value}`;
+    text = `Single-select submitted: ${selectCallback.value}`;
   }
   const synthetic = buildSynthetic(text);
   await processMessageWithReplyChain({

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -144,7 +144,7 @@ export function createTelegramCallbackRouter({
         callbackMessage.chat.type === "group" || callbackMessage.chat.type === "supergroup";
       const nativeCallbackCommand = parseTelegramNativeCommandCallbackData(data);
       const hasReservedOpaquePrefix = hasTelegramOpaqueCallbackPrefix(data);
-      const opaqueCallbackData = parseTelegramOpaqueCallbackData(data);
+      const opaqueCallbackData = parseTelegramOpaqueCallbackData(callback.data?.trimStart());
       const genericCallbackText = data.startsWith("/") ? data : `callback_data: ${data}`;
       const callbackCommandText =
         nativeCallbackCommand ?? (opaqueCallbackData ? "" : genericCallbackText);

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1806,44 +1806,54 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-1");
   });
 
-  it("routes plugin callback_query payloads to plugin handlers without fallback callback_data text", async () => {
-    const pluginHandler = vi.fn(async (ctx) => {
-      expect(ctx.callback.namespace).toBe("code-agent");
-      expect(ctx.callback.payload).toBe("approve-123");
-      await ctx.respond.clearButtons();
-      return { handled: true };
-    });
-    expect(
-      registerPluginInteractiveHandler("openclaw-code-agent", {
-        channel: "telegram",
-        namespace: "code-agent",
-        handler: pluginHandler,
-      }),
-    ).toEqual({ ok: true });
+  it.each([
+    { name: "raw", data: "code-agent:approve-123", payload: "approve-123" },
+    {
+      name: "opaque with trailing whitespace",
+      data: buildTelegramOpaqueCallbackData("code-agent:approve-123 "),
+      payload: "approve-123",
+    },
+  ])(
+    "routes $name plugin callback_query payloads without fallback callback_data text",
+    async ({ data, payload }) => {
+      const pluginHandler = vi.fn(async (ctx) => {
+        expect(ctx.callback.namespace).toBe("code-agent");
+        expect(ctx.callback.payload).toBe(payload);
+        await ctx.respond.clearButtons();
+        return { handled: true };
+      });
+      expect(
+        registerPluginInteractiveHandler("openclaw-code-agent", {
+          channel: "telegram",
+          namespace: "code-agent",
+          handler: pluginHandler,
+        }),
+      ).toEqual({ ok: true });
 
-    createTelegramBot({ token: "tok" });
-    const callbackHandler = getCallbackHandler();
-    await callbackHandler(
-      makeCallbackRetryContext({
-        id: "cbq-plugin-1",
-        data: "code-agent:approve-123",
-        messageId: 10,
-        text: "Approve this code-agent action?",
-        message: {
-          reply_markup: {
-            inline_keyboard: [[{ text: "Approve", callback_data: "code-agent:approve-123" }]],
+      createTelegramBot({ token: "tok" });
+      const callbackHandler = getCallbackHandler();
+      await callbackHandler(
+        makeCallbackRetryContext({
+          id: "cbq-plugin-1",
+          data,
+          messageId: 10,
+          text: "Approve this code-agent action?",
+          message: {
+            reply_markup: {
+              inline_keyboard: [[{ text: "Approve", callback_data: data }]],
+            },
           },
-        },
-      }),
-    );
+        }),
+      );
 
-    expect(pluginHandler).toHaveBeenCalledTimes(1);
-    expect(replySpy).not.toHaveBeenCalled();
-    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
-      reply_markup: { inline_keyboard: [] },
-    });
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-plugin-1");
-  });
+      expect(pluginHandler).toHaveBeenCalledTimes(1);
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
+        reply_markup: { inline_keyboard: [] },
+      });
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-plugin-1");
+    },
+  );
 
   it("preserves raw tgcb1 callbacks emitted before the prefix became reserved", async () => {
     const pluginHandler = vi.fn(async (ctx) => {
@@ -1957,32 +1967,39 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-opaque-1");
   });
 
-  it("toggles OC_MULTI buttons without routing through the generic callback message path", async () => {
-    createTelegramBot({ token: "tok" });
-    const callbackHandler = getCallbackHandler();
-    await callbackHandler(
-      makeCallbackRetryContext({
-        id: "cbq-multi-toggle-1",
-        data: "OC_MULTI|toggle|env|prod",
-        messageId: 10,
-        message: {
-          business_connection_id: "biz-multi-1",
-          reply_markup: {
-            inline_keyboard: [[{ text: "Prod", callback_data: "OC_MULTI|toggle|env|prod" }]],
+  it.each([
+    { name: "delimited", value: "env|prod" },
+    { name: "trailing-whitespace", value: "env|prod " },
+  ])(
+    "toggles $name OC_MULTI buttons without routing through generic messages",
+    async ({ value }) => {
+      const data = `OC_MULTI|toggle|${value}`;
+      createTelegramBot({ token: "tok" });
+      const callbackHandler = getCallbackHandler();
+      await callbackHandler(
+        makeCallbackRetryContext({
+          id: "cbq-multi-toggle-1",
+          data,
+          messageId: 10,
+          message: {
+            business_connection_id: "biz-multi-1",
+            reply_markup: {
+              inline_keyboard: [[{ text: "Prod", callback_data: data }]],
+            },
           },
-        },
-      }),
-    );
+        }),
+      );
 
-    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
-      business_connection_id: "biz-multi-1",
-      reply_markup: {
-        inline_keyboard: [[{ text: "✅ Prod", callback_data: "OC_MULTI|toggle|env|prod" }]],
-      },
-    });
-    expect(replySpy).not.toHaveBeenCalled();
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-multi-toggle-1");
-  });
+      expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
+        business_connection_id: "biz-multi-1",
+        reply_markup: {
+          inline_keyboard: [[{ text: "✅ Prod", callback_data: data }]],
+        },
+      });
+      expect(replySpy).not.toHaveBeenCalled();
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-multi-toggle-1");
+    },
+  );
 
   it("submits OC_MULTI selections as a synthetic inbound message", async () => {
     createTelegramBot({ token: "tok" });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users pressing Telegram inline buttons could see a valid plugin action silently disappear or a multi-select option fail to toggle when its callback value ended in meaningful whitespace.

## Why This Change Was Made

Telegram callback routing normalized the entire callback before decoding, which invalidated the checksum of opaque callback envelopes and made managed multi-select values differ from the exact callback bytes stored on their buttons. Decode those two Telegram-owned values from the original callback while keeping existing normalized approval, question, native-command, model, authorization, and shared plugin-payload behavior unchanged. The owner cleanup removes three production lines overall.

## User Impact

Telegram plugin buttons whose signed callback values contain trailing whitespace now reach their registered handlers, and Telegram multi-select buttons with trailing-whitespace values visibly toggle as expected. Existing plugin payload normalization and single-select message normalization are unchanged.

## Evidence

- Regression-first Telegram bot integration: two new callback scenarios failed against unchanged production (opaque plugin handler was never called; multi-select button stayed unselected), then both passed after the owner fix.
- All six relevant Telegram owner and security-sibling suites passed: **342 tests across 6 files**, including the full bot integration, approvals, question envelopes, native commands, malformed reserved callbacks, outbound buttons, and 64-byte callback limits.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot.test.ts extensions/telegram/src/approval-callback-data.test.ts extensions/telegram/src/question-callback-data.test.ts extensions/telegram/src/button-types.test.ts extensions/telegram/src/native-command-callback-data.test.ts --maxWorkers 1`
- Max-lines and assertion-safety ratchets, focused extension lint, formatting, and `git diff --check` all pass; independent security/source review and authenticated Codex review are clean.
- Production delta: **-3 lines**; regression-test delta: **+17 lines**.
- Live Telegram proof was unavailable because this isolated campaign has no dedicated authorized Telegram bot/account lease; the real Telegram bot callback integration was exercised end-to-end with the existing mocked Telegram API harness.
