### PR TITLE
fix(backup): reject malformed git log limits

### DIFF
--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -5,6 +5,11 @@ import { registerBackupCommand } from "./register.backup.js";
 
 const mocks = vi.hoisted(() => ({
   backupCreateCommand: vi.fn(),
+  backupGitCreateCommand: vi.fn(),
+  backupGitInitCommand: vi.fn(),
+  backupGitLogCommand: vi.fn(),
+  backupGitRestoreCommand: vi.fn(),
+  backupGitVerifyCommand: vi.fn(),
   backupRestoreCommand: vi.fn(),
   backupSqliteCreateCommand: vi.fn(),
   backupSqliteListCommand: vi.fn(),
@@ -19,6 +24,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 const backupCreateCommand = mocks.backupCreateCommand;
+const backupGitLogCommand = mocks.backupGitLogCommand;
 const backupRestoreCommand = mocks.backupRestoreCommand;
 const backupSqliteCreateCommand = mocks.backupSqliteCreateCommand;
 const backupSqliteListCommand = mocks.backupSqliteListCommand;
@@ -29,6 +35,14 @@ const runtime = mocks.runtime;
 
 vi.mock("../../commands/backup.js", () => ({
   backupCreateCommand: mocks.backupCreateCommand,
+}));
+
+vi.mock("../../commands/backup-git.js", () => ({
+  backupGitCreateCommand: mocks.backupGitCreateCommand,
+  backupGitInitCommand: mocks.backupGitInitCommand,
+  backupGitLogCommand: mocks.backupGitLogCommand,
+  backupGitRestoreCommand: mocks.backupGitRestoreCommand,
+  backupGitVerifyCommand: mocks.backupGitVerifyCommand,
 }));
 
 vi.mock("../../commands/backup-restore.js", () => ({
@@ -60,6 +74,11 @@ describe("registerBackupCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     backupCreateCommand.mockResolvedValue(undefined);
+    mocks.backupGitCreateCommand.mockResolvedValue(undefined);
+    mocks.backupGitInitCommand.mockResolvedValue(undefined);
+    backupGitLogCommand.mockResolvedValue(undefined);
+    mocks.backupGitRestoreCommand.mockResolvedValue(undefined);
+    mocks.backupGitVerifyCommand.mockResolvedValue(undefined);
     backupRestoreCommand.mockResolvedValue(undefined);
     backupSqliteCreateCommand.mockResolvedValue(undefined);
     backupSqliteListCommand.mockResolvedValue(undefined);
@@ -136,6 +155,19 @@ describe("registerBackupCommand", () => {
       target: "/tmp/restored-openclaw",
       json: true,
     });
+  });
+
+  it.each(["1oops", "1.5"])("rejects partial Git log limit %s", async (limit) => {
+    const program = new Command().exitOverride().configureOutput({ writeErr: () => {} });
+    registerBackupCommand(program);
+
+    await expect(
+      program.parseAsync(
+        ["backup", "git", "log", "--repository", "/tmp/backups", "--limit", limit],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("--limit must be a positive integer.");
+    expect(backupGitLogCommand).not.toHaveBeenCalled();
   });
 
   it("registers the SQLite snapshot command group", () => {

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -23,6 +23,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { addGatewayClientOptions } from "../gateway-rpc.js";
 import { formatHelpExamples } from "../help-format.js";
+import { parseStrictPositiveIntOption } from "./helpers.js";
 
 /** Register backup create/verify subcommands. */
 export function registerBackupCommand(program: Command) {
@@ -230,7 +231,12 @@ function registerBackupGitCommands(backup: Command): void {
     .command("log")
     .description("Show Git backup commits")
     .requiredOption("--repository <path>", "Git backup repository directory")
-    .option("--limit <n>", "Maximum commits to show", (value) => Number.parseInt(value, 10), 20)
+    .option(
+      "--limit <n>",
+      "Maximum commits to show",
+      (value) => parseStrictPositiveIntOption(value, "--limit"),
+      20,
+    )
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `backup git log --limit` could pass partially numeric values such as `1oops` or `1.5`, which were silently truncated and accepted as `1`.

## Why This Change Was Made

The command registration now uses the repository's shared strict positive-integer parser instead of `Number.parseInt`, preserving the existing default and downstream positive-integer validation while rejecting malformed tokens before the backup command runs.

## User Impact

Backup Git-log inspection now fails clearly for malformed limits instead of returning a misleading truncated result. Valid positive integers and the default limit are unchanged.

## Evidence

- Before fix: focused registration regression failed because `1oops` and `1.5` resolved successfully and invoked the command with `limit: 1`.
- After fix: `src/cli/program/register.backup.test.ts` focused regression: 2 passed.
- Full owner/helper coverage: 13 passed (`register.backup.test.ts` 11, `helpers.test.ts` 2).
- Changed-file gate: all guards, formatting, lint, production typecheck, and core-test typecheck passed. The initial linked-worktree core-test typecheck resolved a stale parent `pako@1`; after exposing the UI workspace's installed typed `pako@3`, the failed shard passed unchanged.
- `git diff --check`: clean.
- Fresh Codex autoreview: no accepted/actionable findings; patch correctness 0.99.
- Production LOC: +7/-1; tests: +32/-0.

Provenance: clearly introduced by merged PR #122485 on 2026-08-12; code author, PR author, and merger were @steipete (merge commit `37b4fc8621d98a3debbd2202d27f40aa039f386f`).
