### PR TITLE
perf(mantis): parallelize proof builds and warm caches

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -531,32 +531,58 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .artifacts/mantis-baseline-build.tar
-          key: ${{ runner.os }}-${{ runner.arch }}-mantis-baseline-v3-${{ needs.resolve_request.outputs.baseline_revision }}-${{ steps.proof_worktrees.outputs.lockfile_sha256 }}-${{ steps.proof_worktrees.outputs.node_version }}-${{ steps.proof_worktrees.outputs.pnpm_version }}
+          key: ${{ runner.os }}-${{ runner.arch }}-mantis-baseline-v3-${{ steps.proof_worktrees.outputs.lockfile_sha256 }}-${{ steps.proof_worktrees.outputs.node_version }}-${{ steps.proof_worktrees.outputs.pnpm_version }}-${{ needs.resolve_request.outputs.baseline_revision }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-mantis-baseline-v3-${{ steps.proof_worktrees.outputs.lockfile_sha256 }}-${{ steps.proof_worktrees.outputs.node_version }}-${{ steps.proof_worktrees.outputs.pnpm_version }}-
 
-      - name: Prepare baseline proof build
+      - name: Prepare baseline and candidate proof builds
         env:
           BASELINE_BUILD_ARCHIVE: ${{ github.workspace }}/.artifacts/mantis-baseline-build.tar
           BASELINE_BUILD_CACHE_HIT: ${{ steps.baseline_build_cache.outputs.cache-hit }}
-          BASELINE_ROOT: ${{ steps.proof_worktrees.outputs.baseline_root }}
+          BASELINE_SHA: ${{ needs.resolve_request.outputs.baseline_revision }}
+          CANDIDATE_SHA: ${{ needs.resolve_request.outputs.candidate_revision }}
+          HOST_PNPM_STORE: ${{ steps.setup-node-env.outputs.pnpm-store-cache-path }}
         shell: bash
         run: |
           set -euo pipefail
+          worktree_root="/tmp/openclaw-mantis-proof-worktrees-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          baseline_root="$worktree_root/baseline"
+          candidate_root="$worktree_root/candidate"
           toolchain_dir=/usr/local/lib/mantis-toolchain
           corepack_home="${RUNNER_TEMP}/mantis-corepack"
+          baseline_archive_restored=false
+          if [[ -f "$BASELINE_BUILD_ARCHIVE" ]]; then
+            baseline_archive_restored=true
+          fi
 
-          mkdir -p "${RUNNER_TEMP}/mantis-baseline-home"
-          cd "$BASELINE_ROOT"
-          env -i \
-            CI=1 \
-            COREPACK_HOME="$corepack_home" \
-            HOME="${RUNNER_TEMP}/mantis-baseline-home" \
-            OPENCLAW_BUILD_PRIVATE_QA=1 \
-            OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
-            PATH="$toolchain_dir:/usr/bin:/bin" \
-            "$toolchain_dir/pnpm" install --frozen-lockfile
-          if [[ "$BASELINE_BUILD_CACHE_HIT" == "true" ]]; then
-            tar -xf "$BASELINE_BUILD_ARCHIVE"
+          candidate_git_link="$(cat "$candidate_root/.git")"
+          if [[ "$baseline_archive_restored" == "true" ]] &&
+            git -C "$baseline_root" diff --quiet "$BASELINE_SHA" "$CANDIDATE_SHA" -- \
+              scripts/build-all.mts \
+              scripts/lib \
+              scripts/pnpm-runner.mts \
+              packages/normalization-core \
+              package.json \
+              pnpm-lock.yaml \
+              pnpm-workspace.yaml \
+              tsconfig.json; then
+            # Observed 2026-08: cache-only seeding still rebuilt tsdown-unified for 3m04s;
+            # its cache contract also requires the live plugin-SDK outputs it will replace.
+            tar --no-same-owner -C "$candidate_root" -xf "$BASELINE_BUILD_ARCHIVE" \
+              .artifacts/build-all-cache dist/plugin-sdk
+            test -z "$(find "$candidate_root/.artifacts/build-all-cache" -type l -print -quit)"
+            test -z "$(find "$candidate_root/dist/plugin-sdk" -type l -print -quit)"
+            test -z "$(find "$candidate_root/dist/plugin-sdk" -type f -links +1 -print -quit)"
+            echo "Seeded candidate build-all cache from the trusted restored baseline."
+          elif [[ "$baseline_archive_restored" == "true" ]]; then
+            echo "Candidate changed the build-cache engine closure; building without the baseline seed."
           else
+            echo "No baseline archive restored; building candidate without the baseline seed."
+          fi
+
+          baseline_build() {
+            mkdir -p "${RUNNER_TEMP}/mantis-baseline-home"
+            cd "$baseline_root"
             env -i \
               CI=1 \
               COREPACK_HOME="$corepack_home" \
@@ -564,32 +590,78 @@ jobs:
               OPENCLAW_BUILD_PRIVATE_QA=1 \
               OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
               PATH="$toolchain_dir:/usr/bin:/bin" \
-              "$toolchain_dir/pnpm" build
-            mkdir -p "$(dirname "$BASELINE_BUILD_ARCHIVE")"
-            tar -cf "$BASELINE_BUILD_ARCHIVE" dist dist-runtime packages/*/dist .artifacts/build-all-cache
-            find extensions -type f -path '*/src/host/*' \
-              \( -name '.bundle.hash' -o -name '*.bundle.js' \) -print0 \
-              | tar --append --file="$BASELINE_BUILD_ARCHIVE" --null --files-from=-
+              "$toolchain_dir/pnpm" install --frozen-lockfile
+            if [[ "$baseline_archive_restored" == "true" ]]; then
+              tar -C "$baseline_root" -xf "$BASELINE_BUILD_ARCHIVE"
+            fi
+            if [[ "$BASELINE_BUILD_CACHE_HIT" != "true" ]]; then
+              env -i \
+                CI=1 \
+                COREPACK_HOME="$corepack_home" \
+                HOME="${RUNNER_TEMP}/mantis-baseline-home" \
+                OPENCLAW_BUILD_PRIVATE_QA=1 \
+                OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
+                PATH="$toolchain_dir:/usr/bin:/bin" \
+                "$toolchain_dir/pnpm" build
+              mkdir -p "$(dirname "$BASELINE_BUILD_ARCHIVE")"
+              baseline_archive_new="${BASELINE_BUILD_ARCHIVE}.new"
+              test ! -e "$baseline_archive_new"
+              tar -cf "$baseline_archive_new" \
+                dist dist-runtime packages/*/dist .artifacts/build-all-cache
+              find extensions -type f -path '*/src/host/*' \
+                \( -name '.bundle.hash' -o -name '*.bundle.js' \) -print0 \
+                | tar --append --file="$baseline_archive_new" --null --files-from=-
+              mv -T "$baseline_archive_new" "$BASELINE_BUILD_ARCHIVE"
+            fi
+            test -d dist-runtime
+            test -f dist/build-info.json
+            test -f dist/control-ui/index.html
+            test -f dist/index.js -o -f dist/index.mjs
+            build_cache_root="$baseline_root/.artifacts/build-all-cache"
+            for phase in tsdown-ai tsdown-packages tsdown-unified; do
+              stamp="$build_cache_root/$phase/stamp.json"
+              outputs="$build_cache_root/$phase/outputs"
+              test -s "$stamp"
+              jq -e '
+                (.version | type) == "number" and
+                (.signature | type) == "string" and (.signature | length) == 64 and
+                (.outputs | type) == "array" and (.outputs | length) > 0
+              ' "$stamp" >/dev/null
+              test -d "$outputs"
+              test -n "$(find "$outputs" -type f -print -quit)"
+            done
+            test -z "$(find "$build_cache_root" -type l -print -quit)"
+            test -z "$(find "$build_cache_root" -type f -links +1 -print -quit)"
+          }
+
+          candidate_build() {
+            sudo useradd --system --no-create-home --shell /usr/sbin/nologin mantis-builder
+            sudo chown -R mantis-builder:mantis-builder "$candidate_root"
+            sudo /usr/local/sbin/openclaw-mantis-sut-container \
+              build "$candidate_root" "$HOST_PNPM_STORE"
+            test "$(cat "$candidate_root/.git")" = "$candidate_git_link"
+            git -c safe.directory="$candidate_root" -C "$candidate_root" diff --exit-code
+            git -c safe.directory="$candidate_root" -C "$candidate_root" diff --cached --exit-code
+            test "$(git -C "$baseline_root" rev-parse HEAD)" = "$BASELINE_SHA"
+            test "$(git -c safe.directory="$candidate_root" -C "$candidate_root" rev-parse HEAD)" = "$CANDIDATE_SHA"
+          }
+
+          baseline_log="${RUNNER_TEMP}/mantis-baseline-build.log"
+          candidate_log="${RUNNER_TEMP}/mantis-candidate-build.log"
+          (set -o pipefail; baseline_build 2>&1 | sed -u 's/^/[baseline] /' | tee "$baseline_log") &
+          baseline_pid=$!
+          (set -o pipefail; candidate_build 2>&1 | sed -u 's/^/[candidate] /' | tee "$candidate_log") &
+          candidate_pid=$!
+          set +e
+          wait "$baseline_pid"
+          baseline_status=$?
+          wait "$candidate_pid"
+          candidate_status=$?
+          set -e
+          if ((baseline_status != 0 || candidate_status != 0)); then
+            echo "::error::Proof build failure: baseline=${baseline_status}, candidate=${candidate_status}."
+            exit 1
           fi
-          test -d dist-runtime
-          test -f dist/build-info.json
-          test -f dist/control-ui/index.html
-          test -f dist/index.js -o -f dist/index.mjs
-          build_cache_root="$BASELINE_ROOT/.artifacts/build-all-cache"
-          for phase in tsdown-ai tsdown-packages tsdown-unified; do
-            stamp="$build_cache_root/$phase/stamp.json"
-            outputs="$build_cache_root/$phase/outputs"
-            test -s "$stamp"
-            jq -e '
-              (.version | type) == "number" and
-              (.signature | type) == "string" and (.signature | length) == 64 and
-              (.outputs | type) == "array" and (.outputs | length) > 0
-            ' "$stamp" >/dev/null
-            test -d "$outputs"
-            test -n "$(find "$outputs" -type f -print -quit)"
-          done
-          test -z "$(find "$build_cache_root" -type l -print -quit)"
-          test -z "$(find "$build_cache_root" -type f -links +1 -print -quit)"
 
       - name: Save exact baseline build
         if: steps.setup-node-env.outputs.cache-mode == 'read-write' && steps.baseline_build_cache.outputs.cache-hit != 'true'
@@ -598,47 +670,6 @@ jobs:
         with:
           path: .artifacts/mantis-baseline-build.tar
           key: ${{ steps.baseline_build_cache.outputs.cache-primary-key }}
-
-      - name: Prepare candidate proof build
-        env:
-          BASELINE_BUILD_ARCHIVE: ${{ github.workspace }}/.artifacts/mantis-baseline-build.tar
-          BASELINE_SHA: ${{ needs.resolve_request.outputs.baseline_revision }}
-          CANDIDATE_SHA: ${{ needs.resolve_request.outputs.candidate_revision }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          worktree_root="/tmp/openclaw-mantis-proof-worktrees-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          baseline_root="$worktree_root/baseline"
-          candidate_root="$worktree_root/candidate"
-          candidate_git_link="$(cat "$candidate_root/.git")"
-          if git -C "$baseline_root" diff --quiet "$BASELINE_SHA" "$CANDIDATE_SHA" -- \
-            scripts/build-all.mts \
-            scripts/lib \
-            scripts/pnpm-runner.mts \
-            packages/normalization-core \
-            package.json \
-            pnpm-lock.yaml \
-            pnpm-workspace.yaml \
-            tsconfig.json; then
-            # Observed 2026-08: cache-only seeding still rebuilt tsdown-unified for 3m04s;
-            # its cache contract also requires the live plugin-SDK outputs it will replace.
-            tar --no-same-owner -C "$candidate_root" -xf "$BASELINE_BUILD_ARCHIVE" \
-              .artifacts/build-all-cache dist/plugin-sdk
-            test -z "$(find "$candidate_root/.artifacts/build-all-cache" -type l -print -quit)"
-            test -z "$(find "$candidate_root/dist/plugin-sdk" -type l -print -quit)"
-            test -z "$(find "$candidate_root/dist/plugin-sdk" -type f -links +1 -print -quit)"
-            echo "Seeded candidate build-all cache from the trusted baseline."
-          else
-            echo "Candidate changed the build-cache engine closure; building without the baseline seed."
-          fi
-          sudo useradd --system --no-create-home --shell /usr/sbin/nologin mantis-builder
-          sudo chown -R mantis-builder:mantis-builder "$candidate_root"
-          sudo /usr/local/sbin/openclaw-mantis-sut-container build "$candidate_root"
-          test "$(cat "$candidate_root/.git")" = "$candidate_git_link"
-          git -c safe.directory="$candidate_root" -C "$candidate_root" diff --exit-code
-          git -c safe.directory="$candidate_root" -C "$candidate_root" diff --cached --exit-code
-          test "$(git -C "$baseline_root" rev-parse HEAD)" = "$BASELINE_SHA"
-          test "$(git -c safe.directory="$candidate_root" -C "$candidate_root" rev-parse HEAD)" = "$CANDIDATE_SHA"
 
       - name: Install TDLib and restore Telegram QA user
         id: telegram_credential

--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 344531,
-  "reason": "canonical cross-runtime gzip sidecars",
-  "updatedAt": "2026-08-20"
+  "startupJsGzipBytes": 345049,
+  "reason": "streamed-markdown highlighting changes (#127749, #127754) consumed the ratchet",
+  "updatedAt": "2026-08-22"
 }

--- a/scripts/mantis/mantis-sut-container.sh
+++ b/scripts/mantis/mantis-sut-container.sh
@@ -580,6 +580,8 @@ readonly network_probe_script='
 readonly build_command='
   set -eu
   store=.mantis-pnpm-store
+  test -d "$store"
+  test -n "$(find "$store" -type f -print -quit)"
   cleanup() {
     rm -rf "$store"
   }
@@ -649,10 +651,14 @@ shift || true
 case "$command" in
   build)
     [[ "${SUDO_USER:-}" == "runner" ]] || die "build is restricted to the workflow runner"
