### PR TITLE
fix(ui): stop empty protected secrets before Gateway save

### DIFF
--- a/ui/src/pages/secrets/secrets-page.ts
+++ b/ui/src/pages/secrets/secrets-page.ts
@@ -160,21 +160,21 @@ class SecretsPage extends OpenClawLightDomElement {
     });
   }
 
+  private validateValue(value: string, kind: SecretsStoreDraft["kind"]): string | null {
+    if (kind === "secret" && value.length === 0) {
+      return t("secretsStore.required");
+    }
+    if (new TextEncoder().encode(value).byteLength > MAX_VALUE_BYTES) {
+      return t("secretsStore.tooLarge");
+    }
+    return null;
+  }
+
   private validateDraft(): string | null {
     if (!ENV_SECRET_REF_ID_RE.test(this.draft.name)) {
       return t("secretsStore.badName");
     }
-    if (
-      this.dialogMode === "edit" &&
-      this.draft.kind === "secret" &&
-      this.draft.value.length === 0
-    ) {
-      return t("secretsStore.required");
-    }
-    if (new TextEncoder().encode(this.draft.value).byteLength > MAX_VALUE_BYTES) {
-      return t("secretsStore.tooLarge");
-    }
-    return null;
+    return this.validateValue(this.draft.value, this.draft.kind);
   }
 
   private submitDraft() {
@@ -243,12 +243,12 @@ class SecretsPage extends OpenClawLightDomElement {
       this.formError = t("secretsStore.required");
       return;
     }
-    const oversized = parsed.entries.find(
-      (entry) => new TextEncoder().encode(entry.value).byteLength > MAX_VALUE_BYTES,
-    );
-    if (oversized) {
-      this.formError = `${oversized.name}: ${t("secretsStore.tooLarge")}`;
-      return;
+    for (const entry of parsed.entries) {
+      const error = this.validateValue(entry.value, entry.kind);
+      if (error) {
+        this.formError = `${entry.name}: ${error}`;
+        return;
+      }
     }
     void this.runStoreTask(async (store) => {
       const result = await bulkSetSecretsStoreEntries(store, parsed.entries);

--- a/ui/src/pages/secrets/secrets.e2e.test.ts
+++ b/ui/src/pages/secrets/secrets.e2e.test.ts
@@ -85,6 +85,101 @@ async function tableBodyContrast(page: Page): Promise<number> {
 }
 
 suite.define(() => {
+  it("blocks empty protected values without rejecting empty environment entries", async () => {
+    await suite.withPage({}, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["secrets.store.list", "secrets.store.set"],
+        methodResponses: {
+          "secrets.store.list": {
+            sequence: [
+              { entries: [secretEntry] },
+              { entries: [secretEntry] },
+              { entries: [secretEntry] },
+            ],
+          },
+          "secrets.store.set": {
+            sequence: [
+              { ok: true, reloaded: false },
+              { ok: true, reloaded: false },
+            ],
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}settings/secrets`);
+      await page.getByRole("heading", { name: "Secrets" }).waitFor();
+
+      const existingSecretRow = page.getByRole("row", { name: /SERVICE_API_KEY/u });
+      await existingSecretRow.getByRole("button", { name: "Actions: SERVICE_API_KEY" }).click();
+      await existingSecretRow.locator('wa-dropdown-item[value="edit"]').click();
+      const editSecretDialog = page.locator('openclaw-modal-dialog[label="Edit"]');
+      await editSecretDialog.getByRole("button", { name: "Save", exact: true }).click();
+      await editSecretDialog.getByRole("alert").getByText("Enter a value.").waitFor();
+      expect(await gateway.getRequests("secrets.store.set")).toHaveLength(0);
+      await editSecretDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+
+      await page.getByRole("button", { name: "Add", exact: true }).click();
+      const addSecretDialog = page.locator('openclaw-modal-dialog[label="Add"]');
+      await addSecretDialog.getByLabel("Name", { exact: true }).fill("EMPTY_API_KEY");
+      expect(
+        await addSecretDialog.getByRole("radio", { name: /Protected secret/u }).isChecked(),
+      ).toBe(true);
+      await addSecretDialog.getByRole("button", { name: "Save", exact: true }).click();
+      await addSecretDialog.getByRole("alert").getByText("Enter a value.").waitFor();
+      expect(await gateway.getRequests("secrets.store.set")).toHaveLength(0);
+      await capture(page, "04-empty-secret-local-validation.png");
+      await addSecretDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+
+      await page.getByRole("button", { name: "Bulk Add", exact: true }).click();
+      const protectedBulkDialog = page.locator('openclaw-modal-dialog[label="Bulk Add"]');
+      await protectedBulkDialog
+        .getByRole("textbox", { name: "Value", exact: true })
+        .fill("EMPTY_API_KEY=\nEMPTY_ENV=");
+      await protectedBulkDialog.getByText("1 protected secret detected").waitFor();
+      await protectedBulkDialog.getByRole("button", { name: "Save", exact: true }).click();
+      await protectedBulkDialog
+        .getByRole("alert")
+        .getByText("EMPTY_API_KEY: Enter a value.")
+        .waitFor();
+      expect(await gateway.getRequests("secrets.store.set")).toHaveLength(0);
+      await capture(page, "05-empty-bulk-local-validation.png");
+      await protectedBulkDialog.getByRole("button", { name: "Cancel", exact: true }).click();
+
+      await page.getByRole("button", { name: "Add", exact: true }).click();
+      const addEnvDialog = page.locator('openclaw-modal-dialog[label="Add"]');
+      await addEnvDialog.getByLabel("Name", { exact: true }).fill("EMPTY_ENV");
+      expect(
+        await addEnvDialog.getByRole("radio", { name: /Agent-readable environment/u }).isChecked(),
+      ).toBe(true);
+      await addEnvDialog.getByRole("button", { name: "Save", exact: true }).click();
+      await page
+        .getByRole("status")
+        .getByText(/Saved EMPTY_ENV/u)
+        .waitFor();
+
+      await page.getByRole("button", { name: "Bulk Add", exact: true }).click();
+      const envBulkDialog = page.locator('openclaw-modal-dialog[label="Bulk Add"]');
+      await envBulkDialog
+        .getByRole("textbox", { name: "Value", exact: true })
+        .fill("EMPTY_BULK_ENV=");
+      await envBulkDialog.getByText("0 protected secrets detected").waitFor();
+      await envBulkDialog.getByRole("button", { name: "Save", exact: true }).click();
+      await page
+        .getByRole("status")
+        .getByText(/Saved 1 entries/u)
+        .waitFor();
+
+      expect(await gateway.getRequests("secrets.store.set")).toEqual([
+        expect.objectContaining({
+          params: expect.objectContaining({ name: "EMPTY_ENV", value: "", kind: "env" }),
+        }),
+        expect.objectContaining({
+          params: { name: "EMPTY_BULK_ENV", value: "", kind: "env" },
+        }),
+      ]);
+    });
+  });
+
   it("adds env and secret values, bulk imports, and deletes without revealing secrets", async () => {
     if (captureUiProofEnabled) {
       await mkdir(proofDir, { recursive: true });
@@ -155,7 +250,7 @@ suite.define(() => {
         await secretDialog.getByLabel("Value", { exact: true }).fill("super-secret-material");
         await secretDialog.locator('textarea[name="allowed-hosts"]').fill("api.example.com");
         await capture(page, "02-secret-allowed-hosts.png");
-        await secretDialog.getByRole("button", { name: "Save", exact: true }).click();
+        await secretDialog.getByLabel("Name", { exact: true }).press("Enter");
         await page
           .getByRole("status")
           .getByText(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users adding a protected secret with an empty value—individually or through Bulk Add—would send a doomed `secrets.store.set` request and only then see the Gateway's longer rejection. Editing an existing protected secret already blocked the same empty value locally, while empty agent-readable environment entries are intentionally legal.

## Why This Change Was Made

The Secrets page now applies one UI-owned value validator to Add, Edit, and Bulk Add. It keeps the existing 64 KiB limit, rejects empty values only for protected secrets, and leaves the authoritative Gateway/store/security/protocol contracts unchanged.

The root cause was an edit-only condition in the UI plus a separate Bulk Add size-only check. The edit-only check came from #121724 (`ea06d72e8519`, code author and merger @steipete); the authoritative empty-secret rejection in #121947 (`b067a4dce343`, code author and merger @steipete) made the Add/Bulk mismatch visible.

Production LOC: +16/-16 (net 0) | Tests: +96/-1

AI-assisted change. The implementation and evidence were reviewed against the owning UI, Gateway, and store paths. The required sibling Codex source inspection covered `codex-rs/secrets/src/local.rs` and `codex-rs/protocol/src/shell_environment.rs`; Codex has no shared Control UI/Gateway seam to change.

## User Impact

Empty protected secrets now stay in the form with the concise local message `Enter a value.` and produce no Gateway mutation. Empty environment values remain saveable, and valid protected secrets still submit normally from a single-line field with Enter.

## Evidence

Authentic pre-fix source-Chromium regression: Add with `EMPTY_API_KEY` and Bulk Add with `EMPTY_API_KEY=` timed out waiting for the local `Enter a value.` alert because the baseline sent `secrets.store.set`. The post-fix mocked-Gateway test requires zero mutation requests for both protected-secret cases, retains the existing protected-edit check, and verifies empty env Add/Bulk each send exactly one legal empty env mutation.

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/secrets/secrets.e2e.test.ts` — 3/3 passed after rebase
- `node scripts/run-vitest.mjs ui/src/lib/secrets-store/index.test.ts ui/src/pages/secrets/view.test.ts` — 7/7 passed after rebase
- Full changed-file gate (`coreTests, ui`) — passed before the mechanical rebase
- Post-rebase UI typecheck, OXLint, oxfmt, and `git diff --check` — passed
- Fresh Codex autoreview — clean, no accepted/actionable findings; overall patch confidence 0.99

**Before — server rejection after the doomed request**

![Before: empty protected secret reaches the Gateway and shows the server rejection](https://ampcode.com/user-content/artifacts/ff358c2aee282b67ec9ebfb5e44dd033357d62469116a209120a4debf951c57d-file.png)

**After — Add blocks locally**

![After: Add remains open with Enter a value](https://ampcode.com/user-content/artifacts/0b9a2ef2d8f341d8f4911e072cbd3f0a576c2ddeee955835a6c5bb8151938fd4-file.png)

**After — Bulk Add names the invalid protected entry**

![After: Bulk Add reports EMPTY_API_KEY Enter a value](https://ampcode.com/user-content/artifacts/cffd16da700d1c92b5dcc497311cbd180544453da56299c90f214e2207a7a247-file.png)
