### PR TITLE
fix: current chat attachments fail after send acknowledgement

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -259,6 +259,7 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
         requesterSenderId: options?.requesterSenderId ?? undefined,
         senderIsOwner: options?.senderIsOwner,
         conversationReadOrigin: options?.conversationReadOrigin,
+        workspaceDir,
       });
   const heartbeatTool = options?.enableHeartbeatTool ? createHeartbeatResponseTool() : null;
   options?.recordToolPrepStage?.("openclaw-tools:message-tool");

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -242,6 +242,7 @@ type MessageToolOptions = {
   requesterSenderId?: string;
   senderIsOwner?: boolean;
   conversationReadOrigin?: ConversationReadInvocationOrigin;
+  workspaceDir?: string;
 };
 
 export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
@@ -660,6 +661,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           },
           senderIsOwner: options?.senderIsOwner,
           conversationReadOrigin: options?.conversationReadOrigin,
+          workspaceDir: options?.workspaceDir,
           broadcastAccountPlan,
           gateway,
           toolContext,

--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -1,28 +1,36 @@
 // Integration coverage for targetless WebChat tool sends through the internal
 // source-reply sink and embedded-run payload projection.
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import { buildReplyPayloads } from "../../auto-reply/reply/agent-runner-payloads.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { extractMessagingToolSourceReplyPayload } from "../embedded-agent-messaging-extraction.js";
 import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
 import { createMessageTool } from "./message-tool-execution.js";
 
