### PR TITLE
feat(mantis): programmable proof boundaries with recipe library

### DIFF
--- a/.github/codex/prompts/mantis-recipes/README.md
+++ b/.github/codex/prompts/mantis-recipes/README.md
@@ -1,0 +1,11 @@
+# Mantis proof recipes
+
+Use the closest recipe, keep baseline and candidate inputs identical, and adapt
+only identifiers returned by the lane. Trusted request facts can prove a change
+even when Telegram Desktop pixels match.
+
+- `send-failure-injection.md`: outbound Bot API failures and retry behavior
+- `busy-queue-scripted-provider.md`: ordered slow/fast multi-turn responses
+- `callback-data-payload-proof.md`: byte-level callback payload differences
+
+Return to `mantis-telegram-desktop-proof.md` for limits, cleanup, and publishing.

--- a/.github/codex/prompts/mantis-recipes/busy-queue-scripted-provider.md
+++ b/.github/codex/prompts/mantis-recipes/busy-queue-scripted-provider.md
@@ -27,6 +27,7 @@ $lane requests --lane baseline
 $lane finish --lane baseline
 ```
 
-Repeat for `candidate`. Proof facts: provider request log `scriptEntry` values
-show entries 0 then 1; request bodies preserve turn order; session events show
-the slow first and distinct second outcomes without a control-file race.
+Repeat for `candidate`. Proof facts: session events and recorded Bot API
+messages show the slow first and distinct second outcomes without a
+control-file race. The provider request log (`scriptEntry` 0 then 1, turn
+order in bodies) is diagnostic context, not the comparison evidence.

--- a/.github/codex/prompts/mantis-recipes/busy-queue-scripted-provider.md
+++ b/.github/codex/prompts/mantis-recipes/busy-queue-scripted-provider.md
@@ -1,0 +1,32 @@
+# Busy queue with scripted provider responses
+
+Use when two turns overlap and response order or queue draining is under test.
+
+Write `provider-script.json`:
+
+```json
+{
+  "responses": [
+    { "text": "slow first response", "chunkDelayMs": 5000 },
+    { "text": "distinct second response" }
+  ]
+}
+```
+
+Then run each lane without changing provider controls mid-flight:
+
+```bash
+sha="$(sha256sum "$MANTIS_OUTPUT_DIR/provider-script.json" | cut -d ' ' -f1)"
+lane="$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD"
+$lane start --lane baseline --repo-root "$MANTIS_BASELINE_ROOT" --config "$config"
+$lane mock --lane baseline --script "$MANTIS_OUTPUT_DIR/provider-script.json" "$sha"
+$lane send --lane baseline --text '@{sut} turn one'
+$lane send --lane baseline --text '@{sut} turn two'
+$lane observe --lane baseline --seconds 60 --until-text 'distinct second response' --until-provider-requests 2
+$lane requests --lane baseline
+$lane finish --lane baseline
+```
+
+Repeat for `candidate`. Proof facts: provider request log `scriptEntry` values
+show entries 0 then 1; request bodies preserve turn order; session events show
+the slow first and distinct second outcomes without a control-file race.

--- a/.github/codex/prompts/mantis-recipes/callback-data-payload-proof.md
+++ b/.github/codex/prompts/mantis-recipes/callback-data-payload-proof.md
@@ -1,0 +1,21 @@
+# Callback data payload proof
+
+Use when a button looks identical but its callback bytes or follow-up Bot API
+payload changed.
+
+```bash
+lane="$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD"
+$lane start --lane baseline --repo-root "$MANTIS_BASELINE_ROOT" --config "$config"
+$lane turn --lane baseline --text '@{sut} show the callback button' --observe-seconds 30
+$lane press --lane baseline --message-id "$bot_message_id" --button 0
+$lane observe --lane baseline --seconds 60 --until-events "$expected_event_count"
+$lane botapi-requests --lane baseline --method answerCallbackQuery --limit 20
+$lane botapi-requests --lane baseline --method editMessageText --limit 20
+$lane finish --lane baseline --focus-message-id "$bot_message_id"
+```
+
+Repeat for `candidate`, using each lane's returned bot message id. Proof facts:
+compare parsed `requestBody` values for `answerCallbackQuery` and
+`editMessageText`, including exact callback-related strings and whitespace.
+Screenshots establish identical visible context; a material recorded payload-byte
+difference is the comparison evidence.

--- a/.github/codex/prompts/mantis-recipes/send-failure-injection.md
+++ b/.github/codex/prompts/mantis-recipes/send-failure-injection.md
@@ -1,0 +1,19 @@
+# Send failure injection
+
+Use when the change affects Telegram send failure handling, retrying, or visible
+failure evidence.
+
+```bash
+lane="$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD"
+$lane start --lane baseline --repo-root "$MANTIS_BASELINE_ROOT" --config "$config"
+$lane botapi-fail sendMessage --lane baseline --times 2 --status 429
+$lane send --lane baseline --text '@{sut} prove send failure handling'
+$lane observe --lane baseline --seconds 60 --until-provider-requests 1
+$lane botapi-requests --lane baseline --method sendMessage --limit 20
+$lane finish --lane baseline
+```
+
+Repeat with `candidate` and `MANTIS_CANDIDATE_ROOT`. Proof facts: two ordered
+`sendMessage` entries with `status:429` and `injected:true`, followed by any retry
+or recovery call; lane events/screenshots show the corresponding visible outcome.
+Use `botapi-clear` only when the scenario needs recovery before finishing.

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -67,7 +67,9 @@ Use `$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD` with `--lane baseline|candidate`:
 - `send --text <text>`; also `--text-file`, `--media` (document), `--reply-to`
 - `turn --text <text> --observe-seconds 15` (send + observe convenience)
 - `observe --seconds N [--since cursor] [--until-events N] [--until-text substring]
-[--until-provider-requests N]` (returns early when all supplied conditions hold)
+[--until-provider-requests N]` (returns early when all supplied conditions hold;
+  event/text conditions count only events after the cursor, provider count is
+  cumulative for the lane)
 - `requests` (redacted provider requests; zero is a valid recorded fact)
 - `press --message-id ID --button INDEX`
 - `delete --message-id ID` (only user messages sent in this session)

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -115,9 +115,10 @@ Use the same scenario inputs in both lanes; only the SUT revision changes. A
 baseline lane that reproduces the defect is a successful capture. A PR-level
 pass claim requires an observed, material baseline/candidate difference caused
 by the changed behavior. That difference may be trusted Bot API payload/status
-facts or provider request count/order even when pixels are identical; screenshots
-remain comparison context. Identical pixels alone do not force `block` when those
-recorded facts differ materially. If neither pixels nor trusted facts prove a
+facts even when pixels are identical; screenshots remain comparison context.
+Provider request logs are diagnostic and pacing signals, not standalone
+comparison evidence. Identical pixels alone do not force `block` when the
+trusted recorded facts differ materially. If neither pixels nor trusted facts prove a
 difference, use `block`. When the expected result is silence, focus the
 session-owned user message that triggered the silent outcome.
 Decide before finalizing each lane. If its setup did not exercise the intended

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -25,6 +25,7 @@ commands, routing, stop behavior, TTS/audio, and timing as visible.
 
 Write a short Bash scenario under `MANTIS_OUTPUT_DIR`; use TypeScript only when
 timing or concurrency needs it. Compose the primitives below in any order needed.
+Start from `.github/codex/prompts/mantis-recipes/` when a listed pattern matches.
 Use `jq` or code for scenario-specific assertions, not generic wrappers or schema
 parsers. The helper's JSON is factual evidence, not a semantic verdict. Run
 TypeScript scenarios with `$MANTIS_NODE_BIN --import tsx <scenario.ts>`.
@@ -57,9 +58,16 @@ Use `$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD` with `--lane baseline|candidate`:
 - `mock --response-events-file <public-json>` (replace a later Responses API turn
   with a JSON array of raw response events; use for reasoning, tool calls, or any
   stream shape that plain text cannot express)
+- `mock --script <public-json> <sha256>` (consume `responses` in request order,
+  then `default` or the last entry; entries choose `text`, `eventsFile`, or
+  `fail` with `status`/`mode:"drop"`, plus optional `chunkDelayMs`)
+- `botapi-fail <method> [--times N] [--status CODE | --drop]`; `botapi-clear`
+- `botapi-requests [--method M] [--limit N]` (bounded recorded outbound Bot API
+  calls, parsed payloads, statuses, and injected-fault facts)
 - `send --text <text>`; also `--text-file`, `--media` (document), `--reply-to`
 - `turn --text <text> --observe-seconds 15` (send + observe convenience)
-- `observe --seconds N [--since cursor]` (messages, edits, deletes, typing)
+- `observe --seconds N [--since cursor] [--until-events N] [--until-text substring]
+[--until-provider-requests N]` (returns early when all supplied conditions hold)
 - `requests` (redacted provider requests; zero is a valid recorded fact)
 - `press --message-id ID --button INDEX`
 - `delete --message-id ID` (only user messages sent in this session)
@@ -104,9 +112,12 @@ each side ends as complete, failed, or blocked with its own trusted facts.
 Use the same scenario inputs in both lanes; only the SUT revision changes. A
 baseline lane that reproduces the defect is a successful capture. A PR-level
 pass claim requires an observed, material baseline/candidate difference caused
-by the changed behavior. Identical relevant observations are unproven: use
-`block`, never claim the PR fixed them. When the expected result is silence,
-focus the session-owned user message that triggered the silent outcome.
+by the changed behavior. That difference may be trusted Bot API payload/status
+facts or provider request count/order even when pixels are identical; screenshots
+remain comparison context. Identical pixels alone do not force `block` when those
+recorded facts differ materially. If neither pixels nor trusted facts prove a
+difference, use `block`. When the expected result is silence, focus the
+session-owned user message that triggered the silent outcome.
 Decide before finalizing each lane. If its setup did not exercise the intended
 behavior, call `block`; do not call `finish` and describe the block only in prose.
 
@@ -116,6 +127,10 @@ Inspect `mantis-lane-facts.json`, every returned event/request, the inspection
 PNG, final PNG, and cropped GIF. Confirm the evaluated message is fully visible
 near the bottom and the recording covers the behavior—not only its final state.
 Iterate as needed; all attempts remain recorded.
+
+If you design a novel working scenario worth reusing, optionally write
+`MANTIS_OUTPUT_DIR/recipe-suggestion.md` with its trigger, exact commands, and
+proof facts. The builder publishes it as a non-inline attachment.
 
 Build `mantis-evidence.json` with
 `scripts/mantis/build-telegram-desktop-proof-evidence.mts` as before, using each

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -778,7 +778,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENCLAW_MANTIS_AGENT_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
           prompt-file: .github/codex/prompts/mantis-telegram-desktop-proof.md
           model: ${{ vars.OPENCLAW_CI_OPENAI_MODEL_BARE }}
-          effort: medium
+          effort: high
           sandbox: danger-full-access
           codex-args: '["-c","service_tier=\"fast\""]'
           codex-home: /tmp/mantis-codex-home-${{ github.run_id }}
@@ -897,6 +897,16 @@ jobs:
           sudo install -m 0400 -o root -g root "$agent_manifest" "$trusted_agent_manifest"
           agent_manifest="$trusted_agent_manifest"
           sudo install -d -m 0755 -o root -g root "$trusted_output"
+          recipe_suggestion="$quarantine/recipe-suggestion.md"
+          if sudo test -e "$recipe_suggestion" || sudo test -L "$recipe_suggestion"; then
+            sudo test -f "$recipe_suggestion"
+            sudo test ! -L "$recipe_suggestion"
+            test "$(sudo stat -c %h "$recipe_suggestion")" = 1
+            recipe_bytes="$(sudo stat -c %s "$recipe_suggestion")"
+            ((recipe_bytes > 0 && recipe_bytes <= 65536))
+            sudo install -m 0644 -o root -g root "$recipe_suggestion" \
+              "$trusted_output/recipe-suggestion.md"
+          fi
           manifest="$trusted_output/mantis-evidence.json"
           judgment="$RUNNER_TEMP/mantis-agent-judgment.json"
           sudo jq -e '
