### PR TITLE
fix(agents): include ctimeMs in workspace file cache identity

### DIFF
--- a/src/agents/workspace.bootstrap-cache.test.ts
+++ b/src/agents/workspace.bootstrap-cache.test.ts
@@ -124,6 +124,10 @@ describe("workspace bootstrap file caching", () => {
       name: DEFAULT_AGENTS_FILENAME,
       content: content1,
     });
+    // Use integer-second mtime so utimes can restore it exactly, isolating ctime as the
+    // only changed stat field after the in-place edit.
+    const cleanTime = new Date(Math.floor(Date.now() / 1000) * 1000);
+    await fs.utimes(filePath, cleanTime, cleanTime);
     const originalStat = await fs.stat(filePath);
 
     const agentsFile1 = await loadAgentsFile(workspaceDir);
@@ -132,6 +136,36 @@ describe("workspace bootstrap file caching", () => {
     await fs.writeFile(tempPath, content2, "utf-8");
     await fs.utimes(tempPath, originalStat.atime, originalStat.mtime);
     await fs.rename(tempPath, filePath);
+    await fs.utimes(filePath, originalStat.atime, originalStat.mtime);
+
+    const agentsFile2 = await loadAgentsFile(workspaceDir);
+    expectAgentsContent(agentsFile2, content2);
+  });
+
+  it("invalidates cache when content changes in-place with restored mtime", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const content1 = "# old guidance";
+    const content2 = "# new guidance";
+    const filePath = path.join(workspaceDir, DEFAULT_AGENTS_FILENAME);
+
+    await writeWorkspaceFile({
+      dir: workspaceDir,
+      name: DEFAULT_AGENTS_FILENAME,
+      content: content1,
+    });
+    // Use integer-second mtime so utimes can restore it exactly, isolating ctime as the
+    // only changed stat field after the in-place edit.
+    const cleanTime = new Date(Math.floor(Date.now() / 1000) * 1000);
+    await fs.utimes(filePath, cleanTime, cleanTime);
+    const originalStat = await fs.stat(filePath);
+
+    const agentsFile1 = await loadAgentsFile(workspaceDir);
+    expectAgentsContent(agentsFile1, content1);
+
+    // In-place edit: same path, same size, restore mtime — only ctime changes.
+    await fs.writeFile(filePath, content2, "utf-8");
     await fs.utimes(filePath, originalStat.atime, originalStat.mtime);
 
     const agentsFile2 = await loadAgentsFile(workspaceDir);

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -96,14 +96,16 @@ type WorkspaceFileSourceIdentity = readonly [
 const workspaceFileSourceIdentities = new WeakMap<object, WorkspaceFileSourceIdentity>();
 
 /**
- * Read workspace files via boundary-safe open and cache by inode/dev/size/mtime identity.
+ * Read workspace files via boundary-safe open and cache by inode/dev/size/mtime/ctime identity.
  */
 type WorkspaceGuardedReadResult =
   | { ok: true; content: string; sourceIdentity: WorkspaceFileSourceIdentity }
   | { ok: false; reason: "path" | "validation" | "io"; error?: unknown };
 
 function workspaceFileIdentity(stat: syncFs.Stats, canonicalPath: string): string {
-  return `${canonicalPath}|${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
+  // ctimeMs catches in-place edits that restore mtime (sync/restore/editor tooling);
+  // matches the freshness pattern in assistant-avatar-cache.ts and plugin-registry-snapshot.ts.
+  return `${canonicalPath}|${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`;
 }
 
 function setWorkspaceFileSourceIdentity(


### PR DESCRIPTION
Closes #127504

## What Problem This Solves

A program that caches file contents to save time checks whether a file changed by looking at its "modification time" (mtime). But if someone edits a file and then restores the original modification time (via sync tools, editors, or file restore operations), the program sees "time unchanged" and keeps serving stale cached content — even though the actual bytes on disk are different. This fix adds `ctime` (a system record the OS updates on every file change and cannot be restored via `utimes`) to the cache identity, so the program always detects in-place edits regardless of mtime restoration.

- Problem: `workspaceFileCache` in `src/agents/workspace.ts` identifies cached files by `path|dev:ino:size:mtimeMs`, omitting `ctimeMs`. A same-inode, equal-size in-place edit with restored mtime produces an identical identity, causing the cache to return stale content for the lifetime of the process.
- Solution: Include `ctimeMs` in the cache identity string so any metadata change (including in-place edits that restore mtime) invalidates the cache.
- What changed: `src/agents/workspace.ts` (1 line in `workspaceFileIdentity` + comment + JSDoc), `src/agents/workspace.bootstrap-cache.test.ts` (1 regression test + cleanTime helper in existing inode test).
- What did NOT change: Read logic, session snapshot cache (`bootstrap-cache.ts`), `openRootFileFollowingParents`, public API, schema, config. Does not touch `src/skills/**`.

## Why This Change Was Made

The workspace bootstrap file cache runs every turn for long-lived agent sessions, loading AGENTS.md, SOUL.md, IDENTITY.md, USER.md, BOOTSTRAP.md, MEMORY.md, and extra bootstrap-pattern files. A stale cache means the agent silently operates on obsolete workspace instructions until the process restarts.

`ctimeMs` is a Node.js `Stats` standard property updated by the OS on every inode metadata change. Unlike `mtimeMs`, it cannot be restored via `utimes` — the OS always updates it when file content changes, even if mtime is explicitly set back. This makes it a reliable change-detection signal for the in-place-edit-with-restored-mtime scenario described in the issue.

This matches the existing ctime-based freshness pattern already used in the codebase:
- `src/gateway/assistant-avatar-cache.ts` — uses `ctimeMs` in its cache identity with a comment noting "an atomic same-size replacement could leave stale identity data indefinitely"
- `src/plugins/plugin-registry-snapshot.ts` — uses `ctimeMs` alongside `size` and `mtimeMs` for file content matching

**Alternative considered**: A content hash fallback (like `plugin-registry-snapshot.ts`'s `safeHashFile` path) would be stronger but requires reading file content on every cache check, defeating the purpose of the stat-based cache (skip reading when unchanged). Since `assistant-avatar-cache.ts` already uses `ctimeMs` without a hash fallback for the same class of problem, and `ctimeMs` is reliable on all supported platforms (Linux ext4/btrfs, macOS APFS, Windows NTFS), the simpler approach is sufficient.

## User Impact

After editing a workspace guidance file (e.g., AGENTS.md) in-place with a tool that restores mtime, long-running agent sessions now pick up the new content on the next turn instead of silently using stale cached content until process restart. No configuration changes required.

## Evidence

**Direct loader proof — before fix** (calling `loadWorkspaceBootstrapFiles` from `src/agents/workspace.ts` with the identity function reverted to `mtimeMs` only):

```
$ node --import tsx proof-loader.mts   # identity = path|dev:ino:size:mtimeMs (no ctimeMs)

=== Step 1: Initial load (populates cache) ===
Content loaded: "# old guidance"
stat: size=14 mtimeMs=1787378863000 ctimeMs=1787378863993.1855 ino=211830636

=== Step 2: In-place edit + restored mtime ===
Disk content: "# new guidance"
stat: size=14 mtimeMs=1787378863000 ctimeMs=1787378864012.1868 ino=211830636
mtimeMs unchanged: true
ctimeMs changed:   true

=== Step 3: Second load (cache should be invalidated by ctimeMs) ===
Content loaded: "# old guidance"

=== Result ===
Expected: "# new guidance"
Got:      "# old guidance"
Fix verified: false
```

**Direct loader proof — after fix** (same script, identity now includes `ctimeMs`):

```
$ node --import tsx proof-loader.mts   # identity = path|dev:ino:size:mtimeMs:ctimeMs

=== Step 1: Initial load (populates cache) ===
Content loaded: "# old guidance"
stat: size=14 mtimeMs=1787378868000 ctimeMs=1787378868232.4824 ino=270698368

=== Step 2: In-place edit + restored mtime ===
Disk content: "# new guidance"
stat: size=14 mtimeMs=1787378868000 ctimeMs=1787378868251.4836 ino=270698368
mtimeMs unchanged: true
ctimeMs changed:   true

=== Step 3: Second load (cache should be invalidated by ctimeMs) ===
Content loaded: "# new guidance"

=== Result ===
Expected: "# new guidance"
Got:      "# new guidance"
Fix verified: true
```

The proof script imports `loadWorkspaceBootstrapFiles` from `src/agents/workspace.ts` and calls it directly — this is the real OpenClaw workspace bootstrap loader, not a mock. It writes an AGENTS.md file, loads it (populating the process-level cache), then performs an in-place edit with restored mtime and loads again. Before the fix, the second load returns stale cached content. After the fix, ctimeMs differs and the cache is invalidated, returning fresh content.

**Regression test** (real filesystem, `node scripts/run-vitest.mjs`):

```
$ OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/workspace.bootstrap-cache.test.ts --reporter=verbose

 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > returns cached content when mtime unchanged 66ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > invalidates cache when mtime changes 12ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > refreshes session bootstrap snapshots after workspace file changes 8ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > invalidates cache when inode changes with same mtime 6ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > invalidates cache when content changes in-place with restored mtime 6ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > replaces a session snapshot when inode changes with identical bytes 10ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > handles file deletion gracefully 5ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > handles concurrent access 12ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > caches files independently by path 9ms
 ✓ |agents| src/agents/workspace.bootstrap-cache.test.ts > workspace bootstrap file caching > returns missing=true when bootstrap file never existed 4ms

 Test Files  1 passed (1)
      Tests 10 passed (10)
```

What was not tested: Windows platform (test skips on win32, consistent with existing inode-change tests in the same file). No network filesystem or Docker overlay FS tested.

## AI Assistance

- AI-assisted: Yes
- Tools: Codex CLI (OpenAI)
- Prompts / session excerpts: Assisted with issue analysis, root cause investigation, and implementation following the open-source-pr skill workflow. Key prompts: "analyze issue #127504 root cause", "implement ctimeMs fix in workspaceFileIdentity", "write regression test for in-place edit with restored mtime", "generate direct loader proof for ClawSweeper".
- Confirmed understanding of code changes: Yes — the fix adds `stat.ctimeMs` to the cache identity string in `workspaceFileIdentity()`. This function is the single identity computation point used by `readWorkspaceFileWithGuards` for both cache-hit decisions (line 171) and source identity storage (line 168, consumed by `workspaceFileSourceIdentitiesMatch` in `bootstrap-cache.ts`). Adding `ctimeMs` ensures that any in-place file edit — even when mtime is restored — produces a different identity, invalidating the cache and forcing a fresh disk read.
- autoreview: N/A
