### PR TITLE
fix(ui): show channel probe progress while refreshing

### DIFF
--- a/ui/src/pages/channels/view.detail.ts
+++ b/ui/src/pages/channels/view.detail.ts
@@ -160,9 +160,16 @@ function renderChannelStatusBody(
       ${standardKey && status?.probe ? renderChannelProbeRow(status.probe) : nothing}
       ${renderChannelConfigSection({ channelId: key, props })}
       ${standardKey
-        ? renderChannelActionRow(html`<button class="btn" @click=${() => props.onRefresh(true)}>
-            ${t("common.probe")}
-          </button>`)
+        ? renderChannelActionRow(html`
+            <button
+              class="btn"
+              ?disabled=${props.loading}
+              aria-busy=${String(props.loading)}
+              @click=${() => props.onRefresh(true)}
+            >
+              ${t(props.loading ? "common.refreshing" : "common.probe")}
+            </button>
+          `)
         : nothing}
     `,
   );

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -157,7 +157,11 @@ function renderWhatsAppButtons(params: {
 function renderChannelDetailFixture(
   channelId: string,
   data: ChannelsChannelData,
-  options: { label?: string; onRefresh?: ChannelsProps["onRefresh"] } = {},
+  options: {
+    label?: string;
+    loading?: boolean;
+    onRefresh?: ChannelsProps["onRefresh"];
+  } = {},
 ) {
   const status = Object.entries(data).find(([key]) => key === channelId)?.[1] ?? {};
   const channelAccounts = data.channelAccounts ?? {};
@@ -170,6 +174,7 @@ function renderChannelDetailFixture(
     channelAccounts,
     channelDefaultAccountId: accounts?.length ? { [channelId]: accounts[0]!.accountId } : {},
   });
+  props.loading = options.loading ?? false;
   if (options.onRefresh) {
     props.onRefresh = options.onRefresh;
   }
@@ -372,6 +377,22 @@ describe("channel detail", () => {
       expect(onRefresh).toHaveBeenCalledWith(true);
     },
   );
+
+  it("projects an in-flight channel read onto the detail Probe action", () => {
+    const onRefresh = vi.fn();
+    const container = renderChannelDetailFixture(
+      "telegram",
+      { telegram: { configured: true, running: true }, channelAccounts: {} },
+      { loading: true, onRefresh },
+    );
+    const probe = container.querySelector<HTMLButtonElement>(".settings-row--actions button");
+
+    expect(probe?.disabled).toBe(true);
+    expect(probe?.getAttribute("aria-busy")).toBe("true");
+    expect(probe?.textContent?.trim()).toBe("Refreshing…");
+    probe?.click();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
 
   it("keeps missing Google Chat status unknown while other known channels are stopped", () => {
     const google = renderChannelDetailFixture("googlechat", { googlechat: null });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators probing a channel from its detail dialog would see an enabled, apparently idle **Probe** button while the status read was already in flight. Repeated activation looked actionable but was silently coalesced.

## Why This Change Was Made

The detail action now projects the existing Channels loading lifecycle: it becomes disabled, publishes `aria-busy`, and uses the existing **Refreshing…** copy until the read settles. This is localized to the Control UI template and does not change Gateway or channel behavior.

## User Impact

Visual, keyboard, and assistive-technology users can tell that a channel probe is running and cannot invoke an action that cannot start another read.

## Evidence

- Authentic mocked-Gateway Chromium proof through `channels.status { probe: true, timeoutMs: 8000 }`:
  - before: `{"disabled":false,"ariaBusy":null,"label":"Probe"}`
  - after: `{"disabled":true,"ariaBusy":"true","label":"Refreshing…"}`
- Pre-fix regression failed because the button remained enabled; post-fix focused and Channels suites pass: 52/52 tests.
- `node scripts/check-changed.mjs -- ui/src/pages/channels/view.detail.ts ui/src/pages/channels/view.test.ts`
- `pnpm ui:build`
- Autoreview: clean, no accepted/actionable findings.

Root: `UI-CHANNELS-DETAIL-PROBE-BUSY-TRUTH-001`
