### PR TITLE
perf(ui): stop rescanning the whole snapshot cache on every write

### DIFF
--- a/ui/src/e2e/chat-history-stale-geometry.e2e.test.ts
+++ b/ui/src/e2e/chat-history-stale-geometry.e2e.test.ts
@@ -4,7 +4,7 @@ import { expect, it } from "vitest";
 import {
   CHAT_SNAPSHOT_DB_NAME,
   CHAT_SNAPSHOT_STORE_NAME,
-} from "../pages/chat/session-snapshot-invalidation.ts";
+} from "../pages/chat/session-snapshot-database.ts";
 import {
   createChatFlowE2eSuite,
   installMockGateway,

--- a/ui/src/pages/chat/session-snapshot-database.ts
+++ b/ui/src/pages/chat/session-snapshot-database.ts
@@ -1,9 +1,6 @@
-import {
-  CHAT_SNAPSHOT_DB_NAME,
-  CHAT_SNAPSHOT_METADATA_STORE_NAME,
-  CHAT_SNAPSHOT_STORE_NAME,
-} from "./session-snapshot-invalidation.ts";
-
+export const CHAT_SNAPSHOT_DB_NAME = "openclaw-chat-snapshots";
+export const CHAT_SNAPSHOT_STORE_NAME = "snapshots";
+export const CHAT_SNAPSHOT_METADATA_STORE_NAME = "snapshotMetadata";
 const CHAT_SNAPSHOT_DB_VERSION = 2;
 
 function debugSnapshotDatabase(message: string, error?: unknown): void {
@@ -103,5 +100,28 @@ export async function resetSessionSnapshotDatabase(database?: IDBDatabase | null
   const factory = indexedDbFactory();
   if (factory && !(await deleteIndexedDb(factory))) {
     debugSnapshotDatabase("IndexedDB cache reset was blocked");
+  }
+}
+
+export async function deleteSessionSnapshotDatabaseRecord(sessionKey: string): Promise<void> {
+  const database = await openSessionSnapshotDatabase();
+  if (!database) {
+    return;
+  }
+  try {
+    await new Promise<void>((resolve) => {
+      const transaction = database.transaction(
+        [CHAT_SNAPSHOT_STORE_NAME, CHAT_SNAPSHOT_METADATA_STORE_NAME],
+        "readwrite",
+      );
+      transaction.addEventListener("complete", () => resolve());
+      transaction.addEventListener("error", () => resolve());
+      transaction.addEventListener("abort", () => resolve());
+      transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).delete(sessionKey);
+      transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME).delete(sessionKey);
+    });
+  } catch {
+  } finally {
+    database.close();
   }
 }

--- a/ui/src/pages/chat/session-snapshot-database.ts
+++ b/ui/src/pages/chat/session-snapshot-database.ts
@@ -1,9 +1,10 @@
 import {
   CHAT_SNAPSHOT_DB_NAME,
+  CHAT_SNAPSHOT_METADATA_STORE_NAME,
   CHAT_SNAPSHOT_STORE_NAME,
 } from "./session-snapshot-invalidation.ts";
 
-const CHAT_SNAPSHOT_DB_VERSION = 1;
+const CHAT_SNAPSHOT_DB_VERSION = 2;
 
 function debugSnapshotDatabase(message: string, error?: unknown): void {
   if (error === undefined) {
@@ -31,6 +32,7 @@ function openIndexedDb(factory: IDBFactory): Promise<IDBDatabase> {
         database.deleteObjectStore(name);
       }
       database.createObjectStore(CHAT_SNAPSHOT_STORE_NAME, { keyPath: "sessionKey" });
+      database.createObjectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME, { keyPath: "sessionKey" });
     });
     request.addEventListener("success", () => resolve(request.result));
     request.addEventListener("error", () =>
@@ -75,8 +77,9 @@ export async function openSessionSnapshotDatabase(): Promise<IDBDatabase | null>
   }
   database.addEventListener("versionchange", () => database.close());
   if (
-    database.objectStoreNames.length === 1 &&
-    database.objectStoreNames.contains(CHAT_SNAPSHOT_STORE_NAME)
+    database.objectStoreNames.length === 2 &&
+    database.objectStoreNames.contains(CHAT_SNAPSHOT_STORE_NAME) &&
+    database.objectStoreNames.contains(CHAT_SNAPSHOT_METADATA_STORE_NAME)
   ) {
     return database;
   }

