### PR TITLE
improve(imessage): reuse prepared inbound account service

### DIFF
--- a/extensions/imessage/src/monitor.gating.test-support.ts
+++ b/extensions/imessage/src/monitor.gating.test-support.ts
@@ -93,6 +93,7 @@ async function buildDispatchContextPayload(params: {
 
   const { ctxPayload } = await buildIMessageInboundContext({
     cfg,
+    accountService: cfg.channels?.imessage?.service,
     decision,
     message,
     historyLimit: 0,

--- a/extensions/imessage/src/monitor/conversation-repair.test-support.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.test-support.ts
@@ -229,6 +229,7 @@ describe("repairIMessageConversationAnchor", () => {
 
     const { imessageTo, ctxPayload } = await buildIMessageInboundContext({
       cfg: {} as never,
+      accountService: undefined,
       decision,
       message: repaired!,
       historyLimit: 0,
@@ -293,6 +294,7 @@ describe("repairIMessageConversationAnchor", () => {
 
     const { imessageTo, ctxPayload } = await buildIMessageInboundContext({
       cfg: {} as never,
+      accountService: undefined,
       decision,
       message: repaired!,
       historyLimit: 0,

--- a/extensions/imessage/src/monitor/inbound-processing.systemPrompt.test-support.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.systemPrompt.test-support.ts
@@ -193,6 +193,7 @@ describe("buildIMessageInboundContext forwards GroupSystemPrompt", () => {
   }): Parameters<typeof buildIMessageInboundContext>[0] {
     return {
       cfg: {} as OpenClawConfig,
+      accountService: undefined,
       decision: {
         kind: "dispatch",
         isGroup: decision.isGroup,

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -749,6 +749,7 @@ describe("buildIMessageInboundContext", () => {
 
     const { ctxPayload } = await buildIMessageInboundContext({
       cfg: {} as OpenClawConfig,
+      accountService: undefined,
       decision,
       message,
       historyLimit: 0,
@@ -777,6 +778,7 @@ describe("buildIMessageInboundContext", () => {
 
     const { ctxPayload } = await buildIMessageInboundContext({
       cfg: {} as OpenClawConfig,
+      accountService: undefined,
       decision: {
         ...decision,
         agentBodyText: "/reset\n\n[imessage attachment unavailable]",
@@ -809,6 +811,7 @@ describe("buildIMessageInboundContext", () => {
 
     const { ctxPayload, inboundHistory } = await buildIMessageInboundContext({
       cfg: {} as OpenClawConfig,
+      accountService: undefined,
       decision,
       message,
       historyLimit: 0,
@@ -823,6 +826,41 @@ describe("buildIMessageInboundContext", () => {
     expect(ctxPayload.Body).toContain("current");
     expect(ctxPayload.InboundHistory).toEqual([{ sender: "+15555550123", body: "previous" }]);
     expect(inboundHistory).toEqual([{ sender: "+15555550123", body: "previous" }]);
+  });
+
+  it("uses the monitor's prepared account service without re-reading channel config", async () => {
+    const message = {
+      id: 12348,
+      sender: "+15555550123",
+      text: "current",
+      is_from_me: false,
+      is_group: false,
+    };
+    const decision = await resolveDecision({ message });
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+
+    let channelConfigReads = 0;
+    const projectionCfg = Object.defineProperty({}, "channels", {
+      enumerable: true,
+      get: () => {
+        channelConfigReads += 1;
+        return { imessage: { service: "imessage" } };
+      },
+    }) as OpenClawConfig;
+    const { imessageTo } = await buildIMessageInboundContext({
+      cfg: projectionCfg,
+      accountService: "sms",
+      decision,
+      message,
+      historyLimit: 0,
+      groupHistories: new Map(),
+    });
+
+    expect(imessageTo).toBe("sms:+15555550123");
+    expect(channelConfigReads).toBe(0);
   });
 });
 
@@ -886,6 +924,7 @@ describe("resolveIMessageInboundDecision command auth", () => {
 
     const { ctxPayload } = await buildIMessageInboundContext({
       cfg,
+      accountService: undefined,
       decision,
       message: {
         id: 102,
@@ -927,6 +966,7 @@ describe("resolveIMessageInboundDecision command auth", () => {
 
     const { ctxPayload } = await buildIMessageInboundContext({
       cfg,
+      accountService: undefined,
       decision,
       message: {
         id: 103,
@@ -971,6 +1011,7 @@ describe("buildIMessageInboundContext MessageSid handling (rowid-leak regression
     };
     return {
       cfg: {} as OpenClawConfig,
+      accountService: undefined,
       decision: decision as unknown as Parameters<
         typeof buildIMessageInboundContext
       >[0]["decision"],

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -36,7 +36,6 @@ import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sanitizeTerminalText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { resolveIMessageAccount } from "../accounts.js";
 import { resolveIMessageDirectChatService } from "../chat-context.js";
 import { resolveIMessageConversationRoute } from "../conversation-route.js";
 import {
@@ -48,6 +47,7 @@ import {
   isAllowedIMessageReplyContextSender,
   normalizeIMessageHandle,
   parseIMessageAllowTarget,
+  type IMessageService,
 } from "../targets.js";
 import type { IMessageDmHistoryContext } from "./dm-history.js";
 import {
@@ -895,6 +895,7 @@ export async function resolveIMessageInboundDecision(params: {
 
 export async function buildIMessageInboundContext(params: {
   cfg: OpenClawConfig;
+  accountService: IMessageService | undefined;
   decision: IMessageInboundDispatchDecision;
   message: IMessagePayload;
   envelopeOptions?: EnvelopeFormatOptions;
@@ -989,11 +990,7 @@ export async function buildIMessageInboundContext(params: {
   }
 
   const directService =
-    resolveIMessageDirectChatService(
-      resolveIMessageAccount({ cfg: params.cfg, accountId: decision.route.accountId }).config
-        .service,
-      decision.chatGuid,
-    ) ?? "auto";
+    resolveIMessageDirectChatService(params.accountService, decision.chatGuid) ?? "auto";
   const imessageTo = decision.isGroup
     ? chatTarget || `imessage:${decision.sender}`
     : `${directService}:${decision.sender}`;

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -1061,6 +1061,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         : undefined;
     const { ctxPayload, chatTarget, imessageTo } = await buildIMessageInboundContext({
       cfg,
+      accountService: imessageCfg.service,
       decision: contextDecision,
       message,
       previousTimestamp,


### PR DESCRIPTION
## What Problem This Solves

Accepted ordinary iMessage/BlueBubbles inbound messages resolved the same account configuration twice before context dispatch. The monitor had already resolved the account and retained its service setting, but context construction repeated the broader account lookup for every accepted message.

## Why This Change Was Made

Require inbound context construction to receive the monitor's prepared account service, including explicit `undefined` for auto mode. This removes the duplicate account resolver and makes every internal caller state the service fact it owns. Routing, policy, durable ingress, media, reply history, and delivery remain unchanged.

## User Impact

iMessage inbound processing performs less repeated configuration projection, with no user-visible behavior or configuration change.

## Evidence

- Exact-current-base regression: the new owner test failed because context construction ignored the monitor-prepared `sms` service, reread configured `imessage` service, and produced the wrong target; the candidate passes with `sms:` routing and zero monitored config reads.
- Owner and routing siblings: 4 files, 347 tests passed.
- Full bundled iMessage extension: 50 files, 1,129 tests passed.
- `node scripts/check-changed.mjs -- <six changed iMessage owner/test paths>` passed.
- `GIT_BRANCH=main pnpm build` passed.
- Exact base/candidate semantic differential covered direct SMS, groups, reply/media/history facts, getter/error ordering, and private-field non-projection with identical output SHA-256 `f84e01f1d790215553da85c98ad0cfc4be17b0491b348fafb7d95f537a5b99d1`; configuration reads fell from 20 to 0.
- Owner-path microbenchmark: 20,000 representative messages reduced median context time 357.708 ms → 344.349 ms (3.73%); a 128-account case reduced 185.999 ms → 178.276 ms (4.15%). These are owner-microstage measurements, not end-to-end throughput claims.
- Production diff is net negative: +4/−6. Tests and test support are +45/−0.
- Codex Sol/high autoreview and TruffleHog scans passed on the exact final commit.
- No live iMessage service was invoked: this Linux orb cannot run macOS/iMessage/BlueBubbles, and the internal configuration projection is not service-observable. Deterministic red/green, provider behavior and routing tests, exact differential proof, and the full extension suite exercise the changed contract.
