### PR TITLE
fix(pdf): support native OpenAI Responses input

### DIFF
--- a/docs/tools/pdf.md
+++ b/docs/tools/pdf.md
@@ -15,10 +15,12 @@ The tool registers only when OpenClaw can resolve a PDF-capable model for the ag
 
 1. `agents.defaults.pdfModel` (explicit primary/fallbacks)
 2. `agents.defaults.imageModel` (explicit primary/fallbacks)
-3. The agent's resolved session/default model, if its provider supports native PDF input (Anthropic, Google) or already has a configured vision model
+3. The agent's resolved session/default model, if its provider supports native PDF input (Anthropic, Google, OpenAI) or already has a configured vision model
 4. Auto-detected image/vision-capable providers with usable auth, preferring native-PDF providers first
 
 Every fallback candidate is auth-checked before use, so a configured `provider/model` only counts if OpenClaw can authenticate that provider for the agent. If no usable model resolves, the `pdf` tool is not exposed.
+
+On fresh installs and after upgrades, automatic selection can prefer OpenAI's PDF model when OpenAI is the default provider with usable auth, even when Anthropic is also available. Explicit `pdfModel` and `imageModel` settings keep their precedence. Saved configuration is not rewritten.
 
 ## Input reference
 
@@ -72,13 +74,16 @@ Used for providers `anthropic` and `google`, and for `openai` with the `openai-r
 
 Limits:
 
+- OpenAI native input requires `image` in the resolved model's input capabilities. Configured text-only models retain extraction, including explicit `input: ["text"]` overrides.
 - Anthropic and Google reject `pages` and `password` with `pages is not supported with native PDF providers` or `password is not supported with native PDF providers`. Use an extraction-capable route for these options.
 - OpenAI uses extraction when `pages` or `password` is set, preserving page filtering and encrypted-PDF support.
 - OpenAI native input requires each PDF to be smaller than `50,000,000` bytes and all PDFs together to be at most `50,000,000` bytes. Larger requests use extraction. These conservative decimal-byte bounds follow the [OpenAI file input limits](https://developers.openai.com/api/docs/guides/file-inputs#usage-considerations); the per-PDF loader cap still applies first.
 
+An existing OpenAI configuration that meets these requirements sends the complete original PDFs after upgrading, rather than only locally extracted content. `pdfMaxPages` limits extraction only; it does not limit native uploads.
+
 ### Extraction fallback mode
 
-Used for every other provider, custom OpenAI endpoints, ChatGPT/Codex transports, and OpenAI requests that need filtering, decryption, or exceed the native file limits.
+Used for every other provider, custom OpenAI endpoints, and ChatGPT/Codex transports. OpenAI also uses extraction for text-only models, page filtering, decryption, and requests exceeding the native file limits.
 
 1. Extract text from the selected pages (up to `agents.defaults.pdfMaxPages`, default `20`) via the bundled `document-extract` plugin, which uses the `clawpdf` package (PDFium WebAssembly) for text and image extraction.
 2. If the extracted text is shorter than `200` characters, render the same pages to PNG images. The render budget is `4,000,000` pixels total, shared across all pages needing images (allocated proportionally per remaining page, not per page), so text pages that already have enough text skip rendering entirely.

--- a/docs/tools/pdf.md
+++ b/docs/tools/pdf.md
@@ -7,7 +7,7 @@ read_when:
   - You are debugging native PDF mode vs extraction fallback
 ---
 
-`pdf` analyzes one or more PDF documents and returns text. It uses native document input on Anthropic and Google models, and falls back to text/image extraction for every other provider.
+`pdf` analyzes one or more PDF documents and returns text. It uses native document input on Anthropic, Google, and supported OpenAI Responses routes, and falls back to text/image extraction otherwise.
 
 ## Availability
 
@@ -35,7 +35,7 @@ Analysis prompt.
 </ParamField>
 
 <ParamField path="pages" type="string">
-Page filter like `1-5` or `1,3,7-9`. Not supported in native provider mode.
+Page filter like `1-5` or `1,3,7-9`. OpenAI uses extraction when this is set. Not supported with Anthropic or Google native PDF input.
 </ParamField>
 
 <ParamField path="password" type="string">
@@ -68,16 +68,17 @@ Other URI schemes (for example `ftp://`) return `details.error = "unsupported_pd
 
 ### Native provider mode
 
-Used for provider `anthropic` and `google` (the only providers that currently declare native PDF document support). Raw PDF bytes go directly to the provider API as a native document/inline-PDF part per file.
+Used for providers `anthropic` and `google`, and for `openai` with the `openai-responses` transport at the official HTTPS `api.openai.com` endpoint. Raw PDF bytes go directly to the provider API as a native document/inline-PDF part per file. OpenAI receives the complete documents as `input_file` parts; local extraction page limits do not apply to native input.
 
 Limits:
 
-- `pages` is not supported; if set, the tool throws `pages is not supported with native PDF providers`.
-- `password` is not supported; if set, the tool throws `password is not supported with native PDF providers`. Use a non-native model for encrypted PDFs.
+- Anthropic and Google reject `pages` and `password` with `pages is not supported with native PDF providers` or `password is not supported with native PDF providers`. Use an extraction-capable route for these options.
+- OpenAI uses extraction when `pages` or `password` is set, preserving page filtering and encrypted-PDF support.
+- OpenAI native input requires each PDF to be smaller than `50,000,000` bytes and all PDFs together to be at most `50,000,000` bytes. Larger requests use extraction. These conservative decimal-byte bounds follow the [OpenAI file input limits](https://developers.openai.com/api/docs/guides/file-inputs#usage-considerations); the per-PDF loader cap still applies first.
 
 ### Extraction fallback mode
 
-Used for every other provider.
+Used for every other provider, custom OpenAI endpoints, ChatGPT/Codex transports, and OpenAI requests that need filtering, decryption, or exceed the native file limits.
 
 1. Extract text from the selected pages (up to `agents.defaults.pdfMaxPages`, default `20`) via the bundled `document-extract` plugin, which uses the `clawpdf` package (PDFium WebAssembly) for text and image extraction.
 2. If the extracted text is shorter than `200` characters, render the same pages to PNG images. The render budget is `4,000,000` pixels total, shared across all pages needing images (allocated proportionally per remaining page, not per page), so text pages that already have enough text skip rendering entirely.

--- a/extensions/openai/media-understanding-provider.test.ts
+++ b/extensions/openai/media-understanding-provider.test.ts
@@ -30,6 +30,7 @@ describe("openaiMediaUnderstandingProvider", () => {
       audio: "gpt-4o-transcribe",
     });
     expect(openaiMediaUnderstandingProvider.autoPriority).toEqual({ image: 20, audio: 20 });
+    expect(openaiMediaUnderstandingProvider.nativeDocumentInputs).toEqual(["pdf"]);
     expect(openaiMediaUnderstandingProvider.transcribeAudio).toBeTypeOf("function");
   });
 });