--- a/ui/src/pages/chat/session-snapshot-invalidation.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.ts
@@ -9,11 +9,11 @@ import {
   resolveUiSelectedGlobalAgentId,
   type UiSessionDefaultsHost,
 } from "../../lib/sessions/session-key.ts";
+import {
+  CHAT_SNAPSHOT_DB_NAME,
+  deleteSessionSnapshotDatabaseRecord,
+} from "./session-snapshot-database.ts";
 import { publishSnapshotInvalidation } from "./session-snapshot-invalidation-events.ts";
-
-export const CHAT_SNAPSHOT_DB_NAME = "openclaw-chat-snapshots";
-export const CHAT_SNAPSHOT_STORE_NAME = "snapshots";
-export const CHAT_SNAPSHOT_METADATA_STORE_NAME = "snapshotMetadata";
 
 type ChatSnapshotKeyHost = Pick<UiSessionDefaultsHost, "assistantAgentId" | "agentsList" | "hello">;
 
@@ -59,44 +59,7 @@ function indexedDbFactory(): IDBFactory | null {
 
 export async function deleteStoredChatSnapshot(sessionKey: string): Promise<void> {
   await publishSnapshotInvalidation({ sessionKey });
-  const factory = indexedDbFactory();
-  if (!factory) {
-    return;
-  }
-  try {
-    await new Promise<void>((resolve) => {
-      const request = factory.open(CHAT_SNAPSHOT_DB_NAME);
-      request.addEventListener("error", () => resolve());
-      request.addEventListener("blocked", () => resolve());
-      request.addEventListener("success", () => {
-        const database = request.result;
-        if (
-          !database.objectStoreNames.contains(CHAT_SNAPSHOT_STORE_NAME) ||
-          !database.objectStoreNames.contains(CHAT_SNAPSHOT_METADATA_STORE_NAME)
-        ) {
-          database.close();
-          resolve();
-          return;
-        }
-        const transaction = database.transaction(
-          [CHAT_SNAPSHOT_STORE_NAME, CHAT_SNAPSHOT_METADATA_STORE_NAME],
-          "readwrite",
-        );
-        transaction.addEventListener("complete", () => {
-          database.close();
-          resolve();
-        });
-        const settleFailure = () => {
-          database.close();
-          resolve();
-        };
-        transaction.addEventListener("error", settleFailure);
-        transaction.addEventListener("abort", settleFailure);
-        transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).delete(sessionKey);
-        transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME).delete(sessionKey);
-      });
-    });
-  } catch {}
+  await deleteSessionSnapshotDatabaseRecord(sessionKey);
 }
 
 export async function clearStoredChatSnapshotStorage(): Promise<void> {

--- a/ui/src/pages/chat/session-snapshot-invalidation.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation.ts
@@ -13,6 +13,7 @@ import { publishSnapshotInvalidation } from "./session-snapshot-invalidation-eve
 
 export const CHAT_SNAPSHOT_DB_NAME = "openclaw-chat-snapshots";
 export const CHAT_SNAPSHOT_STORE_NAME = "snapshots";
+export const CHAT_SNAPSHOT_METADATA_STORE_NAME = "snapshotMetadata";
 
 type ChatSnapshotKeyHost = Pick<UiSessionDefaultsHost, "assistantAgentId" | "agentsList" | "hello">;
 
@@ -69,12 +70,18 @@ export async function deleteStoredChatSnapshot(sessionKey: string): Promise<void
       request.addEventListener("blocked", () => resolve());
       request.addEventListener("success", () => {
         const database = request.result;
-        if (!database.objectStoreNames.contains(CHAT_SNAPSHOT_STORE_NAME)) {
+        if (
+          !database.objectStoreNames.contains(CHAT_SNAPSHOT_STORE_NAME) ||
+          !database.objectStoreNames.contains(CHAT_SNAPSHOT_METADATA_STORE_NAME)
+        ) {
           database.close();
           resolve();
           return;
         }
-        const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readwrite");
+        const transaction = database.transaction(
+          [CHAT_SNAPSHOT_STORE_NAME, CHAT_SNAPSHOT_METADATA_STORE_NAME],
+          "readwrite",
+        );
         transaction.addEventListener("complete", () => {
           database.close();
           resolve();
@@ -86,6 +93,7 @@ export async function deleteStoredChatSnapshot(sessionKey: string): Promise<void
         transaction.addEventListener("error", settleFailure);
         transaction.addEventListener("abort", settleFailure);
         transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).delete(sessionKey);
+        transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME).delete(sessionKey);
       });
     });
   } catch {}

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -14,8 +14,8 @@ import {
   CHAT_SNAPSHOT_DB_NAME,
   CHAT_SNAPSHOT_METADATA_STORE_NAME,
   CHAT_SNAPSHOT_STORE_NAME,
-  clearStoredChatSnapshots,
-} from "./session-snapshot-invalidation.ts";
+} from "./session-snapshot-database.ts";
+import { clearStoredChatSnapshots } from "./session-snapshot-invalidation.ts";
 import { SessionSnapshotStore } from "./session-snapshot-store.ts";
 
 function snapshot(message: unknown, sessionId = "session-1"): ChatSessionSnapshot {
@@ -55,6 +55,24 @@ async function putRawRecord(record: unknown): Promise<void> {
     sessionKey: (record as { sessionKey: string }).sessionKey,
     weight: 0,
   });
