### PR TITLE
fix(agents): keep replies available during credential refresh

### DIFF
--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -88,6 +88,10 @@ export class PreparedModelRuntimeAuthPublicationOwner {
     return true;
   }
 
+  owners(transaction: PreparedModelRuntimeAuthTransaction): readonly PreparedModelRuntimeOwner[] {
+    return [...transaction.ownerGates.keys()];
+  }
+
   resolve(
     transaction: PreparedModelRuntimeAuthTransaction,
     owners: Map<string, PreparedModelRuntimeOwner>,
@@ -136,6 +140,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
       }>,
     ) => Promise<void>;
     commit?: () => void;
+    onOwnerFailure?: (error: unknown) => void;
   }): Promise<void> {
     while (this.#events.length > 0) {
       const events = this.#events.splice(0);
@@ -152,17 +157,30 @@ export class PreparedModelRuntimeAuthPublicationOwner {
       try {
         await params.publish(entries);
       } catch (error) {
-        // A newer mutation supersedes this failed batch and already belongs to this worker.
-        // Keep draining so its corrective generation is never left without a publication owner.
-        const failedOwnersCovered = entries.every(({ owner }) =>
-          this.#events.some(
-            (event) =>
-              event.affectsInheritedStores ||
-              owner.input.agentDir === event.agentDir ||
-              owner.input.inheritedAuthDir === event.agentDir,
-          ),
+        const failedOwners = entries.filter(
+          ({ owner }) =>
+            !this.#events.some(
+              (event) =>
+                event.affectsInheritedStores ||
+                owner.input.agentDir === event.agentDir ||
+                owner.input.inheritedAuthDir === event.agentDir,
+            ),
         );
-        if (!failedOwnersCovered) {
+        for (const { owner } of failedOwners) {
+          const gate = this.#transaction?.ownerGates.get(owner);
+          if (gate) {
+            if (owner.pending === gate.promise) {
+              owner.pending = undefined;
+            }
+            this.#transaction?.ownerGates.delete(owner);
+            gate.reject(error);
+          }
+        }
+        if (failedOwners.length > 0) {
+          params.onOwnerFailure?.(error);
+        }
+        // Newer events remain owned by this worker even when they target independent owners.
+        if (this.#events.length === 0) {
           throw error;
         }
       }

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -149,7 +149,23 @@ export class PreparedModelRuntimeAuthPublicationOwner {
           ),
         )
         .map((owner) => ({ owner, input: owner.input }));
-      await params.publish(entries);
+      try {
+        await params.publish(entries);
+      } catch (error) {
+        // A newer mutation supersedes this failed batch and already belongs to this worker.
+        // Keep draining so its corrective generation is never left without a publication owner.
+        const failedOwnersCovered = entries.every(({ owner }) =>
+          this.#events.some(
+            (event) =>
+              event.affectsInheritedStores ||
+              owner.input.agentDir === event.agentDir ||
+              owner.input.inheritedAuthDir === event.agentDir,
+          ),
+        );
+        if (!failedOwnersCovered) {
+          throw error;
+        }
+      }
     }
     // The queue check and commit share one synchronous section so no mutation can be orphaned.
     params.commit?.();

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -16,6 +16,7 @@ type PreparedModelRuntimeAuthTransaction = {
   adoptedBy?: PreparedModelRuntimeReplacementGateId;
   ownerGates: Map<PreparedModelRuntimeOwner, Deferred<PreparedModelRuntimeSnapshot>>;
   publicationQueued: boolean;
+  readyOwners: Set<PreparedModelRuntimeOwner>;
 };
 
 export class PreparedModelRuntimeAuthPublicationOwner {
@@ -29,8 +30,13 @@ export class PreparedModelRuntimeAuthPublicationOwner {
     this.#events.push(event);
     const transaction =
       this.#transaction ??
-      (this.#transaction = { ownerGates: new Map(), publicationQueued: false });
+      (this.#transaction = {
+        ownerGates: new Map(),
+        publicationQueued: false,
+        readyOwners: new Set(),
+      });
     for (const owner of invalidatedOwners) {
+      transaction.readyOwners.delete(owner);
       let gate = transaction.ownerGates.get(owner);
       if (!gate) {
         gate = createDeferredCore<PreparedModelRuntimeSnapshot>();
@@ -156,7 +162,16 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         .map((owner) => ({ owner, input: owner.input }));
       try {
         await params.publish(entries);
+        for (const { owner } of entries) {
+          if (!owner.needsRefresh) {
+            this.#transaction?.readyOwners.add(owner);
+          }
+        }
       } catch (error) {
+        if (this.#transaction?.adoptedBy) {
+          // The replacement transaction exclusively settles adopted gates from its own result.
+          throw error;
+        }
         const failedOwners = entries.filter(
           ({ owner }) =>
             !this.#events.some(
@@ -167,6 +182,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
             ),
         );
         for (const { owner } of failedOwners) {
+          this.#transaction?.readyOwners.delete(owner);
           const gate = this.#transaction?.ownerGates.get(owner);
           if (gate) {
             if (owner.pending === gate.promise) {
@@ -180,7 +196,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
           params.onOwnerFailure?.(error);
         }
         // Newer events remain owned by this worker even when they target independent owners.
-        if (this.#events.length === 0) {
+        if (this.#events.length === 0 && this.#transaction?.readyOwners.size === 0) {
           throw error;
         }
       }

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -1,0 +1,172 @@
+import { createDeferredCore, type Deferred } from "../shared/deferred.js";
+import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
+import { ownerKey, resolveConfiguredOwner } from "./prepared-model-runtime.owner.js";
+import type {
+  PreparedModelRuntimeOwner,
+  PreparedModelRuntimeReplacementGateId,
+  PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.types.js";
+
+export type PreparedModelRuntimeAuthMutation = {
+  agentDir?: string;
+  affectsInheritedStores: boolean;
+};
+
+type PreparedModelRuntimeAuthTransaction = {
+  adoptedBy?: PreparedModelRuntimeReplacementGateId;
+  ownerGates: Map<PreparedModelRuntimeOwner, Deferred<PreparedModelRuntimeSnapshot>>;
+  publicationQueued: boolean;
+};
+
+export class PreparedModelRuntimeAuthPublicationOwner {
+  readonly #events: PreparedModelRuntimeAuthMutation[] = [];
+  #transaction: PreparedModelRuntimeAuthTransaction | undefined;
+
+  enqueue(
+    event: PreparedModelRuntimeAuthMutation,
+    invalidatedOwners: readonly PreparedModelRuntimeOwner[],
+  ): PreparedModelRuntimeAuthTransaction {
+    this.#events.push(event);
+    const transaction =
+      this.#transaction ??
+      (this.#transaction = { ownerGates: new Map(), publicationQueued: false });
+    for (const owner of invalidatedOwners) {
+      let gate = transaction.ownerGates.get(owner);
+      if (!gate) {
+        gate = createDeferredCore<PreparedModelRuntimeSnapshot>();
+        transaction.ownerGates.set(owner, gate);
+        void gate.promise.catch(() => undefined);
+      }
+      owner.pending = gate.promise;
+    }
+    return transaction;
+  }
+
+  claimPublication(transaction: PreparedModelRuntimeAuthTransaction): boolean {
+    if (transaction.publicationQueued) {
+      return false;
+    }
+    transaction.publicationQueued = true;
+    return true;
+  }
+
+  isCurrent(transaction: PreparedModelRuntimeAuthTransaction): boolean {
+    return this.#transaction === transaction;
+  }
+
+  adopt(gateId: PreparedModelRuntimeReplacementGateId): void {
+    if (this.#transaction) {
+      this.#transaction.adoptedBy = gateId;
+    }
+  }
+
+  adoptTransaction(
+    transaction: PreparedModelRuntimeAuthTransaction,
+    gateId: PreparedModelRuntimeReplacementGateId,
+  ): void {
+    if (this.#transaction === transaction) {
+      transaction.adoptedBy = gateId;
+    }
+  }
+
+  prepareAdoptedCommit(
+    gateId: PreparedModelRuntimeReplacementGateId,
+  ): PreparedModelRuntimeAuthTransaction | undefined {
+    const transaction = this.#transaction;
+    if (transaction?.adoptedBy !== gateId) {
+      return undefined;
+    }
+    this.clearOwnerGates(transaction);
+    return transaction;
+  }
+
+  prepareCommit(transaction: PreparedModelRuntimeAuthTransaction): boolean {
+    if (this.#transaction !== transaction) {
+      return false;
+    }
+    this.clearOwnerGates(transaction);
+    return true;
+  }
+
+  resolve(
+    transaction: PreparedModelRuntimeAuthTransaction,
+    owners: Map<string, PreparedModelRuntimeOwner>,
+  ): void {
+    if (this.#transaction === transaction) {
+      this.#transaction = undefined;
+    }
+    this.clearOwnerGates(transaction);
+    for (const [owner, gate] of transaction.ownerGates) {
+      const published =
+        owners.get(ownerKey(owner.input)) ?? resolveConfiguredOwner(owners, owner.input);
+      if (published?.snapshot && !published.needsRefresh && !published.pending) {
+        gate.resolve(published.snapshot);
+      } else {
+        gate.reject(
+          new PreparedModelRuntimePublicationSupersededError(
+            `prepared model runtime publication was superseded for ${owner.input.agentDir}`,
+          ),
+        );
+      }
+    }
+  }
+
+  reject(transaction: PreparedModelRuntimeAuthTransaction, error: Error): void {
+    if (this.#transaction === transaction) {
+      this.#transaction = undefined;
+    }
+    this.clearOwnerGates(transaction);
+    for (const gate of transaction.ownerGates.values()) {
+      gate.reject(error);
+    }
+  }
+
+  rejectAdopted(gateId: PreparedModelRuntimeReplacementGateId, error: Error): void {
+    if (this.#transaction?.adoptedBy === gateId) {
+      this.reject(this.#transaction, error);
+    }
+  }
+
+  async drain(params: {
+    owners: Map<string, PreparedModelRuntimeOwner>;
+    publish: (
+      entries: Array<{
+        owner: PreparedModelRuntimeOwner;
+        input: PreparedModelRuntimeOwner["input"];
+      }>,
+    ) => Promise<void>;
+    commit?: () => void;
+  }): Promise<void> {
+    while (this.#events.length > 0) {
+      const events = this.#events.splice(0);
+      const entries = [...params.owners.values()]
+        .filter((owner) =>
+          events.some(
+            (event) =>
+              event.affectsInheritedStores ||
+              owner.input.agentDir === event.agentDir ||
+              owner.input.inheritedAuthDir === event.agentDir,
+          ),
+        )
+        .map((owner) => ({ owner, input: owner.input }));
+      await params.publish(entries);
+    }
+    // The queue check and commit share one synchronous section so no mutation can be orphaned.
+    params.commit?.();
+  }
+
+  reset(error: Error): void {
+    if (this.#transaction) {
+      this.reject(this.#transaction, error);
+    }
+    this.#events.length = 0;
+  }
+
+  private clearOwnerGates(transaction: PreparedModelRuntimeAuthTransaction): void {
+    for (const [owner, gate] of transaction.ownerGates) {
+      if (owner.pending === gate.promise) {
+        owner.pending = undefined;
+      }
+    }
+  }
+}

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -5,13 +5,13 @@ import { getPreparedModelRuntimeBorrowedSnapshot } from "./prepared-model-runtim
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimePublicationSupersededError,
-  hasConfiguredOwnerMatching,
   ownerKey,
   normalizePreparedModelRuntimeInput,
   preparedModelRuntimeConfigsMatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
   resolveConfiguredOwner,
+  resolveConfiguredOwnerPublication,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeLease,
   type PreparedModelRuntimeOwner,
@@ -155,7 +155,13 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         }
         const canActivateConfiglessSetup =
           input.agentId !== undefined && isReservedSystemAgentId(input.agentId);
-        if (hasConfiguredOwnerMatching(context.owners, input) || !canActivateConfiglessSetup) {
+        const configuredOwner = resolveConfiguredOwnerPublication(context.owners, input);
+        if (configuredOwner.matches || !canActivateConfiglessSetup) {
+          const pending = configuredOwner.pending;
+          if (pending) {
+            await pending;
+            continue;
+          }
           throw error;
         }
         // First-run Model Setup uses the reserved system-agent identity before a configless gateway

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -240,7 +240,7 @@ describe("prepared reply dispatch runtime", () => {
     expect(configuredSelectedBefore).not.toBe(configuredRuntimeBefore?.inboundPluginRegistry);
   });
 
-  it("removes only the affected configured projection during an auth refresh", async () => {
+  it("waits only the affected configured projection during an auth refresh", async () => {
     mocks.configuredAgentIds = ["default", "worker"];
     const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     await refreshPreparedModelRuntimeSnapshots(config, {
@@ -264,9 +264,7 @@ describe("prepared reply dispatch runtime", () => {
     const defaultRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
     const workerRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
     await expect(defaultRead).resolves.toBe(defaultRuntime);
-    await expect(workerRead).rejects.toThrow(
-      "prepared reply dispatch runtime owner was not published for worker",
-    );
+    await expect(workerRead).resolves.not.toBe(workerRuntime);
 
     await published.promise;
     unregister();
@@ -278,5 +276,38 @@ describe("prepared reply dispatch runtime", () => {
       workspaceDir: "/tmp/workspace-worker",
     });
     expect(refreshedWorker).not.toBe(workerRuntime);
+  });
+
+  it("keeps run admission pending while auth publication replaces its projection", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    const input = {
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      config,
+      workspaceDir: "/tmp/unused-workspace",
+    };
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    let finishAuthRefresh: (() => void) | undefined;
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
+      async () =>
+        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+          finishAuthRefresh = () => resolve({ agentDir: input.agentDir, wrote: false });
+        }),
+    );
+
+    mocks.mutationListener?.({ agentDir: input.agentDir, affectsInheritedStores: false });
+    await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
+    const admission = acquireAgentRunPreparedModelRuntime(input);
+    const observed = admission.then(
+      () => "resolved",
+      () => "rejected",
+    );
+    await expect(Promise.race([observed, Promise.resolve("pending")])).resolves.toBe("pending");
+
+    finishAuthRefresh?.();
+    const lease = await admission;
+    expect(lease.snapshot).toMatchObject({ agentId: "default", agentDir: input.agentDir });
+    lease.release();
   });
 });

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -278,6 +278,41 @@ describe("prepared reply dispatch runtime", () => {
     expect(refreshedWorker).not.toBe(workerRuntime);
   });
 
+  it("keeps a rejected auth refresh projection unavailable without affecting siblings", async () => {
+    mocks.configuredAgentIds = ["default", "worker"];
+    await refreshPreparedModelRuntimeSnapshots(
+      {},
+      {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+      },
+    );
+    const defaultRuntime = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    const refreshFailed = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "failed") {
+        refreshFailed.resolve();
+      }
+    });
+    mocks.discoverAuthStorage.mockImplementationOnce(() => {
+      throw new Error("auth refresh rejected");
+    });
+
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-worker",
+      affectsInheritedStores: false,
+    });
+    await refreshFailed.promise;
+    unregister();
+
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for worker",
+    );
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })).resolves.toBe(
+      defaultRuntime,
+    );
+  });
+
   it("keeps run admission pending while auth publication replaces its projection", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import {
   acquireAgentRunPreparedModelRuntime,
@@ -921,6 +922,34 @@ describe("prepared model runtime snapshots", () => {
     expect(runtime).toBe(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }));
     expect(events.filter((phase) => phase === "published")).toHaveLength(1);
     expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("continues with a corrective auth mutation after the earlier build fails", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    const agentDir = "/tmp/unused-agent";
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const firstBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const secondBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const firstError = new Error("superseded auth build failed");
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await firstBuild.promise)
+      .mockImplementationOnce(async () => await secondBuild.promise);
+
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void dispatch.catch(() => undefined);
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    firstBuild.reject(firstError);
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(
+      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    secondBuild.resolve({ agentDir, wrote: false });
+    await expect(dispatch).resolves.toMatchObject({ agentId: "default", agentDir });
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -780,42 +780,6 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.discoverModels).toHaveBeenCalledOnce();
   });
 
-  it("awaits auth invalidation queued during lifecycle publication", async () => {
-    mocks.configuredAgentIds = ["default"];
-    await refreshPreparedModelRuntimeSnapshots({});
-    let finishConfigRefresh: (() => void) | undefined;
-    let finishAuthRefresh: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-            finishConfigRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-          }),
-      )
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-            finishAuthRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-          }),
-      );
-
-    const publication = refreshPreparedModelRuntimeSnapshots({});
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
-    finishConfigRefresh?.();
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    let settled = false;
-    void publication.then(() => {
-      settled = true;
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
-
-    finishAuthRefresh?.();
-    await publication;
-    expect(settled).toBe(true);
-  });
-
   it("defers an in-flight auth refresh to a superseding config publication", async () => {
     mocks.configuredAgentIds = ["default"];
     await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
@@ -866,8 +830,8 @@ describe("prepared model runtime snapshots", () => {
       }
     });
 
-    // The mutation queues an auth task; the synchronous stale edge of the config
-    // refresh opens the replacement gate before that task runs.
+    // The auth mutation starts first; the synchronous stale edge of the config refresh transfers
+    // its queued event to the replacement transaction before the auth task can publish.
     mocks.mutationListener?.({ affectsInheritedStores: true });
     await refreshPreparedModelRuntimeSnapshots(replacementConfig, { gatewayLifecycle: true });
     unregister();

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -876,15 +876,13 @@ describe("prepared model runtime snapshots", () => {
     expect(publishedSnapshots[0]).toMatchObject({ config: replacementConfig });
   });
 
-  it("invalidates and refreshes the affected owner at auth publication", async () => {
+  it("waits for the affected owner at auth publication", async () => {
     const config = {};
     const agentDir = "/tmp/prepared-model-runtime-auth";
     const first = await publishPreparedModelRuntimeSnapshot({ config, agentDir });
 
     mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    await expect(prepareModelRuntimeSnapshot({ config, agentDir })).rejects.toThrow(
-      "stale after auth mutation",
-    );
+    await expect(prepareModelRuntimeSnapshot({ config, agentDir })).resolves.not.toBe(first);
 
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
     const refreshed = await prepareModelRuntimeSnapshot({ config, agentDir });

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -6,7 +6,6 @@ import {
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import {
   acquireAgentRunPreparedModelRuntime,
@@ -922,34 +921,6 @@ describe("prepared model runtime snapshots", () => {
     expect(runtime).toBe(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }));
     expect(events.filter((phase) => phase === "published")).toHaveLength(1);
     expect(events).not.toContain("failed");
-    expect(mocks.warn).not.toHaveBeenCalled();
-  });
-
-  it("continues with a corrective auth mutation after the earlier build fails", async () => {
-    mocks.configuredAgentIds = ["default"];
-    const config = {};
-    const agentDir = "/tmp/unused-agent";
-    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
-    const firstBuild = createDeferred<{ agentDir: string; wrote: false }>();
-    const secondBuild = createDeferred<{ agentDir: string; wrote: false }>();
-    const firstError = new Error("superseded auth build failed");
-    mocks.ensureOpenClawModelsJson
-      .mockImplementationOnce(async () => await firstBuild.promise)
-      .mockImplementationOnce(async () => await secondBuild.promise);
-
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    void dispatch.catch(() => undefined);
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    firstBuild.reject(firstError);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(
-      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
-
-    secondBuild.resolve({ agentDir, wrote: false });
-    await expect(dispatch).resolves.toMatchObject({ agentId: "default", agentDir });
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -878,29 +878,50 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 
-  it("rejects a deduplicated caller when an auth refresh is superseded", async () => {
+  it("keeps one dispatch gate across overlapping auth mutations", async () => {
+    mocks.configuredAgentIds = ["default"];
     const config = {};
-    const agentDir = "/tmp/prepared-model-runtime-auth-pending-superseded";
-    await publishPreparedModelRuntimeSnapshot({ config, agentDir });
+    const agentDir = "/tmp/unused-agent";
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+    });
     let finishFirstRefresh: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishFirstRefresh = () => resolve({ agentDir, wrote: false });
-        }),
-    );
+    let finishSecondRefresh: (() => void) | undefined;
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+            finishFirstRefresh = () => resolve({ agentDir, wrote: false });
+          }),
+      )
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+            finishSecondRefresh = () => resolve({ agentDir, wrote: false });
+          }),
+      );
 
     mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const deduplicated = publishPreparedModelRuntimeSnapshot({ config, agentDir });
+    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void dispatch.catch(() => undefined);
     mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
     finishFirstRefresh?.();
-
-    await expect(deduplicated).rejects.toThrow("superseded");
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(prepareModelRuntimeSnapshot({ config, agentDir })).resolves.toMatchObject({
-      agentDir,
-    });
+    await expect(
+      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    finishSecondRefresh?.();
+    const runtime = await dispatch;
+    unregister();
+
+    expect(runtime).toBe(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }));
+    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+    expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
   });
 
   it("does not let a superseded owner hide a genuine sibling refresh failure", async () => {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -453,6 +453,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     owner.pendingPluginGeneration = params.reusePluginGenerations
       ? owner.pluginGeneration
       : undefined;
+    // Auth invalidation wraps this batch in a transaction-wide promise. The batch promise keeps
+    // its own supersession guard, then restores the outer promise until dispatch publication.
+    const previousPending = owner.pending;
     const generation = owner.generation;
     const key = ownerKey(input);
     let registered = params.owners.get(key) === owner;
@@ -471,12 +474,17 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         params.owners.get(key) === owner,
       key,
       generation,
+      previousPending,
       markRegistered: () => {
         registered = true;
       },
       owner,
     };
   });
