### PR TITLE
perf(ui): stop re-comparing the whole session catalog on every live event

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-live.test.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import type { SessionCatalog } from "../../../packages/gateway-protocol/src/index.ts";
+import { SessionCatalogLiveState } from "./app-sidebar-session-catalog-live.ts";
+
+function catalog(id: string, hostCount: number): SessionCatalog {
+  return {
+    id,
+    label: id,
+    capabilities: { continueSession: true, archive: true },
+    hosts: Array.from({ length: hostCount }, (_, hostIndex) => ({
+      hostId: `${id}-host-${hostIndex}`,
+      label: `Host ${hostIndex}`,
+      kind: "node",
+      connected: true,
+      sessions: [
+        {
+          threadId: `${id}-thread-${hostIndex}`,
+          name: `Session ${hostIndex}`,
+          status: "idle",
+          archived: false,
+          canContinue: true,
+          canArchive: true,
+        },
+      ],
+    })),
+  };
+}
+
+describe("SessionCatalogLiveState", () => {
+  it("compares a host event only with the catalog and host it can replace", () => {
+    const live = new SessionCatalogLiveState();
+    const { progressId } = live.beginRequest(1);
+    const changed = catalog("changed", 1);
+    const unrelated = catalog("unrelated", 100);
+    Object.defineProperty(unrelated, "toJSON", {
+      value: () => {
+        throw new Error("unrelated catalog serialized");
+      },
+    });
+
+    let result: ReturnType<SessionCatalogLiveState["applyHost"]>;
+    expect(() => {
+      result = live.applyHost({
+        payload: {
+          progressId,
+          agentId: "main",
+          catalog: { ...changed, hosts: [changed.hosts[0]!] },
+        },
+        agentId: "main",
+        catalogs: [changed, unrelated],
+        pageDepths: new Map(),
+      });
+    }).not.toThrow();
+    expect(result!).toBeNull();
+  });
+});

--- a/ui/src/components/app-sidebar-session-catalog-live.test.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.test.ts
@@ -54,4 +54,43 @@ describe("SessionCatalogLiveState", () => {
     }).not.toThrow();
     expect(result!).toBeNull();
   });
+
+  it.each([
+    {
+      metadata: "capabilities",
+      update: (current: SessionCatalog): SessionCatalog => ({
+        ...current,
+        capabilities: {
+          ...current.capabilities,
+          createSession: { model: "openai/gpt-5.6-luna" },
+        },
+      }),
+    },
+    {
+      metadata: "catalog error",
+      update: (current: SessionCatalog): SessionCatalog => ({
+        ...current,
+        error: { code: "unavailable", message: "Catalog temporarily unavailable" },
+      }),
+    },
+  ])("applies $metadata without marking a material change", ({ update }) => {
+    const live = new SessionCatalogLiveState();
+    const { progressId } = live.beginRequest(1);
+    const current = catalog("changed", 1);
+
+    const result = live.applyHost({
+      payload: {
+        progressId,
+        agentId: "main",
+        catalog: { ...update(current), hosts: [current.hosts[0]!] },
+      },
+      agentId: "main",
+      catalogs: [current],
+      pageDepths: new Map(),
+    });
+
+    expect(result?.catalogs[0]).toEqual(update(current));
+    expect(result?.materialChange).toBe(false);
+    expect(live.sawChange).toBe(false);
+  });
 });

--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -385,7 +385,7 @@ export class SessionCatalogLiveState {
       return null;
     }
     const materialChange =
-      !sameCatalogMetadata ||
+      !currentCatalog ||
       !currentHost ||
       !nextHost ||
       sessionCatalogMaterialSnapshot([{ ...nextCatalog, hosts: [nextHost] }]) !==

--- a/ui/src/components/app-sidebar-session-catalog-live.ts
+++ b/ui/src/components/app-sidebar-session-catalog-live.ts
@@ -351,9 +351,11 @@ export class SessionCatalogLiveState {
     }
     const currentCatalog = params.catalogs.find((catalog) => catalog.id === event.catalog.id);
     let catalogs: SessionCatalog[];
