### PR TITLE
fix(agents): preserve authoritative child completion results

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-output.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.test.ts
@@ -578,13 +578,13 @@ describe("buildChildCompletionFindings", () => {
     expect(findings).toContain("ANNOUNCE_SKIP");
   });
 
-  it("uses frozen child completion text when normalized completion is absent", () => {
+  it("uses the canonical captured child completion text", () => {
     const findings = buildChildCompletionFindings([
       {
         childSessionKey: "agent:main:subagent:child",
         task: "child task",
         createdAt: 1,
-        frozenResultText: "final child output",
+        completion: { resultText: "final child output" },
         execution: { outcome: { status: "ok" } },
       },
     ]);
@@ -624,6 +624,72 @@ describe("buildChildCompletionFindings", () => {
     expect(findings).toContain("findings captured before the wake");
     expect(findings).not.toContain("NO_REPLY");
   });
+
+  it.each([
+    {
+      name: "visible",
+      terminalReply: { disposition: "visible", text: "authoritative final output" } as const,
+      resultText: "older captured output",
+      expected: "authoritative final output",
+    },
+    {
+      name: "silent",
+      terminalReply: { disposition: "silent" } as const,
+      resultText: "NO_REPLY",
+      expected: undefined,
+    },
+    {
+      name: "empty",
+      terminalReply: { disposition: "empty" } as const,
+      resultText: null,
+      expected: undefined,
+    },
+  ])(
+    "keeps producer-owned $name terminal evidence authoritative over older fallback",
+    ({ terminalReply, resultText, expected }) => {
+      const findings = buildChildCompletionFindings([
+        {
+          childSessionKey: "agent:main:subagent:child",
+          task: "child task",
+          createdAt: 1,
+          completion: {
+            required: true,
+            resultText,
+            fallbackResultText: "older captured fallback",
+            terminalReply,
+          },
+          execution: { outcome: { status: "ok" } },
+        },
+      ]);
+
+      if (expected === undefined) {
+        expect(findings).toBeUndefined();
+      } else {
+        expect(findings).toContain(expected);
+        expect(findings).not.toContain("older captured output");
+      }
+    },
+  );
+
+  it.each(["silent", "empty"] as const)(
+    "treats %s terminal evidence without retained text as an intentional non-result",
+    (disposition) => {
+      const findings = buildChildCompletionFindings([
+        {
+          childSessionKey: "agent:main:subagent:child",
+          task: "child task",
+          createdAt: 1,
+          completion: {
+            resultText: disposition === "silent" ? "NO_REPLY" : null,
+            terminalReply: { disposition },
+          },
+          execution: { outcome: { status: "ok" } },
+        },
+      ]);
+
+      expect(findings).toBeUndefined();
+    },
+  );
 
   it.each(["ANNOUNCE_SKIP", "REPLY_SKIP", "HEARTBEAT_OK"])(
     "does not override an intentional %s completion with fallback output",

--- a/src/agents/subagents/announce/subagent-announce-output.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.ts
@@ -13,10 +13,9 @@ import { formatDurationCompact } from "../../../infra/format-time/format-duratio
 import { buildAgentRunTerminalOutcomeFromWaitResult } from "../../agent-run-terminal-outcome.js";
 import { wrapPromptDataBlock } from "../../sanitize-for-prompt.js";
 import { extractStoredAssistantText, sanitizeTextContent } from "../../tools/chat-history-text.js";
-import {
-  isAnnounceSkip,
-  selectDeliverableSessionsReply,
-} from "../../tools/sessions-send-tokens.js";
+import { isAnnounceSkip } from "../../tools/sessions-send-tokens.js";
+import { resolveSubagentCompletionResultText } from "../completion/subagent-completion-result.js";
+import type { SubagentCompletionState } from "../registry/subagent-registry.types.js";
 import { compareSubagentRunGeneration } from "../registry/subagent-run-generation.js";
 import { classifySubagentTerminalOutcome } from "../subagent-terminal-outcome.js";
 import {
@@ -441,11 +440,7 @@ type ChildCompletionRow = {
   label?: string;
   createdAt: number;
   execution: ChildCompletionExecution;
-  frozenResultText?: string | null;
-  completion?: {
-    resultText?: string | null;
-    fallbackResultText?: string | null;
-  };
+  completion?: Pick<SubagentCompletionState, "resultText" | "fallbackResultText" | "terminalReply">;
 };
 
 type ChildCompletionSection = {
@@ -454,21 +449,12 @@ type ChildCompletionSection = {
   actionable: boolean;
 };
 
-function selectChildCompletionResultText(child: ChildCompletionRow): string | undefined {
-  const primary = child.completion?.resultText;
-  const fallback = child.completion?.fallbackResultText ?? child.frozenResultText;
-  if (child.execution.outcome?.status === "ok") {
-    return selectDeliverableSessionsReply(primary, fallback);
-  }
-  return (primary ?? fallback)?.trim() || undefined;
-}
-
 function hasCapturedChildCompletionReply(child: ChildCompletionRow): boolean {
-  return [
-    child.completion?.resultText,
-    child.completion?.fallbackResultText,
-    child.frozenResultText,
-  ].some((value) => Boolean(value?.trim()));
+  return Boolean(
+    child.completion?.terminalReply ||
+    child.completion?.resultText?.trim() ||
+    child.completion?.fallbackResultText?.trim(),
+  );
 }
 
 export function buildChildCompletionFindings(
@@ -496,7 +482,7 @@ export function buildChildCompletionFindings(
 
   const sections: ChildCompletionSection[] = [];
   for (const [index, child] of sorted.entries()) {
-    const resultText = selectChildCompletionResultText(child);
+    const resultText = resolveSubagentCompletionResultText(child);
     const outcome = describeSubagentOutcome(child.execution.outcome);
     if (
       child.execution.outcome?.status === "ok" &&
@@ -569,20 +555,12 @@ export function buildChildCompletionFindings(
 }
 
 export function dedupeLatestChildCompletionRows(
-  children: Array<{
-    runId: string;
-    childSessionKey: string;
-    task: string;
-    label?: string;
-    generation?: number;
-    createdAt: number;
-    execution: ChildCompletionExecution;
-    frozenResultText?: string | null;
-    completion?: {
-      resultText?: string | null;
-      fallbackResultText?: string | null;
-    };
-  }>,
+  children: Array<
+    ChildCompletionRow & {
+      runId: string;
+      generation?: number;
+    }
+  >,
 ) {
   const latestByChildSessionKey = new Map<string, (typeof children)[number]>();
   for (const child of children) {
@@ -595,21 +573,13 @@ export function dedupeLatestChildCompletionRows(
 }
 
 export function filterCurrentDirectChildCompletionRows(
-  children: Array<{
-    runId: string;
-    childSessionKey: string;
-    requesterSessionKey: string;
-    requesterAgentId?: string;
-    task: string;
-    label?: string;
-    createdAt: number;
-    execution: ChildCompletionExecution;
-    frozenResultText?: string | null;
-    completion?: {
-      resultText?: string | null;
-      fallbackResultText?: string | null;
-    };
-  }>,
+  children: Array<
+    ChildCompletionRow & {
+      runId: string;
+      requesterSessionKey: string;
+      requesterAgentId?: string;
+    }
+  >,
   params: {
     requesterSessionKey: string;
     requesterAgentId?: string;

--- a/src/agents/subagents/announce/subagent-announce-output.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.ts
@@ -15,7 +15,6 @@ import { wrapPromptDataBlock } from "../../sanitize-for-prompt.js";
 import { extractStoredAssistantText, sanitizeTextContent } from "../../tools/chat-history-text.js";
 import { isAnnounceSkip } from "../../tools/sessions-send-tokens.js";
 import { resolveSubagentCompletionResultText } from "../completion/subagent-completion-result.js";
-import type { SubagentCompletionState } from "../registry/subagent-registry.types.js";
 import { compareSubagentRunGeneration } from "../registry/subagent-run-generation.js";
 import { classifySubagentTerminalOutcome } from "../subagent-terminal-outcome.js";
 import {
@@ -440,7 +439,7 @@ type ChildCompletionRow = {
   label?: string;
   createdAt: number;
   execution: ChildCompletionExecution;
-  completion?: Pick<SubagentCompletionState, "resultText" | "fallbackResultText" | "terminalReply">;
+  completion?: Parameters<typeof resolveSubagentCompletionResultText>[0]["completion"];
 };
 
 type ChildCompletionSection = {

--- a/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
@@ -68,7 +68,7 @@ type MockSubagentRun = {
   };
   cleanupCompletedAt?: number;
   label?: string;
-  frozenResultText?: string | null;
+  completion?: { required: boolean; resultText?: string | null };
 };
 type SessionEntryFixture = Partial<Omit<SessionEntry, "updatedAt">> & {
   updatedAt?: number;
@@ -2586,7 +2586,7 @@ describe("subagent announce formatting", () => {
               createdAt: 1,
               execution: { endedAt: 2, outcome: { status: "ok" } },
               cleanupCompletedAt: 3,
-              frozenResultText: "stale result that should be filtered",
+              completion: { required: true, resultText: "stale result that should be filtered" },
             },
           ];
         }
@@ -2602,7 +2602,7 @@ describe("subagent announce formatting", () => {
             createdAt: 10,
             execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
-            frozenResultText: "result from child a",
+            completion: { required: true, resultText: "result from child a" },
           },
           {
             runId: "run-child-b",
@@ -2615,7 +2615,7 @@ describe("subagent announce formatting", () => {
             createdAt: 11,
             execution: { endedAt: 21, outcome: { status: "ok" } },
             cleanupCompletedAt: 22,
-            frozenResultText: "result from child b",
+            completion: { required: true, resultText: "result from child b" },
           },
         ];
       },
@@ -2671,7 +2671,7 @@ describe("subagent announce formatting", () => {
             createdAt: 10,
             execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
-            frozenResultText: "stale result from child a",
+            completion: { required: true, resultText: "stale result from child a" },
           },
           {
             runId: "run-child-current",
@@ -2684,7 +2684,7 @@ describe("subagent announce formatting", () => {
             createdAt: 11,
             execution: { endedAt: 22, outcome: { status: "ok" } },
             cleanupCompletedAt: 23,
-            frozenResultText: "current result from child a",
+            completion: { required: true, resultText: "current result from child a" },
           },
           {
             runId: "run-child-b",
@@ -2697,7 +2697,7 @@ describe("subagent announce formatting", () => {
             createdAt: 12,
             execution: { endedAt: 24, outcome: { status: "ok" } },
             cleanupCompletedAt: 25,
-            frozenResultText: "result from child b",
+            completion: { required: true, resultText: "result from child b" },
           },
         ];
       },
@@ -2744,7 +2744,7 @@ describe("subagent announce formatting", () => {
             createdAt: 10,
             execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
-            frozenResultText: "stale old parent result",
+            completion: { required: true, resultText: "stale old parent result" },
           },
         ];
       },
@@ -2765,7 +2765,7 @@ describe("subagent announce formatting", () => {
           createdAt: 11,
           execution: { endedAt: 22, outcome: { status: "ok" } },
           cleanupCompletedAt: 23,
-          frozenResultText: "current new parent result",
+          completion: { required: true, resultText: "current new parent result" },
         };
       },
     );
@@ -2817,7 +2817,7 @@ describe("subagent announce formatting", () => {
             createdAt: 10,
             execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
-            frozenResultText: "result from child a",
+            completion: { required: true, resultText: "result from child a" },
           },
           {
             runId: "run-child-b",
@@ -2830,7 +2830,7 @@ describe("subagent announce formatting", () => {
             createdAt: 11,
             execution: { endedAt: 21, outcome: { status: "ok" } },
             cleanupCompletedAt: 22,
-            frozenResultText: "result from child b",
+            completion: { required: true, resultText: "result from child b" },
           },
         ];
       },
@@ -2897,7 +2897,7 @@ describe("subagent announce formatting", () => {
             createdAt: 10,
             execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
-            frozenResultText: "result from child a",
+            completion: { required: true, resultText: "result from child a" },
           },
         ];
       },
@@ -2952,7 +2952,7 @@ describe("subagent announce formatting", () => {
             createdAt: 10,
             execution: { endedAt: 20, outcome: { status: "ok" } },
             cleanupCompletedAt: 21,
-            frozenResultText: "grandchild final output",
+            completion: { required: true, resultText: "grandchild final output" },
           },
         ];
       }
@@ -2969,7 +2969,7 @@ describe("subagent announce formatting", () => {
             createdAt: 11,
             execution: { endedAt: 21, outcome: { status: "ok" } },
             cleanupCompletedAt: 22,
-            frozenResultText: "child synthesized output from grandchild",
+            completion: { required: true, resultText: "child synthesized output from grandchild" },
           },
         ];
       }
@@ -3266,7 +3266,7 @@ describe("subagent announce formatting", () => {
       requesterSessionKey: string;
       task: string;
       createdAt: number;
-      frozenResultText: string;
+      resultText: string;
       outcome?: { status: "ok" | "error" | "timeout"; error?: string };
       endedAt?: number;
       cleanupCompletedAt?: number;
@@ -3286,7 +3286,7 @@ describe("subagent announce formatting", () => {
           outcome: params.outcome ?? ({ status: "ok" } as const),
         },
         cleanupCompletedAt: params.cleanupCompletedAt ?? params.createdAt + 2,
-        frozenResultText: params.frozenResultText,
+        completion: { required: true, resultText: params.resultText },
       };
     }
 
@@ -3322,7 +3322,7 @@ describe("subagent announce formatting", () => {
                 requesterSessionKey: "agent:main:subagent:parent-2-level",
                 task: "child task",
                 createdAt: 10,
-                frozenResultText: "child final answer",
+                resultText: "child final answer",
               }),
             ]
           : [],
@@ -3361,7 +3361,7 @@ describe("subagent announce formatting", () => {
                 requesterSessionKey: "agent:main:subagent:parent-fanout",
                 task: "child a",
                 createdAt: 10,
-                frozenResultText: "result A",
+                resultText: "result A",
               }),
               makeChildCompletion({
                 runId: "run-fanout-b",
@@ -3369,7 +3369,7 @@ describe("subagent announce formatting", () => {
                 requesterSessionKey: "agent:main:subagent:parent-fanout",
                 task: "child b",
                 createdAt: 11,
-                frozenResultText: "result B",
+                resultText: "result B",
               }),
             ]
           : [],
@@ -3419,7 +3419,7 @@ describe("subagent announce formatting", () => {
                 task: "fast child",
                 createdAt: 10,
                 endedAt: 11,
-                frozenResultText: "fast child result",
+                resultText: "fast child result",
               }),
               makeChildCompletion({
                 runId: "run-slow",
@@ -3428,7 +3428,7 @@ describe("subagent announce formatting", () => {
                 task: "slow child",
                 createdAt: 11,
                 endedAt: 40,
-                frozenResultText: "slow child result",
+                resultText: "slow child result",
               }),
             ]
           : [],
@@ -3480,7 +3480,7 @@ describe("subagent announce formatting", () => {
               requesterSessionKey: middleSessionKey,
               task: "middle child a",
               createdAt: 10,
-              frozenResultText: "middle child result A",
+              resultText: "middle child result A",
             }),
             makeChildCompletion({
               runId: "run-middle-b",
@@ -3488,7 +3488,7 @@ describe("subagent announce formatting", () => {
               requesterSessionKey: middleSessionKey,
               task: "middle child b",
               createdAt: 11,
-              frozenResultText: "middle child result B",
+              resultText: "middle child result B",
             }),
           ];
         }
@@ -3500,7 +3500,7 @@ describe("subagent announce formatting", () => {
               requesterSessionKey: "agent:main:subagent:parent-nested",
               task: "middle orchestrator",
               createdAt: 12,
-              frozenResultText: "middle synthesized output from A and B",
+              resultText: "middle synthesized output from A and B",
             }),
           ];
         }
@@ -3555,7 +3555,7 @@ describe("subagent announce formatting", () => {
                 requesterSessionKey: "agent:main:subagent:parent-sequential",
                 task: "step one",
                 createdAt: 10,
-                frozenResultText: "result one",
+                resultText: "result one",
               }),
               makeChildCompletion({
                 runId: "run-seq-2",
@@ -3563,7 +3563,7 @@ describe("subagent announce formatting", () => {
                 requesterSessionKey: "agent:main:subagent:parent-sequential",
                 task: "step two",
                 createdAt: 20,
-                frozenResultText: "result two",
+                resultText: "result two",
               }),
               makeChildCompletion({
                 runId: "run-seq-3",
@@ -3571,7 +3571,7 @@ describe("subagent announce formatting", () => {
                 requesterSessionKey: "agent:main:subagent:parent-sequential",
                 task: "step three",
                 createdAt: 30,
-                frozenResultText: "result three",
+                resultText: "result three",
               }),
             ]
           : [],
@@ -3609,7 +3609,7 @@ describe("subagent announce formatting", () => {
                 requesterSessionKey: "agent:main:subagent:parent-error",
                 task: "error child",
                 createdAt: 10,
-                frozenResultText: "traceback: child exploded",
+                resultText: "traceback: child exploded",
                 outcome: { status: "error", error: "child exploded" },
               }),
             ]
@@ -3647,7 +3647,7 @@ describe("subagent announce formatting", () => {
                 requesterSessionKey: "agent:main:subagent:parent-gated",
                 task: "gated child",
                 createdAt: 10,
-                frozenResultText: "gated child output",
+                resultText: "gated child output",
               }),
             ]
           : [],
@@ -3702,7 +3702,7 @@ describe("subagent announce formatting", () => {
               requesterSessionKey: childSessionKey,
               task: "grandchild task",
               createdAt: 10,
-              frozenResultText: "grandchild settled output",
+              resultText: "grandchild settled output",
             }),
           ];
         }
@@ -3714,7 +3714,7 @@ describe("subagent announce formatting", () => {
               requesterSessionKey: parentSessionKey,
               task: "child task",
               createdAt: 20,
-              frozenResultText: "child synthesized from grandchild",
+              resultText: "child synthesized from grandchild",
             }),
           ];
         }

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -578,6 +578,52 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     expect(message).not.toContain("<prompt-data>\nNO_REPLY\n</prompt-data>");
   });
 
+  it.each([
+    {
+      name: "visible",
+      terminalReply: { disposition: "visible", text: "authoritative final output" } as const,
+      resultText: "stale child output",
+      expected: "authoritative final output",
+    },
+    {
+      name: "silent",
+      terminalReply: { disposition: "silent" } as const,
+      resultText: "NO_REPLY",
+      expected: undefined,
+    },
+    {
+      name: "empty",
+      terminalReply: { disposition: "empty" } as const,
+      resultText: null,
+      expected: undefined,
+    },
+  ])(
+    "keeps producer-owned $name terminal evidence in the requester settle wake",
+    async ({ terminalReply, resultText, expected }) => {
+      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([
+        makeSettledChild({
+          runId: "run-b",
+          delivery: { status: "failed" },
+          completion: {
+            required: true,
+            resultText,
+            fallbackResultText: "stale retained findings",
+            terminalReply,
+          },
+          outcome: { status: "ok" },
+        }),
+      ]);
+
+      expect(await maybeWakeRequesterAfterAllChildrenSettled(wakeParams())).toBe(true);
+      const message = String(deliveredCallArg().triggerMessage);
+      expect(message).not.toContain("stale retained findings");
+      expect(message).not.toContain("stale child output");
+      if (expected) {
+        expect(message).toContain(expected);
+      }
+    },
+  );
+
   it("stays out of pure fire-and-forget batches", async () => {
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([
       makeSettledChild({

--- a/src/agents/subagents/completion/subagent-completion-result.ts
+++ b/src/agents/subagents/completion/subagent-completion-result.ts
@@ -1,10 +1,14 @@
 import { selectDeliverableSessionsReply } from "../../tools/sessions-send-tokens.js";
-import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
+import type {
+  SubagentCompletionState,
+  SubagentRunRecord,
+} from "../registry/subagent-registry.types.js";
 
 /** Selects the canonical operator-visible result from captured completion state. */
-export function resolveSubagentCompletionResultText(
-  entry: Pick<SubagentRunRecord, "completion" | "execution">,
-): string | undefined {
+export function resolveSubagentCompletionResultText(entry: {
+  completion?: Pick<SubagentCompletionState, "resultText" | "fallbackResultText" | "terminalReply">;
+  execution: Pick<SubagentRunRecord["execution"], "outcome">;
+}): string | undefined {
   const terminalReply = entry.completion?.terminalReply;
   // Producer-owned terminal evidence outranks retained transcript fallback text.
   // Otherwise an intentionally silent/empty run can leak an older visible reply.

--- a/src/agents/subagents/completion/subagent-completion-result.ts
+++ b/src/agents/subagents/completion/subagent-completion-result.ts
@@ -1,13 +1,18 @@
+import type { AgentRunTerminalReplySnapshot } from "../../agent-run-terminal-reply.js";
 import { selectDeliverableSessionsReply } from "../../tools/sessions-send-tokens.js";
-import type {
-  SubagentCompletionState,
-  SubagentRunRecord,
-} from "../registry/subagent-registry.types.js";
 
 /** Selects the canonical operator-visible result from captured completion state. */
 export function resolveSubagentCompletionResultText(entry: {
-  completion?: Pick<SubagentCompletionState, "resultText" | "fallbackResultText" | "terminalReply">;
-  execution: Pick<SubagentRunRecord["execution"], "outcome">;
+  completion?: {
+    required?: boolean;
+    resultText?: string | null;
+    fallbackResultText?: string | null;
+    terminalReply?: AgentRunTerminalReplySnapshot;
+  };
+  execution: {
+    status?: "queued" | "running" | "interrupted" | "terminal";
+    outcome?: { status: "ok" | "error" | "timeout" | "unknown" };
+  };
 }): string | undefined {
   const terminalReply = entry.completion?.terminalReply;
   // Producer-owned terminal evidence outranks retained transcript fallback text.

--- a/src/cron/isolated-agent/subagent-followup.test.ts
+++ b/src/cron/isolated-agent/subagent-followup.test.ts
@@ -168,6 +168,68 @@ describe("readDescendantSubagentFallbackReply", () => {
     expect(result).toBe("live transcript text");
   });
 
+  it.each([
+    {
+      name: "visible",
+      terminalReply: { disposition: "visible", text: "authoritative child output" } as const,
+      resultText: "older captured output",
+      expected: "authoritative child output",
+    },
+    {
+      name: "silent",
+      terminalReply: { disposition: "silent" } as const,
+      resultText: "NO_REPLY",
+      expected: undefined,
+    },
+    {
+      name: "empty",
+      terminalReply: { disposition: "empty" } as const,
+      resultText: null,
+      expected: undefined,
+    },
+  ])(
+    "uses producer-owned $name terminal evidence instead of a stale child transcript",
+    async ({ terminalReply, resultText, expected }) => {
+      const descendant = createDescendantRun({ resultText });
+      descendant.execution.outcome = { status: "ok" };
+      descendant.completion = {
+        required: true,
+        resultText,
+        fallbackResultText: "older captured fallback",
+        terminalReply,
+      };
+      vi.mocked(listDescendantRunsForRequester).mockReturnValue([descendant]);
+      vi.mocked(readLatestAssistantReply).mockResolvedValue("stale child transcript");
+
+      await expect(
+        readDescendantSubagentFallbackReply({ sessionKey: "test-session", runStartedAt }),
+      ).resolves.toBe(expected);
+    },
+  );
+
+  it.each([
+    { name: "missing transcript", hasInternalTranscript: false, transcript: undefined },
+    { name: "silent transcript", hasInternalTranscript: false, transcript: "NO_REPLY" },
+    { name: "internal resume", hasInternalTranscript: true, transcript: undefined },
+  ])(
+    "retains a successful NO_REPLY fallback with a $name",
+    async ({ hasInternalTranscript, transcript }) => {
+      const descendant = createDescendantRun({ resultText: "NO_REPLY", hasInternalTranscript });
+      descendant.execution.outcome = { status: "ok" };
+      descendant.completion = {
+        required: true,
+        resultText: "NO_REPLY",
+        fallbackResultText: "captured child findings",
+      };
+      vi.mocked(listDescendantRunsForRequester).mockReturnValue([descendant]);
+      vi.mocked(readLatestAssistantReply).mockResolvedValue(transcript);
+
+      await expect(
+        readDescendantSubagentFallbackReply({ sessionKey: "test-session", runStartedAt }),
+      ).resolves.toBe("captured child findings");
+    },
+  );
+
   it("prefers captured completion for internally resumed descendants", async () => {
     vi.mocked(listDescendantRunsForRequester).mockReturnValue([
       createDescendantRun({

--- a/src/cron/isolated-agent/subagent-followup.ts
+++ b/src/cron/isolated-agent/subagent-followup.ts
@@ -1,6 +1,8 @@
 /** Reads or waits for descendant subagent summaries after isolated cron orchestration. */
 import { readLatestAssistantReply, waitForAgentRunsToDrain } from "../../agents/run-wait.js";
+import { resolveSubagentCompletionResultText } from "../../agents/subagents/completion/subagent-completion-result.js";
 import { listDescendantRunsForRequester } from "../../agents/subagents/registry/subagent-registry-read.js";
+import { selectDeliverableSessionsReply } from "../../agents/tools/sessions-send-tokens.js";
 import { stripHeartbeatToken } from "../../auto-reply/heartbeat.js";
 import {
   HEARTBEAT_TOKEN,
@@ -55,22 +57,18 @@ export async function readDescendantSubagentFallbackReply(params: {
     .toSorted((a, b) => (a.execution.endedAt ?? 0) - (b.execution.endedAt ?? 0))
     .slice(-4);
   for (const entry of latestRuns) {
-    const frozenResultText = entry.completion?.resultText;
-    const frozenReply =
-      typeof frozenResultText === "string" && frozenResultText.trim()
-        ? frozenResultText.trim()
-        : undefined;
-    const usesInternalTranscript = entry.execution?.transcriptTarget !== undefined;
-    let reply = usesInternalTranscript ? frozenReply : undefined;
-    if (!reply && !usesInternalTranscript) {
-      reply = (await readLatestAssistantReply({ sessionKey: entry.childSessionKey }))?.trim();
-    }
-    // Fall back to the registry's frozen result text when the session transcript
-    // is unavailable (e.g. child session already deleted by announce cleanup) or
-    // intentionally bypassed by an internal interrupted-resume run.
-    if (!reply && frozenReply) {
-      reply = frozenReply;
-    }
+    const completionReply = resolveSubagentCompletionResultText(entry);
+    // Producer-owned terminal evidence and private resume transcripts must
+    // never be replaced by an older visible child-session reply.
+    const canReadTranscript =
+      entry.completion?.terminalReply === undefined &&
+      entry.execution.transcriptTarget === undefined;
+    const reply = canReadTranscript
+      ? selectDeliverableSessionsReply(
+          await readLatestAssistantReply({ sessionKey: entry.childSessionKey }),
+          completionReply,
+        )
+      : completionReply;
     if (!reply || reply.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running scheduled jobs or waiting for multiple subagents could receive stale results from an earlier child turn, or lose a real child result, after the child finished silently, finished without output, produced a newer authoritative reply, or resumed with an intentional silent marker.

## Why This Change Was Made

Cron follow-up and parent completion summaries independently reimplemented child-result selection instead of using the existing canonical completion owner. Both now consume the same producer-owned terminal result and retained-result rules already used by task delivery and agent waiting. Parent summaries no longer accept the obsolete top-level fixture-only result shape, and their existing nested/parallel completion fixtures now model the actual canonical registry record.

Authoritative visible, silent, and empty terminal outcomes always win. Without terminal evidence, normal child sessions still prefer a genuinely deliverable current transcript, an intentional silent marker can recover the already-retained visible fallback, and private resumed transcripts are never inspected. Existing timeout/failure visibility, session-generation ownership, canonical SQLite migration, authorization, and protocol contracts remain unchanged.

Production change: **-24 lines**. Existing and added behavior tests: **+174 lines**.

## User Impact

Scheduled jobs and multi-agent parent sessions report the child result belonging to the completed run, preserve real captured findings across silent continuations, and never resurrect an older answer after the child explicitly completed silently or without output.

## Evidence

- Before the repair, **11 newly added real owner/boundary regressions failed**: five cron completion cases, three parent-output cases, and three actual requester-wake cases. A separate immutable-main execution also reproduced the additional silent-transcript/fallback sibling failure.
- After the repair, **220 tests passed across five suites/four Vitest shards**, including all terminal dispositions, normal and internal-resume fallbacks, actual requester wake delivery, and **84 existing nested, parallel, error, generation, and channel-routing announcement E2E cases**:

  ```text
  OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs \
    src/cron/isolated-agent/subagent-followup.test.ts \
    src/agents/subagents/completion/subagent-completion-result.test.ts \
    src/agents/subagents/announce/subagent-announce-output.test.ts \
    src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts \
    src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
  ```

  The repository-supported `OPENCLAW_E2E_SKIP_BUILD=1` switch only omits the unrelated shared distribution prebuild for this source-fixture E2E suite; all 84 E2E scenarios execute.
- Max-lines ratchet passed, including the unchanged environment-variable surface; assertion-safety ratchet passed; targeted formatting, direct lint, and `git diff --check` passed.
- Both runtime import-cycle and type-inclusive Madge architecture guards passed with **zero cycles**. The first hosted run exposed a private type-only owner cycle and overly narrow direct-literal types; the follow-up removes both registry-type edges, retains closed existing status unions, and accepts the real existing completion/execution fields. The exact hosted type stripe now has none of those original errors locally; its complete local run is blocked only by the existing unrelated missing `@panzoom/panzoom` and `@types/pako` workspace dependencies, so the corrected exact-head hosted stripe remains authoritative.
- Independent full owner/caller/sibling review and authenticated Codex structured review both reported no actionable findings.
- A live operator Gateway/model/channel run is intentionally not claimed: exercising it would require changing the operator-owned running Gateway or unavailable isolated authenticated live infrastructure. The actual requester-delivery boundary and source-backed nested announcement E2E flows are executed instead.
- No authentication, security, delegated authority, persistence, SQLite migration/schema, configuration, public SDK, or Gateway protocol changes.
