### PR TITLE
fix(ui): prevent duplicate selected-text actions on context clicks

### DIFF
--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -358,7 +358,26 @@ describeControlUiE2e("Control UI chat message actions", () => {
         "Reply",
         "Copy as markdown",
       ]);
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            window.setTimeout(resolve, 0);
+          }),
+      );
+      expect(await page.locator(".chat-selection-popup").count()).toBe(0);
       await screenshot(page, "04-selected-text-context-menu.png");
+      await bubble.dispatchEvent("pointerup", {
+        button: 0,
+        ctrlKey: true,
+        pointerType: "mouse",
+      });
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            window.setTimeout(resolve, 0);
+          }),
+      );
+      expect(await page.locator(".chat-selection-popup").count()).toBe(0);
       await menu.getByRole("menuitem", { name: "Copy", exact: true }).click();
       await expect
         .poll(() => page.evaluate(() => navigator.clipboard.readText()))

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -395,6 +395,8 @@ function toggleTouchMessageMeta(event: PointerEvent): void {
 export function handleTranscriptPointerUp(event: PointerEvent, props: TranscriptInteractionProps) {
   toggleTouchMessageMeta(event);
   if (
+    event.button !== 0 ||
+    event.ctrlKey ||
     typeof props.onCompanionQuestion !== "function" ||
     typeof props.onCompanionPrefill !== "function"
   ) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users who selected message text and then right-clicked it could see OpenClaw's selected-text action popup in addition to the chat message-actions context menu. The same duplicate interaction could occur with macOS-style Control-click.

## Why This Change Was Made

The selected-text pointer-release owner now ignores non-primary releases and Ctrl-modified primary releases before opening the companion UI. Ordinary unmodified primary selection remains unchanged, while context-menu gestures stay owned by the existing message-actions path.

## User Impact

Right-clicking selected chat text now opens only the expected chat message-actions context menu instead of also opening OpenClaw's selected-text action popup.

## Evidence

- Real Chrome-for-Testing E2E against Control UI source modules reproduces the ordinary selected-text right-click through rendered chat content and confirms `.chat-selection-popup` remains absent after the fix.
- The macOS Control-click boundary is covered by dispatching the exact browser `PointerEvent` shape (`button: 0`, `ctrlKey: true`, `pointerType: "mouse"`) to the production listener. The Linux runner cannot produce an authentic native macOS Control-click.
- Before: https://ampcode.com/user-content/artifacts/c1b448438877cbbf035ad0a15b55252c41db5e07f3d6ce837aa4cd2f20ca5a09-file.png
- After: https://ampcode.com/user-content/artifacts/cfefbfb52ab7a0c1d9004528c8256d26dbf4a863d3fd6a461737f4ffc450e7e4-file.png
- Pre-fix synthetic Ctrl-pointer regression: failed 1/1 with popup count 1.
- Fixed focused E2E: 1/1 passed.
- Focused sibling tests: 265/265 passed (`chat-selection-popup.test.ts` 6, `chat-view.test.ts` 259).
- Full changed-file gate passed.
- Exact Node 24.19.0 direct `pnpm ui:build`: 345,018 bytes (limit 345,043 bytes).
- Final branch autoreview: clean, confidence 0.94.
- Commit: `ece55620f092f8e7527c6875148b02797d9dcb1b`.
- Diff: production +2/−0; tests +19/−0.

