### PR TITLE
fix(ui): align page titles with page content

### DIFF
--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -230,6 +230,13 @@ suite.define(() => {
         await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
         const activityPage = page.locator("openclaw-activity-page");
         await expect.poll(() => activityPage.count()).toBe(1);
+        const titleLeft = await activityPage
+          .locator(".page-title")
+          .evaluate((element) => element.getBoundingClientRect().left);
+        const tabsLeft = await activityPage
+          .locator(".activity-mode-tabs")
+          .evaluate((element) => element.getBoundingClientRect().left);
+        expect(Math.abs(titleLeft - tabsLeft)).toBeLessThanOrEqual(8);
         await activityPage.locator(".activity-feed__people-trigger").click();
         await expect
           .poll(() =>

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4018,20 +4018,14 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   max-height: 80px;
 }
 
-/* The fixed web chrome sits over the top-left of ordinary page headers too.
-   Settings, mobile drawers, and native hosts own different chrome. */
+/* Keep ordinary page headers below the fixed web chrome instead of shifting
+   their titles away from the page content. Settings, mobile drawers, and
+   native hosts own different chrome. */
 html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-web-chrome)
-  .shell:not(.shell--nav-collapsed):not(.shell--mobile-nav):not(.shell--settings)
+  .shell:not(.shell--mobile-nav):not(.shell--settings)
   .content:not(.content--chat)
   .content-header {
-  padding-left: 88px;
-}
-
-html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-web-chrome)
-  .shell--nav-collapsed:not(.shell--mobile-nav):not(.shell--settings)
-  .content:not(.content--chat)
-  .content-header {
-  padding-left: 124px;
+  margin-top: 48px;
 }
 
 .content-header--page + * {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary Control UI page titles were pushed far to the right when the fixed web chrome was visible, leaving headings such as Activity misaligned with their tabs and page content.

## Why This Change Was Made

The shared page-header layout now clears fixed web chrome vertically instead of reserving 88px or 124px of horizontal title space. Mobile drawers, settings takeover pages, chat, and native-host chrome remain excluded from the rule. A browser-level regression assertion keeps the Activity title aligned with its mode tabs.

This change is AI-assisted and was reviewed against the rendered Control UI and the owning shared layout rules.

## User Impact

Page titles align with the content below them while the existing web chrome controls remain available above the header. The change applies consistently across ordinary desktop pages rather than special-casing Activity.

## Evidence

### Before

![Activity title before](https://github.com/user-attachments/assets/e74119d5-8d1e-45d4-84fa-8e2a70dd5096)

### After

![Activity title after](https://github.com/user-attachments/assets/d2461c8b-a0da-4c61-bec0-63971d004194)

Validation:

- Pre-fix regression proof: the new browser assertion failed with an 88px title/tabs mismatch.
- `node scripts/run-vitest.mjs ui/src/e2e/activity-session-feed.capture.e2e.test.ts` — passed after the fix and again after rebasing onto current `origin/main`.
- `node scripts/check-changed.mjs -- ui/src/styles/layout.css ui/src/e2e/activity-session-feed.capture.e2e.test.ts` — passed.
- Fresh Codex review of the uncommitted patch: no actionable findings.
- `git diff --check` — passed.

Production LOC: +5/-11 (net -6). Tests: +7/-0.
