### PR TITLE
fix(onboard): name the available providers when --import-from is unknown

### DIFF
--- a/src/wizard/setup.migration-import.test.ts
+++ b/src/wizard/setup.migration-import.test.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { listSetupMigrationOptions } from "./setup.migration-import.js";
+import type { OnboardOptions } from "../commands/onboard-types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "./prompts.js";
+import { listSetupMigrationOptions, runSetupMigrationImport } from "./setup.migration-import.js";
 import {
   assertFreshSetupMigrationTarget,
   buildSetupMigrationTargetSnapshot,
@@ -173,5 +176,27 @@ describe("setup migration import options", () => {
         process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS = previousDisableBundled;
       }
     }
+  });
+});
+
+describe("setup migration import provider selection", () => {
+  function runImportWith(importFrom: string) {
+    return runSetupMigrationImport({
+      opts: { importFrom } as OnboardOptions,
+      baseConfig: {},
+      detections: [],
+      prompter: {} as WizardPrompter,
+      runtime: { log: () => {}, error: () => {}, exit: () => {} } as unknown as RuntimeEnv,
+      readConfigFile: async () => ({}),
+      commitConfigFile: async (config) => config,
+    });
+  }
+
+  it("names the available providers when --import-from does not match one", async () => {
+    // The bundled ids come from the same listing the picker renders, so assert the shape and one
+    // known bundled id rather than pinning the full set, which grows with every bundled provider.
+    await expect(runImportWith("bogus")).rejects.toThrow(
+      /^Unknown migration provider "bogus"\. Available providers: .*codex.*\. Run .*openclaw migrate list.* to see the current list\.$/,
+    );
   });
 });

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -1,3 +1,4 @@
+import { formatCliCommand } from "../cli/command-format.js";
 import type { OnboardOptions } from "../commands/onboard-types.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -217,44 +218,57 @@ async function selectSetupMigrationProvider(params: {
     detections: params.detections,
   });
   const requestedProviderId = params.opts.importFrom?.trim();
