### PR TITLE
fix(android): make unreachable gateway retries battery-safe

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2004,8 +2004,11 @@ class NodeRuntime private constructor(
 
   private fun retryGatewaySessionsAfterNetworkRestore() {
     launchGatewayLifecycle {
-      operatorSession.retryAfterNetworkRestore()
-      nodeSession.retryAfterNetworkRestore()
+      gatewaySessionsToWakeOnNetworkRestore(
+        operator = operatorSession,
+        node = nodeSession,
+        secondary = secondaryOperatorSessions.mapValues { (_, runtime) -> runtime.session },
+      ).forEach { it.retryAfterNetworkRestore() }
     }
   }
 
@@ -9229,6 +9232,22 @@ internal fun normalizeOperatorScopes(scopes: List<String>): List<String> =
     .filter { it.isNotEmpty() }
     .distinct()
     .sorted()
+
+/**
+ * Sessions a validated-network restore has to wake: the operator and node pair plus every live
+ * secondary gateway.
+ *
+ * Takes the secondary fleet itself rather than a pre-flattened list, so a caller cannot leave it
+ * out without saying so, and snapshots it here so a fleet edit while the wake is fanning out
+ * cannot make it skip a session. Each session still owns its own desired-connection, auth-pause
+ * and retry state; this only decides who gets told. Generic in the session type for the same
+ * reason ValidatedNetworkState is: the decision can then be tested without an Android runtime.
+ */
+internal fun <T> gatewaySessionsToWakeOnNetworkRestore(
+  operator: T,
+  node: T,
+  secondary: Map<String, T>,
+): List<T> = listOf(operator, node) + secondary.values.toList()
 
 internal fun backgroundGatewayStableIds(
   entries: List<GatewayRegistryEntry>,

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -5,7 +5,6 @@ import android.net.ConnectivityManager
 import android.net.DnsResolver
 import android.net.Network
 import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
@@ -146,7 +145,7 @@ class GatewayDiscovery(
     try {
       // Track all networks so wide-area DNS can prefer VPN/split-DNS answers
       // even when Android's active network is not the VPN.
-      cm.registerNetworkCallback(NetworkRequest.Builder().build(), networkCallback)
+      cm.registerNetworkCallback(appUsableNetworkRequest(), networkCallback)
     } catch (_: Throwable) {
       // ignore (best-effort)
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -751,6 +751,7 @@ enum class GatewayMethod(
   GatewayIdentityGet("gateway.identity.get"),
   GatewayRestartPreflight("gateway.restart.preflight"),
   GatewayRestartRequest("gateway.restart.request"),
+  GatewayPing("gateway.ping"),
   SystemPresence("system-presence"),
   SystemEvent("system-event"),
   MessageAction("message.action"),

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -500,7 +500,7 @@ class GatewaySession(
 
   /** Forces the current socket closed so the loop reconnects to the current desired endpoint. */
   fun reconnect() {
-    signalReconnect(resumeAuthPaused = true)
+    signalReconnect(resumeAuthPaused = true, skipIfReady = false)
   }
 
   /**
@@ -509,14 +509,19 @@ class GatewaySession(
    * A network-restore fan-out reaches every session, including ones that are already connected
    * over a different route (e.g. cellular kept a secondary alive while its own Wi-Fi was down).
    * Forcing that connection closed would interrupt real in-flight work for no benefit, so a ready
-   * session is left alone here; [reconnect] still overrides it for a deliberate manual retry.
+   * session is left alone here; [reconnect] still overrides it for a deliberate manual retry. The
+   * readiness check itself happens inside [signalReconnect]'s lock, not here: reading it outside
+   * the lock would leave a window where a connecting session finishes becoming ready between the
+   * check and the close, and gets closed anyway.
    */
   internal fun retryAfterNetworkRestore() {
-    if (isReady()) return
-    signalReconnect(resumeAuthPaused = false)
+    signalReconnect(resumeAuthPaused = false, skipIfReady = true)
   }
 
-  private fun signalReconnect(resumeAuthPaused: Boolean) {
+  private fun signalReconnect(
+    resumeAuthPaused: Boolean,
+    skipIfReady: Boolean,
+  ) {
     synchronized(lifecycleLock) {
       val target = desired ?: return
       if (resumeAuthPaused) {
@@ -524,6 +529,7 @@ class GatewaySession(
       } else if (target.reconnectPausedForAuthFailure) {
         return
       }
+      if (skipIfReady && currentConnection?.isReady() == true) return
       currentConnection?.closeQuietly()
       reconnectWakeCount += 1
       reconnectSignal.trySend(Unit)

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -424,6 +424,12 @@ class GatewaySession(
   // Network recovery must interrupt the current backoff without creating a parallel loop.
   private val reconnectSignal = Channel<Unit>(Channel.CONFLATED)
 
+  // Counts wakes rather than carrying them. A receive cancelled by its own timeout can take the
+  // element out of the channel without delivering it, which would drop the ladder reset a wake is
+  // for; the count survives that, so the waiter can still see that a wake happened. Written under
+  // the same lock as the send, and never read for anything but that comparison.
+  @Volatile private var reconnectWakeCount = 0L
+
   /** Starts or replaces the desired gateway connection and launches the reconnect loop. */
   fun connect(
     endpoint: GatewayEndpoint,
@@ -441,6 +447,7 @@ class GatewaySession(
         if (job?.isActive != true) {
           job = scope.launch(Dispatchers.IO) { runLoop() }
         } else {
+          reconnectWakeCount += 1
           reconnectSignal.trySend(Unit)
         }
       }
@@ -510,6 +517,7 @@ class GatewaySession(
         return
       }
       currentConnection?.closeQuietly()
+      reconnectWakeCount += 1
       reconnectSignal.trySend(Unit)
     }
   }
@@ -522,7 +530,11 @@ class GatewaySession(
    * long wait they had climbed to. They reset to the first retry step rather than to zero, so an
    * in-progress reconnect keeps reporting "Reconnecting…" and holds the guidance attached to it.
    */
-  private suspend fun awaitReconnectWake(timeoutMs: Long): Boolean = withTimeoutOrNull(timeoutMs) { reconnectSignal.receive() } != null
+  private suspend fun awaitReconnectWake(timeoutMs: Long): Boolean {
+    val wakesBefore = reconnectWakeCount
+    val delivered = withTimeoutOrNull(timeoutMs) { reconnectSignal.receive() } != null
+    return reconnectWakeObserved(delivered, wakesBefore, reconnectWakeCount)
+  }
 
   /** Discards retry requests the attempt about to start already satisfies; true if any was queued. */
   private fun drainReconnectSignals(): Boolean {
@@ -2162,6 +2174,20 @@ class GatewaySession(
     return tls?.expectedFingerprint?.trim()?.isNotEmpty() == true
   }
 }
+
+/**
+ * Whether a wait ended because a wake arrived, given whether the channel delivered one and the
+ * wake count on either side of the wait.
+ *
+ * Delivery alone is not enough: a wake that is signalled while the wait's own timeout is winning
+ * can be taken out of the channel by the receive that is being cancelled, and is then delivered to
+ * nobody. The count moves in that case too, which is why it is the second term.
+ */
+internal fun reconnectWakeObserved(
+  delivered: Boolean,
+  wakesBefore: Long,
+  wakesAfter: Long,
+): Boolean = delivered || wakesAfter != wakesBefore
 
 /** Retry step a deliberate wake restarts from; not 0, which would report a first connect instead. */
 private const val FIRST_RETRY_ATTEMPT = 1

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -503,8 +503,16 @@ class GatewaySession(
     signalReconnect(resumeAuthPaused = true)
   }
 
-  /** Wakes transport backoff without overriding a deliberate auth-failure pause. */
+  /**
+   * Wakes transport backoff without overriding a deliberate auth-failure pause.
+   *
+   * A network-restore fan-out reaches every session, including ones that are already connected
+   * over a different route (e.g. cellular kept a secondary alive while its own Wi-Fi was down).
+   * Forcing that connection closed would interrupt real in-flight work for no benefit, so a ready
+   * session is left alone here; [reconnect] still overrides it for a deliberate manual retry.
+   */
   internal fun retryAfterNetworkRestore() {
+    if (isReady()) return
     signalReconnect(resumeAuthPaused = false)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -2222,9 +2222,9 @@ internal const val GATEWAY_RECONNECT_MIN_STEADY_DELAY_MS = 8_000L
 /**
  * Ceiling for steady probing. A gateway can come back without Android ever reporting a network
  * change (the process restarts, or the LAN becomes routable again), so the loop must keep probing;
- * this bounds how long that recovery can take while keeping the radio idle nearly all of the time.
+ * this keeps endpoint-only recovery within one minute while still reducing radio activity.
  */
-internal const val GATEWAY_RECONNECT_MAX_DELAY_MS = 300_000L
+internal const val GATEWAY_RECONNECT_MAX_DELAY_MS = 60_000L
 
 /**
  * Delay before retry number [attempt] (1-based) against a gateway that keeps failing to connect.

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -47,6 +47,7 @@ import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 
@@ -506,13 +507,9 @@ class GatewaySession(
   /**
    * Wakes transport backoff without overriding a deliberate auth-failure pause.
    *
-   * A network-restore fan-out reaches every session, including ones that are already connected
-   * over a different route (e.g. cellular kept a secondary alive while its own Wi-Fi was down).
-   * Forcing that connection closed would interrupt real in-flight work for no benefit, so a ready
-   * session is left alone here; [reconnect] still overrides it for a deliberate manual retry. The
-   * readiness check itself happens inside [signalReconnect]'s lock, not here: reading it outside
-   * the lock would leave a window where a connecting session finishes becoming ready between the
-   * check and the close, and gets closed anyway.
+   * Restore reaches healthy sessions on unrelated routes as well as silently broken TCP flows.
+   * A completed handshake cannot distinguish them: check the ready socket before retiring it.
+   * [reconnect] still forces immediate retirement for a deliberate manual retry.
    */
   internal fun retryAfterNetworkRestore() {
     signalReconnect(resumeAuthPaused = false, skipIfReady = true)
@@ -529,7 +526,10 @@ class GatewaySession(
       } else if (target.reconnectPausedForAuthFailure) {
         return
       }
-      if (skipIfReady && currentConnection?.isReady() == true) return
+      if (skipIfReady && currentConnection?.isReady() == true) {
+        currentConnection?.checkLivenessAfterNetworkRestore()
+        return
+      }
       currentConnection?.closeQuietly()
       reconnectWakeCount += 1
       reconnectSignal.trySend(Unit)
@@ -963,6 +963,12 @@ class GatewaySession(
     val error: ErrorShape?,
   )
 
+  private class PendingRequest {
+    val response = CompletableDeferred<RpcResponse>()
+
+    @Volatile var sentSequence = 0L
+  }
+
   private data class TicketedMediaRequest(
     val url: String,
     val headers: Map<String, String>,
@@ -1002,6 +1008,9 @@ class GatewaySession(
 
     @Volatile
     private var connectRequestId: String? = null
+
+    // Accessed under lifecycleLock; repeated restore callbacks share this socket's check.
+    private var networkRestoreCheck: Job? = null
     val tlsConfig: GatewayTlsConfig? =
       buildGatewayTlsConfig(target.tls) { fingerprint ->
         onTlsFingerprint?.invoke(target.tls?.stableId ?: target.endpoint.stableId, fingerprint)
@@ -1011,10 +1020,12 @@ class GatewaySession(
     private var socket: WebSocket? = null
     private val loggerTag = "OpenClawGateway"
     private val incomingMessages = Channel<String>(Channel.UNLIMITED)
+    private val sentRequestSequence = AtomicLong()
+    private val answeredRequestSequence = AtomicLong()
     private var lastEventSequence: Long? = null
 
     // RPC waiters belong to this socket generation. Closing it must not touch a replacement connection.
-    private val pending = ConcurrentHashMap<String, CompletableDeferred<RpcResponse>>()
+    private val pending = ConcurrentHashMap<String, PendingRequest>()
 
     private val pendingLock = Any()
     private val messagePumpJob =
@@ -1056,10 +1067,10 @@ class GatewaySession(
     ): RpcResponse {
       val id = UUID.randomUUID().toString()
       if (method == "connect") connectRequestId = id
-      val deferred = registerPending(id)
+      val waiter = registerPending(id)
       try {
-        sendJson(buildRequestFrame(id = id, method = method, params = params), withEnqueue)
-        return withTimeout(timeoutMs) { deferred.await() }
+        sendJson(buildRequestFrame(id = id, method = method, params = params), waiter, withEnqueue)
+        return withTimeout(timeoutMs) { waiter.response.await() }
       } catch (err: TimeoutCancellationException) {
         throw GatewayRequestOutcomeUnknown("request timeout")
       } finally {
@@ -1181,9 +1192,9 @@ class GatewaySession(
       onError: (ErrorShape) -> Unit,
     ) {
       val id = UUID.randomUUID().toString()
-      val deferred = registerPending(id)
+      val waiter = registerPending(id)
       try {
-        sendJson(buildRequestFrame(id = id, method = method, params = params), withEnqueue)
+        sendJson(buildRequestFrame(id = id, method = method, params = params), waiter, withEnqueue)
       } catch (err: Throwable) {
         pending.remove(id)
         throw err
@@ -1195,7 +1206,7 @@ class GatewaySession(
           try {
             val response =
               try {
-                withTimeout(timeoutMs) { deferred.await() }
+                withTimeout(timeoutMs) { waiter.response.await() }
               } catch (_: TimeoutCancellationException) {
                 onError(ErrorShape("UNAVAILABLE", "request timeout"))
                 return@withContext
@@ -1213,26 +1224,29 @@ class GatewaySession(
       }
     }
 
-    private fun registerPending(id: String): CompletableDeferred<RpcResponse> {
-      val deferred = CompletableDeferred<RpcResponse>()
+    private fun registerPending(id: String): PendingRequest {
+      val waiter = PendingRequest()
       // Registration and the close drain are one lifecycle decision; no waiter may slip between them.
       synchronized(pendingLock) {
         if (state.get() == ConnectionState.CLOSED) {
           throw GatewayRequestNotEnqueued("Gateway closed")
         }
-        pending[id] = deferred
+        pending[id] = waiter
       }
-      return deferred
+      return waiter
     }
 
     suspend fun sendJson(
       obj: JsonObject,
+      waiter: PendingRequest,
       withEnqueue: (() -> Unit) -> Unit = { it() },
     ) {
       val jsonString = obj.toString()
       writeLock.withLock {
         currentCoroutineContext().ensureActive()
         withEnqueue {
+          // Stamp the actual send boundary, not registration before the write-lock wait.
+          waiter.sentSequence = sentRequestSequence.incrementAndGet()
           if (state.get() == ConnectionState.CLOSED || socket?.send(jsonString) != true) {
             // Closing during the lock wait, like an OkHttp false return, means no frame was queued.
             throw GatewayRequestNotEnqueued("gateway send failed")
@@ -1264,6 +1278,32 @@ class GatewaySession(
       // still parse and persist its issued token before remaining connection work is cancelled.
       connectHandshakeJob?.join()
       connectionJob.cancelAndJoin()
+    }
+
+    fun checkLivenessAfterNetworkRestore() {
+      if (networkRestoreCheck?.isActive == true) return
+      networkRestoreCheck =
+        connectionScope.launch(Dispatchers.IO) {
+          val sentBefore = writeLock.withLock { sentRequestSequence.get() }
+          try {
+            // health is allowed for both node and operator roles. Even an error response proves
+            // round-trip liveness; do not request channel probes or interpret application health.
+            request(GatewayMethod.Health.rawValue, null, timeoutMs = 8_000, withEnqueue = guardRequestEnqueue(this@Connection) { it() })
+          } catch (_: GatewayRequestNotEnqueued) {
+            // Retirement won before enqueue; its owner already handles recovery.
+          } catch (_: GatewayRequestOutcomeUnknown) {
+            synchronized(lifecycleLock) {
+              // Only a reply to a request sent after this check proves both directions are live.
+              // Events and delayed replies to earlier requests cannot rescue a broken send path.
+              // Never let a late check retire a replacement or override Disconnect/auth pause.
+              if (currentConnection === this@Connection && desired === target && isReady() &&
+                answeredRequestSequence.get() <= sentBefore
+              ) {
+                signalReconnect(resumeAuthPaused = false, skipIfReady = false)
+              }
+            }
+          }
+        }
     }
 
     fun isReady(): Boolean = state.get() == ConnectionState.READY
@@ -1763,7 +1803,10 @@ class GatewaySession(
             }
           ErrorShape(wireError.code, wireError.message, details)
         }
-      pending.remove(id)?.complete(RpcResponse(id, response.ok, payloadJson, error))
+      pending.remove(id)?.let { waiter ->
+        answeredRequestSequence.accumulateAndGet(waiter.sentSequence) { previous, answered -> maxOf(previous, answered) }
+        waiter.response.complete(RpcResponse(id, response.ok, payloadJson, error))
+      }
     }
 
     private fun handleEvent(frame: JsonObject) {
@@ -1922,7 +1965,7 @@ class GatewaySession(
           pending.values.toList().also { pending.clear() }
         }
       for (waiter in waiters) {
-        waiter.completeExceptionally(GatewayRequestOutcomeUnknown("Gateway disconnected before response"))
+        waiter.response.completeExceptionally(GatewayRequestOutcomeUnknown("Gateway disconnected before response"))
       }
     }
   }
@@ -2222,7 +2265,7 @@ internal const val GATEWAY_RECONNECT_MIN_STEADY_DELAY_MS = 8_000L
 /**
  * Ceiling for steady probing. A gateway can come back without Android ever reporting a network
  * change (the process restarts, or the LAN becomes routable again), so the loop must keep probing;
- * this keeps endpoint-only recovery within one minute while still reducing radio activity.
+ * the retry timer is at most one minute, plus the time the next connection attempt takes.
  */
 internal const val GATEWAY_RECONNECT_MAX_DELAY_MS = 60_000L
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -48,6 +48,7 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.random.Random
 
 /**
  * Identity advertised during gateway connect; these fields become the device row users approve.
@@ -513,10 +514,24 @@ class GatewaySession(
     }
   }
 
-  private fun drainReconnectSignals() {
+  /**
+   * Waits out [timeoutMs] unless the loop is woken deliberately, and reports which happened.
+   *
+   * A wake — a restored network, a manual reconnect, a cleared auth pause, or a new desired
+   * endpoint — is fresh information, so callers restart the retry ladder instead of resuming the
+   * long wait they had climbed to. They reset to the first retry step rather than to zero, so an
+   * in-progress reconnect keeps reporting "Reconnecting…" and holds the guidance attached to it.
+   */
+  private suspend fun awaitReconnectWake(timeoutMs: Long): Boolean = withTimeoutOrNull(timeoutMs) { reconnectSignal.receive() } != null
+
+  /** Discards retry requests the attempt about to start already satisfies; true if any was queued. */
+  private fun drainReconnectSignals(): Boolean {
+    var drained = false
     while (reconnectSignal.tryReceive().isSuccess) {
       // A newly ready connection already incorporates every earlier retry request.
+      drained = true
     }
+    return drained
   }
 
   private fun readyConnection(): Connection? = currentConnection?.takeIf { it.isReady() }
@@ -1895,14 +1910,16 @@ class GatewaySession(
           desired ?: return
         }
       if (target.reconnectPausedForAuthFailure) {
-        withTimeoutOrNull(250) { reconnectSignal.receive() }
+        if (awaitReconnectWake(250)) target.attempt = FIRST_RETRY_ATTEMPT
         continue
       }
 
       try {
         synchronized(notificationLock) {
           if (synchronized(lifecycleLock) { job === loopJob && loopJob.isActive && desired === target }) {
-            drainReconnectSignals()
+            // A wake can land between the backoff expiring and this drain. Dropping it silently
+            // would let a failed attempt resume the pre-wake ladder, so it resets here too.
+            if (drainReconnectSignals()) target.attempt = FIRST_RETRY_ATTEMPT
             onDisconnected(if (target.attempt == 0) "Connecting…" else "Reconnecting…")
           }
         }
@@ -1933,8 +1950,8 @@ class GatewaySession(
           }
         }
         if (desired !== target || target.reconnectPausedForAuthFailure) continue
-        val sleepMs = minOf(8_000L, (350.0 * Math.pow(1.7, target.attempt.toDouble())).toLong())
-        withTimeoutOrNull(sleepMs) { reconnectSignal.receive() }
+        val sleepMs = gatewayReconnectDelayMs(target.attempt, jitter = Random.nextDouble())
+        if (awaitReconnectWake(sleepMs)) target.attempt = FIRST_RETRY_ATTEMPT
       }
     }
   }
@@ -2144,6 +2161,49 @@ class GatewaySession(
     // remote gateways when an existing TLS pin already identifies the endpoint.
     return tls?.expectedFingerprint?.trim()?.isNotEmpty() == true
   }
+}
+
+/** Retry step a deliberate wake restarts from; not 0, which would report a first connect instead. */
+private const val FIRST_RETRY_ATTEMPT = 1
+
+/** First retry delay after a failed connect; unchanged, so a brief blip still recovers sub-second. */
+internal const val GATEWAY_RECONNECT_BASE_DELAY_MS = 350L
+
+/** Per-attempt growth factor; unchanged. */
+internal const val GATEWAY_RECONNECT_GROWTH = 1.7
+
+/**
+ * Delay at which retries stop being "transient recovery" and become steady probing of an endpoint
+ * that is simply not there. Retries never get *more* frequent than this, which is the cadence this
+ * loop used to hold forever.
+ */
+internal const val GATEWAY_RECONNECT_MIN_STEADY_DELAY_MS = 8_000L
+
+/**
+ * Ceiling for steady probing. A gateway can come back without Android ever reporting a network
+ * change (the process restarts, or the LAN becomes routable again), so the loop must keep probing;
+ * this bounds how long that recovery can take while keeping the radio idle nearly all of the time.
+ */
+internal const val GATEWAY_RECONNECT_MAX_DELAY_MS = 300_000L
+
+/**
+ * Delay before retry number [attempt] (1-based) against a gateway that keeps failing to connect.
+ *
+ * Growth continues past [GATEWAY_RECONNECT_MIN_STEADY_DELAY_MS] instead of flattening there, so a
+ * gateway that stays unreachable costs progressively less. Once past that point the delay is spread
+ * over the upper half of its window ([jitter] in `0.0..1.0`) so a gateway that restarts is not met
+ * by every waiting device at the same instant.
+ */
+internal fun gatewayReconnectDelayMs(
+  attempt: Int,
+  jitter: Double,
+): Long {
+  // Guard the 1-based contract: a non-positive attempt would otherwise shrink the delay below base.
+  val growth = Math.pow(GATEWAY_RECONNECT_GROWTH, attempt.coerceAtLeast(1).toDouble())
+  val delay = minOf(GATEWAY_RECONNECT_BASE_DELAY_MS * growth, GATEWAY_RECONNECT_MAX_DELAY_MS.toDouble())
+  if (delay <= GATEWAY_RECONNECT_MIN_STEADY_DELAY_MS) return delay.toLong()
+  val spread = delay / 2 + delay / 2 * jitter.coerceIn(0.0, 1.0)
+  return maxOf(spread, GATEWAY_RECONNECT_MIN_STEADY_DELAY_MS.toDouble()).toLong()
 }
 
 /** Decides whether auth failures should stop reconnect churn until the user changes credentials. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -47,7 +47,6 @@ import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 
@@ -963,12 +962,6 @@ class GatewaySession(
     val error: ErrorShape?,
   )
 
-  private class PendingRequest {
-    val response = CompletableDeferred<RpcResponse>()
-
-    @Volatile var sentSequence = 0L
-  }
-
   private data class TicketedMediaRequest(
     val url: String,
     val headers: Map<String, String>,
@@ -1020,12 +1013,11 @@ class GatewaySession(
     private var socket: WebSocket? = null
     private val loggerTag = "OpenClawGateway"
     private val incomingMessages = Channel<String>(Channel.UNLIMITED)
-    private val sentRequestSequence = AtomicLong()
-    private val answeredRequestSequence = AtomicLong()
+    private var supportsLivenessAck = false
     private var lastEventSequence: Long? = null
 
     // RPC waiters belong to this socket generation. Closing it must not touch a replacement connection.
-    private val pending = ConcurrentHashMap<String, PendingRequest>()
+    private val pending = ConcurrentHashMap<String, CompletableDeferred<RpcResponse>>()
 
     private val pendingLock = Any()
     private val messagePumpJob =
@@ -1069,8 +1061,8 @@ class GatewaySession(
       if (method == "connect") connectRequestId = id
       val waiter = registerPending(id)
       try {
-        sendJson(buildRequestFrame(id = id, method = method, params = params), waiter, withEnqueue)
-        return withTimeout(timeoutMs) { waiter.response.await() }
+        sendJson(buildRequestFrame(id = id, method = method, params = params), withEnqueue)
+        return withTimeout(timeoutMs) { waiter.await() }
       } catch (err: TimeoutCancellationException) {
         throw GatewayRequestOutcomeUnknown("request timeout")
       } finally {
@@ -1194,7 +1186,7 @@ class GatewaySession(
       val id = UUID.randomUUID().toString()
       val waiter = registerPending(id)
       try {
-        sendJson(buildRequestFrame(id = id, method = method, params = params), waiter, withEnqueue)
+        sendJson(buildRequestFrame(id = id, method = method, params = params), withEnqueue)
       } catch (err: Throwable) {
         pending.remove(id)
         throw err
@@ -1206,7 +1198,7 @@ class GatewaySession(
           try {
             val response =
               try {
-                withTimeout(timeoutMs) { waiter.response.await() }
+                withTimeout(timeoutMs) { waiter.await() }
               } catch (_: TimeoutCancellationException) {
                 onError(ErrorShape("UNAVAILABLE", "request timeout"))
                 return@withContext
@@ -1224,8 +1216,8 @@ class GatewaySession(
       }
     }
 
-    private fun registerPending(id: String): PendingRequest {
-      val waiter = PendingRequest()
+    private fun registerPending(id: String): CompletableDeferred<RpcResponse> {
+      val waiter = CompletableDeferred<RpcResponse>()
       // Registration and the close drain are one lifecycle decision; no waiter may slip between them.
       synchronized(pendingLock) {
         if (state.get() == ConnectionState.CLOSED) {
@@ -1238,15 +1230,12 @@ class GatewaySession(
 
     suspend fun sendJson(
       obj: JsonObject,
-      waiter: PendingRequest,
       withEnqueue: (() -> Unit) -> Unit = { it() },
     ) {
       val jsonString = obj.toString()
       writeLock.withLock {
         currentCoroutineContext().ensureActive()
         withEnqueue {
-          // Stamp the actual send boundary, not registration before the write-lock wait.
-          waiter.sentSequence = sentRequestSequence.incrementAndGet()
           if (state.get() == ConnectionState.CLOSED || socket?.send(jsonString) != true) {
             // Closing during the lock wait, like an OkHttp false return, means no frame was queued.
             throw GatewayRequestNotEnqueued("gateway send failed")
@@ -1281,24 +1270,21 @@ class GatewaySession(
     }
 
     fun checkLivenessAfterNetworkRestore() {
-      if (networkRestoreCheck?.isActive == true) return
+      // Older Gateways retain OkHttp transport/ping detection; health is not a liveness fallback.
+      if (!supportsLivenessAck || networkRestoreCheck?.isActive == true) return
       networkRestoreCheck =
         connectionScope.launch(Dispatchers.IO) {
-          val sentBefore = writeLock.withLock { sentRequestSequence.get() }
           try {
-            // health is allowed for both node and operator roles. Even an error response proves
-            // round-trip liveness; do not request channel probes or interpret application health.
-            request(GatewayMethod.Health.rawValue, null, timeoutMs = 8_000, withEnqueue = guardRequestEnqueue(this@Connection) { it() })
-          } catch (_: GatewayRequestNotEnqueued) {
-            // Retirement won before enqueue; its owner already handles recovery.
-          } catch (_: GatewayRequestOutcomeUnknown) {
+            // Only this request's ID on this socket proves the round trip. The Gateway ACK
+            // bypasses health collection; unrelated events and old replies cannot satisfy it.
+            request(GatewayMethod.GatewayPing.rawValue, null, timeoutMs = 8_000, withEnqueue = guardRequestEnqueue(this@Connection) { it() })
+          } catch (error: Exception) {
+            if (error !is GatewayRequestNotEnqueued && error !is GatewayRequestOutcomeUnknown) throw error
+            // OkHttp can refuse an enqueue while this session still appears READY (for example,
+            // after queue overflow). Recheck ownership instead of assuming retirement won.
             synchronized(lifecycleLock) {
-              // Only a reply to a request sent after this check proves both directions are live.
-              // Events and delayed replies to earlier requests cannot rescue a broken send path.
               // Never let a late check retire a replacement or override Disconnect/auth pause.
-              if (currentConnection === this@Connection && desired === target && isReady() &&
-                answeredRequestSequence.get() <= sentBefore
-              ) {
+              if (currentConnection === this@Connection && desired === target && isReady()) {
                 signalReconnect(resumeAuthPaused = false, skipIfReady = false)
               }
             }
@@ -1555,6 +1541,7 @@ class GatewaySession(
           .asArrayOrNull()
           ?.mapNotNull { it.asStringOrNull()?.trim()?.takeIf { method -> method.isNotEmpty() } }
           ?.toSet()
+      supportsLivenessAck = methods?.contains(GatewayMethod.GatewayPing.rawValue) == true
       val capabilities =
         obj["features"]
           .asObjectOrNull()
@@ -1804,8 +1791,7 @@ class GatewaySession(
           ErrorShape(wireError.code, wireError.message, details)
         }
       pending.remove(id)?.let { waiter ->
-        answeredRequestSequence.accumulateAndGet(waiter.sentSequence) { previous, answered -> maxOf(previous, answered) }
-        waiter.response.complete(RpcResponse(id, response.ok, payloadJson, error))
+        waiter.complete(RpcResponse(id, response.ok, payloadJson, error))
       }
     }
 
@@ -1965,7 +1951,7 @@ class GatewaySession(
           pending.values.toList().also { pending.clear() }
         }
       for (waiter in waiters) {
-        waiter.response.completeExceptionally(GatewayRequestOutcomeUnknown("Gateway disconnected before response"))
+        waiter.completeExceptionally(GatewayRequestOutcomeUnknown("Gateway disconnected before response"))
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -31,28 +31,15 @@ internal class NetworkMonitor(
 
   private val restoreState = NetworkRestoreState<Network>()
 
-  // registerNetworkCallback() replays every already-matching network's current state right after
-  // registration, and that replay is indistinguishable from a later genuine change: there is no
-  // non-deprecated synchronous "list every current network" call to seed all of them up front
-  // (only the single active one, below), so any other network that was already validated before
-  // this monitor existed looks like a fresh restore the moment its replay arrives. The replay
-  // delivers cached state ConnectivityService already holds, not a fresh validation check, so it
-  // resolves within milliseconds of registration; the window only needs to be short enough to
-  // cover that, not long enough to risk absorbing a genuine restore that happens to land in the
-  // same instant. A missed genuine restore in this narrow window is not unbounded: the affected
-  // session still falls back to the bounded retry ceiling owned by GatewaySession.
-  private val registeredAtNanos = System.nanoTime()
-
   private val callback =
     object : ConnectivityManager.NetworkCallback() {
       override fun onAvailable(network: Network) {
         // Fires once per network attach, before validation resolves, so it also covers a
-        // restored private LAN/VPN route that never reaches NET_CAPABILITY_VALIDATED. Same
-        // registration-replay hazard as onCapabilitiesChanged below: registerNetworkCallback()
-        // replays onAvailable for every network already connected at registration time, so the
-        // same bootstrap grace absorbs it.
+        // restored private LAN/VPN route that never reaches NET_CAPABILITY_VALIDATED.
+        // Registration can replay an existing route, but session guards make that wake harmless;
+        // dropping it here would also drop an indistinguishable genuine restore.
         val newlyAvailable = restoreState.onAvailable(network)
-        if (newlyAvailable && !isWithinNetworkMonitorBootstrapGrace(registeredAtNanos, System.nanoTime())) {
+        if (newlyAvailable) {
           notifyNetworkAvailable()
         }
       }
@@ -66,7 +53,7 @@ internal class NetworkMonitor(
             network,
             isTransportValidated(capabilities),
           )
-        if (justValidated && !isWithinNetworkMonitorBootstrapGrace(registeredAtNanos, System.nanoTime())) {
+        if (justValidated) {
           notifyNetworkAvailable()
         }
       }
@@ -173,20 +160,3 @@ internal class NetworkRestoreState<T>(
  * predicate can be unit-tested without a Robolectric ConnectivityManager shadow.
  */
 internal fun isTransportValidated(capabilities: NetworkCapabilities): Boolean = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-
-/**
- * How long after registration a just-validated network is treated as registration replay, not a
- * restore. Short by design: the replay carries cached state, not a fresh validation check, so it
- * resolves in milliseconds; this only needs to outlast that, not cover any real elapsed time.
- */
-internal const val NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS = 500_000_000L
-
-/**
- * Whether a just-validated network observed at [nowNanos] is still inside the registration replay
- * window that started at [registeredAtNanos]. Exposed internal so the boundary can be unit-tested
- * without a Robolectric ConnectivityManager shadow.
- */
-internal fun isWithinNetworkMonitorBootstrapGrace(
-  registeredAtNanos: Long,
-  nowNanos: Long,
-): Boolean = nowNanos - registeredAtNanos < NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -9,8 +9,14 @@ import android.util.Log
 
 /**
  * Listens for Android transport restores and signals [onValidatedNetworkAvailable] when the device
- * regains a validated internet connection. Used to trigger an immediate gateway
- * reconnect instead of waiting out the time-based backoff slot in [GatewaySession].
+ * regains a validated internet connection, or when any network newly attaches at all. Used to
+ * trigger an immediate gateway reconnect instead of waiting out the time-based backoff slot in
+ * [GatewaySession].
+ *
+ * Validation (`NET_CAPABILITY_VALIDATED`) only confirms general internet reachability; a saved
+ * Gateway on a private LAN or a split-tunnel VPN route can be reachable without ever validating,
+ * so this monitor also wakes on the plain network-attach event. A wake that turns out to be wrong
+ * (the attached network cannot actually reach the Gateway) just costs one failed connect attempt.
  *
  * This monitor only reports "transport came back". Each gateway session still owns
  * desired-connection and auth-pause decisions. The application context keeps this
@@ -51,6 +57,17 @@ internal class NetworkMonitor(
 
   private val callback =
     object : ConnectivityManager.NetworkCallback() {
+      override fun onAvailable(network: Network) {
+        // Fires once per network attach, before validation resolves, so it also covers a
+        // restored private LAN/VPN route that never reaches NET_CAPABILITY_VALIDATED. Same
+        // registration-replay hazard as onCapabilitiesChanged below: registerNetworkCallback()
+        // replays onAvailable for every network already connected at registration time, so the
+        // same bootstrap grace absorbs it.
+        if (!isWithinNetworkMonitorBootstrapGrace(registeredAtNanos, System.nanoTime())) {
+          notifyValidatedNetworkAvailableDebounced()
+        }
+      }
+
       override fun onCapabilitiesChanged(
         network: Network,
         capabilities: NetworkCapabilities,

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -40,8 +40,7 @@ internal class NetworkMonitor(
   // resolves within milliseconds of registration; the window only needs to be short enough to
   // cover that, not long enough to risk absorbing a genuine restore that happens to land in the
   // same instant. A missed genuine restore in this narrow window is not unbounded: the affected
-  // session still falls back to its own independent backoff retry, the same bound this PR already
-  // asks for acceptance of elsewhere in this body.
+  // session still falls back to the bounded retry ceiling owned by GatewaySession.
   private val registeredAtNanos = System.nanoTime()
 
   private val callback =

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -88,18 +88,27 @@ internal class ValidatedNetworkState<T>(
 ) {
   private val validatedNetworks = initialValidatedNetworks.toMutableSet()
 
+  /**
+   * Records [network]'s current validated state and reports whether it just became reachable.
+   *
+   * Signals on this network's own offline->online edge, not on the aggregate "is anything
+   * online" state: a saved Gateway can be reachable over one specific route only, so cellular
+   * staying validated the whole time must not swallow a returning Wi-Fi/LAN network's own
+   * restore. A network already known validated still reports no change, which is what keeps
+   * capability churn (e.g. signal-strength updates) from re-firing.
+   */
   @Synchronized
   fun update(
     network: T,
     isValidated: Boolean,
   ): Boolean {
-    val wasOnline = validatedNetworks.isNotEmpty()
+    val wasValidated = validatedNetworks.contains(network)
     if (isValidated) {
       validatedNetworks.add(network)
     } else {
       validatedNetworks.remove(network)
     }
-    return !wasOnline && validatedNetworks.isNotEmpty()
+    return isValidated && !wasValidated
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -28,14 +28,36 @@ internal class NetworkMonitor(
   // should signal.
   private val validatedNetworks = ValidatedNetworkState<Network>()
 
+  // registerNetworkCallback() replays every already-matching network's current state right after
+  // registration, and that replay is indistinguishable from a later genuine change: there is no
+  // non-deprecated synchronous "list every current network" call to seed all of them up front
+  // (only the single active one, below), so any other network that was already validated before
+  // this monitor existed looks like a fresh restore the moment its replay arrives. The replay
+  // delivers cached state ConnectivityService already holds, not a fresh validation check, so it
+  // resolves within milliseconds of registration; the window only needs to be short enough to
+  // cover that, not long enough to risk absorbing a genuine restore that happens to land in the
+  // same instant. A missed genuine restore in this narrow window is not unbounded: the affected
+  // session still falls back to its own independent backoff retry, the same bound this PR already
+  // asks for acceptance of elsewhere in this body.
+  private val registeredAtNanos = System.nanoTime()
+
+  // The fan-out a notification triggers reaches every session regardless of which network
+  // changed, so when several transports validate close together (e.g. Wi-Fi and cellular both
+  // reactivating from doze at once) each one's own edge would otherwise fire its own full
+  // fan-out — repeatedly closing a session's just-started reconnect attempt before its handshake
+  // can finish. This debounces to one notification per burst; nothing about which network caused
+  // it is lost, because the fan-out is not per-network to begin with.
+  @Volatile private var lastNotifiedAtNanos: Long? = null
+
   private val callback =
     object : ConnectivityManager.NetworkCallback() {
       override fun onCapabilitiesChanged(
         network: Network,
         capabilities: NetworkCapabilities,
       ) {
-        if (validatedNetworks.update(network, isTransportValidated(capabilities))) {
-          notifyValidatedNetworkAvailable()
+        val justValidated = validatedNetworks.update(network, isTransportValidated(capabilities))
+        if (justValidated && !isWithinNetworkMonitorBootstrapGrace(registeredAtNanos, System.nanoTime())) {
+          notifyValidatedNetworkAvailableDebounced()
         }
       }
 
@@ -59,6 +81,15 @@ internal class NetworkMonitor(
     } catch (err: Throwable) {
       Log.w(logTag, "registerNetworkCallback failed: ${err.message ?: err::class.java.simpleName}")
     }
+  }
+
+  private fun notifyValidatedNetworkAvailableDebounced() {
+    val now = System.nanoTime()
+    synchronized(this) {
+      if (isWithinNetworkMonitorNotifyDebounce(lastNotifiedAtNanos, now)) return
+      lastNotifiedAtNanos = now
+    }
+    notifyValidatedNetworkAvailable()
   }
 
   private fun notifyValidatedNetworkAvailable() {
@@ -117,3 +148,38 @@ internal class ValidatedNetworkState<T>(
  * predicate can be unit-tested without a Robolectric ConnectivityManager shadow.
  */
 internal fun isTransportValidated(capabilities: NetworkCapabilities): Boolean = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+
+/**
+ * How long after registration a just-validated network is treated as registration replay, not a
+ * restore. Short by design: the replay carries cached state, not a fresh validation check, so it
+ * resolves in milliseconds; this only needs to outlast that, not cover any real elapsed time.
+ */
+internal const val NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS = 500_000_000L
+
+/**
+ * Whether a just-validated network observed at [nowNanos] is still inside the registration replay
+ * window that started at [registeredAtNanos]. Exposed internal so the boundary can be unit-tested
+ * without a Robolectric ConnectivityManager shadow.
+ */
+internal fun isWithinNetworkMonitorBootstrapGrace(
+  registeredAtNanos: Long,
+  nowNanos: Long,
+): Boolean = nowNanos - registeredAtNanos < NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS
+
+/**
+ * How long one notification suppresses another. Long enough to coalesce several transports
+ * validating together (radios reactivating from doze tend to land within the same instant, not
+ * seconds apart); short enough that a later, genuinely separate restore is not meaningfully
+ * delayed.
+ */
+internal const val NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS = 2_000_000_000L
+
+/**
+ * Whether a notification at [nowNanos] falls inside the debounce window after [lastNotifiedAtNanos]
+ * (`null` meaning no notification has happened yet). Exposed internal so the boundary can be
+ * unit-tested without a Robolectric ConnectivityManager shadow.
+ */
+internal fun isWithinNetworkMonitorNotifyDebounce(
+  lastNotifiedAtNanos: Long?,
+  nowNanos: Long,
+): Boolean = lastNotifiedAtNanos != null && nowNanos - lastNotifiedAtNanos < NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -8,7 +8,7 @@ import android.net.NetworkRequest
 import android.util.Log
 
 /**
- * Listens for Android transport restores and signals [onValidatedNetworkAvailable] when the device
+ * Listens for Android transport restores and signals [onNetworkAvailable] when the device
  * regains a validated internet connection, or when any network newly attaches at all. Used to
  * trigger an immediate gateway reconnect instead of waiting out the time-based backoff slot in
  * [GatewaySession].
@@ -24,15 +24,12 @@ import android.util.Log
  */
 internal class NetworkMonitor(
   context: Context,
-  private val onValidatedNetworkAvailable: () -> Unit,
+  private val onNetworkAvailable: () -> Unit,
 ) {
   private val connectivity = context.getSystemService(ConnectivityManager::class.java)
   private val logTag = "OpenClaw/NetworkMonitor"
 
-  // Tracks the last emitted transport state so capability churn (e.g. signal strength
-  // changes) does not re-fire the reconnect path. Only a lost->validated transition
-  // should signal.
-  private val validatedNetworks = ValidatedNetworkState<Network>()
+  private val restoreState = NetworkRestoreState<Network>()
 
   // registerNetworkCallback() replays every already-matching network's current state right after
   // registration, and that replay is indistinguishable from a later genuine change: there is no
@@ -47,14 +44,6 @@ internal class NetworkMonitor(
   // asks for acceptance of elsewhere in this body.
   private val registeredAtNanos = System.nanoTime()
 
-  // The fan-out a notification triggers reaches every session regardless of which network
-  // changed, so when several transports validate close together (e.g. Wi-Fi and cellular both
-  // reactivating from doze at once) each one's own edge would otherwise fire its own full
-  // fan-out — repeatedly closing a session's just-started reconnect attempt before its handshake
-  // can finish. This debounces to one notification per burst; nothing about which network caused
-  // it is lost, because the fan-out is not per-network to begin with.
-  @Volatile private var lastNotifiedAtNanos: Long? = null
-
   private val callback =
     object : ConnectivityManager.NetworkCallback() {
       override fun onAvailable(network: Network) {
@@ -63,8 +52,9 @@ internal class NetworkMonitor(
         // registration-replay hazard as onCapabilitiesChanged below: registerNetworkCallback()
         // replays onAvailable for every network already connected at registration time, so the
         // same bootstrap grace absorbs it.
-        if (!isWithinNetworkMonitorBootstrapGrace(registeredAtNanos, System.nanoTime())) {
-          notifyValidatedNetworkAvailableDebounced()
+        val newlyAvailable = restoreState.onAvailable(network)
+        if (newlyAvailable && !isWithinNetworkMonitorBootstrapGrace(registeredAtNanos, System.nanoTime())) {
+          notifyNetworkAvailable()
         }
       }
 
@@ -72,14 +62,18 @@ internal class NetworkMonitor(
         network: Network,
         capabilities: NetworkCapabilities,
       ) {
-        val justValidated = validatedNetworks.update(network, isTransportValidated(capabilities))
+        val justValidated =
+          restoreState.onCapabilitiesChanged(
+            network,
+            isTransportValidated(capabilities),
+          )
         if (justValidated && !isWithinNetworkMonitorBootstrapGrace(registeredAtNanos, System.nanoTime())) {
-          notifyValidatedNetworkAvailableDebounced()
+          notifyNetworkAvailable()
         }
       }
 
       override fun onLost(network: Network) {
-        validatedNetworks.update(network, isValidated = false)
+        restoreState.onLost(network)
       }
     }
 
@@ -93,25 +87,15 @@ internal class NetworkMonitor(
   private fun start() {
     val cm = connectivity ?: return
     try {
-      // Equivalent to the default request used by GatewayDiscovery: match any network.
-      cm.registerNetworkCallback(NetworkRequest.Builder().build(), callback)
+      cm.registerNetworkCallback(appUsableNetworkRequest(), callback)
     } catch (err: Throwable) {
       Log.w(logTag, "registerNetworkCallback failed: ${err.message ?: err::class.java.simpleName}")
     }
   }
 
-  private fun notifyValidatedNetworkAvailableDebounced() {
-    val now = System.nanoTime()
-    synchronized(this) {
-      if (isWithinNetworkMonitorNotifyDebounce(lastNotifiedAtNanos, now)) return
-      lastNotifiedAtNanos = now
-    }
-    notifyValidatedNetworkAvailable()
-  }
-
-  private fun notifyValidatedNetworkAvailable() {
+  private fun notifyNetworkAvailable() {
     try {
-      onValidatedNetworkAvailable()
+      onNetworkAvailable()
     } catch (err: Throwable) {
       Log.w(logTag, "network restore callback threw: ${err.message ?: err::class.java.simpleName}")
     }
@@ -123,7 +107,7 @@ internal class NetworkMonitor(
       val active = cm.activeNetwork ?: return
       val caps = cm.getNetworkCapabilities(active) ?: return
       if (isTransportValidated(caps)) {
-        validatedNetworks.update(active, isValidated = true)
+        restoreState.seedValidated(active)
       }
     } catch (_: Throwable) {
       // Callback delivery remains the source of truth when the initial snapshot races.
@@ -131,32 +115,57 @@ internal class NetworkMonitor(
   }
 }
 
-internal class ValidatedNetworkState<T>(
+// Android requests exclude VPNs by default. Both discovery and reconnect monitoring need every
+// app-visible route or a private Gateway can return without either owner observing its VPN.
+internal fun appUsableNetworkRequest(): NetworkRequest =
+  NetworkRequest
+    .Builder()
+    .removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
+    .build()
+
+// onAvailable and its first capability callback describe one availability episode. Coalesce only
+// that pair per network; a different route must always be able to wake the reconnect fleet.
+internal class NetworkRestoreState<T>(
   initialValidatedNetworks: Set<T> = emptySet(),
 ) {
+  private val availableNetworks = initialValidatedNetworks.toMutableSet()
   private val validatedNetworks = initialValidatedNetworks.toMutableSet()
+  private val awaitingInitialCapabilities = mutableSetOf<T>()
 
-  /**
-   * Records [network]'s current validated state and reports whether it just became reachable.
-   *
-   * Signals on this network's own offline->online edge, not on the aggregate "is anything
-   * online" state: a saved Gateway can be reachable over one specific route only, so cellular
-   * staying validated the whole time must not swallow a returning Wi-Fi/LAN network's own
-   * restore. A network already known validated still reports no change, which is what keeps
-   * capability churn (e.g. signal-strength updates) from re-firing.
-   */
   @Synchronized
-  fun update(
+  fun onAvailable(network: T): Boolean {
+    if (!availableNetworks.add(network)) return false
+    awaitingInitialCapabilities.add(network)
+    return true
+  }
+
+  @Synchronized
+  fun onCapabilitiesChanged(
     network: T,
     isValidated: Boolean,
   ): Boolean {
+    availableNetworks.add(network)
+    val followsAvailability = awaitingInitialCapabilities.remove(network)
     val wasValidated = validatedNetworks.contains(network)
     if (isValidated) {
       validatedNetworks.add(network)
     } else {
       validatedNetworks.remove(network)
     }
-    return isValidated && !wasValidated
+    return isValidated && !wasValidated && !followsAvailability
+  }
+
+  @Synchronized
+  fun onLost(network: T) {
+    availableNetworks.remove(network)
+    validatedNetworks.remove(network)
+    awaitingInitialCapabilities.remove(network)
+  }
+
+  @Synchronized
+  fun seedValidated(network: T) {
+    availableNetworks.add(network)
+    validatedNetworks.add(network)
   }
 }
 
@@ -182,21 +191,3 @@ internal fun isWithinNetworkMonitorBootstrapGrace(
   registeredAtNanos: Long,
   nowNanos: Long,
 ): Boolean = nowNanos - registeredAtNanos < NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS
-
-/**
- * How long one notification suppresses another. Long enough to coalesce several transports
- * validating together (radios reactivating from doze tend to land within the same instant, not
- * seconds apart); short enough that a later, genuinely separate restore is not meaningfully
- * delayed.
- */
-internal const val NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS = 2_000_000_000L
-
-/**
- * Whether a notification at [nowNanos] falls inside the debounce window after [lastNotifiedAtNanos]
- * (`null` meaning no notification has happened yet). Exposed internal so the boundary can be
- * unit-tested without a Robolectric ConnectivityManager shadow.
- */
-internal fun isWithinNetworkMonitorNotifyDebounce(
-  lastNotifiedAtNanos: Long?,
-  nowNanos: Long,
-): Boolean = lastNotifiedAtNanos != null && nowNanos - lastNotifiedAtNanos < NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -2,14 +2,16 @@ package ai.openclaw.app.gateway
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.LinkProperties
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.os.Parcel
 import android.util.Log
 
 /**
  * Listens for Android transport restores and signals [onNetworkAvailable] when the device
- * regains a validated internet connection, or when any network newly attaches at all. Used to
+ * regains validation, any network attaches, or an existing network changes link properties. Used to
  * trigger an immediate gateway reconnect instead of waiting out the time-based backoff slot in
  * [GatewaySession].
  *
@@ -54,6 +56,15 @@ internal class NetworkMonitor(
             isTransportValidated(capabilities),
           )
         if (justValidated) {
+          notifyNetworkAvailable()
+        }
+      }
+
+      override fun onLinkPropertiesChanged(
+        network: Network,
+        linkProperties: LinkProperties,
+      ) {
+        if (restoreState.onLinkPropertiesChanged(network, linkProperties)) {
           notifyNetworkAvailable()
         }
       }
@@ -109,19 +120,23 @@ internal fun appUsableNetworkRequest(): NetworkRequest =
     .removeCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)
     .build()
 
-// onAvailable and its first capability callback describe one availability episode. Coalesce only
-// that pair per network; a different route must always be able to wake the reconnect fleet.
+// Initial capability/link snapshots describe one availability episode. Later link changes
+// can restore private routes or DNS without another availability or validation transition.
 internal class NetworkRestoreState<T>(
   initialValidatedNetworks: Set<T> = emptySet(),
 ) {
-  private val availableNetworks = initialValidatedNetworks.toMutableSet()
-  private val validatedNetworks = initialValidatedNetworks.toMutableSet()
-  private val awaitingInitialCapabilities = mutableSetOf<T>()
+  private class State(
+    var validated: Boolean = false,
+    var awaitingInitialCapabilities: Boolean = false,
+    var linkProperties: LinkProperties? = null,
+  )
+
+  private val networks = initialValidatedNetworks.associateWith { State(validated = true) }.toMutableMap()
 
   @Synchronized
   fun onAvailable(network: T): Boolean {
-    if (!availableNetworks.add(network)) return false
-    awaitingInitialCapabilities.add(network)
+    if (networks.containsKey(network)) return false
+    networks[network] = State(awaitingInitialCapabilities = true)
     return true
   }
 
@@ -130,28 +145,43 @@ internal class NetworkRestoreState<T>(
     network: T,
     isValidated: Boolean,
   ): Boolean {
-    availableNetworks.add(network)
-    val followsAvailability = awaitingInitialCapabilities.remove(network)
-    val wasValidated = validatedNetworks.contains(network)
-    if (isValidated) {
-      validatedNetworks.add(network)
-    } else {
-      validatedNetworks.remove(network)
-    }
-    return isValidated && !wasValidated && !followsAvailability
+    val state = networks.getOrPut(network) { State() }
+    val restored = isValidated && !state.validated && !state.awaitingInitialCapabilities
+    state.validated = isValidated
+    state.awaitingInitialCapabilities = false
+    return restored
+  }
+
+  @Synchronized
+  fun onLinkPropertiesChanged(
+    network: T,
+    properties: LinkProperties,
+  ): Boolean {
+    val state = networks[network] ?: return false
+    // LinkProperties is mutable and has no public copy constructor in the SDK. Keep an owned
+    // Parcelable snapshot so later callback mutations cannot erase a route/DNS change.
+    val parcel = Parcel.obtain()
+    val snapshot =
+      try {
+        properties.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+        LinkProperties.CREATOR.createFromParcel(parcel)
+      } finally {
+        parcel.recycle()
+      }
+    val previous = state.linkProperties
+    state.linkProperties = snapshot
+    return previous != null && previous != snapshot
   }
 
   @Synchronized
   fun onLost(network: T) {
-    availableNetworks.remove(network)
-    validatedNetworks.remove(network)
-    awaitingInitialCapabilities.remove(network)
+    networks.remove(network)
   }
 
   @Synchronized
   fun seedValidated(network: T) {
-    availableNetworks.add(network)
-    validatedNetworks.add(network)
+    networks.getOrPut(network) { State() }.validated = true
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayFleetSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayFleetSelectionTest.kt
@@ -8,6 +8,7 @@ import ai.openclaw.app.ui.desktopUrl
 import ai.openclaw.app.ui.sessionDashboardUrl
 import ai.openclaw.app.ui.terminalUrl
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,6 +38,70 @@ class GatewayFleetSelectionTest {
         foreground = false,
       ),
     )
+  }
+
+  @Test
+  fun networkRestoreWakesTheOperatorNodeAndEverySecondaryGateway() {
+    // The regression this pins: the fan-out used to name only the operator and node pair, so a
+    // secondary gateway kept waiting out its retry timer after the network came back. That cost
+    // at most ~8s before this policy allowed minutes.
+    val operator = session()
+    val node = session()
+    val first = session()
+    val second = session()
+    val third = session()
+
+    val woken =
+      gatewaySessionsToWakeOnNetworkRestore(
+        operator = operator,
+        node = node,
+        secondary = mapOf("a" to first, "b" to second, "c" to third),
+      )
+
+    assertEquals(5, woken.size)
+    assertSame(operator, woken[0])
+    assertSame(node, woken[1])
+    for (secondary in listOf(first, second, third)) {
+      assertTrue("secondary gateway was left out of the wake", woken.any { it === secondary })
+    }
+  }
+
+  @Test
+  fun networkRestoreWakesASingleSecondaryGateway() {
+    val operator = session()
+    val node = session()
+    val only = session()
+
+    val woken =
+      gatewaySessionsToWakeOnNetworkRestore(operator = operator, node = node, secondary = mapOf("only" to only))
+
+    assertEquals(3, woken.size)
+    assertTrue("the one secondary gateway was left out of the wake", woken.any { it === only })
+  }
+
+  @Test
+  fun networkRestoreStillWakesThePrimaryPairWithNoSecondaries() {
+    val operator = session()
+    val node = session()
+
+    val woken = gatewaySessionsToWakeOnNetworkRestore(operator = operator, node = node, secondary = emptyMap())
+
+    assertEquals(listOf(operator, node), woken)
+  }
+
+  @Test
+  fun networkRestoreSnapshotsTheFleetSoALaterEditCannotShrinkIt() {
+    // The fleet is a live ConcurrentHashMap in NodeRuntime; the wake must act on what it captured.
+    val operator = session()
+    val node = session()
+    val leaving = session()
+    val fleet = linkedMapOf("leaving" to leaving)
+
+    val woken = gatewaySessionsToWakeOnNetworkRestore(operator = operator, node = node, secondary = fleet)
+    fleet.clear()
+
+    assertEquals(3, woken.size)
+    assertTrue("the wake list changed when the fleet was edited afterwards", woken.any { it === leaving })
   }
 
   @Test
@@ -114,6 +179,9 @@ class GatewayFleetSelectionTest {
       name = stableId,
     )
 }
+
+/** Stands in for a GatewaySession: the wake decision only cares about session identity. */
+private fun session(): Any = Any()
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -2071,6 +2071,50 @@ class GatewaySessionReconnectTest {
 
   private fun legacyReconnectDelayMs(attempt: Int): Long = minOf(8_000L, (350.0 * Math.pow(1.7, attempt.toDouble())).toLong())
 
+  @Test
+  fun aWakeTheChannelNeverDeliveredStillCountsAsAWake() {
+    // The wait is cancelled by its own timeout at the moment a wake is signalled, so the receive
+    // takes the element and hands it to nobody. Delivery alone would call that a plain timeout and
+    // keep the long ladder; the count is what stops the wake being lost.
+    assertTrue(reconnectWakeObserved(delivered = false, wakesBefore = 4L, wakesAfter = 5L))
+    assertTrue(reconnectWakeObserved(delivered = true, wakesBefore = 4L, wakesAfter = 5L))
+    // A wake already queued when the wait began is delivered immediately without moving the count.
+    assertTrue(reconnectWakeObserved(delivered = true, wakesBefore = 4L, wakesAfter = 4L))
+    // Nothing was signalled, so the wait really did time out.
+    assertEquals(false, reconnectWakeObserved(delivered = false, wakesBefore = 4L, wakesAfter = 4L))
+  }
+
+  @Test
+  fun everyWakeProducerAdvancesTheWakeCount() =
+    runBlocking {
+      // The count only closes the delivery hole if each producer moves it, so pin them together
+      // rather than trusting the one call site the boundary test happens to exercise.
+      val harness = createReconnectHarness()
+      val deadPort =
+        MockWebServer().run {
+          start()
+          val assigned = port
+          shutdown()
+          assigned
+        }
+      try {
+        connectNodeSession(harness.session, deadPort)
+        val start: Long = readField(harness.session, "reconnectWakeCount")
+        harness.session.retryAfterNetworkRestore()
+        val afterRestore: Long = readField(harness.session, "reconnectWakeCount")
+        assertTrue("network restore did not advance the wake count", afterRestore > start)
+        harness.session.reconnect()
+        val afterManual: Long = readField(harness.session, "reconnectWakeCount")
+        assertTrue("manual reconnect did not advance the wake count", afterManual > afterRestore)
+        connectNodeSession(harness.session, deadPort)
+        val afterEndpoint: Long = readField(harness.session, "reconnectWakeCount")
+        assertTrue("replacing the desired endpoint did not advance the wake count", afterEndpoint > afterManual)
+      } finally {
+        harness.session.disconnect()
+        harness.sessionJob.cancelAndJoin()
+      }
+    }
+
   // --- reconnect wake semantics -------------------------------------------------------------
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -2024,10 +2024,12 @@ class GatewaySessionReconnectTest {
   }
 
   @Test
-  fun steadyReconnectDelayStaysInsideItsJitterBand() {
-    assertEquals(GATEWAY_RECONNECT_MAX_DELAY_MS / 2, gatewayReconnectDelayMs(20, jitter = 0.0))
-    assertEquals(GATEWAY_RECONNECT_MAX_DELAY_MS, gatewayReconnectDelayMs(20, jitter = 1.0))
-    assertEquals(225_000L, gatewayReconnectDelayMs(20, jitter = 0.5))
+  fun steadyReconnectDelayKeepsEndpointOnlyRecoveryWithinOneMinute() {
+    // Android emits no network callback when only the Gateway process restarts. Pin the absolute
+    // user wait, not just a value derived from the production ceiling, so it cannot drift upward.
+    assertEquals(30_000L, gatewayReconnectDelayMs(20, jitter = 0.0))
+    assertEquals(60_000L, gatewayReconnectDelayMs(20, jitter = 1.0))
+    assertEquals(45_000L, gatewayReconnectDelayMs(20, jitter = 0.5))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -1112,8 +1112,9 @@ class GatewaySessionReconnectTest {
         assertNull(firstAuth["deviceToken"])
         assertNull(firstAuth["password"])
 
+        harness.session.retryAfterNetworkRestore()
         assertNull(
-          "Terminal authentication failure must suppress automatic reconnects",
+          "Terminal authentication failure must suppress automatic and network-restore reconnects",
           withTimeoutOrNull(LIFECYCLE_TEST_TIMEOUT_MS) { secondAttempt.await() },
         )
         assertTrue(readField<Boolean>(desiredConnection, "reconnectPausedForAuthFailure"))
@@ -2024,9 +2025,9 @@ class GatewaySessionReconnectTest {
   }
 
   @Test
-  fun steadyReconnectDelayKeepsEndpointOnlyRecoveryWithinOneMinute() {
-    // Android emits no network callback when only the Gateway process restarts. Pin the absolute
-    // user wait, not just a value derived from the production ceiling, so it cannot drift upward.
+  fun steadyReconnectTimerIsThirtyToSixtySecondsBeforeConnectionTime() {
+    // Endpoint-only restarts do not emit network callbacks. Bound the retry timer; completing
+    // the next TCP/TLS and gateway handshake takes additional time.
     assertEquals(30_000L, gatewayReconnectDelayMs(20, jitter = 0.0))
     assertEquals(60_000L, gatewayReconnectDelayMs(20, jitter = 1.0))
     assertEquals(45_000L, gatewayReconnectDelayMs(20, jitter = 0.5))
@@ -2120,16 +2121,20 @@ class GatewaySessionReconnectTest {
   @Test
   fun networkRestoreDoesNotDisconnectAnAlreadyReadyConnection() =
     runBlocking {
-      // Regression for the P2 finding on #127873: the network-restore fan-out reaches every
-      // session, including one that is already connected over a different route (e.g. cellular
-      // kept a secondary alive while its own Wi-Fi was down) — forcing that connection closed
-      // would interrupt real in-flight work for no benefit.
+      // A restore can concern another route. Even an application-level error proves that this
+      // socket is live; preserve its unrelated in-flight work and do not enqueue a reconnect.
       val json = Json { ignoreUnknownKeys = true }
       val connected = CompletableDeferred<Unit>()
+      val checkReceived = CompletableDeferred<Pair<WebSocket, String>>()
+      val slowRequest = CompletableDeferred<Pair<WebSocket, String>>()
       val disconnectedReasons = ConcurrentLinkedQueue<String>()
       val server =
         startGatewayServer(json = json) { webSocket, id, method ->
-          if (method == "connect") webSocket.send(connectResponseFrame(id))
+          when (method) {
+            "connect" -> webSocket.send(connectResponseFrame(id))
+            "health" -> checkReceived.complete(webSocket to id)
+            "slow.method" -> slowRequest.complete(webSocket to id)
+          }
         }
       val harness =
         createReconnectHarness(
@@ -2145,15 +2150,219 @@ class GatewaySessionReconnectTest {
         disconnectedReasons.clear()
         val wakesBefore: Long = readField(harness.session, "reconnectWakeCount")
 
+        val lease = requireNotNull(harness.session.captureRequestLease())
+        val pending = async { lease.request("slow.method", null) }
+        val (slowSocket, slowId) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { slowRequest.await() }
         harness.session.retryAfterNetworkRestore()
-        delay(SETTLE_INTO_BACKOFF_MS)
-
+        val (checkSocket, checkId) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { checkReceived.await() }
+        repeat(5) { harness.session.retryAfterNetworkRestore() }
+        checkSocket.send("""{"type":"res","id":"$checkId","ok":false,"error":{"code":"UNAVAILABLE","message":"health summary unavailable"}}""")
+        // Observe beyond the check deadline: a delayed timeout must not kill this live socket.
+        delay(8_500)
+        slowSocket.send("""{"type":"res","id":"$slowId","ok":true,"payload":{}}""")
+        assertEquals("{}", withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { pending.await() })
+        assertTrue(lease.isCurrent())
+        assertEquals(1, server.requestFrames.count { it["method"]?.jsonPrimitive?.content == "health" })
         assertEquals("a ready connection must not be reopened", 1, server.requestCount)
         assertEquals(emptyList<String>(), disconnectedReasons.toList())
         val wakesAfter: Long = readField(harness.session, "reconnectWakeCount")
         assertEquals("an already-ready session must not be woken", wakesBefore, wakesAfter)
       } finally {
         shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun networkRestoreKeepsResponsiveSocketWhileHealthSummaryIsSlow() =
+    runBlocking {
+      val connected = CompletableDeferred<Unit>()
+      val healthRequest = CompletableDeferred<Pair<WebSocket, String>>()
+      val eventReceived = CompletableDeferred<Unit>()
+      val server =
+        startGatewayServer(json = Json) { socket, id, method ->
+          when (method) {
+            "connect" -> socket.send(connectResponseFrame(id))
+            "health" -> healthRequest.complete(socket to id)
+            else -> socket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+          }
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = { connected.complete(Unit) },
+          onEvent = { event, _ -> if (event == "tick") eventReceived.complete(Unit) },
+        )
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+        val lease = requireNotNull(harness.session.captureRequestLease())
+        harness.session.retryAfterNetworkRestore()
+        val (socket, id) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { healthRequest.await() }
+        socket.send("""{"type":"event","event":"tick","payload":{}}""")
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { eventReceived.await() }
+        // Prove both directions while the unrelated health computation remains pending.
+        assertEquals("{}", lease.request("test.echo", null))
+        delay(8_500)
+        assertTrue("Health latency is not transport failure when this socket still receives frames", lease.isCurrent())
+        // A response arriving after the check's waiter expired must remain harmless.
+        socket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+        assertEquals("{}", lease.request("test.echo", null))
+        assertEquals(1, server.requestCount)
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun networkRestoreReplacesSilentlyBlackholedReadyConnection() = assertNetworkRestoreReplacesBrokenFlow(keepInbound = false)
+
+  @Test
+  fun networkRestoreReplacesBrokenOutboundPathDespiteIncomingEvents() = assertNetworkRestoreReplacesBrokenFlow(keepInbound = true)
+
+  private fun assertNetworkRestoreReplacesBrokenFlow(keepInbound: Boolean) =
+    runBlocking {
+      val connections = Channel<Unit>(Channel.UNLIMITED)
+      val freshConnected = CompletableDeferred<Unit>()
+      val eventReceived = CompletableDeferred<Unit>()
+      val oldRequest = CompletableDeferred<Pair<WebSocket, String>>()
+      var heartbeat: Job? = null
+      val server =
+        startGatewayServer(json = Json) { socket, id, method ->
+          when (method) {
+            "connect" -> socket.send(connectResponseFrame(id))
+            "hold.before.restore" -> oldRequest.complete(socket to id)
+            else -> socket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+          }
+        }
+      val proxy = SilentFlowProxy(server.port)
+      val harness =
+        createReconnectHarness(
+          onConnected = { connections.trySend(Unit) },
+          onEvent = { event, _ -> if (event == "tick") eventReceived.complete(Unit) },
+        )
+      val fresh = createReconnectHarness(onConnected = { freshConnected.complete(Unit) })
+      try {
+        connectNodeSession(harness.session, proxy.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connections.receive() }
+        val originalLease = requireNotNull(harness.session.captureRequestLease())
+        assertEquals("{}", originalLease.request("health", null))
+        val delayedReply = if (keepInbound) async { originalLease.request("hold.before.restore", null, timeoutMs = 20_000) } else null
+        val oldWireRequest = if (keepInbound) withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { oldRequest.await() } else null
+        proxy.blackholeExistingFlows(keepInbound)
+
+        // Network validation can return while only the old flow is broken. Prove that a new
+        // connection through the same listener can handshake and exchange real frames.
+        connectNodeSession(fresh.session, proxy.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { freshConnected.await() }
+        assertEquals("{}", fresh.session.request("health", null))
+        assertTrue("No EOF or socket error should have retired the stale flow", originalLease.isCurrent())
+        val started = System.nanoTime()
+        val stranded =
+          async(start = CoroutineStart.UNDISPATCHED) {
+            runCatching { originalLease.request("health", null) }
+          }
+        harness.session.retryAfterNetworkRestore()
+        if (keepInbound) {
+          val staleSocket = server.sockets.first()
+          heartbeat =
+            launch {
+              repeat(24) {
+                staleSocket.send("""{"type":"event","event":"tick","payload":{}}""")
+                delay(500)
+              }
+            }
+          withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { eventReceived.await() }
+          // A late reply to a pre-restore request also cannot prove that new outbound work arrives.
+          val (oldSocket, oldId) = requireNotNull(oldWireRequest)
+          oldSocket.send("""{"type":"res","id":"$oldId","ok":true,"payload":{}}""")
+          assertEquals("{}", withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { requireNotNull(delayedReply).await() })
+        }
+        val outcome = withTimeout(17_000) { stranded.await() }
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+        println("silent-flow request: elapsedMs=$elapsedMs error=${outcome.exceptionOrNull()?.message} ready=${originalLease.isCurrent()}")
+        assertTrue(outcome.exceptionOrNull() is GatewayRequestOutcomeUnknown)
+        assertTrue("Restore must retire the stale flow before the normal 15s RPC deadline (observed ${elapsedMs}ms)", elapsedMs < 12_000)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connections.receive() }
+        assertFalse(originalLease.isCurrent())
+        assertEquals("{}", harness.session.request("health", null))
+      } finally {
+        heartbeat?.cancelAndJoin()
+        shutdownReconnectHarness(fresh)
+        shutdownReconnectHarness(harness)
+        proxy.close()
+        server.shutdown()
+      }
+    }
+
+  @Test
+  fun networkRestoreCheckCannotRetireReplacementOrUndoDisconnect() =
+    runBlocking {
+      for (replace in listOf(false, true)) {
+        val connected = Channel<Unit>(Channel.UNLIMITED)
+        val checkReceived = CompletableDeferred<Unit>()
+        val oldEventStarted = CountDownLatch(1)
+        val releaseOldEvent = CountDownLatch(1)
+        val first =
+          startGatewayServer(json = Json) { socket, id, method ->
+            if (method == "connect") socket.send(connectResponseFrame(id))
+            if (method == "health") {
+              if (replace) socket.send("""{"type":"event","event":"hold-old-check","payload":{}}""")
+              checkReceived.complete(Unit)
+            }
+          }
+        val replacement =
+          startGatewayServer(json = Json) { socket, id, method ->
+            socket.send(
+              if (method == "connect") {
+                connectResponseFrame(id)
+              } else {
+                """{"type":"res","id":"$id","ok":true,"payload":{}}"""
+              },
+            )
+          }
+        val harness =
+          createReconnectHarness(
+            onConnected = { connected.trySend(Unit) },
+            onEvent = { event, _ ->
+              if (event == "hold-old-check") {
+                oldEventStarted.countDown()
+                check(releaseOldEvent.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+              }
+            },
+          )
+        try {
+          connectNodeSession(harness.session, first.port)
+          withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.receive() }
+          val lease = requireNotNull(harness.session.captureRequestLease())
+          harness.session.retryAfterNetworkRestore()
+          withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { checkReceived.await() }
+          if (replace) {
+            // Keep the old message pump (and pending-check failure) alive until a fresh loop
+            // has published its replacement. A late failure must not close that new socket.
+            assertTrue(oldEventStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+            harness.session.disconnect()
+            val oldCleanup = readField<Job>(harness.session, "disconnectTail")
+            connectNodeSession(harness.session, replacement.port)
+            withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.receive() }
+            releaseOldEvent.countDown()
+            withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { oldCleanup.join() }
+          } else {
+            harness.session.disconnectAndJoin()
+            harness.session.retryAfterNetworkRestore()
+          }
+          // A cancelled/late probe must not act on the next desired intent, even past its deadline.
+          delay(8_500)
+          assertFalse(lease.isCurrent())
+          assertEquals(1, first.requestCount)
+          assertEquals(if (replace) 1 else 0, replacement.requestCount)
+          if (replace) {
+            assertEquals("{}", harness.session.request("health", null))
+          } else {
+            assertFalse(harness.session.isReady())
+          }
+        } finally {
+          releaseOldEvent.countDown()
+          shutdownReconnectHarness(harness, first, replacement)
+        }
       }
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -52,6 +53,14 @@ import java.util.concurrent.atomic.AtomicReference
 private const val LIFECYCLE_TEST_TIMEOUT_MS = 8_000L
 private const val LIFECYCLE_CONNECT_CHALLENGE_FRAME =
   """{"type":"event","event":"connect.challenge","payload":{"nonce":"android-test-nonce","ts":1700000000123}}"""
+
+// After this many retry starts the pending wait is ~5s, so an un-interrupted wait is unmistakable,
+// and a ladder that failed to reset would wait ~8s next instead of ~1s.
+private const val BACKOFF_PROBE_RETRIES = 4
+private const val SETTLE_INTO_BACKOFF_MS = 250L
+private const val BACKOFF_TEST_TIMEOUT_MS = 30_000L
+private const val WAKE_LATENCY_BUDGET_MS = 1_500L
+private const val FAST_BAND_BUDGET_MS = 3_000L
 
 private class ReconnectDeviceAuthStore(
   private val entry: DeviceAuthEntry? = null,
@@ -1962,6 +1971,213 @@ class GatewaySessionReconnectTest {
       sockets = sockets,
       requestFrames = requestFrames,
     )
+  }
+
+  // --- reconnect backoff policy -------------------------------------------------------------
+  //
+  // The delay policy is a pure function so these can pin every band without waiting minutes of
+  // wall clock. `legacyReconnectDelayMs` reproduces the delay this loop shipped before the
+  // battery fix and is used as a control: the new policy must never retry sooner than it did.
+
+  @Test
+  fun transientReconnectDelaysAreUnchanged() {
+    // A brief blip must still recover as fast as it always did, whatever jitter is drawn.
+    for (attempt in 1..5) {
+      for (jitter in listOf(0.0, 0.25, 0.5, 0.75, 1.0)) {
+        assertEquals(
+          "attempt $attempt jitter $jitter",
+          legacyReconnectDelayMs(attempt),
+          gatewayReconnectDelayMs(attempt, jitter),
+        )
+      }
+    }
+  }
+
+  @Test
+  fun reconnectDelayKeepsGrowingPastTheOldSteadyCadence() {
+    // The defect was that growth stopped here and the loop probed at this cadence forever.
+    for (jitter in listOf(0.0, 0.5, 1.0)) {
+      var previous = 0L
+      for (attempt in 1..24) {
+        val delay = gatewayReconnectDelayMs(attempt, jitter)
+        assertTrue("attempt $attempt jitter $jitter went backwards", delay >= previous)
+        previous = delay
+      }
+      assertTrue(
+        "jitter $jitter never left the old cadence",
+        gatewayReconnectDelayMs(12, jitter) > GATEWAY_RECONNECT_MIN_STEADY_DELAY_MS,
+      )
+    }
+  }
+
+  @Test
+  fun sustainedFailureLeavesSecondsScaleCadence() {
+    // The user-visible defect: an unreachable gateway kept being probed every few seconds all day.
+    for (attempt in 13..64) {
+      for (jitter in listOf(0.0, 0.5, 1.0)) {
+        assertTrue(
+          "attempt $attempt jitter $jitter still probes every ${gatewayReconnectDelayMs(attempt, jitter)}ms",
+          gatewayReconnectDelayMs(attempt, jitter) >= GATEWAY_RECONNECT_MAX_DELAY_MS / 2,
+        )
+      }
+    }
+  }
+
+  @Test
+  fun steadyReconnectDelayStaysInsideItsJitterBand() {
+    assertEquals(GATEWAY_RECONNECT_MAX_DELAY_MS / 2, gatewayReconnectDelayMs(20, jitter = 0.0))
+    assertEquals(GATEWAY_RECONNECT_MAX_DELAY_MS, gatewayReconnectDelayMs(20, jitter = 1.0))
+    assertEquals(225_000L, gatewayReconnectDelayMs(20, jitter = 0.5))
+  }
+
+  @Test
+  fun reconnectDelayIsNeverShorterThanBeforeThisChange() {
+    // The whole point is less radio work, so no attempt number may retry sooner than it used to.
+    for (attempt in 1..256) {
+      for (jitter in listOf(0.0, 0.33, 1.0)) {
+        assertTrue(
+          "attempt $attempt jitter $jitter retries sooner than the old policy",
+          gatewayReconnectDelayMs(attempt, jitter) >= legacyReconnectDelayMs(attempt),
+        )
+      }
+    }
+  }
+
+  @Test
+  fun reconnectDelayStaysBoundedSoAnEndpointOnlyRestartIsStillFound() {
+    // Android never reports a network change when only the gateway process restarts, so probing
+    // must never stop or drift unbounded; it just has to get cheap.
+    for (attempt in 1..1024) {
+      val delay = gatewayReconnectDelayMs(attempt, jitter = 1.0)
+      assertTrue("attempt $attempt stopped probing", delay > 0)
+      assertTrue("attempt $attempt exceeded the ceiling", delay <= GATEWAY_RECONNECT_MAX_DELAY_MS)
+    }
+  }
+
+  @Test
+  fun reconnectDelayClampsOutOfRangeInputs() {
+    val first = gatewayReconnectDelayMs(1, jitter = 0.0)
+    assertEquals(first, gatewayReconnectDelayMs(0, jitter = 0.0))
+    assertEquals(first, gatewayReconnectDelayMs(-7, jitter = 0.0))
+    assertEquals(
+      gatewayReconnectDelayMs(20, jitter = 0.0),
+      gatewayReconnectDelayMs(20, jitter = -1.0),
+    )
+    assertEquals(
+      gatewayReconnectDelayMs(20, jitter = 1.0),
+      gatewayReconnectDelayMs(20, jitter = 4.0),
+    )
+  }
+
+  private fun legacyReconnectDelayMs(attempt: Int): Long = minOf(8_000L, (350.0 * Math.pow(1.7, attempt.toDouble())).toLong())
+
+  // --- reconnect wake semantics -------------------------------------------------------------
+
+  @Test
+  fun networkRestoreDuringBackoffRetriesNowAndResumesTheFastBand() = runBlocking { assertWakeInterruptsBackoff { it.retryAfterNetworkRestore() } }
+
+  @Test
+  fun manualReconnectDuringBackoffRetriesNowAndResumesTheFastBand() = runBlocking { assertWakeInterruptsBackoff { it.reconnect() } }
+
+  @Test
+  fun clearingAnAuthPauseAfterALongOutageResumesTheFastBand() =
+    runBlocking {
+      // An auth pause can be entered after the ladder has already climbed. Clearing the pause is a
+      // deliberate user action, so the retry that follows must not inherit the long steady wait.
+      val json = Json { ignoreUnknownKeys = true }
+      val pauseNext = AtomicBoolean(false)
+      val retryStarts = Channel<Long>(Channel.UNLIMITED)
+      val paused = CompletableDeferred<Unit>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") {
+            val details =
+              if (pauseNext.get()) {
+                """{"code":"AUTH_TOKEN_MISSING"}"""
+              } else {
+                """{"code":"AUTH_TOKEN_INVALID","recommendedNextStep":"wait_then_retry"}"""
+              }
+            webSocket.send("""{"type":"res","id":"$id","ok":false,"error":{"code":"UNAUTHORIZED","message":"denied","details":$details}}""")
+          }
+        }
+      val harness =
+        createReconnectHarness(
+          onDisconnected = { status -> if (status == "Reconnecting…") retryStarts.trySend(System.nanoTime()) },
+          onConnectFailure = { _, pauseReconnect -> if (pauseReconnect) paused.complete(Unit) },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        // Climb the ladder on failures that explicitly do not pause reconnect.
+        withTimeout(BACKOFF_TEST_TIMEOUT_MS) { repeat(BACKOFF_PROBE_RETRIES) { retryStarts.receive() } }
+        pauseNext.set(true)
+        withTimeout(BACKOFF_TEST_TIMEOUT_MS) { paused.await() }
+
+        // Clear the pause the way the user would, and let the next attempt fail normally again.
+        pauseNext.set(false)
+        harness.session.reconnect()
+        val resumedAt = withTimeout(BACKOFF_TEST_TIMEOUT_MS) { retryStarts.receive() }
+        val nextAt = withTimeout(BACKOFF_TEST_TIMEOUT_MS) { retryStarts.receive() }
+        val gapMs = (nextAt - resumedAt) / 1_000_000
+        assertTrue(
+          "next retry waited ${gapMs}ms; clearing the auth pause did not reset the ladder",
+          gapMs < FAST_BAND_BUDGET_MS,
+        )
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  /**
+   * Drives real connect failures until the loop is deep enough in backoff for the wait to be
+   * unmistakable, then wakes it and checks both halves of the contract: the wait ends immediately,
+   * and the attempt that follows a failed wake is back in the fast band instead of the steady one.
+   *
+   * Retry starts are counted through the status callback, which reports "Reconnecting…" exactly
+   * once per retry iteration; the gap between two of them is the reconnect cadence itself.
+   */
+  private suspend fun assertWakeInterruptsBackoff(wake: (GatewaySession) -> Unit) {
+    val retryStarts = Channel<Long>(Channel.UNLIMITED)
+    val harness =
+      createReconnectHarness(
+        onDisconnected = { status -> if (status == "Reconnecting…") retryStarts.trySend(System.nanoTime()) },
+      )
+    // A port with nothing listening: every connect fails immediately, so backoff sets the pace.
+    val deadPort =
+      MockWebServer().run {
+        start()
+        val assigned = port
+        shutdown()
+        assigned
+      }
+
+    try {
+      connectNodeSession(harness.session, deadPort)
+      withTimeout(BACKOFF_TEST_TIMEOUT_MS) { repeat(BACKOFF_PROBE_RETRIES) { retryStarts.receive() } }
+
+      // That retry fails too, so the loop is now waiting out a multi-second backoff.
+      delay(SETTLE_INTO_BACKOFF_MS)
+      val wokeAt = System.nanoTime()
+      wake(harness.session)
+      val retriedAt = withTimeout(BACKOFF_TEST_TIMEOUT_MS) { retryStarts.receive() }
+      val wakeLatencyMs = (retriedAt - wokeAt) / 1_000_000
+      assertTrue(
+        "wake took ${wakeLatencyMs}ms; the pending backoff was not interrupted",
+        wakeLatencyMs < WAKE_LATENCY_BUDGET_MS,
+      )
+
+      // The woken attempt fails as well. The ladder must have restarted, so the next retry comes
+      // back in the fast band instead of at the steady cadence the loop had already climbed to.
+      val followUpAt = withTimeout(BACKOFF_TEST_TIMEOUT_MS) { retryStarts.receive() }
+      val followUpMs = (followUpAt - retriedAt) / 1_000_000
+      assertTrue(
+        "next retry waited ${followUpMs}ms; the ladder did not reset after the wake",
+        followUpMs < FAST_BAND_BUDGET_MS,
+      )
+    } finally {
+      harness.session.disconnect()
+      harness.sessionJob.cancelAndJoin()
+    }
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -2115,6 +2115,46 @@ class GatewaySessionReconnectTest {
       }
     }
 
+  @Test
+  fun networkRestoreDoesNotDisconnectAnAlreadyReadyConnection() =
+    runBlocking {
+      // Regression for the P2 finding on #127873: the network-restore fan-out reaches every
+      // session, including one that is already connected over a different route (e.g. cellular
+      // kept a secondary alive while its own Wi-Fi was down) — forcing that connection closed
+      // would interrupt real in-flight work for no benefit.
+      val json = Json { ignoreUnknownKeys = true }
+      val connected = CompletableDeferred<Unit>()
+      val disconnectedReasons = ConcurrentLinkedQueue<String>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = { connected.complete(Unit) },
+          onDisconnected = { disconnectedReasons += it },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+        // The initial "Connecting…" announcement from before this connection was ready is
+        // expected noise; only reasons emitted after readiness are this test's concern.
+        disconnectedReasons.clear()
+        val wakesBefore: Long = readField(harness.session, "reconnectWakeCount")
+
+        harness.session.retryAfterNetworkRestore()
+        delay(SETTLE_INTO_BACKOFF_MS)
+
+        assertEquals("a ready connection must not be reopened", 1, server.requestCount)
+        assertEquals(emptyList<String>(), disconnectedReasons.toList())
+        val wakesAfter: Long = readField(harness.session, "reconnectWakeCount")
+        assertEquals("an already-ready session must not be woken", wakesBefore, wakesAfter)
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
   // --- reconnect wake semantics -------------------------------------------------------------
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -2131,8 +2131,8 @@ class GatewaySessionReconnectTest {
       val server =
         startGatewayServer(json = json) { webSocket, id, method ->
           when (method) {
-            "connect" -> webSocket.send(connectResponseFrame(id))
-            "health" -> checkReceived.complete(webSocket to id)
+            "connect" -> webSocket.send(connectResponseFrame(id, methods = setOf("gateway.ping")))
+            "gateway.ping" -> checkReceived.complete(webSocket to id)
             "slow.method" -> slowRequest.complete(webSocket to id)
           }
         }
@@ -2156,13 +2156,13 @@ class GatewaySessionReconnectTest {
         harness.session.retryAfterNetworkRestore()
         val (checkSocket, checkId) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { checkReceived.await() }
         repeat(5) { harness.session.retryAfterNetworkRestore() }
-        checkSocket.send("""{"type":"res","id":"$checkId","ok":false,"error":{"code":"UNAVAILABLE","message":"health summary unavailable"}}""")
+        checkSocket.send("""{"type":"res","id":"$checkId","ok":false,"error":{"code":"UNAVAILABLE","message":"gateway unavailable"}}""")
         // Observe beyond the check deadline: a delayed timeout must not kill this live socket.
         delay(8_500)
         slowSocket.send("""{"type":"res","id":"$slowId","ok":true,"payload":{}}""")
         assertEquals("{}", withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { pending.await() })
         assertTrue(lease.isCurrent())
-        assertEquals(1, server.requestFrames.count { it["method"]?.jsonPrimitive?.content == "health" })
+        assertEquals(1, server.requestFrames.count { it["method"]?.jsonPrimitive?.content == "gateway.ping" })
         assertEquals("a ready connection must not be reopened", 1, server.requestCount)
         assertEquals(emptyList<String>(), disconnectedReasons.toList())
         val wakesAfter: Long = readField(harness.session, "reconnectWakeCount")
@@ -2177,38 +2177,80 @@ class GatewaySessionReconnectTest {
     runBlocking {
       val connected = CompletableDeferred<Unit>()
       val healthRequest = CompletableDeferred<Pair<WebSocket, String>>()
-      val eventReceived = CompletableDeferred<Unit>()
       val server =
         startGatewayServer(json = Json) { socket, id, method ->
           when (method) {
-            "connect" -> socket.send(connectResponseFrame(id))
+            "connect" -> socket.send(connectResponseFrame(id, methods = setOf("gateway.ping")))
             "health" -> healthRequest.complete(socket to id)
-            else -> socket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+            "gateway.ping" -> socket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
           }
         }
       val harness =
         createReconnectHarness(
           onConnected = { connected.complete(Unit) },
-          onEvent = { event, _ -> if (event == "tick") eventReceived.complete(Unit) },
         )
       try {
         connectNodeSession(harness.session, server.port)
         withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
         val lease = requireNotNull(harness.session.captureRequestLease())
-        harness.session.retryAfterNetworkRestore()
+        val health = async { runCatching { lease.request("health", null, timeoutMs = 15_000) } }
         val (socket, id) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { healthRequest.await() }
-        socket.send("""{"type":"event","event":"tick","payload":{}}""")
-        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { eventReceived.await() }
-        // Prove both directions while the unrelated health computation remains pending.
-        assertEquals("{}", lease.request("test.echo", null))
+        harness.session.retryAfterNetworkRestore()
+        // Only the dedicated ACK may prove liveness. No unrelated fast RPC rescues health.
         delay(8_500)
-        assertTrue("Health latency is not transport failure when this socket still receives frames", lease.isCurrent())
-        // A response arriving after the check's waiter expired must remain harmless.
+        assertTrue("Slow health collection must not retire a responsive socket", lease.isCurrent())
+        assertEquals(1, server.requestFrames.count { it["method"]?.jsonPrimitive?.content == "gateway.ping" })
+        assertEquals(1, server.requestFrames.count { it["method"]?.jsonPrimitive?.content == "health" })
         socket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
-        assertEquals("{}", lease.request("test.echo", null))
+        assertEquals("{}", health.await().getOrThrow())
         assertEquals(1, server.requestCount)
       } finally {
         shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun networkRestoreRetiresSocketWhenAckCannotEnqueue() =
+    runBlocking {
+      val connections = Channel<Unit>(Channel.UNLIMITED)
+      val server =
+        startGatewayServer(json = Json) { socket, id, method ->
+          socket.send(
+            if (method == "connect") {
+              connectResponseFrame(id, methods = setOf("gateway.ping"))
+            } else {
+              """{"type":"res","id":"$id","ok":true,"payload":{}}"""
+            },
+          )
+        }
+      val proxy = SilentFlowProxy(server.port)
+      val harness = createReconnectHarness(onConnected = { connections.trySend(Unit) })
+      try {
+        connectNodeSession(harness.session, proxy.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connections.receive() }
+        val lease = requireNotNull(harness.session.captureRequestLease())
+        proxy.blackholeExistingFlows()
+        // The real OkHttp limit queues a graceful close but does not notify onFailure.
+        // Dropping that close exchange keeps the physical socket in this distinct state.
+        val oversized =
+          JsonObject(
+            mapOf(
+              "event" to JsonPrimitive("test.large"),
+              "payloadJSON" to JsonPrimitive("x".repeat(16 * 1024 * 1024)),
+            ),
+          ).toString()
+        val rejected = runCatching { lease.request("node.event", oversized, timeoutMs = 1_000) }
+        assertTrue(rejected.exceptionOrNull() is GatewayRequestNotEnqueued)
+        assertTrue("A refused send alone has not retired the session", lease.isCurrent())
+        harness.session.retryAfterNetworkRestore()
+        val reconnected = withTimeoutOrNull(LIFECYCLE_TEST_TIMEOUT_MS) { connections.receive() } != null
+        assertTrue("A current READY socket that refuses the ACK must reconnect", reconnected)
+        assertFalse(lease.isCurrent())
+        assertEquals("{}", harness.session.request("health", null))
+      } finally {
+        shutdownReconnectHarness(harness)
+        proxy.close()
+        server.shutdown()
       }
     }
 
@@ -2228,7 +2270,7 @@ class GatewaySessionReconnectTest {
       val server =
         startGatewayServer(json = Json) { socket, id, method ->
           when (method) {
-            "connect" -> socket.send(connectResponseFrame(id))
+            "connect" -> socket.send(connectResponseFrame(id, methods = setOf("gateway.ping")))
             "hold.before.restore" -> oldRequest.complete(socket to id)
             else -> socket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
           }
@@ -2303,8 +2345,8 @@ class GatewaySessionReconnectTest {
         val releaseOldEvent = CountDownLatch(1)
         val first =
           startGatewayServer(json = Json) { socket, id, method ->
-            if (method == "connect") socket.send(connectResponseFrame(id))
-            if (method == "health") {
+            if (method == "connect") socket.send(connectResponseFrame(id, methods = setOf("gateway.ping")))
+            if (method == "gateway.ping") {
               if (replace) socket.send("""{"type":"event","event":"hold-old-check","payload":{}}""")
               checkReceived.complete(Unit)
             }
@@ -2313,7 +2355,7 @@ class GatewaySessionReconnectTest {
           startGatewayServer(json = Json) { socket, id, method ->
             socket.send(
               if (method == "connect") {
-                connectResponseFrame(id)
+                connectResponseFrame(id, methods = setOf("gateway.ping"))
               } else {
                 """{"type":"res","id":"$id","ok":true,"payload":{}}"""
               },
@@ -2362,6 +2404,31 @@ class GatewaySessionReconnectTest {
         } finally {
           releaseOldEvent.countDown()
           shutdownReconnectHarness(harness, first, replacement)
+        }
+      }
+    }
+
+  @Test
+  fun networkRestoreWithoutAdvertisedAckKeepsTransportDetection() =
+    runBlocking {
+      for (methods in listOf(null, emptySet<String>(), setOf("health"))) {
+        val connected = CompletableDeferred<Unit>()
+        val server =
+          startGatewayServer(json = Json) { socket, id, method ->
+            if (method == "connect") socket.send(connectResponseFrame(id, methods = methods))
+          }
+        val harness = createReconnectHarness(onConnected = { connected.complete(Unit) })
+        try {
+          connectNodeSession(harness.session, server.port)
+          withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+          val lease = requireNotNull(harness.session.captureRequestLease())
+          repeat(5) { harness.session.retryAfterNetworkRestore() }
+          delay(8_500)
+          assertTrue("Old Gateway must retain ordinary transport/ping detection", lease.isCurrent())
+          assertEquals(listOf("connect"), server.requestFrames.map { it["method"]?.jsonPrimitive?.content })
+          assertEquals(1, server.requestCount)
+        } finally {
+          shutdownReconnectHarness(harness, server)
         }
       }
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.gateway
 
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,52 +15,47 @@ import org.robolectric.shadows.ShadowNetwork
 @Config(sdk = [34])
 class NetworkMonitorTest {
   @Test
-  fun emitsOnceOnOfflineToOnline() {
-    val state = ValidatedNetworkState<String>()
+  fun networkAvailabilityWakesOncePerEpisode() {
+    val state = NetworkRestoreState<String>()
 
-    assertEquals(true, state.update("wifi", isValidated = true))
-    assertEquals(false, state.update("wifi", isValidated = true))
+    assertEquals(true, state.onAvailable("wifi"))
+    assertEquals(false, state.onAvailable("wifi"))
+    state.onLost("wifi")
+    assertEquals(true, state.onAvailable("wifi"))
   }
 
   @Test
-  fun emitsAgainAfterAllValidatedNetworksAreLost() {
-    val state = ValidatedNetworkState<String>()
+  fun initialCapabilitiesAfterAvailabilityDoNotWakeTwice() {
+    val state = NetworkRestoreState<String>()
 
-    assertEquals(true, state.update("wifi", isValidated = true))
-    assertEquals(false, state.update("wifi", isValidated = false))
-    assertEquals(true, state.update("wifi", isValidated = true))
+    assertEquals(true, state.onAvailable("wifi"))
+    assertEquals(false, state.onCapabilitiesChanged("wifi", isValidated = true))
+    assertEquals(false, state.onCapabilitiesChanged("wifi", isValidated = true))
   }
 
   @Test
-  fun aSecondNetworkValidatingWhileAnotherIsAlreadyOnlineStillWakes() {
-    // A saved Gateway can be reachable over one specific route only (a returning Wi-Fi/LAN
-    // network), not merely "the internet is up somewhere" — so cellular staying validated the
-    // whole time must not swallow Wi-Fi's own restore. Regression for the P1 finding on #127873.
-    val state = ValidatedNetworkState<String>()
+  fun validationReturningOnAnAvailableNetworkWakes() {
+    val state = NetworkRestoreState<String>()
 
-    assertEquals(true, state.update("cellular", isValidated = true))
-    assertEquals(true, state.update("wifi", isValidated = true))
+    assertEquals(true, state.onAvailable("wifi"))
+    assertEquals(false, state.onCapabilitiesChanged("wifi", isValidated = false))
+    assertEquals(true, state.onCapabilitiesChanged("wifi", isValidated = true))
   }
 
   @Test
-  fun losingOneOfMultipleValidatedNetworksDoesNotWake() {
-    val state = ValidatedNetworkState<String>()
+  fun eachNetworkAvailabilityIsIndependent() {
+    val state = NetworkRestoreState<String>()
 
-    assertEquals(true, state.update("wifi", isValidated = true))
-    assertEquals(true, state.update("cellular", isValidated = true))
-    assertEquals(false, state.update("wifi", isValidated = false))
-    // Capability churn on the still-validated network must not re-fire either.
-    assertEquals(false, state.update("cellular", isValidated = true))
-    // The last validated network being lost is an offline transition, not a restore.
-    assertEquals(false, state.update("cellular", isValidated = false))
-    assertEquals(true, state.update("wifi", isValidated = true))
+    assertEquals(true, state.onAvailable("cellular"))
+    assertEquals(true, state.onAvailable("wifi"))
   }
 
   @Test
   fun initialValidatedNetworkSuppressesRegistrationSnapshot() {
-    val state = ValidatedNetworkState(setOf("wifi"))
+    val state = NetworkRestoreState(setOf("wifi"))
 
-    assertEquals(false, state.update("wifi", isValidated = true))
+    assertEquals(false, state.onAvailable("wifi"))
+    assertEquals(false, state.onCapabilitiesChanged("wifi", isValidated = true))
   }
 
   @Test
@@ -93,36 +89,6 @@ class NetworkMonitorTest {
   }
 
   @Test
-  fun notifyDebounceCoalescesASimultaneousMultiNetworkRestore() {
-    // Wi-Fi and cellular reactivating together (e.g. leaving doze) each produce their own
-    // ValidatedNetworkState edge; without coalescing, the second one's fan-out would close the
-    // reconnect attempt the first one just started. Regression for the P2 finding on #127873.
-    val firstNotifyAt = 1_000_000_000L
-
-    assertEquals(false, isWithinNetworkMonitorNotifyDebounce(lastNotifiedAtNanos = null, nowNanos = firstNotifyAt))
-    assertEquals(
-      true,
-      isWithinNetworkMonitorNotifyDebounce(
-        lastNotifiedAtNanos = firstNotifyAt,
-        nowNanos = firstNotifyAt + NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS - 1,
-      ),
-    )
-  }
-
-  @Test
-  fun notifyDebounceExpiresSoALaterRestoreStillWakes() {
-    val firstNotifyAt = 1_000_000_000L
-
-    assertEquals(
-      false,
-      isWithinNetworkMonitorNotifyDebounce(
-        lastNotifiedAtNanos = firstNotifyAt,
-        nowNanos = firstNotifyAt + NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS,
-      ),
-    )
-  }
-
-  @Test
   fun aPlainNetworkAttachWakesEvenWithoutValidation() {
     // A saved Gateway on a private LAN or a split-tunnel VPN route can be reachable without the
     // network ever reporting NET_CAPABILITY_VALIDATED (that capability only confirms general
@@ -140,6 +106,31 @@ class NetworkMonitorTest {
     callback.onAvailable(ShadowNetwork.newInstance(101))
 
     assertEquals(1, wakeCount)
+  }
+
+  @Test
+  fun callbackRequestIncludesVpnRoutes() {
+    val request = appUsableNetworkRequest()
+
+    assertEquals(
+      false,
+      request.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN),
+    )
+  }
+
+  @Test
+  fun differentNetworkAttachesEachWakeTheFleet() {
+    val context = RuntimeEnvironment.getApplication()
+    var wakeCount = 0
+    NetworkMonitor(context) { wakeCount += 1 }
+    Thread.sleep(600)
+
+    val connectivity = context.getSystemService(ConnectivityManager::class.java)
+    val callback = shadowOf(connectivity).networkCallbacks.single()
+    callback.onAvailable(ShadowNetwork.newInstance(101))
+    callback.onAvailable(ShadowNetwork.newInstance(202))
+
+    assertEquals(2, wakeCount)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -1,8 +1,17 @@
 package ai.openclaw.app.gateway
 
+import android.net.ConnectivityManager
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowNetwork
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class NetworkMonitorTest {
   @Test
   fun emitsOnceOnOfflineToOnline() {
@@ -111,5 +120,38 @@ class NetworkMonitorTest {
         nowNanos = firstNotifyAt + NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS,
       ),
     )
+  }
+
+  @Test
+  fun aPlainNetworkAttachWakesEvenWithoutValidation() {
+    // A saved Gateway on a private LAN or a split-tunnel VPN route can be reachable without the
+    // network ever reporting NET_CAPABILITY_VALIDATED (that capability only confirms general
+    // internet reachability), so the wake must not depend on validation. Regression for the P1
+    // finding on #127873.
+    val context = RuntimeEnvironment.getApplication()
+    var wakeCount = 0
+    NetworkMonitor(context) { wakeCount += 1 }
+    // Outlast NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS so this attach reads as a genuine restore,
+    // not registerNetworkCallback()'s own registration replay.
+    Thread.sleep(600)
+
+    val connectivity = context.getSystemService(ConnectivityManager::class.java)
+    val callback = shadowOf(connectivity).networkCallbacks.single()
+    callback.onAvailable(ShadowNetwork.newInstance(101))
+
+    assertEquals(1, wakeCount)
+  }
+
+  @Test
+  fun networkAttachDuringBootstrapGraceDoesNotWake() {
+    val context = RuntimeEnvironment.getApplication()
+    var wakeCount = 0
+    NetworkMonitor(context) { wakeCount += 1 }
+
+    val connectivity = context.getSystemService(ConnectivityManager::class.java)
+    val callback = shadowOf(connectivity).networkCallbacks.single()
+    callback.onAvailable(ShadowNetwork.newInstance(101))
+
+    assertEquals(0, wakeCount)
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -98,17 +98,4 @@ class NetworkMonitorTest {
 
     assertEquals(2, wakeCount)
   }
-
-  @Test
-  fun networkAttachDuringStartupWakes() {
-    val context = RuntimeEnvironment.getApplication()
-    var wakeCount = 0
-    NetworkMonitor(context) { wakeCount += 1 }
-
-    val connectivity = context.getSystemService(ConnectivityManager::class.java)
-    val callback = shadowOf(connectivity).networkCallbacks.single()
-    callback.onAvailable(ShadowNetwork.newInstance(101))
-
-    assertEquals(1, wakeCount)
-  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -59,36 +59,6 @@ class NetworkMonitorTest {
   }
 
   @Test
-  fun bootstrapGraceCoversTheRegistrationReplayWindow() {
-    // registerNetworkCallback() replays every already-validated network's state right after
-    // registration, and there is no non-deprecated synchronous way to seed all of them up front
-    // (only the single active network). Without this grace window, a second already-validated
-    // network's replay would misread as a fresh restore at every cold start. Regression for the
-    // P2 finding on #127873.
-    val registeredAt = 1_000_000_000L
-
-    assertEquals(true, isWithinNetworkMonitorBootstrapGrace(registeredAt, registeredAt))
-    assertEquals(
-      true,
-      isWithinNetworkMonitorBootstrapGrace(registeredAt, registeredAt + NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS - 1),
-    )
-  }
-
-  @Test
-  fun bootstrapGraceExpiresSoALaterRestoreStillWakes() {
-    val registeredAt = 1_000_000_000L
-
-    assertEquals(
-      false,
-      isWithinNetworkMonitorBootstrapGrace(registeredAt, registeredAt + NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS),
-    )
-    assertEquals(
-      false,
-      isWithinNetworkMonitorBootstrapGrace(registeredAt, registeredAt + NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS * 100),
-    )
-  }
-
-  @Test
   fun aPlainNetworkAttachWakesEvenWithoutValidation() {
     // A saved Gateway on a private LAN or a split-tunnel VPN route can be reachable without the
     // network ever reporting NET_CAPABILITY_VALIDATED (that capability only confirms general
@@ -97,9 +67,6 @@ class NetworkMonitorTest {
     val context = RuntimeEnvironment.getApplication()
     var wakeCount = 0
     NetworkMonitor(context) { wakeCount += 1 }
-    // Outlast NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS so this attach reads as a genuine restore,
-    // not registerNetworkCallback()'s own registration replay.
-    Thread.sleep(600)
 
     val connectivity = context.getSystemService(ConnectivityManager::class.java)
     val callback = shadowOf(connectivity).networkCallbacks.single()
@@ -123,7 +90,6 @@ class NetworkMonitorTest {
     val context = RuntimeEnvironment.getApplication()
     var wakeCount = 0
     NetworkMonitor(context) { wakeCount += 1 }
-    Thread.sleep(600)
 
     val connectivity = context.getSystemService(ConnectivityManager::class.java)
     val callback = shadowOf(connectivity).networkCallbacks.single()
@@ -134,7 +100,7 @@ class NetworkMonitorTest {
   }
 
   @Test
-  fun networkAttachDuringBootstrapGraceDoesNotWake() {
+  fun networkAttachDuringStartupWakes() {
     val context = RuntimeEnvironment.getApplication()
     var wakeCount = 0
     NetworkMonitor(context) { wakeCount += 1 }
@@ -143,6 +109,6 @@ class NetworkMonitorTest {
     val callback = shadowOf(connectivity).networkCallbacks.single()
     callback.onAvailable(ShadowNetwork.newInstance(101))
 
-    assertEquals(0, wakeCount)
+    assertEquals(1, wakeCount)
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -52,4 +52,64 @@ class NetworkMonitorTest {
 
     assertEquals(false, state.update("wifi", isValidated = true))
   }
+
+  @Test
+  fun bootstrapGraceCoversTheRegistrationReplayWindow() {
+    // registerNetworkCallback() replays every already-validated network's state right after
+    // registration, and there is no non-deprecated synchronous way to seed all of them up front
+    // (only the single active network). Without this grace window, a second already-validated
+    // network's replay would misread as a fresh restore at every cold start. Regression for the
+    // P2 finding on #127873.
+    val registeredAt = 1_000_000_000L
+
+    assertEquals(true, isWithinNetworkMonitorBootstrapGrace(registeredAt, registeredAt))
+    assertEquals(
+      true,
+      isWithinNetworkMonitorBootstrapGrace(registeredAt, registeredAt + NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS - 1),
+    )
+  }
+
+  @Test
+  fun bootstrapGraceExpiresSoALaterRestoreStillWakes() {
+    val registeredAt = 1_000_000_000L
+
+    assertEquals(
+      false,
+      isWithinNetworkMonitorBootstrapGrace(registeredAt, registeredAt + NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS),
+    )
+    assertEquals(
+      false,
+      isWithinNetworkMonitorBootstrapGrace(registeredAt, registeredAt + NETWORK_MONITOR_BOOTSTRAP_GRACE_NANOS * 100),
+    )
+  }
+
+  @Test
+  fun notifyDebounceCoalescesASimultaneousMultiNetworkRestore() {
+    // Wi-Fi and cellular reactivating together (e.g. leaving doze) each produce their own
+    // ValidatedNetworkState edge; without coalescing, the second one's fan-out would close the
+    // reconnect attempt the first one just started. Regression for the P2 finding on #127873.
+    val firstNotifyAt = 1_000_000_000L
+
+    assertEquals(false, isWithinNetworkMonitorNotifyDebounce(lastNotifiedAtNanos = null, nowNanos = firstNotifyAt))
+    assertEquals(
+      true,
+      isWithinNetworkMonitorNotifyDebounce(
+        lastNotifiedAtNanos = firstNotifyAt,
+        nowNanos = firstNotifyAt + NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS - 1,
+      ),
+    )
+  }
+
+  @Test
+  fun notifyDebounceExpiresSoALaterRestoreStillWakes() {
+    val firstNotifyAt = 1_000_000_000L
+
+    assertEquals(
+      false,
+      isWithinNetworkMonitorNotifyDebounce(
+        lastNotifiedAtNanos = firstNotifyAt,
+        nowNanos = firstNotifyAt + NETWORK_MONITOR_NOTIFY_DEBOUNCE_NANOS,
+      ),
+    )
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -22,13 +22,26 @@ class NetworkMonitorTest {
   }
 
   @Test
-  fun suppressesReconnectWhenOneOfMultipleValidatedNetworksIsLost() {
+  fun aSecondNetworkValidatingWhileAnotherIsAlreadyOnlineStillWakes() {
+    // A saved Gateway can be reachable over one specific route only (a returning Wi-Fi/LAN
+    // network), not merely "the internet is up somewhere" — so cellular staying validated the
+    // whole time must not swallow Wi-Fi's own restore. Regression for the P1 finding on #127873.
+    val state = ValidatedNetworkState<String>()
+
+    assertEquals(true, state.update("cellular", isValidated = true))
+    assertEquals(true, state.update("wifi", isValidated = true))
+  }
+
+  @Test
+  fun losingOneOfMultipleValidatedNetworksDoesNotWake() {
     val state = ValidatedNetworkState<String>()
 
     assertEquals(true, state.update("wifi", isValidated = true))
-    assertEquals(false, state.update("cellular", isValidated = true))
+    assertEquals(true, state.update("cellular", isValidated = true))
     assertEquals(false, state.update("wifi", isValidated = false))
+    // Capability churn on the still-validated network must not re-fire either.
     assertEquals(false, state.update("cellular", isValidated = true))
+    // The last validated network being lost is an offline transition, not a restore.
     assertEquals(false, state.update("cellular", isValidated = false))
     assertEquals(true, state.update("wifi", isValidated = true))
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.gateway
 
 import android.net.ConnectivityManager
+import android.net.LinkProperties
 import android.net.NetworkCapabilities
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -10,6 +11,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowNetwork
+import java.net.InetAddress
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -83,6 +85,40 @@ class NetworkMonitorTest {
       false,
       request.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN),
     )
+  }
+
+  @Test
+  fun linkPropertiesChangesWakeAnExistingNetworkWithoutValidationChange() {
+    val context = RuntimeEnvironment.getApplication()
+    var wakeCount = 0
+    NetworkMonitor(context) { wakeCount += 1 }
+    val connectivity = context.getSystemService(ConnectivityManager::class.java)
+    val callback = shadowOf(connectivity).networkCallbacks.single()
+    val network = ShadowNetwork.newInstance(501)
+    val properties =
+      LinkProperties().apply {
+        interfaceName = "wlan0"
+        setDnsServers(listOf(InetAddress.getByName("192.0.2.1")))
+      }
+    callback.onAvailable(network)
+    callback.onCapabilitiesChanged(network, NetworkCapabilities())
+    callback.onLinkPropertiesChanged(network, properties)
+    callback.onLinkPropertiesChanged(network, properties)
+    assertEquals("Initial properties and identical snapshots coalesce with availability", 1, wakeCount)
+
+    properties.setDnsServers(listOf(InetAddress.getByName("192.0.2.2")))
+    callback.onLinkPropertiesChanged(network, properties)
+    assertEquals("A DNS-only link change must wake without onAvailable or validation change", 2, wakeCount)
+    callback.onLinkPropertiesChanged(network, properties)
+    assertEquals(2, wakeCount)
+
+    callback.onLost(network)
+    properties.setDnsServers(listOf(InetAddress.getByName("192.0.2.3")))
+    callback.onLinkPropertiesChanged(network, properties)
+    assertEquals("A late properties event must not resurrect a lost network", 2, wakeCount)
+    callback.onAvailable(network)
+    callback.onLinkPropertiesChanged(network, properties)
+    assertEquals("Reattachment owns a new initial properties snapshot", 3, wakeCount)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/SilentFlowProxy.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/SilentFlowProxy.kt
@@ -1,0 +1,87 @@
+package ai.openclaw.app.gateway
+
+import java.io.Closeable
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Drops bytes on existing TCP flows without EOF/reset; newly accepted flows still work. */
+internal class SilentFlowProxy(
+  private val upstreamPort: Int,
+) : Closeable {
+  private val listener = ServerSocket(0, 50, InetAddress.getLoopbackAddress())
+  private val workers = Executors.newCachedThreadPool()
+  private val flows = ConcurrentLinkedQueue<Flow>()
+  val port: Int get() = listener.localPort
+
+  private class Flow(
+    val downstream: Socket,
+    val upstream: Socket,
+  ) {
+    val dropOutbound = AtomicBoolean()
+    val dropInbound = AtomicBoolean()
+  }
+
+  private val acceptTask =
+    workers.submit {
+      while (!listener.isClosed) {
+        val downstream =
+          try {
+            listener.accept()
+          } catch (_: java.io.IOException) {
+            break
+          }
+        val flow = Flow(downstream, Socket(InetAddress.getLoopbackAddress(), upstreamPort))
+        flows += flow
+        workers.submit { forward(flow, flow.downstream, flow.upstream) }
+        workers.submit { forward(flow, flow.upstream, flow.downstream) }
+      }
+    }
+
+  fun blackholeExistingFlows(keepInbound: Boolean = false) {
+    flows.forEach {
+      it.dropOutbound.set(true)
+      it.dropInbound.set(!keepInbound)
+    }
+  }
+
+  private fun forward(
+    flow: Flow,
+    source: Socket,
+    destination: Socket,
+  ) {
+    try {
+      val bytes = ByteArray(8192)
+      while (true) {
+        val count = source.getInputStream().read(bytes)
+        if (count < 0) break
+        val dropped = if (source === flow.downstream) flow.dropOutbound.get() else flow.dropInbound.get()
+        if (!dropped) {
+          destination.getOutputStream().write(bytes, 0, count)
+          destination.getOutputStream().flush()
+        }
+      }
+    } catch (_: java.io.IOException) {
+      // Cancellation and teardown close the real sockets, never a synthetic session callback.
+    } finally {
+      source.close()
+      destination.close()
+    }
+  }
+
+  override fun close() {
+    listener.close()
+    // Finish registration before draining: an accepted flow must not escape teardown.
+    acceptTask.get(8, TimeUnit.SECONDS)
+    flows.forEach {
+      it.downstream.close()
+      it.upstream.close()
+    }
+    workers.shutdown()
+    check(workers.awaitTermination(8, TimeUnit.SECONDS)) { "Silent-flow proxy did not stop" }
+  }
+}

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -100,6 +100,22 @@ use HTTP status `403`.
 
 Side-effecting methods require idempotency keys (see schema).
 
+## Connection liveness
+
+When `hello-ok.features.methods` includes `gateway.ping`, an authenticated
+`node` or `operator` may send `{type:"req", id, method:"gateway.ping"}` on that
+same WebSocket. No operator scope is required. The Gateway returns
+`{type:"res", id, ok:true, payload:{}}` directly from the authenticated transport,
+without collecting health, invoking plugins or providers, or reading a database.
+Existing credential invalidation and socket authority checks still apply.
+
+Use a fresh request ID and accept only its response on the same connection as
+round-trip evidence. Events and replies to older requests do not prove that new
+outbound traffic reaches the Gateway. This ACK is not an application-health check
+or a recovery-time guarantee. Clients connecting to a Gateway that does not
+advertise the method should retain their existing transport/ping detection, not
+substitute the potentially slow `health` RPC.
+
 ## Gateway-controlled WebRTC Talk
 
 `talk.client.create` accepts the additive capability `gateway-control-v1`.

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -341,6 +341,8 @@ const CORE_GATEWAY_METHOD_SPECS = [
     { compatibilityRestored: true },
   ],
   ["gateway.restart.request", "restart", "operator.admin", "<=2026.7", CONTROL_PLANE_WRITE],
+  // Transport-owned: both authenticated roles may ACK without an operator scope.
+  ["gateway.ping", null, "dynamic", "2026.9"],
   ["system-presence", "system", "operator.read", "<=2026.7"],
   ["system-event", "system", "operator.admin", "<=2026.7"],
   ["message.action", "send", "operator.write", "<=2026.7"],

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -86,6 +86,10 @@ function authorizeGatewayMethod(
   if (!role) {
     return errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${roleRaw}`);
   }
+  // Transport liveness is scope-free for either valid authenticated role.
+  if (method === "gateway.ping") {
+    return null;
+  }
   const scopes = client.connect.scopes ?? [];
   if (!isRoleAuthorizedForMethod(role, method)) {
     return errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${role}`);

--- a/src/gateway/server-methods/core-handlers.ts
+++ b/src/gateway/server-methods/core-handlers.ts
@@ -4,6 +4,7 @@ import {
   listCoreGatewayHandlerMethodNames,
   type CoreGatewayHandlerFamily,
 } from "../methods/core-descriptors.js";
+import { handleGatewayPing } from "./gateway-ping.js";
 import { createLazyCoreHandlers } from "./lazy-core-handlers.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
@@ -156,16 +157,20 @@ const CORE_GATEWAY_HANDLER_MODULES = {
   wizard: () => import("./wizard.js").then((module) => module.wizardHandlers),
 } satisfies Record<CoreGatewayHandlerFamily, CoreGatewayHandlerModuleLoader>;
 
-export const coreGatewayHandlers: GatewayRequestHandlers = Object.fromEntries(
-  Array.from(listCoreGatewayHandlerMethodNames()).flatMap(([family, methods]) =>
-    Object.entries(
-      createLazyCoreHandlers({
-        methods,
-        // Failed family imports stay cached until restart, just like successful loads.
-        loadHandlers: createLazyPromise(CORE_GATEWAY_HANDLER_MODULES[family], {
-          cacheRejections: true,
+export const coreGatewayHandlers: GatewayRequestHandlers = {
+  ...Object.fromEntries(
+    Array.from(listCoreGatewayHandlerMethodNames()).flatMap(([family, methods]) =>
+      Object.entries(
+        createLazyCoreHandlers({
+          methods,
+          // Failed family imports stay cached until restart, just like successful loads.
+          loadHandlers: createLazyPromise(CORE_GATEWAY_HANDLER_MODULES[family], {
+            cacheRejections: true,
+          }),
         }),
-      }),
+      ),
     ),
   ),
-);
+  // The attached registry advertises only bound handlers, including transport-owned ACKs.
+  "gateway.ping": handleGatewayPing,
+};

--- a/src/gateway/server-methods/gateway-ping.ts
+++ b/src/gateway/server-methods/gateway-ping.ts
@@ -1,0 +1,15 @@
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import type { GatewayRequestOptions } from "./types.js";
+
+/** One scope-free ACK implementation shared by the transport and its registered descriptor. */
+export function handleGatewayPing({
+  client,
+  respond,
+}: Pick<GatewayRequestOptions, "client" | "respond">): void {
+  const role = client?.connect.role;
+  if (role !== "node" && role !== "operator") {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${role}`));
+    return;
+  }
+  respond(true, {});
+}

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -612,6 +612,24 @@ describe("gateway pre-auth hardening", () => {
     await expectIdlePreauthSocketClose();
   });
 
+  it("rejects a liveness request before authentication", async () => {
+    const harness = await createGatewaySuiteHarness();
+    try {
+      const ws = await harness.openWs();
+      await readConnectChallengeNonce(ws);
+      const responses: unknown[] = [];
+      ws.on("message", (data) => responses.push(JSON.parse(rawDataToString(data))));
+      const closed = new Promise<number>((resolve) => {
+        ws.once("close", resolve);
+      });
+      ws.send(JSON.stringify({ type: "req", id: "preauth-ping", method: "gateway.ping" }));
+      expect(await closed).toBe(1008);
+      expect(responses).toContainEqual(expect.objectContaining({ id: "preauth-ping", ok: false }));
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("rejects oversized pre-auth connect frames before application-level auth responses", async () => {
     resetDiagnosticEventsForTest();
     const events: DiagnosticEventPayload[] = [];

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ping.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ping.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../../shared/deferred.js";
+import {
+  createCoreGatewayMethodDescriptors,
+  createGatewayMethodRegistry,
+} from "../../methods/registry.js";
+import { listGatewayMethods } from "../../server-methods-list.js";
+import { handleGatewayRequest } from "../../server-methods.js";
+import { coreGatewayHandlers } from "../../server-methods/core-handlers.js";
+import type { GatewayRequestOptions } from "../../server-methods/types.js";
+import {
+  createDispatchTestHarness,
+  createOperatorWsClient,
+} from "./authenticated-request-dispatch.test-support.js";
+
+const runtime = vi.hoisted(() => ({
+  handler: vi.fn<(options: GatewayRequestOptions) => Promise<void>>(),
+}));
+vi.mock("./authenticated-request-dispatch.server-methods.runtime.js", () => ({
+  handleGatewayRequest: runtime.handler,
+}));
+
+const ping: GatewayRequestOptions["req"] = {
+  type: "req",
+  id: "restore-check",
+  method: "gateway.ping",
+};
+
+describe("authenticated WebSocket liveness ACK", () => {
+  beforeEach(() => {
+    runtime.handler.mockReset();
+  });
+
+  it.each(["node", "operator"])("ACKs %s with no scopes or application work", async (role) => {
+    const client = createOperatorWsClient({ scopes: [] });
+    client.connect.role = role;
+    const applicationWork = vi.fn(() => {
+      throw new Error("ACK entered application work");
+    });
+    const harness = createDispatchTestHarness({
+      buildRequestContext: () => ({
+        getRuntimeConfig: applicationWork,
+        getHealthCache: applicationWork,
+        refreshHealthSnapshot: applicationWork,
+        nodeRegistry: { isConnectionCurrentPairingState: applicationWork },
+      }),
+    });
+    expect(listGatewayMethods()).toContain(ping.method);
+    const registry = createGatewayMethodRegistry(
+      createCoreGatewayMethodDescriptors(coreGatewayHandlers),
+    );
+    expect(registry.listAdvertisedMethods()).toContain(ping.method);
+    await harness.dispatcher.dispatch(ping, client);
+    expect(await harness.awaitResponseFrame(ping.id)).toEqual({
+      type: "res",
+      id: ping.id,
+      ok: true,
+      payload: {},
+      error: undefined,
+    });
+    expect(applicationWork).not.toHaveBeenCalled();
+    expect(runtime.handler).not.toHaveBeenCalled();
+    expect(harness.close).not.toHaveBeenCalled();
+  });
+
+  it.each(["node", "operator", "unknown"])(
+    "keeps registered authorization for %s without scopes",
+    async (role) => {
+      const client = createOperatorWsClient({ scopes: [] });
+      client.connect.role = role;
+      const respond = vi.fn();
+      await handleGatewayRequest({
+        req: ping,
+        client,
+        respond,
+        isWebchatConnect: () => false,
+        context: {
+          logGateway: { warn: vi.fn() },
+          nodeRegistry: { isConnectionCurrentPairingState: vi.fn().mockResolvedValue(true) },
+        } as unknown as GatewayRequestOptions["context"],
+      });
+      if (role === "unknown") {
+        expect(respond).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "INVALID_REQUEST" }),
+        );
+      } else {
+        expect(respond).toHaveBeenCalledWith(true, {});
+      }
+    },
+  );
+
+  it("does not extend the ACK exception to an unknown role", async () => {
+    const client = createOperatorWsClient();
+    client.connect.role = "unknown";
+    const harness = createDispatchTestHarness();
+    await harness.dispatcher.dispatch(ping, client);
+    expect(await harness.awaitResponseFrame(ping.id)).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST" },
+    });
+    expect(runtime.handler).not.toHaveBeenCalled();
+  });
+
+  it.each(["invalidated", "rotated", "closed"])("does not ACK a %s socket", async (state) => {
+    const client = createOperatorWsClient();
+    client.invalidated = state === "invalidated";
+    client.usesSharedGatewayAuth = state === "rotated";
+    client.sharedGatewaySessionGeneration = "old";
+    const harness = createDispatchTestHarness({
+      isClosed: () => state === "closed",
+      getRequiredSharedGatewaySessionGeneration: () => "new",
+    });
+    await harness.dispatcher.dispatch(ping, client);
+    expect(harness.send).not.toHaveBeenCalled();
+    expect(runtime.handler).not.toHaveBeenCalled();
+  });
+
+  it("keeps credential mutation ordering and rechecks authority before ACK", async () => {
+    const held = createDeferredCore();
+    const started = createDeferredCore();
+    const client = createOperatorWsClient();
+    runtime.handler.mockImplementation(async ({ respond }) => {
+      started.resolve();
+      await held.promise;
+      client.invalidated = true;
+      respond(true, {});
+    });
+    const harness = createDispatchTestHarness();
+    await harness.dispatcher.dispatch(
+      { ...ping, id: "rotate", method: "device.token.rotate" },
+      client,
+    );
+    await started.promise;
+    await harness.dispatcher.dispatch(ping, client);
+    expect(harness.send).not.toHaveBeenCalled();
+    held.resolve();
+    await vi.waitFor(() => expect(harness.close).toHaveBeenCalled());
+    expect(
+      harness.send.mock.calls.some(([frame]) => (frame as { id?: string }).id === ping.id),
+    ).toBe(false);
+    expect(runtime.handler).toHaveBeenCalledOnce();
+  });
+});

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.test-support.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.test-support.ts
@@ -5,6 +5,7 @@ import { createDeferredCore, type Deferred } from "../../../shared/deferred.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
 import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
 export type GatewayTestResponseFrame = {
   type: "res";
@@ -76,6 +77,7 @@ export function createDispatchTestHarness(
     handler: {
       connId: options.connId ?? "dispatch-test-connection",
       extraHandlers: options.extraHandlers ?? {},
+      nodeLifecycleDispatch: new GatewayNodeLifecycleDispatchTracker(),
       buildRequestContext: () => (options.buildRequestContext?.() ?? {}) as never,
       send: sendForDispatcher,
       close,

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../infra/diagnostic-trace-context.js";
 import { runOutsideGatewayRootWorkAdmission } from "../../../process/gateway-work-admission.js";
 import { createLazyPromise } from "../../../shared/lazy-runtime.js";
+import { handleGatewayPing } from "../../server-methods/gateway-ping.js";
 import type { GatewayRequestEntry } from "../../server-request-entry.js";
 import { classifyGatewayStaleInstall } from "../../stale-install.js";
 import { formatForLog, logWs } from "../../ws-log.js";
@@ -247,6 +248,16 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
           }
         }
         if (!hasCurrentClientAuthority() || !hasCurrentRuntimeAuthority()) {
+          return;
+        }
+        if (req.method === "gateway.ping") {
+          // A transport ACK, not application health: stay ahead of handler loading, start
+          // queues, and plugin/store work, but behind the same socket's authority fences.
+          entry?.assertOpen();
+          if (isClosed()) {
+            return;
+          }
+          handleGatewayPing({ client, respond: respondWithAuthority });
           return;
         }
         const { handleGatewayRequest } = await loadGatewayServerMethods();


### PR DESCRIPTION
Fixes #127872

## What Problem This Solves

Fixes an issue where the Android node keeps attempting to reconnect every few seconds, indefinitely, for as long as a saved Gateway stays unreachable, and keeps doing so after the app is dismissed from Android Recents. This sustained background reconnect activity is what was reported as causing severe battery drain; a normal user has no obvious way to stop it and no explanation for it. Severe battery drain is the reported motivation, not a demonstrated outcome: what is measured here is the reconnect workload itself, on a real device, before and after. No battery percentage or mAh improvement is claimed anywhere in this PR.

The production diff keeps retry timing in GatewaySession.runLoop(), ready-socket verification in the connection/pending-RPC owner, live-session fan-out in NodeRuntime, and route observation in NetworkMonitor/GatewayDiscovery. One registered gateway.ping handler supplies a lightweight authenticated transport ACK. The foreground service keeps its existing lifecycle; the remaining changes are tests and protocol documentation.

## Why This Change Was Made

The reconnect loop already backed off exponentially, but it stopped growing at 8 seconds and then held that cadence for the whole outage — reaching the cap at attempt 6, after about 11 s of accumulated backoff — nearer a minute of wall clock once each failed attempt's own connect timeout is counted. Persistent failure never reduced the amount of work being done. Android's guidance on background network use warns that frequent recurring network activity can keep the mobile radio active and consume battery quickly, which is the region this loop settles into and stays in.

This PR changes `gatewayReconnectDelayMs` and the three wake sites in `runLoop()` so the ladder keeps growing to a bounded ceiling instead of flattening, and extends the existing network-restore wake to every live session. The delay is not simply made larger; growth is restored for the region where it had stopped. Before and after, where `n` is the count of consecutive failures so far (`n = 1` for the first retry after a drop, so the old cap first binds at `n = 6`):

```
before:  delay = min(8_000, 350 * 1.7^n)
after:   raw   = min(60_000, 350 * 1.7^n)
         delay = raw                                    if raw <= 8_000     # n <= 5, unchanged
                 max(raw/2 + raw/2 * u, 8_000)            otherwise, u ~ uniform [0,1)
```

`u` is drawn once per retry from `Random.nextDouble()`, so the interval is half-open at the top; the result is truncated to whole milliseconds. Attempts 1-5 are the same expression as today, the old 8 s cap becomes the floor of the jittered range instead of the ladder ceiling, and once `raw` saturates at 60 s the steady band is 30 s to just under 60 s.

- **Transient failures use the same formula as before.** Base delay (350 ms) and growth factor (1.7) are unchanged, and the spread below applies only above the old cap, so attempts 1–5 compute exactly the values they compute today. `transientReconnectDelaysAreUnchanged` asserts this against the previous formula for every jitter input. (The measured values are deltas between notification posts, so they carry scheduling and post latency and are not expected to match the computed values digit for digit. What is identical between the two builds is the formula and its constants.)
- **Prolonged failure keeps backing off** instead of flattening, up to a one-minute ceiling.
- **Sustained probing is spread** across the top of its window: the jittered value runs from half the window up to just under it, and is then clamped up to the old 8 s cap, so between 8 s and 16 s of raw delay the effective band is 8 s to just under the raw value, and from 16 s upward it is the window's upper half. This is two terms in the same delay expression rather than a separable mechanism, and it exists because of the ceiling: once every client converges on the same maximum, a Gateway that restarts is met by all of them at the same instant. It applies only above the old cap, so it cannot affect transient recovery.
- **The ceiling is one minute.** Android guidance on regular updates warns that frequent recurring network activity keeps the mobile radio active; it does not define a numeric limit, and none is claimed here. The final steady retry band is 30-60 s: 3.75-7.5x wider than the previous fixed 8 s delay, with a 45 s mean timer delay (5.6x wider), while an endpoint-only Gateway restart is discovered within at most one steady interval plus the connection attempt itself. Network and manual wakes remain immediate and reset the ladder.
- **No attempt number retries sooner than it used to.** This holds by construction — the jittered value is clamped up to the old cap — and is asserted for every `n` up to 256 against the previous formula by `reconnectDelayIsNeverShorterThanBeforeThisChange`. Beyond the tested range the old policy is the constant 8 s and the new one is clamped at or above 8 s, so the inequality cannot turn over. That is a comparison of the two delay policies at the *same* `n`, evaluated on the computed values. Wake handling is a different axis: it lowers `n` itself, so it shortens real-world recovery latency without ever making the delay for a given `n` shorter than before. The two claims never apply to the same quantity.
- **Event-driven recovery preserves healthy sockets and restarts failed ones.** Network/manual wakes interrupt non-ready sessions and reset the retry ladder. Ready sessions use one coalesced gateway.ping request only when the same authenticated WebSocket advertises it. Only that request ID's response on that socket proves the round trip; events and old replies do not. Failed enqueue or an unanswered 8 s check retires only the still-current, desired, ready connection, preserving Disconnect and auth pauses. Older Gateways keep existing transport/ping detection, never a slow health fallback. The 30–60 s timer plus connection/scheduling time is not an end-to-end recovery SLA.
- **Probing is bounded, not stopped.** Android reports no network change when only the Gateway process restarts, so a design that waits for a network callback would never recover. That the delay stays finite and capped is a unit-test invariant; that a real restart is then discovered is measured under "Evidence" — twelve Gateway process restarts across the two campaigns, twelve reconnections, no network event involved.

### Design note

The retry policy stays inside `GatewaySession.runLoop()`, the live-session fan-out stays with `NodeRuntime`, and route restoration stays with `NetworkMonitor`. `GatewayDiscovery` and `NetworkMonitor` now share one request that preserves Android's normal app-visible-network constraints while removing the default `NET_CAPABILITY_NOT_VPN` exclusion. That is the smallest owner-level repair: both consumers that claim to observe VPN/split-DNS routes use the same request.

The retry ladder remains in the per-desired-connection `attempt` counter owned by `runLoop()`. The monotonic wake count closes the channel-timeout race without adding persisted lifecycle state. `NetworkRestoreState` is process-local callback state: it records each network's availability episode so `onAvailable` and that same network's first capability snapshot coalesce, while an unrelated route can never be suppressed by another network's timestamp. Ready sessions are checked for a fresh round trip without disturbing healthy unrelated-route sessions; non-ready sessions are woken immediately.

### Why these pieces land together

Raising the ceiling is the fix; the wake resets are what make raising it safe. With an 8 s ceiling a stale ladder cost at most 8 s, so nothing had to reset it. At 60 s the same staleness can become a one-minute silence, so every path that consumes a wake has to restart the ladder or the ceiling introduces a regression: the backoff wait, the auth-pause wait, the drain immediately before a connect attempt, and the network-restore fan-out. These are call sites of one invariant, not separate features: timer-driven work becomes materially less frequent while explicit network and user recovery stays immediate.

### Review findings resolved

**VPN/private-route matching.** Android adds `NET_CAPABILITY_NOT_VPN` to a default `NetworkRequest`, so the prior empty builder excluded the split-tunnel/VPN route the callback was meant to observe. `appUsableNetworkRequest()` now removes that default capability and is shared by `NetworkMonitor` and `GatewayDiscovery`. `callbackRequestIncludesVpnRoutes` asserts the built request contract directly.

**Cross-route wake isolation.** The process-global two-second debounce could discard a different network's only attach event. It has been removed. `NetworkRestoreState` coalesces only `onAvailable` with the immediately following capability snapshot for the same network and availability episode. `differentNetworkAttachesEachWakeTheFleet` proves that two distinct networks both wake the fleet, while `initialCapabilitiesAfterAvailabilityDoNotWakeTwice` preserves same-network callback-pair coalescing.

**Healthy-session preservation and stale-READY repair.** The connection-owned pending-RPC map correlates a fresh lightweight gateway.ping response on the same socket. The registered handler is advertised by the attached method registry and shared with early authenticated dispatch, behind socket/runtime authority and credential-mutation ordering. This removes health-collection latency and the old sequence-counter wrapper from liveness decisions. Tests cover healthy slow-health traffic, error replies, blackholes, one-way failure, replacement, Disconnect and old-server capability negotiation.

**Failed ACK enqueue.** Real OkHttp queue overflow can refuse send without immediately notifying onFailure. The probe now retires a still-current READY socket instead of swallowing that failure.

**Existing-network link changes.** NetworkMonitor now observes onLinkPropertiesChanged, compares owned Parcelable snapshots, coalesces initial/duplicate snapshots, ignores lost-network updates, and detects mutable DNS/route changes without requiring a validation transition.

### Non-scope

The change is limited to retry timing, route/fleet wakes, and the advertised same-WebSocket transport ACK; unrelated session behavior is unchanged. Two behaviours in the same loop keep their current semantics: `attempt` is still reset whenever `connectOnce` returns normally, so a Gateway that accepts a socket and immediately closes it interacts with the reset exactly as it does today (bounding that needs a dwell clock and would change what "success" means), and the auth-pause branch keeps its existing 250 ms poll, which performs no network work and is not part of the reported drain.

## User Impact

An unreachable Gateway now settles into infrequent, timer-driven probing instead of retrying every few seconds for the whole outage. (This bounds the retries the loop schedules for itself; wakes driven by the user or by the network are unbounded by design and stay immediate.) Transient retry timing is unchanged and wake handling deliberately changes — a wake now also restarts the ladder, so for any given pending backoff the next attempt is never later than it would have been without the wake. The first retries after a drop are still sub-second-to-second (0.97 s and 1.70 s open the fixed build's outage ladder below, and a later induced outage restarted at 0.60 s), and rejoining the network or tapping reconnect still triggers an attempt immediately rather than waiting out the backoff.

| Behaviour (measured values are aggregate notification intervals, not computed delays) | Before | After |
|---|---|---|
| initial retry | 0.32 s, 1.02 s, 1.76 s … | 0.97 s, 1.70 s, 2.97 s … (same formula) |
| persistent retry delay | flattens at ~8 s indefinitely | keeps increasing beyond 8 s |
| long-failure steady band | flattens at ~8 s indefinitely | final policy is 30 to just under 60 s; the earlier 300 s candidate capture reached 115.52 s, 174.85 s, and 225.52 s |
| after dismissal from Recents | ~8 s retry continues | progressive backoff survives dismissal; the earlier 300 s candidate capture reached 87.06 s then 117.14 s |
| network restore | reaches the operator and node sessions | now observes app-visible VPN/private routes, preserves distinct route wakes, and reaches every live secondary session; final-head boundary proof is under Evidence |
| manual reconnect | existing behaviour | 0.51 s from tap to attempt |
| wake ladder reset | n/a — old ceiling was 8 s | next delays 1.062 s / 1.034 s |
| success reset | fast ladder | 0.60 s, 0.99 s, 1.75 s after the next outage |

## Real behavior proof (progressive-backoff mechanics; intermediate 300 s candidate)

Behavior addressed: an unreachable Gateway is retried on a seconds-scale cadence for the entire outage, including after the app is dismissed from Android Recents. The device evidence below is app-level reconnect cadence; per-attempt policy values are covered by the unit tests.

Real environment tested: physical Xiaomi 2107113SR, Android 14 (SDK 34), attached over USB. Real OpenClaw Gateway on a private LAN, real pairing, real outage induced by turning Wi-Fi off while mobile data stayed on, so the Gateway address stops being routable while the phone is still online. Nothing was mocked or stubbed; both builds come from the same Gradle assemble task with identical applicationId, versionCode and signing certificate, swapped with `adb install -r` so the app's pairing survives the swap.

Exact steps run for the earlier progressive-backoff candidate: build both APKs with `./gradlew :app:assemblePlayDebug` at base `ff6db34233d` and at candidate `cc3460fcbd2e`; install the base build, pair it and confirm `Connected`; turn Wi-Fi off with mobile data on; sample Android notifications and record each app timestamp; repeat after installing the candidate build. These measurements establish the progressive-backoff and wake mechanics, not the final 60 s ceiling.

What this capture measures: the app's own reconnect activity as a whole. The foreground-service notification is one merged surface for both gateway sessions the app runs, and the capture does not attribute a transition to a particular session. So the intervals below are the spacing between successive reconnect state changes of the app, not a reconstruction of one loop's timer. That is the right granularity for the reported problem — the concern is how often the app does reconnect work at all — but it means individual intervals should not be read as exact per-session policy values, and indeed one of them (7.975 s) sits just under the 8.0 s the policy computes for that step. The claims below are about the shape of that aggregate activity: 31 consecutive intervals pinned between 7.97 s and 8.06 s before, against a sequence that keeps growing after.

Two different things are established by two different means, and it matters which is which:

- **What the device shows** is how often the app does reconnect work: the gap from one failure post to the next attempt post (the captures label this column `retry_delay`) and from one attempt post to the next (`cadence`, which additionally contains the ~10 s connect timeout). Because the surface is merged, these are app-level event intervals — the next post may belong to either session — so they are evidence about the app's reconnect activity, not a reconstruction of one loop's timer.
- **What the policy does per attempt** — the exact ladder, the floor, the ceiling, the jitter bounds — is established by the unit tests against the computed values, which is where per-attempt precision belongs.

The claim this PR rests on needs both, and each is carried by the right one: the tests show the ladder now grows instead of flattening, and the device shows that this actually changes how often the app reconnects in the failure users hit.

Measurement note: the app re-posts its foreground-service notification on every reconnect state change (`Reconnecting…` when an attempt starts, `Gateway error: …` when it fails) and each post carries the app's own device-side `when` timestamp. Each session posts `Reconnecting…` when one of its attempts starts and `Gateway error: …` when it fails, from the two `onDisconnected` calls in the retry loop; the surface the host samples is the merged result for both sessions, which is why the intervals are read as app-level rather than per-loop. All delays below are deltas between those device timestamps, so they do not depend on host sampling. **No production instrumentation was added to either build**; the proof deliberately reads the notification timestamps the app already posts. Because packets to the unreachable LAN address are dropped rather than refused, each attempt additionally spends a ~10 s socket connect timeout before failing; that constant is identical in both arms. `retry_delay` below is the failure-to-next-attempt interval; `cadence` is attempt-to-attempt, i.e. `retry_delay` plus that timeout.

Before evidence:

```
# BEFORE — base ff6db34233dfa1540dcf18cadf5ba6d34727936c
# observed timing (notification-post deltas), not the policy's computed values
host_wall                device_when    kind      retry_delay   cadence  state
2026-08-22T17:04:34.625  17:04:34.554   ATTEMPT         0.324            Reconnecting…   <- pre-outage churn
2026-08-22T17:04:38.444                 MARKER                           >>> WIFI_OFF
2026-08-22T17:04:45.843  17:04:45.607   ATTEMPT         1.016    11.053  Reconnecting…   <- outage ladder starts
2026-08-22T17:04:57.641  17:04:57.394   ATTEMPT         1.757    11.787  Reconnecting…
2026-08-22T17:05:10.322  17:05:10.305   ATTEMPT         2.936    12.911  Reconnecting…
2026-08-22T17:05:25.482  17:05:25.317   ATTEMPT         4.948    15.012  Reconnecting…
2026-08-22T17:05:43.556  17:05:43.419   ATTEMPT         8.056    18.102  Reconnecting…
2026-08-22T17:06:01.396  17:06:01.420   ATTEMPT         7.973    18.001  Reconnecting…
...  31 consecutive intervals, every one between 7.97s and 8.06s  ...

retry_delay (FAIL -> next ATTEMPT)  (n=36)
  min 0.324s   max 8.056s   last 8.024s
  > 9s: 0    >= 150s: 0

# after the app was dismissed from Android Recents (verified absent; pid 22121 alive)
2026-08-22T17:12:28.795  17:12:28.763   ATTEMPT         8.024    18.059  Reconnecting…
2026-08-22T17:12:47.028  17:12:46.832   ATTEMPT         8.022    18.069  Reconnecting…
2026-08-22T17:13:04.962  17:13:04.889   ATTEMPT         8.018    18.057  Reconnecting…
2026-08-22T17:13:23.235  17:13:22.951   ATTEMPT         8.026    18.062  Reconnecting…
```

Evidence after fix:

```
# AFTER — head cc3460fcbd2e9cfc4b4f43f3787691f97271332b, same phone, same Gateway, same failure mode
# observed timing (notification-post deltas), not the policy's computed values
host_wall                device_when    kind      retry_delay   cadence  state
2026-08-22T17:17:21.075                 MARKER                           >>> WIFI_OFF_AFTER
2026-08-22T17:17:35.176  17:17:34.960   ATTEMPT         0.969    14.750  Reconnecting…   <- outage ladder starts
2026-08-22T17:17:46.800  17:17:46.755   ATTEMPT         1.698    11.795  Reconnecting…
2026-08-22T17:17:59.904  17:17:59.750   ATTEMPT         2.965    12.995  Reconnecting…
2026-08-22T17:18:15.001  17:18:14.721   ATTEMPT         4.946    14.971  Reconnecting…
2026-08-22T17:18:33.047  17:18:32.765   ATTEMPT         7.975    18.044  Reconnecting…   <- BEFORE flattened here
2026-08-22T17:18:55.229  17:18:55.196   ATTEMPT        12.388    22.431  Reconnecting…   <- AFTER keeps growing
2026-08-22T17:19:24.760  17:19:24.581   ATTEMPT        19.360    29.385  Reconnecting…
2026-08-22T17:20:00.698  17:20:00.439   ATTEMPT        25.794    35.858  Reconnecting…
2026-08-22T17:20:55.171  17:20:55.204   ATTEMPT        44.780    54.765  Reconnecting…
2026-08-22T17:23:00.880  17:23:00.753   ATTEMPT       115.516   125.549  Reconnecting…
2026-08-22T17:26:05.588  17:26:05.643   ATTEMPT       174.851   184.890  Reconnecting…
2026-08-22T17:34:49.207  ...            ATTEMPT       225.517   235.556  Reconnecting…

retry_delay (FAIL -> next ATTEMPT)  (n=47)
  min 0.504s   max 225.517s
  > 9s: 24    >= 150s: 2
```

Reading the tables: each arm's capture begins while the app is still connected, and the induced outage starts at the marker shown in each trace. The BEFORE excerpt is shown from before its marker, so its first row (0.324 s) is that pre-outage churn; the AFTER excerpt is shown from its marker onwards, so every row in it is inside the outage. In both arms the loop was already one failure into its ladder when Wi-Fi went off, so the first interval after the marker is the second step (computed 1.011 s), not the first (0.595 s). Through that region the two arms track the same values — 1.02, 1.76, 2.94, 4.95, 8.06 s before, against 0.97, 1.70, 2.97, 4.95, 7.98 s after — and they diverge at the next step, where the old build repeats 8 s and the new one goes to 12.39 s.

Counts: `retry_delay` is measured from a failure to the next attempt, so an attempt that is not preceded by a failure has none. Exactly two `ATTEMPT` rows in the AFTER capture are immediately preceded by a `CONNECTED` row (17:30:53 and 17:55:35), each the first attempt of a fresh outage after a successful reconnection, which is why 49 attempts yield 47 delays. The BEFORE arm never reconnected, so all 36 of its attempts follow a failure.

I am not quoting an attempts-per-minute comparison: the two windows differ in length by design (the AFTER ladder needs several minutes to climb, so a duration-matched window would truncate the behaviour under test), and while preparing this PR I found that the capture's own rate summaries were computed over a window that ended before the recovery tests were appended. The recomputation is written up in the corrections note of the linked artifact. It changes no claim here: the cadence claims rest on the per-interval delays, which are unaffected. The Recents and network-restore claims rest instead on recorded app-process state, Recents contents and event ordering, which the artifact keeps separately.

Observed result on the earlier 300 s candidate: the early transient ladder is unchanged, but at the attempt where the old build flattened to 7.97 s the candidate went to 12.39 s and kept climbing to 225.52 s. Over the whole BEFORE window no delay exceeded 8.056 s; in AFTER, 24 of 47 delays exceeded 9 s. Dismissal from Android Recents did not restore seconds-scale retry. This is historical progressive-backoff evidence, not final-head timing evidence.

After dismissal from Android Recents (the swipe is bracketed by Recents holding 10 entries at 17:54:24 and 0 at 17:54:50, process unchanged):

```
2026-08-22T17:57:12.227  17:57:12.151   ATTEMPT        87.063    97.111  Reconnecting…
2026-08-22T17:59:19.373  17:59:19.326   ATTEMPT       117.138   127.175  Reconnecting…
```

Recovery, on the same device:

```
network restore   NOT ESTABLISHED by this capture, see below. An attempt did fire at
                  17:35:29.884, 30.649s after the failure at 17:34:59.235, and reached
                  Connected at 17:35:40.774 — but this capture cannot show that a restore
                  caused it
manual reconnect  operator tap 17:51:45.505 -> attempt 17:51:46.015  =  0.51s
wake resets       woken attempt failed 17:47:28.015 -> next delay 1.062s
                  woken attempt failed 17:51:56.263 -> next delay 1.034s
success resets    after the 17:35:40.774 success, the next induced outage restarted at
                  0.602, 0.994, 1.747, 2.894s
```

What is not yet tested on a physical device: final head `d7d5c4e0ec166e1c0d776cc1217dfd073212f9ca` with the 60 s ceiling and VPN/private-LAN restore path. The absolute policy bound is covered by `steadyReconnectTimerIsThirtyToSixtySecondsBeforeConnectionTime`, which failed against the intermediate 300 s candidate (`expected:<30000> but was:<150000>`, that being its jitter-floor value, not main's 8 s ceiling) and passes after it; `reconnectDelayStaysBoundedSoAnEndpointOnlyRestartIsStillFound` keeps probing finite across 1024 attempts. Earlier hardware campaigns establish that endpoint-only Gateway restarts are rediscovered under progressive backoff, but they used the intermediate 300 s candidate and are not claimed as final-head timing proof. No battery benchmark was run.

Proof limitations or environment constraints: the physical-device campaigns below establish the before/after retry workload and endpoint-only recovery mechanics, but they predate final head `d7d5c4e0ec166e1c0d776cc1217dfd073212f9ca` and used the intermediate 300 s policy. The final 30-60 s policy is pinned by a failing/passing absolute-bound regression and by both Android flavor suites in AWS Crabbox. No final-head physical VPN/private-LAN campaign, battery percentage, mAh improvement, or battery benchmark is claimed.

## Evidence

<!-- pr127873-ack-verification -->
### Current ACK candidate — September 4, 2026

Published head: 38acb9e1605c077636542e60a0e526bfb36db13f. Reviewed/tested tree: 7146a0c416a38f88a7f55b367d9809c4a721002c. Original commits and hardware evidence are preserved; the new commit includes IWhatsskill's coauthor trailer.

| Regression | Runnable BEFORE | Current AFTER |
|---|---|---|
| ACK cannot enqueue after real OkHttp >16 MiB overflow and dropped close exchange | assertion fails: READY socket does not reconnect | passes: current socket retires and reconnects |
| DNS-only change on the same mutable LinkProperties object | assertion fails: no wake | passes: one wake; duplicates/lost/reattach coalesce correctly |

The focused pair failed 2/2 before and passed 2/2 after. Final software validation: 120 Play + 120 ThirdParty tests (zero failures/errors/skips), all four Android modules' ktlintCheck, 111 Gateway tests across 10 files, all changed gates, and full pnpm build (4m 8.8s): exit 0. An earlier build topology-fence failure and an execution-context-loss interruption were diagnosed; neither is counted as a pass.

Toolchain: Gradle 9.7.1 and JDK 21. From apps/android:

```sh
./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.gateway.GatewaySession*' --tests 'ai.openclaw.app.gateway.NetworkMonitorTest' --tests 'ai.openclaw.app.GatewayFleetSelectionTest' :app:testThirdPartyDebugUnitTest --tests 'ai.openclaw.app.gateway.GatewaySession*' --tests 'ai.openclaw.app.gateway.NetworkMonitorTest' --tests 'ai.openclaw.app.GatewayFleetSelectionTest' ktlintCheck --max-workers=2 --no-daemon --console=plain
```

From the repository root:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/gateway/role-policy.test.ts src/gateway/server-methods-list.test.ts src/gateway/server-methods.authorization.test.ts src/gateway/server.preauth-hardening.test.ts src/gateway/server/ws-connection/authenticated-request-dispatch
node scripts/check-changed.mjs
pnpm build
```

**Native Codex:** fresh full-PR local review against 0f429cef53d8d1dfbe5358b962f56c70c6db8153, scoped-clean through P2. **Independent maintainer review:** no remaining source-backed correctness finding; the bounded owner-level fix is appropriate, but this is not overall merge readiness. Full PR production +324/-57 (net +267), tests/test support +1013/-20, docs +16; growth implements retry/fleet/route ownership and an authenticated ACK, while removing the sequence-counter wrapper.

**Exact-head CI:** being watched; no green result claimed yet. **ClawSweeper:** the prior d7d5c4e review requires physical proof; a new-head verdict is not yet verified.

**Unwaived proof gap:** exact-final-head physical Android private-LAN/VPN restoration through NetworkMonitor → NodeRuntime → GatewaySession, automatic recovery without manual reconnect, build identity and elapsed time. Local ADB exposed no physical device. Earlier real-Gateway/Robolectric ACK timing retained the same socket beyond 9.5 s under 600 ms each-way delay, but predates the final two Android fixes and is not physical-device proof. No battery benchmark or improvement is claimed. Older sections below are historical evidence, not final-head proof.
<!-- /pr127873-ack-verification -->

### Earlier d7d5c4e maintainer verification (superseded)

Candidate head: `d7d5c4e0ec166e1c0d776cc1217dfd073212f9ca`, rebased onto `0f429cef53d8d1dfbe5358b962f56c70c6db8153`. The main branch already contains the central npm advisory/CI repairs; this PR does not add a security-audit bypass.

**Repair owner:** GatewaySession's pending-RPC and connection lifecycle. A coalesced check accepts a response only when its matching request was enqueued after the restore baseline. That baseline and enqueue use the same write mutex. Replies settle the existing waiter and record their sequence at the response owner. Fully silent and one-way-broken flows are retired without invalidating a later connection or overriding an auth pause/Disconnect.

| Scenario | Before evidence | After evidence |
| --- | --- | --- |
| Silently broken READY socket | Published head `8e36d6b0496503c606a018199154c7b8e12b44f7` plus the regression: the ordinary RPC timed out after 15,011 ms and the old lease was still current; a fresh TCP flow through the same listener succeeded. | Both-flavor pre-rebase after proof retired the failed flow at approximately 8.0 s, reconnected, and completed a fresh RPC. |
| Slow health summary, healthy transport | An intermediate health-only candidate closed a still-responsive socket; its dedicated negative control failed. | A fresh non-health RPC while health remains pending preserves the same lease and unrelated work. An application-error health reply also proves liveness. |
| Broken outbound path with live inbound events | The intermediate inbound-counter candidate still reached the 15,001 ms RPC timeout. | The directional TCP test now retires the stale flow and reconnects. It also delivers a late reply to a pre-restore request, which must not count as new liveness. |
| Replacement, Disconnect, auth pause | Existing lifecycle regression boundaries remain in scope. | A late check cannot retire the replacement, undo Disconnect, or clear a deliberate auth pause; repeated callbacks coalesce per physical socket. |

These are host-JVM/Robolectric tests using the production GatewaySession with real OkHttp WebSockets and a real loopback TCP forwarding proxy. Fault injection drops application bytes without EOF/reset, while new connections remain usable. This is deterministic transport-boundary proof, **not** a physical Android radio, private-LAN/VPN campaign, UI recording, or battery benchmark.

**Executed pre-rebase validation:** 117 tests per flavor (234 total), zero errors/failures/skips; app KtLint and the repository changed gate including all four Android KtLint modules passed. A fresh independent P0-P2 Codex review of the final repair reported no actionable findings. All four repair/test file hashes and the relevant unchanged callers/contracts were rechecked across the rebase.

**Final-head local validation:** Completed on d7d5c4e0ec166e1c0d776cc1217dfd073212f9ca: 117 Play + 117 Third-Party tests, zero failures/errors/skips, followed by the complete changed gate over all eight PR paths including all Android KtLint modules. The worktree is clean; repaired source/test hashes match the independently reviewed candidate.

Reproduction commands from repository root (with the installed Android SDK selected normally):

```sh
apps/android/gradlew -p apps/android --no-daemon --max-workers=2 :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.gateway.GatewaySession*Test' --tests ai.openclaw.app.gateway.NetworkMonitorTest --tests ai.openclaw.app.GatewayFleetSelectionTest
apps/android/gradlew -p apps/android --no-daemon --max-workers=2 :app:testThirdPartyDebugUnitTest --tests 'ai.openclaw.app.gateway.GatewaySession*Test' --tests ai.openclaw.app.gateway.NetworkMonitorTest --tests ai.openclaw.app.GatewayFleetSelectionTest
apps/android/gradlew -p apps/android :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck
```

**Exact-head GitHub CI:** [run 33878942077, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33878942077) completed successfully on `d7d5c4e0ec166e1c0d776cc1217dfd073212f9ca`. `security-fast`, all six Android lanes, and `openclaw/ci-gate` are green. The npm bulk audit returned no matching high-or-higher production advisories; this is not comprehensive vulnerability clearance.

**Exact-head ClawSweeper status (reviewed September 4, 2026, 13:55 UTC):** [no actionable code or security findings](https://github.com/openclaw/openclaw/pull/127873#issuecomment-5380037956), but still `needs-human` / blocked. Remaining gates are a redacted final-head real Android private-LAN/VPN restoration trace and explicit maintainer acceptance of the 30–60 s passive retry timer plus connection time. Neither gate is marked resolved here; no merge or formal review-status change has been made.

**Remaining real-device boundary:** the gate named above stays open. What is new is a final-head *emulator* callback-boundary run, in the section below, which states its own limits there. The earlier physical campaigns further below used the intermediate 300 s policy and are not final-head measurements.

**Production/test delta against the rebased main:** production +259/-46 (net +213); tests/test support +745/-20 (net +725), across eight files. The new repair itself is production +65/-22 (net +43): the added state records a previously missing connection-owned, request-correlated liveness fact. It replaces the rejected inbound-traffic heuristic rather than layering both policies.

**Earlier regression evidence retained as historical only:** VPN matching/cross-route wake controls were red in AWS run `run_787f8457d0e8` and green in `run_90d71d93ae8f`; the one-minute policy was verified in `run_6e43f376aa60` on an earlier head; startup suppression was red in `run_d7ad9197a7a6` and green in `run_27cdafa16f4e`. Their results are not relabeled as tests of this final SHA. The duplicate startup callback test was consolidated into the equivalent retained plain-attach boundary test.

### Tests

Tests, by file, at this head:

- `apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt` — the
  retry-delay policy and the wake semantics: transient delays identical to the previous formula,
  continued growth past the old ceiling, the steady band's absolute bounds, that no attempt retries
  sooner than before, that probing stays bounded so an endpoint-only restart is still found, and
  that a network restore, a manual reconnect and a cleared auth pause each interrupt a pending
  backoff and resume in the fast band.
- `apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt` — the route
  callback boundary: an attach edge is a restore on its own, a network's attach and its first
  capability snapshot coalesce into one wake, two different networks each wake the fleet, and the
  registered request no longer excludes VPN routes.
- `apps/android/app/src/test/java/ai/openclaw/app/GatewayFleetSelectionTest.kt` — the
  network-restore fan-out: operator, node and every live secondary are woken; a single secondary;
  no secondaries at all; and a fleet cleared after the call, to show the wake acted on a snapshot.

Both Android flavours pass at this head (117 Play + 117 Third-Party on the focused selection above,
zero failures, errors or skips), with the changed gate and all four Android KtLint modules green.
The absolute policy bound is pinned by
`steadyReconnectTimerIsThirtyToSixtySecondsBeforeConnectionTime`, which fails when the ceiling moves
(it failed against the intermediate 300 s candidate with `expected:<30000> but was:<150000>`).

### Earlier d7d5c4e emulator evidence (not current physical-device proof)

This is a partial answer to the request on this PR for a run on exact head
`d7d5c4e0ec166e1c0d776cc1217dfd073212f9ca` showing a saved Gateway recovering, without a manual
Reconnect, when a route that never validates comes back.

**What it is and is not, plainly.** It is an Android emulator running the real app against a real
Gateway, so it is a live behavioural run rather than a host-JVM test. It is **not** a physical
handset, it carries no radio evidence, and the network it uses is an ordinary **non-VPN** one —
`dumpsys` reports `NOT_VPN` throughout — that was made unable to validate. What it reproduces is the
"attaches but never validates" property a private LAN shares, not a VPN transport and not the
removal of the default `NOT_VPN` request filter. The physical private-LAN/VPN gate therefore stays
open. What the run provides is controlled evidence consistent with the
attribution — which build shows an early, route-associated attempt and which does not.

Environment: headless emulator, `aosp_atd` API 31 (Android 12), `pixel_6` profile, x86_64,
software-rendered. Its only network is `eth0`/`10.0.2.15`, reported as `MOBILE`, whose default route
reaches the host at `10.0.2.2`. A real OpenClaw Gateway built from this same head runs on the host,
loopback-bound on its own port under its own profile with token auth; the app is really paired to it
(`devices approve` and `nodes approve` were run) and reached `Connected` before each run. The outage
is that Gateway process being stopped. No instrumentation was added to either build — the observable
is the app's own foreground-service notification and its device-side `when` timestamp, sampled every
250 ms.

**Induced condition, stated plainly.** The emulator's route validates normally because the host has
internet. To reproduce a private-LAN/split-tunnel capability state, Android's captive-portal probe
URLs were pointed at an unreachable address, so validation cannot succeed. The route then attaches
and carries traffic while never gaining `NET_CAPABILITY_VALIDATED`, confirmed in
`dumpsys connectivity` at each step:

```
while down    Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN&NOT_VCN_MANAGED
after it returns
              Capabilities: MMS&SUPL&DUN&FOTA&IMS&CBS&INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN
              &NOT_ROAMING&FOREGROUND&NOT_CONGESTED&NOT_SUSPENDED&NOT_VCN_MANAGED
```

Two builds, both from the same `:app:assemblePlayDebug` on this head, installed into the same app
slot with `adb install -r` so the pairing survives the swap. **A** is this head unmodified; **B** is this
head with exactly this block deleted from `NetworkMonitor`'s `ConnectivityManager.NetworkCallback`,
and nothing else changed:

```kotlin
      override fun onAvailable(network: Network) {
        // Fires once per network attach, before validation resolves, so it also covers a
        // restored private LAN/VPN route that never reaches NET_CAPABILITY_VALIDATED.
        // Registration can replay an existing route, but session guards make that wake harmless;
        // dropping it here would also drop an indistinguishable genuine restore.
        val newlyAvailable = restoreState.onAvailable(network)
        if (newlyAvailable) {
          notifyNetworkAvailable()
        }
      }
```

APK sha256:

```
A  dc5e4e38bf097ad2a02afcb9a75cacc1de95d6c9f1986ee0b6015334a7e2b4c6
B  7213892037de3fe44478aec5695d0f649857d5715b25d0051ef9988254da6bc3
```
 `NetworkMonitor` has exactly two calls to
`notifyNetworkAvailable()`, one in each callback, so with that block gone B's only remaining wake
path in this class is the validated edge in `onCapabilitiesChanged` — which this route never
produces. That is a source-level property of the build, not something the trace shows.

Exact steps or command run after this patch: build both APKs from the repository root with
`apps/android/gradlew -p apps/android :app:assemblePlayDebug` on this head, deleting only the
`onAvailable` override for B;
`adb install -r` each into the same slot; stop the Gateway; wait for the retry ladder to reach its
steady band; restart the Gateway (which produces no Android network event); then
`adb shell svc data disable`, wait, `adb shell svc data enable`; sample
`adb shell dumpsys notification` every 250 ms and record each change with the app's own `when`
timestamp, and read `dumpsys connectivity` at each step. Restarting the Gateway before touching the
route is what makes the timer excludable: an attempt that lands before the timer floor cannot be the
timer.

```
                                     A (this head)          B (onAvailable removed)
ladder before the sequence           …32.8  35.7  46.6      …40.5  43.2  39.8  39.9
last failure                         14:43:41.849           14:51:58.974
floor implied by that row            14:44:11.849           14:52:28.974   (that failure + the 30 s floor)
Gateway listening again              14:43:52.690           14:52:11.631
route down                           14:43:56.692           14:52:15.632
route up (command issued)            14:44:02.293           14:52:21.596
first reconnect-status row after it  14:44:08.088           14:52:49.642
   vs route-up command                +5.80 s                +28.05 s
   vs floor implied by that row       -3.76 s  (before it)   +20.67 s  (after it)
Connected                            14:44:14.227           14:53:02.451
   vs route-up command               +11.93 s               +40.86 s
```

Observed result after fix: the callbacks themselves are not logged, so what follows is behavioural
evidence, not a direct observation of a callback firing.

One limit has to be stated before the numbers are read. This notification surface merges the
operator and node sessions, exactly as the earlier sections of this body say, so no row in the
stream can be attributed to a particular loop. The `-3.76 s` figure therefore excludes *the timer of
the session whose failure is the row above it*; it only excludes the timer outright if that attempt
and that failure belong to the same session, which this capture cannot show. One observation points that way
without settling it: no attempt of any kind appears anywhere in the 26.24 s between them. A second
laddering session whose last failure was the earlier 14:42:55.253 row would have been due between
14:43:25.253 and 14:43:55.253, which overlaps that silence by only its final 13.40 s — so this is
partial support, not an argument that closes the question. It also assumes every attempt produces an
observable re-post, which this capture does not itself verify.

**What does not depend on any of that is the contrast.** Both runs share the same merged surface and
the same ambiguity. In A an attempt-start row appeared 5.80 s after the route-up command and
before the floor implied by the preceding row; in B, differing only by the quoted block, no
reconnect row of any kind appeared until 20.67 s past that floor. That difference is what the controlled comparison buys, and it is the claim
this section rests on. It supports the `onAvailable` route wake being what produced A's early
attempt; with one run per build it does not exclude a wake path shared by both builds happening to
fire in A and not in B. The Gateway had been
listening for 15.40 s by then as a raw cross-clock subtraction, about 16.02 s once the measured
offset is applied. That interval is **not** endpoint-only evidence: it contains the deliberate route
cycle. The endpoint-only part of it is the 4.00 s between the Gateway starting to listen at
14:43:52.690 and the route going down at 14:43:56.692, during which no attempt appeared — too short
to say much on its own, and stated here only so the window is not read as more than it is. The route comes back unvalidated, an attempt follows, and
a merged `Connected` row follows 6.14 s after that attempt on the
device clock, 11.93 s after the route-up command. Because the surface merges the two sessions, that
row is an app-level status rather than a named session's recovery, and the capture does not tie it
to the attempt above it beyond their order.

In **B**, with only that override removed, the same route return produces nothing early. Its first reconnect-status
notification — `Connected (operator: Reconnecting…)`, not a standalone attempt-start row, which the
merged surface does not give here — comes 50.67 s after the previous failure row. That interval is
the gap to the first visible reconnect status, not a measured retry delay: the row is a status, not
an attempt start, and the failure it is measured from may belong to a different session. It is
*consistent with* timer-driven recovery, and it sits past the 30 s floor implied by that preceding
row rather than provably past B's own. What the trace does establish is an absence: **after the
14:51:58.974 failure row, no reconnect row of any kind appeared in B until 14:52:49.642** — nothing
showed up early after the route returned the way it did in A. (B's stream does contain earlier
`Reconnecting…` rows from before that failure; the claim is scoped to the window after it.) B's stream does reach a merged `Connected`
row either way, which is what the bounded ceiling is for; what it does not show is anything early
after the route returned, the way A's does.

The "route up" row is the host clock when `svc data enable` was issued, not a callback timestamp,
so the 5.80 s in A would include the emulator re-attaching the interface, whatever callback delivery
occurred, and the loop starting a connect — it is not a measure of wake latency alone. The same marker definition and the same
procedure were used for both runs, but the two "vs route-up command" figures are **not** comparable
wake latencies: A's interval ends with an attempt-start row before the floor implied by the
preceding row, B's with a reconnect-status row after that floor, and each also carries its own interface re-attach time and cross-clock
offset. Do not read +5.80 s against
+28.05 s as one being a faster wake than the other. The evidence in this table is narrower and
harder: A's first reconnect row lands *before* the floor implied by the failure row above it,
and B's lands *after* the floor implied by its own preceding row. Because the surface is merged,
those are floors implied by the stream, not verified floors of a named session. In A that row is an attempt start (`Reconnecting…`); in B the merged surface gives a
combined `Connected (operator: Reconnecting…)` row instead, so B's marker is the first reconnect
status of any kind rather than a separately visible attempt start. Every delta above is computed from the millisecond timestamps shown and rounded to two
decimals.

Two clocks appear in that table, and it matters which claim rests on which. The `Gateway listening`,
`route down` and `route up` rows are host-clock markers written when the command was issued; the
`last failure`, `first attempt` and `Connected` rows are the app's own device-side `when` values.
Measured at capture time by comparing `date +%s%3N` on both sides, the device clock ran about 620 ms
behind the host, with roughly ±250 ms of uncertainty from the adb round trip, so the rows that cross
the two clocks — everything labelled "vs route-up command" — carry that much slack. **The attribution
claim does not.** `last failure`, `floor implied by that row` and the first reconnect row are all
device-clock values, so A's 3.76 s margin before that floor is a within-clock comparison and no
offset can move it.

The two builds differ only by that override, which is what makes this a controlled comparison. It is
one run per build, with independently drawn jitter, so this is attribution from a controlled
difference rather than from a distribution.


Raw capture, run A (this head, unmodified) — every recorded notification change:

```
device_when_ms   utc            notification
1788532648669    14:37:28.669   Reconnecting…
1788532649027    14:37:29.027   Gateway error: Failed to connect to /10.0.2.2:18899
1788532673802    14:37:53.802   Reconnecting…
1788532673945    14:37:53.945   Gateway error: Failed to connect to /10.0.2.2:18899
1788532715549    14:38:35.549   Gateway error: Failed to connect to /10.0.2.2:18899
1788532758585    14:39:18.585   Gateway error: Failed to connect to /10.0.2.2:18899
1788532810239    14:40:10.239   Gateway error: Failed to connect to /10.0.2.2:18899
1788532847589    14:40:47.589   Gateway error: Failed to connect to /10.0.2.2:18899
1788532906769    14:41:46.769   Gateway error: Failed to connect to /10.0.2.2:18899
1788532939530    14:42:19.530   Gateway error: Failed to connect to /10.0.2.2:18899
1788532975253    14:42:55.253   Gateway error: Failed to connect to /10.0.2.2:18899
1788533020710    14:43:40.710   Reconnecting…
1788533021849    14:43:41.849   Gateway error: Failed to connect to /10.0.2.2:18899
1788533048088    14:44:08.088   Reconnecting…
1788533051394    14:44:11.394   Connected (operator: Reconnecting…
1788533054227    14:44:14.227   Connected
```

Raw capture, run B (control) — same:

```
device_when_ms   utc            notification
1788533272067    14:47:52.067   Starting…
1788533276382    14:47:56.382   Gateway error: Failed to connect to /10.0.2.2:18899
1788533280629    14:48:00.629   Gateway error: Failed to connect to /10.0.2.2:18899
1788533288148    14:48:08.148   Gateway error: Failed to connect to /10.0.2.2:18899
1788533297713    14:48:17.713   Gateway error: Failed to connect to /10.0.2.2:18899
1788533307584    14:48:27.584   Gateway error: Failed to connect to /10.0.2.2:18899
1788533325389    14:48:45.389   Gateway error: Failed to connect to /10.0.2.2:18899
1788533355671    14:49:15.671   Gateway error: Failed to connect to /10.0.2.2:18899
1788533396123    14:49:56.123   Gateway error: Failed to connect to /10.0.2.2:18899
1788533435990    14:50:35.990   Reconnecting…
1788533439317    14:50:39.317   Gateway error: Failed to connect to /10.0.2.2:18899
1788533478034    14:51:18.034   Reconnecting…
1788533479090    14:51:19.090   Gateway error: Failed to connect to /10.0.2.2:18899
1788533518974    14:51:58.974   Gateway error: Failed to connect to /10.0.2.2:18899
1788533569642    14:52:49.642   Connected (operator: Reconnecting…
1788533582451    14:53:02.451   Connected
```

These two blocks are the complete captures, not excerpts; the host-clock markers and the
`dumpsys connectivity` reads quoted above are retained alongside them.

What was not tested: it is an emulator, not a physical handset, and carries no radio evidence; it reproduces the unvalidated-attach edge that the VPN case shares, not a VPN transport;
one run per build; and the fan-out to secondary sessions is still covered by tests rather than by a
device run, because this emulator had one saved Gateway — two sessions, operator and node, but no
secondary Gateway for the fan-out to reach.

### Earlier physical-device campaign (intermediate 300 s policy)

An earlier candidate was measured on a physical handset against a live Gateway, with both builds made from that campaign base and candidate head. The campaign proves progressive backoff and endpoint-only rediscovery; it predates the final one-minute policy.

Real environment tested: a physical Xiaomi Redmi Note 11 (`2201117TL`), Android 13
(SDK 33), attached over USB to a separate machine that drives it. A real OpenClaw
Gateway on the LAN, in its own state directory on its own port; real pairing, a real
node session. The outage is that Gateway process being stopped and started again, so
the device is retrying an endpoint that genuinely is not answering and the recovery is
a real reconnect. Nothing is mocked or stubbed, and no instrumentation was added to
either build.

Both APKs are `./gradlew :app:assemblePlayDebug` builds from the same toolchain with
the same pinned build stamps, installed by `adb install -r` into a single app slot —
so package id, uid, data directory and node identity cannot differ between the two
groups:

```
BEFORE  openclaw@28164d093498 (this PR's base)  sha256:a5016b2d808770de…
AFTER   openclaw@b6338e7773e3 (intermediate 300 s candidate)  sha256:694b2b5fd4c479dd…
```

Comparing the two archives entry by entry (name, uncompressed size, CRC): both hold
1,238 entries, 1,235 of them identical, and the three that differ are `classes5.dex`,
`classes6.dex` and `classes10.dex`, 3,196 bytes of uncompressed content in total. `gatewayReconnectDelayMs`, `awaitReconnectWake`,
`reconnectWakeObserved`, `GATEWAY_RECONNECT_MAX_DELAY_MS` and
`gatewaySessionsToWakeOnNetworkRestore` are in the AFTER dex and in no BEFORE dex, and each APK carries its own build commit, so a
reader can tell the two apart from the artifacts alone.

The Gateway runs the same revision as this PR's base, so the server side of the
experiment and the BEFORE build are one commit, not two.

What is measured: the interval from the restarted Gateway reporting itself ready to the
device's node session reappearing on it — read from the Gateway's own account of its
nodes, not from the app under test, and counted only for a session that started after
the one the repetition began with, so a stale reading cannot pass as an instant
recovery. Three repetitions per build per outage length, alternating between the builds
so session drift lands on both, medians compared. The measurement has a floor: a device
that reconnects before the readiness probe observes the Gateway as ready is recorded as
zero rather than as a negative interval. No repetition here hit that floor — every one
of the twelve has its reconnect after its readiness observation — but it is the reason
the BEFORE values are worth reading as real waits rather than as a clamp.

Two outage lengths were run, because the length of the outage is what decides whether
the changed region of the ladder is reached at all:

```
                   BEFORE  (openclaw@28164d09)      AFTER  (openclaw@b6338e77)
outage 60 s        3.988 s   3.942 s   3.944 s      2.062 s   29.080 s   20.919 s
  median           3.944 s                          20.919 s
outage 300 s       6.474 s   5.184 s   6.467 s     86.073 s   30.338 s   32.770 s
  median           6.467 s                          32.770 s

each outage length: 6/6 repetitions admitted, 6/6 reconnected (12/12 overall), none
           discarded, executed base-1, candidate-1, base-2, candidate-2, base-3,
           candidate-3; tolerance 1.5 s (absolute) or 20% of the base median, whichever
           is wider — the width a difference between the two medians has to exceed before
           the comparison calls it a difference at all, derived from within-group spread
           on this deployment rather than chosen for this change. Both runs clear it.
```

These historical comparisons describe the intermediate 300 s candidate. They remain evidence that progressive backoff reduces retry frequency and that endpoint-only restarts are rediscovered, but they are not evidence for the final 60 s ceiling.


This is the cost side of the trade, and it is the worst case for it: the Gateway here
comes back with no network change and no user action, the one path that has nothing but
the timer to find it. The recovery paths a user actually exercises keep firing
immediately and were measured separately in the capture under "Real behavior proof" — a
manual reconnect produced an attempt 0.51 s after the operator's tap rather than waiting
out the pending timer. Its timing afterwards does change, in the user's favour: the wake
resets the ladder, so the retries that follow one are back in the fast band (1.062 s and
1.034 s in that capture) rather than resuming the long wait the loop had climbed to. The benefit side, how often the device does reconnect work during the
outage, is what that capture measures.

### Provenance of the tables above

The tables under "Real behavior proof" were captured on a build pair pinned to base
`ff6db34233d` (BEFORE) and head `cc3460fcbd2e` (AFTER). This branch has since been
rebased onto `28164d09349`, and the reconnect behaviour was re-measured there, on a
different physical handset, against a live Gateway — that is the campaign above. The
older tables are kept because they are the finer-grained record: per-attempt intervals
across a 42-minute outage, which the newer run does not reproduce.

Nothing the older capture measured moved between those two bases, and that is
checkable rather than asserted. In
`git diff ff6db34233d 28164d09349 -- apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt`:

- no hunk falls inside `runLoop()` or the connect path it drives — the region from
  `private suspend fun runLoop()` through the opening half of `connectOnce()` is
  byte-identical across the two bases;
- neither does any hunk fall inside the block from `connect()` to
  `readyConnection()`, which holds `disconnect()`, `reconnect()`,
  `retryAfterNetworkRestore()`, `signalReconnect()` and `drainReconnectSignals()` —
  every producer and consumer of `reconnectSignal`. That block is byte-identical too.
- The observable is unchanged as well: `NodeForegroundService.kt` has no commit in
  that range and `gatewayConnectionStatusForDisplay()` in `NodeRuntime.kt` is
  byte-identical, so the two notification writes that capture times are still the
  same two writes.

What upstream did change in that file over the range is the canvas surface URL
resolver, an event sequence-gap check and a TLS fingerprint helper. The reconnect
loop calls none of them.

The following source-equivalence discussion applies only to the earlier 300 s campaign candidates, not the current 60 s policy or round-trip repair. For that historical comparison, the patch was unchanged by the rebase: `gatewayReconnectDelayMs`,
`drainReconnectSignals` and the three `runLoop` call sites are byte-identical between the
measured head `cc3460fcbd2e` and this head. `awaitReconnectWake` is the one piece that is not:
it now also compares a wake count across the wait, so that a wake taken out of the channel by
the receive its own timeout cancels is still seen. That cannot move anything the older tables
measured, and the reason is structural rather than empirical — the new condition is
`delivered || the count moved`, which is true wherever the old condition `delivered` was true.
It only adds a second way for a wake to be noticed; it can never make a delivered one
unnoticed. Every wake that capture does establish was delivered normally, which is visible in it:
the manual reconnect produced an attempt 0.51 s after the tap, followed by a fast-band
retry. The later
commit adds the network-restore fan-out described in "Why these pieces land
together"; it touches `NodeRuntime.kt` only, so the retry algorithm those
measurements exercise is unchanged by it. The fan-out itself is covered by the fleet
tests, not by a device run: a two-gateway physical scenario was not performed.

![before/after reconnect cadence on a physical device](https://github.com/user-attachments/assets/3a537187-340b-4180-b0be-eb86f0ee6c21)

Full sanitized capture: the interval tables quoted above, the raw notification stream they are derived from, the recovery observations, a per-claim mapping giving each claim its result and the timestamp that shows it, the environment and limitations, and a corrections note for the summary aggregates.
**https://gist.github.com/masatohoshino/97b35625a41c4610e323278519b14935**

Historical campaign test inventory (not final-head test totals):

- `GatewaySessionReconnectTest` — the earlier campaign grew from 30 to 42 tests; the earlier d7d5c4e validation included 54 reconnect tests per flavor.
- `GatewayFleetSelectionTest` — 4 to 8, covering the network-restore fan-out: one asserts operator, node and three secondaries are all woken; one covers a single secondary; one covers no secondaries at all, so the primary pair is still woken; and one clears the fleet after the call to show the wake acted on a snapshot. Supplemental (not the proof): `:app:testPlayDebugUnitTest` (2424 tests) and `:app:testThirdPartyDebugUnitTest` (2555 tests) pass, `:app:ktlintCheck` and `:app:lintPlayDebug` clean. The new tests cover the delay policy — transient delays identical to the previous formula, continued growth past the old ceiling, the sustained band, exact jitter bounds, that no attempt retries sooner than before, that probing stays bounded so an endpoint-only restart is still found, and that a network restore, a manual reconnect and a cleared auth pause each interrupt a pending backoff and resume in the fast band. Five negative controls were run against the retry policy, one per behaviour it introduces: removing the wake reset fails the network-restore and manual-reconnect tests (`next retry waited 8013ms`), restoring the 8 s ceiling fails the sustained-band tests (`attempt 13 jitter 0.0 still probes every 8000ms`), removing the auth-pause reset fails its own test (`next retry waited 8025ms`), dropping the wake-count term from the wait's decision fails `aWakeTheChannelNeverDeliveredStillCountsAsAWake`, and leaving the endpoint-replacement producer out of the count fails `everyWakeProducerAdvancesTheWakeCount` (`replacing the desired endpoint did not advance the wake count`). Each control was produced by reverting that one line in the working tree and running the same Gradle test task; the quoted strings are the resulting assertion messages. The fan-out has its own control: dropping the secondary fleet from the selection helper fails three of its four tests (`expected:<5> but was:<2>`). Passing an empty fleet at the call site does not fail anything, because `NodeRuntime` cannot be constructed in a unit test, so the call site is asserted by reading rather than by a test. The remaining tests were not individually mutation-checked.

### Verification boundary

The reported user impact is severe battery drain. This PR claims no measured percentage, mAh or battery-life improvement; no battery benchmark or usage attribution was used as evidence. It verifies the causal workload — sustained frequent reconnect attempts against a genuinely unreachable Gateway — and that it becomes low-duty while prompt recovery is preserved.

Worked on by:
- @IWhatsskill

Team session: https://team.openclaw.ai/chat/roboclaw/dashboard/75783fbd-fc4d-4efb-b241-e3ab44545dd7