@@ -944,13 +954,14 @@ jobs:
                .lane == $lane and
                (if .sutAttestation == null then
                   .status == "infra-error" and .artifacts == {} and .sendCount == 0 and
-                  .providerRequests == [] and .observation.events == [] and
+                  .botApiRequests == [] and .providerRequests == [] and .observation.events == [] and
                   .observation.truncated == false and
                   (.invocations | length) == 1 and .invocations[0].command == "start"
                 else
                   .sutAttestation.lane == $lane and .sutAttestation.sha == $sha
                 end) and
                (.invocations | type == "array") and (.observation.events | type == "array") and
+               (.botApiRequests | type == "array") and
                (.providerRequests | type == "array") and
                (if .status == "complete" or .status == "blocked" then (.cleanupErrors | length) == 0 else true end)' \
               "$verdict" >/dev/null
@@ -1090,6 +1101,7 @@ jobs:
                 hasFocusMessage: (.focusMessageId != null),
                 invocationCount: (.invocations | length),
                 observedEventCount: (.observation.events | length),
+                botApiRequestCount: (.botApiRequests | length),
                 providerRequestCount: (.providerRequests | length),
                 artifactNames: (.artifacts | keys),
                 cleanupErrorCount: (.cleanupErrors | length)

--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -24,35 +24,124 @@ const initialResponseChunkDelayMs = process.env.MOCK_RESPONSE_CHUNK_DELAY_MS
   ? readPositiveIntEnv("MOCK_RESPONSE_CHUNK_DELAY_MS", undefined)
   : 0;
 const responseControl = process.env.MOCK_RESPONSE_CONTROL;
+let scriptState;
 
