### PR TITLE
improve(signal): reuse parsed inbound payload

### DIFF
--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -946,17 +946,20 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   return async (
     event: { event?: string; data?: string },
     turnAdoptionLifecycle?: SignalIngressLifecycle,
+    preparedPayload?: SignalReceivePayload,
   ): Promise<{ kind: "deferred" } | { kind: "failed-retryable"; error: unknown } | void> => {
     if (event.event !== "receive" || !event.data) {
       return;
     }
 
-    let payload: SignalReceivePayload | null;
-    try {
-      payload = JSON.parse(event.data) as SignalReceivePayload;
-    } catch (err) {
-      deps.runtime.error?.(`failed to parse event: ${String(err)}`);
-      return;
+    let payload: SignalReceivePayload | null = preparedPayload ?? null;
+    if (!preparedPayload) {
+      try {
+        payload = JSON.parse(event.data) as SignalReceivePayload;
+      } catch (err) {
+        deps.runtime.error?.(`failed to parse event: ${String(err)}`);
+        return;
+      }
     }
     if (payload?.exception?.message) {
       deps.runtime.error?.(`receive exception: ${payload.exception.message}`);

--- a/extensions/signal/src/signal-ingress.test.ts
+++ b/extensions/signal/src/signal-ingress.test.ts
@@ -119,7 +119,9 @@ describe("Signal durable ingress", () => {
       try {
         await recovered.waitForIdle();
         expect(recoveredDispatch).toHaveBeenCalledTimes(1);
-        expect(recoveredDispatch).toHaveBeenCalledWith(event, expect.any(Object));
+        const [recoveredEvent, recoveredLifecycle] = recoveredDispatch.mock.calls[0] ?? [];
+        expect(recoveredEvent).toEqual(event);
+        expect(recoveredLifecycle).toEqual(expect.any(Object));
       } finally {
         await recovered.monitor.stop();
       }

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -13,6 +13,7 @@ import {
   normalizeNullableString as normalizeRawString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SignalSseEvent } from "./client-adapter.js";
+import type { SignalReceivePayload } from "./monitor/event-handler.types.js";
 import { getOptionalSignalRuntime } from "./runtime.js";
 
 const SIGNAL_INGRESS_DRAIN_INTERVAL_MS = 1_000;
@@ -33,6 +34,11 @@ type SignalIngressEventFacts = {
   numberAliasEventId?: string;
 };
 
+type SignalPreparedIngressEvent = [
+  event: SignalSseEvent,
+  parsedPayload: SignalReceivePayload | null | undefined,
+];
+
 type SignalIngressPayload = {
   version: 1;
   receivedAt: number;
@@ -48,6 +54,7 @@ type SignalIngressDispatchResult = ChannelIngressMonitorDeliveryResult;
 type SignalIngressDispatch = (
   event: SignalSseEvent,
   lifecycle: SignalIngressLifecycle,
+  parsedPayload: SignalReceivePayload,
 ) => Promise<SignalIngressDispatchResult | void> | SignalIngressDispatchResult | void;
 
 const SignalIngressPermanentError = createChannelIngressError<
@@ -58,7 +65,7 @@ function normalizeTimestamp(value: unknown): number | null {
   return asPositiveSafeInteger(value) ?? null;
 }
 
-function parseReceiveEnvelope(event: SignalSseEvent): SignalIngressEnvelope | null {
+function parseReceivePayload(event: SignalSseEvent): SignalReceivePayload | null {
   if (event.event !== "receive" || !event.data) {
     return null;
   }
@@ -80,7 +87,8 @@ function parseReceiveEnvelope(event: SignalSseEvent): SignalIngressEnvelope | nu
       "Signal receive event must contain a JSON object",
     );
   }
-  return isRecord(parsed.envelope) ? (parsed.envelope as SignalIngressEnvelope) : null;
+  // SAFETY: SignalReceivePayload has only optional fields; downstream code validates each field.
+  return parsed as SignalReceivePayload;
 }
 
 function resolveDataMessage(envelope: SignalIngressEnvelope): Record<string, unknown> | null {
@@ -90,8 +98,11 @@ function resolveDataMessage(envelope: SignalIngressEnvelope): Record<string, unk
   return isRecord(envelope.editMessage?.dataMessage) ? envelope.editMessage.dataMessage : null;
 }
 
-function inspectSignalIngressEvent(event: SignalSseEvent): SignalIngressEventFacts | null {
-  const envelope = parseReceiveEnvelope(event);
+function inspectSignalIngressEvent(
+  prepared: SignalPreparedIngressEvent,
+): SignalIngressEventFacts | null {
+  const payload = (prepared[1] ??= parseReceivePayload(prepared[0]));
+  const envelope = isRecord(payload?.envelope) ? (payload.envelope as SignalIngressEnvelope) : null;
   if (!envelope || "syncMessage" in envelope) {
     return null;
   }
@@ -166,16 +177,17 @@ export async function startSignalIngressMonitor(params: {
   }
   const ingressQueue = queue;
   const monitor = createChannelIngressMonitor<
-    SignalSseEvent,
+    SignalPreparedIngressEvent,
     SignalIngressBody,
     SignalIngressPayload
   >({
     queue: ingressQueue,
-    inspect: (event) => inspectSignalIngressEvent(event),
+    inspect: (prepared) => inspectSignalIngressEvent(prepared),
     payload: {
       version: 1,
-      serialize: (event, { receivedAt }) => ({ receivedAt, event }),
-      deserialize: (body) => body.event,
+      // Parsed JSON remains transient; durable rows retain the exact raw event shape.
+      serialize: ([event], { receivedAt }) => ({ receivedAt, event }),
+      deserialize: (body) => [body.event, undefined],
       encode: ({ body }) => ({ version: 1, ...body }),
       decode: (payload) => ({ version: payload.version, body: payload }),
       createClaimError: (_kind, claim) =>
@@ -184,7 +196,8 @@ export async function startSignalIngressMonitor(params: {
           `Signal ingress row ${claim.id} has an invalid payload`,
         ),
     },
-    deliver: (event, lifecycle) => params.dispatch(event, lifecycle),
+    deliver: ([event, parsedPayload], lifecycle) =>
+      parsedPayload ? params.dispatch(event, lifecycle, parsedPayload) : undefined,
     onDurableAdmission: async (_event, { facts }) => {
       const { numberAliasEventId } = facts as SignalIngressEventFacts;
       if (!numberAliasEventId) {
@@ -215,7 +228,7 @@ export async function startSignalIngressMonitor(params: {
 
   return {
     receive: async (event) => {
-      await monitor.admit(event);
+      await monitor.admit([event, undefined]);
       await monitor.waitForPumpIdle();
     },
     stop: monitor.stop,


### PR DESCRIPTION
## What Problem This Solves

Signal's durable ingress parsed every accepted receive event to derive stable sender, timestamp, and conversation-lane facts, persisted the unchanged raw event, then discarded the parsed object. Claim inspection parsed the same raw JSON again and the production event handler parsed it a third time before sender, group, media, mention, and context work.

## Why This Change Was Made

Signal ingress now carries its claim-inspected payload transiently beside the raw event and passes it to the Signal event handler. Durable rows retain exactly the existing `{ version, receivedAt, event }` shape, while direct/internal handler callers keep the existing parse fallback. This PR was AI-assisted.

## User Impact

Accepted Signal inbound events perform one fewer full JSON parse before message handling. There is no authorization, routing, durable storage, delivery, protocol, configuration, or privacy-contract change.

## Evidence

- Exact-current pre-fix proof on `04d174584d1b20c8bb3802576e04e4925ff7b4a3`: a focused owner test failed because dispatch received no claim-inspected payload; the exact candidate passes with a payload equal to the raw JSON. The implementation-coupled probe was removed before commit.
- Current-main integration retained source patch ID `936dfce755b38d768eafff6453bdfad017f5910f`; remote main advanced once afterward only in unrelated Control UI transcript files, with no Signal owner overlap.
- Focused durable-ingress and control-lane coverage: 2 files / 51 tests passed.
- Full Signal extension: 43 files / 778 tests passed.
- `node scripts/check-changed.mjs -- extensions/signal/src/monitor/event-handler.ts extensions/signal/src/signal-ingress.ts extensions/signal/src/signal-ingress.test.ts` passed formatting, production/test type checks, lint, dead exports, boundaries, cycle checks, and repository guards; `git diff --check` passed.
- Full `pnpm build` passed, including runtime/plugin SDK/postbuild and Control UI performance gates.
- Source-lane exact differential covered direct/group media+mention+quote, edit, reaction/deferred, malformed/non-object JSON, missing identity/timestamp, ignored sync/typing events, runtime failures, queue lifecycle, durable key shape, raw bytes, and dispatch order. Outputs and errors matched; only transient prepared-payload availability differed.
- Owner microbenchmark (16,572-byte ordinary payload, 25,000 iterations × 9 rounds) reduced the handler microstage median from 226.460 ms to 11.520 ms (94.91%). Claim inspection plus handler work changes from two parses to one; the full admission-through-handler path changes from three parses to two because durable claim identity is intentionally revalidated. This is a parse-isolated microbenchmark, not an end-to-end provider throughput claim.
- Pre-commit and committed-head Codex `gpt-5.6-sol` / high autoreviews were clean after clean TruffleHog scans; final correctness confidence was 0.93.
- No live Signal service was required: durable/raw shape, lifecycle, error, and delivery semantics have deterministic differential and full extension coverage.
