### PR TITLE
fix(channels): keep a queued message alive through a long turn instead of dead-lettering it

### DIFF
--- a/extensions/feishu/src/bot-broadcast.ts
+++ b/extensions/feishu/src/bot-broadcast.ts
@@ -182,6 +182,7 @@ export function createFeishuBroadcastIngressSettlement(params: {
             lane.status = "deferred";
             defer();
           },
+          onDeferredHeartbeat: () => params.lifecycle?.onDeferredHeartbeat?.(),
           onAdoptionFinalizing: beginFinalizing,
           onAbandoned: async () => {
             if (

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -112,6 +112,7 @@ function createIngressLifecycle() {
   const calls = {
     adopted: vi.fn(async () => {}),
     deferred: vi.fn(),
+    deferredHeartbeat: vi.fn(),
     finalizing: vi.fn(),
     abandoned: vi.fn(async () => {}),
   };
@@ -119,6 +120,7 @@ function createIngressLifecycle() {
     abortSignal: new AbortController().signal,
     onAdopted: calls.adopted,
     onDeferred: calls.deferred,
+    onDeferredHeartbeat: calls.deferredHeartbeat,
     onAdoptionFinalizing: calls.finalizing,
     onAbandoned: calls.abandoned,
   };
@@ -950,7 +952,10 @@ describe("broadcast dispatch", () => {
             : broadcastClaim,
     }));
     let deferredLifecycle:
-      | Pick<FeishuIngressLifecycle, "onAdopted" | "onDeferred" | "onAbandoned">
+      | Pick<
+          FeishuIngressLifecycle,
+          "onAdopted" | "onDeferred" | "onDeferredHeartbeat" | "onAbandoned"
+        >
       | undefined;
     mockDispatchReply.mockImplementation(async ({ ctx, replyOptions }) => {
       if (String(ctx.SessionKey).startsWith("agent:susan:")) {
@@ -976,6 +981,8 @@ describe("broadcast dispatch", () => {
 
     expect(transport.calls.deferred).toHaveBeenCalledTimes(1);
     expect(transport.calls.adopted).not.toHaveBeenCalled();
+    deferredLifecycle?.onDeferredHeartbeat?.();
+    expect(transport.calls.deferredHeartbeat).toHaveBeenCalledOnce();
     expect(broadcastClaim.commit).not.toHaveBeenCalled();
     expect(mainClaim.commit).toHaveBeenCalledTimes(1);
     expect(susanClaim.commit).not.toHaveBeenCalled();

--- a/extensions/feishu/src/feishu-ingress.ts
+++ b/extensions/feishu/src/feishu-ingress.ts
@@ -316,6 +316,7 @@ export function buildFeishuFlushIngressLifecycle(
         handedOff = true;
         transportLifecycle.onDeferred();
       },
+      onDeferredHeartbeat: () => transportLifecycle.onDeferredHeartbeat?.(),
       onAdoptionFinalizing: () => {
         transportLifecycle.onAdoptionFinalizing();
       },

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -352,6 +352,10 @@ export function createSlackMessageHandler(params: {
                     settlementHandedOff = true;
                     return undefined;
                   },
+                  onDeferredHeartbeat: () => {
+                    turnAdoptionLifecycle?.onDeferredHeartbeat?.();
+                    admissionLifecycle.onDeferredHeartbeat?.();
+                  },
                   onAbandoned: () => {
                     settlementHandedOff = true;
                     releaseClaims();

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -150,6 +150,7 @@ export async function runTelegramDispatchTurn(turn: Turn) {
                   admission: turn.turnAdoptionLifecycle.admission ?? "exclusive",
                   onAdopted: turn.turnAdoptionLifecycle.onAdopted,
                   onDeferred: turn.turnAdoptionLifecycle.onDeferred,
+                  onDeferredHeartbeat: turn.turnAdoptionLifecycle.onDeferredHeartbeat,
                   onAbandoned: turn.turnAdoptionLifecycle.onAbandoned,
                   abortSignal: turn.turnAdoptionLifecycle.abortSignal,
                 }

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -49,6 +49,7 @@ export type DispatchTelegramMessageParams = {
     admission?: "exclusive" | "cancel-only";
     onAdopted: () => void | Promise<void>;
     onDeferred?: () => void;
+    onDeferredHeartbeat?: () => void;
     onAbandoned?: () => void;
     abortSignal?: AbortSignal;
   };

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -276,6 +276,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         admission?: "exclusive" | "cancel-only";
         onAdopted: () => void | Promise<void>;
         onDeferred?: () => void;
+        onDeferredHeartbeat?: () => void;
         onAbandoned?: () => void;
         abortSignal?: AbortSignal;
       };
@@ -436,6 +437,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
               deferred = true;
               drainLifecycle?.onDeferred();
             },
+            onDeferredHeartbeat: () => drainLifecycle?.onDeferredHeartbeat?.(),
             onAbandoned: () => {
               if (!adopted) {
                 void settle({ kind: "failed-retryable", error: "turn-abandoned" }, "terminal");

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -14,6 +14,7 @@ type TelegramSpooledReplayLifecycle = {
   abortSignal: AbortSignal;
   onAdopted: () => void | Promise<void>;
   onDeferred: () => void;
+  onDeferredHeartbeat?: () => void;
   /** Clears pre-adoption stall while durable adoption finalization is held. */
   onAdoptionFinalizing?: () => void;
   onAbandoned: () => void | Promise<void>;

--- a/extensions/twitch/src/twitch-ingress.ts
+++ b/extensions/twitch/src/twitch-ingress.ts
@@ -138,6 +138,7 @@ export function createTwitchIngress(options: {
             handedOff = true;
             lifecycle.onDeferred();
           },
+          onDeferredHeartbeat: () => lifecycle.onDeferredHeartbeat?.(),
           onAbandoned: async () => {
             handedOff = true;
             await lifecycle.onAbandoned();

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -72,6 +72,8 @@ export type TurnAdoptionLifecycle = {
   onAdopted: () => void | Promise<void>;
   /** Return false to reject followup enqueue. */
   onDeferred?: () => boolean | void;
+  /** Reports that a deferred turn is still queued behind an active turn. */
+  onDeferredHeartbeat?: () => void;
   /** Deferred turn finished without owning the reply lane. */
   onAbandoned?: () => void;
   /** Always fires when the followup ownership cycle ends (admitted or not). Gateway cleanup. */

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -56,6 +56,7 @@ type InboundDebounceAdmissionLifecycleInput = {
   abortSignal?: AbortSignal;
   onAdopted?: () => void | Promise<void>;
   onDeferred?: () => boolean | void;
+  onDeferredHeartbeat?: () => void;
   onAdoptionFinalizing?: () => void;
   onFailed?: (error: unknown) => void | Promise<void>;
   onAbandoned?: () => void | Promise<void>;
@@ -66,6 +67,7 @@ type InboundDebounceAdmissionLifecycle = {
   abortSignal: AbortSignal;
   onAdopted: () => Promise<void>;
   onDeferred: () => boolean | void;
+  onDeferredHeartbeat?: () => void;
   onAdoptionFinalizing: () => void;
   onFailed?: (error: unknown) => Promise<void>;
   onAbandoned: () => Promise<void>;
@@ -105,6 +107,7 @@ function createInboundDebounceFlush(params: {
       }
       return accepted;
     },
+    onDeferredHeartbeat: () => source?.onDeferredHeartbeat?.(),
     onAdoptionFinalizing: () => source?.onAdoptionFinalizing?.(),
     onFailed: source?.onFailed
       ? async (error) => {

--- a/src/auto-reply/reply/followup-turn-admission.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.test.ts
@@ -123,12 +123,22 @@ beforeEach(() => {
 });
 
 describe("admitFollowupTurn", () => {
-  it("returns a closed deferral without adopting the queued source", async () => {
+  it("reports each active-run deferral without adopting the queued source", async () => {
     state.admitReply.mockResolvedValue({ status: "skipped", reason: "active-run" });
+    const onDeferredHeartbeat = vi.fn();
+    const queued = createRun({
+      turnAdoptionLifecycle: { onAdopted: async () => {}, onDeferredHeartbeat },
+    });
 
-    await expect(
-      admitFollowupTurn({ queued: createRun(), defaults: createDefaults() }),
-    ).resolves.toEqual({ kind: "deferred", reason: "active-run" });
+    await expect(admitFollowupTurn({ queued, defaults: createDefaults() })).resolves.toEqual({
+      kind: "deferred",
+      reason: "active-run",
+    });
+    await expect(admitFollowupTurn({ queued, defaults: createDefaults() })).resolves.toEqual({
+      kind: "deferred",
+      reason: "active-run",
+    });
+    expect(onDeferredHeartbeat).toHaveBeenCalledTimes(2);
     expect(state.admitLifecycle).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -152,9 +152,11 @@ export async function admitFollowupTurn(params: {
     upstreamAbortSignal: resolveFollowupAbortSignal(params.queued),
   });
   if (admission.status === "skipped") {
-    return admission.reason === "active-run"
-      ? { kind: "deferred", reason: "active-run" }
-      : { kind: "skipped", reason: admission.reason };
+    if (admission.reason !== "active-run") {
+      return { kind: "skipped", reason: admission.reason };
+    }
+    params.queued.turnAdoptionLifecycle?.onDeferredHeartbeat?.();
+    return { kind: "deferred", reason: "active-run" };
   }
   const operation = admission.operation;
   operation.retainFailureUntilComplete();

--- a/src/channels/message/ingress-drain-lifecycle.ts
+++ b/src/channels/message/ingress-drain-lifecycle.ts
@@ -12,6 +12,8 @@ export type ChannelIngressDispatchLifecycle = {
    * Claim remains held until adopted or abandoned.
    */
   onDeferred: () => void;
+  /** Deferred reply-lane admission is still waiting behind an active turn. */
+  onDeferredHeartbeat?: () => void;
   /**
    * Durable adoption finalization is in progress (e.g. settlement hold while
    * committing dedupe). Clears the pre-adoption stall watchdog so a timeout
@@ -36,6 +38,7 @@ export function bindIngressLifecycleToReplyOptions(lifecycle: ChannelIngressDisp
     admission: "exclusive";
     onAdopted: () => void | Promise<void>;
     onDeferred: () => void;
+    onDeferredHeartbeat?: () => void;
     onAbandoned: () => void | Promise<void>;
     abortSignal: AbortSignal;
   };
@@ -45,6 +48,7 @@ export function bindIngressLifecycleToReplyOptions(lifecycle: ChannelIngressDisp
       admission: "exclusive",
       onAdopted: lifecycle.onAdopted,
       onDeferred: lifecycle.onDeferred,
+      onDeferredHeartbeat: lifecycle.onDeferredHeartbeat,
       onAbandoned: lifecycle.onAbandoned,
       abortSignal: lifecycle.abortSignal,
     },

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -478,6 +478,11 @@ export function createChannelIngressDrain<
           state.occupiesLane = false;
         }
       },
+      onDeferredHeartbeat: () => {
+        if (state.phase === "deferred" && !state.guillotined && !state.superseded) {
+          armStallWatchdog(state);
+        }
+      },
       onAdoptionFinalizing: () => {
         if (state.phase !== "dispatching" && state.phase !== "deferred") {
           return;

--- a/src/channels/message/ingress-drain.watchdog.test.ts
+++ b/src/channels/message/ingress-drain.watchdog.test.ts
@@ -65,11 +65,12 @@ describe("channel ingress drain watchdog", () => {
     });
   });
 
-  it("guillotines deferred stalls", async () => {
+  it("rearms a live deferred wait, then guillotines silence", async () => {
     await withTempState(async (stateDir) => {
       let clock = 30_000;
       const queue = createTestIngressQueue(stateDir, { now: () => clock });
       await queue.enqueue("evt-def-stall", { text: "x" }, { laneKey: "l1" });
+      let heartbeat: (() => void) | undefined;
 
       const drain = createChannelIngressDrain<Payload>({
         queue,
@@ -77,6 +78,7 @@ describe("channel ingress drain watchdog", () => {
         adoptionStallTimeoutMs: 5_000,
         dispatchClaimedEvent: async (_event, lifecycle) => {
           lifecycle.onDeferred();
+          heartbeat = lifecycle.onDeferredHeartbeat;
           // Stay deferred without adoption -- watchdog must still fire.
           await new Promise(() => {});
         },
@@ -84,8 +86,14 @@ describe("channel ingress drain watchdog", () => {
 
       await drain.drainOnce();
       expect(await queue.listClaims()).toHaveLength(1);
-      clock += 5_000;
-      await vi.advanceTimersByTimeAsync(5_000);
+      clock += 4_000;
+      await vi.advanceTimersByTimeAsync(4_000);
+      heartbeat?.();
+      clock += 1_000;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(await queue.listClaims()).toHaveLength(1);
+      clock += 4_000;
+      await vi.advanceTimersByTimeAsync(4_000);
       await drain.waitForIdle();
 
       expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -28,6 +28,7 @@ export type ChannelIngressMonitorLifecycle = {
   abortSignal: AbortSignal;
   onAdopted: () => void | Promise<void>;
   onDeferred: () => void;
+  onDeferredHeartbeat?: () => void;
   onAdoptionFinalizing: () => void;
   onFailed?: (error: unknown) => void | Promise<void>;
   onCancelled?: () => void | Promise<void>;

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -187,6 +187,11 @@ export function fanInChannelIngressLifecycles(
           lifecycle.onDeferred();
         }
       },
+      onDeferredHeartbeat: () => {
+        for (const lifecycle of lifecycles) {
+          lifecycle.onDeferredHeartbeat?.();
+        }
+      },
       onAdoptionFinalizing: () => {
         for (const lifecycle of lifecycles) {
           lifecycle.onAdoptionFinalizing();

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -30,6 +30,7 @@ export const createTestInboundDebounceFlush: InboundDebounceFlushFactory = (para
     abortSignal: source?.abortSignal ?? new AbortController().signal,
     onAdopted: async () => await source?.onAdopted?.(),
     onDeferred: () => source?.onDeferred?.(),
+    onDeferredHeartbeat: () => source?.onDeferredHeartbeat?.(),
     onAdoptionFinalizing: () => source?.onAdoptionFinalizing?.(),
     onFailed: source?.onFailed ? async (error) => await source.onFailed?.(error) : undefined,
     onAbandoned: async () => await source?.onAbandoned?.(),


### PR DESCRIPTION
Fixes #97435.

## What Problem This Solves

A message that arrives while its session is busy can be retried and lost when the running turn lasts longer than the five-minute ingress watchdog.

## Root Cause

The follow-up queue rechecks active-turn admission every 15 seconds, but it did not report those successful rechecks to the durable ingress claim. The ingress owner therefore treated a healthy queued wait as a silent handler when the five-minute watchdog expired.

## Fix

The follow-up admission owner now reports a liveness heartbeat after each fresh `active-run` result. The existing ingress watchdog rearms only while the claim remains deferred. Silent handlers still reach the same timeout and retry path.

Lifecycle wrappers that own or combine durable claims forward the heartbeat through the shared core and Plugin SDK boundaries. The earlier separate watchdog module and deferred-log state are no longer needed.

## User Impact

A second message sent during a long-running turn stays durable and runs after the first turn ends. Operators do not need a new setting or migration.

## Evidence

### Real Telegram red and green

A real Telegram Test Server user sent message 1, then sent message 2 five seconds later. The mock provider held message 1 for 315 seconds, past the default 300-second watchdog.

- Current main `f7a9a361d99176628faac626be54bace2ed05380`: message 2 hit `handler-timeout` at 300 seconds. Only message 1 reached the model and replied.
- Repaired head `06c16bf08ed4045e71580035a84486ed3cdb0ebf`: no watchdog timeout occurred. Both messages reached the model, and Telegram delivered the two replies at 316.7 and 317.7 seconds.

### Regression and repository checks

- The admission regression failed before the fix with zero heartbeats and passed after the fix with two.
- The ingress regression failed before the fix because the live deferred claim disappeared at the original deadline. It passed after the fix and still proved that silence eventually times out.
- Focused admission, ingress-watchdog, and Feishu broadcast suites passed.
- Build, formatting, four type-check lanes, changed-file lint, Plugin SDK surface checks, architecture guards, schema guards, and import-cycle checks passed.

Production code is +35 net lines. Tests are +25 net lines. The production growth is the new liveness capability and the relays required to preserve it across existing ownership boundaries.