+  await completed;
+  database.close();
+}
+
+async function putVersionOneRecord(sessionKey: string): Promise<void> {
+  const request = indexedDB.open(CHAT_SNAPSHOT_DB_NAME, 1);
+  request.addEventListener("upgradeneeded", () => {
+    request.result.createObjectStore(CHAT_SNAPSHOT_STORE_NAME, { keyPath: "sessionKey" });
+  });
+  const database = await new Promise<IDBDatabase>((resolve, reject) => {
+    request.addEventListener("success", () => resolve(request.result));
+    request.addEventListener("error", () =>
+      reject(request.error ?? new Error("database open failed")),
+    );
+  });
+  const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readwrite");
+  const completed = transactionDone(transaction);
+  transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).put({ sessionKey });
   await completed;
   database.close();
 }
@@ -294,6 +312,47 @@ describe("persistent chat session snapshots", () => {
     const reader = new SessionSnapshotStore();
     expect(await reader.read("agent:main:deleted")).toBeNull();
     expect(await reader.read("agent:main:retained")).not.toBeNull();
+  });
+
+  it("upgrades a version one database before deleting an invalidated snapshot", async () => {
+    const sessionKey = "agent:main:legacy-delete";
+    await putVersionOneRecord(sessionKey);
+
+    await new SessionSnapshotStore().delete(sessionKey);
+
+    const request = indexedDB.open(CHAT_SNAPSHOT_DB_NAME);
+    const database = await new Promise<IDBDatabase>((resolve, reject) => {
+      request.addEventListener("success", () => resolve(request.result));
+      request.addEventListener("error", () =>
+        reject(request.error ?? new Error("database open failed")),
+      );
+    });
+    expect(database.version).toBe(2);
+    expect(Array.from(database.objectStoreNames)).toEqual([
+      CHAT_SNAPSHOT_METADATA_STORE_NAME,
+      CHAT_SNAPSHOT_STORE_NAME,
+    ]);
+    const transaction = database.transaction(
+      [CHAT_SNAPSHOT_STORE_NAME, CHAT_SNAPSHOT_METADATA_STORE_NAME],
+      "readonly",
+    );
+    const snapshotRequest = transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).get(sessionKey);
+    const metadataRequest = transaction
+      .objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME)
+      .get(sessionKey);
+    const completed = transactionDone(transaction);
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        snapshotRequest.addEventListener("success", () => resolve());
+      }),
+      new Promise<void>((resolve) => {
+        metadataRequest.addEventListener("success", () => resolve());
+      }),
+      completed,
+    ]);
+    expect(snapshotRequest.result).toBeUndefined();
+    expect(metadataRequest.result).toBeUndefined();
+    database.close();
   });
 
   it("broadcasts invalidation and clears active memory for a peer-tab signal", async () => {

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./session-message-cache.ts";
 import {
   CHAT_SNAPSHOT_DB_NAME,
+  CHAT_SNAPSHOT_METADATA_STORE_NAME,
   CHAT_SNAPSHOT_STORE_NAME,
   clearStoredChatSnapshots,
 } from "./session-snapshot-invalidation.ts";
@@ -43,9 +44,17 @@ async function putRawRecord(record: unknown): Promise<void> {
       reject(request.error ?? new Error("database open failed")),
     );
   });
-  const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readwrite");
+  const transaction = database.transaction(
+    [CHAT_SNAPSHOT_STORE_NAME, CHAT_SNAPSHOT_METADATA_STORE_NAME],
+    "readwrite",
+  );
   const completed = transactionDone(transaction);
   transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).put(record);
+  transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME).put({
+    savedAt: Date.now(),
+    sessionKey: (record as { sessionKey: string }).sessionKey,
+    weight: 0,
+  });
   await completed;
   database.close();
 }
