### PR TITLE
refactor(ui): count background tasks in one place

### DIFF
--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -27,7 +27,6 @@ import {
   canDeleteSessionRows,
   resolveUiConfiguredMainKey,
 } from "../../lib/sessions/session-key.ts";
-import { isActiveTask } from "../../lib/tasks/data.ts";
 import { renderBoardViewSwitch } from "./board-session-surface.ts";
 import { displayedChatSessionBranches } from "./chat-history.ts";
 import { ChatPaneDiscussion } from "./chat-pane-discussion.ts";
@@ -355,7 +354,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
         ),
         icon: icons.listChecks,
         active: !backgroundTasks.collapsed,
-        badge: backgroundTasks.tasks?.filter(isActiveTask).length ?? 0,
+        badge: backgroundTasks.activeCount,
         onActivate: backgroundTasks.onToggleCollapsed,
       });
     }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -843,6 +843,7 @@ function createBackgroundTasks(
     loading: false,
     error: null,
     tasks: [],
+    activeCount: 0,
     subagentActivity: {
       rows: [],
       overflowWorking: 0,

--- a/ui/src/pages/chat/components/chat-background-tasks-render.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-render.ts
@@ -4,7 +4,7 @@ import { icons } from "../../../components/icons.ts";
 import { renderPanelEmptyState } from "../../../components/panel-empty-state.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
-import { isActiveTask, partitionTasks } from "../../../lib/tasks/data.ts";
+import { partitionTasks } from "../../../lib/tasks/data.ts";
 import type { TaskSummary } from "../../../lib/tasks/task-summary.ts";
 import { renderTaskRow } from "./chat-background-task-row.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
@@ -17,7 +17,6 @@ export function renderBackgroundTasksToggle(
   }
   const expanded = !backgroundTasks.collapsed;
   const label = t(expanded ? "chat.backgroundTasks.collapse" : "chat.backgroundTasks.show");
-  const activeCount = backgroundTasks.tasks?.filter(isActiveTask).length ?? 0;
   return html`<openclaw-tooltip .content=${label}>
     <button
       class="btn btn--ghost btn--icon chat-icon-btn chat-tasks-toggle"
@@ -27,8 +26,10 @@ export function renderBackgroundTasksToggle(
       @click=${backgroundTasks.onToggleCollapsed}
     >
       ${icons.listChecks}
-      ${!expanded && activeCount > 0
-        ? html`<span class="chat-tasks-toggle__badge" aria-hidden="true">${activeCount}</span>`
+      ${!expanded && backgroundTasks.activeCount > 0
+        ? html`<span class="chat-tasks-toggle__badge" aria-hidden="true"
+            >${backgroundTasks.activeCount}</span
+          >`
         : nothing}
     </button>
   </openclaw-tooltip>`;

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -72,6 +72,7 @@ function makeProps(overrides: Partial<BackgroundTasksProps> = {}): BackgroundTas
     loading: false,
     error: null,
     tasks: null,
+    activeCount: 0,
     subagentActivity: deriveSubagentActivity({
       tasks: [],
       sessionKey: "agent:main:current",
@@ -171,6 +172,7 @@ describe("background tasks rail state", () => {
     expect(props.finishedCollapsed).toBe(true);
     expect(request).toHaveBeenCalledTimes(2);
     expect(props.tasks?.map((task) => task.id)).toEqual(["task-1"]);
+    expect(props.activeCount).toBe(1);
   });
 
   it("keeps the later recent page's equally current running progress", async () => {

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -579,6 +579,7 @@ export function createBackgroundTasksProps(
     loading: state.loading,
     error: state.error,
     tasks: state.tasks,
+    activeCount: state.tasks?.filter(isActiveTask).length ?? 0,
     subagentActivity,
     openTaskId: opts.openTaskId,
     taskDetails: state.taskDetails,

--- a/ui/src/pages/chat/components/chat-background-tasks.types.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.types.ts
@@ -5,15 +5,14 @@ export type BackgroundTasksProps = {
   sessionKey: string;
   statusRowId: string;
   collapsed: boolean;
-  /** Pane too narrow for a side rail: presentation moves to a bottom strip
-   * (mirrors the workspace rail's narrow mode). */
+  /** Narrow panes move the rail to a bottom strip. */
   narrowLayout: boolean;
   connected: boolean;
   canCancel: boolean;
   loading: boolean;
   error: string | null;
-  /** null until the first load for this session finished. */
   tasks: TaskSummary[] | null;
+  activeCount: number;
   subagentActivity: SubagentActivityPresentation;
   openTaskId?: string;
   taskDetails: ReadonlyMap<string, TaskSummary>;

--- a/ui/src/pages/chat/components/chat-subagent-activity.test.ts
+++ b/ui/src/pages/chat/components/chat-subagent-activity.test.ts
@@ -39,6 +39,7 @@ function makeProps(overrides: Partial<BackgroundTasksProps>): BackgroundTasksPro
     loading: false,
     error: null,
     tasks: [],
+    activeCount: 0,
     subagentActivity: deriveSubagentActivity({
       tasks: [],
       sessionKey: "agent:main:current",

--- a/ui/src/pages/chat/components/chat-task-detail-state.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail-state.test.ts
@@ -68,6 +68,7 @@ function backgroundTasks(selectedTask: TaskSummary): BackgroundTasksProps {
     loading: false,
     error: null,
     tasks: [selectedTask],
+    activeCount: selectedTask.status === "queued" || selectedTask.status === "running" ? 1 : 0,
     subagentActivity: {
       rows: [],
       overflowWorking: 0,

--- a/ui/src/pages/chat/components/chat-task-detail.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail.test.ts
@@ -20,6 +20,7 @@ function backgroundTasks(task: TaskSummary): BackgroundTasksProps {
     loading: false,
     error: null,
     tasks: [task],
+    activeCount: task.status === "queued" || task.status === "running" ? 1 : 0,
     subagentActivity: deriveSubagentActivity({
       tasks: [],
       sessionKey: "agent:main:main",


### PR DESCRIPTION
## What Problem This Solves

Closes #127829

The Chat header and background-task toggle each filtered the same task snapshot to derive the same active count on every pane render. Measurement found the cost below the performance threshold, but confirmed redundant work and duplicated presentation policy.

## Why This Change Was Made

The background-task owner now computes `activeCount` once when it builds the pane props. Both consumers read that canonical value; task grouping and status-row behavior remain unchanged.

## User Impact

No visible behavior changes. Header and toggle badges remain identical while duplicate active-task scans are removed.

## Evidence

Five remote Chromium rounds:

| Scenario | 1 pane p95 | 4 panes p95 | Verdict |
| --- | ---: | ---: | --- |
| Realistic: 70 tasks, 50 sessions | 0.1-0.2 ms | 0.2 ms | Below perf gate; redundancy confirmed |
| Bounded stress: 300 tasks, 300 sessions | 0.2-0.3 ms | 0.7 ms | Below perf gate; redundancy confirmed |

Provenance: `{sha: 36d50b20098e8e45bc7a97b020d9755ab7a27414, provider: blacksmith-testbox, boxId: tbx_01m0magfv6e9a4rv61kx1g7gjw}`

Run: https://app.blacksmith.sh/testbox/tbx_01m0magfv6e9a4rv61kx1g7gjw

Validation: 303 focused Chat/background-task tests passed, including one canonical active count feeding both badge outputs; `pnpm check:changed` passed. The 303-test suite passed again after rebase.

Production LOC: +8/-8 (net 0). Tests: +6/-0.
