### PR TITLE
fix(ui): avoid duplicate main landmark on Activity

### DIFF
--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -46,6 +46,21 @@ function props(overrides: Partial<Parameters<typeof renderSessionActivityView>[0
   };
 }
 
+describe("session activity semantics", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("leaves the page main landmark to the app shell", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(renderSessionActivityView(props()), container);
+
+    expect(container.querySelectorAll("main")).toHaveLength(0);
+  });
+});
+
 describe("session activity people filter", () => {
   beforeEach(() => {
     document.body.innerHTML = "";

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -458,7 +458,7 @@ export function renderSessionActivityView(props: SessionActivityViewProps) {
         </div>
         ${renderPeopleControl(props, people, selectedPerson, projection.timeCount)}
       </div>
-      <main class="activity-feed__main">
+      <div class="activity-feed__main">
         ${props.filters.personId
           ? identity
             ? renderIdentityHeader(props.context, identity, props.rows)
@@ -490,7 +490,7 @@ export function renderSessionActivityView(props: SessionActivityViewProps) {
                   </section>`}
             `
           : nothing}
-      </main>
+      </div>
     </div>
   `;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **Activity → Sessions** would encounter two nested `main` landmarks: the app shell's page landmark and a second unnamed Activity landmark. Screen-reader landmark navigation therefore exposed an ambiguous duplicate main region on both desktop and mobile.

## Why This Change Was Made

The app shell remains the single owner of the page `main` landmark. The Activity feed keeps its existing class, layout, and content in a neutral container, with a focused renderer regression preventing the nested landmark from returning.

This is a semantics-only change: no visual styling, routing, or Activity behavior changes.

## User Impact

Activity now exposes one unambiguous main content landmark, improving screen-reader navigation without changing the page's appearance or controls.

## Evidence

- Pre-fix focused regression failed with one nested `main`; post-fix renderer emits zero page-owned `main` elements while the shell retains the route landmark.
- Exact-head source-browser proof at 1280×900 and 390×844: exactly one visible DOM `main` (`#control-ui-main`), one Playwright `main` role, and one non-ignored accessibility-tree `main`; it contains the Activity page in both viewports.
- Focused unit: `session-activity-view.test.ts` — 6/6 passed.
- Activity source-browser capture: 1/1 passed.
- Broad Activity/app proof: 92 tests passed.
- Full changed-file gate passed, including core/UI typechecking, lint, deadcode, i18n, and related checks.
- Exact-head Codex branch autoreview: clean, confidence 0.99, no findings.
- Inspected desktop 1280×900 and mobile 390×844 screenshots show unchanged healthy layout with no clipping, overflow, or error state.

Provenance: the nested landmark was introduced in #125695 (`d9dfc5b3d98cae82542b0d46a28fd5d58ccf0e43`, 2026-08-18).

### Inspected visual proof

The semantic repair is intentionally visually neutral; both captures show the unchanged healthy Activity layout after the landmark fix.

- [Desktop Activity — 1280×900](https://ampcode.com/user-content/artifacts/1cc9feed53e78acc504148d1f6af76f1d1b083d0c9dfe1f10f82807f7a3abafb-file.png)
- [Mobile Activity — 390×844](https://ampcode.com/user-content/artifacts/3a797cdeed8e8d323027cd87fff2d99013d813581482e87b7188f5e45ba961de-file.png)