--- a/extensions/openai/media-understanding-provider.ts
+++ b/extensions/openai/media-understanding-provider.ts
@@ -5,6 +5,7 @@ import { OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL } from "./default-models.js";
 export const openaiMediaUnderstandingProvider: MediaUnderstandingProvider = {
   id: "openai",
   capabilities: ["image", "audio"],
+  nativeDocumentInputs: ["pdf"],
   defaultModels: { image: "gpt-5.6-sol", audio: OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL },
   autoPriority: { image: 20, audio: 20 },
   async describeImage(req) {

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -332,7 +332,8 @@
       "autoPriority": {
         "image": 20,
         "audio": 20
-      }
+      },
+      "nativeDocumentInputs": ["pdf"]
     }
   },
   "configSchema": {

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -53,6 +53,18 @@ function makeGeminiAnalyzeParams(
   };
 }
 
+function makeOpenAIAnalyzeParams(
+  overrides: Partial<Parameters<typeof pdfNativeProviders.openaiAnalyzePdf>[0]> = {},
+) {
+  return {
+    apiKey: "test-key",
+    modelId: "gpt-5.4-mini",
+    prompt: "test",
+    pdfs: [TEST_PDF_INPUT],
+    ...overrides,
+  };
+}
+
 describe("native PDF provider API calls", () => {
   const priorFetch = global.fetch;
 
@@ -490,6 +502,79 @@ describe("native PDF provider API calls", () => {
     await expect(
       pdfNativeProviders.anthropicAnalyzePdf(makeAnthropicAnalyzeParams()),
     ).rejects.toThrow("JSON response exceeds");
+  });
+
+  it.each([
+    undefined,
+    "https://api.openai.com",
+    "https://api.openai.com/",
+    "https://api.openai.com/v1",
+    "https://api.openai.com/v1/",
+  ])(
+    "openaiAnalyzePdf sends input_file to the public Responses API with base %s",
+    async (baseUrl) => {
+      const fetchMock = mockFetchResponse(
+        jsonResponse({
+          output: [
+            { type: "message", content: [{ type: "output_text", text: "OpenAI PDF analysis" }] },
+          ],
+        }),
+      );
+
+      const result = await pdfNativeProviders.openaiAnalyzePdf(
+        makeOpenAIAnalyzeParams({ prompt: "Summarize this document", baseUrl }),
+      );
+
+      expect(result).toBe("OpenAI PDF analysis");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, opts] = firstFetchCall(fetchMock) as [
+        string,
+        { body: string; headers: Headers; signal: AbortSignal },
+      ];
+      expect(url).toBe("https://api.openai.com/v1/responses");
+      expect(opts.headers.get("Authorization")).toBe("Bearer test-key");
+      expect(opts.signal).toBeInstanceOf(AbortSignal);
+      const body = JSON.parse(opts.body);
+      expect(body.store).toBe(false);
+      expect(body.input[0].content).toEqual([
+        {
+          type: "input_file",
+          filename: "doc.pdf",
+          file_data: "data:application/pdf;base64,dGVzdA==",
+        },
+        { type: "input_text", text: "Summarize this document" },
+      ]);
+    },
+  );
+
+  it("redacts reflected OpenAI bearer credentials from bounded errors", async () => {
+    const credential = "sk-openai-native-pdf-secret-value";
+    mockFetchResponse(
+      textResponse(`upstream echoed Bearer ${credential}`, {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+
+    const error = await captureError(
+      pdfNativeProviders.openaiAnalyzePdf(makeOpenAIAnalyzeParams({ apiKey: credential })),
+      "OpenAI PDF request",
+    );
+    expect(error.message).toContain("OpenAI PDF request failed (401");
+    expect(error.message).not.toContain(credential);
+    expect(error.message).toContain("upstream echoed ***");
+  });
+
+  it("forwards cancellation to the OpenAI Responses request", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled"));
+    const fetchMock = vi.fn();
+    global.fetch = Object.assign(fetchMock, { preconnect: vi.fn() }) as typeof global.fetch;
+
+    await expect(
+      pdfNativeProviders.openaiAnalyzePdf(makeOpenAIAnalyzeParams({ signal: controller.signal })),
+    ).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("geminiAnalyzePdf sends correct request shape", async () => {

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -205,6 +205,91 @@ export async function anthropicAnalyzePdf(params: {
 }
 
 // ---------------------------------------------------------------------------
+// OpenAI – native PDF via public Responses API
+// ---------------------------------------------------------------------------
+
+export async function openaiAnalyzePdf(params: {
+  apiKey: string;
+  modelId: string;
+  prompt: string;
+  pdfs: PdfInput[];
+  maxTokens?: number;
+  baseUrl?: string;
+  requestConfig?: NativePdfProviderRequestConfig;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const apiKey = normalizeSecretInput(params.apiKey);
+  if (!apiKey) {
+    throw new Error("OpenAI PDF: apiKey required");
+  }
+
+  const content: Array<Record<string, string>> = params.pdfs.map((pdf) => ({
+    type: "input_file",
+    filename: pdf.filename ?? "document.pdf",
+    file_data: `data:application/pdf;base64,${pdf.base64}`,
+  }));
+  content.push({ type: "input_text", text: params.prompt });
+
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy, trustConfiguredBaseUrlOrigin } =
+    resolveProviderHttpRequestConfigWithOriginTrust({
+      baseUrl: params.baseUrl,
+      defaultBaseUrl: "https://api.openai.com/v1",
+      defaultHeaders: {
+        ...params.requestConfig?.headers,
+        Authorization: `Bearer ${apiKey}`,
+      },
+      request: params.requestConfig?.request,
+      provider: "openai",
+      api: "openai-responses",
+      capability: "other",
+      transport: "http",
+    });
+  headers.set("Content-Type", "application/json");
+  const url = new URL("/v1/responses", baseUrl).href;
+
+  const json = await postNativePdfJson({
+    url,
+    headers,
+    body: {
+      model: params.modelId,
+      input: [{ role: "user", content }],
+      max_output_tokens: params.maxTokens ?? 4096,
+      store: false,
+    },
+    allowPrivateNetwork,
+    ssrfPolicy: resolveProviderTransportSsrFPolicy({
+      baseUrl,
+      url,
+      allowPrivateNetwork,
+      trustConfiguredBaseUrlOrigin,
+    }),
+    dispatcherPolicy,
+    failureLabel: "OpenAI PDF request failed",
+    responseLabel: "OpenAI PDF response",
+    nonJsonMessage: "OpenAI PDF response was not JSON.",
+    request: params.requestConfig?.request,
+    defaultAuthHeader: "authorization",
+    signal: params.signal,
+  });
+
+  const output = Array.isArray(json.output) ? json.output : [];
+  const text = output
+    .flatMap((item) =>
+      isRecord(item) && item.type === "message" && Array.isArray(item.content) ? item.content : [],
+    )
+    .flatMap((item) =>
+      isRecord(item) && item.type === "output_text" && typeof item.text === "string"
+        ? [item.text]
+        : [],
+    )
+    .join("");
+  if (!text.trim()) {
+    throw new Error("OpenAI PDF returned no text.");
+  }
+  return text.trim();
+}
+
+// ---------------------------------------------------------------------------
 // Google Gemini – native PDF via generateContent API
 // ---------------------------------------------------------------------------
 

--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -23,7 +23,7 @@ const pdfMetadataSnapshot = createPluginMetadataSnapshotFixture({
       mediaUnderstandingProviderMetadata: {
         anthropic: { capabilities: ["image"], nativeDocumentInputs: ["pdf"] },
         google: { capabilities: ["image"], nativeDocumentInputs: ["pdf"] },
-        openai: { capabilities: ["image"], nativeDocumentInputs: [] },
+        openai: { capabilities: ["image"], nativeDocumentInputs: ["pdf"] },
       },
     },
   ],
@@ -94,6 +94,38 @@ describe("parsePageRange", () => {
 });
 
 describe("providerSupportsNativePdf", () => {
+  it("enables OpenAI only for the public Responses transport", () => {
+    withPluginMetadataSnapshotScope(pdfMetadataSnapshot, () => {
+      for (const baseUrl of [
+        "https://api.openai.com",
+        "https://api.openai.com/v1",
+        "https://api.openai.com:443/v1",
+        "https://api.openai.com./v1/",
+      ]) {
+        expect(providerSupportsNativePdf("openai", "openai-responses", baseUrl)).toBe(true);
+      }
+      for (const baseUrl of [
+        "http://api.openai.com/v1",
+        "https://api.openai.com:8443/v1",
+        "https://user@api.openai.com/v1",
+        "https://api.openai.com/v1?proxy=1",
+        "https://api.openai.com/v1/responses",
+        "https://proxy.example.com/v1",
+      ]) {
+        expect(providerSupportsNativePdf("openai", "openai-responses", baseUrl)).toBe(false);
+      }
+      expect(
+        providerSupportsNativePdf(
+          "openai",
+          "openai-chatgpt-responses",
+          "https://chatgpt.com/backend-api/codex",
+        ),
+      ).toBe(false);
+      expect(providerSupportsNativePdf("openai", "openai-responses")).toBe(false);
+      expect(providerSupportsNativePdf("openai")).toBe(false);
+    });
+  });
+
   it.each([
     ["anthropic", true],
     ["google", true],

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -41,9 +41,44 @@ export function resolvePdfInputs(record: Record<string, unknown>): string[] {
   return pdfInputs;
 }
 
-/** Checks whether a provider supports native PDF document input. */
-export function providerSupportsNativePdf(provider: string): boolean {
-  return providerSupportsNativePdfDocument({ providerId: provider });
+function isOfficialOpenAIPlatformBaseUrl(baseUrl?: string): boolean {
+  if (typeof baseUrl !== "string") {
+    return false;
+  }
+  try {
+    const url = new URL(baseUrl.trim());
+    const hostname = url.hostname.toLowerCase().replace(/\.$/u, "");
+    return (
+      url.protocol === "https:" &&
+      hostname === "api.openai.com" &&
+      !url.port &&
+      !url.username &&
+      !url.password &&
+      !url.search &&
+      !url.hash &&
+      (url.pathname === "/" || url.pathname === "/v1" || url.pathname === "/v1/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Checks whether a resolved provider route supports native PDF document input. */
+export function providerSupportsNativePdf(
+  provider: string,
+  api?: string,
+  baseUrl?: string,
+): boolean {
+  if (!providerSupportsNativePdfDocument({ providerId: provider })) {
+    return false;
+  }
+  // OpenAI's public Responses API accepts input_file. Custom Responses and
+  // ChatGPT/Codex endpoints have separate contracts, so provider metadata and
+  // adapter identity alone are not sufficient to permit raw PDF egress.
+  if (provider.trim().toLowerCase() === "openai") {
+    return api === "openai-responses" && isOfficialOpenAIPlatformBaseUrl(baseUrl);
+  }
+  return true;
 }
 
 /** Parses a page range string into sorted, unique, 1-based page numbers within `maxPages`. */

--- a/src/agents/tools/pdf-tool.model-config.test.ts
+++ b/src/agents/tools/pdf-tool.model-config.test.ts
@@ -103,13 +103,14 @@ describe("resolvePdfModelConfigForTool", () => {
     });
   });
 
-  it("prefers anthropic when available for native PDF support", () => {
+  it("prefers the OpenAI primary provider with native PDF support and retains Anthropic fallback", () => {
     vi.stubEnv("ANTHROPIC_API_KEY", "anthropic-test");
     vi.stubEnv("OPENAI_API_KEY", "openai-test");
     const cfg = withDefaultModel("openai/gpt-5.4");
-    expect(resolvePdfModelConfigForTool({ cfg, agentDir: TEST_AGENT_DIR })?.primary).toBe(
-      ANTHROPIC_PDF_MODEL,
-    );
+    expect(resolvePdfModelConfigForTool({ cfg, agentDir: TEST_AGENT_DIR })).toEqual({
+      primary: "openai/gpt-5.6-sol",
+      fallbacks: [ANTHROPIC_PDF_MODEL],
+    });
   });
 
   it("uses anthropic primary when provider is anthropic", () => {

--- a/src/agents/tools/pdf-tool.openai-native.test.ts
+++ b/src/agents/tools/pdf-tool.openai-native.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import * as pdfExtractModule from "../../media/pdf-extract.js";
+import { isRecord } from "../../utils.js";
+import * as pdfNativeProviders from "./pdf-native-providers.js";
+import {
+  createPdfToolInfraStub,
+  resetPdfToolAuthEnv,
+  withTempPdfAgentDir,
+} from "./pdf-tool.test-support.js";
+
+const completeMock = vi.hoisted(() => vi.fn());
+const registerProviderStreamForModelMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../llm/stream.js", async () => {
+  const actual = await vi.importActual<typeof import("../../llm/stream.js")>("../../llm/stream.js");
+  return { ...actual, complete: completeMock };
+});
+
+vi.mock("../provider-stream.js", () => ({
+  registerProviderStreamForModel: registerProviderStreamForModelMock,
+}));
+
+const { stubPdfToolInfra } = createPdfToolInfraStub(completeMock);
+const OPENAI_PDF_MODEL = "openai/gpt-5.4-mini";
+
+function withPdfModel(primary: string): OpenClawConfig {
+  return { agents: { defaults: { pdfModel: { primary } } } };
+}
+
+function expectDetails(value: unknown, expected: Record<string, unknown>): void {
+  if (!isRecord(value)) {
+    throw new Error("expected details object");
+  }
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    expect(value[key], key).toEqual(expectedValue);
+  }
+}
+
+describe("createPdfTool OpenAI native routing", () => {
+  beforeEach(() => {
+    resetPdfToolAuthEnv();
+    completeMock.mockReset();
+    registerProviderStreamForModelMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses native input for the public OpenAI Responses endpoint", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      });
+      vi.spyOn(pdfNativeProviders, "openaiAnalyzePdf").mockResolvedValue("native OpenAI summary");
+      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent");
+      const { createPdfTool } = await import("./pdf-tool.js");
+      const tool = createPdfTool({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir });
+      if (!tool) {
+        throw new Error("expected pdf tool");
+      }
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+      });
+
+      expect(pdfNativeProviders.openaiAnalyzePdf).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelId: "gpt-5.4-mini",
+          baseUrl: "https://api.openai.com/v1",
+        }),
+      );
+      expect(extractSpy).not.toHaveBeenCalled();
+      expect(result.content).toEqual([{ type: "text", text: "native OpenAI summary" }]);
+      expectDetails(result.details, { native: true, model: OPENAI_PDF_MODEL });
+    });
+  });
+
+  it("uses extraction fallback for custom OpenAI Responses endpoints", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://proxy.example.com/v1",
+      });
+      const nativeSpy = vi.spyOn(pdfNativeProviders, "openaiAnalyzePdf");
+      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted content",
+        images: [],
+      });
+      completeMock.mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "fallback summary" }],
+      } as never);
+      const { createPdfTool } = await import("./pdf-tool.js");
+      const tool = createPdfTool({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir });
+      if (!tool) {
+        throw new Error("expected pdf tool");
+      }
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+      });
+
+      expect(nativeSpy).not.toHaveBeenCalled();
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+      expect(result.content).toEqual([{ type: "text", text: "fallback summary" }]);
+      expectDetails(result.details, { native: false, model: OPENAI_PDF_MODEL });
+      expect(completeMock.mock.calls[0]?.[1].systemPrompt).toBeUndefined();
+    });
+  });
+
+  it("uses extraction fallback for the ChatGPT/Codex transport", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-chatgpt-responses",
+      });
+      const nativeSpy = vi.spyOn(pdfNativeProviders, "openaiAnalyzePdf");
+      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted content",
+        images: [],
+      });
+      completeMock.mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "fallback summary" }],
+      } as never);
+      const { createPdfTool } = await import("./pdf-tool.js");
+      const tool = createPdfTool({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir });
+      if (!tool) {
+        throw new Error("expected pdf tool");
+      }
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+      });
+
+      expect(nativeSpy).not.toHaveBeenCalled();
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+      expect(result.content).toEqual([{ type: "text", text: "fallback summary" }]);
+      expectDetails(result.details, { native: false, model: OPENAI_PDF_MODEL });
+    });
+  });
+});

