### PR TITLE
test(skills): stabilize refresh Windows symlink typing

### DIFF
--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -1,4 +1,5 @@
 // Skill refresh tests cover runtime reload events and refresh-state updates.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +8,30 @@ import type { SkillsChangeEvent } from "./refresh.js";
 
 type WatchEvent = "add" | "addDir" | "change" | "unlink" | "unlinkDir" | "raw" | "error";
 type WatchCallback = (...args: unknown[]) => void;
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir: string | undefined;
+  try {
+    probeDir = fsSync.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-refresh-dir-symlink-probe-"),
+    );
+    const targetDir = path.join(probeDir, "target");
+    const linkDir = path.join(probeDir, "link");
+    fsSync.mkdirSync(targetDir);
+    fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
 
 function createMockWatcher() {
   const handlers = new Map<WatchEvent, WatchCallback[]>();
@@ -315,7 +340,7 @@ describe("ensureSkillsWatcher", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "watches allowed symlink skill targets without following every root symlink",
     async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-symlink-"));
@@ -330,7 +355,7 @@ describe("ensureSkillsWatcher", () => {
           path.join(targetSkillDir, "SKILL.md"),
           "---\nname: linked-skill\ndescription: Linked\n---\n",
         );
-        await fs.symlink(targetSkillDir, path.join(groupedLinkDir, "linked-skill"), "dir");
+        await fs.symlink(targetSkillDir, path.join(groupedLinkDir, "linked-skill"), directorySymlinkType);
 
         refreshModule.ensureSkillsWatcher({
           workspaceDir,
@@ -351,7 +376,7 @@ describe("ensureSkillsWatcher", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")("watches symlinked skill root targets", async () => {
+  it.skipIf(!canCreateDirectorySymlinks)("watches symlinked skill root targets", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watch-root-link-"));
     const targetSkillsDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "openclaw-watch-root-link-target-"),
@@ -361,7 +386,7 @@ describe("ensureSkillsWatcher", () => {
         path.join(targetSkillsDir, "SKILL.md"),
         "---\nname: linked-root\ndescription: Linked root\n---\n",
       );
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
 
       refreshModule.ensureSkillsWatcher({ workspaceDir });
 
@@ -378,7 +403,7 @@ describe("ensureSkillsWatcher", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "does not watch untrusted companion skills symlink targets",
     async () => {
       const workspaceDir = await fs.mkdtemp(
@@ -393,7 +418,7 @@ describe("ensureSkillsWatcher", () => {
           path.join(outsideDir, "SKILL.md"),
           "---\nname: untrusted\ndescription: Untrusted\n---\n",
         );
-        await fs.symlink(outsideDir, path.join(repoDir, "skills"), "dir");
+        await fs.symlink(outsideDir, path.join(repoDir, "skills"), directorySymlinkType);
 
         refreshModule.ensureSkillsWatcher({
           workspaceDir,
@@ -664,7 +689,7 @@ describe("ensureSkillsWatcher", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "does not watch untrusted plugin skill symlink targets",
     async () => {
       const pluginDir = await fs.mkdtemp(
@@ -679,7 +704,7 @@ describe("ensureSkillsWatcher", () => {
           path.join(outsideDir, "SKILL.md"),
           "---\nname: untrusted-plugin\ndescription: Untrusted plugin\n---\n",
         );
-        await fs.symlink(outsideDir, path.join(pluginDir, "skills", "untrusted"), "dir");
+        await fs.symlink(outsideDir, path.join(pluginDir, "skills", "untrusted"), directorySymlinkType);
         const pluginSkills = await import("../loading/plugin-skills.js");
         vi.mocked(pluginSkills.resolvePluginSkillDirs).mockReturnValueOnce([pluginDir]);
 


### PR DESCRIPTION
## What Problem This Solves
Fixes #127928.

## Why This Change Was Made
Refresh tests need explicit Windows symlink typing behavior.

## User Impact
Improves Windows test reliability for refresh flows.

## Evidence
- Branch focus: src/skills/runtime/refresh.test.ts.
- Issue-linked and scoped to test reliability.