### PR TITLE
fix(channels): hold an ingress lane on its head, not on any retrying row

### DIFF
--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -535,7 +535,11 @@ describe("createDiscordMessageHandler queue behavior", () => {
           },
         });
         try {
+          // Frozen fake time stamps every admission with the same receipt instant, which
+          // orders the lane by event id and puts "poison" behind "follower". Separate the
+          // admissions so the poison event really is the lane head this case is about.
           await handler(createRawMessage("poison", "lane-a") as never, {} as never);
+          await vi.advanceTimersByTimeAsync(1);
           await handler(createRawMessage("follower", "lane-a") as never, {} as never);
           await handler(createRawMessage("independent", "lane-b") as never, {} as never);
 
@@ -549,15 +553,14 @@ describe("createDiscordMessageHandler queue behavior", () => {
           expect(attempted.filter((id) => id === "poison")).toHaveLength(
             DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
           );
-          await expect(queue.enqueue("poison", {} as DiscordIngressPayload)).resolves.toMatchObject(
-            {
-              kind: "failed",
-              record: { reason: "retry-limit-exceeded" },
-            },
-          );
-          await expect(
-            queue.enqueue("follower", {} as DiscordIngressPayload),
-          ).resolves.toMatchObject({ kind: "completed" });
+          const settled = {} as DiscordIngressPayload;
+          await expect(queue.enqueue("poison", settled)).resolves.toMatchObject({
+            kind: "failed",
+            record: { reason: "retry-limit-exceeded" },
+          });
+          await expect(queue.enqueue("follower", settled)).resolves.toMatchObject({
+            kind: "completed",
+          });
           const runtimeErrors = mockCalls(params.runtime.error as unknown as MockCallSource).map(
             ([message]) => String(message),
           );

--- a/src/channels/message/ingress-drain-lanes.test.ts
+++ b/src/channels/message/ingress-drain-lanes.test.ts
@@ -46,4 +46,100 @@ describe("channel ingress drain lanes", () => {
       drain.dispose();
     });
   });
+
+  // LINE-shaped lanes: one user/group id owns a lane, so a lane head parked behind
+  // a newer failing sibling reads to the sender as an ignored message.
+  it("starts an eligible lane head while a newer same-lane event waits out its retry backoff", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      const currentNow = 10_000_000;
+      await queue.enqueue("head", { text: "head" }, { laneKey: "user:U1", receivedAt: 1_000 });
+      await queue.enqueue("tail", { text: "tail" }, { laneKey: "user:U1", receivedAt: 2_000 });
+      const tailClaim = await queue.claim("tail");
+      expect(tailClaim).not.toBeNull();
+      await queue.release(tailClaim!, { lastError: "boom", releasedAt: currentNow });
+
+      const dispatches: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => currentNow,
+        retryPolicy: { baseMs: 60_000, maxMs: 60_000 },
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatches.push(event.id);
+          await lifecycle.onAdopted();
+        },
+      });
+
+      await expect(drain.drainOnce()).resolves.toEqual({ started: 1 });
+      await vi.waitFor(() => expect(dispatches).toEqual(["head"]));
+
+      await drain.waitForIdle();
+      drain.dispose();
+    });
+  });
+
+  it("keeps the lane blocked while its oldest pending event is retry-delayed", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      const currentNow = 10_000_000;
+      await queue.enqueue("head", { text: "head" }, { laneKey: "user:U1", receivedAt: 1_000 });
+      await queue.enqueue("tail", { text: "tail" }, { laneKey: "user:U1", receivedAt: 2_000 });
+      const headClaim = await queue.claim("head");
+      expect(headClaim).not.toBeNull();
+      await queue.release(headClaim!, { lastError: "boom", releasedAt: currentNow });
+
+      const dispatches: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => currentNow,
+        retryPolicy: { baseMs: 60_000, maxMs: 60_000 },
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatches.push(event.id);
+          await lifecycle.onAdopted();
+        },
+      });
+
+      await expect(drain.drainOnce()).resolves.toEqual({ started: 0 });
+      expect(dispatches).toEqual([]);
+
+      await drain.waitForIdle();
+      drain.dispose();
+    });
+  });
+
+  it("never claims a retry-delayed event whose lane head settled after the drain snapshot", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      const currentNow = 10_000_000;
+      await queue.enqueue("head", { text: "head" }, { laneKey: "user:U1", receivedAt: 1_000 });
+      await queue.enqueue("tail", { text: "tail" }, { laneKey: "user:U1", receivedAt: 2_000 });
+      const tailClaim = await queue.claim("tail");
+      await queue.release(tailClaim!, { lastError: "boom", releasedAt: currentNow });
+
+      // Snapshot keeps the eligible head, then a sibling drainer settles it. The
+      // freed lane must not hand the still-delayed tail an early attempt.
+      const snapshot = await queue.listPending({ limit: "all", orderBy: "received" });
+      const headClaim = await queue.claim("head");
+      expect(headClaim).not.toBeNull();
+      await queue.complete(headClaim!);
+      vi.spyOn(queue, "listPending").mockResolvedValue(snapshot);
+
+      const dispatches: string[] = [];
+      const drain = createChannelIngressDrain<Payload>({
+        queue,
+        now: () => currentNow,
+        retryPolicy: { baseMs: 60_000, maxMs: 60_000 },
+        dispatchClaimedEvent: async (event, lifecycle) => {
+          dispatches.push(event.id);
+          await lifecycle.onAdopted();
+        },
+      });
+
+      await expect(drain.drainOnce()).resolves.toEqual({ started: 0 });
+      expect(dispatches).toEqual([]);
+
+      await drain.waitForIdle();
+      drain.dispose();
+    });
+  });
 });

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -705,12 +705,19 @@ export function createChannelIngressDrain<
         ),
     );
     const retryDelayedLaneKeys = new Set<string>();
