### PR TITLE
refactor(tui): stop sanitizing each streamed markdown chunk twice

### DIFF
--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -467,7 +467,7 @@ function formatAssistantErrorFromRecord(record: Record<string, unknown>): string
   return formatRawAssistantErrorForUi(errorMessage);
 }
 
-function collectSanitizedBlockStrings(params: {
+function collectBlockStrings(params: {
   content: unknown;
   blockType: "text" | "thinking";
   valueKey: "text" | "thinking";
@@ -482,7 +482,7 @@ function collectSanitizedBlockStrings(params: {
     }
     const rec = block as Record<string, unknown>;
     if (rec.type === params.blockType && typeof rec[params.valueKey] === "string") {
-      parts.push(sanitizeRenderableText(rec[params.valueKey] as string));
+      parts.push(rec[params.valueKey] as string);
     }
   }
   return parts;
@@ -501,7 +501,7 @@ export function extractThinkingFromMessage(message: unknown): string {
   if (typeof content === "string") {
     return "";
   }
-  const parts = collectSanitizedBlockStrings({
+  const parts = collectBlockStrings({
     content,
     blockType: "thinking",
     valueKey: "thinking",
@@ -522,10 +522,14 @@ export function extractContentFromMessage(message: unknown): string {
 
   if (record.role === "assistant") {
     if (typeof content === "string") {
-      return sanitizeRenderableText(content).trim();
+      return content.trim();
     }
     if (Array.isArray(content)) {
-      return extractAssistantRenderableContent(record);
+      const text = (extractAssistantPhaseText(record) ?? "").trim();
+      const pairingQr = extractPairingQrTerminalText(record);
+      return (
+        [text, pairingQr].filter(Boolean).join("\n\n") || formatAssistantErrorFromRecord(record)
+      );
     }
   }
 
@@ -533,11 +537,11 @@ export function extractContentFromMessage(message: unknown): string {
     return sanitizeRenderableText(content).trim();
   }
 
-  const parts = collectSanitizedBlockStrings({
+  const parts = collectBlockStrings({
     content,
     blockType: "text",
     valueKey: "text",
-  });
+  }).map(sanitizeRenderableText);
   if (parts.length > 0) {
     return parts.join("\n").trim();
   }
@@ -586,18 +590,14 @@ function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean 
     return "";
   }
 
-  const textParts = collectSanitizedBlockStrings({
-    content,
-    blockType: "text",
-    valueKey: "text",
-  });
+  const textParts = collectBlockStrings({ content, blockType: "text", valueKey: "text" }).map(
+    sanitizeRenderableText,
+  );
   const thinkingParts =
     opts?.includeThinking === true
-      ? collectSanitizedBlockStrings({
-          content,
-          blockType: "thinking",
-          valueKey: "thinking",
-        })
+      ? collectBlockStrings({ content, blockType: "thinking", valueKey: "thinking" }).map(
+          sanitizeRenderableText,
+        )
       : [];
 
   return composeThinkingAndContent({

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -72,6 +72,15 @@ describe("TuiStreamAssembler", () => {
     expect(second).toBe("[thinking]\nBrain\n\nHello");
   });
 
+  it("defers streamed terminal sanitization to the markdown boundary", () => {
+    const assembler = new TuiStreamAssembler();
+    const unsafe = "before\x1b]52;c;unsafe\x07after";
+
+    expect(assembler.ingestDelta("run-unsafe", messageWithContent([text(unsafe)]), false)).toBe(
+      unsafe,
+    );
+  });
+
   it("omits thinking when showThinking is false", () => {
     const assembler = new TuiStreamAssembler();
     const output = assembler.ingestDelta(


### PR DESCRIPTION
## What Problem This Solves

Streaming assistant snapshots crossed the TUI terminal-safety sanitizer in the stream assembler and then crossed the same sanitizer again at the markdown rendering boundary. A 400-delta cumulative stream therefore scanned 5,535,190 bytes while producing a final 13,890-byte response.

## Why This Change Was Made

The stream-only extractors now preserve assistant text until `HyperlinkMarkdown`, the terminal rendering boundary that already owns markdown sanitization, URL extraction, and rendered-line isolation. Generic message extraction, history rendering, command output, attachment labels, errors, and non-assistant fallback paths retain their existing explicit sanitization.

Production LOC: +17/-17 (net 0). Tests: +9/-0.

## User Impact

Streaming output is unchanged. Each cumulative assistant snapshot now crosses markdown source sanitization once instead of twice, reducing duplicate sanitizer work without adding a cache, trusted-text bypass, fallback, or compatibility path.

## Evidence

Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/32565865725

| 400 cumulative deltas, 5 runs | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Bytes processed by `sanitizeMarkdownSource` | 5,535,190 | 2,767,595 | -50.0% |
| End-to-end harness median (IQR) | 646.857 ms (3.022) | 617.064 ms (2.917) | -4.61% |

The timing change is incidental; this change removes the duplicate sanitization pass.

Regression proof:

```text
FAIL TuiStreamAssembler > defers streamed terminal sanitization to the markdown boundary
Expected: before<OSC52>after
Received: beforeafter
```

Validation:

- `node scripts/run-vitest.mjs src/tui/tui-formatters.test.ts src/tui/tui-stream-assembler.test.ts src/tui/components/hyperlink-markdown.test.ts` (120 passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts -t "authenticates a streamed prefix before the complete ordered final frame"` (passed)
- `node scripts/check-changed.mjs -- src/tui/tui-formatters.ts src/tui/tui-stream-assembler.test.ts` (passed)
- `git diff --check origin/main...HEAD` (passed)

The full PTY suite encountered an unrelated timeout in `reconciles active and terminal runs after reconnect history`; the focused streaming PTY proof passed before and after the final rebase. Autoreview was attempted three times, including against the final branch, but its Codex subprocess exited before returning structured findings each time.
