### PR TITLE
fix(ui): restore drafts before expiry maintenance

### DIFF
--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -64,6 +64,76 @@ async function rawDraftRecords(page: Page, scopes: readonly TestDraftScope[], ex
 }
 
 suite.define(() => {
+  it("reads the requested draft before global expiry maintenance settles", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block" },
+      async ({ context, page }) => {
+        await installMockGateway(page);
+        await page.goto(`${suite.server.baseUrl}settings`);
+        const scope = {
+          gatewayOwner: "foreground-gateway",
+          recoveryScope: "foreground-credential",
+          scopeKey: "foreground-draft",
+        };
+        const seedStoreHandle = await page.evaluateHandle<
+          typeof import("../lib/chat/composer-draft-store.runtime.ts")
+        >('import("/src/lib/chat/composer-draft-store.runtime.ts")');
+        await page.evaluate(
+          ({ draftScope, draftStore }) =>
+            draftStore.writeDurableComposerDraft(
+              draftScope,
+              { revision: 1, text: "restore before maintenance", attachments: [] },
+              { expectedRevision: 0, writeId: "foreground-write" },
+            ),
+          { draftScope: scope, draftStore: seedStoreHandle },
+        );
+
+        await page.close();
+        const reopened = await context.newPage();
+        await reopened.addInitScript(() => {
+          const blockedTransactions = new WeakSet<IDBTransaction>();
+          const originalOpenCursor = IDBObjectStore.prototype.openCursor;
+          IDBObjectStore.prototype.openCursor = function (...args) {
+            if (this.name === "composerDrafts") {
+              blockedTransactions.add(this.transaction);
+            }
+            return originalOpenCursor.apply(this, args);
+          };
+          IDBTransaction.prototype.addEventListener = function (
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | AddEventListenerOptions,
+          ) {
+            if (type === "complete" && blockedTransactions.has(this)) {
+              return;
+            }
+            return EventTarget.prototype.addEventListener.call(this, type, listener, options);
+          } as IDBTransaction["addEventListener"];
+        });
+        await installMockGateway(reopened);
+        await reopened.goto(`${suite.server.baseUrl}settings`);
+        const reopenedStoreHandle = await reopened.evaluateHandle<
+          typeof import("../lib/chat/composer-draft-store.runtime.ts")
+        >('import("/src/lib/chat/composer-draft-store.runtime.ts")');
+        const result = await reopened.evaluate(
+          ({ draftScope, draftStore }) =>
+            Promise.race([
+              draftStore.readDurableComposerDraft(draftScope),
+              new Promise((resolve) =>
+                setTimeout(() => resolve({ status: "maintenance-blocked-read" }), 1_000),
+              ),
+            ]),
+          { draftScope: scope, draftStore: reopenedStoreHandle },
+        );
+
+        expect(result).toMatchObject({
+          status: "found",
+          draft: { text: "restore before maintenance" },
+        });
+      },
+    );
+  });
+
   it("expires drafts across abandoned credential owners on the next database open", async () => {
     await suite.withPage(
       { locale: "en-US", serviceWorkers: "block" },

--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -92,7 +92,10 @@ suite.define(() => {
         const reopened = await context.newPage();
         await reopened.addInitScript(() => {
           const blockedTransactions = new WeakSet<IDBTransaction>();
-          const originalOpenCursor = IDBObjectStore.prototype.openCursor;
+          const originalOpenCursor = Object.getOwnPropertyDescriptor(
+            IDBObjectStore.prototype,
+            "openCursor",
+          )?.value as IDBObjectStore["openCursor"];
           IDBObjectStore.prototype.openCursor = function (...args) {
             if (this.name === "composerDrafts") {
               blockedTransactions.add(this.transaction);
@@ -119,9 +122,9 @@ suite.define(() => {
           ({ draftScope, draftStore }) =>
             Promise.race([
               draftStore.readDurableComposerDraft(draftScope),
-              new Promise((resolve) =>
-                setTimeout(() => resolve({ status: "maintenance-blocked-read" }), 1_000),
-              ),
+              new Promise((resolve) => {
+                setTimeout(() => resolve({ status: "maintenance-blocked-read" }), 1_000);
+              }),
             ]),
           { draftScope: scope, draftStore: reopenedStoreHandle },
         );

--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -96,13 +96,14 @@ suite.define(() => {
             IDBObjectStore.prototype,
             "openCursor",
           )?.value as IDBObjectStore["openCursor"];
-          IDBObjectStore.prototype.openCursor = function (...args) {
+          IDBObjectStore.prototype.openCursor = function (this: IDBObjectStore, ...args) {
             if (this.name === "composerDrafts") {
               blockedTransactions.add(this.transaction);
             }
             return originalOpenCursor.apply(this, args);
           };
           IDBTransaction.prototype.addEventListener = function (
+            this: IDBTransaction,
             type: string,
             listener: EventListenerOrEventListenerObject,
             options?: boolean | AddEventListenerOptions,

--- a/ui/src/lib/chat/composer-draft-store.runtime.ts
+++ b/ui/src/lib/chat/composer-draft-store.runtime.ts
@@ -131,14 +131,11 @@ function openDatabase(): Promise<IDBDatabase> {
           database.close();
           databasePromise = null;
         });
-        void sweepExpiredRecords(database).then(
-          () => resolve(database),
-          (error: unknown) => {
-            database.close();
-            databasePromise = null;
-            reject(error instanceof Error ? error : new Error("IndexedDB maintenance failed"));
-          },
-        );
+        resolve(database);
+        // Expiry cleanup spans every owner and must not hold foreground draft reads
+        // behind a database-wide cursor scan. Start it in the next task so the
+        // operation that opened the database registers its transaction first.
+        globalThis.setTimeout(() => void sweepExpiredRecords(database).catch(() => undefined), 0);
       },
       { once: true },
     );


### PR DESCRIPTION
## Summary

- let foreground composer-draft reads register before the database-wide expiry sweep
- keep expiry cleanup best-effort in the next browser task
- prove a requested draft restores even while global maintenance remains pending

## Root cause

`openDatabase()` did not resolve until `sweepExpiredRecords()` completed a read-write cursor scan across every stored draft. A cold or loaded browser therefore queued the requested draft read behind unrelated global maintenance. In main CI job 96964900519, the New Session page had activated the correct durable owner and route but remained at revision zero until the restore assertion expired.

The draft store owns both foreground reads and lifecycle maintenance. The canonical fix keeps per-record expiry enforcement in the foreground read while scheduling the global orphan cleanup after the opening operation has registered its transaction.

## Verification

- pre-fix regression: `maintenance-blocked-read` instead of the stored draft
- post-fix: `composer-draft-store.e2e.test.ts` — 4/4 passed
- combined draft-store + New Session prompt/attachment E2E — 18/18 passed
- `git diff --check` — passed
- autoreview — clean (0.98)
- changed gate — all completed guards passed; typecheck reached an unrelated existing checkout dependency error: `ui/vite.config.ts` cannot find declarations for `pako`

## Scope

- production: +5 / -8 (net -3)
- tests: +70 / -0
- sibling coverage: expiry cleanup on reopen, text-only reload restore, attachment-bearing reload restore

## Release note

Fix Control UI New Session drafts occasionally appearing empty after a page reload while browser storage maintenance was still running.
