### PR TITLE
fix(agents): resolve pdf tool models through the canonical resolver

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2126,7 +2126,7 @@ src/agents/tools/image-tool.helpers.ts	2
 src/agents/tools/image-tool.ts	3
 src/agents/tools/in-process-gateway.ts	1
 src/agents/tools/media-generate-tool-actions-shared.ts	1
-src/agents/tools/media-tool-shared.ts	4
+src/agents/tools/media-tool-shared.ts	2
 src/agents/tools/message-tool-discovery.ts	3
 src/agents/tools/message-tool-execution.ts	4
 src/agents/tools/message-tool-visible-content.ts	9

--- a/scripts/e2e/telegram-mantis-sut.ts
+++ b/scripts/e2e/telegram-mantis-sut.ts
@@ -209,8 +209,8 @@ export function writeSutConfig(params: {
         models: {
           "openai/gpt-5.6-luna": { params: { openaiWsWarmup: false, transport: "sse" } },
         },
-        // Auto-resolution walks plugin manifest defaults (gpt-5.5), which this
-        // catalog does not define; pin the pdf tool to the only harness model.
+        // Keep the pdf tool on the one catalog model instead of walking fallback
+        // candidates the mock never scripted.
         pdfModel: { primary: "openai/gpt-5.6-luna" },
       },
       entries: {

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -12,7 +12,6 @@ import {
   resolveMediaToolInboundRoots,
   resolveCapabilityModelConfigForTool,
   resolveMediaToolReferenceAccess,
-  resolveModelFromRegistry,
 } from "./media-tool-shared.js";
 
 // Keep media-tool-shared tests focused on root separation; channel-inbound
@@ -42,22 +41,6 @@ vi.mock("../../media/channel-inbound-roots.js", () => ({
 
 function normalizeHostPath(value: string): string {
   return path.normalize(path.resolve(value));
-}
-
-function createModelRegistryStub(resolve: (provider: string, modelId: string) => unknown): {
-  calls: Array<[string, string]>;
-  registry: { find: (provider: string, modelId: string) => unknown };
-} {
-  const calls: Array<[string, string]> = [];
-  return {
-    calls,
-    registry: {
-      find(provider, modelId) {
-        calls.push([provider, modelId]);
-        return resolve(provider, modelId);
-      },
-    },
-  };
 }
 
 describe("readBooleanToolParam", () => {
@@ -192,55 +175,6 @@ describe("resolveMediaToolReferenceAccess", () => {
       }),
     ).rejects.toThrow(expected);
   });
-});
-
-describe("resolveModelFromRegistry", () => {
-  it("normalizes provider and model refs before registry lookup", () => {
-    const foundModel = { provider: "ollama", id: "qwen3.5:397b-cloud" };
-    const { calls, registry } = createModelRegistryStub(() => foundModel);
-
-    const result = resolveModelFromRegistry({
-      modelRegistry: registry,
-      provider: " OLLAMA ",
-      modelId: " qwen3.5:397b-cloud ",
-    });
-
-    expect(calls).toEqual([["ollama", "qwen3.5:397b-cloud"]]);
-    expect(result).toBe(foundModel);
-  });
-
-  it("reports the normalized ref when the registry lookup misses", () => {
-    const { registry } = createModelRegistryStub(() => null);
-
-    expect(() =>
-      resolveModelFromRegistry({
-        modelRegistry: registry,
-        provider: " OLLAMA ",
-        modelId: " qwen3.5:397b-cloud ",
-      }),
-    ).toThrow("Unknown model: ollama/qwen3.5:397b-cloud");
-  });
-
-  it("falls back to provider-prefixed custom model IDs", () => {
-    // Custom providers can store ids with provider prefixes; try both forms so
-    // callers can pass the short local model id.
-    const foundModel = { provider: "kimchi", id: "kimchi/claude-opus-4-6" };
-    const { calls, registry } = createModelRegistryStub((_, modelId) =>
-      modelId === "kimchi/claude-opus-4-6" ? foundModel : null,
-    );
-
-    const result = resolveModelFromRegistry({
-      modelRegistry: registry,
-      provider: "kimchi",
-      modelId: "claude-opus-4-6",
-    });
-
-    expect(calls).toEqual([
-      ["kimchi", "claude-opus-4-6"],
-      ["kimchi", "kimchi/claude-opus-4-6"],
-    ]);
-    expect(result).toBe(foundModel);
-  }, 180_000);
 });
 
 describe("hasGenerationToolAvailability", () => {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -23,7 +23,6 @@ import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { loadCapabilityManifestSnapshot } from "../../plugins/capability-provider-runtime.js";
 import { listAvailableManifestContractValues } from "../../plugins/manifest-contract-eligibility.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
-import { normalizeModelRef } from "../model-selection.js";
 import {
   resolveSandboxedBridgeMediaPath,
   type SandboxedBridgeMediaPathConfig,
@@ -694,30 +693,6 @@ export function buildTextToolResult(
       attempts: result.attempts,
     },
   };
-}
-
-/**
- * Resolves a catalog model while supporting registries that index model ids with provider prefixes.
- */
-export function resolveModelFromRegistry(params: {
-  modelRegistry: { find: (provider: string, modelId: string) => unknown };
-  provider: string;
-  modelId: string;
-}): Model {
-  const resolvedRef = normalizeModelRef(params.provider, params.modelId, {
-    allowPluginNormalization: false,
-  });
-  let model = params.modelRegistry.find(resolvedRef.provider, resolvedRef.model) as Model | null;
-  if (!model && !resolvedRef.model.includes("/")) {
-    model = params.modelRegistry.find(
-      resolvedRef.provider,
-      `${resolvedRef.provider}/${resolvedRef.model}`,
-    ) as Model | null;
-  }
-  if (!model) {
-    throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
-  }
-  return model;
 }
 
 /**

--- a/src/agents/tools/pdf-tool.static-runtime.test.ts
+++ b/src/agents/tools/pdf-tool.static-runtime.test.ts
@@ -1,0 +1,129 @@
+// PDF model resolution must consume configured facts from static prepared runtimes.
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../../config/config.js";
+import * as pdfExtractModule from "../../media/pdf-extract.js";
+import * as webMedia from "../../media/web-media.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { acquireAgentRunPreparedModelRuntime } from "../prepared-model-runtime.js";
+
+const completeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../llm/stream.js", async () => {
+  const actual = await vi.importActual<typeof import("../../llm/stream.js")>("../../llm/stream.js");
+  return { ...actual, complete: completeMock };
+});
+
+vi.mock("../provider-stream.js", () => ({
+  registerProviderStreamForModel: vi.fn(),
+}));
+
+describe("PDF tool static prepared runtime", () => {
+  afterEach(() => {
+    completeMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves a config-inline model when the static registry is empty", async () => {
+    await withOpenClawTestState(
+      {
+        label: "pdf-static-inline-model",
+        env: { OPENAI_API_KEY: "test-key" },
+      },
+      async (state) => {
+        const modelId = "gpt-5.6-luna";
+        const modelRef = `openai/${modelId}`;
+        await state.writeConfig({
+          models: {
+            mode: "replace",
+            providers: {
+              openai: {
+                api: "openai-responses",
+                baseUrl: "http://127.0.0.1:9/v1",
+                models: [
+                  {
+                    id: modelId,
+                    name: "GPT-5.6 Luna inline fixture",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 128_000,
+                    maxTokens: 8_192,
+                  },
+                ],
+              },
+            },
+          },
+          agents: {
+            defaults: {
+              model: { primary: modelRef },
+              pdfModel: { primary: modelRef },
+            },
+          },
+        });
+        const config = loadConfig({
+          pin: false,
+          skipPluginValidation: true,
+          skipShellEnvFallback: true,
+        });
+        const agentDir = state.agentDir();
+        await fs.mkdir(agentDir, { recursive: true });
+        const lease = await acquireAgentRunPreparedModelRuntime(
+          { agentDir, config },
+          { catalogMode: "static" },
+        );
+
+        try {
+          const stores = lease.snapshot.createStores();
+          expect(stores.modelRegistry.find("openai", modelId)).toBeUndefined();
+          expect(
+            lease.snapshot.configuredRuntimeModels.map((entry) => ({
+              provider: entry.provider,
+              modelId: entry.modelId,
+            })),
+          ).toContainEqual({ provider: "openai", modelId });
+
+          vi.spyOn(webMedia, "loadWebMediaRaw").mockResolvedValue({
+            kind: "document",
+            buffer: Buffer.from("%PDF-1.4 inline model fixture"),
+            contentType: "application/pdf",
+            fileName: "inline-model.pdf",
+          });
+          vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+            text: "Inline model regression fixture",
+            images: [],
+          });
+          completeMock.mockResolvedValue({
+            role: "assistant",
+            stopReason: "stop",
+            content: [{ type: "text", text: "resolved inline model" }],
+          });
+
+          const { createPdfTool } = await import("./pdf-tool.js");
+          const tool = createPdfTool({
+            config,
+            agentDir,
+            preparedModelRuntime: lease.snapshot,
+          });
+          if (!tool) {
+            throw new Error("expected PDF tool");
+          }
+
+          const result = await tool.execute("pdf-static-inline", {
+            prompt: "Summarize",
+            pdf: "/tmp/inline-model.pdf",
+          });
+
+          expect(completeMock).toHaveBeenCalledWith(
+            expect.objectContaining({ provider: "openai", id: modelId }),
+            expect.any(Object),
+            expect.any(Object),
+          );
+          expect(result.details).toMatchObject({ model: modelRef, native: false });
+        } finally {
+          lease.release();
+        }
+      },
+    );
+  }, 180_000);
+});

--- a/src/agents/tools/pdf-tool.test-support.ts
+++ b/src/agents/tools/pdf-tool.test-support.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { type Mock, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import * as webMedia from "../../media/web-media.js";
 import * as modelAuth from "../model-auth.js";
 import * as modelsConfig from "../models-config.js";
@@ -12,6 +13,25 @@ import {
   getModelRegistryRuntime,
   initializeModelRegistryRuntime,
 } from "../sessions/model-registry-runtime.js";
+import { createEmptyPluginMetadataSnapshot } from "../test-helpers/embedded-agent-runner-e2e-mocks.js";
+
+type StubPreparedRuntimeSnapshot = {
+  agentDir: string;
+  config: OpenClawConfig;
+  workspaceDir?: string;
+  createStores: () => { authStorage: unknown; modelRegistry: unknown };
+};
+
+// The canonical resolver reads prepared facts before the registry; stub snapshots
+// carry empty facts so registry-driven fixtures keep deciding resolution.
+export function withPreparedRuntimeFacts(snapshot: StubPreparedRuntimeSnapshot) {
+  return {
+    ...snapshot,
+    metadataSnapshot: createEmptyPluginMetadataSnapshot(snapshot.workspaceDir),
+    configuredRuntimeModels: [],
+    inlineProviderModels: [],
+  };
+}
 
 export async function withTempPdfAgentDir<T>(run: (agentDir: string) => Promise<T>): Promise<T> {
   const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pdf-"));
@@ -95,12 +115,12 @@ export function createPdfToolInfraStub(completeMock: Mock) {
     vi.spyOn(preparedModelRuntime, "acquireAgentRunPreparedModelRuntime").mockImplementation(
       async (input) =>
         ({
-          snapshot: {
+          snapshot: withPreparedRuntimeFacts({
             agentDir: input.agentDir,
             config: input.config,
             workspaceDir: input.workspaceDir,
             createStores: () => ({ authStorage, modelRegistry }),
-          },
+          }),
           release,
         }) as never,
     );

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -18,6 +18,7 @@ import {
   createPdfToolInfraStub,
   FAKE_PDF_MEDIA,
   resetPdfToolAuthEnv,
+  withPreparedRuntimeFacts,
   withTempPdfAgentDir,
 } from "./pdf-tool.test-support.js";
 
@@ -603,11 +604,11 @@ describe("createPdfTool", () => {
       );
       vi.spyOn(pdfNativeProviders, "anthropicAnalyzePdf").mockResolvedValue("parent summary");
       const cfg = withPdfModel(ANTHROPIC_PDF_MODEL);
-      const parentPreparedModelRuntime = {
+      const parentPreparedModelRuntime = withPreparedRuntimeFacts({
         agentDir,
         config: cfg,
         createStores: () => ({ authStorage, modelRegistry }),
-      } as never;
+      }) as never;
       const tool = requirePdfTool(
         (await loadCreatePdfTool())({
           config: cfg,
@@ -642,12 +643,12 @@ describe("createPdfTool", () => {
       const modelRegistry = createPdfModelRegistry(find);
       const release = vi.fn();
       vi.mocked(preparedModelRuntime.acquireAgentRunPreparedModelRuntime).mockResolvedValueOnce({
-        snapshot: {
+        snapshot: withPreparedRuntimeFacts({
           agentDir: "/tmp/committed-pdf-agent",
           workspaceDir: committedWorkspace,
           config: withPdfModel(GOOGLE_PDF_MODEL),
           createStores: () => ({ authStorage, modelRegistry }),
-        },
+        }),
         release,
       } as never);
       const geminiSpy = vi

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -20,6 +20,7 @@ import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-ext
 import { loadWebMediaRaw } from "../../media/web-media.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import { resolveModelAsync } from "../embedded-agent-runner/model.js";
 import { abortable } from "../embedded-agent-runner/run/abortable.js";
 import { applySecretRefHeaderSentinels } from "../model-auth.js";
 import {
@@ -36,7 +37,6 @@ import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
   REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
-  resolveModelFromRegistry,
   resolveMediaToolReferenceAccess,
   resolveModelRuntimeApiKey,
   resolvePromptAndModelOverride,
@@ -196,8 +196,7 @@ async function runPdfPrompt(params: {
     const preparedRuntime = preparedRuntimeLease.snapshot;
     const runtimeAgentDir = preparedRuntime.agentDir;
     const runtimeWorkspaceDir = preparedRuntime.workspaceDir ?? params.workspaceDir;
-    const { authStorage, modelRegistry } = preparedRuntime.createStores();
-    const modelRuntime = getModelRegistryRuntime(modelRegistry);
+    const preparedStores = preparedRuntime.createStores();
     const committedPdfModelConfig = resolvePdfModelConfigForTool({
       cfg: preparedRuntime.config,
       agentDir: runtimeAgentDir,
@@ -223,18 +222,27 @@ async function runPdfPrompt(params: {
       modelOverride: params.modelOverride,
       abortSignal: params.signal,
       run: async (provider, modelId) => {
+        // Static snapshots serve configured models through prepared facts; a fresh registry can be empty.
+        const resolved = await resolveModelAsync(provider, modelId, runtimeAgentDir, effectiveCfg, {
+          allowBundledStaticCatalogFallback: true,
+          ...preparedStores,
+          preparedModelRuntime: preparedRuntime,
+          skipAgentDiscovery: true,
+          ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
+        });
+        if (resolved.error || !resolved.model) {
+          throw new Error(resolved.error ?? `Unknown model: ${provider}/${modelId}`);
+        }
+        const modelRuntime = getModelRegistryRuntime(resolved.modelRegistry);
         const model = bindModelLlmRuntime(
-          applySecretRefHeaderSentinels(
-            resolveModelFromRegistry({ modelRegistry, provider, modelId }),
-            effectiveCfg,
-          ),
+          applySecretRefHeaderSentinels(resolved.model, effectiveCfg),
           modelRuntime.llmRuntime,
         );
         const apiKey = await resolveModelRuntimeApiKey({
           model,
           cfg: effectiveCfg,
           agentDir: runtimeAgentDir,
-          authStorage,
+          authStorage: resolved.authStorage,
         });
 
         if (providerSupportsNativePdf(provider)) {


### PR DESCRIPTION
## What Problem This Solves

Inside a Gateway agent run, the `pdf` tool fails with `Unknown model: <provider>/<model>` for every candidate — including an explicitly configured `agents.defaults.pdfModel` — whenever the agent state dir has never had its model catalog materialized (fresh Docker-style deployments, hand-written `openclaw.json`, CI harnesses). The main turn and the `image` tool resolve the same model fine.

Observed live in Mantis run [32574012855](https://github.com/openclaw/openclaw/actions/runs/32574012855): both lanes died in the pdf tool bridge with `Unknown model: openai/gpt-5.6-luna` (then sol / gpt-5.5 fallback candidates) while the same turn's main dispatch used `openai/gpt-5.6-luna` successfully.

## Why This Change Was Made

Gateway/embedded runs publish prepared model runtimes with `catalogMode: "static"` (`src/gateway/server-startup-post-attach.ts`, `src/agents/embedded-agent-runner/run-orchestrator.ts`). By design, static snapshots build their `ModelRegistry` only from on-disk captured catalog bytes and serve configured models through the snapshot's `configuredRuntimeModels` prepared facts instead (`src/agents/prepared-model-runtime.startup-static.test.ts` pins that `planOpenClawModelsJsonSource` is never called on that path). On a fresh state dir that registry is empty.

The canonical resolver `resolveModelAsync` (`src/agents/embedded-agent-runner/model.ts`) consults the registry, `configuredRuntimeModels`, inline provider models, and the bundled static catalog in order — and the image media path already uses it with the prepared stores (`src/media-understanding/image-model-runtime.ts`). The pdf tool was the lone sibling resolving through `resolveModelFromRegistry`, a raw `registry.find`-only helper in `media-tool-shared.ts` with the pdf tool as its only consumer.

Fix: the pdf tool resolves each fallback candidate through `resolveModelAsync` with the prepared runtime's stores (same shape as the image sibling); `resolveModelFromRegistry` and its tests are deleted. Resolution errors still throw so the fallback loop's per-candidate `attempts` are preserved. Production LOC: net −14 (`pdf-tool.ts` +16/−8, `media-tool-shared.ts` −25 after dropping an unneeded cast).

Also corrects the harness comment from #127882: the `pdfModel` pin in `scripts/e2e/telegram-mantis-sut.ts` stays (it keeps the pdf tool on the one catalog model instead of walking fallback candidates), but its stated reason ("auto-resolution picks gpt-5.5") was this bug's symptom, not its cause.

## User Impact

Operators running a gateway on a state dir that never went through a catalog-materializing flow (onboarding, `openclaw models`, any live-mode CLI path) get a working `pdf` tool instead of `Unknown model` for every ref. No config, protocol, or schema change.

## Evidence

- Regression test `src/agents/tools/pdf-tool.static-runtime.test.ts`: real `acquireAgentRunPreparedModelRuntime(..., { catalogMode: "static" })` on a fresh state dir with a config-inline `openai/gpt-5.6-luna`; asserts the static registry is empty, the configured facts carry the model, and the pdf tool resolves and dispatches it. Pre-fix (production files from `origin/main`): `FailoverError: Unknown model: openai/gpt-5.6-luna`. Post-fix: passes.
- `node scripts/run-vitest.mjs src/agents/tools/pdf-tool.test.ts src/agents/tools/pdf-tool.model-catalog.test.ts src/agents/tools/pdf-tool.runtime-abort.test.ts src/agents/tools/pdf-tool.helpers.test.ts src/agents/tools/media-tool-shared.test.ts src/agents/tools/pdf-tool.static-runtime.test.ts` — 2 shards, 6 files / 83 tests passed (exit 0)
- `node scripts/check-changed.mjs -- <changed files>` — all lanes ok (oxfmt, oxlint, SAFETY ratchet shrink-only prune, dead-export scan, typecheck core + core tests + scripts)
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` — pass.
- Autoreview: Codex gpt-5.6-sol high, `patch is correct` (0.96), no findings
- Live proof: Mantis dispatch on this PR — run [32578074819](https://github.com/openclaw/openclaw/actions/runs/32578074819) — baseline `pass` at `ea1cd39d` (reproduces Code Mode `pdf(...)` `Unknown model` after a staged Telegram PDF), candidate `pass` at `2ca1a9d5` (pdf call completes; provider request carries the extracted PDF text), overall `pass`. CI run 32578075001 green on the exact head; ClawSweeper local review `patch is correct`, 0 findings.