-function readCurrentResponse() {
-  if (!responseControl) {
-    return { text: successMarker, chunkDelayMs: initialResponseChunkDelayMs, hold: false };
-  }
-  const value = JSON.parse(readFileSync(responseControl, "utf8"));
-  if (Array.isArray(value.events) && value.events.length > 0) {
-    return { events: value.events, hold: value.hold ?? false };
-  }
-  if (typeof value.text !== "string" || value.text.length === 0 || value.text.length > 100_000) {
-    throw new Error("mock response control text is invalid");
+function readResponseEntry(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} is invalid`);
   }
   const chunkDelayMs = value.chunkDelayMs ?? 0;
   if (!Number.isInteger(chunkDelayMs) || chunkDelayMs < 0 || chunkDelayMs > 15 * 60_000) {
-    throw new Error("mock response control chunkDelayMs is invalid");
+    throw new Error(`${label} chunkDelayMs is invalid`);
   }
+  if (value.fail !== undefined) {
+    if (!value.fail || typeof value.fail !== "object" || Array.isArray(value.fail)) {
+      throw new Error(`${label} fail is invalid`);
+    }
+    const status = value.fail.status ?? 500;
+    if (!Number.isInteger(status) || status < 400 || status > 599) {
+      throw new Error(`${label} fail status is invalid`);
+    }
+    if (value.fail.mode !== undefined && value.fail.mode !== "drop") {
+      throw new Error(`${label} fail mode is invalid`);
+    }
+    if (value.fail.mode === "drop" && value.fail.status !== undefined) {
+      throw new Error(`${label} fail cannot combine status and drop`);
+    }
+    return {
+      fail: value.fail.mode === "drop" ? { mode: "drop" } : { status },
+      chunkDelayMs,
+    };
+  }
+  if (Array.isArray(value.events) && value.events.length > 0) {
+    return { events: value.events, chunkDelayMs };
+  }
+  if (typeof value.text !== "string" || value.text.length === 0 || value.text.length > 100_000) {
+    throw new Error(`${label} text is invalid`);
+  }
+  return { text: value.text, chunkDelayMs };
+}
+
+function readResponseControl() {
+  if (!responseControl) {
+    return {
+      hold: false,
+      response: { text: successMarker, chunkDelayMs: initialResponseChunkDelayMs },
+    };
+  }
+  const value = JSON.parse(readFileSync(responseControl, "utf8"));
   if (value.hold !== undefined && typeof value.hold !== "boolean") {
     throw new Error("mock response control hold is invalid");
   }
-  return { text: value.text, chunkDelayMs, hold: value.hold ?? false };
+  if (value.responses !== undefined) {
+    if (!Array.isArray(value.responses) || value.responses.length === 0) {
+      throw new Error("mock response control responses are invalid");
+    }
+    const responses = value.responses.map((entry, index) =>
+      readResponseEntry(entry, `mock response control responses[${index}]`),
+    );
+    const defaultResponse =
+      value.default === undefined
+        ? undefined
+        : readResponseEntry(value.default, "mock response control default");
+    const version =
+      typeof value.scriptVersion === "string" && value.scriptVersion
+        ? value.scriptVersion
+        : createHash("sha256")
+            .update(JSON.stringify({ default: value.default, responses: value.responses }))
+            .digest("hex");
+    return { defaultResponse, hold: value.hold ?? false, responses, version };
+  }
+  return {
+    hold: value.hold ?? false,
+    response: readResponseEntry(value, "mock response control"),
+  };
 }
 
-async function currentResponse() {
-  let response = readCurrentResponse();
-  while (response.hold) {
-    await delay(25);
-    response = readCurrentResponse();
+function selectCurrentResponse() {
+  const control = readResponseControl();
+  if (!control.responses) {
+    return { response: control.response };
   }
-  return response;
+  if (scriptState?.version !== control.version) {
+    scriptState = { nextIndex: 0, version: control.version };
+  }
+  const requestIndex = scriptState.nextIndex;
+  scriptState.nextIndex += 1;
+  if (requestIndex < control.responses.length) {
+    return {
+      response: control.responses[requestIndex],
+      scriptEntry: { entryIndex: requestIndex, requestIndex, source: "responses" },
+    };
+  }
+  if (control.defaultResponse) {
+    return {
+      response: control.defaultResponse,
+      scriptEntry: { requestIndex, source: "default" },
+    };
+  }
+  return {
+    response: control.responses.at(-1),
+    scriptEntry: {
+      entryIndex: control.responses.length - 1,
+      requestIndex,
+      source: "last",
+    },
+  };
+}
+
+async function waitForResponseRelease() {
+  while (readResponseControl().hold) {
+    await delay(25);
+  }
+}
+
+function writeInjectedFailure(res, fail) {
+  if (fail.mode === "drop") {
+    res.destroy();
+    return;
+  }
+  writeJson(res, fail.status, { error: { message: "mantis injected fault" } });
 }
 
 function splitResponseText(text) {
@@ -570,6 +659,13 @@ const server = http.createServer((req, res) => {
       return;
     }
 
+    const scriptedRoute =
+      req.method === "POST" &&
+      (url.pathname === "/v1/responses" || url.pathname === "/v1/chat/completions");
+    // Reserve before body reads or hold waits so concurrent turns consume the script
+    // in arrival order. The explicit version survives hold-only control rewrites.
+    const selectedResponse = responseControl && scriptedRoute ? selectCurrentResponse() : undefined;
+
     let bodyText;
     try {
       bodyText = await readBody(req);
@@ -593,10 +689,18 @@ const server = http.createServer((req, res) => {
           method: req.method,
           path: url.pathname,
           body: boundedRequestLogBody(bodyText, bodyText),
+          ...(selectedResponse?.scriptEntry ? { scriptEntry: selectedResponse.scriptEntry } : {}),
         },
       })
     ) {
       return;
+    }
+    if (selectedResponse) {
+      await waitForResponseRelease();
+      if (selectedResponse.response.fail) {
+        writeInjectedFailure(res, selectedResponse.response.fail);
+        return;
+      }
     }
 
     if (req.method === "POST" && url.pathname === "/v1/responses") {
@@ -622,7 +726,7 @@ const server = http.createServer((req, res) => {
           return;
         }
       }
-      const response = await currentResponse();
+      const response = selectedResponse?.response ?? selectCurrentResponse().response;
       if (response.events) {
         writeResponsesEvents(res, body.stream, response.events);
         return;
@@ -674,7 +778,7 @@ const server = http.createServer((req, res) => {
         writeChatCompletion(res, body.stream !== false, "OPENCLAW_E2E_DRAFTPROOF");
         return;
       }
-      const response = await currentResponse();
+      const response = selectedResponse?.response ?? selectCurrentResponse().response;
       const responseText = responseControl ? response.text : resolveResponseText(bodyText);
       writeChatCompletion(res, body.stream !== false, responseText);
       return;

--- a/scripts/e2e/telegram-bot-api-proxy.ts
+++ b/scripts/e2e/telegram-bot-api-proxy.ts
@@ -1,8 +1,12 @@
 #!/usr/bin/env -S node --import tsx
 
+import { appendFileSync, closeSync, fstatSync, openSync, readFileSync } from "node:fs";
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import https from "node:https";
 import { pathToFileURL } from "node:url";
+
+const MAX_RECORDED_BODY_BYTES = 32 * 1024;
+const MAX_TRUNCATED_PREVIEW_BYTES = 8 * 1024;
 
 const hopByHopHeaders = new Set([
   "connection",
@@ -55,13 +59,194 @@ function forwardedHeaders(headers: IncomingMessage["headers"]): http.OutgoingHtt
   );
 }
 
+type FaultRule = {
+  method: string;
+  mode?: "drop";
+  status?: number;
+  times?: number;
+};
+
+type FaultControlState = {
+  remaining: number[];
+  rules: FaultRule[];
+  version: string;
+};
+
+type RequestBodyCapture = {
+  contentType?: string;
+  requestBody?: unknown;
+};
+
+function botApiMethod(requestPath: string, aliasToken: string): string | undefined {
+  const match = new RegExp(
+    `^/bot${escapeRegExp(aliasToken)}/([A-Za-z][A-Za-z0-9_]{0,63})(?:\\?.*)?$`,
+    "u",
+  ).exec(requestPath);
+  return match?.[1];
+}
+
+function parseFaultRules(value: unknown): FaultRule[] {
+  if (!value || typeof value !== "object" || !("rules" in value) || !Array.isArray(value.rules)) {
+    throw new Error("Telegram proxy control rules are invalid");
+  }
+  return value.rules.map((rawRule) => {
+    if (!rawRule || typeof rawRule !== "object" || Array.isArray(rawRule)) {
+      throw new Error("Telegram proxy fault rule is invalid");
+    }
+    const method = "method" in rawRule ? rawRule.method : undefined;
+    const times = "times" in rawRule ? rawRule.times : undefined;
+    const status = "status" in rawRule ? rawRule.status : undefined;
+    const mode = "mode" in rawRule ? rawRule.mode : undefined;
+    if (typeof method !== "string" || !/^[A-Za-z][A-Za-z0-9_]{0,63}$/u.test(method)) {
+      throw new Error("Telegram proxy fault rule method is invalid");
+    }
+    if (times !== undefined && (!Number.isInteger(times) || Number(times) < 1)) {
+      throw new Error("Telegram proxy fault rule times is invalid");
+    }
+    if (
+      status !== undefined &&
+      (!Number.isInteger(status) || Number(status) < 400 || Number(status) > 599)
+    ) {
+      throw new Error("Telegram proxy fault rule status is invalid");
+    }
+    if (mode !== undefined && mode !== "drop") {
+      throw new Error("Telegram proxy fault rule mode is invalid");
+    }
+    if (mode === "drop" && status !== undefined) {
+      throw new Error("Telegram proxy fault rule cannot combine status and drop");
+    }
+    return {
+      method,
+      ...(times === undefined ? {} : { times: Number(times) }),
+      ...(status === undefined ? {} : { status: Number(status) }),
+      ...(mode === undefined ? {} : { mode }),
+    };
+  });
+}
+
+function readControlFile(file: string): { text: string; version: string } {
+  const descriptor = openSync(file, "r");
+  try {
+    const stat = fstatSync(descriptor, { bigint: true });
+    return {
+      text: readFileSync(descriptor, "utf8"),
+      version: `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}`,
+    };
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function matchingFaultRule(
+  controlFile: string,
+  method: string,
+  state: { current?: FaultControlState },
+): FaultRule | undefined {
+  // Atomic lane writes replace the inode. Read and version one descriptor so a
+  // replacement cannot pair new rules with an old finite-use counter.
+  const { text, version } = readControlFile(controlFile);
+  if (state.current?.version !== version) {
+    const rules = parseFaultRules(JSON.parse(text));
+    state.current = {
+      remaining: rules.map((rule) => rule.times ?? -1),
+      rules,
+      version,
+    };
+  }
+  const current = state.current;
+  for (let index = 0; index < current.rules.length; index += 1) {
+    const remaining = current.remaining[index];
+    if (current.rules[index]?.method !== method || remaining === undefined || remaining === 0) {
+      continue;
+    }
+    if (remaining !== -1) {
+      current.remaining[index] = remaining - 1;
+    }
+    return current.rules[index];
+  }
+  return undefined;
+}
+
+function boundedBodyMarker(buffer: Buffer, byteLength: number, reason: string): unknown {
+  return {
+    __mantisTruncated: true,
+    byteLength,
+    preview: buffer.subarray(0, MAX_TRUNCATED_PREVIEW_BYTES).toString("utf8"),
+    reason,
+  };
+}
+
+function captureRequestBody(request: IncomingMessage): Promise<RequestBodyCapture> {
+  const contentType = request.headers["content-type"]?.split(";", 1)[0]?.trim().toLowerCase();
+  const multipart = contentType === "multipart/form-data";
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    let capturedBytes = 0;
+    let byteLength = 0;
+    const finish = () => {
+      if (multipart) {
+        resolve({ contentType: request.headers["content-type"] });
+        return;
+      }
+      const buffer = Buffer.concat(chunks, capturedBytes);
+      if (byteLength > MAX_RECORDED_BODY_BYTES) {
+        resolve({ requestBody: boundedBodyMarker(buffer, byteLength, "body exceeds 32 KiB") });
+        return;
+      }
+      if (buffer.length === 0) {
+        resolve({ requestBody: null });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(buffer.toString("utf8"));
+        if (Buffer.byteLength(JSON.stringify(parsed)) > MAX_RECORDED_BODY_BYTES) {
+          resolve({
+            requestBody: boundedBodyMarker(buffer, byteLength, "parsed JSON exceeds 32 KiB"),
+          });
+          return;
+        }
+        resolve({ requestBody: parsed });
+      } catch {
+        resolve({ requestBody: boundedBodyMarker(buffer, byteLength, "body is not JSON") });
+      }
+    };
+    let finished = false;
+    const finishOnce = () => {
+      if (!finished) {
+        finished = true;
+        finish();
+      }
+    };
+    request.on("data", (chunk: Buffer) => {
+      byteLength += chunk.length;
+      if (!multipart && capturedBytes < MAX_RECORDED_BODY_BYTES) {
+        const captured = chunk.subarray(0, MAX_RECORDED_BODY_BYTES - capturedBytes);
+        chunks.push(captured);
+        capturedBytes += captured.length;
+      }
+    });
+    request.once("end", finishOnce);
+    request.once("aborted", finishOnce);
+    request.once("error", finishOnce);
+  });
+}
+
+function appendRecord(recordFile: string | undefined, entry: Record<string, unknown>): void {
+  if (recordFile) {
+    appendFileSync(recordFile, `${JSON.stringify(entry)}\n`);
+  }
+}
+
 export function createTelegramBotApiProxy(params: {
   aliasToken: string;
+  controlFile?: string;
+  recordFile?: string;
   upstreamOrigin?: URL;
   upstreamToken: string;
 }): http.Server {
   const upstreamOrigin = params.upstreamOrigin ?? new URL("https://api.telegram.org");
   const transport = upstreamOrigin.protocol === "https:" ? https : http;
+  const faultState: { current?: FaultControlState } = {};
   return http.createServer((request: IncomingMessage, response: ServerResponse) => {
     const upstreamPath = rewriteTelegramBotApiPath(
       request.url ?? "",
@@ -72,6 +257,73 @@ export function createTelegramBotApiProxy(params: {
       response.writeHead(404).end();
       return;
     }
+    const method = botApiMethod(request.url ?? "", params.aliasToken);
+    const startedAt = Date.now();
+    let injectedRule: FaultRule | undefined;
+    try {
+      injectedRule =
+        method && params.controlFile
+          ? matchingFaultRule(params.controlFile, method, faultState)
+          : undefined;
+    } catch (error) {
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: false, description: "mantis proxy control invalid" }));
+      console.error(error);
+      return;
+    }
+    const bodyCapture =
+      method && (params.recordFile || injectedRule)
+        ? captureRequestBody(request)
+        : Promise.resolve({});
+    if (method && injectedRule) {
+      void bodyCapture.then((body) => {
+        const status = injectedRule.mode === "drop" ? null : (injectedRule.status ?? 500);
+        try {
+          appendRecord(params.recordFile, {
+            at: new Date().toISOString(),
+            method,
+            status,
+            ok: false,
+            injected: true,
+            durationMs: Date.now() - startedAt,
+            ...body,
+          });
+        } catch (error) {
+          console.error(error);
+          request.socket.destroy(error instanceof Error ? error : new Error(String(error)));
+          return;
+        }
+        if (injectedRule.mode === "drop") {
+          request.socket.destroy();
+          return;
+        }
+        response.writeHead(status ?? 500, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            ok: false,
+            error_code: status ?? 500,
+            description: "mantis injected fault",
+          }),
+        );
+      });
+      return;
+    }
+    let recorded = false;
+    const record = async (status: number) => {
+      if (!method || recorded) {
+        return;
+      }
+      recorded = true;
+      appendRecord(params.recordFile, {
+        at: new Date().toISOString(),
+        method,
+        status,
+        ok: status >= 200 && status < 300,
+        injected: false,
+        durationMs: Date.now() - startedAt,
+        ...(await bodyCapture),
+      });
+    };
     const upstream = transport.request(
       {
         headers: { ...forwardedHeaders(request.headers), host: upstreamOrigin.host },
@@ -82,15 +334,20 @@ export function createTelegramBotApiProxy(params: {
         protocol: upstreamOrigin.protocol,
       },
       (upstreamResponse) => {
-        response.writeHead(
-          upstreamResponse.statusCode ?? 502,
-          forwardedHeaders(upstreamResponse.headers),
-        );
+        const status = upstreamResponse.statusCode ?? 502;
+        response.writeHead(status, forwardedHeaders(upstreamResponse.headers));
+        upstreamResponse.once("end", () => {
+          void record(status).catch((error: unknown) => {
+            console.error(error);
+            response.destroy(error instanceof Error ? error : new Error(String(error)));
+          });
+        });
         upstreamResponse.pipe(response);
       },
     );
     upstream.setTimeout(90_000, () => upstream.destroy(new Error("Telegram Bot API timed out")));
     upstream.on("error", () => {
+      void record(502).catch((error: unknown) => console.error(error));
       if (!response.headersSent) {
         response.writeHead(502);
       }
@@ -103,6 +360,8 @@ export function createTelegramBotApiProxy(params: {
 function main(): void {
   const server = createTelegramBotApiProxy({
     aliasToken: requiredEnv("TELEGRAM_PROXY_ALIAS_TOKEN"),
+    controlFile: process.env.TELEGRAM_PROXY_CONTROL?.trim() || undefined,
+    recordFile: process.env.TELEGRAM_PROXY_RECORD_FILE?.trim() || undefined,
     upstreamToken: requiredEnv("TELEGRAM_PROXY_UPSTREAM_TOKEN"),
   });
   server.listen(8080, "0.0.0.0", () => console.log("Telegram Bot API proxy listening"));

--- a/scripts/e2e/telegram-mantis-lane.ts
+++ b/scripts/e2e/telegram-mantis-lane.ts
@@ -1126,9 +1126,15 @@ async function observe(
       since: 0,
     });
     const events = Array.isArray(timeline.events) ? timeline.events : [];
+    // Event predicates scope to post-`since` events so stale timeline history
+    // (a reused marker, prior turns) cannot satisfy an early return before the
+    // observed action produces evidence. Provider counts stay cumulative: the
+    // provider log has no per-observe cursor and requests can land before the
+    // observe starts, so a relative baseline would miss them.
+    const newEvents = events.slice(since);
     const textMatched =
-      untilText === undefined || events.some((event) => valueContainsText(event, untilText));
-    const eventCountMatched = untilEvents === undefined || (timeline.cursor ?? 0) >= untilEvents;
+      untilText === undefined || newEvents.some((event) => valueContainsText(event, untilText));
+    const eventCountMatched = untilEvents === undefined || newEvents.length >= untilEvents;
     const providerCountMatched =
       untilProviderRequests === undefined ||
       providerRequests(state, secret).length >= untilProviderRequests;

--- a/scripts/e2e/telegram-mantis-lane.ts
+++ b/scripts/e2e/telegram-mantis-lane.ts
@@ -27,12 +27,56 @@ const configSchema = z.object({
   mockResponse: z.string().min(1).max(100_000),
   mockResponseChunkDelayMs: z.number().int().positive().max(MAX_MOCK_DELAY_MS).optional(),
 });
-const mockResponseControlSchema = z.object({
+const mockFailureSchema = z
+  .object({
+    mode: z.literal("drop").optional(),
+    status: z.number().int().min(400).max(599).optional(),
+  })
+  .superRefine((value, context) => {
+    if (value.mode === "drop" && value.status !== undefined) {
+      context.addIssue({ code: "custom", message: "fail cannot combine status and drop" });
+    }
+  });
+const mockControlEntrySchema = z.object({
   chunkDelayMs: z.number().int().min(0).max(MAX_MOCK_DELAY_MS).optional(),
   events: z.array(z.record(z.string(), z.unknown())).min(1).optional(),
-  hold: z.boolean().optional(),
+  fail: mockFailureSchema.optional(),
   text: z.string().min(1).max(100_000).optional(),
 });
+const mockResponseControlSchema = z.object({
+  chunkDelayMs: z.number().int().min(0).max(MAX_MOCK_DELAY_MS).optional(),
+  default: mockControlEntrySchema.optional(),
+  events: z.array(z.record(z.string(), z.unknown())).min(1).optional(),
+  hold: z.boolean().optional(),
+  responses: z.array(mockControlEntrySchema).min(1).optional(),
+  scriptVersion: z.string().min(1).optional(),
+  text: z.string().min(1).max(100_000).optional(),
+});
+const mockScriptEntrySchema = z
+  .object({
+    chunkDelayMs: z.number().int().min(0).max(MAX_MOCK_DELAY_MS).optional(),
+    eventsFile: z.string().min(1).max(4_096).optional(),
+    fail: mockFailureSchema.optional(),
+    text: z.string().min(1).max(100_000).optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const variants = [value.eventsFile, value.fail, value.text].filter(
+      (entry) => entry !== undefined,
+    );
+    if (variants.length !== 1) {
+      context.addIssue({
+        code: "custom",
+        message: "each scripted response needs exactly one of text, eventsFile, or fail",
+      });
+    }
+  });
+const mockScriptSchema = z
+  .object({
+    default: mockScriptEntrySchema.optional(),
+    responses: z.array(mockScriptEntrySchema).min(1).max(100),
+  })
+  .strict();
 const credentialSchema = z.object({
   groupId: z.string().regex(/^-100\d+$/u),
   sutToken: z.string().min(1),
@@ -43,6 +87,8 @@ const sutRecoverySchema = z.object({
   gatewayLog: z.string(),
   mockLog: z.string(),
   mockResponseControl: z.string(),
+  proxyControl: z.string(),
+  proxyRequestLog: z.string(),
   requestLog: z.string(),
   tempRoot: z.string(),
 });
@@ -111,11 +157,28 @@ const MAX_RPC_BYTES = 4 * 1024 * 1024;
 const commandOptions: Record<string, readonly string[]> = {
   abort: ["--lane"],
   block: ["--lane", "--missing-primitive", "--reason"],
+  "botapi-clear": ["--lane"],
+  "botapi-fail": ["--lane", "--method", "--times", "--status", "--drop"],
+  "botapi-requests": ["--lane", "--method", "--limit"],
   delete: ["--lane", "--message-id"],
   desktop: ["--lane", "--actions-file", "--timeout-seconds"],
   finish: ["--lane", "--focus-message-id"],
-  mock: ["--lane", "--response-file", "--response-events-file", "--chunk-delay-ms"],
-  observe: ["--lane", "--seconds", "--since"],
+  mock: [
+    "--lane",
+    "--response-file",
+    "--response-events-file",
+    "--chunk-delay-ms",
+    "--script",
+    "--script-sha256",
+  ],
+  observe: [
+    "--lane",
+    "--seconds",
+    "--since",
+    "--until-events",
+    "--until-text",
+    "--until-provider-requests",
+  ],
   press: ["--lane", "--message-id", "--button"],
   requests: ["--lane"],
   screenshot: ["--lane"],
@@ -166,18 +229,42 @@ function recorderRelativePath(file: string): string {
 }
 
 function parseCli(argv: string[]): { command: string; values: Map<string, string> } {
-  const [command, ...args] = argv;
-  if (!command || command.startsWith("--") || args.length % 2 !== 0) {
+  const [command, ...rawArgs] = argv;
+  if (!command || command.startsWith("--")) {
     throw new Error(usageText());
   }
+  const args = [...rawArgs];
   const values = new Map<string, string>();
-  for (let index = 0; index < args.length; index += 2) {
+  if (command === "botapi-fail" && args[0] && !args[0].startsWith("--")) {
+    values.set("--method", args.shift() ?? "");
+  }
+  for (let index = 0; index < args.length;) {
     const name = args[index];
+    if (!name?.startsWith("--") || values.has(name)) {
+      throw new Error(usageText());
+    }
+    if (name === "--drop") {
+      values.set(name, "true");
+      index += 1;
+      continue;
+    }
+    if (command === "mock" && name === "--script") {
+      const file = args[index + 1];
+      const sha256 = args[index + 2];
+      if (!file || !sha256 || sha256.startsWith("--")) {
+        throw new Error("mock --script needs a file and sha256.");
+      }
+      values.set(name, file);
+      values.set("--script-sha256", sha256);
+      index += 3;
+      continue;
+    }
     const value = args[index + 1];
-    if (!name?.startsWith("--") || value === undefined || values.has(name)) {
+    if (value === undefined || value.startsWith("--")) {
       throw new Error(usageText());
     }
     values.set(name, value);
+    index += 2;
   }
   const allowed = commandOptions[command];
   if (!allowed) {
@@ -252,7 +339,7 @@ function readPublicFile(
   input: string,
   label: string,
   maxBytes: number,
-): { relative: string; text: string } {
+): { relative: string; resolved: string; text: string } {
   const resolved = fs.realpathSync(input);
   const descriptor = fs.openSync(resolved, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
   try {
@@ -263,7 +350,7 @@ function readPublicFile(
     if (!stat.isFile() || stat.size > maxBytes) {
       throw new Error(`${label} must be a regular file no larger than ${maxBytes} bytes.`);
     }
-    return { relative, text: fs.readFileSync(descriptor, "utf8") };
+    return { relative, resolved, text: fs.readFileSync(descriptor, "utf8") };
   } finally {
     fs.closeSync(descriptor);
   }
@@ -506,6 +593,49 @@ function providerRequests(state: ActiveSession, secret: string): unknown[] {
     );
 }
 
+function boundedNdjson(file: string, limit: number): unknown[] {
+  if (!fs.existsSync(file)) {
+    return [];
+  }
+  const stat = fs.statSync(file);
+  const readBytes = Math.min(stat.size, MAX_RPC_BYTES);
+  const descriptor = fs.openSync(file, "r");
+  try {
+    const buffer = Buffer.alloc(readBytes);
+    fs.readSync(descriptor, buffer, 0, readBytes, stat.size - readBytes);
+    let text = buffer.toString("utf8");
+    if (readBytes < stat.size) {
+      text = text.slice(text.indexOf("\n") + 1);
+    }
+    return text
+      .split("\n")
+      .filter(Boolean)
+      .slice(-limit)
+      .map((line) => JSON.parse(line));
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function botApiRequests(
+  state: ActiveSession,
+  secret: string,
+  options: { limit?: number; method?: string } = {},
+): unknown[] {
+  const method = options.method;
+  const limit = options.limit ?? 100;
+  const requests = boundedNdjson(state.sut.proxyRequestLog, 128).filter(
+    (entry) =>
+      !method ||
+      (entry !== null && typeof entry === "object" && "method" in entry && entry.method === method),
+  );
+  return requests
+    .slice(-limit)
+    .map((entry, index) =>
+      Object.assign({ index: index + 1 }, redact(entry, secret) as Record<string, unknown>),
+    );
+}
+
 function outputJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
 }
@@ -560,6 +690,7 @@ export function publishStartupFailure(params: {
     {
       artifacts: {},
       attempt: params.startup.attempt,
+      botApiRequests: [],
       cleanupErrors: params.cleanupErrors,
       completedAt: new Date().toISOString(),
       error: coerceErrorMessage(params.error),
@@ -962,10 +1093,87 @@ async function observe(
   const since = values.has("--since")
     ? numberOption(values, "--since", Number.MAX_SAFE_INTEGER)
     : state.lastCursor;
-  const response = await observerCall(state.observerSocket, { command: "events", seconds, since });
-  state.observeSeconds += seconds;
-  appendInvocation(state, "observe", { seconds, since }, response.cursor);
+  const untilEvents = values.has("--until-events")
+    ? numberOption(values, "--until-events", 500)
+    : undefined;
+  const untilProviderRequests = values.has("--until-provider-requests")
+    ? numberOption(values, "--until-provider-requests", 100)
+    : undefined;
+  const untilText = values.get("--until-text");
+  if (untilText !== undefined && (untilText.length < 1 || untilText.length > 1_000)) {
+    throw new Error("--until-text must contain 1 to 1000 characters.");
+  }
+  const conditions =
+    untilEvents !== undefined || untilProviderRequests !== undefined || untilText !== undefined;
+  if (!conditions) {
+    const response = await observerCall(state.observerSocket, {
+      command: "events",
+      seconds,
+      since,
+    });
+    state.observeSeconds += seconds;
+    appendInvocation(state, "observe", { seconds, since }, response.cursor);
+    return redact(response, secret) as ObserverResponse;
+  }
+
+  const startedAt = Date.now();
+  const deadline = startedAt + seconds * 1_000;
+  let timeline: ObserverResponse;
+  while (true) {
+    timeline = await observerCall(state.observerSocket, {
+      command: "events",
+      seconds: 0,
+      since: 0,
+    });
+    const events = Array.isArray(timeline.events) ? timeline.events : [];
+    const textMatched =
+      untilText === undefined || events.some((event) => valueContainsText(event, untilText));
+    const eventCountMatched = untilEvents === undefined || (timeline.cursor ?? 0) >= untilEvents;
+    const providerCountMatched =
+      untilProviderRequests === undefined ||
+      providerRequests(state, secret).length >= untilProviderRequests;
+    if (textMatched && eventCountMatched && providerCountMatched) {
+      break;
+    }
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      break;
+    }
+    await observerCall(state.observerSocket, {
+      command: "events",
+      seconds: Math.min(1.5, remainingMs / 1_000),
+      since: 0,
+    });
+  }
+  const cursor = timeline.cursor ?? 0;
+  if (since > cursor) {
+    throw new Error("Observation cursor is outside this session's timeline.");
+  }
+  const response = {
+    ...timeline,
+    events: Array.isArray(timeline.events) ? timeline.events.slice(since) : [],
+  };
+  state.observeSeconds += (Date.now() - startedAt) / 1_000;
+  appendInvocation(
+    state,
+    "observe",
+    { seconds, since, untilEvents, untilProviderRequests, untilText },
+    response.cursor,
+  );
   return redact(response, secret) as ObserverResponse;
+}
+
+function valueContainsText(value: unknown, text: string): boolean {
+  if (typeof value === "string") {
+    return value.includes(text);
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => valueContainsText(entry, text));
+  }
+  if (value && typeof value === "object") {
+    return Object.values(value).some((entry) => valueContainsText(entry, text));
+  }
+  return false;
 }
 
 function updateMockResponse(
@@ -973,7 +1181,83 @@ function updateMockResponse(
   values: Map<string, string>,
   outputRoot: string,
 ): Record<string, unknown> {
+  if (values.has("--script")) {
+    if (
+      values.has("--response-file") ||
+      values.has("--response-events-file") ||
+      values.has("--chunk-delay-ms")
+    ) {
+      throw new Error("mock --script cannot be combined with single-response options.");
+    }
+    const scriptFile = readPublicFile(
+      outputRoot,
+      required(values, "--script"),
+      "--script",
+      512 * 1024,
+    );
+    const expectedSha256 = required(values, "--script-sha256").toLowerCase();
+    if (!/^[0-9a-f]{64}$/u.test(expectedSha256)) {
+      throw new Error("mock --script sha256 must be 64 lowercase hexadecimal characters.");
+    }
+    const scriptSha256 = createHash("sha256").update(scriptFile.text).digest("hex");
+    if (scriptSha256 !== expectedSha256) {
+      throw new Error("mock --script sha256 mismatch.");
+    }
+    const script = mockScriptSchema.parse(JSON.parse(scriptFile.text));
+    const eventFiles: Array<{ bytes: number; file: string; sha256: string }> = [];
+    let eventFileBytes = 0;
+    const materialize = (entry: z.infer<typeof mockScriptEntrySchema>) => {
+      if (!entry.eventsFile) {
+        return {
+          ...(entry.chunkDelayMs === undefined ? {} : { chunkDelayMs: entry.chunkDelayMs }),
+          ...(entry.fail === undefined ? {} : { fail: entry.fail }),
+          ...(entry.text === undefined ? {} : { text: entry.text }),
+        };
+      }
+      const eventsPath = path.resolve(path.dirname(scriptFile.resolved), entry.eventsFile);
+      const eventsFile = readPublicFile(outputRoot, eventsPath, "script eventsFile", MAX_RPC_BYTES);
+      eventFileBytes += Buffer.byteLength(eventsFile.text);
+      if (eventFileBytes > MAX_RPC_BYTES) {
+        throw new Error("mock --script event files exceed 4 MiB in total.");
+      }
+      const events = z
+        .array(z.record(z.string(), z.unknown()))
+        .min(1)
+        .parse(JSON.parse(eventsFile.text));
+      eventFiles.push({
+        bytes: Buffer.byteLength(eventsFile.text),
+        file: eventsFile.relative,
+        sha256: createHash("sha256").update(eventsFile.text).digest("hex"),
+      });
+      return {
+        ...(entry.chunkDelayMs === undefined ? {} : { chunkDelayMs: entry.chunkDelayMs }),
+        events,
+      };
+    };
+    const current = readMockResponseControl(state);
+    writeJsonAtomic(state.sut.mockResponseControl, {
+      ...(script.default === undefined ? {} : { default: materialize(script.default) }),
+      hold: current.hold,
+      responses: script.responses.map(materialize),
+      scriptVersion: `${scriptSha256}:${state.invocations.length + 1}`,
+    });
+    appendInvocation(state, "mock", {
+      bytes: Buffer.byteLength(scriptFile.text),
+      eventFiles,
+      responses: script.responses.length,
+      scriptFile: scriptFile.relative,
+      scriptSha256,
+    });
+    return {
+      eventFiles: eventFiles.length,
+      responses: script.responses.length,
+      scriptSha256,
+    };
+  }
   if (values.has("--response-events-file")) {
+    if (values.has("--response-file") || values.has("--chunk-delay-ms")) {
+      throw new Error("Use one mock response form at a time.");
+    }
     const eventsFile = readPublicFile(
       outputRoot,
       required(values, "--response-events-file"),
@@ -1017,6 +1301,48 @@ function updateMockResponse(
     textSha256,
   });
   return { bytes: Buffer.byteLength(text), chunkDelayMs, textSha256 };
+}
+
+function requireBotApiMethod(value: string): string {
+  if (!/^[A-Za-z][A-Za-z0-9_]{0,63}$/u.test(value)) {
+    throw new Error("Bot API method is invalid.");
+  }
+  return value;
+}
+
+function validateProxyControlFile(state: ActiveSession): void {
+  const control = fs.lstatSync(state.sut.proxyControl);
+  if (!control.isFile() || control.nlink !== 1) {
+    throw new Error("The private Telegram proxy control is no longer a regular file.");
+  }
+}
+
+function updateBotApiFault(
+  state: ActiveSession,
+  values: Map<string, string>,
+): Record<string, unknown> {
+  validateProxyControlFile(state);
+  const method = requireBotApiMethod(required(values, "--method"));
+  if (values.has("--drop") && values.has("--status")) {
+    throw new Error("Use only one of --status or --drop.");
+  }
+  const times = values.has("--times") ? numberOption(values, "--times", 100, 1) : undefined;
+  const status = values.has("--status") ? numberOption(values, "--status", 599, 400) : undefined;
+  const rule = {
+    method,
+    ...(times === undefined ? {} : { times }),
+    ...(values.has("--drop") ? { mode: "drop" } : { status: status ?? 500 }),
+  };
+  writeJsonAtomic(state.sut.proxyControl, { rules: [rule] });
+  appendInvocation(state, "botapi-fail", rule);
+  return rule;
+}
+
+function clearBotApiFaults(state: ActiveSession): Record<string, unknown> {
+  validateProxyControlFile(state);
+  writeJsonAtomic(state.sut.proxyControl, { rules: [] });
+  appendInvocation(state, "botapi-clear", {});
+  return { rules: 0 };
 }
 
 function readMockResponseControl(state: ActiveSession): z.infer<typeof mockResponseControlSchema> {
@@ -1207,6 +1533,7 @@ async function stopActiveLane(
   secret: string,
   crop: boolean,
 ): Promise<{
+  botApiRequests: unknown[];
   cleanupErrors: string[];
   cursor?: number;
   events: unknown[];
@@ -1217,6 +1544,7 @@ async function stopActiveLane(
   const cleanupErrors: string[] = [];
   const evidenceErrors: unknown[] = [];
   let cursor: number | undefined;
+  let recordedBotApiRequests: unknown[] = [];
   let events: unknown[] = [];
   let requests: unknown[] = [];
   let truncated = false;
@@ -1250,6 +1578,11 @@ async function stopActiveLane(
   } catch (error) {
     evidenceErrors.push(error);
   }
+  try {
+    recordedBotApiRequests = botApiRequests(state, secret);
+  } catch (error) {
+    evidenceErrors.push(error);
+  }
   // Recorder export and SUT teardown are independent; start export before the
   // synchronous container calls so both cleanup paths make progress together.
   const recorderStop = runCommand(requiredEnv("OPENCLAW_TELEGRAM_DESKTOP_RECORDER_CMD"), [
@@ -1264,7 +1597,15 @@ async function stopActiveLane(
   } catch (error) {
     cleanupErrors.push(coerceErrorMessage(error));
   }
-  return { cleanupErrors, cursor, events, evidenceErrors, requests, truncated };
+  return {
+    botApiRequests: recordedBotApiRequests,
+    cleanupErrors,
+    cursor,
+    events,
+    evidenceErrors,
+    requests,
+    truncated,
+  };
 }
 
 async function finalize(
@@ -1355,6 +1696,7 @@ async function finalize(
   const factsRaw = {
     artifacts: artifactRecords,
     attempt: state.attempt,
+    botApiRequests: stopped.botApiRequests,
     blocked: options.blocked,
     cleanupErrors: cleanupErrors.map((entry) => redact(entry, secret)),
     completedAt: new Date().toISOString(),
@@ -1448,6 +1790,7 @@ async function abort(state: ActiveSession, roots: Roots): Promise<void> {
     {
       artifacts: artifactRecords,
       attempt: state.attempt,
+      botApiRequests: stopped.botApiRequests,
       cleanupErrors: errors,
       completedAt: new Date().toISOString(),
       invocations: state.invocations,
@@ -1516,6 +1859,18 @@ async function main(): Promise<void> {
     const credential = credentialSchema.parse(readJson(roots.credentialFile));
     if (cli.command === "mock") {
       outputJson(updateMockResponse(state, cli.values, roots.outputRoot));
+    } else if (cli.command === "botapi-fail") {
+      outputJson(updateBotApiFault(state, cli.values));
+    } else if (cli.command === "botapi-clear") {
+      outputJson(clearBotApiFaults(state));
+    } else if (cli.command === "botapi-requests") {
+      const method = cli.values.has("--method")
+        ? requireBotApiMethod(required(cli.values, "--method"))
+        : undefined;
+      const limit = cli.values.has("--limit") ? numberOption(cli.values, "--limit", 100, 1) : 100;
+      const requests = botApiRequests(state, credential.sutToken, { limit, method });
+      appendInvocation(state, "botapi-requests", { count: requests.length, limit, method });
+      outputJson({ count: requests.length, requests });
     } else if (cli.command === "desktop") {
       outputJson(await runDesktopActions(state, cli.values, roots));
     } else if (cli.command === "send") {

--- a/scripts/e2e/telegram-mantis-sut.ts
+++ b/scripts/e2e/telegram-mantis-sut.ts
@@ -50,6 +50,8 @@ type MantisSutRuntime = {
   gatewayPid: number;
   mockLog: string;
   mockResponseControl: string;
+  proxyControl: string;
+  proxyRequestLog: string;
   requestLog: string;
   stateDir: string;
   sutAttestation: { lane: MantisSutLane; sha: string };
@@ -59,7 +61,14 @@ type MantisSutRuntime = {
 
 export type MantisSutRecovery = Pick<
   MantisSutRuntime,
-  "containerName" | "gatewayLog" | "mockLog" | "mockResponseControl" | "requestLog" | "tempRoot"
+  | "containerName"
+  | "gatewayLog"
+  | "mockLog"
+  | "mockResponseControl"
+  | "proxyControl"
+  | "proxyRequestLog"
+  | "requestLog"
+  | "tempRoot"
 >;
 
 function childProcessBaseEnv(): NodeJS.ProcessEnv {
@@ -503,10 +512,15 @@ export function runSutContainerAction(
 }
 
 export function preserveMantisSutRuntimeArtifacts(
-  sut: Pick<MantisSutRuntime, "gatewayLog" | "mockLog" | "requestLog">,
+  sut: Pick<MantisSutRuntime, "gatewayLog" | "mockLog" | "requestLog"> & {
+    proxyRequestLog?: string;
+  },
   outputDir: string,
 ): void {
-  for (const source of [sut.gatewayLog, sut.mockLog, sut.requestLog]) {
+  for (const source of [sut.gatewayLog, sut.mockLog, sut.requestLog, sut.proxyRequestLog]) {
+    if (!source) {
+      continue;
+    }
     const target = path.join(outputDir, path.basename(source));
     if (path.resolve(source) !== path.resolve(target) && fs.existsSync(source)) {
       fs.copyFileSync(source, target);
@@ -562,6 +576,12 @@ export async function startMantisSut(params: {
     })}\n`,
     { mode: 0o600 },
   );
