### PR TITLE
fix(plugins): plugins update reports a version downgrade as a successful update

### DIFF
--- a/src/hooks/update.test.ts
+++ b/src/hooks/update.test.ts
@@ -1,4 +1,7 @@
 // Hook update tests cover updating installed hook records and config.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookInstallRecord } from "../config/types.hooks.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -34,16 +37,26 @@ function createHookInstallConfig(params: {
   hookId: string;
   spec: string;
   integrity?: string;
+  installPath?: string;
 }): OpenClawConfig {
   hookInstalls = {
     [params.hookId]: {
       source: "npm",
       spec: params.spec,
-      installPath: `/tmp/hooks/${params.hookId}`,
+      installPath: params.installPath ?? `/tmp/hooks/${params.hookId}`,
       ...(params.integrity ? { integrity: params.integrity } : {}),
     },
   };
   return {};
+}
+
+function createInstalledHookPackDir(version: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hook-pack-"));
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "@openclaw/demo-hooks", version }),
+  );
+  return dir;
 }
 
 describe("updateNpmInstalledHookPacks", () => {
@@ -160,4 +173,38 @@ describe("updateNpmInstalledHookPacks", () => {
       installedAt: "2026-05-11T20:00:00.000Z",
     });
   });
+
+  it.each([
+    { dryRun: false, message: 'Downgraded hook pack "demo-hooks": 1.2.3 -> 1.2.2.' },
+    { dryRun: true, message: 'Would downgrade hook pack "demo-hooks": 1.2.3 -> 1.2.2.' },
+  ])(
+    "reports hook pack installs that move backwards as downgrades (dryRun: $dryRun)",
+    async ({ dryRun, message }) => {
+      const installPath = createInstalledHookPackDir("1.2.3");
+      installHooksFromNpmSpecMock.mockResolvedValue({
+        ok: true,
+        hookPackId: "demo-hooks",
+        hooks: ["demo"],
+        targetDir: installPath,
+        version: "1.2.2",
+      });
+
+      const config = createHookInstallConfig({
+        hookId: "demo-hooks",
+        spec: "@openclaw/demo-hooks",
+        installPath,
+      });
+      const result = await updateNpmInstalledHookPacks({ config, hookIds: ["demo-hooks"], dryRun });
+
+      expect(result.outcomes).toEqual([
+        {
+          hookId: "demo-hooks",
+          status: "updated",
+          currentVersion: "1.2.3",
+          nextVersion: "1.2.2",
+          message,
+        },
+      ]);
+    },
+  );
 });

--- a/src/hooks/update.test.ts
+++ b/src/hooks/update.test.ts
@@ -1,10 +1,10 @@
 // Hook update tests cover updating installed hook records and config.
-import fs from "node:fs";
-import os from "node:os";
+import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookInstallRecord } from "../config/types.hooks.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import type { HookNpmIntegrityDriftParams } from "./install.js";
 
 const installHooksFromNpmSpecMock = vi.fn();