+  const candidatePublications = new Map<
+    PreparedModelRuntimeOwner,
+    Promise<PreparedModelRuntimeSnapshot>
+  >();
   const groups = new Map<PreparedModelRuntimeOwner["catalogMode"], typeof candidates>();
   for (const candidate of candidates) {
     const group = groups.get(candidate.catalogMode);
@@ -584,7 +592,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         candidate.owner.snapshot = snapshot;
         results.set(candidate.owner, { ...result, snapshot });
         candidate.owner.pluginGeneration = result.pluginGeneration;
-        candidate.owner.pending = undefined;
+        if (candidate.owner.pending === candidatePublications.get(candidate.owner)) {
+          candidate.owner.pending = candidate.previousPending;
+        }
         candidate.owner.needsRefresh = false;
       }
     } catch (error) {
@@ -596,7 +606,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         if (!candidate.isCurrent()) {
           continue;
         }
-        candidate.owner.pending = undefined;
+        if (candidate.owner.pending === candidatePublications.get(candidate.owner)) {
+          candidate.owner.pending = candidate.previousPending;
+        }
         candidate.owner.needsRefresh = true;
         candidate.owner.refreshError = refreshError;
       }
@@ -614,6 +626,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
       }
       return results.get(candidate.owner)!.snapshot;
     });
