### PR TITLE
fix(codex): keep Computer Use working after desktop updates

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -158,14 +158,15 @@ Gateway, restart the Gateway and start a new chat before relying on the new
 selection.
 
 The Gateway watches all standard ChatGPT and Codex desktop candidates that can
-supply the app-server or Computer Use artifacts. It does not poll the request path. After a detected update
-settles, existing turns continue on their current app-server generation, while
-new acquisitions wait for the new generation. OpenClaw then retires the old
-app-server gracefully, refreshes the signed Computer Use service and managed
-marketplace wrapper for eligible isolated homes, and starts the first new turn
-on the replacement. If the bundle changes again during startup, OpenClaw fences
-the stale client before login or `thread/start` and uses the
-normal bounded startup retry.
+supply the app-server or Computer Use artifacts. It does not poll the request
+path. After a detected update settles, existing turns continue on their current
+app-server generation and new acquisitions stop using it. For each eligible
+isolated home, OpenClaw waits for the last old-generation turn to release its
+client before refreshing the signed Computer Use service, shared cache, and
+managed marketplace wrapper. Queued new turns then start on the replacement; an
+active turn for another home does not block them. If the bundle changes again
+during startup, OpenClaw fences the stale client before login or `thread/start`
+and uses the normal bounded startup retry.
 
 This makes the first new request after a detected, settled standard desktop
 replacement transparent under normal updater behavior. It is not a general

--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -168,6 +168,10 @@ active turn for another home does not block them. If the bundle changes again
 during startup, OpenClaw fences the stale client before login or `thread/start`
 and uses the normal bounded startup retry.
 
+Explicit `appServer.command` and `OPENCLAW_CODEX_APP_SERVER_BIN` clients remain
+operator-owned and are not retired by standard desktop update events. Restart
+the Gateway after replacing a custom executable.
+
 This makes the first new request after a detected, settled standard desktop
 replacement transparent under normal updater behavior. It is not a general
 retry promise for unrelated Computer Use transport failures. A watcher failure

--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -121,13 +121,13 @@ OpenClaw-owned isolated agent homes. User-scoped homes and explicit
 The agent directory is the trusted ownership boundary. Within it, native-service
 provisioning rejects symlinked Codex-home, `computer-use`, and service-app paths,
 and revalidates the owned parent around each staged swap.
-On macOS, when no matching
-marketplace is registered and a standard desktop app bundle exists, OpenClaw
-also tries to register the bundled Codex marketplace from
-`/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled`, with
-`/Applications/Codex.app/Contents/Resources/plugins/openai-bundled` retained
-as a fallback for legacy standalone installs. If setup still cannot make the
-MCP server available, the turn fails before the thread starts.
+On macOS, OpenClaw exposes the selected desktop app's bundled marketplace
+through a real, isolated-home-owned wrapper at
+`$CODEX_HOME/.tmp/bundled-marketplaces/openai-bundled`. Codex reserves that
+path for the `openai-bundled` marketplace; the wrapper links only the manifest
+and plugin directory from the selected standard desktop app. OpenClaw then asks
+Codex app-server to register the wrapper. If setup still cannot make the MCP
+server available, the turn fails before the thread starts.
 Strict readiness failures are harness preflight failures, so model fallback
 does not repeat the same local readiness sequence for every Codex candidate.
 A candidate resolved to another harness remains eligible and enters that
@@ -155,10 +155,26 @@ OpenClaw serializes native Codex config reads and Computer Use installation
 inside one running Gateway. A separate Codex process or another Gateway is not
 part of that fence. After changing native Codex plugin config outside the
 Gateway, restart the Gateway and start a new chat before relying on the new
-selection. Restart the Gateway after updating the selected ChatGPT or Codex
-desktop app as well; cold app-server startup then verifies and, when needed,
-refreshes each isolated home's signed Computer Use service before launching it.
-Warm clients are intentionally not polled for desktop bundle changes.
+selection.
+
+The Gateway watches all standard ChatGPT and Codex desktop candidates that can
+supply the app-server or Computer Use artifacts. It does not poll the request path. After a detected update
+settles, existing turns continue on their current app-server generation, while
+new acquisitions wait for the new generation. OpenClaw then retires the old
+app-server gracefully, refreshes the signed Computer Use service and managed
+marketplace wrapper for eligible isolated homes, and starts the first new turn
+on the replacement. If the bundle changes again during startup, OpenClaw fences
+the stale client before login or `thread/start` and uses the
+normal bounded startup retry.
+
+This makes the first new request after a detected, settled standard desktop
+replacement transparent under normal updater behavior. It is not a general
+retry promise for unrelated Computer Use transport failures. A watcher failure
+or an unsupported out-of-band path can still require a Gateway restart.
+`autoInstall: false` continues to prohibit automatic native-service and
+marketplace provisioning. `autoRepair` controls only the one-time stale MCP
+child repair after a failed readiness probe; it does not control desktop
+generation convergence.
 
 ## Commands
 
@@ -225,19 +241,17 @@ Codex desktop builds use the same layout under `Codex.app`:
 ```
 
 When `computerUse.autoInstall` is true and no marketplace containing
-`computer-use` is registered, OpenClaw tries to add the first standard
-bundled marketplace root that exists:
+`computer-use` is registered, OpenClaw selects the first valid standard desktop
+bundle in the same ChatGPT-then-Codex order and creates this reserved local wrapper:
 
 ```text
-/Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled
-/Applications/Codex.app/Contents/Resources/plugins/openai-bundled
+$CODEX_HOME/.tmp/bundled-marketplaces/openai-bundled
 ```
 
-You can also register it explicitly from a shell with Codex:
-
-```bash
-codex plugin marketplace add /Applications/ChatGPT.app/Contents/Resources/plugins/openai-bundled
-```
+Do not add the `/Applications/.../openai-bundled` root directly under the
+reserved `openai-bundled` name. Codex accepts that reserved marketplace only
+from its managed path under `CODEX_HOME`; OpenClaw owns the wrapper lifecycle
+for isolated homes.
 
 If you use a nonstandard Codex app path, run `/codex computer-use install
 --source <marketplace-root>` once, or set `computerUse.marketplacePath` to a

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -154,12 +154,14 @@ describe("codex plugin", () => {
       }),
     );
 
-    expect(registerService).toHaveBeenCalledOnce();
-    expect(mockCallArg(registerService)).toMatchObject({
-      id: "codex-app-server-connection-health",
-      start: expect.any(Function),
-      stop: expect.any(Function),
-    });
+    expect(registerService).toHaveBeenCalledTimes(2);
+    expect(registerService.mock.calls.map(([service]) => service)).toContainEqual(
+      expect.objectContaining({
+        id: "codex-app-server-connection-health",
+        start: expect.any(Function),
+        stop: expect.any(Function),
+      }),
+    );
   });
 
   it("does not start remote connection monitoring for local Codex transports", () => {
@@ -178,7 +180,12 @@ describe("codex plugin", () => {
         }),
       );
 
-      expect(registerService).not.toHaveBeenCalled();
+      expect(registerService).toHaveBeenCalledOnce();
+      expect(mockCallArg(registerService)).toMatchObject({
+        id: "codex-desktop-generation",
+        start: expect.any(Function),
+        stop: expect.any(Function),
+      });
     }
   });
 

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -19,6 +19,7 @@ import {
 import { buildCodexMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { readCodexPluginConfig } from "./src/app-server/config.js";
 import { createCodexAppServerConnectionHealthService } from "./src/app-server/connection-health.js";
+import { createCodexDesktopGenerationService } from "./src/app-server/desktop-generation.js";
 import { setManagedCodexPluginRoot } from "./src/app-server/managed-binary.js";
 import {
   CODEX_MANAGED_THREAD_MAX_ENTRIES,
@@ -31,6 +32,7 @@ import {
   createLazyCodexAppServerBindingStore,
   type StoredCodexAppServerBinding,
 } from "./src/app-server/session-binding-store.js";
+import { retireSharedCodexAppServerClientsBeforeDesktopGeneration } from "./src/app-server/shared-client.js";
 import type { CodexPluginsConfigBlock } from "./src/command-plugins-management.js";
 import { createCodexCommand } from "./src/commands.js";
 import { codexConversationBindingRuntime } from "./src/conversation-binding.js";
@@ -109,6 +111,11 @@ export default definePluginEntry({
     };
     const resolveCurrentPluginConfig = () => resolvePluginConfig(resolveCurrentConfig);
     const appServerConfig = readCodexPluginConfig(resolveCurrentPluginConfig()).appServer;
+    api.registerService(
+      createCodexDesktopGenerationService({
+        onGenerationChange: retireSharedCodexAppServerClientsBeforeDesktopGeneration,
+      }),
+    );
     if (appServerConfig?.transport === "websocket") {
       api.registerService(
         createCodexAppServerConnectionHealthService({

--- a/extensions/codex/src/app-server/attempt-startup.test-support.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test-support.ts
@@ -1,0 +1,61 @@
+import { expect, vi } from "vitest";
+import { createClientHarness } from "./test-support.js";
+
+export type AttemptClientHarness = ReturnType<typeof createClientHarness>;
+export const HARNESS_REQUEST_TIMEOUT_MS = 15_000;
+
+export function readHarnessMessages(
+  writes: string[],
+): Array<{ id?: number; method?: string; params?: unknown }> {
+  return writes.map(
+    (write) => JSON.parse(write) as { id?: number; method?: string; params?: unknown },
+  );
+}
+
+export function readHarnessRequestMethods(
+  harness: AttemptClientHarness,
+): Array<string | undefined> {
+  return readHarnessMessages(harness.writes)
+    .filter(({ id }) => id !== undefined)
+    .map(({ method }) => method);
+}
+
+export async function answerInitialize(harness: AttemptClientHarness): Promise<void> {
+  await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(1), {
+    interval: 1,
+    timeout: HARNESS_REQUEST_TIMEOUT_MS,
+  });
+  const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
+  harness.send({ id: initialize.id, result: { userAgent: "openclaw/0.149.0 (macOS; test)" } });
+}
+
+export async function answerPreparedApiKeyLogin(harness: AttemptClientHarness): Promise<void> {
+  const login = await waitForRequest(harness, "account/login/start");
+  expect(login.params).toEqual({
+    type: "apiKey",
+    apiKey: "prepared-platform-key",
+  });
+  harness.send({ id: login.id, result: { type: "apiKey" } });
+}
+
+export async function waitForRequest(
+  harness: AttemptClientHarness,
+  method: string,
+): Promise<{ id?: number; method?: string; params?: unknown }> {
+  await vi.waitFor(
+    () =>
+      expect(readHarnessMessages(harness.writes).some((write) => write.method === method)).toBe(
+        true,
+      ),
+    { interval: 1, timeout: HARNESS_REQUEST_TIMEOUT_MS },
+  );
+  const request = readHarnessMessages(harness.writes).find((write) => write.method === method);
+  if (!request) {
+    throw new Error(`${method} request was not written`);
+  }
+  return request;
+}
+
+export async function waitForThreadStart(harness: AttemptClientHarness): Promise<{ id?: number }> {
+  return waitForRequest(harness, "thread/start");
+}

--- a/extensions/codex/src/app-server/attempt-startup.test-support.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test-support.ts
@@ -1,4 +1,8 @@
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { expect, vi } from "vitest";
+import type { startCodexAttemptThread } from "./attempt-startup.js";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { resolveCodexAppServerSpawnIdentity } from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
 
 export type AttemptClientHarness = ReturnType<typeof createClientHarness>;
@@ -58,4 +62,50 @@ export async function waitForRequest(
 
 export async function waitForThreadStart(harness: AttemptClientHarness): Promise<{ id?: number }> {
   return waitForRequest(harness, "thread/start");
+}
+
+export async function captureExpectedRuntimeArtifact(
+  appServer: ReturnType<typeof resolveCodexAppServerRuntimeOptions>,
+) {
+  const { captureCodexAppServerRuntimeArtifactBeforeStart, finalizeCodexAppServerRuntimeArtifact } =
+    await import("./runtime-artifact.js");
+  const spawnIdentity = resolveCodexAppServerSpawnIdentity(appServer.start);
+  const before = await captureCodexAppServerRuntimeArtifactBeforeStart({
+    startOptions: appServer.start,
+    spawnIdentity,
+  });
+  return finalizeCodexAppServerRuntimeArtifact({
+    before,
+    startOptions: appServer.start,
+    spawnIdentity,
+    runtimeIdentity: { serverVersion: "0.149.0", userAgent: "openclaw/0.149.0 (macOS; test)" },
+  });
+}
+
+export function createPairedAttemptRuntime() {
+  const channels: Array<{ close: ReturnType<typeof vi.fn>; sessionId: string }> = [];
+  const openDuplex = vi.fn<
+    NonNullable<Parameters<typeof startCodexAttemptThread>[0]["runtime"]>["nodes"]["openDuplex"]
+  >(async (request) => {
+    let resolveClosed: (value: unknown) => void = () => undefined;
+    const closed = new Promise<unknown>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const channel = {
+      send: vi.fn(async () => undefined),
+      onMessage: vi.fn(() => () => undefined),
+      closed,
+      close: vi.fn(() => resolveClosed({ ok: true })),
+    };
+    channels.push({
+      close: channel.close,
+      sessionId: (request.params as { sessionId: string }).sessionId,
+    });
+    return channel;
+  });
+  return {
+    runtime: createPluginRuntimeMock({ nodes: { openDuplex } }),
+    channels,
+    openDuplex,
+  };
 }

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -8,12 +8,13 @@ import {
   type CodexBundleMcpThreadConfig,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startCodexAttemptThread } from "./attempt-startup.js";
 import {
   answerInitialize,
   answerPreparedApiKeyLogin,
+  captureExpectedRuntimeArtifact,
+  createPairedAttemptRuntime,
   HARNESS_REQUEST_TIMEOUT_MS,
   readHarnessMessages,
   readHarnessRequestMethods,
@@ -45,7 +46,6 @@ import {
   createIsolatedCodexAppServerClient,
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
-  resolveCodexAppServerSpawnIdentity,
   type CodexAppServerPreparedAuth,
   type CodexAppServerClientFactory,
 } from "./shared-client.js";
@@ -54,6 +54,9 @@ import { createClientHarness, createCodexTestModel } from "./test-support.js";
 const desktopGeneration = vi.hoisted(() => ({
   current: undefined as { epoch: number; fingerprint: string } | undefined,
 }));
+const computerUseReadinessFailure = vi.hoisted(() => ({
+  next: undefined as Error | undefined,
+}));
 
 vi.mock("./desktop-generation.js", () => ({
   isCodexDesktopGenerationCurrent: (candidate: { epoch: number; fingerprint: string }) =>
@@ -61,6 +64,22 @@ vi.mock("./desktop-generation.js", () => ({
     candidate.fingerprint === desktopGeneration.current?.fingerprint,
   waitForCodexDesktopGeneration: async () => desktopGeneration.current,
 }));
+
+vi.mock("./computer-use.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./computer-use.js")>();
+  return {
+    ...actual,
+    ensureCodexComputerUse: async (...args: Parameters<typeof actual.ensureCodexComputerUse>) => {
+      const error = computerUseReadinessFailure.next;
+      computerUseReadinessFailure.next = undefined;
+      if (error) {
+        desktopGeneration.current = { epoch: 2, fingerprint: "desktop-y" };
+        throw error;
+      }
+      return await actual.ensureCodexComputerUse(...args);
+    },
+  };
+});
 
 type AttemptPaths = {
   agentDir: string;
@@ -188,52 +207,6 @@ function startThreadWithHarness(
   return { harness, run, startSpy };
 }
 
-async function captureExpectedRuntimeArtifact(
-  appServer: ReturnType<typeof resolveCodexAppServerRuntimeOptions>,
-) {
-  const { captureCodexAppServerRuntimeArtifactBeforeStart, finalizeCodexAppServerRuntimeArtifact } =
-    await import("./runtime-artifact.js");
-  const spawnIdentity = resolveCodexAppServerSpawnIdentity(appServer.start);
-  const before = await captureCodexAppServerRuntimeArtifactBeforeStart({
-    startOptions: appServer.start,
-    spawnIdentity,
-  });
-  return finalizeCodexAppServerRuntimeArtifact({
-    before,
-    startOptions: appServer.start,
-    spawnIdentity,
-    runtimeIdentity: { serverVersion: "0.149.0", userAgent: "openclaw/0.149.0 (macOS; test)" },
-  });
-}
-
-function createPairedAttemptRuntime() {
-  const channels: Array<{ close: ReturnType<typeof vi.fn>; sessionId: string }> = [];
-  const openDuplex = vi.fn<
-    NonNullable<Parameters<typeof startCodexAttemptThread>[0]["runtime"]>["nodes"]["openDuplex"]
-  >(async (request) => {
-    let resolveClosed: (value: unknown) => void = () => undefined;
-    const closed = new Promise<unknown>((resolve) => {
-      resolveClosed = resolve;
-    });
-    const channel = {
-      send: vi.fn(async () => undefined),
-      onMessage: vi.fn(() => () => undefined),
-      closed,
-      close: vi.fn(() => resolveClosed({ ok: true })),
-    };
-    channels.push({
-      close: channel.close,
-      sessionId: (request.params as { sessionId: string }).sessionId,
-    });
-    return channel;
-  });
-  return {
-    runtime: createPluginRuntimeMock({ nodes: { openDuplex } }),
-    channels,
-    openDuplex,
-  };
-}
-
 async function startIsolatedPairedAttempt(params: {
   harness: ClientHarness;
   sessionId: string;
@@ -302,6 +275,7 @@ describe("startCodexAttemptThread", () => {
     defaultCodexPluginMetadataCache.clear();
     resetCodexTestBindingStore();
     desktopGeneration.current = undefined;
+    computerUseReadinessFailure.next = undefined;
   });
 
   afterEach(async () => {
@@ -474,51 +448,66 @@ describe("startCodexAttemptThread", () => {
     await vi.waitFor(() => expect(second.process.stdin.destroyed).toBe(true));
   });
 
-  it("restarts before auth when the desktop generation changes during initialize", async () => {
-    const first = createClientHarness();
-    const second = createClientHarness();
-    const startSpy = vi
-      .spyOn(CodexAppServerClient, "start")
-      .mockReturnValueOnce(first.client)
-      .mockReturnValueOnce(second.client);
-    desktopGeneration.current = { epoch: 1, fingerprint: "desktop-x" };
-    const { run } = startThreadWithHarness(10_000, new AbortController().signal, {
-      harness: first,
-      paths: createAttemptPaths(),
-      pluginConfig: {},
-      skipStartSpy: true,
-      startupPreparedAuth: { kind: "api-key", apiKey: "prepared-platform-key" },
-      appServer: resolveCodexAppServerRuntimeOptions({
+  it.each(["initialize", "Computer Use readiness"] as const)(
+    "restarts when the desktop generation changes during %s",
+    async (changeStage) => {
+      const first = createClientHarness();
+      const second = createClientHarness();
+      const startSpy = vi
+        .spyOn(CodexAppServerClient, "start")
+        .mockReturnValueOnce(first.client)
+        .mockReturnValueOnce(second.client);
+      desktopGeneration.current = { epoch: 1, fingerprint: "desktop-x" };
+      if (changeStage === "Computer Use readiness") {
+        computerUseReadinessFailure.next = Object.assign(new Error("desktop selection changed"), {
+          code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
+        });
+      }
+      const { run } = startThreadWithHarness(10_000, new AbortController().signal, {
+        harness: first,
+        paths: createAttemptPaths(),
         pluginConfig: {},
-        managedCommandOrder: "desktop-first",
-      }),
-    });
+        skipStartSpy: true,
+        startupPreparedAuth: { kind: "api-key", apiKey: "prepared-platform-key" },
+        appServer: resolveCodexAppServerRuntimeOptions({
+          pluginConfig: {},
+          managedCommandOrder: "desktop-first",
+        }),
+      });
 
-    await vi.waitFor(() => expect(first.writes).toHaveLength(1));
-    desktopGeneration.current = { epoch: 2, fingerprint: "desktop-y" };
-    await answerInitialize(first);
-    await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2), {
-      timeout: HARNESS_REQUEST_TIMEOUT_MS,
-    });
-    expect(readHarnessRequestMethods(first)).toEqual(["initialize"]);
+      await vi.waitFor(() => expect(first.writes).toHaveLength(1));
+      if (changeStage === "initialize") {
+        desktopGeneration.current = { epoch: 2, fingerprint: "desktop-y" };
+      }
+      await answerInitialize(first);
+      if (changeStage === "Computer Use readiness") {
+        await answerPreparedApiKeyLogin(first);
+      }
+      await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2), {
+        timeout: HARNESS_REQUEST_TIMEOUT_MS,
+      });
+      expect(readHarnessRequestMethods(first)).toEqual(
+        changeStage === "initialize" ? ["initialize"] : ["initialize", "account/login/start"],
+      );
 
-    await answerInitialize(second);
-    await answerPreparedApiKeyLogin(second);
-    const threadStart = await waitForThreadStart(second);
-    second.send({ id: threadStart.id, result: threadStartResult("thread-y") });
-    const result = await run;
+      await answerInitialize(second);
+      await answerPreparedApiKeyLogin(second);
+      const threadStart = await waitForThreadStart(second);
+      second.send({ id: threadStart.id, result: threadStartResult("thread-y") });
+      const result = await run;
 
-    expect(readHarnessRequestMethods(second)).toEqual([
-      "initialize",
-      "account/login/start",
-      "thread/start",
-    ]);
-    await vi.waitFor(() => expect(first.process.stdin.destroyed).toBe(true));
-    result.turnRoute.release();
-    result.releaseSharedClientLease();
-    await clearSharedCodexAppServerClientAndWait();
-    await vi.waitFor(() => expect(second.process.stdin.destroyed).toBe(true));
-  });
+      expect(readHarnessRequestMethods(second)).toEqual([
+        "initialize",
+        "account/login/start",
+        "thread/start",
+      ]);
+      await vi.waitFor(() => expect(first.process.stdin.destroyed).toBe(true));
+      result.turnRoute.release();
+      result.releaseSharedClientLease();
+      await clearSharedCodexAppServerClientAndWait();
+      await vi.waitFor(() => expect(second.process.stdin.destroyed).toBe(true));
+    },
+  );
 
   it("retires the startup generation when context restart sees a new executable owner", async () => {
     const harness = createClientHarness();

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -11,6 +11,16 @@ import {
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startCodexAttemptThread } from "./attempt-startup.js";
+import {
+  answerInitialize,
+  answerPreparedApiKeyLogin,
+  HARNESS_REQUEST_TIMEOUT_MS,
+  readHarnessMessages,
+  readHarnessRequestMethods,
+  waitForRequest,
+  waitForThreadStart,
+  type AttemptClientHarness as ClientHarness,
+} from "./attempt-startup.test-support.js";
 import { isCodexAppServerStartupError } from "./attempt-timeouts.js";
 import { CodexAppServerClient, isCodexAppServerRequestTimeoutError } from "./client.js";
 import { threadStartResult as createThreadStartResult } from "./codex-app-server.test-fixtures.js";
@@ -41,7 +51,16 @@ import {
 } from "./shared-client.js";
 import { createClientHarness, createCodexTestModel } from "./test-support.js";
 
-type ClientHarness = ReturnType<typeof createClientHarness>;
+const desktopGeneration = vi.hoisted(() => ({
+  current: undefined as { epoch: number; fingerprint: string } | undefined,
+}));
+
+vi.mock("./desktop-generation.js", () => ({
+  isCodexDesktopGenerationCurrent: (candidate: { epoch: number; fingerprint: string }) =>
+    candidate.epoch === desktopGeneration.current?.epoch &&
+    candidate.fingerprint === desktopGeneration.current?.fingerprint,
+  waitForCodexDesktopGeneration: async () => desktopGeneration.current,
+}));
 
 type AttemptPaths = {
   agentDir: string;
@@ -99,16 +118,6 @@ const bundleMcpThreadConfig = {
   userStaticServerNames: [],
 } satisfies CodexBundleMcpThreadConfig;
 
-const HARNESS_REQUEST_TIMEOUT_MS = 15_000;
-
-function readHarnessMessages(
-  writes: string[],
-): Array<{ id?: number; method?: string; params?: unknown }> {
-  return writes.map(
-    (write) => JSON.parse(write) as { id?: number; method?: string; params?: unknown },
-  );
-}
-
 function startThreadWithHarness(
   startupTimeoutMs: number,
   signal = new AbortController().signal,
@@ -126,6 +135,7 @@ function startThreadWithHarness(
     sandbox?: Parameters<typeof startCodexAttemptThread>[0]["sandbox"];
     sandboxExecServerEnabled?: boolean;
     runtime?: Parameters<typeof startCodexAttemptThread>[0]["runtime"];
+    appServer?: Parameters<typeof startCodexAttemptThread>[0]["appServer"];
   },
 ) {
   const harness = overrides?.harness ?? createClientHarness();
@@ -140,7 +150,9 @@ function startThreadWithHarness(
     runtime: overrides?.runtime,
     attemptClientFactory:
       overrides?.attemptClientFactory?.(harness) ?? getLeasedSharedCodexAppServerClient,
-    appServer: resolveCodexAppServerRuntimeOptions({ pluginConfig: effectivePluginConfig }),
+    appServer:
+      overrides?.appServer ??
+      resolveCodexAppServerRuntimeOptions({ pluginConfig: effectivePluginConfig }),
     pluginConfig: effectivePluginConfig,
     computerUseConfig: resolveCodexComputerUseConfig({ pluginConfig: effectivePluginConfig }),
     startupAuthProfileId: undefined,
@@ -192,46 +204,6 @@ async function captureExpectedRuntimeArtifact(
     spawnIdentity,
     runtimeIdentity: { serverVersion: "0.149.0", userAgent: "openclaw/0.149.0 (macOS; test)" },
   });
-}
-
-async function answerInitialize(harness: ClientHarness): Promise<void> {
-  await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(1), {
-    interval: 1,
-    timeout: HARNESS_REQUEST_TIMEOUT_MS,
-  });
-  const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
-  harness.send({ id: initialize.id, result: { userAgent: "openclaw/0.149.0 (macOS; test)" } });
-}
-
-async function answerPreparedApiKeyLogin(harness: ClientHarness): Promise<void> {
-  const login = await waitForRequest(harness, "account/login/start");
-  expect(login.params).toEqual({
-    type: "apiKey",
-    apiKey: "prepared-platform-key",
-  });
-  harness.send({ id: login.id, result: { type: "apiKey" } });
-}
-
-async function waitForRequest(
-  harness: ClientHarness,
-  method: string,
-): Promise<{ id?: number; method?: string; params?: unknown }> {
-  await vi.waitFor(
-    () =>
-      expect(readHarnessMessages(harness.writes).some((write) => write.method === method)).toBe(
-        true,
-      ),
-    { interval: 1, timeout: HARNESS_REQUEST_TIMEOUT_MS },
-  );
-  const request = readHarnessMessages(harness.writes).find((write) => write.method === method);
-  if (!request) {
-    throw new Error(`${method} request was not written`);
-  }
-  return request;
-}
-
-async function waitForThreadStart(harness: ClientHarness): Promise<{ id?: number }> {
-  return waitForRequest(harness, "thread/start");
 }
 
 function createPairedAttemptRuntime() {
@@ -329,6 +301,7 @@ describe("startCodexAttemptThread", () => {
     clearSharedCodexAppServerClient();
     defaultCodexPluginMetadataCache.clear();
     resetCodexTestBindingStore();
+    desktopGeneration.current = undefined;
   });
 
   afterEach(async () => {
@@ -489,19 +462,61 @@ describe("startCodexAttemptThread", () => {
         message: "401 authentication_error: Invalid bearer token",
       }),
     });
-    expect(
-      readHarnessMessages(first.writes)
-        .filter((entry) => entry.id !== undefined)
-        .map((entry) => entry.method),
-    ).toEqual(["initialize", "account/login/start"]);
-    expect(
-      readHarnessMessages(second.writes)
-        .filter((entry) => entry.id !== undefined)
-        .map((entry) => entry.method),
-    ).toEqual(["initialize", "account/login/start", "thread/start"]);
+    expect(readHarnessRequestMethods(first)).toEqual(["initialize", "account/login/start"]);
+    expect(readHarnessRequestMethods(second)).toEqual([
+      "initialize",
+      "account/login/start",
+      "thread/start",
+    ]);
     expect(startSpy).toHaveBeenCalledTimes(2);
     expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
     await vi.waitFor(() => expect(first.process.stdin.destroyed).toBe(true));
+    await vi.waitFor(() => expect(second.process.stdin.destroyed).toBe(true));
+  });
+
+  it("restarts before auth when the desktop generation changes during initialize", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+    desktopGeneration.current = { epoch: 1, fingerprint: "desktop-x" };
+    const { run } = startThreadWithHarness(10_000, new AbortController().signal, {
+      harness: first,
+      paths: createAttemptPaths(),
+      pluginConfig: {},
+      skipStartSpy: true,
+      startupPreparedAuth: { kind: "api-key", apiKey: "prepared-platform-key" },
+      appServer: resolveCodexAppServerRuntimeOptions({
+        pluginConfig: {},
+        managedCommandOrder: "desktop-first",
+      }),
+    });
+
+    await vi.waitFor(() => expect(first.writes).toHaveLength(1));
+    desktopGeneration.current = { epoch: 2, fingerprint: "desktop-y" };
+    await answerInitialize(first);
+    await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2), {
+      timeout: HARNESS_REQUEST_TIMEOUT_MS,
+    });
+    expect(readHarnessRequestMethods(first)).toEqual(["initialize"]);
+
+    await answerInitialize(second);
+    await answerPreparedApiKeyLogin(second);
+    const threadStart = await waitForThreadStart(second);
+    second.send({ id: threadStart.id, result: threadStartResult("thread-y") });
+    const result = await run;
+
+    expect(readHarnessRequestMethods(second)).toEqual([
+      "initialize",
+      "account/login/start",
+      "thread/start",
+    ]);
+    await vi.waitFor(() => expect(first.process.stdin.destroyed).toBe(true));
+    result.turnRoute.release();
+    result.releaseSharedClientLease();
+    await clearSharedCodexAppServerClientAndWait();
     await vi.waitFor(() => expect(second.process.stdin.destroyed).toBe(true));
   });
 

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -76,6 +76,7 @@ import {
   clearSharedCodexAppServerClientIfCurrentAndUnclaimed,
   createIsolatedCodexAppServerClient,
   isCodexAppServerStartSelectionChangedError,
+  readCodexAppServerClientDesktopGenerationFingerprint,
   releaseLeasedSharedCodexAppServerClient,
   retireSharedCodexAppServerClientIfCurrent,
   type CodexAppServerClientOptions,
@@ -335,6 +336,8 @@ export async function startCodexAttemptThread(params: {
               envApiKeyFingerprint: params.startupEnvApiKeyCacheKey,
               appServerVersion: activeStartupClient.getServerVersion(),
               runtimeIdentity: startupRuntimeIdentity,
+              desktopGenerationFingerprint:
+                readCodexAppServerClientDesktopGenerationFingerprint(activeStartupClient),
             });
             const appServerRuntimeFingerprint = buildCodexAppServerRuntimeFingerprint({
               appServer: params.appServer,

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -319,7 +319,10 @@ export async function startCodexAttemptThread(params: {
                 signal: startupAbandonController.signal,
               });
             } catch (error) {
-              if (startupAbandonController.signal.aborted) {
+              if (
+                startupAbandonController.signal.aborted ||
+                isCodexAppServerStartSelectionChangedError(error)
+              ) {
                 throw error;
               }
               throw new AgentHarnessPreflightError(

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -31,6 +31,7 @@ const oauthMocks = vi.hoisted(() => ({
 }));
 
 const computerUseServiceMocks = vi.hoisted(() => ({
+  ensureCodexManagedBundledMarketplace: vi.fn(async () => undefined),
   ensureCodexComputerUseServiceApp: vi.fn(async () => ({
     status: "already_current" as const,
     changed: false,
@@ -128,6 +129,11 @@ vi.mock("./computer-use-service.js", () => ({
   ensureCodexComputerUseServiceApp: computerUseServiceMocks.ensureCodexComputerUseServiceApp,
 }));
 
+vi.mock("./computer-use-marketplace.js", () => ({
+  ensureCodexManagedBundledMarketplace:
+    computerUseServiceMocks.ensureCodexManagedBundledMarketplace,
+}));
+
 afterEach(() => {
   vi.unstubAllEnvs();
   clearRuntimeAuthProfileStoreSnapshots();
@@ -135,6 +141,7 @@ afterEach(() => {
   providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockReset();
   providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockClear();
   computerUseServiceMocks.ensureCodexComputerUseServiceApp.mockClear();
+  computerUseServiceMocks.ensureCodexManagedBundledMarketplace.mockClear();
 });
 
 function createStartOptions(
@@ -364,6 +371,11 @@ describe("bridgeCodexAppServerStartOptions", () => {
         ownershipRoot: agentDir,
         appServerCommand: startOptions.command,
       });
+      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith({
+        codexHome,
+        ownershipRoot: agentDir,
+        appServerCommand: startOptions.command,
+      });
     });
   });
 
@@ -376,6 +388,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       });
 
       expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).not.toHaveBeenCalled();
     });
   });
 
@@ -391,6 +404,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       });
 
       expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).not.toHaveBeenCalled();
     });
   });
 
@@ -405,6 +419,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
       });
 
       expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).not.toHaveBeenCalled();
     });
   });
 

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -176,6 +176,15 @@ vi.mock("./computer-use-cache.js", () => ({
     computerUseServiceMocks.ensureCodexComputerUseSharedPluginCache,
 }));
 
+vi.mock("./desktop-app-paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./desktop-app-paths.js")>();
+  return {
+    ...actual,
+    resolveMacOSDesktopCodexAppPathCandidates: (platform?: NodeJS.Platform) =>
+      actual.resolveMacOSDesktopCodexAppPathCandidates(platform ?? "darwin"),
+  };
+});
+
 afterEach(() => {
   vi.unstubAllEnvs();
   clearRuntimeAuthProfileStoreSnapshots();

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -7,6 +7,7 @@ import {
   loadAuthProfileStoreForSecretsRuntime,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "openclaw/plugin-sdk/agent-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -14,6 +15,7 @@ import {
   applyCodexAppServerAuthProfile,
   bridgeCodexAppServerStartOptions,
   refreshCodexAppServerAuthTokens,
+  reconcileCodexComputerUseStartArtifacts,
   resolveCodexAppServerAuthAccountCacheKey,
   resolveCodexAppServerAuthProfileId,
   resolveCodexAppServerAuthProfileStore,
@@ -24,18 +26,49 @@ import {
   resolveCodexAppServerPreparedApiKeyCacheKey,
 } from "./auth-bridge.js";
 import type { CodexAppServerStartOptions } from "./config.js";
+import { resolveMacOSDesktopCodexAppPathCandidates } from "./desktop-app-paths.js";
 import { resolveCodexAppServerSpawnEnv } from "./transport-stdio.js";
 
 const oauthMocks = vi.hoisted(() => ({
   refreshOpenAICodexToken: vi.fn(),
 }));
 
+type MockDesktopCandidate = ReturnType<typeof resolveMacOSDesktopCodexAppPathCandidates>[number];
+type MockCacheResult = {
+  status: "independent" | "shared";
+  changed: boolean;
+  message: string;
+  removedStaleVersions: string[];
+  warnings: string[];
+};
+
 const computerUseServiceMocks = vi.hoisted(() => ({
-  ensureCodexManagedBundledMarketplace: vi.fn(async () => undefined),
-  ensureCodexComputerUseServiceApp: vi.fn(async () => ({
-    status: "already_current" as const,
+  ensureCodexComputerUseSharedPluginCache: vi.fn<
+    (_params: { forceRefresh?: boolean }) => Promise<MockCacheResult>
+  >(async () => ({
+    status: "independent",
     changed: false,
+    message: "independent",
+    removedStaleVersions: [],
+    warnings: [],
   })),
+  ensureCodexManagedBundledMarketplace: vi.fn<(_params?: unknown) => Promise<string | undefined>>(
+    async () => undefined,
+  ),
+  ensureCodexComputerUseServiceApp: vi.fn<
+    (_params?: unknown) => Promise<{
+      status: "already_current" | "source_missing";
+      changed: boolean;
+    }>
+  >(async () => ({ status: "already_current", changed: false })),
+  resolveCodexManagedBundledMarketplaceSource: vi.fn<
+    (params: {
+      candidates?: readonly MockDesktopCandidate[];
+    }) => Promise<MockDesktopCandidate | undefined>
+  >(async (params) => params.candidates?.[0]),
+  resolveCodexComputerUseServiceAppSourcePath: vi.fn<
+    (params: { sourceAppCandidates?: readonly string[] }) => Promise<string | undefined>
+  >(async (params) => params.sourceAppCandidates?.[0]),
 }));
 
 const providerRuntimeMocks = vi.hoisted(() => ({
@@ -127,11 +160,20 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
 
 vi.mock("./computer-use-service.js", () => ({
   ensureCodexComputerUseServiceApp: computerUseServiceMocks.ensureCodexComputerUseServiceApp,
+  resolveCodexComputerUseServiceAppSourcePath:
+    computerUseServiceMocks.resolveCodexComputerUseServiceAppSourcePath,
 }));
 
 vi.mock("./computer-use-marketplace.js", () => ({
   ensureCodexManagedBundledMarketplace:
     computerUseServiceMocks.ensureCodexManagedBundledMarketplace,
+  resolveCodexManagedBundledMarketplaceSource:
+    computerUseServiceMocks.resolveCodexManagedBundledMarketplaceSource,
+}));
+
+vi.mock("./computer-use-cache.js", () => ({
+  ensureCodexComputerUseSharedPluginCache:
+    computerUseServiceMocks.ensureCodexComputerUseSharedPluginCache,
 }));
 
 afterEach(() => {
@@ -142,6 +184,22 @@ afterEach(() => {
   providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockClear();
   computerUseServiceMocks.ensureCodexComputerUseServiceApp.mockClear();
   computerUseServiceMocks.ensureCodexManagedBundledMarketplace.mockClear();
+  computerUseServiceMocks.ensureCodexComputerUseSharedPluginCache.mockReset();
+  computerUseServiceMocks.ensureCodexComputerUseSharedPluginCache.mockResolvedValue({
+    status: "independent",
+    changed: false,
+    message: "independent",
+    removedStaleVersions: [],
+    warnings: [],
+  });
+  computerUseServiceMocks.resolveCodexManagedBundledMarketplaceSource.mockReset();
+  computerUseServiceMocks.resolveCodexManagedBundledMarketplaceSource.mockImplementation(
+    async (params) => params.candidates?.[0],
+  );
+  computerUseServiceMocks.resolveCodexComputerUseServiceAppSourcePath.mockReset();
+  computerUseServiceMocks.resolveCodexComputerUseServiceAppSourcePath.mockImplementation(
+    async (params: { sourceAppCandidates?: readonly string[] }) => params.sourceAppCandidates?.[0],
+  );
 });
 
 function createStartOptions(
@@ -357,31 +415,36 @@ describe("bridgeCodexAppServerStartOptions", () => {
 
   it("provisions the native Computer Use client before auto-install startup", async () => {
     await withTempDir("openclaw-codex-computer-use-service-", async (agentDir) => {
+      computerUseServiceMocks.ensureCodexManagedBundledMarketplace.mockResolvedValueOnce(
+        "/managed/openai-bundled",
+      );
       const startOptions = createStartOptions();
       const codexHome = resolveCodexAppServerHomeDir(agentDir);
 
-      await bridgeCodexAppServerStartOptions({
+      await reconcileCodexComputerUseStartArtifacts({
         startOptions,
         agentDir,
         pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
       });
 
-      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith({
-        codexHome,
-        ownershipRoot: agentDir,
-        appServerCommand: startOptions.command,
-      });
-      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith({
-        codexHome,
-        ownershipRoot: agentDir,
-        appServerCommand: startOptions.command,
-      });
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          codexHome,
+          ownershipRoot: agentDir,
+        }),
+      );
+      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          codexHome,
+          ownershipRoot: agentDir,
+        }),
+      );
     });
   });
 
   it("does not provision the native client without auto-install authorization", async () => {
     await withTempDir("openclaw-codex-computer-use-service-", async (agentDir) => {
-      await bridgeCodexAppServerStartOptions({
+      await reconcileCodexComputerUseStartArtifacts({
         startOptions: createStartOptions(),
         agentDir,
         pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
@@ -392,12 +455,136 @@ describe("bridgeCodexAppServerStartOptions", () => {
     });
   });
 
+  it("rejects a desktop candidate whose exact bundled marketplace is unavailable", async () => {
+    await withTempDir("openclaw-codex-computer-use-source-missing-", async (agentDir) => {
+      computerUseServiceMocks.resolveCodexManagedBundledMarketplaceSource.mockResolvedValueOnce(
+        undefined,
+      );
+
+      await expect(
+        reconcileCodexComputerUseStartArtifacts({
+          startOptions: createStartOptions({
+            command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+          }),
+          agentDir,
+          pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        }),
+      ).rejects.toMatchObject({
+        code: "CODEX_COMPUTER_USE_CANDIDATE_ARTIFACTS_UNAVAILABLE",
+      });
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects a desktop candidate whose exact signed service is unavailable", async () => {
+    await withTempDir("openclaw-codex-computer-use-service-missing-", async (agentDir) => {
+      computerUseServiceMocks.resolveCodexComputerUseServiceAppSourcePath.mockResolvedValueOnce(
+        undefined,
+      );
+
+      await expect(
+        reconcileCodexComputerUseStartArtifacts({
+          startOptions: createStartOptions({
+            command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+          }),
+          agentDir,
+          pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        }),
+      ).rejects.toMatchObject({
+        code: "CODEX_COMPUTER_USE_CANDIDATE_ARTIFACTS_UNAVAILABLE",
+      });
+      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).not.toHaveBeenCalled();
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each([
+    { marketplaceSource: "file:///tmp/custom-marketplace" },
+    { marketplacePath: "/tmp/custom-marketplace/marketplace.json" },
+    { marketplaceName: "custom-marketplace" },
+  ])("keeps an exact desktop candidate with configured marketplace selection", async (selector) => {
+    await withTempDir("openclaw-codex-computer-use-custom-source-", async (agentDir) => {
+      await expect(
+        reconcileCodexComputerUseStartArtifacts({
+          startOptions: createStartOptions({
+            command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+          }),
+          agentDir,
+          pluginConfig: {
+            computerUse: { enabled: true, autoInstall: true, ...selector },
+          },
+        }),
+      ).resolves.toBeUndefined();
+      expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).not.toHaveBeenCalled();
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledOnce();
+    });
+  });
+
+  it.each(["marketplace", "service"] as const)(
+    "keeps package fallback artifacts on one complete desktop owner when ChatGPT lacks %s",
+    async (missingArtifact) => {
+      await withTempDir("openclaw-codex-computer-use-package-owner-", async (agentDir) => {
+        const candidates = resolveMacOSDesktopCodexAppPathCandidates("darwin");
+        const codexCandidate = candidates.find((candidate) => candidate.appName === "Codex.app");
+        if (!codexCandidate) {
+          throw new Error("expected Codex.app candidate");
+        }
+        computerUseServiceMocks.resolveCodexManagedBundledMarketplaceSource.mockImplementation(
+          async (params) => {
+            const candidate = params.candidates?.[0];
+            return missingArtifact === "marketplace" && candidate?.appName === "ChatGPT.app"
+              ? undefined
+              : candidate;
+          },
+        );
+        computerUseServiceMocks.resolveCodexComputerUseServiceAppSourcePath.mockImplementation(
+          async (params: { sourceAppCandidates?: readonly string[] }) => {
+            const source = params.sourceAppCandidates?.[0];
+            return missingArtifact === "service" && source?.includes("ChatGPT.app")
+              ? undefined
+              : source;
+          },
+        );
+        computerUseServiceMocks.ensureCodexManagedBundledMarketplace.mockResolvedValueOnce(
+          "/managed/openai-bundled",
+        );
+
+        await reconcileCodexComputerUseStartArtifacts({
+          startOptions: createStartOptions({ command: "/cache/openclaw/codex" }),
+          agentDir,
+          pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        });
+
+        expect(computerUseServiceMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            candidates: [codexCandidate],
+            appServerCommand: codexCandidate.appServerCommandPath,
+          }),
+        );
+        expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sourceAppCandidates: codexCandidate.computerUseServiceAppPaths,
+            appServerCommand: codexCandidate.appServerCommandPath,
+          }),
+        );
+        expect(
+          computerUseServiceMocks.ensureCodexComputerUseSharedPluginCache,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            bundledMarketplacePath: codexCandidate.bundledMarketplacePath,
+          }),
+        );
+      });
+    },
+  );
+
   it("does not replace the native service app for user-scoped homes", async () => {
     await withTempDir("openclaw-codex-computer-use-user-home-", async (root) => {
       const codexHome = path.join(root, "user-codex-home");
       vi.stubEnv("CODEX_HOME", codexHome);
 
-      await bridgeCodexAppServerStartOptions({
+      await reconcileCodexComputerUseStartArtifacts({
         startOptions: createStartOptions({ homeScope: "user" }),
         agentDir: path.join(root, "agent"),
         pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
@@ -412,7 +599,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     await withTempDir("openclaw-codex-computer-use-explicit-home-", async (root) => {
       const codexHome = path.join(root, "explicit-codex-home");
 
-      await bridgeCodexAppServerStartOptions({
+      await reconcileCodexComputerUseStartArtifacts({
         startOptions: createStartOptions({ env: { CODEX_HOME: codexHome } }),
         agentDir: path.join(root, "agent"),
         pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
@@ -424,17 +611,126 @@ describe("bridgeCodexAppServerStartOptions", () => {
   });
 
   it("classifies native client provisioning failures as harness preflight", async () => {
+    computerUseServiceMocks.ensureCodexManagedBundledMarketplace.mockResolvedValueOnce(
+      "/managed/openai-bundled",
+    );
     computerUseServiceMocks.ensureCodexComputerUseServiceApp.mockRejectedValueOnce(
       new Error("copy failed"),
     );
 
     await expect(
-      bridgeCodexAppServerStartOptions({
+      reconcileCodexComputerUseStartArtifacts({
         startOptions: createStartOptions(),
         agentDir: "/tmp/openclaw-codex-computer-use-failed",
         pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
       }),
     ).rejects.toMatchObject({ name: "AgentHarnessPreflightError", scope: "harness" });
+  });
+
+  it("refreshes shared cache once per selected desktop source generation", async () => {
+    await withTempDir("openclaw-codex-computer-use-cache-owner-", async (agentDir) => {
+      computerUseServiceMocks.ensureCodexComputerUseSharedPluginCache.mockResolvedValue({
+        status: "shared",
+        changed: true,
+        message: "shared",
+        removedStaleVersions: [],
+        warnings: [],
+      });
+      const startOptions = createStartOptions({
+        command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      });
+      const pluginConfig = {
+        computerUse: {
+          enabled: true,
+          autoInstall: false,
+          pluginCacheMode: "shared" as const,
+        },
+      };
+
+      await reconcileCodexComputerUseStartArtifacts({
+        startOptions,
+        agentDir,
+        pluginConfig,
+        desktopGeneration: { epoch: 1, fingerprint: "desktop-x" },
+      });
+      await reconcileCodexComputerUseStartArtifacts({
+        startOptions,
+        agentDir,
+        pluginConfig,
+        desktopGeneration: { epoch: 1, fingerprint: "desktop-x" },
+      });
+      await reconcileCodexComputerUseStartArtifacts({
+        startOptions,
+        agentDir,
+        pluginConfig,
+        desktopGeneration: { epoch: 2, fingerprint: "desktop-y" },
+      });
+
+      expect(
+        computerUseServiceMocks.ensureCodexComputerUseSharedPluginCache.mock.calls.map(
+          ([params]) => params.forceRefresh,
+        ),
+      ).toEqual([true, false, true]);
+    });
+  });
+
+  it("does not let a stale desktop generation publish artifacts after its successor", async () => {
+    await withTempDir("openclaw-codex-computer-use-generation-", async (agentDir) => {
+      const firstMarketplaceStarted = createDeferred<void>();
+      const releaseFirstMarketplace = createDeferred<void>();
+      let activeMarketplaceCalls = 0;
+      let maxActiveMarketplaceCalls = 0;
+      computerUseServiceMocks.ensureCodexManagedBundledMarketplace
+        .mockImplementationOnce(async () => {
+          activeMarketplaceCalls += 1;
+          maxActiveMarketplaceCalls = Math.max(maxActiveMarketplaceCalls, activeMarketplaceCalls);
+          firstMarketplaceStarted.resolve();
+          try {
+            await releaseFirstMarketplace.promise;
+            return "/managed/openai-bundled";
+          } finally {
+            activeMarketplaceCalls -= 1;
+          }
+        })
+        .mockImplementationOnce(async () => {
+          activeMarketplaceCalls += 1;
+          maxActiveMarketplaceCalls = Math.max(maxActiveMarketplaceCalls, activeMarketplaceCalls);
+          activeMarketplaceCalls -= 1;
+          return "/managed/openai-bundled";
+        });
+      let currentEpoch = 1;
+      const startOptions = createStartOptions();
+      const first = reconcileCodexComputerUseStartArtifacts({
+        startOptions,
+        agentDir,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        desktopGeneration: { epoch: 1, fingerprint: "desktop-x" },
+        assertCurrent: () => {
+          if (currentEpoch !== 1) {
+            throw new Error("desktop generation X is stale");
+          }
+        },
+      });
+      await firstMarketplaceStarted.promise;
+      currentEpoch = 2;
+      const second = reconcileCodexComputerUseStartArtifacts({
+        startOptions,
+        agentDir,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        desktopGeneration: { epoch: 2, fingerprint: "desktop-y" },
+        assertCurrent: () => {
+          if (currentEpoch !== 2) {
+            throw new Error("desktop generation Y is stale");
+          }
+        },
+      });
+      releaseFirstMarketplace.resolve();
+
+      await expect(first).rejects.toThrow("desktop generation X is stale");
+      await expect(second).resolves.toBeUndefined();
+      expect(maxActiveMarketplaceCalls).toBe(1);
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("uses the native user Codex home for coexistence mode", async () => {

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -33,15 +33,25 @@ import {
 } from "./auth-start-options.js";
 import type { CodexAppServerClient } from "./client.js";
 import { ensureCodexComputerUseSharedPluginCache } from "./computer-use-cache.js";
-import { ensureCodexManagedBundledMarketplace } from "./computer-use-marketplace.js";
+import {
+  ensureCodexManagedBundledMarketplace,
+  resolveCodexManagedBundledMarketplaceSource,
+} from "./computer-use-marketplace.js";
 import { ensureOwnedCodexHome } from "./computer-use-service-path.js";
-import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
+import {
+  ensureCodexComputerUseServiceApp,
+  resolveCodexComputerUseServiceAppSourcePath,
+} from "./computer-use-service.js";
 import {
   resolveCodexComputerUseConfig,
   type CodexAppServerHomeScope,
   type CodexAppServerStartOptions,
 } from "./config.js";
-import { resolveMacOSDesktopCodexAppPathCandidates } from "./desktop-app-paths.js";
+import {
+  resolveMacOSDesktopCodexAppPathCandidates,
+  type MacOSDesktopCodexAppPathCandidate,
+} from "./desktop-app-paths.js";
+import type { CodexDesktopGeneration } from "./desktop-generation-owner.js";
 import {
   isJsonObject,
   type CodexChatgptAuthTokensRefreshResponse,
@@ -68,6 +78,11 @@ const CODEX_APP_SERVER_PREPARED_AUTH_ENV_VARS = [
 const CODEX_APP_SERVER_HOME_ENV_VARS = [CODEX_HOME_ENV_VAR, HOME_ENV_VAR];
 const CODEX_AUTH_JSON_FILENAME = "auth.json";
 const CODEX_HOME_DIRNAME = ".codex";
+const MAX_COMPUTER_USE_ARTIFACT_OWNERS = 128;
+const activeComputerUseArtifactReconciliations = new Map<
+  string,
+  { latestEpoch?: number; appliedCacheBinding?: string; active: number; tail: Promise<void> }
+>();
 type AuthProfileOrderConfig = Parameters<typeof resolveAuthProfileOrder>[0]["cfg"];
 export type CodexAppServerAuthRequirement = "api-key" | "subscription";
 const scopedOAuthRefreshQueues = new WeakMap<
@@ -90,11 +105,7 @@ export async function bridgeCodexAppServerStartOptions(params: {
     return params.startOptions;
   }
   const scopeStartOptions = () =>
-    withCodexHomeEnvironment(
-      withEphemeralCodexAuthStore(params),
-      params.agentDir,
-      params.pluginConfig,
-    );
+    withCodexHomeEnvironment(withEphemeralCodexAuthStore(params), params.agentDir);
 
   if (params.preparedAuth) {
     const scopedStartOptions = await scopeStartOptions();
@@ -522,13 +533,12 @@ export { resolveCodexAppServerHomeDir } from "./auth-start-options.js";
 async function withCodexHomeEnvironment(
   startOptions: CodexAppServerStartOptions,
   agentDir: string,
-  pluginConfig?: unknown,
 ): Promise<CodexAppServerStartOptions> {
   const codexHome = resolveCodexAppServerLocalHomeDir(startOptions, agentDir);
   const nativeHome = startOptions.env?.[HOME_ENV_VAR]?.trim()
     ? startOptions.env[HOME_ENV_VAR]
     : undefined;
-  await reconcileCodexComputerUseStartArtifacts({ startOptions, agentDir, pluginConfig });
+  await fs.mkdir(codexHome, { recursive: true });
   if (nativeHome) {
     await fs.mkdir(nativeHome, { recursive: true });
   }
@@ -555,11 +565,80 @@ export async function reconcileCodexComputerUseStartArtifacts(params: {
   agentDir: string;
   pluginConfig?: unknown;
   ownsIsolatedCodexHome?: boolean;
+  desktopGeneration?: CodexDesktopGeneration;
+  assertCurrent?: () => void;
+  forceCacheRefresh?: boolean;
 }): Promise<void> {
   if (params.startOptions.transport !== "stdio") {
     return;
   }
   const codexHome = resolveCodexAppServerLocalHomeDir(params.startOptions, params.agentDir);
+  const key = path.resolve(codexHome);
+  let owner = activeComputerUseArtifactReconciliations.get(key);
+  if (!owner) {
+    owner = { active: 0, tail: Promise.resolve() };
+    activeComputerUseArtifactReconciliations.set(key, owner);
+  } else {
+    activeComputerUseArtifactReconciliations.delete(key);
+    activeComputerUseArtifactReconciliations.set(key, owner);
+  }
+  owner.active += 1;
+  const epoch = params.desktopGeneration?.epoch;
+  if (epoch !== undefined && (owner.latestEpoch === undefined || epoch > owner.latestEpoch)) {
+    owner.latestEpoch = epoch;
+  }
+  const assertCurrent = () => {
+    params.assertCurrent?.();
+    if (epoch !== undefined && owner.latestEpoch !== epoch) {
+      throw new Error("Codex Computer Use artifact reconciliation was superseded.");
+    }
+  };
+  const operation = owner.tail
+    .catch(() => undefined)
+    .then(async () => {
+      assertCurrent();
+      const appliedCacheBinding = await reconcileCodexComputerUseStartArtifactsOnce({
+        ...params,
+        codexHome,
+        assertCurrent,
+        previousCacheBinding: owner.appliedCacheBinding,
+      });
+      assertCurrent();
+      owner.appliedCacheBinding = appliedCacheBinding;
+    });
+  const settled = operation.then(
+    () => undefined,
+    () => undefined,
+  );
+  owner.tail = settled;
+  try {
+    await operation;
+  } finally {
+    owner.active = Math.max(0, owner.active - 1);
+    if (
+      owner.active === 0 &&
+      owner.latestEpoch === undefined &&
+      activeComputerUseArtifactReconciliations.get(key) === owner &&
+      owner.tail === settled
+    ) {
+      activeComputerUseArtifactReconciliations.delete(key);
+    }
+    pruneComputerUseArtifactOwners();
+  }
+}
+
+async function reconcileCodexComputerUseStartArtifactsOnce(params: {
+  startOptions: CodexAppServerStartOptions;
+  agentDir: string;
+  pluginConfig?: unknown;
+  ownsIsolatedCodexHome?: boolean;
+  codexHome: string;
+  assertCurrent: () => void;
+  desktopGeneration?: CodexDesktopGeneration;
+  forceCacheRefresh?: boolean;
+  previousCacheBinding?: string;
+}): Promise<string | undefined> {
+  const codexHome = params.codexHome;
   const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig: params.pluginConfig });
   const ownsIsolatedCodexHome =
     params.ownsIsolatedCodexHome ??
@@ -577,37 +656,131 @@ export async function reconcileCodexComputerUseStartArtifacts(params: {
     (candidate) =>
       path.resolve(candidate.appServerCommandPath) === path.resolve(params.startOptions.command),
   );
-  await ensureCodexComputerUseSharedPluginCache({
+  const usesManagedBundledMarketplace =
+    !computerUseConfig.marketplaceSource &&
+    !computerUseConfig.marketplacePath &&
+    !computerUseConfig.marketplaceName;
+  const needsBundledMarketplace =
+    usesManagedBundledMarketplace ||
+    (computerUseConfig.pluginCacheMode === "shared" &&
+      !computerUseConfig.marketplaceName &&
+      !computerUseConfig.marketplacePath);
+  const artifactCandidate = shouldProvisionComputerUse
+    ? await resolveCompleteComputerUseArtifactCandidate({
+        candidates: exactDesktopCandidate ? [exactDesktopCandidate] : desktopCandidates,
+        needsBundledMarketplace,
+      })
+    : exactDesktopCandidate;
+  params.assertCurrent();
+  if (shouldProvisionComputerUse) {
+    if (desktopCandidates.length > 0 && !artifactCandidate) {
+      throw new CodexComputerUseCandidateArtifactsUnavailableError();
+    }
+    try {
+      const marketplacePath = usesManagedBundledMarketplace
+        ? await ensureCodexManagedBundledMarketplace({
+            codexHome,
+            ownershipRoot: params.agentDir,
+            ...(artifactCandidate
+              ? {
+                  appServerCommand: artifactCandidate.appServerCommandPath,
+                  candidates: [artifactCandidate],
+                  ownershipCandidates: desktopCandidates,
+                }
+              : {}),
+            assertCurrent: params.assertCurrent,
+          })
+        : undefined;
+      params.assertCurrent();
+      if (usesManagedBundledMarketplace && desktopCandidates.length > 0 && !marketplacePath) {
+        throw new CodexComputerUseCandidateArtifactsUnavailableError();
+      }
+      const service = await ensureCodexComputerUseServiceApp({
+        codexHome,
+        ownershipRoot: params.agentDir,
+        ...(artifactCandidate
+          ? {
+              appServerCommand: artifactCandidate.appServerCommandPath,
+              sourceAppCandidates: artifactCandidate.computerUseServiceAppPaths,
+            }
+          : {}),
+        assertCurrent: params.assertCurrent,
+      });
+      params.assertCurrent();
+      if (desktopCandidates.length > 0 && service.status === "source_missing") {
+        throw new CodexComputerUseCandidateArtifactsUnavailableError();
+      }
+    } catch (error) {
+      params.assertCurrent();
+      if (error instanceof CodexComputerUseCandidateArtifactsUnavailableError) {
+        throw error;
+      }
+      throw new AgentHarnessPreflightError("Codex Computer Use client provisioning failed.", {
+        cause: error,
+        scope: "harness",
+      });
+    }
+  }
+  params.assertCurrent();
+  const cacheBinding = [
+    params.desktopGeneration?.epoch ?? "manual",
+    artifactCandidate?.bundledMarketplacePath ?? "default",
+    computerUseConfig.pluginName,
+  ].join("\0");
+  const cache = await ensureCodexComputerUseSharedPluginCache({
     codexHome,
     config: computerUseConfig,
     ...(ownsIsolatedCodexHome ? { ownershipRoot: params.agentDir } : {}),
-    ...(exactDesktopCandidate
-      ? { bundledMarketplacePath: exactDesktopCandidate.bundledMarketplacePath }
+    ...(artifactCandidate
+      ? { bundledMarketplacePath: artifactCandidate.bundledMarketplacePath }
       : {}),
+    assertCurrent: params.assertCurrent,
+    forceRefresh: params.forceCacheRefresh === true || params.previousCacheBinding !== cacheBinding,
   });
-  if (!shouldProvisionComputerUse) {
-    return;
+  params.assertCurrent();
+  return cache.status === "shared" ? cacheBinding : undefined;
+}
+
+async function resolveCompleteComputerUseArtifactCandidate(params: {
+  candidates: readonly MacOSDesktopCodexAppPathCandidate[];
+  needsBundledMarketplace: boolean;
+}): Promise<MacOSDesktopCodexAppPathCandidate | undefined> {
+  for (const candidate of params.candidates) {
+    if (
+      params.needsBundledMarketplace &&
+      !(await resolveCodexManagedBundledMarketplaceSource({ candidates: [candidate] }))
+    ) {
+      continue;
+    }
+    if (
+      await resolveCodexComputerUseServiceAppSourcePath({
+        sourceAppCandidates: candidate.computerUseServiceAppPaths,
+      })
+    ) {
+      return candidate;
+    }
   }
-  try {
-    await ensureCodexManagedBundledMarketplace({
-      codexHome,
-      ownershipRoot: params.agentDir,
-      appServerCommand: params.startOptions.command,
-      ...(exactDesktopCandidate ? { candidates: [exactDesktopCandidate] } : {}),
-    });
-    await ensureCodexComputerUseServiceApp({
-      codexHome,
-      ownershipRoot: params.agentDir,
-      appServerCommand: params.startOptions.command,
-      ...(exactDesktopCandidate
-        ? { sourceAppCandidates: exactDesktopCandidate.computerUseServiceAppPaths }
-        : {}),
-    });
-  } catch (error) {
-    throw new AgentHarnessPreflightError("Codex Computer Use client provisioning failed.", {
-      cause: error,
-      scope: "harness",
-    });
+  return undefined;
+}
+
+function pruneComputerUseArtifactOwners(): void {
+  while (activeComputerUseArtifactReconciliations.size > MAX_COMPUTER_USE_ARTIFACT_OWNERS) {
+    const inactive = [...activeComputerUseArtifactReconciliations].find(
+      ([, owner]) => owner.active === 0,
+    );
+    if (!inactive) {
+      return;
+    }
+    activeComputerUseArtifactReconciliations.delete(inactive[0]);
+  }
+}
+
+class CodexComputerUseCandidateArtifactsUnavailableError extends Error {
+  readonly code = "CODEX_COMPUTER_USE_CANDIDATE_ARTIFACTS_UNAVAILABLE";
+
+  constructor() {
+    super("The selected Codex desktop app does not contain complete Computer Use artifacts.");
+    this.name = "CodexComputerUseCandidateArtifactsUnavailableError";
   }
 }
 

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -33,12 +33,15 @@ import {
 } from "./auth-start-options.js";
 import type { CodexAppServerClient } from "./client.js";
 import { ensureCodexComputerUseSharedPluginCache } from "./computer-use-cache.js";
+import { ensureCodexManagedBundledMarketplace } from "./computer-use-marketplace.js";
+import { ensureOwnedCodexHome } from "./computer-use-service-path.js";
 import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
   resolveCodexComputerUseConfig,
   type CodexAppServerHomeScope,
   type CodexAppServerStartOptions,
 } from "./config.js";
+import { resolveMacOSDesktopCodexAppPathCandidates } from "./desktop-app-paths.js";
 import {
   isJsonObject,
   type CodexChatgptAuthTokensRefreshResponse,
@@ -525,28 +528,7 @@ async function withCodexHomeEnvironment(
   const nativeHome = startOptions.env?.[HOME_ENV_VAR]?.trim()
     ? startOptions.env[HOME_ENV_VAR]
     : undefined;
-  await fs.mkdir(codexHome, { recursive: true });
-  const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig });
-  await ensureCodexComputerUseSharedPluginCache({
-    codexHome,
-    config: computerUseConfig,
-  });
-  const ownsIsolatedCodexHome =
-    startOptions.homeScope !== "user" && !startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim();
-  if (computerUseConfig.enabled && computerUseConfig.autoInstall && ownsIsolatedCodexHome) {
-    try {
-      await ensureCodexComputerUseServiceApp({
-        codexHome,
-        ownershipRoot: agentDir,
-        appServerCommand: startOptions.command,
-      });
-    } catch (error) {
-      throw new AgentHarnessPreflightError("Codex Computer Use client provisioning failed.", {
-        cause: error,
-        scope: "harness",
-      });
-    }
-  }
+  await reconcileCodexComputerUseStartArtifacts({ startOptions, agentDir, pluginConfig });
   if (nativeHome) {
     await fs.mkdir(nativeHome, { recursive: true });
   }
@@ -565,6 +547,68 @@ async function withCodexHomeEnvironment(
     delete nextStartOptions.clearEnv;
   }
   return nextStartOptions;
+}
+
+/** Reconciles Computer Use artifacts for the exact managed command about to start. */
+export async function reconcileCodexComputerUseStartArtifacts(params: {
+  startOptions: CodexAppServerStartOptions;
+  agentDir: string;
+  pluginConfig?: unknown;
+  ownsIsolatedCodexHome?: boolean;
+}): Promise<void> {
+  if (params.startOptions.transport !== "stdio") {
+    return;
+  }
+  const codexHome = resolveCodexAppServerLocalHomeDir(params.startOptions, params.agentDir);
+  const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig: params.pluginConfig });
+  const ownsIsolatedCodexHome =
+    params.ownsIsolatedCodexHome ??
+    (params.startOptions.homeScope !== "user" &&
+      !params.startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim());
+  const shouldProvisionComputerUse =
+    computerUseConfig.enabled && computerUseConfig.autoInstall && ownsIsolatedCodexHome;
+  if (shouldProvisionComputerUse) {
+    await ensureOwnedCodexHome(codexHome, params.agentDir);
+  } else {
+    await fs.mkdir(codexHome, { recursive: true });
+  }
+  const desktopCandidates = resolveMacOSDesktopCodexAppPathCandidates();
+  const exactDesktopCandidate = desktopCandidates.find(
+    (candidate) =>
+      path.resolve(candidate.appServerCommandPath) === path.resolve(params.startOptions.command),
+  );
+  await ensureCodexComputerUseSharedPluginCache({
+    codexHome,
+    config: computerUseConfig,
+    ...(ownsIsolatedCodexHome ? { ownershipRoot: params.agentDir } : {}),
+    ...(exactDesktopCandidate
+      ? { bundledMarketplacePath: exactDesktopCandidate.bundledMarketplacePath }
+      : {}),
+  });
+  if (!shouldProvisionComputerUse) {
+    return;
+  }
+  try {
+    await ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: params.agentDir,
+      appServerCommand: params.startOptions.command,
+      ...(exactDesktopCandidate ? { candidates: [exactDesktopCandidate] } : {}),
+    });
+    await ensureCodexComputerUseServiceApp({
+      codexHome,
+      ownershipRoot: params.agentDir,
+      appServerCommand: params.startOptions.command,
+      ...(exactDesktopCandidate
+        ? { sourceAppCandidates: exactDesktopCandidate.computerUseServiceAppPaths }
+        : {}),
+    });
+  } catch (error) {
+    throw new AgentHarnessPreflightError("Codex Computer Use client provisioning failed.", {
+      cause: error,
+      scope: "harness",
+    });
+  }
 }
 
 function withoutClearedCodexHomeEnv(clearEnv: string[] | undefined): string[] | undefined {

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -676,6 +676,17 @@ export class CodexAppServerClient {
     return () => this.closeHandlers.delete(handler);
   }
 
+  /** Registers a handler for physical transport exit and returns its disposer. */
+  addTransportExitHandler(handler: (client: CodexAppServerClient) => void): () => void {
+    if (this.transportExited) {
+      handler(this);
+      return () => undefined;
+    }
+    const onExit = () => handler(this);
+    this.child.once("exit", onExit);
+    return () => this.child.off?.("exit", onExit);
+  }
+
   /** Closes the transport without waiting for process/socket shutdown. */
   close(): void {
     if (!this.markClosed(new Error("codex app-server client is closed"))) {

--- a/extensions/codex/src/app-server/computer-use-cache.test.ts
+++ b/extensions/codex/src/app-server/computer-use-cache.test.ts
@@ -220,6 +220,33 @@ describe("Codex Computer Use shared plugin cache", () => {
     ).resolves.toContain('"version":"1.0.857"');
   });
 
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked managed cache parent without touching its external target",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-cache-link-");
+      const agentDir = path.join(root, "agent");
+      const codexHome = path.join(agentDir, "codex-home");
+      const bundledMarketplacePath = path.join(root, "bundled-marketplace");
+      const external = path.join(root, "external-cache");
+      await writeBundledComputerUsePlugin(bundledMarketplacePath, "2.0.0");
+      await fs.mkdir(codexHome, { recursive: true });
+      await fs.mkdir(external, { recursive: true });
+      await fs.writeFile(path.join(external, "sentinel"), "outside");
+      await fs.symlink(external, path.join(codexHome, "plugins"), "dir");
+
+      await expect(
+        ensureCodexComputerUseSharedPluginCache({
+          codexHome,
+          ownershipRoot: agentDir,
+          bundledMarketplacePath,
+          config: computerUseConfig(),
+        }),
+      ).rejects.toThrow(/symlink|real directories/u);
+      await expect(fs.readFile(path.join(external, "sentinel"), "utf8")).resolves.toBe("outside");
+      await expect(fs.access(path.join(external, "cache"))).rejects.toThrow();
+    },
+  );
+
   it("leaves cache entries alone in independent mode", async () => {
     const root = tempDirs.make("openclaw-computer-use-cache-");
     const result = await ensureCodexComputerUseSharedPluginCache({

--- a/extensions/codex/src/app-server/computer-use-cache.test.ts
+++ b/extensions/codex/src/app-server/computer-use-cache.test.ts
@@ -179,6 +179,90 @@ describe("Codex Computer Use shared plugin cache", () => {
     ).resolves.toBe(undefined);
   });
 
+  it("refreshes same-version cache bytes for a new desktop generation", async () => {
+    const root = tempDirs.make("openclaw-computer-use-cache-generation-");
+    const bundledMarketplacePath = path.join(root, "Codex.app", "plugins", "openai-bundled");
+    const bundledPluginRoot = path.join(bundledMarketplacePath, "plugins", "computer-use");
+    await writeBundledComputerUsePlugin(bundledMarketplacePath, "1.0.857");
+    await fs.writeFile(path.join(bundledPluginRoot, "generation.txt"), "generation-y");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const activeCachePath = path.join(
+      codexHome,
+      "plugins",
+      "cache",
+      "openai-bundled",
+      "computer-use",
+      "1.0.857",
+    );
+    await fs.mkdir(path.join(activeCachePath, ".codex-plugin"), { recursive: true });
+    await fs.writeFile(
+      path.join(activeCachePath, ".codex-plugin", "plugin.json"),
+      JSON.stringify({ name: "computer-use", version: "1.0.857" }),
+    );
+    await fs.writeFile(path.join(activeCachePath, "generation.txt"), "generation-x");
+
+    const result = await ensureCodexComputerUseSharedPluginCache({
+      codexHome,
+      bundledMarketplacePath,
+      config: computerUseConfig(),
+      forceRefresh: true,
+    });
+
+    expect(result).toMatchObject({ status: "shared", changed: true, version: "1.0.857" });
+    await expect(fs.readFile(path.join(activeCachePath, "generation.txt"), "utf8")).resolves.toBe(
+      "generation-y",
+    );
+  });
+
+  it("leaves same-version cache bytes intact when the generation is stale before publication", async () => {
+    const root = tempDirs.make("openclaw-computer-use-cache-stale-");
+    const bundledMarketplacePath = path.join(root, "Codex.app", "plugins", "openai-bundled");
+    const bundledPluginRoot = path.join(bundledMarketplacePath, "plugins", "computer-use");
+    await writeBundledComputerUsePlugin(bundledMarketplacePath, "1.0.857");
+    await fs.writeFile(path.join(bundledPluginRoot, "generation.txt"), "generation-y");
+    const codexHome = path.join(root, "agent", "codex-home");
+    const activeCachePath = path.join(
+      codexHome,
+      "plugins",
+      "cache",
+      "openai-bundled",
+      "computer-use",
+      "1.0.857",
+    );
+    await fs.mkdir(path.join(activeCachePath, ".codex-plugin"), { recursive: true });
+    await fs.writeFile(
+      path.join(activeCachePath, ".codex-plugin", "plugin.json"),
+      JSON.stringify({ name: "computer-use", version: "1.0.857" }),
+    );
+    await fs.writeFile(path.join(activeCachePath, "generation.txt"), "generation-x");
+
+    let currentnessChecks = 0;
+    await expect(
+      ensureCodexComputerUseSharedPluginCache({
+        codexHome,
+        bundledMarketplacePath,
+        config: computerUseConfig(),
+        forceRefresh: true,
+        assertCurrent: () => {
+          currentnessChecks += 1;
+          if (currentnessChecks === 2) {
+            throw new Error("desktop generation is stale");
+          }
+        },
+      }),
+    ).rejects.toThrow("desktop generation is stale");
+    expect(currentnessChecks).toBe(2);
+
+    await expect(fs.readFile(path.join(activeCachePath, "generation.txt"), "utf8")).resolves.toBe(
+      "generation-x",
+    );
+    expect(
+      (await fs.readdir(path.dirname(activeCachePath))).filter((entry) =>
+        entry.startsWith(".1.0.857"),
+      ),
+    ).toEqual([]);
+  });
+
   it("refreshes a stale copied cache entry with the bundled version", async () => {
     const root = tempDirs.make("openclaw-computer-use-cache-");
     const bundledMarketplacePath = path.join(root, "Codex.app", "plugins", "openai-bundled");

--- a/extensions/codex/src/app-server/computer-use-cache.ts
+++ b/extensions/codex/src/app-server/computer-use-cache.ts
@@ -41,6 +41,8 @@ export async function ensureCodexComputerUseSharedPluginCache(params: {
   bundledMarketplacePath?: string;
   bundledMarketplacePathCandidates?: readonly string[];
   ownershipRoot?: string;
+  assertCurrent?: () => void;
+  forceRefresh?: boolean;
 }): Promise<CodexComputerUsePluginCacheRepairResult> {
   if (!params.config.enabled) {
     return skippedCacheResult(
@@ -83,6 +85,8 @@ export async function ensureCodexComputerUseSharedPluginCache(params: {
   const changed = await ensureRealDirectoryCopy(cachePath, sourcePluginRoot, version, {
     codexHome: params.codexHome,
     ownershipRoot: params.ownershipRoot,
+    assertCurrent: params.assertCurrent,
+    forceRefresh: params.forceRefresh,
   });
   return {
     status: "shared",
@@ -132,7 +136,12 @@ async function ensureRealDirectoryCopy(
   cachePath: string,
   sourcePluginRoot: string,
   version: string,
-  boundary: { codexHome: string; ownershipRoot?: string },
+  boundary: {
+    codexHome: string;
+    ownershipRoot?: string;
+    assertCurrent?: () => void;
+    forceRefresh?: boolean;
+  },
 ): Promise<boolean> {
   const cacheRoot = path.dirname(cachePath);
   const ownedParent = boundary.ownershipRoot
@@ -151,7 +160,7 @@ async function ensureRealDirectoryCopy(
   const stat = await fs.lstat(physicalCachePath).catch(() => undefined);
   if (stat?.isDirectory() && !stat.isSymbolicLink()) {
     const cachedVersion = await readBundledPluginVersion(physicalCachePath);
-    if (cachedVersion === version) {
+    if (cachedVersion === version && !boundary.forceRefresh) {
       return false;
     }
   }
@@ -170,6 +179,7 @@ async function ensureRealDirectoryCopy(
       await assertDirectoryIdentityStable(ownedParent, "Computer Use plugin cache parent");
     }
     if (stat) {
+      boundary.assertCurrent?.();
       await fs.rename(physicalCachePath, backupPath);
       backupCreated = true;
     }
@@ -177,6 +187,7 @@ async function ensureRealDirectoryCopy(
       if (ownedParent) {
         await assertDirectoryIdentityStable(ownedParent, "Computer Use plugin cache parent");
       }
+      boundary.assertCurrent?.();
       await fs.rename(stagedPath, physicalCachePath);
     } catch (error) {
       if (backupCreated) {

--- a/extensions/codex/src/app-server/computer-use-cache.ts
+++ b/extensions/codex/src/app-server/computer-use-cache.ts
@@ -1,6 +1,11 @@
 /** Shared Computer Use plugin cache reconciliation for isolated Codex homes. */
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  assertDirectoryIdentityStable,
+  directoryIdentityIsStable,
+  prepareOwnedServiceParent,
+} from "./computer-use-service-path.js";
 import type { ResolvedCodexComputerUseConfig } from "./config.js";
 import {
   resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath,
@@ -30,12 +35,12 @@ const DEFAULT_CODEX_COMPUTER_USE_BUNDLED_MARKETPLACE_PATH =
   resolveMacOSDesktopCodexBundledMarketplaceCandidates("darwin")[0] ?? "";
 
 const DEFAULT_BUNDLED_MARKETPLACE_NAME = "openai-bundled";
-
 export async function ensureCodexComputerUseSharedPluginCache(params: {
   codexHome: string;
   config: ResolvedCodexComputerUseConfig;
   bundledMarketplacePath?: string;
   bundledMarketplacePathCandidates?: readonly string[];
+  ownershipRoot?: string;
 }): Promise<CodexComputerUsePluginCacheRepairResult> {
   if (!params.config.enabled) {
     return skippedCacheResult(
@@ -75,7 +80,10 @@ export async function ensureCodexComputerUseSharedPluginCache(params: {
     params.config.pluginName,
   );
   const cachePath = path.join(cacheRoot, version);
-  const changed = await ensureRealDirectoryCopy(cachePath, sourcePluginRoot, version);
+  const changed = await ensureRealDirectoryCopy(cachePath, sourcePluginRoot, version, {
+    codexHome: params.codexHome,
+    ownershipRoot: params.ownershipRoot,
+  });
   return {
     status: "shared",
     changed,
@@ -124,33 +132,59 @@ async function ensureRealDirectoryCopy(
   cachePath: string,
   sourcePluginRoot: string,
   version: string,
+  boundary: { codexHome: string; ownershipRoot?: string },
 ): Promise<boolean> {
-  await fs.mkdir(path.dirname(cachePath), { recursive: true });
-  const stat = await fs.lstat(cachePath).catch(() => undefined);
+  const cacheRoot = path.dirname(cachePath);
+  const ownedParent = boundary.ownershipRoot
+    ? await prepareOwnedServiceParent({
+        ownershipRoot: boundary.ownershipRoot,
+        codexHome: boundary.codexHome,
+        targetParent: cacheRoot,
+      })
+    : undefined;
+  if (!ownedParent) {
+    await fs.mkdir(cacheRoot, { recursive: true });
+  }
+  const physicalCachePath = ownedParent
+    ? path.join(ownedParent.realPath, path.basename(cachePath))
+    : cachePath;
+  const stat = await fs.lstat(physicalCachePath).catch(() => undefined);
   if (stat?.isDirectory() && !stat.isSymbolicLink()) {
-    const cachedVersion = await readBundledPluginVersion(cachePath);
+    const cachedVersion = await readBundledPluginVersion(physicalCachePath);
     if (cachedVersion === version) {
       return false;
     }
   }
-  const cacheRoot = path.dirname(cachePath);
   const cacheName = path.basename(cachePath);
-  const stagingRoot = await fs.mkdtemp(path.join(cacheRoot, `.${cacheName}.staging-`));
+  const physicalCacheRoot = path.dirname(physicalCachePath);
+  const stagingRoot = await fs.mkdtemp(path.join(physicalCacheRoot, `.${cacheName}.staging-`));
   const stagedPath = path.join(stagingRoot, cacheName);
-  const backupPath = path.join(cacheRoot, `.${cacheName}.backup-${process.pid}-${Date.now()}`);
+  const backupPath = path.join(
+    physicalCacheRoot,
+    `.${cacheName}.backup-${process.pid}-${Date.now()}`,
+  );
   let backupCreated = false;
   try {
     await fs.cp(sourcePluginRoot, stagedPath, { recursive: true });
+    if (ownedParent) {
+      await assertDirectoryIdentityStable(ownedParent, "Computer Use plugin cache parent");
+    }
     if (stat) {
-      await fs.rename(cachePath, backupPath);
+      await fs.rename(physicalCachePath, backupPath);
       backupCreated = true;
     }
     try {
-      await fs.rename(stagedPath, cachePath);
+      if (ownedParent) {
+        await assertDirectoryIdentityStable(ownedParent, "Computer Use plugin cache parent");
+      }
+      await fs.rename(stagedPath, physicalCachePath);
     } catch (error) {
       if (backupCreated) {
         try {
-          await fs.rename(backupPath, cachePath);
+          if (ownedParent) {
+            await assertDirectoryIdentityStable(ownedParent, "Computer Use plugin cache parent");
+          }
+          await fs.rename(backupPath, physicalCachePath);
           backupCreated = false;
         } catch (restoreError) {
           throw new Error(
@@ -162,11 +196,16 @@ async function ensureRealDirectoryCopy(
       throw error;
     }
     if (backupCreated) {
+      if (ownedParent) {
+        await assertDirectoryIdentityStable(ownedParent, "Computer Use plugin cache parent");
+      }
       await fs.rm(backupPath, { recursive: true, force: true });
     }
     return true;
   } finally {
-    await fs.rm(stagingRoot, { recursive: true, force: true });
+    if (!ownedParent || (await directoryIdentityIsStable(ownedParent))) {
+      await fs.rm(stagingRoot, { recursive: true, force: true });
+    }
   }
 }
 

--- a/extensions/codex/src/app-server/computer-use-marketplace.test.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.test.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureCodexManagedBundledMarketplace,
+  resolveCodexManagedBundledMarketplacePath,
+} from "./computer-use-marketplace.js";
+import type { MacOSDesktopCodexAppPathCandidate } from "./desktop-app-paths.js";
+import { useAutoCleanupTempDirTracker } from "./test-support.js";
+
+describe("managed Codex bundled marketplace", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("publishes a real reserved root with links to the selected desktop marketplace", async () => {
+    const root = tempDirs.make("openclaw-codex-marketplace-");
+    const candidate = await writeCandidate(root);
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+
+    const result = await ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      appServerCommand: candidate.appServerCommandPath,
+      candidates: [candidate],
+    });
+
+    const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+    expect(result).toBe(target);
+    expect((await fs.lstat(target)).isDirectory()).toBe(true);
+    expect(await fs.realpath(target)).toBe(target);
+    expect(await fs.readlink(path.join(target, "plugins"))).toBe(
+      path.join(candidate.bundledMarketplacePath, "plugins"),
+    );
+    await expect(
+      ensureCodexManagedBundledMarketplace({
+        codexHome,
+        ownershipRoot: agentDir,
+        candidates: [candidate],
+      }),
+    ).resolves.toBe(target);
+  });
+
+  it("coalesces concurrent publication without leaving swap debris", async () => {
+    const root = tempDirs.make("openclaw-codex-marketplace-concurrent-");
+    const candidate = await writeCandidate(root);
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+
+    const results = await Promise.all(
+      Array.from({ length: 3 }, () =>
+        ensureCodexManagedBundledMarketplace({
+          codexHome,
+          ownershipRoot: agentDir,
+          candidates: [candidate],
+        }),
+      ),
+    );
+
+    const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+    expect(results).toEqual([target, target, target]);
+    expect(await fs.readlink(path.join(target, "plugins"))).toBe(
+      path.join(candidate.bundledMarketplacePath, "plugins"),
+    );
+    expect(
+      (await fs.readdir(path.dirname(target))).filter((entry) =>
+        entry.startsWith(".openai-bundled"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not replace an unowned directory at the reserved managed path", async () => {
+    const root = tempDirs.make("openclaw-codex-marketplace-unowned-");
+    const candidate = await writeCandidate(root);
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+    await fs.mkdir(target, { recursive: true });
+    await fs.writeFile(path.join(target, "sentinel"), "operator-owned");
+
+    await expect(
+      ensureCodexManagedBundledMarketplace({
+        codexHome,
+        ownershipRoot: agentDir,
+        candidates: [candidate],
+      }),
+    ).rejects.toThrow("unowned bundled marketplace");
+    await expect(fs.readFile(path.join(target, "sentinel"), "utf8")).resolves.toBe(
+      "operator-owned",
+    );
+  });
+
+  it("restores the prior managed wrapper when publication fails after backup", async () => {
+    const root = tempDirs.make("openclaw-codex-marketplace-rollback-");
+    const firstCandidate = await writeCandidate(path.join(root, "first"));
+    const secondCandidate = await writeCandidate(path.join(root, "second"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+    await ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      appServerCommand: firstCandidate.appServerCommandPath,
+      candidates: [firstCandidate, secondCandidate],
+    });
+    const rename = fs.rename.bind(fs);
+    let renameCount = 0;
+    vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      renameCount += 1;
+      if (renameCount === 2) {
+        throw new Error("injected publish failure");
+      }
+      return await rename(source, destination);
+    });
+
+    await expect(
+      ensureCodexManagedBundledMarketplace({
+        codexHome,
+        ownershipRoot: agentDir,
+        appServerCommand: secondCandidate.appServerCommandPath,
+        candidates: [firstCandidate, secondCandidate],
+      }),
+    ).rejects.toThrow("injected publish failure");
+
+    expect(await fs.readlink(path.join(target, "plugins"))).toBe(
+      path.join(firstCandidate.bundledMarketplacePath, "plugins"),
+    );
+    expect(
+      (await fs.readdir(path.dirname(target))).filter((entry) =>
+        entry.startsWith(".openai-bundled"),
+      ),
+    ).toEqual([]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked isolated home without touching its external target",
+    async () => {
+      const root = tempDirs.make("openclaw-codex-marketplace-home-link-");
+      const candidate = await writeCandidate(root);
+      const agentDir = path.join(root, "agent");
+      const external = path.join(root, "external");
+      const codexHome = path.join(agentDir, "codex-home");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.mkdir(external, { recursive: true });
+      await fs.writeFile(path.join(external, "sentinel"), "outside");
+      await fs.symlink(external, codexHome, "dir");
+
+      await expect(
+        ensureCodexManagedBundledMarketplace({
+          codexHome,
+          ownershipRoot: agentDir,
+          candidates: [candidate],
+        }),
+      ).rejects.toThrow(/symlink|symbolic link|real directories/u);
+      await expect(fs.readFile(path.join(external, "sentinel"), "utf8")).resolves.toBe("outside");
+      await expect(fs.access(path.join(external, ".tmp"))).rejects.toThrow();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not publish through a marketplace parent rebound during the staged swap",
+    async () => {
+      const root = tempDirs.make("openclaw-codex-marketplace-rebind-");
+      const candidate = await writeCandidate(root);
+      const agentDir = path.join(root, "agent");
+      const codexHome = path.join(agentDir, "codex-home");
+      const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+      const parent = path.dirname(target);
+      const movedParent = `${parent}.moved`;
+      const external = path.join(root, "external");
+      await fs.mkdir(external, { recursive: true });
+      await fs.writeFile(path.join(external, "sentinel"), "outside");
+      const rename = fs.rename.bind(fs);
+      vi.spyOn(fs, "rename").mockImplementationOnce(async (source, destination) => {
+        await rename(parent, movedParent);
+        await fs.symlink(external, parent, "dir");
+        return await rename(source, destination);
+      });
+
+      await expect(
+        ensureCodexManagedBundledMarketplace({
+          codexHome,
+          ownershipRoot: agentDir,
+          candidates: [candidate],
+        }),
+      ).rejects.toThrow();
+      await expect(fs.readFile(path.join(external, "sentinel"), "utf8")).resolves.toBe("outside");
+      await expect(fs.access(path.join(external, "openai-bundled"))).rejects.toThrow();
+    },
+  );
+});
+
+async function writeCandidate(root: string): Promise<MacOSDesktopCodexAppPathCandidate> {
+  const appBundlePath = path.join(root, "ChatGPT.app");
+  const bundledMarketplacePath = path.join(appBundlePath, "openai-bundled");
+  await fs.mkdir(path.join(bundledMarketplacePath, ".agents", "plugins"), { recursive: true });
+  await fs.mkdir(path.join(bundledMarketplacePath, "plugins", "computer-use", ".codex-plugin"), {
+    recursive: true,
+  });
+  await fs.writeFile(
+    path.join(bundledMarketplacePath, ".agents", "plugins", "marketplace.json"),
+    JSON.stringify({ name: "openai-bundled", plugins: [{ name: "computer-use" }] }),
+  );
+  await fs.writeFile(
+    path.join(bundledMarketplacePath, "plugins", "computer-use", ".codex-plugin", "plugin.json"),
+    JSON.stringify({ name: "computer-use", version: "1.0.0" }),
+  );
+  return {
+    appName: "ChatGPT.app",
+    appBundlePath,
+    appServerCommandPath: path.join(appBundlePath, "codex"),
+    bundledMarketplacePath,
+    computerUseServiceAppPaths: [],
+  };
+}

--- a/extensions/codex/src/app-server/computer-use-marketplace.test.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensureCodexManagedBundledMarketplace,
@@ -10,6 +11,10 @@ import { useAutoCleanupTempDirTracker } from "./test-support.js";
 
 describe("managed Codex bundled marketplace", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("publishes a real reserved root with links to the selected desktop marketplace", async () => {
     const root = tempDirs.make("openclaw-codex-marketplace-");
@@ -60,6 +65,189 @@ describe("managed Codex bundled marketplace", () => {
     expect(results).toEqual([target, target, target]);
     expect(await fs.readlink(path.join(target, "plugins"))).toBe(
       path.join(candidate.bundledMarketplacePath, "plugins"),
+    );
+    expect(
+      (await fs.readdir(path.dirname(target))).filter((entry) =>
+        entry.startsWith(".openai-bundled"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("converges a concurrent replacement to the newly selected desktop source", async () => {
+    const root = tempDirs.make("openclaw-codex-marketplace-transition-");
+    const firstCandidate = await writeCandidate(path.join(root, "first"));
+    const secondCandidate = await writeCandidate(path.join(root, "second"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+    const firstPublishStarted = createDeferred<void>();
+    const releaseFirstPublish = createDeferred<void>();
+    const rename = fs.rename.bind(fs);
+    let heldFirstPublish = false;
+    vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      if (!heldFirstPublish && destination === target) {
+        heldFirstPublish = true;
+        firstPublishStarted.resolve();
+        await releaseFirstPublish.promise;
+      }
+      return await rename(source, destination);
+    });
+
+    const first = ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      appServerCommand: firstCandidate.appServerCommandPath,
+      candidates: [firstCandidate],
+      ownershipCandidates: [firstCandidate, secondCandidate],
+    });
+    await firstPublishStarted.promise;
+    const second = ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      appServerCommand: secondCandidate.appServerCommandPath,
+      candidates: [secondCandidate],
+      ownershipCandidates: [firstCandidate, secondCandidate],
+    });
+    releaseFirstPublish.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([target, target]);
+    expect(await fs.readlink(path.join(target, "plugins"))).toBe(
+      path.join(secondCandidate.bundledMarketplacePath, "plugins"),
+    );
+    expect(
+      (await fs.readdir(path.dirname(target))).filter((entry) =>
+        entry.startsWith(".openai-bundled"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not let a matching fast path outrun a conflicting publication", async () => {
+    const root = tempDirs.make("openclaw-codex-marketplace-conflict-");
+    const firstCandidate = await writeCandidate(path.join(root, "first"));
+    const secondCandidate = await writeCandidate(path.join(root, "second"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+    const ownershipCandidates = [firstCandidate, secondCandidate];
+    await ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      candidates: [secondCandidate],
+      ownershipCandidates,
+    });
+
+    const firstStagingStarted = createDeferred<void>();
+    const releaseFirstStaging = createDeferred<void>();
+    const createStagingDir = fs.mkdtemp.bind(fs);
+    vi.spyOn(fs, "mkdtemp").mockImplementationOnce(async (prefix, options) => {
+      firstStagingStarted.resolve();
+      await releaseFirstStaging.promise;
+      return await createStagingDir(prefix, options);
+    });
+    const first = ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      candidates: [firstCandidate],
+      ownershipCandidates,
+    });
+    await firstStagingStarted.promise;
+    const lstat = fs.lstat.bind(fs);
+    let firstReleased = false;
+    let targetChecksBeforeRelease = 0;
+    vi.spyOn(fs, "lstat").mockImplementation(async (filePath, options) => {
+      if (path.resolve(String(filePath)) === target && !firstReleased) {
+        targetChecksBeforeRelease += 1;
+        if (targetChecksBeforeRelease > 1) {
+          throw new Error("conflicting wrapper fast path ran before active publication settled");
+        }
+        setImmediate(() => {
+          firstReleased = true;
+          releaseFirstStaging.resolve();
+        });
+      }
+      return await lstat(filePath, options);
+    });
+    const second = ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      candidates: [secondCandidate],
+      ownershipCandidates,
+    });
+    const results = await Promise.allSettled([first, second]);
+
+    expect(targetChecksBeforeRelease).toBe(1);
+    expect(results).toEqual([
+      { status: "fulfilled", value: target },
+      { status: "fulfilled", value: target },
+    ]);
+    expect(await fs.readlink(path.join(target, "plugins"))).toBe(
+      path.join(secondCandidate.bundledMarketplacePath, "plugins"),
+    );
+  });
+
+  it("replaces a prior owned wrapper when desktop app selection changes", async () => {
+    const root = tempDirs.make("openclaw-codex-marketplace-owner-transition-");
+    const firstCandidate = await writeCandidate(path.join(root, "first"));
+    const secondCandidate = await writeCandidate(path.join(root, "second"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+    const ownershipCandidates = [firstCandidate, secondCandidate];
+
+    await ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      appServerCommand: firstCandidate.appServerCommandPath,
+      candidates: [firstCandidate],
+      ownershipCandidates,
+    });
+    await ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      appServerCommand: secondCandidate.appServerCommandPath,
+      candidates: [secondCandidate],
+      ownershipCandidates,
+    });
+
+    expect(await fs.readlink(path.join(target, "plugins"))).toBe(
+      path.join(secondCandidate.bundledMarketplacePath, "plugins"),
+    );
+  });
+
+  it("leaves the prior wrapper intact when its generation becomes stale before publication", async () => {
+    const root = tempDirs.make("openclaw-codex-marketplace-stale-");
+    const firstCandidate = await writeCandidate(path.join(root, "first"));
+    const secondCandidate = await writeCandidate(path.join(root, "second"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    const target = resolveCodexManagedBundledMarketplacePath(codexHome);
+    const ownershipCandidates = [firstCandidate, secondCandidate];
+    await ensureCodexManagedBundledMarketplace({
+      codexHome,
+      ownershipRoot: agentDir,
+      candidates: [firstCandidate],
+      ownershipCandidates,
+    });
+
+    let currentnessChecks = 0;
+    await expect(
+      ensureCodexManagedBundledMarketplace({
+        codexHome,
+        ownershipRoot: agentDir,
+        candidates: [secondCandidate],
+        ownershipCandidates,
+        assertCurrent: () => {
+          currentnessChecks += 1;
+          if (currentnessChecks === 2) {
+            throw new Error("desktop generation is stale");
+          }
+        },
+      }),
+    ).rejects.toThrow("desktop generation is stale");
+    expect(currentnessChecks).toBe(2);
+
+    expect(await fs.readlink(path.join(target, "plugins"))).toBe(
+      path.join(firstCandidate.bundledMarketplacePath, "plugins"),
     );
     expect(
       (await fs.readdir(path.dirname(target))).filter((entry) =>

--- a/extensions/codex/src/app-server/computer-use-marketplace.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.ts
@@ -1,0 +1,229 @@
+/** Managed local wrapper for Codex's reserved bundled marketplace. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  assertDirectoryIdentityStable,
+  assertNotSymlink,
+  directoryIdentityIsStable,
+  prepareOwnedServiceParent,
+} from "./computer-use-service-path.js";
+import {
+  resolveMacOSDesktopCodexAppPathCandidates,
+  type MacOSDesktopCodexAppPathCandidate,
+} from "./desktop-app-paths.js";
+
+const MARKETPLACE_NAME = "openai-bundled";
+const activeInstalls = new Map<string, Promise<string | undefined>>();
+
+export function resolveCodexManagedBundledMarketplacePath(codexHome: string): string {
+  return path.join(codexHome, ".tmp", "bundled-marketplaces", MARKETPLACE_NAME);
+}
+
+export async function ensureCodexManagedBundledMarketplace(params: {
+  codexHome: string;
+  ownershipRoot: string;
+  appServerCommand?: string;
+  candidates?: readonly MacOSDesktopCodexAppPathCandidate[];
+}): Promise<string | undefined> {
+  const candidates = params.candidates ?? resolveMacOSDesktopCodexAppPathCandidates();
+  const source = await resolveSource({ ...params, candidates });
+  if (!source) {
+    return undefined;
+  }
+  const parentPath = path.dirname(resolveCodexManagedBundledMarketplacePath(params.codexHome));
+  const targetPath = path.join(parentPath, MARKETPLACE_NAME);
+  const parent = await prepareOwnedServiceParent({
+    ownershipRoot: params.ownershipRoot,
+    codexHome: params.codexHome,
+    targetParent: parentPath,
+  });
+  const physicalTargetPath = path.join(parent.realPath, MARKETPLACE_NAME);
+  await assertNotSymlink(physicalTargetPath, "managed bundled marketplace");
+  if (await wrapperMatches(physicalTargetPath, source.bundledMarketplacePath)) {
+    return targetPath;
+  }
+  const active = activeInstalls.get(physicalTargetPath);
+  if (active) {
+    return await active;
+  }
+
+  const install = publishManagedWrapper({
+    parent,
+    physicalTargetPath,
+    targetPath,
+    source,
+    candidates,
+  });
+  activeInstalls.set(physicalTargetPath, install);
+  const clearActive = () => {
+    if (activeInstalls.get(physicalTargetPath) === install) {
+      activeInstalls.delete(physicalTargetPath);
+    }
+  };
+  void install.then(clearActive, clearActive);
+  return await install;
+}
+
+async function publishManagedWrapper(params: {
+  parent: Awaited<ReturnType<typeof prepareOwnedServiceParent>>;
+  physicalTargetPath: string;
+  targetPath: string;
+  source: MacOSDesktopCodexAppPathCandidate;
+  candidates: readonly MacOSDesktopCodexAppPathCandidate[];
+}): Promise<string> {
+  const { parent, physicalTargetPath, targetPath, source, candidates } = params;
+
+  const stagingPath = await fs.mkdtemp(path.join(parent.realPath, `.${MARKETPLACE_NAME}.staging-`));
+  const backupPath = path.join(
+    parent.realPath,
+    `.${MARKETPLACE_NAME}.backup-${process.pid}-${Date.now()}`,
+  );
+  let backupCreated = false;
+  try {
+    const manifestParent = path.join(stagingPath, ".agents", "plugins");
+    await fs.mkdir(manifestParent, { recursive: true, mode: 0o700 });
+    await Promise.all([
+      fs.symlink(
+        path.join(source.bundledMarketplacePath, ".agents", "plugins", "marketplace.json"),
+        path.join(manifestParent, "marketplace.json"),
+      ),
+      fs.symlink(
+        path.join(source.bundledMarketplacePath, "plugins"),
+        path.join(stagingPath, "plugins"),
+      ),
+    ]);
+    await assertDirectoryIdentityStable(parent, "managed bundled marketplace parent");
+    const existing = await fs.lstat(physicalTargetPath).catch((error: unknown) => {
+      if (hasNodeErrorCode(error, "ENOENT")) {
+        return undefined;
+      }
+      throw error;
+    });
+    if (existing && !existing.isDirectory()) {
+      throw new Error(`Managed bundled marketplace must be a real directory: ${targetPath}`);
+    }
+    if (existing && !(await wrapperMatchesAnySource(physicalTargetPath, candidates))) {
+      throw new Error(
+        `Refusing to replace an unowned bundled marketplace directory: ${targetPath}`,
+      );
+    }
+    if (existing) {
+      await fs.rename(physicalTargetPath, backupPath);
+      backupCreated = true;
+      await assertDirectoryIdentityStable(parent, "managed bundled marketplace parent");
+    }
+    await fs.rename(stagingPath, physicalTargetPath);
+    await assertDirectoryIdentityStable(parent, "managed bundled marketplace parent");
+    if (backupCreated) {
+      await fs.rm(backupPath, { recursive: true });
+      backupCreated = false;
+    }
+    return targetPath;
+  } catch (error) {
+    if (backupCreated) {
+      try {
+        await assertDirectoryIdentityStable(parent, "managed bundled marketplace parent");
+        const replacement = await fs.lstat(physicalTargetPath).catch(() => undefined);
+        if (replacement) {
+          if (!(await wrapperMatches(physicalTargetPath, source.bundledMarketplacePath))) {
+            throw new Error("managed bundled marketplace replacement is no longer owned", {
+              cause: error,
+            });
+          }
+          await fs.rm(physicalTargetPath, { recursive: true });
+        }
+        await fs.rename(backupPath, physicalTargetPath);
+        backupCreated = false;
+      } catch (restoreError) {
+        throw new Error(
+          `Failed to restore the prior managed bundled marketplace: ${String(error)}`,
+          {
+            cause: restoreError,
+          },
+        );
+      }
+    }
+    throw error;
+  } finally {
+    if (await directoryIdentityIsStable(parent)) {
+      await fs.rm(stagingPath, { recursive: true, force: true });
+    }
+  }
+}
+
+async function resolveSource(params: {
+  appServerCommand?: string;
+  candidates?: readonly MacOSDesktopCodexAppPathCandidate[];
+}): Promise<MacOSDesktopCodexAppPathCandidate | undefined> {
+  const candidates = params.candidates ?? resolveMacOSDesktopCodexAppPathCandidates();
+  const command = params.appServerCommand && path.resolve(params.appServerCommand);
+  const ordered = command
+    ? [
+        ...candidates.filter(
+          (candidate) => path.resolve(candidate.appServerCommandPath) === command,
+        ),
+        ...candidates.filter(
+          (candidate) => path.resolve(candidate.appServerCommandPath) !== command,
+        ),
+      ]
+    : candidates;
+  for (const candidate of ordered) {
+    if (await isExpectedMarketplace(candidate.bundledMarketplacePath)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function isExpectedMarketplace(root: string): Promise<boolean> {
+  try {
+    const manifest: unknown = JSON.parse(
+      await fs.readFile(path.join(root, ".agents", "plugins", "marketplace.json"), "utf8"),
+    );
+    await fs.access(path.join(root, "plugins", "computer-use", ".codex-plugin", "plugin.json"));
+    return (
+      isRecord(manifest) &&
+      manifest.name === MARKETPLACE_NAME &&
+      Array.isArray(manifest.plugins) &&
+      manifest.plugins.some((plugin) => isRecord(plugin) && plugin.name === "computer-use")
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function wrapperMatches(targetPath: string, sourcePath: string): Promise<boolean> {
+  try {
+    const target = await fs.lstat(targetPath);
+    if (!target.isDirectory() || target.isSymbolicLink()) {
+      return false;
+    }
+    const [manifest, plugins] = await Promise.all([
+      fs.readlink(path.join(targetPath, ".agents", "plugins", "marketplace.json")),
+      fs.readlink(path.join(targetPath, "plugins")),
+    ]);
+    return (
+      manifest === path.join(sourcePath, ".agents", "plugins", "marketplace.json") &&
+      plugins === path.join(sourcePath, "plugins")
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function wrapperMatchesAnySource(
+  targetPath: string,
+  candidates: readonly MacOSDesktopCodexAppPathCandidate[],
+): Promise<boolean> {
+  for (const candidate of candidates) {
+    if (await wrapperMatches(targetPath, candidate.bundledMarketplacePath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasNodeErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
+}

--- a/extensions/codex/src/app-server/computer-use-marketplace.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.ts
@@ -14,7 +14,10 @@ import {
 } from "./desktop-app-paths.js";
 
 const MARKETPLACE_NAME = "openai-bundled";
-const activeInstalls = new Map<string, Promise<string | undefined>>();
+const activeInstalls = new Map<
+  string,
+  { sourcePath: string; promise: Promise<string | undefined> }
+>();
 
 export function resolveCodexManagedBundledMarketplacePath(codexHome: string): string {
   return path.join(codexHome, ".tmp", "bundled-marketplaces", MARKETPLACE_NAME);
@@ -25,9 +28,11 @@ export async function ensureCodexManagedBundledMarketplace(params: {
   ownershipRoot: string;
   appServerCommand?: string;
   candidates?: readonly MacOSDesktopCodexAppPathCandidate[];
+  ownershipCandidates?: readonly MacOSDesktopCodexAppPathCandidate[];
+  assertCurrent?: () => void;
 }): Promise<string | undefined> {
   const candidates = params.candidates ?? resolveMacOSDesktopCodexAppPathCandidates();
-  const source = await resolveSource({ ...params, candidates });
+  const source = await resolveCodexManagedBundledMarketplaceSource({ ...params, candidates });
   if (!source) {
     return undefined;
   }
@@ -40,24 +45,26 @@ export async function ensureCodexManagedBundledMarketplace(params: {
   });
   const physicalTargetPath = path.join(parent.realPath, MARKETPLACE_NAME);
   await assertNotSymlink(physicalTargetPath, "managed bundled marketplace");
-  if (await wrapperMatches(physicalTargetPath, source.bundledMarketplacePath)) {
-    return targetPath;
-  }
   const active = activeInstalls.get(physicalTargetPath);
   if (active) {
-    return await active;
+    if (active.sourcePath === source.bundledMarketplacePath) {
+      return await active.promise;
+    }
+    await active.promise.catch(() => undefined);
+    return await ensureCodexManagedBundledMarketplace(params);
   }
-
-  const install = publishManagedWrapper({
+  const install = reconcileManagedWrapper({
     parent,
     physicalTargetPath,
     targetPath,
     source,
-    candidates,
+    ownershipCandidates: params.ownershipCandidates ?? candidates,
+    assertCurrent: params.assertCurrent,
   });
-  activeInstalls.set(physicalTargetPath, install);
+  const activeEntry = { sourcePath: source.bundledMarketplacePath, promise: install };
+  activeInstalls.set(physicalTargetPath, activeEntry);
   const clearActive = () => {
-    if (activeInstalls.get(physicalTargetPath) === install) {
+    if (activeInstalls.get(physicalTargetPath) === activeEntry) {
       activeInstalls.delete(physicalTargetPath);
     }
   };
@@ -65,14 +72,25 @@ export async function ensureCodexManagedBundledMarketplace(params: {
   return await install;
 }
 
+async function reconcileManagedWrapper(
+  params: Parameters<typeof publishManagedWrapper>[0],
+): Promise<string> {
+  if (await wrapperMatches(params.physicalTargetPath, params.source.bundledMarketplacePath)) {
+    return params.targetPath;
+  }
+  return await publishManagedWrapper(params);
+}
+
 async function publishManagedWrapper(params: {
   parent: Awaited<ReturnType<typeof prepareOwnedServiceParent>>;
   physicalTargetPath: string;
   targetPath: string;
   source: MacOSDesktopCodexAppPathCandidate;
-  candidates: readonly MacOSDesktopCodexAppPathCandidate[];
+  ownershipCandidates: readonly MacOSDesktopCodexAppPathCandidate[];
+  assertCurrent?: () => void;
 }): Promise<string> {
-  const { parent, physicalTargetPath, targetPath, source, candidates } = params;
+  const { parent, physicalTargetPath, targetPath, source, ownershipCandidates, assertCurrent } =
+    params;
 
   const stagingPath = await fs.mkdtemp(path.join(parent.realPath, `.${MARKETPLACE_NAME}.staging-`));
   const backupPath = path.join(
@@ -103,16 +121,18 @@ async function publishManagedWrapper(params: {
     if (existing && !existing.isDirectory()) {
       throw new Error(`Managed bundled marketplace must be a real directory: ${targetPath}`);
     }
-    if (existing && !(await wrapperMatchesAnySource(physicalTargetPath, candidates))) {
+    if (existing && !(await wrapperMatchesAnySource(physicalTargetPath, ownershipCandidates))) {
       throw new Error(
         `Refusing to replace an unowned bundled marketplace directory: ${targetPath}`,
       );
     }
     if (existing) {
+      assertCurrent?.();
       await fs.rename(physicalTargetPath, backupPath);
       backupCreated = true;
       await assertDirectoryIdentityStable(parent, "managed bundled marketplace parent");
     }
+    assertCurrent?.();
     await fs.rename(stagingPath, physicalTargetPath);
     await assertDirectoryIdentityStable(parent, "managed bundled marketplace parent");
     if (backupCreated) {
@@ -152,21 +172,14 @@ async function publishManagedWrapper(params: {
   }
 }
 
-async function resolveSource(params: {
+export async function resolveCodexManagedBundledMarketplaceSource(params: {
   appServerCommand?: string;
   candidates?: readonly MacOSDesktopCodexAppPathCandidate[];
 }): Promise<MacOSDesktopCodexAppPathCandidate | undefined> {
   const candidates = params.candidates ?? resolveMacOSDesktopCodexAppPathCandidates();
   const command = params.appServerCommand && path.resolve(params.appServerCommand);
   const ordered = command
-    ? [
-        ...candidates.filter(
-          (candidate) => path.resolve(candidate.appServerCommandPath) === command,
-        ),
-        ...candidates.filter(
-          (candidate) => path.resolve(candidate.appServerCommandPath) !== command,
-        ),
-      ]
+    ? candidates.filter((candidate) => path.resolve(candidate.appServerCommandPath) === command)
     : candidates;
   for (const candidate of ordered) {
     if (await isExpectedMarketplace(candidate.bundledMarketplacePath)) {

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -298,7 +298,7 @@ describe("Codex Computer Use native service", () => {
     expect(copyServiceApp).not.toHaveBeenCalled();
   });
 
-  it("reuses a completed process-lifetime sync without repeated signature inspection", async () => {
+  it("refreshes when the signed desktop service changes at the same source path", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");
     const sourcePath = path.join(root, "source", "Codex Computer Use.app");
     const codexHome = path.join(root, "codex-home");
@@ -314,8 +314,7 @@ describe("Codex Computer Use native service", () => {
       inspectServiceApp,
     });
     expect(first.status).toBe("installed");
-    const inspectionCount = inspectServiceApp.mock.calls.length;
-    const copyCount = copyServiceApp.mock.calls.length;
+    await writeServiceFixture(sourcePath, UNEXPECTED_IDENTITY);
 
     const second = await ensureCodexComputerUseServiceApp({
       codexHome,
@@ -326,51 +325,18 @@ describe("Codex Computer Use native service", () => {
     });
 
     expect(second).toMatchObject({
-      status: "already_current",
-      changed: false,
-      sourceBuild: "1000761",
+      status: "refreshed",
+      changed: true,
+      previousBuild: "1000761",
+      sourceBuild: "1000900",
     });
-    expect(inspectServiceApp).toHaveBeenCalledTimes(inspectionCount);
-    expect(copyServiceApp).toHaveBeenCalledTimes(copyCount);
+    expect(copyServiceApp).toHaveBeenCalledTimes(2);
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(UNEXPECTED_IDENTITY);
+    await expect(findInstallDebris(path.dirname(targetPath))).resolves.toEqual([]);
   });
 
-  it("bounds completed synchronization state and re-inspects an evicted home", async () => {
-    const root = tempDirs.make("openclaw-computer-use-service-cache-");
-    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
-    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
-    const inspectServiceApp = vi.fn(inspectServiceFixture);
-    const codexHomes = Array.from({ length: 65 }, (_, index) =>
-      path.join(root, `codex-home-${index}`),
-    );
-    const oldestCodexHome = codexHomes[0];
-    if (!oldestCodexHome) {
-      throw new Error("expected at least one Codex home fixture");
-    }
-
-    for (const codexHome of codexHomes) {
-      const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
-      await writeServiceFixture(targetPath, CURRENT_IDENTITY);
-      await ensureCodexComputerUseServiceApp({
-        codexHome,
-        platform: "darwin",
-        sourceAppCandidates: [sourcePath],
-        inspectServiceApp,
-      });
-    }
-
-    const inspectionsBeforeRecall = inspectServiceApp.mock.calls.length;
-    await expect(
-      ensureCodexComputerUseServiceApp({
-        codexHome: oldestCodexHome,
-        platform: "darwin",
-        sourceAppCandidates: [sourcePath],
-        inspectServiceApp,
-      }),
-    ).resolves.toMatchObject({ status: "already_current", changed: false });
-    expect(inspectServiceApp.mock.calls.length).toBeGreaterThan(inspectionsBeforeRecall);
-  });
-
-  it("invalidates a completed selection before a different selection fails", async () => {
+  it("revalidates the current source after a different selection fails", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");
     const firstSourcePath = path.join(root, "first", "Codex Computer Use.app");
     const failingSourcePath = path.join(root, "failing", "Codex Computer Use.app");
@@ -555,7 +521,7 @@ describe("Codex Computer Use native service", () => {
     await expect(findInstallDebris(path.dirname(targetPath))).resolves.toEqual([]);
   });
 
-  it("serializes different selected sources and invalidates the prior completed selection", async () => {
+  it("serializes different selected sources and revalidates each selection", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");
     const firstSourcePath = path.join(root, "first", "Codex Computer Use.app");
     const secondSourcePath = path.join(root, "second", "Codex Computer Use.app");

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -595,6 +595,44 @@ describe("Codex Computer Use native service", () => {
     await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
   });
 
+  it("leaves the prior service intact when its generation becomes stale before publication", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-stale-");
+    const firstSourcePath = path.join(root, "first", "Codex Computer Use.app");
+    const secondSourcePath = path.join(root, "second", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(firstSourcePath, CURRENT_IDENTITY);
+    await writeServiceFixture(secondSourcePath, UNEXPECTED_IDENTITY);
+    await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [firstSourcePath],
+      copyServiceApp: copyServiceFixture,
+      inspectServiceApp: inspectServiceFixture,
+    });
+
+    let currentnessChecks = 0;
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [secondSourcePath],
+        copyServiceApp: copyServiceFixture,
+        inspectServiceApp: inspectServiceFixture,
+        assertCurrent: () => {
+          currentnessChecks += 1;
+          if (currentnessChecks === 2) {
+            throw new Error("desktop generation is stale");
+          }
+        },
+      }),
+    ).rejects.toThrow("desktop generation is stale");
+    expect(currentnessChecks).toBe(2);
+
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
+    await expect(findInstallDebris(path.dirname(targetPath))).resolves.toEqual([]);
+  });
+
   it("does not provision the macOS service on other platforms", async () => {
     const inspectServiceApp = vi.fn();
     const result = await ensureCodexComputerUseServiceApp({

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -64,6 +64,25 @@ type ServiceAppSnapshot = {
   filesystemKey?: string;
 };
 
+/** Finds the first signed native service from one ordered desktop owner set. */
+export async function resolveCodexComputerUseServiceAppSourcePath(params: {
+  platform?: NodeJS.Platform;
+  appServerCommand?: string;
+  sourceAppCandidates?: readonly string[];
+  inspectServiceApp?: InspectServiceApp;
+}): Promise<string | undefined> {
+  const platform = params.platform ?? process.platform;
+  if (platform !== "darwin") {
+    return undefined;
+  }
+  const candidates =
+    params.sourceAppCandidates ??
+    resolveMacOSDesktopCodexComputerUseServiceAppCandidates(platform, params.appServerCommand);
+  return (
+    await findUsableServiceApp(candidates, params.inspectServiceApp ?? inspectTrustedServiceApp)
+  )?.path;
+}
+
 /** Synchronizes the CODEX_HOME native client with the selected signed desktop distribution. */
 export async function ensureCodexComputerUseServiceApp(params: {
   codexHome: string;
@@ -73,6 +92,7 @@ export async function ensureCodexComputerUseServiceApp(params: {
   sourceAppCandidates?: readonly string[];
   copyServiceApp?: CopyServiceApp;
   inspectServiceApp?: InspectServiceApp;
+  assertCurrent?: () => void;
 }): Promise<CodexComputerUseServiceStatus> {
   const platform = params.platform ?? process.platform;
   if (platform !== "darwin") {
@@ -126,6 +146,7 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
   sourceAppCandidates?: readonly string[];
   copyServiceApp?: CopyServiceApp;
   inspectServiceApp?: InspectServiceApp;
+  assertCurrent?: () => void;
 }): Promise<CodexComputerUseServiceStatus> {
   const inspectServiceApp = params.inspectServiceApp ?? inspectTrustedServiceApp;
   const candidates = params.sourceAppCandidates ?? [];
@@ -187,6 +208,7 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
     await assertNotSymlink(operationTargetPath, "Computer Use service target");
     if (await pathExists(operationTargetPath)) {
       await assertOwnedServiceParentStable(ownedParent);
+      params.assertCurrent?.();
       await fs.rename(operationTargetPath, backupPath);
       await assertOwnedServiceParentStable(ownedParent);
       backupCreated = true;
@@ -218,6 +240,7 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
     }
     try {
       await assertOwnedServiceParentStable(ownedParent);
+      params.assertCurrent?.();
       await fs.rename(stagedPath, operationTargetPath);
       await assertOwnedServiceParentStable(ownedParent);
     } catch (error) {

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -2,7 +2,6 @@
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { runExec } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -31,16 +30,9 @@ const CLIENT_RELATIVE_PATH = path.join(
 );
 const COPY_TIMEOUT_MS = 120_000;
 const INSPECT_TIMEOUT_MS = 30_000;
-const COMPLETED_SYNC_CACHE_MAX_ENTRIES = 64;
 const activeInstalls = new Map<
   string,
   { syncKey: string; promise: Promise<CodexComputerUseServiceStatus> }
->();
-const completedSyncs = new Map<
-  string,
-  Pick<CodexComputerUseServiceStatus, "targetPath" | "sourcePath" | "sourceBuild"> & {
-    syncKey: string;
-  }
 >();
 
 type CodexComputerUseServiceStatus = {
@@ -96,19 +88,6 @@ export async function ensureCodexComputerUseServiceApp(params: {
     params.sourceAppCandidates ??
     resolveMacOSDesktopCodexComputerUseServiceAppCandidates(platform, params.appServerCommand);
   const syncKey = [targetPath, ...candidates].join("\0");
-  const completed = completedSyncs.get(targetPath);
-  if (completed?.syncKey === syncKey) {
-    // Keep frequently reused homes while bounding dynamic-agent history.
-    completedSyncs.delete(targetPath);
-    completedSyncs.set(targetPath, completed);
-    return {
-      status: "already_current",
-      changed: false,
-      targetPath: completed.targetPath,
-      sourcePath: completed.sourcePath,
-      sourceBuild: completed.sourceBuild,
-    };
-  }
   const active = activeInstalls.get(targetPath);
   if (active) {
     if (active.syncKey === syncKey) {
@@ -116,9 +95,6 @@ export async function ensureCodexComputerUseServiceApp(params: {
     }
     await active.promise.catch(() => undefined);
     return await ensureCodexComputerUseServiceApp(params);
-  }
-  if (completed) {
-    completedSyncs.delete(targetPath);
   }
   const install = ensureCodexComputerUseServiceAppOnce({
     ...params,
@@ -128,18 +104,6 @@ export async function ensureCodexComputerUseServiceApp(params: {
     targetPath,
     platform,
     sourceAppCandidates: candidates,
-  }).then((result) => {
-    if (isCompletedSyncStatus(result.status)) {
-      completedSyncs.delete(targetPath);
-      completedSyncs.set(targetPath, {
-        syncKey,
-        targetPath: result.targetPath,
-        sourcePath: result.sourcePath,
-        sourceBuild: result.sourceBuild,
-      });
-      pruneMapToMaxSize(completedSyncs, COMPLETED_SYNC_CACHE_MAX_ENTRIES);
-    }
-    return result;
   });
   const activeEntry = { syncKey, promise: install };
   activeInstalls.set(targetPath, activeEntry);
@@ -150,10 +114,6 @@ export async function ensureCodexComputerUseServiceApp(params: {
   };
   void install.then(clearActive, clearActive);
   return await install;
-}
-
-function isCompletedSyncStatus(status: CodexComputerUseServiceStatus["status"]): boolean {
-  return status === "installed" || status === "refreshed" || status === "already_current";
 }
 
 async function ensureCodexComputerUseServiceAppOnce(params: {

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1077,9 +1077,42 @@ describe("Codex Computer Use setup", () => {
     });
   });
 
-  it.each(["config", "env"] as const)(
-    "provisions the managed wrapper and service for a %s-selected desktop install",
-    async (commandSource) => {
+  it.each([
+    {
+      label: "config-selected default marketplace",
+      commandSource: "config" as const,
+      selector: {},
+      provisionsWrapper: true,
+    },
+    {
+      label: "env-selected default marketplace",
+      commandSource: "env" as const,
+      selector: {},
+      provisionsWrapper: true,
+    },
+    {
+      label: "configured marketplace source",
+      commandSource: "config" as const,
+      selector: { marketplaceSource: "github:example/desktop-tools" },
+      provisionsWrapper: false,
+    },
+    {
+      label: "configured marketplace path",
+      commandSource: "config" as const,
+      selector: {
+        marketplacePath: "/marketplaces/desktop-tools/.agents/plugins/marketplace.json",
+      },
+      provisionsWrapper: false,
+    },
+    {
+      label: "configured marketplace name",
+      commandSource: "config" as const,
+      selector: { marketplaceName: "desktop-tools" },
+      provisionsWrapper: false,
+    },
+  ])(
+    "provisions the managed service for a $label explicit desktop install",
+    async ({ commandSource, selector, provisionsWrapper }) => {
       const root = tempDirs.make("openclaw-codex-explicit-install-");
       const agentDir = path.join(root, "agent");
       const codexHome = path.join(agentDir, "codex-home");
@@ -1123,24 +1156,32 @@ describe("Codex Computer Use setup", () => {
           release();
         },
       );
-      const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath);
+      const request = provisionsWrapper
+        ? createBundledMarketplaceComputerUseRequest(managedMarketplacePath)
+        : createComputerUseRequest({ installed: false });
 
       const status = await installCodexComputerUse({
         agentDir,
         client: harness.client,
         request,
-        pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
+        pluginConfig: { computerUse: { enabled: true, autoInstall: false, ...selector } },
       });
 
       expect(status.ready).toBe(true);
       expect(drainedBeforeFence).toBe(true);
-      expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith(
-        expect.objectContaining({
-          codexHome,
-          ownershipRoot: agentDir,
-          appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
-        }),
-      );
+      if (provisionsWrapper) {
+        expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            codexHome,
+            ownershipRoot: agentDir,
+            appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
+          }),
+        );
+      } else {
+        expect(
+          managedProvisioningMocks.ensureCodexManagedBundledMarketplace,
+        ).not.toHaveBeenCalled();
+      }
       expect(managedProvisioningMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith(
         expect.objectContaining({
           codexHome,
@@ -1156,8 +1197,11 @@ describe("Codex Computer Use setup", () => {
         sharedClientMocks.waitForCodexAppServerClientDesktopGenerationDrain.mock
           .invocationCallOrder[0],
       ).toBeLessThan(
-        managedProvisioningMocks.ensureCodexManagedBundledMarketplace.mock.invocationCallOrder[0] ??
-          Number.POSITIVE_INFINITY,
+        (provisionsWrapper
+          ? managedProvisioningMocks.ensureCodexManagedBundledMarketplace.mock
+              .invocationCallOrder[0]
+          : managedProvisioningMocks.ensureCodexComputerUseServiceApp.mock
+              .invocationCallOrder[0]) ?? Number.POSITIVE_INFINITY,
       );
       expect(sharedClientMocks.readCodexAppServerClientDesktopGeneration).toHaveReturnedWith(
         desktopGeneration,

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -15,6 +15,7 @@ const sharedClientMocks = vi.hoisted(() => ({
   readCodexAppServerClientDesktopGeneration: vi.fn(),
   readCodexAppServerClientProcessIdentity: vi.fn(),
   releaseLeasedSharedCodexAppServerClient: vi.fn(),
+  waitForCodexAppServerClientDesktopGenerationDrain: vi.fn(),
 }));
 const managedProvisioningMocks = vi.hoisted(() => ({
   ensureCodexComputerUseSharedPluginCache: vi.fn(async () => ({
@@ -133,6 +134,10 @@ describe("Codex Computer Use setup", () => {
     sharedClientMocks.readCodexAppServerClientDesktopGeneration.mockReset();
     sharedClientMocks.readCodexAppServerClientProcessIdentity.mockReset();
     sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockReset();
+    sharedClientMocks.waitForCodexAppServerClientDesktopGenerationDrain.mockReset();
+    sharedClientMocks.waitForCodexAppServerClientDesktopGenerationDrain.mockResolvedValue(
+      undefined,
+    );
     managedProvisioningMocks.ensureCodexManagedBundledMarketplace.mockReset();
     managedProvisioningMocks.ensureCodexComputerUseServiceApp.mockReset();
     managedProvisioningMocks.ensureCodexComputerUseSharedPluginCache.mockReset();
@@ -1096,6 +1101,10 @@ describe("Codex Computer Use setup", () => {
         commandSource,
         argsFingerprint: "args",
       });
+      const desktopGeneration = { epoch: 1, fingerprint: "desktop-current" };
+      sharedClientMocks.readCodexAppServerClientDesktopGeneration.mockReturnValue(
+        desktopGeneration,
+      );
       managedProvisioningMocks.ensureCodexManagedBundledMarketplace.mockResolvedValue(
         managedMarketplacePath,
       );
@@ -1103,6 +1112,17 @@ describe("Codex Computer Use setup", () => {
         status: "already_current",
         changed: false,
       });
+      let drainedBeforeFence = false;
+      sharedClientMocks.waitForCodexAppServerClientDesktopGenerationDrain.mockImplementationOnce(
+        async () => {
+          const release = await acquireCodexNativeConfigFence(
+            `codex-home:${path.resolve(codexHome)}`,
+            { timeoutMs: 50 },
+          );
+          drainedBeforeFence = true;
+          release();
+        },
+      );
       const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath);
 
       const status = await installCodexComputerUse({
@@ -1113,6 +1133,7 @@ describe("Codex Computer Use setup", () => {
       });
 
       expect(status.ready).toBe(true);
+      expect(drainedBeforeFence).toBe(true);
       expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith(
         expect.objectContaining({
           codexHome,
@@ -1128,14 +1149,55 @@ describe("Codex Computer Use setup", () => {
         }),
       );
       expect(sharedClientMocks.assertCodexAppServerClientStartSelectionCurrent).toHaveBeenCalled();
+      expect(
+        sharedClientMocks.waitForCodexAppServerClientDesktopGenerationDrain,
+      ).toHaveBeenCalledWith({ client: harness.client, timeoutMs: expect.any(Number) });
+      expect(
+        sharedClientMocks.waitForCodexAppServerClientDesktopGenerationDrain.mock
+          .invocationCallOrder[0],
+      ).toBeLessThan(
+        managedProvisioningMocks.ensureCodexManagedBundledMarketplace.mock.invocationCallOrder[0] ??
+          Number.POSITIVE_INFINITY,
+      );
       expect(sharedClientMocks.readCodexAppServerClientDesktopGeneration).toHaveReturnedWith(
-        undefined,
+        desktopGeneration,
       );
       expect(managedProvisioningMocks.ensureCodexComputerUseSharedPluginCache).toHaveBeenCalledWith(
         expect.objectContaining({ forceRefresh: true }),
       );
     },
   );
+
+  it("rejects explicit managed provisioning from a desktop client without a generation", async () => {
+    const root = tempDirs.make("openclaw-codex-explicit-install-unbound-");
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    fs.mkdirSync(codexHome, { recursive: true });
+    const harness = createClientHarness();
+    vi.spyOn(harness.client, "getRuntimeIdentity").mockReturnValue({
+      serverVersion: "0.148.0",
+      codexHome,
+    });
+    sharedClientMocks.readCodexAppServerClientProcessIdentity.mockReturnValue({
+      clientId: "client-explicit-install-unbound",
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "config",
+      argsFingerprint: "args",
+    });
+
+    await expect(
+      installCodexComputerUse({
+        agentDir,
+        client: harness.client,
+        request: vi.fn(),
+        pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
+      }),
+    ).rejects.toThrow("requires a desktop-generation-bound client");
+    expect(
+      sharedClientMocks.waitForCodexAppServerClientDesktopGenerationDrain,
+    ).not.toHaveBeenCalled();
+    expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).not.toHaveBeenCalled();
+  });
 
   it("rejects explicit provisioning from a stale desktop client", async () => {
     const root = tempDirs.make("openclaw-codex-explicit-install-stale-");

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -63,6 +63,15 @@ vi.mock("./computer-use-cache.js", () => ({
     managedProvisioningMocks.ensureCodexComputerUseSharedPluginCache,
 }));
 
+vi.mock("./desktop-app-paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./desktop-app-paths.js")>();
+  return {
+    ...actual,
+    resolveMacOSDesktopCodexAppPathCandidates: (platform?: NodeJS.Platform) =>
+      actual.resolveMacOSDesktopCodexAppPathCandidates(platform ?? "darwin"),
+  };
+});
+
 import {
   ensureCodexComputerUse,
   installCodexComputerUse,

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 // Codex tests cover computer use plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { resolveCodexAppServerRuntimeOptions, resolveCodexComputerUseConfig } from "./config.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import { resolveCodexNativeConfigFenceKey } from "./shared-client.js";
 import { createClientHarness, useAutoCleanupTempDirTracker } from "./test-support.js";
@@ -77,6 +77,7 @@ import {
   ensureCodexComputerUse,
   installCodexComputerUse,
   readCodexComputerUseStatus,
+  runCodexComputerUseLiveTest,
   type CodexComputerUseStatus,
 } from "./computer-use.js";
 
@@ -557,6 +558,39 @@ describe("Codex Computer Use setup", () => {
     expect(status.warnings).toContain(
       "Could not reload Computer Use MCP servers: MCP runtime reload failed",
     );
+  });
+
+  it("propagates a desktop selection change without retrying the stale client", async () => {
+    const selectionChanged = Object.assign(new Error("desktop selection changed"), {
+      code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return { thread: { id: "probe-thread" } };
+      }
+      if (method === "mcpServer/tool/call") {
+        throw selectionChanged;
+      }
+      if (method === "thread/unsubscribe" || method === "thread/archive") {
+        return undefined;
+      }
+      throw new Error(`unexpected request: ${method}`);
+    }) as CodexComputerUseRequest;
+
+    await expect(
+      runCodexComputerUseLiveTest({
+        request,
+        config: resolveCodexComputerUseConfig({
+          pluginConfig: { computerUse: { enabled: true, autoRepair: true } },
+        }),
+      }),
+    ).rejects.toBe(selectionChanged);
+    expect(requestCalls(request).map(([method]) => method)).toEqual([
+      "thread/start",
+      "mcpServer/tool/call",
+      "thread/unsubscribe",
+      "thread/archive",
+    ]);
   });
 
   it("fails fast when the named MCP server exposes no tools", async () => {

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -1020,49 +1020,52 @@ describe("Codex Computer Use setup", () => {
     });
   });
 
-  it("provisions the managed wrapper and service for an explicit isolated-home install", async () => {
-    const root = tempDirs.make("openclaw-codex-explicit-install-");
-    const agentDir = path.join(root, "agent");
-    const codexHome = path.join(agentDir, "codex-home");
-    const managedMarketplacePath = path.join(
-      codexHome,
-      ".tmp",
-      "bundled-marketplaces",
-      "openai-bundled",
-    );
-    fs.mkdirSync(managedMarketplacePath, { recursive: true });
-    const harness = createClientHarness();
-    vi.spyOn(harness.client, "getRuntimeIdentity").mockReturnValue({
-      serverVersion: "0.148.0",
-      codexHome,
-    });
-    sharedClientMocks.readCodexAppServerClientProcessIdentity.mockReturnValue({
-      clientId: "client-explicit-install",
-      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
-      nativeCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
-      argsFingerprint: "args",
-    });
-    const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath);
+  it.each(["config", "env"] as const)(
+    "provisions the managed wrapper and service for a %s-selected desktop install",
+    async (commandSource) => {
+      const root = tempDirs.make("openclaw-codex-explicit-install-");
+      const agentDir = path.join(root, "agent");
+      const codexHome = path.join(agentDir, "codex-home");
+      const managedMarketplacePath = path.join(
+        codexHome,
+        ".tmp",
+        "bundled-marketplaces",
+        "openai-bundled",
+      );
+      fs.mkdirSync(managedMarketplacePath, { recursive: true });
+      const harness = createClientHarness();
+      vi.spyOn(harness.client, "getRuntimeIdentity").mockReturnValue({
+        serverVersion: "0.148.0",
+        codexHome,
+      });
+      sharedClientMocks.readCodexAppServerClientProcessIdentity.mockReturnValue({
+        clientId: "client-explicit-install",
+        command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+        commandSource,
+        argsFingerprint: "args",
+      });
+      const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath);
 
-    const status = await installCodexComputerUse({
-      agentDir,
-      client: harness.client,
-      request,
-      pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
-    });
+      const status = await installCodexComputerUse({
+        agentDir,
+        client: harness.client,
+        request,
+        pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
+      });
 
-    expect(status.ready).toBe(true);
-    expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith({
-      codexHome,
-      ownershipRoot: agentDir,
-      appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
-    });
-    expect(managedProvisioningMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith({
-      codexHome,
-      ownershipRoot: agentDir,
-      appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
-    });
-  });
+      expect(status.ready).toBe(true);
+      expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith({
+        codexHome,
+        ownershipRoot: agentDir,
+        appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      });
+      expect(managedProvisioningMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith({
+        codexHome,
+        ownershipRoot: agentDir,
+        appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      });
+    },
+  );
 
   it("allows auto-install from a configured local marketplace path", async () => {
     const request = createComputerUseRequest({ installed: false });

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -11,7 +11,12 @@ import { createClientHarness, useAutoCleanupTempDirTracker } from "./test-suppor
 const requestCodexAppServerJsonMock = vi.hoisted(() => vi.fn());
 const sharedClientMocks = vi.hoisted(() => ({
   getLeasedSharedCodexAppServerClient: vi.fn(),
+  readCodexAppServerClientProcessIdentity: vi.fn(),
   releaseLeasedSharedCodexAppServerClient: vi.fn(),
+}));
+const managedProvisioningMocks = vi.hoisted(() => ({
+  ensureCodexManagedBundledMarketplace: vi.fn(),
+  ensureCodexComputerUseServiceApp: vi.fn(),
 }));
 
 vi.mock("./request.js", () => ({
@@ -21,6 +26,17 @@ vi.mock("./request.js", () => ({
 vi.mock("./shared-client.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./shared-client.js")>()),
   ...sharedClientMocks,
+}));
+
+vi.mock("./computer-use-marketplace.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./computer-use-marketplace.js")>()),
+  ensureCodexManagedBundledMarketplace:
+    managedProvisioningMocks.ensureCodexManagedBundledMarketplace,
+}));
+
+vi.mock("./computer-use-service.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./computer-use-service.js")>()),
+  ensureCodexComputerUseServiceApp: managedProvisioningMocks.ensureCodexComputerUseServiceApp,
 }));
 
 import {
@@ -80,7 +96,10 @@ describe("Codex Computer Use setup", () => {
     vi.useRealTimers();
     requestCodexAppServerJsonMock.mockReset();
     sharedClientMocks.getLeasedSharedCodexAppServerClient.mockReset();
+    sharedClientMocks.readCodexAppServerClientProcessIdentity.mockReset();
     sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockReset();
+    managedProvisioningMocks.ensureCodexManagedBundledMarketplace.mockReset();
+    managedProvisioningMocks.ensureCodexComputerUseServiceApp.mockReset();
   });
 
   it("stays disabled until configured", async () => {
@@ -127,6 +146,7 @@ describe("Codex Computer Use setup", () => {
     const client = {
       request,
       closeAndRunAfterExit: vi.fn(),
+      getRuntimeIdentity: vi.fn(() => undefined),
     };
     sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client);
     const install = installCodexComputerUse({ pluginConfig: {}, agentDir });
@@ -997,6 +1017,50 @@ describe("Codex Computer Use setup", () => {
     expect(request).toHaveBeenCalledWith("plugin/install", {
       marketplacePath: `${bundledMarketplacePath}/.agents/plugins/marketplace.json`,
       pluginName: "computer-use",
+    });
+  });
+
+  it("provisions the managed wrapper and service for an explicit isolated-home install", async () => {
+    const root = tempDirs.make("openclaw-codex-explicit-install-");
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    const managedMarketplacePath = path.join(
+      codexHome,
+      ".tmp",
+      "bundled-marketplaces",
+      "openai-bundled",
+    );
+    fs.mkdirSync(managedMarketplacePath, { recursive: true });
+    const harness = createClientHarness();
+    vi.spyOn(harness.client, "getRuntimeIdentity").mockReturnValue({
+      serverVersion: "0.148.0",
+      codexHome,
+    });
+    sharedClientMocks.readCodexAppServerClientProcessIdentity.mockReturnValue({
+      clientId: "client-explicit-install",
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      nativeCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      argsFingerprint: "args",
+    });
+    const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath);
+
+    const status = await installCodexComputerUse({
+      agentDir,
+      client: harness.client,
+      request,
+      pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
+    });
+
+    expect(status.ready).toBe(true);
+    expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith({
+      codexHome,
+      ownershipRoot: agentDir,
+      appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
+    });
+    expect(managedProvisioningMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith({
+      codexHome,
+      ownershipRoot: agentDir,
+      appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
     });
   });
 

--- a/extensions/codex/src/app-server/computer-use.test.ts
+++ b/extensions/codex/src/app-server/computer-use.test.ts
@@ -10,13 +10,28 @@ import { createClientHarness, useAutoCleanupTempDirTracker } from "./test-suppor
 
 const requestCodexAppServerJsonMock = vi.hoisted(() => vi.fn());
 const sharedClientMocks = vi.hoisted(() => ({
+  assertCodexAppServerClientStartSelectionCurrent: vi.fn(),
   getLeasedSharedCodexAppServerClient: vi.fn(),
+  readCodexAppServerClientDesktopGeneration: vi.fn(),
   readCodexAppServerClientProcessIdentity: vi.fn(),
   releaseLeasedSharedCodexAppServerClient: vi.fn(),
 }));
 const managedProvisioningMocks = vi.hoisted(() => ({
+  ensureCodexComputerUseSharedPluginCache: vi.fn(async () => ({
+    status: "independent" as const,
+    changed: false,
+    message: "independent",
+    removedStaleVersions: [],
+    warnings: [],
+  })),
   ensureCodexManagedBundledMarketplace: vi.fn(),
   ensureCodexComputerUseServiceApp: vi.fn(),
+  resolveCodexManagedBundledMarketplaceSource: vi.fn(
+    async (params: { candidates?: readonly unknown[] }) => params.candidates?.[0],
+  ),
+  resolveCodexComputerUseServiceAppSourcePath: vi.fn(
+    async (params: { sourceAppCandidates?: readonly string[] }) => params.sourceAppCandidates?.[0],
+  ),
 }));
 
 vi.mock("./request.js", () => ({
@@ -32,11 +47,20 @@ vi.mock("./computer-use-marketplace.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./computer-use-marketplace.js")>()),
   ensureCodexManagedBundledMarketplace:
     managedProvisioningMocks.ensureCodexManagedBundledMarketplace,
+  resolveCodexManagedBundledMarketplaceSource:
+    managedProvisioningMocks.resolveCodexManagedBundledMarketplaceSource,
 }));
 
 vi.mock("./computer-use-service.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./computer-use-service.js")>()),
   ensureCodexComputerUseServiceApp: managedProvisioningMocks.ensureCodexComputerUseServiceApp,
+  resolveCodexComputerUseServiceAppSourcePath:
+    managedProvisioningMocks.resolveCodexComputerUseServiceAppSourcePath,
+}));
+
+vi.mock("./computer-use-cache.js", () => ({
+  ensureCodexComputerUseSharedPluginCache:
+    managedProvisioningMocks.ensureCodexComputerUseSharedPluginCache,
 }));
 
 import {
@@ -95,11 +119,30 @@ describe("Codex Computer Use setup", () => {
   afterEach(() => {
     vi.useRealTimers();
     requestCodexAppServerJsonMock.mockReset();
+    sharedClientMocks.assertCodexAppServerClientStartSelectionCurrent.mockReset();
     sharedClientMocks.getLeasedSharedCodexAppServerClient.mockReset();
+    sharedClientMocks.readCodexAppServerClientDesktopGeneration.mockReset();
     sharedClientMocks.readCodexAppServerClientProcessIdentity.mockReset();
     sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockReset();
     managedProvisioningMocks.ensureCodexManagedBundledMarketplace.mockReset();
     managedProvisioningMocks.ensureCodexComputerUseServiceApp.mockReset();
+    managedProvisioningMocks.ensureCodexComputerUseSharedPluginCache.mockReset();
+    managedProvisioningMocks.ensureCodexComputerUseSharedPluginCache.mockResolvedValue({
+      status: "independent",
+      changed: false,
+      message: "independent",
+      removedStaleVersions: [],
+      warnings: [],
+    });
+    managedProvisioningMocks.resolveCodexManagedBundledMarketplaceSource.mockReset();
+    managedProvisioningMocks.resolveCodexManagedBundledMarketplaceSource.mockImplementation(
+      async (params: { candidates?: readonly unknown[] }) => params.candidates?.[0],
+    );
+    managedProvisioningMocks.resolveCodexComputerUseServiceAppSourcePath.mockReset();
+    managedProvisioningMocks.resolveCodexComputerUseServiceAppSourcePath.mockImplementation(
+      async (params: { sourceAppCandidates?: readonly string[] }) =>
+        params.sourceAppCandidates?.[0],
+    );
   });
 
   it("stays disabled until configured", async () => {
@@ -1044,6 +1087,13 @@ describe("Codex Computer Use setup", () => {
         commandSource,
         argsFingerprint: "args",
       });
+      managedProvisioningMocks.ensureCodexManagedBundledMarketplace.mockResolvedValue(
+        managedMarketplacePath,
+      );
+      managedProvisioningMocks.ensureCodexComputerUseServiceApp.mockResolvedValue({
+        status: "already_current",
+        changed: false,
+      });
       const request = createBundledMarketplaceComputerUseRequest(managedMarketplacePath);
 
       const status = await installCodexComputerUse({
@@ -1054,18 +1104,67 @@ describe("Codex Computer Use setup", () => {
       });
 
       expect(status.ready).toBe(true);
-      expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith({
-        codexHome,
-        ownershipRoot: agentDir,
-        appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
-      });
-      expect(managedProvisioningMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith({
-        codexHome,
-        ownershipRoot: agentDir,
-        appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
-      });
+      expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          codexHome,
+          ownershipRoot: agentDir,
+          appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
+        }),
+      );
+      expect(managedProvisioningMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          codexHome,
+          ownershipRoot: agentDir,
+          appServerCommand: "/Applications/ChatGPT.app/Contents/Resources/codex",
+        }),
+      );
+      expect(sharedClientMocks.assertCodexAppServerClientStartSelectionCurrent).toHaveBeenCalled();
+      expect(sharedClientMocks.readCodexAppServerClientDesktopGeneration).toHaveReturnedWith(
+        undefined,
+      );
+      expect(managedProvisioningMocks.ensureCodexComputerUseSharedPluginCache).toHaveBeenCalledWith(
+        expect.objectContaining({ forceRefresh: true }),
+      );
     },
   );
+
+  it("rejects explicit provisioning from a stale desktop client", async () => {
+    const root = tempDirs.make("openclaw-codex-explicit-install-stale-");
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(agentDir, "codex-home");
+    fs.mkdirSync(codexHome, { recursive: true });
+    const harness = createClientHarness();
+    vi.spyOn(harness.client, "getRuntimeIdentity").mockReturnValue({
+      serverVersion: "0.148.0",
+      codexHome,
+    });
+    sharedClientMocks.readCodexAppServerClientProcessIdentity.mockReturnValue({
+      clientId: "client-explicit-install-stale",
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed",
+      argsFingerprint: "args",
+    });
+    sharedClientMocks.readCodexAppServerClientDesktopGeneration.mockReturnValue({
+      epoch: 1,
+      fingerprint: "desktop-x",
+    });
+    sharedClientMocks.assertCodexAppServerClientStartSelectionCurrent.mockImplementation(() => {
+      throw Object.assign(new Error("desktop selection changed"), {
+        code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
+      });
+    });
+
+    await expect(
+      installCodexComputerUse({
+        agentDir,
+        client: harness.client,
+        request: vi.fn(),
+        pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
+      }),
+    ).rejects.toThrow("desktop selection changed");
+    expect(managedProvisioningMocks.ensureCodexManagedBundledMarketplace).not.toHaveBeenCalled();
+    expect(managedProvisioningMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+  });
 
   it("allows auto-install from a configured local marketplace path", async () => {
     const request = createComputerUseRequest({ installed: false });

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -43,6 +43,7 @@ import {
   readCodexAppServerClientProcessIdentity,
   releaseLeasedSharedCodexAppServerClient,
   resolveCodexNativeConfigFenceKey,
+  waitForCodexAppServerClientDesktopGenerationDrain,
 } from "./shared-client.js";
 
 /** Minimal app-server request function needed by Computer Use setup. */
@@ -165,6 +166,15 @@ type CodexComputerUseInspectionParams = {
   defaultBundledMarketplacePath?: string;
   defaultBundledMarketplacePathCandidates?: readonly string[];
   releaseNativeConfigFence?: () => void;
+  explicitManagedInstall?: ExplicitManagedComputerUseInstallContext;
+};
+
+type ExplicitManagedComputerUseInstallContext = {
+  client: CodexAppServerClient;
+  agentDir: string;
+  codexHome: string;
+  command: string;
+  desktopGeneration: NonNullable<ReturnType<typeof readCodexAppServerClientDesktopGeneration>>;
 };
 
 type MarketplaceRef =
@@ -301,77 +311,90 @@ async function inspectCodexComputerUse(
   if (!params.installPlugin) {
     return await inspectCodexComputerUseWithoutFence(params);
   }
-  const runtime = params.client
-    ? undefined
-    : resolveCodexAppServerRuntimeOptions({
-        pluginConfig: params.pluginConfig,
-        managedCommandOrder: "desktop-first",
-      });
-  const fenceKey = resolveCodexNativeConfigFenceKey({
-    client: params.client,
-    startOptions: runtime?.start,
-    agentDir: params.agentDir,
-    config: params.config,
+  const resolvedRuntime = resolveCodexAppServerRuntimeOptions({
+    pluginConfig: params.pluginConfig,
+    managedCommandOrder: "desktop-first",
   });
-  if (!fenceKey) {
-    return await inspectCodexComputerUseWithoutFence(params);
-  }
-  const release = await acquireCodexNativeConfigFence(fenceKey, {
-    signal: params.signal,
-    timeoutMs: params.timeoutMs ?? runtime?.requestTimeoutMs,
-    timeoutMessage: "Codex Computer Use install timed out waiting for native config",
-    abortMessage: "Codex Computer Use install aborted waiting for native config",
-  });
-  let releaseFenceOnReturn = true;
+  const operationTimeoutMs = params.timeoutMs ?? resolvedRuntime.requestTimeoutMs;
+  const deadline = operationTimeoutMs > 0 ? Date.now() + operationTimeoutMs : undefined;
+  const remainingTimeoutMs = () =>
+    deadline === undefined ? operationTimeoutMs : Math.max(1, deadline - Date.now());
   let leasedClient: CodexAppServerClient | undefined;
   try {
     let client = params.client;
     if (!client && !params.request) {
-      if (!runtime) {
-        throw new Error("Computer Use install could not resolve its app-server runtime");
-      }
       client = await getLeasedSharedCodexAppServerClient({
-        startOptions: runtime.start,
+        startOptions: resolvedRuntime.start,
         pluginConfig: params.pluginConfig,
-        timeoutMs: params.timeoutMs ?? runtime.requestTimeoutMs,
+        timeoutMs: remainingTimeoutMs(),
         config: params.config,
         agentDir: params.agentDir,
         abandonSignal: params.signal,
       });
       leasedClient = client;
     }
-    try {
-      return await inspectCodexComputerUseWithoutFence({
-        ...params,
-        releaseNativeConfigFence: release,
-        ...(client
-          ? {
-              client,
-              timeoutMs: params.timeoutMs ?? runtime?.requestTimeoutMs,
-            }
-          : {}),
+    const explicitManagedInstall =
+      client && !resolveCodexComputerUseConfig({ pluginConfig: params.pluginConfig }).autoInstall
+        ? await resolveExplicitManagedComputerUseInstallContext({ ...params, client })
+        : undefined;
+    if (explicitManagedInstall) {
+      await waitForCodexAppServerClientDesktopGenerationDrain({
+        client: explicitManagedInstall.client,
+        timeoutMs: remainingTimeoutMs(),
+        ...(params.signal ? { signal: params.signal } : {}),
       });
-    } catch (error) {
-      if (
-        client &&
-        (isCodexAppServerIndeterminateRequestCancellationError(error) ||
-          isCodexAppServerIndeterminateTransportError(error) ||
-          isCodexAppServerConnectionClosedError(error))
-      ) {
-        // Codex may still commit a config mutation after local cancellation.
-        // Transfer fence ownership to physical process exit before surfacing it.
-        releaseFenceOnReturn = false;
-        await client.closeAndRunAfterExit(release, "Computer Use config mutation");
+      assertCodexAppServerClientStartSelectionCurrent({ client: explicitManagedInstall.client });
+    }
+    const inspectionParams: CodexComputerUseInspectionParams = {
+      ...params,
+      ...(client ? { client } : {}),
+      timeoutMs: remainingTimeoutMs(),
+      ...(explicitManagedInstall ? { explicitManagedInstall } : {}),
+    };
+    const fenceKey = resolveCodexNativeConfigFenceKey({
+      client,
+      startOptions: resolvedRuntime.start,
+      agentDir: params.agentDir,
+      config: params.config,
+    });
+    if (!fenceKey) {
+      return await inspectCodexComputerUseWithoutFence(inspectionParams);
+    }
+    const release = await acquireCodexNativeConfigFence(fenceKey, {
+      signal: params.signal,
+      timeoutMs: remainingTimeoutMs(),
+      timeoutMessage: "Codex Computer Use install timed out waiting for native config",
+      abortMessage: "Codex Computer Use install aborted waiting for native config",
+    });
+    let releaseFenceOnReturn = true;
+    try {
+      try {
+        return await inspectCodexComputerUseWithoutFence({
+          ...inspectionParams,
+          releaseNativeConfigFence: release,
+        });
+      } catch (error) {
+        if (
+          client &&
+          (isCodexAppServerIndeterminateRequestCancellationError(error) ||
+            isCodexAppServerIndeterminateTransportError(error) ||
+            isCodexAppServerConnectionClosedError(error))
+        ) {
+          // Codex may still commit a config mutation after local cancellation.
+          // Transfer fence ownership to physical process exit before surfacing it.
+          releaseFenceOnReturn = false;
+          await client.closeAndRunAfterExit(release, "Computer Use config mutation");
+        }
+        throw error;
       }
-      throw error;
     } finally {
-      if (leasedClient) {
-        releaseLeasedSharedCodexAppServerClient(leasedClient);
+      if (releaseFenceOnReturn) {
+        release();
       }
     }
   } finally {
-    if (releaseFenceOnReturn) {
-      release();
+    if (leasedClient) {
+      releaseLeasedSharedCodexAppServerClient(leasedClient);
     }
   }
 }
@@ -438,51 +461,71 @@ async function inspectCodexComputerUseWithoutFence(
 async function prepareExplicitManagedComputerUseInstall(
   params: CodexComputerUseInspectionParams,
 ): Promise<void> {
+  const context = params.explicitManagedInstall;
+  if (!context) {
+    return;
+  }
+  await reconcileCodexComputerUseStartArtifacts({
+    startOptions: {
+      transport: "stdio",
+      command: context.command,
+      commandSource: "resolved-managed",
+      args: ["app-server"],
+      headers: {},
+      env: { CODEX_HOME: context.codexHome },
+    },
+    agentDir: context.agentDir,
+    pluginConfig: { computerUse: { ...params.computerUseConfig, autoInstall: true } },
+    ownsIsolatedCodexHome: true,
+    desktopGeneration: context.desktopGeneration,
+    forceCacheRefresh: true,
+    assertCurrent: () =>
+      assertCodexAppServerClientStartSelectionCurrent({ client: context.client }),
+  });
+}
+
+async function resolveExplicitManagedComputerUseInstallContext(
+  params: CodexComputerUseInspectionParams & { client: CodexAppServerClient },
+): Promise<ExplicitManagedComputerUseInstallContext | undefined> {
   if (
-    !params.client ||
     !params.agentDir ||
     params.computerUseConfig.marketplaceSource ||
     params.computerUseConfig.marketplacePath ||
     params.computerUseConfig.marketplaceName
   ) {
-    return;
+    return undefined;
   }
-  const client = params.client;
-  const codexHome = client.getRuntimeIdentity()?.codexHome;
-  const processIdentity = readCodexAppServerClientProcessIdentity(client);
+  const codexHome = params.client.getRuntimeIdentity()?.codexHome;
+  const processIdentity = readCodexAppServerClientProcessIdentity(params.client);
   const command =
     processIdentity?.nativeCommand ??
     (processIdentity && isManagedCodexDesktopCommand(processIdentity.command, "darwin")
       ? processIdentity.command
       : undefined);
   if (!codexHome || !command) {
-    return;
+    return undefined;
   }
-  const desktopGeneration = readCodexAppServerClientDesktopGeneration(client);
+  const desktopGeneration = readCodexAppServerClientDesktopGeneration(params.client);
+  if (!desktopGeneration) {
+    throw new Error(
+      "Codex Computer Use install requires a desktop-generation-bound client; reconnect and retry.",
+    );
+  }
   const expectedHome = resolveCodexAppServerHomeDir(params.agentDir);
   const [actualRealHome, expectedRealHome] = await Promise.all([
     fs.realpath(codexHome).catch(() => undefined),
     fs.realpath(expectedHome).catch(() => undefined),
   ]);
   if (!actualRealHome || actualRealHome !== expectedRealHome) {
-    return;
+    return undefined;
   }
-  await reconcileCodexComputerUseStartArtifacts({
-    startOptions: {
-      transport: "stdio",
-      command,
-      commandSource: "resolved-managed",
-      args: ["app-server"],
-      headers: {},
-      env: { CODEX_HOME: codexHome },
-    },
+  return {
+    client: params.client,
     agentDir: params.agentDir,
-    pluginConfig: { computerUse: { ...params.computerUseConfig, autoInstall: true } },
-    ownsIsolatedCodexHome: true,
-    ...(desktopGeneration ? { desktopGeneration } : {}),
-    forceCacheRefresh: true,
-    assertCurrent: () => assertCodexAppServerClientStartSelectionCurrent({ client }),
-  });
+    codexHome,
+    command,
+    desktopGeneration,
+  };
 }
 
 async function resolveClientManagedBundledMarketplacePath(

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -26,6 +26,7 @@ import {
   type ResolvedCodexComputerUseConfig,
 } from "./config.js";
 import { resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath } from "./desktop-app-paths.js";
+import { isManagedCodexDesktopCommand } from "./managed-binary.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import type {
   CodexListMcpServerStatusResponse,
@@ -448,7 +449,12 @@ async function prepareExplicitManagedComputerUseInstall(
     return;
   }
   const codexHome = params.client.getRuntimeIdentity()?.codexHome;
-  const command = readCodexAppServerClientProcessIdentity(params.client)?.nativeCommand;
+  const processIdentity = readCodexAppServerClientProcessIdentity(params.client);
+  const command =
+    processIdentity?.nativeCommand ??
+    (processIdentity && isManagedCodexDesktopCommand(processIdentity.command, "darwin")
+      ? processIdentity.command
+      : undefined);
   if (!codexHome || !command) {
     return;
   }

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -5,6 +5,7 @@
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { reconcileCodexComputerUseStartArtifacts } from "./auth-bridge.js";
 import { resolveCodexAppServerHomeDir } from "./auth-start-options.js";
 import { describeControlFailure } from "./capabilities.js";
 import {
@@ -13,12 +14,8 @@ import {
   isCodexAppServerIndeterminateTransportError,
   type CodexAppServerClient,
 } from "./client.js";
-import {
-  ensureCodexManagedBundledMarketplace,
-  resolveCodexManagedBundledMarketplacePath,
-} from "./computer-use-marketplace.js";
+import { resolveCodexManagedBundledMarketplacePath } from "./computer-use-marketplace.js";
 import { assertNotSymlink } from "./computer-use-service-path.js";
-import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
@@ -40,7 +37,9 @@ import type {
 } from "./protocol.js";
 import { requestCodexAppServerJson } from "./request.js";
 import {
+  assertCodexAppServerClientStartSelectionCurrent,
   getLeasedSharedCodexAppServerClient,
+  readCodexAppServerClientDesktopGeneration,
   readCodexAppServerClientProcessIdentity,
   releaseLeasedSharedCodexAppServerClient,
   resolveCodexNativeConfigFenceKey,
@@ -448,8 +447,9 @@ async function prepareExplicitManagedComputerUseInstall(
   ) {
     return;
   }
-  const codexHome = params.client.getRuntimeIdentity()?.codexHome;
-  const processIdentity = readCodexAppServerClientProcessIdentity(params.client);
+  const client = params.client;
+  const codexHome = client.getRuntimeIdentity()?.codexHome;
+  const processIdentity = readCodexAppServerClientProcessIdentity(client);
   const command =
     processIdentity?.nativeCommand ??
     (processIdentity && isManagedCodexDesktopCommand(processIdentity.command, "darwin")
@@ -458,6 +458,7 @@ async function prepareExplicitManagedComputerUseInstall(
   if (!codexHome || !command) {
     return;
   }
+  const desktopGeneration = readCodexAppServerClientDesktopGeneration(client);
   const expectedHome = resolveCodexAppServerHomeDir(params.agentDir);
   const [actualRealHome, expectedRealHome] = await Promise.all([
     fs.realpath(codexHome).catch(() => undefined),
@@ -466,15 +467,21 @@ async function prepareExplicitManagedComputerUseInstall(
   if (!actualRealHome || actualRealHome !== expectedRealHome) {
     return;
   }
-  await ensureCodexManagedBundledMarketplace({
-    codexHome,
-    ownershipRoot: params.agentDir,
-    appServerCommand: command,
-  });
-  await ensureCodexComputerUseServiceApp({
-    codexHome,
-    ownershipRoot: params.agentDir,
-    appServerCommand: command,
+  await reconcileCodexComputerUseStartArtifacts({
+    startOptions: {
+      transport: "stdio",
+      command,
+      commandSource: "resolved-managed",
+      args: ["app-server"],
+      headers: {},
+      env: { CODEX_HOME: codexHome },
+    },
+    agentDir: params.agentDir,
+    pluginConfig: { computerUse: { ...params.computerUseConfig, autoInstall: true } },
+    ownsIsolatedCodexHome: true,
+    ...(desktopGeneration ? { desktopGeneration } : {}),
+    forceCacheRefresh: true,
+    assertCurrent: () => assertCodexAppServerClientStartSelectionCurrent({ client }),
   });
 }
 

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -487,12 +487,7 @@ async function prepareExplicitManagedComputerUseInstall(
 async function resolveExplicitManagedComputerUseInstallContext(
   params: CodexComputerUseInspectionParams & { client: CodexAppServerClient },
 ): Promise<ExplicitManagedComputerUseInstallContext | undefined> {
-  if (
-    !params.agentDir ||
-    params.computerUseConfig.marketplaceSource ||
-    params.computerUseConfig.marketplacePath ||
-    params.computerUseConfig.marketplaceName
-  ) {
+  if (!params.agentDir) {
     return undefined;
   }
   const codexHome = params.client.getRuntimeIdentity()?.codexHome;

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -39,6 +39,7 @@ import { requestCodexAppServerJson } from "./request.js";
 import {
   assertCodexAppServerClientStartSelectionCurrent,
   getLeasedSharedCodexAppServerClient,
+  isCodexAppServerStartSelectionChangedError,
   readCodexAppServerClientDesktopGeneration,
   readCodexAppServerClientProcessIdentity,
   releaseLeasedSharedCodexAppServerClient,
@@ -726,6 +727,9 @@ export async function runCodexComputerUseLiveTest(params: {
         ...(repair ? { repair } : {}),
       };
     } catch (error) {
+      if (isCodexAppServerStartSelectionChangedError(error)) {
+        throw error;
+      }
       lastError = error;
     } finally {
       if (threadId) {

--- a/extensions/codex/src/app-server/computer-use.ts
+++ b/extensions/codex/src/app-server/computer-use.ts
@@ -3,6 +3,9 @@
  * app-server sessions.
  */
 import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveCodexAppServerHomeDir } from "./auth-start-options.js";
 import { describeControlFailure } from "./capabilities.js";
 import {
   isCodexAppServerConnectionClosedError,
@@ -10,6 +13,12 @@ import {
   isCodexAppServerIndeterminateTransportError,
   type CodexAppServerClient,
 } from "./client.js";
+import {
+  ensureCodexManagedBundledMarketplace,
+  resolveCodexManagedBundledMarketplacePath,
+} from "./computer-use-marketplace.js";
+import { assertNotSymlink } from "./computer-use-service-path.js";
+import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
@@ -31,6 +40,7 @@ import type {
 import { requestCodexAppServerJson } from "./request.js";
 import {
   getLeasedSharedCodexAppServerClient,
+  readCodexAppServerClientProcessIdentity,
   releaseLeasedSharedCodexAppServerClient,
   resolveCodexNativeConfigFenceKey,
 } from "./shared-client.js";
@@ -371,17 +381,30 @@ async function inspectCodexComputerUseWithoutFence(
 ): Promise<CodexComputerUseStatus> {
   const request = createComputerUseRequest(params);
   if (params.installPlugin) {
+    if (!resolveCodexComputerUseConfig({ pluginConfig: params.pluginConfig }).autoInstall) {
+      await prepareExplicitManagedComputerUseInstall(params);
+    }
     await request<JsonValue>("experimentalFeature/enablement/set", {
       enablement: { plugins: true },
     } satisfies CodexRequestObject);
   }
 
+  const managedMarketplacePath = await resolveClientManagedBundledMarketplacePath(
+    params.client,
+    params.agentDir,
+  );
+  if (params.installPlugin && managedMarketplacePath) {
+    const codexHome = params.client?.getRuntimeIdentity()?.codexHome;
+    if (codexHome) {
+      await assertNotSymlink(path.join(codexHome, "config.toml"), "Codex config");
+    }
+  }
   const marketplace = await resolveMarketplaceRef({
     request,
     config: params.computerUseConfig,
     allowAdd: params.installPlugin,
     signal: params.signal,
-    defaultBundledMarketplacePath: params.defaultBundledMarketplacePath,
+    defaultBundledMarketplacePath: params.defaultBundledMarketplacePath ?? managedMarketplacePath,
     defaultBundledMarketplacePathCandidates: params.defaultBundledMarketplacePathCandidates,
   });
   if (!marketplace.marketplace) {
@@ -410,6 +433,62 @@ async function inspectCodexComputerUseWithoutFence(
     installPlugin: params.installPlugin,
     releaseNativeConfigFence: params.releaseNativeConfigFence,
   });
+}
+
+async function prepareExplicitManagedComputerUseInstall(
+  params: CodexComputerUseInspectionParams,
+): Promise<void> {
+  if (
+    !params.client ||
+    !params.agentDir ||
+    params.computerUseConfig.marketplaceSource ||
+    params.computerUseConfig.marketplacePath ||
+    params.computerUseConfig.marketplaceName
+  ) {
+    return;
+  }
+  const codexHome = params.client.getRuntimeIdentity()?.codexHome;
+  const command = readCodexAppServerClientProcessIdentity(params.client)?.nativeCommand;
+  if (!codexHome || !command) {
+    return;
+  }
+  const expectedHome = resolveCodexAppServerHomeDir(params.agentDir);
+  const [actualRealHome, expectedRealHome] = await Promise.all([
+    fs.realpath(codexHome).catch(() => undefined),
+    fs.realpath(expectedHome).catch(() => undefined),
+  ]);
+  if (!actualRealHome || actualRealHome !== expectedRealHome) {
+    return;
+  }
+  await ensureCodexManagedBundledMarketplace({
+    codexHome,
+    ownershipRoot: params.agentDir,
+    appServerCommand: command,
+  });
+  await ensureCodexComputerUseServiceApp({
+    codexHome,
+    ownershipRoot: params.agentDir,
+    appServerCommand: command,
+  });
+}
+
+async function resolveClientManagedBundledMarketplacePath(
+  client: CodexAppServerClient | undefined,
+  agentDir: string | undefined,
+): Promise<string | undefined> {
+  const codexHome = client?.getRuntimeIdentity()?.codexHome;
+  if (!codexHome || !agentDir) {
+    return undefined;
+  }
+  const [actualRealHome, expectedRealHome] = await Promise.all([
+    fs.realpath(codexHome).catch(() => undefined),
+    fs.realpath(resolveCodexAppServerHomeDir(agentDir)).catch(() => undefined),
+  ]);
+  if (!actualRealHome || actualRealHome !== expectedRealHome) {
+    return undefined;
+  }
+  const managedPath = resolveCodexManagedBundledMarketplacePath(codexHome);
+  return existsSync(managedPath) ? managedPath : undefined;
 }
 
 async function ensureComputerUsePlugin(params: {
@@ -777,6 +856,9 @@ function resolveBundledComputerUseMarketplacePath(params: {
     return existsSync(params.defaultBundledMarketplacePath)
       ? params.defaultBundledMarketplacePath
       : undefined;
+  }
+  if (!params.defaultBundledMarketplacePathCandidates) {
+    return undefined;
   }
   return resolveFirstExistingMacOSDesktopCodexBundledMarketplacePath({
     candidates: params.defaultBundledMarketplacePathCandidates,

--- a/extensions/codex/src/app-server/desktop-app-paths.ts
+++ b/extensions/codex/src/app-server/desktop-app-paths.ts
@@ -2,7 +2,7 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-type MacOSDesktopCodexAppPathCandidate = {
+export type MacOSDesktopCodexAppPathCandidate = {
   appName: "ChatGPT.app" | "Codex.app";
   appBundlePath: string;
   appServerCommandPath: string;
@@ -33,12 +33,26 @@ const MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES: readonly MacOSDesktopCodexAppPath
   },
 ] as const;
 
+export function resolveMacOSDesktopCodexAppPathCandidates(
+  platform: NodeJS.Platform = process.platform,
+): readonly MacOSDesktopCodexAppPathCandidate[] {
+  return platform === "darwin" ? MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES : [];
+}
+
+export function resolveMacOSDesktopCodexAppServerCommandCandidates(
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  return resolveMacOSDesktopCodexAppPathCandidates(platform).map(
+    (candidate) => candidate.appServerCommandPath,
+  );
+}
+
 export function resolveMacOSDesktopCodexBundledMarketplaceCandidates(
   platform: NodeJS.Platform = process.platform,
 ): string[] {
-  return platform === "darwin"
-    ? MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES.map((candidate) => candidate.bundledMarketplacePath)
-    : [];
+  return resolveMacOSDesktopCodexAppPathCandidates(platform).map(
+    (candidate) => candidate.bundledMarketplacePath,
+  );
 }
 
 export function resolveMacOSDesktopCodexComputerUseServiceAppCandidates(
@@ -48,20 +62,16 @@ export function resolveMacOSDesktopCodexComputerUseServiceAppCandidates(
   if (platform !== "darwin") {
     return [];
   }
+  const candidates = resolveMacOSDesktopCodexAppPathCandidates(platform);
   const matchingCandidate = appServerCommand
-    ? MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES.find(
+    ? candidates.find(
         (candidate) =>
           path.resolve(candidate.appServerCommandPath) === path.resolve(appServerCommand),
       )
     : undefined;
   const orderedCandidates = matchingCandidate
-    ? [
-        matchingCandidate,
-        ...MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES.filter(
-          (candidate) => candidate !== matchingCandidate,
-        ),
-      ]
-    : MACOS_DESKTOP_CODEX_APP_PATH_CANDIDATES;
+    ? [matchingCandidate, ...candidates.filter((candidate) => candidate !== matchingCandidate)]
+    : candidates;
   return [
     ...new Set(orderedCandidates.flatMap((candidate) => candidate.computerUseServiceAppPaths)),
   ];

--- a/extensions/codex/src/app-server/desktop-generation-fingerprint.ts
+++ b/extensions/codex/src/app-server/desktop-generation-fingerprint.ts
@@ -8,6 +8,8 @@ import {
   type MacOSDesktopCodexAppPathCandidate,
 } from "./desktop-app-paths.js";
 
+const MAX_COMPUTER_USE_PLUGIN_TREE_ENTRIES = 4_096;
+
 /** Fingerprints every desktop candidate that can own a managed fallback artifact. */
 export async function readMacOSDesktopGenerationFingerprint(
   candidates: readonly MacOSDesktopCodexAppPathCandidate[] = resolveMacOSDesktopCodexAppPathCandidates(
@@ -21,6 +23,8 @@ export async function readMacOSDesktopGenerationFingerprint(
     for (const artifactPath of resolveMacOSDesktopGenerationPaths(candidate)) {
       entries.push(`${artifactPath}\0${await statFingerprint(artifactPath)}`);
     }
+    const pluginRoot = resolveComputerUsePluginRoot(candidate);
+    entries.push(`${pluginRoot}\0${await directoryTreeFingerprint(pluginRoot)}`);
   }
   return createHash("sha256").update(entries.join("\0")).digest("hex");
 }
@@ -31,13 +35,6 @@ function resolveMacOSDesktopGenerationPaths(
   return [
     candidate.appBundlePath,
     path.join(candidate.bundledMarketplacePath, ".agents", "plugins", "marketplace.json"),
-    path.join(
-      candidate.bundledMarketplacePath,
-      "plugins",
-      "computer-use",
-      ".codex-plugin",
-      "plugin.json",
-    ),
     ...candidate.computerUseServiceAppPaths.flatMap((servicePath) => [
       servicePath,
       path.join(servicePath, "Contents", "Info.plist"),
@@ -54,7 +51,11 @@ function resolveMacOSDesktopGenerationPaths(
   ];
 }
 
-/** Stable directories whose immediate children cover every fingerprinted artifact. */
+function resolveComputerUsePluginRoot(candidate: MacOSDesktopCodexAppPathCandidate): string {
+  return path.join(candidate.bundledMarketplacePath, "plugins", "computer-use");
+}
+
+/** Stable roots that cover bundle replacement and recursive artifact updates. */
 export function resolveMacOSDesktopGenerationWatchPaths(
   candidates: readonly MacOSDesktopCodexAppPathCandidate[] = resolveMacOSDesktopCodexAppPathCandidates(
     "darwin",
@@ -63,24 +64,53 @@ export function resolveMacOSDesktopGenerationWatchPaths(
   const watched = new Set<string>(["/Applications"]);
   for (const candidate of candidates) {
     watched.add(candidate.appBundlePath);
-    const directoryArtifacts = new Set([
-      candidate.appBundlePath,
-      ...candidate.computerUseServiceAppPaths,
-    ]);
-    for (const artifactPath of [
-      candidate.appServerCommandPath,
-      ...resolveMacOSDesktopGenerationPaths(candidate),
-    ]) {
-      let directory = directoryArtifacts.has(artifactPath)
-        ? artifactPath
-        : path.dirname(artifactPath);
-      while (directory.startsWith(`${candidate.appBundlePath}${path.sep}`)) {
-        watched.add(directory);
-        directory = path.dirname(directory);
-      }
-    }
   }
   return [...watched];
+}
+
+async function directoryTreeFingerprint(root: string): Promise<string> {
+  let rootStat: BigIntStats;
+  try {
+    rootStat = await fs.lstat(root, { bigint: true });
+  } catch (error) {
+    if (isNodeError(error, "ENOENT") || isNodeError(error, "ENOTDIR")) {
+      return "missing";
+    }
+    throw error;
+  }
+  if (!rootStat.isDirectory()) {
+    return statFingerprint(root);
+  }
+
+  let entryCount = 0;
+  const hash = createHash("sha256");
+  hash.update("openclaw-codex-computer-use-plugin-tree-v1\0");
+  const visit = async (directory: string, relativeDirectory: string, before: BigIntStats) => {
+    hash.update(`directory\0${relativeDirectory}\0${statTuple(before)}\0`);
+    const entries = (await fs.readdir(directory, { withFileTypes: true })).toSorted(
+      (left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0),
+    );
+    for (const entry of entries) {
+      entryCount += 1;
+      if (entryCount > MAX_COMPUTER_USE_PLUGIN_TREE_ENTRIES) {
+        throw new Error("Codex Computer Use plugin exceeds the bounded tree size");
+      }
+      const entryPath = path.join(directory, entry.name);
+      const relativePath = path.join(relativeDirectory, entry.name);
+      const entryStat = await fs.lstat(entryPath, { bigint: true });
+      if (entryStat.isDirectory()) {
+        await visit(entryPath, relativePath, entryStat);
+      } else {
+        hash.update(`entry\0${relativePath}\0${await statFingerprint(entryPath)}\0`);
+      }
+    }
+    const after = await fs.lstat(directory, { bigint: true });
+    if (!sameStat(before, after)) {
+      throw new Error(`Codex desktop artifact changed while fingerprinting: ${directory}`);
+    }
+  };
+  await visit(root, ".", rootStat);
+  return hash.digest("hex");
 }
 
 async function statFingerprint(filePath: string): Promise<string> {

--- a/extensions/codex/src/app-server/desktop-generation-fingerprint.ts
+++ b/extensions/codex/src/app-server/desktop-generation-fingerprint.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
 import type { BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -94,20 +95,54 @@ async function statFingerprint(filePath: string): Promise<string> {
           : "other";
     const own = statTuple(entry);
     if (!entry.isSymbolicLink()) {
-      return `${type}:${own}`;
+      const content = entry.isFile() ? await readFileFingerprint(filePath, entry, false) : "";
+      return `${type}:${own}:${content}`;
     }
     const [link, realPath, target] = await Promise.all([
       fs.readlink(filePath),
       fs.realpath(filePath),
       fs.stat(filePath, { bigint: true }),
     ]);
-    return `${type}:${own}:${link}:${realPath}:${statTuple(target)}`;
+    const content = target.isFile() ? await readFileFingerprint(filePath, target, true) : "";
+    return `${type}:${own}:${link}:${realPath}:${statTuple(target)}:${content}`;
   } catch (error) {
     if (isNodeError(error, "ENOENT") || isNodeError(error, "ENOTDIR")) {
       return "missing";
     }
     throw error;
   }
+}
+
+async function readFileFingerprint(
+  filePath: string,
+  expected: BigIntStats,
+  followsSymlink: boolean,
+): Promise<string> {
+  const noFollow = followsSymlink ? 0 : (fsConstants.O_NOFOLLOW ?? 0);
+  const handle = await fs.open(filePath, fsConstants.O_RDONLY | noFollow);
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (!sameStat(before, expected)) {
+      throw new Error(`Codex desktop artifact changed while fingerprinting: ${filePath}`);
+    }
+    const hash = createHash("sha256");
+    // Metadata can collide on coarse filesystems. Content binds an event-driven generation
+    // to the exact executable/config bytes without adding request-hot-path polling.
+    for await (const chunk of handle.createReadStream({ autoClose: false })) {
+      hash.update(chunk);
+    }
+    const after = await handle.stat({ bigint: true });
+    if (!sameStat(before, after)) {
+      throw new Error(`Codex desktop artifact changed while fingerprinting: ${filePath}`);
+    }
+    return hash.digest("hex");
+  } finally {
+    await handle.close();
+  }
+}
+
+function sameStat(left: BigIntStats, right: BigIntStats): boolean {
+  return statTuple(left) === statTuple(right);
 }
 
 function statTuple(stat: BigIntStats): string {

--- a/extensions/codex/src/app-server/desktop-generation-fingerprint.ts
+++ b/extensions/codex/src/app-server/desktop-generation-fingerprint.ts
@@ -1,0 +1,119 @@
+import { createHash } from "node:crypto";
+import type { BigIntStats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  resolveMacOSDesktopCodexAppPathCandidates,
+  type MacOSDesktopCodexAppPathCandidate,
+} from "./desktop-app-paths.js";
+
+/** Fingerprints every desktop candidate that can own a managed fallback artifact. */
+export async function readMacOSDesktopGenerationFingerprint(
+  candidates: readonly MacOSDesktopCodexAppPathCandidate[] = resolveMacOSDesktopCodexAppPathCandidates(
+    "darwin",
+  ),
+): Promise<string> {
+  const entries: string[] = [];
+  for (const candidate of candidates) {
+    const command = await statFingerprint(candidate.appServerCommandPath);
+    entries.push(`candidate:${candidate.appName}:${candidate.appServerCommandPath}:${command}`);
+    for (const artifactPath of resolveMacOSDesktopGenerationPaths(candidate)) {
+      entries.push(`${artifactPath}\0${await statFingerprint(artifactPath)}`);
+    }
+  }
+  return createHash("sha256").update(entries.join("\0")).digest("hex");
+}
+
+function resolveMacOSDesktopGenerationPaths(
+  candidate: MacOSDesktopCodexAppPathCandidate,
+): string[] {
+  return [
+    candidate.appBundlePath,
+    path.join(candidate.bundledMarketplacePath, ".agents", "plugins", "marketplace.json"),
+    path.join(
+      candidate.bundledMarketplacePath,
+      "plugins",
+      "computer-use",
+      ".codex-plugin",
+      "plugin.json",
+    ),
+    ...candidate.computerUseServiceAppPaths.flatMap((servicePath) => [
+      servicePath,
+      path.join(servicePath, "Contents", "Info.plist"),
+      path.join(
+        servicePath,
+        "Contents",
+        "SharedSupport",
+        "SkyComputerUseClient.app",
+        "Contents",
+        "MacOS",
+        "SkyComputerUseClient",
+      ),
+    ]),
+  ];
+}
+
+/** Stable directories whose immediate children cover every fingerprinted artifact. */
+export function resolveMacOSDesktopGenerationWatchPaths(
+  candidates: readonly MacOSDesktopCodexAppPathCandidate[] = resolveMacOSDesktopCodexAppPathCandidates(
+    "darwin",
+  ),
+): string[] {
+  const watched = new Set<string>(["/Applications"]);
+  for (const candidate of candidates) {
+    watched.add(candidate.appBundlePath);
+    const directoryArtifacts = new Set([
+      candidate.appBundlePath,
+      ...candidate.computerUseServiceAppPaths,
+    ]);
+    for (const artifactPath of [
+      candidate.appServerCommandPath,
+      ...resolveMacOSDesktopGenerationPaths(candidate),
+    ]) {
+      let directory = directoryArtifacts.has(artifactPath)
+        ? artifactPath
+        : path.dirname(artifactPath);
+      while (directory.startsWith(`${candidate.appBundlePath}${path.sep}`)) {
+        watched.add(directory);
+        directory = path.dirname(directory);
+      }
+    }
+  }
+  return [...watched];
+}
+
+async function statFingerprint(filePath: string): Promise<string> {
+  try {
+    const entry = await fs.lstat(filePath, { bigint: true });
+    const type = entry.isSymbolicLink()
+      ? "link"
+      : entry.isDirectory()
+        ? "directory"
+        : entry.isFile()
+          ? "file"
+          : "other";
+    const own = statTuple(entry);
+    if (!entry.isSymbolicLink()) {
+      return `${type}:${own}`;
+    }
+    const [link, realPath, target] = await Promise.all([
+      fs.readlink(filePath),
+      fs.realpath(filePath),
+      fs.stat(filePath, { bigint: true }),
+    ]);
+    return `${type}:${own}:${link}:${realPath}:${statTuple(target)}`;
+  } catch (error) {
+    if (isNodeError(error, "ENOENT") || isNodeError(error, "ENOTDIR")) {
+      return "missing";
+    }
+    throw error;
+  }
+}
+
+function statTuple(stat: BigIntStats): string {
+  return [stat.dev, stat.ino, stat.mode, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
+}

--- a/extensions/codex/src/app-server/desktop-generation-owner.ts
+++ b/extensions/codex/src/app-server/desktop-generation-owner.ts
@@ -1,0 +1,85 @@
+const SETTLE_DELAY_MS = 1_000;
+
+export type CodexDesktopGeneration = Readonly<{ epoch: number; fingerprint: string }>;
+
+/** Coalesces filesystem invalidations into one stable desktop generation. */
+export function createCodexDesktopGenerationOwner(params: {
+  readFingerprint: () => Promise<string>;
+  onGenerationChange?: (generation: CodexDesktopGeneration) => void;
+  initialGeneration?: CodexDesktopGeneration;
+}) {
+  let generation = params.initialGeneration;
+  let invalidation = 0;
+  let dirty = false;
+  let refresh: Promise<CodexDesktopGeneration> | undefined;
+  let stopped = false;
+
+  const markDirty = () => {
+    invalidation += 1;
+    dirty = true;
+  };
+  const reconcile = () => {
+    if (refresh) {
+      return refresh;
+    }
+    refresh = (async () => {
+      for (;;) {
+        if (stopped) {
+          throw new Error("Codex desktop generation owner stopped");
+        }
+        const observedInvalidation = invalidation;
+        const first = await params.readFingerprint();
+        await delay(SETTLE_DELAY_MS);
+        if (stopped) {
+          throw new Error("Codex desktop generation owner stopped");
+        }
+        const second = await params.readFingerprint();
+        if (stopped) {
+          throw new Error("Codex desktop generation owner stopped");
+        }
+        if (observedInvalidation !== invalidation || first !== second) {
+          continue;
+        }
+        const previous = generation;
+        generation =
+          previous?.fingerprint === second
+            ? previous
+            : { epoch: (previous?.epoch ?? 0) + 1, fingerprint: second };
+        dirty = false;
+        if (previous && generation !== previous) {
+          params.onGenerationChange?.(generation);
+        }
+        return generation;
+      }
+    })().finally(() => {
+      refresh = undefined;
+    });
+    return refresh;
+  };
+  return {
+    read: () => generation,
+    markDirty,
+    wait: () => (dirty ? reconcile() : Promise.resolve(generation)),
+    refresh: () => {
+      markDirty();
+      return reconcile();
+    },
+    isCurrent: (candidate: CodexDesktopGeneration | undefined) =>
+      Boolean(
+        candidate &&
+        !dirty &&
+        generation &&
+        candidate.epoch === generation.epoch &&
+        candidate.fingerprint === generation.fingerprint,
+      ),
+    stop: () => {
+      stopped = true;
+    },
+  };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/extensions/codex/src/app-server/desktop-generation-service.test.ts
+++ b/extensions/codex/src/app-server/desktop-generation-service.test.ts
@@ -1,0 +1,166 @@
+import { EventEmitter } from "node:events";
+import type { FSWatcher } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCodexDesktopGenerationService } from "./desktop-generation.js";
+
+class FakeWatcher extends EventEmitter {
+  close = vi.fn();
+  ref = vi.fn(() => this);
+  unref = vi.fn(() => this);
+}
+
+type WatchRegistration = {
+  watchedPath: string;
+  listener: (eventType: string, filename: string | Buffer | null) => void;
+  watcher: FakeWatcher;
+};
+
+function createHarness(initialFingerprint: string) {
+  let fingerprint = initialFingerprint;
+  const registrations: WatchRegistration[] = [];
+  const readFingerprint = vi.fn(async () => fingerprint);
+  const onGenerationChange = vi.fn();
+  const clearFailure = vi.fn();
+  const reportFailure = vi.fn();
+  const warn = vi.fn();
+  const service = createCodexDesktopGenerationService(
+    { onGenerationChange },
+    {
+      platform: "darwin",
+      readFingerprint,
+      resolveWatchPaths: () => ["/Applications", "/Applications/ChatGPT.app/Contents/Resources"],
+      pathExists: () => true,
+      watchPath: (watchedPath, listener) => {
+        const watcher = new FakeWatcher();
+        registrations.push({ watchedPath, listener, watcher });
+        return watcher as FSWatcher;
+      },
+    },
+  );
+  return {
+    service,
+    registrations,
+    readFingerprint,
+    onGenerationChange,
+    clearFailure,
+    reportFailure,
+    warn,
+    setFingerprint: (next: string) => {
+      fingerprint = next;
+    },
+  };
+}
+
+async function startAndSettle(harness: ReturnType<typeof createHarness>): Promise<void> {
+  await harness.service.start?.({
+    logger: { warn: harness.warn },
+    serviceHealth: {
+      clearFailure: harness.clearFailure,
+      reportFailure: harness.reportFailure,
+    },
+  } as never);
+  await vi.waitFor(() => expect(harness.readFingerprint).toHaveBeenCalledOnce());
+  await vi.advanceTimersByTimeAsync(1_000);
+  await vi.waitFor(() => expect(harness.readFingerprint).toHaveBeenCalledTimes(2));
+}
+
+describe("Codex desktop generation service", () => {
+  let service: ReturnType<typeof createCodexDesktopGenerationService> | undefined;
+
+  afterEach(async () => {
+    await service?.stop?.({} as never);
+    service = undefined;
+    vi.useRealTimers();
+  });
+
+  it("starts without blocking on initial convergence", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness("desktop-start");
+    service = harness.service;
+
+    await service.start?.({
+      logger: { warn: harness.warn },
+      serviceHealth: {
+        clearFailure: harness.clearFailure,
+        reportFailure: harness.reportFailure,
+      },
+    } as never);
+
+    expect(harness.registrations).toHaveLength(2);
+    expect(harness.clearFailure).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => expect(harness.clearFailure).toHaveBeenCalledOnce());
+  });
+
+  it("rearms stable directory watches and publishes a settled root replacement", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness("desktop-x");
+    service = harness.service;
+    await startAndSettle(harness);
+    harness.onGenerationChange.mockClear();
+    harness.clearFailure.mockClear();
+    const oldArm = [...harness.registrations];
+    const applications = oldArm.find((entry) => entry.watchedPath === "/Applications");
+    expect(applications).toBeDefined();
+
+    harness.setFingerprint("desktop-y");
+    applications?.listener("rename", "ChatGPT.app");
+    await vi.advanceTimersByTimeAsync(100);
+    expect(oldArm.every((entry) => entry.watcher.close.mock.calls.length === 1)).toBe(true);
+    expect(harness.registrations).toHaveLength(4);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => expect(harness.onGenerationChange).toHaveBeenCalledOnce());
+    expect(harness.onGenerationChange).toHaveBeenCalledWith({
+      epoch: expect.any(Number),
+      fingerprint: "desktop-y",
+    });
+
+    applications?.listener("rename", "ChatGPT.app");
+    oldArm[0]?.watcher.emit("error", new Error("stale watcher"));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(harness.registrations).toHaveLength(4);
+    expect(harness.reportFailure).not.toHaveBeenCalled();
+  });
+
+  it("ignores unrelated application events and recovers a watcher error", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness("desktop-errors");
+    service = harness.service;
+    await startAndSettle(harness);
+    const oldArm = [...harness.registrations];
+    const applications = oldArm.find((entry) => entry.watchedPath === "/Applications");
+
+    applications?.listener("rename", "Safari.app");
+    await vi.advanceTimersByTimeAsync(100);
+    expect(harness.registrations).toHaveLength(2);
+
+    oldArm[0]?.watcher.emit("error", new Error("watch lost"));
+    expect(harness.reportFailure).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(harness.registrations).toHaveLength(4);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => expect(harness.clearFailure).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not publish a generation after service stop during settling", async () => {
+    vi.useFakeTimers();
+    const harness = createHarness("desktop-stop");
+    service = harness.service;
+    await service.start?.({
+      logger: { warn: harness.warn },
+      serviceHealth: {
+        clearFailure: harness.clearFailure,
+        reportFailure: harness.reportFailure,
+      },
+    } as never);
+    await vi.waitFor(() => expect(harness.readFingerprint).toHaveBeenCalledOnce());
+
+    await service.stop?.({} as never);
+    service = undefined;
+    harness.setFingerprint("desktop-after-stop");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(harness.onGenerationChange).not.toHaveBeenCalled();
+    expect(harness.readFingerprint).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/codex/src/app-server/desktop-generation-service.test.ts
+++ b/extensions/codex/src/app-server/desktop-generation-service.test.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from "node:events";
 import type { FSWatcher } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createCodexDesktopGenerationService } from "./desktop-generation.js";
+import {
+  createCodexDesktopGenerationService,
+  waitForCodexDesktopGeneration,
+} from "./desktop-generation.js";
 
 class FakeWatcher extends EventEmitter {
   close = vi.fn();
@@ -140,6 +143,54 @@ describe("Codex desktop generation service", () => {
     expect(harness.registrations).toHaveLength(4);
     await vi.advanceTimersByTimeAsync(1_000);
     await vi.waitFor(() => expect(harness.clearFailure).toHaveBeenCalledTimes(2));
+  });
+
+  it("settles the current generation while persistent watcher registration retries", async () => {
+    vi.useFakeTimers();
+    let fingerprint = "desktop-stable";
+    const readFingerprint = vi.fn(async () => fingerprint);
+    const onGenerationChange = vi.fn();
+    const clearFailure = vi.fn();
+    const reportFailure = vi.fn();
+    const warn = vi.fn();
+    const watchPath = vi.fn((): FSWatcher => {
+      throw new Error("watch unavailable");
+    });
+    service = createCodexDesktopGenerationService(
+      { onGenerationChange },
+      {
+        platform: "darwin",
+        readFingerprint,
+        resolveWatchPaths: () => ["/Applications"],
+        pathExists: () => true,
+        watchPath,
+      },
+    );
+    await service.start?.({
+      logger: { warn },
+      serviceHealth: { clearFailure, reportFailure },
+    } as never);
+    let settled = false;
+    void waitForCodexDesktopGeneration().then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(settled).toBe(true);
+    fingerprint = "desktop-updated";
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(watchPath.mock.calls.length).toBeGreaterThan(2);
+    expect(watchPath.mock.calls.length).toBeLessThan(20);
+    expect(readFingerprint.mock.calls.length).toBeGreaterThan(2);
+    expect(onGenerationChange).toHaveBeenCalledWith({
+      epoch: expect.any(Number),
+      fingerprint: "desktop-updated",
+    });
+    expect(reportFailure).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(clearFailure).not.toHaveBeenCalled();
   });
 
   it("does not publish a generation after service stop during settling", async () => {

--- a/extensions/codex/src/app-server/desktop-generation-service.test.ts
+++ b/extensions/codex/src/app-server/desktop-generation-service.test.ts
@@ -14,6 +14,7 @@ class FakeWatcher extends EventEmitter {
 
 type WatchRegistration = {
   watchedPath: string;
+  recursive: boolean;
   listener: (eventType: string, filename: string | Buffer | null) => void;
   watcher: FakeWatcher;
 };
@@ -31,11 +32,11 @@ function createHarness(initialFingerprint: string) {
     {
       platform: "darwin",
       readFingerprint,
-      resolveWatchPaths: () => ["/Applications", "/Applications/ChatGPT.app/Contents/Resources"],
+      resolveWatchPaths: () => ["/Applications", "/Applications/ChatGPT.app"],
       pathExists: () => true,
-      watchPath: (watchedPath, listener) => {
+      watchPath: (watchedPath, options, listener) => {
         const watcher = new FakeWatcher();
-        registrations.push({ watchedPath, listener, watcher });
+        registrations.push({ watchedPath, recursive: options.recursive, listener, watcher });
         return watcher as FSWatcher;
       },
     },
@@ -90,6 +91,12 @@ describe("Codex desktop generation service", () => {
     } as never);
 
     expect(harness.registrations).toHaveLength(2);
+    expect(
+      harness.registrations.map(({ watchedPath, recursive }) => [watchedPath, recursive]),
+    ).toEqual([
+      ["/Applications", false],
+      ["/Applications/ChatGPT.app", true],
+    ]);
     expect(harness.clearFailure).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1_000);
     await vi.waitFor(() => expect(harness.clearFailure).toHaveBeenCalledOnce());
@@ -153,9 +160,15 @@ describe("Codex desktop generation service", () => {
     const clearFailure = vi.fn();
     const reportFailure = vi.fn();
     const warn = vi.fn();
-    const watchPath = vi.fn((): FSWatcher => {
-      throw new Error("watch unavailable");
-    });
+    const watchPath = vi.fn(
+      (
+        _watchedPath: string,
+        _options: { recursive: boolean },
+        _listener: (eventType: string, filename: string | Buffer | null) => void,
+      ): FSWatcher => {
+        throw new Error("watch unavailable");
+      },
+    );
     service = createCodexDesktopGenerationService(
       { onGenerationChange },
       {

--- a/extensions/codex/src/app-server/desktop-generation.test.ts
+++ b/extensions/codex/src/app-server/desktop-generation.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  readMacOSDesktopGenerationFingerprint,
+  resolveMacOSDesktopGenerationWatchPaths,
+} from "./desktop-generation-fingerprint.js";
+import { createCodexDesktopGenerationOwner } from "./desktop-generation-owner.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("Codex desktop generation owner", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("restarts reconciliation when invalidated during a snapshot read", async () => {
+    vi.useFakeTimers();
+    const reads: ReturnType<typeof deferred<string>>[] = [];
+    const changed = vi.fn();
+    const owner = createCodexDesktopGenerationOwner({
+      readFingerprint: () => {
+        const read = deferred<string>();
+        reads.push(read);
+        return read.promise;
+      },
+      onGenerationChange: changed,
+    });
+
+    owner.markDirty();
+    const pending = owner.wait();
+    await vi.waitFor(() => expect(reads).toHaveLength(1));
+    owner.markDirty();
+    reads[0]?.resolve("X");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => expect(reads).toHaveLength(2));
+    reads[1]?.resolve("X");
+    await vi.waitFor(() => expect(reads).toHaveLength(3));
+    reads[2]?.resolve("Y");
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => expect(reads).toHaveLength(4));
+    reads[3]?.resolve("Y");
+
+    await expect(pending).resolves.toEqual({ epoch: 1, fingerprint: "Y" });
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it("coalesces waiters and keeps the generation for an unchanged snapshot", async () => {
+    vi.useFakeTimers();
+    const fingerprint = "X";
+    const readFingerprint = vi.fn(async () => fingerprint);
+    const changed = vi.fn();
+    const owner = createCodexDesktopGenerationOwner({
+      readFingerprint,
+      onGenerationChange: changed,
+    });
+    const initial = owner.refresh();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await initial;
+    readFingerprint.mockClear();
+
+    owner.markDirty();
+    const pending = Promise.all([owner.wait(), owner.wait()]);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const [left, right] = await pending;
+
+    expect(left).toBe(right);
+    expect(left).toEqual({ epoch: 1, fingerprint: "X" });
+    expect(readFingerprint).toHaveBeenCalledTimes(2);
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it("keeps a failed refresh dirty for the next waiter", async () => {
+    vi.useFakeTimers();
+    const readFingerprint = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("transient update"))
+      .mockResolvedValue("Y");
+    const owner = createCodexDesktopGenerationOwner({
+      readFingerprint,
+    });
+    owner.markDirty();
+
+    await expect(owner.wait()).rejects.toThrow("transient update");
+    const retry = owner.wait();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(retry).resolves.toEqual({ epoch: 1, fingerprint: "Y" });
+  });
+
+  it("detects changes in every desktop candidate that can supply a fallback artifact", async () => {
+    await withTempDir("openclaw-codex-generation-fingerprint-", async (root) => {
+      const chatGpt = candidate(root, "ChatGPT.app");
+      const codex = candidate(root, "Codex.app");
+      await Promise.all([
+        writeCommand(chatGpt.appServerCommandPath, "chatgpt-x"),
+        writeCommand(codex.appServerCommandPath, "codex-x"),
+      ]);
+      const initial = await readMacOSDesktopGenerationFingerprint([chatGpt, codex]);
+
+      await writeCommand(codex.appServerCommandPath, "codex-y");
+      await expect(readMacOSDesktopGenerationFingerprint([chatGpt, codex])).resolves.not.toBe(
+        initial,
+      );
+    });
+  });
+
+  it("watches the stable parent chain for every fingerprinted artifact", () => {
+    const fixture = candidate("/Applications", "ChatGPT.app");
+    const servicePath = path.join(fixture.appBundlePath, "service", "Computer Use.app");
+    const watchPaths = resolveMacOSDesktopGenerationWatchPaths([
+      { ...fixture, computerUseServiceAppPaths: [servicePath] },
+    ]);
+
+    expect(watchPaths).toEqual(
+      expect.arrayContaining([
+        "/Applications",
+        fixture.appBundlePath,
+        path.dirname(fixture.appServerCommandPath),
+        path.join(fixture.bundledMarketplacePath, ".agents", "plugins"),
+        path.join(fixture.bundledMarketplacePath, "plugins", "computer-use", ".codex-plugin"),
+        servicePath,
+        path.join(servicePath, "Contents"),
+        path.join(
+          servicePath,
+          "Contents",
+          "SharedSupport",
+          "SkyComputerUseClient.app",
+          "Contents",
+          "MacOS",
+        ),
+      ]),
+    );
+  });
+});
+
+function candidate(root: string, appName: "ChatGPT.app" | "Codex.app") {
+  const appBundlePath = path.join(root, appName);
+  return {
+    appName,
+    appBundlePath,
+    appServerCommandPath: path.join(appBundlePath, "Contents", "Resources", "codex"),
+    bundledMarketplacePath: path.join(appBundlePath, "marketplace"),
+    computerUseServiceAppPaths: [],
+  };
+}
+
+async function writeCommand(commandPath: string, contents: string): Promise<void> {
+  await fs.mkdir(path.dirname(commandPath), { recursive: true });
+  await fs.writeFile(commandPath, contents);
+}

--- a/extensions/codex/src/app-server/desktop-generation.test.ts
+++ b/extensions/codex/src/app-server/desktop-generation.test.ts
@@ -111,32 +111,49 @@ describe("Codex desktop generation owner", () => {
     });
   });
 
-  it("watches the stable parent chain for every fingerprinted artifact", () => {
-    const fixture = candidate("/Applications", "ChatGPT.app");
-    const servicePath = path.join(fixture.appBundlePath, "service", "Computer Use.app");
-    const watchPaths = resolveMacOSDesktopGenerationWatchPaths([
-      { ...fixture, computerUseServiceAppPaths: [servicePath] },
-    ]);
+  it("settles same-version Computer Use plugin content changes as a new generation", async () => {
+    await withTempDir("openclaw-codex-generation-plugin-fingerprint-", async (root) => {
+      const chatGpt = candidate(root, "ChatGPT.app");
+      const pluginRoot = path.join(chatGpt.bundledMarketplacePath, "plugins", "computer-use");
+      await Promise.all([
+        writeCommand(chatGpt.appServerCommandPath, "chatgpt-x"),
+        fs.mkdir(path.join(pluginRoot, ".codex-plugin"), { recursive: true }),
+      ]);
+      await fs.writeFile(
+        path.join(pluginRoot, ".codex-plugin", "plugin.json"),
+        JSON.stringify({ name: "computer-use", version: "1.0.0" }),
+      );
+      await fs.writeFile(path.join(pluginRoot, ".mcp.json"), "plugin-content-x");
+      const initialFingerprint = await readMacOSDesktopGenerationFingerprint([chatGpt]);
 
-    expect(watchPaths).toEqual(
-      expect.arrayContaining([
-        "/Applications",
-        fixture.appBundlePath,
-        path.dirname(fixture.appServerCommandPath),
-        path.join(fixture.bundledMarketplacePath, ".agents", "plugins"),
-        path.join(fixture.bundledMarketplacePath, "plugins", "computer-use", ".codex-plugin"),
-        servicePath,
-        path.join(servicePath, "Contents"),
-        path.join(
-          servicePath,
-          "Contents",
-          "SharedSupport",
-          "SkyComputerUseClient.app",
-          "Contents",
-          "MacOS",
-        ),
-      ]),
-    );
+      await fs.writeFile(path.join(pluginRoot, ".mcp.json"), "plugin-content-y");
+      const updatedFingerprint = await readMacOSDesktopGenerationFingerprint([chatGpt]);
+      expect(updatedFingerprint).not.toBe(initialFingerprint);
+
+      vi.useFakeTimers();
+      let fingerprint = initialFingerprint;
+      const owner = createCodexDesktopGenerationOwner({
+        readFingerprint: async () => fingerprint,
+      });
+      const initial = owner.refresh();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(initial).resolves.toMatchObject({ epoch: 1 });
+
+      fingerprint = updatedFingerprint;
+      owner.markDirty();
+      const updated = owner.wait();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(updated).resolves.toMatchObject({ epoch: 2 });
+    });
+  });
+
+  it("watches stable application roots for recursive artifact updates", () => {
+    const fixture = candidate("/Applications", "ChatGPT.app");
+    expect(resolveMacOSDesktopGenerationWatchPaths([fixture])).toEqual([
+      "/Applications",
+      fixture.appBundlePath,
+    ]);
   });
 });
 

--- a/extensions/codex/src/app-server/desktop-generation.ts
+++ b/extensions/codex/src/app-server/desktop-generation.ts
@@ -1,0 +1,226 @@
+/** Lifecycle-owned generation for managed macOS Codex desktop artifacts. */
+import { existsSync, watch, type FSWatcher } from "node:fs";
+import path from "node:path";
+import type {
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { resolveMacOSDesktopCodexAppPathCandidates } from "./desktop-app-paths.js";
+import {
+  readMacOSDesktopGenerationFingerprint,
+  resolveMacOSDesktopGenerationWatchPaths,
+} from "./desktop-generation-fingerprint.js";
+import {
+  createCodexDesktopGenerationOwner,
+  type CodexDesktopGeneration,
+} from "./desktop-generation-owner.js";
+
+const APPLICATIONS_PATH = "/Applications";
+const REARM_DELAY_MS = 100;
+const DESKTOP_GENERATION_STATE = Symbol.for("openclaw.codexDesktopGenerationState");
+
+type GenerationOwner = ReturnType<typeof createCodexDesktopGenerationOwner>;
+type WatchFactory = (
+  watchedPath: string,
+  listener: (eventType: string, filename: string | Buffer | null) => void,
+) => FSWatcher;
+type DesktopGenerationRuntime = {
+  platform: NodeJS.Platform;
+  readFingerprint: () => Promise<string>;
+  resolveWatchPaths: () => string[];
+  pathExists: (watchedPath: string) => boolean;
+  watchPath: WatchFactory;
+};
+type DesktopGenerationState = {
+  owner?: GenerationOwner;
+  lastGeneration?: CodexDesktopGeneration;
+  watchers?: Set<FSWatcher>;
+  armEpoch?: number;
+  rearmTimer?: NodeJS.Timeout;
+  context?: OpenClawPluginServiceContext;
+  readFingerprint?: () => Promise<string>;
+  resolveWatchPaths?: () => string[];
+  pathExists?: (watchedPath: string) => boolean;
+  watchPath?: WatchFactory;
+};
+
+function state(): DesktopGenerationState {
+  // SAFETY: this process-global symbol is owned exclusively by this module.
+  const globalState = globalThis as typeof globalThis & {
+    [DESKTOP_GENERATION_STATE]?: DesktopGenerationState;
+  };
+  return (globalState[DESKTOP_GENERATION_STATE] ??= {});
+}
+
+export function waitForCodexDesktopGeneration(): Promise<CodexDesktopGeneration | undefined> {
+  return state().owner?.wait() ?? Promise.resolve(undefined);
+}
+
+export function isCodexDesktopGenerationCurrent(
+  generation: CodexDesktopGeneration | undefined,
+): boolean {
+  return state().owner?.isCurrent(generation) ?? false;
+}
+
+export function createCodexDesktopGenerationService(
+  params: {
+    onGenerationChange: (generation: CodexDesktopGeneration) => void;
+  },
+  runtime: DesktopGenerationRuntime = {
+    platform: process.platform,
+    readFingerprint: readMacOSDesktopGenerationFingerprint,
+    resolveWatchPaths: resolveMacOSDesktopGenerationWatchPaths,
+    pathExists: existsSync,
+    watchPath: (watchedPath, listener) => watch(watchedPath, listener),
+  },
+): OpenClawPluginService {
+  return {
+    id: "codex-desktop-generation",
+    async start(ctx) {
+      if (runtime.platform !== "darwin") {
+        return;
+      }
+      const current = state();
+      current.context = ctx;
+      current.readFingerprint = runtime.readFingerprint;
+      current.resolveWatchPaths = runtime.resolveWatchPaths;
+      current.pathExists = runtime.pathExists;
+      current.watchPath = runtime.watchPath;
+      current.owner = createCodexDesktopGenerationOwner({
+        readFingerprint: current.readFingerprint,
+        onGenerationChange: params.onGenerationChange,
+        initialGeneration: current.lastGeneration,
+      });
+      armWatchers(current);
+      refreshGeneration(current, current.owner, current.owner.refresh());
+    },
+    async stop() {
+      const current = state();
+      current.lastGeneration = current.owner?.read() ?? current.lastGeneration;
+      current.owner?.stop();
+      current.owner = undefined;
+      current.armEpoch = (current.armEpoch ?? 0) + 1;
+      current.context = undefined;
+      current.readFingerprint = undefined;
+      current.resolveWatchPaths = undefined;
+      current.pathExists = undefined;
+      current.watchPath = undefined;
+      if (current.rearmTimer) {
+        clearTimeout(current.rearmTimer);
+        current.rearmTimer = undefined;
+      }
+      closeWatchers(current);
+    },
+  };
+}
+
+function armWatchers(current: DesktopGenerationState): void {
+  const owner = current.owner;
+  if (!owner || current.watchers) {
+    return;
+  }
+  const armEpoch = (current.armEpoch ?? 0) + 1;
+  current.armEpoch = armEpoch;
+  const watchers = new Set<FSWatcher>();
+  current.watchers = watchers;
+  const candidateNames = new Set<string>(
+    resolveMacOSDesktopCodexAppPathCandidates("darwin").map((candidate) => candidate.appName),
+  );
+  for (const watchedPath of current.resolveWatchPaths?.() ?? []) {
+    if (!current.pathExists?.(watchedPath)) {
+      continue;
+    }
+    try {
+      const watcher = current.watchPath?.(watchedPath, (_eventType, filename) => {
+        if (!isCurrentArm(current, owner, watchers, armEpoch)) {
+          return;
+        }
+        if (
+          watchedPath === APPLICATIONS_PATH &&
+          filename &&
+          !candidateNames.has(filename.toString().split(path.sep)[0] ?? "")
+        ) {
+          return;
+        }
+        owner.markDirty();
+        scheduleRearm(current, owner);
+      });
+      if (!watcher) {
+        continue;
+      }
+      watchers.add(watcher);
+      watcher.on("error", (error) => {
+        if (!isCurrentArm(current, owner, watchers, armEpoch)) {
+          return;
+        }
+        current.context?.serviceHealth?.reportFailure(error);
+        current.context?.logger.warn(`codex desktop generation watcher failed: ${String(error)}`);
+        owner.markDirty();
+        scheduleRearm(current, owner);
+      });
+    } catch (error) {
+      current.context?.serviceHealth?.reportFailure(error);
+      current.context?.logger.warn(`codex desktop generation watcher failed: ${String(error)}`);
+      owner.markDirty();
+      scheduleRearm(current, owner);
+    }
+  }
+}
+
+function isCurrentArm(
+  current: DesktopGenerationState,
+  owner: GenerationOwner,
+  watchers: Set<FSWatcher>,
+  armEpoch: number,
+): boolean {
+  return current.owner === owner && current.watchers === watchers && current.armEpoch === armEpoch;
+}
+
+function scheduleRearm(current: DesktopGenerationState, owner: GenerationOwner): void {
+  if (current.rearmTimer) {
+    clearTimeout(current.rearmTimer);
+  }
+  current.rearmTimer = setTimeout(() => {
+    current.rearmTimer = undefined;
+    if (current.owner !== owner) {
+      return;
+    }
+    closeWatchers(current);
+    armWatchers(current);
+    owner.markDirty();
+    refreshGeneration(current, owner, owner.wait());
+  }, REARM_DELAY_MS);
+  current.rearmTimer.unref();
+}
+
+function logRefreshFailure(current: DesktopGenerationState, owner: GenerationOwner) {
+  return (error: unknown) => {
+    if (current.owner !== owner) {
+      return;
+    }
+    current.context?.serviceHealth?.reportFailure(error);
+    current.context?.logger.warn(`codex desktop generation refresh failed: ${String(error)}`);
+  };
+}
+
+function refreshGeneration(
+  current: DesktopGenerationState,
+  owner: GenerationOwner,
+  refresh: Promise<CodexDesktopGeneration | undefined>,
+): void {
+  void refresh
+    .then(() => {
+      if (current.owner === owner) {
+        current.context?.serviceHealth?.clearFailure();
+      }
+    })
+    .catch(logRefreshFailure(current, owner));
+}
+
+function closeWatchers(current: DesktopGenerationState): void {
+  const watchers = current.watchers;
+  current.watchers = undefined;
+  for (const watcher of watchers ?? []) {
+    watcher.close();
+  }
+}

--- a/extensions/codex/src/app-server/desktop-generation.ts
+++ b/extensions/codex/src/app-server/desktop-generation.ts
@@ -23,6 +23,7 @@ const DESKTOP_GENERATION_STATE = Symbol.for("openclaw.codexDesktopGenerationStat
 type GenerationOwner = ReturnType<typeof createCodexDesktopGenerationOwner>;
 type WatchFactory = (
   watchedPath: string,
+  options: { recursive: boolean },
   listener: (eventType: string, filename: string | Buffer | null) => void,
 ) => FSWatcher;
 type DesktopGenerationRuntime = {
@@ -74,7 +75,7 @@ export function createCodexDesktopGenerationService(
     readFingerprint: readMacOSDesktopGenerationFingerprint,
     resolveWatchPaths: resolveMacOSDesktopGenerationWatchPaths,
     pathExists: existsSync,
-    watchPath: (watchedPath, listener) => watch(watchedPath, listener),
+    watchPath: (watchedPath, options, listener) => watch(watchedPath, options, listener),
   },
 ): OpenClawPluginService {
   return {
@@ -137,20 +138,26 @@ function armWatchers(current: DesktopGenerationState): boolean {
       continue;
     }
     try {
-      const watcher = current.watchPath?.(watchedPath, (_eventType, filename) => {
-        if (!isCurrentArm(current, owner, watchers, armEpoch)) {
-          return;
-        }
-        if (
-          watchedPath === APPLICATIONS_PATH &&
-          filename &&
-          !candidateNames.has(filename.toString().split(path.sep)[0] ?? "")
-        ) {
-          return;
-        }
-        owner.markDirty();
-        scheduleRearm(current, owner);
-      });
+      // Bundle roots need recursive invalidation: nested plugin bytes can change without
+      // updating the app directory metadata that the settled fingerprint observes first.
+      const watcher = current.watchPath?.(
+        watchedPath,
+        { recursive: watchedPath !== APPLICATIONS_PATH },
+        (_eventType, filename) => {
+          if (!isCurrentArm(current, owner, watchers, armEpoch)) {
+            return;
+          }
+          if (
+            watchedPath === APPLICATIONS_PATH &&
+            filename &&
+            !candidateNames.has(filename.toString().split(path.sep)[0] ?? "")
+          ) {
+            return;
+          }
+          owner.markDirty();
+          scheduleRearm(current, owner);
+        },
+      );
       if (!watcher) {
         complete = false;
         reportWatcherFailure(current, owner, new Error(`Could not watch ${watchedPath}`));

--- a/extensions/codex/src/app-server/desktop-generation.ts
+++ b/extensions/codex/src/app-server/desktop-generation.ts
@@ -16,7 +16,8 @@ import {
 } from "./desktop-generation-owner.js";
 
 const APPLICATIONS_PATH = "/Applications";
-const REARM_DELAY_MS = 100;
+const REARM_INITIAL_DELAY_MS = 100;
+const REARM_MAX_DELAY_MS = 30_000;
 const DESKTOP_GENERATION_STATE = Symbol.for("openclaw.codexDesktopGenerationState");
 
 type GenerationOwner = ReturnType<typeof createCodexDesktopGenerationOwner>;
@@ -35,8 +36,10 @@ type DesktopGenerationState = {
   owner?: GenerationOwner;
   lastGeneration?: CodexDesktopGeneration;
   watchers?: Set<FSWatcher>;
+  watchHealthy?: boolean;
   armEpoch?: number;
   rearmTimer?: NodeJS.Timeout;
+  rearmDelayMs?: number;
   context?: OpenClawPluginServiceContext;
   readFingerprint?: () => Promise<string>;
   resolveWatchPaths?: () => string[];
@@ -105,6 +108,8 @@ export function createCodexDesktopGenerationService(
       current.resolveWatchPaths = undefined;
       current.pathExists = undefined;
       current.watchPath = undefined;
+      current.watchHealthy = undefined;
+      current.rearmDelayMs = undefined;
       if (current.rearmTimer) {
         clearTimeout(current.rearmTimer);
         current.rearmTimer = undefined;
@@ -114,10 +119,10 @@ export function createCodexDesktopGenerationService(
   };
 }
 
-function armWatchers(current: DesktopGenerationState): void {
+function armWatchers(current: DesktopGenerationState): boolean {
   const owner = current.owner;
   if (!owner || current.watchers) {
-    return;
+    return false;
   }
   const armEpoch = (current.armEpoch ?? 0) + 1;
   current.armEpoch = armEpoch;
@@ -126,6 +131,7 @@ function armWatchers(current: DesktopGenerationState): void {
   const candidateNames = new Set<string>(
     resolveMacOSDesktopCodexAppPathCandidates("darwin").map((candidate) => candidate.appName),
   );
+  let complete = true;
   for (const watchedPath of current.resolveWatchPaths?.() ?? []) {
     if (!current.pathExists?.(watchedPath)) {
       continue;
@@ -146,6 +152,9 @@ function armWatchers(current: DesktopGenerationState): void {
         scheduleRearm(current, owner);
       });
       if (!watcher) {
+        complete = false;
+        reportWatcherFailure(current, owner, new Error(`Could not watch ${watchedPath}`));
+        scheduleRearm(current, owner);
         continue;
       }
       watchers.add(watcher);
@@ -153,18 +162,34 @@ function armWatchers(current: DesktopGenerationState): void {
         if (!isCurrentArm(current, owner, watchers, armEpoch)) {
           return;
         }
-        current.context?.serviceHealth?.reportFailure(error);
-        current.context?.logger.warn(`codex desktop generation watcher failed: ${String(error)}`);
-        owner.markDirty();
+        reportWatcherFailure(current, owner, error);
         scheduleRearm(current, owner);
       });
     } catch (error) {
-      current.context?.serviceHealth?.reportFailure(error);
-      current.context?.logger.warn(`codex desktop generation watcher failed: ${String(error)}`);
-      owner.markDirty();
+      complete = false;
+      reportWatcherFailure(current, owner, error);
       scheduleRearm(current, owner);
     }
   }
+  current.watchHealthy = complete;
+  if (complete) {
+    current.rearmDelayMs = REARM_INITIAL_DELAY_MS;
+  }
+  return complete;
+}
+
+function reportWatcherFailure(
+  current: DesktopGenerationState,
+  owner: GenerationOwner,
+  error: unknown,
+): void {
+  if (current.watchHealthy === false) {
+    return;
+  }
+  current.watchHealthy = false;
+  owner.markDirty();
+  current.context?.serviceHealth?.reportFailure(error);
+  current.context?.logger.warn(`codex desktop generation watcher failed: ${String(error)}`);
 }
 
 function isCurrentArm(
@@ -178,18 +203,30 @@ function isCurrentArm(
 
 function scheduleRearm(current: DesktopGenerationState, owner: GenerationOwner): void {
   if (current.rearmTimer) {
+    if (current.watchHealthy === false) {
+      return;
+    }
     clearTimeout(current.rearmTimer);
+  }
+  const delayMs =
+    current.watchHealthy === false
+      ? (current.rearmDelayMs ?? REARM_INITIAL_DELAY_MS)
+      : REARM_INITIAL_DELAY_MS;
+  if (current.watchHealthy === false) {
+    current.rearmDelayMs = Math.min(delayMs * 2, REARM_MAX_DELAY_MS);
   }
   current.rearmTimer = setTimeout(() => {
     current.rearmTimer = undefined;
     if (current.owner !== owner) {
       return;
     }
+    const wasUnhealthy = current.watchHealthy === false;
     closeWatchers(current);
-    armWatchers(current);
-    owner.markDirty();
+    if (!armWatchers(current) || wasUnhealthy) {
+      owner.markDirty();
+    }
     refreshGeneration(current, owner, owner.wait());
-  }, REARM_DELAY_MS);
+  }, delayMs);
   current.rearmTimer.unref();
 }
 
@@ -210,7 +247,7 @@ function refreshGeneration(
 ): void {
   void refresh
     .then(() => {
-      if (current.owner === owner) {
+      if (current.owner === owner && current.watchHealthy) {
         current.context?.serviceHealth?.clearFailure();
       }
     })

--- a/extensions/codex/src/app-server/managed-binary.ts
+++ b/extensions/codex/src/app-server/managed-binary.ts
@@ -9,16 +9,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import type { CodexAppServerStartOptions, CodexManagedCommandOrder } from "./config.js";
+import { resolveMacOSDesktopCodexAppServerCommandCandidates } from "./desktop-app-paths.js";
 import { MANAGED_CODEX_APP_SERVER_PACKAGE } from "./version.js";
 
 const CODEX_APP_SERVER_MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_PLUGIN_ROOT = resolveDefaultCodexPluginRoot(CODEX_APP_SERVER_MODULE_DIR);
 let registeredCodexPluginRoot: string | undefined;
-// ChatGPT.app is the current desktop owner; keep Codex.app as the legacy fallback.
-const MACOS_DESKTOP_CODEX_APP_SERVER_COMMANDS = [
-  "/Applications/ChatGPT.app/Contents/Resources/codex",
-  "/Applications/Codex.app/Contents/Resources/codex",
-] as const;
 
 type ResolveManagedCodexAppServerOptions = {
   platform?: NodeJS.Platform;
@@ -115,7 +111,9 @@ export function isManagedCodexDesktopCommand(
 ): boolean {
   return (
     platform === "darwin" &&
-    MACOS_DESKTOP_CODEX_APP_SERVER_COMMANDS.some((candidate) => candidate === command)
+    resolveMacOSDesktopCodexAppServerCommandCandidates(platform).some(
+      (candidate) => candidate === command,
+    )
   );
 }
 
@@ -210,7 +208,7 @@ function resolveManagedCodexAppServerCommandCandidates(
 }
 
 function resolveDesktopCodexAppServerCommandCandidates(platform: NodeJS.Platform): string[] {
-  return platform === "darwin" ? [...MACOS_DESKTOP_CODEX_APP_SERVER_COMMANDS] : [];
+  return resolveMacOSDesktopCodexAppServerCommandCandidates(platform);
 }
 
 function resolveDefaultCodexPluginRoot(moduleDir: string): string {

--- a/extensions/codex/src/app-server/managed-binary.ts
+++ b/extensions/codex/src/app-server/managed-binary.ts
@@ -104,7 +104,7 @@ export function resolveManagedCodexNativeCommand(
   return undefined;
 }
 
-/** Returns whether a resolved managed command is owned by the macOS desktop app. */
+/** Returns whether a command is one of the standard macOS desktop app executables. */
 export function isManagedCodexDesktopCommand(
   command: string,
   platform: NodeJS.Platform = process.platform,

--- a/extensions/codex/src/app-server/models.test.ts
+++ b/extensions/codex/src/app-server/models.test.ts
@@ -28,7 +28,8 @@ vi.mock("./auth-bridge.js", () => ({
   resolveCodexAppServerHomeDir: (agentDir: string) => `${agentDir}/codex-home`,
 }));
 
-vi.mock("./managed-binary.js", () => ({
+vi.mock("./managed-binary.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./managed-binary.js")>()),
   resolveManagedCodexAppServerStartOptions: mocks.managedBinary.startOptions,
   resolveManagedCodexNativeCommand: mocks.managedBinary.nativeCommand,
 }));

--- a/extensions/codex/src/app-server/models.test.ts
+++ b/extensions/codex/src/app-server/models.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => {
     applyAuthProfile: vi.fn(async () => undefined),
     authProfileId: vi.fn((params?: { authProfileId?: string }) => params?.authProfileId),
     fallbackApiKeyCacheKey: vi.fn(() => undefined),
+    reconcileComputerUseArtifacts: vi.fn(async () => undefined),
     startOptions: vi.fn(async ({ startOptions }) => startOptions),
   };
   const managedBinary = {
@@ -23,6 +24,7 @@ const mocks = vi.hoisted(() => {
 vi.mock("./auth-bridge.js", () => ({
   applyCodexAppServerAuthProfile: mocks.authBridge.applyAuthProfile,
   bridgeCodexAppServerStartOptions: mocks.authBridge.startOptions,
+  reconcileCodexComputerUseStartArtifacts: mocks.authBridge.reconcileComputerUseArtifacts,
   resolveCodexAppServerFallbackApiKeyCacheKey: mocks.authBridge.fallbackApiKeyCacheKey,
   resolveCodexAppServerAuthProfileIdForAgent: mocks.authBridge.authProfileId,
   resolveCodexAppServerHomeDir: (agentDir: string) => `${agentDir}/codex-home`,

--- a/extensions/codex/src/app-server/plugin-app-cache-key.test.ts
+++ b/extensions/codex/src/app-server/plugin-app-cache-key.test.ts
@@ -50,6 +50,35 @@ describe("resolveCodexPluginAppCacheEndpoint", () => {
     expect(second).not.toContain("secret-token");
   });
 
+  it("separates plugin inventory across managed desktop generations", () => {
+    const base = {
+      appServer: {
+        start: {
+          transport: "stdio" as const,
+          command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+          args: ["app-server"],
+          headers: {},
+        },
+      },
+      agentDir: "/tmp/openclaw-agent",
+      runtimeIdentity: {
+        serverVersion: "0.20.0",
+        codexHome: "/tmp/openclaw-agent/codex-home",
+      },
+    };
+
+    const generationX = buildCodexPluginAppCacheKey({
+      ...base,
+      desktopGenerationFingerprint: "desktop-x",
+    });
+    const generationY = buildCodexPluginAppCacheKey({
+      ...base,
+      desktopGenerationFingerprint: "desktop-y",
+    });
+
+    expect(generationX).not.toEqual(generationY);
+  });
+
   it("fingerprints the remote app-server runtime used by thread bindings", () => {
     const first = buildCodexAppServerRuntimeFingerprint({
       appServer: {

--- a/extensions/codex/src/app-server/plugin-app-cache-key.ts
+++ b/extensions/codex/src/app-server/plugin-app-cache-key.ts
@@ -54,6 +54,7 @@ type CodexPluginAppCacheKeyParams = Omit<
   appServer: Pick<CodexAppServerRuntimeOptions, "start">;
   agentDir?: string;
   runtimeIdentity?: CodexAppServerRuntimeIdentity;
+  desktopGenerationFingerprint?: string;
 };
 
 /** Builds the full app inventory cache key for Codex plugin/app discovery. */
@@ -68,7 +69,12 @@ export function buildCodexPluginAppCacheKey(params: CodexPluginAppCacheKeyParams
       accountId: params.accountId,
       envApiKeyFingerprint: params.envApiKeyFingerprint,
       appServerVersion: params.appServerVersion ?? params.runtimeIdentity?.serverVersion,
-      runtimeIdentity: params.runtimeIdentity,
+      runtimeIdentity: params.desktopGenerationFingerprint
+        ? {
+            ...params.runtimeIdentity,
+            desktopGeneration: params.desktopGenerationFingerprint,
+          }
+        : params.runtimeIdentity,
     },
     OPENCLAW_VERSION,
     CODEX_PLUGIN_VERSION,

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -2307,7 +2307,7 @@ describe("shared Codex app-server client", () => {
     expect(startSpy).not.toHaveBeenCalled();
   });
 
-  it("drains active desktop generation X while new acquisitions use Y", async () => {
+  it("waits for active generation X leases before publishing generation Y artifacts", async () => {
     const generationX = { epoch: 1, fingerprint: "desktop-x" };
     const generationY = { epoch: 2, fingerprint: "desktop-y" };
     mocks.desktopGeneration = generationX;
@@ -2332,7 +2332,12 @@ describe("shared Codex app-server client", () => {
       args: ["app-server"],
       headers: {},
     };
-    const options = { config, startOptions, agentDir: "/tmp/openclaw-agent" };
+    const options = {
+      config,
+      startOptions,
+      agentDir: "/tmp/openclaw-agent",
+      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+    };
 
     const firstAcquire = getLeasedSharedCodexAppServerClient(options);
     const siblingAcquire = getLeasedSharedCodexAppServerClient(options);
@@ -2345,11 +2350,14 @@ describe("shared Codex app-server client", () => {
     mocks.desktopGeneration = generationY;
     retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
     const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
-    const clientY = await replacementAcquire;
-    expect(clientY).toBe(second.client);
-    expect(clientY).not.toBe(clientX);
-    expect(startSpy).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() =>
+      expect(mocks.resolveManagedCodexAppServerStartOptions).toHaveBeenCalledTimes(2),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledTimes(1);
     expect(first.process.stdin.destroyed).toBe(false);
 
     const pendingRequest = JSON.parse(first.writes.at(-1) ?? "{}") as { id?: number };
@@ -2359,7 +2367,67 @@ describe("shared Codex app-server client", () => {
     expect(first.process.stdin.destroyed).toBe(false);
     expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
     expect(first.process.stdin.destroyed).toBe(true);
+
+    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await replacementAcquire;
+    expect(clientY).toBe(second.client);
+    expect(clientY).not.toBe(clientX);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(2);
     expect(second.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
+  });
+
+  it("does not block generation Y artifacts on an older client for another home", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed" as const,
+    }));
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+    const startOptions: CodexAppServerStartOptions = {
+      transport: "stdio",
+      homeScope: "agent",
+      command: "codex",
+      commandSource: "managed",
+      managedCommandOrder: "desktop-first",
+      args: ["app-server"],
+      headers: {},
+    };
+    const common = {
+      config: {},
+      startOptions,
+      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+    };
+
+    const firstAcquire = getLeasedSharedCodexAppServerClient({
+      ...common,
+      agentDir: "/tmp/openclaw-agent-a",
+    });
+    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    const clientX = await firstAcquire;
+
+    mocks.desktopGeneration = generationY;
+    retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
+    const secondAcquire = getLeasedSharedCodexAppServerClient({
+      ...common,
+      agentDir: "/tmp/openclaw-agent-b",
+    });
+    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await secondAcquire;
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(first.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
+    expect(first.process.stdin.destroyed).toBe(true);
     expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
   });
 
@@ -2401,6 +2469,13 @@ describe("shared Codex app-server client", () => {
     mocks.desktopGeneration = generationY;
     retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
     const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(packageX.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
+    expect(packageX.process.stdin.destroyed).toBe(true);
     await sendInitializeResult(packageY, "openclaw/0.148.0 (macOS; test)");
     const clientY = await replacementAcquire;
 
@@ -2411,9 +2486,58 @@ describe("shared Codex app-server client", () => {
         ([params]) => params?.desktopGeneration,
       ),
     ).toEqual([generationX, generationY]);
-    expect(packageX.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
+  });
+
+  it("tracks an explicit package client that uses managed desktop Computer Use artifacts", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    const packageX = createClientHarness();
+    const packageY = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(packageX.client)
+      .mockReturnValueOnce(packageY.client);
+    const options = {
+      config: {},
+      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      agentDir: "/tmp/openclaw-agent",
+      startOptions: {
+        transport: "stdio" as const,
+        homeScope: "agent" as const,
+        command: "/opt/codex/bin/codex",
+        commandSource: "config" as const,
+        args: ["app-server"],
+        headers: {},
+      },
+    };
+
+    const firstAcquire = getLeasedSharedCodexAppServerClient(options);
+    await sendInitializeResult(packageX, "openclaw/0.148.0 (macOS; test)");
+    const clientX = await firstAcquire;
+
+    mocks.desktopGeneration = generationY;
+    retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
+    let replacementSettled = false;
+    const replacementAcquire = getLeasedSharedCodexAppServerClient(options).finally(() => {
+      replacementSettled = true;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(replacementSettled).toBe(false);
     expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
-    expect(packageX.process.stdin.destroyed).toBe(true);
+    await sendInitializeResult(packageY, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await replacementAcquire;
+
+    expect(clientY).not.toBe(clientX);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.reconcileCodexComputerUseStartArtifacts.mock.calls.map(
+        ([params]) => params?.desktopGeneration,
+      ),
+    ).toEqual([generationX, generationY]);
     expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
   });
 

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -2714,57 +2714,48 @@ describe("shared Codex app-server client", () => {
     expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
   });
 
-  it("tracks an explicit package client that uses managed desktop Computer Use artifacts", async () => {
-    const generationX = { epoch: 1, fingerprint: "desktop-x" };
-    const generationY = { epoch: 2, fingerprint: "desktop-y" };
-    mocks.desktopGeneration = generationX;
-    const packageX = createClientHarness();
-    const packageY = createClientHarness();
-    const startSpy = vi
-      .spyOn(CodexAppServerClient, "start")
-      .mockReturnValueOnce(packageX.client)
-      .mockReturnValueOnce(packageY.client);
-    const options = {
-      config: {},
-      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
-      agentDir: "/tmp/openclaw-agent",
-      startOptions: {
-        transport: "stdio" as const,
-        homeScope: "agent" as const,
-        command: "/opt/codex/bin/codex",
-        commandSource: "config" as const,
-        args: ["app-server"],
-        headers: {},
-      },
-    };
+  it.each(["config", "env"] as const)(
+    "does not generation-bind a custom Computer Use app-server selected by %s",
+    async (commandSource) => {
+      const generationX = { epoch: 1, fingerprint: "desktop-x" };
+      const generationY = { epoch: 2, fingerprint: "desktop-y" };
+      mocks.desktopGeneration = generationX;
+      const packageX = createClientHarness();
+      const startSpy = vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(packageX.client);
+      const options = {
+        config: {},
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+        agentDir: "/tmp/openclaw-agent",
+        startOptions: {
+          transport: "stdio" as const,
+          homeScope: "agent" as const,
+          command: "/opt/codex/bin/codex",
+          commandSource,
+          args: ["app-server"],
+          headers: {},
+        },
+      };
 
-    const firstAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(packageX, "openclaw/0.148.0 (macOS; test)");
-    const clientX = await firstAcquire;
+      const firstAcquire = getLeasedSharedCodexAppServerClient(options);
+      await sendInitializeResult(packageX, "openclaw/0.148.0 (macOS; test)");
+      const clientX = await firstAcquire;
+      expect(readCodexAppServerClientDesktopGeneration(clientX)).toBeUndefined();
 
-    mocks.desktopGeneration = generationY;
-    retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
-    let replacementSettled = false;
-    const replacementAcquire = getLeasedSharedCodexAppServerClient(options).finally(() => {
-      replacementSettled = true;
-    });
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    expect(replacementSettled).toBe(false);
-    expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
-    await sendInitializeResult(packageY, "openclaw/0.148.0 (macOS; test)");
-    const clientY = await replacementAcquire;
+      mocks.desktopGeneration = generationY;
+      retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
+      const clientAfterDesktopUpdate = await getLeasedSharedCodexAppServerClient(options);
 
-    expect(clientY).not.toBe(clientX);
-    expect(startSpy).toHaveBeenCalledTimes(2);
-    expect(
-      mocks.reconcileCodexComputerUseStartArtifacts.mock.calls.map(
-        ([params]) => params?.desktopGeneration,
-      ),
-    ).toEqual([generationX, generationY]);
-    expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
-  });
+      expect(clientAfterDesktopUpdate).toBe(clientX);
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.reconcileCodexComputerUseStartArtifacts.mock.calls.map(
+          ([params]) => params?.desktopGeneration,
+        ),
+      ).toEqual([undefined]);
+      expect(releaseLeasedSharedCodexAppServerClient(clientAfterDesktopUpdate)).toBe(true);
+      expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
+    },
+  );
 
   it("generation-binds an explicit desktop client while Computer Use is disabled", async () => {
     const generation = { epoch: 1, fingerprint: "desktop-x" };

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover shared client plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type RawData } from "ws";
@@ -13,6 +14,7 @@ import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from
 
 const mocks = vi.hoisted(() => ({
   bridgeCodexAppServerStartOptions: vi.fn(async ({ startOptions }) => startOptions),
+  reconcileCodexComputerUseStartArtifacts: vi.fn(async () => undefined),
   applyCodexAppServerAuthProfile: vi.fn(
     async (_params?: {
       agentDir?: string;
@@ -46,13 +48,19 @@ const mocks = vi.hoisted(() => ({
   ),
   resolveManagedCodexAppServerStartOptions: vi.fn(async (startOptions) => startOptions),
   resolveManagedCodexNativeCommand: vi.fn((command: string) => `${command}.native`),
+  isManagedCodexDesktopCommand: vi.fn((command: string) => command.startsWith("/Applications/")),
   embeddedAgentLog: { debug: vi.fn(), warn: vi.fn() },
   resolveDefaultAgentDir: vi.fn(() => "/tmp/openclaw-agent"),
+  desktopGeneration: undefined as { epoch: number; fingerprint: string } | undefined,
+  desktopGenerationCurrent: true,
+  waitForCodexDesktopGeneration: vi.fn(),
 }));
+mocks.waitForCodexDesktopGeneration.mockImplementation(async () => mocks.desktopGeneration);
 
 vi.mock("./auth-bridge.js", () => ({
   applyCodexAppServerAuthProfile: mocks.applyCodexAppServerAuthProfile,
   bridgeCodexAppServerStartOptions: mocks.bridgeCodexAppServerStartOptions,
+  reconcileCodexComputerUseStartArtifacts: mocks.reconcileCodexComputerUseStartArtifacts,
   resolveCodexAppServerAuthProfileIdForAgent: mocks.resolveCodexAppServerAuthProfileIdForAgent,
   resolveCodexAppServerAuthProfileStore: mocks.resolveCodexAppServerAuthProfileStore,
   resolveCodexAppServerPreparedAuthProfileSnapshot:
@@ -65,8 +73,17 @@ vi.mock("./auth-bridge.js", () => ({
 }));
 
 vi.mock("./managed-binary.js", () => ({
+  isManagedCodexDesktopCommand: mocks.isManagedCodexDesktopCommand,
   resolveManagedCodexAppServerStartOptions: mocks.resolveManagedCodexAppServerStartOptions,
   resolveManagedCodexNativeCommand: mocks.resolveManagedCodexNativeCommand,
+}));
+
+vi.mock("./desktop-generation.js", () => ({
+  isCodexDesktopGenerationCurrent: (generation: { epoch: number; fingerprint: string }) =>
+    mocks.desktopGenerationCurrent &&
+    generation.epoch === mocks.desktopGeneration?.epoch &&
+    generation.fingerprint === mocks.desktopGeneration?.fingerprint,
+  waitForCodexDesktopGeneration: mocks.waitForCodexDesktopGeneration,
 }));
 
 vi.mock("openclaw/plugin-sdk/agent-harness-runtime", () => ({
@@ -101,6 +118,7 @@ let releaseCodexAppServerClientLease: typeof import("./shared-client.js").releas
 let resolveCodexNativeConfigFenceKey: typeof import("./shared-client.js").resolveCodexNativeConfigFenceKey;
 let resolveCodexAppServerSpawnIdentity: typeof import("./shared-client.js").resolveCodexAppServerSpawnIdentity;
 let retireSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js").retireSharedCodexAppServerClientIfCurrent;
+let retireSharedCodexAppServerClientsBeforeDesktopGeneration: typeof import("./shared-client.js").retireSharedCodexAppServerClientsBeforeDesktopGeneration;
 let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
 let withLeasedCodexAppServerClientStartSelectionRetry: typeof import("./shared-client.js").withLeasedCodexAppServerClientStartSelectionRetry;
 
@@ -222,6 +240,7 @@ describe("shared Codex app-server client", () => {
       resolveCodexNativeConfigFenceKey,
       resolveCodexAppServerSpawnIdentity,
       retireSharedCodexAppServerClientIfCurrent,
+      retireSharedCodexAppServerClientsBeforeDesktopGeneration,
       resetSharedCodexAppServerClientForTests,
       withLeasedCodexAppServerClientStartSelectionRetry,
     } = await import("./shared-client.js"));
@@ -232,6 +251,7 @@ describe("shared Codex app-server client", () => {
     vi.restoreAllMocks();
     vi.useRealTimers();
     mocks.bridgeCodexAppServerStartOptions.mockClear();
+    mocks.reconcileCodexComputerUseStartArtifacts.mockClear();
     mocks.applyCodexAppServerAuthProfile.mockClear();
     mocks.applyCodexAppServerAuthProfile.mockResolvedValue(undefined);
     mocks.resolveCodexAppServerAuthProfileIdForAgent.mockClear();
@@ -260,6 +280,10 @@ describe("shared Codex app-server client", () => {
     mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(
       async (startOptions) => startOptions,
     );
+    mocks.desktopGeneration = undefined;
+    mocks.desktopGenerationCurrent = true;
+    mocks.waitForCodexDesktopGeneration.mockReset();
+    mocks.waitForCodexDesktopGeneration.mockImplementation(async () => mocks.desktopGeneration);
     mocks.resolveManagedCodexNativeCommand.mockClear();
     mocks.resolveManagedCodexNativeCommand.mockImplementation(
       (command: string) => `${command}.native`,
@@ -2042,6 +2066,225 @@ describe("shared Codex app-server client", () => {
 
     expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
     expect(first.process.stdin.destroyed).toBe(true);
+  });
+
+  it("waits for a dirty desktop generation before reusing a warm managed client", async () => {
+    const generation = { epoch: 1, fingerprint: "desktop-x" };
+    mocks.desktopGeneration = generation;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed" as const,
+    }));
+    const harness = createClientHarness();
+    const startSpy = vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(harness.client);
+    const config = {};
+    const startOptions: CodexAppServerStartOptions = {
+      transport: "stdio",
+      homeScope: "agent",
+      command: "codex",
+      commandSource: "managed",
+      managedCommandOrder: "desktop-first",
+      args: ["app-server"],
+      headers: {},
+    };
+    const options = { config, startOptions, agentDir: "/tmp/openclaw-agent" };
+
+    const firstAcquire = getLeasedSharedCodexAppServerClient(options);
+    await sendInitializeResult(harness, "openclaw/0.148.0 (macOS; test)");
+    const first = await firstAcquire;
+    const dirty = createDeferred<typeof generation>();
+    mocks.desktopGenerationCurrent = false;
+    mocks.waitForCodexDesktopGeneration.mockReturnValue(dirty.promise);
+    let settled = false;
+    const secondAcquire = getLeasedSharedCodexAppServerClient(options).then((client) => {
+      settled = true;
+      return client;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(startSpy).toHaveBeenCalledOnce();
+    mocks.desktopGenerationCurrent = true;
+    dirty.resolve(generation);
+    await expect(secondAcquire).resolves.toBe(first);
+    expect(startSpy).toHaveBeenCalledOnce();
+    expect(releaseLeasedSharedCodexAppServerClient(first)).toBe(true);
+    expect(releaseLeasedSharedCodexAppServerClient(first)).toBe(true);
+  });
+
+  it("bounds a dirty desktop generation wait by the acquisition abort signal", async () => {
+    mocks.desktopGeneration = { epoch: 1, fingerprint: "desktop-x" };
+    mocks.waitForCodexDesktopGeneration.mockReturnValue(new Promise(() => {}));
+    const abort = new AbortController();
+    const acquire = getLeasedSharedCodexAppServerClient({
+      timeoutMs: 1_000,
+      abandonSignal: abort.signal,
+      startOptions: {
+        transport: "stdio",
+        homeScope: "agent",
+        command: "codex",
+        commandSource: "managed",
+        managedCommandOrder: "desktop-first",
+        args: ["app-server"],
+        headers: {},
+      },
+    });
+
+    abort.abort();
+
+    await expect(acquire).rejects.toThrow("codex app-server initialize aborted");
+  });
+
+  it("drains active desktop generation X while new acquisitions use Y", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed" as const,
+    }));
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+    const config = {};
+    const startOptions: CodexAppServerStartOptions = {
+      transport: "stdio",
+      homeScope: "agent",
+      command: "codex",
+      commandSource: "managed",
+      managedCommandOrder: "desktop-first",
+      args: ["app-server"],
+      headers: {},
+    };
+    const options = { config, startOptions, agentDir: "/tmp/openclaw-agent" };
+
+    const firstAcquire = getLeasedSharedCodexAppServerClient(options);
+    const siblingAcquire = getLeasedSharedCodexAppServerClient(options);
+    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    const clientX = await firstAcquire;
+    await expect(siblingAcquire).resolves.toBe(clientX);
+    const pending = clientX.request("test/pending", {});
+    await vi.waitFor(() => expect(first.writes.length).toBeGreaterThanOrEqual(2));
+
+    mocks.desktopGeneration = generationY;
+    retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
+    const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
+    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await replacementAcquire;
+    expect(clientY).toBe(second.client);
+    expect(clientY).not.toBe(clientX);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(first.process.stdin.destroyed).toBe(false);
+
+    const pendingRequest = JSON.parse(first.writes.at(-1) ?? "{}") as { id?: number };
+    first.send({ id: pendingRequest.id, result: { ok: true } });
+    await expect(pending).resolves.toEqual({ ok: true });
+    expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
+    expect(first.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(second.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
+  });
+
+  it("binds a package-first acquisition when its actual fallback is a desktop app", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/cache/openclaw/codex",
+      commandSource: "resolved-managed" as const,
+      managedFallbackCommandPaths: ["/Applications/Codex.app/Contents/Resources/codex"],
+    }));
+    const packageX = createClientHarness();
+    const desktopX = createClientHarness();
+    const packageY = createClientHarness();
+    const desktopY = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(packageX.client)
+      .mockReturnValueOnce(desktopX.client)
+      .mockReturnValueOnce(packageY.client)
+      .mockReturnValueOnce(desktopY.client);
+    const options = {
+      config: {},
+      agentDir: "/tmp/openclaw-agent",
+      startOptions: {
+        transport: "stdio" as const,
+        homeScope: "agent" as const,
+        command: "codex",
+        commandSource: "managed" as const,
+        managedCommandOrder: "package-first" as const,
+        args: ["app-server"],
+        headers: {},
+      },
+    };
+
+    const firstAcquire = getLeasedSharedCodexAppServerClient(options);
+    await sendInitializeResult(packageX, "openclaw/0.124.9 (macOS; test)");
+    await sendInitializeResult(desktopX, "openclaw/0.148.0 (macOS; test)");
+    const clientX = await firstAcquire;
+
+    mocks.desktopGeneration = generationY;
+    retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
+    const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
+    await sendInitializeResult(packageY, "openclaw/0.124.9 (macOS; test)");
+    await sendInitializeResult(desktopY, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await replacementAcquire;
+
+    expect(clientX).toBe(desktopX.client);
+    expect(clientY).toBe(desktopY.client);
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(2);
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startOptions: expect.objectContaining({
+          command: "/Applications/Codex.app/Contents/Resources/codex",
+        }),
+      }),
+    );
+    expect(desktopX.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
+    expect(desktopX.process.stdin.destroyed).toBe(true);
+    expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
+  });
+
+  it("does not publish a desktop client superseded during initialization", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed" as const,
+    }));
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(harness.client);
+    const acquire = getLeasedSharedCodexAppServerClient({
+      config: {},
+      agentDir: "/tmp/openclaw-agent",
+      startOptions: {
+        transport: "stdio",
+        homeScope: "agent",
+        command: "codex",
+        commandSource: "managed",
+        managedCommandOrder: "desktop-first",
+        args: ["app-server"],
+        headers: {},
+      },
+    });
+    await vi.waitFor(() => expect(harness.writes).toHaveLength(1));
+
+    mocks.desktopGeneration = { epoch: 2, fingerprint: "desktop-y" };
+    await sendInitializeResult(harness, "openclaw/0.148.0 (macOS; test)");
+
+    const error = await acquire.catch((caught: unknown) => caught);
+    expect(isCodexAppServerStartSelectionChangedError(error)).toBe(true);
+    expect(mocks.applyCodexAppServerAuthProfile).not.toHaveBeenCalled();
+    expect(harness.process.stdin.destroyed).toBe(true);
   });
 
   it("globally disposes a gracefully detached client with an explicit retain", async () => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -13,8 +13,13 @@ import { createClientHarness } from "./test-support.js";
 import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from "./version.js";
 
 const mocks = vi.hoisted(() => ({
+  CodexComputerUseCandidateArtifactsUnavailableError: class extends Error {
+    readonly code = "CODEX_COMPUTER_USE_CANDIDATE_ARTIFACTS_UNAVAILABLE";
+  },
   bridgeCodexAppServerStartOptions: vi.fn(async ({ startOptions }) => startOptions),
-  reconcileCodexComputerUseStartArtifacts: vi.fn(async () => undefined),
+  reconcileCodexComputerUseStartArtifacts: vi.fn(
+    async (_params?: { startOptions: { command: string } }) => undefined,
+  ),
   applyCodexAppServerAuthProfile: vi.fn(
     async (_params?: {
       agentDir?: string;
@@ -87,6 +92,15 @@ vi.mock("./desktop-generation.js", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk/agent-harness-runtime", () => ({
+  AgentHarnessPreflightError: class extends Error {
+    readonly scope: string;
+
+    constructor(message: string, options: { scope: string; cause?: unknown }) {
+      super(message, { cause: options.cause });
+      this.name = "AgentHarnessPreflightError";
+      this.scope = options.scope;
+    }
+  },
   embeddedAgentLog: mocks.embeddedAgentLog,
   formatErrorMessage: (error: unknown) => String(error),
   OPENCLAW_VERSION: "test",
@@ -489,6 +503,60 @@ describe("shared Codex app-server client", () => {
     expect(harness.stdinDestroyed).toBe(false);
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
     await vi.waitFor(() => expect(harness.stdinDestroyed).toBe(true));
+  });
+
+  it("falls back before starting a desktop candidate with incomplete Computer Use artifacts", async () => {
+    const pluginLocal = createClientHarness();
+    const startSpy = vi.spyOn(CodexAppServerClient, "start").mockReturnValue(pluginLocal.client);
+    mocks.reconcileCodexComputerUseStartArtifacts
+      .mockRejectedValueOnce(
+        new mocks.CodexComputerUseCandidateArtifactsUnavailableError(
+          "desktop artifacts unavailable",
+        ),
+      )
+      .mockResolvedValueOnce(undefined);
+    const startOptions = configureManagedDesktopFallback();
+
+    const acquire = getSharedCodexAppServerClient({ startOptions, timeoutMs: 1_000 });
+    await sendInitializeResult(pluginLocal, "openclaw/0.147.0 (macOS; test)");
+    const client = await acquire;
+
+    expect(client).toBe(pluginLocal.client);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ command: "/cache/openclaw/codex" }),
+    );
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(2);
+    expect(mocks.reconcileCodexComputerUseStartArtifacts.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        startOptions: expect.objectContaining({
+          command: "/Applications/Codex.app/Contents/Resources/codex",
+        }),
+      }),
+    );
+    expect(mocks.reconcileCodexComputerUseStartArtifacts.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        startOptions: expect.objectContaining({ command: "/cache/openclaw/codex" }),
+      }),
+    );
+  });
+
+  it("classifies terminal incomplete Computer Use artifacts as harness preflight", async () => {
+    mocks.reconcileCodexComputerUseStartArtifacts.mockRejectedValueOnce(
+      new mocks.CodexComputerUseCandidateArtifactsUnavailableError("desktop artifacts unavailable"),
+    );
+
+    await expect(
+      getSharedCodexAppServerClient({
+        startOptions: {
+          transport: "stdio",
+          command: "/Applications/Codex.app/Contents/Resources/codex",
+          commandSource: "config",
+          args: ["app-server"],
+          headers: {},
+        },
+      }),
+    ).rejects.toMatchObject({ name: "AgentHarnessPreflightError", scope: "harness" });
   });
 
   it("reuses the successful managed fallback after desktop initialize is unsupported", async () => {
@@ -2136,6 +2204,78 @@ describe("shared Codex app-server client", () => {
     await expect(acquire).rejects.toThrow("codex app-server initialize aborted");
   });
 
+  it("does not start a client after its sole waiter abandons artifact reconciliation", async () => {
+    const reconcileStarted = createDeferred<void>();
+    const releaseReconcile = createDeferred<void>();
+    const reconcileFinished = createDeferred<void>();
+    mocks.reconcileCodexComputerUseStartArtifacts.mockImplementationOnce(
+      async (value?: unknown) => {
+        const params = value as { assertCurrent?: () => void };
+        reconcileStarted.resolve();
+        await releaseReconcile.promise;
+        try {
+          params.assertCurrent?.();
+        } finally {
+          reconcileFinished.resolve();
+        }
+      },
+    );
+    const startSpy = vi.spyOn(CodexAppServerClient, "start");
+    const abort = new AbortController();
+    const acquire = getLeasedSharedCodexAppServerClient({
+      config: {},
+      agentDir: "/tmp/openclaw-agent",
+      startOptions: {
+        transport: "stdio",
+        homeScope: "agent",
+        command: "codex",
+        commandSource: "managed",
+        args: ["app-server"],
+        headers: {},
+      },
+      timeoutMs: 1_000,
+      abandonSignal: abort.signal,
+    });
+    await reconcileStarted.promise;
+
+    abort.abort();
+    await expect(acquire).rejects.toThrow("codex app-server initialize aborted");
+    releaseReconcile.resolve();
+    await reconcileFinished.promise;
+    await Promise.resolve();
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not start a client abandoned after reconciliation's final currentness check", async () => {
+    const abort = new AbortController();
+    mocks.reconcileCodexComputerUseStartArtifacts.mockImplementationOnce(
+      async (value?: unknown) => {
+        const params = value as { assertCurrent?: () => void };
+        params.assertCurrent?.();
+        abort.abort();
+      },
+    );
+    const startSpy = vi.spyOn(CodexAppServerClient, "start");
+
+    await expect(
+      getLeasedSharedCodexAppServerClient({
+        config: {},
+        agentDir: "/tmp/openclaw-agent",
+        startOptions: {
+          transport: "stdio",
+          homeScope: "agent",
+          command: "codex",
+          commandSource: "managed",
+          args: ["app-server"],
+          headers: {},
+        },
+        timeoutMs: 1_000,
+        abandonSignal: abort.signal,
+      }),
+    ).rejects.toThrow("codex app-server initialize aborted");
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+
   it("drains active desktop generation X while new acquisitions use Y", async () => {
     const generationX = { epoch: 1, fingerprint: "desktop-x" };
     const generationY = { epoch: 2, fingerprint: "desktop-y" };
@@ -2239,14 +2379,16 @@ describe("shared Codex app-server client", () => {
 
     expect(clientX).toBe(desktopX.client);
     expect(clientY).toBe(desktopY.client);
-    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(2);
-    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        startOptions: expect.objectContaining({
-          command: "/Applications/Codex.app/Contents/Resources/codex",
-        }),
-      }),
-    );
+    expect(
+      mocks.reconcileCodexComputerUseStartArtifacts.mock.calls.map(
+        ([params]) => params?.startOptions.command,
+      ),
+    ).toEqual([
+      "/cache/openclaw/codex",
+      "/Applications/Codex.app/Contents/Resources/codex",
+      "/cache/openclaw/codex",
+      "/Applications/Codex.app/Contents/Resources/codex",
+    ]);
     expect(desktopX.process.stdin.destroyed).toBe(false);
     expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
     expect(desktopX.process.stdin.destroyed).toBe(true);

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -524,7 +524,7 @@ describe("shared Codex app-server client", () => {
     const startOptions = configureManagedDesktopFallback();
 
     const acquire = getSharedCodexAppServerClient({ startOptions, timeoutMs: 1_000 });
-    await sendInitializeResult(pluginLocal, "openclaw/0.147.0 (macOS; test)");
+    await sendInitializeResult(pluginLocal, "openclaw/0.149.0 (macOS; test)");
     const client = await acquire;
 
     expect(client).toBe(pluginLocal.client);
@@ -889,7 +889,7 @@ describe("shared Codex app-server client", () => {
       };
 
       const clientPromise = createIsolatedCodexAppServerClient({ startOptions });
-      await sendInitializeResult(harness, "openclaw/0.148.0 (macOS; test)");
+      await sendInitializeResult(harness, "openclaw/0.149.0 (macOS; test)");
       const client = await clientPromise;
 
       mocks.desktopGeneration = { epoch: 2, fingerprint: "desktop-y" };
@@ -2193,7 +2193,7 @@ describe("shared Codex app-server client", () => {
     const options = { config, startOptions, agentDir: "/tmp/openclaw-agent" };
 
     const firstAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(harness, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.149.0 (macOS; test)");
     const first = await firstAcquire;
     const dirty = createDeferred<typeof generation>();
     mocks.desktopGenerationCurrent = false;
@@ -2344,7 +2344,7 @@ describe("shared Codex app-server client", () => {
 
     const firstAcquire = getLeasedSharedCodexAppServerClient(options);
     const siblingAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.149.0 (macOS; test)");
     const clientX = await firstAcquire;
     await expect(siblingAcquire).resolves.toBe(clientX);
     const pending = clientX.request("test/pending", {});
@@ -2377,7 +2377,7 @@ describe("shared Codex app-server client", () => {
     expect(startSpy).toHaveBeenCalledTimes(1);
     first.emitExit();
 
-    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.149.0 (macOS; test)");
     const clientY = await replacementAcquire;
     expect(clientY).toBe(second.client);
     expect(clientY).not.toBe(clientX);
@@ -2431,11 +2431,11 @@ describe("shared Codex app-server client", () => {
     expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
     expect(startSpy).toHaveBeenCalledTimes(1);
 
-    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.149.0 (macOS; test)");
     await expect(firstAcquire).rejects.toMatchObject({
       code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
     });
-    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.149.0 (macOS; test)");
     const clientY = await replacementAcquire;
 
     expect(startSpy).toHaveBeenCalledTimes(2);
@@ -2474,7 +2474,7 @@ describe("shared Codex app-server client", () => {
     };
 
     const clientXPromise = createIsolatedCodexAppServerClient(options);
-    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.149.0 (macOS; test)");
     const clientX = await clientXPromise;
 
     mocks.desktopGeneration = generationY;
@@ -2495,7 +2495,7 @@ describe("shared Codex app-server client", () => {
     expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
     expect(startSpy).toHaveBeenCalledTimes(1);
     first.emitExit();
-    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.149.0 (macOS; test)");
     const clientY = await clientYPromise;
 
     expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(2);
@@ -2533,11 +2533,11 @@ describe("shared Codex app-server client", () => {
     };
 
     const clientXPromise = createIsolatedCodexAppServerClient(options);
-    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.149.0 (macOS; test)");
     const clientX = await clientXPromise;
     mocks.desktopGeneration = generationY;
     const clientYPromise = createIsolatedCodexAppServerClient(options);
-    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.149.0 (macOS; test)");
     const clientY = await clientYPromise;
 
     await expect(
@@ -2591,11 +2591,11 @@ describe("shared Codex app-server client", () => {
     expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
     expect(startSpy).toHaveBeenCalledTimes(1);
 
-    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.149.0 (macOS; test)");
     await expect(clientXPromise).rejects.toMatchObject({
       code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
     });
-    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.149.0 (macOS; test)");
     const clientY = await clientYPromise;
 
     expect(startSpy).toHaveBeenCalledTimes(2);
@@ -2637,7 +2637,7 @@ describe("shared Codex app-server client", () => {
       ...common,
       agentDir: "/tmp/openclaw-agent-a",
     });
-    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(first, "openclaw/0.149.0 (macOS; test)");
     const clientX = await firstAcquire;
 
     mocks.desktopGeneration = generationY;
@@ -2646,7 +2646,7 @@ describe("shared Codex app-server client", () => {
       ...common,
       agentDir: "/tmp/openclaw-agent-b",
     });
-    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(second, "openclaw/0.149.0 (macOS; test)");
     const clientY = await secondAcquire;
 
     expect(startSpy).toHaveBeenCalledTimes(2);
@@ -2688,7 +2688,7 @@ describe("shared Codex app-server client", () => {
     };
 
     const firstAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(packageX, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(packageX, "openclaw/0.149.0 (macOS; test)");
     const clientX = await firstAcquire;
 
     mocks.desktopGeneration = generationY;
@@ -2701,7 +2701,7 @@ describe("shared Codex app-server client", () => {
     expect(packageX.process.stdin.destroyed).toBe(false);
     expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
     expect(packageX.process.stdin.destroyed).toBe(true);
-    await sendInitializeResult(packageY, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(packageY, "openclaw/0.149.0 (macOS; test)");
     const clientY = await replacementAcquire;
 
     expect(clientY).not.toBe(clientX);
@@ -2737,7 +2737,7 @@ describe("shared Codex app-server client", () => {
       };
 
       const firstAcquire = getLeasedSharedCodexAppServerClient(options);
-      await sendInitializeResult(packageX, "openclaw/0.148.0 (macOS; test)");
+      await sendInitializeResult(packageX, "openclaw/0.149.0 (macOS; test)");
       const clientX = await firstAcquire;
       expect(readCodexAppServerClientDesktopGeneration(clientX)).toBeUndefined();
 
@@ -2776,7 +2776,7 @@ describe("shared Codex app-server client", () => {
         headers: {},
       },
     });
-    await sendInitializeResult(harness, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.149.0 (macOS; test)");
     const client = await clientPromise;
 
     expect(readCodexAppServerClientDesktopGeneration(client)).toEqual(generation);
@@ -2818,14 +2818,14 @@ describe("shared Codex app-server client", () => {
 
     const firstAcquire = getLeasedSharedCodexAppServerClient(options);
     await sendInitializeResult(packageX, "openclaw/0.124.9 (macOS; test)");
-    await sendInitializeResult(desktopX, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(desktopX, "openclaw/0.149.0 (macOS; test)");
     const clientX = await firstAcquire;
 
     mocks.desktopGeneration = generationY;
     retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
     const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
     await sendInitializeResult(packageY, "openclaw/0.124.9 (macOS; test)");
-    await sendInitializeResult(desktopY, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(desktopY, "openclaw/0.149.0 (macOS; test)");
     const clientY = await replacementAcquire;
 
     expect(clientX).toBe(desktopX.client);
@@ -2872,7 +2872,7 @@ describe("shared Codex app-server client", () => {
     await vi.waitFor(() => expect(harness.writes).toHaveLength(1));
 
     mocks.desktopGeneration = { epoch: 2, fingerprint: "desktop-y" };
-    await sendInitializeResult(harness, "openclaw/0.148.0 (macOS; test)");
+    await sendInitializeResult(harness, "openclaw/0.149.0 (macOS; test)");
 
     const error = await acquire.catch((caught: unknown) => caught);
     expect(isCodexAppServerStartSelectionChangedError(error)).toBe(true);

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -869,6 +869,34 @@ describe("shared Codex app-server client", () => {
     });
   });
 
+  it.each(["config", "env"] as const)(
+    "rejects a stale %s-selected standard desktop client",
+    async (commandSource) => {
+      const generationX = { epoch: 1, fingerprint: "desktop-x" };
+      mocks.desktopGeneration = generationX;
+      const harness = createClientHarness();
+      vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(harness.client);
+      const startOptions: CodexAppServerStartOptions = {
+        transport: "stdio",
+        homeScope: "agent",
+        command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+        commandSource,
+        args: ["app-server"],
+        headers: {},
+      };
+
+      const clientPromise = createIsolatedCodexAppServerClient({ startOptions });
+      await sendInitializeResult(harness, "openclaw/0.148.0 (macOS; test)");
+      const client = await clientPromise;
+
+      mocks.desktopGeneration = { epoch: 2, fingerprint: "desktop-y" };
+      expect(() =>
+        assertCodexAppServerClientStartSelectionCurrent({ client, startOptions }),
+      ).toThrow("managed executable selection changed during startup");
+      client.close();
+    },
+  );
+
   it.each(["abort", "timeout"] as const)(
     "holds the native config fence through process exit after a post-write %s",
     async (mode) => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -116,6 +116,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
 import {
   assertCodexAppServerClientStartSelectionCurrent,
   getSharedCodexAppServerClient,
+  readCodexAppServerClientDesktopGeneration,
   readCodexAppServerClientProcessIdentity,
 } from "./shared-client.js";
 
@@ -136,6 +137,7 @@ let resolveCodexNativeConfigFenceKey: typeof import("./shared-client.js").resolv
 let resolveCodexAppServerSpawnIdentity: typeof import("./shared-client.js").resolveCodexAppServerSpawnIdentity;
 let retireSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js").retireSharedCodexAppServerClientIfCurrent;
 let retireSharedCodexAppServerClientsBeforeDesktopGeneration: typeof import("./shared-client.js").retireSharedCodexAppServerClientsBeforeDesktopGeneration;
+let waitForCodexAppServerClientDesktopGenerationDrain: typeof import("./shared-client.js").waitForCodexAppServerClientDesktopGenerationDrain;
 let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
 let withLeasedCodexAppServerClientStartSelectionRetry: typeof import("./shared-client.js").withLeasedCodexAppServerClientStartSelectionRetry;
 
@@ -258,6 +260,7 @@ describe("shared Codex app-server client", () => {
       resolveCodexAppServerSpawnIdentity,
       retireSharedCodexAppServerClientIfCurrent,
       retireSharedCodexAppServerClientsBeforeDesktopGeneration,
+      waitForCodexAppServerClientDesktopGenerationDrain,
       resetSharedCodexAppServerClientForTests,
       withLeasedCodexAppServerClientStartSelectionRetry,
     } = await import("./shared-client.js"));
@@ -2316,7 +2319,7 @@ describe("shared Codex app-server client", () => {
       command: "/Applications/ChatGPT.app/Contents/Resources/codex",
       commandSource: "resolved-managed" as const,
     }));
-    const first = createClientHarness();
+    const first = createClientHarness({ autoEmitExit: false });
     const second = createClientHarness();
     const startSpy = vi
       .spyOn(CodexAppServerClient, "start")
@@ -2367,6 +2370,12 @@ describe("shared Codex app-server client", () => {
     expect(first.process.stdin.destroyed).toBe(false);
     expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
     expect(first.process.stdin.destroyed).toBe(true);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    first.emitExit();
 
     await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
     const clientY = await replacementAcquire;
@@ -2376,6 +2385,222 @@ describe("shared Codex app-server client", () => {
     expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(2);
     expect(second.process.stdin.destroyed).toBe(false);
     expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
+  });
+
+  it("waits for an initializing generation X client before publishing generation Y artifacts", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed" as const,
+    }));
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+    const options = {
+      config: {},
+      agentDir: "/tmp/openclaw-agent",
+      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      startOptions: {
+        transport: "stdio" as const,
+        homeScope: "agent" as const,
+        command: "codex",
+        commandSource: "managed" as const,
+        managedCommandOrder: "desktop-first" as const,
+        args: ["app-server"],
+        headers: {},
+      },
+    };
+
+    const firstAcquire = getLeasedSharedCodexAppServerClient(options);
+    await vi.waitFor(() => expect(first.writes).toHaveLength(1));
+    mocks.desktopGeneration = generationY;
+    retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
+    const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
+    await vi.waitFor(() =>
+      expect(mocks.resolveManagedCodexAppServerStartOptions).toHaveBeenCalledTimes(2),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    await expect(firstAcquire).rejects.toMatchObject({
+      code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
+    });
+    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await replacementAcquire;
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
+  });
+
+  it("waits for an isolated generation X client before publishing generation Y artifacts", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed" as const,
+    }));
+    const first = createClientHarness({ autoEmitExit: false });
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+    const options = {
+      config: {},
+      agentDir: "/tmp/openclaw-agent",
+      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      startOptions: {
+        transport: "stdio" as const,
+        homeScope: "agent" as const,
+        command: "codex",
+        commandSource: "managed" as const,
+        managedCommandOrder: "desktop-first" as const,
+        args: ["app-server"],
+        headers: {},
+      },
+    };
+
+    const clientXPromise = createIsolatedCodexAppServerClient(options);
+    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    const clientX = await clientXPromise;
+
+    mocks.desktopGeneration = generationY;
+    const clientYPromise = createIsolatedCodexAppServerClient(options);
+    await vi.waitFor(() =>
+      expect(mocks.resolveManagedCodexAppServerStartOptions).toHaveBeenCalledTimes(2),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    clientX.close();
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    first.emitExit();
+    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await clientYPromise;
+
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(2);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    clientY.close();
+  });
+
+  it("bounds an explicit install drain while an isolated generation X client remains live", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed" as const,
+    }));
+    const first = createClientHarness();
+    const second = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+    const options = {
+      config: {},
+      agentDir: "/tmp/openclaw-agent",
+      pluginConfig: { computerUse: { enabled: true, autoInstall: false } },
+      startOptions: {
+        transport: "stdio" as const,
+        homeScope: "agent" as const,
+        command: "codex",
+        commandSource: "managed" as const,
+        managedCommandOrder: "desktop-first" as const,
+        args: ["app-server"],
+        headers: {},
+      },
+    };
+
+    const clientXPromise = createIsolatedCodexAppServerClient(options);
+    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    const clientX = await clientXPromise;
+    mocks.desktopGeneration = generationY;
+    const clientYPromise = createIsolatedCodexAppServerClient(options);
+    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await clientYPromise;
+
+    await expect(
+      waitForCodexAppServerClientDesktopGenerationDrain({ client: clientY, timeoutMs: 25 }),
+    ).rejects.toThrow("timed out waiting for older desktop clients");
+
+    clientX.close();
+    clientY.close();
+  });
+
+  it("waits for an initializing isolated generation X client before publishing generation Y artifacts", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+      commandSource: "resolved-managed" as const,
+    }));
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+    const options = {
+      config: {},
+      agentDir: "/tmp/openclaw-agent",
+      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      startOptions: {
+        transport: "stdio" as const,
+        homeScope: "agent" as const,
+        command: "codex",
+        commandSource: "managed" as const,
+        managedCommandOrder: "desktop-first" as const,
+        args: ["app-server"],
+        headers: {},
+      },
+    };
+
+    const clientXPromise = createIsolatedCodexAppServerClient(options);
+    await vi.waitFor(() => expect(first.writes).toHaveLength(1));
+    mocks.desktopGeneration = generationY;
+    const clientYPromise = createIsolatedCodexAppServerClient(options);
+    await vi.waitFor(() =>
+      expect(mocks.resolveManagedCodexAppServerStartOptions).toHaveBeenCalledTimes(2),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(mocks.reconcileCodexComputerUseStartArtifacts).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledTimes(1);
+
+    await sendInitializeResult(first, "openclaw/0.148.0 (macOS; test)");
+    await expect(clientXPromise).rejects.toMatchObject({
+      code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
+    });
+    await sendInitializeResult(second, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await clientYPromise;
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(first.process.stdin.destroyed).toBe(true);
+    clientY.close();
   });
 
   it("does not block generation Y artifacts on an older client for another home", async () => {
@@ -2539,6 +2764,32 @@ describe("shared Codex app-server client", () => {
       ),
     ).toEqual([generationX, generationY]);
     expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
+  });
+
+  it("generation-binds an explicit desktop client while Computer Use is disabled", async () => {
+    const generation = { epoch: 1, fingerprint: "desktop-x" };
+    mocks.desktopGeneration = generation;
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(harness.client);
+
+    const clientPromise = getLeasedSharedCodexAppServerClient({
+      config: {},
+      pluginConfig: { computerUse: { enabled: false } },
+      agentDir: "/tmp/openclaw-agent",
+      startOptions: {
+        transport: "stdio",
+        homeScope: "agent",
+        command: "/Applications/ChatGPT.app/Contents/Resources/codex",
+        commandSource: "config",
+        args: ["app-server"],
+        headers: {},
+      },
+    });
+    await sendInitializeResult(harness, "openclaw/0.148.0 (macOS; test)");
+    const client = await clientPromise;
+
+    expect(readCodexAppServerClientDesktopGeneration(client)).toEqual(generation);
+    expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
   });
 
   it("binds a package-first acquisition when its actual fallback is a desktop app", async () => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -18,7 +18,10 @@ const mocks = vi.hoisted(() => ({
   },
   bridgeCodexAppServerStartOptions: vi.fn(async ({ startOptions }) => startOptions),
   reconcileCodexComputerUseStartArtifacts: vi.fn(
-    async (_params?: { startOptions: { command: string } }) => undefined,
+    async (_params?: {
+      startOptions: { command: string };
+      desktopGeneration?: { epoch: number; fingerprint: string };
+    }) => undefined,
   ),
   applyCodexAppServerAuthProfile: vi.fn(
     async (_params?: {
@@ -2329,6 +2332,60 @@ describe("shared Codex app-server client", () => {
     expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
     expect(first.process.stdin.destroyed).toBe(true);
     expect(second.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
+  });
+
+  it("tracks a package-first client whose Computer Use artifacts come from the desktop", async () => {
+    const generationX = { epoch: 1, fingerprint: "desktop-x" };
+    const generationY = { epoch: 2, fingerprint: "desktop-y" };
+    mocks.desktopGeneration = generationX;
+    mocks.resolveManagedCodexAppServerStartOptions.mockImplementation(async (startOptions) => ({
+      ...startOptions,
+      command: "/cache/openclaw/codex",
+      commandSource: "resolved-managed" as const,
+      managedFallbackCommandPaths: ["/Applications/Codex.app/Contents/Resources/codex"],
+    }));
+    const packageX = createClientHarness();
+    const packageY = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(packageX.client)
+      .mockReturnValueOnce(packageY.client);
+    const options = {
+      config: {},
+      pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      agentDir: "/tmp/openclaw-agent",
+      startOptions: {
+        transport: "stdio" as const,
+        homeScope: "agent" as const,
+        command: "codex",
+        commandSource: "managed" as const,
+        managedCommandOrder: "package-first" as const,
+        args: ["app-server"],
+        headers: {},
+      },
+    };
+
+    const firstAcquire = getLeasedSharedCodexAppServerClient(options);
+    await sendInitializeResult(packageX, "openclaw/0.148.0 (macOS; test)");
+    const clientX = await firstAcquire;
+
+    mocks.desktopGeneration = generationY;
+    retireSharedCodexAppServerClientsBeforeDesktopGeneration(generationY);
+    const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
+    await sendInitializeResult(packageY, "openclaw/0.148.0 (macOS; test)");
+    const clientY = await replacementAcquire;
+
+    expect(clientY).not.toBe(clientX);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.reconcileCodexComputerUseStartArtifacts.mock.calls.map(
+        ([params]) => params?.desktopGeneration,
+      ),
+    ).toEqual([generationX, generationY]);
+    expect(packageX.process.stdin.destroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(clientX)).toBe(true);
+    expect(packageX.process.stdin.destroyed).toBe(true);
     expect(releaseLeasedSharedCodexAppServerClient(clientY)).toBe(true);
   });
 

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -238,12 +238,12 @@ export function assertCodexAppServerClientStartSelectionCurrent(params: {
   if (!metadata) {
     return;
   }
+  if (metadata.desktopGeneration && !isCodexDesktopGenerationCurrent(metadata.desktopGeneration)) {
+    throw new CodexAppServerStartSelectionChangedError();
+  }
   const requestedStartOptions = params.startOptions ?? metadata.requestedStartOptions;
   if (requestedStartOptions.commandSource !== "managed") {
     return;
-  }
-  if (metadata.desktopGeneration && !isCodexDesktopGenerationCurrent(metadata.desktopGeneration)) {
-    throw new CodexAppServerStartSelectionChangedError();
   }
   const current = resolveCodexAppServerStartOptionsForAgent({
     startOptions: requestedStartOptions,

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -165,6 +165,13 @@ export function readCodexAppServerClientProcessIdentity(
   };
 }
 
+/** Returns the lifecycle generation that owns a managed desktop client. */
+export function readCodexAppServerClientDesktopGenerationFingerprint(
+  client: CodexAppServerClient,
+): string | undefined {
+  return getCodexAppServerClientStartMetadata().get(client)?.desktopGeneration?.fingerprint;
+}
+
 /** Resolves non-secret spawn identity before startup; argv is represented only by its hash. */
 export function resolveCodexAppServerSpawnIdentity(
   startOptions: CodexAppServerStartOptions,

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -489,9 +489,12 @@ function shouldTrackDesktopGeneration(
   if (startOptions.transport !== "stdio") {
     return false;
   }
-  // Computer Use can publish desktop-owned artifacts even when an explicit
-  // package command owns the process, so both must share one generation fence.
-  if (resolveCodexComputerUseConfig({ pluginConfig }).enabled) {
+  // A managed package process can publish desktop-owned Computer Use artifacts,
+  // so both share one generation. Custom operator commands remain independent.
+  if (
+    resolveCodexComputerUseConfig({ pluginConfig }).enabled &&
+    (startOptions.commandSource === "managed" || startOptions.commandSource === "resolved-managed")
+  ) {
     return true;
   }
   return (

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -71,6 +71,7 @@ type SharedCodexAppServerClientStartup = {
 type SharedCodexAppServerClientState = {
   clients: Map<string, SharedCodexAppServerClientEntry>;
   liveClients: Set<CodexAppServerClient>;
+  isolatedClients: Set<CodexAppServerClient>;
   entriesByClient: WeakMap<CodexAppServerClient, SharedCodexAppServerClientEntry>;
   leasedReleases: WeakMap<CodexAppServerClient, Array<() => void>>;
   desktopGenerationDrainChecks: Set<() => void>;
@@ -133,6 +134,7 @@ function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
   globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] ??= {
     clients: new Map(),
     liveClients: new Set(),
+    isolatedClients: new Set(),
     entriesByClient: new WeakMap(),
     leasedReleases: new WeakMap(),
     desktopGenerationDrainChecks: new Set(),
@@ -183,6 +185,33 @@ export function readCodexAppServerClientDesktopGeneration(
   client: CodexAppServerClient,
 ): CodexDesktopGeneration | undefined {
   return getCodexAppServerClientStartMetadata().get(client)?.desktopGeneration;
+}
+
+/** Waits until older physical desktop clients for this client's Codex home exit. */
+export async function waitForCodexAppServerClientDesktopGenerationDrain(params: {
+  client: CodexAppServerClient;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}): Promise<void> {
+  const metadata = getCodexAppServerClientStartMetadata().get(params.client);
+  if (!metadata?.desktopGeneration) {
+    return;
+  }
+  const drain = createOlderDesktopGenerationDrainWait({
+    generation: metadata.desktopGeneration,
+    startOptions: metadata.startOptions,
+    agentDir: metadata.agentDir,
+  });
+  try {
+    await withCodexAppServerAcquireDeadline(
+      params.timeoutMs ?? 0,
+      drain.promise,
+      params.signal,
+      "Codex Computer Use install timed out waiting for older desktop clients",
+    );
+  } finally {
+    drain.cancel();
+  }
 }
 
 /** Resolves non-secret spawn identity before startup; argv is represented only by its hash. */
@@ -268,7 +297,7 @@ export function resolveCodexNativeConfigFenceKey(params: {
   const metadata = params.client
     ? getCodexAppServerClientStartMetadata().get(params.client)
     : undefined;
-  const startOptions = params.startOptions ?? metadata?.startOptions;
+  const startOptions = metadata?.startOptions ?? params.startOptions;
   if (!startOptions || startOptions.transport !== "stdio") {
     return undefined;
   }
@@ -944,14 +973,16 @@ function createSharedCodexAppServerClientStartup(params: {
       const state = getSharedCodexAppServerClientState();
       params.entry.client = startedClient;
       // Graceful retirement detaches active clients from the acquisition map,
-      // so global teardown tracks physical lifetime until the close notification.
+      // so generation fencing tracks physical lifetime until transport exit.
       state.liveClients.add(startedClient);
+      startedClient.addTransportExitHandler((exitedClient) => {
+        state.liveClients.delete(exitedClient);
+        notifyDesktopGenerationDrainChecks(state);
+      });
       startedClient.addCloseHandler((closedClient) => {
-        state.liveClients.delete(closedClient);
         if (state.entriesByClient.get(closedClient) === params.entry) {
           clearSharedClientEntryIfCurrent(params.key, closedClient);
         }
-        notifyDesktopGenerationDrainChecks(state);
       });
       for (const callback of params.entry.onStartedClientCallbacks) {
         callback(startedClient);
@@ -1021,7 +1052,19 @@ export async function createIsolatedCodexAppServerClient(
     config: options?.config,
     timeoutMs: resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
     abandonSignal: options?.abandonSignal,
-    onStartedClient: options?.onStartedClient,
+    onStartedClient: (client) => {
+      trackIsolatedCodexAppServerClient(client);
+      options?.onStartedClient?.(client);
+    },
+  });
+}
+
+function trackIsolatedCodexAppServerClient(client: CodexAppServerClient): void {
+  const state = getSharedCodexAppServerClientState();
+  state.isolatedClients.add(client);
+  client.addTransportExitHandler((exitedClient) => {
+    state.isolatedClients.delete(exitedClient);
+    notifyDesktopGenerationDrainChecks(state);
   });
 }
 
@@ -1304,11 +1347,17 @@ function shouldTryManagedFallbackStartOption(
 export function resetSharedCodexAppServerClientForTests(): void {
   const state = getSharedCodexAppServerClientState();
   const clients = collectSharedClients(state);
+  const isolatedClients = [...state.isolatedClients];
   state.clients.clear();
+  state.liveClients.clear();
+  state.isolatedClients.clear();
   state.entriesByClient = new WeakMap();
   state.leasedReleases = new WeakMap();
   state.warmClientsByConfig = new WeakMap();
   for (const client of clients) {
+    client.close();
+  }
+  for (const client of isolatedClients) {
     client.close();
   }
   notifyDesktopGenerationDrainChecks(state);
@@ -1472,7 +1521,7 @@ function createOlderDesktopGenerationDrainWait(params: {
   };
   const check = () => {
     if (
-      !hasClaimedOlderDesktopGenerationClient({
+      !hasLiveOlderDesktopGenerationClient({
         state,
         generation: params.generation,
         targetHome,
@@ -1486,26 +1535,35 @@ function createOlderDesktopGenerationDrainWait(params: {
   return { promise, cancel };
 }
 
-function hasClaimedOlderDesktopGenerationClient(params: {
+function hasLiveOlderDesktopGenerationClient(params: {
   state: SharedCodexAppServerClientState;
   generation: CodexDesktopGeneration;
   targetHome: string;
 }): boolean {
   for (const client of params.state.liveClients) {
-    const metadata = getCodexAppServerClientStartMetadata().get(client);
-    if (
-      !metadata?.desktopGeneration ||
-      metadata.desktopGeneration.epoch >= params.generation.epoch ||
-      resolveCodexNativeConfigFenceKey({ client }) !== params.targetHome
-    ) {
-      continue;
+    if (isOlderDesktopGenerationClientForHome(client, params.generation, params.targetHome)) {
+      return true;
     }
-    const entry = params.state.entriesByClient.get(client);
-    if (entry && (entry.activeLeases > 0 || entry.pendingAcquires > 0)) {
+  }
+  for (const client of params.state.isolatedClients) {
+    if (isOlderDesktopGenerationClientForHome(client, params.generation, params.targetHome)) {
       return true;
     }
   }
   return false;
+}
+
+function isOlderDesktopGenerationClientForHome(
+  client: CodexAppServerClient,
+  generation: CodexDesktopGeneration,
+  targetHome: string,
+): boolean {
+  const metadata = getCodexAppServerClientStartMetadata().get(client);
+  return Boolean(
+    metadata?.desktopGeneration &&
+    metadata.desktopGeneration.epoch < generation.epoch &&
+    resolveCodexNativeConfigFenceKey({ client }) === targetHome,
+  );
 }
 
 function notifyDesktopGenerationDrainChecks(state: SharedCodexAppServerClientState): void {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -4,7 +4,10 @@
  */
 import { createHash } from "node:crypto";
 import path from "node:path";
-import type { AgentHarnessRuntimeArtifactBinding } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  AgentHarnessPreflightError,
+  type AgentHarnessRuntimeArtifactBinding,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveDefaultAgentDir, type AuthProfileStore } from "openclaw/plugin-sdk/agent-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { CodexAppServerStartupError } from "./attempt-timeouts.js";
@@ -55,7 +58,7 @@ type SharedCodexAppServerClientEntry = {
   pendingAcquires: number;
   closeWhenIdle: boolean;
   closeError?: Error;
-  runtimeArtifactStartupAbort?: AbortController;
+  startupAbort?: AbortController;
   onStartedClientCallbacks: Set<(client: CodexAppServerClient) => void>;
 };
 
@@ -165,11 +168,18 @@ export function readCodexAppServerClientProcessIdentity(
   };
 }
 
-/** Returns the lifecycle generation that owns a managed desktop client. */
+/** Returns the lifecycle fingerprint that owns a managed desktop client. */
 export function readCodexAppServerClientDesktopGenerationFingerprint(
   client: CodexAppServerClient,
 ): string | undefined {
-  return getCodexAppServerClientStartMetadata().get(client)?.desktopGeneration?.fingerprint;
+  return readCodexAppServerClientDesktopGeneration(client)?.fingerprint;
+}
+
+/** Returns the lifecycle generation that owns a managed desktop client. */
+export function readCodexAppServerClientDesktopGeneration(
+  client: CodexAppServerClient,
+): CodexDesktopGeneration | undefined {
+  return getCodexAppServerClientStartMetadata().get(client)?.desktopGeneration;
 }
 
 /** Resolves non-secret spawn identity before startup; argv is represented only by its hash. */
@@ -732,9 +742,7 @@ async function acquireSharedCodexAppServerClient(
     retireSharedCodexAppServerClientIfCurrent(existingClient);
     entry = getOrCreateSharedClientEntry(state, key);
   }
-  if (runtimeArtifactMode) {
-    entry.runtimeArtifactStartupAbort ??= new AbortController();
-  }
+  entry.startupAbort ??= new AbortController();
   entry.closeWhenIdle = false;
   const releasePendingAcquire = retainPendingSharedClientAcquire(entry);
   const startedCallback = options?.onStartedClient;
@@ -782,7 +790,8 @@ async function acquireSharedCodexAppServerClient(
       ...(options?.expectedRuntimeArtifact
         ? { expectedRuntimeArtifact: options.expectedRuntimeArtifact }
         : {}),
-      runtimeArtifactSignal: entry.runtimeArtifactStartupAbort?.signal,
+      runtimeArtifactSignal: entry.startupAbort.signal,
+      abandonSignal: entry.startupAbort.signal,
       config: options?.config,
     }));
   try {
@@ -892,6 +901,7 @@ function createSharedCodexAppServerClientStartup(params: {
   runtimeArtifactMode?: "capture";
   expectedRuntimeArtifact?: AgentHarnessRuntimeArtifactBinding;
   runtimeArtifactSignal?: AbortSignal;
+  abandonSignal?: AbortSignal;
   preparedAuth?: CodexAppServerResolvedPreparedAuth;
   authRequirement?: CodexAppServerAuthRequirement;
   config?: CodexAppServerClientOptions["config"];
@@ -912,6 +922,7 @@ function createSharedCodexAppServerClientStartup(params: {
       ? { expectedRuntimeArtifact: params.expectedRuntimeArtifact }
       : {}),
     runtimeArtifactSignal: params.runtimeArtifactSignal,
+    abandonSignal: params.abandonSignal,
     config: params.config,
     onStartedClient: (startedClient) => {
       const state = getSharedCodexAppServerClientState();
@@ -944,6 +955,7 @@ function createSharedCodexAppServerClientStartup(params: {
     },
   );
   // Callers observe pre-initialize failures through the phase promise first.
+  void initialized.promise.catch(() => undefined);
   void ready.catch(() => undefined);
   return { initialized: initialized.promise, ready };
 }
@@ -1028,15 +1040,36 @@ async function startInitializedCodexAppServerClient(params: {
             params.abandonSignal,
           )
         : undefined);
-    if (index > 0) {
+    const assertDesktopGenerationCurrent = () => {
+      if (params.abandonSignal?.aborted) {
+        throw new CodexAppServerStartupError("aborted", "codex app-server initialize aborted");
+      }
+      if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
+        throw new CodexAppServerStartSelectionChangedError();
+      }
+    };
+    try {
       await reconcileCodexComputerUseStartArtifacts({
         startOptions,
         agentDir: params.agentDir,
         pluginConfig: params.pluginConfig,
+        ...(desktopGeneration ? { desktopGeneration } : {}),
+        assertCurrent: assertDesktopGenerationCurrent,
         ownsIsolatedCodexHome:
           params.requestedStartOptions.homeScope !== "user" &&
           !params.requestedStartOptions.env?.CODEX_HOME?.trim(),
       });
+    } catch (error) {
+      if (isCodexComputerUseCandidateArtifactsUnavailableError(error)) {
+        if (index + 1 < startOptionsCandidates.length) {
+          continue;
+        }
+        throw new AgentHarnessPreflightError(
+          "Codex Computer Use artifacts are unavailable from the installed desktop apps.",
+          { cause: error, scope: "harness" },
+        );
+      }
+      throw error;
     }
     const runtimeArtifactModule = params.runtimeArtifactMode
       ? await import("./runtime-artifact.js")
@@ -1066,9 +1099,7 @@ async function startInitializedCodexAppServerClient(params: {
       }
       throw new Error("Codex app-server runtime artifact does not match verified inference");
     }
-    if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
-      throw new CodexAppServerStartSelectionChangedError();
-    }
+    assertDesktopGenerationCurrent();
     const client = CodexAppServerClient.start(startOptions);
     const nativeCommandAtStart =
       startOptions.commandSource === "resolved-managed"
@@ -1100,9 +1131,11 @@ async function startInitializedCodexAppServerClient(params: {
       throw error;
     }
 
-    if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
+    try {
+      assertDesktopGenerationCurrent();
+    } catch (error) {
       client.close();
-      throw new CodexAppServerStartSelectionChangedError();
+      throw error;
     }
     params.onInitializedClient?.();
 
@@ -1141,9 +1174,7 @@ async function startInitializedCodexAppServerClient(params: {
     });
 
     try {
-      if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
-        throw new CodexAppServerStartSelectionChangedError();
-      }
+      assertDesktopGenerationCurrent();
       await withCodexAppServerAcquireDeadline(
         resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
         applyCodexAppServerAuthProfile({
@@ -1161,9 +1192,7 @@ async function startInitializedCodexAppServerClient(params: {
       if (runtimeArtifactModule && runtimeArtifact) {
         runtimeArtifactModule.bindCodexAppServerRuntimeArtifact(client, runtimeArtifact);
       }
-      if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
-        throw new CodexAppServerStartSelectionChangedError();
-      }
+      assertDesktopGenerationCurrent();
       const fenceKey = resolveCodexNativeConfigFenceKey({ client });
       if (fenceKey) {
         client.setThreadSessionRequestGuard(async (options) => {
@@ -1184,6 +1213,15 @@ async function startInitializedCodexAppServerClient(params: {
     }
   }
   throw new Error("Managed Codex app-server fallback candidates were exhausted.");
+}
+
+function isCodexComputerUseCandidateArtifactsUnavailableError(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    error.code === "CODEX_COMPUTER_USE_CANDIDATE_ARTIFACTS_UNAVAILABLE"
+  );
 }
 
 function resolveManagedFallbackStartOptions(
@@ -1523,9 +1561,7 @@ function retirePendingSharedClientEntryIfUnclaimed(
   if (entry.activeLeases > 0 || entry.pendingAcquires > 0) {
     return;
   }
-  entry.runtimeArtifactStartupAbort?.abort(
-    new Error("Codex runtime artifact startup was abandoned"),
-  );
+  entry.startupAbort?.abort(new Error("Codex app-server startup was abandoned"));
   entry.closeWhenIdle = true;
   const state = getSharedCodexAppServerClientState();
   if (state.clients.get(key) === entry) {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -73,6 +73,7 @@ type SharedCodexAppServerClientState = {
   liveClients: Set<CodexAppServerClient>;
   entriesByClient: WeakMap<CodexAppServerClient, SharedCodexAppServerClientEntry>;
   leasedReleases: WeakMap<CodexAppServerClient, Array<() => void>>;
+  desktopGenerationDrainChecks: Set<() => void>;
   warmClientsByConfig?: WeakMap<
     object,
     WeakMap<CodexAppServerStartOptions, Map<string, WarmSharedCodexAppServerClient>>
@@ -134,6 +135,7 @@ function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
     liveClients: new Set(),
     entriesByClient: new WeakMap(),
     leasedReleases: new WeakMap(),
+    desktopGenerationDrainChecks: new Set(),
   };
   return globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE];
 }
@@ -455,14 +457,17 @@ function shouldTrackDesktopGeneration(
   startOptions: CodexAppServerStartOptions,
   pluginConfig: unknown,
 ): boolean {
-  if (startOptions.transport !== "stdio" || startOptions.commandSource !== "managed") {
+  if (startOptions.transport !== "stdio") {
     return false;
   }
-  // An explicitly package-first process can still publish and load Computer Use
-  // artifacts from a desktop app, so it belongs to that desktop generation too.
+  // Computer Use can publish desktop-owned artifacts even when an explicit
+  // package command owns the process, so both must share one generation fence.
+  if (resolveCodexComputerUseConfig({ pluginConfig }).enabled) {
+    return true;
+  }
   return (
-    (startOptions.managedCommandOrder ?? "package-first") === "desktop-first" ||
-    resolveCodexComputerUseConfig({ pluginConfig }).enabled
+    startOptions.commandSource === "managed" &&
+    (startOptions.managedCommandOrder ?? "package-first") === "desktop-first"
   );
 }
 
@@ -946,6 +951,7 @@ function createSharedCodexAppServerClientStartup(params: {
         if (state.entriesByClient.get(closedClient) === params.entry) {
           clearSharedClientEntryIfCurrent(params.key, closedClient);
         }
+        notifyDesktopGenerationDrainChecks(state);
       });
       for (const callback of params.entry.onStartedClientCallbacks) {
         callback(startedClient);
@@ -1059,16 +1065,39 @@ async function startInitializedCodexAppServerClient(params: {
         throw new CodexAppServerStartSelectionChangedError();
       }
     };
+    const computerUseConfig = resolveCodexComputerUseConfig({ pluginConfig: params.pluginConfig });
+    const ownsIsolatedCodexHome =
+      params.requestedStartOptions.homeScope !== "user" &&
+      !params.requestedStartOptions.env?.CODEX_HOME?.trim();
+    const needsComputerUseArtifactDrain =
+      desktopGeneration &&
+      ownsIsolatedCodexHome &&
+      computerUseConfig.enabled &&
+      (computerUseConfig.autoInstall || computerUseConfig.pluginCacheMode === "shared");
+    const artifactDrain = needsComputerUseArtifactDrain
+      ? createOlderDesktopGenerationDrainWait({
+          generation: desktopGeneration,
+          startOptions,
+          agentDir: params.agentDir,
+        })
+      : undefined;
     try {
+      if (artifactDrain) {
+        // These artifacts have stable paths per CODEX_HOME. Publish Y only after
+        // every X claimant has stopped reading X, or an active turn can mix both.
+        await withCodexAppServerAcquireDeadline(
+          resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
+          artifactDrain.promise,
+          params.abandonSignal,
+        );
+      }
       await reconcileCodexComputerUseStartArtifacts({
         startOptions,
         agentDir: params.agentDir,
         pluginConfig: params.pluginConfig,
         ...(desktopGeneration ? { desktopGeneration } : {}),
         assertCurrent: assertDesktopGenerationCurrent,
-        ownsIsolatedCodexHome:
-          params.requestedStartOptions.homeScope !== "user" &&
-          !params.requestedStartOptions.env?.CODEX_HOME?.trim(),
+        ownsIsolatedCodexHome,
       });
     } catch (error) {
       if (isCodexComputerUseCandidateArtifactsUnavailableError(error)) {
@@ -1081,6 +1110,8 @@ async function startInitializedCodexAppServerClient(params: {
         );
       }
       throw error;
+    } finally {
+      artifactDrain?.cancel();
     }
     const runtimeArtifactModule = params.runtimeArtifactMode
       ? await import("./runtime-artifact.js")
@@ -1280,6 +1311,7 @@ export function resetSharedCodexAppServerClientForTests(): void {
   for (const client of clients) {
     client.close();
   }
+  notifyDesktopGenerationDrainChecks(state);
 }
 
 /** Clears and closes all shared clients. */
@@ -1291,6 +1323,7 @@ export function clearSharedCodexAppServerClient(): void {
   for (const client of clients) {
     client.close();
   }
+  notifyDesktopGenerationDrainChecks(state);
 }
 
 /** Clears and closes the shared entry only if it still owns the supplied client. */
@@ -1411,6 +1444,76 @@ export function retireSharedCodexAppServerClientsBeforeDesktopGeneration(
   }
 }
 
+function createOlderDesktopGenerationDrainWait(params: {
+  generation: CodexDesktopGeneration;
+  startOptions: CodexAppServerStartOptions;
+  agentDir: string;
+}): { promise: Promise<void>; cancel: () => void } {
+  const targetHome = resolveCodexNativeConfigFenceKey({
+    startOptions: params.startOptions,
+    agentDir: params.agentDir,
+  });
+  if (!targetHome) {
+    return { promise: Promise.resolve(), cancel: () => undefined };
+  }
+  const state = getSharedCodexAppServerClientState();
+  let settled = false;
+  let resolveWait!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    resolveWait = resolve;
+  });
+  const cancel = () => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    state.desktopGenerationDrainChecks.delete(check);
+    resolveWait();
+  };
+  const check = () => {
+    if (
+      !hasClaimedOlderDesktopGenerationClient({
+        state,
+        generation: params.generation,
+        targetHome,
+      })
+    ) {
+      cancel();
+    }
+  };
+  state.desktopGenerationDrainChecks.add(check);
+  check();
+  return { promise, cancel };
+}
+
+function hasClaimedOlderDesktopGenerationClient(params: {
+  state: SharedCodexAppServerClientState;
+  generation: CodexDesktopGeneration;
+  targetHome: string;
+}): boolean {
+  for (const client of params.state.liveClients) {
+    const metadata = getCodexAppServerClientStartMetadata().get(client);
+    if (
+      !metadata?.desktopGeneration ||
+      metadata.desktopGeneration.epoch >= params.generation.epoch ||
+      resolveCodexNativeConfigFenceKey({ client }) !== params.targetHome
+    ) {
+      continue;
+    }
+    const entry = params.state.entriesByClient.get(client);
+    if (entry && (entry.activeLeases > 0 || entry.pendingAcquires > 0)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function notifyDesktopGenerationDrainChecks(state: SharedCodexAppServerClientState): void {
+  for (const check of state.desktopGenerationDrainChecks) {
+    check();
+  }
+}
+
 /** Clears a matching shared client and waits for its process to exit. */
 export async function clearSharedCodexAppServerClientIfCurrentAndWait(
   client: CodexAppServerClient | undefined,
@@ -1507,6 +1610,7 @@ function retainPendingSharedClientAcquire(entry: SharedCodexAppServerClientEntry
     released = true;
     entry.pendingAcquires = Math.max(0, entry.pendingAcquires - 1);
     closeRetiredSharedClientEntryIfIdle(entry);
+    notifyDesktopGenerationDrainChecks(getSharedCodexAppServerClientState());
   };
 }
 
@@ -1520,6 +1624,7 @@ function retainSharedClientEntry(entry: SharedCodexAppServerClientEntry): () => 
     released = true;
     entry.activeLeases = Math.max(0, entry.activeLeases - 1);
     closeRetiredSharedClientEntryIfIdle(entry);
+    notifyDesktopGenerationDrainChecks(getSharedCodexAppServerClientState());
   };
 }
 

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -29,6 +29,7 @@ import { ensureCodexAppServerClientRuntime } from "./client-runtime.js";
 import { CodexAppServerClient, isUnsupportedCodexAppServerVersionError } from "./client.js";
 import {
   codexAppServerStartOptionsKey,
+  resolveCodexComputerUseConfig,
   resolveCodexAppServerRuntimeOptions,
   resolveCodexAppServerStartOptionsForAgent,
   resolveCodexAppServerUserHomeDir,
@@ -335,7 +336,10 @@ async function resolveCodexAppServerClientStartContext(
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
   const requestedStartOptions =
     options?.startOptions ?? resolveCodexAppServerRuntimeOptions().start;
-  const desktopGeneration = shouldTrackDesktopGeneration(requestedStartOptions)
+  const desktopGeneration = shouldTrackDesktopGeneration(
+    requestedStartOptions,
+    options?.pluginConfig,
+  )
     ? await waitForCodexDesktopGeneration()
     : undefined;
   const preparedAuth = options?.preparedAuth;
@@ -447,11 +451,18 @@ async function resolveCodexAppServerClientStartContext(
   };
 }
 
-function shouldTrackDesktopGeneration(startOptions: CodexAppServerStartOptions): boolean {
+function shouldTrackDesktopGeneration(
+  startOptions: CodexAppServerStartOptions,
+  pluginConfig: unknown,
+): boolean {
+  if (startOptions.transport !== "stdio" || startOptions.commandSource !== "managed") {
+    return false;
+  }
+  // An explicitly package-first process can still publish and load Computer Use
+  // artifacts from a desktop app, so it belongs to that desktop generation too.
   return (
-    startOptions.transport === "stdio" &&
-    startOptions.commandSource === "managed" &&
-    (startOptions.managedCommandOrder ?? "package-first") === "desktop-first"
+    (startOptions.managedCommandOrder ?? "package-first") === "desktop-first" ||
+    resolveCodexComputerUseConfig({ pluginConfig }).enabled
   );
 }
 

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -17,6 +17,7 @@ import {
   resolveCodexAppServerHomeDir,
   resolveCodexAppServerPreparedAuthProfileSnapshot,
   resolveCodexAppServerPreparedApiKeyCacheKey,
+  reconcileCodexComputerUseStartArtifacts,
   type CodexAppServerPreparedAuth,
   type CodexAppServerAuthRequirement,
   type CodexAppServerResolvedPreparedAuth,
@@ -30,7 +31,13 @@ import {
   resolveCodexAppServerUserHomeDir,
   type CodexAppServerStartOptions,
 } from "./config.js";
+import type { CodexDesktopGeneration } from "./desktop-generation-owner.js";
 import {
+  isCodexDesktopGenerationCurrent,
+  waitForCodexDesktopGeneration,
+} from "./desktop-generation.js";
+import {
+  isManagedCodexDesktopCommand,
   resolveManagedCodexAppServerStartOptions,
   resolveManagedCodexNativeCommand,
 } from "./managed-binary.js";
@@ -85,6 +92,7 @@ type CodexAppServerClientStartMetadata = {
   startOptions: CodexAppServerStartOptions;
   agentDir: string;
   nativeCommand?: string;
+  desktopGeneration?: CodexDesktopGeneration;
 };
 
 /** Successful physical process identity, excluding environment and credentials. */
@@ -216,6 +224,9 @@ export function assertCodexAppServerClientStartSelectionCurrent(params: {
   if (requestedStartOptions.commandSource !== "managed") {
     return;
   }
+  if (metadata.desktopGeneration && !isCodexDesktopGenerationCurrent(metadata.desktopGeneration)) {
+    throw new CodexAppServerStartSelectionChangedError();
+  }
   const current = resolveCodexAppServerStartOptionsForAgent({
     startOptions: requestedStartOptions,
     agentDir: params.agentDir ?? metadata.agentDir,
@@ -288,6 +299,8 @@ type ResolvedCodexAppServerClientStartContext = {
   authRequirement: CodexAppServerAuthRequirement | undefined;
   requestedStartOptions: CodexAppServerStartOptions;
   startOptions: CodexAppServerStartOptions;
+  desktopGeneration?: CodexDesktopGeneration;
+  pluginConfig?: unknown;
 };
 
 function inferAuthRequirement(
@@ -305,6 +318,9 @@ async function resolveCodexAppServerClientStartContext(
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
   const requestedStartOptions =
     options?.startOptions ?? resolveCodexAppServerRuntimeOptions().start;
+  const desktopGeneration = shouldTrackDesktopGeneration(requestedStartOptions)
+    ? await waitForCodexDesktopGeneration()
+    : undefined;
   const preparedAuth = options?.preparedAuth;
   const preparedApiKey = preparedAuth?.kind === "api-key" ? preparedAuth.apiKey.trim() : undefined;
   if (preparedAuth && options?.authProfileId !== undefined) {
@@ -409,7 +425,17 @@ async function resolveCodexAppServerClientStartContext(
     preparedAuth: resolvedPreparedAuth,
     authRequirement,
     startOptions,
+    ...(options?.pluginConfig !== undefined ? { pluginConfig: options.pluginConfig } : {}),
+    ...(desktopGeneration ? { desktopGeneration } : {}),
   };
+}
+
+function shouldTrackDesktopGeneration(startOptions: CodexAppServerStartOptions): boolean {
+  return (
+    startOptions.transport === "stdio" &&
+    startOptions.commandSource === "managed" &&
+    (startOptions.managedCommandOrder ?? "package-first") === "desktop-first"
+  );
 }
 
 function resolveWarmSharedCodexAppServerClientIdentity(
@@ -613,18 +639,32 @@ async function acquireSharedCodexAppServerClient(
   if (options?.abandonSignal?.aborted) {
     throw new CodexAppServerStartupError("aborted", "codex app-server initialize aborted");
   }
+  const acquireStartedAt = Date.now();
+  const timeoutMs = options?.timeoutMs ?? 0;
   const state = getSharedCodexAppServerClientState();
   const warmIdentity = resolveWarmSharedCodexAppServerClientIdentity(options);
-  const warmClient = warmIdentity
+  let warmClient = warmIdentity
     ? readWarmSharedCodexAppServerClient(state, warmIdentity)
     : undefined;
+  const warmGeneration = warmClient
+    ? getCodexAppServerClientStartMetadata().get(warmClient.client)?.desktopGeneration
+    : undefined;
+  if (warmClient && warmGeneration && !isCodexDesktopGenerationCurrent(warmGeneration)) {
+    await withCodexAppServerAcquireDeadline(
+      resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
+      waitForCodexDesktopGeneration(),
+      options?.abandonSignal,
+    );
+    if (!isCodexDesktopGenerationCurrent(warmGeneration)) {
+      retireSharedCodexAppServerClientIfCurrent(warmClient.client);
+      warmClient = undefined;
+    }
+  }
   if (warmClient) {
     options?.onStartedClient?.(warmClient.client);
     const release = leaseOptions?.leased ? retainSharedClientEntry(warmClient.entry) : undefined;
     return release ? { client: warmClient.client, release } : { client: warmClient.client };
   }
-  const acquireStartedAt = Date.now();
-  const timeoutMs = options?.timeoutMs ?? 0;
   const context = await withCodexAppServerAcquireDeadline(
     timeoutMs,
     resolveCodexAppServerClientStartContext(options),
@@ -639,6 +679,8 @@ async function acquireSharedCodexAppServerClient(
     authRequirement,
     requestedStartOptions,
     startOptions,
+    desktopGeneration,
+    pluginConfig,
   } = context;
   const remainingTimeoutMs = resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt);
   const authIdentityCacheKey =
@@ -653,7 +695,9 @@ async function acquireSharedCodexAppServerClient(
     authBindingFingerprint: options?.authBindingFingerprint,
     agentDir: usesNativeAuth ? undefined : agentDir,
     fallbackApiKeyCacheKey: authIdentityCacheKey,
-  })}\0auth-requirement:${authRequirement ?? "native"}`;
+  })}\0auth-requirement:${authRequirement ?? "native"}${
+    desktopGeneration ? `\0desktop-generation:${desktopGeneration.epoch}` : ""
+  }`;
   // Capture turns cannot inherit a normal client whose loaded bytes predate the
   // filesystem snapshot. Keep their physical process generation separate.
   const runtimeArtifactMode =
@@ -668,7 +712,19 @@ async function acquireSharedCodexAppServerClient(
   const key = runtimeArtifactMode
     ? `${baseKey}\0runtime-artifact:capture-v1:${expectedRuntimeArtifactKey}`
     : baseKey;
-  const entry = getOrCreateSharedClientEntry(state, key);
+  let entry = getOrCreateSharedClientEntry(state, key);
+  const existingClient = entry.client;
+  const existingGeneration = existingClient
+    ? getCodexAppServerClientStartMetadata().get(existingClient)?.desktopGeneration
+    : undefined;
+  if (
+    existingClient &&
+    existingGeneration &&
+    !isCodexDesktopGenerationCurrent(existingGeneration)
+  ) {
+    retireSharedCodexAppServerClientIfCurrent(existingClient);
+    entry = getOrCreateSharedClientEntry(state, key);
+  }
   if (runtimeArtifactMode) {
     entry.runtimeArtifactStartupAbort ??= new AbortController();
   }
@@ -708,6 +764,8 @@ async function acquireSharedCodexAppServerClient(
       key,
       requestedStartOptions,
       startOptions,
+      desktopGeneration,
+      ...(pluginConfig !== undefined ? { pluginConfig } : {}),
       agentDir,
       authProfileId: usesNativeAuth || preparedAuth?.kind === "api-key" ? null : authProfileId,
       authProfileStore,
@@ -819,6 +877,8 @@ function createSharedCodexAppServerClientStartup(params: {
   key: string;
   requestedStartOptions: CodexAppServerStartOptions;
   startOptions: CodexAppServerStartOptions;
+  desktopGeneration?: CodexDesktopGeneration;
+  pluginConfig?: unknown;
   agentDir: string;
   authProfileId: string | null | undefined;
   authProfileStore?: AuthProfileStore;
@@ -833,6 +893,8 @@ function createSharedCodexAppServerClientStartup(params: {
   const ready = startInitializedCodexAppServerClient({
     requestedStartOptions: params.requestedStartOptions,
     startOptions: params.startOptions,
+    ...(params.desktopGeneration ? { desktopGeneration: params.desktopGeneration } : {}),
+    ...(params.pluginConfig !== undefined ? { pluginConfig: params.pluginConfig } : {}),
     agentDir: params.agentDir,
     authProfileId: params.authProfileId,
     authProfileStore: params.authProfileStore,
@@ -897,6 +959,8 @@ export async function createIsolatedCodexAppServerClient(
     authRequirement,
     requestedStartOptions,
     startOptions,
+    desktopGeneration,
+    pluginConfig,
   } = await withCodexAppServerAcquireDeadline(
     timeoutMs,
     resolveCodexAppServerClientStartContext(options),
@@ -905,6 +969,8 @@ export async function createIsolatedCodexAppServerClient(
   return await startInitializedCodexAppServerClient({
     requestedStartOptions,
     startOptions,
+    ...(desktopGeneration ? { desktopGeneration } : {}),
+    ...(pluginConfig !== undefined ? { pluginConfig } : {}),
     agentDir,
     authProfileId: usesNativeAuth || preparedAuth?.kind === "api-key" ? null : authProfileId,
     authProfileStore,
@@ -926,6 +992,8 @@ export async function createIsolatedCodexAppServerClient(
 async function startInitializedCodexAppServerClient(params: {
   requestedStartOptions: CodexAppServerStartOptions;
   startOptions: CodexAppServerStartOptions;
+  desktopGeneration?: CodexDesktopGeneration;
+  pluginConfig?: unknown;
   agentDir: string;
   authProfileId: string | null | undefined;
   authProfileStore?: AuthProfileStore;
@@ -944,6 +1012,25 @@ async function startInitializedCodexAppServerClient(params: {
   const timeoutMs = params.timeoutMs ?? 0;
   const startOptionsCandidates = resolveManagedFallbackStartOptions(params.startOptions);
   for (const [index, startOptions] of startOptionsCandidates.entries()) {
+    const desktopGeneration =
+      params.desktopGeneration ??
+      (isManagedCodexDesktopCommand(startOptions.command)
+        ? await withCodexAppServerAcquireDeadline(
+            resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
+            waitForCodexDesktopGeneration(),
+            params.abandonSignal,
+          )
+        : undefined);
+    if (index > 0) {
+      await reconcileCodexComputerUseStartArtifacts({
+        startOptions,
+        agentDir: params.agentDir,
+        pluginConfig: params.pluginConfig,
+        ownsIsolatedCodexHome:
+          params.requestedStartOptions.homeScope !== "user" &&
+          !params.requestedStartOptions.env?.CODEX_HOME?.trim(),
+      });
+    }
     const runtimeArtifactModule = params.runtimeArtifactMode
       ? await import("./runtime-artifact.js")
       : undefined;
@@ -972,7 +1059,21 @@ async function startInitializedCodexAppServerClient(params: {
       }
       throw new Error("Codex app-server runtime artifact does not match verified inference");
     }
+    if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
+      throw new CodexAppServerStartSelectionChangedError();
+    }
     const client = CodexAppServerClient.start(startOptions);
+    const nativeCommandAtStart =
+      startOptions.commandSource === "resolved-managed"
+        ? resolveManagedCodexNativeCommand(startOptions.command)
+        : undefined;
+    getCodexAppServerClientStartMetadata().set(client, {
+      requestedStartOptions: params.requestedStartOptions,
+      startOptions,
+      agentDir: params.agentDir,
+      ...(nativeCommandAtStart ? { nativeCommand: nativeCommandAtStart } : {}),
+      ...(desktopGeneration ? { desktopGeneration } : {}),
+    });
     params.onStartedClient?.(client);
     let initialize: Promise<void> | undefined;
     try {
@@ -992,6 +1093,10 @@ async function startInitializedCodexAppServerClient(params: {
       throw error;
     }
 
+    if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
+      client.close();
+      throw new CodexAppServerStartSelectionChangedError();
+    }
     params.onInitializedClient?.();
 
     let runtimeArtifact: AgentHarnessRuntimeArtifactBinding | undefined;
@@ -1029,6 +1134,9 @@ async function startInitializedCodexAppServerClient(params: {
     });
 
     try {
+      if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
+        throw new CodexAppServerStartSelectionChangedError();
+      }
       await withCodexAppServerAcquireDeadline(
         resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
         applyCodexAppServerAuthProfile({
@@ -1043,19 +1151,12 @@ async function startInitializedCodexAppServerClient(params: {
         }),
         params.abandonSignal,
       );
-      const nativeCommand =
-        startOptions.commandSource === "resolved-managed"
-          ? resolveManagedCodexNativeCommand(startOptions.command)
-          : undefined;
       if (runtimeArtifactModule && runtimeArtifact) {
         runtimeArtifactModule.bindCodexAppServerRuntimeArtifact(client, runtimeArtifact);
       }
-      getCodexAppServerClientStartMetadata().set(client, {
-        requestedStartOptions: params.requestedStartOptions,
-        startOptions,
-        agentDir: params.agentDir,
-        ...(nativeCommand ? { nativeCommand } : {}),
-      });
+      if (desktopGeneration && !isCodexDesktopGenerationCurrent(desktopGeneration)) {
+        throw new CodexAppServerStartSelectionChangedError();
+      }
       const fenceKey = resolveCodexNativeConfigFenceKey({ client });
       if (fenceKey) {
         client.setThreadSessionRequestGuard(async (options) => {
@@ -1234,6 +1335,24 @@ export function retireSharedCodexAppServerClientIfCurrent(
     return { activeLeases: detachedEntry.activeLeases, closed: false };
   }
   return undefined;
+}
+
+/** Gracefully retires exact clients attached to an older desktop generation. */
+export function retireSharedCodexAppServerClientsBeforeDesktopGeneration(
+  generation: CodexDesktopGeneration,
+): void {
+  const state = getSharedCodexAppServerClientState();
+  for (const entry of state.clients.values()) {
+    const client = entry.client;
+    const attached = client ? getCodexAppServerClientStartMetadata().get(client) : undefined;
+    if (
+      client &&
+      attached?.desktopGeneration &&
+      attached.desktopGeneration.epoch < generation.epoch
+    ) {
+      retireSharedCodexAppServerClientIfCurrent(client);
+    }
+  }
 }
 
 /** Clears a matching shared client and waits for its process to exit. */

--- a/extensions/codex/src/app-server/test-support.ts
+++ b/extensions/codex/src/app-server/test-support.ts
@@ -90,12 +90,18 @@ export function createCodexTestModel(provider = "openai", input = ["text"]): Mod
 }
 
 /** Creates an in-memory Codex app-server client harness with writable stdout frames. */
-export function createClientHarness() {
+export function createClientHarness(options: { autoEmitExit?: boolean } = {}) {
   const stdout = new PassThrough();
   const writes: string[] = [];
   let stdinDestroyed = false;
   let exitEmitted = false;
   let emitProcessExit: () => void = () => undefined;
+  const emitExit = () => {
+    if (!exitEmitted) {
+      exitEmitted = true;
+      emitProcessExit();
+    }
+  };
   type HarnessProcess = EventEmitter & {
     stdin: Writable;
     stdout: PassThrough;
@@ -113,11 +119,10 @@ export function createClientHarness() {
   stdin.destroy = ((error?: Error) => {
     stdinDestroyed = true;
     const result = destroyStdin(error);
-    if (!exitEmitted) {
-      exitEmitted = true;
+    if (!exitEmitted && options.autoEmitExit !== false) {
       // Let stdin surface pipe errors before the harness emits the fake child exit.
       // Otherwise close-reason tests can race EPIPE against a synthetic clean exit.
-      setImmediate(emitProcessExit);
+      setImmediate(emitExit);
     }
     return result;
   }) as typeof stdin.destroy;
@@ -141,6 +146,7 @@ export function createClientHarness() {
     get stdinDestroyed() {
       return stdinDestroyed;
     },
+    emitExit,
     send(message: unknown) {
       stdout.write(`${JSON.stringify(message)}\n`);
     },


### PR DESCRIPTION
Related: #127024

## What Problem This Solves

Codex-native Computer Use could retain an app-server loaded from the previous ChatGPT or Codex desktop build after the desktop updated in place. The first request after the update could then fail with a closed transport until the Gateway restarted.

## Architecture and Product Decision

The Codex plugin now owns one event-driven desktop generation for the standard macOS ChatGPT and Codex candidates. A settled generation change gracefully detaches only older physical app-server clients. Active X turns finish on X; new acquisitions for the same isolated home wait for X to physically exit, reconcile the fixed-path artifacts, and start on Y. Unrelated homes remain independent.

The owner also materializes Codex's reserved `openai-bundled` marketplace as a contained real wrapper inside an eligible isolated `CODEX_HOME`, then lets Codex app-server own `marketplace/add`. Codex canonicalizes local sources and accepts the reserved name only at `$CODEX_HOME/.tmp/bundled-marketplaces/openai-bundled`, so a direct symlink to `/Applications/...` cannot satisfy the dependency contract.

This lifecycle-owned automatic convergence is the accepted default for standard managed ChatGPT/Codex desktop candidates on the existing macOS native-Computer-Use surface. It does not widen platform support, custom executable support, or mutation authority. There is no request-hot-path freshness polling, new config, or new dependency. `autoInstall: false`, user homes, and explicit `CODEX_HOME` remain opt-outs. `autoRepair` remains limited to failed-readiness stale-MCP repair.

If the bundle changes again during startup, the stale client is fenced before login or `thread/start`; the existing bounded startup retry owns recovery. This is not a blanket retry promise for unrelated transport failures, unsupported update mechanisms, or custom executable paths. Gateway restart remains the visible recovery for those cases.

## Root Cause and Canonical Fix

Current `main` memoizes native service selection by path strings and warm app-server identity does not encode same-path desktop replacement. Failure-driven retry cannot reliably distinguish a desktop-generation transition from the unrelated random Computer Use transport closures observed during the spike.

The canonical owner is therefore the desktop generation plus its per-`CODEX_HOME` artifact reconciliation. Filesystem events only invalidate that owner; settled fingerprints identify a change, while authenticity and mutation authority still come from known candidate resolution, signed service inspection, and captured managed-home identities. The old completed-service path cache is removed. No parallel polling or compatibility path remains. The settled fingerprint includes a deterministic, bounded hash of the complete Computer Use plugin tree—not only `plugin.json`—and recursive app-root watching observes in-place skill, MCP-config, launcher, and asset changes. A same-version non-manifest byte change therefore advances the generation and forces the managed cache to replace those bytes.

## Exact-head Live Proof

PR head `89906f686f2211af94349939d30d6ae6182f9903`, based on `935c555c98d6b38af76faa6a0b1370353d1828df`, was built and exercised in the existing macOS UTM testbox with two notarized official ChatGPT desktop generations and two simultaneous isolated agents.

- This proof includes #128370's runtime contract: managed Codex was stable `0.149.1`; desktop X/Y embedded `0.149.0-alpha.4.1` and `.4.3`, so both desktop binaries were rejected for app-server ownership and the actual OpenClaw app-server processes ran from `node_modules/@openai/codex-darwin-arm64`. Desktop artifacts still supplied Computer Use, exercising the package-fallback path this PR must support.
- Gateway PID `14037` remained unchanged while `/Applications/ChatGPT.app` was physically replaced X → Y.
- X: ChatGPT `26.818.41509` build `6962`; Computer Use `1.0.1000816`; Codex SHA-256 `09db9560f6f9dec139d3324254fb3c8fdbad5ecce1d8c794113dc15294f6aefd`; app CDHash `59729f374e9041c73fae77d3fb33ce323d514ba4`.
- Y: ChatGPT `26.818.61809` build `7019`; Computer Use `1.0.1000854`; Codex SHA-256 `dd304ffe232fa9e782ed3e5358776d270e394c2fb85cab846f989823f0843313`; app CDHash `379714a99e8aa5451a17f85033b2a5b0e1bad74a`.
- Both apps were accepted by Gatekeeper as notarized Developer ID builds with identifier `com.openai.codex` and Team ID `2DC432GLL2`.
- On X, simultaneous `multi-a` and `multi-b` turns each recorded exactly one successful `computer-use.list_apps` MCP completion and returned `SUCCEEDED` (OpenClaw run IDs `2088908a-fda8-498d-9869-27d272b71c6a` and `dee8beda-205a-44fc-b06f-dd69e4df88f1`). Both isolated homes held service/cache build `1000816`.
- Before the swap, the two physical managed app-servers were PIDs `14313/14315`. After Y settled, replacements `14922/14926` owned the two homes.
- The first two post-swap turns were started concurrently. Each recorded exactly one successful `computer-use.list_apps` MCP completion and returned `SUCCEEDED` (run IDs `ae138469-27fd-4897-9103-2fc31deb9b54` and `71cae688-7ba9-48ed-aa0c-5493c7665f27`). No turn replay or Gateway restart occurred.
- Both isolated homes converged service/client build `1000816 → 1000854`, added cache `1.0.1000854`, and resolved the managed wrapper to plugin `1.0.1000854`.
- The current-run gateway log contained no failed response, readiness failure, closed transport, or timeout. The test Gateway/LaunchAgent was removed, port `19321` was released, Y remained installed, the X backup was restored, and the unrelated preserved Gateway remained healthy on PID `750`.

The redacted evidence summary and exact MCP completion records are posted as a PR comment; 51 local evidence files are SHA-256 inventoried. The exact-head redacted evidence summary is available at https://gist.github.com/joshavant/6e55755f03913bffb13dc4e1575de5eb (evidence SHA-256 `9409b66319b234c0470f6541e961b5cbfa0ea86c0a368d0dad6579605a4fe187`; native-call proof SHA-256 `dbcba8f6e23880e864f33e8a4e74d45d5aa05d1e31f66eb62c4f8570aeeeee49`; inventory SHA-256 `dc461d5c50e1a0be04d65959470e1a4870fc968e92264de89941574b3439b20b`); a prior-head artifact remains at https://gist.github.com/joshavant/98fe9317f42147a30621ad5f85923e57.
## Automated Validation

- Exact-head focused Codex lifecycle suites: 12 files, 362 tests passed on Node 24.
- Real-filesystem regressions cover same-path service replacement, managed-home symlink/rebind containment, stale-after-backup rollback, conflicting wrapper generations, and same-version cache refresh.
- Lifecycle coverage includes dirty-during-read convergence, watcher re-arm/stop ownership, bounded degraded-watcher reconciliation, active and initializing shared/isolated X processes, physical-exit fencing, cross-home independence, package fallback, generation changes during initialize and Computer Use readiness, bounded startup retry, explicit-install drain-before-config-fence ordering, last-claimant cancellation, and terminal harness-preflight classification.
- `node scripts/check-changed.mjs`: passed formatting, production/test types, lint, package/lock guards, plugin boundaries, database guards, docs checks, dead-export checks, and import-cycle checks.
- Exact-head guest `pnpm install --frozen-lockfile` and full `pnpm build`: passed, including the Control UI size gate.
- Exact-head hosted checks: 128 successful and 52 intentionally skipped; every applicable hosted check is green. CI: https://github.com/openclaw/openclaw/actions/runs/32812028797.
- Exact-head P1 autoreview (`gpt-5.6-sol`, high reasoning): clean, no accepted/actionable findings. The post-review plugin-byte repair was rated correct with confidence `0.90`.
## Current-main Comparison

The branch is based directly on `origin/main` at `935c555c98d6b38af76faa6a0b1370353d1828df`. Live `origin/main` is now `e9017714c2d64cb564b467648d8a5c36dd191bff`; all commits after the branch base leave `extensions/codex` unchanged. This includes #128370 (`b68c136609049e65852cb400052fec65539f066a`), which upgrades managed Codex to `0.149.1`, rejects older/prerelease desktop app-servers, and replaces stale-child killing with Codex-owned `config/mcpServer/reload`.

That merge does not replace this PR's generation owner. Upstream reload refreshes config and MCP runtimes inside the existing app-server; it does not identify same-path desktop replacement, retire the physical app-server, or converge the per-agent Computer Use service/cache/wrapper. The integration preserves #128370's reload for ordinary readiness failures. Only typed `CODEX_APP_SERVER_START_SELECTION_CHANGED` bypasses that stale-client retry and reaches the existing bounded physical-startup retry after probe-thread cleanup.

The exact-head VM proof above exercises this combined behavior: stable managed app-server `0.149.1`, desktop-owned Computer Use `1000816 → 1000854`, two isolated homes, and simultaneous first requests without a Gateway restart.
## Dependency Contract Checked

Personally inspected the sibling OpenAI Codex checkout at exact release tag `rust-v0.149.1` (`ff29a44391deccde0aba0f8390337d7f3c319ea4`) after fetching current upstream refs (`origin/main` `3a469a297daeab77a60c142669262366f344a830`):

- `codex-rs/core-plugins/src/marketplace_add/source.rs:149-167`: local sources are canonicalized.
- `codex-rs/core-plugins/src/marketplace_policy.rs:306-336,493-537`: reserved bundled names are accepted only from the managed `CODEX_HOME` root.
- `codex-rs/core-plugins/src/marketplace.rs:312-333,650-692`: the real wrapper manifest and controlled local plugin links satisfy marketplace loading while plugin paths remain rooted.
- `codex-rs/core-plugins/src/marketplace_add.rs:91-153`: `marketplace/add` validates and records the local source.
- `codex-rs/utils/home-dir/src/lib.rs:9-50`: explicit `CODEX_HOME` must exist and is canonicalized.
- `codex-rs/app-server/src/request_processors/initialize_processor.rs:96-147` and `app-server-protocol/src/protocol/v1.rs:68-79`: initialize reports the configured absolute home, not a desktop-generation token.
- `codex-rs/app-server-protocol/src/protocol/common.rs:1129-1133`, `app-server/src/request_processors/mcp_processor.rs:79-86`, and `app-server/src/mcp_refresh.rs:9-28`: `config/mcpServer/reload` reloads config and refreshes existing threads; it does not replace the physical app-server or supply a desktop generation.
- `codex-rs/core/src/session/turn.rs:659-670,1450-1477`: MCP/plugin state is refreshed and plugins are loaded during turn work, so Y publication waits for the X physical process to exit, not merely for logical client closure.

This direct exact-release inspection satisfies the repository's Codex hard gate. A hosted reviewer that cannot access a sibling checkout can reproduce the check from the immutable tag and paths above; its environment limitation is not a missing contributor action.
## Safety and Compatibility

- Managed-home marketplace/cache/service writes reuse the captured owner boundary and reject redirected or rebound parents in external-sentinel tests.
- Replacement events are invalidation hints only. Known candidates are re-resolved and the full signed service/client identity is checked before native artifacts publish.
- Automatic provisioning still requires enabled Computer Use, `autoInstall`, and an OpenClaw-owned isolated home. User homes, explicit `CODEX_HOME`, and custom commands are not seized by the generation owner.
- No authentication, policy, sandbox, allowlist, approval, or tool-authorization boundary is widened under `SECURITY.md`. Same-path trusted-host replacement and pre-existing trusted-local symlink priming remain outside the public boundary; containment is nevertheless enforced as production hardening.

## Size and Best-fix Judgment

Production: `+1728/-183` (net `+1545`) | Tests/test support: `+2733/-181` (net `+2552`) | Docs: `+39/-20` (net `+19`).

The positive production delta is the concrete lifecycle capability and its ownership/security boundaries: one generation service, a complete desktop-artifact fingerprint, contained reserved-marketplace ownership, exact physical-client retirement, per-home publication fencing, and exact-candidate reconciliation. The implementation removes the old completed-service path cache, reuses the existing exact-client retirement and managed-home identity helpers, and adds no compatibility shim or public configuration.

Maintainer judgment: this production growth is accepted as warranted for the lifecycle capability and its containment/compatibility boundaries. The accepted product contract is convergence for standard managed macOS desktop candidates, with active X work draining, new same-home work adopting Y, unrelated homes remaining independent, existing opt-outs preserved, and no request-hot-path polling.

Alternatives rejected:

- request-time `stat`/codesign polling: violates process-stable metadata ownership and adds hot-path latency;
- failure-driven retry alone: reacts after user-visible failure and cannot distinguish unrelated transport closures;
- a direct marketplace-root symlink: rejected by Codex after canonicalization;
- retiring every shared client: breaks unrelated sessions and active-turn drain guarantees.

The optional shared plugin cache is serialized under the same per-home owner, fenced immediately before publication, and bound to the settled desktop epoch plus exact artifact source. The pathfinder cleanup closes the pre-existing same-version/source convergence gap without a sidecar or runtime polling.

Credit: #127024 by @bdjben identified the user-visible update failure and motivated the updater investigation.