+function createCurrentSourceMessageTool(params: { workspaceDir?: string } = {}) {
+  return createMessageTool({
+    config: { agents: { entries: { main: { default: true } } } },
+    currentChannelProvider: "webchat",
+    sourceReplyDeliveryMode: "automatic",
+    agentSessionKey: "agent:main:webchat:dm:dashboard",
+    runId: "webchat-run",
+    workspaceDir: params.workspaceDir,
+    getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
+    resolveCommandSecretRefsViaGateway: async ({ config }) => ({
+      resolvedConfig: config,
+      diagnostics: [],
+      targetStatesByPath: {},
+      hadUnresolvedTargets: false,
+    }),
+  });
+}
+
 describe("WebChat message tool internal source reply", () => {
   it("projects a real targetless send and preserves the automatic final reply", async () => {
-    const tool = createMessageTool({
-      config: { agents: { entries: { main: { default: true } } } },
-      currentChannelProvider: "webchat",
-      sourceReplyDeliveryMode: "automatic",
-      agentSessionKey: "agent:main:webchat:dm:dashboard",
-      runId: "webchat-run",
-      getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
-      resolveCommandSecretRefsViaGateway: async ({ config }) => ({
-        resolvedConfig: config,
-        diagnostics: [],
-        targetStatesByPath: {},
-        hadUnresolvedTargets: false,
-      }),
-    });
+    const tool = createCurrentSourceMessageTool();
 
     const toolResult = await tool.execute("message-call", {
       action: "send",
@@ -75,6 +83,53 @@ describe("WebChat message tool internal source reply", () => {
     });
     expect(getReplyPayloadMetadata(payloads[1] as object)?.sourceReplyTranscriptMirror).toBe(
       undefined,
+    );
+  });
+
+  it("stages buffer media before acknowledging the current-source send", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "message-tool-source-buffer-" },
+      async (state) => {
+        await fs.mkdir(state.workspaceDir, { recursive: true });
+        const tool = createCurrentSourceMessageTool({ workspaceDir: state.workspaceDir });
+        const attachment = Buffer.from("current-source attachment");
+
+        const toolResult = await tool.execute("message-buffer-call", {
+          action: "send",
+          message: "Attached proof.",
+          buffer: attachment.toString("base64"),
+          filename: "proof.txt",
+          contentType: "text/plain",
+        });
+
+        const sourceReply = extractMessagingToolSourceReplyPayload(toolResult);
+        expect(sourceReply).toMatchObject({ text: "Attached proof." });
+        expect(sourceReply?.mediaUrls).toHaveLength(1);
+        const mediaPath = sourceReply?.mediaUrls?.[0];
+        expect(mediaPath).toBeTruthy();
+        await expect(fs.readFile(mediaPath as string)).resolves.toEqual(attachment);
+      },
+    );
+  });
+
+  it("rejects disallowed local media before acknowledging the current-source send", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "message-tool-source-path-" },
+      async (state) => {
+        await fs.mkdir(state.workspaceDir, { recursive: true });
+        const outsidePath = state.path("outside", "blocked.png");
+        await fs.mkdir(path.dirname(outsidePath), { recursive: true });
+        await fs.writeFile(outsidePath, "blocked");
+        const tool = createCurrentSourceMessageTool({ workspaceDir: state.workspaceDir });
+
+        await expect(
+          tool.execute("message-path-call", {
+            action: "send",
+            message: "Attached proof.",
+            media: outsidePath,
+          }),
+        ).rejects.toThrow(/could not be staged|allowed directory/i);
+      },
     );
   });
 });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -236,6 +236,8 @@ type EmbeddedAgentParams = {
   transcriptPrompt?: string;
   memoryFlushWritePath?: string;
   silentExpected?: boolean;
+  allowEmptyAssistantReplyAsSilent?: boolean;
+  terminalReplyExpectation?: "required" | "optional";
   extraSystemPrompt?: string;
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;
@@ -474,6 +476,8 @@ describe("runMemoryFlushIfNeeded", () => {
     const followupRun = createTestFollowupRun({
       authProfileId: "anthropic:work",
       authProfileIdSource: "user",
+      allowEmptyAssistantReplyAsSilent: false,
+      terminalReplyExpectation: "required",
     });
     const { result, sessionKey, storePath } = await runProjectedCompaction(true, followupRun);
 
@@ -489,6 +493,8 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.prompt).not.toBe(flushCall.transcriptPrompt);
     expect(flushCall.memoryFlushWritePath).toMatch(/^memory\/\d{4}-\d{2}-\d{2}\.md$/);
     expect(flushCall.silentExpected).toBe(true);
+    expect(flushCall.allowEmptyAssistantReplyAsSilent).toBe(true);
+    expect(flushCall.terminalReplyExpectation).toBe("optional");
     expect(registerAgentRunContextMock).toHaveBeenCalledWith(
       "00000000-0000-0000-0000-000000000001",
       expect.objectContaining({

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1471,6 +1471,8 @@ export async function runMemoryFlushIfNeeded(params: {
           sandboxSessionKey: params.runtimePolicySessionKey,
           allowGatewaySubagentBinding: true,
           silentExpected: true,
+          allowEmptyAssistantReplyAsSilent: true,
+          terminalReplyExpectation: "optional",
           trigger: "memory",
           memoryFlushWritePath,
           initialTurnTainted:

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -55,6 +55,7 @@ export function createReplyMediaPathNormalizer(params: {
   requesterSenderName?: string;
   requesterSenderUsername?: string;
   requesterSenderE164?: string;
+  sandboxRoot?: string;
 }): (payload: ReplyPayload) => Promise<ReplyPayload> {
   // Prefer an explicit agentId so callers without a resolved sessionKey (e.g.
   // `openclaw agent --deliver` with `--reply-channel/--reply-to`) still get
@@ -69,7 +70,10 @@ export function createReplyMediaPathNormalizer(params: {
     channel: params.messageProvider,
     accountId: params.accountId,
   });
-  let sandboxRootPromise: Promise<string | undefined> | undefined;
+  const explicitSandboxRoot = params.sandboxRoot?.trim();
+  let sandboxRootPromise: Promise<string | undefined> | undefined = explicitSandboxRoot
+    ? Promise.resolve(explicitSandboxRoot)
+    : undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
   const resolveSandboxRoot = async (): Promise<string | undefined> => {

--- a/src/infra/outbound/message-action-contracts.ts
+++ b/src/infra/outbound/message-action-contracts.ts
@@ -51,6 +51,7 @@ export type MessageActionInput = {
   requesterSenderE164?: string | null;
   senderIsOwner?: boolean;
   conversationReadOrigin?: ConversationReadInvocationOrigin;
+  workspaceDir?: string;
   /** @internal Host-owned route plan computed before broadcast SecretRef resolution. */
   broadcastAccountPlan?: MessageBroadcastAccountPlan;
   /**

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -3,7 +3,8 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { AgentToolResult } from "../../agents/runtime/index.js";
 import { readStringArrayParam, readToolStringParam } from "../../agents/tools/common.js";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
@@ -235,16 +236,64 @@ async function handleInternalSourceReplySendAction(
 ): Promise<MessageActionResult> {
   throwIfAborted(input.abortSignal);
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
+  const agentId =
+    input.agentId ??
+    (input.sessionKey
+      ? resolveSessionAgentId({ sessionKey: input.sessionKey, config: input.cfg })
+      : undefined);
+  await hydrateAttachmentParamsForAction({
+    cfg: input.cfg,
+    channel: INTERNAL_MESSAGE_CHANNEL,
+    args: params,
+    action: "send",
+    dryRun,
+    mediaPolicy: resolveAttachmentMediaPolicy({
+      sandboxRoot: input.sandboxRoot,
+      mediaAccess: input.mediaAccess,
+      mediaLocalRoots: getAgentScopedMediaLocalRoots(input.cfg, agentId),
+    }),
+  });
   const sourceReply = await buildMessagePayload({
     cfg: input.cfg,
     actionParams: params,
     input,
-    agentId:
-      input.agentId ??
-      (input.sessionKey
-        ? resolveSessionAgentId({ sessionKey: input.sessionKey, config: input.cfg })
-        : undefined),
+    agentId,
   });
+  let sourceReplyPayload = sourceReply.payload;
+  const requestedMediaCount =
+    resolveSendableOutboundReplyParts(sourceReplyPayload).mediaUrls.length;
+  if (!dryRun && requestedMediaCount > 0) {
+    const workspaceDir =
+      input.workspaceDir ??
+      input.mediaAccess?.workspaceDir ??
+      (agentId ? resolveAgentWorkspaceDir(input.cfg, agentId) : undefined);
+    if (!workspaceDir) {
+      throw new Error("Current-source media requires an agent workspace.");
+    }
+    const { createReplyMediaPathNormalizer } =
+      await import("../../auto-reply/reply/reply-media-paths.runtime.js");
+    sourceReplyPayload = await createReplyMediaPathNormalizer({
+      cfg: input.cfg,
+      sessionKey: input.sessionKey,
+      agentId,
+      workspaceDir,
+      messageProvider: INTERNAL_MESSAGE_CHANNEL,
+      requesterSenderId: input.requesterSenderId ?? undefined,
+      requesterSenderName: input.requesterSenderName ?? undefined,
+      requesterSenderUsername: input.requesterSenderUsername ?? undefined,
+      requesterSenderE164: input.requesterSenderE164 ?? undefined,
+      sandboxRoot: input.sandboxRoot,
+    })(sourceReplyPayload);
+    if (
+      resolveSendableOutboundReplyParts(sourceReplyPayload).mediaUrls.length !== requestedMediaCount
+    ) {
+      throw new Error(
+        "Current-source media could not be staged. Use an accessible URL, a file inside the agent workspace, or the buffer field.",
+      );
+    }
+  }
+  const sourceReplyMediaUrls = resolveSendableOutboundReplyParts(sourceReplyPayload).mediaUrls;
+  const sourceReplyMessage = sourceReplyPayload.text ?? sourceReply.message;
   const payload = {
     status: "ok",
     deliveryStatus: dryRun ? "dry_run" : "sent",
@@ -252,10 +301,10 @@ async function handleInternalSourceReplySendAction(
     target: "current-run",
     sourceReplyDeliveryMode: input.sourceReplyDeliveryMode,
     ...(dryRun ? {} : { sourceReplySink: "internal-ui" as const }),
-    sourceReply: sourceReply.payload,
-    ...(sourceReply.message ? { message: sourceReply.message } : {}),
-    ...(sourceReply.mediaUrl ? { mediaUrl: sourceReply.mediaUrl } : {}),
-    ...(sourceReply.mediaUrls?.length ? { mediaUrls: sourceReply.mediaUrls } : {}),
+    sourceReply: sourceReplyPayload,
+    ...(sourceReplyMessage ? { message: sourceReplyMessage } : {}),
+    ...(sourceReplyMediaUrls[0] ? { mediaUrl: sourceReplyMediaUrls[0] } : {}),
+    ...(sourceReplyMediaUrls.length ? { mediaUrls: sourceReplyMediaUrls } : {}),
     dryRun,
   };
   return withSendNormalization(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where targetless message-tool replies in WebChat and TUI could report an attachment as sent before OpenClaw had staged the binary. Users would receive a caption followed by “Media failed,” while buffer-backed attachments could be reduced to text-only replies.

It also removes spurious hidden finalization work after successful memory-maintenance turns, which could log a misleading finalization failure even though the expected outcome was silence.

## Why This Change Was Made

The internal current-source reply path now takes custody of media before it publishes a settled delivery result. Buffers are staged into managed outbound storage, local paths are checked through the existing workspace/sandbox policy, and inaccessible media fails the tool call with actionable guidance instead of producing a later caption-only warning.

Memory flushes now explicitly opt into an optional terminal reply and expected empty-assistant silence rather than inheriting the foreground turn’s required-reply policy.

The production growth establishes the missing binary-custody boundary and carries the already-prepared workspace/sandbox context into that owner. It does not widen local-file access or add a compatibility fallback.

AI-assisted: yes. The implementation was source-audited, regression-tested, independently reviewed, and verified against the current upstream dynamic-tool response contract.

## User Impact

Generated screenshots and other attachments sent into the current WebChat or TUI conversation now either arrive as real managed media or fail immediately with a useful retry path. OpenClaw no longer claims success before attachment staging completes.

Operators also avoid misleading hidden settled-turn finalization warnings after successful memory maintenance.

## Evidence

Pre-fix regression proof:

- Buffer-backed current-source send returned success without any media URL.
- A disallowed local path returned success first and degraded later to a caption plus “Media failed.”
- A memory flush inherited `terminalReplyExpectation: "required"` and `allowEmptyAssistantReplyAsSilent: false`.

Post-fix focused proof:

- `node scripts/run-vitest.mjs src/agents/tools/message-tool.internal-source-reply.integration.test.ts src/agents/tools/message-tool.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/reply-media-paths.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-send.media.test.ts src/agents/embedded-agent-runner/run/terminal-resolution.test.ts`
  - 381 tests passed across four routed shards.
- `node scripts/check-changed.mjs -- <changed files>`
  - formatting, core/core-test typechecking, lint, import cycles, database/state guards, plugin boundaries, and media helper guards passed.
- `pnpm build`
  - completed successfully with no ineffective dynamic-import warning.
- Fresh independent autoreview reported no accepted/actionable findings.

Production LOC: +70/-11 (net +59) | Tests: +75/-14 (net +61).
