### PR TITLE
test(fs-safe): make hardlink tests Windows-compatible

### DIFF
--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -1,8 +1,25 @@
 // Tests safe filesystem wrappers and protected file-handle behavior.
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
+
+const canCreateHardlinks = (() => {
+  const probeDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-fs-hardlink-probe-"));
+  const targetFile = path.join(probeDir, "target.txt");
+  const linkFile = path.join(probeDir, "link.txt");
+  try {
+    fsSync.writeFileSync(targetFile, "target", "utf8");
+    fsSync.linkSync(targetFile, linkFile);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import {
@@ -348,7 +365,7 @@ describe("fs-safe", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")("blocks hardlink aliases under root", async () => {
+  it.skipIf(!canCreateHardlinks)("blocks hardlink aliases under root", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const hardlinkPath = path.join(root, "link.txt");
     await withOutsideHardlinkAlias({
@@ -475,7 +492,7 @@ describe("fs-safe", () => {
     await expectRejectCode((await openRoot(root)).write("../escape.txt", "x"), "outside-workspace");
   });
 
-  it.runIf(process.platform !== "win32")("rejects writing through hardlink aliases", async () => {
+  it.skipIf(!canCreateHardlinks)("rejects writing through hardlink aliases", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const hardlinkPath = path.join(root, "alias.txt");
     await withOutsideHardlinkAlias({
@@ -487,7 +504,7 @@ describe("fs-safe", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")("rejects appending through hardlink aliases", async () => {
+  it.skipIf(!canCreateHardlinks)("rejects appending through hardlink aliases", async () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const hardlinkPath = path.join(root, "alias.txt");
     await withOutsideHardlinkAlias({

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -1,25 +1,8 @@
 // Tests safe filesystem wrappers and protected file-handle behavior.
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
-import fsSync from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
-
-const canCreateHardlinks = (() => {
-  const probeDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-fs-hardlink-probe-"));
-  const targetFile = path.join(probeDir, "target.txt");
-  const linkFile = path.join(probeDir, "link.txt");
-  try {
-    fsSync.writeFileSync(targetFile, "target", "utf8");
-    fsSync.linkSync(targetFile, linkFile);
-    return true;
-  } catch {
-    return false;
-  } finally {
-    fsSync.rmSync(probeDir, { recursive: true, force: true });
-  }
-})();
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import {
@@ -36,12 +19,34 @@ import {
 } from "./fs-safe.js";
 
 const tempDirs = createTrackedTempDirs();
+let hardlinkSupport: Promise<boolean> | undefined;
 
 afterEach(async () => {
   __setFsSafeTestHooksForTest(undefined);
   vi.restoreAllMocks();
   await tempDirs.cleanup();
 });
+
+async function canCreateHardlinks(): Promise<boolean> {
+  hardlinkSupport ??= (async () => {
+    let probeDir: string | undefined;
+    try {
+      probeDir = await tempDirs.make("openclaw-fs-hardlink-probe-");
+      const targetFile = path.join(probeDir, "target.txt");
+      const linkFile = path.join(probeDir, "link.txt");
+      await fs.writeFile(targetFile, "target", "utf8");
+      await fs.link(targetFile, linkFile);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      if (probeDir !== undefined) {
+        await fs.rm(probeDir, { recursive: true, force: true });
+      }
+    }
+  })();
+  return await hardlinkSupport;
+}
 
 async function expectRejectCode(promise: Promise<unknown>, expected: string | RegExp) {
   const err = await promise.catch((caught: unknown) => caught);
@@ -365,7 +370,10 @@ describe("fs-safe", () => {
     });
   });
 
-  it.skipIf(!canCreateHardlinks)("blocks hardlink aliases under root", async () => {
+  it("blocks hardlink aliases under root", async () => {
+    if (!(await canCreateHardlinks())) {
+      return;
+    }
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const hardlinkPath = path.join(root, "link.txt");
     await withOutsideHardlinkAlias({
@@ -492,7 +500,10 @@ describe("fs-safe", () => {
     await expectRejectCode((await openRoot(root)).write("../escape.txt", "x"), "outside-workspace");
   });
 
-  it.skipIf(!canCreateHardlinks)("rejects writing through hardlink aliases", async () => {
+  it("rejects writing through hardlink aliases", async () => {
+    if (!(await canCreateHardlinks())) {
+      return;
+    }
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const hardlinkPath = path.join(root, "alias.txt");
     await withOutsideHardlinkAlias({
@@ -504,7 +515,10 @@ describe("fs-safe", () => {
     });
   });
 
-  it.skipIf(!canCreateHardlinks)("rejects appending through hardlink aliases", async () => {
+  it("rejects appending through hardlink aliases", async () => {
+    if (!(await canCreateHardlinks())) {
+      return;
+    }
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const hardlinkPath = path.join(root, "alias.txt");
     await withOutsideHardlinkAlias({


### PR DESCRIPTION
## What Problem This Solves
Fixes #127930.

## Why This Change Was Made
Hardlink assertions and setup in fs-safe tests need Windows-compatible behavior handling.

## User Impact
Improves cross-platform reliability and prevents Windows-only fs-safe test failures.

## Evidence
- Branch scope: src/infra/fs-safe.test.ts.
- Conflict preflight against current main completed.
- CI checks run on this PR head.