### PR TITLE
fix(ui): announce session sharing failures

### DIFF
--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -440,11 +440,11 @@ suite.define(() => {
       code: "INVALID_REQUEST",
       message,
     });
-    const alert = currentPage.getByRole("alert").filter({ hasText: message });
+    const alert = currentPage.locator(".chat-error[role=alert]").filter({ hasText: message });
     await expectBrowser(alert).toBeVisible();
 
     await currentPage.getByRole("button", { name: "Session sharing" }).click();
-    await expectBrowser(dropdown.locator(".chat-pane__sharing-status--error")).toBeVisible();
+    await expectBrowser(dropdown.getByRole("alert").filter({ hasText: message })).toBeVisible();
   });
 
   it("lets a read-scoped owner inspect sharing but blocks mutations", async () => {

--- a/ui/src/pages/chat/components/chat-session-sharing.test.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.test.ts
@@ -353,9 +353,9 @@ describe("chat session sharing menu", () => {
       }),
     );
 
-    expect(root.querySelector(".chat-pane__sharing-status--error")?.textContent).toContain(
-      "Visibility update rejected",
-    );
+    const error = root.querySelector(".chat-pane__sharing-status--error");
+    expect(error?.textContent).toContain("Visibility update rejected");
+    expect(error?.getAttribute("role")).toBe("alert");
     expect(root.querySelectorAll(".chat-pane__sharing-title")).toHaveLength(
       membersAvailable ? 2 : 1,
     );

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -192,7 +192,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
           `
         : nothing}
       ${props.state?.error
-        ? html`<div class="chat-pane__sharing-status chat-pane__sharing-status--error">
+        ? html`<div class="chat-pane__sharing-status chat-pane__sharing-status--error" role="alert">
             ${props.state.error}
           </div>`
         : nothing}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users of assistive technology received no announcement when loading or changing a chat session's sharing settings failed. The failure text was visible in the sharing menu, but it exposed no alert or live-region semantics.

## Why This Change Was Made

The existing sharing error surface now carries the repository's established `role="alert"` semantics. Request, authorization, state, copy, dropdown, and layout behavior are unchanged. Existing component and browser coverage now assert the error through its semantic owner rather than only its CSS class.

Provenance: [#118135](https://github.com/openclaw/openclaw/pull/118135), authored and merged by @steipete on 2026-08-02, made session-sharing failures visible; this repair adds the missing announcement semantics at that renderer. No exact open or closed issue/PR duplicate was found.

## User Impact

Screen readers now announce rejected session-sharing list loads and mutations instead of leaving users with silent visible feedback.

## Evidence

- Pre-fix table-driven renderer regression: both visibility-only and member-enabled cases failed because the error role was absent.
- Focused post-fix suites: **40/40 passed** (`chat-session-sharing` + sharing lifecycle owner).
- Authentic source-browser deferred `session.members.list` rejection: **1/1 passed** on Chrome 152; Playwright located the menu failure by `role="alert"` at 390×740.
- Full session-ownership Chromium suite: **11/11 passed**, including rejected visibility mutation and reopened-menu announcement.
- Final `pnpm check:changed`: passed conflict, ratchet, format, deadcode, i18n, core/UI type, oxlint, and style checks.
- Fresh isolated Codex autoreview: clean, **0.99 confidence**.
- Production LOC: **+1/-1 (net 0)**. Tests: **+5/-5 (net 0)**.
- Exact head: `b865b242e071050868f08e2773bf7881e3c7bf2e`.

Inspected mobile proof (layout unchanged; sharing failure visible and unclipped):

![Session sharing failure alert on mobile](https://ampcode.com/user-content/artifacts/91a31e47e736a2b32da26f171fdf5385683cbe4df4b32dcb89234da5c84bf29e-file.png)