-  if (requestedProviderId && !options.some((option) => option.providerId === requestedProviderId)) {
-    throw new Error(
-      `Migration provider "${requestedProviderId}" is not installed or bundled. Install it before starting the transactional import.`,
-    );
+  if (requestedProviderId) {
+    return assertListedMigrationProvider(requestedProviderId, options);
   }
   if (options.length === 0) {
     throw new Error("No migration providers found.");
   }
-  let providerId = requestedProviderId;
-  if (!providerId) {
-    const prompt = {
-      message: t("wizard.migration.source"),
-      options: options.map((option) => ({
-        value: option.providerId,
-        label: option.label,
-        ...(option.hint ? { hint: option.hint } : {}),
-      })),
-      initialValue: params.detections[0]?.providerId ?? options[0]?.providerId,
-    };
-    if (!params.allowBack) {
-      params.prompter.disableBackNavigation?.();
-      return await params.prompter.select(prompt);
-    }
-    const selection = await runWizardWithPromptNavigationScope(
-      params.prompter,
-      async (prompter) => await prompter.select(prompt),
-    );
-    if (selection.status === "back") {
-      return undefined;
-    }
-    providerId = selection.value;
+  const prompt = {
+    message: t("wizard.migration.source"),
+    options: options.map((option) => ({
+      value: option.providerId,
+      label: option.label,
+      ...(option.hint ? { hint: option.hint } : {}),
+    })),
+    initialValue: params.detections[0]?.providerId ?? options[0]?.providerId,
+  };
+  if (!params.allowBack) {
+    params.prompter.disableBackNavigation?.();
+    return assertListedMigrationProvider(await params.prompter.select(prompt), options);
   }
-  if (!options.some((option) => option.providerId === providerId)) {
-    throw new Error(
-      `Migration provider "${providerId}" is not installed or bundled. Install it before starting the transactional import.`,
-    );
+  const selection = await runWizardWithPromptNavigationScope(
+    params.prompter,
+    async (prompter) => await prompter.select(prompt),
+  );
+  if (selection.status === "back") {
+    return undefined;
   }
-  return providerId;
+  return assertListedMigrationProvider(selection.value, options);
+}
+
+/**
+ * Rejects a provider id that is absent from the listed options, naming the ids that are present.
+ * `openclaw migrate` already answers an unknown provider this way; onboarding has to match, because
+ * a typed id is far likelier to be a typo here than a genuinely missing plugin. An undefined id
+ * means the operator dismissed the prompt, which is a cancellation rather than a bad choice.
+ */
+function assertListedMigrationProvider(
+  providerId: string | undefined,
+  options: readonly SetupMigrationOption[],
+): string | undefined {
+  if (providerId === undefined || options.some((option) => option.providerId === providerId)) {
+    return providerId;
+  }
+  const available = options.map((option) => option.providerId);
+  const suffix =
+    available.length > 0
+      ? ` Available providers: ${available.join(", ")}.`
+      : " No migration providers are installed.";
+  const listCommand = formatCliCommand("openclaw migrate list");
+  throw new Error(
+    `Unknown migration provider "${providerId}".${suffix} Run ${listCommand} to see the current list.`,
+  );
 }
 
 async function resolveSetupMigrationProvider(params: {


### PR DESCRIPTION
## What Problem This Solves

A typo in `--import-from` during onboarding dead-ends:

```
$ openclaw onboard --non-interactive --accept-risk --flow import --import-from bogus
Migration provider "bogus" is not installed or bundled. Install it before starting the transactional import.
```

No list of valid ids, no next command, and the one piece of advice it does give — "install it" — is wrong for the overwhelmingly common cause, which is a misspelling of a provider that is already bundled.

The same feature answers every other unknown-id case properly:

- `src/commands/migrate/providers.ts:29` → `Unknown migration provider "x". Available providers: codex, claude, hermes.`
- `src/commands/migrate/selection.ts:143` → `... Available skills: alpha, beta.`
- `src/commands/onboard.ts:216`, for a *missing* `--import-from` → `... Run openclaw migrate list to choose a provider.`

So onboarding already knows to point at `openclaw migrate list` when the flag is absent, and the migrate command already knows to enumerate ids when the flag is wrong. The unknown-id path in the wizard was the only one that did neither — while holding the complete list of valid options in a local variable at the throw site.

This is also the lone exception across onboarding's whole flag surface. `--flow`, `--mode`, `--gateway-bind`, `--daemon-runtime`, `--auth-choice`, and `--gateway-auth` all enumerate their valid values on a bad input.

## Why This Change Was Made

`selectSetupMigrationProvider` carried the same message twice, and the two copies did not guard the same thing. The second copy also sat behind an early return: the no-back-navigation branch did `return await params.prompter.select(prompt)` and skipped validation entirely, while the back-navigation branch fell through to it.

Rather than fix the text in two places and leave that asymmetry, all three exits now converge on one guard, phrased to match `resolveMigrationProvider`. An undefined id still means "the operator dismissed the picker" and passes through as the existing cancellation signal — that distinction is called out at the helper so a later reader does not convert a cancel into an error.

## User Impact

```
Unknown migration provider "bogus". Available providers: codex, claude, hermes, …. Run `openclaw migrate list` to see the current list.
```

Behavior is otherwise unchanged: valid ids resolve as before, a genuinely empty registry still reports that no providers are installed, `No migration providers found.` still guards the interactive picker, and cancelling the picker still returns to setup instead of erroring.

## Evidence

Reproduced against a built CLI in an isolated profile — `--flow import --import-from bogus` printed the old message and exited 1.

Tests — `node scripts/run-vitest.mjs`:

- `src/wizard/setup.migration-import.test.ts` — 10 passed (9 existing + 1 new).
- The new case drives the public `runSetupMigrationImport` entry point, not the private helper, so it covers the real caller path.
- Reverting only `setup.migration-import.ts` to `main` fails exactly that case.
- `src/wizard/setup.test.ts` — passed alongside it (80 total across both files).

Production LOC +46/-32 (net +14), tests +26/-1. The growth is one shared guard replacing two divergent copies, and it buys an actionable error plus validation on a path that previously had none.

Autoreview (codex/gpt-5.6-sol, xhigh): clean, no accepted or actionable findings.
