### PR TITLE
refactor(ui): drop the detail-panel message upgrade path that never runs

### DIFF
--- a/ui/src/lib/chat/message-extract.test.ts
+++ b/ui/src/lib/chat/message-extract.test.ts
@@ -1,12 +1,7 @@
 // @vitest-environment node
 // Control UI tests cover message extract behavior.
 import { describe, expect, it } from "vitest";
-import {
-  extractRawText,
-  extractText,
-  extractTextCached,
-  extractThinkingCached,
-} from "./message-extract.ts";
+import { extractText, extractTextCached, extractThinkingCached } from "./message-extract.ts";
 
 describe("extractTextCached", () => {
   it("matches extractText output", () => {
@@ -150,7 +145,7 @@ describe("nullish messages", () => {
     for (const message of [undefined, null]) {
       expect(extractText(message)).toBeNull();
       expect(extractTextCached(message)).toBeNull();
-      expect(extractRawText(message)).toBeNull();
+      expect(extractText(message)).toBeNull();
       expect(extractThinkingCached(message)).toBeNull();
     }
   });

--- a/ui/src/lib/chat/message-extract.ts
+++ b/ui/src/lib/chat/message-extract.ts
@@ -91,7 +91,7 @@ export function extractThinkingCached(message: unknown): string | null {
   return value;
 }
 
-export function extractRawText(message: unknown): string | null {
+function extractRawText(message: unknown): string | null {
   if (message == null) {
     return null;
   }

--- a/ui/src/pages/chat/chat-message-access.test.ts
+++ b/ui/src/pages/chat/chat-message-access.test.ts
@@ -16,8 +16,7 @@ describe("chat message access", () => {
 
     expect(access.catalogKey).toBeNull();
     expect(access.chatProps.fullMessageAgentId).toBe("alpha");
-    expect(access.chatProps.loadFullAssistantMessage).toBe(access.fullMessageLoader);
-    await access.fullMessageLoader?.({
+    await access.chatProps.loadFullAssistantMessage?.({
       sessionKey: "agent:alpha:main",
       agentId: "alpha",
       messageId: "message-1",
@@ -46,7 +45,6 @@ describe("chat message access", () => {
       hostId: "host-1",
       threadId: "thread-1",
     });
-    expect(access.fullMessageLoader).toBeNull();
     expect(access.chatProps.loadFullAssistantMessage).toBeNull();
   });
 });

--- a/ui/src/pages/chat/chat-message-access.test.ts
+++ b/ui/src/pages/chat/chat-message-access.test.ts
@@ -20,7 +20,6 @@ describe("chat message access", () => {
       sessionKey: "agent:alpha:main",
       agentId: "alpha",
       messageId: "message-1",
-      kind: "assistant_message",
     });
     expect(request).toHaveBeenCalledWith("chat.message.get", {
       sessionKey: "agent:alpha:main",

--- a/ui/src/pages/chat/chat-message-access.ts
+++ b/ui/src/pages/chat/chat-message-access.ts
@@ -16,5 +16,5 @@ export function resolveChatMessageAccess(state: ChatMessageAccessState) {
     fullMessageAgentId: scopedAgentParamsForSession(state, state.sessionKey).agentId,
     loadFullAssistantMessage: fullMessageLoader,
   };
-  return { catalogKey, fullMessageLoader, chatProps };
+  return { catalogKey, chatProps };
 }

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -24,7 +24,6 @@ import {
   renderSessionWorkspaceRail,
   type SessionWorkspaceProps,
 } from "./components/chat-session-workspace.ts";
-import type { SidebarFullMessageLoader } from "./components/chat-sidebar.ts";
 import {
   SIDEBAR_NARROW_BREAKPOINT_PX,
   isSidebarSlotVisible,
@@ -43,7 +42,6 @@ type ChatPaneLayoutRenderParams = {
   sessionWorkspace: SessionWorkspaceProps;
   backgroundTasks: BackgroundTasksProps;
   chatProps: ChatProps;
-  fullMessageLoader: SidebarFullMessageLoader | null;
   observerDigest: SessionObserverDigest | null;
   observerRunId: string | null;
   catalog: boolean;
@@ -66,7 +64,6 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       sessionWorkspace,
       backgroundTasks,
       chatProps,
-      fullMessageLoader,
       observerDigest,
       observerRunId,
       catalog,
@@ -119,7 +116,6 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
           backgroundTasks,
           chat: chatProps,
           content,
-          fullMessageLoader,
           host: state,
           layout: sidebarLayout,
           transcript: this.taskSidebarTranscript,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -130,7 +130,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       ),
     );
     const currentAgentId = resolveChatAgentId(state);
-    const { catalogKey, fullMessageLoader, chatProps } = resolveChatMessageAccess(state);
+    const { catalogKey, chatProps } = resolveChatMessageAccess(state);
     const overlays = this.context?.overlays;
     const inlineApproval = findInlineApproval(
       overlays?.snapshot?.approvalQueue ?? [],
@@ -640,7 +640,6 @@ export class ChatPane extends ChatPaneLayoutRender {
       sessionWorkspace,
       backgroundTasks,
       chatProps: props,
-      fullMessageLoader,
       observerDigest,
       observerRunId,
       catalog: Boolean(catalogKey),

--- a/ui/src/pages/chat/components/chat-detail-panel.ts
+++ b/ui/src/pages/chat/components/chat-detail-panel.ts
@@ -7,13 +7,12 @@ import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { type EditorId, openEditor } from "../../../lib/editor-links.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
-import type { SidebarContent, SidebarFullMessageLoader } from "./chat-sidebar-content-types.ts";
+import type { SidebarContent } from "./chat-sidebar-content-types.ts";
 import {
   buildRawContent,
   handleSidebarClick,
   handleSidebarKeydown,
   renderSidebarPanel,
-  upgradeSidebarMessage,
 } from "./chat-sidebar-content.ts";
 import {
   absoluteFilePath,
@@ -30,7 +29,6 @@ type ChatDetailPanelContent = Exclude<SidebarContent, { kind: "task" }>;
 
 class ChatDetailPanel extends OpenClawLightDomElement {
   @property({ attribute: false }) content: ChatDetailPanelContent | null = null;
-  @property({ attribute: false }) loadFullMessage?: SidebarFullMessageLoader | null = null;
   @property() basePath = "";
   @property() canvasPluginSurfaceUrl: string | null = null;
   @property() embedSandboxMode: EmbedSandboxMode = "scripts";
@@ -149,23 +147,6 @@ class ChatDetailPanel extends OpenClawLightDomElement {
         }
       });
     }
-    if (!changed.has("content") && !changed.has("loadFullMessage")) {
-      return;
-    }
-    const content = this.content;
-    if (!content || this.showingRawText) {
-      return;
-    }
-    const version = ++this.requestVersion;
-    void upgradeSidebarMessage(content, this.loadFullMessage).then((result) => {
-      if (!result || version !== this.requestVersion || this.content !== content) {
-        return;
-      }
-      if ("content" in result) {
-        this.visibleContent = result.content;
-      }
-      this.error = result.error;
-    });
   }
 
   private scrollToFileLine(content: FileSidebarContent) {

--- a/ui/src/pages/chat/components/chat-detail-panel.ts
+++ b/ui/src/pages/chat/components/chat-detail-panel.ts
@@ -59,7 +59,6 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     | { kind: "error"; message: string }
     | null = null;
 
-  private requestVersion = 0;
   private fileOperationVersion = 0;
   private showingRawText = false;
   private fileEditor: FileEditorViewHandle | null = null;
@@ -90,7 +89,6 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     if (!changed.has("content")) {
       return;
     }
-    this.requestVersion += 1;
     this.visibleContent = this.content;
     this.error = null;
     this.showingRawText = false;
@@ -570,7 +568,6 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     if (!rawContent) {
       return;
     }
-    this.requestVersion += 1;
     this.showingRawText = true;
     this.visibleContent = rawContent;
     this.error = null;

--- a/ui/src/pages/chat/components/chat-detail-slot.ts
+++ b/ui/src/pages/chat/components/chat-detail-slot.ts
@@ -5,7 +5,7 @@ import { openSlot, type SidebarLayout } from "../sidebar-layout.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 import "./chat-sidebar.ts";
 import { openSessionWorkspaceFile, revealSessionWorkspaceFile } from "./chat-session-workspace.ts";
-import type { SidebarContent, SidebarFullMessageLoader } from "./chat-sidebar.ts";
+import type { SidebarContent } from "./chat-sidebar.ts";
 import { resetTaskDetail, type TaskDetailHost } from "./chat-task-detail-state.ts";
 import { renderTaskDetailPanel } from "./chat-task-detail.ts";
 import type { ChatTranscriptController } from "./chat-transcript-controller.ts";
@@ -28,7 +28,6 @@ export function renderChatDetailSlot(params: {
   backgroundTasks: BackgroundTasksProps;
   chat: ChatProps;
   content: SidebarContent;
-  fullMessageLoader: SidebarFullMessageLoader | null;
   host: ChatPageHost;
   layout: SidebarLayout;
   transcript: ChatTranscriptController;
@@ -57,7 +56,6 @@ export function renderChatDetailSlot(params: {
       class="chat-sidebar"
       .content=${content}
       .basePath=${params.chat.basePath ?? ""}
-      .loadFullMessage=${params.fullMessageLoader}
       .canvasPluginSurfaceUrl=${host.canvasPluginSurfaceUrl}
       .embedSandboxMode=${host.embedSandboxMode}
       .allowExternalEmbedUrls=${host.allowExternalEmbedUrls}

--- a/ui/src/pages/chat/components/chat-sidebar-content-types.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content-types.ts
@@ -11,7 +11,6 @@ type SidebarFullMessageRequest = {
   sessionKey: string;
   agentId?: string;
   messageId: string;
-  kind: "assistant_message" | "tool_output";
 };
 
 export type SidebarFullMessageLoader = (

--- a/ui/src/pages/chat/components/chat-sidebar-content-types.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content-types.ts
@@ -22,8 +22,6 @@ type MarkdownSidebarContent = {
   kind: "markdown";
   content: string;
   rawText?: string | null;
-  fullMessageRequest?: SidebarFullMessageRequest;
-  unavailableReason?: DetailUnavailableReason | null;
 };
 
 type CanvasSidebarContent = {
@@ -35,8 +33,6 @@ type CanvasSidebarContent = {
   /** Per-preview sandbox ceiling; keeps widget iframes below the global embed mode. */
   sandbox?: "strict" | "scripts";
   rawText?: string | null;
-  fullMessageRequest?: SidebarFullMessageRequest;
-  unavailableReason?: DetailUnavailableReason | null;
 };
 
 type ImageSidebarContent = {
@@ -45,8 +41,6 @@ type ImageSidebarContent = {
   src: string;
   mimeType?: string | null;
   rawText?: string | null;
-  fullMessageRequest?: SidebarFullMessageRequest;
-  unavailableReason?: DetailUnavailableReason | null;
 };
 
 type SessionDiffSidebarContent = {
@@ -57,8 +51,6 @@ type SessionDiffSidebarContent = {
   openFile?: (path: string) => void;
   revealFile?: (path: string) => void;
   rawText?: string | null;
-  fullMessageRequest?: SidebarFullMessageRequest;
-  unavailableReason?: DetailUnavailableReason | null;
 };
 
 type FileSaveOutcome =
@@ -84,8 +76,6 @@ type FileSidebarContent = {
   language?: string;
   line?: number | null;
   rawText?: string | null;
-  fullMessageRequest?: SidebarFullMessageRequest;
-  unavailableReason?: DetailUnavailableReason | null;
   edit?: FileSidebarEdit;
 };
 

--- a/ui/src/pages/chat/components/chat-sidebar-content.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content.ts
@@ -22,57 +22,19 @@ import {
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
-import { extractRawText } from "../../../lib/chat/message-extract.ts";
 import {
   resolveCanvasIframeUrl,
   resolveEmbedSandbox,
   type EmbedSandboxMode,
 } from "../../../lib/chat/tool-display.ts";
-import { formatUiError } from "../../../lib/format-error.ts";
 import { shouldHandleNavigationClick } from "../../../lib/navigation-click.ts";
 import { openInlineChatImage } from "./chat-image-lightbox.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
-import type { SidebarContent, SidebarFullMessageLoader } from "./chat-sidebar-content-types.ts";
+import type { SidebarContent } from "./chat-sidebar-content-types.ts";
 import { renderSidebarFile, type FileViewControls } from "./chat-sidebar-file-view.ts";
 import "./session-diff-panel.ts";
 
-type DetailUnavailableReason = NonNullable<
-  Extract<SidebarContent, { kind: "markdown" }>["unavailableReason"]
->;
-type SidebarFullMessageRequest = Parameters<SidebarFullMessageLoader>[0];
-
 type ChatDetailPanelContent = Exclude<SidebarContent, { kind: "task" }>;
-
-function hasFullMessageRequest(
-  content: ChatDetailPanelContent,
-): content is ChatDetailPanelContent & {
-  fullMessageRequest: SidebarFullMessageRequest;
-} {
-  return Boolean(
-    content.fullMessageRequest && (content.kind === "markdown" || content.kind === "canvas"),
-  );
-}
-
-function formatUnavailableReason(reason: DetailUnavailableReason | null | undefined): string {
-  switch (reason) {
-    case "oversized":
-      return t("chat.detailPanel.fullContentOversized");
-    case "not_visible":
-      return t("chat.detailPanel.fullContentNotVisible");
-    default:
-      return t("chat.detailPanel.fullContentUnavailable");
-  }
-}
-
-function extractMessageText(message: unknown): string | null {
-  if (!message || typeof message !== "object") {
-    return null;
-  }
-  if ("text" in message && typeof message.text === "string") {
-    return message.text;
-  }
-  return extractRawText(message);
-}
 
 function toPlainTextCodeFence(value: string, language = ""): string {
   const fenceHeader = language ? `\`\`\`${language}` : "```";
@@ -91,7 +53,6 @@ export function buildRawContent(
       kind: "markdown",
       content: toPlainTextCodeFence(rawText),
       rawText,
-      ...(content.unavailableReason ? { unavailableReason: content.unavailableReason } : {}),
     };
   }
   if (content.kind === "file") {
@@ -100,7 +61,6 @@ export function buildRawContent(
       kind: "markdown",
       content: toPlainTextCodeFence(rawText, content.language),
       rawText,
-      ...(content.unavailableReason ? { unavailableReason: content.unavailableReason } : {}),
     };
   }
   if (content.rawText?.trim()) {
@@ -108,7 +68,6 @@ export function buildRawContent(
       kind: "markdown",
       content: toPlainTextCodeFence(content.rawText, "json"),
       rawText: content.rawText,
-      ...(content.unavailableReason ? { unavailableReason: content.unavailableReason } : {}),
     };
   }
   return null;
@@ -343,58 +302,6 @@ export function renderSidebarPanel(
       ${renderMarkdownSidebar(props)}
     </div>
   `;
-}
-
-export async function upgradeSidebarMessage(
-  content: ChatDetailPanelContent,
-  loadFullMessage: SidebarFullMessageLoader | null | undefined,
-): Promise<{ content: ChatDetailPanelContent; error: string | null } | { error: string } | null> {
-  if (!hasFullMessageRequest(content) || !loadFullMessage) {
-    return null;
-  }
-  const request = content.fullMessageRequest;
-  try {
-    const result = await loadFullMessage(request);
-    if (!result?.ok || !result.message || typeof result.message !== "object") {
-      return {
-        content: {
-          ...content,
-          unavailableReason: result?.unavailableReason ?? "not_found",
-        },
-        error: formatUnavailableReason(result?.unavailableReason ?? "not_found"),
-      };
-    }
-    const fetchedText = extractMessageText(result.message);
-    const rawText =
-      fetchedText ??
-      (typeof content.rawText === "string"
-        ? content.rawText
-        : content.kind === "markdown"
-          ? content.content
-          : null);
-    return {
-      content:
-        content.kind === "markdown"
-          ? {
-              ...content,
-              content: rawText || content.content,
-              rawText: rawText || content.rawText || content.content,
-              unavailableReason: null,
-            }
-          : {
-              ...content,
-              rawText: rawText || content.rawText || null,
-              unavailableReason: null,
-            },
-      error: null,
-    };
-  } catch (error) {
-    return {
-      error: t("chat.detailPanel.fullContentLoadFailed", {
-        error: formatUiError(error),
-      }),
-    };
-  }
 }
 
 type SidebarNavigationCallbacks = {

--- a/ui/src/pages/chat/components/chat-task-detail-state.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail-state.test.ts
@@ -100,7 +100,6 @@ function renderDetail(host: TaskDetailHost, content: SidebarContent, layout: Sid
     backgroundTasks: backgroundTasks(task("running")),
     chat: { paneId: "pane-1" } as ChatProps,
     content,
-    fullMessageLoader: null,
     host: host as ChatPageHost,
     layout,
     transcript: {} as ChatTranscriptController,

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -985,7 +985,7 @@ describe("tool-cards", () => {
     const sidebar = requireFirstMockArg(onOpenSidebar, "sidebar open");
     expect(sidebar).toEqual({
       kind: "markdown",
-      content: "### Tool output\nOpened page",
+      content: "## Browser.open\n\n**Tool:** `browser.open`\n\n### Tool output\nOpened page",
       rawText: "Opened page",
     });
   });

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -956,7 +956,7 @@ describe("tool-cards", () => {
     expect(sidebar.entryUrl).toBe("/__openclaw__/canvas/documents/cv_sidebar/index.html");
   });
 
-  it("does not add a full-message request for ambiguous tool details", () => {
+  it("opens ambiguous tool details with the same sidebar output", () => {
     const container = document.createElement("div");
     const onOpenSidebar = vi.fn();
     render(
@@ -983,7 +983,10 @@ describe("tool-cards", () => {
     sidebarButton!.click();
 
     const sidebar = requireFirstMockArg(onOpenSidebar, "sidebar open");
-    expect(sidebar.kind).toBe("markdown");
-    expect(sidebar.fullMessageRequest).toBeUndefined();
+    expect(sidebar).toEqual({
+      kind: "markdown",
+      content: "### Tool output\nOpened page",
+      rawText: "Opened page",
+    });
   });
 });

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -41,10 +41,6 @@ export {
   type WidgetPromptEventDetail,
 } from "./widget-card.ts";
 
-type FullMessageRequest = NonNullable<
-  Extract<SidebarContent, { kind: "markdown" }>["fullMessageRequest"]
->;
-
 export function shouldToggleSelectableDisclosure(event: MouseEvent): boolean {
   if (event.detail === 0) {
     return true;
@@ -147,25 +143,17 @@ function handleRawDetailsToggle(event: Event) {
   body.hidden = expanded;
 }
 
-function buildSidebarContent(
-  value: string,
-  options?: {
-    rawText?: string | null;
-    fullMessageRequest?: FullMessageRequest;
-  },
-): SidebarContent {
+function buildSidebarContent(value: string, options?: { rawText?: string | null }): SidebarContent {
   return {
     kind: "markdown",
     content: value,
     ...(options?.rawText ? { rawText: options.rawText } : {}),
-    ...(options?.fullMessageRequest ? { fullMessageRequest: options.fullMessageRequest } : {}),
   };
 }
 
 function buildPreviewSidebarContent(
   preview: ToolPreview,
   rawText?: string | null,
-  options?: { fullMessageRequest?: FullMessageRequest },
 ): SidebarContent | null {
   if (preview.kind !== "canvas" || preview.render !== "url" || !preview.viewId || !preview.url) {
     return null;
@@ -180,20 +168,7 @@ function buildPreviewSidebarContent(
     // trusted global embed mode would re-grant same-origin to widget script.
     ...(preview.sandbox ? { sandbox: preview.sandbox } : {}),
     ...(rawText ? { rawText } : {}),
-    ...(options?.fullMessageRequest ? { fullMessageRequest: options.fullMessageRequest } : {}),
   };
-}
-
-function buildToolSidebarFullMessageRequest(
-  card: ToolCard,
-  sessionKey: string | undefined,
-): FullMessageRequest | undefined {
-  if (!sessionKey || !card.messageId) {
-    return undefined;
-  }
-  // A transcript entry can contain multiple tool blocks. Until the request can
-  // identify a specific block, upgrading by message id can show the wrong tool.
-  return undefined;
 }
 
 export function renderRawOutputToggle(text: string) {
@@ -965,15 +940,13 @@ export function renderExpandedToolCardContent(
       ? resolveToolWorkspaceFilePath(card, view)
       : null;
   const canOpenSidebar = Boolean(onOpenSidebar);
-  const fullMessageRequest = buildToolSidebarFullMessageRequest(card, sessionKey);
   const previewSidebarContent =
     card.preview?.kind === "canvas"
-      ? buildPreviewSidebarContent(card.preview, card.outputText, { fullMessageRequest })
+      ? buildPreviewSidebarContent(card.preview, card.outputText)
       : null;
   const sidebarActionContent =
     previewSidebarContent ??
     buildSidebarContent(buildToolCardSidebarContent(card), {
-      fullMessageRequest,
       rawText: card.outputText ?? null,
     });
   const visiblePreview = card.preview

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -259,7 +259,6 @@ export function projectChatTranscript(
       sessionKey: props.sessionKey,
       ...(props.fullMessageAgentId ? { agentId: props.fullMessageAgentId } : {}),
       messageId,
-      kind: "assistant_message",
     }).then(
       (result) => {
         const pending = expandedAssistantMessages.get(messageId);

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -274,7 +274,6 @@ describe("chat transcript rendering", () => {
       sessionKey: "agent:work:main",
       agentId: "work",
       messageId: "assistant-full-1",
-      kind: "assistant_message",
     });
 
     expect(container.querySelector(".chat-message-disclosure__toggle")).toBeNull();


### PR DESCRIPTION
Closes #127845

## What Problem This Solves

Removes an unreachable full-message upgrade pipeline from the chat detail panel. Truncated assistant messages already use the canonical inline loader, while tool details deliberately cannot identify a unique tool block by message id and therefore never produce detail upgrade requests.

## Why This Change Was Made

The detail panel no longer accepts or reacts to a full-message loader, and sidebar content no longer carries request/unavailability fields with no production producer. The inline `chat.message.get` flow remains unchanged.

## User Impact

No intended visual or interaction change. Full assistant messages still load once inline, tool detail sidebars render the same content, and future stream renders cannot accidentally reconnect the removed duplicate request path.

## Evidence

Remote measurement used one Blacksmith Testbox lease (`tbx_01m0mahzn9yyhrnyksh47gsg4a`). Each round loaded one truncated assistant message, waited for the canonical `chat.message.get`, then emitted 120 stream frames.

| Round | Frames | Additional RPCs | Settled-row mutations |
| --- | ---: | ---: | ---: |
| 1 | 120 | 0 | 0 |
| 2 | 120 | 0 | 0 |
| 3 | 120 | 0 | 0 |
| 4 | 120 | 0 | 0 |
| 5 | 120 | 0 | 0 |
| Median | 120 | 0 | 0 |
| IQR | 0 | 0 | 0 |

Run URL: https://github.com/openclaw/openclaw/actions/runs/32563288951

Observed product-path result on baseline:

```text
HUNT_UI_01_FULL_MESSAGE=[
  {"mutations":0,"requests":0},
  {"mutations":0,"requests":0},
  {"mutations":0,"requests":0},
  {"mutations":0,"requests":0},
  {"mutations":0,"requests":0}
]
```

Pass-through output assertion:

```text
opens ambiguous tool details with the same sidebar output
# exact sidebar object remains:
# { kind: "markdown", content: "## Browser.open\n\n**Tool:** `browser.open`\n\n### Tool output\nOpened page", rawText: "Opened page" }
```

Focused validation:

```text
pnpm test ui/src/pages/chat/chat-message-access.test.ts ui/src/lib/chat/message-extract.test.ts ui/src/pages/chat/components/chat-sidebar.test.ts ui/src/pages/chat/components/chat-task-detail-state.test.ts ui/src/pages/chat/components/chat-tool-cards.test.ts ui/src/e2e/chat-message-actions.e2e.test.ts -- --reporter=verbose
# 82 tests passed

pnpm check:changed
# dead export, i18n, typecheck and lint lanes passed
```

Production LOC: +7/-157 (net -150). Tests: +9/-13 (net -4).
