### PR TITLE
perf(ui): keep split divider drag within frame budget

### DIFF
--- a/ui/src/components/resizable-divider.test.ts
+++ b/ui/src/components/resizable-divider.test.ts
@@ -233,14 +233,18 @@ describe("resizable-divider", () => {
     expect([...divider.classList]).toEqual(["dragging"]);
 
     dispatchPointer(document, "pointermove", 220, 7);
-    expectLastResizeRatio(resized, 0.7);
+    dispatchPointer(document, "pointermove", 120, 7);
+    expect(resized).not.toHaveBeenCalled();
+    await nextFrame();
+    expectLastResizeRatio(resized, 0.65);
+    expect(resized).toHaveBeenCalledTimes(1);
     expect(resizeEnded).not.toHaveBeenCalled();
 
     dispatchPointer(document, "pointerup", 220, 7);
     const endEvent = resizeEnded.mock.lastCall?.[0] as
       | CustomEvent<{ splitRatio: number }>
       | undefined;
-    expect(endEvent?.detail).toEqual({ splitRatio: 0.7 });
+    expect(endEvent?.detail).toEqual({ splitRatio: 0.65 });
     expect(resizeEnded).toHaveBeenCalledTimes(1);
     expect([...divider.classList]).toEqual([]);
     expect(releasePointerCapture).toHaveBeenCalledWith(7);

--- a/ui/src/components/resizable-divider.test.ts
+++ b/ui/src/components/resizable-divider.test.ts
@@ -268,4 +268,21 @@ describe("resizable-divider", () => {
     dispatchPointer(document, "pointermove", 220);
     expect(resized).not.toHaveBeenCalled();
   });
+
+  it("commits the final pointer position when disconnected", async () => {
+    const divider = await renderDivider();
+    const resized = vi.fn();
+    const resizeEnded = vi.fn();
+    divider.setPointerCapture = vi.fn();
+    divider.releasePointerCapture = vi.fn();
+    divider.addEventListener("resize", resized);
+    divider.addEventListener("resize-end", resizeEnded);
+
+    dispatchPointer(divider, "pointerdown", 100);
+    dispatchPointer(document, "pointermove", 120);
+    divider.remove();
+
+    expectLastResizeRatio(resized, 0.65);
+    expectLastResizeRatio(resizeEnded, 0.65);
+  });
 });

