### PR TITLE
improve(googlechat): skip empty inbound media projection

### DIFF
--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -42,13 +42,18 @@ const routingMocks = vi.hoisted(() => ({
 const inboundMocks = vi.hoisted(() => ({
   buildEnvelope: vi.fn(({ body }: { body: string }) => body),
   resolveChannelInboundRouteEnvelope: vi.fn(),
+  toInboundMediaFactsWithMetadata: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  inboundMocks.toInboundMediaFactsWithMetadata.mockImplementation(
+    actual.toInboundMediaFactsWithMetadata,
+  );
   return {
     ...actual,
     resolveChannelInboundRouteEnvelope: inboundMocks.resolveChannelInboundRouteEnvelope,
+    toInboundMediaFactsWithMetadata: inboundMocks.toInboundMediaFactsWithMetadata,
   };
 });
 
@@ -95,6 +100,7 @@ beforeEach(() => {
       },
       buildEnvelope: inboundMocks.buildEnvelope,
     }));
+  inboundMocks.toInboundMediaFactsWithMetadata.mockClear();
 });
 
 function createInboundClassificationHarness() {
@@ -313,6 +319,7 @@ describe("googlechat monitor inbound space classification", () => {
         extra: expect.objectContaining({ ChatType: isGroup ? "channel" : "direct" }),
       }),
     );
+    expect(inboundMocks.toInboundMediaFactsWithMetadata).not.toHaveBeenCalled();
     expect(runTurn).toHaveBeenCalledOnce();
   });
 

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -307,7 +307,7 @@ async function processMessageWithPipeline(params: {
       );
     }
   }
-  const media = await toInboundMediaFactsWithMetadata(mediaInputs);
+  const media = mediaInputs.length === 0 ? [] : await toInboundMediaFactsWithMetadata(mediaInputs);
 
   const fromLabel = isGroup
     ? space.displayName || `space:${spaceId}`


### PR DESCRIPTION
## What Problem This Solves

Google Chat text-only inbound messages performed the full asynchronous media metadata projection even after the channel owner had established that there were no attachments. That added avoidable normalization, allocation, scheduler, and async-suspension work to every ordinary text message.

## Why This Change Was Made

The Google Chat inbound owner now returns the same empty media-facts array directly when its prepared media input list is empty. Nonempty attachment handling still calls the existing shared metadata projector unchanged, preserving media probing and error behavior.

The existing ordinary direct-message/group-space table now asserts that its six text-only cases do not enter the media projector. This PR was AI-assisted.

## User Impact

Ordinary Google Chat text messages require less per-message CPU and allocation work. Message content, routing, authorization, ordering, threading, attachment handling, and public contracts are unchanged.

## Evidence

- Exact-current pre-fix regression: applying only the final test hunk produced 6 expected failures and 18 passes; every failure showed one `toInboundMediaFactsWithMetadata([])` call.
- Exact final head: focused webhook/ingress/access/monitor suite passed, 4 files and 66 tests.
- Full Google Chat extension passed, 29 files and 330 tests.
- Shared inbound media/envelope owner suites passed, 77 tests.
- `node scripts/check-changed.mjs -- extensions/googlechat/src/monitor.ts extensions/googlechat/src/monitor.test.ts` passed all extension production/test format, type, lint, boundary, dead-export, and guard checks.
- `pnpm build` passed, including runtime postbuild and Control UI performance checks.
- Owner-local benchmark (12 alternating rounds × 150,000 empty projections): median 91.596 ms before vs 11.667 ms after, removing about 532.8 ns per text-only message.
- Fresh bundled autoreview on the exact final head with Codex `gpt-5.6-sol`, high reasoning: no accepted/actionable findings; confidence 0.99.
- Proof gap: no live Google Chat service was invoked. This behavior-neutral branch only bypasses an internal no-op for an owner-proven empty array; exact red/green owner proof, unchanged attachment/error suites, full extension coverage, and exact-head hosted checks exercise the changed boundary.