+    candidatePublications.set(candidate.owner, pending);
     candidate.owner.pending = pending;
     void pending.catch(() => undefined);
   }

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -141,12 +141,15 @@ function findConfiguredOwnerCandidates(
       : identityCandidates;
 }
 
-/** Whether a configured owner matches the requesting runtime's identity/directory. */
-export function hasConfiguredOwnerMatching(
+export function resolveConfiguredOwnerPublication(
   owners: Map<string, PreparedModelRuntimeOwner>,
   rawInput: PreparedModelRuntimeInput,
-): boolean {
-  return findConfiguredOwnerCandidates(owners, rawInput).length > 0;
+): { matches: boolean; pending?: Promise<PreparedModelRuntimeSnapshot> } {
+  const candidates = findConfiguredOwnerCandidates(owners, rawInput);
+  return {
+    matches: candidates.length > 0,
+    pending: candidates.length === 1 ? candidates[0]?.pending : undefined,
+  };
 }
 
 export function resolveConfiguredOwner(

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -453,9 +453,6 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     owner.pendingPluginGeneration = params.reusePluginGenerations
       ? owner.pluginGeneration
       : undefined;
-    // Auth invalidation wraps this batch in a transaction-wide promise. The batch promise keeps
-    // its own supersession guard, then restores the outer promise until dispatch publication.
-    const previousPending = owner.pending;
     const generation = owner.generation;
     const key = ownerKey(input);
     let registered = params.owners.get(key) === owner;
@@ -474,17 +471,12 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         params.owners.get(key) === owner,
       key,
       generation,
-      previousPending,
       markRegistered: () => {
         registered = true;
       },
       owner,
     };
   });
-  const candidatePublications = new Map<
-    PreparedModelRuntimeOwner,
-    Promise<PreparedModelRuntimeSnapshot>
-  >();
   const groups = new Map<PreparedModelRuntimeOwner["catalogMode"], typeof candidates>();
   for (const candidate of candidates) {
     const group = groups.get(candidate.catalogMode);
@@ -592,9 +584,6 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         candidate.owner.snapshot = snapshot;
         results.set(candidate.owner, { ...result, snapshot });
         candidate.owner.pluginGeneration = result.pluginGeneration;
-        if (candidate.owner.pending === candidatePublications.get(candidate.owner)) {
-          candidate.owner.pending = candidate.previousPending;
-        }
         candidate.owner.needsRefresh = false;
       }
     } catch (error) {
@@ -606,30 +595,12 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         if (!candidate.isCurrent()) {
           continue;
         }
-        if (candidate.owner.pending === candidatePublications.get(candidate.owner)) {
-          candidate.owner.pending = candidate.previousPending;
-        }
         candidate.owner.needsRefresh = true;
         candidate.owner.refreshError = refreshError;
       }
       throw refreshError;
     }
   })();
