### PR TITLE
fix(mantis): pin harness pdf tool model to the catalog model

### DIFF
--- a/.github/codex/prompts/mantis-recipes/staged-media-provider-proof.md
+++ b/.github/codex/prompts/mantis-recipes/staged-media-provider-proof.md
@@ -103,7 +103,7 @@ sha256="$(sha256sum "$script" | cut -d ' ' -f 1)"
 $lane mock --lane baseline --script "$script" "$sha256"
 tool_sent="$($lane send --lane baseline --text '@{sut} inspect the staged PDF with the pdf tool')"
 tool_message_id="$(jq -er '.sent.messageId' <<<"$tool_sent")"
-$lane observe --lane baseline --seconds 120 --until-provider-requests 3
+$lane observe --lane baseline --seconds 120 --until-provider-requests 4
 requests="$($lane requests --lane baseline)"
 jq -e '[.requests[] | .body.input[]? | select(.type == "function_call_output"
   and .call_id == "call_mantis_pdf_exec")] | length > 0' <<<"$requests"
@@ -111,6 +111,10 @@ $lane finish --lane baseline --focus-message-id "$tool_message_id"
 ```
 
 `finish` tears the lane down, so wait for the cumulative provider-request count
-(staging turn, exec turn, follow-up) and assert the recorded
-`function_call_output` before finishing; its `output` carries the serialized
-exec result. Repeat the same script, turn, wait, and assertions for `candidate`.
+(staging turn, exec turn, the pdf tool's own model call, follow-up) and assert
+the recorded `function_call_output` before finishing; its `output` carries the
+serialized exec result. The pdf tool's model call consumes the script's second
+response; the follow-up then repeats the exhausted script's last entry, which
+is fine. The pdf tool's request is where the lanes diverge: compare its
+`contentFacts` for `input_file` versus extracted text. Repeat the same script,
+turn, wait, and assertions for `candidate`.

--- a/scripts/e2e/telegram-mantis-sut.ts
+++ b/scripts/e2e/telegram-mantis-sut.ts
@@ -209,6 +209,9 @@ export function writeSutConfig(params: {
         models: {
           "openai/gpt-5.6-luna": { params: { openaiWsWarmup: false, transport: "sse" } },
         },
+        // Auto-resolution walks plugin manifest defaults (gpt-5.5), which this
+        // catalog does not define; pin the pdf tool to the only harness model.
+        pdfModel: { primary: "openai/gpt-5.6-luna" },
       },
       entries: {
         main: {

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -788,9 +788,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
       ".github/codex/prompts/mantis-recipes/staged-media-provider-proof.md",
       "utf8",
     );
-    expect(stagedMediaRecipe).toContain("--until-provider-requests 3");
+    expect(stagedMediaRecipe).toContain("--until-provider-requests 4");
     expect(stagedMediaRecipe).toContain('select(.type == "function_call_output"');
-    expect(stagedMediaRecipe.indexOf("--until-provider-requests 3")).toBeLessThan(
+    expect(stagedMediaRecipe.indexOf("--until-provider-requests 4")).toBeLessThan(
       stagedMediaRecipe.lastIndexOf("finish --lane baseline"),
     );
     expect(prompt).toContain("mantis-recipes/");


### PR DESCRIPTION
## What Problem This Solves

Mantis run [32572580656](https://github.com/openclaw/openclaw/actions/runs/32572580656) (proof attempt on #127770) got past scripting the Code Mode `exec(pdf)` turn, but both lanes then died inside the pdf tool with `Unknown model: openai/gpt-5.5` before the native-vs-fallback provider dispatch the scenario exists to compare.

Root cause: `createPdfTool` auto-resolves its model through the media-understanding defaults, which walk plugin manifest defaults and pick `openai/gpt-5.5` (`extensions/openai/openclaw.plugin.json`). The Mantis SUT catalog defines exactly one model, `gpt-5.6-luna` (`scripts/e2e/telegram-mantis-sut.ts`), so the resolved ref cannot be constructed and the tool fails.

## Why This Change Was Made

Explicit `agents.defaults.pdfModel` short-circuits the auto-resolution path entirely (`src/agents/tools/pdf-tool.model-config.ts:200-207`), so the harness config — the owner of "the SUT's only model is gpt-5.6-luna" — pins it there. Every media recipe benefits, not just the staged-PDF one.

With the pdf tool actually running, its own provider call becomes a real mock request that consumes the staged-media script's second response (mock-openai repeats the exhausted script's last entry, so the follow-up turn still resolves). The recipe wait moves from `--until-provider-requests 3` to `4`, the prose names the pdf tool's request as the point where the lanes diverge (`input_file` vs extracted text), and the workflow-test recipe pins follow.

## User Impact

Maintainer/CI tooling only — no product code. Mantis staged-media proofs on PDF-path PRs (first consumer: #127770, which flips openai `nativeDocumentInputs` to `["pdf"]`) can now reach the provider dispatch under comparison instead of failing on model resolution.

## Evidence

- Failing behavior: run 32572580656 verdict — both lanes `Unknown model: openai/gpt-5.5` inside the pdf tool bridge.
- `node scripts/run-vitest.mjs test/scripts/mantis-telegram-desktop-proof-workflow.test.ts` — pass.
- `node scripts/check-changed.mjs -- <3 changed files>` — pass (format, lint, guards).
- Autoreview (codex gpt-5.6-sol, high): clean, "patch is correct" 0.98.
- Live proof: next Mantis dispatch on #127770 after this lands exercises the changed path end to end.
