### PR TITLE
perf(tui): stop blocking the editor on every path autocomplete keystroke

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -1,12 +1,16 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FileLockOptions } from "../../infra/file-lock.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 const extractArchiveMock = vi.hoisted(() => vi.fn());
+const withFileLockMock = vi.hoisted(() =>
+  vi.fn(async (_path: string, _options: FileLockOptions, fn: () => Promise<unknown>) => fn()),
+);
 
 vi.mock("../../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
@@ -21,6 +25,10 @@ vi.mock("../../infra/archive.js", () => ({
   extractArchive: extractArchiveMock,
 }));
 
+vi.mock("../../infra/file-lock.js", () => ({
+  withFileLock: withFileLockMock,
+}));
+
 let originalAgentDir: string | undefined;
 let tempAgentDir: string | undefined;
 
@@ -30,6 +38,11 @@ beforeEach(() => {
   setTestEnvValue("OPENCLAW_AGENT_DIR", tempAgentDir);
   fetchWithSsrFGuardMock.mockReset();
   extractArchiveMock.mockReset();
+  withFileLockMock
+    .mockReset()
+    .mockImplementation(
+      async (_path: string, _options: FileLockOptions, fn: () => Promise<unknown>) => fn(),
+    );
   spawnSyncMock.mockReturnValue({
     error: new Error("ENOENT"),
     status: null,
@@ -54,6 +67,80 @@ afterEach(() => {
 });
 
 describe("ensureTool", () => {
+  it("single-flights concurrent installs of the same tool", async () => {
+    const { ensureTool } = await import("./tools-manager.js");
+    const releaseCheckRelease = vi.fn(async () => {});
+    const downloadRelease = vi.fn(async () => {});
+    let resolveReleaseCheck!: (value: {
+      response: Response;
+      release: typeof releaseCheckRelease;
+      finalUrl: string;
+    }) => void;
+    const releaseCheck = new Promise<Parameters<typeof resolveReleaseCheck>[0]>((resolve) => {
+      resolveReleaseCheck = resolve;
+    });
+    extractArchiveMock.mockImplementation(async (params: { destDir: string }) => {
+      writeFileSync(join(params.destDir, "fd"), "binary");
+    });
+    fetchWithSsrFGuardMock.mockReturnValueOnce(releaseCheck).mockResolvedValueOnce({
+      response: new Response("archive-bytes", { status: 200 }),
+      release: downloadRelease,
+      finalUrl: "https://github.com/sharkdp/fd/releases/download/v10.3.0/archive.tar.gz",
+    });
+    withFileLockMock.mockImplementationOnce(
+      async (lockPath: string, _options: FileLockOptions, fn: () => Promise<unknown>) => {
+        expect(existsSync(dirname(lockPath))).toBe(true);
+        return fn();
+      },
+    );
+
+    const installs = [ensureTool("fd", true), ensureTool("fd", true)];
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+    resolveReleaseCheck({
+      response: new Response(JSON.stringify({ tag_name: "v10.3.0" }), { status: 200 }),
+      release: releaseCheckRelease,
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
+    await expect(Promise.all(installs)).resolves.toEqual([
+      join(tempAgentDir!, "bin", "fd"),
+      join(tempAgentDir!, "bin", "fd"),
+    ]);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+    expect(extractArchiveMock).toHaveBeenCalledOnce();
+    expect(withFileLockMock).toHaveBeenCalledOnce();
+    const lockOptions = withFileLockMock.mock.calls[0]?.[1];
+    if (!lockOptions) {
+      throw new Error("expected tool installation lock options");
+    }
+    const minimumLockWaitMs = Array.from({ length: lockOptions.retries.retries }, (_, attempt) =>
+      Math.min(
+        lockOptions.retries.maxTimeout,
+        Math.max(
+          lockOptions.retries.minTimeout,
+          lockOptions.retries.minTimeout * lockOptions.retries.factor ** attempt,
+        ),
+      ),
+    ).reduce((total, delay) => total + delay, 0);
+    expect(minimumLockWaitMs).toBeGreaterThan(lockOptions.stale);
+  });
+
+  it("reuses an installation published while waiting for the file lock", async () => {
+    const binaryPath = join(tempAgentDir!, "bin", "fd");
+    withFileLockMock.mockImplementationOnce(
+      async (_path: string, _options: FileLockOptions, fn: () => Promise<unknown>) => {
+        mkdirSync(join(tempAgentDir!, "bin"), { recursive: true });
+        writeFileSync(binaryPath, "binary");
+        return fn();
+      },
+    );
+    const { ensureTool } = await import("./tools-manager.js");
+
+    await expect(ensureTool("fd", true)).resolves.toBe(binaryPath);
+
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
   it("treats trimmed on as the canonical offline opt-in", async () => {
     vi.stubEnv("OPENCLAW_OFFLINE", " ON ");
     const { ensureTool } = await import("./tools-manager.js");
@@ -135,7 +222,7 @@ describe("ensureTool", () => {
     expect(extractArchiveMock).toHaveBeenCalledWith(
       expect.objectContaining({
         archivePath: expect.stringContaining(".zip"),
-        destDir: expect.stringContaining("extract_tmp_rg_"),
+        destDir: expect.stringMatching(/install_tmp_rg_.+[\\/]extract$/),
         timeoutMs: 60_000,
         limits: {
           maxArchiveBytes: 100 * 1024 * 1024,

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -22,6 +22,7 @@ import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import chalk from "chalk";
 import { extractArchive } from "../../infra/archive.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
+import { type FileLockOptions, withFileLock } from "../../infra/file-lock.js";
 import { cancelUnreadResponseBody } from "../../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { APP_NAME, getBinDir } from "../config.js";
@@ -36,6 +37,21 @@ const MAX_ARCHIVE_ENTRIES = 1_000;
 const ARCHIVE_EXTRACT_TIMEOUT_MS = 60_000;
 const CONTENT_LENGTH_RE = /^\d+$/;
 const GITHUB_RELEASE_JSON_MAX_BYTES = 1024 * 1024;
+const TOOL_INSTALL_STALE_MS =
+  DOWNLOAD_TIMEOUT_MS + ARCHIVE_EXTRACT_TIMEOUT_MS + NETWORK_TIMEOUT_MS + 30_000;
+const toolInstallations = new Map<"fd" | "rg", Promise<string>>();
+const TOOL_INSTALL_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    // The minimum backoff total is about 234s, beyond the full 220s install bound.
+    retries: 480,
+    factor: 1.2,
+    minTimeout: 25,
+    maxTimeout: 500,
+    randomize: true,
+  },
+  stale: TOOL_INSTALL_STALE_MS,
+  staleRecovery: "remove-if-unchanged",
+};
 
 function isOfflineModeEnabled(): boolean {
   return isTruthyEnvValue(process.env.OPENCLAW_OFFLINE);
@@ -50,7 +66,7 @@ interface ToolConfig {
   getAssetName: (version: string, plat: string, architecture: string) => string | null;
 }
 
-const TOOLS: Record<string, ToolConfig> = {
+const TOOLS: Record<"fd" | "rg", ToolConfig> = {
   fd: {
     name: "fd",
     repo: "sharkdp/fd",
@@ -115,9 +131,6 @@ function commandExists(cmd: string): boolean {
 // Get the path to a tool (system-wide or in our tools dir)
 function getToolPath(tool: "fd" | "rg"): string | null {
   const config = TOOLS[tool];
-  if (!config) {
-    return null;
-  }
 
   // Check our tools directory first
   const localPath = join(TOOLS_DIR, config.binaryName + (platform() === "win32" ? ".exe" : ""));
@@ -275,9 +288,6 @@ async function extractArchiveSafe(
 // Download and install a tool
 async function downloadTool(tool: "fd" | "rg"): Promise<string> {
   const config = TOOLS[tool];
-  if (!config) {
-    throw new Error(`Unknown tool: ${tool}`);
-  }
 
   const plat = platform();
   const architecture = arch();
@@ -298,23 +308,23 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
   mkdirSync(TOOLS_DIR, { recursive: true });
 
   const downloadUrl = `https://github.com/${config.repo}/releases/download/${config.tagPrefix}${version}/${assetName}`;
-  const archivePath = join(TOOLS_DIR, assetName);
   const binaryExt = plat === "win32" ? ".exe" : "";
   const binaryPath = join(TOOLS_DIR, config.binaryName + binaryExt);
-
-  // Download with byte cap so oversized archives are rejected before
-  // hitting disk, not just during extraction.
-  await downloadFile(downloadUrl, archivePath, MAX_ARCHIVE_BYTES);
-
-  // Extract into a unique temp directory. fd and rg downloads can run concurrently
-  // during startup, so sharing a fixed directory causes races.
-  const extractDir = join(
+  // Keep every installation's archive and extracted files together so parallel
+  // processes cannot remove or overwrite another installation's staging files.
+  const stagingDir = join(
     TOOLS_DIR,
-    `extract_tmp_${config.binaryName}_${process.pid}_${randomUUID()}`,
+    `install_tmp_${config.binaryName}_${process.pid}_${randomUUID()}`,
   );
+  const archivePath = join(stagingDir, assetName);
+  const extractDir = join(stagingDir, "extract");
   mkdirSync(extractDir, { recursive: true });
 
   try {
+    // Download with byte cap so oversized archives are rejected before
+    // hitting disk, not just during extraction.
+    await downloadFile(downloadUrl, archivePath, MAX_ARCHIVE_BYTES);
+
     if (assetName.endsWith(".tar.gz") || assetName.endsWith(".zip")) {
       await extractArchiveSafe(archivePath, extractDir, assetName);
     } else {
@@ -348,12 +358,39 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
       chmodSync(binaryPath, 0o755);
     }
   } finally {
-    // Cleanup
-    rmSync(archivePath, { force: true });
-    rmSync(extractDir, { recursive: true, force: true });
+    rmSync(stagingDir, { recursive: true, force: true });
   }
 
   return binaryPath;
+}
+
+function installTool(tool: "fd" | "rg"): Promise<string> {
+  const currentInstallation = toolInstallations.get(tool);
+  if (currentInstallation) {
+    return currentInstallation;
+  }
+
+  const config = TOOLS[tool];
+  const binaryPath = join(TOOLS_DIR, config.binaryName + (platform() === "win32" ? ".exe" : ""));
+  mkdirSync(TOOLS_DIR, { recursive: true });
+  const installation = withFileLock(binaryPath, TOOL_INSTALL_LOCK_OPTIONS, async () => {
+    const existingPath = getToolPath(tool);
+    return existingPath ?? downloadTool(tool);
+  });
+  toolInstallations.set(tool, installation);
+  void installation.then(
+    () => {
+      if (toolInstallations.get(tool) === installation) {
+        toolInstallations.delete(tool);
+      }
+    },
+    () => {
+      if (toolInstallations.get(tool) === installation) {
+        toolInstallations.delete(tool);
+      }
+    },
+  );
+  return installation;
 }
 
 // Termux package names for tools
@@ -371,9 +408,6 @@ export async function ensureTool(tool: "fd" | "rg", silent = false): Promise<str
   }
 
   const config = TOOLS[tool];
-  if (!config) {
-    return undefined;
-  }
 
   if (isOfflineModeEnabled()) {
     if (!silent) {
@@ -400,7 +434,7 @@ export async function ensureTool(tool: "fd" | "rg", silent = false): Promise<str
   }
 
   try {
-    const path = await downloadTool(tool);
+    const path = await installTool(tool);
     if (!silent) {
       console.log(chalk.dim(`${config.name} installed to ${path}`));
     }

--- a/src/tui/tui-autocomplete.test.ts
+++ b/src/tui/tui-autocomplete.test.ts
@@ -1,109 +1,90 @@
-import type { AutocompleteItem, AutocompleteProvider } from "@earendil-works/pi-tui";
-import { describe, expect, it, vi } from "vitest";
-import { sanitizeAutocompleteProvider } from "./tui-autocomplete.js";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createTuiAutocompleteProvider } from "./tui-autocomplete.js";
 
-describe("sanitizeAutocompleteProvider", () => {
-  it("omits unsafe values while sanitizing safe display copies", async () => {
-    const safe: AutocompleteItem = {
-      value: "safe-value",
-      label: `label\x1b]52;c;Y2xpcGJvYXJk\x07\r\nمرحبا`,
-      description: "description\u009b31munsafe\u009b0m\tשלום",
-    };
-    const unsafe: AutocompleteItem = { value: "raw\x1b[31m-value", label: "unsafe" };
-    const applyCompletion = vi.fn(() => ({
-      lines: [safe.value],
-      cursorLine: 0,
-      cursorCol: safe.value.length,
-    }));
-    const inner: AutocompleteProvider = {
-      getSuggestions: vi.fn(async () => ({ items: [unsafe, safe], prefix: "/" })),
-      applyCompletion,
-    };
-    const provider = sanitizeAutocompleteProvider(inner);
-
-    const suggestions = await provider.getSuggestions(["/"], 0, 1, {
-      signal: new AbortController().signal,
-    });
-    const displayItem = suggestions?.items[0];
-
-    expect(displayItem).toEqual({
-      value: safe.value,
-      label: "\u2067label مرحبا\u2069",
-      description: "\u2067descriptionunsafe שלום\u2069",
-    });
-    expect(suggestions?.items).toHaveLength(1);
-
-    provider.applyCompletion(["/"], 0, 1, displayItem!, "/");
-    expect(applyCompletion).toHaveBeenCalledWith(["/"], 0, 1, safe, "/");
-  });
-
-  it("preserves exact safe RTL paths and delegates file-completion triggers", async () => {
-    const value = "/tmp/مرحبا-東京/";
-    const original = { value, label: value };
-    const applyCompletion = vi.fn(() => ({
-      lines: [value],
-      cursorLine: 0,
-      cursorCol: value.length,
-    }));
-    const inner: AutocompleteProvider = {
-      triggerCharacters: ["@"],
-      getSuggestions: vi.fn(async () => ({
-        items: [original],
-        prefix: "@",
-      })),
-      applyCompletion,
-      shouldTriggerFileCompletion: vi.fn(() => true),
-    };
-    const provider = sanitizeAutocompleteProvider(inner);
-
-    const suggestions = await provider.getSuggestions(["@"], 0, 1, {
+describe("createTuiAutocompleteProvider", () => {
+  it("only scans ordinary paths after explicit completion", async () => {
+    const provider = createTuiAutocompleteProvider([], process.cwd());
+    const natural = provider.getSuggestions(["./src/"], 0, 6, {
       signal: new AbortController().signal,
     });
 
-    expect(suggestions?.items[0]).toEqual({
-      value,
-      label: `\u2067${value}\u2069`,
-    });
-    provider.applyCompletion(["@"], 0, 1, suggestions!.items[0]!, "@");
-    expect(applyCompletion).toHaveBeenCalledWith(["@"], 0, 1, original, "@");
-    expect(provider.triggerCharacters).toEqual(["@"]);
-    expect(provider.shouldTriggerFileCompletion?.(["@"], 0, 1)).toBe(true);
-  });
-
-  it("returns null when every completion value is unsafe", async () => {
-    const inner: AutocompleteProvider = {
-      getSuggestions: vi.fn(async () => ({
-        items: [{ value: "bad\tvalue", label: "bad" }],
-        prefix: "/",
-      })),
-      applyCompletion: vi.fn(() => ({ lines: [], cursorLine: 0, cursorCol: 0 })),
-    };
-    const provider = sanitizeAutocompleteProvider(inner);
-
+    await expect(natural).resolves.toBeNull();
     await expect(
-      provider.getSuggestions(["/"], 0, 1, { signal: new AbortController().signal }),
-    ).resolves.toBeNull();
+      provider.getSuggestions(["./src/"], 0, 6, {
+        force: true,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.not.toBeNull();
   });
 
-  it("falls back to a visible sanitized value and omits empty descriptions", async () => {
-    const original: AutocompleteItem = {
-      value: "fallback-value",
-      label: "\x1b]0;hidden\x07",
-      description: "\u009b31m\u009b0m",
-    };
-    const inner: AutocompleteProvider = {
-      getSuggestions: vi.fn(async () => ({ items: [original], prefix: "/" })),
-      applyCompletion: vi.fn(() => ({ lines: [original.value], cursorLine: 0, cursorCol: 0 })),
-    };
-    const provider = sanitizeAutocompleteProvider(inner);
+  it("uses the provisioned file finder for attachment completion", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "openclaw-tui-autocomplete-"));
+    const fdPath = join(fixture, "fd");
+    await writeFile(fdPath, "#!/bin/sh\nprintf 'nested/needle.txt\\n'\n");
+    await chmod(fdPath, 0o755);
 
-    const suggestions = await provider.getSuggestions(["/"], 0, 1, {
-      signal: new AbortController().signal,
-    });
+    try {
+      const provider = createTuiAutocompleteProvider([], fixture, fdPath);
+      const suggestions = await provider.getSuggestions(["@needle"], 0, 7, {
+        signal: new AbortController().signal,
+      });
 
-    expect(suggestions?.items[0]).toEqual({
-      value: original.value,
-      label: "fallback-value",
-    });
+      expect(suggestions).toMatchObject({
+        items: [{ label: "needle.txt", value: "@nested/needle.txt" }],
+        prefix: "@needle",
+      });
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("supports quoted attachment prefixes", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "openclaw-tui-autocomplete-"));
+    const fdPath = join(fixture, "fd");
+    await writeFile(fdPath, "#!/bin/sh\nprintf 'needle file.txt\\n'\n");
+    await chmod(fdPath, 0o755);
+
+    try {
+      const provider = createTuiAutocompleteProvider([], fixture, fdPath);
+      const suggestions = await provider.getSuggestions(['@"needle'], 0, 8, {
+        signal: new AbortController().signal,
+      });
+
+      expect(suggestions?.items[0]?.value).toBe('@"needle file.txt"');
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("omits terminal-unsafe paths while preserving safe Unicode paths", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "openclaw-tui-autocomplete-"));
+    const fdPath = join(fixture, "fd");
+    await writeFile(fdPath, "#!/bin/sh\nprintf 'raw\\033value.txt\\nمرحبا-東京.txt\\n'\n");
+    await chmod(fdPath, 0o755);
+
+    try {
+      const provider = createTuiAutocompleteProvider([], fixture, fdPath);
+      const suggestions = await provider.getSuggestions(["@"], 0, 1, {
+        signal: new AbortController().signal,
+      });
+
+      expect(suggestions?.items).toEqual([
+        {
+          description: "\u2067مرحبا-東京.txt\u2069",
+          label: "\u2067مرحبا-東京.txt\u2069",
+          value: "@مرحبا-東京.txt",
+        },
+      ]);
+      expect(provider.applyCompletion(["@"], 0, 1, suggestions!.items[0]!, "@")).toEqual({
+        cursorCol: "@مرحبا-東京.txt ".length,
+        cursorLine: 0,
+        lines: ["@مرحبا-東京.txt "],
+      });
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
   });
 });

--- a/src/tui/tui-autocomplete.ts
+++ b/src/tui/tui-autocomplete.ts
@@ -1,9 +1,14 @@
-import type { AutocompleteItem, AutocompleteProvider } from "@earendil-works/pi-tui";
+import {
+  CombinedAutocompleteProvider,
+  type AutocompleteItem,
+  type AutocompleteProvider,
+  type SlashCommand,
+} from "@earendil-works/pi-tui";
 import { isTerminalSafeAutocompleteValue, sanitizeRenderableLine } from "./tui-formatters.js";
 
 const originalSafeItem = Symbol("originalSafeItem");
 /** Sanitize autocomplete presentation and omit values unsafe for editor rendering. */
-export function sanitizeAutocompleteProvider(inner: AutocompleteProvider): AutocompleteProvider {
+function sanitizeAutocompleteProvider(inner: AutocompleteProvider): AutocompleteProvider {
   return {
     triggerCharacters: inner.triggerCharacters,
     async getSuggestions(...args) {
@@ -47,4 +52,25 @@ export function sanitizeAutocompleteProvider(inner: AutocompleteProvider): Autoc
       ? (...args) => inner.shouldTriggerFileCompletion!(...args)
       : undefined,
   };
+}
+
+export function createTuiAutocompleteProvider(
+  commands: SlashCommand[],
+  basePath: string,
+  fdPath?: string,
+): AutocompleteProvider {
+  const inner = new CombinedAutocompleteProvider(commands, basePath, fdPath);
+  return sanitizeAutocompleteProvider({
+    getSuggestions(lines, cursorLine, cursorCol, options) {
+      const textBeforeCursor = (lines[cursorLine] ?? "").slice(0, cursorCol);
+      const isAttachment = /(?:^|[\s='"])@(?:"[^"]*|[^\s='"]*)$/u.test(textBeforeCursor);
+      const isNaturalCompletion = isAttachment || textBeforeCursor.startsWith("/");
+      if (!options.force && !isNaturalCompletion) {
+        return Promise.resolve(null);
+      }
+      return inner.getSuggestions(lines, cursorLine, cursorCol, options);
+    },
+    applyCompletion: (...args) => inner.applyCompletion(...args),
+    shouldTriggerFileCompletion: (...args) => inner.shouldTriggerFileCompletion(...args),
+  });
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1,15 +1,7 @@
 // Runs the interactive TUI loop and coordinates backend, input, and rendering.
 import { spawn } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
-import {
-  CombinedAutocompleteProvider,
-  Container,
-  Loader,
-  matchesKey,
-  ProcessTerminal,
-  Text,
-  TUI,
-} from "@earendil-works/pi-tui";
+import { Container, Loader, matchesKey, ProcessTerminal, Text, TUI } from "@earendil-works/pi-tui";
 import { classifyGatewayConnectFailure } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import type { CommandEntry } from "../../packages/gateway-protocol/src/index.js";
 import {
@@ -50,7 +42,7 @@ import { CustomEditor } from "./components/custom-editor.js";
 import { resolveLocalRunShutdownGraceMs } from "./local-run-shutdown.js";
 import { editorTheme, tuiTheme as theme } from "./theme/theme.js";
 import { createTuiAuthChildOwner } from "./tui-auth-child.js";
-import { sanitizeAutocompleteProvider } from "./tui-autocomplete.js";
+import { createTuiAutocompleteProvider } from "./tui-autocomplete.js";
 import type { TuiBackend } from "./tui-backend.js";
 import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
@@ -940,6 +932,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
 
   const resolveDynamicSlashCommandsKey = () => state.currentAgentId;
 
+  let autocompleteFdPath: string | undefined;
   const applyAutocompleteProvider = () => {
     const dynamicKey = resolveDynamicSlashCommandsKey();
     const slashCommands = getSlashCommands({
@@ -954,11 +947,18 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     editor.shouldSubmitAutocomplete = (text) =>
       shouldSubmitExactArgumentCompletion(text, slashCommands);
     editor.setAutocompleteProvider(
-      sanitizeAutocompleteProvider(
-        new CombinedAutocompleteProvider(slashCommands, resolveUsableCwd()),
-      ),
+      createTuiAutocompleteProvider(slashCommands, resolveUsableCwd(), autocompleteFdPath),
     );
   };
+
+  void import("../agents/utils/tools-manager.js")
+    .then(({ ensureTool }) => ensureTool("fd", true))
+    .then((fdPath) => {
+      if (fdPath) {
+        autocompleteFdPath = fdPath;
+        applyAutocompleteProvider();
+      }
+    });
 
   const clearDynamicSlashCommandsRefreshTimer = () => {
     if (!dynamicSlashCommandsRefreshTimer) {


### PR DESCRIPTION
Closes #127833

## What Problem This Solves

Fixes an issue where users typing ordinary paths in the TUI could experience
input stalls when the directory was large or slow. It also restores the
`@file` attachment picker, which previously returned no suggestions.

## Why This Change Was Made

Ordinary path discovery now runs only after explicit Tab completion instead of
on each keystroke. The existing `fd` provisioner runs in the background and
refreshes the autocomplete provider when ready, so attachment search remains
asynchronous and does not delay TUI startup.

## User Impact

Typing paths no longer blocks on directory scans. Tab still completes paths,
and typing `@file` now finds matching files without requiring a separate system
installation of `fd`.

## Evidence

Blacksmith Testbox: `tbx_01m0madtmms96n71n2cp6kg0cc`

Run URL: https://github.com/openclaw/openclaw/actions/runs/32563188940

| Scenario | Before, 5 runs (ms) | Before median / IQR | After, 5 runs (ms) | After median / IQR | Result |
| --- | --- | --- | --- | --- | --- |
| Natural `./large/link-`, 20k symlinks | 55.111, 44.209, 38.925, 44.372, 40.670 | 44.209 / 3.702 ms | 0.164, 0.039, 0.005, 0.027, 0.012 | 0.027 / 0.027 ms | no synchronous scan |
| Explicit Tab path | n/a | n/a | 56.312, 51.134, 48.501, 47.116, 49.341 | 49.341 / 2.633 ms | 20,000 items, explicit action |
| `@needle-result` | 0.173, 0.007, 0.003, 0.009, 0.017 | 0.009 / 0.011 ms | 35.164, 25.744, 30.643, 28.513, 26.136 | 28.513 / 4.507 ms | 0 items before, 1 item after |

Regression on `main`: the owner-boundary assertion that a natural `./src/`
request returns `null` fails because the dependency synchronously returns path
items. The same test passes after the fix while an explicit `force: true`
request still returns suggestions.

Validation:

- `node scripts/run-vitest.mjs src/tui/tui-autocomplete.test.ts`
- `node scripts/check-changed.mjs -- src/tui/tui.ts src/tui/tui-autocomplete.ts src/tui/tui-autocomplete.test.ts`
- `pnpm build`
- Remote A/B harness on the Testbox above

Production LOC: +41/-15 (net +26). Tests: +73/-92 (net -19). The production
growth owns two concrete capabilities at the TUI boundary: suppressing implicit
synchronous scans and provisioning the existing asynchronous attachment finder.

Autoreview infrastructure gap: three local attempts could not authenticate the
Codex CLI (`401 Unauthorized`); the Testbox had credentials but no `codex`
executable. No clean autoreview result is claimed.
