### PR TITLE
fix(sqlite): isolate read-only snapshot preparation to stop WAL lock drops

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -157,6 +157,8 @@ const rootEntries = [
   // Loaded by URL from the SQLite lifecycle archive owner.
   "src/config/sessions/session-accessor.sqlite-archive.worker.ts!",
   "src/state/openclaw-database-verify.worker.ts!",
+  // Spawned by path from sqlite-readonly-location.ts to isolate raw-fd snapshot preparation.
+  "src/infra/sqlite-readonly-location.worker.ts!",
   // Loaded by URL from tailscale.ts to outlive abrupt Gateway process exit.
   "src/infra/tailscale-route-owner.worker.ts!",
   "src/agents/model-provider-auth.worker.ts!",

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -5,7 +6,12 @@ import { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
-import { prepareSqliteReadOnlyLocation } from "./sqlite-readonly-location.js";
+import {
+  prepareSqliteReadOnlyLocation as prepareSqliteReadOnlyLocationIsolated,
+  prepareSqliteReadOnlyLocationInProcess as prepareSqliteReadOnlyLocation,
+  prepareSqliteReadOnlyLocationSync,
+  prepareSqliteReadOnlyLocationSyncInProcess,
+} from "./sqlite-readonly-location.js";
 
 const workers: Worker[] = [];
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
@@ -56,7 +62,83 @@ function waitForWorkerMessage(worker: Worker, expected: string): Promise<void> {
   });
 }
 
