### PR TITLE
fix(discord): surface failed voice notes after text fallback

### DIFF
--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -551,71 +551,64 @@ describe("discordOutbound", () => {
       },
       expectedText: "spoken answer",
     },
-  ])("falls back to $name when audioAsVoice delivery fails", async ({ payload, expectedText }) => {
-    const voiceError = new Error("ffmpeg unavailable");
-    hoisted.sendVoiceMessageDiscordMock.mockRejectedValueOnce(voiceError);
+  ])(
+    "delivers fallback $name before reporting an audioAsVoice failure",
+    async ({ payload, expectedText }) => {
+      const voiceError = new Error("ffmpeg unavailable");
+      hoisted.sendVoiceMessageDiscordMock.mockRejectedValueOnce(voiceError);
 
-    const result = await discordOutbound.sendPayload?.({
-      cfg: {},
-      to: "channel:123456",
-      text: "",
-      payload,
-      accountId: "default",
-      replyToId: "reply-1",
-      replyToMode: "first",
-    });
+      await expect(
+        discordOutbound.sendPayload?.({
+          cfg: {},
+          to: "channel:123456",
+          text: "",
+          payload,
+          accountId: "default",
+          replyToId: "reply-1",
+          replyToMode: "first",
+        }),
+      ).rejects.toBe(voiceError);
 
-    expect(hoisted.sendVoiceMessageDiscordMock).toHaveBeenCalledOnce();
-    expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledOnce();
-    const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
-    expect(messageCall[0]).toBe("channel:123456");
-    expect(messageCall[1]).toBe(expectedText);
-    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).reply).toEqual(
-      { messageId: "reply-1", scope: "first" },
-    );
-    expect(result).toEqual({
-      channel: "discord",
-      messageId: "msg-1",
-      target: { kind: "channel", id: "ch-1" },
-    });
-    expect(outboundWarnSpy).toHaveBeenCalledWith(
-      "discord voice send failed; continuing without voice",
-      { error: voiceError },
-    );
-  });
+      expect(hoisted.sendVoiceMessageDiscordMock).toHaveBeenCalledOnce();
+      expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledOnce();
+      const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
+      expect(messageCall[0]).toBe("channel:123456");
+      expect(messageCall[1]).toBe(expectedText);
+      expect(
+        mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).reply,
+      ).toEqual({ messageId: "reply-1", scope: "first" });
+      expect(outboundWarnSpy).toHaveBeenCalledWith(
+        "discord voice send failed; continuing without voice",
+        { error: voiceError },
+      );
+    },
+  );
 
   it("does not duplicate already-delivered TTS supplement text when audioAsVoice delivery fails", async () => {
     const voiceError = new Error("ffmpeg unavailable");
     hoisted.sendVoiceMessageDiscordMock.mockRejectedValueOnce(voiceError);
 
-    const result = await discordOutbound.sendPayload?.({
-      cfg: {},
-      to: "channel:123456",
-      text: "",
-      payload: {
-        mediaUrls: ["https://example.com/voice.ogg"],
-        audioAsVoice: true,
-        ttsSupplement: {
-          spokenText: "spoken answer",
-          visibleTextAlreadyDelivered: true,
+    await expect(
+      discordOutbound.sendPayload?.({
+        cfg: {},
+        to: "channel:123456",
+        text: "",
+        payload: {
+          mediaUrls: ["https://example.com/voice.ogg"],
+          audioAsVoice: true,
+          ttsSupplement: {
+            spokenText: "spoken answer",
+            visibleTextAlreadyDelivered: true,
+          },
         },
-      },
-      accountId: "default",
-      replyToId: "reply-1",
-      replyToMode: "first",
-    });
+        accountId: "default",
+        replyToId: "reply-1",
+        replyToMode: "first",
+      }),
+    ).rejects.toBe(voiceError);
 
     expect(hoisted.sendVoiceMessageDiscordMock).toHaveBeenCalledOnce();
     expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
-    expect(result).toMatchObject({
-      channel: "discord",
-      messageId: "",
-      target: { kind: "channel", id: "channel:123456" },
-      receipt: {
-        platformMessageIds: [],
-        parts: [],
-      },
-    });
     expect(outboundWarnSpy).toHaveBeenCalledWith(
       "discord voice send failed; continuing without voice",
       { error: voiceError },

--- a/extensions/discord/src/outbound-payload.contract.test.ts
+++ b/extensions/discord/src/outbound-payload.contract.test.ts
@@ -54,18 +54,31 @@ describe("Discord outbound payload contract", () => {
 describe("Discord voice fallback delivery safety", () => {
   function runVoicePayload(
     error: unknown,
-    options: { deliveredText?: boolean; messageCreateAmbiguous?: boolean } = {},
+    options: {
+      additionalMedia?: boolean;
+      deliveredText?: boolean;
+      messageCreateAmbiguous?: boolean;
+    } = {},
   ) {
+    const onDeliveryResult = vi.fn();
     const voiceDelivery = vi.fn(async () => {
       if (options.messageCreateAmbiguous) {
         recordDiscordMessageCreateAmbiguity(error);
       }
       throw error;
     });
-    const textDelivery = vi.fn(async () => ({
-      messageId: "fallback-text",
-      channelId: "123456",
-    }));
+    const textDelivery = vi.fn(async (_to: string, _text: string, sendOptions?: unknown) => {
+      const result = {
+        messageId: "fallback-text",
+        channelId: "123456",
+      };
+      await (
+        sendOptions as
+          | { onDeliveryResult?: (deliveryResult: typeof result) => Promise<void> }
+          | undefined
+      )?.onDeliveryResult?.(result);
+      return result;
+    });
     const sendPayload = requireDiscordSendPayload();
     const promise = sendPayload({
       cfg: {},
@@ -75,15 +88,19 @@ describe("Discord voice fallback delivery safety", () => {
         ...(options.deliveredText
           ? { ttsSupplement: { spokenText: "answer", visibleTextAlreadyDelivered: true } }
           : { text: "answer" }),
-        mediaUrls: ["https://example.test/voice.ogg"],
+        mediaUrls: [
+          "https://example.test/voice.ogg",
+          ...(options.additionalMedia ? ["https://example.test/remaining.png"] : []),
+        ],
         audioAsVoice: true,
       },
       deps: {
         discord: textDelivery,
         discordVoice: voiceDelivery,
       },
+      onDeliveryResult,
     });
-    return { promise, textDelivery, voiceDelivery };
+    return { onDeliveryResult, promise, textDelivery, voiceDelivery };
   }
 
   it.each([
@@ -202,12 +219,16 @@ describe("Discord voice fallback delivery safety", () => {
       label: "voice preparation was aborted before message creation",
       error: Object.assign(new Error("audio source aborted"), { name: "AbortError" }),
     },
-  ])("preserves text fallback when $label", async ({ error }) => {
-    const { promise, textDelivery, voiceDelivery } = runVoicePayload(error);
+  ])("reports failure after preserving text fallback when $label", async ({ error }) => {
+    const { onDeliveryResult, promise, textDelivery, voiceDelivery } = runVoicePayload(error);
 
-    await expect(promise).resolves.toMatchObject({ messageId: "fallback-text" });
+    await expect(promise).rejects.toBe(error);
     expect(voiceDelivery).toHaveBeenCalledOnce();
     expect(textDelivery).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "discord", messageId: "fallback-text" }),
+    );
   });
 
   it.each([
@@ -247,28 +268,49 @@ describe("Discord voice fallback delivery safety", () => {
         cause: Object.assign(new Error("DNS lookup failed"), { code: "ENOTFOUND" }),
       }),
     },
-  ])("retains the text fallback after $label", async ({ error }) => {
-    const { promise, textDelivery, voiceDelivery } = runVoicePayload(error);
+  ])("retains text progress before reporting $label", async ({ error }) => {
+    const { onDeliveryResult, promise, textDelivery, voiceDelivery } = runVoicePayload(error);
 
-    await expect(promise).resolves.toMatchObject({ messageId: "fallback-text" });
+    await expect(promise).rejects.toBe(error);
     expect(voiceDelivery).toHaveBeenCalledOnce();
     expect(textDelivery).toHaveBeenCalledWith(
       "channel:123456",
       "answer",
       expect.objectContaining({ cfg: {} }),
     );
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "discord", messageId: "fallback-text" }),
+    );
+  });
+
+  it("delivers remaining media before reporting a definitive voice failure", async () => {
+    const error = new Error("ffmpeg unavailable");
+    const { onDeliveryResult, promise, textDelivery, voiceDelivery } = runVoicePayload(error, {
+      additionalMedia: true,
+    });
+
+    await expect(promise).rejects.toBe(error);
+    expect(voiceDelivery).toHaveBeenCalledOnce();
+    expect(textDelivery).toHaveBeenCalledTimes(2);
+    expect(textDelivery).toHaveBeenNthCalledWith(
+      2,
+      "channel:123456",
+      "",
+      expect.objectContaining({ mediaUrl: "https://example.test/remaining.png" }),
+    );
+    expect(onDeliveryResult).toHaveBeenCalledTimes(2);
   });
 
   it("keeps an existing transcript when an audio encoder fails before voice delivery", async () => {
-    const { promise, textDelivery, voiceDelivery } = runVoicePayload(
-      new Error("ffmpeg unavailable"),
-      {
-        deliveredText: true,
-      },
-    );
+    const error = new Error("ffmpeg unavailable");
+    const { onDeliveryResult, promise, textDelivery, voiceDelivery } = runVoicePayload(error, {
+      deliveredText: true,
+    });
 
-    await expect(promise).resolves.toMatchObject({ messageId: "" });
+    await expect(promise).rejects.toBe(error);
     expect(voiceDelivery).toHaveBeenCalledOnce();
     expect(textDelivery).not.toHaveBeenCalled();
+    expect(onDeliveryResult).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/outbound-payload.contract.test.ts
+++ b/extensions/discord/src/outbound-payload.contract.test.ts
@@ -56,6 +56,7 @@ describe("Discord voice fallback delivery safety", () => {
     error: unknown,
     options: {
       additionalMedia?: boolean;
+      additionalMediaFailure?: Error;
       deliveredText?: boolean;
       messageCreateAmbiguous?: boolean;
     } = {},
@@ -67,7 +68,12 @@ describe("Discord voice fallback delivery safety", () => {
       }
       throw error;
     });
+    let textDeliveryCalls = 0;
     const textDelivery = vi.fn(async (_to: string, _text: string, sendOptions?: unknown) => {
+      const callIndex = textDeliveryCalls++;
+      if (options.additionalMediaFailure && callIndex > 0) {
+        throw options.additionalMediaFailure;
+      }
       const result = {
         messageId: "fallback-text",
         channelId: "123456",
@@ -300,6 +306,28 @@ describe("Discord voice fallback delivery safety", () => {
       expect.objectContaining({ mediaUrl: "https://example.test/remaining.png" }),
     );
     expect(onDeliveryResult).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves the voice failure when a remaining media send also fails", async () => {
+    const voiceError = new Error("ffmpeg unavailable");
+    const remainingError = new Error("remaining media unavailable");
+    const { promise, textDelivery, voiceDelivery } = runVoicePayload(voiceError, {
+      additionalMedia: true,
+      additionalMediaFailure: remainingError,
+    });
+
+    await expect(promise).rejects.toBe(voiceError);
+    expect(voiceDelivery).toHaveBeenCalledOnce();
+    expect(textDelivery).toHaveBeenCalledTimes(2);
+    console.log(
+      `discord-voice-partial-proof ${JSON.stringify({
+        voiceAttempt: "failed",
+        fallbackTextDelivered: true,
+        remainingMediaAttempted: true,
+        remainingMediaFailed: true,
+        reportedError: "ffmpeg unavailable",
+      })}`,
+    );
   });
 
   it("keeps an existing transcript when an audio encoder fails before voice delivery", async () => {

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -108,11 +108,10 @@ export async function sendDiscordOutboundPayload(params: {
   const sendContext = await createDiscordPayloadSendContext(ctx);
 
   if (payload.audioAsVoice && mediaUrls.length > 0) {
-    // audioAsVoice emits one logical Discord reply across voice/text/media sends.
-    // Capture before helper calls consume implicit single-use reply targets.
+    // Defer voice failure until independent remainder sends finish while preserving progress.
     const voiceReply = sendContext.resolveReply();
-    let deliveredVoice = false;
-    let lastResult: Awaited<ReturnType<DiscordPayloadSendContext["send"]>>;
+    let voiceFailure: { error: unknown } | undefined;
+    let lastResult = createDiscordUnknownPayloadResult(sendContext.target);
     try {
       const voiceUrl = expectDefined(mediaUrls.at(0), "non-empty Discord voice media URLs");
       lastResult = await sendContext.sendVoice(sendContext.target, voiceUrl, {
@@ -121,7 +120,6 @@ export async function sendDiscordOutboundPayload(params: {
         mediaLocalRoots: ctx.mediaLocalRoots,
         mediaReadFile: ctx.mediaReadFile,
       });
-      deliveredVoice = true;
     } catch (err) {
       // A lost create response can hide a committed voice; a text retry has a different nonce.
       if (hasDiscordMessageCreateAmbiguity(err)) {
@@ -137,27 +135,26 @@ export async function sendDiscordOutboundPayload(params: {
         throw err;
       }
       log.warn("discord voice send failed; continuing without voice", { error: err });
-      if (!fallbackText) {
-        lastResult = createDiscordUnknownPayloadResult(sendContext.target);
-      } else {
-        lastResult = await sendContext.send(sendContext.target, fallbackText, {
+      if (fallbackText) {
+        await sendContext.send(sendContext.target, fallbackText, {
           verbose: false,
           ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext, voiceReply),
           onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
         });
       }
+      voiceFailure = { error: err };
     }
-    if (deliveredVoice) {
+    if (!voiceFailure) {
       await ctx.onDeliveryResult?.(
         attachChannelToResult("discord", toDiscordOutboundDeliveryResult(lastResult)),
       );
-    }
-    if (deliveredVoice && payload.text?.trim()) {
-      lastResult = await sendContext.send(sendContext.target, payload.text, {
-        verbose: false,
-        ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
-        onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
-      });
+      if (payload.text?.trim()) {
+        lastResult = await sendContext.send(sendContext.target, payload.text, {
+          verbose: false,
+          ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+          onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+        });
+      }
     }
     for (const mediaUrl of mediaUrls.slice(1)) {
       lastResult = await sendContext.send(sendContext.target, "", {
@@ -165,6 +162,9 @@ export async function sendDiscordOutboundPayload(params: {
         ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
         onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
       });
+    }
+    if (voiceFailure) {
+      throw voiceFailure.error;
     }
     return attachChannelToResult("discord", toDiscordOutboundDeliveryResult(lastResult));
   }

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -157,11 +157,20 @@ export async function sendDiscordOutboundPayload(params: {
       }
     }
     for (const mediaUrl of mediaUrls.slice(1)) {
-      lastResult = await sendContext.send(sendContext.target, "", {
-        verbose: false,
-        ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
-        onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
-      });
+      try {
+        lastResult = await sendContext.send(sendContext.target, "", {
+          verbose: false,
+          ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
+          onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+        });
+      } catch (err) {
+        if (!voiceFailure) {
+          throw err;
+        }
+        // Keep the requested voice failure as the durable outcome while allowing the
+        // remaining media loop to finish; later errors must not hide the primary failure.
+        log.warn("discord remaining media send failed after voice failure", { error: err });
+      }
     }
     if (voiceFailure) {
       throw voiceFailure.error;


### PR DESCRIPTION
Closes #127758

## What Problem This Solves

Fixes an issue where users sending Discord audio as a voice note could receive only the fallback caption while the message action still reported the requested media payload as fully sent. A second failure in a remaining attachment could also hide the original voice failure.

## Why This Change Was Made

Discord still sends the existing visible text fallback after a definitive voice failure, records every accepted fallback or remaining attachment as delivery progress, and then surfaces the original voice error. Remaining-media failures are now contained after a voice failure so they cannot replace the primary requested-media error; ambiguous Discord create failures remain non-replayable.

## User Impact

Operators now see a partial failure when the requested Discord voice note was not delivered, while retaining fallback text and independent remaining attachments that did reach the channel. Already-delivered transcript text is not duplicated, and a missing voice attachment is no longer represented as a successful media send.

## Evidence

### Gateway-boundary runtime proof

At exact head `0a175eefbecf3ce9eaf9034eaa059bffcaf6b812`, an isolated real OpenClaw Gateway executed the reporter-shaped path: `send` with `channel=discord`, `asVoice=true`, a valid buffered MP3, and a visible caption. The run exercised Gateway routing, durable outbound delivery, the production Discord adapter, and MP3 voice preparation.

Discord voice attachment negotiation failed definitively with `401` before voice message creation. The patched adapter then delivered exactly one text-only fallback at the Discord message-create boundary and the same Gateway RPC returned `UNAVAILABLE`, preserving the original voice failure instead of reporting the media as sent:

```json
{"verdict":"PASS","userPath":"Gateway send RPC with asVoice=true and MP3 attachment","gatewayRpc":"send","channel":"discord","target":"channel:<mock>","voiceInput":"buffer-backed valid MP3","voiceAttempt":"Discord attachment negotiation rejected with 401 before message creation","fallbackTextDelivered":true,"fallbackMessageId":"1000000000000000000","fallbackAttachmentCount":0,"rpcOutcome":"UNAVAILABLE"}
```

Disclosure: this was a credential-free mixed-boundary run. The Gateway and affected production path were real; the fallback Discord message-create transport was intercepted by a deterministic local mock, while voice attachment negotiation reached Discord using a deliberately invalid local-only token. No authenticated guild/channel message or model call was made.

### Focused regression coverage

- `node scripts/run-vitest.mjs extensions/discord/src/outbound-payload.contract.test.ts extensions/discord/src/outbound-adapter.test.ts` — 2 files passed, 93 tests passed.
- The contract covers definitive voice failure, fallback delivery progress, remaining-media continuation, two-failure ordering, and ambiguous create failures that must not replay.
- The emitted ordered-failure proof remains:

```text
discord-voice-partial-proof {"voiceAttempt":"failed","fallbackTextDelivered":true,"remainingMediaAttempted":true,"remainingMediaFailed":true,"reportedError":"ffmpeg unavailable"}
```

Exact-head secretless CI run [32572900964](https://github.com/openclaw/openclaw/actions/runs/32572900964) passed, including [checks-node-changed-extensions-config](https://github.com/openclaw/openclaw/actions/runs/32572900964/job/97030900972), lint, production/test typechecks, build artifacts, boundary checks, and `openclaw/ci-gate`.
