### PR TITLE
improve(gateway): reduce scoped broadcast dispatch work

### DIFF
--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -164,6 +164,32 @@ describe("collaboration event scope guards", () => {
     expect(unsubscribed.socket.events).toEqual([]);
   });
 
+  it("prepares session subscription lookups once per ordinary broadcast", () => {
+    const first = makeClient("first", "operator", ["operator.read"]);
+    const second = makeClient("second", "operator", ["operator.read"]);
+    const unrelated = makeClient("unrelated", "operator", ["operator.read"]);
+    const legacy = makeClient("legacy", "operator", ["operator.read"]);
+    for (const entry of [first, second, unrelated]) {
+      entry.client.connect.caps = [GATEWAY_CLIENT_CAPS.SESSION_SCOPED_EVENTS];
+    }
+    const subscribers = createSessionMessageSubscriberRegistry();
+    subscribers.subscribe(first.client.connId, "session-a");
+    subscribers.subscribe(second.client.connId, "session-a");
+    const getSubscribers = vi.spyOn(subscribers, "get");
+    const { broadcast } = createGatewayBroadcaster({
+      clients: new Set([first.client, second.client, unrelated.client, legacy.client]),
+      sessionMessageSubscribers: subscribers,
+    });
+
+    broadcast("chat", { sessionKey: "session-a", state: "delta" });
+
+    expect(getSubscribers).toHaveBeenCalledExactlyOnceWith("session-a");
+    expect(first.socket.events).toEqual(["chat"]);
+    expect(second.socket.events).toEqual(["chat"]);
+    expect(unrelated.socket.events).toEqual([]);
+    expect(legacy.socket.events).toEqual(["chat"]);
+  });
+
   it("suppresses session.tool mirrors for scoped clients without a matching subscription", () => {
     const subscribed = makeClient("subscribed", "operator", ["operator.read"]);
     const otherSession = makeClient("other-session", "operator", ["operator.read"]);

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -265,6 +265,9 @@ export function createGatewayBroadcaster(params: {
     const sessionSubscriptionVerified =
       (opts as { sessionSubscriptionVerified?: boolean } | undefined)
         ?.sessionSubscriptionVerified === true;
+    const isSessionSubscriptionEvent = SESSION_SUBSCRIPTION_EVENTS.has(event);
+    const sessionMessageSubscribers = params.sessionMessageSubscribers;
+    let sessionSubscriberConnIdsByKey: Array<ReadonlySet<string> | undefined> | undefined;
     for (const c of params.clients) {
       if (c.invalidated === true) {
         continue;
@@ -286,18 +289,30 @@ export function createGatewayBroadcaster(params: {
         event === "session.typing" ||
         ((isBrowserCopilotClient(c.connect.client) ||
           hasGatewayClientCap(c.connect.caps, GATEWAY_CLIENT_CAPS.SESSION_SCOPED_EVENTS)) &&
-          SESSION_SUBSCRIPTION_EVENTS.has(event));
-      if (
-        requiresSessionSubscription &&
-        !(isTargeted && sessionSubscriptionVerified) &&
-        (!sessionKeys.length ||
-          !sessionKeys.some((sessionKey) =>
-            params.sessionMessageSubscribers?.get(sessionKey).has(c.connId),
-          ))
-      ) {
-        // Scoped clients opt out of cross-session fanout, including critical observer announces.
-        // The registry is authoritative; for cap-gated events, unscoped Control UI clients keep full fanout.
-        continue;
+          isSessionSubscriptionEvent);
+      if (requiresSessionSubscription && !(isTargeted && sessionSubscriptionVerified)) {
+        if (!sessionKeys.length || !sessionMessageSubscribers) {
+          continue;
+        }
+        // Resolve keys lazily to preserve short-circuit order, then reuse their live sets across clients.
+        // This avoids repeated normalization and map lookups without snapshotting recipients.
+        sessionSubscriberConnIdsByKey ??= [];
+        let subscribed = false;
+        let sessionKeyIndex = 0;
+        for (const sessionKey of sessionKeys) {
+          const subscriberConnIds = (sessionSubscriberConnIdsByKey[sessionKeyIndex] ??=
+            sessionMessageSubscribers.get(sessionKey));
+          if (subscriberConnIds.has(c.connId)) {
+            subscribed = true;
+            break;
+          }
+          sessionKeyIndex += 1;
+        }
+        if (!subscribed) {
+          // Scoped clients opt out of cross-session fanout, including critical observer announces.
+          // The registry is authoritative; for cap-gated events, unscoped Control UI clients keep full fanout.
+          continue;
+        }
       }
       if (!outboundEventLogged) {
         outboundEventLogged = true;


### PR DESCRIPTION
## What Problem This Solves

Ordinary session-scoped Gateway broadcasts repeated the same subscriber-registry key preparation and map lookup once per eligible scoped client. Busy sessions with many connected recipients therefore spent avoidable CPU in dispatch before performing each client's membership check.

## Why This Change Was Made

The Gateway broadcaster now resolves each ordered session subscription key lazily once per broadcast and reuses the registry-owned live set for later clients. Per-client membership checks, short-circuit order, visibility and scope gates, targeted verified delivery, legacy unscoped fanout, sequence/backpressure handling, and serialized frames remain unchanged.

The owner regression proves that lookup preparation remains bounded per broadcast while subscribed, unrelated scoped, and legacy recipients retain their exact delivery outcomes. This PR was AI-assisted.

## User Impact

Session-scoped Gateway events require less dispatch CPU as connected client count grows. There is no user-visible or protocol behavior change.

## Evidence

- Exact-current pre-fix proof: applying only the final owner regression to `10c774cf38eb8ef0b9456f949fcb2ec782320168` failed in both Gateway projects because three eligible scoped clients caused three `get("session-a")` calls; all delivery outcomes were otherwise correct.
- Exact final head: 10 test files and 486 tests passed across broadcaster scope/serialization, Gateway misc behavior, agent event producers, and runtime subscriptions.
- `node scripts/check-changed.mjs -- src/gateway/server-broadcast.ts src/gateway/server-broadcast.board.test.ts` passed formatting, typechecks, lint, dead-export, cycle, boundary, and policy guards.
- Owner benchmark: 128 scoped recipients × 20,000 ordinary broadcasts reduced registry resolutions from 2,560,000 to 20,000 (99.21875%) and median wall time from 603.253 ms to 498.105 ms (17.43%).
- Exact before/after frame extracts were byte-identical, including ordered multi-key subscriptions, a legacy recipient, `stateVersion`, and raw serialized frames.
- Fresh exact-head Codex `gpt-5.6-sol` / high autoreview returned no accepted/actionable findings with 0.99 confidence; TruffleHog was clean.
- No live external service was needed: this is a synchronous internal dispatch optimization with deterministic owner-boundary red/green proof and unchanged producer/runtime coverage.