+type PosixLock = {
+  length: number;
+  pid: number;
+  start: number;
+  type: string;
+};
+
+function readMainDatabasePosixLocks(pathname: string): PosixLock[] {
+  const result = spawnSync(
+    "python3",
+    [
+      "-c",
+      `
+import fcntl, json, os, struct, sys
+layout = struct.Struct("hhqqi4x")
+request = layout.pack(fcntl.F_WRLCK, os.SEEK_SET, 1073741826, 510, 0)
+with open(sys.argv[1], "rb") as database:
+    result = layout.unpack(fcntl.fcntl(database.fileno(), fcntl.F_GETLK, request))
+lock_type, _, start, length, pid = result
+locks = [] if lock_type == fcntl.F_UNLCK else [{
+    "length": length,
+    "pid": pid,
+    "start": start,
+    "type": "read" if lock_type == fcntl.F_RDLCK else "write",
+}]
+print(json.dumps(locks))
+`,
+      pathname,
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr || "POSIX lock probe failed");
+  }
+  return JSON.parse(result.stdout) as PosixLock[];
+}
+
 describe("prepareSqliteReadOnlyLocation", () => {
+  it.runIf(process.platform === "linux")(
+    "keeps a live WAL connection's POSIX locks in the owning process",
+    async () => {
+      const sqlite = requireNodeSqlite();
+      const databasePath = createTempDatabasePath();
+      const writer = new sqlite.DatabaseSync(databasePath);
+      writer.exec(`
+        PRAGMA journal_mode = WAL;
+        CREATE TABLE writes (id INTEGER PRIMARY KEY);
+        INSERT INTO writes DEFAULT VALUES;
+      `);
+      const locksBefore = readMainDatabasePosixLocks(databasePath);
+      const cleanups: Array<() => boolean> = [];
+      try {
+        expect(locksBefore).toHaveLength(1);
+
+        const preparedAsync = await prepareSqliteReadOnlyLocationIsolated(databasePath);
+        cleanups.push(preparedAsync.cleanup);
+        expect(readMainDatabasePosixLocks(databasePath)).toEqual(locksBefore);
+        expect(preparedAsync.cleanup()).toBe(true);
+
+        const preparedSync = prepareSqliteReadOnlyLocationSync(databasePath);
+        cleanups.push(preparedSync.cleanup);
+        expect(readMainDatabasePosixLocks(databasePath)).toEqual(locksBefore);
+        expect(preparedSync.cleanup()).toBe(true);
+
+        const characterized = prepareSqliteReadOnlyLocationSyncInProcess(databasePath);
+        cleanups.push(characterized.cleanup);
+        expect(readMainDatabasePosixLocks(databasePath)).toEqual([]);
+        expect(characterized.cleanup()).toBe(true);
+      } finally {
+        for (const cleanup of cleanups) {
+          cleanup();
+        }
+        writer.close();
+      }
+    },
+  );
+
   it("retries a same-size WAL reset instead of accepting an impossible pair", async () => {
     const sqlite = requireNodeSqlite();
     const livePath = createTempDatabasePath();

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -7,8 +7,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import {
-  prepareSqliteReadOnlyLocation as prepareSqliteReadOnlyLocationIsolated,
-  prepareSqliteReadOnlyLocationInProcess as prepareSqliteReadOnlyLocation,
+  prepareSqliteReadOnlyLocation,
+  prepareSqliteReadOnlyLocationInProcess,
   prepareSqliteReadOnlyLocationSync,
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
@@ -25,6 +25,42 @@ const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
 function createTempDatabasePath(): string {
   const tempDir = tempDirs.make("openclaw-sqlite-readonly-");
   return path.join(tempDir, "state.sqlite");
+}
+
+async function expectPublicSnapshot(
+  prepare: (
+    pathname: string,
+  ) =>
+    | { cleanup: () => boolean; location: string }
+    | Promise<{ cleanup: () => boolean; location: string }>,
+): Promise<void> {
+  const sqlite = requireNodeSqlite();
+  const databasePath = createTempDatabasePath();
+  const writer = new sqlite.DatabaseSync(databasePath);
+  let cleanup: (() => boolean) | undefined;
+  try {
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      CREATE TABLE probe (value TEXT NOT NULL);
+      INSERT INTO probe VALUES ('from-wal');
+    `);
+    expect(fs.existsSync(`${databasePath}-wal`)).toBe(true);
+
+    const prepared = await prepare(databasePath);
+    cleanup = prepared.cleanup;
+    const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+    try {
+      expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "from-wal" }]);
+    } finally {
+      snapshot.close();
+    }
+    expect(prepared.cleanup()).toBe(true);
+    cleanup = undefined;
+  } finally {
+    cleanup?.();
+    writer.close();
+  }
 }
 
 function readFamily(pathname: string): Map<string, Buffer> {
@@ -100,6 +136,28 @@ print(json.dumps(locks))
 }
 
 describe("prepareSqliteReadOnlyLocation", () => {
+  it("prepares a readable WAL snapshot through the async public entry point", async () => {
+    await expectPublicSnapshot(prepareSqliteReadOnlyLocation);
+  });
+
+  it("prepares a readable WAL snapshot through the sync public entry point", async () => {
+    await expectPublicSnapshot(prepareSqliteReadOnlyLocationSync);
+  });
+
+  it("propagates async public entry point failures", async () => {
+    const missingPath = path.join(tempDirs.make("openclaw-sqlite-readonly-missing-"), "missing.db");
+    await expect(prepareSqliteReadOnlyLocation(missingPath)).rejects.toThrow(
+      /SQLite read-only worker .*ENOENT/u,
+    );
+  });
+
+  it("propagates sync public entry point failures", () => {
+    const missingPath = path.join(tempDirs.make("openclaw-sqlite-readonly-missing-"), "missing.db");
+    expect(() => prepareSqliteReadOnlyLocationSync(missingPath)).toThrow(
+      /SQLite read-only worker .*ENOENT/u,
+    );
+  });
+
   it.runIf(process.platform === "linux")(
     "keeps a live WAL connection's POSIX locks in the owning process",
     async () => {
@@ -116,7 +174,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
       try {
         expect(locksBefore).toHaveLength(1);
 
-        const preparedAsync = await prepareSqliteReadOnlyLocationIsolated(databasePath);
+        const preparedAsync = await prepareSqliteReadOnlyLocation(databasePath);
         cleanups.push(preparedAsync.cleanup);
         expect(readMainDatabasePosixLocks(databasePath)).toEqual(locksBefore);
         expect(preparedAsync.cleanup()).toBe(true);
@@ -174,7 +232,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
       }
     });
 
-    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
     expect(injected).toBe(true);
     expect(fs.statSync(`${databasePath}-wal`).size).toBe(walSizeBeforeReset);
     const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
@@ -234,7 +292,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
     try {
       await waitForWorkerMessage(worker, "ready");
 
-      const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+      const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
       const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
       expect(snapshot.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
       expect(snapshot.prepare("SELECT COUNT(*) AS count FROM payload").get()).toEqual({ count: 1 });
@@ -278,7 +336,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
       return statSync(pathname, options as never);
     }) as typeof fs.statSync);
 
-    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
     const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
     expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "ok" }]);
     snapshot.close();
@@ -331,7 +389,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
     try {
       await waitForWorkerMessage(worker, "ready");
 
-      const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+      const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
       const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
       const values = snapshot
         .prepare("SELECT value FROM pair ORDER BY name")
@@ -372,7 +430,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
       }
     });
 
-    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
     expect(injected).toBe(true);
     expect(path.resolve(prepared.location)).not.toBe(path.resolve(databasePath));
     const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
@@ -398,7 +456,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
       const symlinkPath = path.join(path.dirname(databasePath), "state-link.sqlite");
       fs.symlinkSync(path.basename(databasePath), symlinkPath);
 
-      const prepared = await prepareSqliteReadOnlyLocation(symlinkPath);
+      const prepared = await prepareSqliteReadOnlyLocationInProcess(symlinkPath);
       const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
       expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "from-wal" }]);
       snapshot.close();
@@ -428,7 +486,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
       return statSync(pathname, options as never);
     }) as typeof fs.statSync);
 
-    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
     expect(injected).toBe(true);
     const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
     expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "ok" }]);
@@ -442,7 +500,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
     const seed = new sqlite.DatabaseSync(databasePath);
     seed.exec("CREATE TABLE probe (value TEXT);");
     seed.close();
-    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
     const privateDirectory = path.dirname(prepared.location);
     const rmSync = fs.rmSync.bind(fs);
     let failRemoval = true;
@@ -479,7 +537,7 @@ describe("prepareSqliteReadOnlyLocation", () => {
     const beforeMain = fs.readFileSync(databasePath);
     const beforeEntries = fs.readdirSync(path.dirname(databasePath)).toSorted();
 
-    const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+    const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
     const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
     expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "committed" }]);
     snapshot.close();

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -588,11 +588,12 @@ function isSqliteReadOnlyWorkerResult(value: unknown): value is SqliteReadOnlyWo
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
   }
-  const result = value as Record<string, unknown>;
-  const keys = Object.keys(result);
+  if (Object.keys(value).length !== 2 || !("ok" in value)) {
+    return false;
+  }
   return (
-    (keys.length === 2 && result.ok === true && typeof result.location === "string") ||
-    (keys.length === 2 && result.ok === false && typeof result.message === "string")
+    (value.ok === true && "location" in value && typeof value.location === "string") ||
+    (value.ok === false && "message" in value && typeof value.message === "string")
   );
 }
 
@@ -652,7 +653,12 @@ export async function prepareSqliteReadOnlyLocation(
   return await new Promise((resolve, reject) => {
     execFile(
       process.execPath,
-      [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, path.resolve(pathname)],
+      [
+        ...resolveRuntimeWorkerArgv(workerUrl),
+        SQLITE_READONLY_CHILD_ARG,
+        "async",
+        path.resolve(pathname),
+      ],
       { encoding: "utf8" },
       (error, stdout, stderr) => {
         try {
@@ -672,7 +678,12 @@ export function prepareSqliteReadOnlyLocationSync(
   const workerUrl = resolveSqliteReadOnlyWorkerUrl();
   const result = spawnSync(
     process.execPath,
-    [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, path.resolve(pathname)],
+    [
+      ...resolveRuntimeWorkerArgv(workerUrl),
+      SQLITE_READONLY_CHILD_ARG,
+      "sync",
+      path.resolve(pathname),
+    ],
     { encoding: "utf8" },
   );
   const failure = result.error

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -22,7 +22,6 @@ const SQLITE_READONLY_RESULT_CODE = 8;
 const SQLITE_RESULT_CODE_MASK = 0xff;
 const SQLITE_JOURNAL_MAGIC = Buffer.from([0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7]);
 export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
-const SQLITE_READONLY_CHILD_TIMEOUT_MS = 60_000;
 const SQLITE_READONLY_STDERR_TAIL_CHARS = 4_000;
 const pendingTempDirectoryCleanup = new Set<string>();
 let cleanupExitHandlerInstalled = false;
@@ -654,14 +653,10 @@ export async function prepareSqliteReadOnlyLocation(
     execFile(
       process.execPath,
       [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, path.resolve(pathname)],
-      { encoding: "utf8", timeout: SQLITE_READONLY_CHILD_TIMEOUT_MS },
+      { encoding: "utf8" },
       (error, stdout, stderr) => {
         try {
-          const failure = error
-            ? error.killed
-              ? `timed out after ${SQLITE_READONLY_CHILD_TIMEOUT_MS}ms`
-              : `exited unsuccessfully: ${error.message}`
-            : undefined;
+          const failure = error ? `exited unsuccessfully: ${error.message}` : undefined;
           resolve(adoptSqliteReadOnlyWorkerResult({ failure, stderr, stdout }));
         } catch (workerError) {
           reject(workerError instanceof Error ? workerError : new Error(String(workerError)));
@@ -678,12 +673,10 @@ export function prepareSqliteReadOnlyLocationSync(
   const result = spawnSync(
     process.execPath,
     [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, path.resolve(pathname)],
-    { encoding: "utf8", timeout: SQLITE_READONLY_CHILD_TIMEOUT_MS },
+    { encoding: "utf8" },
   );
   const failure = result.error
-    ? "code" in result.error && result.error.code === "ETIMEDOUT"
-      ? `timed out after ${SQLITE_READONLY_CHILD_TIMEOUT_MS}ms`
-      : `failed to start: ${result.error.message}`
+    ? `failed to start: ${result.error.message}`
     : result.status === 0
       ? undefined
       : `exited with ${result.signal ? `signal ${result.signal}` : `code ${result.status}`}`;

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -1,12 +1,15 @@
 // Prepares consistent private SQLite read-only snapshots.
+import { fork, spawnSync } from "node:child_process";
 import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import {
   openNodeSqliteDatabase,
   requireNodeSqlite,
   resolveSqliteFilesystemPath,
 } from "./node-sqlite.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import {
   createPrivateSqliteTempDirectory,
   createPrivateSqliteTempDirectorySync,
@@ -19,6 +22,8 @@ const SQLITE_HEADER_BYTES = 20;
 const SQLITE_READONLY_RESULT_CODE = 8;
 const SQLITE_RESULT_CODE_MASK = 0xff;
 const SQLITE_JOURNAL_MAGIC = Buffer.from([0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7]);
+const SQLITE_READONLY_ASYNC_CHILD_ARG = "--openclaw-sqlite-readonly-async-child";
+const SQLITE_READONLY_SYNC_CHILD_ARG = "--openclaw-sqlite-readonly-sync-child";
 const pendingTempDirectoryCleanup = new Set<string>();
 let cleanupExitHandlerInstalled = false;
 
@@ -40,6 +45,8 @@ type PreparedSqliteReadOnlyLocation = {
   cleanup: () => boolean;
   location: string;
 };
+
+type SqliteReadOnlyWorkerResult = { location: string } | { error: string };
 
 class SqliteSourceChangedError extends Error {}
 
@@ -281,6 +288,24 @@ function removeTempDirectory(tempDir: string): boolean {
   }
 }
 
+function adoptPreparedLocation(location: string): PreparedSqliteReadOnlyLocation {
+  const tempDir = path.dirname(location);
+  let active = true;
+  return {
+    location,
+    cleanup: () => {
+      if (!active) {
+        return true;
+      }
+      const removed = removeTempDirectory(tempDir);
+      if (removed) {
+        active = false;
+      }
+      return removed;
+    },
+  };
+}
+
 function recoverPrivateRollbackCopy(snapshotPath: string): void {
   if (rollbackJournalReferencesSuperJournal(`${snapshotPath}-journal`)) {
     throw new Error(
@@ -355,20 +380,7 @@ function createStableReadOnlyCopyInTempDirectory(
       // a later writable open can perform SQLite's normal crash recovery.
       recoverPrivateRollbackCopy(snapshotPath);
     }
-    let active = true;
-    return {
-      location: snapshotPath,
-      cleanup: () => {
-        if (!active) {
-          return true;
-        }
-        const removed = removeTempDirectory(tempDir);
-        if (removed) {
-          active = false;
-        }
-        return removed;
-      },
-    };
+    return adoptPreparedLocation(snapshotPath);
   } catch (error) {
     removeTempDirectory(tempDir);
     throw error;
@@ -435,20 +447,7 @@ async function createOnlineReadOnlyBackup(
     } finally {
       fs.closeSync(descriptor);
     }
-    let active = true;
-    return {
-      location: snapshotPath,
-      cleanup: () => {
-        if (!active) {
-          return true;
-        }
-        const removed = removeTempDirectory(tempDir);
-        if (removed) {
-          active = false;
-        }
-        return removed;
-      },
-    };
+    return adoptPreparedLocation(snapshotPath);
   } catch (error) {
     removeTempDirectory(tempDir);
     throw error;
@@ -459,8 +458,10 @@ async function createOnlineReadOnlyBackup(
  * Active rollback and WAL state use SQLite's locking and backup protocol.
  * Crash residue that cannot be opened read-only is copied and recovered
  * privately so inspection never mutates coordination files beside the source.
+ * The InProcess exports are child-only: POSIX close() can release every lock
+ * the calling process holds on the same source inode.
  */
-export async function prepareSqliteReadOnlyLocation(
+export async function prepareSqliteReadOnlyLocationInProcess(
   pathname: string,
 ): Promise<PreparedSqliteReadOnlyLocation> {
   const canonicalPath = fs.realpathSync.native(pathname);
@@ -540,8 +541,7 @@ export async function prepareSqliteReadOnlyLocation(
   });
 }
 
-/** Synchronously prepares a stable private family for lock-free public inspection. */
-export function prepareSqliteReadOnlyLocationSync(
+export function prepareSqliteReadOnlyLocationSyncInProcess(
   pathname: string,
 ): PreparedSqliteReadOnlyLocation {
   const canonicalPath = fs.realpathSync.native(pathname);
@@ -577,6 +577,133 @@ export function prepareSqliteReadOnlyLocationSync(
   });
 }
 
+function resolveSqliteReadOnlyWorkerUrl(): URL {
+  return resolveRuntimeWorkerUrl({
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "sqlite-readonly-location.worker",
+    distWorkerPath: "infra/sqlite-readonly-location.worker.js",
+  });
+}
+
+function isSqliteReadOnlyWorkerResult(value: unknown): value is SqliteReadOnlyWorkerResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const result = value as Record<string, unknown>;
+  const keys = Object.keys(result);
+  return (
+    (keys.length === 1 && typeof result.location === "string") ||
+    (keys.length === 1 && typeof result.error === "string")
+  );
+}
+
+export async function prepareSqliteReadOnlyLocation(
+  pathname: string,
+): Promise<PreparedSqliteReadOnlyLocation> {
+  const workerUrl = resolveSqliteReadOnlyWorkerUrl();
+  const worker = fork(fileURLToPath(workerUrl), [SQLITE_READONLY_ASYNC_CHILD_ARG], {
+    execArgv: workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined,
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  });
+
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+    let result: SqliteReadOnlyWorkerResult | undefined;
+    let exit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+    let disconnected = !worker.connected;
+    const settle = (finish: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      worker.removeAllListeners();
+      finish();
+    };
+    const settleAfterExitAndDisconnect = () => {
+      if (!exit || !disconnected) {
+        return;
+      }
+      settle(() => {
+        if (exit?.code !== 0) {
+          reject(
+            new Error(
+              `SQLite read-only worker exited with ${exit?.signal ? `signal ${exit.signal}` : `code ${exit?.code}`}`,
+            ),
+          );
+        } else if (!result) {
+          reject(new Error("SQLite read-only worker exited without a result"));
+        } else if ("error" in result) {
+          reject(new Error(result.error));
+        } else {
+          resolve(adoptPreparedLocation(result.location));
+        }
+      });
+    };
+    worker.once("message", (message: unknown) => {
+      if (!isSqliteReadOnlyWorkerResult(message)) {
+        worker.kill();
+        settle(() => reject(new Error("SQLite read-only worker returned an invalid result")));
+        return;
+      }
+      result = message;
+    });
+    worker.once("error", (error) => settle(() => reject(error)));
+    worker.once("disconnect", () => {
+      disconnected = true;
+      settleAfterExitAndDisconnect();
+    });
+    worker.once("exit", (code, signal) => {
+      exit = { code, signal };
+      disconnected ||= !worker.connected;
+      settleAfterExitAndDisconnect();
+    });
+    worker.send(pathname, (error) => {
+      if (!error) {
+        return;
+      }
+      worker.kill();
+      settle(() => reject(error));
+    });
+  });
+}
+
+export function prepareSqliteReadOnlyLocationSync(
+  pathname: string,
+): PreparedSqliteReadOnlyLocation {
+  const workerUrl = resolveSqliteReadOnlyWorkerUrl();
+  const result = spawnSync(
+    process.execPath,
+    [
+      ...resolveRuntimeWorkerArgv(workerUrl),
+      SQLITE_READONLY_SYNC_CHILD_ARG,
+      path.resolve(pathname),
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      result.stderr.trim() ||
+        `SQLite read-only worker exited with ${result.signal ? `signal ${result.signal}` : `code ${result.status}`}`,
+    );
+  }
+  let message: unknown;
+  try {
+    message = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("SQLite read-only worker returned invalid JSON");
+  }
+  if (!isSqliteReadOnlyWorkerResult(message)) {
+    throw new Error("SQLite read-only worker returned an invalid result");
+  }
+  if ("error" in message) {
+    throw new Error(message.error);
+  }
+  return adoptPreparedLocation(message.location);
+}
+
 async function prepareSqliteSnapshotSource(
   pathname: string,
 ): Promise<PreparedSqliteReadOnlyLocation | undefined> {
@@ -594,7 +721,7 @@ async function prepareSqliteSnapshotSource(
   if (!journal.isFile()) {
     throw new Error(`SQLite rollback journal must be a regular file: ${journalPath}`);
   }
-  return await prepareSqliteReadOnlyLocation(canonicalPath);
+  return await prepareSqliteReadOnlyLocationInProcess(canonicalPath);
 }
 
 export async function withSqliteSnapshotSource<T>(

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -1,8 +1,7 @@
 // Prepares consistent private SQLite read-only snapshots.
-import { fork, spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import {
   openNodeSqliteDatabase,
@@ -22,8 +21,9 @@ const SQLITE_HEADER_BYTES = 20;
 const SQLITE_READONLY_RESULT_CODE = 8;
 const SQLITE_RESULT_CODE_MASK = 0xff;
 const SQLITE_JOURNAL_MAGIC = Buffer.from([0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7]);
-const SQLITE_READONLY_ASYNC_CHILD_ARG = "--openclaw-sqlite-readonly-async-child";
-const SQLITE_READONLY_SYNC_CHILD_ARG = "--openclaw-sqlite-readonly-sync-child";
+export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
+const SQLITE_READONLY_CHILD_TIMEOUT_MS = 60_000;
+const SQLITE_READONLY_STDERR_TAIL_CHARS = 4_000;
 const pendingTempDirectoryCleanup = new Set<string>();
 let cleanupExitHandlerInstalled = false;
 
@@ -46,7 +46,7 @@ type PreparedSqliteReadOnlyLocation = {
   location: string;
 };
 
-type SqliteReadOnlyWorkerResult = { location: string } | { error: string };
+type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; message: string };
 
 class SqliteSourceChangedError extends Error {}
 
@@ -592,78 +592,82 @@ function isSqliteReadOnlyWorkerResult(value: unknown): value is SqliteReadOnlyWo
   const result = value as Record<string, unknown>;
   const keys = Object.keys(result);
   return (
-    (keys.length === 1 && typeof result.location === "string") ||
-    (keys.length === 1 && typeof result.error === "string")
+    (keys.length === 2 && result.ok === true && typeof result.location === "string") ||
+    (keys.length === 2 && result.ok === false && typeof result.message === "string")
   );
+}
+
+function createSqliteReadOnlyWorkerError(message: string, stderr: string): Error {
+  const stderrTail = stderr.trim().slice(-SQLITE_READONLY_STDERR_TAIL_CHARS);
+  return new Error(
+    `SQLite read-only worker ${message}${stderrTail ? `\nstderr (tail): ${stderrTail}` : ""}`,
+  );
+}
+
+function parseSqliteReadOnlyWorkerResult(
+  stdout: string,
+  stderr: string,
+): SqliteReadOnlyWorkerResult {
+  if (!stdout.trim()) {
+    throw createSqliteReadOnlyWorkerError("returned no JSON result", stderr);
+  }
+  let message: unknown;
+  try {
+    message = JSON.parse(stdout);
+  } catch {
+    throw createSqliteReadOnlyWorkerError("returned invalid JSON", stderr);
+  }
+  if (!isSqliteReadOnlyWorkerResult(message)) {
+    throw createSqliteReadOnlyWorkerError("returned an invalid result", stderr);
+  }
+  return message;
+}
+
+function adoptSqliteReadOnlyWorkerResult(params: {
+  failure?: string;
+  stderr: string;
+  stdout: string;
+}): PreparedSqliteReadOnlyLocation {
+  let result: SqliteReadOnlyWorkerResult;
+  try {
+    result = parseSqliteReadOnlyWorkerResult(params.stdout, params.stderr);
+  } catch (error) {
+    if (params.failure) {
+      throw createSqliteReadOnlyWorkerError(params.failure, params.stderr);
+    }
+    throw error;
+  }
+  if (params.failure || !result.ok) {
+    throw createSqliteReadOnlyWorkerError(
+      !result.ok ? result.message : (params.failure ?? "failed"),
+      params.stderr,
+    );
+  }
+  return adoptPreparedLocation(result.location);
 }
 
 export async function prepareSqliteReadOnlyLocation(
   pathname: string,
 ): Promise<PreparedSqliteReadOnlyLocation> {
   const workerUrl = resolveSqliteReadOnlyWorkerUrl();
-  const worker = fork(fileURLToPath(workerUrl), [SQLITE_READONLY_ASYNC_CHILD_ARG], {
-    execArgv: workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined,
-    stdio: ["ignore", "ignore", "ignore", "ipc"],
-  });
-
   return await new Promise((resolve, reject) => {
-    let settled = false;
-    let result: SqliteReadOnlyWorkerResult | undefined;
-    let exit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
-    let disconnected = !worker.connected;
-    const settle = (finish: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      worker.removeAllListeners();
-      finish();
-    };
-    const settleAfterExitAndDisconnect = () => {
-      if (!exit || !disconnected) {
-        return;
-      }
-      settle(() => {
-        if (exit?.code !== 0) {
-          reject(
-            new Error(
-              `SQLite read-only worker exited with ${exit?.signal ? `signal ${exit.signal}` : `code ${exit?.code}`}`,
-            ),
-          );
-        } else if (!result) {
-          reject(new Error("SQLite read-only worker exited without a result"));
-        } else if ("error" in result) {
-          reject(new Error(result.error));
-        } else {
-          resolve(adoptPreparedLocation(result.location));
+    execFile(
+      process.execPath,
+      [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, path.resolve(pathname)],
+      { encoding: "utf8", timeout: SQLITE_READONLY_CHILD_TIMEOUT_MS },
+      (error, stdout, stderr) => {
+        try {
+          const failure = error
+            ? error.killed
+              ? `timed out after ${SQLITE_READONLY_CHILD_TIMEOUT_MS}ms`
+              : `exited unsuccessfully: ${error.message}`
+            : undefined;
+          resolve(adoptSqliteReadOnlyWorkerResult({ failure, stderr, stdout }));
+        } catch (workerError) {
+          reject(workerError instanceof Error ? workerError : new Error(String(workerError)));
         }
-      });
-    };
-    worker.once("message", (message: unknown) => {
-      if (!isSqliteReadOnlyWorkerResult(message)) {
-        worker.kill();
-        settle(() => reject(new Error("SQLite read-only worker returned an invalid result")));
-        return;
-      }
-      result = message;
-    });
-    worker.once("error", (error) => settle(() => reject(error)));
-    worker.once("disconnect", () => {
-      disconnected = true;
-      settleAfterExitAndDisconnect();
-    });
-    worker.once("exit", (code, signal) => {
-      exit = { code, signal };
-      disconnected ||= !worker.connected;
-      settleAfterExitAndDisconnect();
-    });
-    worker.send(pathname, (error) => {
-      if (!error) {
-        return;
-      }
-      worker.kill();
-      settle(() => reject(error));
-    });
+      },
+    );
   });
 }
 
@@ -673,35 +677,17 @@ export function prepareSqliteReadOnlyLocationSync(
   const workerUrl = resolveSqliteReadOnlyWorkerUrl();
   const result = spawnSync(
     process.execPath,
-    [
-      ...resolveRuntimeWorkerArgv(workerUrl),
-      SQLITE_READONLY_SYNC_CHILD_ARG,
-      path.resolve(pathname),
-    ],
-    { encoding: "utf8" },
+    [...resolveRuntimeWorkerArgv(workerUrl), SQLITE_READONLY_CHILD_ARG, path.resolve(pathname)],
+    { encoding: "utf8", timeout: SQLITE_READONLY_CHILD_TIMEOUT_MS },
   );
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    throw new Error(
-      result.stderr.trim() ||
-        `SQLite read-only worker exited with ${result.signal ? `signal ${result.signal}` : `code ${result.status}`}`,
-    );
-  }
-  let message: unknown;
-  try {
-    message = JSON.parse(result.stdout);
-  } catch {
-    throw new Error("SQLite read-only worker returned invalid JSON");
-  }
-  if (!isSqliteReadOnlyWorkerResult(message)) {
-    throw new Error("SQLite read-only worker returned an invalid result");
-  }
-  if ("error" in message) {
-    throw new Error(message.error);
-  }
-  return adoptPreparedLocation(message.location);
+  const failure = result.error
+    ? "code" in result.error && result.error.code === "ETIMEDOUT"
+      ? `timed out after ${SQLITE_READONLY_CHILD_TIMEOUT_MS}ms`
+      : `failed to start: ${result.error.message}`
+    : result.status === 0
+      ? undefined
+      : `exited with ${result.signal ? `signal ${result.signal}` : `code ${result.status}`}`;
+  return adoptSqliteReadOnlyWorkerResult({ failure, stderr: result.stderr, stdout: result.stdout });
 }
 
 async function prepareSqliteSnapshotSource(

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -721,7 +721,7 @@ async function prepareSqliteSnapshotSource(
   if (!journal.isFile()) {
     throw new Error(`SQLite rollback journal must be a regular file: ${journalPath}`);
   }
-  return await prepareSqliteReadOnlyLocationInProcess(canonicalPath);
+  return await prepareSqliteReadOnlyLocation(canonicalPath);
 }
 
 export async function withSqliteSnapshotSource<T>(

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -1,0 +1,63 @@
+import {
+  prepareSqliteReadOnlyLocationInProcess,
+  prepareSqliteReadOnlyLocationSyncInProcess,
+} from "./sqlite-readonly-location.js";
+
+const SQLITE_READONLY_ASYNC_CHILD_ARG = "--openclaw-sqlite-readonly-async-child";
+const SQLITE_READONLY_SYNC_CHILD_ARG = "--openclaw-sqlite-readonly-sync-child";
+
+function formatWorkerError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+if (process.argv[2] === SQLITE_READONLY_SYNC_CHILD_ARG) {
+  const pathname = process.argv[3];
+  if (!pathname) {
+    process.stderr.write("SQLite read-only worker requires a database path\n");
+    process.exitCode = 1;
+  } else {
+    try {
+      const prepared = prepareSqliteReadOnlyLocationSyncInProcess(pathname);
+      process.stdout.write(JSON.stringify({ location: prepared.location }));
+    } catch (error) {
+      process.stderr.write(`${formatWorkerError(error)}\n`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+const sendToParent =
+  process.argv[2] === SQLITE_READONLY_ASYNC_CHILD_ARG ? process.send?.bind(process) : undefined;
+if (sendToParent) {
+  process.once("message", (message: unknown) => {
+    void (async () => {
+      let cleanup: (() => boolean) | undefined;
+      const result = await (async () => {
+        if (typeof message !== "string") {
+          return { error: "SQLite read-only worker requires a database path" };
+        }
+        try {
+          const prepared = await prepareSqliteReadOnlyLocationInProcess(message);
+          cleanup = prepared.cleanup;
+          return { location: prepared.location };
+        } catch (error) {
+          return { error: formatWorkerError(error) };
+        }
+      })();
+      await new Promise<void>((resolve, reject) => {
+        sendToParent(result, (error) => {
+          if (error) {
+            reject(error);
+          } else {
+            cleanup = undefined;
+            resolve();
+          }
+        });
+      }).catch(() => {
+        cleanup?.();
+        process.exitCode = 1;
+      });
+      process.disconnect?.();
+    })();
+  });
+}

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -1,23 +1,34 @@
 import {
   SQLITE_READONLY_CHILD_ARG,
   prepareSqliteReadOnlyLocationInProcess,
+  prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
 
 function formatWorkerError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+// The sync strategy raw-copies without attaching SQLite to the source, so sync
+// callers stay byte-neutral on the live family; the async strategy holds a read
+// transaction on the source and may update its WAL index.
 async function runWorker(): Promise<void> {
-  const pathname = process.argv[3];
-  if (!pathname) {
+  const mode = process.argv[3];
+  const pathname = process.argv[4];
+  if ((mode !== "sync" && mode !== "async") || !pathname) {
     process.exitCode = 1;
     process.stdout.write(
-      JSON.stringify({ ok: false, message: "SQLite read-only worker requires a database path" }),
+      JSON.stringify({
+        ok: false,
+        message: "SQLite read-only worker requires a mode and a database path",
+      }),
     );
     return;
   }
   try {
-    const prepared = await prepareSqliteReadOnlyLocationInProcess(pathname);
+    const prepared =
+      mode === "sync"
+        ? prepareSqliteReadOnlyLocationSyncInProcess(pathname)
+        : await prepareSqliteReadOnlyLocationInProcess(pathname);
     process.stdout.write(JSON.stringify({ ok: true, location: prepared.location }));
   } catch (error) {
     process.exitCode = 1;

--- a/src/infra/sqlite-readonly-location.worker.ts
+++ b/src/infra/sqlite-readonly-location.worker.ts
@@ -1,63 +1,30 @@
 import {
+  SQLITE_READONLY_CHILD_ARG,
   prepareSqliteReadOnlyLocationInProcess,
-  prepareSqliteReadOnlyLocationSyncInProcess,
 } from "./sqlite-readonly-location.js";
-
-const SQLITE_READONLY_ASYNC_CHILD_ARG = "--openclaw-sqlite-readonly-async-child";
-const SQLITE_READONLY_SYNC_CHILD_ARG = "--openclaw-sqlite-readonly-sync-child";
 
 function formatWorkerError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-if (process.argv[2] === SQLITE_READONLY_SYNC_CHILD_ARG) {
+async function runWorker(): Promise<void> {
   const pathname = process.argv[3];
   if (!pathname) {
-    process.stderr.write("SQLite read-only worker requires a database path\n");
     process.exitCode = 1;
-  } else {
-    try {
-      const prepared = prepareSqliteReadOnlyLocationSyncInProcess(pathname);
-      process.stdout.write(JSON.stringify({ location: prepared.location }));
-    } catch (error) {
-      process.stderr.write(`${formatWorkerError(error)}\n`);
-      process.exitCode = 1;
-    }
+    process.stdout.write(
+      JSON.stringify({ ok: false, message: "SQLite read-only worker requires a database path" }),
+    );
+    return;
+  }
+  try {
+    const prepared = await prepareSqliteReadOnlyLocationInProcess(pathname);
+    process.stdout.write(JSON.stringify({ ok: true, location: prepared.location }));
+  } catch (error) {
+    process.exitCode = 1;
+    process.stdout.write(JSON.stringify({ ok: false, message: formatWorkerError(error) }));
   }
 }
 
-const sendToParent =
-  process.argv[2] === SQLITE_READONLY_ASYNC_CHILD_ARG ? process.send?.bind(process) : undefined;
-if (sendToParent) {
-  process.once("message", (message: unknown) => {
-    void (async () => {
-      let cleanup: (() => boolean) | undefined;
-      const result = await (async () => {
-        if (typeof message !== "string") {
-          return { error: "SQLite read-only worker requires a database path" };
-        }
-        try {
-          const prepared = await prepareSqliteReadOnlyLocationInProcess(message);
-          cleanup = prepared.cleanup;
-          return { location: prepared.location };
-        } catch (error) {
-          return { error: formatWorkerError(error) };
-        }
-      })();
-      await new Promise<void>((resolve, reject) => {
-        sendToParent(result, (error) => {
-          if (error) {
-            reject(error);
-          } else {
-            cleanup = undefined;
-            resolve();
-          }
-        });
-      }).catch(() => {
-        cleanup?.();
-        process.exitCode = 1;
-      });
-      process.disconnect?.();
-    })();
-  });
+if (process.argv[2] === SQLITE_READONLY_CHILD_ARG) {
+  void runWorker();
 }

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -622,6 +622,54 @@ describe("sqlite WAL maintenance", () => {
     },
   );
 
+  it.runIf(process.platform === "linux")(
+    "disables split-brain detection after an unexpected scan error",
+    () => {
+      vi.useFakeTimers();
+      const tempDir = tempDirs.make("openclaw-sqlite-wal-tripwire-error-");
+      const databasePath = path.join(tempDir, "state.sqlite");
+      const { DatabaseSync } = requireNodeSqlite();
+      const writer = new DatabaseSync(databasePath);
+      const events: unknown[] = [];
+      const maintenance = configureSqliteWalMaintenance(writer, {
+        checkpointIntervalMs: 100,
+        databasePath,
+        onWalSplitBrain: (event) => events.push(event),
+      });
+      const prepare = vi.spyOn(writer, "prepare");
+      const readdir = vi.spyOn(fs, "readdirSync").mockImplementationOnce(() => {
+        const error = new Error("restricted procfs");
+        (error as NodeJS.ErrnoException).code = "EPERM";
+        throw error;
+      });
+      try {
+        writer.exec("CREATE TABLE events (value TEXT NOT NULL);");
+
+        expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+        expect(readdir).toHaveBeenCalledTimes(1);
+        expect(() =>
+          writer.prepare("INSERT INTO events VALUES (?)").run("still-open"),
+        ).not.toThrow();
+
+        fs.unlinkSync(`${databasePath}-wal`);
+        fs.unlinkSync(`${databasePath}-shm`);
+        expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+
+        expect(readdir).toHaveBeenCalledTimes(1);
+        expect(events).toEqual([]);
+        expect(
+          prepare.mock.calls.filter(([sql]) => sql === "PRAGMA wal_checkpoint(PASSIVE);"),
+        ).toHaveLength(2);
+        expect(writer.isOpen).toBe(true);
+      } finally {
+        maintenance.close();
+        if (writer.isOpen) {
+          writer.close();
+        }
+      }
+    },
+  );
+
   it("clamps oversized checkpoint intervals before arming timers", () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -564,6 +564,64 @@ describe("sqlite WAL maintenance", () => {
     expect(db["exec"]).toHaveBeenCalledTimes(4);
   });
 
+  it.runIf(process.platform === "linux")(
+    "invalidates an unlinked WAL family and permits a clean reopen",
+    () => {
+      vi.useFakeTimers();
+      const tempDir = tempDirs.make("openclaw-sqlite-wal-split-brain-");
+      const databasePath = path.join(tempDir, "state.sqlite");
+      const { DatabaseSync } = requireNodeSqlite();
+      const writer = new DatabaseSync(databasePath);
+      const events: unknown[] = [];
+      let reopened: InstanceType<typeof DatabaseSync> | undefined;
+      let reopenedMaintenance: ReturnType<typeof configureSqliteWalMaintenance> | undefined;
+      const maintenance = configureSqliteWalMaintenance(writer, {
+        checkpointIntervalMs: 100,
+        databaseLabel: "split-brain-test",
+        databasePath,
+        onWalSplitBrain: (event) => events.push(event),
+      });
+      try {
+        writer.exec("CREATE TABLE events (id INTEGER PRIMARY KEY, value TEXT NOT NULL);");
+        writer.prepare("INSERT INTO events (value) VALUES (?)").run("before-unlink");
+        expect(maintenance.checkpoint()).toBe(true);
+        fs.unlinkSync(`${databasePath}-wal`);
+        fs.unlinkSync(`${databasePath}-shm`);
+
+        vi.advanceTimersByTime(100);
+
+        expect(events).toEqual([
+          expect.objectContaining({
+            event: "sqlite_wal_sidecar_identity_mismatch",
+            databasePath,
+            sidecarPath: expect.stringMatching(/-wal$|-shm$/u),
+          }),
+        ]);
+        expect(writer.isOpen).toBe(false);
+        expect(() => writer.prepare("INSERT INTO events (value) VALUES ('stale')").run()).toThrow();
+
+        const fresh = new DatabaseSync(databasePath);
+        reopened = fresh;
+        reopenedMaintenance = configureSqliteWalMaintenance(fresh, {
+          checkpointIntervalMs: 0,
+          databasePath,
+        });
+        expect(() =>
+          fresh.prepare("INSERT INTO events (value) VALUES (?)").run("after-reopen"),
+        ).not.toThrow();
+      } finally {
+        maintenance.close();
+        reopenedMaintenance?.close();
+        if (reopened?.isOpen) {
+          reopened.close();
+        }
+        if (writer.isOpen) {
+          writer.close();
+        }
+      }
+    },
+  );
+
   it("clamps oversized checkpoint intervals before arming timers", () => {
     vi.useFakeTimers();
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -622,9 +622,9 @@ describe("sqlite WAL maintenance", () => {
     },
   );
 
-  it.runIf(process.platform === "linux")(
-    "disables split-brain detection after an unexpected scan error",
-    () => {
+  it.runIf(process.platform === "linux").each(["EACCES", "EPERM"] as const)(
+    "disables split-brain detection after a %s scan error",
+    (code) => {
       vi.useFakeTimers();
       const tempDir = tempDirs.make("openclaw-sqlite-wal-tripwire-error-");
       const databasePath = path.join(tempDir, "state.sqlite");
@@ -639,7 +639,7 @@ describe("sqlite WAL maintenance", () => {
       const prepare = vi.spyOn(writer, "prepare");
       const readdir = vi.spyOn(fs, "readdirSync").mockImplementationOnce(() => {
         const error = new Error("restricted procfs");
-        (error as NodeJS.ErrnoException).code = "EPERM";
+        (error as NodeJS.ErrnoException).code = code;
         throw error;
       });
       try {

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -384,8 +384,7 @@ function detectSqliteWalSplitBrain(databasePath: string): SqliteWalSplitBrainEve
   try {
     descriptors = fs.readdirSync(PROC_SELF_FD_PATH);
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ENOENT" || code === "EACCES") {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return undefined;
     }
     throw error;

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -1,9 +1,10 @@
 // Configures SQLite WAL and related pragmas for local stores.
-import fs from "node:fs";
+import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import type { Result } from "@openclaw/normalization-core/result";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeSqliteNonNegativeInteger } from "./sqlite-busy-timeout.js";
 import { isSqliteLockError } from "./sqlite-transaction.js";
 
@@ -28,6 +29,9 @@ const MOUNT_COMMAND_TIMEOUT_MS = 1_000;
 const NETWORK_FILESYSTEM_TYPES = new Set(["cifs", "smbfs", "smb2", "smb3"]);
 const JOURNAL_MODE_RETRY_INTERVAL_MS = 10;
 const JOURNAL_MODE_RETRY_SLEEP = new Int32Array(new SharedArrayBuffer(4));
+const PROC_SELF_FD_PATH = "/proc/self/fd";
+
+const log = createSubsystemLogger("infra/sqlite-wal");
 
 type IntervalHandle = ReturnType<typeof setInterval> & {
   unref?: () => void;
@@ -36,6 +40,16 @@ type IntervalHandle = ReturnType<typeof setInterval> & {
 type SqliteWalCheckpointMode = "PASSIVE" | "FULL" | "RESTART" | "TRUNCATE";
 type SqliteFilesystemJournalPolicy = "rollback" | "unsupported" | "wal";
 type MountEntry = { mountPoint: string; fsType: string; source?: string };
+
+export type SqliteWalSplitBrainEvent = {
+  event: "sqlite_wal_sidecar_identity_mismatch";
+  databasePath: string;
+  descriptorDevice: string;
+  descriptorInode: string;
+  sidecarPath: string;
+  targetDevice?: string;
+  targetInode?: string;
+};
 
 export type SqliteWalMaintenance = {
   checkpoint: () => boolean;
@@ -51,6 +65,7 @@ export type SqliteWalMaintenanceOptions = {
   databaseLabel?: string;
   databasePath?: string;
   onCheckpointError?: (error: unknown) => void;
+  onWalSplitBrain?: (event: SqliteWalSplitBrainEvent) => void;
 };
 
 export type SqliteConnectionPragmaOptions = SqliteWalMaintenanceOptions & {
@@ -341,6 +356,99 @@ function readCheckpointBusyResult(row: unknown): boolean {
   return value === 1 || value === 1n;
 }
 
+function statSqliteSidecarTarget(pathname: string): BigIntStats | undefined {
+  try {
+    return fs.statSync(pathname, { bigint: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isSqliteWalSidecarSplitBrain(
+  descriptor: BigIntStats,
+  target: BigIntStats | undefined,
+): boolean {
+  return (
+    descriptor.nlink === 0n ||
+    !target ||
+    descriptor.dev !== target.dev ||
+    descriptor.ino !== target.ino
+  );
+}
+
+function detectSqliteWalSplitBrain(databasePath: string): SqliteWalSplitBrainEvent | undefined {
+  let descriptors: string[];
+  try {
+    descriptors = fs.readdirSync(PROC_SELF_FD_PATH);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "EACCES") {
+      return undefined;
+    }
+    throw error;
+  }
+  const sidecarPaths = [`${databasePath}-wal`, `${databasePath}-shm`];
+  for (const descriptorName of descriptors) {
+    const descriptorPath = path.join(PROC_SELF_FD_PATH, descriptorName);
+    let linkedPath: string;
+    try {
+      linkedPath = fs.readlinkSync(descriptorPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    const sidecarPath = sidecarPaths.find(
+      (candidate) => linkedPath === candidate || linkedPath === `${candidate} (deleted)`,
+    );
+    if (!sidecarPath) {
+      continue;
+    }
+    let descriptor: BigIntStats;
+    try {
+      descriptor = fs.fstatSync(Number(descriptorName), { bigint: true });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EBADF" || code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    try {
+      if (fs.readlinkSync(descriptorPath) !== linkedPath) {
+        continue;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+    const target = statSqliteSidecarTarget(sidecarPath);
+    if (!isSqliteWalSidecarSplitBrain(descriptor, target)) {
+      continue;
+    }
+    return {
+      event: "sqlite_wal_sidecar_identity_mismatch",
+      databasePath,
+      descriptorDevice: descriptor.dev.toString(),
+      descriptorInode: descriptor.ino.toString(),
+      sidecarPath,
+      ...(target
+        ? {
+            targetDevice: target.dev.toString(),
+            targetInode: target.ino.toString(),
+          }
+        : {}),
+    };
+  }
+  return undefined;
+}
+
 function requireRollbackJournalMode(db: DatabaseSync, options: SqliteWalMaintenanceOptions): void {
   const row = db.prepare("PRAGMA journal_mode = DELETE;").get();
   const journalMode = readJournalModeResult(row);
@@ -466,6 +574,11 @@ export function configureSqliteWalMaintenance(
   enableMacosCheckpointFullfsync(db);
   db.exec(`PRAGMA wal_autocheckpoint = ${autoCheckpointPages};`);
   db.exec(`PRAGMA journal_size_limit = ${DEFAULT_SQLITE_WAL_JOURNAL_SIZE_LIMIT_BYTES};`);
+  const tripwireDatabasePath =
+    process.platform === "linux" && options.databasePath && fs.existsSync(options.databasePath)
+      ? fs.realpathSync.native(options.databasePath)
+      : undefined;
+  let invalidated = false;
 
   const runCheckpoint = (mode: SqliteWalCheckpointMode): boolean => {
     try {
@@ -494,11 +607,33 @@ export function configureSqliteWalMaintenance(
     }
   };
 
-  const checkpoint = (): boolean => runCheckpoint(checkpointMode);
+  const checkpoint = (): boolean => !invalidated && runCheckpoint(checkpointMode);
 
   let timer: IntervalHandle | null = null;
   if (timerIntervalMs > 0) {
     timer = setInterval(() => {
+      const splitBrain = tripwireDatabasePath
+        ? detectSqliteWalSplitBrain(tripwireDatabasePath)
+        : undefined;
+      if (splitBrain) {
+        invalidated = true;
+        if (timer) {
+          clearInterval(timer);
+          timer = null;
+        }
+        log.error("SQLite WAL sidecar identity mismatch", {
+          ...splitBrain,
+          databaseLabel: options.databaseLabel,
+        });
+        try {
+          options.onWalSplitBrain?.(splitBrain);
+        } finally {
+          if (db.isOpen) {
+            db.close();
+          }
+        }
+        return;
+      }
       runCheckpoint(periodicCheckpointMode);
       runIncrementalVacuum();
     }, timerIntervalMs) as IntervalHandle;
@@ -511,6 +646,9 @@ export function configureSqliteWalMaintenance(
       if (timer) {
         clearInterval(timer);
         timer = null;
+      }
+      if (invalidated) {
+        return false;
       }
       // Cache eviction passes PASSIVE: a TRUNCATE close-checkpoint waits on
       // readers and has starved the event loop for seconds under fleet churn.

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -579,6 +579,8 @@ export function configureSqliteWalMaintenance(
       ? fs.realpathSync.native(options.databasePath)
       : undefined;
   let invalidated = false;
+  let splitBrainDetectionEnabled = Boolean(tripwireDatabasePath);
+  let splitBrainDetectionWarningLogged = false;
 
   const runCheckpoint = (mode: SqliteWalCheckpointMode): boolean => {
     try {
@@ -612,27 +614,52 @@ export function configureSqliteWalMaintenance(
   let timer: IntervalHandle | null = null;
   if (timerIntervalMs > 0) {
     timer = setInterval(() => {
-      const splitBrain = tripwireDatabasePath
-        ? detectSqliteWalSplitBrain(tripwireDatabasePath)
-        : undefined;
-      if (splitBrain) {
-        invalidated = true;
-        if (timer) {
-          clearInterval(timer);
-          timer = null;
-        }
-        log.error("SQLite WAL sidecar identity mismatch", {
-          ...splitBrain,
-          databaseLabel: options.databaseLabel,
-        });
+      if (tripwireDatabasePath && splitBrainDetectionEnabled) {
         try {
-          options.onWalSplitBrain?.(splitBrain);
-        } finally {
-          if (db.isOpen) {
-            db.close();
+          const splitBrain = detectSqliteWalSplitBrain(tripwireDatabasePath);
+          if (splitBrain) {
+            invalidated = true;
+            if (timer) {
+              clearInterval(timer);
+              timer = null;
+            }
+            log.error("SQLite WAL sidecar identity mismatch", {
+              ...splitBrain,
+              databaseLabel: options.databaseLabel,
+            });
+            try {
+              options.onWalSplitBrain?.(splitBrain);
+            } catch (error) {
+              log.error("SQLite WAL split-brain hook failed", {
+                databaseLabel: options.databaseLabel,
+                databasePath: tripwireDatabasePath,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+            try {
+              if (db.isOpen) {
+                db.close();
+              }
+            } catch (error) {
+              log.error("SQLite WAL split-brain close failed", {
+                databaseLabel: options.databaseLabel,
+                databasePath: tripwireDatabasePath,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+            return;
+          }
+        } catch (error) {
+          splitBrainDetectionEnabled = false;
+          if (!splitBrainDetectionWarningLogged) {
+            splitBrainDetectionWarningLogged = true;
+            log.warn("SQLite WAL split-brain detection disabled", {
+              databaseLabel: options.databaseLabel,
+              databasePath: tripwireDatabasePath,
+              error: error instanceof Error ? error.message : String(error),
+            });
           }
         }
-        return;
       }
       runCheckpoint(periodicCheckpointMode);
       runIncrementalVacuum();

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -5,6 +5,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import type { Result } from "@openclaw/normalization-core/result";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { hasErrnoCode } from "./errno.js";
 import { normalizeSqliteNonNegativeInteger } from "./sqlite-busy-timeout.js";
 import { isSqliteLockError } from "./sqlite-transaction.js";
 
@@ -41,7 +42,7 @@ type SqliteWalCheckpointMode = "PASSIVE" | "FULL" | "RESTART" | "TRUNCATE";
 type SqliteFilesystemJournalPolicy = "rollback" | "unsupported" | "wal";
 type MountEntry = { mountPoint: string; fsType: string; source?: string };
 
-export type SqliteWalSplitBrainEvent = {
+type SqliteWalSplitBrainEvent = {
   event: "sqlite_wal_sidecar_identity_mismatch";
   databasePath: string;
   descriptorDevice: string;
@@ -360,7 +361,7 @@ function statSqliteSidecarTarget(pathname: string): BigIntStats | undefined {
   try {
     return fs.statSync(pathname, { bigint: true });
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+    if (hasErrnoCode(error, "ENOENT")) {
       return undefined;
     }
     throw error;
@@ -384,7 +385,7 @@ function detectSqliteWalSplitBrain(databasePath: string): SqliteWalSplitBrainEve
   try {
     descriptors = fs.readdirSync(PROC_SELF_FD_PATH);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+    if (hasErrnoCode(error, "ENOENT")) {
       return undefined;
     }
     throw error;
@@ -396,7 +397,7 @@ function detectSqliteWalSplitBrain(databasePath: string): SqliteWalSplitBrainEve
     try {
       linkedPath = fs.readlinkSync(descriptorPath);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      if (hasErrnoCode(error, "ENOENT")) {
         continue;
       }
       throw error;
@@ -411,8 +412,7 @@ function detectSqliteWalSplitBrain(databasePath: string): SqliteWalSplitBrainEve
     try {
       descriptor = fs.fstatSync(Number(descriptorName), { bigint: true });
     } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "EBADF" || code === "ENOENT") {
+      if (hasErrnoCode(error, "EBADF") || hasErrnoCode(error, "ENOENT")) {
         continue;
       }
       throw error;
@@ -422,7 +422,7 @@ function detectSqliteWalSplitBrain(databasePath: string): SqliteWalSplitBrainEve
         continue;
       }
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      if (hasErrnoCode(error, "ENOENT")) {
         continue;
       }
       throw error;

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -177,6 +177,7 @@ describe("tsdown config", () => {
       "agents/compaction-planning.worker",
       "agents/model-provider-auth.worker",
       "config/sessions/session-accessor.sqlite-archive.worker",
+      "infra/sqlite-readonly-location.worker",
       "state/openclaw-database-verify.worker",
       "system-agent/setup-inference-detection.worker",
       "plugins/memory-state",

--- a/src/state/openclaw-database-verify.worker.ts
+++ b/src/state/openclaw-database-verify.worker.ts
@@ -3,7 +3,7 @@ import {
   assertSqliteIntegrity,
   isTerminalSqliteIntegrityError,
 } from "../infra/sqlite-integrity.js";
-import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location.js";
+import { prepareSqliteReadOnlyLocationInProcess } from "../infra/sqlite-readonly-location.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
 
 const DATABASE_VERIFY_CHILD_ARG = "--openclaw-database-verify-child";
@@ -44,7 +44,7 @@ async function verifyOpenClawDatabase(
   let database: import("node:sqlite").DatabaseSync | undefined;
   let result = await (async (): Promise<OpenClawDatabaseVerifyResult> => {
     try {
-      const prepared = await prepareSqliteReadOnlyLocation(target.path);
+      const prepared = await prepareSqliteReadOnlyLocationInProcess(target.path);
       cleanup = prepared.cleanup;
       database = openNodeSqliteDatabase(prepared.location, {
         readOnly: true,

--- a/src/state/openclaw-state-db-open.ts
+++ b/src/state/openclaw-state-db-open.ts
@@ -56,6 +56,7 @@ export function openUnpublishedStateDatabase(params: {
   busyTimeoutMs: number;
   lockFailureReporting: SqliteLockFailureReporting;
   ensureSchema: (database: DatabaseSync) => void;
+  onWalSplitBrain: () => void;
   recordOpenFailure: (pathname: string, error: Error) => void;
 }): OpenClawStateDatabase {
   const { busyTimeoutMs, lockFailureReporting } = params;
@@ -77,6 +78,7 @@ export function openUnpublishedStateDatabase(params: {
           databaseLabel: "openclaw-state",
           databasePath: params.pathname,
           foreignKeys: true,
+          onWalSplitBrain: params.onWalSplitBrain,
           synchronous: "NORMAL",
         });
         params.ensureSchema(db);

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1480,6 +1480,39 @@ afterEach(() => {
 });
 
 describe("openclaw state database", () => {
+  it.runIf(process.platform === "linux")(
+    "evicts a detached WAL family before reopening the shared state database",
+    () => {
+      vi.useFakeTimers();
+      try {
+        const stateDir = createTempStateDir();
+        const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+        const opened = openOpenClawStateDatabase(options);
+        expect(opened.walMaintenance.checkpoint()).toBe(true);
+        fs.unlinkSync(`${opened.path}-wal`);
+        fs.unlinkSync(`${opened.path}-shm`);
+
+        vi.advanceTimersByTime(30 * 60 * 1000);
+
+        expect(opened.db.isOpen).toBe(false);
+        expect(() => opened.db.prepare("PRAGMA schema_version").get()).toThrow();
+        const reopened = openOpenClawStateDatabase(options);
+        expect(reopened).not.toBe(opened);
+        expect(reopened.db.isOpen).toBe(true);
+        expect(() =>
+          reopened.db
+            .prepare(
+              "UPDATE schema_meta SET updated_at = updated_at + 1 WHERE meta_key = 'primary'",
+            )
+            .run(),
+        ).not.toThrow();
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("resolves under the shared state database directory", () => {
     const stateDir = createTempStateDir();
 

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -607,6 +607,11 @@ function openOpenClawStateDatabaseWithBusyTimeout(
           busyTimeoutMs,
           lockFailureReporting,
           ensureSchema: (database) => ensureSchema(database, pathname, env, busyTimeoutMs),
+          onWalSplitBrain: () => {
+            if (unpublished) {
+              stateDbCache.evictCachedOpenClawStateDatabase(unpublished);
+            }
+          },
           recordOpenFailure: recordOpenClawStateDatabaseOpenFailure,
         }));
       },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -362,6 +362,7 @@ function buildCoreDistEntries(): Record<string, string> {
       "src/config/sessions/session-accessor.sqlite-archive.worker.ts",
     "config/sessions/session-transcript-reconcile.worker":
       "src/config/sessions/session-transcript-reconcile.worker.ts",
+    "infra/sqlite-readonly-location.worker": "src/infra/sqlite-readonly-location.worker.ts",
     "state/openclaw-database-verify.worker": "src/state/openclaw-database-verify.worker.ts",
     "infra/tailscale-route-owner.worker": "src/infra/tailscale-route-owner.worker.ts",
     "system-agent/setup-inference-detection.worker":


### PR DESCRIPTION
Fixes #125744.

## Producer (F1): in-process raw-fd snapshot preparation drops the gateway's SQLite locks

`prepareSqliteReadOnlyLocation[Sync]` raw-opens and closes fds on the live main DB to build a consistent read-only snapshot. POSIX semantics: `close()` on any fd releases **all** of the process's fcntl locks on that inode — so every in-process call silently dropped the gateway's own WAL locks, opening the window for a second WAL family over the same main file (the ptrmap/btree corruption reported in #125744). This is the same defect class already conceded and fixed for the database verifier in #114016 (see the comment at `src/state/openclaw-database-verify.impl.ts`).

Fix: the public entry points now run the preparation in a short-lived child process (one argv→JSON-stdout protocol for both async `execFile` and sync `spawnSync`, 60s timeout). The in-process implementations are renamed `*InProcess` and used only inside already-isolated child workers. `prepareSqliteSnapshotSource` (rollback-journal crash residue, reachable from in-gateway backup) is routed through the isolated child too, since a stale `-journal` can coexist with a live WAL connection.

Regression net: a Linux `F_GETLK` probe test asserts the holder's locks survive isolated preparation — and includes a characterization showing the in-process variant drops them. Platform-agnostic smoke and error-propagation tests cover both public entry points.

## Containment (F2): WAL sidecar split-brain tripwire

The periodic WAL maintenance tick (Linux only) now verifies the connection's `-wal`/`-shm` fds still point at the on-disk sidecars (`/proc/self/fd` scan, `st_nlink == 0` / dev-inode mismatch, TOCTOU-guarded). On mismatch it logs `sqlite_wal_sidecar_identity_mismatch`, invalidates the connection, closes it, and the state-db cache evicts the handle so the next open is fresh. Unexpected scan errors (e.g. restricted `/proc` under seccomp) disable detection for that connection with a single warning — the tripwire can never become a crash vector; checkpointing continues.

Notes for reviewers:
- Detection latency equals the checkpoint cadence (30 min for the state DB). The tripwire is containment for unknown producers, not prevention — F1 removes the known producer.
- Consumers holding the closed handle without the eviction hook (proxy-capture, plugin SDK) get a dead handle until reopen; failing closed beats writing into a divergent WAL family.
- Per-preparation child spawn costs one Node boot (~50–150ms); all current callers are cold paths (write-admission at startup, read-only CLI opens, doctor-lint, crash-residue snapshots).

## Field evidence

Three independent corruption incidents on our fleet on 2026-08-22 (2026.8.1 stable and beta.2; details in #125744 thread): `diagnostic_events` / `task_runs` btree+ptrmap corruption, gateways holding unlinked `-shm`/`-wal` fds confirmed via `lsof`. Corrupt originals preserved for forensics.
