### PR TITLE
perf(ui): stop hidden split panes from fetching data they never show

### DIFF
--- a/ui/src/e2e/chat-retained-pane-hydration.e2e.test.ts
+++ b/ui/src/e2e/chat-retained-pane-hydration.e2e.test.ts
@@ -1,0 +1,114 @@
+import { expect, it } from "vitest";
+import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI retained pane hydration",
+  startServerBeforeBrowser: true,
+});
+
+const sessionKeys = ["agent:main:perf-a", "agent:main:perf-b", "agent:main:perf-c"];
+
+function sessionsResponse() {
+  return {
+    count: sessionKeys.length,
+    defaults: { contextTokens: null, model: "gpt-5.6-luna", modelProvider: "openai" },
+    path: "",
+    sessions: sessionKeys.map((key, index) => ({
+      key,
+      kind: "direct",
+      label: `Perf ${index + 1}`,
+      updatedAt: sessionKeys.length - index,
+    })),
+    ts: Date.now(),
+  };
+}
+
+suite.define(() => {
+  it("hydrates only the visible retained session after reconnect", async () => {
+    const rounds: Array<Record<string, number>> = [];
+    for (let round = 0; round < 5; round += 1) {
+      const context = await suite.newBrowserContext({ viewport: { height: 900, width: 1440 } });
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        featureMethods: [
+          "artifacts.list",
+          "chat.metadata",
+          "chat.startup",
+          "sessions.diff",
+          "sessions.files.list",
+          "tasks.list",
+        ],
+        methodResponses: {
+          "artifacts.list": { artifacts: [] },
+          "sessions.files.list": {
+            browser: { entries: [], path: "" },
+            files: [],
+            gitCheckout: false,
+            root: "",
+          },
+          "sessions.list": sessionsResponse(),
+          "tasks.list": { tasks: [] },
+        },
+        sessionKey: sessionKeys[0],
+      });
+      try {
+        await page.goto(new URL(controlUiSessionPath(sessionKeys[0]!), suite.server.baseUrl).href);
+        for (const key of sessionKeys.slice(1)) {
+          await page.locator(`.sidebar-recent-session[data-session-key="${key}"] a`).click();
+          await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(key));
+        }
+        await expect.poll(() => page.locator("openclaw-chat-pane").count()).toBe(3);
+        const before = (await gateway.getRequests()).length;
+        const connectBefore = (await gateway.getRequests("connect")).length;
+        await gateway.closeLatest(1012, "retained pane reconnect proof");
+        await expect
+          .poll(async () => (await gateway.getRequests("connect")).length, { timeout: 10_000 })
+          .toBeGreaterThan(connectBefore);
+        await expect
+          .poll(async () => (await gateway.getRequests()).length, { timeout: 10_000 })
+          .toBeGreaterThan(before + 6);
+        const requests = (await gateway.getRequests()).slice(before);
+        const counts: Record<string, number> = {};
+        for (const key of sessionKeys) {
+          counts[key] = requests.filter((request) => {
+            const params = request.params as { sessionKey?: unknown } | undefined;
+            return (
+              params?.sessionKey === key &&
+              ["tasks.list", "sessions.files.list", "artifacts.list"].includes(request.method)
+            );
+          }).length;
+        }
+        rounds.push(counts);
+        const hiddenLink = page.locator(
+          `.sidebar-recent-session[data-session-key="${sessionKeys[0]}"] a`,
+        );
+        await hiddenLink.click();
+        await expect
+          .poll(() => new URL(page.url()).pathname)
+          .toBe(controlUiSessionPath(sessionKeys[0]!));
+        await expect
+          .poll(async () => {
+            const later = (await gateway.getRequests()).slice(before + requests.length);
+            return later.filter((request) => {
+              const params = request.params as { sessionKey?: unknown } | undefined;
+              return (
+                params?.sessionKey === sessionKeys[0] &&
+                ["tasks.list", "sessions.files.list", "artifacts.list"].includes(request.method)
+              );
+            }).length;
+          })
+          .toBe(4);
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    }
+    expect(rounds).toEqual(
+      Array.from({ length: 5 }, () => ({
+        [sessionKeys[0]!]: 0,
+        [sessionKeys[1]!]: 0,
+        [sessionKeys[2]!]: 4,
+      })),
+    );
+  });
+});

--- a/ui/src/e2e/chat-retained-pane-hydration.e2e.test.ts
+++ b/ui/src/e2e/chat-retained-pane-hydration.e2e.test.ts
@@ -1,5 +1,9 @@
 import { expect, it } from "vitest";
