### PR TITLE
feat(ollama): record provider prompt/output timing in usage

### DIFF
--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -381,7 +381,14 @@ const NANOSECONDS_PER_MILLISECOND = 1_000_000;
 function resolveUsageTiming(response: OllamaChatResponse): Usage["timing"] {
   const promptNs = response.prompt_eval_duration;
   const outputNs = response.eval_duration;
-  if (typeof promptNs !== "number" || typeof outputNs !== "number") {
+  if (
+    typeof promptNs !== "number" ||
+    !Number.isFinite(promptNs) ||
+    promptNs < 0 ||
+    typeof outputNs !== "number" ||
+    !Number.isFinite(outputNs) ||
+    outputNs < 0
+  ) {
     return undefined;
   }
   return {

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -352,6 +352,7 @@ function buildUsageWithNoCost(params: {
   cacheWrite?: number;
   cacheTelemetry?: Usage["cacheTelemetry"];
   totalTokens?: number;
+  timing?: Usage["timing"];
 }): Usage {
   const input = params.input ?? 0;
   const output = params.output ?? 0;
@@ -368,8 +369,24 @@ function buildUsageWithNoCost(params: {
     cacheRead,
     cacheWrite,
     cacheTelemetry,
+    ...(params.timing ? { timing: params.timing } : {}),
     totalTokens: params.totalTokens ?? input + output,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+const NANOSECONDS_PER_MILLISECOND = 1_000_000;
+
+/** Ollama reports durations in nanoseconds; both must be present for a usable split. */
+function resolveUsageTiming(response: OllamaChatResponse): Usage["timing"] {
+  const promptNs = response.prompt_eval_duration;
+  const outputNs = response.eval_duration;
+  if (typeof promptNs !== "number" || typeof outputNs !== "number") {
+    return undefined;
+  }
+  return {
+    promptMs: Math.round(promptNs / NANOSECONDS_PER_MILLISECOND),
+    outputMs: Math.round(outputNs / NANOSECONDS_PER_MILLISECOND),
   };
 }
 
@@ -866,6 +883,7 @@ export function buildAssistantMessage(
     usage: buildUsageWithNoCost({
       input: resolveUsageCount(response.prompt_eval_count, usageFallback?.input),
       output: resolveUsageCount(response.eval_count, usageFallback?.output),
+      timing: resolveUsageTiming(response),
     }),
   });
 }

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -915,6 +915,35 @@ describe("createOllamaStreamFn thinking events", () => {
     expect(done?.message?.usage).not.toHaveProperty("timing");
   });
 
+  it.each([
+    { prompt_eval_duration: -1, eval_duration: 10 },
+    { prompt_eval_duration: 10, eval_duration: -1 },
+    { prompt_eval_duration: Number.NaN, eval_duration: 10 },
+    { prompt_eval_duration: 10, eval_duration: Number.POSITIVE_INFINITY },
+  ])("omits invalid provider timing %#", async (durations) => {
+    const events = await streamOllamaEvents(
+      [
+        {
+          model: "qwen3.5",
+          created_at: "2026-01-01T00:00:00Z",
+          message: { role: "assistant", content: "ok" },
+          done: true,
+          done_reason: "stop",
+          prompt_eval_count: 10,
+          eval_count: 1,
+          ...durations,
+        },
+      ],
+      {},
+      { messages: [{ role: "user", content: "hi" }] } as never,
+    );
+
+    const done = events.find((event) => event.type === "done") as {
+      message?: { usage?: { timing?: unknown } };
+    };
+    expect(done?.message?.usage).not.toHaveProperty("timing");
+  });
+
   it("keeps provider usage authoritative over the CJK fallback", async () => {
     const events = await streamOllamaEvents(
       [

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -867,6 +867,54 @@ describe("createOllamaStreamFn thinking events", () => {
     });
   });
 
+  it("records the provider prompt/output timing split in milliseconds", async () => {
+    const events = await streamOllamaEvents(
+      [
+        {
+          model: "qwen3.5",
+          created_at: "2026-01-01T00:00:00Z",
+          message: { role: "assistant", content: "ok" },
+          done: true,
+          done_reason: "stop",
+          prompt_eval_count: 10,
+          eval_count: 1,
+          prompt_eval_duration: 1_234_567_890,
+          eval_duration: 98_765_432,
+        },
+      ],
+      {},
+      { messages: [{ role: "user", content: "hi" }] } as never,
+    );
+
+    const done = events.find((event) => event.type === "done") as {
+      message?: { usage?: { timing?: { promptMs: number; outputMs: number } } };
+    };
+    expect(done?.message?.usage?.timing).toEqual({ promptMs: 1235, outputMs: 99 });
+  });
+
+  it("omits usage timing when the provider reports no durations", async () => {
+    const events = await streamOllamaEvents(
+      [
+        {
+          model: "qwen3.5",
+          created_at: "2026-01-01T00:00:00Z",
+          message: { role: "assistant", content: "ok" },
+          done: true,
+          done_reason: "stop",
+          prompt_eval_count: 10,
+          eval_count: 1,
+        },
+      ],
+      {},
+      { messages: [{ role: "user", content: "hi" }] } as never,
+    );
+
+    const done = events.find((event) => event.type === "done") as {
+      message?: { usage?: { timing?: unknown } };
+    };
+    expect(done?.message?.usage).not.toHaveProperty("timing");
+  });
+
   it("keeps provider usage authoritative over the CJK fallback", async () => {
     const events = await streamOllamaEvents(
       [

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -293,6 +293,12 @@ export interface Usage {
   cacheTelemetry?: { state: "available" | "unavailable" };
   /** Subset of `cacheWrite` written with 1-hour retention when reported. */
   cacheWrite1h?: number;
+  /**
+   * Provider-reported wall-clock split for the final iteration, when the API
+   * exposes it. Prefill time that stays flat while the prompt grows is the only
+   * cache-reuse signal for providers that report no cached-token counts.
+   */
+  timing?: { promptMs: number; outputMs: number };
   /** Exact context snapshot for the final provider iteration. */
   contextUsage?:
     | { state: "available"; promptTokens: number; totalTokens: number }

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -283,7 +283,13 @@ export interface ToolCall {
   executionMode?: "sequential" | "parallel";
 }
 
-/** Normalized token and cost accounting for a provider response. */
+/** Provider-reported wall-clock split for the final response iteration. */
+export interface UsageTiming {
+  promptMs: number;
+  outputMs: number;
+}
+
+/** Normalized token, timing, and cost accounting for a provider response. */
 export interface Usage {
   input: number;
   output: number;
@@ -298,7 +304,7 @@ export interface Usage {
    * exposes it. Prefill time that stays flat while the prompt grows is the only
    * cache-reuse signal for providers that report no cached-token counts.
    */
-  timing?: { promptMs: number; outputMs: number };
+  timing?: UsageTiming;
   /** Exact context snapshot for the final provider iteration. */
   contextUsage?:
     | { state: "available"; promptTokens: number; totalTokens: number }

--- a/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
@@ -616,6 +616,31 @@ describe("sanitizeSessionHistory", () => {
     });
   });
 
+  it("preserves provider timing while rebuilding assistant usage snapshots", async () => {
+    const assistant = await getSingleAssistantUsage(
+      castAgentMessages([
+        { role: "user", content: "question" },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "answer with timing" }],
+          usage: {
+            input: 4,
+            output: 2,
+            totalTokens: 6,
+            timing: { promptMs: 123.45, outputMs: 67.89 },
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+        },
+      ]),
+    );
+
+    expect((assistant?.usage as Usage | undefined)?.timing).toEqual({
+      promptMs: 123.45,
+      outputMs: 67.89,
+    });
+    expectAssistantUsageSnapshot(assistant);
+  });
+
   it("preserves existing usage cost while normalizing token fields", async () => {
     const assistant = await getSingleAssistantUsage(
       castAgentMessages([

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -494,9 +494,27 @@ function normalizeAssistantUsageSnapshot(usage: unknown) {
     cacheRead,
     cacheWrite,
     ...(normalized.contextUsage ? { contextUsage: { ...normalized.contextUsage } } : {}),
+    ...(normalized.timing ? { timing: { ...normalized.timing } } : {}),
     totalTokens,
     ...(cost ? { cost } : {}),
   };
+}
+
+function assistantUsageTimingMatches(
+  raw: unknown,
+  normalized: AssistantUsageSnapshot["timing"],
+): boolean {
+  if (!normalized) {
+    return raw === undefined;
+  }
+  return (
+    raw !== null &&
+    typeof raw === "object" &&
+    "promptMs" in raw &&
+    raw.promptMs === normalized.promptMs &&
+    "outputMs" in raw &&
+    raw.outputMs === normalized.outputMs
+  );
 }
 
 function normalizeAssistantUsageCost(usage: unknown): AssistantUsageSnapshot["cost"] | undefined {
@@ -570,6 +588,12 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
               normalizedContextUsage.promptTokens &&
             (rawContextUsage as { totalTokens?: unknown }).totalTokens ===
               normalizedContextUsage.totalTokens;
+    const rawTiming =
+      message.usage && typeof message.usage === "object" && "timing" in message.usage
+        ? message.usage.timing
+        : undefined;
+    const normalizedTiming = normalizedUsage.timing;
+    const timingMatches = assistantUsageTimingMatches(rawTiming, normalizedTiming);
     const normalizedCost = normalizedUsage.cost;
     if (
       message.usage &&
@@ -580,6 +604,7 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
       (message.usage as { cacheWrite?: unknown }).cacheWrite === normalizedUsage.cacheWrite &&
       (message.usage as { totalTokens?: unknown }).totalTokens === normalizedUsage.totalTokens &&
       contextUsageMatches &&
+      timingMatches &&
       ((normalizedCost &&
         usageCost &&
         typeof usageCost === "object" &&

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -197,6 +197,25 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("preserves finite non-negative provider timing", () => {
+    expect(
+      normalizeUsage({
+        input: 12,
+        output: 3,
+        timing: { promptMs: 123.45, outputMs: 67.89 },
+      }),
+    ).toMatchObject({ timing: { promptMs: 123.45, outputMs: 67.89 } });
+  });
+
+  it.each([
+    { promptMs: -1, outputMs: 2 },
+    { promptMs: 1, outputMs: -2 },
+    { promptMs: Number.NaN, outputMs: 2 },
+    { promptMs: 1, outputMs: Number.POSITIVE_INFINITY },
+  ])("drops invalid provider timing %#", (timing) => {
+    expect(normalizeUsage({ input: 12, timing })).not.toHaveProperty("timing");
+  });
+
   it.each([
     { provider: "Anthropic", details: { thinking_tokens: 17 }, expected: 17 },
     { provider: "Anthropic zero", details: { thinking_tokens: 0 }, expected: 0 },

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -15,6 +15,7 @@ export type UsageLike = {
   cacheRead?: number;
   cacheWrite?: number;
   contextUsage?: ContextUsage;
+  timing?: Usage["timing"];
   total?: number;
   // Common alternates across providers/SDKs.
   inputTokens?: number;
@@ -68,6 +69,7 @@ export type NormalizedUsage = {
   cacheRead?: number;
   cacheWrite?: number;
   contextUsage?: ContextUsage;
+  timing?: Usage["timing"];
   reasoningTokens?: number;
   total?: number;
 };
@@ -143,6 +145,18 @@ const normalizeTokenCount = (value: unknown): number | undefined => {
     return 0;
   }
   return Math.min(Math.trunc(numeric), Number.MAX_SAFE_INTEGER);
+};
+
+const normalizeUsageTiming = (timing: UsageLike["timing"]): Usage["timing"] => {
+  if (!timing) {
+    return undefined;
+  }
+  const promptMs = asFiniteNumber(timing.promptMs);
+  const outputMs = asFiniteNumber(timing.outputMs);
+  if (promptMs === undefined || outputMs === undefined || promptMs < 0 || outputMs < 0) {
+    return undefined;
+  }
+  return { promptMs, outputMs };
 };
 
 /** Normalize provider-specific token usage fields into OpenClaw usage buckets. */
@@ -236,6 +250,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
             totalTokens: contextTotalTokens,
           } as const)
         : undefined;
+  const timing = normalizeUsageTiming(raw.timing);
   const reasoningTokens = normalizeTokenCount(
     raw.reasoningTokens ??
       raw.reasoning_tokens ??
@@ -251,6 +266,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     cacheRead === undefined &&
     cacheWrite === undefined &&
     contextUsage === undefined &&
+    timing === undefined &&
     reasoningTokens === undefined &&
     total === undefined
   ) {
@@ -263,6 +279,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     cacheRead,
     cacheWrite,
     ...(contextUsage ? { contextUsage } : {}),
+    ...(timing ? { timing } : {}),
     ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
     total,
   };


### PR DESCRIPTION
## What Problem This Solves

Ollama-backed sessions (`ollama-cloud/*`, `ollama-local/*`, and custom `api: "ollama"` providers) always show `cacheRead: 0 / cacheWrite: 0` because Ollama's `/api/chat` response has no cached-token field. It does report prompt-evaluation and output-evaluation durations, so operators can use prefill time as the available cache-reuse signal.

## Why This Change Was Made

This adds an optional generic `usage.timing = { promptMs, outputMs }` contract and populates it from Ollama's `prompt_eval_duration` / `eval_duration` fields (nanoseconds to milliseconds). The timing split is preserved by shared usage normalization and replay reconstruction, while malformed negative or non-finite durations are omitted.

This is diagnostic parity rather than identical telemetry: providers that expose cached-token counts continue to populate `cacheRead`; Ollama timing helps distinguish flat prefill latency from prompt-size-linear prefill when exact cache counts are unavailable.

## User Impact

Ollama turns persist `usage.timing` alongside existing usage fields, including after transcript replay normalization. Other providers are unchanged and leave `timing` absent unless they adopt the generic contract.

## Evidence

- Ollama's current API contract documents all durations as nanoseconds and exposes `prompt_eval_duration` / `eval_duration` on final chat responses: https://github.com/ollama/ollama/blob/main/docs/api.md
- `node scripts/run-vitest.mjs extensions/ollama/src/stream.test.ts` — 39/39 passed.
- `node scripts/run-vitest.mjs src/agents/usage.test.ts` — 55/55 passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner.sanitize-session-history.test.ts` — 81/81 passed.
- Changed-file coverage — all selected typecheck, lint, formatting, dead-code, and repository contract lanes passed; the extension-lint wrapper timed out once behind an orphaned boundary-artifact process (exit 143), then its exact lane rerun passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings.

## Remaining Proof Gap

A real Ollama completion/transcript artifact was not produced: this host has no running Ollama service, and no paired node advertises a local Ollama model. The implementation and replay path are covered, but this external live-provider proof remains required before merge unless a maintainer explicitly waives it. No cloud subscription usage was spent.

https://claude.ai/code/session_01Bgm7tHSDcDc8RaFnH9YJHL


## Worked on by
- @VACInc