--- a/ui/src/components/resizable-divider.ts
+++ b/ui/src/components/resizable-divider.ts
@@ -117,7 +117,7 @@ class ResizableDivider extends OpenClawLitElement {
     super.disconnectedCallback();
     this.removeEventListener("pointerdown", this.handlePointerDown);
     this.removeEventListener("keydown", this.handleKeyDown);
-    this.stopDragging();
+    this.finishDragging(new Event("disconnect"));
   }
 
   protected override updated() {

--- a/ui/src/components/resizable-divider.ts
+++ b/ui/src/components/resizable-divider.ts
@@ -22,6 +22,9 @@ class ResizableDivider extends OpenClawLitElement {
   private startPosition = 0;
   private startRatio = 0;
   private dragRatio = 0;
+  private dragSize = 0;
+  private dragFrame = 0;
+  private pendingPosition: number | null = null;
   private activePointerId: number | null = null;
 
   static override styles = css`
@@ -132,6 +135,10 @@ class ResizableDivider extends OpenClawLitElement {
     this.startPosition = this.orientation === "horizontal" ? e.clientY : e.clientX;
     this.startRatio = this.currentRatio();
     this.dragRatio = this.startRatio;
+    this.dragSize = this.measureDragSize();
+    if (this.dragSize <= 0) {
+      return;
+    }
     this.classList.add("dragging");
     this.capturePointer(e.pointerId);
 
@@ -148,35 +155,21 @@ class ResizableDivider extends OpenClawLitElement {
       return;
     }
 
-    const container = this.parentElement;
-    if (!container) {
-      return;
+    this.pendingPosition = this.orientation === "horizontal" ? e.clientY : e.clientX;
+    if (!this.dragFrame) {
+      this.dragFrame = requestAnimationFrame(this.flushPointerMove);
     }
+  };
 
-    // Ratio is local to the two adjacent siblings, not the whole container:
-    // split-view rows/columns hold N panes, and a drag must only redistribute
-    // the pair this divider sits between. Container size is the 2-child
-    // fallback (legacy chat sidebar split).
-    const previousBounds = this.previousElementSibling?.getBoundingClientRect();
-    const nextBounds = this.nextElementSibling?.getBoundingClientRect();
-    const containerBounds = container.getBoundingClientRect();
-    const measuredSize = this.measureSize?.() ?? 0;
-    const siblingSize =
-      this.orientation === "horizontal"
-        ? (previousBounds?.height ?? 0) + (nextBounds?.height ?? 0)
-        : (previousBounds?.width ?? 0) + (nextBounds?.width ?? 0);
-    const containerSize =
-      measuredSize > 0
-        ? measuredSize
-        : siblingSize ||
-          (this.orientation === "horizontal" ? containerBounds.height : containerBounds.width);
-    if (containerSize <= 0) {
-      return;
+  private readonly flushPointerMove = () => {
+    this.dragFrame = 0;
+    const position = this.pendingPosition;
+    this.pendingPosition = null;
+    if (position !== null) {
+      this.dragRatio = this.emitResize(
+        this.startRatio + (position - this.startPosition) / this.dragSize,
+      );
     }
-    const position = this.orientation === "horizontal" ? e.clientY : e.clientX;
-    const deltaRatio = (position - this.startPosition) / containerSize;
-
-    this.dragRatio = this.emitResize(this.startRatio + deltaRatio);
   };
 
   private handleKeyDown = (e: KeyboardEvent) => {
@@ -210,6 +203,11 @@ class ResizableDivider extends OpenClawLitElement {
       return;
     }
     if (this.activePointerId !== null) {
+      if (this.dragFrame) {
+        cancelAnimationFrame(this.dragFrame);
+        this.dragFrame = 0;
+      }
+      this.flushPointerMove();
       this.emitResizeEnd(this.dragRatio);
     }
     this.stopDragging();
@@ -222,6 +220,11 @@ class ResizableDivider extends OpenClawLitElement {
     }
     this.classList.remove("dragging");
     this.releaseActivePointer(pointerId);
+    if (this.dragFrame) {
+      cancelAnimationFrame(this.dragFrame);
+      this.dragFrame = 0;
+    }
+    this.pendingPosition = null;
 
     window.removeEventListener("pointermove", this.handlePointerMove);
     for (const type of DRAG_END_EVENTS) {
@@ -254,6 +257,26 @@ class ResizableDivider extends OpenClawLitElement {
 
   private clampRatio(value: number) {
     return Math.max(this.minRatio, Math.min(this.maxRatio, value));
+  }
+
+  private measureDragSize() {
+    const measuredSize = this.measureSize?.() ?? 0;
+    if (measuredSize > 0) {
+      return measuredSize;
+    }
+    const previousBounds = this.previousElementSibling?.getBoundingClientRect();
+    const nextBounds = this.nextElementSibling?.getBoundingClientRect();
+    const siblingSize =
+      this.orientation === "horizontal"
+        ? (previousBounds?.height ?? 0) + (nextBounds?.height ?? 0)
+        : (previousBounds?.width ?? 0) + (nextBounds?.width ?? 0);
+    if (siblingSize > 0) {
+      return siblingSize;
+    }
+    const containerBounds = this.parentElement?.getBoundingClientRect();
+    return this.orientation === "horizontal"
+      ? (containerBounds?.height ?? 0)
+      : (containerBounds?.width ?? 0);
   }
 
   private currentRatio() {

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -391,16 +391,16 @@ suite.define(() => {
     const divider = page.locator(".board-session-surface__divider");
     const dock = page.locator(".board-session-surface__chat");
     const dockHeight = () => dock.evaluate((element) => getComputedStyle(element).height);
-    await divider.focus();
-    await page.keyboard.press("End");
+    const dividerBounds = await divider.boundingBox();
+    expect(dividerBounds).not.toBeNull();
+    await page.mouse.move(
+      dividerBounds!.x + dividerBounds!.width / 2,
+      dividerBounds!.y + dividerBounds!.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(dividerBounds!.x, dividerBounds!.y - 80);
+    await page.mouse.up();
     await expect.poll(dockHeight).not.toBe("320px");
-    const clampedHeight = await dockHeight();
-    // End pins the bottom dock against its clamp, so step back off it: comparing
-    // a clamped height to itself after reload would pass if persistence broke and
-    // the dock merely fell back to its minimum.
-    await page.keyboard.press("ArrowUp");
-    await page.keyboard.press("ArrowUp");
-    await expect.poll(dockHeight).not.toBe(clampedHeight);
     const persistedHeight = await dockHeight();
     expect(persistedHeight).toMatch(/^\d+(?:\.\d+)?px$/u);
 

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -669,6 +669,18 @@ describe("chat page split layout host", () => {
     expect(panes.every((pane) => pane.onOpenSplitView === undefined)).toBe(true);
     expect(panes[0]?.chatMessagesBySession).toBe(panes[1]?.chatMessagesBySession);
 
+    itemAt(dividers, 0, "split divider").dispatchEvent(
+      new CustomEvent("resize", { detail: { splitRatio: 0.7 } }),
+    );
+    await page.updateComplete;
+    expect(getLayout(page)?.columnWeights[0]).toBeCloseTo(0.7);
+    expect(getLayout(page)?.columnWeights[1]).toBeCloseTo(0.3);
+    expect(loadSettings().chatSplitLayout).toBeUndefined();
+
+    itemAt(dividers, 0, "split divider").dispatchEvent(new CustomEvent("resize-end"));
+    expect(loadSettings().chatSplitLayout?.columnWeights[0]).toBeCloseTo(0.7);
+    expect(loadSettings().chatSplitLayout?.columnWeights[1]).toBeCloseTo(0.3);
+
     itemAt(cells, 0, "split cell").dispatchEvent(new Event("pointerdown"));
     await page.updateComplete;
 

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -51,6 +51,7 @@ import {
   splitRatio,
   splitWeight,
 } from "./split-layout.ts";
+
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
 
 export class ChatPage extends OpenClawLightDomElement {
@@ -93,10 +94,12 @@ export class ChatPage extends OpenClawLightDomElement {
       this.handlePaneSessionChange(paneId, sourceSessionKey, sessionKey);
     },
   });
+
   constructor() {
     super();
     installSessionPrefetch(this, this.messageCache, this.snapshotStore, () => this.context);
   }
+
   override connectedCallback() {
     super.connectedCallback();
     this.snapshotStore.connect();
@@ -161,6 +164,7 @@ export class ChatPage extends OpenClawLightDomElement {
         data?.canonicalLocation &&
         stillOwnsCanonicalLocation(data.canonicalLocationSource, this.consumedDraftData === data)
       ) {
+        // Move a route matched under the wrong namespace to its resolved board face.
         this.context.replace(data.face ?? "chat", data.canonicalLocation);
         return;
       }
@@ -542,6 +546,7 @@ export class ChatPage extends OpenClawLightDomElement {
 
   private readonly handleSplitRight = (paneId: string) => this.handleSplit(paneId, "right");
   private readonly handleSplitDown = (paneId: string) => this.handleSplit(paneId, "down");
+
   private closeSplitPane(layout: ChatSplitLayout, paneId: string): void {
     const survivingPane = closeStagedPane(this.context, this, layout, paneId);
     this.retainedSessions.discardPane(paneId);
@@ -565,6 +570,7 @@ export class ChatPage extends OpenClawLightDomElement {
       this.closeSplitPane(this.layout, paneId);
     }
   };
+
   private classicLayout(sessionKey = this.data?.sessionKey?.trim() ?? ""): ChatSplitLayout {
     return singlePaneLayout(this.classicColumnId, this.classicPaneId, sessionKey);
   }

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -51,7 +51,6 @@ import {
   splitRatio,
   splitWeight,
 } from "./split-layout.ts";
-
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
 
 export class ChatPage extends OpenClawLightDomElement {
@@ -94,12 +93,10 @@ export class ChatPage extends OpenClawLightDomElement {
       this.handlePaneSessionChange(paneId, sourceSessionKey, sessionKey);
     },
   });
-
   constructor() {
     super();
     installSessionPrefetch(this, this.messageCache, this.snapshotStore, () => this.context);
   }
-
   override connectedCallback() {
     super.connectedCallback();
     this.snapshotStore.connect();
@@ -164,7 +161,6 @@ export class ChatPage extends OpenClawLightDomElement {
         data?.canonicalLocation &&
         stillOwnsCanonicalLocation(data.canonicalLocationSource, this.consumedDraftData === data)
       ) {
-        // Move a route matched under the wrong namespace to its resolved board face.
         this.context.replace(data.face ?? "chat", data.canonicalLocation);
         return;
       }
@@ -546,7 +542,6 @@ export class ChatPage extends OpenClawLightDomElement {
 
   private readonly handleSplitRight = (paneId: string) => this.handleSplit(paneId, "right");
   private readonly handleSplitDown = (paneId: string) => this.handleSplit(paneId, "down");
-
   private closeSplitPane(layout: ChatSplitLayout, paneId: string): void {
     const survivingPane = closeStagedPane(this.context, this, layout, paneId);
     this.retainedSessions.discardPane(paneId);
@@ -570,7 +565,6 @@ export class ChatPage extends OpenClawLightDomElement {
       this.closeSplitPane(this.layout, paneId);
     }
   };
-
   private classicLayout(sessionKey = this.data?.sessionKey?.trim() ?? ""): ChatSplitLayout {
     return singlePaneLayout(this.classicColumnId, this.classicPaneId, sessionKey);
   }
@@ -647,13 +641,16 @@ export class ChatPage extends OpenClawLightDomElement {
                           .maxRatio=${0.85}
                           .label=${t("nav.resize")}
                           @resize=${(event: CustomEvent<{ splitRatio: number }>) => {
-                            const current = this.layout;
-                            if (current) {
-                              this.persistLayout(
-                                resizePanes(current, column.id, paneIndex, event.detail.splitRatio),
-                              );
-                            }
+                            this.layout = this.layout
+                              ? resizePanes(
+                                  this.layout,
+                                  column.id,
+                                  paneIndex,
+                                  event.detail.splitRatio,
+                                )
+                              : undefined;
                           }}
+                          @resize-end=${() => this.persistLayout(this.layout)}
                         ></resizable-divider>
                       `
                     : nothing}
@@ -672,13 +669,11 @@ export class ChatPage extends OpenClawLightDomElement {
                     .maxRatio=${0.85}
                     .label=${t("nav.resize")}
                     @resize=${(event: CustomEvent<{ splitRatio: number }>) => {
-                      const current = this.layout;
-                      if (current) {
-                        this.persistLayout(
-                          resizeColumns(current, columnIndex, event.detail.splitRatio),
-                        );
-                      }
+                      this.layout = this.layout
+                        ? resizeColumns(this.layout, columnIndex, event.detail.splitRatio)
+                        : undefined;
                     }}
+                    @resize-end=${() => this.persistLayout(this.layout)}
                   ></resizable-divider>
                 `
               : nothing}


### PR DESCRIPTION
Closes #127839

## What Problem This Solves

Fixes an issue where users dragging a chat split divider would see the divider lag when a long transcript or several panes were open.

## Why This Change Was Made

Divider movement now measures its drag geometry once, coalesces pointer positions to animation frames, and updates only in-memory split state while dragging. The final layout persists once through the existing `resize-end` contract.

## User Impact

Split dividers track the pointer smoothly under the measured four-pane transcript load, without synchronous settings rewrites on every movement. Keyboard resizing remains immediate and persists as before.

## Evidence

### Before / After

Five rounds on one Blacksmith Testbox lease:

| Round | Before p50 (ms) | Before p95 (ms) | Before writes/event | After p50 (ms) | After p95 (ms) | After writes/event |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 22.1 | 25.5 | 1.000 | 0.0 | 0.0 | 0.006 |
| 2 | 21.3 | 25.4 | 1.000 | 0.0 | 0.0 | 0.000 |
| 3 | 22.1 | 25.1 | 1.000 | 0.0 | 0.0 | 0.000 |
| 4 | 21.0 | 24.4 | 1.000 | 0.0 | 0.0 | 0.006 |
| 5 | 21.3 | 24.8 | 1.000 | 0.0 | 0.0 | 0.000 |

Across-round median (IQR): before p50 21.3 ms (0.8 ms), p95 25.1 ms (0.6 ms), writes/event 1.000 (0.000); after p50 0.0 ms (0.0 ms), p95 0.0 ms (0.0 ms), writes/event 0.000 (0.006).

Provider: `blacksmith-testbox`
Box: `tbx_01m0mahb6njb5t0a4dj8m36fm6`
Run: https://github.com/openclaw/openclaw/actions/runs/32563274165

Baseline SHA: `6b46183281202d07fdd175e6277c0105faf8e565`
Candidate measured working tree: `b993ef613f9ccefc2e819e26075c1ab8180afb71`

### Regression proof

With production files reverted to baseline, `pnpm test ui/src/pages/chat/chat-page.test.ts -- --reporter=verbose` fails at the new assertion because `loadSettings().chatSplitLayout` is already populated after the intermediate `resize` event.

### Validation

- `node scripts/run-vitest.mjs ui/src/components/resizable-divider.test.ts ui/src/components/dock-panel-layout.test.ts ui/src/pages/chat/chat-page.test.ts`: 46 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-dashboard.e2e.test.ts`: 8 passed
- `pnpm check:changed`: passed
- `git diff --check`: passed
- Production LOC: +63/-39 (net +24); tests: +44/-11. The production growth owns generic frame coalescing, one-time drag geometry, final-position flushing, and disconnect finalization in the shared divider; the chat owner is net positive only from restored pre-existing whitespace/comment context.

### Packaged non-Chat proof

The production-bundle E2E opens the dashboard session surface, drags its shared horizontal divider with real pointer input, observes the Dock height change, reloads the page, and verifies the exact final height is restored. This exercises a packaged non-Chat consumer through `DockLayoutController` and proves the shared divider still emits and persists the final drag value.

### Exact-head CI

Head: `c9c0f92d653ee44b19911e1a38c80be9b0f0187e`
Run: https://github.com/openclaw/openclaw/actions/runs/32576687253

The exact-head manual PR release-gate ran three attempts because the draft PR cannot attach normal pull-request CI. All UI lanes passed after one unrelated draft-restoration E2E timeout cleared on rerun. The only remaining failure is infrastructure: `checks-fast-baseline-ratchets` is killed by its runner timeout while `oxlint:core` is still running (exit 143) in every attempt; both baseline ratchets complete successfully before that timeout.

### Review

OpenCode `/review` with `github-copilot/gpt-5.6-sol`, variant `high`, found one actionable disconnect-finalization issue. The shared divider now flushes and commits the pending final position on disconnect; the recursive rerun reported no actionable findings.