+    const pendingLaneKeys = new Set<string>();
+    const candidateIds = new Set(pending.map((event) => event.id));
+    // listPending and claimNext share order, so the first row per lane is its head.
+    // Delayed tails leave this snapshot so a sibling cannot make them start early.
     for (const event of pending) {
+      const laneKey = resolveLaneKey(event, options.deriveLaneKey, options.reconcileStoredLaneKey);
       if (resolveIngressRetryDelayMs(event, options.retryPolicy, now()) > 0) {
-        retryDelayedLaneKeys.add(
-          resolveLaneKey(event, options.deriveLaneKey, options.reconcileStoredLaneKey),
-        );
+        candidateIds.delete(event.id);
+        if (!pendingLaneKeys.has(laneKey)) {
+          retryDelayedLaneKeys.add(laneKey);
+        }
       }
+      pendingLaneKeys.add(laneKey);
     }
 
     // Deterministic blocked set for claimNext lane serialization.
@@ -732,7 +739,6 @@ export function createChannelIngressDrain<
       }
     }
 
-    const candidateIds = new Set(pending.map((event) => event.id));
     let started = 0;
     while (started < startLimit) {
       if (shouldStop()) {

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -70,6 +70,7 @@ function createMonitor(
         waitForDeliveryIdleBeforeRepump?: boolean;
         waitForDeliveryIdleOnStop?: boolean;
         retryPolicy?: IngressRetryPolicyConfig;
+        deferredLaneOccupancy?: "hold" | "release";
         runPumpTask?: (work: () => Promise<void>) => Promise<void>;
       },
   onError?: (error: unknown) => void,
@@ -81,7 +82,7 @@ function createMonitor(
     typeof activityOrMonitorOptions === "function" ? activityOrMonitorOptions : undefined;
   const monitorOptions =
     typeof activityOrMonitorOptions === "object" ? activityOrMonitorOptions : {};
-  const { inspect, retryPolicy, ...baseMonitorOptions } = monitorOptions;
+  const { inspect, retryPolicy, deferredLaneOccupancy, ...baseMonitorOptions } = monitorOptions;
   return createChannelIngressMonitor<RawEvent, string, StoredEvent>({
     queue,
     inspect: inspect ?? ((raw) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` })),
@@ -99,6 +100,7 @@ function createMonitor(
     drain: {
       adoptionStallTimeoutMs: 5_000,
       retryPolicy: retryPolicy ?? { baseMs: retryBaseMs, maxMs: retryBaseMs },
+      ...(deferredLaneOccupancy ? { deferredLaneOccupancy } : {}),
       resolveNonRetryableFailure: (error) =>
         error instanceof PermanentIngressError
           ? { reason: "invalid-event", message: error.message }
@@ -462,6 +464,56 @@ describe("channel ingress monitor", () => {
         expect(delivered).toEqual(["event-first", "event-retry", "event-retry"]),
       );
       await monitor.waitForIdle();
+
+      await monitor.stop();
+    });
+  });
+
+  // Telegram and Slack release the ingress lane while a turn is deferred, so a
+  // newer same-lane event can be claimed and fail while the older one is still
+  // held. Cancelling that deferred owner reopens its row without consuming retry
+  // budget, leaving an eligible lane head behind its own newer sibling's backoff.
+  it("dispatches a reopened lane head while its newer sibling waits out backoff", async () => {
+    await withQueue(async (queue) => {
+      const delivered: string[] = [];
+      let cancelHead: (() => Promise<void>) | undefined;
+      const monitor = createMonitor(
+        queue,
+        async (raw, lifecycle) => {
+          delivered.push(raw.id);
+          if (raw.id !== "event-head") {
+            return { kind: "failed-retryable", error: new Error("tail delivery failed") };
+          }
+          if (cancelHead) {
+            return { kind: "completed" };
+          }
+          cancelHead = async () => await lifecycle.onCancelled?.();
+          return { kind: "deferred" };
+        },
+        {
+          deferredLaneOccupancy: "release",
+          retryPolicy: { baseMs: 60_000, maxMs: 60_000 },
+        },
+      );
+      monitor.start();
+      await monitor.admit({ id: "event-head", lane: "a", text: "head" });
+      await vi.waitFor(() => expect(delivered).toEqual(["event-head"]));
+      await monitor.admit({ id: "event-tail", lane: "a", text: "tail" });
+      await vi.waitFor(() => expect(delivered).toEqual(["event-head", "event-tail"]));
+      // The failed tail is pending inside its backoff; the head is still claimed.
+      await vi.waitFor(async () =>
+        expect(
+          (await queue.listPending({ limit: "all", orderBy: "received" })).map((event) => event.id),
+        ).toEqual(["event-tail"]),
+      );
+
+      expect(cancelHead).toBeDefined();
+      await cancelHead?.();
+
+      await vi.waitFor(() => expect(delivered).toEqual(["event-head", "event-tail", "event-head"]));
+      await monitor.waitForIdle();
+      // The tail still never starts early: it stays parked for its own backoff.
+      expect(delivered).toEqual(["event-head", "event-tail", "event-head"]);
 
       await monitor.stop();
     });


### PR DESCRIPTION
Found while investigating #97435. This is a separate shared-drain ordering bug; #127950 owns that report's deferred-liveness root cause.

## What Problem This Solves

Retry backoff belongs to one queued event, but the shared durable ingress drain blocked a whole conversation lane when any pending row in that lane was delayed.

The failure is reachable when an older deferred row reopens after a newer same-lane row has failed. The older row is ready, but the newer row's backoff makes the user wait with no reply.

## Why This Change Was Made

The shared drain now follows the queue's canonical claim order:

- The oldest pending row decides whether its lane is blocked.
- Every retry-delayed row is removed from the current claim snapshot.
- A delayed head still preserves first-in, first-out ordering.
- A delayed tail cannot start early if another drainer settles the head after the snapshot.

The repair stays in `src/channels/message/ingress-drain.ts`. It removes the earlier one-use retry helper and changes production code by `+10/-4` lines. No channel-specific bypass, configuration, schema, fallback, or retry timing changes.

## User Impact

An older ready message no longer waits behind a newer message's retry delay. Message order remains unchanged, and the delayed message still waits for its own backoff.

## Evidence

### Live Telegram red and green

The same Telegram Test Server direct-message scenario ran on both revisions with the real Telegram plugin, real SQLite ingress queue, shared drain, and a controlled model endpoint. A real inbound message supplied the transport payload. The scenario then added an older eligible head and a newer same-lane tail with eight recorded attempts under the default retry policy.

- Dispatch main `1deff1bac414e9474182f0c386983f0d7d508433`: one provider request and one bot reply. The eligible head stayed pending at zero attempts, and the retry-delayed tail stayed pending at eight attempts.
- Repaired head `35bbacaf6321bb7b0ed53e6f827a0510ce6948c6`: two provider requests and two bot replies. The eligible head completed at zero attempts, and the retry-delayed tail stayed pending at eight attempts.

The second provider request contained the eligible-head marker, and Telegram recorded its distinct reply only on the repaired head. Both runs completed and cleaned their temporary Gateway and credential state.

### Regression and sibling coverage

The new eligible-head regression fails on dispatch main with `{ started: 0 }` instead of `{ started: 1 }`.

On the repaired head:

- `src/channels/message/ingress-drain-lanes.test.ts`: 4 passed, including delayed head, delayed tail, and snapshot race.
- `src/channels/message/ingress-monitor.test.ts`: 32 passed, including deferred release, retry, cancellation, and reopened head.
- `extensions/discord/src/monitor/message-handler.queue.test.ts`: 23 passed.
- `src/channels/message/` plus `extensions/slack/src/monitor/ingress.test.ts`: 260 passed across the selected shards.
- Exact changed-scope gate passed core production, core test, and extension test type checks, lint, formatting, boundaries, database guards, import cycles, and repository ratchets.

Related open PR #129717 changes candidate snapshot handling for large backlogs. A later integration must keep the delayed-event snapshot fence established here.