+  const proxyControlDir = path.join(config.tempRoot, "proxy-control");
+  fs.mkdirSync(proxyControlDir, { mode: 0o700 });
+  const proxyControl = path.join(proxyControlDir, "control.json");
+  const proxyRequestLog = path.join(proxyControlDir, "requests.ndjson");
+  fs.writeFileSync(proxyControl, '{"rules":[]}\n', { mode: 0o600 });
+  fs.writeFileSync(proxyRequestLog, "", { mode: 0o600 });
   const gatewayLog = path.join(config.tempRoot, "gateway.log");
   const gatewayEnv = createMantisGatewayEnv({ ...config, sutToken: params.sutToken });
   const containerName = `openclaw-telegram-sut-${randomUUID()}`;
@@ -581,6 +601,8 @@ export async function startMantisSut(params: {
     gatewayLog,
     mockLog,
     mockResponseControl,
+    proxyControl,
+    proxyRequestLog,
     requestLog,
     tempRoot: config.tempRoot,
   });
@@ -617,6 +639,8 @@ export async function startMantisSut(params: {
       gatewayPid,
       mockLog,
       mockResponseControl,
+      proxyControl,
+      proxyRequestLog,
       requestLog,
       sutAttestation,
     };
@@ -631,7 +655,10 @@ export async function startMantisSut(params: {
     }
     if (stopped) {
       try {
-        preserveMantisSutRuntimeArtifacts({ gatewayLog, mockLog, requestLog }, params.outputDir);
+        preserveMantisSutRuntimeArtifacts(
+          { gatewayLog, mockLog, proxyRequestLog, requestLog },
+          params.outputDir,
+        );
       } catch (cleanupError) {
         cleanupErrors.push(cleanupError);
       }

--- a/scripts/mantis/build-telegram-desktop-proof-evidence.mts
+++ b/scripts/mantis/build-telegram-desktop-proof-evidence.mts
@@ -19,6 +19,7 @@ type SessionSummary = {
   sutAttestation?: { lane?: string; sha?: string };
 };
 type LoadedLane = {
+  factsPath: string;
   outputDir: string;
   repoRoot: string;
   status: string;
@@ -30,7 +31,7 @@ type EvidenceArtifact = {
   inline?: boolean;
   kind: string;
   label: string;
-  lane: LaneName;
+  lane: LaneName | "run";
   path: string;
   required?: boolean;
   targetPath: string;
@@ -117,7 +118,9 @@ function copyArtifact({
   }
   const target = path.join(outputDir, targetPath);
   mkdirSync(path.dirname(target), { recursive: true });
-  copyFileSync(source, target);
+  if (path.resolve(source) !== path.resolve(target)) {
+    copyFileSync(source, target);
+  }
   return true;
 }
 
@@ -141,6 +144,7 @@ function loadLane({
   const summaryPath = path.join(outputDir, "telegram-user-crabbox-session-summary.json");
   const summary = readJson(summaryPath);
   return {
+    factsPath: path.join(outputDir, "mantis-lane-facts.json"),
     outputDir,
     repoRoot,
     status: status || summary.status || "unknown",
@@ -185,6 +189,11 @@ function copyLaneArtifacts({
     outputDir,
     source: lane.summaryPath,
     targetPath: `${prefix}/summary.json`,
+  });
+  copyArtifact({
+    outputDir,
+    source: lane.factsPath,
+    targetPath: `${prefix}/mantis-lane-facts.json`,
   });
   copyArtifact({
     outputDir,
@@ -257,6 +266,13 @@ function laneArtifactEntries(statuses: Record<LaneName, LaneStatus>): EvidenceAr
       targetPath: `${lane}/summary.json`,
     },
     {
+      kind: "metadata",
+      label: `${label} lane facts`,
+      lane,
+      path: `${lane}/mantis-lane-facts.json`,
+      targetPath: `${lane}/mantis-lane-facts.json`,
+    },
+    {
       kind: "report",
       label: `${label} session report`,
       lane,
@@ -318,7 +334,18 @@ function buildTelegramDesktopProofManifest({
       outcome,
       pass: outcome === "pass",
     },
-    artifacts: laneArtifactEntries({ baseline: baselineStatus, candidate: candidateStatus }),
+    artifacts: [
+      ...laneArtifactEntries({ baseline: baselineStatus, candidate: candidateStatus }),
+      {
+        inline: false,
+        kind: "attachment",
+        label: "Recipe suggestion",
+        lane: "run",
+        path: "recipe-suggestion.md",
+        required: false,
+        targetPath: "recipe-suggestion.md",
+      },
+    ],
   };
 }
 
@@ -351,6 +378,12 @@ export function writeTelegramDesktopProofEvidence(rawArgs: string[] = process.ar
   requireLaneAttestation(candidate, "candidate", candidateSha);
   copyLaneArtifacts({ lane: baseline, laneName: "baseline", outputDir });
   copyLaneArtifacts({ lane: candidate, laneName: "candidate", outputDir });
+  copyArtifact({
+    outputDir,
+    required: false,
+    source: path.join(outputDir, "recipe-suggestion.md"),
+    targetPath: "recipe-suggestion.md",
+  });
   const manifest = buildTelegramDesktopProofManifest({
     baseline,
     baselineRef: args.baseline_ref,

--- a/scripts/mantis/mantis-sut-container.sh
+++ b/scripts/mantis/mantis-sut-container.sh
@@ -904,11 +904,16 @@ case "$command" in
       "$image" node /opt/mantis/telegram-bot-api-proxy.mjs >/dev/null
     "$docker_bin" network connect --alias telegram-api-proxy "$network_name" "$proxy_container_name"
     require_runtime_claim_active "$container_name"
+    # proxy-control holds the proxy's fault rules and recorded Bot API facts.
+    # The SUT runs untrusted candidate code as the same mantis-sut UID, so an
+    # inaccessible tmpfs must shadow the directory inside the runtime mount;
+    # without it the lane under test could rewrite its own trusted evidence.
     "$docker_bin" run --rm --init --name "$container_name" --network "$network_name" \
       "${container_security_args[@]}" "${runtime_resource_args[@]}" \
       --mount "type=bind,src=$repo_root,dst=$repo_root,readonly" \
       --mount "type=bind,src=$mock_server_script,dst=/opt/mantis/mock-openai-server.mjs,readonly" \
       --mount "type=bind,src=$safe_runtime,dst=$runtime_source" \
+      --mount "type=tmpfs,dst=$runtime_source/proxy-control,tmpfs-size=65536,tmpfs-mode=0000" \
       --workdir "$repo_root" \
       --user "$(id -u mantis-sut):$(id -g mantis-sut)" \
       "${docker_env[@]}" \

--- a/scripts/mantis/mantis-sut-container.sh
+++ b/scripts/mantis/mantis-sut-container.sh
@@ -784,6 +784,24 @@ case "$command" in
       || die "mock response control mode mismatch"
     [[ "$(stat -c %h "$response_control")" == "1" ]] \
       || die "mock response control must not be hard-linked"
+    proxy_control_dir="$safe_runtime/proxy-control"
+    [[ -d "$proxy_control_dir" && ! -L "$proxy_control_dir" ]] \
+      || die "invalid Telegram proxy control directory"
+    [[ "$(stat -c %u "$proxy_control_dir")" == "$(id -u mantis-sut)" ]] \
+      || die "Telegram proxy control directory owner mismatch"
+    [[ "$(stat -c %a "$proxy_control_dir")" == "700" ]] \
+      || die "Telegram proxy control directory mode mismatch"
+    proxy_control="$proxy_control_dir/control.json"
+    proxy_record="$proxy_control_dir/requests.ndjson"
+    for file in "$proxy_control" "$proxy_record"; do
+      [[ -f "$file" && ! -L "$file" ]] || die "invalid Telegram proxy control file"
+      [[ "$(stat -c %u "$file")" == "$(id -u mantis-sut)" ]] \
+        || die "Telegram proxy control file owner mismatch"
+      [[ "$(stat -c %a "$file")" == "600" ]] \
+        || die "Telegram proxy control file mode mismatch"
+      [[ "$(stat -c %h "$file")" == "1" ]] \
+        || die "Telegram proxy control file must not be hard-linked"
+    done
     for name in gateway.log mock-openai.log mock-openai-requests.ndjson sut-attestation.json; do
       [[ ! -e "$safe_runtime/$name" && ! -L "$safe_runtime/$name" ]] \
         || die "runtime output was pre-created"
@@ -877,8 +895,11 @@ case "$command" in
     "$docker_bin" run --detach --name "$proxy_container_name" --network "$egress_network_name" \
       "${container_security_args[@]}" "${proxy_resource_args[@]}" \
       --mount "type=bind,src=$telegram_proxy_script,dst=/opt/mantis/telegram-bot-api-proxy.mjs,readonly" \
+      --mount "type=bind,src=$proxy_control_dir,dst=/opt/mantis/proxy-control" \
       --user "$(id -u mantis-sut):$(id -g mantis-sut)" \
       --env TELEGRAM_PROXY_ALIAS_TOKEN="$telegram_alias_token" \
+      --env TELEGRAM_PROXY_CONTROL=/opt/mantis/proxy-control/control.json \
+      --env TELEGRAM_PROXY_RECORD_FILE=/opt/mantis/proxy-control/requests.ndjson \
       --env TELEGRAM_PROXY_UPSTREAM_TOKEN="$telegram_bot_token" \
       "$image" node /opt/mantis/telegram-bot-api-proxy.mjs >/dev/null
     "$docker_bin" network connect --alias telegram-api-proxy "$network_name" "$proxy_container_name"

--- a/test/scripts/e2e-mock-config-limits.test.ts
+++ b/test/scripts/e2e-mock-config-limits.test.ts
@@ -1,7 +1,7 @@
 // E2E Mock Config Limits tests cover e2e mock config limits script behavior.
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -288,6 +288,104 @@ describe("mock OpenAI response markers", () => {
           JSON.stringify({ chunkDelayMs: 0, hold: false, text: "visible after reveal" }),
         );
         expect((await request).output?.[0]?.content?.[0]?.text).toBe("visible after reveal");
+      });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("consumes scripted responses in order and logs the selected entries", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-mock-response-script-"));
+    const control = join(root, "response.json");
+    const requestLog = join(root, "requests.ndjson");
+    const script = {
+      scriptVersion: "script-1",
+      hold: true,
+      responses: [
+        { text: "first response" },
+        { fail: { status: 429 } },
+        { text: "third response" },
+      ],
+      default: { text: "default response" },
+    };
+    try {
+      await writeFile(control, JSON.stringify(script));
+      await writeFile(requestLog, "");
+      await withMockServer(
+        mockOpenAiPath,
+        { MOCK_REQUEST_LOG: requestLog, MOCK_RESPONSE_CONTROL: control },
+        async (baseUrl) => {
+          const request = () =>
+            fetch(`${baseUrl}/v1/responses`, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ input: "scripted turn", stream: false }),
+            });
+          const firstPromise = request();
+          await delay(75);
+          await writeFile(control, JSON.stringify({ ...script, hold: false }));
+          const first = await firstPromise;
+          expect((await first.json()).output?.[0]?.content?.[0]?.text).toBe("first response");
+          const second = await request();
+          expect(second.status).toBe(429);
+          expect(await second.json()).toEqual({ error: { message: "mantis injected fault" } });
+          const third = await request();
+          expect((await third.json()).output?.[0]?.content?.[0]?.text).toBe("third response");
+          const fourth = await request();
+          expect((await fourth.json()).output?.[0]?.content?.[0]?.text).toBe("default response");
+          await writeFile(
+            control,
+            JSON.stringify({ ...script, hold: false, scriptVersion: "script-2" }),
+          );
+          const reset = await request();
+          expect((await reset.json()).output?.[0]?.content?.[0]?.text).toBe("first response");
+          await writeFile(
+            control,
+            JSON.stringify({ responses: [{ text: "last response" }], scriptVersion: "script-3" }),
+          );
+          expect((await (await request()).json()).output?.[0]?.content?.[0]?.text).toBe(
+            "last response",
+          );
+          expect((await (await request()).json()).output?.[0]?.content?.[0]?.text).toBe(
+            "last response",
+          );
+
+          const entries = (await readFile(requestLog, "utf8"))
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+          expect(entries.map((entry) => entry.scriptEntry)).toEqual([
+            { entryIndex: 0, requestIndex: 0, source: "responses" },
+            { entryIndex: 1, requestIndex: 1, source: "responses" },
+            { entryIndex: 2, requestIndex: 2, source: "responses" },
+            { requestIndex: 3, source: "default" },
+            { entryIndex: 0, requestIndex: 0, source: "responses" },
+            { entryIndex: 0, requestIndex: 0, source: "responses" },
+            { entryIndex: 0, requestIndex: 1, source: "last" },
+          ]);
+        },
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("supports scripted connection drops", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-mock-response-drop-"));
+    const control = join(root, "response.json");
+    try {
+      await writeFile(
+        control,
+        JSON.stringify({ responses: [{ fail: { mode: "drop" } }], scriptVersion: "drop-1" }),
+      );
+      await withMockServer(mockOpenAiPath, { MOCK_RESPONSE_CONTROL: control }, async (baseUrl) => {
+        await expect(
+          fetch(`${baseUrl}/v1/responses`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ input: "drop this turn", stream: false }),
+          }),
+        ).rejects.toThrow();
       });
     } finally {
       await rm(root, { force: true, recursive: true });

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -61,6 +61,19 @@ function makeLane(
       ...(options.diagnosticOnly ? {} : { sutAttestation: { lane: name, sha } }),
     }),
   );
+  writeFileSync(
+    path.join(outputDir, "mantis-lane-facts.json"),
+    JSON.stringify({
+      botApiRequests: [{ injected: true, method: "sendMessage", status: 429 }],
+      invocations: [
+        { command: "botapi-fail" },
+        { args: { scriptFile: "provider-script.json" }, command: "mock" },
+      ],
+      lane: name,
+      providerRequests: [],
+      schemaVersion: 2,
+    }),
+  );
   return { outputDir, repo };
 }
 
@@ -105,6 +118,15 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(manifest.artifacts.map((artifact) => artifact.targetPath)).toContain(
       "candidate/telegram-desktop-proof.gif",
     );
+    expect(manifest.artifacts.map((artifact) => artifact.targetPath)).toContain(
+      "candidate/mantis-lane-facts.json",
+    );
+    expect(
+      JSON.parse(readFileSync(path.join(outputDir, "candidate", "mantis-lane-facts.json"), "utf8")),
+    ).toMatchObject({
+      botApiRequests: [{ injected: true, method: "sendMessage", status: 429 }],
+      invocations: [{ command: "botapi-fail" }, { command: "mock" }],
+    });
     const artifactUrl = "https://github.com/openclaw/openclaw/actions/runs/1/artifacts/2";
     const body = renderEvidenceComment({
       artifactUrl,
@@ -278,5 +300,45 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(
       JSON.parse(readFileSync(path.join(outputDir, "baseline", "summary.json"), "utf8")),
     ).toEqual({ artifacts: {}, status: "infra-error" });
+  });
+
+  it("publishes an optional recipe suggestion as a non-inline attachment", () => {
+    const baselineSha = "a".repeat(40);
+    const candidateSha = "b".repeat(40);
+    const baseline = makeLane("baseline", baselineSha);
+    const candidate = makeLane("candidate", candidateSha);
+    const outputDir = mkdtempSync(path.join(tmpdir(), "mantis-telegram-recipe-proof-"));
+    tempDirs.push(outputDir);
+    writeFileSync(path.join(outputDir, "recipe-suggestion.md"), "# Reusable proof\n");
+
+    const result = writeTelegramDesktopProofEvidence([
+      "--output-dir",
+      outputDir,
+      "--baseline-repo-root",
+      baseline.repo,
+      "--baseline-output-dir",
+      baseline.outputDir,
+      "--baseline-sha",
+      baselineSha,
+      "--candidate-repo-root",
+      candidate.repo,
+      "--candidate-output-dir",
+      candidate.outputDir,
+      "--candidate-sha",
+      candidateSha,
+    ]);
+
+    const manifest = loadEvidenceManifest(result.manifestPath);
+    expect(manifest.artifacts).toContainEqual(
+      expect.objectContaining({
+        inline: false,
+        kind: "attachment",
+        lane: "run",
+        targetPath: "recipe-suggestion.md",
+      }),
+    );
+    expect(readFileSync(path.join(outputDir, "recipe-suggestion.md"), "utf8")).toBe(
+      "# Reusable proof\n",
+    );
   });
 });

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -1128,6 +1128,15 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(wrapper).toContain(
       "--env TELEGRAM_PROXY_RECORD_FILE=/opt/mantis/proxy-control/requests.ndjson",
     );
+    // Candidate code shares the mantis-sut UID with the proxy record sink, so
+    // the SUT container must shadow proxy-control; otherwise the lane under
+    // test could rewrite its own trusted Bot API evidence before publication.
+    const proxyControlShadow =
+      '--mount "type=tmpfs,dst=$runtime_source/proxy-control,tmpfs-size=65536,tmpfs-mode=0000"';
+    expect(wrapper).toContain(proxyControlShadow);
+    expect(wrapper.indexOf(proxyControlShadow)).toBeGreaterThan(
+      wrapper.indexOf('--mount "type=bind,src=$safe_runtime,dst=$runtime_source"'),
+    );
     expect(wrapper).toContain('export TELEGRAM_BOT_TOKEN="$telegram_alias_token"');
     expect(wrapper).not.toContain('export TELEGRAM_BOT_TOKEN="$telegram_bot_token"');
     expect(wrapper).toContain('remove_container_or_fail "${1}-telegram-proxy"');

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -273,6 +273,7 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(gate).toContain('any(.invocations[]; .command == "finish")');
     expect(gate).toContain(".observation.events");
     expect(gate).toContain(".blocked.name == null or");
+    expect(gate).toContain(".botApiRequests");
     expect(gate).toContain(".providerRequests");
     expect(gate).toContain('copy_verified_artifacts "$lane" "$attempt_facts"');
     expect(gate).toContain('copy_verified_artifacts "$lane" "$verdict"');
@@ -295,6 +296,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
       'sudo install -m 0400 -o root -g root "$agent_manifest" "$trusted_agent_manifest"',
     );
     expect(gate).toContain('agent_manifest="$trusted_agent_manifest"');
+    expect(gate).toContain('recipe_suggestion="$quarantine/recipe-suggestion.md"');
+    expect(gate).toContain("((recipe_bytes > 0 && recipe_bytes <= 65536))");
+    expect(gate).toContain('"$trusted_output/recipe-suggestion.md"');
     expect(
       gate.indexOf(
         'sudo install -m 0400 -o root -g root "$agent_manifest" "$trusted_agent_manifest"',
@@ -662,10 +666,15 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     const prompt = readFileSync(PROMPT, "utf8");
     expect(prompt).toContain("$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD");
     expect(prompt).toContain("Write a short Bash scenario");
-    expect(prompt).toContain("`observe --seconds N [--since cursor]`");
+    expect(prompt).toContain("`observe --seconds N [--since cursor] [--until-events N]");
+    expect(prompt).toContain("`mock --script <public-json> <sha256>`");
+    expect(prompt).toContain("`botapi-fail <method> [--times N] [--status CODE | --drop]`");
+    expect(prompt).toContain("`botapi-requests [--method M] [--limit N]`");
     expect(prompt).toContain("`requests`");
     expect(prompt).toContain("`finish [--focus-message-id ID]`");
-    expect(prompt).toContain("Identical relevant observations are unproven");
+    expect(prompt).toContain("Identical pixels alone do not force `block`");
+    expect(prompt).toContain("mantis-recipes/");
+    expect(prompt).toContain("recipe-suggestion.md");
     expect(prompt).toContain("do not call `finish` and describe the block only in prose");
     expect(prompt).toContain("`block --reason TEXT [--missing-primitive NAME]`");
     expect(prompt).toContain("`@{sut}`");
@@ -798,11 +807,11 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(readFileSync(WORKFLOW, "utf8")).not.toContain("CRABBOX_COORDINATOR");
   });
 
-  it("runs the Mantis Codex agent in fast medium-effort mode", () => {
+  it("runs the Mantis Codex agent in fast high-effort mode", () => {
     const agent = workflowStep("Run Codex Mantis Telegram agent");
 
     expect(agent.uses).toContain("openai/codex-action@");
-    expect(agent.with?.effort).toBe("medium");
+    expect(agent.with?.effort).toBe("high");
     expect(agent.with?.["codex-args"]).toBe('["-c","service_tier=\\"fast\\""]');
   });
 
@@ -1110,6 +1119,15 @@ describe("Mantis Telegram Desktop proof workflow", () => {
       'network connect --alias telegram-api-proxy "$network_name" "$proxy_container_name"',
     );
     expect(wrapper).toContain('--env TELEGRAM_PROXY_UPSTREAM_TOKEN="$telegram_bot_token"');
+    expect(wrapper).toContain(
+      '--mount "type=bind,src=$proxy_control_dir,dst=/opt/mantis/proxy-control"',
+    );
+    expect(wrapper).toContain(
+      "--env TELEGRAM_PROXY_CONTROL=/opt/mantis/proxy-control/control.json",
+    );
+    expect(wrapper).toContain(
+      "--env TELEGRAM_PROXY_RECORD_FILE=/opt/mantis/proxy-control/requests.ndjson",
+    );
     expect(wrapper).toContain('export TELEGRAM_BOT_TOKEN="$telegram_alias_token"');
     expect(wrapper).not.toContain('export TELEGRAM_BOT_TOKEN="$telegram_bot_token"');
     expect(wrapper).toContain('remove_container_or_fail "${1}-telegram-proxy"');
@@ -1138,6 +1156,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     );
     expect(sutScript).toContain(
       'const mockResponseControlDir = path.join(config.tempRoot, "mock-control")',
+    );
+    expect(sutScript).toContain(
+      'const proxyControlDir = path.join(config.tempRoot, "proxy-control")',
     );
     expect(sutScript).toContain(
       'const requestLog = path.join(config.tempRoot, "mock-openai-requests.ndjson")',

--- a/test/scripts/telegram-bot-api-proxy.test.ts
+++ b/test/scripts/telegram-bot-api-proxy.test.ts
@@ -1,11 +1,15 @@
+import fs from "node:fs";
 import http from "node:http";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createTelegramBotApiProxy,
   rewriteTelegramBotApiPath,
 } from "../../scripts/e2e/telegram-bot-api-proxy.ts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const servers: http.Server[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(async () => {
   await Promise.all(
@@ -38,6 +42,15 @@ describe("Telegram Bot API credential proxy", () => {
     ).toBeUndefined();
     expect(
       rewriteTelegramBotApiPath("/bot123:alias/../getMe", "123:alias", "123:real"),
+    ).toBeUndefined();
+    expect(rewriteTelegramBotApiPath("/bot123.+:alias/getMe", "123.+:alias", "123:real")).toBe(
+      "/bot123:real/getMe",
+    );
+    expect(
+      rewriteTelegramBotApiPath(`/bot123:alias/${"a".repeat(65)}`, "123:alias", "123:real"),
+    ).toBeUndefined();
+    expect(
+      rewriteTelegramBotApiPath("/file/bot123:alias/photos/../secret.jpg", "123:alias", "123:real"),
     ).toBeUndefined();
   });
 
@@ -81,5 +94,125 @@ describe("Telegram Bot API credential proxy", () => {
       "status",
       404,
     );
+  });
+
+  it("injects bounded status failures and records every ordered request", async () => {
+    const root = tempDirs.make("telegram-proxy-record-");
+    const controlFile = path.join(root, "control.json");
+    const recordFile = path.join(root, "requests.ndjson");
+    fs.writeFileSync(
+      controlFile,
+      JSON.stringify({ rules: [{ method: "sendMessage", status: 429, times: 2 }] }),
+    );
+    fs.writeFileSync(recordFile, "");
+    let upstreamCalls = 0;
+    const upstreamPort = await listen(
+      http.createServer((request, response) => {
+        upstreamCalls += 1;
+        request.resume();
+        request.on("end", () => {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end('{"ok":true}');
+        });
+      }),
+    );
+    const proxyPort = await listen(
+      createTelegramBotApiProxy({
+        aliasToken: "123:alias",
+        controlFile,
+        recordFile,
+        upstreamOrigin: new URL(`http://127.0.0.1:${upstreamPort}`),
+        upstreamToken: "123:real",
+      }),
+    );
+    const request = (text: string) =>
+      fetch(`http://127.0.0.1:${proxyPort}/bot123:alias/sendMessage`, {
+        body: JSON.stringify({ chat_id: "1", text }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+
+    expect((await request("first")).status).toBe(429);
+    expect((await request("second")).status).toBe(429);
+    expect((await request("x".repeat(40_000))).status).toBe(200);
+    expect(upstreamCalls).toBe(1);
+    await expect.poll(() => fs.readFileSync(recordFile, "utf8").trim().split("\n")).toHaveLength(3);
+    const records = fs
+      .readFileSync(recordFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(records).toMatchObject([
+      {
+        method: "sendMessage",
+        status: 429,
+        ok: false,
+        injected: true,
+        requestBody: { text: "first" },
+      },
+      {
+        method: "sendMessage",
+        status: 429,
+        ok: false,
+        injected: true,
+        requestBody: { text: "second" },
+      },
+      {
+        method: "sendMessage",
+        status: 200,
+        ok: true,
+        injected: false,
+        requestBody: { __mantisTruncated: true, reason: "body exceeds 32 KiB" },
+      },
+    ]);
+    expect(records[2].requestBody.byteLength).toBeGreaterThan(32 * 1024);
+    expect(JSON.stringify(records)).not.toContain("123:real");
+    expect(records.every((entry) => Number.isInteger(entry.durationMs))).toBe(true);
+  });
+
+  it("drops injected sockets without forwarding and omits multipart bodies", async () => {
+    const root = tempDirs.make("telegram-proxy-drop-");
+    const controlFile = path.join(root, "control.json");
+    const recordFile = path.join(root, "requests.ndjson");
+    fs.writeFileSync(
+      controlFile,
+      JSON.stringify({ rules: [{ method: "sendDocument", mode: "drop" }] }),
+    );
+    fs.writeFileSync(recordFile, "");
+    let upstreamCalls = 0;
+    const upstreamPort = await listen(
+      http.createServer((_request, response) => {
+        upstreamCalls += 1;
+        response.end('{"ok":true}');
+      }),
+    );
+    const proxyPort = await listen(
+      createTelegramBotApiProxy({
+        aliasToken: "123:alias",
+        controlFile,
+        recordFile,
+        upstreamOrigin: new URL(`http://127.0.0.1:${upstreamPort}`),
+        upstreamToken: "123:real",
+      }),
+    );
+
+    await expect(
+      fetch(`http://127.0.0.1:${proxyPort}/bot123:alias/sendDocument`, {
+        body: "--boundary\r\nsecret bytes\r\n--boundary--",
+        headers: { "content-type": "multipart/form-data; boundary=boundary" },
+        method: "POST",
+      }),
+    ).rejects.toThrow();
+    expect(upstreamCalls).toBe(0);
+    await expect.poll(() => fs.readFileSync(recordFile, "utf8").trim()).not.toBe("");
+    const record = JSON.parse(fs.readFileSync(recordFile, "utf8").trim());
+    expect(record).toMatchObject({
+      contentType: "multipart/form-data; boundary=boundary",
+      injected: true,
+      method: "sendDocument",
+      ok: false,
+      status: null,
+    });
+    expect(record).not.toHaveProperty("requestBody");
   });
 });

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
@@ -35,8 +36,12 @@ async function setupHarness(
   const screenshot = path.join(root, "proof.png");
   const previewGif = path.join(root, "proof.gif");
   const trimmedVideo = path.join(root, "proof.mp4");
+  const proxyControl = path.join(root, "proxy-control.json");
+  const proxyRequestLog = path.join(root, "proxy-requests.ndjson");
+  const requestLog = path.join(root, "requests.ndjson");
   fs.mkdirSync(outputRoot);
   fs.mkdirSync(sessionRoot);
+  fs.mkdirSync(path.join(sessionRoot, "attempt"));
   fs.mkdirSync(binDir);
   writeJson(credentialFile, {
     groupId: "-100123456789",
@@ -44,6 +49,9 @@ async function setupHarness(
     testerUserId: "77",
   });
   writeJson(path.join(root, "mock-response.json"), { chunkDelayMs: 0, text: "initial" });
+  writeJson(proxyControl, { rules: [] });
+  fs.writeFileSync(proxyRequestLog, "");
+  fs.writeFileSync(requestLog, "");
   fs.writeFileSync(
     screenshot,
     Buffer.concat([Buffer.from("89504e470d0a1a0a", "hex"), Buffer.alloc(10_001)]),
@@ -78,7 +86,9 @@ async function setupHarness(
       gatewayLog: path.join(root, "gateway.log"),
       mockLog: path.join(root, "mock.log"),
       mockResponseControl: path.join(root, "mock-response.json"),
-      requestLog: path.join(root, "requests.ndjson"),
+      proxyControl,
+      proxyRequestLog,
+      requestLog,
       sutAttestation: { lane: "candidate", sha: "a".repeat(40) },
       tempRoot: path.join(root, "sut"),
     },
@@ -149,8 +159,11 @@ async function setupHarness(
       PATH: `${binDir}:${process.env.PATH}`,
     },
     outputRoot,
+    proxyControl,
+    proxyRequestLog,
     recorderControlLog,
     recorderLog,
+    requestLog,
     requests,
     sessionRoot,
   };
@@ -221,6 +234,7 @@ describe("Telegram Mantis free-form lane", () => {
     expect(facts).toMatchObject({
       artifacts: {},
       attempt: 1,
+      botApiRequests: [],
       cleanupErrors: [],
       error: "desktop failed with [redacted]",
       invocations: [
@@ -515,6 +529,176 @@ describe("Telegram Mantis free-form lane", () => {
     }
   });
 
+  it("materializes a verified per-request provider script into private control", async () => {
+    const harness = await setupHarness();
+    const eventsFile = path.join(harness.outputRoot, "turn-events.json");
+    const scriptFile = path.join(harness.outputRoot, "provider-script.json");
+    fs.writeFileSync(eventsFile, JSON.stringify([{ type: "response.completed", response: {} }]));
+    fs.writeFileSync(
+      scriptFile,
+      JSON.stringify({
+        responses: [
+          { chunkDelayMs: 50, text: "first" },
+          { eventsFile: "turn-events.json" },
+          { fail: { status: 503 } },
+        ],
+        default: { fail: { mode: "drop" } },
+      }),
+    );
+    const sha256 = createHash("sha256").update(fs.readFileSync(scriptFile)).digest("hex");
+    try {
+      const result = await runLane(harness.env, [
+        "mock",
+        "--lane",
+        "candidate",
+        "--script",
+        scriptFile,
+        sha256,
+      ]);
+      expect(JSON.parse(result.stdout)).toEqual({
+        eventFiles: 1,
+        responses: 3,
+        scriptSha256: sha256,
+      });
+      const control = JSON.parse(
+        fs.readFileSync(path.join(path.dirname(harness.outputRoot), "mock-response.json"), "utf8"),
+      );
+      expect(control).toMatchObject({
+        default: { fail: { mode: "drop" } },
+        responses: [
+          { chunkDelayMs: 50, text: "first" },
+          { events: [{ type: "response.completed", response: {} }] },
+          { fail: { status: 503 } },
+        ],
+        scriptVersion: expect.stringContaining(sha256),
+      });
+      const state = JSON.parse(
+        fs.readFileSync(path.join(harness.sessionRoot, "candidate.active.json"), "utf8"),
+      );
+      expect(state.invocations.at(-1)).toMatchObject({
+        args: {
+          eventFiles: [
+            { file: "turn-events.json", sha256: expect.stringMatching(/^[0-9a-f]{64}$/u) },
+          ],
+          scriptFile: "provider-script.json",
+          scriptSha256: sha256,
+        },
+        command: "mock",
+      });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("rejects a provider script whose public bytes do not match its sha256", async () => {
+    const harness = await setupHarness();
+    const scriptFile = path.join(harness.outputRoot, "provider-script.json");
+    fs.writeFileSync(scriptFile, JSON.stringify({ responses: [{ text: "first" }] }));
+    try {
+      await expect(
+        runLane(harness.env, [
+          "mock",
+          "--lane",
+          "candidate",
+          "--script",
+          scriptFile,
+          "0".repeat(64),
+        ]),
+      ).rejects.toThrow("mock --script sha256 mismatch");
+      expect(
+        JSON.parse(
+          fs.readFileSync(
+            path.join(path.dirname(harness.outputRoot), "mock-response.json"),
+            "utf8",
+          ),
+        ),
+      ).toEqual({ chunkDelayMs: 0, text: "initial" });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("programs Bot API faults and reads bounded method-filtered request facts", async () => {
+    const harness = await setupHarness();
+    fs.writeFileSync(
+      harness.proxyRequestLog,
+      [
+        JSON.stringify({ method: "sendMessage", status: 429, injected: true }),
+        JSON.stringify({ method: "editMessageText", status: 200, injected: false }),
+        JSON.stringify({ method: "sendMessage", status: 200, injected: false }),
+      ].join("\n") + "\n",
+    );
+    try {
+      await runLane(harness.env, [
+        "botapi-fail",
+        "sendMessage",
+        "--lane",
+        "candidate",
+        "--times",
+        "2",
+        "--status",
+        "429",
+      ]);
+      expect(JSON.parse(fs.readFileSync(harness.proxyControl, "utf8"))).toEqual({
+        rules: [{ method: "sendMessage", status: 429, times: 2 }],
+      });
+      const requests = await runLane(harness.env, [
+        "botapi-requests",
+        "--lane",
+        "candidate",
+        "--method",
+        "sendMessage",
+        "--limit",
+        "1",
+      ]);
+      expect(JSON.parse(requests.stdout)).toEqual({
+        count: 1,
+        requests: [{ index: 1, injected: false, method: "sendMessage", status: 200 }],
+      });
+      await runLane(harness.env, ["botapi-clear", "--lane", "candidate"]);
+      expect(JSON.parse(fs.readFileSync(harness.proxyControl, "utf8"))).toEqual({ rules: [] });
+      const state = JSON.parse(
+        fs.readFileSync(path.join(harness.sessionRoot, "candidate.active.json"), "utf8"),
+      );
+      expect(
+        state.invocations.slice(-3).map((entry: { command: string }) => entry.command),
+      ).toEqual(["botapi-fail", "botapi-requests", "botapi-clear"]);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("returns early when all observe fact conditions are satisfied", async () => {
+    const harness = await setupHarness();
+    fs.writeFileSync(harness.requestLog, `${JSON.stringify({ path: "/v1/responses" })}\n`);
+    try {
+      const startedAt = Date.now();
+      const result = await runLane(harness.env, [
+        "observe",
+        "--lane",
+        "candidate",
+        "--seconds",
+        "60",
+        "--since",
+        "0",
+        "--until-events",
+        "2",
+        "--until-text",
+        "final",
+        "--until-provider-requests",
+        "1",
+      ]);
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        cursor: 2,
+        events: [{ text: "draft" }, { text: "final" }],
+      });
+      expect(harness.requests).toEqual([{ command: "events", seconds: 0, since: 0 }]);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("serializes commands across both lanes on the shared user session", async () => {
     const harness = await setupHarness();
     fs.writeFileSync(path.join(harness.sessionRoot, "harness.lock"), `${process.pid}\n`);
@@ -608,7 +792,12 @@ describe("Telegram Mantis free-form lane", () => {
       });
       expect(
         JSON.parse(fs.readFileSync(path.join(harness.sessionRoot, "candidate.json"), "utf8")),
-      ).toMatchObject({ focusMessageId: "101", sendCount: 1, status: "complete" });
+      ).toMatchObject({
+        botApiRequests: [],
+        focusMessageId: "101",
+        sendCount: 1,
+        status: "complete",
+      });
     } finally {
       await harness.close();
     }

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -699,6 +699,33 @@ describe("Telegram Mantis free-form lane", () => {
     }
   });
 
+  it("ignores stale pre-cursor events when evaluating observe conditions", async () => {
+    const harness = await setupHarness();
+    try {
+      const startedAt = Date.now();
+      // The mock observer timeline always holds two events ("draft", "final");
+      // with --since past them, a reused marker or count must not return early.
+      const result = await runLane(harness.env, [
+        "observe",
+        "--lane",
+        "candidate",
+        "--seconds",
+        "1",
+        "--since",
+        "2",
+        "--until-events",
+        "1",
+        "--until-text",
+        "final",
+      ]);
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(1_000);
+      expect(JSON.parse(result.stdout)).toMatchObject({ events: [] });
+      expect(harness.requests.length).toBeGreaterThan(1);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("serializes commands across both lanes on the shared user session", async () => {
     const harness = await setupHarness();
     fs.writeFileSync(path.join(harness.sessionRoot, "harness.lock"), `${process.pid}\n`);


### PR DESCRIPTION
## What Problem This Solves

Mantis (the automated Telegram Desktop PR proof agent) currently blocks on three recurring scenario classes because its harness boundaries are static:

1. No way to inject Bot API failures (429/5xx/connection drops), so retry/error-path PRs cannot be exercised.
2. One global mock-provider response makes multi-turn scenarios racy — concurrent turns consume the wrong response.
3. PRs whose real difference is outbound Bot API payload bytes (e.g. `callback_data`) produce pixel-identical lanes, forcing `block` even when the change is provable.

All three blocked runs in the recent evidence archive fail at exactly these seams.

## Why This Change Was Made

Instead of letting the proof agent author harness code (which would break the trusted evidence chain), the boundaries become data-programmable: the agent supplies declarative JSON (fault rules, ordered provider response scripts, observe-until predicates) through the existing sudo-wrapped lane CLI, and trusted root/`mantis-sut`-owned code interprets it and records bounded facts into the lane facts file. The prompt gains a recipes library (`.github/codex/prompts/mantis-recipes/`) mirroring the Telegram E2E userbot skill's feature-recipe pattern, so working scenarios accumulate; the agent can propose new ones via a quarantined `recipe-suggestion.md` artifact.

The trust boundary is unchanged: the unprivileged `codex` user gains no new writable paths, controls land in `mantis-sut`-owned mode-0700 directories, workflow validation of lane facts is strengthened (Bot API request facts are now required), and no sudoers changes. The candidate SUT container cannot see the proxy's record sink: an inaccessible tmpfs shadows `proxy-control/` inside the runtime mount, so the lane under test cannot rewrite its own recorded Bot API evidence, and the prompt treats SUT-co-located provider request logs as diagnostic rather than standalone comparison evidence. Follow-up worth naming: moving the mock OpenAI server out of the SUT container (its own container like the Bot API proxy) would make provider request facts trustworthy against candidate code too.

## User Impact

Maintainers get Mantis proofs for whole PR classes that previously ended in `block`: Bot API failure/retry behavior, ordered multi-turn provider scenarios, and payload-level differences with pixel-identical UI. Runs also finish faster: `observe --until-*` predicates replace fixed 60-second windows (~14 minutes of dead waiting in one archived run), and agent effort rises to `high` (verified against the Codex runtime source: `codex-rs/protocol/src/openai_models.rs:62`, `sdk/typescript/src/exec.ts:129`).

New primitives (all declarative, executed by trusted code):

- `botapi-fail <method> [--times N] [--status CODE | --drop]` / `botapi-clear` / `botapi-requests` — injected faults plus bounded outbound Bot API payload/status recording (32 KiB body cap, token-redacted), always published in lane facts.
- `mock --script <file> <sha256>` — ordered per-request provider responses (text, raw events file, or injected failure), with `default`/last-entry exhaustion semantics.
- `observe --until-events/--until-text/--until-provider-requests` — AND-semantics early return, 60 s cap retained.
- Prompt doctrine update: trusted payload/status/ordering facts can prove a lane difference even when pixels are identical.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/telegram-bot-api-proxy.test.ts test/scripts/e2e-mock-config-limits.test.ts test/scripts/telegram-mantis-lane.test.ts test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts test/scripts/mantis-telegram-desktop-proof-workflow.test.ts` — 5 files, 79/79 passed.
- `node scripts/check-changed.mjs -- <all touched files>` — formatting, lint, Node erasability, and type checks passed.
- `git diff --check` clean.
- Workflow jq validation is additive-strict: `.botApiRequests` array is now required in lane facts (empty array required for infra-error lanes); recipe-suggestion quarantine copy enforces regular-file/no-link/size bounds with root installation.
- Not run: a live GitHub Mantis workflow run (requires a PR to target); the changed proxy/mock/lane/evidence paths are covered by the focused tests above, and the first Mantis run on a subsequent PR exercises the workflow end to end.