@@ -64,6 +73,29 @@ async function readRawRecord(sessionKey: string): Promise<{ savedAt: number } | 
     get.addEventListener("success", () => resolve(get.result));
     get.addEventListener("error", () => reject(get.error ?? new Error("record read failed")));
   });
+  await transactionDone(transaction);
+  database.close();
+  return result;
+}
+
+async function readRawMetadata(
+  sessionKey: string,
+): Promise<{ savedAt: number; weight: number } | undefined> {
+  const request = indexedDB.open(CHAT_SNAPSHOT_DB_NAME);
+  const database = await new Promise<IDBDatabase>((resolve, reject) => {
+    request.addEventListener("success", () => resolve(request.result));
+    request.addEventListener("error", () =>
+      reject(request.error ?? new Error("database open failed")),
+    );
+  });
+  const transaction = database.transaction(CHAT_SNAPSHOT_METADATA_STORE_NAME, "readonly");
+  const result = await new Promise<{ savedAt: number; weight: number } | undefined>(
+    (resolve, reject) => {
+      const get = transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME).get(sessionKey);
+      get.addEventListener("success", () => resolve(get.result));
+      get.addEventListener("error", () => reject(get.error ?? new Error("metadata read failed")));
+    },
+  );
   await transactionDone(transaction);
   database.close();
   return result;
