### PR TITLE
fix(ui): scope new-session skill catalogs

### DIFF
--- a/ui/src/app/app-host.chat-metadata.test.ts
+++ b/ui/src/app/app-host.chat-metadata.test.ts
@@ -3,22 +3,51 @@
 import { afterEach, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { peekChatMetadata, rememberChatMetadata } from "../lib/chat/chat-metadata-store.ts";
+import { loadSlashCommandCatalog } from "../lib/chat/slash-command-catalog.ts";
 import "./app-host.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "./context.ts";
 
 type ChatMetadataShell = HTMLElement & {
+  agentRosterRefreshTimer: ReturnType<typeof globalThis.setTimeout> | null;
   runtime: { context: ApplicationContext };
   handleGatewayEvent: (event: { event: string; payload: unknown }) => void;
   synchronizeGateway: (snapshot: ApplicationGatewaySnapshot) => void;
 };
 
+const shells = new Set<ChatMetadataShell>();
+
 afterEach(() => {
+  for (const shell of shells) {
+    if (shell.agentRosterRefreshTimer !== null) {
+      globalThis.clearTimeout(shell.agentRosterRefreshTimer);
+      shell.agentRosterRefreshTimer = null;
+    }
+  }
+  shells.clear();
   vi.useRealTimers();
 });
 
-it("invalidates chat metadata on config changes and same-client reconnects", () => {
-  vi.useFakeTimers();
-  const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+function commandCatalog(name: string) {
+  return {
+    commands: [
+      {
+        name,
+        textAliases: [`/${name}`],
+        description: `${name} skill`,
+        source: "skill" as const,
+        scope: "text" as const,
+        acceptsArgs: false,
+        skillModelVisible: true,
+      },
+    ],
+  };
+}
+
+function catalogNames(catalog: Awaited<ReturnType<typeof loadSlashCommandCatalog>>) {
+  return catalog.filter((command) => command.source === "skill").map((command) => command.name);
+}
+
+function createShell(client: GatewayBrowserClient) {
   const connected = {
     client,
     phase: "connected",
@@ -33,9 +62,16 @@ it("invalidates chat metadata on config changes and same-client reconnects", () 
     },
   } as unknown as ApplicationContext;
   const shell = document.createElement("openclaw-app-shell") as unknown as ChatMetadataShell;
+  shells.add(shell);
   shell.runtime = { context };
-
   shell.synchronizeGateway(connected);
+  return { connected, shell };
+}
+
+it("invalidates chat metadata on config changes and same-client reconnects", () => {
+  vi.useFakeTimers();
+  const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+  const { connected, shell } = createShell(client);
   rememberChatMetadata(client, "main", { commands: [], models: [] });
   shell.handleGatewayEvent({ event: "config.changed", payload: {} });
   expect(peekChatMetadata(client, "main")).toBeUndefined();
@@ -44,4 +80,48 @@ it("invalidates chat metadata on config changes and same-client reconnects", () 
   shell.synchronizeGateway({ ...connected, phase: "reconnecting" });
   shell.synchronizeGateway(connected);
   expect(peekChatMetadata(client, "main")).toBeUndefined();
+});
+
+it.each(["config.changed", "skills.changed"])(
+  "invalidates every agent command catalog after %s",
+  async (event) => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(commandCatalog("agent_a_before"))
+      .mockResolvedValueOnce(commandCatalog("agent_b_before"))
+      .mockResolvedValueOnce(commandCatalog("agent_a_after"))
+      .mockResolvedValueOnce(commandCatalog("agent_b_after"));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { shell } = createShell(client);
+
+    await loadSlashCommandCatalog(client, "agent-a");
+    await loadSlashCommandCatalog(client, "agent-b");
+    shell.handleGatewayEvent({ event, payload: {} });
+
+    expect(catalogNames(await loadSlashCommandCatalog(client, "agent-a"))).toEqual([
+      "agent_a_after",
+    ]);
+    expect(catalogNames(await loadSlashCommandCatalog(client, "agent-b"))).toEqual([
+      "agent_b_after",
+    ]);
+    expect(request).toHaveBeenCalledTimes(4);
+  },
+);
+
+it("invalidates every agent command catalog after a same-client reconnect", async () => {
+  const request = vi
+    .fn()
+    .mockResolvedValueOnce(commandCatalog("agent_b_before"))
+    .mockResolvedValueOnce(commandCatalog("agent_a_before"))
+    .mockResolvedValueOnce(commandCatalog("agent_b_after"));
+  const client = { request } as unknown as GatewayBrowserClient;
+  const { connected, shell } = createShell(client);
+
+  await loadSlashCommandCatalog(client, "agent-b");
+  await loadSlashCommandCatalog(client, "agent-a");
+  shell.synchronizeGateway({ ...connected, phase: "reconnecting" });
+  shell.synchronizeGateway(connected);
+
+  expect(catalogNames(await loadSlashCommandCatalog(client, "agent-b"))).toEqual(["agent_b_after"]);
+  expect(request).toHaveBeenCalledTimes(3);
 });

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -26,7 +26,7 @@ import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
-import { invalidateChatMetadataStore } from "../lib/chat/chat-metadata-store.ts";
+import { invalidateSlashCommandCatalog } from "../lib/chat/slash-command-catalog-cache.ts";
 import { canCallGatewayMethod } from "../lib/gateway-methods.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
@@ -516,10 +516,10 @@ class OpenClawShell
     this.shellNavigation.selectChatSession(sessionKey, agentId);
   }
   private readonly handleGatewayEvent = (event: GatewayEventFrame) => {
-    if (event.event === "config.changed") {
+    if (event.event === "config.changed" || event.event === "skills.changed") {
       const client = this.context?.gateway?.snapshot.client;
       if (client) {
-        invalidateChatMetadataStore(client);
+        invalidateSlashCommandCatalog(client);
       }
     }
     this.shellGateway.handleGatewayEvent(event);
@@ -727,7 +727,7 @@ class OpenClawShell
       // A reconnect can retain the browser client, so object identity alone
       // cannot keep metadata from crossing logical Gateway connections.
       if (snapshot.client) {
-        invalidateChatMetadataStore(snapshot.client);
+        invalidateSlashCommandCatalog(snapshot.client);
       }
     }
     this.shellGateway.synchronizeGateway(snapshot);

--- a/ui/src/e2e/new-session-page.skill-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.skill-catalog.e2e.test.ts
@@ -1,0 +1,95 @@
+import { expect, it } from "vitest";
+import {
+  createNewSessionPageE2eSuite,
+  installMockGateway,
+  pollLocatorText,
+} from "./new-session-page.test-support.ts";
+
+const suite = createNewSessionPageE2eSuite();
+
+function skillCommand(name: string) {
+  return {
+    name,
+    textAliases: [`/${name}`],
+    description: `${name} skill`,
+    source: "skill",
+    scope: "text",
+    acceptsArgs: false,
+    skillModelVisible: true,
+  };
+}
+
+suite.define(() => {
+  it("scopes skills to the selected agent and refreshes an open menu", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      defaultAgentId: "main",
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "commands.list",
+        "sessions.create",
+        "sessions.dispatch",
+      ],
+      methodResponses: {
+        "agents.list": {
+          agents: [{ id: "main" }, { id: "research" }],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "chat.metadata": { models: [] },
+        "commands.list": {
+          commands: [skillCommand("research_before")],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new?agent=research`);
+      const textarea = page.locator(".new-session-page__message");
+      await textarea.waitFor({ state: "visible" });
+      await textarea.fill("$");
+      const menu = page.locator(".skill-menu");
+      await pollLocatorText(menu).toContain("research_before");
+      expect((await gateway.waitForRequest("commands.list")).params).toEqual({
+        agentId: "research",
+        includeArgs: true,
+        scope: "text",
+      });
+
+      await gateway.setMethodResponse("commands.list", {
+        commands: [skillCommand("research_after")],
+      });
+      await gateway.emitGatewayEvent("skills.changed", {});
+
+      await pollLocatorText(menu).toContain("research_after");
+      expect(await menu.textContent()).not.toContain("research_before");
+      expect(await gateway.getRequests("commands.list")).toHaveLength(2);
+
+      await gateway.setMethodResponse("commands.list", {
+        commands: [skillCommand("main_after")],
+      });
+      const agentPicker = page.locator(".new-session-page__select--agent openclaw-agent-select");
+      await agentPicker.locator(".agent-select__trigger").evaluate((trigger) => {
+        (trigger as HTMLButtonElement).click();
+      });
+      await agentPicker.getByRole("menuitemradio", { name: "main", exact: true }).click();
+
+      await pollLocatorText(menu).toContain("main_after");
+      expect(await textarea.inputValue()).toBe("$");
+      expect((await gateway.getRequests("commands.list")).at(-1)?.params).toEqual({
+        agentId: "main",
+        includeArgs: true,
+        scope: "text",
+      });
+      expect(await menu.textContent()).not.toContain("research_after");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -556,12 +556,14 @@ export function getSkillDisplayName(command: SlashCommandDef): string {
   return command.skillDisplayName?.trim() || command.name;
 }
 
-export function getSkillCommandCompletions(filter: string): SlashCommandDef[] {
+export function getSkillCommandCompletions(
+  filter: string,
+  catalog: readonly SlashCommandDef[] = SLASH_COMMANDS,
+): SlashCommandDef[] {
   const lower = normalizeLowercaseStringOrEmpty(filter);
   const normalized = lower.replace(/[\s_]+/gu, "-");
-  return SLASH_COMMANDS.filter(
-    (command) => command.source === "skill" && command.skillModelVisible === true,
-  )
+  return catalog
+    .filter((command) => command.source === "skill" && command.skillModelVisible === true)
     .filter((command) => {
       const displayName = normalizeLowercaseStringOrEmpty(getSkillDisplayName(command));
       const displayLookup = displayName.replace(/[\s_]+/gu, "-");

--- a/ui/src/lib/chat/slash-command-catalog-cache.ts
+++ b/ui/src/lib/chat/slash-command-catalog-cache.ts
@@ -1,0 +1,36 @@
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { invalidateChatMetadataStore } from "./chat-metadata-store.ts";
+import type { SlashCommandDef } from "./commands.ts";
+
+type SlashCommandCatalogCacheEntry = {
+  commands?: readonly SlashCommandDef[];
+  expiresAt: number;
+  inFlight?: Promise<readonly SlashCommandDef[]>;
+};
+
+const remoteCatalogs = new WeakMap<
+  GatewayBrowserClient,
+  Map<string, SlashCommandCatalogCacheEntry>
+>();
+const catalogGenerations = new WeakMap<GatewayBrowserClient, number>();
+
+export function getSlashCommandCatalogGeneration(client: GatewayBrowserClient): number {
+  return catalogGenerations.get(client) ?? 0;
+}
+
+export function getSlashCommandCatalogCache(
+  client: GatewayBrowserClient,
+): Map<string, SlashCommandCatalogCacheEntry> {
+  let catalogs = remoteCatalogs.get(client);
+  if (!catalogs) {
+    catalogs = new Map();
+    remoteCatalogs.set(client, catalogs);
+  }
+  return catalogs;
+}
+
+export function invalidateSlashCommandCatalog(client: GatewayBrowserClient): void {
+  invalidateChatMetadataStore(client);
+  catalogGenerations.set(client, getSlashCommandCatalogGeneration(client) + 1);
+  remoteCatalogs.delete(client);
+}

--- a/ui/src/lib/chat/slash-command-catalog.ts
+++ b/ui/src/lib/chat/slash-command-catalog.ts
@@ -1,0 +1,83 @@
+import type { CommandsListResult } from "../../../../packages/gateway-protocol/src/index.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { peekChatMetadata } from "./chat-metadata-store.ts";
+import {
+  buildFallbackSlashCommands,
+  buildSlashCommandsFromEntries,
+  getRemoteCommandEntries,
+  type SlashCommandDef,
+} from "./commands.ts";
+import {
+  getSlashCommandCatalogCache,
+  getSlashCommandCatalogGeneration,
+} from "./slash-command-catalog-cache.ts";
+
+const CATALOG_TTL_MS = 60_000;
+
+function agentKey(agentId: string | undefined): string {
+  return agentId ?? "";
+}
+
+async function requestCatalog(
+  client: GatewayBrowserClient,
+  agentId: string | undefined,
+): Promise<SlashCommandDef[]> {
+  const result = await client.request<CommandsListResult>("commands.list", {
+    ...(agentId ? { agentId } : {}),
+    includeArgs: true,
+    scope: "text",
+  });
+  if (!Array.isArray(result?.commands)) {
+    throw new Error("Gateway returned an invalid command catalog");
+  }
+  return buildSlashCommandsFromEntries(getRemoteCommandEntries(result));
+}
+
+export function loadSlashCommandCatalog(
+  client: GatewayBrowserClient,
+  agentId: string | undefined,
+): Promise<readonly SlashCommandDef[]> {
+  const metadata = peekChatMetadata(client, agentId);
+  if (Array.isArray(metadata?.commands)) {
+    return Promise.resolve(buildSlashCommandsFromEntries(getRemoteCommandEntries(metadata)));
+  }
+
+  const catalogs = getSlashCommandCatalogCache(client);
+  const generation = getSlashCommandCatalogGeneration(client);
+  const key = agentKey(agentId);
+  const cached = catalogs.get(key);
+  if (cached?.commands && cached.expiresAt > Date.now()) {
+    return Promise.resolve(cached.commands);
+  }
+  if (cached?.inFlight) {
+    return cached.inFlight;
+  }
+
+  const request = requestCatalog(client, agentId).then(
+    (commands) => ({ commands, succeeded: true }) as const,
+    () =>
+      ({ commands: cached?.commands ?? buildFallbackSlashCommands(), succeeded: false }) as const,
+  );
+  const inFlight = request
+    .then((result) => {
+      if (getSlashCommandCatalogGeneration(client) !== generation) {
+        return loadSlashCommandCatalog(client, agentId);
+      }
+      if (result.succeeded && catalogs.get(key)?.inFlight === inFlight) {
+        catalogs.set(key, { commands: result.commands, expiresAt: Date.now() + CATALOG_TTL_MS });
+      }
+      return result.commands;
+    })
+    .finally(() => {
+      const latest = catalogs.get(key);
+      if (latest?.inFlight === inFlight) {
+        delete latest.inFlight;
+      }
+    });
+  catalogs.set(key, {
+    ...(cached?.commands ? { commands: cached.commands } : {}),
+    expiresAt: cached?.expiresAt ?? 0,
+    inFlight,
+  });
+  return inFlight;
+}

--- a/ui/src/pages/chat/chat-commands.test.ts
+++ b/ui/src/pages/chat/chat-commands.test.ts
@@ -12,6 +12,7 @@ import {
   getSlashCommandDescription,
   type SlashCommandDef,
 } from "../../lib/chat/commands.ts";
+import { invalidateSlashCommandCatalog } from "../../lib/chat/slash-command-catalog-cache.ts";
 import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import {
   applyRemoteSlashCommandsResult,
@@ -199,6 +200,31 @@ describe("refreshSlashCommands", () => {
       executeLocal: false,
       tier: "standard",
     });
+  });
+
+  it("reissues an in-flight catalog after app-level invalidation", async () => {
+    let resolveStale: ((value: unknown) => void) | undefined;
+    const stale = new Promise((resolve) => {
+      resolveStale = resolve;
+    });
+    const request = vi
+      .fn()
+      .mockImplementationOnce(async () => await stale)
+      .mockResolvedValueOnce({
+        commands: [remoteCommand("fresh-command", "Loaded after invalidation.")],
+      });
+    const client = { request } as never;
+
+    const pending = refreshSlashCommands({ client, agentId: "main" });
+    invalidateSlashCommandCatalog(client);
+    resolveStale?.({ commands: [remoteCommand("stale-command", "Removed command.")] });
+    await pending;
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expectRecordFields(requireCommandByName("fresh-command"), "fresh command", {
+      description: "Loaded after invalidation.",
+    });
+    expect(SLASH_COMMANDS.find((entry) => entry.name === "stale-command")).toBeUndefined();
   });
 
   it("ignores stale refresh responses after switching agents", async () => {

--- a/ui/src/pages/chat/chat-commands.ts
+++ b/ui/src/pages/chat/chat-commands.ts
@@ -3,16 +3,15 @@ import type { CommandsListResult } from "../../../../packages/gateway-protocol/s
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelCatalogEntry, SessionsListResult } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
-import { peekChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import {
   buildFallbackSlashCommands,
   buildSlashCommandsFromEntries,
   getRemoteCommandEntries,
   replaceSlashCommands,
-  type SlashCommandDef,
 } from "../../lib/chat/commands.ts";
 import { resolveCurrentUserIdentity } from "../../lib/chat/current-user-identity.ts";
+import { loadSlashCommandCatalog } from "../../lib/chat/slash-command-catalog.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import {
@@ -35,18 +34,6 @@ import { handleAbortChat } from "./run-lifecycle.ts";
 import { scheduleChatScroll, type ChatScrollHost } from "./scroll.ts";
 
 let refreshSeq = 0;
-const REMOTE_SLASH_COMMAND_CACHE_TTL_MS = 60_000;
-
-type RemoteSlashCommandCacheEntry = {
-  commands?: SlashCommandDef[];
-  expiresAt: number;
-  inFlight?: Promise<SlashCommandDef[]>;
-};
-
-const remoteSlashCommandCache = new WeakMap<
-  GatewayBrowserClient,
-  Map<string, RemoteSlashCommandCacheEntry>
->();
 
 export type ChatCommandResetOptions = {
   previousDraft?: string;
@@ -186,80 +173,6 @@ function failStaleChatCommand(host: ChatCommandHost): ChatCommandDispatchResult 
   return "failed";
 }
 
-function remoteSlashCommandCacheKey(agentId: string | undefined): string {
-  return agentId ?? "";
-}
-
-function getRemoteSlashCommandCache(
-  client: GatewayBrowserClient,
-): Map<string, RemoteSlashCommandCacheEntry> {
-  let cache = remoteSlashCommandCache.get(client);
-  if (!cache) {
-    cache = new Map();
-    remoteSlashCommandCache.set(client, cache);
-  }
-  return cache;
-}
-
-async function requestRemoteSlashCommands(
-  client: GatewayBrowserClient,
-  agentId: string | undefined,
-  fallback: SlashCommandDef[] | undefined,
-): Promise<SlashCommandDef[]> {
-  try {
-    const result = await client.request<CommandsListResult>("commands.list", {
-      ...(agentId ? { agentId } : {}),
-      includeArgs: true,
-      scope: "text",
-    });
-    if (!Array.isArray(result?.commands)) {
-      return buildFallbackSlashCommands();
-    }
-    const commands = buildSlashCommandsFromEntries(getRemoteCommandEntries(result));
-    getRemoteSlashCommandCache(client).set(remoteSlashCommandCacheKey(agentId), {
-      commands,
-      expiresAt: Date.now() + REMOTE_SLASH_COMMAND_CACHE_TTL_MS,
-    });
-    return commands;
-  } catch {
-    return fallback ?? buildFallbackSlashCommands();
-  }
-}
-
-function loadRemoteSlashCommands(
-  client: GatewayBrowserClient,
-  agentId: string | undefined,
-): Promise<SlashCommandDef[]> {
-  const metadata = peekChatMetadata(client, agentId);
-  // Store-held metadata carries app-level invalidation on config changes and logical reconnects,
-  // so no TTL applies here. The cache below owns only commands.list-derived entries.
-  if (Array.isArray(metadata?.commands)) {
-    return Promise.resolve(buildSlashCommandsFromEntries(getRemoteCommandEntries(metadata)));
-  }
-  const cache = getRemoteSlashCommandCache(client);
-  const key = remoteSlashCommandCacheKey(agentId);
-  const cached = cache.get(key);
-  const now = Date.now();
-  if (cached?.commands && cached.expiresAt > now) {
-    return Promise.resolve(cached.commands);
-  }
-  if (cached?.inFlight) {
-    return cached.inFlight;
-  }
-  const inFlight = requestRemoteSlashCommands(client, agentId, cached?.commands).finally(() => {
-    const latest = cache.get(key);
-    if (latest?.inFlight === inFlight) {
-      delete latest.inFlight;
-    }
-  });
-  cache.set(key, {
-    ...(cached?.commands ? { commands: cached.commands } : {}),
-    expiresAt: cached?.expiresAt ?? 0,
-    inFlight,
-  });
-  return inFlight;
-}
-
 export function applyRemoteSlashCommandsResult(params: {
   client: GatewayBrowserClient | null;
   agentId?: string | null;
@@ -288,11 +201,11 @@ export async function refreshSlashCommands(params: {
     replaceSlashCommands(buildFallbackSlashCommands());
     return;
   }
-  const commands = await loadRemoteSlashCommands(params.client, agentId);
+  const commands = await loadSlashCommandCatalog(params.client, agentId);
   if (seq !== refreshSeq || params.shouldApply?.() === false) {
     return;
   }
-  replaceSlashCommands(commands);
+  replaceSlashCommands([...commands]);
 }
 
 export function shouldQueueLocalSlashCommand(name: string): boolean {

--- a/ui/src/pages/chat/components/chat-composer-skill-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-skill-menu.ts
@@ -32,6 +32,7 @@ export type SkillMenuHost = {
   getDraft: () => string;
   commitDraft: (next: string) => void;
   getTextarea: () => HTMLTextAreaElement | null;
+  getCommandCatalog?: () => readonly SlashCommandDef[];
   refreshCommands?: () => void | Promise<void>;
 };
 
@@ -159,7 +160,7 @@ export function updateSkillMenu(
     state.skillCommandRefreshTargetStart = target.start;
     requestSkillCommandRefresh(state, host, requestUpdate);
   }
-  const items = getSkillCommandCompletions(target.query);
+  const items = getSkillCommandCompletions(target.query, host.getCommandCatalog?.());
   state.skillMenuTarget = target;
   state.skillMenuItems = items;
   state.skillMenuIndex = Math.min(state.skillMenuIndex, Math.max(0, items.length - 1));

--- a/ui/src/pages/new-session/composer-skill-catalog.test.ts
+++ b/ui/src/pages/new-session/composer-skill-catalog.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { rememberChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
+import { invalidateSlashCommandCatalog } from "../../lib/chat/slash-command-catalog-cache.ts";
+import { NewSessionComposerTextareaController } from "./composer.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function skillCatalog(name: string) {
+  return {
+    commands: [
+      {
+        name,
+        textAliases: [`/${name}`],
+        description: `${name} skill`,
+        source: "skill" as const,
+        scope: "text" as const,
+        acceptsArgs: false,
+        skillModelVisible: true,
+      },
+    ],
+  };
+}
+
+function skillNames(controller: NewSessionComposerTextareaController) {
+  return controller
+    .getCommandCatalog()
+    .filter((command) => command.source === "skill")
+    .map((command) => command.name);
+}
+
+function mockClient(request: ReturnType<typeof vi.fn>) {
+  return { request } as unknown as GatewayBrowserClient;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("new-session command catalog ownership", () => {
+  it("uses the selected agent's shared metadata catalog without another request", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("commands.list unavailable"));
+    const client = mockClient(request);
+    rememberChatMetadata(client, "agent-a", skillCatalog("metadata_skill"));
+    const controller = new NewSessionComposerTextareaController();
+
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(skillNames(controller)).toEqual(["metadata_skill"]);
+  });
+
+  it("reuses a fresh owner catalog and revalidates it after the cache window", async () => {
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(skillCatalog("first"))
+      .mockResolvedValueOnce(skillCatalog("refreshed"));
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    expect(request).toHaveBeenCalledOnce();
+    expect(skillNames(controller)).toEqual(["first"]);
+
+    now = Number.MAX_SAFE_INTEGER;
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(skillNames(controller)).toEqual(["refreshed"]);
+  });
+
+  it("clears a warm catalog as soon as the selected agent changes", async () => {
+    const request = vi.fn().mockResolvedValue(skillCatalog("skill_a"));
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    expect(skillNames(controller)).toEqual(["skill_a"]);
+
+    controller.syncCommandOwner(client, "agent-b", 1);
+    expect(skillNames(controller)).toEqual([]);
+  });
+
+  it("reuses an in-flight catalog after returning to the same owner", async () => {
+    const firstA = deferred<ReturnType<typeof skillCatalog>>();
+    const agentB = deferred<ReturnType<typeof skillCatalog>>();
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => firstA.promise)
+      .mockImplementationOnce(() => agentB.promise);
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    const firstRequest = controller.refreshCommandCatalog(client, "agent-a", 1);
+    const secondRequest = controller.refreshCommandCatalog(client, "agent-b", 1);
+    const thirdRequest = controller.refreshCommandCatalog(client, "agent-a", 1);
+    firstA.resolve(skillCatalog("skill_a"));
+    await thirdRequest;
+    agentB.resolve(skillCatalog("skill_b"));
+    await Promise.all([firstRequest, secondRequest]);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(skillNames(controller)).toEqual(["skill_a"]);
+  });
+
+  it("ignores a delayed catalog from the previous connection epoch", async () => {
+    const oldConnection = deferred<ReturnType<typeof skillCatalog>>();
+    const newConnection = deferred<ReturnType<typeof skillCatalog>>();
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => oldConnection.promise)
+      .mockImplementationOnce(() => newConnection.promise);
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    const oldRequest = controller.refreshCommandCatalog(client, "agent-a", 1);
+    invalidateSlashCommandCatalog(client);
+    const freshRequest = controller.refreshCommandCatalog(client, "agent-a", 2);
+    newConnection.resolve(skillCatalog("fresh"));
+    await freshRequest;
+    oldConnection.resolve(skillCatalog("stale"));
+    await oldRequest;
+
+    expect(skillNames(controller)).toEqual(["fresh"]);
+  });
+
+  it("retries after a failed catalog request", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("catalog unavailable"))
+      .mockResolvedValueOnce(skillCatalog("recovered"));
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    expect(skillNames(controller)).toEqual([]);
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(skillNames(controller)).toEqual(["recovered"]);
+  });
+
+  it("coalesces concurrent requests for the same owner", async () => {
+    const pending = deferred<ReturnType<typeof skillCatalog>>();
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => pending.promise)
+      .mockRejectedValueOnce(new Error("duplicate request failed"));
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    const firstRequest = controller.refreshCommandCatalog(client, "agent-a", 1);
+    const secondRequest = controller.refreshCommandCatalog(client, "agent-a", 1);
+    pending.resolve(skillCatalog("available"));
+    await Promise.all([firstRequest, secondRequest]);
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(skillNames(controller)).toEqual(["available"]);
+  });
+
+  it.each(["config.changed", "skills.changed"])(
+    "invalidates a warm catalog after %s",
+    async (event) => {
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce(skillCatalog("before_change"))
+        .mockResolvedValueOnce(skillCatalog("after_change"));
+      const client = mockClient(request);
+      const controller = new NewSessionComposerTextareaController();
+      const requestUpdate = vi.fn();
+
+      await controller.refreshCommandCatalog(client, "agent-a", 1);
+      invalidateSlashCommandCatalog(client);
+      controller.handleGatewayEvent(event, requestUpdate);
+      expect(skillNames(controller)).toEqual([]);
+
+      await controller.refreshCommandCatalog(client, "agent-a", 1);
+      expect(request).toHaveBeenNthCalledWith(2, "commands.list", {
+        agentId: "agent-a",
+        includeArgs: true,
+        scope: "text",
+      });
+      expect(skillNames(controller)).toEqual(["after_change"]);
+    },
+  );
+
+  it("does not retain a catalog request invalidated by a live skill change", async () => {
+    const stale = deferred<ReturnType<typeof skillCatalog>>();
+    const request = vi
+      .fn()
+      .mockImplementationOnce(() => stale.promise)
+      .mockResolvedValueOnce(skillCatalog("fresh"));
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    const staleRefresh = controller.refreshCommandCatalog(client, "agent-a", 1);
+    invalidateSlashCommandCatalog(client);
+    controller.handleGatewayEvent("skills.changed", () => undefined);
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    stale.resolve(skillCatalog("stale"));
+    await staleRefresh;
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(skillNames(controller)).toEqual(["fresh"]);
+  });
+
+  it("invalidates cached catalogs for every agent after a gateway-wide change", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(skillCatalog("agent_a_before"))
+      .mockResolvedValueOnce(skillCatalog("agent_b_before"))
+      .mockResolvedValueOnce(skillCatalog("agent_a_after"));
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    await controller.refreshCommandCatalog(client, "agent-b", 1);
+    invalidateSlashCommandCatalog(client);
+    controller.handleGatewayEvent("skills.changed", () => undefined);
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(skillNames(controller)).toEqual(["agent_a_after"]);
+  });
+
+  it("replaces metadata-backed skills after app-level invalidation", async () => {
+    const request = vi.fn().mockResolvedValueOnce(skillCatalog("fresh_skill"));
+    const client = mockClient(request);
+    rememberChatMetadata(client, "agent-a", skillCatalog("stale_metadata_skill"));
+    const controller = new NewSessionComposerTextareaController();
+
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    expect(skillNames(controller)).toEqual(["stale_metadata_skill"]);
+    invalidateSlashCommandCatalog(client);
+    controller.handleGatewayEvent("skills.changed", () => undefined);
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(skillNames(controller)).toEqual(["fresh_skill"]);
+  });
+
+  it("keeps an expired catalog on transient failure and recovers on retry", async () => {
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(skillCatalog("available"))
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce(skillCatalog("recovered"));
+    const client = mockClient(request);
+    const controller = new NewSessionComposerTextareaController();
+
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    now = Number.MAX_SAFE_INTEGER;
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+    expect(skillNames(controller)).toEqual(["available"]);
+    await controller.refreshCommandCatalog(client, "agent-a", 1);
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(skillNames(controller)).toEqual(["recovered"]);
+  });
+});

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -2,7 +2,13 @@
 
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildFallbackSlashCommands, replaceSlashCommands } from "../../lib/chat/commands.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import {
+  SLASH_COMMANDS,
+  buildFallbackSlashCommands,
+  replaceSlashCommands,
+} from "../../lib/chat/commands.ts";
+import { invalidateSlashCommandCatalog } from "../../lib/chat/slash-command-catalog-cache.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { adjustTextareaHeight } from "../chat/components/chat-composer-dom.ts";
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
@@ -33,6 +39,9 @@ function renderComposer(
     onInput?: (message: string) => void;
     onSubmit?: () => void;
     textareaController?: NewSessionComposerTextareaController;
+    context?: ApplicationContext;
+    agentId?: string;
+    connectionEpoch?: number;
   } = {},
 ) {
   const container = document.createElement("div");
@@ -47,13 +56,16 @@ function renderComposer(
     textareaControllers.push(textareaController);
   }
   let message = overrides.message ?? "";
+  let agentId = overrides.agentId ?? "main";
+  let connectionEpoch = overrides.connectionEpoch ?? 1;
   const renderCurrent = () =>
     render(
       renderNewSessionDraftComposer({
-        agentId: "main",
+        agentId,
+        connectionEpoch,
         attachmentDraft,
         canSubmit: overrides.canSubmit ?? true,
-        context: undefined,
+        context: overrides.context,
         isCatalogTarget: true,
         message,
         visibility: overrides.visibility,
@@ -82,7 +94,17 @@ function renderComposer(
   if (!composer) {
     throw new Error("Expected new-session composer");
   }
-  return { attachmentDraft, composer, container, textareaController };
+  return {
+    attachmentDraft,
+    composer,
+    container,
+    textareaController,
+    rerenderOwner(nextAgentId: string, nextConnectionEpoch: number) {
+      agentId = nextAgentId;
+      connectionEpoch = nextConnectionEpoch;
+      renderCurrent();
+    },
+  };
 }
 
 function createDragEvent(type: string, files: File[] = [], types = ["Files"]): Event {
@@ -91,6 +113,18 @@ function createDragEvent(type: string, files: File[] = [], types = ["Files"]): E
     value: { files, types },
   });
   return event;
+}
+
+function skillCommand(name: string) {
+  return {
+    name,
+    textAliases: [`/${name}`],
+    description: `${name} skill`,
+    source: "skill",
+    scope: "text",
+    acceptsArgs: false,
+    skillModelVisible: true,
+  };
 }
 
 afterEach(() => {
@@ -108,18 +142,34 @@ afterEach(() => {
 });
 
 describe("new-session composer keyboard submission", () => {
-  it("opens skill mentions and inserts the selected skill with Enter", () => {
+  it("opens skill mentions and inserts the selected skill with Enter", async () => {
     replaceSlashCommands([
       {
-        key: "release_notes",
-        name: "release_notes",
-        description: "Draft release notes.",
+        key: "chat_skill",
+        name: "chat_skill",
+        description: "Active chat skill.",
         source: "skill",
         skillModelVisible: true,
       },
     ]);
+    const request = vi.fn().mockResolvedValue({
+      commands: [
+        {
+          name: "release_notes",
+          textAliases: ["/release_notes"],
+          description: "Draft release notes.",
+          source: "skill",
+          scope: "text",
+          acceptsArgs: false,
+          skillModelVisible: true,
+        },
+      ],
+    });
     let message = "";
     const { composer } = renderComposer({
+      context: {
+        gateway: { snapshot: { client: { request } } },
+      } as unknown as ApplicationContext,
       onInput: (next) => {
         message = next;
       },
@@ -133,11 +183,96 @@ describe("new-session composer keyboard submission", () => {
     textarea.setSelectionRange(1, 1);
     textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
 
-    expect(composer.querySelector(".skill-menu")?.textContent).toContain("release_notes");
+    await waitForFast(() =>
+      expect(composer.querySelector(".skill-menu")?.textContent).toContain("release_notes"),
+    );
+    expect(request).toHaveBeenCalledWith("commands.list", {
+      agentId: "main",
+      includeArgs: true,
+      scope: "text",
+    });
+    expect(SLASH_COMMANDS.map((command) => command.name)).toEqual(["chat_skill"]);
     textarea.dispatchEvent(
       new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Enter" }),
     );
     expect(message).toBe("$release_notes ");
+  });
+
+  it("refreshes an open skill menu after live skill changes", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ commands: [skillCommand("before_change")] })
+      .mockResolvedValueOnce({ commands: [skillCommand("after_change")] });
+    const client = { request } as never;
+    const { composer, textareaController } = renderComposer({
+      context: {
+        gateway: { snapshot: { client } },
+      } as unknown as ApplicationContext,
+    });
+    const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
+
+    textarea.value = "$";
+    textarea.setSelectionRange(1, 1);
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    await waitForFast(() =>
+      expect(composer.querySelector(".skill-menu")?.textContent).toContain("before_change"),
+    );
+
+    invalidateSlashCommandCatalog(client);
+    textareaController.handleGatewayEvent("skills.changed", () => undefined);
+    await waitForFast(() =>
+      expect(composer.querySelector(".skill-menu")?.textContent).toContain("after_change"),
+    );
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(composer.querySelector(".skill-menu")?.textContent).not.toContain("before_change");
+  });
+
+  it.each([
+    { label: "selected agent changes", agentId: "research", connectionEpoch: 1 },
+    { label: "connection changes", agentId: "main", connectionEpoch: 2 },
+  ])("reopens an active skill menu when the $label", async (owner) => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ commands: [skillCommand("before_change")] })
+      .mockResolvedValueOnce({ commands: [skillCommand("after_change")] });
+    const client = { request } as never;
+    const rendered = renderComposer({
+      context: {
+        gateway: { snapshot: { client } },
+      } as unknown as ApplicationContext,
+    });
+    const { composer } = rendered;
+    const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
+
+    textarea.value = "$";
+    textarea.setSelectionRange(1, 1);
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+    await waitForFast(() =>
+      expect(composer.querySelector(".skill-menu")?.textContent).toContain("before_change"),
+    );
+
+    if (owner.connectionEpoch !== 1) {
+      invalidateSlashCommandCatalog(client);
+    }
+    rendered.rerenderOwner(owner.agentId, owner.connectionEpoch);
+
+    await waitForFast(() =>
+      expect(composer.querySelector(".skill-menu")?.textContent).toContain("after_change"),
+    );
+    expect(textarea.value).toBe("$");
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenLastCalledWith("commands.list", {
+      agentId: owner.agentId,
+      includeArgs: true,
+      scope: "text",
+    });
+    expect(composer.querySelector(".skill-menu")?.textContent).not.toContain("before_change");
   });
 
   it.each([
@@ -338,6 +473,7 @@ describe("new-session composer sizing lifecycle", () => {
     render(
       renderNewSessionDraftComposer({
         agentId: "main",
+        connectionEpoch: 1,
         attachmentDraft: first.attachmentDraft,
         canSubmit: true,
         context: undefined,
@@ -363,6 +499,7 @@ describe("new-session composer sizing lifecycle", () => {
     render(
       renderNewSessionDraftComposer({
         agentId: "main",
+        connectionEpoch: 1,
         attachmentDraft: first.attachmentDraft,
         canSubmit: true,
         context: undefined,

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -1,13 +1,15 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { icons } from "../../components/icons.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import { t } from "../../i18n/index.ts";
 import "../../components/tooltip.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import { buildFallbackSlashCommands, type SlashCommandDef } from "../../lib/chat/commands.ts";
+import { loadSlashCommandCatalog } from "../../lib/chat/slash-command-catalog.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { refreshSlashCommands } from "../chat/chat-commands.ts";
 import {
   createChatAttachmentDropHandlers,
   handleChatAttachmentPaste,
@@ -140,6 +142,13 @@ function renderStartControl(options: NewSessionComposerOptions) {
 
 export class NewSessionComposerTextareaController {
   private textarea: HTMLTextAreaElement | null = null;
+  private commandClient: GatewayBrowserClient | null = null;
+  private commandAgentId = "";
+  private commandConnectionEpoch = 0;
+  private commandGeneration = 0;
+  private commandCatalog: readonly SlashCommandDef[] = buildFallbackSlashCommands();
+  private reconcileCommandMenu: (() => void) | null = null;
+  private commandMenuReconcilePending = false;
   readonly skillMenuState = createSkillMenuState();
 
   readonly ref = (element?: Element) => {
@@ -164,8 +173,90 @@ export class NewSessionComposerTextareaController {
 
   readonly getTextarea = () => this.textarea;
 
-  disconnect() {
+  syncCommandOwner(client: GatewayBrowserClient | null, agentId: string, connectionEpoch: number) {
+    const normalizedAgentId = agentId.trim();
+    if (
+      this.commandClient === client &&
+      this.commandAgentId === normalizedAgentId &&
+      this.commandConnectionEpoch === connectionEpoch
+    ) {
+      return;
+    }
+    const shouldReconcile =
+      this.skillMenuState.skillMenuTarget !== null || this.commandMenuReconcilePending;
+    this.commandClient = client;
+    this.commandAgentId = normalizedAgentId;
+    this.commandConnectionEpoch = connectionEpoch;
+    this.invalidateCommandCatalog();
+    this.commandMenuReconcilePending = shouldReconcile;
+  }
+
+  invalidateCommandCatalog() {
+    this.commandGeneration += 1;
+    this.commandCatalog = buildFallbackSlashCommands();
     resetSkillMenuState(this.skillMenuState);
+  }
+
+  setCommandMenuReconciler(reconcile: () => void) {
+    this.reconcileCommandMenu = reconcile;
+    this.scheduleCommandMenuReconciliation();
+  }
+
+  private scheduleCommandMenuReconciliation(): boolean {
+    if (!this.commandMenuReconcilePending || !this.reconcileCommandMenu) {
+      return false;
+    }
+    queueMicrotask(() => {
+      if (!this.commandMenuReconcilePending) {
+        return;
+      }
+      this.commandMenuReconcilePending = false;
+      this.reconcileCommandMenu?.();
+    });
+    return true;
+  }
+
+  handleGatewayEvent(event: string, requestUpdate: () => void) {
+    if (event !== "config.changed" && event !== "skills.changed") {
+      return;
+    }
+    const shouldReconcile =
+      this.skillMenuState.skillMenuTarget !== null || this.commandMenuReconcilePending;
+    this.invalidateCommandCatalog();
+    this.commandMenuReconcilePending = shouldReconcile;
+    if (!this.scheduleCommandMenuReconciliation()) {
+      requestUpdate();
+    }
+  }
+
+  async refreshCommandCatalog(
+    client: GatewayBrowserClient,
+    agentId: string,
+    connectionEpoch: number,
+  ): Promise<void> {
+    this.syncCommandOwner(client, agentId, connectionEpoch);
+    const normalizedAgentId = agentId.trim();
+    const generation = ++this.commandGeneration;
+    const catalog = await loadSlashCommandCatalog(client, normalizedAgentId);
+    if (
+      this.commandGeneration === generation &&
+      this.commandClient === client &&
+      this.commandAgentId === normalizedAgentId &&
+      this.commandConnectionEpoch === connectionEpoch
+    ) {
+      this.commandCatalog = catalog;
+    }
+  }
+
+  readonly getCommandCatalog = () => this.commandCatalog;
+
+  disconnect() {
+    this.invalidateCommandCatalog();
+    this.commandMenuReconcilePending = false;
+    this.reconcileCommandMenu = null;
+    this.commandClient = null;
+    this.commandAgentId = "";
+    this.commandConnectionEpoch = 0;
     if (this.textarea) {
       disconnectTextareaOverflowObserver(this.textarea);
       this.textarea = null;
@@ -250,6 +341,7 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
     getDraft: () => options.textareaController.getTextarea()?.value ?? options.message,
     commitDraft: options.onInput,
     getTextarea: options.textareaController.getTextarea,
+    getCommandCatalog: options.textareaController.getCommandCatalog,
     refreshCommands: options.refreshCommands,
   };
   const updateSkills = (target: HTMLTextAreaElement) =>
@@ -260,6 +352,14 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
       skillMenuHost,
       options.requestUpdate,
     );
+  options.textareaController.setCommandMenuReconciler(() => {
+    const target = options.textareaController.getTextarea();
+    if (target) {
+      updateSkills(target);
+    } else {
+      options.requestUpdate();
+    }
+  });
   const handleSelect = (event: Event) => {
     const target = event.currentTarget;
     if (target instanceof HTMLTextAreaElement) {
@@ -376,6 +476,7 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
 export function renderNewSessionDraftComposer(options: {
   agent?: import("../../api/types.ts").GatewayAgentRow;
   agentId: string;
+  connectionEpoch: number;
   attachmentDraft: NewSessionAttachmentDraft;
   canSubmit: boolean;
   context: import("../../app/context.ts").ApplicationContext | undefined;
@@ -403,6 +504,11 @@ export function renderNewSessionDraftComposer(options: {
 }) {
   const readSignal = options.attachmentDraft.readSignal;
   const commandClient = options.context?.gateway.snapshot.client;
+  options.textareaController.syncCommandOwner(
+    commandClient ?? null,
+    options.agentId,
+    options.connectionEpoch,
+  );
   return renderNewSessionComposer({
     attachmentLimits: options.context?.gateway.snapshot.hello?.policy?.attachments,
     attachments: options.attachmentDraft.attachments,
@@ -424,7 +530,12 @@ export function renderNewSessionDraftComposer(options: {
     requiresModifier: options.requiresModifier,
     requestUpdate: options.requestUpdate,
     refreshCommands: commandClient
-      ? () => refreshSlashCommands({ client: commandClient, agentId: options.agentId })
+      ? () =>
+          options.textareaController.refreshCommandCatalog(
+            commandClient,
+            options.agentId,
+            options.connectionEpoch,
+          )
       : undefined,
     submitDisabledReason: options.submitDisabledReason,
     blockedSubmitNotice: options.blockedSubmitNotice,

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -168,10 +168,12 @@ export class NewSessionPage extends OpenClawLightDomElement {
           this.presenceSignature = presenceStateSignature(
             readPresenceEntries(gateway.snapshot.hello?.snapshot) ?? [],
           );
+          const requestUpdate = () => this.requestUpdate();
           return gateway.subscribeEvents((event) => {
             if (this.context?.gateway !== gateway) {
               return;
             }
+            this.submission.composerTextarea.handleGatewayEvent(event.event, requestUpdate);
             if (isPlaceTopologyEvent(event.event)) {
               this.refreshPlaceTopology();
               return;
@@ -593,6 +595,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
         ${renderNewSessionDraftComposer({
           agent: this.place.selectedAgent(),
           agentId: this.place.agentId,
+          connectionEpoch: this.gateway.connectionEpoch,
           attachmentDraft: this.submission.attachmentDraft,
           canSubmit: this.submission.canSubmit(),
           submitDisabledReason: this.submission.submitDisabledReason(),


### PR DESCRIPTION
New Session's `$` menu could keep showing removed skills after configuration changes or a reconnect. It could also reuse another agent's or a previous connection's catalog, making completion misleading for the selected agent.

This PR gives New Session an owner-local catalog loaded through the same metadata and `commands.list` path as active chat. The app lifecycle invalidates every affected per-client catalog, and an open menu follows agent or connection changes without losing the draft. New Session now shows only the selected agent's current skills while active chat's global command registry remains unchanged.

## Change Breakdown

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Implementation | 8 | +251 | -102 |
| Tests and fixtures | 5 | +622 | -13 |
| **Total** | **13** | **+873** | **-115** |

The implementation is 353 changed production lines. Most of the diff is focused coverage for cache ownership, invalidation, reconnects, stale responses, retries, owner transitions, and active-chat isolation.

## Proof

Same `/new?agent=research` route and synthetic browser-mock Gateway in both runs:

**Before: direct base**

```text
commands.list params: { agentId: "research", includeArgs: true, scope: "text" }
initial menu: research_before
event: skills.changed
menu after event: research_before
removed skill still present: true
commands.list requests: 1
```

**After: PR**

```text
commands.list params: { agentId: "research", includeArgs: true, scope: "text" }
initial menu: research_before
event: skills.changed
menu after event: research_after
removed skill absent: true
commands.list requests: 2
```

The walkthrough made requests only to the attested browser-mock preview origin; no live Gateway or private data was involved.

## How to verify

1. Open `/new?agent=research` against the Control UI mock and type `$`.
2. Confirm `commands.list` carries `agentId: "research"` and the first skill appears.
3. Change the mock catalog, emit `skills.changed`, and confirm the open menu replaces the old skill without another input event.
4. Change the selected agent while `$` remains open and confirm the draft stays intact while the menu switches to the new agent's catalog.

## Implementation notes

- One canonical loader handles metadata reuse, per-agent TTL caching, in-flight coalescing, stale-result fencing, and transient failure fallback.
- Shared cache invalidation lives in the app/Gateway lifecycle; the composer owns only its local visible catalog.
- Production startup JavaScript is 332.5 KiB gzip against the 332.9 KiB repository budget.
