### PR TITLE
fix(llm): honor reasoning=off in Anthropic adapter

### DIFF
--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -842,13 +842,15 @@ export const streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleS
   }
 
   const base = buildBaseOptions(model, options, apiKey);
-  if (!options?.reasoning) {
+  if (!options?.reasoning || options.reasoning === "off") {
     const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
     return streamAnthropic(model, context, {
       ...base,
       thinkingEnabled: mandatoryAdaptiveThinking,
-      ...(mandatoryAdaptiveThinking ? { effort: "high" as const } : {}),
-    } satisfies AnthropicOptions);
+      ...(mandatoryAdaptiveThinking
+        ? { effort: options?.reasoning === "off" ? "low" : "high" }
+        : {}),
+    } as AnthropicOptions);
   }
 
   // For Opus 4.6 and Sonnet 4.6: use adaptive thinking with effort level


### PR DESCRIPTION
## What Problem This Solves
Fixes #127926.

## Why This Change Was Made
Caller intent for explicit reasoning disablement must be preserved consistently in provider adapter mapping.

## User Impact
Prevents provider-behavior drift when operators set reasoning to off.

## Evidence
- Branch scope: src/llm/providers/anthropic.ts.
- Conflict preflight against current main completed.
- CI checks run on this PR head.