### PR TITLE
fix(models): stop /models from freezing the gateway while it rescans plugins

### DIFF
--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -13,7 +13,6 @@ import { buildModelsProviderData, handleModelsCommand } from "./commands-models.
 import type { HandleCommandsParams } from "./commands-types.js";
 
 const modelCatalogMocks = vi.hoisted(() => ({ loadModelCatalog: vi.fn() }));
-
 const modelAuthLabelMocks = vi.hoisted(() => ({
   resolveModelAuthLabel: vi.fn<(params: unknown) => string | undefined>(() => undefined),
 }));
@@ -70,16 +69,8 @@ const modelProviderAuthMocks = vi.hoisted(() => {
 });
 const normalizeProviderModelIdWithRuntimeMock = vi.hoisted(() => vi.fn());
 const pluginMetadataMocks = vi.hoisted(() => ({
-  snapshot: undefined as
-    | {
-        plugins: unknown[];
-        owners: {
-          cliBackends: Map<string, string>;
-        };
-      }
-    | undefined,
+  getCurrent: vi.fn(),
 }));
-
 const MODELS_ADD_DEPRECATED_TEXT =
   "⚠️ /models add is deprecated. Use /models to browse providers and /model to switch models.";
 
@@ -138,7 +129,7 @@ vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
 }));
 
 vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
