### PR TITLE
fix(ui): prevent second touches from hijacking resize drags

### DIFF
--- a/ui/src/components/resizable-divider.test.ts
+++ b/ui/src/components/resizable-divider.test.ts
@@ -74,14 +74,14 @@ async function renderDivider() {
   return divider;
 }
 
-function dispatchPointer(target: EventTarget, type: string, clientX: number) {
+function dispatchPointer(target: EventTarget, type: string, clientX: number, pointerId = 7) {
   target.dispatchEvent(
     new PointerEvent(type, {
       bubbles: true,
       button: 0,
       cancelable: true,
       clientX,
-      pointerId: 7,
+      pointerId,
       pointerType: "touch",
     }),
   );
@@ -204,7 +204,7 @@ describe("resizable-divider", () => {
     expectLastResizeRatio(resized, 0.65);
   });
 
-  it("uses pointer events for mouse, pen, and touch dragging", async () => {
+  it("keeps dragging owned by the initiating pointer", async () => {
     const divider = await renderDivider();
     const resized = vi.fn();
     const resizeEnded = vi.fn();
@@ -222,17 +222,29 @@ describe("resizable-divider", () => {
     expect([...divider.classList]).toEqual(["dragging"]);
     expect(setPointerCapture).toHaveBeenCalledWith(7);
 
-    dispatchPointer(document, "pointermove", 220);
+    dispatchPointer(divider, "pointerdown", 180, 8);
+    dispatchPointer(document, "pointermove", 220, 8);
+    dispatchPointer(document, "pointercancel", 220, 8);
+    dispatchPointer(document, "pointerup", 220, 8);
+
+    expect(setPointerCapture).toHaveBeenCalledTimes(1);
+    expect(resized).not.toHaveBeenCalled();
+    expect(resizeEnded).not.toHaveBeenCalled();
+    expect([...divider.classList]).toEqual(["dragging"]);
+
+    dispatchPointer(document, "pointermove", 220, 7);
     expectLastResizeRatio(resized, 0.7);
     expect(resizeEnded).not.toHaveBeenCalled();
 
-    dispatchPointer(document, "pointerup", 220);
+    dispatchPointer(document, "pointerup", 220, 7);
     const endEvent = resizeEnded.mock.lastCall?.[0] as
       | CustomEvent<{ splitRatio: number }>
       | undefined;
     expect(endEvent?.detail).toEqual({ splitRatio: 0.7 });
+    expect(resizeEnded).toHaveBeenCalledTimes(1);
     expect([...divider.classList]).toEqual([]);
     expect(releasePointerCapture).toHaveBeenCalledWith(7);
+    expect(releasePointerCapture).toHaveBeenCalledTimes(1);
   });
 
   it("stops dragging when the window loses focus", async () => {

--- a/ui/src/components/resizable-divider.ts
+++ b/ui/src/components/resizable-divider.ts
@@ -126,7 +126,7 @@ class ResizableDivider extends OpenClawLitElement {
   }
 
   private handlePointerDown = (e: PointerEvent) => {
-    if (e.button !== 0) {
+    if (e.button !== 0 || this.activePointerId !== null) {
       return;
     }
     this.startPosition = this.orientation === "horizontal" ? e.clientY : e.clientX;
@@ -144,7 +144,7 @@ class ResizableDivider extends OpenClawLitElement {
   };
 
   private handlePointerMove = (e: PointerEvent) => {
-    if (this.activePointerId === null) {
+    if (e.pointerId !== this.activePointerId) {
       return;
     }
 
@@ -205,7 +205,10 @@ class ResizableDivider extends OpenClawLitElement {
     this.emitResizeEnd(nextRatio);
   };
 
-  private readonly finishDragging = () => {
+  private readonly finishDragging = (event: Event) => {
+    if ("pointerId" in event && event.pointerId !== this.activePointerId) {
+      return;
+    }
     if (this.activePointerId !== null) {
       this.emitResizeEnd(this.dragRatio);
     }
@@ -213,11 +216,12 @@ class ResizableDivider extends OpenClawLitElement {
   };
 
   private stopDragging() {
-    if (this.activePointerId === null) {
+    const pointerId = this.activePointerId;
+    if (pointerId === null) {
       return;
     }
     this.classList.remove("dragging");
-    this.releaseActivePointer();
+    this.releaseActivePointer(pointerId);
 
     window.removeEventListener("pointermove", this.handlePointerMove);
     for (const type of DRAG_END_EVENTS) {
@@ -281,10 +285,9 @@ class ResizableDivider extends OpenClawLitElement {
     this.setPointerCapture(pointerId);
   }
 
-  private releaseActivePointer() {
-    const pointerId = this.activePointerId;
+  private releaseActivePointer(pointerId: number) {
     this.activePointerId = null;
-    if (pointerId == null || typeof this.releasePointerCapture !== "function") {
+    if (typeof this.releasePointerCapture !== "function") {
       return;
     }
     if (typeof this.hasPointerCapture === "function" && !this.hasPointerCapture(pointerId)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users resizing a Control UI split view with touch could have a second contact unexpectedly move the divider or end the first contact's drag. The defect affected every surface using the shared resizable divider, including the chat sidebar.

## Why This Change Was Made

The shared divider now binds each drag to the pointer that started it: later pointer-downs and foreign moves/ends are ignored, while the owning pointer can continue and finish exactly once. Pointer up, pointer cancel, and window blur share one completion listener; pointer events must match the active pointer, while blur remains global cleanup. This preserves pointer capture/release and `resize-end` semantics without adding a parallel lifecycle.

## User Impact

Multi-touch interactions no longer let another finger hijack or terminate an in-progress resize. Mouse, pen, single-touch, keyboard resizing, and blur cleanup retain their existing behavior.

## Evidence

**Before fix** — a real source-mode Chromium run starts at 20%; the foreign touch moves the divider to 31%, its pointer-up terminates the owner's drag, and the owner then cannot continue:

https://ampcode.com/user-content/artifacts/b82927097bb88fa1a9d9be24db73e1f5668c18f5595cdfacf4fc3bfcc8158f9c-file.mp4

**After fix** — the same concurrent-contact interaction stays at 20% for the foreign move and foreign finish, lets the owner continue to 27%, and ends exactly once on the owner finish:

https://ampcode.com/user-content/artifacts/21b4aebcbed927c714e5a5304422c380ba6bce5cfd2df6d1a3010854ffe74a74-file.mp4

Input-proof scope: native CDP created both concurrent touch contacts and performed the foreign-only move. Chromium mapped touch IDs 11/22 to browser pointer IDs 2/3 in the recorded run. CDP `Input.dispatchTouchEvent` did not provide a selective lift of only the foreign contact, and in this Chrome build it also did not produce the desired owner continuation after that multi-touch sequence. The selective foreign `pointerup` and subsequent owner `pointermove`/`pointerup` were therefore intentionally dispatched as browser `PointerEvent`s on `window`, the divider's real listener boundary. CDP `touchEnd` then cleaned up the native contacts. This is not a fully native selective-lift proof.

Validation on exact head `6abe2d55ee1adcb77b86118b53c638202a0c5778`:

- Authentic pre-fix unit regression failed by showing pointer 8 recaptured an owner-7 drag; fixed focused suite: **6/6 passed**.
- Source-mode Chromium before/after proof exercised concurrent native CDP contacts, a foreign-only native move, and exact browser listener-boundary finish/continuation events.
- `node scripts/check-changed.mjs --timed -- ui/src/components/resizable-divider.ts ui/src/components/resizable-divider.test.ts` passed all `coreTests, ui` checks (format, lint, UI/core-test types, i18n, repository guards, and dead-code scan).
- Exact CI-Node `pnpm ui:build` passed; startup JS gzip is **345,021 B** against the **345,043 B** limit.
- Fresh complete-branch autoreview: no accepted/actionable findings, **0.96 confidence**; verified pointer ownership, foreign-event rejection, blur cleanup, pointer-capture release, and single completion.
- Direct sibling Codex inspection: `codex-rs/tui/src/transcript_reflow.rs` owns terminal resize scheduling only and has no shared browser pointer-capture contract.

Production LOC: **+11/-8 (net +3)** | Tests: **+17/-5**.


