### PR TITLE
fix(ui): expose Advanced Settings accordion state

### DIFF
--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -770,6 +770,41 @@ describe("config view", () => {
     expect(onSectionChange).toHaveBeenCalledWith(null);
   });
 
+  it("exposes accordion category disclosure state and its controlled panel", () => {
+    const overrides: Partial<ConfigProps> = {
+      settingsLayout: "accordion",
+      includeVirtualSections: false,
+      includeSections: ["env"],
+      schema: {
+        type: "object",
+        properties: {
+          env: { type: "object", properties: {} },
+        },
+      },
+    };
+    const collapsed = renderConfigView(overrides);
+    const collapsedHeader = queryRequired(
+      collapsed.container,
+      ".config-accordion-group__header",
+      HTMLButtonElement,
+    );
+    const controlledPanelId = collapsedHeader.getAttribute("aria-controls");
+
+    expect(collapsedHeader.getAttribute("aria-expanded")).toBe("false");
+    expect(controlledPanelId).not.toBeNull();
+    expect(collapsed.container.querySelector(`#${controlledPanelId}`)).toBeNull();
+
+    const expanded = renderConfigView({ ...overrides, activeSection: "env" });
+    const expandedHeader = queryRequired(
+      expanded.container,
+      ".config-accordion-group__header",
+      HTMLButtonElement,
+    );
+    expect(expandedHeader.getAttribute("aria-expanded")).toBe("true");
+    expect(expandedHeader.getAttribute("aria-controls")).toBe(controlledPanelId);
+    expect(expanded.container.querySelector(`#${controlledPanelId}`)).not.toBeNull();
+  });
+
   it("renders the virtual Notifications tab on Notifications settings", () => {
     const onSectionChange = vi.fn();
     const { container } = renderConfigView({

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -789,10 +789,15 @@ describe("config view", () => {
       HTMLButtonElement,
     );
     const controlledPanelId = collapsedHeader.getAttribute("aria-controls");
+    const collapsedPanel = queryRequired(
+      collapsed.container,
+      `#${controlledPanelId}`,
+      HTMLDivElement,
+    );
 
     expect(collapsedHeader.getAttribute("aria-expanded")).toBe("false");
     expect(controlledPanelId).not.toBeNull();
-    expect(collapsed.container.querySelector(`#${controlledPanelId}`)).toBeNull();
+    expect(collapsedPanel.hidden).toBe(true);
 
     const expanded = renderConfigView({ ...overrides, activeSection: "env" });
     const expandedHeader = queryRequired(
@@ -802,7 +807,9 @@ describe("config view", () => {
     );
     expect(expandedHeader.getAttribute("aria-expanded")).toBe("true");
     expect(expandedHeader.getAttribute("aria-controls")).toBe(controlledPanelId);
-    expect(expanded.container.querySelector(`#${controlledPanelId}`)).not.toBeNull();
+    expect(queryRequired(expanded.container, `#${controlledPanelId}`, HTMLDivElement).hidden).toBe(
+      false,
+    );
   });
 
   it("renders the virtual Notifications tab on Notifications settings", () => {

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -239,26 +239,24 @@ export function renderConfig(props: ConfigProps) {
                   <polyline points="6 9 12 15 18 9"></polyline>
                 </svg>
               </button>
-              ${expanded
-                ? html`<div id=${panelId} class="config-accordion-group__items">
-                    ${category.sections.map(
-                      (section) => html`<button
-                        class="config-accordion-group__item ${props.activeSection === section.key
-                          ? "config-accordion-group__item--active"
-                          : ""}"
-                        @click=${(event: Event) => {
-                          props.onSectionChange(section.key);
-                          resetContentScroll(event.currentTarget);
-                        }}
-                      >
-                        <span class="config-accordion-group__item-icon">
-                          ${getSectionIcon(section.key)}
-                        </span>
-                        ${section.label}
-                      </button>`,
-                    )}
-                  </div>`
-                : nothing}
+              <div id=${panelId} class="config-accordion-group__items" ?hidden=${!expanded}>
+                ${category.sections.map(
+                  (section) => html`<button
+                    class="config-accordion-group__item ${props.activeSection === section.key
+                      ? "config-accordion-group__item--active"
+                      : ""}"
+                    @click=${(event: Event) => {
+                      props.onSectionChange(section.key);
+                      resetContentScroll(event.currentTarget);
+                    }}
+                  >
+                    <span class="config-accordion-group__item-icon">
+                      ${getSectionIcon(section.key)}
+                    </span>
+                    ${section.label}
+                  </button>`,
+                )}
+              </div>
             </div>
           `;
         })}

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -204,20 +204,20 @@ export function renderConfig(props: ConfigProps) {
   function renderAccordionNav() {
     return html`
       <div class="config-accordion-nav">
-        ${allCategories.map(
-          (category) => html`
+        ${allCategories.map((category) => {
+          const expanded = category.sections.some((section) => section.key === props.activeSection);
+          const panelId = `config-accordion-panel-${category.id}`;
+          return html`
             <div class="config-accordion-group">
               <button
-                class="config-accordion-group__header ${props.activeSection != null &&
-                category.sections.some((section) => section.key === props.activeSection)
+                class="config-accordion-group__header ${expanded
                   ? "config-accordion-group__header--active"
                   : ""}"
+                aria-expanded=${expanded ? "true" : "false"}
+                aria-controls=${panelId}
                 @click=${(event: Event) => {
                   const firstKey = category.sections[0]?.key ?? null;
-                  const isCurrentlyInGroup = category.sections.some(
-                    (section) => section.key === props.activeSection,
-                  );
-                  props.onSectionChange(isCurrentlyInGroup ? null : firstKey);
+                  props.onSectionChange(expanded ? null : firstKey);
                   resetContentScroll(event.currentTarget);
                 }}
               >
@@ -226,9 +226,7 @@ export function renderConfig(props: ConfigProps) {
                 </span>
                 <span>${category.label}</span>
                 <svg
-                  class="config-accordion-group__chevron ${category.sections.some(
-                    (section) => section.key === props.activeSection,
-                  )
+                  class="config-accordion-group__chevron ${expanded
                     ? "config-accordion-group__chevron--open"
                     : ""}"
                   viewBox="0 0 24 24"
@@ -241,8 +239,8 @@ export function renderConfig(props: ConfigProps) {
                   <polyline points="6 9 12 15 18 9"></polyline>
                 </svg>
               </button>
-              ${category.sections.some((section) => section.key === props.activeSection)
-                ? html`<div class="config-accordion-group__items">
+              ${expanded
+                ? html`<div id=${panelId} class="config-accordion-group__items">
                     ${category.sections.map(
                       (section) => html`<button
                         class="config-accordion-group__item ${props.activeSection === section.key
@@ -262,8 +260,8 @@ export function renderConfig(props: ConfigProps) {
                   </div>`
                 : nothing}
             </div>
-          `,
-        )}
+          `;
+        })}
       </div>
     `;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where screen-reader users could not tell whether an Advanced Settings category was expanded or reliably resolve the panel its category button controls.

## Why This Change Was Made

The accordion owner now publishes its already-computed open state with `aria-expanded` and connects each category button to a stable panel ID. Every controlled panel remains mounted; collapsed panels use the native `hidden` state, so `aria-controls` always resolves without changing the visible accordion behavior.

## User Impact

Assistive technology can identify collapsed and expanded Advanced Settings categories and their associated content. Collapsed content remains unavailable visually and interactively until expanded.

## Evidence

- Pre-fix regression failed because `aria-expanded` was absent.
- Focused browser suite: `node scripts/run-vitest.mjs ui/src/pages/config/view.browser.test.ts` — 54/54 passed under Node 26.7.0.
- Regression now requires the collapsed target to exist with `hidden=true` and the expanded target with `hidden=false`.
- Full changed-file gate: `node scripts/check-changed.mjs -- ui/src/pages/config/view.ts ui/src/pages/config/view.browser.test.ts` — passed formatting, guards, dead-code scans, i18n, core/UI typechecks, and lint.
- Structured Codex autoreview: clean, no accepted/actionable findings; patch correctness 0.99.
- Production surface remains net-negative: +29/-33 across `view.ts`; tests +42.
- ClawSweeper's P2 finding is addressed by keeping each controlled panel mounted and hidden while collapsed.