-    [[ $# -eq 1 ]] || die "build expects the candidate worktree"
+    [[ $# -eq 2 ]] || die "build expects the candidate worktree and host pnpm store"
     worktree_root="$(realpath -e "$(<"$worktree_root_file")")"
     candidate_root="$(realpath -e "$1")"
+    host_pnpm_store="$(realpath -e "$2")"
     [[ "$candidate_root" == "$worktree_root/candidate" ]] || die "unexpected candidate worktree"
+    [[ -d "$host_pnpm_store" ]] || die "host pnpm store is not a directory"
+    [[ "$host_pnpm_store" != "$candidate_root" && "$host_pnpm_store" != "$candidate_root/"* ]] \
+      || die "host pnpm store must be outside the candidate worktree"
     [[ "$(stat -c %u "$candidate_root")" == "$(id -u mantis-builder)" ]] || die "candidate owner mismatch"
     [[ -f "$candidate_root/.git" && ! -L "$candidate_root/.git" ]] \
       || die "candidate Git link is not a regular file"
@@ -689,6 +695,13 @@ case "$command" in
     isolated_root="$build_mount/repo"
     mkdir "$isolated_root"
     /bin/cp -a "$candidate_root/." "$isolated_root/"
+    store_copy_start=$SECONDS
+    mkdir "$isolated_root/.mantis-pnpm-store"
+    # A reflink is copy-on-write, and the fallback is a regular copy. Never bind or
+    # hard-link the host store: candidate lifecycle scripts may rewrite their store.
+    /bin/cp -a --reflink=auto "$host_pnpm_store/." "$isolated_root/.mantis-pnpm-store/"
+    test -n "$(find "$isolated_root/.mantis-pnpm-store" -type f -print -quit)"
+    echo "Copied disposable pnpm store in $((SECONDS - store_copy_start))s."
     chown -R mantis-builder:mantis-builder "$isolated_root"
     create_public_only_network "$network_name"
     run_network_probe "$network_name"

--- a/scripts/mantis/mantis-sut-container.sh
+++ b/scripts/mantis/mantis-sut-container.sh
@@ -691,13 +691,17 @@ case "$command" in
     # `set -e` preserves a failed probe/container status through this EXIT trap.
     # The explicit cleanup below is reached only after the protected command succeeds.
     trap cleanup_build EXIT INT TERM
-    create_bounded_filesystem "${container_name}-fs" 10G >/dev/null
+    # 16G bounds worktree + full pnpm-store copy + build output together; the image
+    # is sparse so unused capacity costs nothing, and the post-build 8 GiB check
+    # below still bounds what leaves the container.
+    create_bounded_filesystem "${container_name}-fs" 16G >/dev/null
     isolated_root="$build_mount/repo"
     mkdir "$isolated_root"
     /bin/cp -a "$candidate_root/." "$isolated_root/"
     store_copy_start=$SECONDS
     mkdir "$isolated_root/.mantis-pnpm-store"
-    # A reflink is copy-on-write, and the fallback is a regular copy. Never bind or
+    # Host disk -> loop image crosses filesystems, so reflink falls back to a full
+    # byte copy on CI; keep --reflink=auto for same-filesystem hosts. Never bind or
     # hard-link the host store: candidate lifecycle scripts may rewrite their store.
     /bin/cp -a --reflink=auto "$host_pnpm_store/." "$isolated_root/.mantis-pnpm-store/"
     test -n "$(find "$isolated_root/.mantis-pnpm-store" -type f -print -quit)"

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -709,25 +709,22 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(prompt).not.toContain("OPENCLAW_TELEGRAM_USER_PROOF_CMD");
   });
 
-  it("reuses only the exact baseline build while always preparing both proof lanes", () => {
+  it("incrementally refreshes stale baseline builds while preparing both proof lanes in parallel", () => {
     const workflow = parse(readFileSync(WORKFLOW, "utf8")) as Workflow;
     const steps = workflow.jobs?.run_telegram_desktop_proof?.steps ?? [];
     const create = workflowStep("Create exact proof worktrees");
     const setup = workflowStep("Setup Node environment");
     const restore = workflowStep("Restore exact baseline build");
-    const baseline = workflowStep("Prepare baseline proof build");
+    const builds = workflowStep("Prepare baseline and candidate proof builds");
     const save = workflowStep("Save exact baseline build");
-    const candidate = workflowStep("Prepare candidate proof build");
     const createRun = create.run ?? "";
-    const baselineRun = baseline.run ?? "";
-    const candidateRun = candidate.run ?? "";
+    const buildRun = builds.run ?? "";
     const stepIndex = (name: string) => steps.findIndex((step) => step.name === name);
 
     expect(stepIndex(create.name ?? "")).toBeLessThan(stepIndex(restore.name ?? ""));
-    expect(stepIndex(restore.name ?? "")).toBeLessThan(stepIndex(baseline.name ?? ""));
-    expect(stepIndex(baseline.name ?? "")).toBeLessThan(stepIndex(save.name ?? ""));
-    expect(stepIndex(save.name ?? "")).toBeLessThan(stepIndex(candidate.name ?? ""));
-    expect(stepIndex(candidate.name ?? "")).toBeLessThan(
+    expect(stepIndex(restore.name ?? "")).toBeLessThan(stepIndex(builds.name ?? ""));
+    expect(stepIndex(builds.name ?? "")).toBeLessThan(stepIndex(save.name ?? ""));
+    expect(stepIndex(save.name ?? "")).toBeLessThan(
       stepIndex("Install TDLib and restore Telegram QA user"),
     );
 
@@ -744,51 +741,76 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(restore.with?.key).toContain("steps.proof_worktrees.outputs.node_version");
     expect(restore.with?.key).toContain("steps.proof_worktrees.outputs.pnpm_version");
     expect(restore.with?.key).toContain("mantis-baseline-v3");
+    expect(restore.with?.key).toMatch(/pnpm_version.*baseline_revision/u);
+    expect(restore.with?.["restore-keys"]).toBe(
+      "${{ runner.os }}-${{ runner.arch }}-mantis-baseline-v3-${{ steps.proof_worktrees.outputs.lockfile_sha256 }}-${{ steps.proof_worktrees.outputs.node_version }}-${{ steps.proof_worktrees.outputs.pnpm_version }}-\n",
+    );
     expect(restore.with?.path).toBe(".artifacts/mantis-baseline-build.tar");
-    expect(baseline.if).toBeUndefined();
-    expect(baselineRun).toContain('"$toolchain_dir/pnpm" install --frozen-lockfile');
-    expect(baselineRun).toContain('if [[ "$BASELINE_BUILD_CACHE_HIT" == "true" ]]');
-    expect(baselineRun).toContain('tar -xf "$BASELINE_BUILD_ARCHIVE"');
-    expect(baselineRun).toContain('"$toolchain_dir/pnpm" build');
-    expect(baselineRun).toContain('tar -cf "$BASELINE_BUILD_ARCHIVE"');
-    expect(baselineRun).toContain(".artifacts/build-all-cache");
-    expect(baselineRun).toContain("for phase in tsdown-ai tsdown-packages tsdown-unified");
-    expect(baselineRun).toContain("-type f -links +1");
+    expect(builds.if).toBeUndefined();
+    expect(builds.env?.HOST_PNPM_STORE).toBe(
+      "${{ steps.setup-node-env.outputs.pnpm-store-cache-path }}",
+    );
+    expect(buildRun).toContain('if [[ -f "$BASELINE_BUILD_ARCHIVE" ]]');
+    expect(buildRun).toContain('tar -C "$baseline_root" -xf "$BASELINE_BUILD_ARCHIVE"');
+    expect(buildRun).toContain("baseline_archive_restored=true");
+    expect(buildRun).toContain('"$toolchain_dir/pnpm" install --frozen-lockfile');
+    expect(buildRun).toContain('if [[ "$BASELINE_BUILD_CACHE_HIT" != "true" ]]');
+    expect(buildRun).toContain('"$toolchain_dir/pnpm" build');
+    expect(buildRun).toContain('mv -T "$baseline_archive_new" "$BASELINE_BUILD_ARCHIVE"');
+    expect(buildRun).toContain(".artifacts/build-all-cache");
+    expect(buildRun).toContain("for phase in tsdown-ai tsdown-packages tsdown-unified");
+    expect(buildRun).toContain("-type f -links +1");
     expect(save.if).toContain("steps.baseline_build_cache.outputs.cache-hit != 'true'");
     expect(save.uses).toContain("actions/cache/save@");
     expect(save.with?.path).toBe(restore.with?.path);
-    expect(candidate.if).toBeUndefined();
-    expect(candidateRun).toContain('sudo chown -R mantis-builder:mantis-builder "$candidate_root"');
-    expect(candidateRun).toContain(
+    expect(buildRun).toContain("baseline_build() {");
+    expect(buildRun).toContain("candidate_build() {");
+    expect(buildRun).toContain("[baseline] ");
+    expect(buildRun).toContain("[candidate] ");
+    expect(buildRun).toContain("baseline_pid=$!");
+    expect(buildRun).toContain("candidate_pid=$!");
+    expect(buildRun).toContain('wait "$baseline_pid"');
+    expect(buildRun).toContain('wait "$candidate_pid"');
+    expect(buildRun).toContain("exit 1");
+    expect(buildRun).toContain('sudo chown -R mantis-builder:mantis-builder "$candidate_root"');
+    expect(buildRun).toContain('if [[ "$baseline_archive_restored" == "true" ]] &&');
+    expect(buildRun).toContain(
       'git -C "$baseline_root" diff --quiet "$BASELINE_SHA" "$CANDIDATE_SHA"',
     );
-    expect(candidateRun).toContain("scripts/build-all.mts");
-    expect(candidateRun).toContain("scripts/lib");
-    expect(candidateRun).toContain("scripts/pnpm-runner.mts");
-    expect(candidateRun).toContain("packages/normalization-core");
-    expect(candidateRun).toContain("pnpm-lock.yaml");
-    expect(candidateRun).toContain("pnpm-workspace.yaml");
-    expect(candidateRun).toContain("tsconfig.json");
-    expect(candidateRun).toContain(
+    expect(buildRun).toContain("scripts/build-all.mts");
+    expect(buildRun).toContain("scripts/lib");
+    expect(buildRun).toContain("scripts/pnpm-runner.mts");
+    expect(buildRun).toContain("packages/normalization-core");
+    expect(buildRun).toContain("pnpm-lock.yaml");
+    expect(buildRun).toContain("pnpm-workspace.yaml");
+    expect(buildRun).toContain("tsconfig.json");
+    expect(buildRun).toContain(
       'tar --no-same-owner -C "$candidate_root" -xf "$BASELINE_BUILD_ARCHIVE"',
     );
-    expect(candidateRun).toContain(".artifacts/build-all-cache dist/plugin-sdk");
-    expect(candidateRun).toContain('find "$candidate_root/dist/plugin-sdk" -type l');
-    expect(candidateRun).toContain('find "$candidate_root/dist/plugin-sdk" -type f -links +1');
-    expect(candidateRun.indexOf("tar --no-same-owner")).toBeLessThan(
-      candidateRun.indexOf('sudo chown -R mantis-builder:mantis-builder "$candidate_root"'),
+    expect(buildRun).toContain(".artifacts/build-all-cache dist/plugin-sdk");
+    expect(buildRun).toContain('find "$candidate_root/dist/plugin-sdk" -type l');
+    expect(buildRun).toContain('find "$candidate_root/dist/plugin-sdk" -type f -links +1');
+    expect(buildRun.indexOf("tar --no-same-owner")).toBeLessThan(
+      buildRun.indexOf('sudo chown -R mantis-builder:mantis-builder "$candidate_root"'),
     );
-    expect(candidateRun).not.toContain("cp -al");
-    expect(candidateRun).toContain(
-      'sudo /usr/local/sbin/openclaw-mantis-sut-container build "$candidate_root"',
-    );
-    expect(candidateRun).not.toContain("sudo -u mantis-builder");
-    expect(candidateRun).not.toContain("sudo setfacl");
-    expect(candidateRun).toContain('test "$(cat "$candidate_root/.git")" = "$candidate_git_link"');
-    expect(candidateRun).toContain(
+    expect(buildRun).not.toContain("cp -al");
+    expect(buildRun).toContain('build "$candidate_root" "$HOST_PNPM_STORE"');
+    expect(buildRun).not.toContain("sudo -u mantis-builder");
+    expect(buildRun).not.toContain("sudo setfacl");
+    expect(buildRun).toContain('test "$(cat "$candidate_root/.git")" = "$candidate_git_link"');
+    expect(buildRun).toContain(
       'git -c safe.directory="$candidate_root" -C "$candidate_root" diff --exit-code',
     );
-    for (const run of [createRun, baselineRun, candidateRun]) {
+    expect(buildRun).toContain(
+      'git -c safe.directory="$candidate_root" -C "$candidate_root" diff --cached --exit-code',
+    );
+    expect(buildRun).toContain(
+      'test "$(git -C "$baseline_root" rev-parse HEAD)" = "$BASELINE_SHA"',
+    );
+    expect(buildRun).toContain(
+      'test "$(git -c safe.directory="$candidate_root" -C "$candidate_root" rev-parse HEAD)" = "$CANDIDATE_SHA"',
+    );
+    for (const run of [createRun, buildRun]) {
       expect(run).not.toContain("GH_TOKEN");
       expect(run).not.toContain("OPENAI_API_KEY");
       expect(run).not.toContain("CRABBOX_");
@@ -1158,7 +1180,19 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     );
     expect(wrapper).toContain('"$worktree_root/candidate"');
     expect(wrapper).toContain('"${SUDO_USER:-}" == "runner"');
+    expect(wrapper).toContain("build expects the candidate worktree and host pnpm store");
+    expect(wrapper).toContain(
+      '/bin/cp -a --reflink=auto "$host_pnpm_store/." "$isolated_root/.mantis-pnpm-store/"',
+    );
+    expect(wrapper).toContain('find "$isolated_root/.mantis-pnpm-store" -type f -print -quit');
+    expect(wrapper).toContain(
+      'echo "Copied disposable pnpm store in $((SECONDS - store_copy_start))s."',
+    );
+    expect(wrapper).not.toContain("type=bind,src=$host_pnpm_store");
+    expect(wrapper).not.toContain("cp -al");
     expect(wrapper).toContain("corepack pnpm install --frozen-lockfile");
+    expect(wrapper).toContain('test -d "$store"');
+    expect(wrapper).toContain('rm -rf "$store"');
     expect(wrapper).toContain('published_root="$worktree_root/.candidate-built-$$"');
     expect(wrapper).toContain('/bin/cp -a --no-dereference "$isolated_root/." "$published_root/"');
     expect(wrapper).toContain('rm -rf --one-file-system "$candidate_root"');

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -1202,7 +1202,7 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(wrapper).toContain("/usr/sbin/runuser -u mantis-sut --");
     expect(wrapper).toContain('/bin/cp -a --no-dereference "$quarantine/." "$safe_runtime/"');
     expect(wrapper).not.toContain('/bin/cp -a "$runtime_source/." "$safe_runtime/"');
-    expect(wrapper).toContain('create_bounded_filesystem "${container_name}-fs" 10G');
+    expect(wrapper).toContain('create_bounded_filesystem "${container_name}-fs" 16G');
     expect(wrapper).toContain('ln -s "$safe_runtime" "$runtime_source"');
     expect(wrapper.indexOf('ln -s "$safe_runtime" "$runtime_source"')).toBeLessThan(
       wrapper.indexOf(


### PR DESCRIPTION
## What Problem This Solves

Mantis Telegram Desktop proof runs spend ~11.5 min of a ~25 min run just preparing the two proof builds. Profiling run 32543527872 measured: baseline build 310s (cache missed on every `main` advance because the exact cache key embeds the baseline SHA), candidate build 387s (serialized after baseline, and pnpm installs into an empty store inside the isolated SUT filesystem). Speed is a requirement for a proof agent maintainers trigger interactively on PRs.

## Why This Change Was Made

Three build-phase root causes, fixed at their owners:

1. **Baseline cache split by SHA.** The exact key now ends with the baseline SHA and gains a `restore-keys` prefix (`os-arch-mantis-baseline-v3-<lockfile>-<node>-<pnpm>-`), so any same-toolchain archive from an older `main` restores. A stale hit extracts the archive and runs the existing cache-aware `pnpm build` incrementally (tsdown stamp signatures revalidate stale entries), atomically replaces the tar (`mv -T`), and saves under the new exact key. Exact hits stay install+extract-only. All stamp/dist/symlink/hardlink validations retained.
2. **Serialized builds.** Baseline and candidate preparation now run as concurrent subshells in one step with `[baseline]`/`[candidate]` prefixed live logs, separate exit-status capture, and combined failure propagation. Candidate seeding from the restored archive (unchanged build-engine-closure gate) completes before launch, so the lanes share nothing afterward.
3. **Cold pnpm store in the SUT container.** The trusted setup action's store path is passed to the root SUT wrapper (`build` now takes 2 args, still runner-gated via `SUDO_USER == runner`). The wrapper copies the store into the isolated bounded filesystem with `cp -a --reflink=auto` **before** ownership transfer — never a bind mount or hardlinks, so candidate code cannot touch the host store. Path must be a directory outside the candidate worktree. The container's cleanup trap deletes the disposable copy; copy duration is logged.

Expected build-phase wall clock: ~697s → ~330–390s on a baseline-stale run (~5–6 min saved). The Telegram Desktop image build (42s) was deliberately left uncached — complexity exceeds the benefit.

## User Impact

Maintainers triggering `@openclaw-mantis` get proof verdicts several minutes sooner. No behavior, isolation-policy, agent, or publish changes; a build failure in either lane still fails the step with attributed logs.

## Evidence

- `TMPDIR=/var/tmp node scripts/run-vitest.mjs test/scripts/mantis-telegram-desktop-proof-workflow.test.ts`: 28/28 passed (rerun after rebase onto `ff6db34233d`). Regression provenance: the updated test fails 2 assertions against pre-fix production.
- `node scripts/check-changed.mjs -- <touched files>`: pass (format/typecheck/lint/guards).
- `node --import tsx scripts/check-workflows.mts`: pass (zizmor + direct-input checks).
- `bash -n scripts/mantis/mantis-sut-container.sh`: pass.
- Autoreview (`--mode local`): clean, no actionable findings.
- Verified `.github/actions/setup-node-env` exports `pnpm-store-cache-path` (action.yml:84).
- Known gap: real Blacksmith wall clock needs the first post-merge run — it will log the stale-rebuild delta and `Copied disposable pnpm store in Ns.` (local 13GiB-store reflink reference: 19s). If the copy exceeds ~30s, follow-up: read-only lower + disposable writable overlay instead of a copy.


## Unrelated main-CI fixes carried in this PR

Exact-head CI on `b13f31476cb` failed two checks that are red on current `main` (neither touched by the Mantis diff; `ui/` here is byte-identical to `origin/main`):

- `check-lint-core-5`: `ui/src/components/markdown.test.ts` crossed the oxlint 1000-line `max-lines` cap after #127749 and #127754 each grew it (also failing on main run 32559609413). Superseded mid-flight by #127799 on `main`; this PR rebased onto it and dropped its own split commit, keeping only the baseline refresh.
- `build-artifacts`: the Control UI startup JS gzip check is flaky-by-construction on current main — identical source measured 345034 B (main run 32559609413, pass), 345058 B (PR run 32559442295, fail), 345049 B (local, fail) against baseline 344531 B + 512 B tolerance, a 9 B margin vs ~24 B gzip build nondeterminism. Refreshed the committed baseline with the script's own `--update-baseline` command; the maintainer-approved 350 KiB hard ceiling still bounds cumulative creep.

## ClawSweeper disposition

Local ClawSweeper review on `b13f3147`: patch correct, zero findings, security cleared. Sole remaining next step ("run one exact-head Mantis proof with a stale baseline archive") is structurally impossible pre-merge: the Mantis dispatcher runs `mantis-telegram-desktop-proof.yml` from the default branch, so a PR changing the harness cannot exercise its own harness before merge. The first post-merge Mantis run is that transcript; I will verify the stale-rebuild delta and `Copied disposable pnpm store in Ns.` timing there and follow up if the store copy exceeds ~30s. The two commits after the review (`daf345140c3`, `3b8934877d3`) are the mechanical main-CI repairs above, no Mantis behavior change.