+  getCurrentPluginMetadataSnapshot: pluginMetadataMocks.getCurrent,
 }));
 
 const telegramModelsTestPlugin: ChannelPlugin = {
@@ -218,7 +209,7 @@ beforeEach(() => {
   modelAuthLabelMocks.resolveModelAuthLabel.mockReset();
   modelAuthLabelMocks.resolveModelAuthLabel.mockReturnValue(undefined);
   normalizeProviderModelIdWithRuntimeMock.mockReset();
-  pluginMetadataMocks.snapshot = undefined;
+  pluginMetadataMocks.getCurrent.mockReset();
   modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "google", "openai"]);
   modelProviderAuthMocks.selectedRoute = undefined;
   modelProviderAuthMocks.createProviderAuthChecker.mockClear();
@@ -381,7 +372,7 @@ describe("handleModelsCommand", () => {
         cliBackends: new Map<string, string>(),
       },
     };
-    pluginMetadataMocks.snapshot = metadataSnapshot;
+    pluginMetadataMocks.getCurrent.mockReturnValue(metadataSnapshot);
 
     await handleModelsCommand(buildParams("/models"), true);
 
@@ -501,34 +492,33 @@ describe("handleModelsCommand", () => {
   });
 
   it("shows plugin-normalized allowlist models in browse data", async () => {
-    normalizeProviderModelIdWithRuntimeMock.mockImplementation(({ provider, context }) => {
-      if (
-        provider === "custom-provider" &&
-        (context as { modelId?: string }).modelId === "custom-legacy-model"
-      ) {
-        return "custom-modern-model";
-      }
-      return undefined;
+    pluginMetadataMocks.getCurrent.mockReturnValue({
+      plugins: [
+        {
+          modelIdNormalization: {
+            providers: {
+              custom: { aliases: { legacy: "modern" } },
+            },
+          },
+        },
+      ],
+      owners: { cliBackends: new Map() },
     });
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
-      { provider: "custom-provider", id: "custom-modern-model", name: "Custom Modern" },
+      { provider: "custom", id: "modern", name: "Modern" },
     ]);
-    modelProviderAuthMocks.authenticatedProviders = new Set(["custom-provider"]);
-
+    modelProviderAuthMocks.authenticatedProviders = new Set(["custom"]);
     const data = await buildModelsProviderData({
       agents: {
         defaults: {
-          model: { primary: "custom-provider/custom-modern-model" },
-          models: {
-            "custom-provider/custom-legacy-model": {},
-          },
+          model: { primary: "custom/modern" },
+          models: { "custom/legacy": {} },
         },
       },
     } as OpenClawConfig);
 
-    expect(data.byProvider.get("custom-provider")).toEqual(new Set(["custom-modern-model"]));
-    expect(data.modelNames.get("custom-provider/custom-modern-model")).toBe("Custom Modern");
-    expect(normalizeProviderModelIdWithRuntimeMock).toHaveBeenCalled();
+    expect(data.byProvider.get("custom")).toEqual(new Set(["modern"]));
+    expect(pluginMetadataMocks.getCurrent).toHaveBeenCalledTimes(1);
   });
 
   it("does not re-add the default provider when provider visibility is restricted", async () => {
@@ -648,12 +638,12 @@ describe("handleModelsCommand", () => {
         },
       ],
     });
-    pluginMetadataMocks.snapshot = {
+    pluginMetadataMocks.getCurrent.mockReturnValue({
       plugins: [],
       owners: {
         cliBackends: new Map([["acme-cli", "acme"]]),
       },
-    };
+    });
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
       { provider: "acme-cli", id: "acme-model", name: "Acme Model" },

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -28,10 +28,7 @@ import {
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
-import {
-  RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
-  createModelVisibilityPolicy,
-} from "../../agents/model-visibility-policy.js";
+import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
 import { openAIModelCatalogRoutePolicy } from "../../agents/openai-model-routes.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import { loadPreparedModelCatalogSnapshot } from "../../agents/prepared-model-catalog.js";
@@ -43,6 +40,7 @@ import { resolveAgentRuntimeLabel } from "../../status/agent-runtime-label.js";
 import type { ReplyPayload } from "../types.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
+import { resolveRuntimeNormalization } from "./model-runtime-normalization.js";
 
 const PAGE_SIZE_DEFAULT = 20;
 const PAGE_SIZE_MAX = 100;
@@ -155,9 +153,11 @@ export async function buildModelsProviderData(
   agentId?: string,
   options: { view?: "default" | "all"; workspaceDir?: string } = {},
 ): Promise<ModelsProviderData> {
+  const runtimeNormalization = resolveRuntimeNormalization(cfg);
   const resolvedDefault = resolveDefaultModelForAgent({
     cfg,
     agentId,
+    ...runtimeNormalization,
   });
   const catalogWorkspaceDir = options.workspaceDir;
   const workspaceDir =
@@ -187,7 +187,7 @@ export async function buildModelsProviderData(
     defaultProvider: resolvedDefault.provider,
     defaultModel: resolvedDefault.model,
     agentId,
-    ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+    ...runtimeNormalization,
   });
   const authChecker = createProviderAuthChecker({
     cfg,
@@ -211,6 +211,7 @@ export async function buildModelsProviderData(
     agentId,
     workspaceDir,
     view: options.view,
+    policy: visibilityPolicy,
     routePolicy: openAIModelCatalogRoutePolicy,
     routeVariants: snapshot.routeVariants,
     evaluateEntry: async (entry, routeVariants) => {
@@ -238,6 +239,7 @@ export async function buildModelsProviderData(
     cfg,
     defaultProvider: resolvedDefault.provider,
     agentId,
+    ...runtimeNormalization,
   });
   const restrictToProviderWildcards =
     options.view !== "all" && visibilityPolicy.hasProviderWildcards;
@@ -272,6 +274,7 @@ export async function buildModelsProviderData(
           model: trimmed,
           defaultProvider: resolvedDefault.provider,
           agentId,
+          manifestPlugins: runtimeNormalization.manifestPlugins,
         })
       : resolvedDefault.provider;
     const resolved = resolveModelRefFromString({
@@ -280,6 +283,7 @@ export async function buildModelsProviderData(
       raw: trimmed,
       defaultProvider,
       aliasIndex,
+      ...runtimeNormalization,
     });
     if (!resolved) {
       return;


### PR DESCRIPTION
Related: #127379

## What Problem This Solves

Fixes an issue where users browsing `/models` from a channel could stall the Gateway event loop when plugin model normalization repeatedly rediscovered metadata.

## Why This Change Was Made

The browse path now resolves the Gateway-owned runtime normalization context once and carries it through default selection, visibility, aliases, configured references, and logical catalog projection. This preserves plugin-owned model aliases instead of disabling normalization, while removing repeated synchronous metadata discovery and duplicate policy construction.

## User Impact

`/models` keeps plugin-normalized model choices correct without repeatedly scanning installed plugin metadata, so unrelated channel delivery and Gateway RPCs remain responsive during model browsing.

## Evidence

- Before fix: focused regression observed 18 `getCurrentPluginMetadataSnapshot` calls for one browse build.
- After fix: the same regression observes exactly 1 call while mapping `custom/legacy` to `custom/modern`.
- Local: `node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.test.ts` (36 passed).
- Local: `node scripts/check-changed.mjs -- src/auto-reply/reply/commands-models.ts src/auto-reply/reply/commands-models.test.ts` (passed).
- Blacksmith Testbox `tbx_01m0me5btz9kj7p6d0n9nvgc4n`: 36 passed. https://github.com/openclaw/openclaw/actions/runs/32566101795
- Production LOC: +9/-5; tests: +23/-33.
- Autoreview gap: the required Codex helper was attempted twice but its subprocess exited before emitting the required JSON; Claude CLI is not installed. No review finding was emitted.