-  for (const candidate of candidates) {
-    const pending = publication.then(() => {
-      // A newer auth publication may win while this batch finishes. Reject deduplicated callers
-      // at the owner boundary so the stale snapshot cannot escape despite being skipped at commit.
-      if (!candidate.isCurrent()) {
-        throw new PreparedModelRuntimePublicationSupersededError(
-          `prepared model runtime publication was superseded for ${candidate.input.agentDir}`,
-        );
-      }
-      return results.get(candidate.owner)!.snapshot;
-    });
-    candidatePublications.set(candidate.owner, pending);
-    candidate.owner.pending = pending;
-    void pending.catch(() => undefined);
-  }
   await publication;
 }
 

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -1,0 +1,111 @@
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import {
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  loadPublishedGatewayReplyDispatchRuntime,
+  registerPreparedModelRuntimePublicationListener,
+  refreshPreparedModelRuntimeSnapshots,
+} from "./prepared-model-runtime.js";
+
+const mocks = getPreparedModelRuntimeMocks();
+
+describe("prepared model runtime reload auth adoption", () => {
+  beforeEach(() => {
+    resetPreparedModelRuntimeHarness();
+  });
+
+  it("commits auth invalidation inside the active lifecycle publication", async () => {
+    mocks.configuredAgentIds = ["default", "worker"];
+    const initialConfig = {};
+    const replacementConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const configBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const order: string[] = [];
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+      if (event.phase === "published") {
+        order.push("config-published");
+      }
+    });
+    let defaultBuildCount = 0;
+    mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
+      if (agentDir !== "/tmp/unused-agent") {
+        return { agentDir: String(agentDir), wrote: false };
+      }
+      defaultBuildCount += 1;
+      if (defaultBuildCount === 1) {
+        order.push("config-build-start");
+        return await configBuild.promise;
+      }
+      order.push("auth-drain-start");
+      return await authBuild.promise;
+    });
+
+    const publication = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    void publication.catch(() => undefined);
+    await vi.waitFor(() => expect(order).toContain("config-build-start"));
+    order.push("auth-mutation");
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    const affectedRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }).then(
+      (runtime) => {
+        order.push("affected-dispatch-resolved");
+        return runtime;
+      },
+    );
+    const siblingRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    void affectedRead.catch(() => undefined);
+    void siblingRead.catch(() => undefined);
+    order.push("config-build-finish");
+    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await vi.waitFor(() => expect(order).toContain("auth-drain-start"));
+    await expect(
+      Promise.race([publication.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+    await expect(
+      Promise.race([affectedRead.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    order.push("auth-drain-finish");
+    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await expect(publication).resolves.toBeUndefined();
+    const [affectedRuntime, siblingRuntime] = await Promise.all([affectedRead, siblingRead]);
+    unregister();
+
+    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+    expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
+    expect(affectedRuntime?.config).toBe(replacementConfig);
+    expect(siblingRuntime?.config).toBe(replacementConfig);
+    expect(order).toEqual([
+      "config-build-start",
+      "auth-mutation",
+      "config-build-finish",
+      "auth-drain-start",
+      "auth-drain-finish",
+      "config-published",
+      "affected-dispatch-resolved",
+    ]);
+    const buildCountAfterPublication = mocks.ensureOpenClawModelsJson.mock.calls.length;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(buildCountAfterPublication);
+    const lease = await acquireAgentRunPreparedModelRuntime({
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      config: replacementConfig,
+      workspaceDir: "/tmp/unused-workspace",
+    });
+    expect(lease.snapshot.config).toBe(replacementConfig);
+    lease.release();
+  });
+});

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -258,4 +258,77 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(mocks.warn).toHaveBeenCalledOnce();
     expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(workerError.message));
   });
+
+  it("commits a successful owner when the final independent owner fails", async () => {
+    mocks.configuredAgentIds = ["default", "worker", "research"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const workerBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const researchBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const researchError = new Error("final research auth build failed");
+    mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
+      if (agentDir === "/tmp/configured-worker") {
+        return await workerBuild.promise;
+      }
+      if (agentDir === "/tmp/configured-research") {
+        return await researchBuild.promise;
+      }
+      return { agentDir: String(agentDir), wrote: false };
+    });
+
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-worker",
+      affectsInheritedStores: false,
+    });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+    const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    void workerDispatch.catch(() => undefined);
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-research",
+      affectsInheritedStores: false,
+    });
+    const researchDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" });
+    void researchDispatch.catch(() => undefined);
+    workerBuild.resolve({ agentDir: "/tmp/configured-worker", wrote: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
+    researchBuild.reject(researchError);
+
+    await expect(workerDispatch).resolves.toMatchObject({ agentId: "worker" });
+    await expect(researchDispatch).rejects.toBe(researchError);
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for research",
+    );
+  });
+
+  it("lets an adopting reload settle the gate after the obsolete auth build fails", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const initialConfig = {};
+    const replacementConfig = { plugins: {} };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const configBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const obsoleteAuthError = new Error("obsolete auth build failed");
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await authBuild.promise)
+      .mockImplementationOnce(async () => await configBuild.promise);
+
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void authWaiter.catch(() => undefined);
+    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    void reload.catch(() => undefined);
+    authBuild.reject(obsoleteAuthError);
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(
+      Promise.race([authWaiter.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await expect(reload).resolves.toBeUndefined();
+    await expect(authWaiter).resolves.toMatchObject({ config: replacementConfig });
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -108,4 +108,77 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(lease.snapshot.config).toBe(replacementConfig);
     lease.release();
   });
+
+  it("adopts an in-flight auth gate into a same-owner config reload", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const initialConfig = {};
+    const replacementConfig = { plugins: {} };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const configBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+    });
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await authBuild.promise)
+      .mockImplementationOnce(async () => await configBuild.promise);
+
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void authWaiter.catch(() => undefined);
+    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    void reload.catch(() => undefined);
+    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(
+      Promise.race([authWaiter.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await expect(reload).resolves.toBeUndefined();
+    const runtime = await authWaiter;
+    unregister();
+
+    expect(runtime?.config).toBe(replacementConfig);
+    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+    expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("rejects an adopted auth gate when config reload fails and permits recovery", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const initialConfig = {};
+    const replacementConfig = { plugins: {} };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const reloadError = new Error("replacement config failed");
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await authBuild.promise)
+      .mockRejectedValueOnce(reloadError);
+
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void authWaiter.catch(() => undefined);
+    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    void reload.catch(() => undefined);
+    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+
+    await expect(reload).rejects.toBe(reloadError);
+    await expect(authWaiter).rejects.toBe(reloadError);
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for default",
+    );
+
+    await refreshPreparedModelRuntimeSnapshots(replacementConfig, { gatewayLifecycle: true });
+    await expect(
+      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+    ).resolves.toMatchObject({ config: replacementConfig });
+  });
 });

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -181,4 +181,81 @@ describe("prepared model runtime reload auth adoption", () => {
       loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
     ).resolves.toMatchObject({ config: replacementConfig });
   });
+
+  it("continues with a corrective auth mutation after the earlier build fails", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    const agentDir = "/tmp/unused-agent";
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const firstBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const secondBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const firstError = new Error("superseded auth build failed");
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await firstBuild.promise)
+      .mockImplementationOnce(async () => await secondBuild.promise);
+
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void dispatch.catch(() => undefined);
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    firstBuild.reject(firstError);
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(
+      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    secondBuild.resolve({ agentDir, wrote: false });
+    await expect(dispatch).resolves.toMatchObject({ agentId: "default", agentDir });
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("publishes an independent queued owner after another auth build fails", async () => {
+    mocks.configuredAgentIds = ["default", "worker", "research"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const workerBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const researchBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const workerError = new Error("worker auth build failed");
+    mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
+      if (agentDir === "/tmp/configured-worker") {
+        return await workerBuild.promise;
+      }
+      if (agentDir === "/tmp/configured-research") {
+        return await researchBuild.promise;
+      }
+      return { agentDir: String(agentDir), wrote: false };
+    });
+
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-worker",
+      affectsInheritedStores: false,
+    });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+    const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    void workerDispatch.catch(() => undefined);
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-research",
+      affectsInheritedStores: false,
+    });
+    const researchDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" });
+    void researchDispatch.catch(() => undefined);
+    workerBuild.reject(workerError);
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
+    await expect(workerDispatch).rejects.toBe(workerError);
+    await expect(
+      Promise.race([researchDispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    researchBuild.resolve({ agentDir: "/tmp/configured-research", wrote: false });
+    await expect(researchDispatch).resolves.toMatchObject({
+      agentId: "research",
+      agentDir: "/tmp/configured-research",
+    });
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for worker",
+    );
+    expect(mocks.warn).toHaveBeenCalledOnce();
+    expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(workerError.message));
+  });
 });

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -620,6 +620,7 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
   };
   const staleError = new Error("prepared model runtime owner is stale after auth mutation");
   const invalidatedOwners: PreparedModelRuntimeOwner[] = [];
