### PR TITLE
fix(onboard): reject --gateway-bind custom without a valid customBindHost

### DIFF
--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -366,4 +366,60 @@ describe("applyNonInteractiveGatewayConfig auth resolution", () => {
 
     expect(result?.nextConfig.gateway?.auth).toEqual({ mode: "password" });
   });
+
+  it("rejects --gateway-bind custom when no gateway.customBindHost is configured", () => {
+    const runtime = createRuntime();
+
+    const result = applyGatewayConfig({
+      opts: { gatewayBind: "custom" } as OnboardOptions,
+      runtime,
+    });
+
+    expect(result).toBeNull();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("--gateway-bind custom requires gateway.customBindHost"),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects --gateway-bind custom when gateway.customBindHost is not a dotted-decimal IPv4", () => {
+    const runtime = createRuntime();
+
+    const result = applyGatewayConfig({
+      nextConfig: { gateway: { customBindHost: "not-an-ip" } } as OpenClawConfig,
+      opts: { gatewayBind: "custom" } as OnboardOptions,
+      runtime,
+    });
+
+    expect(result).toBeNull();
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("Invalid IPv4 address"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("accepts --gateway-bind custom when gateway.customBindHost is already configured", () => {
+    const runtime = createRuntime();
+
+    const result = applyGatewayConfig({
+      nextConfig: { gateway: { customBindHost: "192.168.1.100" } } as OpenClawConfig,
+      opts: { gatewayBind: "custom" } as OnboardOptions,
+      runtime,
+    });
+
+    expect(result?.nextConfig.gateway?.bind).toBe("custom");
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("keeps loopback normalization ahead of the custom bind guard when Tailscale is enabled", () => {
+    const runtime = createRuntime();
+
+    const result = applyGatewayConfig({
+      opts: { gatewayBind: "custom", tailscale: "serve" } as OnboardOptions,
+      runtime,
+    });
+
+    expect(result?.nextConfig.gateway?.bind).toBe("loopback");
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -4,6 +4,7 @@
  * This module owns port/bind/auth validation and existing-setting preservation
  * before the final config write happens.
  */
+import { validateDottedDecimalIPv4Input } from "@openclaw/net-policy/ipv4";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../../../cli/command-format.js";
 import { formatInvalidPortOption } from "../../../cli/error-format.js";
@@ -96,6 +97,24 @@ export function applyNonInteractiveGatewayConfig(params: {
   const changesBindOrTailscale = opts.gatewayBind !== undefined || opts.tailscale !== undefined;
   if (changesBindOrTailscale && tailscaleMode !== "off" && bind !== "loopback") {
     bind = "loopback";
+  }
+
+  // bind=custom is only startable alongside a valid gateway.customBindHost, and the non-interactive
+  // path has no prompt to collect one. Checked after the Tailscale normalization above so a bind
+  // forced back to loopback never trips it. Without this, setup writes a config the Gateway refuses.
+  if (bind === "custom") {
+    const customBindHostIssue = validateDottedDecimalIPv4Input(
+      normalizeOptionalString(existingGateway?.customBindHost ?? ""),
+    );
+    if (customBindHostIssue) {
+      const setCommand = formatCliCommand("openclaw config set gateway.customBindHost <ipv4>");
+      const interactiveCommand = formatCliCommand("openclaw onboard");
+      runtime.error(
+        `--gateway-bind custom requires gateway.customBindHost: ${customBindHostIssue}. Set it with ${setCommand} and rerun, or run ${interactiveCommand} interactively to be prompted for it.`,
+      );
+      runtime.exit(1);
+      return null;
+    }
   }
   const changesAuthOrTailscale =
     explicitAuthMode !== undefined || hasExplicitTokenAuthInput || opts.tailscale !== undefined;


### PR DESCRIPTION
## What Problem This Solves

Non-interactive onboarding accepts `--gateway-bind custom` without a `gateway.customBindHost`, writes `bind: "custom"` to the config, and reports success. The Gateway then refuses to start:

```
$ openclaw onboard --non-interactive --accept-risk --auth-choice skip --gateway-bind custom
Updated config: ~/.openclaw/openclaw.json
  Backup: ~/.openclaw/openclaw.json.bak

$ openclaw gateway run
Gateway failed to start: gateway.bind=custom requires gateway.customBindHost.
```

The operator finishes setup with a Gateway that cannot start, and nothing in the setup output says why. The two surfaces they would reach for next both call the config healthy:

- `openclaw config validate` → `Config valid: ~/.openclaw/openclaw.json`
- `openclaw doctor` → no finding for the missing host, and it actively misreports the state as `WARNING: Gateway bound to "custom" (0.0.0.0) (network-accessible)` for a Gateway that never binds anything.

`src/gateway/server-runtime-config.ts:83` is the authority here: `bind=custom` without `customBindHost` is a hard startup refusal, by design and with no fallback.

## Why This Change Was Made

Every other onboarding flag already rejects a mode whose companion value is missing, and names the missing piece:

| Input | Today |
| --- | --- |
| `--gateway-auth password` (no password) | `Missing --gateway-password for password auth. Pass --gateway-password or use --gateway-auth token.` |
| `--auth-choice openai-api-key` (no key) | `Missing --openai-api-key (or OPENAI_API_KEY in env, ...)` |
| `--auth-choice custom-api-key` (no URL) | `Auth choice "custom-api-key" requires a base URL and model ID.` |
| `--gateway-bind custom` (no host) | *accepted, writes an unstartable config* |

`--gateway-bind custom` was the only exception across the whole onboarding flag surface. The guard restores the shared contract in the module that already owns port/bind/auth validation, and reuses `validateDottedDecimalIPv4Input` — the same validator the interactive wizard (`src/wizard/setup.gateway-config.ts:135`) and `openclaw configure` (`src/commands/configure.gateway.ts:103`) apply to this exact field — rather than adding a second opinion about what a valid host looks like.

It is placed after the existing Tailscale normalization so a bind that gets forced back to `loopback` never trips it.

## User Impact

`--gateway-bind custom` with no usable host now fails immediately with the remedy instead of producing a broken config:

```
--gateway-bind custom requires gateway.customBindHost: IP address is required for custom bind mode.
Set it with `openclaw config set gateway.customBindHost <ipv4>` and rerun, or run `openclaw onboard`
interactively to be prompted for it.
```

No working path is removed. Pre-seeding `gateway.customBindHost` and then running `--gateway-bind custom` non-interactively still succeeds — verified before and after this change — and the interactive wizard, which prompts for the IP, is untouched.

## Evidence

Reproduced against a built CLI in an isolated profile (`HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH` redirected, gateway port pinned to 18997):

- before: onboarding wrote `{"bind": "custom"}` with no `customBindHost`; `gateway run` failed with `gateway.bind=custom requires gateway.customBindHost`; `config validate` reported `Config valid`.
- supported path, before and after: a config pre-seeded with `gateway.customBindHost: "192.168.1.100"` plus `--gateway-bind custom` exits 0 and preserves both fields.

Tests — `node scripts/run-vitest.mjs`:

- `src/commands/onboard-non-interactive/local/gateway-config.test.ts` — 29 passed (25 existing + 4 new).
- Reverting only `gateway-config.ts` to `main` fails exactly the two new rejection cases and nothing else.
- `src/commands/onboard-non-interactive` — 10 files, 116 passed.
- `src/wizard/setup.gateway-config.test.ts` (24) and `src/commands/onboard-non-interactive.gateway.test.ts` (17) — passed.

The file header already claimed "port, bind, auth token" coverage while carrying no bind test; the four added cases cover missing host, malformed host, the valid pre-seeded host, and the Tailscale-forces-loopback ordering.

Production LOC +19/-0, tests +56/-0. The production growth buys a correctness boundary: onboarding can no longer emit a Gateway config that the Gateway rejects.

Autoreview (codex/gpt-5.6-sol, xhigh): clean, no accepted or actionable findings.
