### PR TITLE
fix(cron): prevent stale current-session results after reset

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-transcript-turn.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-turn.ts
@@ -34,6 +34,7 @@ import {
 import { appendTranscriptMessageInTransaction } from "./session-accessor.sqlite-transcript-message-append.js";
 import { rememberCommittedTranscriptMessageSequencesInTransaction } from "./session-accessor.sqlite-transcript-sequences.js";
 import type {
+  SessionLifecycleRevisionExpectation,
   SessionTranscriptTurnExpectedState,
   SessionTranscriptTurnLifecyclePatch,
 } from "./session-transcript-turn-lifecycle.types.js";
@@ -58,7 +59,7 @@ export async function appendExpectedSessionTranscriptTurn(
     atomicGroup?: boolean;
     config?: import("../types.openclaw.js").OpenClawConfig;
     cwd?: string;
-    expectedLifecycleRevision?: string;
+    expectedLifecycleRevision?: SessionLifecycleRevisionExpectation;
     expectedWriterRunId?: SessionTranscriptTurnExpectedState["expectedWriterRunId"];
     expectedSessionState?: SessionTranscriptTurnExpectedState;
     expectedSessionId: string;

--- a/src/config/sessions/session-accessor.transcript-turn.ts
+++ b/src/config/sessions/session-accessor.transcript-turn.ts
@@ -346,7 +346,9 @@ async function persistExpectedSessionTranscriptTurn(
           config: options.config,
           cwd: options.cwd,
           expectedLifecycleRevision:
-            options.expectedLifecycleRevision ?? inheritedWriterFence?.expectedLifecycleRevision,
+            options.expectedLifecycleRevision !== undefined
+              ? options.expectedLifecycleRevision
+              : inheritedWriterFence?.expectedLifecycleRevision,
           expectedWriterRunId:
             options.expectedWriterRunId ?? inheritedWriterFence?.expectedWriterRunId,
           expectedSessionState: options.expectedSessionState,

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -20,6 +20,7 @@ import type {
   SessionLifecycleStoreTarget,
 } from "./session-accessor.lifecycle-types.js";
 import type {
+  SessionLifecycleRevisionExpectation,
   SessionTranscriptTurnExpectedState,
   SessionTranscriptTurnLifecyclePatch,
 } from "./session-transcript-turn-lifecycle.types.js";
@@ -400,7 +401,7 @@ export type SessionTranscriptTurnPersistOptions = {
   /** Creates this entry with the turn only if the logical session is still absent. */
   initialSessionEntry?: SessionEntry;
   /** Rejects the turn when lifecycle ownership changed without rotating the session id. */
-  expectedLifecycleRevision?: string;
+  expectedLifecycleRevision?: SessionLifecycleRevisionExpectation;
   /** Rejects the turn when another admitted run owns transcript writes. */
   expectedWriterRunId?: SessionTranscriptTurnExpectedState["expectedWriterRunId"];
   /** Rejects the turn unless the persisted row still has this exact lifecycle owner state. */

--- a/src/config/sessions/session-transcript-turn-lifecycle.types.ts
+++ b/src/config/sessions/session-transcript-turn-lifecycle.types.ts
@@ -2,6 +2,9 @@ import type { SessionRunStatus } from "../../../packages/gateway-protocol/src/sc
 import type { SessionRestartRecoveryState } from "./restart-recovery-types.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
+/** `null` requires a revision-less row; omitting the field skips the revision fence. */
+export type SessionLifecycleRevisionExpectation = string | null;
+
 /** Authoritative lifecycle snapshot required for an atomic transcript admission. */
 export type SessionTranscriptTurnExpectedState = {
   /** Rejects a run-owned turn after another admitted run takes writer ownership. */

--- a/src/config/sessions/session-transcript-turn-state.ts
+++ b/src/config/sessions/session-transcript-turn-state.ts
@@ -3,6 +3,7 @@ import {
   sameRestartRecoveryTerminalRunIds,
 } from "./restart-recovery-state.js";
 import type {
+  SessionLifecycleRevisionExpectation,
   SessionTranscriptTurnExpectedState,
   SessionTranscriptTurnLifecyclePatch,
 } from "./session-transcript-turn-lifecycle.types.js";
@@ -11,7 +12,7 @@ import type { InternalSessionEntry as SessionEntry } from "./types.js";
 export function sessionMatchesExpectedTranscriptTurn<T extends { entry: SessionEntry }>(
   selected: T | undefined,
   expected: {
-    expectedLifecycleRevision?: string;
+    expectedLifecycleRevision?: SessionLifecycleRevisionExpectation;
     expectedWriterRunId?: SessionTranscriptTurnExpectedState["expectedWriterRunId"];
     expectedSessionState?: SessionTranscriptTurnExpectedState;
     expectedSessionId: string;
@@ -22,7 +23,7 @@ export function sessionMatchesExpectedTranscriptTurn<T extends { entry: SessionE
     selected &&
     selected.entry.sessionId === expected.expectedSessionId &&
     (expected.expectedLifecycleRevision === undefined ||
-      selected.entry.lifecycleRevision === expected.expectedLifecycleRevision) &&
+      selected.entry.lifecycleRevision === (expected.expectedLifecycleRevision ?? undefined)) &&
     (expected.expectedWriterRunId === undefined ||
       selected.entry.activeWriterRunId === expected.expectedWriterRunId) &&
     (expectedState === undefined ||

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { repairToolUseResultPairing } from "../../agents/session-transcript-repair.js";
 import { normalizeLegacySessionEntryDelivery } from "../../infra/state-migrations.legacy-session-store.js";
@@ -1810,6 +1811,48 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       ok: false,
       code: "session-rebound",
     });
+  });
+
+  it("rejects revision materialization between the initial check and SQLite append", async () => {
+    await writeTranscriptStore({ lifecycleRevision: undefined });
+    const databasePath = resolveSqliteTargetFromSessionStorePath(fixture.storePath(), {
+      agentId: "main",
+    }).path;
+    let revisionMaterialized = false;
+
+    const result = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      expectedLifecycleRevision: null,
+      expectedSessionId: sessionId,
+      storePath: fixture.storePath(),
+      beforeMessageWrite: ({ message }) => {
+        const external = new DatabaseSync(databasePath);
+        try {
+          const row = external
+            .prepare("SELECT entry_json FROM session_nodes WHERE session_key = ?")
+            .get(sessionKey) as { entry_json: string };
+          const replacement = {
+            ...(JSON.parse(row.entry_json) as SessionEntry),
+            lifecycleRevision: "replacement-revision",
+            updatedAt: 2,
+          };
+          external
+            .prepare(
+              "UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?",
+            )
+            .run(JSON.stringify(replacement), replacement.updatedAt, sessionKey);
+          revisionMaterialized = true;
+        } finally {
+          external.close();
+        }
+        return message;
+      },
+      message: createExactAssistantMessage({ text: "late output" }),
+    });
+
+    expect(revisionMaterialized).toBe(true);
+    expect(result).toMatchObject({ ok: false, code: "session-rebound" });
+    expect(await loadFixtureMessages()).toEqual([]);
   });
 
   it("rejects a superseded writer claim and accepts the admitted writer", async () => {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -40,7 +40,10 @@ import {
   type SessionTranscriptTurnExpectedState,
   type TranscriptEntryAnchor,
 } from "./session-accessor.js";
-import type { SessionTranscriptTurnLifecyclePatch } from "./session-transcript-turn-lifecycle.types.js";
+import type {
+  SessionLifecycleRevisionExpectation,
+  SessionTranscriptTurnLifecyclePatch,
+} from "./session-transcript-turn-lifecycle.types.js";
 import {
   applyBeforeMessageWriteToAssistant,
   type AssistantBeforeMessageWrite,
@@ -383,7 +386,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;
   expectedSessionId?: string;
-  expectedLifecycleRevision?: string;
+  expectedLifecycleRevision?: SessionLifecycleRevisionExpectation;
   expectedWriterRunId?: string;
   expectedSessionState?: SessionTranscriptTurnExpectedState;
   sessionLifecyclePatch?: SessionTranscriptTurnLifecyclePatch;
@@ -421,7 +424,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     agentId: params.agentId,
     sessionKey,
     ...(params.expectedSessionId ? { expectedSessionId: params.expectedSessionId } : {}),
-    ...(params.expectedLifecycleRevision
+    ...(params.expectedLifecycleRevision !== undefined
       ? { expectedLifecycleRevision: params.expectedLifecycleRevision }
       : {}),
     ...(params.expectedWriterRunId ? { expectedWriterRunId: params.expectedWriterRunId } : {}),
@@ -467,7 +470,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;
   expectedSessionId?: string;
-  expectedLifecycleRevision?: string;
+  expectedLifecycleRevision?: SessionLifecycleRevisionExpectation;
   expectedWriterRunId?: string;
   expectedSessionState?: SessionTranscriptTurnExpectedState;
   sessionLifecyclePatch?: SessionTranscriptTurnLifecyclePatch;
@@ -513,7 +516,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   }
   if (
     params.expectedLifecycleRevision !== undefined &&
-    entry?.lifecycleRevision !== params.expectedLifecycleRevision
+    entry?.lifecycleRevision !== (params.expectedLifecycleRevision ?? undefined)
   ) {
     return {
       ok: false,

--- a/src/cron/isolated-agent/current-session-completion.ts
+++ b/src/cron/isolated-agent/current-session-completion.ts
@@ -24,6 +24,9 @@ export async function commitCurrentSessionCronCompletion(
   if (!sourceSessionKey) {
     return { ok: false, reason: "current cron delivery is missing its source session binding" };
   }
+  if (!params.sourceSessionGeneration) {
+    return { ok: false, reason: "current cron delivery is missing its source session generation" };
+  }
   const completionText =
     resolveDirectCronTranscriptMirrorText(
       projectOutboundPayloadPlanForMirror(
@@ -37,6 +40,7 @@ export async function commitCurrentSessionCronCompletion(
   const committed = await commitBackgroundResultToSession({
     agentId: params.agentId,
     sessionKey: sourceSessionKey,
+    expectedGeneration: params.sourceSessionGeneration,
     text: completionText,
     idempotencyKey: `cron-current-completion:${runId}`,
     provenance: { kind: "cron", jobId: params.job.id, runId },

--- a/src/cron/isolated-agent/delivery-dispatch-types.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-types.ts
@@ -18,6 +18,7 @@ export type DispatchCronDeliveryParams = {
   agentId: string;
   agentSessionKey: string;
   sourceSessionKey?: string;
+  sourceSessionGeneration?: { sessionId: string; lifecycleRevision: string | undefined };
   runSessionKey: string;
   sessionId: string;
   lifecycleRevision: string;

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -270,6 +270,10 @@ function makeBaseParams(overrides: {
     agentSessionKey: "agent:main",
     sourceSessionKey:
       overrides.sessionTarget === "current" ? "agent:main:webchat:direct:owner" : undefined,
+    sourceSessionGeneration:
+      overrides.sessionTarget === "current"
+        ? { sessionId: "source-session-id", lifecycleRevision: "source-lifecycle-revision" }
+        : undefined,
     runSessionKey: overrides.runSessionKey ?? "agent:main",
     sessionId: "test-session-id",
     lifecycleRevision: "test-lifecycle-revision",
@@ -3444,12 +3448,51 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(commitBackgroundResultToSessionMock).toHaveBeenCalledWith({
       agentId: "main",
       sessionKey: "agent:main:webchat:direct:owner",
+      expectedGeneration: {
+        sessionId: "source-session-id",
+        lifecycleRevision: "source-lifecycle-revision",
+      },
       text: "durable WebChat completion",
       idempotencyKey: "cron-current-completion:cron:test-job:1000",
       provenance: { kind: "cron", jobId: "test-job", runId: "cron:test-job:1000" },
       config: params.cfgWithAgentDefaults,
       signal: undefined,
     });
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("preserves an explicitly revision-less source generation", async () => {
+    const params = makeBaseParams({
+      synthesizedText: "durable revision-less completion",
+      sessionTarget: "current",
+    });
+    params.sourceSessionGeneration = {
+      sessionId: "source-session-id",
+      lifecycleRevision: undefined,
+    };
+
+    await dispatchCronDelivery(params);
+
+    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedGeneration: params.sourceSessionGeneration }),
+    );
+  });
+
+  it("refuses a current-target completion without its captured source generation", async () => {
+    const params = makeBaseParams({
+      synthesizedText: "must not attach to a future replacement",
+      sessionTarget: "current",
+    });
+    params.sourceSessionGeneration = undefined;
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state).toMatchObject({
+      delivered: false,
+      deliveryAttempted: true,
+      deliveryError: "current cron delivery is missing its source session generation",
+    });
+    expect(commitBackgroundResultToSessionMock).not.toHaveBeenCalled();
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -508,6 +508,7 @@ export async function finalizeCronRun(params: {
     agentId: prepared.agentId,
     agentSessionKey: prepared.agentSessionKey,
     sourceSessionKey: prepared.sourceSessionKey,
+    sourceSessionGeneration: prepared.sourceSessionGeneration,
     runSessionKey: prepared.runSessionKey,
     sessionId: prepared.currentRunSessionId(),
     lifecycleRevision: prepared.cronSession.lifecycleRevision,

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -97,6 +97,7 @@ export type PreparedCronRunContext = {
   agentDir: string;
   agentSessionKey: string;
   sourceSessionKey?: string;
+  sourceSessionGeneration?: { sessionId: string; lifecycleRevision: string | undefined };
   runSessionId: string;
   currentRunSessionId: () => string;
   runSessionKey: string;
@@ -226,6 +227,10 @@ export async function prepareCronRunContext(params: {
     forceNew: usesDetachedRunSession,
     hookExternalContentSource,
   });
+  const sourceEntry = sourceSessionKey ? cronSession.store[sourceSessionKey] : undefined;
+  const sourceSessionGeneration = sourceEntry
+    ? { sessionId: sourceEntry.sessionId, lifecycleRevision: sourceEntry.lifecycleRevision }
+    : undefined;
   const reservedKey = isAgentHarnessSessionKey(agentSessionKey);
   if (cronSession.initialSessionEntry?.modelSelectionLocked === true) {
     throw new Error(
@@ -484,16 +489,12 @@ export async function prepareCronRunContext(params: {
 
     const { formattedTime, timeLine } = resolveCronStyleNow(runtimeCfg, now);
     const originalMessage = resolveCronAgentTurnMessage(input);
-    const sourceSessionEntry = sourceSessionKey ? cronSession.store[sourceSessionKey] : undefined;
     // Current jobs stay detached; a bounded tail preserves context without transcript continuation.
     const currentConversationContext =
-      input.job.sessionTarget === "current" &&
-      agentPayload &&
-      sourceSessionKey &&
-      sourceSessionEntry
+      input.job.sessionTarget === "current" && agentPayload && sourceSessionKey && sourceEntry
         ? await buildCurrentConversationContextBlock({
             agentId,
-            sourceSessionEntry,
+            sourceSessionEntry: sourceEntry,
             sourceSessionKey,
             storePath: cronSession.storePath,
           })
@@ -642,6 +643,7 @@ export async function prepareCronRunContext(params: {
         agentDir,
         agentSessionKey,
         sourceSessionKey,
+        sourceSessionGeneration,
         runSessionId,
         currentRunSessionId,
         runSessionKey,

--- a/src/cron/isolated-agent/run.current-context.test.ts
+++ b/src/cron/isolated-agent/run.current-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
+  dispatchCronDeliveryMock,
   loadRunCronIsolatedAgentTurn,
   makeCronSession,
   makeCronSessionEntry,
@@ -27,7 +28,10 @@ describe("runCronIsolatedAgentTurn — current conversation context", () => {
 
   it("prepends the bound source conversation to a current-target payload", async () => {
     mockRunCronFallbackPassthrough();
-    const sourceSessionEntry = makeCronSessionEntry({ sessionId: "source-session" });
+    const sourceSessionEntry = makeCronSessionEntry({
+      sessionId: "source-session",
+      lifecycleRevision: "source-revision",
+    });
     resolveCronSessionMock.mockReturnValue(
       makeCronSession({ store: { [sourceSessionKey]: sourceSessionEntry } }),
     );
@@ -57,6 +61,15 @@ describe("runCronIsolatedAgentTurn — current conversation context", () => {
     );
     expect(embeddedPrompt()).toContain(
       "Recent conversation:\n- User: Otters hold hands while sleeping.\n- Assistant: Got it.\n\nSummarize the animal fact.",
+    );
+    expect(dispatchCronDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceSessionKey,
+        sourceSessionGeneration: {
+          sessionId: "source-session",
+          lifecycleRevision: "source-revision",
+        },
+      }),
     );
   });
 

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -1029,6 +1029,10 @@ describe("session.message websocket events", () => {
         agentId: "main",
         agentSessionKey: "cron:job-webchat",
         sourceSessionKey: sessionKey,
+        sourceSessionGeneration: {
+          sessionId,
+          lifecycleRevision: "current-cron-revision",
+        },
         runSessionKey: "cron:job-webchat:run:3000",
         sessionId: "detached-cron-session",
         lifecycleRevision: "detached-cron-revision",

--- a/src/sessions/background-session-result.test.ts
+++ b/src/sessions/background-session-result.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { loadTranscriptEvents, replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { commitBackgroundResultToSession } from "./background-session-result.js";
@@ -11,12 +11,12 @@ import {
 import { onSessionTranscriptUpdate } from "./transcript-events.js";
 
 describe("commitBackgroundResultToSession", () => {
-  const tempDirs = createTempDirTracker();
-
-  afterEach(() => {
-    closeOpenClawAgentDatabasesForTest();
-    tempDirs.cleanup();
-  });
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+    afterEach(() => {
+      closeOpenClawAgentDatabasesForTest();
+      cleanup();
+    }),
+  );
 
   async function createTarget() {
     const dir = tempDirs.make("openclaw-background-result-");

--- a/src/sessions/background-session-result.test.ts
+++ b/src/sessions/background-session-result.test.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { loadTranscriptEvents, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { commitBackgroundResultToSession } from "./background-session-result.js";
 import {
   beginSessionWorkAdmission,
@@ -10,7 +11,12 @@ import {
 import { onSessionTranscriptUpdate } from "./transcript-events.js";
 
 describe("commitBackgroundResultToSession", () => {
-  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  const tempDirs = createTempDirTracker();
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    tempDirs.cleanup();
+  });
 
   async function createTarget() {
     const dir = tempDirs.make("openclaw-background-result-");
@@ -23,6 +29,7 @@ describe("commitBackgroundResultToSession", () => {
     );
     return {
       config: { session: { store: storePath } },
+      generation: { sessionId, lifecycleRevision: "source-revision" },
       sessionId,
       sessionKey,
       storePath,
@@ -42,6 +49,7 @@ describe("commitBackgroundResultToSession", () => {
     const commit = commitBackgroundResultToSession({
       agentId: "main",
       sessionKey: target.sessionKey,
+      expectedGeneration: target.generation,
       text: "Automation finished while the chat was active.",
       idempotencyKey: "cron-current-completion:cron:job-1:1000",
       provenance: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
@@ -72,6 +80,7 @@ describe("commitBackgroundResultToSession", () => {
     const retry = await commitBackgroundResultToSession({
       agentId: "main",
       sessionKey: target.sessionKey,
+      expectedGeneration: target.generation,
       text: "Automation finished while the chat was active.",
       idempotencyKey: "cron-current-completion:cron:job-1:1000",
       provenance: { kind: "cron", jobId: "job-1", runId: "cron:job-1:1000" },
@@ -122,11 +131,93 @@ describe("commitBackgroundResultToSession", () => {
       commitBackgroundResultToSession({
         agentId: "main",
         sessionKey: target.sessionKey,
+        expectedGeneration: target.generation,
         text: "Do not append this.",
         idempotencyKey: "cron-current-completion:cron:job-2:2000",
         provenance: { kind: "cron", jobId: "job-2", runId: "cron:job-2:2000" },
         config: target.config,
       }),
     ).resolves.toMatchObject({ ok: false, reason: expect.stringContaining("archived") });
+  });
+
+  it.each([
+    {
+      name: "session-id replacement",
+      sessionId: "replacement-session",
+      lifecycleRevision: "replacement-revision",
+    },
+    {
+      name: "same-id lifecycle replacement",
+      sessionId: "source-session",
+      lifecycleRevision: "replacement-revision",
+    },
+  ])("refuses a result captured before $name", async (replacement) => {
+    const target = await createTarget();
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey: target.sessionKey, storePath: target.storePath },
+      {
+        sessionId: replacement.sessionId,
+        lifecycleRevision: replacement.lifecycleRevision,
+        updatedAt: 2,
+      },
+    );
+
+    await expect(
+      commitBackgroundResultToSession({
+        agentId: "main",
+        sessionKey: target.sessionKey,
+        expectedGeneration: target.generation,
+        text: "Do not append this stale cron result.",
+        idempotencyKey: "cron-current-completion:cron:job-stale:3000",
+        provenance: { kind: "cron", jobId: "job-stale", runId: "cron:job-stale:3000" },
+        config: target.config,
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: expect.stringContaining("session rebound") });
+
+    await expect(
+      loadTranscriptEvents({
+        agentId: "main",
+        sessionId: replacement.sessionId,
+        sessionKey: target.sessionKey,
+        storePath: target.storePath,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("treats a missing lifecycle revision as exact generation state", async () => {
+    const target = await createTarget();
+    const generation = { sessionId: target.sessionId, lifecycleRevision: undefined };
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey: target.sessionKey, storePath: target.storePath },
+      { sessionId: target.sessionId, updatedAt: 2 },
+    );
+
+    await expect(
+      commitBackgroundResultToSession({
+        agentId: "main",
+        sessionKey: target.sessionKey,
+        expectedGeneration: generation,
+        text: "This still belongs to the revision-less session.",
+        idempotencyKey: "cron-current-completion:cron:job-legacy:4000",
+        provenance: { kind: "cron", jobId: "job-legacy", runId: "cron:job-legacy:4000" },
+        config: target.config,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey: target.sessionKey, storePath: target.storePath },
+      { sessionId: target.sessionId, lifecycleRevision: "materialized-revision", updatedAt: 3 },
+    );
+    await expect(
+      commitBackgroundResultToSession({
+        agentId: "main",
+        sessionKey: target.sessionKey,
+        expectedGeneration: generation,
+        text: "Do not append after the generation changes.",
+        idempotencyKey: "cron-current-completion:cron:job-legacy:5000",
+        provenance: { kind: "cron", jobId: "job-legacy", runId: "cron:job-legacy:5000" },
+        config: target.config,
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: expect.stringContaining("session rebound") });
   });
 });

--- a/src/sessions/background-session-result.ts
+++ b/src/sessions/background-session-result.ts
@@ -118,7 +118,7 @@ export async function commitBackgroundResultToSession(params: {
         agentId: params.agentId,
         sessionKey,
         expectedSessionId,
-        ...(expectedLifecycleRevision ? { expectedLifecycleRevision } : {}),
+        expectedLifecycleRevision: expectedLifecycleRevision ?? null,
         idempotencyKey,
         message,
         storePath,

--- a/src/sessions/background-session-result.ts
+++ b/src/sessions/background-session-result.ts
@@ -35,6 +35,8 @@ type BackgroundSessionResultProvenance = {
 export async function commitBackgroundResultToSession(params: {
   agentId: string;
   sessionKey: string;
+  /** Pins output to the conversation generation that admitted the background run. */
+  expectedGeneration: { sessionId: string; lifecycleRevision: string | undefined };
   text: string;
   idempotencyKey: string;
   provenance: BackgroundSessionResultProvenance;
@@ -51,17 +53,13 @@ export async function commitBackgroundResultToSession(params: {
   const storePath = resolveSessionStorePathCore(params.config.session?.store, {
     agentId: params.agentId,
   });
-  const initial = loadSessionEntryReadOnly({
-    agentId: params.agentId,
-    sessionKey,
-    storePath,
-    readConsistency: "latest",
-  });
-  const expectedSessionId = normalizeOptionalString(initial?.sessionId);
+  const expectedSessionId = normalizeOptionalString(params.expectedGeneration.sessionId);
   if (!expectedSessionId) {
-    return { ok: false, reason: `unknown sessionKey: ${sessionKey}` };
+    return { ok: false, reason: "background session result has an invalid expected generation" };
   }
-  const expectedLifecycleRevision = normalizeOptionalString(initial?.lifecycleRevision);
+  const expectedLifecycleRevision = normalizeOptionalString(
+    params.expectedGeneration.lifecycleRevision,
+  );
   const identities = [sessionKey, expectedSessionId];
 
   return await runExclusiveSessionLifecycleMutation({
@@ -80,8 +78,7 @@ export async function commitBackgroundResultToSession(params: {
       });
       if (
         current?.sessionId !== expectedSessionId ||
-        (expectedLifecycleRevision !== undefined &&
-          current.lifecycleRevision !== expectedLifecycleRevision)
+        normalizeOptionalString(current.lifecycleRevision) !== expectedLifecycleRevision
       ) {
         return { ok: false, reason: `session rebound for sessionKey: ${sessionKey}` };
       }


### PR DESCRIPTION
Closes #127852

## What Problem This Solves

A detached `sessionTarget: "current"` cron run could finish after its source conversation was reset and append old output to the replacement conversation under the same session key.

## Why This Change Was Made

Cron preparation now captures the source session ID and lifecycle revision together. The final completion writer requires that captured generation and compares both fields inside the existing exclusive lifecycle mutation before it writes.

The transcript transaction also carries an explicit revision-less expectation. This closes the cross-process window where a reset could materialize a revision after the initial check but before the SQLite append.

The writer no longer falls back to reading the current generation when the delayed commit starts. A missing captured generation fails closed. Reset and archive remain free to proceed while the model runs.

## User Impact

Resetting a conversation now remains an isolation boundary for an in-flight current-session cron run. Old cron output cannot enter the replacement conversation, while unchanged generations still receive durable, idempotent completions.

## Evidence

Live red and green used the same real Gateway flow with disposable state and a controlled OpenAI-compatible provider:

1. Seed a WebChat source conversation.
2. Start a current-session cron run and hold its provider completion.
3. Reset the source row to a new lifecycle revision under the same session ID.
4. Create replacement conversation history and release the old cron completion.
5. Read final history from the Gateway.

On `1deff1bac414e9474182f0c386983f0d7d508433`, final replacement history contained the stale cron marker. On exact rebased head `b2a9ef4b4194c24996159ad80c15479074de0ce0`, final replacement history retained the new reply and excluded the stale marker. Each run recorded three provider requests and distinct source and replacement lifecycle revisions.

The exact rebased head also passed the same Gateway reset trace from a revision-less source row. Reset materialized a lifecycle revision under the same session ID, the replacement reply remained visible, and stale cron output remained absent.

Focused regression proof:

- `src/sessions/background-session-result.test.ts`: 5 passed. The three new generation cases failed on pre-fix production code and passed after the repair.
- `src/config/sessions/transcript.test.ts`: 64 passed. The cross-connection revision-materialization regression fails before the transaction fix and passes after it.
- `src/cron/isolated-agent/run.current-context.test.ts` and `delivery-dispatch.double-announce.test.ts`: 163 passed.
- `src/gateway/session-message-events.test.ts`: 30 passed, including the current-session WebChat completion case.
- Changed-scope checks passed for core and core tests, including TypeScript, Oxlint, Oxfmt, import cycles, database guards, and repository ratchets.
- Full build passed on exact head `b2a9ef4b4194c24996159ad80c15479074de0ce0`.
- `git diff --check` passed.
- Judged line count: production `+44/-28` (net `+16`); tests `+196/-2` (net `+194`).
