### PR TITLE
fix(e2e): restore package-to-git release validation

### DIFF
--- a/scripts/e2e/lib/package-git-fixture.mjs
+++ b/scripts/e2e/lib/package-git-fixture.mjs
@@ -47,6 +47,7 @@ function prepare(root) {
     ...packageJson.scripts,
     openclaw: "node openclaw.mjs",
   };
+  delete packageJson.scripts.postinstall;
   const aiRuntimeSource = path.join(root, "node_modules", "@openclaw", "ai");
   const aiRuntimePackageJson = path.join(aiRuntimeSource, "package.json");
   if (!fs.existsSync(aiRuntimePackageJson)) {

--- a/test/scripts/package-git-fixture.test.ts
+++ b/test/scripts/package-git-fixture.test.ts
@@ -21,6 +21,7 @@ describe("package git fixture", () => {
           scripts: {
             build: "node build.mjs",
             openclaw: "node scripts/run-node.mjs",
+            postinstall: "node scripts/postinstall-bundled-plugins.mjs",
           },
         },
         null,
@@ -98,6 +99,7 @@ describe("package git fixture", () => {
           scripts: {
             lint: "node lint.mjs",
             openclaw: "node scripts/run-node.mjs",
+            postinstall: "node scripts/postinstall-bundled-plugins.mjs",
           },
         },
         null,
@@ -113,12 +115,9 @@ describe("package git fixture", () => {
 
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
-    expect(packageJson).toMatchObject({
-      dependencies: { chalk: "5.6.2" },
-      scripts: {
-        lint: "node lint.mjs",
-        openclaw: "node openclaw.mjs",
-      },
+    expect(packageJson.scripts).toEqual({
+      lint: "node lint.mjs",
+      openclaw: "node openclaw.mjs",
     });
     expect(packageJson.dependencies).not.toHaveProperty("@openclaw/ai");
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full-release package-to-Git switch validation failed while installing the synthetic Git checkout. The failure appeared in both [OpenClaw Release Checks run 32546714131](https://github.com/openclaw/openclaw/actions/runs/32546714131) and [Plugin Prerelease run 32546713806](https://github.com/openclaw/openclaw/actions/runs/32546713806) at validation SHA `53fbe2eb33adea9eadfa51c01df2d88014990c81` as `ERR_MODULE_NOT_FOUND: Cannot find package 'tslog'` from the extracted package's built logger.

## Why This Change Was Made

The package-derived Git fixture now removes the installed-package-only root `postinstall` script while preserving dependency install scripts and the packed CLI entrypoint. Package postinstall behavior remains covered by the real package-install lanes; the synthetic tree is prepared specifically to model a Git checkout.

## User Impact

No shipped runtime behavior changes. Release qualification can again exercise package-to-Git update and doctor switching against the packed CLI.

## Evidence

- Before fix: focused fixture test failed because `postinstall` remained in the prepared manifest.
- After fix: `node scripts/run-vitest.mjs test/scripts/package-git-fixture.test.ts` — 2 passed.
- Exact downloaded package artifact, transformed by the fixed helper and installed with npm 11.16.0 using lifecycle scripts disabled for local native portability: `tslog` resolved successfully and the transformed manifest had no root `postinstall`.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/package-git-fixture.mjs test/scripts/package-git-fixture.test.ts` — passed all selected lanes.
- `git diff --check` — passed.
- Autoreview: clean; no accepted/actionable findings.
- Local Docker/Crabbox proof unavailable on this host; hosted exact-head Docker CI remains the Linux behavioral gate.
