### PR TITLE
improve(tui): speed up unchanged transcript redraws

### DIFF
--- a/src/tui/components/hyperlink-markdown.test.ts
+++ b/src/tui/components/hyperlink-markdown.test.ts
@@ -17,6 +17,30 @@ function osc8Targets(raw: string) {
 }
 
 describe("HyperlinkMarkdown", () => {
+  it("does not reallocate prepared lines for an unchanged same-width redraw", () => {
+    const markdown = new HyperlinkMarkdown(
+      "مرحبا [docs](https://example.test/path)",
+      0,
+      0,
+      markdownTheme,
+    );
+
+    const first = markdown.render(80);
+    expect(markdown.render(80)).toBe(first);
+
+    const resized = markdown.render(40);
+    expect(resized).not.toBe(first);
+    expect(markdown.render(40)).toBe(resized);
+
+    markdown.setText("updated");
+    const updated = markdown.render(40);
+    expect(updated).not.toBe(resized);
+    expect(markdown.render(40)).toBe(updated);
+
+    markdown.invalidate();
+    expect(markdown.render(40)).not.toBe(updated);
+  });
+
   it("moves dunder identifiers intact across fenced code wrap boundaries", () => {
     const markdown = new HyperlinkMarkdown(
       ["```python", 'if __name__ == "__main__":', "```"].join("\n"),

--- a/src/tui/components/hyperlink-markdown.ts
+++ b/src/tui/components/hyperlink-markdown.ts
@@ -24,6 +24,7 @@ function sanitizeMarkdownDisplayText(text: string): string {
 export class HyperlinkMarkdown implements Component {
   private inner: Markdown;
   private urls: string[];
+  private cachedRender?: { width: number; lines: string[] };
 
   constructor(
     text: string,
@@ -39,16 +40,25 @@ export class HyperlinkMarkdown implements Component {
   }
 
   render(width: number): string[] {
-    return addOsc8Hyperlinks(this.inner.render(width), this.urls).map(isolateRtlRenderedLine);
+    if (this.cachedRender?.width === width) {
+      return this.cachedRender.lines;
+    }
+    const lines = addOsc8Hyperlinks(this.inner.render(width), this.urls).map(
+      isolateRtlRenderedLine,
+    );
+    this.cachedRender = { width, lines };
+    return lines;
   }
 
   setText(text: string): void {
     const displayText = sanitizeMarkdownDisplayText(text);
     this.inner.setText(displayText);
     this.urls = extractUrls(displayText);
+    this.cachedRender = undefined;
   }
 
   invalidate(): void {
     this.inner.invalidate();
+    this.cachedRender = undefined;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated CPU and allocation work when the TUI redraws unchanged markdown transcript rows at the same terminal width. Each redraw previously re-applied OSC-8 hyperlink projection and RTL isolation and allocated a new outer line array even though the underlying markdown renderer had already cached its output.

## Why This Change Was Made

`HyperlinkMarkdown` now retains its latest fully prepared render result by width and clears that cache whenever text or render state is invalidated. This keeps width changes, transcript updates, hyperlink safety, RTL formatting, and explicit invalidation behavior unchanged while avoiding duplicate projection work for stable rows.

The adjacent pi-tui scrollback issue #78017 concerns content-changing redraws and is not addressed or closed by this unchanged-redraw optimization.

## User Impact

Long transcript views redraw substantially faster when content and terminal width are unchanged, reducing TUI CPU usage and transient allocations without changing rendered output.

## Evidence

- Exact current-main owner benchmark, Node 24.15.0, 180 transcript-like rows × 250 redraws × 9 samples: median **245.256 ms → 1.083 ms** per 45,000-call sample (~226× faster); checksum unchanged (`990000`).
- Direct `HyperlinkMarkdown` plus `ChatLog` output differential: byte-identical, 6,128 bytes, SHA-256 `1465d2dc887a44f27f039d1e65405308adad7bb75f8a245baccc449087bb77ff`.
- Focused TUI component coverage: 4 files, **121/121 passed**.
- Full fake-backend PTY lane: **72/74 passed**; both failures were existing harness wait timeouts unrelated to the changed owner. Affected render-path checks passed.
- Post-rebase owner tests: **10/10 passed**.
- `node scripts/check-changed.mjs -- src/tui/components/hyperlink-markdown.ts src/tui/components/hyperlink-markdown.test.ts`: passed.
- `pnpm build`: passed.
- Bundled authenticated Codex `gpt-5.6-sol` / high review: clean, no actionable P0–P3 findings (0.94 after current-main rebase).

No screenshot is included because the intended behavior and output are byte-identical; the fake-backend PTY suite exercises the real terminal boundary.
