### PR TITLE
perf(ui): stop a pending approval countdown from re-rendering the whole chat every second

### DIFF
--- a/ui/src/app/app-host-pairing-access.test.ts
+++ b/ui/src/app/app-host-pairing-access.test.ts
@@ -54,7 +54,6 @@ function createPairingShell(params: {
   const overlaySnapshot = {
     approvalQueue: [],
     approvalErrors: new Map(),
-    approvalNowMs: 0,
     approvalBusy: false,
     devicePairSetupOpen: Boolean(params.setupCode),
     devicePairSetupLifecycle: params.setupCode

--- a/ui/src/app/app-host.dock-suppression.test.ts
+++ b/ui/src/app/app-host.dock-suppression.test.ts
@@ -104,7 +104,6 @@ describe("OpenClaw shell dock suppression", () => {
           approvalQueue: [],
           approvalBusy: false,
           approvalErrors: new Map(),
-          approvalNowMs: 0,
           devicePairSetupOpen: false,
           devicePairSetupLifecycle: { phase: "selection", access: "full" },
           devicePairPendingCount: 0,

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -683,7 +683,6 @@ export function renderApplicationShell(host: ShellViewHost) {
               busy: overlaySnapshot.approvalBusy,
               canGrant: overlaySnapshot.approvalCanGrant,
               errors: overlaySnapshot.approvalErrors,
-              nowMs: overlaySnapshot.approvalNowMs,
               onDecision: (
                 approvalId: string,
                 decision: Parameters<typeof context.overlays.decideApproval>[0],

--- a/ui/src/app/exec-approval.test.ts
+++ b/ui/src/app/exec-approval.test.ts
@@ -371,7 +371,7 @@ describe("approval queue ordering and countdown timer", () => {
     }
   });
 
-  it("publishes one shared countdown tick and cleans every timer", () => {
+  it("does not publish shared countdown ticks", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
     try {
@@ -384,8 +384,7 @@ describe("approval queue ordering and countdown timer", () => {
       enqueueExecApprovalPrompt(state, createExecApproval({ expiresAtMs: Date.now() + 60_000 }));
 
       vi.advanceTimersByTime(1_000);
-      expect(state.execApprovalChanged).toHaveBeenCalledTimes(1);
-      expect(state.execApprovalNowMs).toBe(Date.now());
+      expect(state.execApprovalChanged).not.toHaveBeenCalled();
 
       clearExecApprovalTimers(state);
       expect(vi.getTimerCount()).toBe(0);

--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -48,10 +48,8 @@ export type ExecApprovalPromptState = {
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalBusy: boolean;
   execApprovalErrors: Map<string, string>;
-  execApprovalNowMs?: number;
   execApprovalRefreshes?: Set<{ removedIds: Set<string> }>;
   execApprovalExpiryTimers?: Map<string, ReturnType<typeof globalThis.setTimeout>>;
-  execApprovalCountdownTimer?: ReturnType<typeof globalThis.setTimeout>;
   execApprovalChanged?: () => void;
 };
 
@@ -370,31 +368,6 @@ function mergeRefreshedApprovalQueue(
   return sortApprovalsOldestFirst([...currentRefreshed, ...arrivedDuringRefresh]);
 }
 
-function clearApprovalCountdownTimer(state: ExecApprovalPromptState): void {
-  if (state.execApprovalCountdownTimer === undefined) {
-    return;
-  }
-  globalThis.clearTimeout(state.execApprovalCountdownTimer);
-  state.execApprovalCountdownTimer = undefined;
-}
-
-function synchronizeApprovalCountdownTimer(state: ExecApprovalPromptState): void {
-  if (state.execApprovalQueue.length === 0) {
-    clearApprovalCountdownTimer(state);
-    return;
-  }
-  state.execApprovalNowMs = Date.now();
-  if (state.execApprovalCountdownTimer !== undefined) {
-    return;
-  }
-  state.execApprovalCountdownTimer = globalThis.setTimeout(() => {
-    state.execApprovalCountdownTimer = undefined;
-    state.execApprovalNowMs = Date.now();
-    state.execApprovalChanged?.();
-    synchronizeApprovalCountdownTimer(state);
-  }, 1_000);
-}
-
 function clearApprovalExpiryTimer(state: ExecApprovalPromptState, id: string): void {
   const timer = state.execApprovalExpiryTimers?.get(id);
   if (timer === undefined) {
@@ -431,7 +404,6 @@ function removeExecApprovalFromState(state: ExecApprovalPromptState, id: string)
   clearApprovalExpiryTimer(state, id);
   state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, id);
   state.execApprovalErrors.delete(id);
-  synchronizeApprovalCountdownTimer(state);
 }
 
 function pruneExecApprovalErrors(state: ExecApprovalPromptState): void {
@@ -448,7 +420,6 @@ export function clearExecApprovalTimers(state: ExecApprovalPromptState): void {
     globalThis.clearTimeout(timer);
   }
   state.execApprovalExpiryTimers?.clear();
-  clearApprovalCountdownTimer(state);
 }
 
 export function enqueueExecApprovalPrompt(
@@ -457,7 +428,6 @@ export function enqueueExecApprovalPrompt(
 ): void {
   state.execApprovalQueue = addExecApproval(state.execApprovalQueue, entry);
   scheduleApprovalExpiryPrune(state, entry);
-  synchronizeApprovalCountdownTimer(state);
 }
 
 export async function refreshPendingApprovalQueue(
@@ -515,7 +485,6 @@ export async function refreshPendingApprovalQueue(
     for (const entry of refreshed) {
       scheduleApprovalExpiryPrune(state, entry);
     }
-    synchronizeApprovalCountdownTimer(state);
     return true;
   } finally {
     refreshes.delete(refresh);

--- a/ui/src/app/overlays-types.ts
+++ b/ui/src/app/overlays-types.ts
@@ -17,7 +17,6 @@ export type ApplicationOverlaySnapshot = {
   approvalBusy: boolean;
   approvalCanGrant: boolean;
   approvalErrors: ReadonlyMap<string, string>;
-  approvalNowMs: number;
   devicePairSetupOpen: boolean;
   devicePairSetupLifecycle: DevicePairSetupLifecycle;
   devicePairPendingCount: number;

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -90,7 +90,6 @@ export function createApplicationOverlays(
     approvalBusy: false,
     approvalCanGrant: false,
     approvalErrors: new Map(),
-    approvalNowMs: Date.now(),
     devicePairSetupOpen: false,
     devicePairSetupLifecycle: { phase: "selection", access: "full" },
     devicePairPendingCount: 0,
@@ -124,7 +123,6 @@ export function createApplicationOverlays(
     execApprovalQueue: [],
     execApprovalBusy: false,
     execApprovalErrors: new Map(),
-    execApprovalNowMs: Date.now(),
     execApprovalExpiryTimers: new Map(),
   };
 
@@ -138,7 +136,6 @@ export function createApplicationOverlays(
       approvalBusy: promptState.execApprovalBusy,
       approvalCanGrant: readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals,
       approvalErrors: new Map(promptState.execApprovalErrors),
-      approvalNowMs: promptState.execApprovalNowMs ?? Date.now(),
       ...readDevicePairSetupSnapshot(devicePairSetupState),
     };
     for (const listener of listeners) {

--- a/ui/src/components/exec-approval-card.test.ts
+++ b/ui/src/components/exec-approval-card.test.ts
@@ -33,7 +33,6 @@ function renderCard(request: ExecApprovalRequest, variant: "inline" | "modal" = 
       busy: false,
       canGrant: true,
       error: null,
-      nowMs: 1_000,
       variant,
       onDecision: vi.fn(),
     }),

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -37,7 +37,20 @@ class ApprovalCountdown extends OpenClawLightDomContentsElement {
   @property({ type: Number }) expiresAtMs = 0;
   @property({ type: Boolean }) compact = false;
 
-  private readonly polling = new PollController(this, 1_000, () => this.requestUpdate(), false);
+  private readonly polling = new PollController(
+    this,
+    1_000,
+    () => {
+      this.requestUpdate();
+      if (!this.compact) {
+        this.closest("openclaw-modal-dialog")?.setAttribute(
+          "description",
+          approvalRemainingLabel(this.expiresAtMs, Date.now()),
+        );
+      }
+    },
+    false,
+  );
 
   override connectedCallback() {
     super.connectedCallback();

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -37,7 +37,12 @@ class ApprovalCountdown extends OpenClawLightDomContentsElement {
   @property({ type: Number }) expiresAtMs = 0;
   @property({ type: Boolean }) compact = false;
 
-  private readonly polling = new PollController(this, 1_000, () => this.requestUpdate());
+  private readonly polling = new PollController(this, 1_000, () => this.requestUpdate(), false);
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.polling.start();
+  }
 
   override render() {
     const nowMs = Date.now();

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { property } from "lit/decorators.js";
 import { formatApprovalDisplayPath } from "../../../src/infra/approval-display-paths.ts";
 import type {
   ExecApprovalDecision,
@@ -7,6 +8,8 @@ import type {
 } from "../app/exec-approval.ts";
 import { t } from "../i18n/index.ts";
 import { formatCountdown } from "../lib/format.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+import { PollController } from "../lit/poll-controller.ts";
 
 const DEFAULT_EXEC_APPROVAL_DECISIONS = [
   "allow-once",
@@ -19,7 +22,6 @@ type ExecApprovalCardProps = {
   busy: boolean;
   canGrant: boolean;
   error: string | null;
-  nowMs: number;
   variant: "inline" | "modal";
   queueCount?: number;
   onDecision: (approvalId: string, decision: ExecApprovalDecision) => void | Promise<void>;
@@ -29,6 +31,24 @@ export function approvalRemainingLabel(expiresAtMs: number, nowMs: number): stri
   return expiresAtMs > nowMs
     ? t("execApproval.expiresIn", { time: formatCountdown(expiresAtMs, nowMs, true) })
     : t("execApproval.expired");
+}
+
+class ApprovalCountdown extends OpenClawLightDomContentsElement {
+  @property({ type: Number }) expiresAtMs = 0;
+  @property({ type: Boolean }) compact = false;
+
+  private readonly polling = new PollController(this, 1_000, () => this.requestUpdate());
+
+  override render() {
+    const nowMs = Date.now();
+    return html`${this.compact
+      ? formatCountdown(this.expiresAtMs, nowMs, true)
+      : approvalRemainingLabel(this.expiresAtMs, nowMs)}`;
+  }
+}
+
+if (!customElements.get("openclaw-approval-countdown")) {
+  customElements.define("openclaw-approval-countdown", ApprovalCountdown);
 }
 
 function renderMetaRow(label: string, value?: string | null, opts?: { path?: boolean }) {
@@ -189,9 +209,11 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
               ${renderChip("plugin", pluginId)} ${renderChip("agent", agentId)}
             </div>`
           : nothing}
-        <div class="exec-approval-sub exec-approval-countdown" role="timer">
-          ${approvalRemainingLabel(active.expiresAtMs, props.nowMs)}
-        </div>
+        <openclaw-approval-countdown
+          class="exec-approval-sub exec-approval-countdown"
+          role="timer"
+          .expiresAtMs=${active.expiresAtMs}
+        ></openclaw-approval-countdown>
       </div>
       ${(props.queueCount ?? 0) > 1
         ? html`<div class="exec-approval-queue">

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -152,15 +152,30 @@ describe("openclaw-exec-approval", () => {
     expect(container.querySelector(".exec-approval-warning")).toBeNull();
   });
 
-  it("renders the live expiry countdown as mm:ss", async () => {
-    const now = vi.spyOn(Date, "now").mockReturnValue(0);
-    await renderOpenedApproval(createExecRequest({ expiresAtMs: 90_500 }));
-    await getRenderedModalDialog(container);
+  it("keeps the visible and accessible expiry countdowns synchronized", async () => {
+    let nowMs = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const { approval } = await renderOpenedApproval(createExecRequest({ expiresAtMs: 90_500 }));
+    const { dialog } = await getRenderedModalDialog(container);
 
     expect(container.querySelector(".exec-approval-countdown")?.textContent?.trim()).toBe(
       "expires in 01:31",
     );
-    now.mockRestore();
+    expect(dialog.getAttribute("aria-description")).toBe("expires in 01:31");
+
+    nowMs = 1_000;
+    await vi.waitFor(
+      () => {
+        expect(container.querySelector(".exec-approval-countdown")?.textContent?.trim()).toBe(
+          "expires in 01:30",
+        );
+      },
+      { timeout: 2_000 },
+    );
+    await getRenderedModalDialog(container);
+
+    await approval.updateComplete;
+    expect(dialog.getAttribute("aria-description")).toBe("expires in 01:30");
   });
 
   it("selects another queued request without changing queue order", async () => {

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -163,6 +163,7 @@ describe("openclaw-exec-approval", () => {
     );
     expect(dialog.getAttribute("aria-description")).toBe("expires in 01:31");
 
+    const renderSpy = vi.spyOn(approval as LitElement & { render(): unknown }, "render");
     nowMs = 1_000;
     await vi.waitFor(
       () => {
@@ -174,8 +175,8 @@ describe("openclaw-exec-approval", () => {
     );
     await getRenderedModalDialog(container);
 
-    await approval.updateComplete;
     expect(dialog.getAttribute("aria-description")).toBe("expires in 01:30");
+    expect(renderSpy).not.toHaveBeenCalled();
   });
 
   it("selects another queued request without changing queue order", async () => {

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -30,7 +30,6 @@ async function renderApproval(
     busy: boolean;
     canGrant: boolean;
     errors: ReadonlyMap<string, string>;
-    nowMs: number;
     onDecision: ReturnType<typeof vi.fn>;
   }> = {},
 ) {
@@ -43,7 +42,6 @@ async function renderApproval(
         busy: overrides.busy ?? false,
         canGrant: overrides.canGrant ?? true,
         errors: overrides.errors ?? new Map(),
-        nowMs: overrides.nowMs ?? Date.now(),
         onDecision,
       }}
     ></openclaw-exec-approval>`,
@@ -155,12 +153,14 @@ describe("openclaw-exec-approval", () => {
   });
 
   it("renders the live expiry countdown as mm:ss", async () => {
-    await renderOpenedApproval(createExecRequest({ expiresAtMs: 90_500 }), { nowMs: 0 });
+    const now = vi.spyOn(Date, "now").mockReturnValue(0);
+    await renderOpenedApproval(createExecRequest({ expiresAtMs: 90_500 }));
     await getRenderedModalDialog(container);
 
     expect(container.querySelector(".exec-approval-countdown")?.textContent?.trim()).toBe(
       "expires in 01:31",
     );
+    now.mockRestore();
   });
 
   it("selects another queued request without changing queue order", async () => {

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -157,19 +157,20 @@ describe("openclaw-exec-approval", () => {
     vi.spyOn(Date, "now").mockImplementation(() => nowMs);
     const { approval } = await renderOpenedApproval(createExecRequest({ expiresAtMs: 90_500 }));
     const { dialog } = await getRenderedModalDialog(container);
+    const countdown = container.querySelector<LitElement>(".exec-approval-countdown");
+    if (!countdown) {
+      throw new Error("Expected approval countdown");
+    }
+    await countdown.updateComplete;
 
-    expect(container.querySelector(".exec-approval-countdown")?.textContent?.trim()).toBe(
-      "expires in 01:31",
-    );
+    expect(countdown.textContent?.trim()).toBe("expires in 01:31");
     expect(dialog.getAttribute("aria-description")).toBe("expires in 01:31");
 
     const renderSpy = vi.spyOn(approval as LitElement & { render(): unknown }, "render");
     nowMs = 1_000;
     await vi.waitFor(
       () => {
-        expect(container.querySelector(".exec-approval-countdown")?.textContent?.trim()).toBe(
-          "expires in 01:30",
-        );
+        expect(countdown.textContent?.trim()).toBe("expires in 01:30");
       },
       { timeout: 2_000 },
     );

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -4,7 +4,6 @@ import { html, nothing, type PropertyValues } from "lit";
 import { property, query, state } from "lit/decorators.js";
 import type { ExecApprovalDecision, ExecApprovalRequest } from "../app/exec-approval.ts";
 import { t } from "../i18n/index.ts";
-import { formatCountdown } from "../lib/format.ts";
 import { resolveAsciiShortcutKey } from "../lib/keyboard-shortcuts.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import {
@@ -21,7 +20,6 @@ type ExecApprovalProps = {
   busy: boolean;
   canGrant: boolean;
   errors: ReadonlyMap<string, string>;
-  nowMs: number;
   onDecision: (approvalId: string, decision: ExecApprovalDecision) => void | Promise<void>;
 };
 
@@ -33,7 +31,6 @@ function compactCommand(command: string): string {
 function renderApprovalQueueList(params: {
   queue: readonly ExecApprovalRequest[];
   activeId: string;
-  nowMs: number;
   onSelect: (approvalId: string) => void;
 }) {
   const others = params.queue.filter((entry) => entry.id !== params.activeId);
@@ -46,7 +43,6 @@ function renderApprovalQueueList(params: {
       ${others.map((entry) => {
         const command = compactCommand(entry.request.command);
         const agent = entry.request.agentId?.trim() || "—";
-        const countdown = formatCountdown(entry.expiresAtMs, params.nowMs, true);
         return html`
           <button
             class="exec-approval-list__item"
@@ -56,7 +52,12 @@ function renderApprovalQueueList(params: {
           >
             <span class="exec-approval-list__agent">${agent}</span>
             <span class="exec-approval-list__command mono">${command}</span>
-            <span class="exec-approval-list__expiry" aria-hidden="true">${countdown}</span>
+            <openclaw-approval-countdown
+              class="exec-approval-list__expiry"
+              aria-hidden="true"
+              .expiresAtMs=${entry.expiresAtMs}
+              .compact=${true}
+            ></openclaw-approval-countdown>
           </button>
         `;
       })}
@@ -161,7 +162,7 @@ class ExecApproval extends OpenClawLightDomContentsElement {
     return html`
       <openclaw-modal-dialog
         label=${approvalTitle(active)}
-        description=${approvalRemainingLabel(active.expiresAtMs, props.nowMs)}
+        description=${approvalRemainingLabel(active.expiresAtMs, Date.now())}
         @keydown=${(event: KeyboardEvent) => this.handleKeydown(event, active)}
         @modal-cancel=${handleCancel}
       >
@@ -171,7 +172,6 @@ class ExecApproval extends OpenClawLightDomContentsElement {
             busy: props.busy,
             canGrant: props.canGrant,
             error: props.errors.get(active.id) ?? null,
-            nowMs: props.nowMs,
             variant: "modal",
             queueCount: queue.length,
             onDecision: props.onDecision,
@@ -179,7 +179,6 @@ class ExecApproval extends OpenClawLightDomContentsElement {
           ${renderApprovalQueueList({
             queue,
             activeId: active.id,
-            nowMs: props.nowMs,
             onSelect: (approvalId) => {
               this.selectedApprovalId = approvalId;
             },

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -6,7 +6,6 @@ import type { ExecApprovalDecision, ExecApprovalRequest } from "../app/exec-appr
 import { t } from "../i18n/index.ts";
 import { resolveAsciiShortcutKey } from "../lib/keyboard-shortcuts.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
-import { PollController } from "../lit/poll-controller.ts";
 import {
   approvalRemainingLabel,
   approvalTitle,
@@ -96,19 +95,12 @@ class ExecApproval extends OpenClawLightDomContentsElement {
   @query("openclaw-modal-dialog") private dialog?: OpenClawModalDialog;
   @state() private selectedApprovalId: string | null = null;
   @state() private explicitlyOpen = false;
-  private readonly accessibilityPolling = new PollController(
-    this,
-    1_000,
-    () => this.requestUpdate(),
-    false,
-  );
 
   show(): void {
     if (!this.props?.queue.length) {
       return;
     }
     this.explicitlyOpen = true;
-    this.accessibilityPolling.start();
     void this.updateComplete.then(() => this.dialog?.show());
   }
 
@@ -138,7 +130,6 @@ class ExecApproval extends OpenClawLightDomContentsElement {
     if (previousProps?.queue.length && !this.props?.queue.length) {
       this.explicitlyOpen = false;
       this.selectedApprovalId = null;
-      this.accessibilityPolling.stop();
       return;
     }
     // Pin the presented request: late-arriving older approvals re-sort the
@@ -167,7 +158,6 @@ class ExecApproval extends OpenClawLightDomContentsElement {
       // stays pending and visible via the attention chip and session badges.
       // Denying here would turn Esc into a silent destructive decision.
       this.explicitlyOpen = false;
-      this.accessibilityPolling.stop();
     };
     return html`
       <openclaw-modal-dialog

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -6,6 +6,7 @@ import type { ExecApprovalDecision, ExecApprovalRequest } from "../app/exec-appr
 import { t } from "../i18n/index.ts";
 import { resolveAsciiShortcutKey } from "../lib/keyboard-shortcuts.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+import { PollController } from "../lit/poll-controller.ts";
 import {
   approvalRemainingLabel,
   approvalTitle,
@@ -95,12 +96,19 @@ class ExecApproval extends OpenClawLightDomContentsElement {
   @query("openclaw-modal-dialog") private dialog?: OpenClawModalDialog;
   @state() private selectedApprovalId: string | null = null;
   @state() private explicitlyOpen = false;
+  private readonly accessibilityPolling = new PollController(
+    this,
+    1_000,
+    () => this.requestUpdate(),
+    false,
+  );
 
   show(): void {
     if (!this.props?.queue.length) {
       return;
     }
     this.explicitlyOpen = true;
+    this.accessibilityPolling.start();
     void this.updateComplete.then(() => this.dialog?.show());
   }
 
@@ -130,6 +138,7 @@ class ExecApproval extends OpenClawLightDomContentsElement {
     if (previousProps?.queue.length && !this.props?.queue.length) {
       this.explicitlyOpen = false;
       this.selectedApprovalId = null;
+      this.accessibilityPolling.stop();
       return;
     }
     // Pin the presented request: late-arriving older approvals re-sort the
@@ -158,6 +167,7 @@ class ExecApproval extends OpenClawLightDomContentsElement {
       // stays pending and visible via the attention chip and session badges.
       // Denying here would turn Esc into a silent destructive decision.
       this.explicitlyOpen = false;
+      this.accessibilityPolling.stop();
     };
     return html`
       <openclaw-modal-dialog

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -392,7 +392,6 @@ export class ChatPane extends ChatPaneLayoutRender {
       approvalBusy: overlays?.snapshot?.approvalBusy,
       approvalCanGrant: overlays?.snapshot?.approvalCanGrant ?? false,
       approvalErrors: overlays?.snapshot?.approvalErrors,
-      approvalNowMs: overlays?.snapshot?.approvalNowMs,
       onApprovalDecision:
         overlays && !sessionParticipationBlocked
           ? (approvalId, decision) => overlays.decideApproval(decision, approvalId)

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { html, render } from "lit";
+import { html, render, type LitElement } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -896,7 +896,7 @@ describe("chat Swarm progress", () => {
 });
 
 describe("inline approval card", () => {
-  it("renders between the transcript and composer and enforces its grant projection", () => {
+  it("renders between the transcript and composer and enforces its grant projection", async () => {
     const onApprovalDecision = vi.fn();
     const inlineApproval = {
       id: "approval-inline",
@@ -925,9 +925,19 @@ describe("inline approval card", () => {
     expect(
       inlineSurface?.nextElementSibling?.classList.contains("agent-chat__composer-shell"),
     ).toBe(true);
-    expect(container.querySelector(".exec-approval-countdown")?.textContent?.trim()).toBe(
-      "expires in 01:00",
+    const countdown = expectDefined(
+      container.querySelector<LitElement>(".exec-approval-countdown"),
+      "inline approval countdown",
     );
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    document.body.append(container);
+    try {
+      await countdown.updateComplete;
+      expect(countdown.textContent?.trim()).toBe("expires in 01:00");
+    } finally {
+      container.remove();
+      nowSpy.mockRestore();
+    }
     expect(container.querySelector(".exec-approval-command-span")?.textContent).toBe("rm -r");
     expect(container.querySelector(".exec-approval-error")?.textContent).toBe(
       "Approval failed: gateway unavailable",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -913,7 +913,6 @@ describe("inline approval card", () => {
 
     const container = renderChatView({
       inlineApproval,
-      approvalNowMs: 1_000,
       approvalCanGrant: false,
       approvalErrors: new Map([["approval-inline", "Approval failed: gateway unavailable"]]),
       onApprovalDecision,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -158,7 +158,6 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     approvalBusy?: boolean;
     approvalCanGrant: boolean;
     approvalErrors?: ReadonlyMap<string, string>;
-    approvalNowMs?: number;
     onApprovalDecision?: (
       approvalId: string,
       decision: ExecApprovalDecision,
@@ -568,7 +567,6 @@ export function renderChat(props: ChatProps) {
                           busy: props.approvalBusy === true,
                           canGrant: props.approvalCanGrant,
                           error: props.approvalErrors?.get(props.inlineApproval.id) ?? null,
-                          nowMs: props.approvalNowMs ?? Date.now(),
                           variant: "inline",
                           onDecision: props.onApprovalDecision,
                         })}


### PR DESCRIPTION
Closes #127843

## What Problem This Solves

Fixes an issue where users with a pending execution approval would have the Control UI shell and every connected chat pane rerender once per second until the request resolved or expired.

## Why This Change Was Made

Moves the one-second clock from the application-wide overlay snapshot to the visible approval countdown element. Queue changes and expiry remain owned by the approval state, while only mounted countdown labels receive periodic updates.

## User Impact

Pending approvals no longer keep the whole Control UI rendering at 1 Hz. The visible expiry labels continue updating every second with unchanged text and decision behavior.

## Evidence

Remote A/B used one Blacksmith Testbox lease (`tbx_01m0mahzn9yyhrnyksh47gsg4a`) and the same Playwright mock-Gateway harness for five rounds per variant.

| 10.2-second round | Shell before | Shell after | Chat pane before | Chat pane after | Local countdown after |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 | 10 | 0 | 10 | 0 | 10 |
| 2 | 10 | 0 | 10 | 0 | 10 |
| 3 | 10 | 0 | 10 | 0 | 10 |
| 4 | 10 | 0 | 10 | 0 | 10 |
| 5 | 10 | 0 | 10 | 0 | 10 |
| Median | 10 | 0 | 10 | 0 | 10 |
| IQR | 0 | 0 | 0 | 0 | 0 |

Run URL: https://github.com/openclaw/openclaw/actions/runs/32563288951

Regression on baseline `36d50b20098e8e45bc7a97b020d9755ab7a27414`:

```text
HUNT_UI_01_APPROVAL=[
  {"pending":{"openclaw-app-shell":10,"openclaw-chat-pane":10}},
  {"pending":{"openclaw-app-shell":10,"openclaw-chat-pane":10}},
  {"pending":{"openclaw-app-shell":10,"openclaw-chat-pane":10}},
  {"pending":{"openclaw-app-shell":10,"openclaw-chat-pane":10}},
  {"pending":{"openclaw-app-shell":10,"openclaw-chat-pane":10}}
]
```

Focused validation:

```text
pnpm test ui/src/app/exec-approval.test.ts ui/src/components/exec-approval-card.test.ts ui/src/components/exec-approval.test.ts ui/src/e2e/approval-flow.e2e.test.ts -- --reporter=verbose
# 64 tests passed

pnpm check:changed
# dead export, i18n, typecheck and lint lanes passed

pnpm build
# passed; startup JS gzip 344,919 B vs baseline 345,049 B
```

Production LOC: +42/-55 (net -13). Tests: +5/-10 (net -5).
