### PR TITLE
fix(web-search): honor requested result limits across providers

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.runtime.ts
+++ b/extensions/brave/src/brave-web-search-provider.runtime.ts
@@ -332,7 +332,7 @@ async function runBraveWebSearch(params: {
     "Brave Search API error",
   );
   const results = Array.isArray(data.web?.results) ? (data.web?.results ?? []) : [];
-  return results.map((entry) => {
+  return results.slice(0, params.count).map((entry) => {
     const description = entry.description ?? "";
     const title = entry.title ?? "";
     const url = entry.url ?? "";

--- a/extensions/brave/src/brave-web-search-provider.test.ts
+++ b/extensions/brave/src/brave-web-search-provider.test.ts
@@ -348,6 +348,32 @@ describe("brave web search provider", () => {
     expect(requestUrl.pathname).toBe("/proxy/res/v1/llm/context");
   });
 
+  it("caps returned and cached web results when Brave exceeds the requested count", async () => {
+    const mockFetch = vi.fn(async () =>
+      jsonResponse({
+        web: {
+          results: [
+            { url: "https://example.com/first", title: "First", description: "first" },
+            { url: "https://example.com/second", title: "Second", description: "second" },
+            { url: "https://example.com/third", title: "Third", description: "third" },
+          ],
+        },
+      }),
+    );
+    global.fetch = mockFetch as typeof global.fetch;
+    const tool = createBraveTool({ webSearch: { apiKey: "brave-test-key", mode: "web" } });
+    const args = { query: "brave result count owner", count: 1 };
+
+    const first = await tool.execute(args);
+    const cached = await tool.execute(args);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(fetchRequestUrl(mockFetch).searchParams.get("count")).toBe("1");
+    expect(first).toMatchObject({ provider: "brave", count: 1 });
+    expect(first.results).toHaveLength(1);
+    expect(cached).toEqual({ ...first, cached: true });
+  });
+
   it("reports malformed Brave web search JSON as a provider error", async () => {
     vi.stubEnv("BRAVE_API_KEY", "");
     const mockFetch = vi.fn(async (_input?: unknown, _init?: unknown) => {

--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -431,7 +431,7 @@ async function runExaSearch(params: {
         const detail = await readExaErrorDetail(res);
         throw new Error(`Exa API error (${res.status}): ${detail || res.statusText}`);
       }
-      return readExaSearchResults(res);
+      return (await readExaSearchResults(res)).slice(0, params.count);
     },
   );
 }

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -54,6 +54,46 @@ function streamingJsonResponse(params: { chunkCount: number; chunkSize: number }
 }
 
 describe("exa web search provider", () => {
+  it("caps returned and cached results when Exa exceeds the requested count", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: [
+            { url: "https://example.com/first", title: "First", highlights: ["first"] },
+            { url: "https://example.com/second", title: "Second", highlights: ["second"] },
+            { url: "https://example.com/third", title: "Third", highlights: ["third"] },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const tool = createExaWebSearchProvider().createTool({
+      config: {
+        plugins: { entries: { exa: { config: { webSearch: { apiKey: "exa-test-key" } } } } },
+      },
+      searchConfig: {},
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    try {
+      const args = { query: "exa result count owner", count: 1 };
+      const first = await tool.execute(args);
+      const cached = await tool.execute(args);
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+        numResults: 1,
+      });
+      expect(first).toMatchObject({ provider: "exa", count: 1 });
+      expect(first.results).toHaveLength(1);
+      expect(cached).toEqual({ ...first, cached: true });
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("does not send or cache an already canceled search", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ results: [] }), {

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -83,7 +83,11 @@ describe("exa web search provider", () => {
       const cached = await tool.execute(args);
 
       expect(fetchMock).toHaveBeenCalledOnce();
-      expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+      const requestBody = fetchMock.mock.calls[0]?.[1]?.body;
+      if (typeof requestBody !== "string") {
+        throw new Error("Expected Exa request body to be a JSON string");
+      }
+      expect(JSON.parse(requestBody)).toMatchObject({
         numResults: 1,
       });
       expect(first).toMatchObject({ provider: "exa", count: 1 });

--- a/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
@@ -65,6 +65,7 @@ export async function executeParallelFreeWebSearchProviderTool(
     provider: "parallel-free",
     objective,
     searchQueries,
+    count,
     response,
     start,
   });

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -176,8 +176,9 @@ export function normalizeParallelResults(payload: unknown): ParallelSearchResult
 }
 
 /** Maps a Parallel v1 response into wrapped `web_search` result entries. */
-function mapParallelResults(response: ParallelSearchResponse): Record<string, unknown>[] {
-  return normalizeParallelResults(response).map((entry) => {
+function mapParallelResults(response: ParallelSearchResponse, count: number) {
+  const results = normalizeParallelResults(response).slice(0, count);
+  return results.map((entry) => {
     const title = typeof entry.title === "string" ? entry.title : "";
     const url = typeof entry.url === "string" ? entry.url : "";
     const published =
@@ -205,10 +206,11 @@ export function buildParallelSearchPayload(params: {
   provider: "parallel" | "parallel-free";
   objective?: string;
   searchQueries: readonly string[];
+  count: number;
   response: ParallelSearchResponse;
   start: number;
 }): Record<string, unknown> {
-  const results = mapParallelResults(params.response);
+  const results = mapParallelResults(params.response, params.count);
   const payload: Record<string, unknown> = {
     ...(params.objective ? { objective: params.objective } : {}),
     searchQueries: params.searchQueries,

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -241,6 +241,7 @@ export async function executeParallelWebSearchProviderTool(
     provider: "parallel",
     objective,
     searchQueries,
+    count,
     response,
     start,
   });

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -445,6 +445,40 @@ describe("parallel web search provider", () => {
     const body = readBody() as { advanced_settings?: { max_results?: number } };
     expect(body.advanced_settings?.max_results).toBe(5);
   });
+  it("caps returned and cached results when paid Parallel exceeds the requested count", async () => {
+    enqueueJson({
+      search_id: "parallel-result-cap",
+      session_id: "parallel-cap-session",
+      results: [
+        { url: "https://example.com/first", title: "First", excerpts: ["first"] },
+        { url: "https://example.com/second", title: "Second", excerpts: ["second"] },
+        { url: "https://example.com/third", title: "Third", excerpts: ["third"] },
+      ],
+      warnings: ["provider warning"],
+      usage: [{ count: 1 }],
+    });
+    const tool = paidTool();
+    const args = {
+      search_queries: ["parallel result count owner"],
+      session_id: "parallel-cap-session",
+      count: 1,
+    };
+
+    const first = await tool.execute(args);
+    const cached = await tool.execute(args);
+
+    expect(endpointMockState.calls).toHaveLength(1);
+    expect(readBody()).toMatchObject({ advanced_settings: { max_results: 1 } });
+    expect(first).toMatchObject({
+      count: 1,
+      searchId: "parallel-result-cap",
+      sessionId: "parallel-cap-session",
+      warnings: ["provider warning"],
+      usage: [{ count: 1 }],
+    });
+    expect(first.results).toHaveLength(1);
+    expect(cached).toEqual({ ...first, cached: true });
+  });
   it("bounds Parallel API error bodies without using response.text()", async () => {
     const tracked = cancelTrackedResponse(`${"parallel upstream unavailable ".repeat(1024)}tail`, {
       status: 503,

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -253,7 +253,7 @@ async function runPerplexitySearchApi(params: {
         res,
         "Perplexity Search",
       );
-      return (data.results ?? []).map((entry) => ({
+      return (data.results ?? []).slice(0, params.count).map((entry) => ({
         title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
         url: entry.url ?? "",
         description: entry.snippet ? wrapWebContent(entry.snippet, "web_search") : "",

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -117,6 +117,29 @@ describe("perplexity web search provider", () => {
     expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledTimes(2);
   });
 
+  it("caps returned and cached results when the Perplexity Search API exceeds the requested count", async () => {
+    withTrustedWebSearchEndpointMock.mockReset();
+    mockPerplexityResponseOnce({
+      results: [
+        { url: "https://example.com/first", title: "First", snippet: "first" },
+        { url: "https://example.com/second", title: "Second", snippet: "second" },
+        { url: "https://example.com/third", title: "Third", snippet: "third" },
+      ],
+    });
+    const tool = createConfiguredPerplexityTool(true);
+    const args = { query: "perplexity result count owner", count: 1 };
+
+    const first = await tool.execute(args);
+    const cached = await tool.execute(args);
+
+    expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledOnce();
+    const [request] = withTrustedWebSearchEndpointMock.mock.calls[0] as [{ init: RequestInit }];
+    expect(JSON.parse(request.init.body as string)).toMatchObject({ max_results: 1 });
+    expect(first).toMatchObject({ provider: "perplexity", count: 1 });
+    expect(first.results).toHaveLength(1);
+    expect(cached).toEqual({ ...first, cached: true });
+  });
+
   it.each([
     { name: "chat completions", structured: false, expectedRequests: 1 },
     { name: "native Search API", structured: true, expectedRequests: 2 },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users requesting a bounded number of web search results would receive and cache more results than requested whenever Brave web search, Exa, Parallel, or the Perplexity Search API returned an oversized response.

## Why This Change Was Made

Each affected provider forwarded the requested result limit upstream but trusted the response to honor it. Enforce the limit in each provider-owned result mapper before wrapping or caching results; Parallel carries the authoritative limit through its existing shared paid/free mapper. Brave LLM-context, Perplexity Sonar/chat completions, free Parallel MCP, request payloads, cache identity, metadata, public schemas, configuration, and authentication remain unchanged.

The production change adds four essential lines because the private Parallel mapper must receive the resolved limit from both existing callers. Independent inspection confirmed that DuckDuckGo, SearXNG, MiniMax, Ollama, Tavily, Firecrawl, and QA providers already enforce their result bounds; Gemini, Kimi, and xAI return synthesized answers rather than structured result lists.

## User Impact

Search tools now reliably return and cache no more results than requested across all affected structured search providers, preserving model-context budgets and accurate result-count metadata even when an upstream or compatible proxy overdelivers.

## Evidence

- Regression-first reproduction: Brave, Exa, and paid Parallel each failed with `count: 1` requested but `count: 3` returned; independent review identified the same Perplexity Search API defect, and its separate pre-fix regression failed with the identical mismatch.
- All four new boundary regressions verify the upstream request limit, returned result count, bounded rows, and cache-hit replay with the existing `cached: true` marker. Parallel additionally preserves search/session identifiers, warning metadata, and usage metadata.
- Full owner/sibling verification: **200 tests passed** across Brave, Exa, paid/free Parallel, Perplexity Search API/Sonar, MiniMax, Ollama, SearXNG, and DuckDuckGo provider suites:

  ```sh
  node scripts/run-vitest.mjs \
    extensions/brave/src/brave-web-search-provider.test.ts \
    extensions/exa/src/exa-web-search-provider.test.ts \
    extensions/parallel/src/parallel-web-search-provider.test.ts \
    extensions/perplexity/src/perplexity-web-search-provider.test.ts \
    extensions/minimax/src/minimax-web-search-provider.test.ts \
    extensions/ollama/src/web-search-provider.test.ts \
    extensions/searxng/src/searxng-search-provider.test.ts \
    extensions/duckduckgo/src/ddg-search-provider.test.ts
  ```

- Both max-lines/assertion-safety ratchets, environment-variable budget, focused extension lint, targeted formatting, and `git diff --check` passed.
- Independent source review and fresh authenticated Codex reviews of both the uncommitted change and complete committed branch reported no actionable findings.
- Production delta: **+4 lines**; focused regression coverage: **+123 lines**.
- Exact reviewed head: `48e28177428c0c3952bb50fa9862ab19225bfa8d`.
- Named owner-review follow-up, intentionally excluded from this fix: [Parallel currently documents a maximum of 20 results](https://docs.parallel.ai/search/advanced-search-settings), while the existing OpenClaw paid/free Parallel tool schemas and docs advertise 40. Reconciling that public schema/documentation contract requires an explicit owner/product decision; this PR does not change it.
