### PR TITLE
improve(irc): reuse claimed inbound projection

### DIFF
--- a/extensions/irc/src/irc-ingress.ts
+++ b/extensions/irc/src/irc-ingress.ts
@@ -72,6 +72,11 @@ function inspectRawPrivmsg(rawLine: string): {
   };
 }
 
+type IrcIngressRaw = {
+  body: IrcIngressBody;
+  claimedProjection?: ReturnType<typeof inspectRawPrivmsg>;
+};
+
 function decodeIrcIngressPayload(
   payload: unknown,
   claimedId: string,
@@ -108,15 +113,19 @@ function decodeIrcIngressPayload(
 }
 
 function inspectIrcIngress(
-  raw: IrcIngressBody,
+  raw: IrcIngressRaw,
   phase: "admission" | "claim",
 ): { eventId: string; laneKey: string } {
   try {
-    return { eventId: raw.eventId, laneKey: inspectRawPrivmsg(raw.rawLine).laneKey };
+    const projection = inspectRawPrivmsg(raw.body.rawLine);
+    if (phase === "claim") {
+      raw.claimedProjection = projection;
+    }
+    return { eventId: raw.body.eventId, laneKey: projection.laneKey };
   } catch (error) {
     if (phase === "admission" && error instanceof IrcIngressPayloadError) {
       // IRC cannot replay a rejected socket line; persist it for claim-side dead-lettering.
-      return { eventId: raw.eventId, laneKey: `invalid:${raw.eventId}` };
+      return { eventId: raw.body.eventId, laneKey: `invalid:${raw.body.eventId}` };
     }
     throw error;
   }
@@ -149,7 +158,7 @@ export function createIrcIngressMonitor(options: {
   pollIntervalMs?: number;
   adoptionStallTimeoutMs?: number;
 }): IrcIngressMonitor {
-  const monitor = createChannelIngressMonitor<IrcIngressBody, IrcIngressBody, IrcIngressPayload>({
+  const monitor = createChannelIngressMonitor<IrcIngressRaw, IrcIngressBody, IrcIngressPayload>({
     queue:
       options.queue ??
       (() =>
@@ -159,23 +168,25 @@ export function createIrcIngressMonitor(options: {
     inspect: (raw, context) => inspectIrcIngress(raw, context.phase),
     payload: {
       version: IRC_INGRESS_PAYLOAD_VERSION,
-      serialize: (raw) => raw,
-      deserialize: (body) => body,
+      serialize: (raw) => raw.body,
+      deserialize: (body) => ({ body }),
       encode: ({ body }) => ({ version: IRC_INGRESS_PAYLOAD_VERSION, ...body }),
       decode: (payload, { claim }) => decodeIrcIngressPayload(payload, claim.id),
       createClaimError: (_kind, claim) =>
         new IrcIngressPayloadError(`IRC ingress row ${claim.id} has invalid metadata.`),
     },
     deliver: (raw, lifecycle, claim) => {
-      const inspected = inspectRawPrivmsg(raw.rawLine);
+      // Claim inspection populates this on the same transient raw object immediately before
+      // delivery; malformed or identity-mismatched rows exit before reaching this callback.
+      const projection = raw.claimedProjection!;
       const message: IrcInboundMessage = {
-        ...inspected.message,
+        ...projection.message,
         messageId: claim.id,
-        timestamp: raw.receivedAt,
+        timestamp: raw.body.receivedAt,
       };
       return options.dispatch(message, lifecycle, {
-        connectedNick: raw.connectedNick.trim(),
-        connectionEpoch: raw.connectionEpoch.trim(),
+        connectedNick: raw.body.connectedNick.trim(),
+        connectionEpoch: raw.body.connectionEpoch.trim(),
       });
     },
     pollIntervalMs: options.pollIntervalMs ?? IRC_INGRESS_POLL_INTERVAL_MS,
@@ -219,11 +230,13 @@ export function createIrcIngressMonitor(options: {
           return monitor
             .admit(
               {
-                eventId,
-                rawLine,
-                receivedAt,
-                connectionEpoch: epoch,
-                connectedNick: normalizedNick,
+                body: {
+                  eventId,
+                  rawLine,
+                  receivedAt,
+                  connectionEpoch: epoch,
+                  connectedNick: normalizedNick,
+                },
               },
               { receivedAt },
             )


### PR DESCRIPTION
## What Problem This Solves

Accepted IRC `PRIVMSG` events were parsed and projected three times inside durable ingress: at admission, again to revalidate the claimed row's identity/lane, and immediately again for delivery. The last pass repeated the complete raw-line, prefix, lane, and message projection already proven by claim inspection.

## Why This Change Was Made

The IRC owner now carries claim inspection's prepared projection transiently beside the unchanged durable body and reuses it for delivery. Admission and claim validation still parse independently, malformed rows still dead-letter before dispatch, and persistence remains exactly the versioned raw body. No shared ingress, SDK, protocol, routing, authorization, mention, or outbound contract changes.

Exact PR base: `963fafbb16522239228d10383cf89356c84e2ab3`  
Exact PR head: `57df3472b294c0958f5177a41340fd97d325fe74`

## User Impact

Ordinary IRC inbound messages perform one less duplicate parse/projection before core dispatch. This is behavior-neutral; users should see identical routing, message facts, retries, and delivery outcomes.

## Evidence

- **Deterministic current-base red/green:** a temporary owner probe on exact base observed 3 `parseIrcLine` calls for one accepted/completed message and failed the required count of 2; exact head passed at 2 while dispatching once. The implementation-coupled probe was removed after proof rather than committed.
- **Structural reduction:** IRC owner projections are 3 → 2 per accepted durable event (−33.3%); provider-listener-through-owner parses are 4 → 3 (−25%).
- **Semantic differential:** 17 ordinary, hostile, malformed, and persisted cases produced byte-identical 28,793-byte output snapshots across durable JSON/property order, ids/lanes/timestamps, dispatch context, failures, lifecycle order, and logs.
- **Owner benchmark:** canonical SQLite ingress, 8 fresh-DB samples per variant × 250 accepted/completed messages: median 1706.674 → 1690.809 µs/message (0.93% lower), mean 1744.361 → 1736.594 µs/message (0.45% lower). Timing is intentionally treated as noisy no-regression evidence; the deterministic parse-count reduction is the primary proof.
- **Tests:** exact base and candidate full IRC extension suites each passed 17 files / 154 tests. Final exact-head owner rerun passed 9/9.
- **Checks/build:** `node scripts/check-changed.mjs -- extensions/irc/src/irc-ingress.ts`, `GIT_BRANCH=main pnpm build`, `git diff --check`, committed-head TruffleHog, and Codex Sol/high autoreview all passed. Autoreview reported no accepted/actionable P0/P1 finding (0.96 confidence).
- **Scope:** one IRC production file, +29/−16; no retained test or test-only production seam.
- **Overlap:** live open-PR/issue searches found no IRC ingress/projection/performance repair. Open #119356 changes IRC config metadata only; #124214 changes Feishu and shared ingress lifecycle tests, not this owner or generic monitor implementation.
- **Live service:** no live IRC server was invoked. The changed boundary is a private synchronous handoff between claim inspection and delivery; deterministic parse-count proof, exact differential evidence, full extension tests, and the complete build cover it directly.
