### PR TITLE
fix(onboard): emit JSON on option-validation failures

### DIFF
--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -19,6 +19,7 @@ import { withSetupMigrationTargetLock } from "../wizard/setup.migration-snapshot
 import { createNonInteractiveLoggingPrompter } from "./non-interactive-prompter.js";
 import { runNonInteractiveLocalSetup } from "./onboard-non-interactive/local.js";
 import { runNonInteractiveRemoteSetup } from "./onboard-non-interactive/remote.js";
+import { rejectOnboardingOption } from "./onboard-options.js";
 import type { OnboardOptions } from "./onboard-types.js";
 
 function isMigrationImport(opts: OnboardOptions): boolean {
@@ -37,10 +38,11 @@ async function runNonInteractiveMigrationImport(params: {
   if (!providerId) {
     // Migration import cannot safely prompt in non-interactive mode; require the
     // provider id so the import path is deterministic.
-    params.runtime.error(
+    rejectOnboardingOption(
+      params.opts,
+      params.runtime,
       `--import-from is required for non-interactive migration import. Run ${formatCliCommand("openclaw migrate list")} to choose a provider.`,
     );
-    params.runtime.exit(1);
     return;
   }
   const { detectSetupMigrationSources, runSetupMigrationImport } =
@@ -110,10 +112,11 @@ async function runNonInteractiveSetupExclusive(opts: OnboardOptions, runtime: Ru
     : {};
   const mode = opts.mode ?? "local";
   if (mode !== "local" && mode !== "remote") {
-    runtime.error(
+    rejectOnboardingOption(
+      opts,
+      runtime,
       `Invalid --mode "${String(mode)}". Use "local" or "remote", or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
     );
-    runtime.exit(1);
     return;
   }
 

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -68,19 +68,22 @@ describe("applyNonInteractiveAuthChoice", () => {
   it("rejects an unknown auth choice and lists the valid choices", async () => {
     const runtime = createRuntime();
     const nextConfig = { agents: { defaults: {} } } as OpenClawConfig;
+    const message =
+      'Unknown --auth-choice "definitely-not-a-provider". Valid choices: custom-api-key, skip, demo-provider-api-key.';
 
     const result = await applyNonInteractiveAuthChoice({
       nextConfig,
       authChoice: "definitely-not-a-provider",
-      opts: {} as never,
+      opts: { json: true },
       runtime: runtime as never,
       baseConfig: nextConfig,
       target,
     });
 
     expect(result).toBeNull();
-    expect(runtime.error).toHaveBeenCalledWith(
-      'Unknown --auth-choice "definitely-not-a-provider". Valid choices: custom-api-key, skip, demo-provider-api-key.',
+    expect(runtime.error).toHaveBeenCalledExactlyOnceWith(message);
+    expect(runtime.log).toHaveBeenCalledExactlyOnceWith(
+      JSON.stringify({ ok: false, phase: "options", message }, null, 2),
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -28,6 +28,7 @@ import {
   parseNonInteractiveCustomApiFlags,
   resolveCustomProviderId,
 } from "../../onboard-custom-config.js";
+import { rejectOnboardingOption } from "../../onboard-options.js";
 import type { AuthChoice, OnboardOptions } from "../../onboard-types.js";
 import { resolveNonInteractiveApiKey } from "../api-keys.js";
 import { applyNonInteractivePluginProviderChoice } from "./auth-choice.plugin-providers.js";
@@ -56,10 +57,11 @@ export async function applyNonInteractiveAuthChoice(params: {
   const nextConfig = params.nextConfig;
   const requestedSecretInputMode = normalizeSecretInputModeInput(opts.secretInputMode);
   if (opts.secretInputMode && !requestedSecretInputMode) {
-    runtime.error(
+    rejectOnboardingOption(
+      opts,
+      runtime,
       `Invalid --secret-input-mode. Use "plaintext" or "ref", or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
     );
-    runtime.exit(1);
     return null;
   }
   const toStoredSecretInput = (paramsLocal: {
@@ -78,13 +80,14 @@ export async function applyNonInteractiveAuthChoice(params: {
       const envHint = paramsLocal.envVarName
         ? `Set ${paramsLocal.envVarName} in env and retry`
         : "Set the provider API key env var and retry";
-      runtime.error(
+      rejectOnboardingOption(
+        opts,
+        runtime,
         [
           `--secret-input-mode ref requires an explicit environment variable for provider "${paramsLocal.provider}".`,
           `${envHint}, or use --secret-input-mode plaintext.`,
         ].join("\n"),
       );
-      runtime.exit(1);
       return null;
     }
     return {
@@ -141,14 +144,15 @@ export async function applyNonInteractiveAuthChoice(params: {
       runtime.log(replacement.message);
       authChoice = replacement.normalized;
     } else {
-      runtime.error(
+      rejectOnboardingOption(
+        opts,
+        runtime,
         formatDeprecatedNonInteractiveAuthChoiceError(authChoice, {
           config: nextConfig,
           workspaceDir: params.target.workspaceDir,
           env: process.env,
         })!,
       );
-      runtime.exit(1);
       return null;
     }
   }
@@ -168,10 +172,11 @@ export async function applyNonInteractiveAuthChoice(params: {
       });
   const replacementChoiceId = deprecatedChoice?.choiceId ?? deprecatedInstallChoice?.choiceId;
   if (replacementChoiceId) {
-    runtime.error(
+    rejectOnboardingOption(
+      opts,
+      runtime,
       `${JSON.stringify(authChoice as string)} is no longer supported. Use --auth-choice ${JSON.stringify(replacementChoiceId)} instead.`,
     );
-    runtime.exit(1);
     return null;
   }
 
@@ -182,10 +187,11 @@ export async function applyNonInteractiveAuthChoice(params: {
     env: process.env,
   }).split("|");
   if (!validAuthChoices.includes(authChoice) && !authChoice.startsWith("provider-plugin:")) {
-    runtime.error(
+    rejectOnboardingOption(
+      opts,
+      runtime,
       `Unknown --auth-choice ${JSON.stringify(authChoice)}. Valid choices: ${validAuthChoices.join(", ")}.`,
     );
-    runtime.exit(1);
     return null;
   }
 
@@ -211,13 +217,14 @@ export async function applyNonInteractiveAuthChoice(params: {
   }
 
   if (authChoice === "setup-token" || authChoice === "token") {
-    runtime.error(
+    rejectOnboardingOption(
+      opts,
+      runtime,
       [
         `Auth choice "${params.authChoice}" was not matched to a provider setup flow.`,
         'For Anthropic legacy token auth, use "--auth-choice setup-token --token-provider anthropic --token <token>" or pass "--auth-choice token --token-provider anthropic".',
       ].join("\n"),
     );
-    runtime.exit(1);
     return null;
   }
 
@@ -281,22 +288,12 @@ export async function applyNonInteractiveAuthChoice(params: {
       }
       return result.config;
     } catch (err) {
-      if (err instanceof CustomApiError) {
-        switch (err.code) {
-          case "missing_required":
-          case "invalid_compatibility":
-            runtime.error(err.message);
-            break;
-          default:
-            runtime.error(`Invalid custom provider config: ${err.message}`);
-            break;
-        }
-        runtime.exit(1);
-        return null;
-      }
-      const reason = formatErrorMessage(err);
-      runtime.error(`Invalid custom provider config: ${reason}`);
-      runtime.exit(1);
+      const message =
+        err instanceof CustomApiError &&
+        (err.code === "missing_required" || err.code === "invalid_compatibility")
+          ? err.message
+          : `Invalid custom provider config: ${err instanceof CustomApiError ? err.message : formatErrorMessage(err)}`;
+      rejectOnboardingOption(opts, runtime, message);
       return null;
     }
   }
@@ -306,8 +303,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     authChoice === "minimax-global-oauth" ||
     authChoice === "minimax-cn-oauth"
   ) {
-    runtime.error("OAuth requires interactive mode.");
-    runtime.exit(1);
+    rejectOnboardingOption(opts, runtime, "OAuth requires interactive mode.");
     return null;
   }
 

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -331,15 +331,18 @@ describe("applyNonInteractiveGatewayConfig auth resolution", () => {
 
   it("fails when --gateway-token-ref-env points to a missing env var", () => {
     const runtime = createRuntime();
+    const message =
+      'Environment variable "MISSING_GATEWAY_TOKEN_ENV" is missing or empty. Export it first, then rerun openclaw onboard --non-interactive.';
 
     const result = applyGatewayConfig({
-      opts: { gatewayTokenRefEnv: "MISSING_GATEWAY_TOKEN_ENV" } as OnboardOptions,
+      opts: { gatewayTokenRefEnv: "MISSING_GATEWAY_TOKEN_ENV", json: true } as OnboardOptions,
       runtime,
     });
 
     expect(result).toBeNull();
-    expect(runtime.error).toHaveBeenCalledWith(
-      'Environment variable "MISSING_GATEWAY_TOKEN_ENV" is missing or empty. Export it first, then rerun openclaw onboard --non-interactive.',
+    expect(runtime.error).toHaveBeenCalledExactlyOnceWith(message);
+    expect(runtime.log).toHaveBeenCalledExactlyOnceWith(
+      JSON.stringify({ ok: false, phase: "options", message }, null, 2),
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(randomToken).not.toHaveBeenCalled();

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -18,6 +18,7 @@ import { provisionGatewayTokenStoreRef } from "../../../gateway/auth-token-store
 import type { RuntimeEnv } from "../../../runtime.js";
 import { createGatewayEnvSecretRef } from "../../../secrets/ref-contract.js";
 import { normalizeGatewayTokenInput, randomToken } from "../../onboard-helpers.js";
+import { rejectOnboardingOption } from "../../onboard-options.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 
 /** Resolves what `gateway.auth.token` should hold once setup owns the token value. */
@@ -59,8 +60,7 @@ export function applyNonInteractiveGatewayConfig(params: {
     gatewayPort !== undefined &&
     (!Number.isFinite(gatewayPort) || gatewayPort <= 0 || gatewayPort > 65_535)
   ) {
-    runtime.error(formatInvalidPortOption("--gateway-port"));
-    runtime.exit(1);
+    rejectOnboardingOption(opts, runtime, formatInvalidPortOption("--gateway-port"));
     return null;
   }
 
@@ -73,8 +73,7 @@ export function applyNonInteractiveGatewayConfig(params: {
     explicitAuthMode !== "token" &&
     explicitAuthMode !== "password"
   ) {
-    runtime.error('Invalid --gateway-auth. Use "token" or "password".');
-    runtime.exit(1);
+    rejectOnboardingOption(opts, runtime, 'Invalid --gateway-auth. Use "token" or "password".');
     return null;
   }
   const hasExplicitTokenAuthInput =
@@ -109,10 +108,11 @@ export function applyNonInteractiveGatewayConfig(params: {
     if (customBindHostIssue) {
       const setCommand = formatCliCommand("openclaw config set gateway.customBindHost <ipv4>");
       const interactiveCommand = formatCliCommand("openclaw onboard");
-      runtime.error(
+      rejectOnboardingOption(
+        opts,
+        runtime,
         `--gateway-bind custom requires gateway.customBindHost: ${customBindHostIssue}. Set it with ${setCommand} and rerun, or run ${interactiveCommand} interactively to be prompted for it.`,
       );
-      runtime.exit(1);
       return null;
     }
   }
@@ -147,27 +147,30 @@ export function applyNonInteractiveGatewayConfig(params: {
       // Env refs must be validated before writing config because the daemon
       // install plan will later depend on this exact env-var id.
       if (!isValidEnvSecretRefId(gatewayTokenRefEnv)) {
-        runtime.error(
+        rejectOnboardingOption(
+          opts,
+          runtime,
           "Invalid --gateway-token-ref-env. Use an environment variable name like OPENCLAW_GATEWAY_TOKEN.",
         );
-        runtime.exit(1);
         return null;
       }
       if (explicitGatewayToken) {
         // Avoid ambiguous persistence: a plaintext token and a ref target cannot
         // both represent the same gateway auth field.
-        runtime.error(
+        rejectOnboardingOption(
+          opts,
+          runtime,
           "Use either --gateway-token or --gateway-token-ref-env, not both. Prefer --gateway-token-ref-env to avoid writing plaintext tokens.",
         );
-        runtime.exit(1);
         return null;
       }
       const resolvedFromEnv = process.env[gatewayTokenRefEnv]?.trim();
       if (!resolvedFromEnv) {
-        runtime.error(
+        rejectOnboardingOption(
+          opts,
+          runtime,
           `Environment variable "${gatewayTokenRefEnv}" is missing or empty. Export it first, then rerun ${formatCliCommand("openclaw onboard --non-interactive")}.`,
         );
-        runtime.exit(1);
         return null;
       }
       nextConfig = {
@@ -232,10 +235,11 @@ export function applyNonInteractiveGatewayConfig(params: {
           normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD))
         : normalizeOptionalString(input);
     if (!password) {
-      runtime.error(
+      rejectOnboardingOption(
+        opts,
+        runtime,
         "Missing --gateway-password for password auth. Pass --gateway-password or use --gateway-auth token.",
       );
-      runtime.exit(1);
       return null;
     }
     nextConfig = {

--- a/src/commands/onboard-options.ts
+++ b/src/commands/onboard-options.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared rejection path for `openclaw onboard` option validation.
+ *
+ * Lives above the local/remote split because both the outer command and the
+ * non-interactive handlers reject options, and every one of them must honor --json.
+ */
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import type { OnboardOptions } from "./onboard-types.js";
+
+/** Reports an invalid option and exits; returns false so validators can `return` it directly. */
+export function rejectOnboardingOption(
+  opts: OnboardOptions,
+  runtime: RuntimeEnv,
+  message: string,
+): false {
+  // --json promises exactly one machine-readable object per run, so a rejection has to emit one
+  // too. Without this the caller sees an empty stdout and cannot tell a bad flag from a crash.
+  if (opts.json) {
+    writeRuntimeJson(runtime, { ok: false, phase: "options", message });
+  }
+  runtime.error(message);
+  runtime.exit(1);
+  return false;
+}

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -463,44 +463,35 @@ describe("setupWizardCommand", () => {
     expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
   });
 
-  it("fails fast for invalid non-interactive --mode before reset", async () => {
+  it.each([
+    { mode: "typo", json: true },
+    { mode: "", json: false },
+  ])("fails fast for invalid non-interactive --mode $mode before reset", async ({ mode, json }) => {
     const runtime = makeRuntime();
+    const message = `Invalid --mode "${mode}". Use "local" or "remote", or run ${formatCliCommand("openclaw onboard")} for interactive setup.`;
 
     await setupWizardCommand(
       {
         reset: true,
         nonInteractive: true,
         acceptRisk: true,
-        mode: "typo" as never,
+        mode: mode as never,
+        ...(json && { json }),
       },
       runtime,
     );
 
-    expect(runtime.error).toHaveBeenCalledWith(
-      `Invalid --mode "typo". Use "local" or "remote", or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
-    );
+    expect(runtime.error).toHaveBeenCalledExactlyOnceWith(message);
+    if (json) {
+      expect(runtime.log).toHaveBeenCalledExactlyOnceWith(
+        JSON.stringify({ ok: false, phase: "options", message }, null, 2),
+      );
+    } else {
+      expect(runtime.log).not.toHaveBeenCalled();
+    }
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(mocks.handleReset).not.toHaveBeenCalled();
     expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
-  });
-
-  it("fails fast for an empty non-interactive --mode before reset", async () => {
-    const runtime = makeRuntime();
-
-    await setupWizardCommand(
-      {
-        reset: true,
-        nonInteractive: true,
-        acceptRisk: true,
-        mode: "" as never,
-      },
-      runtime,
-    );
-
-    expect(runtime.error).toHaveBeenCalledWith(
-      `Invalid --mode "". Use "local" or "remote", or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
-    );
-    expect(mocks.handleReset).not.toHaveBeenCalled();
   });
 
   it("validates a remote URL before reset", async () => {

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -49,6 +49,7 @@ import { runNonInteractiveSetup } from "./onboard-non-interactive.js";
 import { resolveNonInteractiveApiKey as resolveNonInteractiveCredential } from "./onboard-non-interactive/api-keys.js";
 import { inferAuthChoiceFromFlags } from "./onboard-non-interactive/local/auth-choice-inference.js";
 import { applyNonInteractiveGatewayConfig } from "./onboard-non-interactive/local/gateway-config.js";
+import { rejectOnboardingOption as rejectOption } from "./onboard-options.js";
 import { validateGatewayWebSocketUrl } from "./onboard-remote.js";
 import {
   isNodeManagerChoice,
@@ -59,15 +60,10 @@ import {
 
 const VALID_RESET_SCOPES = new Set<ResetScope>(["config", "config+creds+sessions", "full"]);
 
-function rejectOption(runtime: RuntimeEnv, message: string): false {
-  runtime.error(message);
-  runtime.exit(1);
-  return false;
-}
-
 function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): boolean {
   if (opts.mode !== undefined && opts.mode !== "local" && opts.mode !== "remote") {
     return rejectOption(
+      opts,
       runtime,
       `Invalid --mode "${String(opts.mode)}". Use "local" or "remote", or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
     );
@@ -79,6 +75,7 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
   ].filter((flag): flag is string => flag !== undefined);
   if (opts.nonInteractive && (opts.mode ?? "local") === "local" && remoteOnlyFlags.length > 0) {
     return rejectOption(
+      opts,
       runtime,
       `${remoteOnlyFlags.join(" and ")} ${remoteOnlyFlags.length === 1 ? "requires" : "require"} --mode remote in non-interactive setup.`,
     );
@@ -88,11 +85,11 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
     ["--remote-password", opts.remotePassword],
   ] as const) {
     if (value !== undefined && !value.trim()) {
-      return rejectOption(runtime, `Invalid ${flag}: value cannot be empty.`);
+      return rejectOption(opts, runtime, `Invalid ${flag}: value cannot be empty.`);
     }
   }
   if (opts.remoteToken !== undefined && opts.remotePassword !== undefined) {
-    return rejectOption(runtime, "Use either --remote-token or --remote-password, not both.");
+    return rejectOption(opts, runtime, "Use either --remote-token or --remote-password, not both.");
   }
   if (opts.mode === "remote") {
     const localGatewayCredentials = [
@@ -107,6 +104,7 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
     for (const [flag, value, remoteFlag] of localGatewayCredentials) {
       if (value !== undefined) {
         return rejectOption(
+          opts,
           runtime,
           `${flag} configures local gateway auth. Use ${remoteFlag} in remote mode.`,
         );
@@ -126,12 +124,14 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
       const envValue = process.env[envName]?.trim();
       if (!envValue) {
         return rejectOption(
+          opts,
           runtime,
           `${flag} requires ${envName} to be set when --secret-input-mode ref is used.`,
         );
       }
       if (value.trim() !== envValue) {
         return rejectOption(
+          opts,
           runtime,
           `${flag} does not match ${envName}. Set the environment variable to the same value or omit the flag.`,
         );
@@ -151,6 +151,7 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
   for (const [flag, value, allowed] of choiceValidations) {
     if (value !== undefined && !allowed.includes(value)) {
       return rejectOption(
+        opts,
         runtime,
         `Invalid ${flag} ${JSON.stringify(value)}. Use ${allowed.map((choice) => JSON.stringify(choice)).join(", ")}.`,
       );
@@ -158,38 +159,42 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
   }
   if (opts.flow !== undefined && !isOnboardFlow(opts.flow)) {
     return rejectOption(
+      opts,
       runtime,
       'Invalid --flow. Use "quickstart", "advanced", "manual", or "import".',
     );
   }
   if (opts.daemonRuntime !== undefined && !isGatewayDaemonRuntime(opts.daemonRuntime)) {
-    return rejectOption(runtime, 'Invalid --daemon-runtime. Use "node".');
+    return rejectOption(opts, runtime, 'Invalid --daemon-runtime. Use "node".');
   }
   if (opts.nodeManager !== undefined && !isNodeManagerChoice(opts.nodeManager)) {
-    return rejectOption(runtime, 'Invalid --node-manager. Use "npm", "pnpm", or "bun".');
+    return rejectOption(opts, runtime, 'Invalid --node-manager. Use "npm", "pnpm", or "bun".');
   }
   if (
     opts.gatewayPort !== undefined &&
     (!Number.isFinite(opts.gatewayPort) || opts.gatewayPort <= 0 || opts.gatewayPort > 65_535)
   ) {
-    return rejectOption(runtime, formatInvalidPortOption("--gateway-port"));
+    return rejectOption(opts, runtime, formatInvalidPortOption("--gateway-port"));
   }
   if (opts.gatewayTokenRefEnv !== undefined) {
     const gatewayTokenRefEnv = opts.gatewayTokenRefEnv.trim();
     if (!isValidEnvSecretRefId(gatewayTokenRefEnv)) {
       return rejectOption(
+        opts,
         runtime,
         "Invalid --gateway-token-ref-env. Use an environment variable name like OPENCLAW_GATEWAY_TOKEN.",
       );
     }
     if (opts.gatewayToken !== undefined) {
       return rejectOption(
+        opts,
         runtime,
         "Use either --gateway-token or --gateway-token-ref-env, not both. Prefer --gateway-token-ref-env to avoid writing plaintext tokens.",
       );
     }
     if (!process.env[gatewayTokenRefEnv]?.trim()) {
       return rejectOption(
+        opts,
         runtime,
         `Environment variable "${gatewayTokenRefEnv}" is missing or empty. Export it first, then rerun ${formatCliCommand("openclaw onboard")}.`,
       );
@@ -197,6 +202,7 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
   }
   if (opts.nonInteractive && opts.mode === "remote" && !opts.remoteUrl?.trim()) {
     return rejectOption(
+      opts,
       runtime,
       `Missing --remote-url for remote mode. Example: ${formatCliCommand("openclaw onboard --non-interactive --mode remote --remote-url ws://127.0.0.1:3000")}.`,
     );
@@ -204,7 +210,7 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
   if (opts.nonInteractive && opts.mode === "remote" && opts.remoteUrl?.trim()) {
     const remoteUrlError = validateGatewayWebSocketUrl(opts.remoteUrl);
     if (remoteUrlError) {
-      return rejectOption(runtime, remoteUrlError);
+      return rejectOption(opts, runtime, remoteUrlError);
     }
   }
   if (
@@ -213,6 +219,7 @@ function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): bo
     !opts.importFrom?.trim()
   ) {
     return rejectOption(
+      opts,
       runtime,
       `--import-from is required for non-interactive migration import. Run ${formatCliCommand("openclaw migrate list")} to choose a provider.`,
     );
@@ -239,6 +246,7 @@ async function validateResetAuthChoice(params: {
         });
   if (inferredAuthChoice && inferredAuthChoice.matches.length > 1) {
     return rejectOption(
+      params.opts,
       params.runtime,
       [
         `Multiple ${params.opts.nonInteractive ? "API key" : "provider credential"} flags were provided for ${params.opts.nonInteractive ? "non-interactive" : "interactive"} setup.`,
@@ -264,6 +272,7 @@ async function validateResetAuthChoice(params: {
   );
   if (!availableChoices.has(authChoice)) {
     return rejectOption(
+      params.opts,
       params.runtime,
       `Auth choice "${authChoice}" was not matched to a provider setup flow. Run ${formatCliCommand("openclaw onboard")} to choose interactively.`,
     );
@@ -310,6 +319,7 @@ async function validateResetAuthChoice(params: {
     !inferredOptionKey
   ) {
     return rejectOption(
+      params.opts,
       params.runtime,
       `Auth choice "${authChoice}" requires --token-provider in non-interactive setup.`,
     );
@@ -320,12 +330,14 @@ async function validateResetAuthChoice(params: {
     !params.opts.token?.trim()
   ) {
     return rejectOption(
+      params.opts,
       params.runtime,
       `Auth choice "${authChoice}" requires --token in non-interactive setup.`,
     );
   }
   if (params.opts.nonInteractive && isGenericProviderChoice && !providerAuthChoice) {
     return rejectOption(
+      params.opts,
       params.runtime,
       `Auth choice "${authChoice}" was not matched to provider "${params.opts.tokenProvider?.trim()}".`,
     );
@@ -385,7 +397,7 @@ async function validateResetAuthChoice(params: {
         (error.code === "missing_required" || error.code === "invalid_compatibility")
           ? error.message
           : `Invalid custom provider config: ${formatErrorMessage(error)}`;
-      return rejectOption(params.runtime, message);
+      return rejectOption(params.opts, params.runtime, message);
     }
   }
   if (authChoice !== "custom-api-key") {
@@ -414,6 +426,7 @@ async function validateResetAuthChoice(params: {
           ? "non-interactive setup unsupported"
           : "reset validation unavailable";
       return rejectOption(
+        params.opts,
         params.runtime,
         `Auth choice "${authChoice}" cannot be safely preflighted with --reset (${reason}). Choose a provider method that supports non-interactive reset validation, or run setup without --reset.`,
       );
@@ -457,6 +470,7 @@ function validateResetMigrationImport(params: {
     return true;
   }
   return rejectOption(
+    params.opts,
     params.runtime,
     "Migration import cannot be combined with --reset because provider input must be planned before any state is removed. Run the import without --reset.",
   );
@@ -534,12 +548,13 @@ export async function setupWizardCommand(
   if (opts.nonInteractive && isDeprecatedAuthChoice(originalAuthChoice, { env: process.env })) {
     // Non-interactive output must be deterministic; reject deprecated aliases
     // instead of printing prompts or compatibility guidance mid-flow.
-    runtime.error(
+    rejectOption(
+      opts,
+      runtime,
       formatDeprecatedNonInteractiveAuthChoiceError(originalAuthChoice, {
         env: process.env,
       })!,
     );
-    runtime.exit(1);
     return;
   }
   if (isDeprecatedAuthChoice(originalAuthChoice, { env: process.env })) {
@@ -556,8 +571,7 @@ export async function setupWizardCommand(
     const { validateFirstOnboardingAgentName } = await import("./onboard-agent.js");
     const error = validateFirstOnboardingAgentName(normalizedOpts.agentName);
     if (error) {
-      runtime.error(`Invalid --agent-name: ${error}`);
-      runtime.exit(1);
+      rejectOption(normalizedOpts, runtime, `Invalid --agent-name: ${error}`);
       return;
     }
   }
@@ -565,17 +579,19 @@ export async function setupWizardCommand(
     return;
   }
   if (normalizedOpts.classic && normalizedOpts.nonInteractive) {
-    runtime.error(
+    rejectOption(
+      normalizedOpts,
+      runtime,
       "--classic cannot be combined with --non-interactive. Remove --non-interactive to open the classic wizard, or remove --classic for automated setup.",
     );
-    runtime.exit(1);
     return;
   }
   if (normalizedOpts.tui && normalizedOpts.nonInteractive) {
-    runtime.error(
+    rejectOption(
+      normalizedOpts,
+      runtime,
       "--tui cannot be combined with --non-interactive. Remove --tui for automation, or remove --non-interactive to open the terminal hatch.",
     );
-    runtime.exit(1);
     return;
   }
   if (
@@ -583,39 +599,43 @@ export async function setupWizardCommand(
     normalizedOpts.secretInputMode !== "plaintext" && // pragma: allowlist secret
     normalizedOpts.secretInputMode !== "ref" // pragma: allowlist secret
   ) {
-    runtime.error(
+    rejectOption(
+      normalizedOpts,
+      runtime,
       `Invalid --secret-input-mode. Use "plaintext" or "ref", or run ${formatCliCommand("openclaw onboard")} for the interactive setup.`,
     );
-    runtime.exit(1);
     return;
   }
 
   if (normalizedOpts.resetScope && !VALID_RESET_SCOPES.has(normalizedOpts.resetScope)) {
-    runtime.error(
+    rejectOption(
+      normalizedOpts,
+      runtime,
       `Invalid --reset-scope. Use "config", "config+creds+sessions", or "full". Run ${formatCliCommand("openclaw onboard --reset --reset-scope config")} for a config-only reset.`,
     );
-    runtime.exit(1);
     return;
   }
   if (normalizedOpts.resetScope && !normalizedOpts.reset) {
-    runtime.error(
+    rejectOption(
+      normalizedOpts,
+      runtime,
       `--reset-scope requires --reset. Re-run with ${formatCliCommand(`openclaw onboard --reset --reset-scope ${normalizedOpts.resetScope}`)}.`,
     );
-    runtime.exit(1);
     return;
   }
 
   if (normalizedOpts.nonInteractive && normalizedOpts.acceptRisk !== true) {
     // Non-interactive setup can write credentials and daemon config without a
     // prompt, so the operator must acknowledge the security docs explicitly.
-    runtime.error(
+    rejectOption(
+      normalizedOpts,
+      runtime,
       [
         "Non-interactive setup requires explicit risk acknowledgement.",
         "Read: https://docs.openclaw.ai/security",
         `Re-run with: ${formatCliCommand("openclaw onboard --non-interactive --accept-risk ...")}`,
       ].join("\n"),
     );
-    runtime.exit(1);
     return;
   }
 
@@ -666,6 +686,7 @@ export async function setupWizardCommand(
         snapshot.readError !== undefined
       ) {
         rejectOption(
+          normalizedOpts,
           runtime,
           "Cannot determine the configured workspace from an unreadable config. Pass --workspace with the workspace to remove, or use a narrower --reset-scope.",
         );
@@ -677,6 +698,7 @@ export async function setupWizardCommand(
         (typeof configuredWorkspace !== "string" || !configuredWorkspace.trim())
       ) {
         rejectOption(
+          normalizedOpts,
           runtime,
           "Configured workspace is invalid. Pass --workspace with the workspace to remove, or use a narrower --reset-scope.",
         );


### PR DESCRIPTION
## What Problem This Solves

`openclaw onboard --json` promises a machine-readable result, but only *some* terminal outcomes produce one. The success path writes a JSON object, and the top-level CLI error handler writes `{"ok":false,"error":...}` for thrown errors — yet every option-validation rejection prints a human string to stderr, exits 1, and writes **nothing** to stdout.

Measured against a built CLI, each run with `--json`, each `exit=1`, each with empty stdout:

| flags | stderr |
| --- | --- |
| `--mode bogus` | `Invalid --mode "bogus". Use "local" or "remote", ...` |
| `--flow bogus` | `Invalid --flow. Use "quickstart", "advanced", "manual", or "import".` |
| `--daemon-runtime bogus` | `Invalid --daemon-runtime. Use "node".` |
| `--gateway-bind bogus` | `Invalid --gateway-bind "bogus". Use "loopback", ...` |
| `--gateway-auth bogus` | `Invalid --gateway-auth "bogus". Use "token", "password".` |
| `--gateway-token-ref-env MISSING_VAR` | `Environment variable "MISSING_VAR" is missing or empty. ...` |
| `--gateway-auth password` (no password) | `Missing --gateway-password for password auth. ...` |
| `--auth-choice totally-bogus` | `Unknown --auth-choice "totally-bogus". Valid choices: ...` |

For contrast, `--gateway-port abc` *does* emit `{"ok":false,"error":...}` — because a non-numeric port is thrown at the option-parsing layer and caught by the generic handler, not rejected by onboarding's own validators.

So a script doing `openclaw onboard --json ... | jq` gets a parseable failure for one bad flag and a JSON parse error for the next, and cannot distinguish "you passed a bad flag" from "the process died before producing output".

## Why This Change Was Made

The invariant is that `--json` means exactly one machine-readable object per run, on every terminal outcome. Onboarding already has the vocabulary for this: `logNonInteractiveOnboardingFailure` emits `{ ok: false, mode, phase, message, ... }` with phases `daemon-install` and `gateway-health`. Option rejection was simply never wired into it.

Rather than patch the eight measured cases, every onboarding option rejection now goes through one shared primitive. A partial fix would leave exactly the inconsistency being repaired — a caller would still have to know which flags are "JSON-safe".

Placement is `src/commands/onboard-options.ts`, above the local/remote split. `output.ts` (the existing JSON emitter) lives under `onboard-non-interactive/local/`, and importing a `local/`-scoped module into the outer `onboard.ts` — which also serves remote and interactive setup — would invert the owner boundary.

`phase: "options"` joins the existing kebab-case phase vocabulary.

## User Impact

```
$ openclaw onboard --non-interactive --accept-risk --json --flow bogus
{
  "ok": false,
  "phase": "options",
  "message": "Invalid --flow. Use \"quickstart\", \"advanced\", \"manual\", or \"import\"."
}
```

Purely additive. Every human message keeps its exact text, stderr keeps every line it had, and exit codes are unchanged — the only difference is the stdout object that was previously absent. Nothing is emitted when `--json` is not passed, which is covered by a test.

## Evidence

Reproduced against a built CLI in an isolated profile (`HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH` redirected, gateway port pinned to 18997), reading stdout and stderr as separate streams so the two channels could not be confused. All eight rows above produced empty stdout before the change.

Tests — `node scripts/run-vitest.mjs`:

- `src/commands/onboard-non-interactive` + `src/commands/onboard.test.ts` — 11 files, 203 passed.
- Load-bearing check: disabling only the JSON emission inside the shared primitive fails exactly three tests — one per routed module (`onboard.ts`, `auth-choice.ts`, `gateway-config.ts`) — and nothing else.
- The `--mode` coverage is now table-driven over `json: true` / `json: false`; the `json: false` row asserts `runtime.log` is never called, which is what pins the "no JSON without `--json`" half of the contract. This replaced two near-duplicate single-case tests.
- Existing assertions were tightened rather than relaxed (`toHaveBeenCalledWith` → `toHaveBeenCalledExactlyOnceWith`).

Full local gate — `node scripts/check-changed.mjs` — passed: conflict markers, max-lines ratchet, assertion-safety ratchet, changelog attributions, doctor deprecation registry, wildcard re-export guards, duplicate coverage, coercion-helper guard, dependency pins, format, deprecated API usage, plugin boundaries, wrapper shadowing, package patches, Knip dead-export scans (0 entries), typecheck core, typecheck core tests, lint, native state schema guard, database-first legacy-store guard, media download guard, runtime sidecar loaders, import cycles (0), webhook body guard, pairing guards.

Production LOC +117/-77 (net +40; 15 of that is the new module, the rest is threading `opts` through existing multi-line call sites). Tests +27/-30 (net -3, from consolidating the duplicated `--mode` cases).

Autoreview (codex/gpt-5.6-sol, xhigh): clean, no accepted or actionable findings.
