### PR TITLE
fix(logging): preserve incomplete tail records

### DIFF
--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -35,7 +35,7 @@ function logLine(params: {
   plugin?: string;
   message: string;
 }) {
-  return JSON.stringify({
+  return `${JSON.stringify({
     time: "2026-04-25T12:00:00.000Z",
     0: params.message,
     _meta: {
@@ -46,7 +46,7 @@ function logLine(params: {
         ...(params.plugin ? { plugin: params.plugin } : {}),
       }),
     },
-  });
+  })}\n`;
 }
 
 function readJsonPayload() {
@@ -86,7 +86,7 @@ describe("channelsLogsCommand", () => {
         logLine({ plugin: "vendor-external-chat", message: "external sent" }),
         logLine({ plugin: "vendor-external-chat-shadow", message: "shadow sent" }),
         logLine({ module: "gateway/channels/slack/send", message: "slack sent" }),
-      ].join("\n"),
+      ].join(""),
     );
 
     await channelsLogsCommand({ channel: "external-chat", json: true }, runtime);
@@ -119,7 +119,7 @@ describe("channelsLogsCommand", () => {
       [
         logLine({ ...fixture.shadow, message: "shadow" }),
         logLine({ ...fixture.match, message: "match" }),
-      ].join("\n"),
+      ].join(""),
     );
 
     await channelsLogsCommand({ channel: fixture.channel, json: true }, runtime);
@@ -190,7 +190,7 @@ describe("channelsLogsCommand", () => {
         logLine({ module: "gateway/channels/slack/send", message: "first" }),
         logLine({ module: "gateway/channels/external-chat/send", message: "second" }),
         logLine({ module: "gateway/channels/slack/send", message: "third" }),
-      ].join("\n"),
+      ].join(""),
     );
 
     await channelsLogsCommand({ channel: "all", lines: 2, json: true }, runtime);
@@ -207,7 +207,7 @@ describe("channelsLogsCommand", () => {
       ...Array.from({ length: 5000 }, () => filler),
       logLine({ module: "gateway/channels/slack/send", message: "second match" }),
     ];
-    await fs.writeFile(logPath, lines.join("\n"));
+    await fs.writeFile(logPath, lines.join(""));
 
     await channelsLogsCommand({ channel: "slack", lines: 2000, json: true }, runtime);
 
@@ -220,7 +220,7 @@ describe("channelsLogsCommand", () => {
   it("reports when the byte window omits all matching channel records", async () => {
     const omitted = logLine({ module: "gateway/channels/slack/send", message: "omitted" });
     const filler = logLine({ module: "gateway/health", message: "x".repeat(1000) });
-    await fs.writeFile(logPath, `${omitted}\n${filler.repeat(1100)}`);
+    await fs.writeFile(logPath, `${omitted}${filler.repeat(1100)}`);
 
     await channelsLogsCommand({ channel: "slack", json: true }, runtime);
     expect(readJsonPayload()).toMatchObject({ truncated: true, lines: [] });
@@ -255,7 +255,7 @@ describe("channelsLogsCommand", () => {
       [
         logLine({ module: "gateway/channels/slack/send", message: "slack fallback" }),
         logLine({ module: "gateway/channels/external-chat/send", message: "fallback sent" }),
-      ].join("\n"),
+      ].join(""),
     );
     await fs.writeFile(
       staleFile,

--- a/src/logging/log-tail-redaction.test.ts
+++ b/src/logging/log-tail-redaction.test.ts
@@ -36,7 +36,7 @@ describe("readConfiguredLogTail redaction", () => {
         `X-OpenClaw-Token: ${openClawToken}`,
         `x-pomerium-jwt-assertion: ${pomeriumJwt}`,
         "normal diagnostic line",
-      ].join("\n"),
+      ].join("\n") + "\n",
       "utf8",
     );
     setLoggerOverride({ file: logFile });

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -95,6 +95,30 @@ describe("readConfiguredLogTail", () => {
     expect(result.lines).toEqual(["old line", "recent one", "recent two"]);
   });
 
+  it("holds an unterminated record until a later read completes it", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+    const completePrefix = "complete-before ✅\n";
+
+    await fs.writeFile(file, `${completePrefix}partial`);
+    setLoggerOverride({ file });
+
+    const initial = await readConfiguredLogTail();
+    expect(initial).toMatchObject({
+      lines: ["complete-before ✅"],
+      cursor: Buffer.byteLength(completePrefix),
+    });
+
+    await fs.appendFile(file, "-completed\n");
+    const continuation = await readConfiguredLogTail({ cursor: initial.cursor });
+
+    expect(continuation).toMatchObject({
+      lines: ["partial-completed"],
+      cursor: Buffer.byteLength(`${completePrefix}partial-completed\n`),
+    });
+  });
+
   it("reports truncation when the line limit omits complete records", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -142,12 +142,10 @@ async function readLogSlice(params: {
     const bytesRead = await readFileWindowFully(handle, buffer, start);
     const text = buffer.toString("utf8", 0, bytesRead);
     let lines = text.split("\n");
+    lines = lines.slice(0, -1);
     if (start > 0 && prefix !== "\n") {
       // Drop the first partial line when starting in the middle of a file.
       lines = lines.slice(1);
-    }
-    if (lines.length > 0 && lines[lines.length - 1] === "") {
-      lines = lines.slice(0, -1);
     }
     if (params.filter) {
       // Sparse consumers inspect the full byte-bounded window before the shared line cap.
@@ -158,7 +156,9 @@ async function readLogSlice(params: {
       lines = lines.slice(lines.length - limit);
     }
 
-    cursor = size;
+    // Keep an unterminated record pending so a later read can emit it whole.
+    const lastNewline = buffer.subarray(0, bytesRead).lastIndexOf(0x0a);
+    cursor = text.endsWith("\n") ? size : start + lastNewline + 1;
 
     return {
       cursor,


### PR DESCRIPTION
## What Problem This Solves

Fixes a log-follow handoff where an initial `logs.tail` snapshot can observe a record while it is still being appended, emit that unterminated fragment, and advance its cursor to EOF. When the writer later appends the rest of the record and its newline, the continuation read starts in the middle and drops the completion, so `openclaw logs --follow` never shows the complete line.

## Why This Change Was Made

The tail reader now treats newline completion as the record-settlement boundary. It always withholds the trailing split fragment; when the current file does not end in a newline, the returned cursor remains at the byte after the last completed newline. A later read can therefore emit the whole completed record. Complete newline-terminated records, byte/line caps, partial-start handling, filters, redaction, and protocol shape remain unchanged.

Fixtures that intentionally model complete redaction and channel-log records now include their JSONL newline delimiters. Exact-head CI exposed the channel fixture gap because those tests had previously relied on the reader accepting an incomplete EOF fragment.

Regression provenance: commit `306fe841f54b4c11c93831d8aff3fabb619dd511` (`fix(cli): add local logs fallback`), authored by @steipete on 2026-04-04, introduced the EOF cursor behavior; no associated PR was found. No exact open or closed issue/PR duplicate was found after all-state searches for partial/incomplete trailing records, newline settlement, and log-tail cursors.

## User Impact

Users following logs no longer lose a line when a poll lands between a writer's partial append and the terminating newline.

## Evidence

- Authentic pre-fix current-reader regression failed because the first read returned the partial fragment and advanced to EOF; the second read then omitted the completed record.
- New two-read regression uses a UTF-8 prefix, asserts the first cursor stays at the incomplete record's byte start, appends the completion, and asserts the second read returns `partial-completed` whole.
- Focused `src/logging/log-tail.test.ts`: **19/19 passed**.
- The exact CI-failing channel-log suite after its fixture correction: **15/15 passed**.
- Broad owner/caller suites (`log-tail`, `log-tail-redaction`, `logs-cli`, `channels.logs`): **74/74 passed** at the current head.
- Complete changed-file gate passed for all four changed files at the current head.
- Runtime sidecar loader guard passed.
- Fresh isolated Codex autoreview of the final fixture correction: clean, **0.99 confidence**; the integrated production patch review and deslop were also clean.
- Native repo review artifacts validate at the exact head with zero findings and `READY FOR /prepare-pr`.
- Production LOC: **+4/-4 (net 0)**. Tests: **+33/-9 (net +24)**.
- Exact head: `c6c9a4fe7bf1802165aea7dbed5ca1d509b393e2`.
