### PR TITLE
fix(browser): give a paired extension time to attach before declaring it offline

### DIFF
--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -12,7 +12,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket, type RawData } from "ws";
 import { parsePairingString } from "../../../chrome-extension/modules/relay-core.js";
 import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
-import { getBrowserControlState, stopBrowserControlService } from "../../control-service.js";
+import {
+  createBrowserControlContext,
+  getBrowserControlState,
+  stopBrowserControlService,
+} from "../../control-service.js";
 import { buildBrowserExtensionPairing } from "../extension-pairing.js";
 import { getFreePort } from "../test-port.js";
 import { createRelayProof, randomRelayNonce, relayKeyIdFromHex } from "./auth-v2-crypto.js";
@@ -153,6 +157,15 @@ describe.sequential("local Gateway extension relay wakeup", () => {
             expect(relay?.port).toBe(pairing.relayPort);
             if (!relay) {
               throw new Error("extension relay did not start");
+            }
+
+            for (let request = 0; request < 3; request += 1) {
+              const profile = createBrowserControlContext().forProfile("chrome").profile;
+              const cdpUrl = new URL(profile.cdpUrl);
+              expect(cdpUrl.username).toBe("openclaw-internal");
+              expect(cdpUrl.password === relay.internalToken).toBe(true);
+              expect(getBrowserControlState()?.extensionRelays?.get("chrome")).toBe(relay);
+              expect(extension.readyState).toBe(WebSocket.OPEN);
             }
 
             const authorization = Buffer.from(`openclaw-internal:${relay.internalToken}`).toString(

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -15,6 +15,7 @@ import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.j
 import {
   createBrowserControlContext,
   getBrowserControlState,
+  startBrowserControlServiceFromConfig,
   stopBrowserControlService,
 } from "../../control-service.js";
 import { buildBrowserExtensionPairing } from "../extension-pairing.js";
@@ -50,144 +51,161 @@ afterEach(async () => {
 });
 
 describe.sequential("local Gateway extension relay wakeup", () => {
-  it("starts Browser control and the CDP relay from the first authenticated extension request", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-relay-wakeup-"));
-    try {
-      const gatewayPort = await getFreePort();
-      let relayPort = await getFreePort();
-      while (relayPort === gatewayPort) {
-        relayPort = await getFreePort();
+  it.each([false, true])(
+    "authenticates the extension while a browser request is already waiting: %s",
+    async (browserRequestAlreadyWaiting) => {
+      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-relay-wakeup-"));
+      try {
+        const gatewayPort = await getFreePort();
+        let relayPort = await getFreePort();
+        while (relayPort === gatewayPort) {
+          relayPort = await getFreePort();
+        }
+        await fs.mkdir(path.join(stateDir, "credentials"), { recursive: true });
+        await fs.writeFile(
+          path.join(stateDir, "credentials", "browser-extension-relay.secret"),
+          `${RELAY_KEY}\n`,
+          { mode: 0o600 },
+        );
+
+        const config = {
+          gateway: {
+            port: gatewayPort,
+            auth: { mode: "token" as const, token: "gateway-integration-test" },
+          },
+          browser: {
+            enabled: true,
+            extensionRelay: { allowLegacyAuth: false },
+            profiles: { chrome: { driver: "extension" as const, cdpPort: relayPort } },
+          },
+        };
+        setRuntimeConfigSnapshot(config, config);
+
+        await withEnvAsync(
+          {
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_GATEWAY_PORT: String(gatewayPort),
+          },
+          async () => {
+            const gatewayServer = http.createServer((_req, res) => {
+              res.writeHead(426);
+              res.end();
+            });
+            gatewayServer.on("upgrade", (req, socket, head) => {
+              void handleGatewayExtensionUpgrade(req, socket, head);
+            });
+            let extension: WebSocket | undefined;
+            const requestController = new AbortController();
+            let browserAvailable: Promise<void> | undefined;
+            try {
+              await new Promise<void>((resolve) => {
+                gatewayServer.listen(gatewayPort, "127.0.0.1", resolve);
+              });
+              expect(getBrowserControlState()).toBeNull();
+
+              const pairing = await buildBrowserExtensionPairing({
+                cfg: config,
+                localTransport: "gateway",
+                ensureToken: async () => RELAY_KEY,
+              });
+              expect(pairing).toMatchObject({ relayPort, topology: "local" });
+              const parsed = parsePairingString(pairing.pairingString);
+              if (!parsed) {
+                throw new Error("local pairing did not parse");
+              }
+
+              if (browserRequestAlreadyWaiting) {
+                await startBrowserControlServiceFromConfig();
+                browserAvailable = createBrowserControlContext()
+                  .forProfile("chrome")
+                  .ensureBrowserAvailable({ signal: requestController.signal });
+              }
+
+              extension = new WebSocket(parsed.relayUrl, BROWSER_RELAY_EXTENSION_SUBPROTOCOL, {
+                origin: "chrome-extension://gateway-wakeup-integration",
+              });
+              await once(extension, "open");
+              const clientNonce = randomRelayNonce();
+              const challengeMessage = once(extension, "message");
+              extension.send(
+                JSON.stringify({
+                  type: "auth.hello",
+                  v: 2,
+                  keyId: relayKeyIdFromHex(RELAY_KEY),
+                  clientNonce,
+                }),
+              );
+              const [challengeData] = (await challengeMessage) as [RawData];
+              const challenge = JSON.parse(rawDataText(challengeData));
+              const okMessage = once(extension, "message", {
+                signal: AbortSignal.timeout(2_000),
+              });
+              extension.send(
+                JSON.stringify({
+                  type: "auth.response",
+                  v: 2,
+                  sessionId: challenge.sessionId,
+                  clientProof: createRelayProof(RELAY_KEY, "client", challenge),
+                }),
+              );
+              const [okData] = (await okMessage) as [RawData];
+              expect(JSON.parse(rawDataText(okData))).toMatchObject({ type: "auth.ok", v: 2 });
+              extension.send(
+                JSON.stringify({
+                  type: "hello",
+                  userAgent: "gateway-wakeup-test",
+                  browserVersion: "Chrome/test",
+                  extensionVersion: "2",
+                  tabs: [],
+                }),
+              );
+
+              await expect
+                .poll(
+                  () =>
+                    getBrowserControlState()?.extensionRelays?.get("chrome")?.bridge
+                      .extensionConnected,
+                )
+                .toBe(true);
+              await expect(browserAvailable ?? Promise.resolve()).resolves.toBeUndefined();
+              const relay = getBrowserControlState()?.extensionRelays?.get("chrome");
+              expect(relay?.port).toBe(pairing.relayPort);
+              if (!relay) {
+                throw new Error("extension relay did not start");
+              }
+
+              for (let request = 0; request < 3; request += 1) {
+                const profile = createBrowserControlContext().forProfile("chrome").profile;
+                const cdpUrl = new URL(profile.cdpUrl);
+                expect(cdpUrl.username).toBe("openclaw-internal");
+                expect(cdpUrl.password === relay.internalToken).toBe(true);
+                expect(getBrowserControlState()?.extensionRelays?.get("chrome")).toBe(relay);
+                expect(extension.readyState).toBe(WebSocket.OPEN);
+              }
+
+              const authorization = Buffer.from(
+                `openclaw-internal:${relay.internalToken}`,
+              ).toString("base64");
+              const response = await fetch(`http://127.0.0.1:${pairing.relayPort}/json/version`, {
+                headers: { Authorization: `Basic ${authorization}` },
+              });
+              expect(response.status).toBe(200);
+              await expect(response.json()).resolves.toMatchObject({
+                Browser: "Chrome/test",
+                webSocketDebuggerUrl: `ws://127.0.0.1:${pairing.relayPort}/cdp`,
+              });
+            } finally {
+              requestController.abort();
+              await browserAvailable?.catch(() => {});
+              extension?.terminate();
+              await stopBrowserControlService();
+              await closeServer(gatewayServer);
+            }
+          },
+        );
+      } finally {
+        await fs.rm(stateDir, { recursive: true, force: true });
       }
-      await fs.mkdir(path.join(stateDir, "credentials"), { recursive: true });
-      await fs.writeFile(
-        path.join(stateDir, "credentials", "browser-extension-relay.secret"),
-        `${RELAY_KEY}\n`,
-        { mode: 0o600 },
-      );
-
-      const config = {
-        gateway: {
-          port: gatewayPort,
-          auth: { mode: "token" as const, token: "gateway-integration-test" },
-        },
-        browser: {
-          enabled: true,
-          extensionRelay: { allowLegacyAuth: false },
-          profiles: { chrome: { driver: "extension" as const, cdpPort: relayPort } },
-        },
-      };
-      setRuntimeConfigSnapshot(config, config);
-
-      await withEnvAsync(
-        {
-          OPENCLAW_STATE_DIR: stateDir,
-          OPENCLAW_GATEWAY_PORT: String(gatewayPort),
-        },
-        async () => {
-          const gatewayServer = http.createServer((_req, res) => {
-            res.writeHead(426);
-            res.end();
-          });
-          gatewayServer.on("upgrade", (req, socket, head) => {
-            void handleGatewayExtensionUpgrade(req, socket, head);
-          });
-          let extension: WebSocket | undefined;
-          try {
-            await new Promise<void>((resolve) => {
-              gatewayServer.listen(gatewayPort, "127.0.0.1", resolve);
-            });
-            expect(getBrowserControlState()).toBeNull();
-
-            const pairing = await buildBrowserExtensionPairing({
-              cfg: config,
-              localTransport: "gateway",
-              ensureToken: async () => RELAY_KEY,
-            });
-            expect(pairing).toMatchObject({ relayPort, topology: "local" });
-            const parsed = parsePairingString(pairing.pairingString);
-            if (!parsed) {
-              throw new Error("local pairing did not parse");
-            }
-
-            extension = new WebSocket(parsed.relayUrl, BROWSER_RELAY_EXTENSION_SUBPROTOCOL, {
-              origin: "chrome-extension://gateway-wakeup-integration",
-            });
-            await once(extension, "open");
-            const clientNonce = randomRelayNonce();
-            const challengeMessage = once(extension, "message");
-            extension.send(
-              JSON.stringify({
-                type: "auth.hello",
-                v: 2,
-                keyId: relayKeyIdFromHex(RELAY_KEY),
-                clientNonce,
-              }),
-            );
-            const [challengeData] = (await challengeMessage) as [RawData];
-            const challenge = JSON.parse(rawDataText(challengeData));
-            const okMessage = once(extension, "message");
-            extension.send(
-              JSON.stringify({
-                type: "auth.response",
-                v: 2,
-                sessionId: challenge.sessionId,
-                clientProof: createRelayProof(RELAY_KEY, "client", challenge),
-              }),
-            );
-            const [okData] = (await okMessage) as [RawData];
-            expect(JSON.parse(rawDataText(okData))).toMatchObject({ type: "auth.ok", v: 2 });
-            extension.send(
-              JSON.stringify({
-                type: "hello",
-                userAgent: "gateway-wakeup-test",
-                browserVersion: "Chrome/test",
-                extensionVersion: "2",
-                tabs: [],
-              }),
-            );
-
-            await expect
-              .poll(
-                () =>
-                  getBrowserControlState()?.extensionRelays?.get("chrome")?.bridge
-                    .extensionConnected,
-              )
-              .toBe(true);
-            const relay = getBrowserControlState()?.extensionRelays?.get("chrome");
-            expect(relay?.port).toBe(pairing.relayPort);
-            if (!relay) {
-              throw new Error("extension relay did not start");
-            }
-
-            for (let request = 0; request < 3; request += 1) {
-              const profile = createBrowserControlContext().forProfile("chrome").profile;
-              const cdpUrl = new URL(profile.cdpUrl);
-              expect(cdpUrl.username).toBe("openclaw-internal");
-              expect(cdpUrl.password === relay.internalToken).toBe(true);
-              expect(getBrowserControlState()?.extensionRelays?.get("chrome")).toBe(relay);
-              expect(extension.readyState).toBe(WebSocket.OPEN);
-            }
-
-            const authorization = Buffer.from(`openclaw-internal:${relay.internalToken}`).toString(
-              "base64",
-            );
-            const response = await fetch(`http://127.0.0.1:${pairing.relayPort}/json/version`, {
-              headers: { Authorization: `Basic ${authorization}` },
-            });
-            expect(response.status).toBe(200);
-            await expect(response.json()).resolves.toMatchObject({
-              Browser: "Chrome/test",
-              webSocketDebuggerUrl: `ws://127.0.0.1:${pairing.relayPort}/cdp`,
-            });
-          } finally {
-            extension?.terminate();
-            await stopBrowserControlService();
-            await closeServer(gatewayServer);
-          }
-        },
-      );
-    } finally {
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 });

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -87,6 +87,53 @@ const flush = () =>
   });
 
 describe("ExtensionRelayBridge", () => {
+  it("notifies connection waiters only after an authenticated valid hello", async () => {
+    vi.useFakeTimers();
+    const bridge = new ExtensionRelayBridge();
+    try {
+      const pending = wireExtension(bridge);
+      let ready = false;
+      const connected = bridge
+        .waitForExtensionConnection(new AbortController().signal, 8_000)
+        .then((result) => {
+          ready = result;
+        });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(ready).toBe(false);
+      pending.handlers.onMessage(JSON.stringify({ type: "not-hello" }));
+      await vi.advanceTimersByTimeAsync(100);
+      expect(ready).toBe(false);
+
+      const replacement = wireExtension(bridge);
+      sendHello(replacement.handlers);
+      await connected;
+
+      expect(ready).toBe(true);
+      expect(bridge.extensionConnected).toBe(true);
+    } finally {
+      bridge.dispose();
+      expect(vi.getTimerCount()).toBe(0);
+      vi.useRealTimers();
+    }
+  });
+
+  it("releases pending connection waiters immediately when their relay is disposed", async () => {
+    vi.useFakeTimers();
+    const bridge = new ExtensionRelayBridge();
+    try {
+      const waiting = bridge.waitForExtensionConnection(new AbortController().signal, 8_000);
+
+      bridge.dispose();
+
+      await expect(waiting).resolves.toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      bridge.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("retires an unresponsive extension and immediately fails pending CDP work", async () => {
     vi.useFakeTimers();
     const onStateChange = vi.fn();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -7,6 +7,7 @@
  * thin forwarder — the old assets/chrome-extension put this logic in an
  * untestable MV3 service worker, which is why it rotted and was removed.
  */
+import { once } from "node:events";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveCreateTargetParams } from "./create-target-params.js";
 import {
@@ -110,6 +111,7 @@ export class ExtensionRelayBridge {
   private pingTimer: NodeJS.Timeout | null = null;
   private missedPongs = 0;
   private readonly onStateChange?: () => void;
+  private readonly connectionEvents = new EventTarget();
 
   constructor(
     opts: {
@@ -122,6 +124,29 @@ export class ExtensionRelayBridge {
   /** True once an extension socket completed its hello handshake. */
   get extensionConnected(): boolean {
     return this.extension !== null;
+  }
+
+  /** Wait for an authenticated extension hello without polling its CDP endpoint. */
+  async waitForExtensionConnection(signal: AbortSignal, timeoutMs: number): Promise<boolean> {
+    if (this.extensionConnected) {
+      return true;
+    }
+    const timeout = new AbortController();
+    const timer = setTimeout(() => timeout.abort(), timeoutMs);
+    try {
+      await once(this.connectionEvents, "ready", {
+        signal: AbortSignal.any([signal, timeout.signal]),
+      });
+      return this.extensionConnected;
+    } catch (error) {
+      signal.throwIfAborted();
+      if (timeout.signal.aborted) {
+        return false;
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /** Identity of the paired browser, when connected. */
@@ -212,6 +237,7 @@ export class ExtensionRelayBridge {
         };
         this.syncTabs(msg.tabs);
         this.startPing();
+        this.connectionEvents.dispatchEvent(new Event("ready"));
         this.onStateChange?.();
         return;
       }
@@ -1000,6 +1026,7 @@ export class ExtensionRelayBridge {
     this.extensionCandidates.clear();
     this.extension?.socket.close(1001, "relay stopped");
     this.extension = null;
+    this.connectionEvents.dispatchEvent(new Event("ready"));
     for (const client of this.clients) {
       client.socket.close(1001, "relay stopped");
     }

--- a/extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
 import { resolveProfile, type ResolvedBrowserConfig } from "../config.js";
-import { getProfileLifecycle } from "../server-context.lifecycle.js";
+import {
+  beginProfileTransition,
+  getOrCreateProfileRuntime,
+  getProfileLifecycle,
+  withProfileOperationLease,
+} from "../server-context.lifecycle.js";
 import type { BrowserServerState } from "../server-context.types.js";
 import type { ExtensionRelayHandle } from "./relay-server.js";
 
@@ -155,5 +160,138 @@ describe("extension relay lifecycle", () => {
     expect(oldRelay.close).toHaveBeenCalledOnce();
     expect(startExtensionRelayServerMock).toHaveBeenCalledOnce();
     expect(state.extensionRelays?.get(PROFILE_NAME)).toBe(replacement);
+  });
+
+  it("keeps a shared HMAC-rotation rebind alive when its first caller is cancelled", async () => {
+    const oldRelay = createHandle(OLD_TOKEN);
+    const { profile, state } = createState(OLD_TOKEN, oldRelay);
+    const runtime = getOrCreateProfileRuntime(state, profile);
+    const startEntered = deferred();
+    const releaseStart = deferred();
+    const replacement = createHandle(ROTATED_TOKEN);
+    startExtensionRelayServerMock.mockImplementationOnce(async () => {
+      startEntered.resolve();
+      await releaseStart.promise;
+      return replacement;
+    });
+    const firstController = new AbortController();
+    const first = withProfileOperationLease({
+      state,
+      runtime,
+      configRevision: getProfileLifecycle(runtime).configRevision,
+      signal: firstController.signal,
+      run: async (signal) => await ensureExtensionRelayForProfile(state, profile, signal),
+    });
+    void first.catch(() => {});
+    await startEntered.promise;
+
+    const sibling = withProfileOperationLease({
+      state,
+      runtime,
+      configRevision: getProfileLifecycle(runtime).configRevision,
+      run: async (signal) => await ensureExtensionRelayForProfile(state, profile, signal),
+    });
+    void sibling.catch(() => {});
+    await expect.poll(() => readExtensionRelayTokenMock.mock.calls.length).toBe(2);
+    firstController.abort(new Error("first browser request cancelled"));
+    releaseStart.resolve();
+
+    await expect(first).rejects.toThrow("first browser request cancelled");
+    await expect(sibling).resolves.toBe(replacement);
+    expect(oldRelay.close).toHaveBeenCalledOnce();
+    expect(startExtensionRelayServerMock).toHaveBeenCalledOnce();
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(state.extensionRelays?.get(PROFILE_NAME)).toBe(replacement);
+    expect(state.resolved.extensionRelayInternalTokens[PROFILE_NAME]).toBe(
+      replacement.internalToken,
+    );
+    expect(getProfileLifecycle(runtime).leases.size).toBe(0);
+  });
+
+  it("releases a cancelled sibling without waiting for another caller's pending rebind", async () => {
+    const oldRelay = createHandle(OLD_TOKEN);
+    const { profile, state } = createState(OLD_TOKEN, oldRelay);
+    const runtime = getOrCreateProfileRuntime(state, profile);
+    const startEntered = deferred();
+    const releaseStart = deferred();
+    const replacement = createHandle(ROTATED_TOKEN);
+    startExtensionRelayServerMock.mockImplementationOnce(async () => {
+      startEntered.resolve();
+      await releaseStart.promise;
+      return replacement;
+    });
+    const owner = withProfileOperationLease({
+      state,
+      runtime,
+      configRevision: getProfileLifecycle(runtime).configRevision,
+      run: async (signal) => await ensureExtensionRelayForProfile(state, profile, signal),
+    });
+    void owner.catch(() => {});
+    await startEntered.promise;
+
+    const siblingController = new AbortController();
+    const sibling = withProfileOperationLease({
+      state,
+      runtime,
+      configRevision: getProfileLifecycle(runtime).configRevision,
+      signal: siblingController.signal,
+      run: async (signal) => await ensureExtensionRelayForProfile(state, profile, signal),
+    });
+    let siblingError: unknown;
+    void sibling.catch((error: unknown) => {
+      siblingError = error;
+    });
+    await expect.poll(() => readExtensionRelayTokenMock.mock.calls.length).toBe(2);
+    siblingController.abort(new Error("sibling browser request cancelled"));
+    try {
+      await expect
+        .poll(() => siblingError, { timeout: 200 })
+        .toEqual(expect.objectContaining({ message: "sibling browser request cancelled" }));
+    } finally {
+      releaseStart.resolve();
+    }
+    await expect(owner).resolves.toBe(replacement);
+    expect(oldRelay.close).toHaveBeenCalledOnce();
+    expect(startExtensionRelayServerMock).toHaveBeenCalledOnce();
+    expect(replacement.close).not.toHaveBeenCalled();
+    expect(getProfileLifecycle(runtime).leases.size).toBe(0);
+  });
+
+  it("fences and drains a lifecycle-owned rebind when its profile transitions", async () => {
+    const oldRelay = createHandle(OLD_TOKEN);
+    const { profile, state } = createState(OLD_TOKEN, oldRelay);
+    const runtime = getOrCreateProfileRuntime(state, profile);
+    const startEntered = deferred();
+    const releaseStart = deferred();
+    const replacement = createHandle(ROTATED_TOKEN);
+    startExtensionRelayServerMock.mockImplementationOnce(async () => {
+      startEntered.resolve();
+      await releaseStart.promise;
+      return replacement;
+    });
+    const pending = withProfileOperationLease({
+      state,
+      runtime,
+      configRevision: getProfileLifecycle(runtime).configRevision,
+      run: async (signal) => await ensureExtensionRelayForProfile(state, profile, signal),
+    });
+    void pending.catch(() => {});
+    await startEntered.promise;
+
+    const transition = beginProfileTransition({
+      state,
+      runtime,
+      reason: "profile configuration changed",
+      closeRelay: true,
+    });
+    await expect(pending).rejects.toThrow("profile configuration changed");
+    releaseStart.resolve();
+    await expect(transition).resolves.toEqual(expect.objectContaining({ stopped: true }));
+
+    expect(oldRelay.close).toHaveBeenCalledOnce();
+    expect(replacement.close).toHaveBeenCalledOnce();
+    expect(state.extensionRelays?.has(PROFILE_NAME)).toBe(false);
+    expect(state.resolved.extensionRelayInternalTokens[PROFILE_NAME]).toBeUndefined();
+    expect(getProfileLifecycle(runtime).leases.size).toBe(0);
   });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-lifecycle.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-lifecycle.ts
@@ -8,6 +8,7 @@ import {
   getProfileLifecycle,
   getOrCreateProfileRuntime,
   isBrowserRuntimeRunning,
+  waitForProfileOperation,
   withProfileOperationLease,
 } from "../server-context.lifecycle.js";
 import type { BrowserServerState, ProfileRuntimeState } from "../server-context.types.js";
@@ -66,8 +67,10 @@ function applyInternalRelayToken(
 export async function ensureExtensionRelayForProfile(
   state: BrowserServerState,
   profile: ResolvedBrowserProfile,
+  signal?: AbortSignal,
 ): Promise<ExtensionRelayHandle> {
   for (;;) {
+    signal?.throwIfAborted();
     if (!isBrowserRuntimeRunning(state)) {
       throw new Error("Browser runtime is stopping");
     }
@@ -104,7 +107,7 @@ export async function ensureExtensionRelayForProfile(
         pending.token === token &&
         pending.allowLegacyAuth === state.resolved.extensionRelay.allowLegacyAuth
       ) {
-        const handle = await pending.promise;
+        const handle = await waitForProfileOperation(pending.promise, signal);
         const current = resolveProfile(state.resolved, profile.name);
         if (current) {
           Object.assign(profile, current);
@@ -112,8 +115,9 @@ export async function ensureExtensionRelayForProfile(
         return handle;
       }
       try {
-        await pending.promise;
+        await waitForProfileOperation(pending.promise, signal);
       } catch (err) {
+        signal?.throwIfAborted();
         if (getProfileLifecycle(runtime).blockedReason) {
           throw err;
         }
@@ -129,18 +133,18 @@ export async function ensureExtensionRelayForProfile(
       promise,
     };
     pendingRelayEnsures.set(runtime, owned);
-    try {
-      const handle = await promise;
-      const current = resolveProfile(state.resolved, profile.name);
-      if (current) {
-        Object.assign(profile, current);
-      }
-      return handle;
-    } finally {
+    const settlePending = () => {
       if (pendingRelayEnsures.get(runtime) === owned) {
         pendingRelayEnsures.delete(runtime);
       }
+    };
+    void promise.then(settlePending, settlePending);
+    const handle = await waitForProfileOperation(promise, signal);
+    const current = resolveProfile(state.resolved, profile.name);
+    if (current) {
+      Object.assign(profile, current);
     }
+    return handle;
   }
 }
 
@@ -155,6 +159,7 @@ async function ensureDesiredRelay(params: {
     state,
     runtime,
     configRevision: getProfileLifecycle(runtime).configRevision,
+    ownership: "lifecycle",
     run: async (signal) => {
       const map = relays(state);
       const actor = getProfileLifecycle(runtime);

--- a/extensions/browser/src/browser/resolved-config-refresh.ts
+++ b/extensions/browser/src/browser/resolved-config-refresh.ts
@@ -92,12 +92,31 @@ function applyResolvedConfig(
   current: BrowserServerState,
   freshResolved: BrowserServerState["resolved"],
 ) {
+  const extensionRelayInternalTokens: Record<string, string> = {};
+  for (const [name, relay] of current.extensionRelays ?? []) {
+    const runtime = current.profiles.get(name);
+    const lifecycle = runtime && getProfileLifecycle(runtime);
+    const profile = resolveProfile(freshResolved, name);
+    if (
+      runtime?.profile.driver === "extension" &&
+      !lifecycle?.terminal &&
+      !lifecycle?.transitionReason &&
+      !lifecycle?.cleanupRelays.has(relay) &&
+      profile?.driver === "extension" &&
+      profile.cdpPort === relay.port
+    ) {
+      extensionRelayInternalTokens[name] = relay.internalToken;
+    }
+  }
   current.resolved = {
     ...freshResolved,
     // Keep the runtime evaluate gate stable across request-time profile refreshes.
     // Security-sensitive behavior should only change via full runtime config reload,
     // not as a side effect of resolving profiles/tabs during a request.
     evaluateEnabled: current.resolved.evaluateEnabled,
+    // Only an exact live relay owns its process-local CDP credential; stale
+    // config snapshots must never resurrect closed or replaced credentials.
+    extensionRelayInternalTokens,
   };
   for (const [name, runtime] of current.profiles) {
     const actor = getProfileLifecycle(runtime);
@@ -108,7 +127,7 @@ function applyResolvedConfig(
     if (actor.terminal) {
       continue;
     }
-    const nextProfile = resolveProfile(freshResolved, name);
+    const nextProfile = resolveProfile(current.resolved, name);
     if (nextProfile) {
       if (actor.blockedReason && !actor.transitionReason) {
         void beginProfileTransition({

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -451,7 +451,22 @@ export function createProfileAvailability({
     const current = state();
     const remoteCdp = capabilities.isRemote;
     const attachOnly = profile.attachOnly;
-    const httpReachable = await isHttpReachable(undefined, signal);
+    let httpReachable: boolean;
+    if (capabilities.mode === "local-extension") {
+      const { ensureExtensionRelayForProfile } = await getExtensionRelayModule();
+      const relay = await ensureExtensionRelayForProfile(current, profile);
+      const connected = await relay.bridge.waitForExtensionConnection(
+        signal,
+        CHROME_MCP_ATTACH_READY_WINDOW_MS,
+      );
+      signal.throwIfAborted();
+      httpReachable =
+        connected &&
+        current.extensionRelays?.get(profile.name) === relay &&
+        (await isHttpReachable(undefined, signal));
+    } else {
+      httpReachable = await isHttpReachable(undefined, signal);
+    }
     const launchOptions = launchOptionsForEnsure(options);
 
     if (!httpReachable) {

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -45,6 +45,7 @@ import {
   ProfileRestartRequiredError,
   registerProfileHandle,
   releaseProfileHandle,
+  withProfileOperationLease,
 } from "./server-context.lifecycle.js";
 import type {
   BrowserServerState,
@@ -572,6 +573,24 @@ export function createProfileAvailability({
   };
 
   const ensureBrowserAvailable = async (options?: BrowserEnsureOptions): Promise<void> => {
+    if (capabilities.mode === "local-extension") {
+      // Gateway authentication needs a concurrent lease before it can send the
+      // hello this caller-owned, abortable readiness operation is waiting for.
+      await withProfileOperationLease({
+        state: state(),
+        runtime,
+        configRevision,
+        signal: options?.signal,
+        run: async (signal) =>
+          await ensureBrowserAvailableOnce(
+            signal,
+            getProfileLifecycle(runtime).generation,
+            options,
+          ),
+      });
+      return;
+    }
+
     const key = ensureOptionsKey(options);
     for (;;) {
       try {

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -182,7 +182,7 @@ export function createProfileAvailability({
     }
     const { ensureExtensionRelayForProfile } = await getExtensionRelayModule();
     const current = state();
-    await ensureExtensionRelayForProfile(current, profile);
+    await ensureExtensionRelayForProfile(current, profile, signal);
     signal?.throwIfAborted();
   };
   const isReachable = async (
@@ -455,7 +455,7 @@ export function createProfileAvailability({
     let httpReachable: boolean;
     if (capabilities.mode === "local-extension") {
       const { ensureExtensionRelayForProfile } = await getExtensionRelayModule();
-      const relay = await ensureExtensionRelayForProfile(current, profile);
+      const relay = await ensureExtensionRelayForProfile(current, profile, signal);
       const connected = await relay.bridge.waitForExtensionConnection(
         signal,
         CHROME_MCP_ATTACH_READY_WINDOW_MS,

--- a/extensions/browser/src/browser/server-context.extension-readiness.test.ts
+++ b/extensions/browser/src/browser/server-context.extension-readiness.test.ts
@@ -4,6 +4,7 @@ import * as chromeModule from "./chrome.js";
 import { ExtensionRelayBridge } from "./extension-relay/relay-bridge.js";
 import type { ExtensionRelayHandle } from "./extension-relay/relay-server.js";
 import { createBrowserRouteContext } from "./server-context.js";
+import { getProfileLifecycle } from "./server-context.lifecycle.js";
 import { makeBrowserProfile, makeBrowserServerState } from "./server-context.test-harness.js";
 import type { BrowserServerState } from "./server-context.types.js";
 
@@ -123,7 +124,46 @@ describe("extension profile readiness", () => {
     controller.abort(new Error("browser request cancelled"));
 
     expect((await cancelled) as Error).toHaveProperty("message", "browser request cancelled");
+    await vi.advanceTimersByTimeAsync(0);
+    const runtime = browser.state.profiles.get("chrome");
+    expect(runtime).toBeDefined();
+    if (runtime) {
+      const actor = getProfileLifecycle(runtime);
+      expect(actor.starts.size).toBe(0);
+      expect(actor.leases.size).toBe(0);
+    }
+    expect(vi.getTimerCount()).toBe(0);
     browser.dispose();
+  });
+
+  it("keeps a sibling attachment wait alive when one request is cancelled", async () => {
+    vi.useFakeTimers();
+    vi.mocked(chromeModule.isChromeReachable).mockResolvedValue(true);
+    const controller = new AbortController();
+    const browser = createExtensionProfile();
+    const cancelled = browser.profile
+      .ensureBrowserAvailable({ signal: controller.signal })
+      .catch((error: unknown) => error);
+    const sibling = browser.profile.ensureBrowserAvailable();
+    await vi.advanceTimersByTimeAsync(100);
+
+    controller.abort(new Error("first browser request cancelled"));
+    expect((await cancelled) as Error).toHaveProperty("message", "first browser request cancelled");
+    const runtime = browser.state.profiles.get("chrome");
+    expect(runtime).toBeDefined();
+    if (runtime) {
+      expect(getProfileLifecycle(runtime).leases.size).toBe(1);
+    }
+    expect(browser.state.extensionRelays?.get("chrome")).toBe(browser.relay);
+
+    browser.connect();
+    await expect(sibling).resolves.toBeUndefined();
+    if (runtime) {
+      expect(getProfileLifecycle(runtime).leases.size).toBe(0);
+    }
+    expect(browser.relay.bridge.extensionConnected).toBe(true);
+    browser.dispose();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("does not accept readiness from a relay replaced while its request was waiting", async () => {

--- a/extensions/browser/src/browser/server-context.extension-readiness.test.ts
+++ b/extensions/browser/src/browser/server-context.extension-readiness.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "./server-context.chrome-test-harness.js";
+import * as chromeModule from "./chrome.js";
+import { ExtensionRelayBridge } from "./extension-relay/relay-bridge.js";
+import type { ExtensionRelayHandle } from "./extension-relay/relay-server.js";
+import { createBrowserRouteContext } from "./server-context.js";
+import { makeBrowserProfile, makeBrowserServerState } from "./server-context.test-harness.js";
+import type { BrowserServerState } from "./server-context.types.js";
+
+const relayMocks = vi.hoisted(() => ({
+  ensureExtensionRelayForProfile: vi.fn(),
+}));
+
+vi.mock("./extension-relay.runtime.js", () => ({
+  getExtensionRelayModule: async () => ({
+    ensureExtensionRelayForProfile: relayMocks.ensureExtensionRelayForProfile,
+    EXTENSION_PAIRING_HINT: "Pair the browser extension.",
+  }),
+}));
+
+function createExtensionProfile() {
+  const profile = makeBrowserProfile({
+    name: "chrome",
+    cdpPort: 18799,
+    cdpUrl: "http://127.0.0.1:18799",
+    driver: "extension",
+    attachOnly: true,
+  });
+  const state = makeBrowserServerState({
+    profile,
+    resolvedOverrides: { extensionRelayPorts: { chrome: 18799 } },
+  });
+  const bridge = new ExtensionRelayBridge();
+  const relay = {
+    port: 18799,
+    token: "relay-test-key",
+    allowLegacyAuth: true,
+    internalToken: "relay-test-internal-key",
+    bridge,
+    close: async () => bridge.dispose(),
+  } satisfies ExtensionRelayHandle;
+  relayMocks.ensureExtensionRelayForProfile.mockImplementation(
+    async (current: BrowserServerState) => {
+      current.extensionRelays ??= new Map();
+      current.extensionRelays.set("chrome", relay);
+      return relay;
+    },
+  );
+  const socket = { send: vi.fn(), close: vi.fn() };
+  const extension = bridge.attachExtensionSocket(socket);
+  return {
+    profile: createBrowserRouteContext({ getState: () => state }).forProfile("chrome"),
+    state,
+    relay,
+    connect: () =>
+      extension.onMessage(
+        JSON.stringify({
+          type: "hello",
+          userAgent: "browser-test",
+          browserVersion: "Chrome/test",
+          extensionVersion: "2",
+          tabs: [],
+        }),
+      ),
+    dispose: () => bridge.dispose(),
+  };
+}
+
+describe("extension profile readiness", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("waits for an authenticated extension after its relay starts", async () => {
+    vi.useFakeTimers();
+    const isChromeReachable = vi.mocked(chromeModule.isChromeReachable);
+    isChromeReachable.mockResolvedValue(false);
+    const browser = createExtensionProfile();
+    setTimeout(() => {
+      isChromeReachable.mockResolvedValue(true);
+      browser.connect();
+    }, 1_400);
+
+    const ready = browser.profile.ensureBrowserAvailable().then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(await ready).toEqual({ ok: true });
+    expect(isChromeReachable).toHaveBeenCalledOnce();
+    browser.dispose();
+  });
+
+  it("keeps the actionable pairing error when no extension connects", async () => {
+    vi.useFakeTimers();
+    vi.mocked(chromeModule.isChromeReachable).mockResolvedValue(false);
+
+    const browser = createExtensionProfile();
+    const unavailable = browser.profile.ensureBrowserAvailable().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(8_500);
+
+    expect(await unavailable).toEqual(expect.objectContaining({ message: expect.any(String) }));
+    expect((await unavailable) as Error).toHaveProperty(
+      "message",
+      expect.stringContaining("Pair the browser extension."),
+    );
+    expect(chromeModule.isChromeReachable).not.toHaveBeenCalled();
+    browser.dispose();
+  });
+
+  it("cancels an attachment wait immediately with its owning browser operation", async () => {
+    vi.useFakeTimers();
+    vi.mocked(chromeModule.isChromeReachable).mockResolvedValue(false);
+    const controller = new AbortController();
+
+    const browser = createExtensionProfile();
+    const cancelled = browser.profile
+      .ensureBrowserAvailable({ signal: controller.signal })
+      .catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(300);
+    controller.abort(new Error("browser request cancelled"));
+
+    expect((await cancelled) as Error).toHaveProperty("message", "browser request cancelled");
+    browser.dispose();
+  });
+
+  it("does not accept readiness from a relay replaced while its request was waiting", async () => {
+    vi.useFakeTimers();
+    vi.mocked(chromeModule.isChromeReachable).mockResolvedValue(true);
+    const browser = createExtensionProfile();
+    const replacement = {
+      ...browser.relay,
+      internalToken: "replacement-relay-test-key",
+      bridge: new ExtensionRelayBridge(),
+    } satisfies ExtensionRelayHandle;
+    setTimeout(() => {
+      browser.state.extensionRelays?.set("chrome", replacement);
+      browser.connect();
+    }, 100);
+
+    const unavailable = browser.profile.ensureBrowserAvailable().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect((await unavailable) as Error).toHaveProperty(
+      "message",
+      expect.stringContaining("Pair the browser extension."),
+    );
+    expect(chromeModule.isChromeReachable).not.toHaveBeenCalled();
+    browser.dispose();
+    replacement.bridge.dispose();
+  });
+});

--- a/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
@@ -2,7 +2,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RunningChrome } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
+import type { ExtensionRelayHandle } from "./extension-relay/relay-server.js";
 import {
+  beginProfileTransition,
   enqueueProfileStart,
   getProfileLifecycle,
   getOrCreateProfileRuntime,
@@ -161,6 +163,32 @@ function createProfileFixture(
   return { state, profile, runtime };
 }
 
+function createExtensionRelayFixture(name = "chrome") {
+  const fixture = createProfileFixture({
+    name,
+    config: { cdpPort: 18799, driver: "extension" },
+    lastTargetId: "shared-tab",
+  });
+  const relay = {
+    port: 18799,
+    token: "persistent-relay-test-key",
+    allowLegacyAuth: true,
+    internalToken: `${name}-process-only-credential`,
+    bridge: {} as ExtensionRelayHandle["bridge"],
+    close: vi.fn(async () => {}),
+  } satisfies ExtensionRelayHandle;
+  fixture.state.extensionRelays = new Map([[name, relay]]);
+  fixture.state.resolved = {
+    ...fixture.state.resolved,
+    extensionRelayInternalTokens: { [name]: relay.internalToken },
+  };
+  fixture.runtime.profile = requireValue(
+    resolveProfile(fixture.state.resolved, name),
+    `${name} extension profile missing`,
+  );
+  return { ...fixture, relay };
+}
+
 function refreshProfiles(state: BrowserServerState) {
   refreshResolvedBrowserConfigFromDisk({ current: state, refreshConfigFromDisk: true });
 }
@@ -285,6 +313,140 @@ describe("server-context hot-reload profiles", () => {
     });
     expect(after?.cdpPort).toBe(19999);
     expect(state.resolved.profiles.openclaw?.cdpPort).toBe(19999);
+  });
+
+  it("keeps only exact live relay credentials stable across repeated profile refreshes", () => {
+    const { state, runtime, relay } = createExtensionRelayFixture();
+    const expectedUrl = runtime.profile.cdpUrl;
+    const freshPersistentKey = resolveBrowserConfig(buildConfig().browser).extensionRelayToken;
+    state.resolved = {
+      ...state.resolved,
+      extensionRelayToken: "stale-persistent-key",
+      extensionRelayInternalTokens: {
+        chrome: relay.internalToken,
+        orphaned: "closed-relay-credential",
+      },
+    };
+
+    for (let request = 0; request < 3; request += 1) {
+      const resolved = resolveBrowserProfileWithHotReload({
+        current: state,
+        refreshConfigFromDisk: true,
+        name: "chrome",
+      });
+
+      expect(resolved?.cdpUrl).toBe(expectedUrl);
+      expect(state.extensionRelays?.get("chrome")).toBe(relay);
+      expect(state.resolved.extensionRelayInternalTokens).toEqual({
+        chrome: relay.internalToken,
+      });
+      expect(state.resolved.extensionRelayToken).toBe(freshPersistentKey);
+      expect(getProfileLifecycle(runtime).configRevision).toBe(0);
+      expect(runtime.lastTargetId).toBe("shared-tab");
+    }
+    expect(relay.close).not.toHaveBeenCalled();
+  });
+
+  it("does not carry a relay credential across a configured profile-port change", async () => {
+    const { state, runtime, relay } = createExtensionRelayFixture();
+
+    updateProfile(state, "chrome", { cdpPort: 18801, driver: "extension" });
+
+    expect(state.resolved.extensionRelayInternalTokens).not.toHaveProperty("chrome");
+    expect(runtime.profile.cdpPort).toBe(18801);
+    expect(getProfileLifecycle(runtime).transitionReason).toContain("cdpPort");
+    await getProfileLifecycle(runtime).tail;
+    expect(relay.close).toHaveBeenCalledOnce();
+    expect(state.extensionRelays?.has("chrome")).toBe(false);
+  });
+
+  it("revokes only the exact closed relay credential after lifecycle cleanup", async () => {
+    const { state, runtime, relay } = createExtensionRelayFixture();
+    state.resolved.extensionRelayInternalTokens.work = "other-live-profile-credential";
+
+    await beginProfileTransition({
+      state,
+      runtime,
+      reason: "extension relay stopped",
+      closeRelay: true,
+    });
+
+    expect(relay.close).toHaveBeenCalledOnce();
+    expect(state.extensionRelays?.has("chrome")).toBe(false);
+    expect(state.resolved.extensionRelayInternalTokens).toEqual({
+      work: "other-live-profile-credential",
+    });
+  });
+
+  it("preserves a replacement relay credential when an older handle finishes closing", async () => {
+    const { state, runtime, relay } = createExtensionRelayFixture();
+    const replacement = {
+      ...relay,
+      internalToken: "replacement-process-only-credential",
+      close: vi.fn(async () => {}),
+    } satisfies ExtensionRelayHandle;
+    relay.close.mockImplementationOnce(async () => {
+      state.extensionRelays?.set("chrome", replacement);
+      state.resolved = {
+        ...state.resolved,
+        extensionRelayInternalTokens: { chrome: replacement.internalToken },
+      };
+    });
+
+    await beginProfileTransition({
+      state,
+      runtime,
+      reason: "superseded extension relay",
+      closeRelay: true,
+    });
+
+    expect(state.extensionRelays?.get("chrome")).toBe(replacement);
+    expect(state.resolved.extensionRelayInternalTokens.chrome).toBe(replacement.internalToken);
+    expect(replacement.close).not.toHaveBeenCalled();
+  });
+
+  it("retains the exact relay credential when its lifecycle close fails", async () => {
+    const { state, runtime, relay } = createExtensionRelayFixture();
+    relay.close.mockRejectedValueOnce(new Error("relay still listening"));
+
+    await expect(
+      beginProfileTransition({
+        state,
+        runtime,
+        reason: "extension relay stopped",
+        closeRelay: true,
+      }),
+    ).rejects.toThrow("relay still listening");
+
+    expect(state.extensionRelays?.get("chrome")).toBe(relay);
+    expect(state.resolved.extensionRelayInternalTokens.chrome).toBe(relay.internalToken);
+  });
+
+  it("never re-adopts a relay credential while an unexposed close is still pending", async () => {
+    const { state, runtime, relay } = createExtensionRelayFixture();
+    const closeStarted = deferred();
+    const closeReleased = deferred();
+    relay.close.mockImplementationOnce(async () => {
+      closeStarted.resolve();
+      await closeReleased.promise;
+    });
+
+    const closing = beginProfileTransition({
+      state,
+      runtime,
+      reason: "extension relay stopped",
+      closeRelay: true,
+    });
+    await closeStarted.promise;
+    expect(getProfileLifecycle(runtime).transitionReason).toBeNull();
+
+    refreshProfiles(state);
+    expect(state.resolved.extensionRelayInternalTokens).not.toHaveProperty("chrome");
+
+    closeReleased.resolve();
+    await closing;
+    await getProfileLifecycle(runtime).tail;
+    expect(relay.close).toHaveBeenCalledOnce();
   });
 
   it("listProfiles refreshes config before enumerating profiles", () => {

--- a/extensions/browser/src/browser/server-context.lifecycle.ts
+++ b/extensions/browser/src/browser/server-context.lifecycle.ts
@@ -171,13 +171,14 @@ function combineSignals(lifecycleSignal: AbortSignal, callerSignal?: AbortSignal
   return AbortSignal.any([lifecycleSignal, callerSignal]);
 }
 
-function waitForStart(promise: Promise<void>, signal?: AbortSignal): Promise<void> {
+/** Observe shared lifecycle work without transferring cancellation ownership. */
+export function waitForProfileOperation<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
   if (!signal) {
     return promise;
   }
   signal.throwIfAborted();
   let onAbort!: () => void;
-  const waiting = new Promise<void>((resolve, reject) => {
+  const waiting = new Promise<T>((resolve, reject) => {
     onAbort = () => reject(toLifecycleError(signal.reason, "Browser operation aborted."));
     signal.addEventListener("abort", onAbort, { once: true });
     void promise.then(resolve, reject);
@@ -274,13 +275,15 @@ export async function withProfileOperationLease<T>(params: {
   runtime: ProfileRuntimeState;
   configRevision: number;
   signal?: AbortSignal;
+  /** Shared producers belong to the lifecycle, never to their first caller. */
+  ownership?: "caller" | "lifecycle";
   run: (signal: AbortSignal) => Promise<T>;
   commit?: (result: T) => void | Promise<void>;
 }): Promise<T> {
   params.signal?.throwIfAborted();
   const actor = getProfileLifecycle(params.runtime);
   const inherited = profileLeaseStorage.getStore();
-  const parent = inherited?.get(params.runtime);
+  const parent = params.ownership === "lifecycle" ? undefined : inherited?.get(params.runtime);
   if (parent) {
     const signal = combineSignals(parent.signal, params.signal);
     signal.throwIfAborted();
@@ -307,7 +310,10 @@ export async function withProfileOperationLease<T>(params: {
   assertProfileCurrent({ ...params, generation: requestedGeneration });
   const generation = requestedGeneration;
   const lifecycleSignal = actor.controller.signal;
-  const signal = combineSignals(lifecycleSignal, params.signal);
+  const signal =
+    params.ownership === "lifecycle"
+      ? lifecycleSignal
+      : combineSignals(lifecycleSignal, params.signal);
   signal.throwIfAborted();
   const release = createLease(actor);
   try {
@@ -340,7 +346,7 @@ export function enqueueProfileStart(params: {
   const actor = getProfileLifecycle(params.runtime);
   const existing = actor.starts.get(params.key);
   if (existing) {
-    return waitForStart(existing, params.signal);
+    return waitForProfileOperation(existing, params.signal);
   }
 
   const generation = actor.generation;
@@ -361,7 +367,7 @@ export function enqueueProfileStart(params: {
     }
   };
   actor.tail = promise.then(settleStart, settleStart);
-  return waitForStart(promise, params.signal);
+  return waitForProfileOperation(promise, params.signal);
 }
 
 function capturePlaywrightRetirement(

--- a/extensions/browser/src/browser/server-context.lifecycle.ts
+++ b/extensions/browser/src/browser/server-context.lifecycle.ts
@@ -437,6 +437,9 @@ async function cleanupProfileResources(params: {
       actor.cleanupRelays.delete(relay);
       if (params.state.extensionRelays?.get(runtime.profile.name) === relay) {
         params.state.extensionRelays.delete(runtime.profile.name);
+        const tokens = { ...params.state.resolved.extensionRelayInternalTokens };
+        delete tokens[runtime.profile.name];
+        params.state.resolved = { ...params.state.resolved, extensionRelayInternalTokens: tokens };
       }
     } catch (err) {
       firstError ??= toLifecycleError(err, "Browser relay cleanup failed.");


### PR DESCRIPTION
Closes #127728

## What Problem This Solves

Fixes an issue where users pairing a remote Chrome extension with an OpenClaw gateway immediately receive an extension-not-connected error before the authenticated extension can attach. Even after pairing succeeds, repeated browser requests can tear down the live relay and lose its process-only credentials.

## Why This Change Was Made

Browser configuration is resolved again for each request, but its extension relay credentials exist only in the current process. Previously, each fresh snapshot forgot those credentials, changed the resolved CDP identity, and caused the lifecycle owner to close an otherwise healthy relay. A successful close also left its process-only credential behind.

The configuration owner now reconstructs transient credentials exclusively from exact, live, matching relay handles that are not closing, and compares profiles against that canonical snapshot. The persistent relay HMAC key is still freshly resolved, so key rotation continues to retire the previous relay. Successful cleanup revokes only the credential belonging to the exact closed handle; failed closes and replacement handles retain their own authority.

Initial attachment now waits for the bridge's authenticated, valid-hello readiness event using the existing sibling attachment budget, then performs one availability probe. Crucially, this wait is owned by a concurrent, caller-cancellable profile lease rather than the serialized startup barrier: Gateway authentication must obtain its own sibling lease before it can acknowledge authentication and accept the extension hello. Shared relay startup and HMAC rotation are separately owned by the profile lifecycle itself, so cancelling the first request cannot cancel a replacement required by another request; each caller observes that shared operation through its own abortable wait, and only the exact producer's completion clears the single-flight registry. Cancellation, disposal, handle replacement, malformed hellos, and closed lifecycle generations fail closed without disrupting another active browser request. This replaces the original HTTP-polling proposal without adding retries, increasing timeouts, weakening authentication, or introducing configuration.

## User Impact

Remote extension pairing has time to complete its existing authenticated handshake, and paired browsers stay connected across subsequent requests. Closed relay credentials no longer outlive their owner, while persistent-key rotation and replacement relays continue to work correctly. Managed and remote CDP profiles retain their existing behavior.

## Evidence

Before the fix, focused regression proof reproduced three independent failures: an unchanged request refresh lost the live CDP identity, successful relay cleanup retained a stale credential, and a real authenticated Gateway/extension WebSocket connection failed on its next browser request. Separate cold-attachment proof reproduced both premature rejection and missing cancellation. Independent reviews also caught two real concurrency traps in early repairs: waiting inside serialized startup blocked the Gateway authentication acknowledgement needed to produce the awaited hello, and allowing shared relay startup to inherit its first caller's cancellation destroyed a rotated replacement needed by another request. Both failures were reproduced at their actual authenticated-protocol and delayed HMAC-rotation owner boundaries before separating caller-owned readiness from lifecycle-owned shared startup.

After the fix, all seven owner, authentication, lifecycle, protocol, and sibling suites pass:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts \
  extensions/browser/src/browser/server-context.extension-readiness.test.ts \
  extensions/browser/src/browser/extension-relay/relay-bridge.test.ts \
  extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts \
  extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts \
  extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts \
  extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts \
  extensions/browser/src/browser/runtime-lifecycle.shutdown-race.test.ts

Test Files  8 passed (8)
     Tests  106 passed (106)
```

The Gateway integration uses an actual local HTTP server and extension WebSocket, completes the authenticated v2 challenge/response and hello handshake, and verifies both first-authentication cold startup and a browser request already waiting before the authentication response arrives. The same authorized connection survives subsequent requests. An independent verifier separately reran both real authenticated WebSocket cases plus caller-cancellation and sibling-request isolation successfully. A physical cross-machine/Tailscale setup was not reproduced.

Coverage includes persistent HMAC rotation, successful and failed cleanup, replacement handles, hidden lifecycle transitions, removed/mismatched profiles, delayed and malformed hellos, concurrent Gateway authentication, immediate caller cancellation with no retained actor starts/leases/timers, independently surviving sibling requests during actual delayed HMAC replacement, exact single-flight bind/token ownership, stale replacement fencing during shutdown, disposal, and managed/remote browser siblings. Structured pre-commit review and formatting checks are clean. Production code is +113/-19 (net +94) because exact process-local credential ownership, authenticated readiness, independent lifecycle-owned shared startup, and caller-owned cancellation are newly explicit security/lifecycle boundaries; regression tests are +698/-126, including table-driven test reindentation.

Original contribution and primary commit authorship: @ayaangazali. Thanks to @scottcha for identifying the request-time credential lifecycle failure.
