### PR TITLE
improve(line): reduce text-only inbound processing

### DIFF
--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -18,6 +18,16 @@ import { buildLineMessageContext, buildLinePostbackContext } from "./bot-message
 import type { ResolvedLineAccount } from "./types.js";
 
 const logVerboseMock = vi.hoisted(() => vi.fn());
+const toInboundMediaFactsWithMetadataMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  toInboundMediaFactsWithMetadataMock.mockImplementation(actual.toInboundMediaFactsWithMetadata);
+  return {
+    ...actual,
+    toInboundMediaFactsWithMetadata: toInboundMediaFactsWithMetadataMock,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
@@ -89,6 +99,7 @@ describe("buildLineMessageContext", () => {
 
   beforeEach(async () => {
     logVerboseMock.mockClear();
+    toInboundMediaFactsWithMetadataMock.mockClear();
     setActivePluginRegistry(
       createTestRegistry([
         {
@@ -127,6 +138,21 @@ describe("buildLineMessageContext", () => {
 
     expect(context?.ctxPayload.OriginatingTo).toBe("line:group:group-1");
     expect(context?.ctxPayload.To).toBe("line:group:group-1");
+  });
+
+  it("skips media metadata projection for text-only messages", async () => {
+    const event = createMessageEvent({ type: "user", userId: "user-1" });
+
+    const context = await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: true,
+    });
+
+    expect(context?.ctxPayload.media).toEqual([]);
+    expect(toInboundMediaFactsWithMetadataMock).not.toHaveBeenCalled();
   });
 
   it("passes the caller-provided inbound history through to the context payload", async () => {

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -296,7 +296,8 @@ async function finalizeLineInboundContext(params: {
   });
 
   const agentBody = params.agentBody ?? params.rawBody;
-  const media = await toInboundMediaFactsWithMetadata(params.media);
+  const media =
+    params.media.length === 0 ? [] : await toInboundMediaFactsWithMetadata(params.media);
   const body = formatInboundEnvelope({
     channel: "LINE",
     from: conversationLabel,


### PR DESCRIPTION
## What Problem This Solves

Ordinary text-only LINE inbound messages entered the full asynchronous media metadata projector even after the LINE owner had established that the prepared media-input array was empty. Each message therefore paid avoidable normalization, scheduling, and Promise work before producing the same empty media facts.

## Why This Change Was Made

The LINE context finalizer now returns an empty media-facts array directly when its prepared media input is empty. Every nonempty attachment path still invokes the existing shared metadata projector unchanged, so attachment metadata and failure behavior keep their existing owner and semantics. This PR was AI-assisted.

## User Impact

Text-only LINE inbound messages require less local projection work. There is no user-visible message, routing, authorization, persistence, or protocol change.

## Evidence

- Exact-current pre-fix proof on `3ae680f7143336e6918f8819163a3cbf21882e92`: applying only the final owner regression failed because one text-only message called `toInboundMediaFactsWithMetadata([])` once; the exact candidate passes with zero calls and the same empty media payload.
- Exact committed head: all 35 LINE test files / 523 tests passed, including ordinary routing/context, nonempty media, failed-media fallback, webhook spool, monitor, and delivery coverage.
- Shared inbound owners: `src/channels/inbound-event/media.test.ts` and `context.test.ts` passed all 104 tests.
- `node scripts/check-changed.mjs -- extensions/line/src/bot-message-context.ts extensions/line/src/bot-message-context.test.ts` passed formatting, extension production/test typechecks, lint, dead exports, cycles, boundaries, and repository policy guards; `git diff --check` passed.
- Owner microbenchmark (same exact owner diff, Node 26.5.1; 12 rounds × 150,000 empty projections) improved median wall time from 77.539 ms to 0.934 ms (98.79%) and median CPU from 82.579 ms to 2.849 ms (96.55%), while Promise resources fell from 4,003 to 3 per 1,000 calls. This isolates projection cost rather than claiming end-to-end provider latency.
- The source lane's exact patch passed the full build. This current-main integration changes no imports, bundles, generated output, packaging, or published surface; hosted exact-head CI covers the fresh integration build.
- Fresh exact-head Codex `gpt-5.6-sol` / high autoreview plus TruffleHog returned no accepted/actionable findings with 0.99 confidence.
- No live LINE service was needed: the change is an internal empty-array no-op bypass with deterministic owner-boundary red/green proof and unchanged nonempty/error sibling coverage.