@@ -50,9 +50,11 @@ function createHookInstallConfig(params: {
   return {};
 }
 
-function createInstalledHookPackDir(version: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hook-pack-"));
-  fs.writeFileSync(
+const tempDirs = createTrackedTempDirs();
+
+async function createInstalledHookPackDir(version: string): Promise<string> {
+  const dir = await tempDirs.make("openclaw-hook-pack-");
+  await fs.writeFile(
     path.join(dir, "package.json"),
     JSON.stringify({ name: "@openclaw/demo-hooks", version }),
   );
@@ -63,6 +65,10 @@ describe("updateNpmInstalledHookPacks", () => {
   beforeEach(() => {
     installHooksFromNpmSpecMock.mockReset();
     hookInstalls = {};
+  });
+
+  afterEach(async () => {
+    await tempDirs.cleanup();
   });
 
   it("aborts exact pinned hook pack updates on integrity drift by default", async () => {
@@ -180,7 +186,7 @@ describe("updateNpmInstalledHookPacks", () => {
   ])(
     "reports hook pack installs that move backwards as downgrades (dryRun: $dryRun)",
     async ({ dryRun, message }) => {
-      const installPath = createInstalledHookPackDir("1.2.3");
+      const installPath = await createInstalledHookPackDir("1.2.3");
       installHooksFromNpmSpecMock.mockResolvedValue({
         ok: true,
         hookPackId: "demo-hooks",

--- a/src/hooks/update.ts
+++ b/src/hooks/update.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildNpmResolutionFields } from "../infra/install-source-utils.js";
 import {
   expectedIntegrityForUpdate,
+  isPackageVersionDowngrade,
   readInstalledPackageVersion,
 } from "../infra/package-update-utils.js";
 import type { InstallSafetyOverrides } from "../plugins/install-security-scan.types.js";
@@ -170,6 +171,7 @@ export async function updateNpmInstalledHookPacks(params: {
     const nextLabel = nextVersion ?? "unknown";
     const status =
       currentVersion && nextVersion && currentVersion === nextVersion ? "unchanged" : "updated";
+    const downgraded = isPackageVersionDowngrade(currentVersion, nextVersion);
 
     if (params.dryRun) {
       outcomes.push({
@@ -180,7 +182,7 @@ export async function updateNpmInstalledHookPacks(params: {
         message:
           status === "unchanged"
             ? `Hook pack "${hookId}" is up to date (${currentLabel}).`
-            : `Would update hook pack "${hookId}": ${currentLabel} -> ${nextLabel}.`,
+            : `${downgraded ? "Would downgrade" : "Would update"} hook pack "${hookId}": ${currentLabel} -> ${nextLabel}.`,
       });
       continue;
     }
@@ -204,7 +206,7 @@ export async function updateNpmInstalledHookPacks(params: {
       message:
         status === "unchanged"
           ? `Hook pack "${hookId}" already at ${currentLabel}.`
-          : `Updated hook pack "${hookId}": ${currentLabel} -> ${nextLabel}.`,
+          : `${downgraded ? "Downgraded" : "Updated"} hook pack "${hookId}": ${currentLabel} -> ${nextLabel}.`,
     });
   }
 

--- a/src/infra/package-update-utils.test.ts
+++ b/src/infra/package-update-utils.test.ts
@@ -1,0 +1,40 @@
+// Package update utility tests cover version ordering used by update reporting.
+import { describe, expect, it } from "vitest";
+import { comparePackageUpdateVersions, isPackageVersionDowngrade } from "./package-update-utils.js";
+
+describe("comparePackageUpdateVersions", () => {
+  it("orders OpenClaw release versions ahead of their prereleases", () => {
+    expect(comparePackageUpdateVersions("2026.7.2-beta.5", "2026.7.1-1")).toBeGreaterThan(0);
+    expect(comparePackageUpdateVersions("2026.7.1-1", "2026.7.2-beta.5")).toBeLessThan(0);
+  });
+
+  it("falls back to semver ordering for plain package versions", () => {
+    expect(comparePackageUpdateVersions("1.2.4", "1.2.3")).toBeGreaterThan(0);
+    expect(comparePackageUpdateVersions("1.2.3", "1.2.3")).toBe(0);
+  });
+
+  it("treats unparseable versions as equal instead of guessing a direction", () => {
+    expect(comparePackageUpdateVersions("not-a-version", "1.2.3")).toBe(0);
+  });
+});
+
+describe("isPackageVersionDowngrade", () => {
+  it("detects an install that moved the version backwards", () => {
+    expect(isPackageVersionDowngrade("2026.7.2-beta.5", "2026.7.1-1")).toBe(true);
+    expect(isPackageVersionDowngrade("1.2.3", "1.2.2")).toBe(true);
+  });
+
+  it("does not flag forward or identical moves", () => {
+    expect(isPackageVersionDowngrade("1.2.3", "1.2.4")).toBe(false);
+    expect(isPackageVersionDowngrade("1.2.3", "1.2.3")).toBe(false);
+  });
+
+  it("does not flag a downgrade when either version is unknown", () => {
+    expect(isPackageVersionDowngrade(undefined, "1.2.3")).toBe(false);
+    expect(isPackageVersionDowngrade("1.2.3", undefined)).toBe(false);
+  });
+
+  it("does not flag a downgrade when a version cannot be parsed", () => {
+    expect(isPackageVersionDowngrade("git-abcdef", "1.2.3")).toBe(false);
+  });
+});

--- a/src/infra/package-update-utils.ts
+++ b/src/infra/package-update-utils.ts
@@ -1,5 +1,27 @@
 // Inspects installed package metadata for update/install verification.
 import { readRootJsonObjectSync } from "@openclaw/fs-safe/json";
+import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
+import { compareValidSemver } from "./semver.js";
+
+/** Compare two package versions, preferring OpenClaw release ordering over plain semver. */
+export function comparePackageUpdateVersions(left: string, right: string): number {
+  const releaseCmp = compareOpenClawReleaseVersions(left, right);
+  if (releaseCmp !== null) {
+    return releaseCmp;
+  }
+  return compareValidSemver(left, right) ?? 0;
+}
+
+/** Return whether an update replaced the installed version with an older one. */
+export function isPackageVersionDowngrade(
+  currentVersion: string | undefined,
+  nextVersion: string | undefined,
+): boolean {
+  if (!currentVersion || !nextVersion) {
+    return false;
+  }
+  return comparePackageUpdateVersions(nextVersion, currentVersion) < 0;
+}
 
 // Package update utilities inspect installed package metadata without trusting
 // paths outside the provided package root.

--- a/src/plugins/update-attempt.ts
+++ b/src/plugins/update-attempt.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ClawHubTrustErrorCode } from "../infra/clawhub-install-trust.js";
+import { isPackageVersionDowngrade } from "../infra/package-update-utils.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "./clawhub-error-codes.js";
 import { installPluginFromClawHub, type ClawHubRiskAcknowledgementRequest } from "./clawhub.js";
@@ -311,12 +312,15 @@ export async function buildDryRunPluginUpdateOutcome(params: {
     };
   }
 
+  const verb = isPackageVersionDowngrade(params.currentVersion, resolvedProbeVersion)
+    ? "Would downgrade"
+    : "Would update";
   return {
     pluginId: params.pluginId,
     status: "updated",
     currentVersion: params.currentVersion,
     nextVersion: resolvedProbeVersion,
-    message: `Would update ${params.pluginId}: ${currentLabel} -> ${nextVersion}.${params.channelFallbackSuffix}`,
+    message: `${verb} ${params.pluginId}: ${currentLabel} -> ${nextVersion}.${params.channelFallbackSuffix}`,
     ...(params.npmChannelFallback ? { channelFallback: params.npmChannelFallback } : {}),
   };
 }

--- a/src/plugins/update-claw-lifecycle.ts
+++ b/src/plugins/update-claw-lifecycle.ts
@@ -1,4 +1,5 @@
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
+import { isPackageVersionDowngrade } from "../infra/package-update-utils.js";
 import { markClawPackageIndependentlyOwned } from "../state/claw-package-adoption.js";
 import { withClawPackageLifecycleLease } from "../state/claw-package-lifecycle-lease.js";
 import type { ClawHubRiskAcknowledgementRequest } from "./clawhub.js";
@@ -53,6 +54,9 @@ export function buildPluginUpdateVersionOutcome(params: {
   const unchanged = Boolean(
     params.currentVersion && params.nextVersion && params.currentVersion === params.nextVersion,
   );
+  const verb = isPackageVersionDowngrade(params.currentVersion, params.nextVersion)
+    ? "Downgraded"
+    : "Updated";
   return {
     pluginId: params.pluginId,
     status: unchanged ? "unchanged" : "updated",
@@ -60,7 +64,7 @@ export function buildPluginUpdateVersionOutcome(params: {
     nextVersion: params.nextVersion,
     message: unchanged
       ? `${params.pluginId} already at ${currentLabel}.${params.channelFallbackSuffix}`
-      : `Updated ${params.pluginId}: ${currentLabel} -> ${nextLabel}.${params.channelFallbackSuffix}`,
+      : `${verb} ${params.pluginId}: ${currentLabel} -> ${nextLabel}.${params.channelFallbackSuffix}`,
     ...(params.channelFallback ? { channelFallback: params.channelFallback } : {}),
   };
 }

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -7,14 +7,15 @@ import { unscopedPackageName } from "../infra/install-safe-path.js";
 import type { NpmSpecResolution } from "../infra/install-source-utils.js";
 import { createNpmMetadataEnv, resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
 import {
-  compareOpenClawReleaseVersions,
   isExactSemverVersion,
   isPrereleaseResolutionAllowed,
   isPrereleaseSemverVersion,
   parseRegistryNpmSpec,
 } from "../infra/npm-registry-spec.js";
-import { expectedIntegrityForUpdate } from "../infra/package-update-utils.js";
-import { compareValidSemver } from "../infra/semver.js";
+import {
+  comparePackageUpdateVersions,
+  expectedIntegrityForUpdate,
+} from "../infra/package-update-utils.js";
 import type { UpdateChannel } from "../infra/update-channels.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
@@ -225,14 +226,6 @@ export function expectedIntegrityForNpmUpdate(params: {
   );
 }
 
-function compareNpmSemverForUpdate(left: string, right: string): number {
-  const releaseCmp = compareOpenClawReleaseVersions(left, right);
-  if (releaseCmp !== null) {
-    return releaseCmp;
-  }
-  return compareValidSemver(left, right) ?? 0;
-}
-
 export async function resolveNewerExactPinnedNpmDefaultLine(params: {
   currentVersion: string | undefined;
   effectiveSpec: string | undefined;
@@ -267,7 +260,7 @@ export async function resolveNewerExactPinnedNpmDefaultLine(params: {
   ) {
     return undefined;
   }
-  return compareNpmSemverForUpdate(metadataResult.metadata.version, params.currentVersion) > 0
+  return comparePackageUpdateVersions(metadataResult.metadata.version, params.currentVersion) > 0
     ? { packageName, registryLine, version: metadataResult.metadata.version }
     : undefined;
 }
@@ -327,7 +320,7 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
   });
   const stableVersion = versions
     ?.filter((value) => !isPrereleaseSemverVersion(value))
-    .toSorted(compareNpmSemverForUpdate)
+    .toSorted(comparePackageUpdateVersions)
     .at(-1);
   if (stableVersion) {
     const stableMetadata = await resolveNpmSpecMetadata({
@@ -339,7 +332,7 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
 
   const prereleaseVersion = versions
     ?.filter(isPrereleaseSemverVersion)
-    .toSorted(compareNpmSemverForUpdate)
+    .toSorted(comparePackageUpdateVersions)
     .at(-1);
   if (!prereleaseVersion || !versions?.every(isPrereleaseSemverVersion)) {
     return undefined;
@@ -420,11 +413,7 @@ export function isNpmMetadataCompatibleWithCurrentHost(metadata: NpmSpecResoluti
 }
 
 export function isBundledVersionNewer(bundledVersion: string, installedVersion: string): boolean {
-  const releaseCmp = compareOpenClawReleaseVersions(bundledVersion, installedVersion);
-  if (releaseCmp !== null) {
-    return releaseCmp > 0;
-  }
-  return (compareValidSemver(bundledVersion, installedVersion) ?? 0) > 0;
+  return comparePackageUpdateVersions(bundledVersion, installedVersion) > 0;
 }
 
 function shouldFallbackClawHubToDefault(result: { ok: false; code?: string }): boolean {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1571,7 +1571,7 @@ describe("updateNpmInstalledPlugins", () => {
           status: "updated",
           currentVersion: "2026.5.28-beta.4",
           nextVersion: "2026.5.28-beta.3",
-          message: "Updated msteams: 2026.5.28-beta.4 -> 2026.5.28-beta.3.",
+          message: "Downgraded msteams: 2026.5.28-beta.4 -> 2026.5.28-beta.3.",
         },
       ]);
     }
@@ -2757,6 +2757,12 @@ describe("updateNpmInstalledPlugins", () => {
       targetVersion: "1.2.3",
       status: "unchanged",
       message: "demo is up to date (1.2.3).",
+    },
+    {
+      name: "reports exact npm dry-runs that move backwards as downgrades",
+      targetVersion: "1.2.2",
+      status: "updated",
+      message: "Would downgrade demo: 1.2.3 -> 1.2.2.",
     },
   ] as const)("$name", async ({ targetVersion, status, message }) => {
     const installPath = createInstalledPackageDir({


### PR DESCRIPTION
Related to #97680

## What Problem This Solves

Running `openclaw plugins update` can leave a plugin on an **older** version than it had before, and the command reports that as a success: it prints `Updated <id>: <newer> -> <older>.` and counts the plugin in the updated tally. The `--dry-run` preview says `Would update <id>: <newer> -> <older>.` for the same move. Users reading either line have no way to tell that the version went backwards — the wording is identical to a genuine upgrade, so a downgrade is only discoverable by manually comparing the two version strings in the message. The same command prints hook pack results through the same renderer, where `Updated hook pack "<id>": <newer> -> <older>.` reports backwards moves the same way. This is reachable today with a stock package: `@openclaw/codex` publishes `latest` as the stable `2026.7.1-1` while `2026.7.2-beta.5` and `2026.8.1-beta.2` are newer prereleases, so a user on a beta who runs `plugins update @openclaw/codex@latest` is moved backwards and told it was an update.

## Why This Change Was Made

Update outcomes were built by comparing the before and after versions for **equality only** — anything not equal was labelled `Updated`, regardless of direction — so the reporting layer had no notion of a version moving backwards even though the product already compares version *order* elsewhere (`isBundledVersionNewer` gates bundled-plugin updates on exactly that ordering). This change compares direction with that same release-aware comparator and reports `Downgraded` / `Would downgrade` when an install moves backwards, at all four sites that emit this message (plugin update, plugin dry-run, hook pack update, hook pack dry-run). The comparator was moved to the `infra/package-update-utils` module both callers already import, so plugins and hook packs share one implementation instead of a second hand-rolled version comparison; that move also collapses two existing copies of the same release-then-semver comparison into one, and the shared direction helper is used only by these reporting paths. The outcome `status` is deliberately left as `updated`: its two consumers read it as "did this install change?" — the update tally in `update-command-plugins.ts` and the "repaired" bookkeeping in the doctor's missing-plugin repair — and a downgrade *is* a change, so introducing a separate status value would silently drop downgrades out of both. When either version is missing or unparseable the comparison is inconclusive and the wording stays `Updated`, so no message can claim a direction the versions do not support. **Intentionally out of scope:** whether a downgrade should be *refused* or whether the beta-tag fallback in #97680 should resolve differently — those are product decisions, and reporting accuracy is correct under either of them. Also out of scope: `skills update` in `src/cli/skills-cli.ts`, which prints a similar arrow message but is a separate command over the ClawHub skill lifecycle with its own change-detection and version semantics.

## User Impact

A `plugins update` that installs an older version now says so — `Downgraded codex: 2026.7.2-beta.5 -> 2026.7.1-1.` instead of `Updated codex: 2026.7.2-beta.5 -> 2026.7.1-1.` — and `--dry-run` warns before anything is installed. Genuine upgrades, unchanged plugins, and every failure path read exactly as before, and no automation that consumes update results changes behavior.

## Evidence

Behavior addressed: `plugins update` reporting a version that moved backwards as `Updated` / `Would update`, in the plugin and hook pack paths of the same command.

Real environment tested: Windows 11, Node v24.18.0, real npm registry, CLI built from this branch and reporting `OpenClaw 2026.8.1 (fe1ceba)`. The run used an isolated `OPENCLAW_STATE_DIR` so nothing outside the test state was touched. The package is the stock `@openclaw/codex` from the report, installed at `2026.7.2-beta.5` and then updated to `@latest`, which resolves to the older stable `2026.7.1-1`. Paths below are redacted as `<STATE_DIR>`.

Exact steps or command run after this patch:

```
export OPENCLAW_STATE_DIR=<STATE_DIR>
pnpm openclaw plugins install "@openclaw/codex@2026.7.2-beta.5" --acknowledge-install-policy-warning --acknowledge-clawhub-risk
pnpm openclaw plugins update  "@openclaw/codex@latest" --dry-run --acknowledge-install-policy-warning --acknowledge-clawhub-risk
pnpm openclaw plugins update  "@openclaw/codex@latest"           --acknowledge-install-policy-warning --acknowledge-clawhub-risk
```

Before evidence: unmodified `origin/main` (the four reporting sites reverted, rebuilt, same state dir, same specs).

```
$ pnpm openclaw plugins update "@openclaw/codex@latest" --dry-run
Would update codex: 2026.7.2-beta.5 -> 2026.7.1-1.

$ pnpm openclaw plugins update "@openclaw/codex@latest"
Updated codex: 2026.7.2-beta.5 -> 2026.7.1-1.
```

Evidence after fix: the installed version is read back from `plugins list` on both sides of the update, so the wording can be checked against what actually happened rather than taken on trust.

```
$ pnpm openclaw plugins list --json      # installed before the update
      "version": "2026.7.2-beta.5",

$ pnpm openclaw plugins update "@openclaw/codex@latest" --dry-run
Would downgrade codex: 2026.7.2-beta.5 -> 2026.7.1-1.

$ pnpm openclaw plugins update "@openclaw/codex@latest"
Downgraded codex: 2026.7.2-beta.5 -> 2026.7.1-1.

$ pnpm openclaw plugins list --json      # installed after the update
      "version": "2026.7.1-1",
```

Observed result after fix: the same command on the same package flips from `Would update` / `Updated` to `Would downgrade` / `Downgraded`, and `plugins list` confirms the install really moved from `2026.7.2-beta.5` to `2026.7.1-1` — so the new wording matches the version that is actually on disk. The only variable between the two transcripts is this patch.

Additional review, unit level: reverting the four reporting sites while keeping the new assertions fails exactly four times, once per site, and each failure prints the message a user would have seen.

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  |hooks| ../../src/hooks/update.test.ts > reports hook pack installs that move backwards as downgrades (dryRun: false)
-     "message": "Downgraded hook pack \"demo-hooks\": 1.2.3 -> 1.2.2.",
 FAIL  |hooks| ../../src/hooks/update.test.ts > reports hook pack installs that move backwards as downgrades (dryRun: true)
-     "message": "Would downgrade hook pack \"demo-hooks\": 1.2.3 -> 1.2.2.",
 FAIL  |plugins| ../../src/plugins/update.test.ts > does not skip unchanged npm plugins w…
-     "message": "Downgraded msteams: 2026.5.28-beta.4 -> 2026.5.28-beta.3.",
 FAIL  |plugins| ../../src/plugins/update.test.ts > reports exact npm dry-runs that move …
AssertionError: expected 'Would update demo: 1.2.3 -> 1.2.2.' to deeply equal 'Would downgrade demo: 1.2.3 -> 1.2.2.'

 Test Files  2 failed (2)
      Tests  4 failed | 145 passed | 1 skipped (150)
```

With the patch applied the same three suites are green (`156 passed | 1 skipped`), which also covers the equality and forward-move cases that must keep their existing wording. The third failure above is an assertion that already existed on `main` and encoded the wrong wording for a `beta.4 -> beta.3` install; it is corrected in this PR.

Toolchain:

```
pnpm tsgo:core                                     -> clean
pnpm tsgo:test:src                                 -> clean
oxlint --config .oxlintrc.json <touched files>     -> exit 0, no findings
npx oxfmt --check <touched files>                  -> All matched files use the correct format.
pnpm check:assertion-safety  --base origin/main    -> OK: 4282 files, 13509 grandfathered assertions
pnpm check:max-lines-ratchet --base origin/main    -> OK: 897 grandfathered suppressions
```

Review follow-up: the hook-pack fixture directories flagged as leaking are now allocated through the shared tracked temp-dir helper and removed after each case. Verified by clearing `openclaw-hook-pack-*` before a run and confirming no per-case directory survives it.

What was not tested: hook pack downgrades were exercised through the exported entry point with a mocked installer rather than a published hook pack, because the plugin path and the hook path build their messages from the same helper and the plugin half is covered live above.

Proof limitations or environment constraints: the live transcript was produced from the source-fix commit of this branch; the later commit on the branch is test-only and does not change runtime behavior. `src/cli/plugins-cli.update.test.ts` fails locally on this machine with `failed to acquire plugin lifecycle lease core:plugin-lifecycle/global`; that shard fails identically on a clean `origin/main` checkout with no changes applied, so it is a pre-existing local environment limitation and is left to CI.
