### PR TITLE
fix(agents): pin legacy default agent workspace on load to prevent silent per-agent move

### DIFF
--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -76,7 +76,16 @@ export function loadConfigFromContext(
     const contextBudgetMigration = migrateLegacyContextBudgetConfig(
       readResolution.resolvedConfigRaw,
     );
-    const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config);
+    // Pin the legacy default agent's workspace into the loaded config, mirroring the
+    // write path (see io.write.ts). Read-time migration strips `default: true`, so
+    // resolveAgentWorkspaceDir otherwise depends on a process-local WeakMap retention
+    // that is lost across config re-materialization — leaving a `default: true` agent
+    // with no explicit workspace resolving to `<workspace>/<agentId>` instead of
+    // `<workspace>` after upgrade (blank persona + empty memory). Pinning into the
+    // config data keeps resolution correct regardless of object identity.
+    const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config, {
+      materializeWorkspace: true,
+    });
     const effectiveConfigRaw = rosterMigration.config;
     const validationConfigRaw = effectiveConfigRaw;
     const snapshotRaw = raw;

--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -76,16 +76,7 @@ export function loadConfigFromContext(
     const contextBudgetMigration = migrateLegacyContextBudgetConfig(
       readResolution.resolvedConfigRaw,
     );
-    // Pin the legacy default agent's workspace into the loaded config, mirroring the
-    // write path (see io.write.ts). Read-time migration strips `default: true`, so
-    // resolveAgentWorkspaceDir otherwise depends on a process-local WeakMap retention
-    // that is lost across config re-materialization — leaving a `default: true` agent
-    // with no explicit workspace resolving to `<workspace>/<agentId>` instead of
-    // `<workspace>` after upgrade (blank persona + empty memory). Pinning into the
-    // config data keeps resolution correct regardless of object identity.
-    const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config, {
-      materializeWorkspace: true,
-    });
+    const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config);
     const effectiveConfigRaw = rosterMigration.config;
     const validationConfigRaw = effectiveConfigRaw;
     const snapshotRaw = raw;

--- a/src/config/legacy.roster.test.ts
+++ b/src/config/legacy.roster.test.ts
@@ -32,6 +32,34 @@ describe("persisted implicit-main roster migration", () => {
     });
   });
 
+  it("pins the legacy default agent's workspace on load so it keeps resolving to defaults.workspace", async () => {
+    await withTempHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          agents: {
+            defaults: { workspace: "/data/team-workspace" },
+            entries: {
+              main: { default: true },
+              voice: { workspace: "/data/team-workspace" },
+            },
+          },
+        }),
+      );
+      resetConfigRuntimeState();
+
+      const snapshot = await readConfigFileSnapshot();
+
+      // The retired `default: true` marker is stripped, but the workspace must be pinned
+      // to defaults.workspace so the agent does not silently move to `<workspace>/main`
+      // (blank persona + empty memory) on upgrade.
+      expect(snapshot.sourceConfig.agents?.entries?.main?.workspace).toBe("/data/team-workspace");
+      expect(snapshot.sourceConfig.agents?.entries?.main?.default).toBeUndefined();
+    });
+  });
+
   it("retains include-resolved roster provenance before migration", async () => {
     await withTempHome(async (home) => {
       const configDir = path.join(home, ".openclaw");

--- a/src/config/legacy.roster.ts
+++ b/src/config/legacy.roster.ts
@@ -124,10 +124,14 @@ export function migratePersistedImplicitMainRoster(
   const diagnostics = convertedLegacyList ? ["Moved agents.list to keyed agents.entries."] : [];
   let changed = convertedLegacyList;
   if (legacyDefaultAgentId) {
+    // Retiring the `default: true` marker (below) must not drop the agent's workspace.
+    // Pin the workspace by default so every read path (load, snapshot, validation) keeps
+    // the legacy default agent resolving to agents.defaults.workspace instead of falling
+    // through to `<workspace>/<agentId>`. Callers may still opt out with materializeWorkspace: false.
     const materialized = materializeLegacyDefaultAgentRoles(
       nextRoot as OpenClawConfig,
       legacyDefaultAgentId,
-      options,
+      { ...options, materializeWorkspace: options.materializeWorkspace ?? true },
     );
     nextRoot = materialized.config as Record<string, unknown>;
     insertedPaths = materialized.insertedPaths;


### PR DESCRIPTION
## What Problem This Solves

A `default: true` agent with **no explicit `workspace`** (inheriting `agents.defaults.workspace`) silently changes its resolved workspace from `<workspace>` to `<workspace>/<agentId>` on upgrade. The new per-agent directory is scaffolded with a blank default identity, and the agent's `memory/` and `outputs/` move to the empty subdir — a silent identity + memory reset, with no error or prompt. Fixes #127802.

## Root Cause

`resolveAgentWorkspaceDir` returns `agents.defaults.workspace` for the legacy default agent only when `tryResolveInheritedWorkspaceAgentId` identifies it. That relies on `getRetainedLegacyDefaultAgentId` — a process-local `WeakMap` keyed by the config object, seeded during the roster migration that strips `default: true`. Across config re-materialization on the read/load path, the config object resolved against is not the one the retention was seeded on, so the retention is lost, `inheritedWorkspaceAgentId` is `undefined`, and resolution falls through to `path.join(defaults.workspace, agentId)` → `<workspace>/<agentId>`.

The write path (`io.write.ts`) already pins the workspace via `materializeWorkspace: true`, but a config that is never rewritten after upgrade (e.g. a read-only mounted config) never receives that pin — so the read path must not depend on the fragile in-process retention.

## Fix

`migratePersistedImplicitMainRoster` now defaults `materializeWorkspace` to `true` when it processes a legacy default agent (callers can still pass `false`). Retiring the `default: true` marker therefore also pins the legacy default agent's workspace into the config **data** on every read path (load, snapshot, validation) — mirroring the write path — so resolution stays correct regardless of `WeakMap` object identity. The pin only applies to a legacy default agent that has no explicit `workspace` (an agent with an explicit workspace is untouched), and it resolves to `agents.defaults.workspace` (its historical value), so behavior is preserved rather than changed. No on-disk config is rewritten on read.

## Evidence

Added a regression test in `legacy.roster.test.ts`: loading a config with `main: { default: true }`, a sibling agent with an explicit `workspace`, and `agents.defaults.workspace` set now yields `entries.main.workspace === defaults.workspace` (previously `main.workspace` was absent, which produced the `<workspace>/main` fallback). Confirmed the failing behavior on latest `main` (`resolveAgentWorkspaceDir` and its `// Read-time migration removes default:true before write-time workspace pinning can run.` comment are unchanged).
