### PR TITLE
fix(cron): throttle session reaper retries on errors

### DIFF
--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -125,9 +125,12 @@ export async function sweepCronRunSessions(params: {
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
     return { swept: false, pruned: 0 };
+  } finally {
+    // Always update the throttle timestamp, even on error, to prevent
+    // unbounded retry loops when the store has a persistent problem
+    // (e.g. EACCES, disk full).
+    lastSweepAtMsByStore.set(storePath, now);
   }
-
-  lastSweepAtMsByStore.set(storePath, now);
 
   if (transcriptCleanupError) {
     params.log.warn(


### PR DESCRIPTION
## What Problem This Solves
Fixes #127933.

## Why This Change Was Made
Ensures the session reaper updates throttle state even when sweep failures occur, preventing immediate retry thrash loops.

## User Impact
Improves runtime stability under persistent cleanup failures and reduces repeated disk/CPU pressure.

## Evidence
- Branch scope: src/cron/session-reaper.ts
- Conflict preflight against current main completed before PR creation.
- CI checks run on this PR head.