### PR TITLE
fix(discord): resolve configured default account for presence actions

### DIFF
--- a/extensions/discord/src/actions/runtime.presence.test.ts
+++ b/extensions/discord/src/actions/runtime.presence.test.ts
@@ -1,9 +1,10 @@
 // Discord tests cover runtime.presence plugin behavior.
-import type { DiscordActionConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { DiscordActionConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayPlugin } from "../internal/gateway.js";
 import { clearGateways, registerGateway } from "../monitor/gateway-registry.js";
 import type { ActionGate } from "../runtime-api.js";
+import { handleDiscordAction } from "./runtime.js";
 import { handleDiscordPresenceAction } from "./runtime.presence.js";
 
 const mockUpdatePresence = vi.fn();
@@ -14,19 +15,27 @@ function createMockGateway(connected = true): GatewayPlugin {
 
 const presenceEnabled: ActionGate<DiscordActionConfig> = (key) => key === "presence";
 const presenceDisabled: ActionGate<DiscordActionConfig> = () => false;
+const defaultDiscordConfig = {
+  channels: { discord: { token: "test-token", actions: { presence: true } } },
+} as OpenClawConfig;
 
 describe("handleDiscordPresenceAction", () => {
   async function setPresence(
     params: Record<string, unknown>,
     actionGate: ActionGate<DiscordActionConfig> = presenceEnabled,
   ) {
-    return await handleDiscordPresenceAction("setPresence", params, actionGate);
+    return await handleDiscordPresenceAction(
+      "setPresence",
+      params,
+      actionGate,
+      defaultDiscordConfig,
+    );
   }
 
   beforeEach(() => {
     mockUpdatePresence.mockClear();
     clearGateways();
-    registerGateway(undefined, createMockGateway());
+    registerGateway("default", createMockGateway());
   });
 
   it("sets playing activity", async () => {
@@ -34,6 +43,7 @@ describe("handleDiscordPresenceAction", () => {
       "setPresence",
       { activityType: "playing", activityName: "with fire", status: "online" },
       presenceEnabled,
+      defaultDiscordConfig,
     );
     expect(mockUpdatePresence).toHaveBeenCalledWith({
       since: null,
@@ -141,16 +151,65 @@ describe("handleDiscordPresenceAction", () => {
 
   it("errors when gateway is not connected", async () => {
     clearGateways();
-    registerGateway(undefined, createMockGateway(false));
+    registerGateway("default", createMockGateway(false));
     await expect(setPresence({ status: "dnd" })).rejects.toThrow(/not connected/);
   });
 
-  it("uses accountId to resolve gateway", async () => {
-    const accountGateway = createMockGateway();
-    registerGateway("my-account", accountGateway);
-    await setPresence({ accountId: "my-account", activityType: "playing", activityName: "test" });
-    expect(mockUpdatePresence).toHaveBeenCalled();
-  });
+  it.each([
+    { name: "implicit default account", cfg: defaultDiscordConfig, accountId: "default" },
+    {
+      name: "configured named default account",
+      cfg: {
+        channels: {
+          discord: {
+            actions: { presence: true },
+            defaultAccount: "ops",
+            accounts: { ops: { token: "ops-token" } },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "ops",
+    },
+    {
+      name: "explicit named account override",
+      cfg: {
+        channels: {
+          discord: {
+            token: "default-token",
+            actions: { presence: true },
+            accounts: { ops: { token: "ops-token" } },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "ops",
+      requestedAccountId: "ops",
+    },
+  ])(
+    "routes the full presence action to the $name",
+    async ({ cfg, accountId, requestedAccountId }) => {
+      const updatePresence = vi.fn();
+      registerGateway(accountId, {
+        isConnected: true,
+        updatePresence,
+      } as unknown as GatewayPlugin);
+
+      await handleDiscordAction(
+        {
+          action: "setPresence",
+          status: "idle",
+          ...(requestedAccountId ? { accountId: requestedAccountId } : {}),
+        },
+        cfg,
+      );
+
+      expect(updatePresence).toHaveBeenCalledWith({
+        since: null,
+        activities: [],
+        status: "idle",
+        afk: false,
+      });
+    },
+  );
 
   it("requires activityType when activityName is provided", async () => {
     await expect(setPresence({ activityName: "My Game" })).rejects.toThrow(
@@ -159,8 +218,8 @@ describe("handleDiscordPresenceAction", () => {
   });
 
   it("rejects unknown presence actions", async () => {
-    await expect(handleDiscordPresenceAction("unknownAction", {}, presenceEnabled)).rejects.toThrow(
-      /Unknown presence action/,
-    );
+    await expect(
+      handleDiscordPresenceAction("unknownAction", {}, presenceEnabled, defaultDiscordConfig),
+    ).rejects.toThrow(/Unknown presence action/);
   });
 });

--- a/extensions/discord/src/actions/runtime.presence.ts
+++ b/extensions/discord/src/actions/runtime.presence.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements runtime.presence behavior.
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveDefaultDiscordAccountId } from "../accounts.js";
 import type { Activity, UpdatePresenceData } from "../internal/gateway.js";
 import { getGateway } from "../monitor/gateway-registry.js";
 import {
@@ -8,6 +9,7 @@ import {
   jsonResult,
   readStringParam,
   type DiscordActionConfig,
+  type OpenClawConfig,
 } from "../runtime-api.js";
 
 const ACTIVITY_TYPE_MAP: Record<string, number> = {
@@ -25,6 +27,7 @@ export async function handleDiscordPresenceAction(
   action: string,
   params: Record<string, unknown>,
   isActionEnabled: ActionGate<DiscordActionConfig>,
+  cfg: OpenClawConfig,
 ): Promise<AgentToolResult<unknown>> {
   if (action !== "setPresence") {
     throw new Error(`Unknown presence action: ${action}`);
@@ -34,17 +37,15 @@ export async function handleDiscordPresenceAction(
     throw new Error("Discord presence changes are disabled.");
   }
 
-  const accountId = readStringParam(params, "accountId");
+  const accountId = readStringParam(params, "accountId") ?? resolveDefaultDiscordAccountId(cfg);
   const gateway = getGateway(accountId);
   if (!gateway) {
     throw new Error(
-      `Discord gateway not available${accountId ? ` for account "${accountId}"` : ""}. The bot may not be connected.`,
+      `Discord gateway not available for account "${accountId}". The bot may not be connected.`,
     );
   }
   if (!gateway.isConnected) {
-    throw new Error(
-      `Discord gateway is not connected${accountId ? ` for account "${accountId}"` : ""}.`,
-    );
+    throw new Error(`Discord gateway is not connected for account "${accountId}".`);
   }
 
   const statusRaw = readStringParam(params, "status") ?? "online";

--- a/extensions/discord/src/actions/runtime.ts
+++ b/extensions/discord/src/actions/runtime.ts
@@ -54,8 +54,6 @@ const guildActions = new Set([
 
 const moderationActions = new Set(["timeout", "kick", "ban"]);
 
-const presenceActions = new Set(["setPresence"]);
-
 export async function handleDiscordAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
@@ -74,8 +72,8 @@ export async function handleDiscordAction(
   if (moderationActions.has(action)) {
     return await handleDiscordModerationAction(action, params, isActionEnabled, cfg);
   }
-  if (presenceActions.has(action)) {
-    return await handleDiscordPresenceAction(action, params, isActionEnabled);
+  if (action === "setPresence") {
+    return await handleDiscordPresenceAction(action, params, isActionEnabled, cfg);
   }
   throw new Error(`Unknown action: ${action}`);
 }


### PR DESCRIPTION
_AI-assisted PR (Claude)._

Closes #127702.

## What Problem This Solves

A connected Discord bot rejects `setPresence` whenever `accountId` is omitted, even though the same action works when the operator supplies the effective account explicitly. The bug affects both the implicit `default` account and configured named default accounts.

## Why This Change Was Made

The presence action previously passed an omitted account ID into the gateway registry, which resolves omission to a private unnamed-account sentinel. Real gateways are registered under their resolved account IDs, so the lookup always missed. Resolve the effective account with `accountId ?? resolveDefaultDiscordAccountId(cfg)` at the canonical presence-action owner, matching sibling Discord account resolution. Keep the private sentinel distinct, retain explicit account overrides, and remove the obsolete single-entry action set.

Production LOC: +8/-9 (net -1). Tests: +72/-13.

## User Impact

Discord presence updates succeed for an implicit default account, a configured named default account, and an explicit named override without requiring operators to pass redundant account IDs. Existing disabled-action, disconnected-gateway, and sentinel behavior remain intact.

## Evidence

- Before repair: the affected owner regressions fail on current `main` (16 failing cases, four unaffected cases passing).
- After repair: all 227 tests pass across the four presence, account-resolution, gateway-registry, and runtime action suites.
- Real isolated Discord transport proof: production code connects to a localhost WebSocket server, completes Discord `HELLO` → `IDENTIFY` → `READY`, and sends an actual serialized opcode-3 presence frame for the implicit default, configured named default, and explicit named account. The registry sentinel remains distinct. No external credentials or networks are involved.
- `env -u OPENCLAW_TESTBOX OPENCLAW_LOCAL_CHECK=1 node scripts/check-changed.mjs -- extensions/discord/src/actions/runtime.presence.ts extensions/discord/src/actions/runtime.ts extensions/discord/src/actions/runtime.presence.test.ts`: complete changed gate passes without skipped guards, including production and test typechecking, lint, formatting, dead code, storage boundaries, and import cycles.
- Fresh structured autoreview: clean. Independent reviewer reran all 227 tests and approved the actual Discord transport proof.
- Exact reviewed head: `ff8cf5971bde563f6468f117a2284c2289375fb2`.
- Original contributor attribution is preserved in the commit as `Co-authored-by: chelsealong <chelsealong@126.com>`.