+  const invalidatedConfiguredAgentIds = new Set<string>();
   for (const owner of owners.values()) {
     if (
       !normalizedEvent.affectsInheritedStores &&
@@ -632,12 +633,16 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     owner.generation += 1;
     owner.needsRefresh = true;
     owner.refreshError = staleError;
+    if (owner.provenance === "configured" && owner.input.agentId) {
+      invalidatedConfiguredAgentIds.add(owner.input.agentId);
+    }
   }
   if (invalidatedOwners.length === 0) {
     // A first owner reads the already-published auth snapshot while it builds. Replaying an earlier
     // mutation would immediately stale that initial generation even though no prior owner existed.
     return;
   }
+  replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
   pendingAuthMutations.push(normalizedEvent);
   const publication = enqueuePreparedModelRuntimePublication(async () => {
     // A pending replacement gate means a queued config publication owns the next generation:

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -644,6 +644,10 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
   pendingAuthMutations.push(normalizedEvent);
+  const ownerPublications = new Map<
+    PreparedModelRuntimeOwner,
+    Promise<PreparedModelRuntimeSnapshot>
+  >();
   const publication = enqueuePreparedModelRuntimePublication(async () => {
     // A pending replacement gate means a queued config publication owns the next generation:
     // it drains queued auth mutations against the new config and rebuilds/announces the
@@ -656,11 +660,19 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     if (pendingModelRuntimeReplacement) {
       return;
     }
+    for (const owner of invalidatedOwners) {
+      if (owner.pending === ownerPublications.get(owner)) {
+        owner.pending = undefined;
+      }
+    }
+    // No await may separate clearing the transaction gate from rebuilding its dispatch projection.
+    // Otherwise an admitted request can observe neither the pending owner nor the new publication.
     replyDispatchPublication.rebuild(owners.values());
     notifyPreparedModelRuntimePublication({ phase: "published" });
   });
   for (const owner of invalidatedOwners) {
     const pending = publication.then(() => owner.snapshot!);
+    ownerPublications.set(owner, pending);
     owner.pending = pending;
     const clearPending = () => {
       if (owner.pending === pending) {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -523,6 +523,21 @@ export function refreshPreparedModelRuntimeSnapshots(
   const replacement = pendingModelRuntimeReplacement;
   const isPublicationCurrent = () =>
     requestEpoch === refreshRequestEpoch && options.isPublicationCurrent?.() !== false;
+  const commitReplacement = () => {
+    if (
+      !isPublicationCurrent() ||
+      !replacement ||
+      pendingModelRuntimeReplacement !== replacement
+    ) {
+      return;
+    }
+    replyDispatchPublication.rebuild(owners.values());
+    pendingModelRuntimeReplacement = undefined;
+    replacement.resolve();
+    // Publication listeners may synchronously read the committed owner. Clear the lifecycle
+    // gate before announcing availability so they cannot observe a false missing generation.
+    notifyPreparedModelRuntimePublication({ phase: "published" });
+  };
   return enqueuePreparedModelRuntimePublication(async () => {
     if (!isPublicationCurrent()) {
       return;
@@ -535,42 +550,35 @@ export function refreshPreparedModelRuntimeSnapshots(
     if (!isPublicationCurrent()) {
       return;
     }
-    await drainPendingAuthMutations();
-    if (!isPublicationCurrent()) {
-      return;
+    await drainPendingAuthMutations({
+      // The final queue check, dispatch rebuild, and replacement resolution are one synchronous
+      // commit. A mutation before it is adopted; a mutation after it starts a new auth transaction.
+      commit: commitReplacement,
+    });
+  }).then(commitReplacement, (error: unknown) => {
+    const refreshError = toStringifiedError(error);
+    if (isPublicationCurrent()) {
+      // Candidate and queued auth builds may finish independently. A failed transaction must
+      // leave no owner from its partially published generation request-visible.
+      for (const owner of owners.values()) {
+        owner.generation += 1;
+        owner.pending = undefined;
+        owner.needsRefresh = true;
+        owner.refreshError = refreshError;
+        owner.pluginGeneration = undefined;
+      }
     }
-    replyDispatchPublication.rebuild(owners.values());
-  }).then(
-    () => {
-      if (isPublicationCurrent() && replacement && pendingModelRuntimeReplacement === replacement) {
-        pendingModelRuntimeReplacement = undefined;
-        replacement.resolve();
-        // Publication listeners may synchronously read the committed owner. Clear the lifecycle
-        // gate before announcing availability so they cannot observe a false missing generation.
-        notifyPreparedModelRuntimePublication({ phase: "published" });
-      }
-    },
-    (error: unknown) => {
-      const refreshError = toStringifiedError(error);
-      if (isPublicationCurrent()) {
-        // Candidate and queued auth builds may finish independently. A failed transaction must
-        // leave no owner from its partially published generation request-visible.
-        for (const owner of owners.values()) {
-          owner.generation += 1;
-          owner.pending = undefined;
-          owner.needsRefresh = true;
-          owner.refreshError = refreshError;
-          owner.pluginGeneration = undefined;
-        }
-      }
-      if (isPublicationCurrent() && replacement && pendingModelRuntimeReplacement === replacement) {
-        pendingModelRuntimeReplacement = undefined;
-        replacement.reject(refreshError);
-        notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
-      }
-      throw refreshError;
-    },
-  );
+    if (
+      isPublicationCurrent() &&
+      replacement &&
+      pendingModelRuntimeReplacement === replacement
+    ) {
+      pendingModelRuntimeReplacement = undefined;
+      replacement.reject(refreshError);
+      notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
+    }
+    throw refreshError;
+  });
 }
 
 function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Promise<void> {
@@ -582,7 +590,11 @@ function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Prom
   return publication;
 }
 
-async function drainPendingAuthMutations(): Promise<void> {
+async function drainPendingAuthMutations(
+  options: {
+    commit?: () => void;
+  } = {},
+): Promise<void> {
   while (pendingAuthMutations.length > 0) {
     const events = pendingAuthMutations.splice(0);
     for (const event of events) {
@@ -611,6 +623,9 @@ async function drainPendingAuthMutations(): Promise<void> {
       reusePluginGenerations: true,
     });
   }
+  // The queue check and commit share one synchronous section. A mutation cannot appear after the
+  // final drain but before its owning transaction publishes the resulting dispatch projection.
+  options.commit?.();
 }
 
 function invalidateForAuthMutation(event: AuthMutationEvent): void {
@@ -644,6 +659,15 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
   pendingAuthMutations.push(normalizedEvent);
+  if (pendingModelRuntimeReplacement) {
+    // The active config transaction drains this event before its atomic dispatch commit. Retire
+    // the superseded build gate; queuing another task would make this commit depend on future work.
+    for (const owner of invalidatedOwners) {
+      owner.pending = undefined;
+    }
+    notifyPreparedModelRuntimePublication({ phase: "invalidated" });
+    return;
+  }
   const ownerPublications = new Map<
     PreparedModelRuntimeOwner,
     Promise<PreparedModelRuntimeSnapshot>
@@ -656,19 +680,20 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     if (pendingModelRuntimeReplacement) {
       return;
     }
-    await drainPendingAuthMutations();
-    if (pendingModelRuntimeReplacement) {
-      return;
-    }
-    for (const owner of invalidatedOwners) {
-      if (owner.pending === ownerPublications.get(owner)) {
-        owner.pending = undefined;
-      }
-    }
-    // No await may separate clearing the transaction gate from rebuilding its dispatch projection.
-    // Otherwise an admitted request can observe neither the pending owner nor the new publication.
-    replyDispatchPublication.rebuild(owners.values());
-    notifyPreparedModelRuntimePublication({ phase: "published" });
+    await drainPendingAuthMutations({
+      commit: () => {
+        if (pendingModelRuntimeReplacement) {
+          return;
+        }
+        for (const owner of invalidatedOwners) {
+          if (owner.pending === ownerPublications.get(owner)) {
+            owner.pending = undefined;
+          }
+        }
+        replyDispatchPublication.rebuild(owners.values());
+        notifyPreparedModelRuntimePublication({ phase: "published" });
+      },
+    });
   });
   for (const owner of invalidatedOwners) {
     const pending = publication.then(() => owner.snapshot!);

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -4,6 +4,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
+import {
+  PreparedModelRuntimeAuthPublicationOwner,
+  type PreparedModelRuntimeAuthMutation,
+} from "./prepared-model-runtime-auth-publication.js";
 import { acquirePreparedModelRuntimeLeaseFromOwners } from "./prepared-model-runtime-lease.js";
 import { registerPreparedRuntimeAuthMaterializationPublisher } from "./prepared-model-runtime-materializations.js";
 import {
@@ -71,8 +75,7 @@ let gatewayLifecycleActive = false;
 let refreshTail: Promise<void> = Promise.resolve();
 let refreshRequestEpoch = 0;
 let pendingModelRuntimeReplacement: PreparedModelRuntimeReplacement | undefined;
-type AuthMutationEvent = { agentDir?: string; affectsInheritedStores: boolean };
-const pendingAuthMutations: AuthMutationEvent[] = [];
+const authPublication = new PreparedModelRuntimeAuthPublicationOwner();
 
 const replyDispatchPublication = new PreparedReplyDispatchPublicationOwner({
   isGatewayLifecycleActive: () => gatewayLifecycleActive,
@@ -386,6 +389,7 @@ export function markPreparedModelRuntimeSnapshotsStale(
   if (options.waitForReplacement) {
     const superseded = pendingModelRuntimeReplacement;
     pendingModelRuntimeReplacement = createPreparedModelRuntimeReplacement();
+    authPublication.adopt(pendingModelRuntimeReplacement.gateId);
     // Superseded readers retry against the newer replacement gate.
     superseded?.resolve();
   } else if (!options.preserveReplacementWait && pendingModelRuntimeReplacement) {
@@ -426,6 +430,7 @@ export function rejectPendingPreparedModelRuntimeReplacement(
   }
   pendingModelRuntimeReplacement = undefined;
   const replacementError = toStringifiedError(error);
+  authPublication.rejectAdopted(replacement.gateId, replacementError);
   replacement.reject(replacementError);
   notifyPreparedModelRuntimePublication({ phase: "failed", error: replacementError });
 }
@@ -531,8 +536,12 @@ export function refreshPreparedModelRuntimeSnapshots(
     ) {
       return;
     }
+    const adoptedAuthTransaction = authPublication.prepareAdoptedCommit(replacement.gateId);
     replyDispatchPublication.rebuild(owners.values());
     pendingModelRuntimeReplacement = undefined;
+    if (adoptedAuthTransaction) {
+      authPublication.resolve(adoptedAuthTransaction, owners);
+    }
     replacement.resolve();
     // Publication listeners may synchronously read the committed owner. Clear the lifecycle
     // gate before announcing availability so they cannot observe a false missing generation.
@@ -574,6 +583,7 @@ export function refreshPreparedModelRuntimeSnapshots(
       pendingModelRuntimeReplacement === replacement
     ) {
       pendingModelRuntimeReplacement = undefined;
+      authPublication.rejectAdopted(replacement.gateId, refreshError);
       replacement.reject(refreshError);
       notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
     }
@@ -590,45 +600,22 @@ function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Prom
   return publication;
 }
 
-async function drainPendingAuthMutations(
-  options: {
-    commit?: () => void;
-  } = {},
-): Promise<void> {
-  while (pendingAuthMutations.length > 0) {
-    const events = pendingAuthMutations.splice(0);
-    for (const event of events) {
-      event.agentDir = normalizeOptionalDir(event.agentDir);
-    }
-    const entries: Array<{
-      owner: PreparedModelRuntimeOwner;
-      input: PreparedModelRuntimeInput;
-    }> = [];
-    for (const owner of owners.values()) {
-      const affected = events.some(
-        (event) =>
-          event.affectsInheritedStores ||
-          owner.input.agentDir === event.agentDir ||
-          owner.input.inheritedAuthDir === event.agentDir,
-      );
-      if (affected) {
-        entries.push({ owner, input: owner.input });
-      }
-    }
-    await publishPreparedModelRuntimeOwnerBatch({
-      entries,
-      owners,
-      agentBuildCompletions,
-      buildTimeoutMs: modelRuntimeBuildTimeoutMs,
-      reusePluginGenerations: true,
-    });
-  }
-  // The queue check and commit share one synchronous section. A mutation cannot appear after the
-  // final drain but before its owning transaction publishes the resulting dispatch projection.
-  options.commit?.();
+async function drainPendingAuthMutations(options: { commit?: () => void } = {}): Promise<void> {
+  await authPublication.drain({
+    owners,
+    publish: async (entries) =>
+      await publishPreparedModelRuntimeOwnerBatch({
+        entries,
+        owners,
+        agentBuildCompletions,
+        buildTimeoutMs: modelRuntimeBuildTimeoutMs,
+        reusePluginGenerations: true,
+      }),
+    commit: options.commit,
+  });
 }
 
-function invalidateForAuthMutation(event: AuthMutationEvent): void {
+function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): void {
   const normalizedEvent = {
     ...event,
     agentDir: normalizeOptionalDir(event.agentDir),
@@ -658,60 +645,56 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     return;
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
-  pendingAuthMutations.push(normalizedEvent);
+  const transaction = authPublication.enqueue(normalizedEvent, invalidatedOwners);
   if (pendingModelRuntimeReplacement) {
     // The active config transaction drains this event before its atomic dispatch commit. Retire
     // the superseded build gate; queuing another task would make this commit depend on future work.
-    for (const owner of invalidatedOwners) {
-      owner.pending = undefined;
-    }
+    authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
     notifyPreparedModelRuntimePublication({ phase: "invalidated" });
     return;
   }
-  const ownerPublications = new Map<
-    PreparedModelRuntimeOwner,
-    Promise<PreparedModelRuntimeSnapshot>
-  >();
+  if (!authPublication.claimPublication(transaction)) {
+    notifyPreparedModelRuntimePublication({ phase: "invalidated" });
+    return;
+  }
   const publication = enqueuePreparedModelRuntimePublication(async () => {
     // A pending replacement gate means a queued config publication owns the next generation:
     // it drains queued auth mutations against the new config and rebuilds/announces the
     // dispatch publication. Rebuilding here would revive stale owners with the old config or
     // throw on them, emitting a spurious failed/published event that wedges chat metadata.
     if (pendingModelRuntimeReplacement) {
+      authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
       return;
     }
     await drainPendingAuthMutations({
       commit: () => {
         if (pendingModelRuntimeReplacement) {
+          authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
           return;
         }
-        for (const owner of invalidatedOwners) {
-          if (owner.pending === ownerPublications.get(owner)) {
-            owner.pending = undefined;
-          }
+        if (!authPublication.prepareCommit(transaction)) {
+          return;
         }
         replyDispatchPublication.rebuild(owners.values());
+        authPublication.resolve(transaction, owners);
         notifyPreparedModelRuntimePublication({ phase: "published" });
       },
     });
   });
-  for (const owner of invalidatedOwners) {
-    const pending = publication.then(() => owner.snapshot!);
-    ownerPublications.set(owner, pending);
-    owner.pending = pending;
-    const clearPending = () => {
-      if (owner.pending === pending) {
-        owner.pending = undefined;
-      }
-    };
-    void pending.then(clearPending, clearPending);
-  }
   notifyPreparedModelRuntimePublication({ phase: "invalidated" });
   void publication.catch((error: unknown) => {
+    if (!authPublication.isCurrent(transaction)) {
+      return;
+    }
+    if (pendingModelRuntimeReplacement) {
+      authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
+      return;
+    }
     if (error instanceof PreparedModelRuntimePublicationSupersededError) {
       return;
     }
     const refreshError = toStringifiedError(error);
+    authPublication.reject(transaction, refreshError);
     notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
     log.warn(`auth-triggered model runtime refresh failed: ${String(refreshError)}`);
   });
@@ -721,6 +704,11 @@ registerRuntimeAuthProfileStoreMutationListener(invalidateForAuthMutation);
 registerPreparedRuntimeAuthMaterializationPublisher(owners, notifyPreparedModelRuntimePublication);
 
 function resetPreparedModelRuntimeSnapshotsForTest(): void {
+  authPublication.reset(
+    new PreparedModelRuntimePublicationSupersededError(
+      "prepared model runtime auth publication reset for test",
+    ),
+  );
   pendingModelRuntimeReplacement?.resolve();
   pendingModelRuntimeReplacement = undefined;
   owners.clear();
@@ -730,7 +718,6 @@ function resetPreparedModelRuntimeSnapshotsForTest(): void {
   gatewayLifecycleActive = false;
   refreshTail = Promise.resolve();
   refreshRequestEpoch = 0;
-  pendingAuthMutations.length = 0;
   replyDispatchPublication.clear();
   resetPreparedModelRuntimePublicationListenersForTest();
   modelRuntimeBuildTimeoutMs = DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS;

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -23,6 +23,7 @@ import {
   publishPreparedModelRuntimeOwnerBatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
+  resolveConfiguredOwnerPublication,
   resolvePublishedOwner,
   type PreparedModelRuntimeOwner,
   type PreparedModelRuntimeInput,
@@ -75,6 +76,12 @@ const pendingAuthMutations: AuthMutationEvent[] = [];
 
 const replyDispatchPublication = new PreparedReplyDispatchPublicationOwner({
   isGatewayLifecycleActive: () => gatewayLifecycleActive,
+  getPendingOwnerPublication: (agentId) =>
+    resolveConfiguredOwnerPublication(owners, {
+      agentId,
+      agentDir: ".",
+      config: {},
+    }).pending,
   getPendingReplacement: () => pendingModelRuntimeReplacement?.promise,
 });
 export const loadPublishedGatewayReplyDispatchRuntime = replyDispatchPublication.load;
@@ -612,8 +619,7 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     agentDir: normalizeOptionalDir(event.agentDir),
   };
   const staleError = new Error("prepared model runtime owner is stale after auth mutation");
-  let invalidatedOwner = false;
-  const invalidatedConfiguredAgentIds = new Set<string>();
+  const invalidatedOwners: PreparedModelRuntimeOwner[] = [];
   for (const owner of owners.values()) {
     if (
       !normalizedEvent.affectsInheritedStores &&
@@ -622,23 +628,18 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     ) {
       continue;
     }
-    invalidatedOwner = true;
+    invalidatedOwners.push(owner);
     owner.generation += 1;
     owner.needsRefresh = true;
     owner.refreshError = staleError;
-    if (owner.provenance === "configured" && owner.input.agentId) {
-      invalidatedConfiguredAgentIds.add(owner.input.agentId);
-    }
   }
-  if (!invalidatedOwner) {
+  if (invalidatedOwners.length === 0) {
     // A first owner reads the already-published auth snapshot while it builds. Replaying an earlier
     // mutation would immediately stale that initial generation even though no prior owner existed.
     return;
   }
-  replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
-  notifyPreparedModelRuntimePublication({ phase: "invalidated" });
   pendingAuthMutations.push(normalizedEvent);
-  void enqueuePreparedModelRuntimePublication(async () => {
+  const publication = enqueuePreparedModelRuntimePublication(async () => {
     // A pending replacement gate means a queued config publication owns the next generation:
     // it drains queued auth mutations against the new config and rebuilds/announces the
     // dispatch publication. Rebuilding here would revive stale owners with the old config or
@@ -652,7 +653,19 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     }
     replyDispatchPublication.rebuild(owners.values());
     notifyPreparedModelRuntimePublication({ phase: "published" });
-  }).catch((error: unknown) => {
+  });
+  for (const owner of invalidatedOwners) {
+    const pending = publication.then(() => owner.snapshot!);
+    owner.pending = pending;
+    const clearPending = () => {
+      if (owner.pending === pending) {
+        owner.pending = undefined;
+      }
+    };
+    void pending.then(clearPending, clearPending);
+  }
+  notifyPreparedModelRuntimePublication({ phase: "invalidated" });
+  void publication.catch((error: unknown) => {
     if (error instanceof PreparedModelRuntimePublicationSupersededError) {
       return;
     }

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -612,6 +612,10 @@ async function drainPendingAuthMutations(options: { commit?: () => void } = {}):
         reusePluginGenerations: true,
       }),
     commit: options.commit,
+    onOwnerFailure: (error) => {
+      const refreshError = toStringifiedError(error);
+      log.warn(`auth-triggered model runtime refresh failed: ${String(refreshError)}`);
+    },
   });
 }
 
@@ -675,7 +679,15 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
         if (!authPublication.prepareCommit(transaction)) {
           return;
         }
-        replyDispatchPublication.rebuild(owners.values());
+        const transactionOwners = authPublication.owners(transaction);
+        replyDispatchPublication.replace(
+          owners.values(),
+          new Set(
+            transactionOwners.flatMap((owner) =>
+              owner.input.agentId ? [owner.input.agentId] : [],
+            ),
+          ),
+        );
         authPublication.resolve(transaction, owners);
         notifyPreparedModelRuntimePublication({ phase: "published" });
       },

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -529,11 +529,7 @@ export function refreshPreparedModelRuntimeSnapshots(
   const isPublicationCurrent = () =>
     requestEpoch === refreshRequestEpoch && options.isPublicationCurrent?.() !== false;
   const commitReplacement = () => {
-    if (
-      !isPublicationCurrent() ||
-      !replacement ||
-      pendingModelRuntimeReplacement !== replacement
-    ) {
+    if (!isPublicationCurrent() || !replacement || pendingModelRuntimeReplacement !== replacement) {
       return;
     }
     const adoptedAuthTransaction = authPublication.prepareAdoptedCommit(replacement.gateId);
@@ -577,11 +573,7 @@ export function refreshPreparedModelRuntimeSnapshots(
         owner.pluginGeneration = undefined;
       }
     }
-    if (
-      isPublicationCurrent() &&
-      replacement &&
-      pendingModelRuntimeReplacement === replacement
-    ) {
+    if (isPublicationCurrent() && replacement && pendingModelRuntimeReplacement === replacement) {
       pendingModelRuntimeReplacement = undefined;
       authPublication.rejectAdopted(replacement.gateId, refreshError);
       replacement.reject(refreshError);

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -73,6 +73,21 @@ function removeReplyDispatchRuntimeProjections(
   });
 }
 
+function replaceReplyDispatchRuntimeProjections(
+  publication: PreparedReplyDispatchPublication,
+  replacement: PreparedReplyDispatchPublication,
+  agentIds: ReadonlySet<string>,
+): PreparedReplyDispatchPublication {
+  return Object.freeze({
+    runtimes: Object.freeze(
+      [
+        ...publication.runtimes.filter((runtime) => !agentIds.has(runtime.agentId)),
+        ...replacement.runtimes,
+      ].toSorted((left, right) => left.agentId.localeCompare(right.agentId)),
+    ),
+  });
+}
+
 type PreparedReplyDispatchPublicationHost = Readonly<{
   isGatewayLifecycleActive: () => boolean;
   getPendingOwnerPublication: (agentId: string) => Promise<unknown> | undefined;
@@ -105,6 +120,19 @@ export class PreparedReplyDispatchPublicationOwner {
 
   remove(agentIds: ReadonlySet<string>): void {
     this.#publication = removeReplyDispatchRuntimeProjections(this.#publication, agentIds);
+  }
+
+  replace(owners: Iterable<PreparedModelRuntimeOwner>, agentIds: ReadonlySet<string>): void {
+    const replacements = buildReplyDispatchPublication(
+      [...owners].filter((owner) =>
+        owner.input.agentId ? agentIds.has(owner.input.agentId) : false,
+      ),
+    );
+    this.#publication = replaceReplyDispatchRuntimeProjections(
+      this.#publication,
+      replacements,
+      agentIds,
+    );
   }
 
   readonly load = async ({

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -116,14 +116,14 @@ export class PreparedReplyDispatchPublicationOwner {
       if (!this.host.isGatewayLifecycleActive()) {
         return undefined;
       }
-      const pendingOwner = this.host.getPendingOwnerPublication(agentId);
-      if (pendingOwner) {
-        await pendingOwner;
-        continue;
-      }
       const replacement = this.host.getPendingReplacement();
       if (replacement) {
         await replacement;
+        continue;
+      }
+      const pendingOwner = this.host.getPendingOwnerPublication(agentId);
+      if (pendingOwner) {
+        await pendingOwner;
         continue;
       }
       const matches = this.#publication.runtimes.filter((runtime) => runtime.agentId === agentId);

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -59,6 +59,20 @@ function buildReplyDispatchPublication(
   return Object.freeze({ runtimes: Object.freeze(runtimes) });
 }
 
+function removeReplyDispatchRuntimeProjections(
+  publication: PreparedReplyDispatchPublication,
+  agentIds: ReadonlySet<string>,
+): PreparedReplyDispatchPublication {
+  if (agentIds.size === 0) {
+    return publication;
+  }
+  return Object.freeze({
+    runtimes: Object.freeze(
+      publication.runtimes.filter((runtime) => !agentIds.has(runtime.agentId)),
+    ),
+  });
+}
+
 type PreparedReplyDispatchPublicationHost = Readonly<{
   isGatewayLifecycleActive: () => boolean;
   getPendingOwnerPublication: (agentId: string) => Promise<unknown> | undefined;
@@ -87,6 +101,10 @@ export class PreparedReplyDispatchPublicationOwner {
     this.#publication = this.host.isGatewayLifecycleActive()
       ? buildReplyDispatchPublication(owners)
       : EMPTY_REPLY_DISPATCH_PUBLICATION;
+  }
+
+  remove(agentIds: ReadonlySet<string>): void {
+    this.#publication = removeReplyDispatchRuntimeProjections(this.#publication, agentIds);
   }
 
   readonly load = async ({

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -59,22 +59,9 @@ function buildReplyDispatchPublication(
   return Object.freeze({ runtimes: Object.freeze(runtimes) });
 }
 
-function removeReplyDispatchRuntimeProjections(
-  publication: PreparedReplyDispatchPublication,
-  agentIds: ReadonlySet<string>,
-): PreparedReplyDispatchPublication {
-  if (agentIds.size === 0) {
-    return publication;
-  }
-  return Object.freeze({
-    runtimes: Object.freeze(
-      publication.runtimes.filter((runtime) => !agentIds.has(runtime.agentId)),
-    ),
-  });
-}
-
 type PreparedReplyDispatchPublicationHost = Readonly<{
   isGatewayLifecycleActive: () => boolean;
+  getPendingOwnerPublication: (agentId: string) => Promise<unknown> | undefined;
   getPendingReplacement: () => Promise<void> | undefined;
 }>;
 
@@ -102,10 +89,6 @@ export class PreparedReplyDispatchPublicationOwner {
       : EMPTY_REPLY_DISPATCH_PUBLICATION;
   }
 
-  remove(agentIds: ReadonlySet<string>): void {
-    this.#publication = removeReplyDispatchRuntimeProjections(this.#publication, agentIds);
-  }
-
   readonly load = async ({
     agentId,
   }: {
@@ -114,6 +97,11 @@ export class PreparedReplyDispatchPublicationOwner {
     for (;;) {
       if (!this.host.isGatewayLifecycleActive()) {
         return undefined;
+      }
+      const pendingOwner = this.host.getPendingOwnerPublication(agentId);
+      if (pendingOwner) {
+        await pendingOwner;
+        continue;
       }
       const replacement = this.host.getPendingReplacement();
       if (replacement) {

--- a/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { resolveAgentDir } from "../agents/agent-scope.js";
+import { setRuntimeAuthProfileStoreSnapshot } from "../agents/auth-profiles/runtime-snapshots.js";
+import {
+  loadPublishedGatewayReplyDispatchRuntime,
+  registerPreparedModelRuntimePublicationListener,
+} from "../agents/prepared-model-runtime.js";
+import { installConnectedSessionStoreGatewaySuite } from "./test-helpers.connected-session-store.js";
+import {
+  agentCommandMock,
+  agentDiscoveryMock,
+  installGatewayTestHooks,
+  onceMessage,
+  prepareGatewayReplyRuntimeForTest,
+  testState,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const gatewaySuite = installConnectedSessionStoreGatewaySuite("openclaw-gw-auth-refresh-", {
+  client: {
+    id: "gateway-client",
+    version: "1.0.0",
+    platform: "test",
+    mode: "backend",
+  },
+});
+
+type AgentRpcFrame = {
+  type: "res";
+  id: string;
+  ok: boolean;
+  payload?: { runId?: string; status?: string };
+  error?: { code?: string; message?: string };
+};
+
+function sendAgentRpc(socket: WebSocket, params: { agentId: string; runId: string }) {
+  const accepted = onceMessage<AgentRpcFrame>(
+    socket,
+    (frame) =>
+      frame.type === "res" && frame.id === params.runId && frame.payload?.status === "accepted",
+  );
+  const final = onceMessage<AgentRpcFrame>(
+    socket,
+    (frame) =>
+      frame.type === "res" && frame.id === params.runId && frame.payload?.status !== "accepted",
+  );
+  socket.send(
+    JSON.stringify({
+      type: "req",
+      id: params.runId,
+      method: "agent",
+      params: {
+        agentId: params.agentId,
+        message: `dispatch ${params.runId}`,
+        idempotencyKey: params.runId,
+      },
+    }),
+  );
+  return { accepted, final };
+}
+
+function agentCommandCallsFor(runId: string) {
+  return vi
+    .mocked(agentCommandMock)
+    .mock.calls.filter(([options]) => (options as { runId?: string }).runId === runId);
+}
+
+async function prepareAuthDispatchAgents(affectedAgentId: string) {
+  testState.agentsConfig = {
+    list: [{ id: "main", default: true }, { id: affectedAgentId }],
+  };
+  agentDiscoveryMock.enabled = true;
+  agentDiscoveryMock.models = [{ id: "claude-opus-4-6", provider: "anthropic", input: ["text"] }];
+  const { clearConfigCache, clearRuntimeConfigSnapshot, getRuntimeConfig } =
+    await import("../config/io.js");
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  await prepareGatewayReplyRuntimeForTest({ force: true });
+  const config = getRuntimeConfig();
+  return {
+    agentDir: resolveAgentDir(config, affectedAgentId),
+    runtime: await loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId }),
+  };
+}
+
+describe("gateway agent auth refresh dispatch", () => {
+  beforeEach(() => {
+    vi.mocked(agentCommandMock).mockClear();
+  });
+
+  afterEach(() => {
+    testState.agentsConfig = undefined;
+  });
+
+  test("waits for an affected auth generation without blocking siblings", async () => {
+    const affectedAgentId = "auth-wait";
+    const affectedRunId = "idem-agent-auth-wait";
+    const siblingRunId = "idem-agent-auth-sibling";
+    const before = await prepareAuthDispatchAgents(affectedAgentId);
+    const publicationGate = createDeferred<{ agentDir: string; wrote: false }>();
+    const modelsConfig = await import("../agents/models-config.js");
+    const ensureOpenClawModelsJson = modelsConfig.ensureOpenClawModelsJson;
+    const ensureSpy = vi
+      .spyOn(modelsConfig, "ensureOpenClawModelsJson")
+      .mockImplementation(async (config, agentDir, options) =>
+        agentDir === before.agentDir
+          ? await publicationGate.promise
+          : await ensureOpenClawModelsJson(config, agentDir, options),
+      );
+    const published = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "published") {
+        published.resolve();
+      }
+    });
+    try {
+      setRuntimeAuthProfileStoreSnapshot(
+        {
+          version: 1,
+          profiles: {
+            "anthropic:default": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "fresh-generation-key",
+            },
+          },
+        },
+        before.agentDir,
+      );
+
+      const affected = sendAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId: affectedRunId,
+      });
+      await affected.accepted;
+      const sibling = sendAgentRpc(gatewaySuite.ws, { agentId: "main", runId: siblingRunId });
+      await sibling.accepted;
+      await expect(sibling.final).resolves.toMatchObject({ ok: true, payload: { status: "ok" } });
+      expect(agentCommandCallsFor(siblingRunId)).toHaveLength(1);
+      expect(agentCommandCallsFor(affectedRunId)).toHaveLength(0);
+      await expect(
+        Promise.race([affected.final.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
+
+      publicationGate.resolve({ agentDir: before.agentDir, wrote: false });
+      await published.promise;
+      const after = await loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId });
+      expect(after).not.toBe(before.runtime);
+      await expect(affected.final).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "ok" },
+      });
+      const affectedCalls = agentCommandCallsFor(affectedRunId);
+      expect(affectedCalls).toHaveLength(1);
+      expect(affectedCalls[0]?.[4]).toMatchObject({
+        config: after?.config,
+        pluginGeneration: after?.pluginGeneration,
+      });
+    } finally {
+      unregister();
+      ensureSpy.mockRestore();
+    }
+  });
+
+  test("never reuses an affected projection after auth publication rejects", async () => {
+    const affectedAgentId = "auth-reject";
+    const runId = "idem-agent-auth-reject";
+    const before = await prepareAuthDispatchAgents(affectedAgentId);
+    const modelsConfig = await import("../agents/models-config.js");
+    const ensureOpenClawModelsJson = modelsConfig.ensureOpenClawModelsJson;
+    const ensureSpy = vi
+      .spyOn(modelsConfig, "ensureOpenClawModelsJson")
+      .mockImplementation(async (config, agentDir, options) => {
+        if (agentDir === before.agentDir) {
+          throw new Error("auth publication rejected");
+        }
+        return await ensureOpenClawModelsJson(config, agentDir, options);
+      });
+    const failed = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "failed") {
+        failed.resolve();
+      }
+    });
+    try {
+      setRuntimeAuthProfileStoreSnapshot(
+        {
+          version: 1,
+          profiles: {
+            "anthropic:default": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "rejected-generation-key",
+            },
+          },
+        },
+        before.agentDir,
+      );
+      await failed.promise;
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId }),
+      ).rejects.toThrow(
+        `prepared reply dispatch runtime owner was not published for ${affectedAgentId}`,
+      );
+
+      const dispatched = sendAgentRpc(gatewaySuite.ws, { agentId: affectedAgentId, runId });
+      await expect(dispatched.accepted).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "accepted" },
+      });
+      await expect(dispatched.final).resolves.toMatchObject({
+        ok: false,
+        payload: { status: "error" },
+        error: {
+          code: "UNAVAILABLE",
+          message: expect.stringContaining(
+            `prepared reply dispatch runtime owner was not published for ${affectedAgentId}`,
+          ),
+        },
+      });
+      expect(agentCommandCallsFor(runId)).toHaveLength(0);
+    } finally {
+      unregister();
+      ensureSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Related: #127710

## What Problem This Solves

Fixes an issue where an inbound message could fail before its turn started when an auth-store mutation raced prepared-model-runtime republication. A rejected credential refresh could also leave the affected agent's previous dispatch projection readable to later messages.

## Why This Change Was Made

Auth mutations now mark one owner-scoped publication pending while synchronously removing only the affected dispatch projections. Affected dispatch lookup and run admission wait for that exact publication, successful refreshes rebuild the projection atomically, and rejected refreshes remain fail-closed. Unaffected agents stay readable, and already-admitted turns retain their pinned generation.

## User Impact

Messages arriving during credential rotation wait for the affected agent's fresh auth generation instead of failing in the publication window. A rejected refresh cannot restore stale credentials or policy for later turns, while unrelated agents continue serving normally.

## Evidence

- Before the repair, `src/agents/prepared-model-runtime.inbound-registry.test.ts` reproduced a rejected refresh followed by a new lookup returning the stale worker projection.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/prepared-model-runtime.lifecycle.test.ts src/agents/prepared-model-runtime.inbound-registry.test.ts --reporter=verbose` passed 51 tests.
- `node scripts/check-changed.mjs` passed formatting, production/test typecheck, lint, dead-export scan, import cycles, and changed-surface guards.
- Complete branch structured review reported no actionable findings.
- Mock-Gateway dispatch regression: before the atomic commit repair, an accepted affected RPC ended `UNAVAILABLE` after a successful refresh; after the repair, the affected RPC stays pending while an unaffected agent completes, then dispatches exactly once with the newly published runtime. A rejected refresh leaves later dispatch `UNAVAILABLE` with zero command calls. The Gateway proof passed 4/4 tests across both Gateway projects, and the owner suites passed 51/51 after rebasing onto current `origin/main`.
- Reload/auth interleaving regression: before the repair, a credential mutation during an active config build made the config publication reject at dispatch rebuild and left all owners unavailable. The active replacement now adopts the mutation, drains it, and performs queue validation, dispatch rebuild, replacement resolution, and publication notification as one synchronous commit. The exact-order regression plus owner-selection and Gateway suites passed 79 tests; `node scripts/check-changed.mjs` and final structured review passed.
- Round 3 reproduces config build -> auth mutation -> config completion -> auth drain with the Gateway lifecycle active. Before the fix, dispatch rebuild rejected because the owner retained a publication queued behind the reload itself; after the fix, the reload commits once, both affected and sibling dispatch resolve on the replacement config, no extra auth publication runs, and normal run admission succeeds.
- Round 4 replaces competing owner promises with one private auth publication owner. Overlapping auth mutations now share stable per-owner gates, and a same-key reload adopts and settles those gates instead of restoring a rejected batch promise. Both exact-order regressions failed before this repair and now pass, including adopted reload failure and recovery.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/prepared-model-runtime.lifecycle.test.ts src/agents/prepared-model-runtime.reload-auth.test.ts src/agents/prepared-model-runtime.inbound-registry.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts --reporter=verbose` passed 79 owner tests and 2 Gateway tests.
- Round 5 reproduces M1 build blocked -> M2 queued -> M1 rejected. Before the fix, M2 remained queued with no worker; now the same transaction worker continues when the newer events cover every failed owner, publishes M2 without a third event, and still surfaces genuine uncovered sibling failures.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/prepared-model-runtime.lifecycle.test.ts src/agents/prepared-model-runtime.reload-auth.test.ts src/agents/prepared-model-runtime.inbound-registry.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts --reporter=verbose` passed 80 owner tests and 2 Gateway tests.
- Production LOC: `+329/-108` (net `+221`) for the dedicated transaction owner and the existing generation/dispatch ownership boundaries. Tests: `+552/-61` (net `+491`).
