### PR TITLE
fix(plugins): normalize correction versions in drift repair commands

### DIFF
--- a/src/plugins/plugin-version-drift.test.ts
+++ b/src/plugins/plugin-version-drift.test.ts
@@ -323,6 +323,19 @@ describe("detectPluginVersionDrift", () => {
 });
 
 describe("resolvePluginVersionDriftUpdateCommand", () => {
+  it("normalizes a gateway correction version for exact npm package targets", () => {
+    expect(
+      resolvePluginVersionDriftUpdateCommand({
+        pluginId: "brave",
+        installedVersion: "2026.7.0",
+        gatewayVersion: "2026.7.1-2",
+        source: "npm",
+        packageName: "@openclaw/brave-plugin",
+        spec: "@openclaw/brave-plugin@2026.7.0",
+      }),
+    ).toBe("openclaw plugins update @openclaw/brave-plugin@2026.7.1");
+  });
+
   it("uses an exact npm package target when the drifted install is pinned", () => {
     expect(
       resolvePluginVersionDriftUpdateCommand({

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -38,7 +38,7 @@ function resolveExactNpmPinPackageName(entry: PluginVersionDriftEntry): string |
 export function resolvePluginVersionDriftUpdateCommand(entry: PluginVersionDriftEntry): string {
   const exactNpmPackageName = resolveExactNpmPinPackageName(entry);
   if (exactNpmPackageName) {
-    const exactNpmTarget = `${exactNpmPackageName}@${entry.gatewayVersion}`;
+    const exactNpmTarget = `${exactNpmPackageName}@${normalizeVersion(entry.gatewayVersion)}`;
     if (parseRegistryNpmSpec(exactNpmTarget)?.selectorKind === "exact-version") {
       return `openclaw plugins update ${exactNpmTarget}`;
     }


### PR DESCRIPTION
Closes #127297

Thanks @vladimirkrdzic for reporting this.

## What Problem This Solves

Fixes an issue where operators repairing plugin version drift from `gateway status --deep` or Doctor could receive an npm update command for a nonexistent correction-suffixed plugin version, such as `@openclaw/brave-plugin@2026.7.1-2`.

## Why This Change Was Made

The shared drift-repair command builder now applies the existing correction-version normalizer to the gateway version before constructing the exact plugin package reference. Detection, status, and Doctor continue to share one canonical path; no registry fallback, retry, config, migration, or release behavior was added.

## User Impact

Operators on correction releases now get an installable exact plugin update command, for example `openclaw plugins update @openclaw/brave-plugin@2026.7.1`.

## Evidence

- Baseline regression reproduced: gateway `2026.7.1-2` emitted `@openclaw/brave-plugin@2026.7.1-2` instead of the expected stable plugin version.
- `node scripts/run-vitest.mjs src/plugins/plugin-version-drift.test.ts` (24 passed).
- `node scripts/run-vitest.mjs src/cli/daemon-cli/status.print.test.ts src/commands/doctor-workspace-status.test.ts` (45 passed, 1 skipped).
- Blacksmith Testbox: exact blob checks, focused suites, and the changed-file gate passed. Run: https://github.com/openclaw/openclaw/actions/runs/32561293351
- Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/32561232279
- Official npm registry: `openclaw@2026.7.1-2` and `@openclaw/brave-plugin@2026.7.1` exist; `@openclaw/brave-plugin@2026.7.1-2` returns E404.
- Targeted `oxfmt --check` and `git diff --check` passed.
- Autoreview: clean, no actionable findings, confidence 0.99.
- Production LOC: +1/-1 (net 0). Tests: +13.

AI-assisted: yes. The change was independently verified with focused local and remote tests plus autoreview.

Punchcard-Session: silver-harbor-cedar-5w