@@ -93,6 +125,21 @@ describe("persistent chat session snapshots", () => {
     await reader.loadSavedAtIndex();
     expect(await reader.read("agent:main:shared")).toEqual(snapshot({ text: "cached" }));
     expect(reader.readSavedAt("agent:main:shared")).toBe(savedAt);
+  });
+
+  it("keeps lightweight eviction metadata alongside each snapshot", async () => {
+    const sessionKey = "agent:main:metadata";
+    const writer = new SessionSnapshotStore();
+    writer.write(sessionKey, snapshot("cached"));
+    await writer.flush();
+
+    const record = await readRawRecord(sessionKey);
+    const metadata = await readRawMetadata(sessionKey);
+    expect(metadata?.savedAt).toBe(record?.savedAt);
+    expect(metadata?.weight).toBeGreaterThan(0);
+
+    await writer.delete(sessionKey);
+    expect(await readRawMetadata(sessionKey)).toBeUndefined();
   });
 
   it("round-trips the optional history delta cursor", async () => {

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -12,15 +12,13 @@ import {
   type ChatSessionSnapshot,
 } from "./session-message-cache.ts";
 import {
+  CHAT_SNAPSHOT_METADATA_STORE_NAME,
+  CHAT_SNAPSHOT_STORE_NAME,
   openSessionSnapshotDatabase,
   resetSessionSnapshotDatabase,
 } from "./session-snapshot-database.ts";
 import { subscribeSnapshotInvalidation } from "./session-snapshot-invalidation-events.ts";
-import {
-  CHAT_SNAPSHOT_STORE_NAME,
-  CHAT_SNAPSHOT_METADATA_STORE_NAME,
-  deleteStoredChatSnapshot,
-} from "./session-snapshot-invalidation.ts";
+import { deleteStoredChatSnapshot } from "./session-snapshot-invalidation.ts";
 const CHAT_SNAPSHOT_WRITE_DELAY_MS = 500;
 
 const paginationSchema = z.discriminatedUnion("hasMore", [

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -18,6 +18,7 @@ import {
 import { subscribeSnapshotInvalidation } from "./session-snapshot-invalidation-events.ts";
 import {
   CHAT_SNAPSHOT_STORE_NAME,
+  CHAT_SNAPSHOT_METADATA_STORE_NAME,
   deleteStoredChatSnapshot,
 } from "./session-snapshot-invalidation.ts";
 const CHAT_SNAPSHOT_WRITE_DELAY_MS = 500;
@@ -60,6 +61,14 @@ const recordSchema = z
   .refine((record) => record.sessionId === record.snapshot.sessionId);
 
 type SessionSnapshotRecord = z.infer<typeof recordSchema>;
+const metadataSchema = z
+  .object({
+    savedAt: z.number().finite().nonnegative(),
+    sessionKey: z.string().min(1),
+    weight: z.number().finite().nonnegative(),
+  })
+  .strict();
+type SessionSnapshotMetadata = z.infer<typeof metadataSchema>;
 type PendingSessionState = {
   savedAt: number;
   snapshot: ChatSessionSnapshot;
@@ -217,35 +226,43 @@ async function writeSnapshotRecords(
     return [];
   }
   try {
-    const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readwrite");
-    const store = transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME);
-    const currentValues = await requestResult(store.getAll());
-    const next = new Map<string, SessionSnapshotRecord>();
+    const transaction = database.transaction(
+      [CHAT_SNAPSHOT_STORE_NAME, CHAT_SNAPSHOT_METADATA_STORE_NAME],
+      "readwrite",
+    );
+    const snapshotStore = transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME);
+    const metadataStore = transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME);
+    const currentValues = await requestResult(metadataStore.getAll());
+    const next = new Map<string, SessionSnapshotMetadata>();
     for (const value of currentValues) {
-      const record = parseSnapshotRecord(value);
-      if (!record) {
+      const metadata = metadataSchema.safeParse(value);
+      if (!metadata.success) {
         transaction.abort();
-        throw new Error("IndexedDB record shape mismatch");
+        throw new Error("IndexedDB metadata shape mismatch");
       }
-      next.set(record.sessionKey, record);
+      next.set(metadata.data.sessionKey, metadata.data);
     }
     for (const record of records) {
-      next.set(record.sessionKey, record);
-      store.put(record);
+      const metadata = {
+        savedAt: record.savedAt,
+        sessionKey: record.sessionKey,
+        weight: measureStoredRecordWeight(record),
+      } satisfies SessionSnapshotMetadata;
+      next.set(record.sessionKey, metadata);
+      snapshotStore.put(record);
+      metadataStore.put(metadata);
     }
     const oldestFirst = [...next.values()].toSorted((left, right) => left.savedAt - right.savedAt);
-    let totalWeight = oldestFirst.reduce(
-      (sum, record) => sum + measureStoredRecordWeight(record),
-      0,
-    );
+    let totalWeight = oldestFirst.reduce((sum, metadata) => sum + metadata.weight, 0);
     const evicted: string[] = [];
     while (oldestFirst.length > MAX_CACHED_CHAT_SESSIONS || totalWeight > MAX_CACHED_CHAT_WEIGHT) {
       const oldest = oldestFirst.shift();
       if (!oldest) {
         break;
       }
-      totalWeight -= measureStoredRecordWeight(oldest);
-      store.delete(oldest.sessionKey);
+      totalWeight -= oldest.weight;
+      snapshotStore.delete(oldest.sessionKey);
+      metadataStore.delete(oldest.sessionKey);
       evicted.push(oldest.sessionKey);
     }
     await transactionDone(transaction);


### PR DESCRIPTION
## What Problem This Solves

Closes #127828

Fixes an issue where active long chat sessions could drop frames when the persistent snapshot cache was near its 24 MB limit. Each debounced update cloned, parsed, sorted, and remeasured every stored transcript before writing one changed session.

## Why This Change Was Made

Snapshot weight and age now live in a lightweight IndexedDB metadata store written atomically with each snapshot. Eviction scans only those small records while preserving the existing count, weight, oldest-first, invalidation, and best-effort cache behavior; the disposable cache is rebuilt by the IndexedDB version upgrade.

## User Impact

Snapshot flushes in a filled cache no longer consume more than a frame on the measured path. The exact-SHA A/B reduced median latency from 21.1 ms to 2.5 ms.

## Evidence

Same Chromium, SHA, Testbox, fixture, and five-round protocol:

| Metric across 5 rounds | Before | After | Change |
| --- | ---: | ---: | ---: |
| Median of round medians | 21.1 ms | 2.5 ms | -88% |
| IQR of round medians | 19.9-21.7 ms | 2.4-2.5 ms | narrower |
| Median of round p95 | 26.7 ms | 2.9 ms | -89% |

Provenance: `{sha: 1cc7dd2083a0dd549ddc30023e56580b021bc4be, provider: blacksmith-testbox, boxId: tbx_01m0magfv6e9a4rv61kx1g7gjw}`

Run: https://app.blacksmith.sh/testbox/tbx_01m0magfv6e9a4rv61kx1g7gjw

Regression before the fix: `pnpm test ui/src/pages/chat/session-snapshot-store.test.ts` failed because the metadata store did not exist. After the fix: 12 snapshot-store tests and 41 sibling snapshot/pane tests passed. `pnpm check:changed` passed before the final rebase; the focused 53-test suite passed again after rebase.

Production LOC: +49/-21 (net +28). Test LOC: +48/-1. The production growth establishes the metadata ownership boundary that removes repeated 24 MB payload scans while preserving exact eviction and cross-tab deletion semantics.
