### PR TITLE
improve(media): skip unused local MIME sniff

### DIFF
--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -1247,7 +1247,7 @@ async function loadWebMediaInternal(
       throw err;
     }
   }
-  const sniffedMime = await detectMime({ buffer: data });
+  const sniffedMime = hostReadCapability ? await detectMime({ buffer: data }) : undefined;
   const mime = await detectMime({ buffer: data, filePath: mediaUrl });
   const kind = kindFromMime(mime);
   if (hostReadCapability) {


### PR DESCRIPTION
## What Problem This Solves

Ordinary local `loadWebMedia` / `loadWebMediaRaw` calls byte-sniffed the same attachment twice. The first byte-only result is consumed only by `hostReadCapability` policy, but it was still computed when that capability was absent.

## Why This Change Was Made

The canonical local-media owner now performs the byte-only sniff only when `hostReadCapability` is enabled. The existing filename-aware detection remains unconditional, and host-read paths still perform both detections in the same order.

This preserves buffer identity and bytes, MIME/kind/filename projection, read and error behavior, host-read text/HTML/archive policy, image optimization, and all local/remote/media-store contracts while removing one redundant `file-type` parse from ordinary local attachments.

The extra byte-only sniff was introduced as part of host-read hardening in #64104 by @Takhoffman. That security behavior remains correct and unchanged for host-read callers; this PR only scopes its preparation to the branch that consumes it.

## User Impact

Local attachment preparation uses less CPU with no output, routing, storage, security, or public API change.

## Evidence

- Exact-current red/green owner instrumentation: an ordinary sandbox-validated local PNG performed **2** `fileTypeFromBuffer` calls before the fix and **1** after; Buffer identity and projected fields were unchanged. The temporary implementation-cardinality test was removed after proof because it is not a durable public behavior contract and required no production seam.
- Exact-current ABBA owner benchmark, Node 24.15.0, 18 samples/side × 1,200 mixed local attachments: median **164.183 → 99.281 ms** (**39.53% lower**, ~65.37% more throughput).
- Six representative result cases plus one exact reader-error case were byte-identical before/after: both JSON outputs were 1,685 bytes with SHA-256 `773f85e665750cad750f1de8d7d7c9c879ec87990ade02fd6bd9b801b7114732`. Buffer identities, read counts, MIME/kind/filenames, six payload hashes, and exact `TypeError: reader sentinel` matched.
- Focused `web-media` suite: **90/90 passed** after the current-main rebase.
- MIME/fetch/outbound/plugin-SDK siblings: **290/290 passed**; **380/380 total**.
- `node scripts/check-changed.mjs -- src/media/web-media.ts`: passed all selected formatting, typecheck, lint, guard, dead-export, and import-cycle lanes.
- `pnpm build`: passed; only existing dependency direct-`eval` warnings.
- `git diff --check`: passed.
- Test-audit: no low-value implementation-coupled test retained; no production test seam added. Deslop: clean, no edits.
- Authenticated bundled Codex `gpt-5.6-sol` / high P0-P3 review on exact current main: **clean / correct (0.99)** with no actionable findings.

No matching open PR or issue was found for local media MIME-sniff duplication.