### PR TITLE
improve(gateway): avoid targetless session cache allocations

### DIFF
--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -440,7 +440,7 @@ export function resolveSessionMutationAuthorization(params: {
     storeCache: GatewaySessionStoreCache;
     targetDiscoveryCache: GatewaySessionStoreDiscoveryCache;
   } => ({ storeCache: new Map(), targetDiscoveryCache: new Map() });
-  const lookupCaches = createLookupCaches();
+  let lookupCaches: ReturnType<typeof createLookupCaches> | undefined;
   const resolveAuthorizedTarget = (
     targetRef: SessionMutationTarget,
   ): { target: SessionSharingTarget | null } | { error: ErrorShape } => {
@@ -450,7 +450,7 @@ export function resolveSessionMutationAuthorization(params: {
           cfg: getCfg(),
           sessionKey: targetRef.sessionKey,
           agentId: targetRef.agentId,
-          ...lookupCaches,
+          ...(lookupCaches ??= createLookupCaches()),
         }),
       };
     } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Ordinary authenticated Gateway RPCs without a session target, such as `status`, allocated two empty session lookup maps during authorization even though they never performed a session lookup.

## Why This Change Was Made

The authorization owner now initializes its request-scoped cache pair only on the first actual target resolution. Requests with targets still share exactly one initial freshness epoch, and commit-time guards continue to use separate fresh cache epochs.

## User Impact

Targetless Gateway RPC authorization performs less allocation work with no protocol, authorization, output, error, or cache-freshness change.

## Evidence

- Exact current-main differential over 100,000 targetless calls: `200,000` map allocations before, `0` after.
- Successful result and getter trace stayed exact: `{"error":null}` and `key>sessionKey>keys>sessionKeys>agentId>agentId`.
- A hostile `sessionKeys` getter retained the exact thrown `Error` identity and getter order.
- Original owner benchmark: 1,675.4 ns/call → 1,514.3 ns/call median across 7 × 1,000,000-call samples (9.62% lower).
- Focused authorization/cache/routing coverage: 478 tests passed.
- `node scripts/check-changed.mjs -- src/gateway/session-sharing.ts`: passed.
- Build note: every non-UI full-build phase passed. The first local UI size gate was 9 bytes over because the long local branch name is embedded in the browser artifact; the exact base and candidate with stable `GIT_BRANCH=main` metadata both passed the UI budget.
- Exact-current Codex `gpt-5.6-sol`/high autoreview: clean, correct 0.99.
