### PR TITLE
fix(cli): prevent node commands from controlling terminal output

### DIFF
--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -489,7 +489,7 @@ export function registerNodesStatusCommands(nodes: Command) {
             defaultRuntime.log(muted("- (none effective)"));
           } else {
             for (const c of commands) {
-              defaultRuntime.log(`- ${c}`);
+              defaultRuntime.log(`- ${sanitizeTerminalText(c)}`);
             }
           }
           if (pendingCommands.length > 0) {

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -593,12 +593,13 @@ describe("cli program (nodes basics)", () => {
   });
 
   it("runs nodes describe and calls node.describe", async () => {
+    const unsafeEffectiveCommand = "camera.snap\u001b[2J\neffective-spoof";
     mockGatewayWithIosNodeListAnd("node.describe", {
       ts: Date.now(),
       nodeId: "ios-node",
       displayName: "iOS Node",
       caps: ["camera"],
-      commands: ["camera.snap"],
+      commands: [unsafeEffectiveCommand],
       approvalState: "pending-reapproval",
       pendingRequestId: "request-approval",
       pendingDeclaredCaps: ["camera", "canvas"],
@@ -620,7 +621,8 @@ describe("cli program (nodes basics)", () => {
 
     const out = getRuntimeOutput();
     expect(out).toContain("Commands");
-    expect(out).toContain("camera.snap");
+    expect(out).toContain("camera.snap\\neffective-spoof");
+    expect(out).not.toContain("\neffective-spoof");
     expect(out).toContain("Approval");
     expect(out).toContain("reapproval pending");
     expect(out).toContain("Pending request");
@@ -632,6 +634,12 @@ describe("cli program (nodes basics)", () => {
     expect(out).toContain("openclaw nodes approve request-approval");
     expect(out).not.toContain("\u001b");
     expect(out).not.toContain("[2K");
+    expect(out).not.toContain("[2J");
+
+    await runProgram(["nodes", "describe", "--node", "ios-node", "--json"]);
+
+    const json = writeJsonArgAt(-1) as { commands?: string[] };
+    expect(json.commands).toEqual([unsafeEffectiveCommand]);
   });
 
   it("keeps explicit gateway options in node reapproval guidance without leaking auth", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw nodes describe` could have terminal escape sequences or forged lines rendered when an approved node command identifier contained control characters.

## Why This Change Was Made

The human-readable effective-command list now passes command identifiers through the existing terminal-text sanitizer at its output boundary. JSON output deliberately retains the exact raw protocol values for machine consumers.

## User Impact

`nodes describe` can no longer let node-supplied command text alter or forge terminal output. Normal command names render unchanged, and JSON compatibility is preserved.

## Evidence

- Pre-fix regression failed on raw `ESC[2J` plus a forged newline.
- `src/cli/program.nodes-basic.e2e.test.ts` and `src/cli/program.nodes-diagnostics-auth.e2e.test.ts`: 44 tests passed.
- Post-rebase targeted `nodes describe` regression: 1 passed, 33 skipped.
- Full changed-file gate passed: typechecks, type-aware lint, schema/legacy-store/media/sidecar/import-cycle/webhook/pairing guards.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings.

Production LOC: +1/-1 (net 0) | Tests: +10/-2
