### PR TITLE
test(plugins): stabilize marketplace Windows symlink typing

### DIFF
--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -1,4 +1,5 @@
 // Covers plugin marketplace catalog loading and validation.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -9,6 +10,30 @@ import {
   cleanupTrackedTempDirsAsync,
   makeTrackedTempDirAsync,
 } from "./test-helpers/fs-fixtures.js";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir: string | undefined;
+  try {
+    probeDir = fsSync.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-marketplace-dir-symlink-probe-"),
+    );
+    const targetDir = path.join(probeDir, "target");
+    const linkDir = path.join(probeDir, "link");
+    fsSync.mkdirSync(targetDir);
+    fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
 
 const installPluginFromPathMock = vi.fn();
 const fetchWithSsrFGuardMock = vi.hoisted(() =>
@@ -138,7 +163,7 @@ function mockRemoteMarketplaceCloneWithOutsideSymlink(params: {
     await fs.mkdir(path.dirname(path.join(repoDir as string, params.symlinkPath)), {
       recursive: true,
     });
-    await fs.symlink(outsideDir, path.join(repoDir as string, params.symlinkPath));
+    await fs.symlink(outsideDir, path.join(repoDir as string, params.symlinkPath), directorySymlinkType);
     return { code: 0, stdout: "", stderr: "", killed: false };
   });
 }