--- a/src/agents/tools/pdf-tool.openai-native.test.ts
+++ b/src/agents/tools/pdf-tool.openai-native.test.ts
@@ -5,6 +5,7 @@ import { isRecord } from "../../utils.js";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
 import {
   createPdfToolInfraStub,
+  FAKE_PDF_MEDIA,
   resetPdfToolAuthEnv,
   withTempPdfAgentDir,
 } from "./pdf-tool.test-support.js";
@@ -77,6 +78,91 @@ describe("createPdfTool OpenAI native routing", () => {
       expect(extractSpy).not.toHaveBeenCalled();
       expect(result.content).toEqual([{ type: "text", text: "native OpenAI summary" }]);
       expectDetails(result.details, { native: true, model: OPENAI_PDF_MODEL });
+    });
+  });
+
+  it.each([
+    { pages: "1,3-4", expected: { pageNumbers: [1, 3, 4] } },
+    { password: " fixture password ", expected: { password: " fixture password " } },
+    { pages: "2", password: "fixture", expected: { pageNumbers: [2], password: "fixture" } },
+  ])("preserves OpenAI extraction options: $expected", async ({ expected, ...options }) => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      });
+      const nativeSpy = vi.spyOn(pdfNativeProviders, "openaiAnalyzePdf");
+      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "Selected and decrypted content",
+        images: [],
+      });
+      completeMock.mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "fallback summary" }],
+      });
+      const { createPdfTool } = await import("./pdf-tool.js");
+      const tool = createPdfTool({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir });
+      if (!tool) {
+        throw new Error("expected pdf tool");
+      }
+
+      const result = await tool.execute("t1", { pdf: "/tmp/doc.pdf", ...options });
+
+      expect(extractSpy).toHaveBeenCalledWith(expect.objectContaining(expected));
+      expect(nativeSpy).not.toHaveBeenCalled();
+      expect(result.content).toEqual([{ type: "text", text: "fallback summary" }]);
+      expectDetails(result.details, { native: false, model: OPENAI_PDF_MODEL });
+    });
+  });
+
+  it.each([
+    { label: "combined limit", sizes: [25_000_000, 25_000_000], native: true },
+    { label: "combined limit plus one byte", sizes: [25_000_000, 25_000_001], native: false },
+    { label: "six individually valid PDFs", sizes: Array(6).fill(9_000_000), native: false },
+    { label: "single file below limit", sizes: [49_999_999], native: true },
+    { label: "single file at strict limit", sizes: [50_000_000], native: false },
+  ])("routes original PDF sizes at $label", async ({ sizes, native }) => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      const { loadSpy } = await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      });
+      for (const size of sizes) {
+        loadSpy.mockResolvedValueOnce({ ...FAKE_PDF_MEDIA, buffer: Buffer.alloc(size) });
+      }
+      const nativeSpy = vi
+        .spyOn(pdfNativeProviders, "openaiAnalyzePdf")
+        .mockResolvedValue("native summary");
+      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted content",
+        images: [],
+      });
+      completeMock.mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "fallback summary" }],
+      });
+      const { createPdfTool } = await import("./pdf-tool.js");
+      const tool = createPdfTool({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir });
+      if (!tool) {
+        throw new Error("expected pdf tool");
+      }
+
+      const result = await tool.execute("t1", {
+        pdfs: sizes.map((_, index) => `/tmp/doc-${index}.pdf`),
+        maxBytesMb: 60,
+      });
+
+      expect(nativeSpy).toHaveBeenCalledTimes(native ? 1 : 0);
+      expect(extractSpy).toHaveBeenCalledTimes(native ? 0 : sizes.length);
+      expect(completeMock).toHaveBeenCalledTimes(native ? 0 : 1);
+      expect(result.content).toEqual([
+        { type: "text", text: native ? "native summary" : "fallback summary" },
+      ]);
+      expectDetails(result.details, { native, model: OPENAI_PDF_MODEL });
     });
   });
 

