### PR TITLE
fix(mantis): keep caller stdin for the lease-fenced command

### DIFF
--- a/scripts/mantis/run-with-lease-fence.sh
+++ b/scripts/mantis/run-with-lease-fence.sh
@@ -12,7 +12,9 @@ shift 2
 # The marker records broker-confirmed loss of the shared-account lease; continuing
 # Telegram I/O would violate broker serialization. The <=10s poll window is accepted
 # against the 20-minute lease TTL.
-setsid "$@" &
+# <&0: a backgrounded command's stdin defaults to /dev/null, which silently
+# swallowed the piped agent prompt. The explicit redirect keeps the caller's stdin.
+setsid "$@" <&0 &
 command_pid=$!
 
 command_exit() {

--- a/test/scripts/run-with-lease-fence.test.ts
+++ b/test/scripts/run-with-lease-fence.test.ts
@@ -72,4 +72,18 @@ describe("run-with-lease-fence", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(result.stderr).toBe("");
   });
+
+  posixIt("passes the caller's stdin through to the fenced command", () => {
+    // The workflow pipes the agent prompt into the fenced Codex process; a
+    // backgrounded child otherwise defaults its stdin to /dev/null, which
+    // made the agent fail with an empty prompt.
+    const root = tempDirs.make("openclaw-lease-fence-stdin-");
+    const result = spawnSync(SCRIPT, [path.join(root, "lease.lost"), "--", "/bin/cat"], {
+      encoding: "utf8",
+      input: "prompt body\n",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("prompt body\n");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Mantis proof run [32569181167](https://github.com/openclaw/openclaw/actions/runs/32569181167) — the first agentic dispatch since #127804 landed — failed instantly: the Codex agent step exited with `No prompt provided via stdin.` before doing any work, cascading into failed evidence restore/manifest steps.

## Why This Change Was Made

`run-with-lease-fence.sh` (added in #127804) backgrounds its fenced child with `setsid "$@" &` so it can watch the lost-lease marker. A backgrounded command in a non-interactive shell gets its stdin assigned to `/dev/null`, so the workflow's piped agent prompt (`< .github/codex/prompts/mantis-telegram-desktop-proof.md`) silently vanished. An explicit `<&0` redirect on the child keeps the caller's stdin; a comment records the invariant.

## User Impact

Agentic Mantis proof runs work again — every dispatch since #127804 merged would have died on the empty prompt.

## Evidence

- Regression: `test/scripts/run-with-lease-fence.test.ts` pipes input through the fence to `/bin/cat` and asserts it round-trips; it fails on pre-fix code with empty stdout (`TMPDIR=/var/tmp node scripts/run-vitest.mjs test/scripts/run-with-lease-fence.test.ts`: 3/3 post-fix, 1 failed pre-fix).
- Shell-level proof: `echo PROMPT | bash -c 'setsid cat & wait $!'` prints nothing; with `<&0` it prints `PROMPT`.
- `node scripts/check-changed.mjs` on both files: green.
- Structured autoreview (Codex `gpt-5.6-sol`, high): clean, `patch is correct (0.99)`.
- Live proof: the post-land Mantis re-dispatch on #127775 exercises the exact failing path.

## Review Dispositions

- ClawSweeper local review (`gpt-5.6-terra`, high) at `0d6e3bc6817`: `patch is correct`, 0 findings, security cleared. Rank-up move "Record a redacted post-merge Mantis trace showing the agent consumes the supplied prompt": accepted as the planned post-land step — the Mantis proof re-dispatch on #127775 exercises this exact path (piped prompt through the lease fence into the Codex agent) and its run log is that trace; it cannot exist pre-merge because dispatched runs execute the workflow from `main`.
