### PR TITLE
test(plugins): preserve configless manifest expectation

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -231,7 +231,10 @@ function requireManifestRegistryLoadParams(index = 0): Record<string, unknown> {
   return call[0];
 }
 
-function expectManifestRegistryLoad(index: number, config: OpenClawConfig | Record<string, never>) {
+function expectManifestRegistryLoad(
+  index: number,
+  config: OpenClawConfig | Record<string, never> | undefined,
+) {
   const params = requireManifestRegistryLoadParams(index);
   expect(params.config).toEqual(config);
   expect(params.env).toBe(process.env);
@@ -1669,7 +1672,7 @@ describe("resolvePluginCapabilityProviders", () => {
     const providers = resolvePluginCapabilityProviders({ key: "mediaUnderstandingProviders" });
 
     expectResolvedCapabilityProviderIds(providers, ["google"]);
-    expectManifestRegistryLoad(0, {});
+    expectManifestRegistryLoad(0, undefined);
     expectActiveRegistryLookup(["google"]);
   });
 


### PR DESCRIPTION
## Summary

- preserve the configless manifest-discovery contract in the capability-provider runtime test
- allow the shared assertion helper to express `undefined` separately from an explicit empty config

## Root cause

The configless capability-provider test originally asserted that manifest discovery received `config: undefined`. A later test-helper refactor changed that expectation to `{}`, while production and the metadata-snapshot owner contract continued to distinguish configless default discovery from an explicit empty config. Plugin Prerelease exposed the stale assertion on exact `main`.

Architectural owner: plugin metadata snapshot discovery. No production path changes.

## Validation

- failing before: `node scripts/run-vitest.mjs src/plugins/capability-provider-runtime.test.ts` (1 failed: expected `{}`, received `undefined`)
- passing after: `node scripts/run-vitest.mjs src/plugins/capability-provider-runtime.test.ts src/plugins/manifest-contract-eligibility.test.ts` (87 passed)
- `node scripts/check-changed.mjs -- src/plugins/capability-provider-runtime.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean; no accepted/actionable findings)

## Scope

- production LOC: +0 / -0
- tests: +5 / -2
- sibling coverage: configless and explicit-empty metadata snapshot contracts