-import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiSessionPath,
+  installMockGateway,
+  type MockGatewayRequest,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -7,7 +11,15 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
-const sessionKeys = ["agent:main:perf-a", "agent:main:perf-b", "agent:main:perf-c"];
+const sessionKeys = ["agent:main:perf-a", "agent:main:perf-b", "agent:main:perf-c"] as const;
+const hydrationMethods = new Set(["tasks.list", "sessions.files.list", "artifacts.list"]);
+
+function countSessionHydrationRequests(requests: MockGatewayRequest[], sessionKey: string): number {
+  return requests.filter((request) => {
+    const params = request.params as { sessionKey?: unknown } | undefined;
+    return params?.sessionKey === sessionKey && hydrationMethods.has(request.method);
+  }).length;
+}
 
 function sessionsResponse() {
   return {
@@ -53,7 +65,7 @@ suite.define(() => {
         sessionKey: sessionKeys[0],
       });
       try {
-        await page.goto(new URL(controlUiSessionPath(sessionKeys[0]!), suite.server.baseUrl).href);
+        await page.goto(new URL(controlUiSessionPath(sessionKeys[0]), suite.server.baseUrl).href);
         for (const key of sessionKeys.slice(1)) {
           await page.locator(`.sidebar-recent-session[data-session-key="${key}"] a`).click();
           await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(key));
@@ -71,32 +83,63 @@ suite.define(() => {
         const requests = (await gateway.getRequests()).slice(before);
         const counts: Record<string, number> = {};
         for (const key of sessionKeys) {
-          counts[key] = requests.filter((request) => {
-            const params = request.params as { sessionKey?: unknown } | undefined;
-            return (
-              params?.sessionKey === key &&
-              ["tasks.list", "sessions.files.list", "artifacts.list"].includes(request.method)
-            );
-          }).length;
+          counts[key] = countSessionHydrationRequests(requests, key);
         }
         rounds.push(counts);
+        const beforeEvents = (await gateway.getRequests()).length;
+        const sessionListCount = (await gateway.getRequests("sessions.list")).length;
+        const branchListCount = (await gateway.getRequests("sessions.branches.list")).length;
+        const hiddenSessionKey = sessionKeys[0];
+        await gateway.emitGatewayEvent("task", {
+          action: "upserted",
+          task: {
+            id: "task-hidden",
+            taskId: "task-hidden",
+            kind: "subagent",
+            runtime: "subagent",
+            status: "running",
+            title: "Hidden retained task",
+            agentId: "main",
+            sessionKey: hiddenSessionKey,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        });
+        await gateway.emitGatewayEvent("sessions.changed", {
+          sessionKey: hiddenSessionKey,
+          agentId: "main",
+          reason: "branch-switch",
+        });
+        await gateway.emitGatewayEvent("chat", {
+          sessionKey: hiddenSessionKey,
+          runId: "run-hidden",
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "Done." }] },
+        });
+        await page.waitForFunction((sessionKey) => {
+          const pane = [...document.querySelectorAll("openclaw-chat-pane")].find(
+            (element) =>
+              (element as HTMLElement & { sessionKey?: string }).sessionKey === sessionKey,
+          ) as (HTMLElement & { state?: { chatMessages?: unknown[] } }) | undefined;
+          return JSON.stringify(pane?.state?.chatMessages ?? []).includes("Done.");
+        }, hiddenSessionKey);
+        await expect
+          .poll(async () => (await gateway.getRequests("sessions.list")).length)
+          .toBeGreaterThan(sessionListCount);
+        expect(await gateway.getRequests("sessions.branches.list")).toHaveLength(branchListCount);
+        const afterEvents = (await gateway.getRequests()).slice(beforeEvents);
+        expect(countSessionHydrationRequests(afterEvents, hiddenSessionKey)).toBe(0);
         const hiddenLink = page.locator(
-          `.sidebar-recent-session[data-session-key="${sessionKeys[0]}"] a`,
+          `.sidebar-recent-session[data-session-key="${hiddenSessionKey}"] a`,
         );
         await hiddenLink.click();
         await expect
           .poll(() => new URL(page.url()).pathname)
-          .toBe(controlUiSessionPath(sessionKeys[0]!));
+          .toBe(controlUiSessionPath(hiddenSessionKey));
         await expect
           .poll(async () => {
             const later = (await gateway.getRequests()).slice(before + requests.length);
-            return later.filter((request) => {
-              const params = request.params as { sessionKey?: unknown } | undefined;
-              return (
-                params?.sessionKey === sessionKeys[0] &&
-                ["tasks.list", "sessions.files.list", "artifacts.list"].includes(request.method)
-              );
-            }).length;
+            return countSessionHydrationRequests(later, hiddenSessionKey);
           })
           .toBe(4);
       } finally {
@@ -105,9 +148,9 @@ suite.define(() => {
     }
     expect(rounds).toEqual(
       Array.from({ length: 5 }, () => ({
-        [sessionKeys[0]!]: 0,
-        [sessionKeys[1]!]: 0,
-        [sessionKeys[2]!]: 4,
+        [sessionKeys[0]]: 0,
+        [sessionKeys[1]]: 0,
+        [sessionKeys[2]]: 4,
       })),
     );
   });

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -121,6 +121,10 @@ function getChatHistoryPaneRequests(owner: object): ChatHistoryPaneRequests {
   return requests;
 }
 
+export function retireChatBranchRequests(state: ChatState): void {
+  getChatHistoryPaneRequests(state).branchVersion += 1;
+}
+
 type ChatHistoryRequestOwnership = {
   version: number;
   client: GatewayBrowserClient;

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -19,6 +19,27 @@ import type { ResolvedBoardView } from "./chat-pane-shared.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { activatePanel, openSlot } from "./sidebar-layout.ts";
 
+const swarmModuleImport = vi.hoisted(() => {
+  let markStarted!: () => void;
+  let release!: () => void;
+  return {
+    started: new Promise<void>((resolve) => {
+      markStarted = resolve;
+    }),
+    pending: new Promise<void>((resolve) => {
+      release = resolve;
+    }),
+    markStarted: () => markStarted(),
+    release: () => release(),
+  };
+});
+
+vi.mock("../../lib/sessions/swarm-roster.ts", async (importOriginal) => {
+  swarmModuleImport.markStarted();
+  await swarmModuleImport.pending;
+  return importOriginal();
+});
+
 type TestChatPane = HTMLElement & {
   boardChatDockSize: { height: number };
   boardProvider?: BoardProvider;
@@ -47,6 +68,7 @@ type TestChatPane = HTMLElement & {
   persistBoardSessionView: (patch: { face?: "chat" | "dashboard"; activeTabId?: string }) => void;
   resolveBoardProvider: () => BoardProvider;
   resolveBoardView: () => ResolvedBoardView;
+  refreshSwarmRoster: () => void;
 };
 
 type MockProvider = BoardProvider & { emitCommand(command: BoardCommandEvent["command"]): void };
@@ -151,6 +173,34 @@ afterEach(() => {
 });
 
 describe("chat pane board shell", () => {
+  it("does not hydrate the swarm after becoming hidden during module loading", async () => {
+    vi.useFakeTimers();
+    const list = vi.fn().mockResolvedValue({ sessions: [] });
+    const sessions = { canonicalListRevision: 0, list } as unknown as SessionCapability;
+    const pane = createTestPane(sessions);
+    pane.context = {
+      ...pane.context,
+      runtimeConfig: {
+        state: { configSnapshot: { config: { tools: { swarm: { enabled: true } } } } },
+      },
+    } as unknown as ApplicationContext;
+    pane.presentedChanged = () => undefined;
+
+    try {
+      pane.refreshSwarmRoster();
+      await swarmModuleImport.started;
+      pane.presented = false;
+      swarmModuleImport.release();
+      await import("../../lib/sessions/swarm-roster.ts");
+      await Promise.resolve();
+      await vi.runAllTimersAsync();
+
+      expect(list).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("gates New Chat when the current session has a board", async () => {
     const sessions = {
       create: vi.fn(async () => "agent:main:new"),

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -29,8 +29,8 @@ const swarmModuleImport = vi.hoisted(() => {
     pending: new Promise<void>((resolve) => {
       release = resolve;
     }),
-    markStarted: () => markStarted(),
-    release: () => release(),
+    markStarted,
+    release,
   };
 });
 

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -237,6 +237,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
       ({ isSwarmEnabledInConfig, SwarmRosterHydrator }) => {
         if (
           !this.state ||
+          !this.presented ||
           this.state.connectionEpoch !== sourceEpoch ||
           parentKey !== this.resolveBoardSessionKey()
         ) {

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -228,7 +228,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
 
   protected refreshSwarmRoster(): void {
     const state = this.state;
-    if (!state) {
+    if (!state || !this.presented) {
       return;
     }
     const parentKey = this.resolveBoardSessionKey();

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -301,7 +301,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     state.connectionEpoch = this.connectionGeneration;
     state.hello = snapshot.hello;
     if (sourceChanged) {
-      retireSessionWorkspaceCheckout(state);
+      retireSessionWorkspaceCheckout(state, this.presented);
     }
     if (!sourceChanged && previousMediaAuthToken !== resolveAssistantAttachmentAuthToken(state)) {
       releaseChatMediaResourceSubscriber(state.requestUpdate);

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -562,7 +562,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
           if (event.event === "session.message") {
             this.clearTypingActorForSessionMessage(event.payload);
           }
-          handlePageGatewayEvent(state, event);
+          handlePageGatewayEvent(state, event, () => this.presented);
         }
       }),
     );
@@ -674,7 +674,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     this.paneResizeObserver = null;
     this.connectionGeneration += 1;
     this.retireHeaderSessionMutations();
-    this.deferredSessionHydrationRequestVersion += 1;
+    this.retireDeferredSessionHydration();
     this.sessionDiscussionPanels.clear();
     this.taskSuggestionsRequestVersion += 1;
     this.setTaskSuggestions([]);

--- a/ui/src/pages/chat/chat-pane-rails.ts
+++ b/ui/src/pages/chat/chat-pane-rails.ts
@@ -20,6 +20,7 @@ export function createChatPaneRails(params: {
   sidebarLayout: ChatPaneSidebarLayout;
   paneWidth: number;
   presentationId: string;
+  presented: boolean;
   gatewaySnapshot: ChatPaneGatewaySnapshot;
   setObserverVisibility: (visible: boolean) => void;
 }) {
@@ -44,6 +45,7 @@ export function createChatPaneRails(params: {
     draftScope: params.presentationId,
     expanded: hasPanelSlot("workspace"),
     narrowLayout: false,
+    presented: params.presented,
   });
   const sessionWorkspace = {
     ...sessionWorkspaceBase,
@@ -60,6 +62,7 @@ export function createChatPaneRails(params: {
     narrowLayout: false,
     openTaskId: openTaskDetailId(state.sidebarContent, sidebarLayout),
     onOpenTaskDetail: (task) => state.handleOpenSidebar({ kind: "task", taskId: task.id }),
+    presented: params.presented,
   });
   const backgroundTasks = {
     ...backgroundTasksBase,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -228,6 +228,7 @@ export class ChatPane extends ChatPaneLayoutRender {
         sidebarLayout,
         paneWidth: this.paneWidth,
         presentationId: this.presentationId,
+        presented: this.presented,
         gatewaySnapshot,
         setObserverVisibility: this.setSessionObserverVisibility,
       });

--- a/ui/src/pages/chat/chat-pane-retained-presentation.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.ts
@@ -46,10 +46,13 @@ export abstract class ChatPaneRetainedPresentation extends ChatPaneBoard {
       this.minutePoll.start();
       this.consumeSessionHandoff(this.sessionKey);
       this.syncActiveBindings();
+      this.refreshSwarmRoster();
       void this.refreshSessionPullRequests();
       return;
     }
     this.minutePoll.stop();
+    this.swarmHydrator?.dispose();
+    this.swarmHydrator = null;
     this.clearHistoryObserver();
     sessionPullRequestsForGateway(this.context.gateway).unwatch(this);
     this.syncActiveBindings();

--- a/ui/src/pages/chat/chat-pane-retained-presentation.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.ts
@@ -1,6 +1,8 @@
 import { formatUiError } from "../../lib/format-error.ts";
 import { sessionPullRequestsForGateway } from "../../lib/session-pull-requests.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { storeChatComposerMemoryFallback } from "./chat-composer-memory-fallback.ts";
+import { loadChatBranches, retireChatBranchRequests } from "./chat-history.ts";
 import { ChatPaneBoard } from "./chat-pane-board.ts";
 import {
   consumePaneSessionHandoff,
@@ -46,11 +48,24 @@ export abstract class ChatPaneRetainedPresentation extends ChatPaneBoard {
       this.minutePoll.start();
       this.consumeSessionHandoff(this.sessionKey);
       this.syncActiveBindings();
+      const state = this.state;
+      const deferredHydrationActive = this.resumeDeferredSessionHydration();
+      if (
+        state &&
+        !deferredHydrationActive &&
+        (!areUiSessionKeysEquivalent(state.chatBranchesSessionKey, state.sessionKey) ||
+          state.chatBranchesConnectionEpoch !== state.connectionEpoch)
+      ) {
+        void loadChatBranches(state);
+      }
       this.refreshSwarmRoster();
       void this.refreshSessionPullRequests();
       return;
     }
     this.minutePoll.stop();
+    if (this.state) {
+      retireChatBranchRequests(this.state);
+    }
     this.swarmHydrator?.dispose();
     this.swarmHydrator = null;
     this.clearHistoryObserver();

--- a/ui/src/pages/chat/chat-pane-session-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-hydration.test.ts
@@ -15,34 +15,39 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+function createSecondaryHydrationPane() {
+  const secondaryResponse = new Promise<never>(() => {});
+  const request = vi.fn((_method: string, _params?: unknown) => secondaryResponse);
+  const listBranches = vi.fn(() => secondaryResponse);
+  const sessions = {
+    capturePullRequestEpoch: vi.fn(() => ({})),
+    listBranches,
+    setPullRequestSummary: vi.fn(),
+  } as unknown as SessionCapability;
+  const { pane, state } = createTestChatPane({
+    client: { request } as unknown as GatewayBrowserClient,
+    sessions,
+  });
+  state.assistantAgentId = "main";
+  state.sessionKey = "agent:work:current";
+  pane.context.gateway.snapshot.hello = {
+    features: {
+      methods: [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, "session.discussion.info"],
+    },
+  } as never;
+  const commitEffects: AfterCommitEffect[] = [];
+  const afterCommit = vi.fn((effect: AfterCommitEffect) => {
+    commitEffects.push(effect);
+    return () => undefined;
+  });
+  state.renderLifecycle = { invalidate: vi.fn(), afterCommit } satisfies RenderLifecycle;
+  return { afterCommit, commitEffects, listBranches, pane, request, state };
+}
+
 describe("chat pane session hydration", () => {
   it("starts secondary RPCs together only after the transcript commit", async () => {
-    const secondaryResponse = new Promise<never>(() => {});
-    const request = vi.fn((_method: string, _params?: unknown) => secondaryResponse);
-    const listBranches = vi.fn(() => secondaryResponse);
-    const sessions = {
-      capturePullRequestEpoch: vi.fn(() => ({})),
-      listBranches,
-      setPullRequestSummary: vi.fn(),
-    } as unknown as SessionCapability;
-    const client = { request } as unknown as GatewayBrowserClient;
-    const { pane, state } = createTestChatPane({ client, sessions });
-    state.assistantAgentId = "main";
-    state.sessionKey = "agent:work:current";
-    pane.context.gateway.snapshot.hello = {
-      features: {
-        methods: [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, "session.discussion.info"],
-      },
-    } as never;
-    const commitEffects: AfterCommitEffect[] = [];
-    const afterCommit = vi.fn((effect: AfterCommitEffect) => {
-      commitEffects.push(effect);
-      return () => undefined;
-    });
-    state.renderLifecycle = {
-      invalidate: vi.fn(),
-      afterCommit,
-    } satisfies RenderLifecycle;
+    const { afterCommit, commitEffects, listBranches, pane, request, state } =
+      createSecondaryHydrationPane();
     const transcript = deferred<void>();
 
     pane.deferSessionHydrationUntilTranscript(state.sessionKey, transcript.promise);
@@ -58,7 +63,7 @@ describe("chat pane session hydration", () => {
     expect(listBranches).not.toHaveBeenCalled();
 
     const complete = vi.fn();
-    commitEffects[0]?.(complete);
+    commitEffects[0]!(complete);
     await Promise.resolve();
 
     expect(listBranches).toHaveBeenCalledOnce();
@@ -97,5 +102,28 @@ describe("chat pane session hydration", () => {
     await currentTranscript.promise;
     await Promise.resolve();
     expect(afterCommit).toHaveBeenCalledOnce();
+  });
+
+  it("resumes deferred companion and discussion hydration when a retained pane returns", async () => {
+    const { commitEffects, pane, request, state } = createSecondaryHydrationPane();
+    const transcript = deferred<void>();
+
+    pane.deferSessionHydrationUntilTranscript(state.sessionKey, transcript.promise);
+    pane.presented = false;
+    transcript.resolve();
+    await transcript.promise;
+    await Promise.resolve();
+
+    expect(commitEffects).toHaveLength(0);
+    expect(request).not.toHaveBeenCalled();
+
+    pane.presented = true;
+    expect(commitEffects).toHaveLength(1);
+    commitEffects[0]!(vi.fn());
+    await Promise.resolve();
+
+    const methods = request.mock.calls.map(([method]) => method);
+    expect(methods).toContain("session.discussion.info");
+    expect(methods).toContain("sessions.companion.state");
   });
 });

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -43,6 +43,9 @@ import {
 import { scheduleChatScroll } from "./scroll.ts";
 
 export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
+  private deferredSessionHydrationActive = false;
+  private pendingDeferredSessionHydration: (() => void) | null = null;
+
   protected async refreshSessionPullRequests(options: { refresh?: boolean } = {}): Promise<void> {
     if (!this.presented) {
       sessionPullRequestsForGateway(this.context.gateway).unwatch(this);
@@ -174,9 +177,17 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
     if (!state) {
       return;
     }
+    this.deferredSessionHydrationActive = true;
+    this.pendingDeferredSessionHydration = null;
     const requestVersion = ++this.deferredSessionHydrationRequestVersion;
     const connectionGeneration = this.connectionGeneration;
     const client = state.client;
+    const retireIfCurrent = () => {
+      if (this.deferredSessionHydrationRequestVersion === requestVersion) {
+        this.deferredSessionHydrationActive = false;
+        this.pendingDeferredSessionHydration = null;
+      }
+    };
     const isCurrent = () =>
       this.deferredSessionHydrationRequestVersion === requestVersion &&
       this.connectionGeneration === connectionGeneration &&
@@ -184,23 +195,47 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
       state.connected &&
       state.client === client &&
       state.sessionKey === sessionKey;
-    const scheduleAfterTranscript = () => {
+    const scheduleHydration = () => {
       if (!isCurrent()) {
+        retireIfCurrent();
         return;
       }
+      if (!this.presented) {
+        this.pendingDeferredSessionHydration = scheduleHydration;
+        return;
+      }
+      this.pendingDeferredSessionHydration = null;
       // These affordances do not shape the transcript. Start them together only
       // after the authoritative history has committed so they cannot delay chat paint.
       state.renderLifecycle.afterCommit((complete) => {
-        if (isCurrent()) {
+        if (isCurrent() && this.presented) {
+          this.deferredSessionHydrationActive = false;
           void loadChatBranches(state);
           void this.probeSessionDiscussion(sessionKey);
           this.hydrateSessionCompanion(sessionKey);
           void this.refreshSessionPullRequests();
+        } else if (isCurrent()) {
+          this.pendingDeferredSessionHydration = scheduleHydration;
+        } else {
+          retireIfCurrent();
         }
         complete();
       });
     };
-    void transcriptLoad.then(scheduleAfterTranscript, scheduleAfterTranscript);
+    void transcriptLoad.then(scheduleHydration, scheduleHydration);
+  }
+
+  protected resumeDeferredSessionHydration(): boolean {
+    const resume = this.pendingDeferredSessionHydration;
+    this.pendingDeferredSessionHydration = null;
+    resume?.();
+    return this.deferredSessionHydrationActive;
+  }
+
+  protected retireDeferredSessionHydration(): void {
+    this.deferredSessionHydrationRequestVersion += 1;
+    this.deferredSessionHydrationActive = false;
+    this.pendingDeferredSessionHydration = null;
   }
 
   protected markSessionRead(row: GatewaySessionRow | undefined) {

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -24,6 +24,7 @@ import {
   isHiddenAssistantStreamText,
   loadChatBranches,
   loadChatHistory,
+  retireChatBranchRequests,
   shouldHideAssistantChatMessage,
 } from "./chat-history.ts";
 import {
@@ -54,6 +55,7 @@ import { rememberAuthoritativeTerminal } from "./terminal-message-identity.ts";
 import { handleAgentEvent, handleSessionOperationEvent } from "./tool-stream.ts";
 
 const BRANCH_TOPOLOGY_REASONS = new Set(["rewind", "branch-switch", "fork", "reset", "new"]);
+type ChatPanePresentation = () => boolean;
 
 function sessionMessageMatchesChat(
   state: ChatPageHost,
@@ -102,6 +104,7 @@ function finishSessionMessageRunReconcile(
   sessionKey: string,
   runId: string | null,
   row: SessionChangedResult["row"] | undefined,
+  presentation: ChatPanePresentation,
 ): boolean {
   const cleared = row
     ? reconcileChatRunFromSessionRow(state, row, { publishRunStatus: true })
@@ -110,7 +113,7 @@ function finishSessionMessageRunReconcile(
     return false;
   }
   clearPendingQueueItemsForRun(state, runId ?? undefined);
-  void loadChatHistory(state)
+  void loadChatHistory(state, { deferBranches: !presentation() })
     .finally(() => {
       if (!areUiSessionKeysEquivalent(state.sessionKey, sessionKey)) {
         return;
@@ -122,7 +125,11 @@ function finishSessionMessageRunReconcile(
   return true;
 }
 
-function handleSessionMessageEvent(state: ChatPageHost, payload: unknown) {
+function handleSessionMessageEvent(
+  state: ChatPageHost,
+  payload: unknown,
+  presentation: ChatPanePresentation,
+) {
   const event = readSessionChangedEvent(payload);
   if (!event || !globalSessionEventMatchesChat(state, event)) {
     return;
@@ -149,7 +156,7 @@ function handleSessionMessageEvent(state: ChatPageHost, payload: unknown) {
     if (event.hasActiveRun === true) {
       return;
     }
-    if (finishSessionMessageRunReconcile(state, event.key, runId, result.row)) {
+    if (finishSessionMessageRunReconcile(state, event.key, runId, result.row, presentation)) {
       state.pendingSessionMessageReloadSessionKey = null;
       return;
     }
@@ -163,6 +170,7 @@ function handleSessionMessageEvent(state: ChatPageHost, payload: unknown) {
           state.pendingSessionMessageReloadSessionKey,
           runId,
           undefined,
+          presentation,
         )
       ) {
         state.pendingSessionMessageReloadSessionKey = null;
@@ -172,13 +180,16 @@ function handleSessionMessageEvent(state: ChatPageHost, payload: unknown) {
   }
   if (matchesChat) {
     state.pendingSessionMessageReloadSessionKey = null;
-    void loadChatHistory(state).finally(() => state.requestUpdate?.());
+    void loadChatHistory(state, { deferBranches: !presentation() }).finally(() =>
+      state.requestUpdate?.(),
+    );
   }
 }
 
 function replayPendingSessionMessageReload(
   state: ChatPageHost,
   payload: ChatEventPayload | undefined,
+  presentation: ChatPanePresentation,
 ) {
   const pendingSessionKey = state.pendingSessionMessageReloadSessionKey;
   const payloadSessionKey = payload?.sessionKey?.trim();
@@ -192,10 +203,17 @@ function replayPendingSessionMessageReload(
     return;
   }
   state.pendingSessionMessageReloadSessionKey = null;
-  void loadChatHistory(state).finally(() => state.requestUpdate?.());
+  void loadChatHistory(state, { deferBranches: !presentation() }).finally(() =>
+    state.requestUpdate?.(),
+  );
 }
 
-function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
+function handleSessionsChangedEvent(
+  state: ChatPageHost,
+  payload: unknown,
+  presentation: ChatPanePresentation,
+) {
+  const presented = presentation();
   const runIdBeforeApply = state.chatRunId;
   const event = readSessionChangedEvent(payload);
   const matchesChat = Boolean(
@@ -218,18 +236,23 @@ function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
     typeof source?.reason === "string" &&
     BRANCH_TOPOLOGY_REASONS.has(source.reason)
   ) {
+    retireChatBranchRequests(state);
     state.chatBranches = [];
     state.chatBranchesSessionKey = null;
     state.chatBranchesConnectionEpoch = null;
-    retireSessionWorkspaceCheckout(state);
-    void loadChatBranches(state);
+    retireSessionWorkspaceCheckout(state, presented);
+    if (presented) {
+      void loadChatBranches(state);
+    }
   }
   if (event && matchesChat && event.archived !== null) {
     state.selectedChatSessionArchived = event.archived;
   }
   const result = reconcileSessionEvent(state, payload);
   if (resetsSelectedSession) {
-    void loadChatHistory(state).finally(() => state.requestUpdate?.());
+    void loadChatHistory(state, { deferBranches: !presented }).finally(() =>
+      state.requestUpdate?.(),
+    );
     return;
   }
   if (
@@ -241,7 +264,9 @@ function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
   ) {
     // Legacy multi-message writes cannot prove individual message cursors.
     // One scoped authoritative snapshot recovers them without ending a run.
-    void loadChatHistory(state).finally(() => state.requestUpdate?.());
+    void loadChatHistory(state, { deferBranches: !presented }).finally(() =>
+      state.requestUpdate?.(),
+    );
     return;
   }
   if (
@@ -254,6 +279,7 @@ function handleSessionsChangedEvent(state: ChatPageHost, payload: unknown) {
       event.key,
       event.clientRunId ?? event.runId ?? runIdBeforeApply,
       result.row,
+      presentation,
     )
   ) {
     return;
@@ -392,7 +418,11 @@ function observerDigestMatchesAuthoritativeRun(
   );
 }
 
-export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventFrame) {
+export function handlePageGatewayEvent(
+  state: ChatPageHost,
+  event: GatewayEventFrame,
+  isPresented: ChatPanePresentation = () => true,
+) {
   if (event.event === "chat") {
     const payload = event.payload as ChatEventPayload | undefined;
     if (
@@ -434,12 +464,16 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
     if (shouldRefreshPullRequests) {
       void state.refreshSessionPullRequests?.({ refresh: true });
     }
-    replayPendingSessionMessageReload(state, payload);
+    replayPendingSessionMessageReload(state, payload, isPresented);
     if (terminal) {
       removeDeliveredQueuedChatSendForRun(state, payload?.runId);
       void resumeStoredChatOutboxes(state);
       if (chatScopedEventSessionMatches(state, payload?.sessionKey, payload?.agentId)) {
-        refreshSessionWorkspace(state);
+        if (isPresented()) {
+          refreshSessionWorkspace(state);
+        } else {
+          retireSessionWorkspaceCheckout(state, false);
+        }
       }
     }
     requestChatPageUpdate(state, payload?.state === "delta" ? "animation-frame" : "immediate");
@@ -481,19 +515,19 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
     return;
   }
   if (event.event === "session.message") {
-    handleSessionMessageEvent(state, event.payload);
+    handleSessionMessageEvent(state, event.payload, isPresented);
     void resumeStoredChatOutboxes(state);
     requestChatPageUpdate(state);
     return;
   }
   if (event.event === "sessions.changed") {
-    handleSessionsChangedEvent(state, event.payload);
+    handleSessionsChangedEvent(state, event.payload, isPresented);
     void resumeStoredChatOutboxes(state);
     requestChatPageUpdate(state);
     return;
   }
   if (event.event === "task") {
-    handleBackgroundTasksEvent(state, event.payload);
+    handleBackgroundTasksEvent(state, event.payload, isPresented());
   }
 }
 

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -1,5 +1,6 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import * as assistantIdentity from "../../app/assistant-identity.ts";
 import type { ApplicationContext } from "../../app/context.ts";
@@ -1215,6 +1216,72 @@ describe("canonical session message recovery", () => {
 
     await Promise.resolve();
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("defers branch hydration when a session reconciliation finishes after the pane hides", async () => {
+    const refreshFinished = createDeferred();
+    let presented = true;
+    const listBranches = vi.fn().mockResolvedValue([]);
+    const { request, state } = createSessionEventState({
+      chatRunId: "run-1",
+      chatStream: "Finishing",
+      sessionsResult: {
+        ts: 1,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [],
+      },
+    });
+    state.sessions = {
+      ...state.sessions,
+      listBranches,
+      reconcileChanged: vi.fn().mockReturnValue({ applied: false }),
+      refresh: vi.fn(async () => {
+        await refreshFinished.promise;
+        state.sessionsResult = {
+          ts: 2,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [
+            {
+              key: state.sessionKey,
+              kind: "direct",
+              hasActiveRun: false,
+              status: "done",
+              updatedAt: 2,
+            },
+          ],
+        };
+      }),
+    };
+
+    handlePageGatewayEvent(
+      state,
+      {
+        type: "event",
+        event: "session.message",
+        payload: {
+          sessionKey: state.sessionKey,
+          runId: "run-1",
+          messageId: "terminal-message",
+          messageSeq: 2,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Finished" }],
+            __openclaw: { id: "terminal-message", seq: 2 },
+          },
+        },
+      },
+      () => presented,
+    );
+    presented = false;
+    refreshFinished.resolve();
+
+    await vi.waitFor(() => expect(state.chatRunId).toBeNull());
+    await vi.waitFor(() => expect(request).toHaveBeenCalled());
+    expect(listBranches).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts
@@ -169,6 +169,29 @@ describe("background tasks concurrent snapshots", () => {
     expect(refresh.request).toHaveBeenCalledTimes(2);
   });
 
+  it("refetches after a hidden registry restore invalidates the initial snapshot", async () => {
+    const stale = [makeTask({ id: "task-before-restore" })];
+    const replacement = [makeTask({ id: "task-after-restore", updatedAt: 4_000 })];
+    const refresh = await refreshingHost(stale, true);
+    refresh.setFallbackTasks(replacement);
+
+    handleBackgroundTasksEvent(refresh.host, { action: "restored" }, false);
+    refresh.resolveActive({ tasks: stale });
+    refresh.resolveRecent({ tasks: stale });
+    await flushAsync();
+
+    expect(createBackgroundTasksProps(refresh.host, { presented: false }).tasks).toBeNull();
+    expect(refresh.request).toHaveBeenCalledTimes(2);
+
+    createBackgroundTasksProps(refresh.host);
+    await flushAsync();
+
+    expect(createBackgroundTasksProps(refresh.host).tasks?.map((task) => task.id)).toEqual([
+      "task-after-restore",
+    ]);
+    expect(refresh.request).toHaveBeenCalledTimes(4);
+  });
+
   it("preserves all ten unopened task completions after both stale pages resolve", async () => {
     const tasks = Array.from({ length: 10 }, (_, index) => makeTask({ id: `task-${index}` }));
     const refresh = await refreshingHost(tasks);

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -540,6 +540,7 @@ export function createBackgroundTasksProps(
     narrowLayout?: boolean;
     openTaskId?: string;
     onOpenTaskDetail?: (task: TaskSummary) => void;
+    presented?: boolean;
   } = {},
 ): BackgroundTasksProps {
   const state = getBackgroundTasksState(host);
@@ -551,6 +552,7 @@ export function createBackgroundTasksProps(
   // Load eagerly even while collapsed: the toggle badge is how running work
   // gets detected at all, so it cannot wait for the rail to be opened first.
   if (
+    opts.presented !== false &&
     host.connected &&
     !state.loading &&
     !state.error &&

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -345,7 +345,11 @@ function bufferBackgroundTaskEvent(
 
 /** Apply a gateway `task` event to the pane's snapshot. Events for other
  * sessions are ignored; a registry restore forces a refetch. */
-export function handleBackgroundTasksEvent(host: BackgroundTasksHost, payload: unknown) {
+export function handleBackgroundTasksEvent(
+  host: BackgroundTasksHost,
+  payload: unknown,
+  presented = true,
+) {
   const state = host.backgroundTasksState;
   if (
     !state ||
@@ -373,10 +377,23 @@ export function handleBackgroundTasksEvent(host: BackgroundTasksHost, payload: u
         }
       : normalizedEvent;
   const bufferedEvent = bufferBackgroundTaskEvent(host, state, event);
+  if (event.action === "restored" && !presented) {
+    // Restore replaces the registry snapshot. Retire any older page without
+    // issuing hidden work; presentation will start the authoritative reload.
+    state.requestId += 1;
+    state.pendingTaskEvents = null;
+    state.pendingReload = false;
+    state.loading = false;
+    state.tasks = null;
+    state.loadedClient = null;
+    state.error = null;
+    host.requestUpdate?.();
+    return;
+  }
   if (state.tasks === null) {
     // The exact in-flight snapshot already replays its buffered events; a
     // redundant stale reload would immediately undo that initial-load replay.
-    if (!bufferedEvent) {
+    if (presented && !bufferedEvent) {
       loadBackgroundTasks(host, state, true);
     }
     return;

--- a/ui/src/pages/chat/components/chat-session-workspace-state.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace-state.ts
@@ -208,7 +208,7 @@ export function refreshSessionWorkspaceState(state: SessionWorkspaceHost): boole
 }
 
 /** Retire facts owned by one checkout without disturbing panel layout or retained drafts. */
-export function retireSessionWorkspaceCheckout(state: SessionWorkspaceHost) {
+export function retireSessionWorkspaceCheckout(state: SessionWorkspaceHost, presented = true) {
   const current = state.sessionWorkspaceState;
   if (!current || current.sessionKey !== state.sessionKey) {
     return;
@@ -217,7 +217,7 @@ export function retireSessionWorkspaceCheckout(state: SessionWorkspaceHost) {
   clearWorkspaceTimer(current);
   const next = createSessionWorkspaceState(state, current);
   state.sessionWorkspaceState = next;
-  if (state.client && state.connected) {
+  if (presented && state.client && state.connected) {
     loadSessionWorkspace(state, next);
   }
   requestWorkspaceUpdate(state);

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -433,13 +433,19 @@ function openArtifact(
 
 export function createSessionWorkspaceProps(
   state: SessionWorkspaceHost,
-  options?: { narrowLayout?: boolean; draftScope?: string; expanded?: boolean },
+  options?: {
+    narrowLayout?: boolean;
+    draftScope?: string;
+    expanded?: boolean;
+    presented?: boolean;
+  },
 ): SessionWorkspaceProps {
   state.sessionWorkspaceDraftScope = options?.draftScope;
   const workspace = getSessionWorkspace(state);
   if (
     // The collapsed header still renders the diff action, so load its checkout
     // capability eagerly instead of waiting for the file rail to open.
+    options?.presented !== false &&
     (options?.expanded === true ||
       !workspace.collapsed ||
       isGatewayMethodAdvertised(state, "sessions.diff") === true) &&


### PR DESCRIPTION
Closes #127820

## What Problem This Solves

Fixes an issue where users switching among retained chat sessions caused hidden panes to refetch task and workspace snapshots after every Gateway reconnect. The unnecessary requests scale with retained sessions and add avoidable Gateway load.

## Why This Change Was Made

Snapshot hydration now follows pane presentation. Hidden retained panes stay mounted and continue receiving live events, but defer tasks, workspace, and swarm hydration until they are presented again; hiding also retires an armed swarm hydration attempt.

## User Impact

Session switching stays warm while reconnects no longer trigger hidden-pane fetch bursts. Returning to a retained session hydrates its current task and workspace state on demand.

## Evidence

Test environment: Blacksmith Testbox, `tbx_01m0mag64fbpmb1jmpfpft85yp`, source SHA `36d50b20098e8e45bc7a97b020d9755ab7a27414`.

Remote run: https://github.com/openclaw/openclaw/actions/runs/32563244041

| Session state | Before, 5 rounds (RPCs/round) | Median (IQR) | After, 5 rounds (RPCs/round) | Median (IQR) |
| --- | --- | --- | --- | --- |
| Hidden retained A | 2, 2, 2, 2, 2 | 2 (0) | 0, 0, 0, 0, 0 | 0 (0) |
| Hidden retained B | 2, 2, 2, 2, 2 | 2 (0) | 0, 0, 0, 0, 0 | 0 (0) |
| Presented C | 4, 4, 4, 4, 4 | 4 (0) | 4, 4, 4, 4, 4 | 4 (0) |

Pre-fix regression failure:

```text
Expected hidden retained sessions: 0 RPCs
Received hidden retained sessions: 2 RPCs each in all five rounds
```

Validation:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-retained-pane-hydration.e2e.test.ts`
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-background-tasks.test.ts ui/src/pages/chat/components/chat-session-workspace.test.ts ui/src/pages/chat/chat-pane-lifecycle.test.ts ui/src/pages/chat/chat-page-retained-sessions.test.ts`
- `node scripts/check-changed.mjs -- <changed files>`

Production LOC: +20/-5 (net +15). Tests: +114/-0. Growth carries the existing `presented` lifecycle fact into the three snapshot owners and adds no new compatibility path.

Autoreview gap: Codex `gpt-5.6-sol` failed twice before returning structured output; Claude CLI was unavailable. No review findings were produced. Focused tests, changed gates, and remote A/B are green.
