### PR TITLE
feat(agent): allow explicit one-shot tools

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -120,6 +120,7 @@ This is evaluation-only evidence, not a CI or release gate. Results do not chang
 - `--model <provider/model>`: explicit primary model
 - `--code-mode <mode>`: select `direct`, `auto`, or forced `code` tool mode
 - `--local-model-lean`: use the reduced local-model tool surface
+- `--also-allow-tool <name>`: allow one additional tool for this run; repeatable, and extends an existing strict `tools.allow` list when present
 - `--thinking <level>`: one-run thinking level
 - `--fallback <provider/model>`: ordered fallback model; repeatable and requires `--model`
 - `--auth-env-only`: use only environment provider keys; skips stored credentials, external CLI credentials, and config entirely

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -27,6 +27,10 @@ function collectFallback(value: string, previous: string[]): string[] {
   return [...previous, value];
 }
 
+function collectAlsoAllowTool(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 async function loadDefaultRuntime(): Promise<RuntimeModule["defaultRuntime"]> {
   return (await import("../../runtime.js")).defaultRuntime;
 }
@@ -139,6 +143,12 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .option("--isolated", "Ignore the ambient config and run against exec defaults only", false)
     .option("--model <provider/model>", "Use an explicit primary model for this run")
     .option("--code-mode <mode>", "Tool mode: direct | auto | code")
+    .option(
+      "--also-allow-tool <name>",
+      "Add a tool to this run's additive allowlist (repeatable)",
+      collectAlsoAllowTool,
+      [],
+    )
     .option("--local-model-lean", "Use the reduced local-model tool surface")
     .option(
       "--thinking <level>",

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -216,6 +216,10 @@ describe("agent command registration", () => {
       "openai/gpt-5.6-sol",
       "--code-mode",
       "code",
+      "--also-allow-tool",
+      "browser",
+      "--also-allow-tool",
+      "read",
       "--local-model-lean",
       "--fallback",
       "anthropic/claude-sonnet-4-6",
@@ -231,6 +235,7 @@ describe("agent command registration", () => {
         cwd: "/tmp/project",
         model: "openai/gpt-5.6-sol",
         codeMode: "code",
+        alsoAllowTool: ["browser", "read"],
         localModelLean: true,
         fallback: ["anthropic/claude-sonnet-4-6", "google/gemini-3.1-pro-preview"],
         // Stored credentials are the default so exec reaches the same logins as

--- a/src/commands/agent-exec-tool-policy.ts
+++ b/src/commands/agent-exec-tool-policy.ts
@@ -1,0 +1,53 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ToolAllowDenyPolicyConfig } from "../config/types.tools.js";
+
+type RequestedToolPolicy = Pick<ToolAllowDenyPolicyConfig, "allow" | "alsoAllow">;
+
+function appendRequestedTools(params: {
+  policy: ToolAllowDenyPolicyConfig | undefined;
+  requestedTools: string[];
+  allowImplicitAlsoAllow: boolean;
+}): RequestedToolPolicy | undefined {
+  if (params.requestedTools.length === 0 || (!params.policy && !params.allowImplicitAlsoAllow)) {
+    return undefined;
+  }
+  const allow = params.policy?.allow ?? [];
+  if (allow.length > 0) {
+    return { allow: [...new Set([...allow, ...params.requestedTools])] };
+  }
+  if (params.policy?.alsoAllow === undefined && !params.allowImplicitAlsoAllow) {
+    return undefined;
+  }
+  return {
+    alsoAllow: [...new Set([...(params.policy?.alsoAllow ?? []), ...params.requestedTools])],
+  };
+}
+
+export function resolveAgentExecRequestedToolPolicies(params: {
+  base: OpenClawConfig;
+  agentId?: string;
+  requestedToolNames?: string[];
+}): {
+  requestedToolPolicy?: RequestedToolPolicy;
+  selectedAgentRequestedToolPolicy?: RequestedToolPolicy;
+} {
+  const requestedTools = params.requestedToolNames?.map((value) => value.trim()) ?? [];
+  if (requestedTools.some((value) => !value)) {
+    throw new Error("--also-allow-tool requires a non-empty tool name.");
+  }
+  const selectedAgentTools = params.agentId
+    ? params.base.agents?.entries?.[params.agentId]?.tools
+    : undefined;
+  return {
+    requestedToolPolicy: appendRequestedTools({
+      policy: params.base.tools,
+      requestedTools,
+      allowImplicitAlsoAllow: true,
+    }),
+    selectedAgentRequestedToolPolicy: appendRequestedTools({
+      policy: selectedAgentTools,
+      requestedTools,
+      allowImplicitAlsoAllow: false,
+    }),
+  };
+}

--- a/src/commands/agent-exec-tool-policy.ts
+++ b/src/commands/agent-exec-tool-policy.ts
@@ -1,7 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { ToolAllowDenyPolicyConfig } from "../config/types.tools.js";
+import type { ToolAllowDenyPolicyConfig, ToolPolicyConfig } from "../config/types.tools.js";
 
-type RequestedToolPolicy = Pick<ToolAllowDenyPolicyConfig, "allow" | "alsoAllow">;
+type RequestedToolPolicy = Pick<ToolAllowDenyPolicyConfig, "allow" | "alsoAllow"> & {
+  byProvider?: Record<string, Pick<ToolPolicyConfig, "allow" | "alsoAllow">>;
+};
 
 function appendRequestedTools(params: {
   policy: ToolAllowDenyPolicyConfig | undefined;
@@ -23,6 +25,45 @@ function appendRequestedTools(params: {
   };
 }
 
+function appendRequestedToolsByProvider(params: {
+  byProvider: Record<string, ToolPolicyConfig> | undefined;
+  requestedTools: string[];
+}): RequestedToolPolicy["byProvider"] {
+  if (!params.byProvider || params.requestedTools.length === 0) {
+    return undefined;
+  }
+  const result: NonNullable<RequestedToolPolicy["byProvider"]> = {};
+  for (const [provider, policy] of Object.entries(params.byProvider)) {
+    const requestedPolicy = appendRequestedTools({
+      policy,
+      requestedTools: params.requestedTools,
+      allowImplicitAlsoAllow: true,
+    });
+    if (requestedPolicy) {
+      result[provider] = requestedPolicy;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function resolveRequestedToolPolicy(params: {
+  policy:
+    | (ToolAllowDenyPolicyConfig & { byProvider?: Record<string, ToolPolicyConfig> })
+    | undefined;
+  requestedTools: string[];
+  allowImplicitAlsoAllow: boolean;
+}): RequestedToolPolicy | undefined {
+  const direct = appendRequestedTools(params);
+  const byProvider = appendRequestedToolsByProvider({
+    byProvider: params.policy?.byProvider,
+    requestedTools: params.requestedTools,
+  });
+  if (!direct && !byProvider) {
+    return undefined;
+  }
+  return { ...direct, ...(byProvider ? { byProvider } : {}) };
+}
+
 export function resolveAgentExecRequestedToolPolicies(params: {
   base: OpenClawConfig;
   agentId?: string;
@@ -39,12 +80,12 @@ export function resolveAgentExecRequestedToolPolicies(params: {
     ? params.base.agents?.entries?.[params.agentId]?.tools
     : undefined;
   return {
-    requestedToolPolicy: appendRequestedTools({
+    requestedToolPolicy: resolveRequestedToolPolicy({
       policy: params.base.tools,
       requestedTools,
       allowImplicitAlsoAllow: true,
     }),
-    selectedAgentRequestedToolPolicy: appendRequestedTools({
+    selectedAgentRequestedToolPolicy: resolveRequestedToolPolicy({
       policy: selectedAgentTools,
       requestedTools,
       allowImplicitAlsoAllow: false,

--- a/src/commands/agent-exec.configless.test.ts
+++ b/src/commands/agent-exec.configless.test.ts
@@ -86,6 +86,62 @@ describe("agent exec configless workspace ownership", () => {
     }
   });
 
+  it.each([
+    {
+      name: "strict allowlists",
+      providerPolicy: { allow: ["read"] },
+      expected: { allow: ["read", "browser"] },
+    },
+    {
+      name: "additive allowlists",
+      providerPolicy: { alsoAllow: ["read"] },
+      expected: { alsoAllow: ["read", "browser"] },
+    },
+    {
+      name: "profile-only policies",
+      providerPolicy: { profile: "minimal" as const, deny: ["write"] },
+      expected: {
+        profile: "minimal" as const,
+        alsoAllow: ["browser"],
+        deny: ["write"],
+      },
+    },
+  ])("composes requested tools through global and selected-agent provider $name", (fixture) => {
+    const config = buildExecRunConfig({
+      base: {
+        tools: { byProvider: { anthropic: fixture.providerPolicy } },
+        agents: {
+          entries: {
+            ops: { tools: { byProvider: { "anthropic/claude-opus-5": fixture.providerPolicy } } },
+          },
+        },
+      },
+      cwd: "/run/here",
+      agentId: "ops",
+      opts: { alsoAllowTool: ["browser"] },
+    });
+
+    expect(config.tools?.byProvider?.anthropic).toEqual(fixture.expected);
+    expect(config.agents?.entries?.ops?.tools?.byProvider?.["anthropic/claude-opus-5"]).toEqual(
+      fixture.expected,
+    );
+  });
+
+  it("keeps provider denies authoritative over a one-shot addition", () => {
+    const config = buildExecRunConfig({
+      base: {
+        tools: { byProvider: { anthropic: { deny: ["browser"] } } },
+      },
+      cwd: "/run/here",
+      opts: { alsoAllowTool: ["browser"] },
+    });
+
+    expect(config.tools?.byProvider?.anthropic).toEqual({
+      alsoAllow: ["browser"],
+      deny: ["browser"],
+    });
+  });
+
   it("rejects empty one-shot tool names", () => {
     expect(() =>
       buildExecRunConfig({

--- a/src/commands/agent-exec.configless.test.ts
+++ b/src/commands/agent-exec.configless.test.ts
@@ -35,6 +35,17 @@ describe("agent exec configless workspace ownership", () => {
     expect(config.tools?.alsoAllow).toEqual(["read", "browser"]);
   });
 
+  it("extends a strict allowlist without creating an additive allowlist", () => {
+    const config = buildExecRunConfig({
+      base: { tools: { allow: ["read"] } },
+      cwd: "/run/here",
+      opts: { alsoAllowTool: [" browser ", "read"] },
+    });
+
+    expect(config.tools?.allow).toEqual(["read", "browser"]);
+    expect(config.tools?.alsoAllow).toBeUndefined();
+  });
+
   it("rejects empty one-shot tool names", () => {
     expect(() =>
       buildExecRunConfig({

--- a/src/commands/agent-exec.configless.test.ts
+++ b/src/commands/agent-exec.configless.test.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveEffectiveToolPolicy } from "../agents/agent-tools.policy.js";
 import { resolveRunWorkspaceDir } from "../agents/workspace-run.js";
 import { buildExecRunConfig, resolveExecBaseConfig } from "./agent-exec.js";
 
@@ -44,6 +45,45 @@ describe("agent exec configless workspace ownership", () => {
 
     expect(config.tools?.allow).toEqual(["read", "browser"]);
     expect(config.tools?.alsoAllow).toBeUndefined();
+  });
+
+  it("preserves global empty-allow additive semantics", () => {
+    const config = buildExecRunConfig({
+      base: { tools: { allow: [], alsoAllow: ["read"] } },
+      cwd: "/run/here",
+      opts: { alsoAllowTool: ["browser"] },
+    });
+
+    expect(config.tools?.allow).toEqual([]);
+    expect(config.tools?.alsoAllow).toEqual(["read", "browser"]);
+  });
+
+  it.each([
+    {
+      name: "strict allowlist",
+      tools: { allow: ["read"] },
+      expectedKey: "allow" as const,
+    },
+    {
+      name: "additive allowlist",
+      tools: { alsoAllow: ["read"] },
+      expectedKey: "alsoAllow" as const,
+    },
+  ])("extends the selected agent's $name", ({ tools, expectedKey }) => {
+    const config = buildExecRunConfig({
+      base: { agents: { entries: { ops: { tools } } } },
+      cwd: "/run/here",
+      agentId: "ops",
+      opts: { alsoAllowTool: ["browser"] },
+    });
+
+    expect(config.agents?.entries?.ops?.tools?.[expectedKey]).toEqual(["read", "browser"]);
+    const effective = resolveEffectiveToolPolicy({ config, agentId: "ops" });
+    if (expectedKey === "allow") {
+      expect(effective.agentPolicy?.allow).toContain("browser");
+    } else {
+      expect(effective.profileAlsoAllow).toContain("browser");
+    }
   });
 
   it("rejects empty one-shot tool names", () => {

--- a/src/commands/agent-exec.configless.test.ts
+++ b/src/commands/agent-exec.configless.test.ts
@@ -24,4 +24,24 @@ describe("agent exec configless workspace ownership", () => {
       workspaceDir: resolve("/run/here"),
     });
   });
+
+  it("adds explicitly requested one-shot tools without replacing configured additions", () => {
+    const config = buildExecRunConfig({
+      base: { tools: { alsoAllow: ["read"] } },
+      cwd: "/run/here",
+      opts: { alsoAllowTool: [" browser ", "read"] },
+    });
+
+    expect(config.tools?.alsoAllow).toEqual(["read", "browser"]);
+  });
+
+  it("rejects empty one-shot tool names", () => {
+    expect(() =>
+      buildExecRunConfig({
+        base: {},
+        cwd: "/run/here",
+        opts: { alsoAllowTool: [" "] },
+      }),
+    ).toThrow("--also-allow-tool requires a non-empty tool name");
+  });
 });

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -19,6 +19,7 @@ import type {
 import { formatErrorMessage } from "../infra/errors.js";
 import type { GatewayLockIdentity, GatewayLockOptions } from "../infra/gateway-lock.js";
 import { writeRuntimeJson, writeRuntimeStdout, type RuntimeEnv } from "../runtime.js";
+import { resolveAgentExecRequestedToolPolicies } from "./agent-exec-tool-policy.js";
 
 const AGENT_EXEC_MESSAGE_MAX_BYTES = 4 * 1024 * 1024;
 const AGENT_EXEC_DEFAULT_TIMEOUT_SECONDS = 600;
@@ -271,19 +272,18 @@ function exitCodeForEnvelope(envelope: AgentExecEnvelope): 0 | 1 | 2 {
 function normalizeCodeMode(
   value: AgentExecCliOptions["codeMode"],
 ): false | "auto" | true | undefined {
-  if (value === undefined) {
-    return undefined;
+  switch (value) {
+    case undefined:
+      return undefined;
+    case "direct":
+      return false;
+    case "auto":
+      return "auto";
+    case "code":
+      return true;
+    default:
+      throw new Error("--code-mode must be one of direct, auto, code.");
   }
-  if (value === "direct") {
-    return false;
-  }
-  if (value === "auto") {
-    return "auto";
-  }
-  if (value === "code") {
-    return true;
-  }
-  throw new Error("--code-mode must be one of direct, auto, code.");
 }
 
 /**
@@ -333,33 +333,12 @@ function buildExecRunOverlay(params: {
   opts: Pick<AgentExecCliOptions, "alsoAllowTool" | "codeMode" | "localModelLean">;
 }): OpenClawConfig {
   const codeMode = normalizeCodeMode(params.opts.codeMode);
-  const requestedTools = params.opts.alsoAllowTool?.map((value) => value.trim()) ?? [];
-  if (requestedTools.some((value) => !value)) {
-    throw new Error("--also-allow-tool requires a non-empty tool name.");
-  }
-  const globalAllow = params.base.tools?.allow ?? [];
-  const requestedToolPolicy =
-    requestedTools.length === 0
-      ? undefined
-      : globalAllow.length > 0
-        ? { allow: [...new Set([...globalAllow, ...requestedTools])] }
-        : {
-            alsoAllow: [...new Set([...(params.base.tools?.alsoAllow ?? []), ...requestedTools])],
-          };
-  const selectedAgentTools = params.agentId
-    ? params.base.agents?.entries?.[params.agentId]?.tools
-    : undefined;
-  const selectedAgentAllow = selectedAgentTools?.allow ?? [];
-  const selectedAgentRequestedToolPolicy =
-    requestedTools.length === 0 || !selectedAgentTools
-      ? undefined
-      : selectedAgentAllow.length > 0
-        ? { allow: [...new Set([...selectedAgentAllow, ...requestedTools])] }
-        : selectedAgentTools.alsoAllow !== undefined
-          ? {
-              alsoAllow: [...new Set([...selectedAgentTools.alsoAllow, ...requestedTools])],
-            }
-          : undefined;
+  const { requestedToolPolicy, selectedAgentRequestedToolPolicy } =
+    resolveAgentExecRequestedToolPolicies({
+      base: params.base,
+      agentId: params.agentId,
+      requestedToolNames: params.opts.alsoAllowTool,
+    });
   // A per-agent `workspace` outranks `agents.defaults`, so pinning only the
   // defaults would let an inherited entry silently run the turn against a
   // different repository. Override every configured entry as well.

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -34,6 +34,7 @@ export type AgentExecCliOptions = {
   thinking?: string;
   fallback?: string[];
   codeMode?: "direct" | "auto" | "code";
+  alsoAllowTool?: string[];
   localModelLean?: boolean;
   authEnvOnly?: boolean;
   timeout?: string;
@@ -328,9 +329,17 @@ function stripInheritedAgentLocations(base: OpenClawConfig): OpenClawConfig {
 function buildExecRunOverlay(params: {
   base: OpenClawConfig;
   cwd: string;
-  opts: Pick<AgentExecCliOptions, "codeMode" | "localModelLean">;
+  opts: Pick<AgentExecCliOptions, "alsoAllowTool" | "codeMode" | "localModelLean">;
 }): OpenClawConfig {
   const codeMode = normalizeCodeMode(params.opts.codeMode);
+  const requestedTools = params.opts.alsoAllowTool?.map((value) => value.trim()) ?? [];
+  if (requestedTools.some((value) => !value)) {
+    throw new Error("--also-allow-tool requires a non-empty tool name.");
+  }
+  const alsoAllow =
+    requestedTools.length > 0
+      ? [...new Set([...(params.base.tools?.alsoAllow ?? []), ...requestedTools])]
+      : undefined;
   // A per-agent `workspace` outranks `agents.defaults`, so pinning only the
   // defaults would let an inherited entry silently run the turn against a
   // different repository. Override every configured entry as well.
@@ -349,7 +358,14 @@ function buildExecRunOverlay(params: {
     // This process exits after one turn, so live skill invalidation cannot be
     // observed and would leave Chokidar retaining the otherwise-finished CLI.
     skills: { load: { watch: false } },
-    ...(codeMode !== undefined ? { tools: { codeMode } } : {}),
+    ...(codeMode !== undefined || alsoAllow
+      ? {
+          tools: {
+            ...(codeMode !== undefined ? { codeMode } : {}),
+            ...(alsoAllow ? { alsoAllow } : {}),
+          },
+        }
+      : {}),
   } as OpenClawConfig;
 }
 
@@ -426,7 +442,7 @@ export async function resolveExecBaseConfig(
 export function buildExecRunConfig(params: {
   base: OpenClawConfig;
   cwd: string;
-  opts?: Pick<AgentExecCliOptions, "codeMode" | "localModelLean">;
+  opts?: Pick<AgentExecCliOptions, "alsoAllowTool" | "codeMode" | "localModelLean">;
 }): OpenClawConfig {
   const opts = params.opts ?? {};
   const base = stripInheritedAgentLocations(params.base);

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -329,6 +329,7 @@ function stripInheritedAgentLocations(base: OpenClawConfig): OpenClawConfig {
 function buildExecRunOverlay(params: {
   base: OpenClawConfig;
   cwd: string;
+  agentId?: string;
   opts: Pick<AgentExecCliOptions, "alsoAllowTool" | "codeMode" | "localModelLean">;
 }): OpenClawConfig {
   const codeMode = normalizeCodeMode(params.opts.codeMode);
@@ -336,14 +337,29 @@ function buildExecRunOverlay(params: {
   if (requestedTools.some((value) => !value)) {
     throw new Error("--also-allow-tool requires a non-empty tool name.");
   }
+  const globalAllow = params.base.tools?.allow ?? [];
   const requestedToolPolicy =
     requestedTools.length === 0
       ? undefined
-      : params.base.tools?.allow !== undefined
-        ? { allow: [...new Set([...params.base.tools.allow, ...requestedTools])] }
+      : globalAllow.length > 0
+        ? { allow: [...new Set([...globalAllow, ...requestedTools])] }
         : {
             alsoAllow: [...new Set([...(params.base.tools?.alsoAllow ?? []), ...requestedTools])],
           };
+  const selectedAgentTools = params.agentId
+    ? params.base.agents?.entries?.[params.agentId]?.tools
+    : undefined;
+  const selectedAgentAllow = selectedAgentTools?.allow ?? [];
+  const selectedAgentRequestedToolPolicy =
+    requestedTools.length === 0 || !selectedAgentTools
+      ? undefined
+      : selectedAgentAllow.length > 0
+        ? { allow: [...new Set([...selectedAgentAllow, ...requestedTools])] }
+        : selectedAgentTools.alsoAllow !== undefined
+          ? {
+              alsoAllow: [...new Set([...selectedAgentTools.alsoAllow, ...requestedTools])],
+            }
+          : undefined;
   // A per-agent `workspace` outranks `agents.defaults`, so pinning only the
   // defaults would let an inherited entry silently run the turn against a
   // different repository. Override every configured entry as well.
@@ -356,7 +372,19 @@ function buildExecRunOverlay(params: {
         ...(params.opts.localModelLean ? { experimental: { localModelLean: true } } : {}),
       },
       ...(entries.length > 0
-        ? { entries: Object.fromEntries(entries.map((id) => [id, { workspace: params.cwd }])) }
+        ? {
+            entries: Object.fromEntries(
+              entries.map((id) => [
+                id,
+                {
+                  workspace: params.cwd,
+                  ...(id === params.agentId && selectedAgentRequestedToolPolicy
+                    ? { tools: selectedAgentRequestedToolPolicy }
+                    : {}),
+                },
+              ]),
+            ),
+          }
         : {}),
     },
     // This process exits after one turn, so live skill invalidation cannot be
@@ -446,6 +474,7 @@ export async function resolveExecBaseConfig(
 export function buildExecRunConfig(params: {
   base: OpenClawConfig;
   cwd: string;
+  agentId?: string;
   opts?: Pick<AgentExecCliOptions, "alsoAllowTool" | "codeMode" | "localModelLean">;
 }): OpenClawConfig {
   const opts = params.opts ?? {};
@@ -453,7 +482,7 @@ export function buildExecRunConfig(params: {
   const withDefaults = mergeDeep(buildExecConfigDefaults(), base) as OpenClawConfig;
   return mergeDeep(
     withDefaults,
-    buildExecRunOverlay({ base, cwd: params.cwd, opts }),
+    buildExecRunOverlay({ base, cwd: params.cwd, agentId: params.agentId, opts }),
   ) as OpenClawConfig;
 }
 
@@ -644,7 +673,13 @@ export async function agentExecCommand(
         before: envBeforeConfigLoad,
         after: envAfterConfigLoad,
       });
-    const runConfig = buildExecRunConfig({ base: baseConfig, cwd, opts });
+    const { resolveAgentDir, resolveAmbientOwnerAgentId } =
+      await import("../agents/agent-scope-config.js");
+    const execAgentId = resolveAmbientOwnerAgentId(baseConfig, undefined, {
+      surface: "agent exec",
+      hint: "Set agents.defaults.systemAgent.agentId.",
+    });
+    const runConfig = buildExecRunConfig({ base: baseConfig, cwd, agentId: execAgentId, opts });
     // Installed plugins belong to the operator config resolved above, not to
     // the disposable state root used for this run. Capture all roots before
     // OPENCLAW_STATE_DIR moves so discovery and the installed-index DB agree.
@@ -655,8 +690,6 @@ export async function agentExecCommand(
     const pluginInstallRoots = pluginInstallContext?.resolvePluginInstallRoots();
     const timeout = normalizeTimeoutSeconds(opts.timeout);
     const fallbacks = normalizeFallbacks(opts.model, opts.fallback);
-    const { resolveAgentDir, resolveAmbientOwnerAgentId } =
-      await import("../agents/agent-scope-config.js");
     // Resolve from the inherited config, not `{}`: the default agent may declare
     // its own `agentDir`, and that is where its stored auth profiles live. This
     // reads `baseConfig` rather than `runConfig` because the run config
@@ -664,10 +697,6 @@ export async function agentExecCommand(
     // credential ownership must still follow the operator's configuration.
     // Computed before the environment repoints the state dir so the unconfigured
     // case still resolves against the real one.
-    const execAgentId = resolveAmbientOwnerAgentId(baseConfig, undefined, {
-      surface: "agent exec",
-      hint: "Set agents.defaults.systemAgent.agentId.",
-    });
     // Auth, session keys, and SQLite ownership must share one resolved owner.
     // Splitting these paths can select an agent's store but emit a `main` key.
     const storedAuthAgentDir = resolveAgentDir(baseConfig, execAgentId);

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -53,10 +53,7 @@ type AgentExecPayload = {
 
 type AgentExecRawPayload = AgentExecPayload & Record<string, unknown>;
 
-type AgentExecRunResult = {
-  payloads?: AgentExecRawPayload[];
-  meta: EmbeddedAgentRunMeta;
-};
+type AgentExecRunResult = { payloads?: AgentExecRawPayload[]; meta: EmbeddedAgentRunMeta };
 
 type AgentExecStatus = "ok" | "error" | "timeout";
 
@@ -80,10 +77,7 @@ export type AgentExecEnvelope = {
   };
 };
 
-type AgentExecCommandResult = {
-  envelope: AgentExecEnvelope;
-  exitCode: 0 | 1 | 2;
-};
+type AgentExecCommandResult = { envelope: AgentExecEnvelope; exitCode: 0 | 1 | 2 };
 
 type AgentExecCommandDeps = {
   stdin?: AsyncIterable<unknown>;

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -336,10 +336,14 @@ function buildExecRunOverlay(params: {
   if (requestedTools.some((value) => !value)) {
     throw new Error("--also-allow-tool requires a non-empty tool name.");
   }
-  const alsoAllow =
-    requestedTools.length > 0
-      ? [...new Set([...(params.base.tools?.alsoAllow ?? []), ...requestedTools])]
-      : undefined;
+  const requestedToolPolicy =
+    requestedTools.length === 0
+      ? undefined
+      : params.base.tools?.allow !== undefined
+        ? { allow: [...new Set([...params.base.tools.allow, ...requestedTools])] }
+        : {
+            alsoAllow: [...new Set([...(params.base.tools?.alsoAllow ?? []), ...requestedTools])],
+          };
   // A per-agent `workspace` outranks `agents.defaults`, so pinning only the
   // defaults would let an inherited entry silently run the turn against a
   // different repository. Override every configured entry as well.
@@ -358,11 +362,11 @@ function buildExecRunOverlay(params: {
     // This process exits after one turn, so live skill invalidation cannot be
     // observed and would leave Chokidar retaining the otherwise-finished CLI.
     skills: { load: { watch: false } },
-    ...(codeMode !== undefined || alsoAllow
+    ...(codeMode !== undefined || requestedToolPolicy
       ? {
           tools: {
             ...(codeMode !== undefined ? { codeMode } : {}),
-            ...(alsoAllow ? { alsoAllow } : {}),
+            ...requestedToolPolicy,
           },
         }
       : {}),


### PR DESCRIPTION
Related: #126255

## What Problem This Solves

`openclaw agent exec` uses a restrictive one-shot tool profile, but a trusted local runner could not add one named tool without persistent configuration. Later global, selected-agent, or provider-specific policy layers could also erase a one-shot grant.

## Design

- Add repeatable `--also-allow-tool <name>` to local `agent exec`.
- Trim values, reject empty names, and deduplicate.
- Extend non-empty strict allowlists in place; preserve additive/allow-all semantics when no strict allowlist exists.
- Compose the grant into global and selected-agent policy, including every authored `tools.byProvider` entry.
- Preserve configured denies; deny remains authoritative.
- Keep the option local to CLI assembly. It does not widen Gateway or public agent-command ingress.

## Evidence

- 6 files, 289 insertions / 24 deletions against current upstream `main`.
- Current head: `900acbbe47f653440a3803124212eb1cc6dedc5b`, rebased onto `3ae680f7143336e6918f8819163a3cbf21882e92`.
- `pnpm check:changed` passed after rebase.
- Focused command/policy suites and both core typecheck lanes pass.
- Coverage includes strict, additive, profile-only, global, selected-agent, and provider-specific policy, plus authoritative deny behavior.
- Required branch autoreview found no finding and rated the patch correct at 0.98 confidence.

## Evaluation result

The evaluated OpenClaw command used `--also-allow-tool browser`. Combined with #126255 and #126404, [full run 32556602972](https://github.com/browser-use/new-eval-platform/actions/runs/32556602972) scored **86/106 (81.13%)**, above historical Laith OpenClaw at 82/106. A final exact-current-head smoke/full rerun is being recorded separately before merge.