+    let nextCatalog: SessionCatalog;
     if (!currentCatalog) {
-      catalogs = [...params.catalogs, { ...event.catalog, hosts: [freshHost] }].toSorted(
-        (left, right) => left.id.localeCompare(right.id),
+      nextCatalog = { ...event.catalog, hosts: [freshHost] };
+      catalogs = [...params.catalogs, nextCatalog].toSorted((left, right) =>
+        left.id.localeCompare(right.id),
       );
     } else {
       const currentHost = currentCatalog.hosts.find((host) => host.hostId === freshHost.hostId);
@@ -364,20 +366,30 @@ export class SessionCatalogLiveState {
       const hosts = currentHost
         ? currentCatalog.hosts.map((host) => (host.hostId === freshHost.hostId ? mergedHost : host))
         : [...currentCatalog.hosts, mergedHost];
+      nextCatalog = {
+        ...event.catalog,
+        hosts: hosts.toSorted((left, right) => left.label.localeCompare(right.label)),
+      };
       catalogs = params.catalogs.map((catalog) =>
-        catalog.id === event.catalog.id
-          ? {
-              ...event.catalog,
-              hosts: hosts.toSorted((left, right) => left.label.localeCompare(right.label)),
-            }
-          : catalog,
+        catalog.id === event.catalog.id ? nextCatalog : catalog,
       );
     }
-    if (JSON.stringify(catalogs) === JSON.stringify(params.catalogs)) {
+    const currentHost = currentCatalog?.hosts.find((host) => host.hostId === freshHost.hostId);
+    const nextHost = nextCatalog.hosts.find((host) => host.hostId === freshHost.hostId);
+    const sameCatalogMetadata =
+      currentCatalog !== undefined &&
+      currentCatalog.label === nextCatalog.label &&
+      JSON.stringify(currentCatalog.capabilities) === JSON.stringify(nextCatalog.capabilities) &&
+      JSON.stringify(currentCatalog.error) === JSON.stringify(nextCatalog.error);
+    if (sameCatalogMetadata && JSON.stringify(currentHost) === JSON.stringify(nextHost)) {
       return null;
     }
     const materialChange =
-      sessionCatalogMaterialSnapshot(catalogs) !== sessionCatalogMaterialSnapshot(params.catalogs);
+      !sameCatalogMetadata ||
+      !currentHost ||
+      !nextHost ||
+      sessionCatalogMaterialSnapshot([{ ...nextCatalog, hosts: [nextHost] }]) !==
+        sessionCatalogMaterialSnapshot([{ ...currentCatalog, hosts: [currentHost] }]);
     this.sawChange ||= materialChange;
     return { catalogs, catalogId: event.catalog.id, materialChange };
   }


### PR DESCRIPTION
Closes #127816

## What Problem This Solves

Fixes an issue where users with large live session catalogs could experience short Control UI stalls during bursts of host updates because every event compared the complete catalog fleet.

## Why This Change Was Made

Host events can replace only one catalog host. The comparison now examines that host and its catalog metadata while preserving expanded-page merges and the existing material-change semantics.

## User Impact

Large live catalogs update with substantially less main-thread work. There is no visual or configuration change.

## Evidence

Fixture: 1 catalog, 20 hosts, 500 sessions per host, 10 host events. Five runs on the same Linux Testbox.

| Variant | Runs (ms) | Median | IQR |
| --- | --- | ---: | ---: |
| `main` | 68.72, 58.23, 65.08, 62.82, 63.22 | 63.22 ms | 2.26 ms |
| Patched | 7.00, 3.00, 2.83, 2.94, 2.70 | 2.94 ms | 0.17 ms |

Reduction: 95%.

Remote proof: https://github.com/openclaw/openclaw/actions/runs/32563257272

Provenance: `sha=36d50b20098e8e45bc7a97b020d9755ab7a27414`, `provider=blacksmith-testbox`, `boxId=tbx_01m0magpzfeq8rzrvb5yy89hzk`.

Regression proof against `main`:

```text
FAIL app-sidebar-session-catalog-live.test.ts
expected function not to throw, but "unrelated catalog serialized" was thrown
```

Passing proof:

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar-session-catalog-live.test.ts`
- `pnpm tsgo:core:test`
- `pnpm tsgo:ui`
- focused oxlint

The structured review helper was attempted twice with its default reviewer; the reviewer process exited before returning structured findings. The alternate reviewer executable is not installed on this host.
