### PR TITLE
fix(ci): stop reply-dispatch shard state leaks

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -1,5 +1,5 @@
 // Tests dispatch-from-config reply dispatch integration and final payload routing.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { clearAgentHarnesses } from "../../agents/harness/registry.js";
 import {
@@ -35,6 +35,7 @@ import { createReplyDispatcher } from "./reply-dispatcher.js";
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
+let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
 let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
 let runAfterReplyOperationClear: typeof import("./reply-run-registry.js").runAfterReplyOperationClear;
 let resetReplyRunRegistry: typeof import("./reply-run-registry.test-support.js").testing.resetReplyRunRegistry;
@@ -103,6 +104,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
     const replyRunRegistryModule = await import("./reply-run-registry.js");
     createReplyOperation = replyRunRegistryModule.createReplyOperation;
+    getActiveReplyRunCount = replyRunRegistryModule.getActiveReplyRunCount;
     replyRunRegistry = replyRunRegistryModule.replyRunRegistry;
     runAfterReplyOperationClear = replyRunRegistryModule.runAfterReplyOperationClear;
     const { testing } = await import("./reply-run-registry.test-support.js");
@@ -186,6 +188,13 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       runtimePluginMocks.pluginRegistry,
     );
     resetPluginTtsAndThreadMocks();
+  });
+
+  afterEach(() => {
+    resetReplyRunRegistry();
+    resetInboundDedupe();
+    vi.useRealTimers();
+    clearAgentHarnesses();
   });
 
   it("runs a handled plugin reply hook in the registry scope", async () => {
@@ -838,6 +847,8 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       releaseOwner.resolve();
       successor?.complete();
       await vi.runOnlyPendingTimersAsync();
+      expect(getActiveReplyRunCount()).toBe(0);
+      expect(vi.getTimerCount()).toBe(0);
       vi.useRealTimers();
     }
   });
@@ -1065,6 +1076,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       dispatcher.markComplete();
       await dispatcher.waitForIdle();
       queuedOperation?.complete();
+      expect(getActiveReplyRunCount()).toBe(0);
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the non-isolated `auto-reply-reply-dispatch` CI shard could retain reply-run registry, inbound dedupe, timer, or agent-harness state after `dispatch-from-config.reply-dispatch.test.ts`, leaving the packed shard silent until the outer no-output watchdog terminated it.

This was the failed `checks-node-auto-reply-reply-dispatch` surface in Full Release Validation run 32555210504.

## Why This Change Was Made

The owning test now restores all shared lifecycle state after every case and asserts that the two lifecycle-heavy cases finish with no active reply runs or pending fake timers. Production behavior is unchanged.

The cleanup is attached to the test owner rather than weakening watchdogs, adding retries, or reducing packed coverage.

## User Impact

Maintainers can run the complete reply-dispatch CI shard without a late retained-state hang forcing another broad release-validation cycle. There is no user-visible runtime change.

## Evidence

- Exact packed CI shard on Blacksmith Testbox:
  - provider: `blacksmith-testbox`
  - lease: `tbx_01m0mbakrw1xp1yn9yrftm5b0e`
  - run: https://github.com/openclaw/openclaw/actions/runs/32563887909
  - result: 39 files, 1,295 tests passed; Vitest 102.32s; shard process exited 0
- Focused post-restack proof:
  - `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`
  - 28 tests passed
- `node_modules/.bin/oxfmt --check src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`
- `git diff --check origin/main...HEAD`
- Fresh autoreview: no accepted/actionable findings; patch correct, confidence 0.99

Production LOC: +0/-0. Tests: +13/-1.
