### PR TITLE
fix(msteams): follow absolute nextLink for thread replies pagination

### DIFF
--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -1,6 +1,6 @@
 // Msteams plugin module implements graph thread behavior.
 import { decodeHtmlEntities } from "openclaw/plugin-sdk/html-entity-runtime";
-import { fetchGraphJson, type GraphResponse } from "./graph.js";
+import { fetchGraphAbsoluteUrl, fetchGraphJson, type GraphResponse } from "./graph.js";
 import type { MSTeamsRequestDeadline } from "./request-timeout.js";
 
 export type GraphThreadMessage = {
@@ -103,17 +103,33 @@ export async function fetchThreadReplies(
   limit = 50,
   deadline?: MSTeamsRequestDeadline,
 ): Promise<GraphThreadMessage[]> {
-  const top = Math.min(Math.max(limit, 1), 50);
   // NOTE: Graph replies endpoint returns oldest-first and does not support $orderby.
-  // For threads with >50 replies, only the oldest 50 are returned. The most recent
-  // replies (often the most relevant context) may be truncated.
-  const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${top}&$select=id,from,body,createdDateTime`;
-  const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({
-    token,
-    path,
-    ...(deadline ? { deadline } : {}),
-  });
-  return res.value ?? [];
+  // We fetch up to 50 at a time and paginate to collect all replies, then take the last `limit`.
+  let path: string | undefined =
+    `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=50&$select=id,from,body,createdDateTime`;
+  let isAbsoluteUrl = false;
+  const allReplies: GraphThreadMessage[] = [];
+
+  while (path && allReplies.length < 500) {
+    const res: GraphResponse<GraphThreadMessage> = isAbsoluteUrl
+      ? await fetchGraphAbsoluteUrl<GraphResponse<GraphThreadMessage>>({
+          token,
+          url: path,
+          ...(deadline ? { deadline } : {}),
+        })
+      : await fetchGraphJson<GraphResponse<GraphThreadMessage>>({
+          token,
+          path,
+          ...(deadline ? { deadline } : {}),
+        });
+    if (res.value) {
+      allReplies.push(...res.value);
+    }
+    path = res["@odata.nextLink"];
+    isAbsoluteUrl = true;
+  }
+
+  return allReplies.slice(-Math.max(limit, 1));
 }
 
 /**

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -35,7 +35,10 @@ export type GraphChannel = {
   displayName?: string;
 };
 
-export type GraphResponse<T> = { value?: T[] };
+export type GraphResponse<T> = {
+  value?: T[];
+  "@odata.nextLink"?: string;
+};
 
 export function normalizeQuery(value?: string | null): string {
   return value?.trim() ?? "";
@@ -128,6 +131,7 @@ export async function fetchGraphAbsoluteUrl<T>(params: {
   token: string;
   url: string;
   headers?: Record<string, string>;
+  deadline?: MSTeamsRequestDeadline;
 }): Promise<T> {
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
@@ -139,7 +143,7 @@ export async function fetchGraphAbsoluteUrl<T>(params: {
       },
     },
     auditContext: "msteams.graph.absolute",
-    timeoutMs: MSTEAMS_REQUEST_TIMEOUT_MS,
+    timeoutMs: resolveMSTeamsRequestTimeoutMs(params.deadline),
   });
   try {
     if (!response.ok) {


### PR DESCRIPTION
## What Problem This Solves
Fixes #98870.

## Why This Change Was Made
Microsoft Graph replies pagination returns absolute nextLink values that must be handled without relative URL assumptions.

## User Impact
Prevents missing newer replies in long Teams threads and restores complete thread context.

## Evidence
- Branch scope: extensions/msteams/src/graph-thread.ts and extensions/msteams/src/graph.ts.
- Conflict preflight against current main completed.
- CI checks run on this PR head.