### PR TITLE
test(skills): fix workspace-load Windows symlink typing

### DIFF
--- a/src/skills/loading/workspace-load.test.ts
+++ b/src/skills/loading/workspace-load.test.ts
@@ -1094,7 +1094,7 @@ description: Broken skill
           description: "Outside linked skill",
         });
         await fs.mkdir(path.join(repoDir, "examples"), { recursive: true });
-        await fs.symlink(outsideDir, path.join(repoDir, "examples", "linked"), "dir");
+        await fs.symlink(outsideDir, path.join(repoDir, "examples", "linked"), directorySymlinkType);
         await writeSkill({
           dir: path.join(repoDir, "skills", "group", "valid"),
           name: "repo-nested-skill",
@@ -1127,7 +1127,7 @@ description: Broken skill
           description: "Allowed linked skill",
         });
         await fs.mkdir(path.join(repoDir, "group"), { recursive: true });
-        await fs.symlink(targetSkillDir, path.join(repoDir, "group", "linked-skill"), "dir");
+        await fs.symlink(targetSkillDir, path.join(repoDir, "group", "linked-skill"), directorySymlinkType);
         await writeSkill({
           dir: path.join(repoDir, "skills", "group", "valid"),
           name: "repo-nested-skill",

--- a/src/skills/loading/workspace-load.test.ts
+++ b/src/skills/loading/workspace-load.test.ts
@@ -1,4 +1,51 @@
 // Workspace load tests cover loading skills from workspace directories and manifests.
+
+import _fsSync from "node:fs";
+import _os from "node:os";
+import _path from "node:path";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir;
+  try {
+    probeDir = _fsSync.mkdtempSync(_path.join(_os.tmpdir(), "openclaw-dir-symlink-probe-"));
+    const targetDir = _path.join(probeDir, "target");
+    const linkDir = _path.join(probeDir, "link");
+    _fsSync.mkdirSync(targetDir);
+    _fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        _fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
+
+const canCreateFileSymlinks = (() => {
+  let probeDir;
+  try {
+    probeDir = _fsSync.mkdtempSync(_path.join(_os.tmpdir(), "openclaw-file-symlink-probe-"));
+    const targetFile = _path.join(probeDir, "target.txt");
+    const linkFile = _path.join(probeDir, "link.txt");
+    _fsSync.writeFileSync(targetFile, "content");
+    _fsSync.symlinkSync(targetFile, linkFile);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        _fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
+
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -272,7 +319,7 @@ async function createEscapedBundledSkillFixture(params?: {
   });
   await fs.mkdir(bundledDir, { recursive: true });
   const requestedPath = path.join(bundledDir, "escaped-bundled-skill");
-  await fs.symlink(escapedSkillDir, requestedPath, "dir");
+  await fs.symlink(escapedSkillDir, requestedPath, directorySymlinkType);
   return { workspaceDir, outsideDir, bundledDir, escapedSkillDir, requestedPath };
 }
 
@@ -563,7 +610,7 @@ description: Broken skill
     expect(entries.map((entry) => entry.skill.name)).toEqual(["local-only"]);
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks || !canCreateFileSymlinks)(
     "skips workspace skill paths that resolve outside the workspace root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -576,7 +623,7 @@ description: Broken skill
       });
       await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
       const requestedPath = path.join(workspaceDir, "skills", "escaped-skill");
-      await fs.symlink(escapedSkillDir, requestedPath, "dir");
+      await fs.symlink(escapedSkillDir, requestedPath, directorySymlinkType);
       const fileLinkSkillDir = path.join(workspaceDir, "skills", "escaped-file");
       await fs.mkdir(fileLinkSkillDir, { recursive: true });
       await fs.symlink(path.join(outsideDir, "SKILL.md"), path.join(fileLinkSkillDir, "SKILL.md"));
@@ -606,7 +653,7 @@ description: Broken skill
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "allows configured skill symlink targets outside their source root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -621,7 +668,7 @@ description: Broken skill
       const workspaceSkillsDir = path.join(workspaceDir, "skills");
       await fs.mkdir(workspaceSkillsDir, { recursive: true });
       const symlinkPath = path.join(workspaceSkillsDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -643,7 +690,7 @@ description: Broken skill
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "loads managed skill directory symlinks outside the managed root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -657,7 +704,7 @@ description: Broken skill
       });
       await fs.mkdir(managedDir, { recursive: true });
       const symlinkPath = path.join(managedDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -673,7 +720,7 @@ description: Broken skill
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks || !canCreateFileSymlinks)(
     "keeps SKILL.md containment for managed symlinked skill directories",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -691,7 +738,7 @@ description: Broken skill
       await fs.symlink(path.join(outsideDir, "SKILL.md"), path.join(targetSkillDir, "SKILL.md"));
       await fs.mkdir(managedDir, { recursive: true });
       const symlinkPath = path.join(managedDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -710,7 +757,7 @@ description: Broken skill
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "calls out bundled symlink escapes with compact home-relative paths",
     async () => {
       const { workspaceDir, bundledDir, requestedPath } = await createEscapedBundledSkillFixture();
@@ -731,7 +778,7 @@ description: Broken skill
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "uses compact home-relative paths in escaped skill console warnings",
     async () => {
       const { workspaceDir, bundledDir } = await createEscapedBundledSkillFixture({
@@ -751,7 +798,7 @@ description: Broken skill
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "reads skill frontmatter when the allowed root is the filesystem root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -1035,7 +1082,7 @@ description: Broken skill
       expect(names).not.toContain("outside-child");
     });
 
-    it.runIf(process.platform !== "win32")(
+    it.skipIf(!canCreateDirectorySymlinks)(
       "does not follow outside symlink dirs during repo-root detection",
       async () => {
         const workspaceDir = await createTempWorkspaceDir();
@@ -1067,7 +1114,7 @@ description: Broken skill
       },
     );
 
-    it.runIf(process.platform !== "win32")(
+    it.skipIf(!canCreateDirectorySymlinks)(
       "keeps configured roots with possible symlink skills outside nested skills",
       async () => {
         const workspaceDir = await createTempWorkspaceDir();


### PR DESCRIPTION
## What Problem This Solves
Fixes #127931.

## Why This Change Was Made
Workspace-load tests use symlink operations that require explicit Windows directory typing.

## User Impact
Reduces Windows CI failures in workspace-load test paths.

## Evidence
- Branch scope: src/skills/loading/workspace-load.test.ts.
- Conflict preflight against current main completed.
- CI checks run on this PR head.