--- a/src/agents/tools/pdf-tool.openai-native.test.ts
+++ b/src/agents/tools/pdf-tool.openai-native.test.ts
@@ -53,6 +53,7 @@ describe("createPdfTool OpenAI native routing", () => {
     await withTempPdfAgentDir(async (agentDir) => {
       await stubPdfToolInfra(agentDir, {
         provider: "openai",
+        input: ["text", "image"],
         api: "openai-responses",
         baseUrl: "https://api.openai.com/v1",
       });
@@ -89,6 +90,7 @@ describe("createPdfTool OpenAI native routing", () => {
     await withTempPdfAgentDir(async (agentDir) => {
       await stubPdfToolInfra(agentDir, {
         provider: "openai",
+        input: ["text", "image"],
         api: "openai-responses",
         baseUrl: "https://api.openai.com/v1",
       });
@@ -127,6 +129,7 @@ describe("createPdfTool OpenAI native routing", () => {
     await withTempPdfAgentDir(async (agentDir) => {
       const { loadSpy } = await stubPdfToolInfra(agentDir, {
         provider: "openai",
+        input: ["text", "image"],
         api: "openai-responses",
         baseUrl: "https://api.openai.com/v1",
       });
@@ -170,6 +173,7 @@ describe("createPdfTool OpenAI native routing", () => {
     await withTempPdfAgentDir(async (agentDir) => {
       await stubPdfToolInfra(agentDir, {
         provider: "openai",
+        input: ["text", "image"],
         api: "openai-responses",
         baseUrl: "https://proxy.example.com/v1",
       });
@@ -206,6 +210,7 @@ describe("createPdfTool OpenAI native routing", () => {
     await withTempPdfAgentDir(async (agentDir) => {
       await stubPdfToolInfra(agentDir, {
         provider: "openai",
+        input: ["text", "image"],
         api: "openai-chatgpt-responses",
       });
       const nativeSpy = vi.spyOn(pdfNativeProviders, "openaiAnalyzePdf");

--- a/src/agents/tools/pdf-tool.static-runtime.test.ts
+++ b/src/agents/tools/pdf-tool.static-runtime.test.ts
@@ -6,6 +6,7 @@ import * as pdfExtractModule from "../../media/pdf-extract.js";
 import * as webMedia from "../../media/web-media.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { acquireAgentRunPreparedModelRuntime } from "../prepared-model-runtime.js";
+import * as pdfNativeProviders from "./pdf-native-providers.js";
 
 const completeMock = vi.hoisted(() => vi.fn());
 
@@ -24,106 +25,125 @@ describe("PDF tool static prepared runtime", () => {
     vi.restoreAllMocks();
   });
 
-  it("resolves a config-inline model when the static registry is empty", async () => {
-    await withOpenClawTestState(
-      {
-        label: "pdf-static-inline-model",
-        env: { OPENAI_API_KEY: "test-key" },
-      },
-      async (state) => {
-        const modelId = "gpt-5.6-luna";
-        const modelRef = `openai/${modelId}`;
-        await state.writeConfig({
-          models: {
-            mode: "replace",
-            providers: {
-              openai: {
-                api: "openai-responses",
-                baseUrl: "http://127.0.0.1:9/v1",
-                models: [
-                  {
-                    id: modelId,
-                    name: "GPT-5.6 Luna inline fixture",
-                    reasoning: true,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 128_000,
-                    maxTokens: 8_192,
-                  },
-                ],
+  it.each([
+    {
+      label: "custom endpoint",
+      baseUrl: "http://127.0.0.1:9/v1",
+    },
+    {
+      label: "official endpoint with text-only metadata",
+      baseUrl: "https://api.openai.com/v1",
+    },
+  ])(
+    "extracts configured text-only models at $baseUrl",
+    async ({ baseUrl }) => {
+      await withOpenClawTestState(
+        {
+          label: "pdf-static-inline-model",
+          env: { OPENAI_API_KEY: "test-key" },
+        },
+        async (state) => {
+          const modelId = "gpt-5.6-luna";
+          const modelRef = `openai/${modelId}`;
+          await state.writeConfig({
+            models: {
+              mode: "replace",
+              providers: {
+                openai: {
+                  api: "openai-responses",
+                  baseUrl,
+                  models: [
+                    {
+                      id: modelId,
+                      name: "GPT-5.6 Luna inline fixture",
+                      reasoning: true,
+                      input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 128_000,
+                      maxTokens: 8_192,
+                    },
+                  ],
+                },
               },
             },
-          },
-          agents: {
-            defaults: {
-              model: { primary: modelRef },
-              pdfModel: { primary: modelRef },
+            agents: {
+              defaults: {
+                model: { primary: modelRef },
+                pdfModel: { primary: modelRef },
+              },
             },
-          },
-        });
-        const config = loadConfig({
-          pin: false,
-          skipPluginValidation: true,
-          skipShellEnvFallback: true,
-        });
-        const agentDir = state.agentDir();
-        await fs.mkdir(agentDir, { recursive: true });
-        const lease = await acquireAgentRunPreparedModelRuntime(
-          { agentDir, config },
-          { catalogMode: "static" },
-        );
-
-        try {
-          const stores = lease.snapshot.createStores();
-          expect(stores.modelRegistry.find("openai", modelId)).toBeUndefined();
-          expect(
-            lease.snapshot.configuredRuntimeModels.map((entry) => ({
-              provider: entry.provider,
-              modelId: entry.modelId,
-            })),
-          ).toContainEqual({ provider: "openai", modelId });
-
-          vi.spyOn(webMedia, "loadWebMediaRaw").mockResolvedValue({
-            kind: "document",
-            buffer: Buffer.from("%PDF-1.4 inline model fixture"),
-            contentType: "application/pdf",
-            fileName: "inline-model.pdf",
           });
-          vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
-            text: "Inline model regression fixture",
-            images: [],
+          const config = loadConfig({
+            pin: false,
+            skipPluginValidation: true,
+            skipShellEnvFallback: true,
           });
-          completeMock.mockResolvedValue({
-            role: "assistant",
-            stopReason: "stop",
-            content: [{ type: "text", text: "resolved inline model" }],
-          });
-
-          const { createPdfTool } = await import("./pdf-tool.js");
-          const tool = createPdfTool({
-            config,
-            agentDir,
-            preparedModelRuntime: lease.snapshot,
-          });
-          if (!tool) {
-            throw new Error("expected PDF tool");
-          }
-
-          const result = await tool.execute("pdf-static-inline", {
-            prompt: "Summarize",
-            pdf: "/tmp/inline-model.pdf",
-          });
-
-          expect(completeMock).toHaveBeenCalledWith(
-            expect.objectContaining({ provider: "openai", id: modelId }),
-            expect.any(Object),
-            expect.any(Object),
+          const agentDir = state.agentDir();
+          await fs.mkdir(agentDir, { recursive: true });
+          const lease = await acquireAgentRunPreparedModelRuntime(
+            { agentDir, config },
+            { catalogMode: "static" },
           );
-          expect(result.details).toMatchObject({ model: modelRef, native: false });
-        } finally {
-          lease.release();
-        }
-      },
-    );
-  }, 180_000);
+
+          try {
+            const stores = lease.snapshot.createStores();
+            expect(stores.modelRegistry.find("openai", modelId)).toBeUndefined();
+            expect(
+              lease.snapshot.configuredRuntimeModels.map((entry) => ({
+                provider: entry.provider,
+                modelId: entry.modelId,
+              })),
+            ).toContainEqual({ provider: "openai", modelId });
+
+            vi.spyOn(webMedia, "loadWebMediaRaw").mockResolvedValue({
+              kind: "document",
+              buffer: Buffer.from("%PDF-1.4 inline model fixture"),
+              contentType: "application/pdf",
+              fileName: "inline-model.pdf",
+            });
+            const nativeSpy = vi
+              .spyOn(pdfNativeProviders, "openaiAnalyzePdf")
+              .mockResolvedValue("unexpected native summary");
+            const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+              text: "Inline model regression fixture",
+              images: [],
+            });
+            completeMock.mockResolvedValue({
+              role: "assistant",
+              stopReason: "stop",
+              content: [{ type: "text", text: "resolved inline model" }],
+            });
+
+            const { createPdfTool } = await import("./pdf-tool.js");
+            const tool = createPdfTool({
+              config,
+              agentDir,
+              preparedModelRuntime: lease.snapshot,
+            });
+            if (!tool) {
+              throw new Error("expected PDF tool");
+            }
+
+            const result = await tool.execute("pdf-static-inline", {
+              prompt: "Summarize",
+              pdf: "/tmp/inline-model.pdf",
+            });
+
+            expect(completeMock).toHaveBeenCalledWith(
+              expect.objectContaining({ provider: "openai", id: modelId, input: ["text"] }),
+              expect.any(Object),
+              expect.any(Object),
+            );
+            expect(nativeSpy).not.toHaveBeenCalled();
+            expect(extractSpy).toHaveBeenCalledOnce();
+            expect(result.content).toEqual([{ type: "text", text: "resolved inline model" }]);
+            expect(result.details).toMatchObject({ model: modelRef, native: false });
+          } finally {
+            lease.release();
+          }
+        },
+      );
+    },
+    180_000,
+  );
 });

--- a/src/agents/tools/pdf-tool.test-support.ts
+++ b/src/agents/tools/pdf-tool.test-support.ts
@@ -84,6 +84,7 @@ export function createPdfToolInfraStub(completeMock: Mock) {
       provider?: string;
       input?: string[];
       api?: string;
+      baseUrl?: string;
       modelFound?: boolean;
       pluginRegistry?: PluginRegistry;
     },
@@ -112,6 +113,7 @@ export function createPdfToolInfraStub(completeMock: Mock) {
                     : "anthropic-messages"),
               maxTokens: 8192,
               input: params?.input ?? ["text", "document"],
+              ...(params?.baseUrl ? { baseUrl: params.baseUrl } : {}),
             }) as never;
     const modelRegistry = createPdfModelRegistry(find);
     const release = vi.fn();

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -650,42 +650,6 @@ describe("createPdfTool", () => {
     });
   });
 
-  it("uses extraction fallback for non-native models", async () => {
-    await withTempPdfAgentDir(async (agentDir) => {
-      await stubPdfToolInfra(agentDir, {
-        provider: "openai",
-        api: "openai-responses",
-        input: ["text"],
-      });
-      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
-        text: "Extracted content",
-        images: [],
-      });
-      completeMock.mockResolvedValue({
-        role: "assistant",
-        stopReason: "stop",
-        content: [{ type: "text", text: "fallback summary" }],
-      } as never);
-
-      const cfg = withPdfModel(OPENAI_PDF_MODEL);
-      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
-
-      const result = await tool.execute("t1", {
-        prompt: "summarize",
-        pdf: "/tmp/doc.pdf",
-      });
-
-      expect(extractSpy).toHaveBeenCalledTimes(1);
-      expect(result.content).toEqual([{ type: "text", text: "fallback summary" }]);
-      expectFields(result.details, {
-        native: false,
-        model: OPENAI_PDF_MODEL,
-        text: "fallback summary",
-      });
-      expect(firstCompletionContext()?.systemPrompt).toBeUndefined();
-    });
-  });
-
   it("uses the prepared provider stream for extraction fallback", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
       const pluginRegistry = createEmptyPluginRegistry();

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -46,7 +46,7 @@ import {
   type MediaToolSandbox,
 } from "./media-tool-shared.js";
 import { hasToolModelConfig } from "./model-config.helpers.js";
-import { anthropicAnalyzePdf, geminiAnalyzePdf } from "./pdf-native-providers.js";
+import { anthropicAnalyzePdf, geminiAnalyzePdf, openaiAnalyzePdf } from "./pdf-native-providers.js";
 import {
   coercePdfAssistantText,
   coercePdfModelConfig,
@@ -247,7 +247,7 @@ async function runPdfPrompt(params: {
           authStorage: resolved.authStorage,
         });
 
-        if (providerSupportsNativePdf(provider)) {
+        if (providerSupportsNativePdf(provider, model.api, model.baseUrl)) {
           if (params.password) {
             throw new Error(
               `password is not supported with native PDF providers (${provider}/${modelId}). Remove password, or use a non-native model for encrypted PDFs.`,
@@ -289,6 +289,26 @@ async function runPdfPrompt(params: {
               modelId,
               prompt: params.prompt,
               pdfs,
+              baseUrl: model.baseUrl,
+              requestConfig: {
+                headers: model.headers,
+                request: getModelProviderRequestTransport(model),
+              },
+              signal: params.signal,
+            });
+            return { text, provider, model: modelId, native: true };
+          }
+
+          if (provider === "openai" && model.api === "openai-responses") {
+            // ChatGPT/Codex OAuth uses a distinct request protocol and remains
+            // on the extraction fallback until that transport supports files.
+            params.signal?.throwIfAborted();
+            const text = await openaiAnalyzePdf({
+              apiKey,
+              modelId,
+              prompt: params.prompt,
+              pdfs,
+              maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
               baseUrl: model.baseUrl,
               requestConfig: {
                 headers: model.headers,
@@ -425,7 +445,7 @@ export function createPdfTool(options?: {
       : DEFAULT_MAX_PAGES;
 
   const description =
-    'Analyze PDF(s): Anthropic/Google native when supported, else text/image extraction. pdf one; pdfs max 10; prompt says inspection. `pages` selects a page range ("1-5", "1,3,5-7"); `password` opens encrypted PDFs (both non-native only).';
+    'Analyze PDF(s): Anthropic/Google/OpenAI Responses native when supported, else text/image extraction. pdf one; pdfs max 10; prompt says inspection. `pages` selects a page range ("1-5", "1,3,5-7"); `password` opens encrypted PDFs (both non-native only).';
   const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(options?.config);
 
   return {

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -250,11 +250,12 @@ async function runPdfPrompt(params: {
           authStorage: resolved.authStorage,
         });
 
-        // Preserve OpenAI extraction for filtering/decryption and inputs outside
-        // its file limits. Decide from original bytes before base64 allocation.
+        // Preserve OpenAI extraction for text-only models, filtering/decryption,
+        // and file limits. Check original bytes before base64 allocation.
         const openaiNeedsExtraction =
           provider === "openai" &&
-          (Boolean(params.password) ||
+          (!model.input?.includes("image") ||
+            Boolean(params.password) ||
             Boolean(params.pageNumbers?.length) ||
             params.pdfBuffers.some(({ buffer }) => buffer.length >= OPENAI_PDF_MAX_BYTES) ||
             params.pdfBuffers.reduce((total, { buffer }) => total + buffer.length, 0) >

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -67,6 +67,9 @@ const DEFAULT_PROMPT = "Analyze this PDF document.";
 const DEFAULT_MAX_PDFS = 10;
 const DEFAULT_MAX_BYTES_MB = 10;
 const DEFAULT_MAX_PAGES = 20;
+// OpenAI documents 50 MB per request and strictly less per file. Use decimal
+// bytes conservatively because the provider does not specify a binary unit.
+const OPENAI_PDF_MAX_BYTES = 50_000_000;
 
 const PDF_MIN_TEXT_CHARS = 200;
 const PDF_MAX_PIXELS = 4_000_000;
@@ -247,7 +250,19 @@ async function runPdfPrompt(params: {
           authStorage: resolved.authStorage,
         });
 
-        if (providerSupportsNativePdf(provider, model.api, model.baseUrl)) {
+        // Preserve OpenAI extraction for filtering/decryption and inputs outside
+        // its file limits. Decide from original bytes before base64 allocation.
+        const openaiNeedsExtraction =
+          provider === "openai" &&
+          (Boolean(params.password) ||
+            Boolean(params.pageNumbers?.length) ||
+            params.pdfBuffers.some(({ buffer }) => buffer.length >= OPENAI_PDF_MAX_BYTES) ||
+            params.pdfBuffers.reduce((total, { buffer }) => total + buffer.length, 0) >
+              OPENAI_PDF_MAX_BYTES);
+        if (
+          providerSupportsNativePdf(provider, model.api, model.baseUrl) &&
+          !openaiNeedsExtraction
+        ) {
           if (params.password) {
             throw new Error(
               `password is not supported with native PDF providers (${provider}/${modelId}). Remove password, or use a non-native model for encrypted PDFs.`,
@@ -445,7 +460,7 @@ export function createPdfTool(options?: {
       : DEFAULT_MAX_PAGES;
 
   const description =
-    'Analyze PDF(s): Anthropic/Google/OpenAI Responses native when supported, else text/image extraction. pdf one; pdfs max 10; prompt says inspection. `pages` selects a page range ("1-5", "1,3,5-7"); `password` opens encrypted PDFs (both non-native only).';
+    'Analyze PDF(s): Anthropic/Google/OpenAI Responses native when supported, else text/image extraction. pdf one; pdfs max 10; prompt says inspection. `pages` selects a page range ("1-5", "1,3,5-7"); `password` opens encrypted PDFs (both use extraction with OpenAI; unsupported with Anthropic/Google).';
   const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(options?.config);
 
   return {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Users analyzing PDFs with official OpenAI Platform models cannot use native PDF input through the PDF tool. They currently rely on local text and page-image extraction even when their model supports whole-PDF understanding.

## Why This Change Was Made

Require image capability on the resolved OpenAI model, then send eligible PDFs as `input_file` parts through the existing guarded HTTP path to the official OpenAI Responses endpoint. Normalize accepted root and `/v1` URL forms to `/v1/responses`.

Preserve existing extraction for configured text-only models, page or password requests, and inputs exceeding the native request limits. Each native file must be smaller than 50,000,000 bytes, and the combined original bytes must be at most 50,000,000. These conservative decimal bounds implement the [documented file-input limits](https://developers.openai.com/api/docs/guides/file-inputs#usage-considerations). The existing loader limit applies first.

Native capability now lets a configured OpenAI primary remain primary; Anthropic is still available as the configured fallback. Custom endpoints and ChatGPT/Codex transports keep extraction. The existing Anthropic and Google page/password contracts are preserved.

## User Impact

Supported OpenAI Platform routes can analyze whole PDFs directly. Page selection and encrypted-PDF workflows continue to work through extraction, and oversized native requests take that existing route before attempting an unsupported upload.

On fresh installs and upgrades, eligible OpenAI configurations send complete original PDFs; `pdfMaxPages` limits extraction only. Automatic selection may now prefer OpenAI when it is the default provider, including setups that also have Anthropic available. Saved configuration is not rewritten. Accepting these upload and provider-selection defaults remains a maintainer product decision. This proposal does not enable native ChatGPT/Codex PDF transport.

## Evidence

Final candidate: d0704d262cbcb56a7ff7e0dad2ab1de0c11c3f1c. Validation uses synthetic documents and an isolated state/agent/workspace; no production Gateway or customer document was used.

- The page/password/size regressions failed before the repair: 6 failures and 5 passes. The later real-config text-only regression separately failed before its image-capability guard (1 failure / 1 pass), then passed.
- All **149 focused and sibling tests** passed after integration onto current main. Coverage includes native endpoints, custom/ChatGPT exclusion, page/password forwarding, exact per-file/aggregate size boundaries, and OpenAI-primary plus Anthropic-fallback selection.
- Production and affected test typechecks, formatting, manifest/config guards, and dead-export checks passed. Focused type-aware lint passed for the changed core and OpenAI files. Independent P0-P2 review found no actionable defect.
- On the preceding candidate, local full-core lint exceeded its unchanged 15-minute runner limit. The final model-eligibility delta passed its focused lint and core/agents-tools typechecks. That monolithic run is not claimed as passing; the complete hosted CI remains required. No timeout increase or CI bypass was introduced.

### Real OpenAI Platform proof

Executed the actual candidate `createPdfTool` with `openai/gpt-4.1-mini`, the real PDF loader/extractor, the actual provider owners, and unmodified provider responses. Passive Undici diagnostics observed `POST https://api.openai.com/v1/responses` and HTTP 200 for each traced scenario. Two visually verified synthetic pages contain ALPHA total 37 and BETA total 61.

| Tool request | Observed route | Observed result |
| --- | --- | --- |
| Two-page PDF, no filtering | `native: true` | Both sections and totals returned correctly |
| Same PDF, `pages: "2"` | `native: false` | BETA total 61 only; unselected ALPHA absent |
| Encrypted PDF with its fixture password | `native: false` | Both sections and totals returned correctly |
| Official OpenAI model configured with `input: ["text"]` | `native: false` | Both totals returned through extraction; native upload not selected |

The recorded page-filter response was `Section=BETA;Total=61`; the native and encrypted responses were `ALPHA=37;BETA=61`.

Source hashes bind the executed owners to this candidate. The API key stayed outside source, command arguments, reports, and generated state. No API response, model execution, extraction function, or PDF-tool owner was mocked for this proof. Larger native limits are verified by boundary tests rather than by uploading oversized documents to the service.