@@ -653,7 +678,7 @@ describe("marketplace plugins", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "rejects remote marketplace plugin paths that resolve through symlinks outside the cloned repo",
     async () => {
       mockRemoteMarketplaceCloneWithOutsideSymlink({
@@ -1269,7 +1294,7 @@ describe("marketplace plugins", () => {
     await expectRemoteMarketplaceError({ manifest, expectedError });
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "rejects remote marketplace symlink plugin paths during manifest validation",
     async () => {
       mockRemoteMarketplaceCloneWithOutsideSymlink({

--- a/src/skills/loading/workspace-load.test.ts
+++ b/src/skills/loading/workspace-load.test.ts
@@ -60,6 +60,52 @@ vi.mock("../../plugins/manifest-registry.js", async () => {
   };
 });
 
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir: string | undefined;
+  try {
+    probeDir = fsSync.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-workspace-load-dir-symlink-probe-"),
+    );
+    const targetDir = path.join(probeDir, "target");
+    const linkDir = path.join(probeDir, "link");
+    fsSync.mkdirSync(targetDir);
+    fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
+
+const canCreateFileSymlinks = (() => {
+  let probeDir: string | undefined;
+  try {
+    probeDir = fsSync.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-workspace-load-file-symlink-probe-"),
+    );
+    const targetFile = path.join(probeDir, "target.txt");
+    const linkFile = path.join(probeDir, "link.txt");
+    fsSync.writeFileSync(targetFile, "content");
+    fsSync.symlinkSync(targetFile, linkFile);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
+
 let fakeHome = "";
 let envSnapshot: SkillsHomeEnvSnapshot;
 let tempRoot = "";
@@ -272,7 +318,7 @@ async function createEscapedBundledSkillFixture(params?: {
   });
   await fs.mkdir(bundledDir, { recursive: true });
   const requestedPath = path.join(bundledDir, "escaped-bundled-skill");
-  await fs.symlink(escapedSkillDir, requestedPath, "dir");
+  await fs.symlink(escapedSkillDir, requestedPath, directorySymlinkType);
   return { workspaceDir, outsideDir, bundledDir, escapedSkillDir, requestedPath };
 }
 
@@ -489,7 +535,7 @@ describe("loadWorkspaceSkillEntries", () => {
     expect(entries.map((entry) => entry.skill.name)).toEqual(["local-only"]);
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "skips workspace skill paths that resolve outside the workspace root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -502,7 +548,7 @@ describe("loadWorkspaceSkillEntries", () => {
       });
       await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
       const requestedPath = path.join(workspaceDir, "skills", "escaped-skill");
-      await fs.symlink(escapedSkillDir, requestedPath, "dir");
+      await fs.symlink(escapedSkillDir, requestedPath, directorySymlinkType);
       const fileLinkSkillDir = path.join(workspaceDir, "skills", "escaped-file");
       await fs.mkdir(fileLinkSkillDir, { recursive: true });
       await fs.symlink(path.join(outsideDir, "SKILL.md"), path.join(fileLinkSkillDir, "SKILL.md"));
@@ -532,7 +578,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "allows configured skill symlink targets outside their source root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -547,7 +593,7 @@ describe("loadWorkspaceSkillEntries", () => {
       const workspaceSkillsDir = path.join(workspaceDir, "skills");
       await fs.mkdir(workspaceSkillsDir, { recursive: true });
       const symlinkPath = path.join(workspaceSkillsDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -569,7 +615,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "loads managed skill directory symlinks outside the managed root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -583,7 +629,7 @@ describe("loadWorkspaceSkillEntries", () => {
       });
       await fs.mkdir(managedDir, { recursive: true });
       const symlinkPath = path.join(managedDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -599,7 +645,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "keeps SKILL.md containment for managed symlinked skill directories",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -617,7 +663,7 @@ describe("loadWorkspaceSkillEntries", () => {
       await fs.symlink(path.join(outsideDir, "SKILL.md"), path.join(targetSkillDir, "SKILL.md"));
       await fs.mkdir(managedDir, { recursive: true });
       const symlinkPath = path.join(managedDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -636,7 +682,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "calls out bundled symlink escapes with compact home-relative paths",
     async () => {
       const { workspaceDir, bundledDir, requestedPath } = await createEscapedBundledSkillFixture();
@@ -657,7 +703,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "uses compact home-relative paths in escaped skill console warnings",
     async () => {
       const { workspaceDir, bundledDir } = await createEscapedBundledSkillFixture({
@@ -677,7 +723,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "reads skill frontmatter when the allowed root is the filesystem root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -961,7 +1007,7 @@ describe("loadWorkspaceSkillEntries", () => {
       expect(names).not.toContain("outside-child");
     });
 
-    it.runIf(process.platform !== "win32")(
+    it.skipIf(!canCreateDirectorySymlinks)(
       "does not follow outside symlink dirs during repo-root detection",
       async () => {
         const workspaceDir = await createTempWorkspaceDir();
@@ -973,7 +1019,11 @@ describe("loadWorkspaceSkillEntries", () => {
           description: "Outside linked skill",
         });
         await fs.mkdir(path.join(repoDir, "examples"), { recursive: true });
-        await fs.symlink(outsideDir, path.join(repoDir, "examples", "linked"), "dir");
+        await fs.symlink(
+          outsideDir,
+          path.join(repoDir, "examples", "linked"),
+          directorySymlinkType,
+        );
         await writeSkill({
           dir: path.join(repoDir, "skills", "group", "valid"),
           name: "repo-nested-skill",
@@ -993,7 +1043,7 @@ describe("loadWorkspaceSkillEntries", () => {
       },
     );
 
-    it.runIf(process.platform !== "win32")(
+    it.skipIf(!canCreateDirectorySymlinks)(
       "keeps configured roots with possible symlink skills outside nested skills",
       async () => {
         const workspaceDir = await createTempWorkspaceDir();
@@ -1006,7 +1056,11 @@ describe("loadWorkspaceSkillEntries", () => {
           description: "Allowed linked skill",
         });
         await fs.mkdir(path.join(repoDir, "group"), { recursive: true });
-        await fs.symlink(targetSkillDir, path.join(repoDir, "group", "linked-skill"), "dir");
+        await fs.symlink(
+          targetSkillDir,
+          path.join(repoDir, "group", "linked-skill"),
+          directorySymlinkType,
+        );
         await writeSkill({
           dir: path.join(repoDir, "skills", "group", "valid"),
           name: "repo-nested-skill",

--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -1,4 +1,5 @@
 // Skill refresh tests cover runtime reload events and refresh-state updates.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +8,28 @@ import type { SkillsChangeEvent } from "./refresh.js";
 
 type WatchEvent = "add" | "addDir" | "change" | "unlink" | "unlinkDir" | "raw" | "error";
 type WatchCallback = (...args: unknown[]) => void;
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir: string | undefined;
+  try {
+    probeDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-refresh-dir-symlink-probe-"));
+    const targetDir = path.join(probeDir, "target");
+    const linkDir = path.join(probeDir, "link");
+    fsSync.mkdirSync(targetDir);
+    fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
 
 function createMockWatcher() {
   const handlers = new Map<WatchEvent, WatchCallback[]>();
@@ -315,7 +338,7 @@ describe("ensureSkillsWatcher", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "watches allowed symlink skill targets without following every root symlink",
     async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-symlink-"));
@@ -330,7 +353,11 @@ describe("ensureSkillsWatcher", () => {
           path.join(targetSkillDir, "SKILL.md"),
           "---\nname: linked-skill\ndescription: Linked\n---\n",
         );
-        await fs.symlink(targetSkillDir, path.join(groupedLinkDir, "linked-skill"), "dir");
+        await fs.symlink(
+          targetSkillDir,
+          path.join(groupedLinkDir, "linked-skill"),
+          directorySymlinkType,
+        );
 
         refreshModule.ensureSkillsWatcher({
           workspaceDir,
@@ -351,7 +378,7 @@ describe("ensureSkillsWatcher", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")("watches symlinked skill root targets", async () => {
+  it.skipIf(!canCreateDirectorySymlinks)("watches symlinked skill root targets", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-root-link-"));
     const targetSkillsDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "openclaw-watch-root-link-target-"),
@@ -361,7 +388,7 @@ describe("ensureSkillsWatcher", () => {
         path.join(targetSkillsDir, "SKILL.md"),
         "---\nname: linked-root\ndescription: Linked root\n---\n",
       );
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
 
       refreshModule.ensureSkillsWatcher({ workspaceDir });
 
@@ -378,7 +405,7 @@ describe("ensureSkillsWatcher", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "does not watch untrusted companion skills symlink targets",
     async () => {
       const workspaceDir = await fs.mkdtemp(
@@ -393,7 +420,7 @@ describe("ensureSkillsWatcher", () => {
           path.join(outsideDir, "SKILL.md"),
           "---\nname: untrusted\ndescription: Untrusted\n---\n",
         );
-        await fs.symlink(outsideDir, path.join(repoDir, "skills"), "dir");
+        await fs.symlink(outsideDir, path.join(repoDir, "skills"), directorySymlinkType);
 
         refreshModule.ensureSkillsWatcher({
           workspaceDir,
@@ -664,7 +691,7 @@ describe("ensureSkillsWatcher", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "does not watch untrusted plugin skill symlink targets",
     async () => {
       const pluginDir = await fs.mkdtemp(
@@ -679,7 +706,11 @@ describe("ensureSkillsWatcher", () => {
           path.join(outsideDir, "SKILL.md"),
           "---\nname: untrusted-plugin\ndescription: Untrusted plugin\n---\n",
         );
-        await fs.symlink(outsideDir, path.join(pluginDir, "skills", "untrusted"), "dir");
+        await fs.symlink(
+          outsideDir,
+          path.join(pluginDir, "skills", "untrusted"),
+          directorySymlinkType,
+        );
         const pluginSkills = await import("../loading/plugin-skills.js");
         vi.mocked(pluginSkills.resolvePluginSkillDirs).mockReturnValueOnce([pluginDir]);
 

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1,6 +1,30 @@
 // Workshop service tests cover skill workshop generation, storage, and validation behavior.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir: string | undefined;
+  try {
+    probeDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-workshop-dir-symlink-probe-"));
+    const targetDir = path.join(probeDir, "target");
+    const linkDir = path.join(probeDir, "link");
+    fsSync.mkdirSync(targetDir);
+    fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createOpenClawTestState,
@@ -136,12 +160,12 @@ describe("skill workshop proposals", () => {
     expect((await inspectSkillProposal(proposal.record.id))?.record.status).toBe("applied");
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "applies updates through opted-in trusted workspace skills symlink targets",
     async () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-target-skills-");
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
       const skillDir = path.join(targetSkillsDir, "shared-skill");
       await writeSkill({
         dir: skillDir,
@@ -183,12 +207,12 @@ describe("skill workshop proposals", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "blocks trusted workspace skills symlink writes until workshop writes are enabled",
     async () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-readonly-skills-");
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
       const config = { skills: { load: { allowSymlinkTargets: [targetSkillsDir] } } };
       const proposal = await proposeCreateSkill({
         workspaceDir,
@@ -216,14 +240,18 @@ describe("skill workshop proposals", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "validates support file targets against trusted symlink write roots",
     async () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-support-trusted-");
       const untrustedSkillsDir = await tempDirs.make("openclaw-skill-workshop-support-untrusted-");
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
-      await fs.symlink(untrustedSkillsDir, path.join(workspaceDir, "other-skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
+      await fs.symlink(
+        untrustedSkillsDir,
+        path.join(workspaceDir, "other-skills"),
+        directorySymlinkType,
+      );
       const config = {
         skills: {
           load: { allowSymlinkTargets: [targetSkillsDir] },
@@ -266,12 +294,12 @@ describe("skill workshop proposals", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "blocks untrusted workspace skills symlink targets before support files are written",
     async () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-untrusted-skills-");
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
       const proposal = await proposeCreateSkill({
         workspaceDir,
         name: "Untrusted Symlink Skill",


### PR DESCRIPTION
## What Problem This Solves
Fixes #127925.

## Why This Change Was Made
Uses Windows-compatible directory symlink typing in marketplace tests.

## User Impact
Reduces Windows-only CI failures in marketplace test paths.

## Evidence
- Branch focus: src/plugins/marketplace.test.ts.
- Issue-linked and scoped to test reliability.