### PR TITLE
improve(mattermost): decode inbound websocket frames once

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -377,7 +377,7 @@ describe("mattermost websocket monitor", () => {
     });
   });
 
-  it("hands posted envelopes to ingress raw and keeps post_edited out", async () => {
+  it("hands posted envelopes to ingress raw without duplicate decoding", async () => {
     const socket = new FakeWebSocket();
     const onPosted = vi.fn(async () => {});
     const connectOnce = createMattermostConnectOnce({
@@ -398,6 +398,9 @@ describe("mattermost websocket monitor", () => {
         }),
       },
     };
+    const raw = JSON.stringify(posted);
+    const frame = Buffer.from(raw);
+    const decode = vi.spyOn(frame, "toString");
 
     const connected = connectOnce();
     socket.emitOpen();
@@ -413,14 +416,15 @@ describe("mattermost websocket monitor", () => {
       queueMicrotask(resolve);
     });
     expect(onPosted).not.toHaveBeenCalled();
-    socket.emitMessage(Buffer.from(JSON.stringify(posted)));
+    socket.emitMessage(frame);
     await vi.waitFor(() => {
       expect(onPosted).toHaveBeenCalledTimes(1);
     });
     socket.emitClose(1000);
     await connected;
 
-    expect(onPosted).toHaveBeenCalledWith(JSON.stringify(posted));
+    expect(onPosted).toHaveBeenCalledWith(raw);
+    expect(decode.mock.calls.length).toBeLessThanOrEqual(1);
   });
 
   it("terminates when bot update_at changes (disable/enable cycle)", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -336,15 +336,15 @@ export function createMattermostConnectOnce(
         });
 
         ws.on("message", async (data) => {
+          const raw = rawDataToString(data);
           captureWsEvent({
             url: opts.wsUrl,
             direction: "inbound",
             kind: "ws-frame",
             flowId,
-            payload: Buffer.from(rawDataToString(data)),
+            payload: Buffer.from(raw),
             meta: { subsystem: "mattermost-websocket" },
           });
-          const raw = rawDataToString(data);
           const payload = parseMattermostEventPayload(raw);
           if (!payload) {
             return;


### PR DESCRIPTION
## What Problem This Solves

Mattermost inbound WebSocket frames were decoded to strings twice in succession before ordinary posted events entered durable ingress. Large posted frames therefore paid duplicate frame-normalization work on every accepted message.

## Why This Change Was Made

Decode each dependency-controlled `ws.RawData` frame once, then reuse the same primitive string for capture and schema parsing. Capture still owns a fresh `Buffer`, and downstream parsing, filtering, durable admission, routing, and delivery are unchanged.

## User Impact

Mattermost inbound processing performs less CPU and allocation work, with no user-visible behavior or configuration change.

## Evidence

- Exact-base regression: the owner test failed because one posted `Buffer` frame was decoded twice; the candidate passes with at most one decode while preserving raw delivery and `post_edited` filtering.
- Owner and durable-ingress siblings: 3 files, 65 tests passed.
- Full bundled Mattermost extension: 50 files, 758 tests passed.
- `node scripts/check-changed.mjs -- extensions/mattermost/src/mattermost/monitor-websocket.ts extensions/mattermost/src/mattermost/monitor-websocket.test.ts` passed.
- `GIT_BRANCH=main pnpm build` passed.
- Owner-path microbenchmark on a 262,293-byte posted frame: combined median 274.004 ms → 212.847 ms per 300 frames (22.32% lower for this decode/parse microstage; not an end-to-end throughput claim).
- Codex Sol/high autoreview and TruffleHog scan: clean.
- No live Mattermost service was invoked: duplicate local `RawData` decoding is not observable over that service boundary, while deterministic owner red/green, dependency-source inspection, exact differential coverage, and the full extension suite exercise the changed contract.

Draft #103842 modifies the same files for voice-call event forwarding but does not overlap this decode hunk.
