### PR TITLE
fix(auto-reply): hand completed source replies to queued successors

### DIFF
--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -37,6 +37,7 @@ import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
 import { type FollowupRun, type QueueSettings, scheduleFollowupDrain } from "./queue.js";
+import { takeReplyOperationCompletionHandoff } from "./reply-completion-handoff.js";
 import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
 import { isReplyOperationSuperseded } from "./reply-operation-abort.js";
 import { type ReplyOperation, runAfterReplyOperationClear } from "./reply-run-registry.js";
@@ -64,7 +65,18 @@ export function scheduleFollowupDrainAfterReplyOperationClear(params: {
                 ? { ...queued, admissionSessionId }
                 : queued,
             );
-    scheduleFollowupDrain(params.queueKey, runFollowupAfterClear);
+    const completionUpdate = takeReplyOperationCompletionHandoff({
+      operation: params.operation,
+      queueKey: params.queueKey,
+      admissionSessionId,
+    });
+    scheduleFollowupDrain(
+      params.queueKey,
+      runFollowupAfterClear,
+      completionUpdate.kind === "claimed"
+        ? { predecessorHandoff: completionUpdate.handoff }
+        : undefined,
+    );
   });
 }
 

--- a/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
@@ -74,11 +74,7 @@ describe("executeAgentTurn: message tool progress", () => {
 
     expect(handoff).toMatchObject({
       kind: "completed_source_reply",
-      route: {
-        channel: "telegram",
-        to: "chat-1",
-        accountId: "primary",
-      },
+      deliveryTargetKey: expect.any(String),
     });
     expect(Object.isFrozen(handoff)).toBe(true);
   });

--- a/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
@@ -15,10 +15,111 @@ import type {
   EmbeddedAgentParams,
 } from "./agent-runner-execution.test-support.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
+import { takeReplyOperationCompletionHandoff } from "./reply-completion-handoff.js";
+import { createReplyOperation } from "./reply-run-registry.js";
 
 const state = setupAgentRunnerExecutionTestState();
 
+async function executeMessageToolOnlyAndTakeHandoff(result: Record<string, unknown>) {
+  const key = `test-message-tool-handoff-${Date.now()}-${Math.random()}`;
+  const sessionId = `session-${Math.random()}`;
+  const operation = createReplyOperation({
+    sessionKey: key,
+    sessionId,
+    resetTriggered: false,
+  });
+  const followupRun = createFollowupRun();
+  followupRun.run.sessionKey = key;
+  followupRun.run.sessionId = sessionId;
+  followupRun.run.messageProvider = "telegram";
+  followupRun.run.agentAccountId = "primary";
+  followupRun.run.sourceReplyDeliveryMode = "message_tool_only";
+  followupRun.originatingChannel = "telegram";
+  followupRun.originatingTo = "chat-1";
+  followupRun.originatingAccountId = "primary";
+  state.runEmbeddedAgentMock.mockResolvedValueOnce(result);
+
+  try {
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const params = createMinimalRunAgentTurnParams({ followupRun, replyOperation: operation });
+    params.sessionKey = key;
+    await executeAgentTurn(params);
+    operation.complete();
+    const take = takeReplyOperationCompletionHandoff({
+      operation,
+      queueKey: key,
+      admissionSessionId: sessionId,
+    });
+    return take.kind === "claimed" ? take.handoff : undefined;
+  } finally {
+    operation.complete();
+  }
+}
+
 describe("executeAgentTurn: message tool progress", () => {
+  it("mints a handoff only from an explicit completed source-final delivery", async () => {
+    const handoff = await executeMessageToolOnlyAndTakeHandoff({
+      payloads: [{ text: "NO_REPLY" }],
+      messagingToolSentTargets: [
+        {
+          channel: "telegram",
+          to: "chat-1",
+          accountId: "primary",
+          text: "Visible final reply",
+          sourceReplyFinal: true,
+        },
+      ],
+      meta: {},
+    });
+
+    expect(handoff).toMatchObject({
+      kind: "completed_source_reply",
+      route: {
+        channel: "telegram",
+        to: "chat-1",
+        accountId: "primary",
+      },
+    });
+    expect(Object.isFrozen(handoff)).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "foreign/unrelated message-tool send",
+      result: {
+        payloads: [{ text: "NO_REPLY" }],
+        didSendViaMessagingTool: true,
+        messagingToolSentTargets: [
+          { channel: "telegram", to: "chat-2", text: "Foreign send", sourceReplyFinal: false },
+        ],
+        meta: {},
+      },
+    },
+    {
+      label: "progress or partial source send",
+      result: {
+        payloads: [{ text: "NO_REPLY" }],
+        didDeliverSourceReplyViaMessageTool: true,
+        messagingToolSentTargets: [
+          { channel: "telegram", to: "chat-1", text: "Partial", sourceReplyFinal: false },
+        ],
+        meta: {},
+      },
+    },
+    {
+      label: "failed run after a source-final marker",
+      result: {
+        payloads: [{ text: "NO_REPLY" }],
+        messagingToolSentTargets: [
+          { channel: "telegram", to: "chat-1", text: "Unsettled", sourceReplyFinal: true },
+        ],
+        meta: { error: { message: "provider crashed" } },
+      },
+    },
+  ])("does not mint a handoff for $label", async ({ result }) => {
+    await expect(executeMessageToolOnlyAndTakeHandoff(result)).resolves.toBeUndefined();
+  });
+
   it("suppresses progress callbacks after message-tool-only delivery completes", async () => {
     let releaseItemEvent: (() => void) | undefined;
     const itemEventGate = new Promise<void>((resolve) => {

--- a/src/auto-reply/reply/agent-runner-message-tool-outcome.ts
+++ b/src/auto-reply/reply/agent-runner-message-tool-outcome.ts
@@ -1,8 +1,8 @@
-import { hasCompletedSourceReplyDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { recordMessageToolRunOutcome } from "../../infra/message-tool-run-outcome-store.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { AgentTurnExecutionResult, AgentTurnParams } from "./agent-runner-execution.types.js";
+import { recordSourceReplyEvidence } from "./reply-completion-handoff-producer.js";
 
 const messageToolOutcomeLog = createSubsystemLogger("auto-reply/message-tool-outcome");
 
@@ -34,8 +34,7 @@ export function recordMessageToolOnlyRunOutcome(
       : !outcome || outcome.kind === "rejected" || outcome.status === "failed"
         ? "errored"
         : "completed";
-  const toolDelivered =
-    outcome?.kind === "settled" && hasCompletedSourceReplyDeliveryEvidence(outcome.result);
+  const toolDelivered = recordSourceReplyEvidence(params, result);
   const values = {
     runId: result?.runId ?? params.opts?.runId ?? "unknown",
     sessionKey,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -35,6 +35,7 @@ import {
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
 import type { TypingMode } from "../../config/types.js";
+import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import {
   buildHandledBeforeAgentReplyPayloads,
   runBeforeAgentReplyForTurn,
@@ -52,6 +53,8 @@ import {
   type FollowupRun,
   type QueueSettings,
 } from "./queue.js";
+import { scheduleFollowupDrain as scheduleFollowupDrainActual } from "./queue/drain.js";
+import { enqueueFollowupRun as enqueueFollowupRunActual } from "./queue/enqueue.js";
 import { resolveReplyOperationAgentTurn } from "./reply-operation-agent-turn-state.js";
 import {
   REPLY_OPERATION_RUN_STATE,
@@ -70,7 +73,11 @@ import { consumeReplyUsageState } from "./reply-usage-state.js";
 import { buildChannelSourceTurnId, setChannelSourceTurnId } from "./source-turn-id.js";
 import { createMockTypingController } from "./test-helpers.js";
 
+const COMPLETED_SOURCE_REPLY_HANDOFF_MARKER = "immediately preceding turn already delivered";
+
 type AgentRunParams = {
+  prompt?: string;
+  currentInboundContext?: { text?: string };
   sessionId?: string;
   sessionFile?: string;
   onPartialReply?: (payload: { text?: string }) => Promise<boolean | void> | boolean | void;
@@ -376,6 +383,7 @@ function createMinimalRun(params?: {
   shouldSteer?: boolean;
   shouldFollowup?: boolean;
   resolvedQueueMode?: string;
+  resolvedQueueOverrides?: Partial<QueueSettings>;
   replyOperation?: ReplyOperation;
   currentInboundEventKind?: FollowupRun["currentInboundEventKind"];
   sessionCtx?: Partial<TemplateContext>;
@@ -403,6 +411,7 @@ function createMinimalRun(params?: {
   setChannelSourceTurnId(sessionCtx, sourceTurnId);
   const resolvedQueue = {
     mode: params?.resolvedQueueMode ?? "interrupt",
+    ...params?.resolvedQueueOverrides,
   } as unknown as QueueSettings;
   const sessionKey = params?.sessionKey ?? "main";
   const followupRun = {
@@ -1667,6 +1676,126 @@ describe("runReplyAgent heartbeat followup guard", () => {
     active.complete();
 
     expect(vi.mocked(scheduleFollowupDrain)).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands a confirmed source reply through owner clear and collect admission without suppressing the new answer", async () => {
+    vi.mocked(enqueueFollowupRun).mockImplementation(enqueueFollowupRunActual);
+    vi.mocked(scheduleFollowupDrain).mockImplementation(scheduleFollowupDrainActual);
+    const owner = createReplyOperation({
+      sessionKey: "main",
+      sessionId: "session",
+      resetTriggered: false,
+    });
+    const onBlockReply = vi.fn();
+    const onObservedReplyDelivery = vi.fn();
+    const sessionCtx = {
+      Provider: "whatsapp",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: "chat-1",
+      AccountId: "primary",
+      MessageSid: "source-message",
+    };
+    const source = createMinimalRun({
+      replyOperation: owner,
+      currentInboundEventKind: "user_request",
+      opts: { sourceReplyDeliveryMode: "message_tool_only", onBlockReply },
+      sessionCtx,
+      runOverrides: {
+        messageProvider: "whatsapp",
+        agentAccountId: "primary",
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+    source.followupRun.originatingAccountId = "primary";
+
+    const createQueuedQuestion = (prompt: string, messageId: string) => {
+      const queued = createMinimalRun({
+        currentInboundEventKind: "user_request",
+        isActive: true,
+        isRunActive: () => true,
+        shouldFollowup: true,
+        resolvedQueueMode: "collect",
+        resolvedQueueOverrides: { debounceMs: 0, cap: 50, dropPolicy: "summarize" },
+        opts: {
+          onBlockReply,
+          onObservedReplyDelivery,
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+        sessionCtx: { ...sessionCtx, MessageSid: messageId },
+        runOverrides: {
+          messageProvider: "whatsapp",
+          agentAccountId: "primary",
+          sourceReplyDeliveryMode: "message_tool_only",
+        },
+      });
+      queued.followupRun.prompt = prompt;
+      queued.followupRun.summaryLine = prompt;
+      queued.followupRun.transcriptPrompt = prompt;
+      queued.followupRun.originatingAccountId = "primary";
+      queued.followupRun.currentInboundContext = { text: MESSAGE_TOOL_ONLY_DELIVERY_HINT };
+      return queued;
+    };
+    const questionB = createQueuedQuestion("Please repeat the prior answer for me.", "question-b");
+    const questionC = createQueuedQuestion("Question C?", "question-c");
+    let admittedPrompt: string | undefined;
+    let admittedContext: string | undefined;
+    state.runEmbeddedAgentMock
+      .mockResolvedValueOnce({
+        payloads: [{ text: "NO_REPLY" }],
+        messagingToolSentTargets: [
+          {
+            channel: "whatsapp",
+            to: "chat-1",
+            accountId: "primary",
+            text: "Visible answer to the source turn",
+            sourceReplyFinal: true,
+          },
+        ],
+        meta: {},
+      })
+      .mockImplementationOnce(async (params: AgentRunParams) => {
+        admittedPrompt = params.prompt;
+        admittedContext = params.currentInboundContext?.text;
+        return {
+          payloads: [{ text: "NO_REPLY" }],
+          messagingToolSentTargets: [
+            {
+              channel: "whatsapp",
+              to: "chat-1",
+              accountId: "primary",
+              text: "Answer to the current queued questions",
+              sourceReplyFinal: true,
+            },
+          ],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+    try {
+      await expect(questionB.run()).resolves.toBeUndefined();
+      await expect(questionC.run()).resolves.toBeUndefined();
+      await expect(source.run()).resolves.toBeUndefined();
+      // The queued runs begin without an admission override; the canonical
+      // owner clear supplies the causal completion update to the real drain.
+      expect(questionB.followupRun.admissionSessionId).toBeUndefined();
+      expect(questionC.followupRun.admissionSessionId).toBeUndefined();
+      owner.complete();
+
+      await vi.waitFor(() => expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2), {
+        timeout: 5_000,
+      });
+      await vi.waitFor(() => expect(onObservedReplyDelivery).toHaveBeenCalledOnce(), {
+        timeout: 5_000,
+      });
+      expect(admittedPrompt).toContain("Please repeat the prior answer for me.");
+      expect(admittedPrompt).toContain("Question C?");
+      expect(admittedContext).toContain(MESSAGE_TOOL_ONLY_DELIVERY_HINT);
+      expect(admittedContext).toContain(COMPLETED_SOURCE_REPLY_HANDOFF_MARKER);
+      expect(onBlockReply).not.toHaveBeenCalled();
+    } finally {
+      owner.complete();
+      clearSessionQueues(["main"]);
+    }
   });
 
   it("drains followup queue when an unexpected exception escapes the run path", async () => {

--- a/src/auto-reply/reply/followup-runner.handoff.test.ts
+++ b/src/auto-reply/reply/followup-runner.handoff.test.ts
@@ -45,10 +45,8 @@ const { scheduleFollowupDrainAfterReplyOperationClear } = await import("./agent-
 const { createFollowupRunner } = await import("./followup-runner.js");
 const { clearSessionQueues, enqueueFollowupRun } = await import("./queue.js");
 const { createQueueTestRun } = await import("./queue.test-helpers.js");
-const {
-  consumeQueuedReplyCompletionHandoff,
-  recordReplyOperationCompletedSourceReply,
-} = await import("./reply-completion-handoff.js");
+const { consumeQueuedReplyCompletionHandoff, recordReplyOperationCompletedSourceReply } =
+  await import("./reply-completion-handoff.js");
 const { createReplyOperation } = await import("./reply-run-registry.js");
 
 function createQueuedRun(key: string, prompt: string): FollowupRun {
@@ -130,10 +128,7 @@ describe("queued completion handoff through FollowupRunner", () => {
       resetTriggered: false,
     });
     const operations = [ownerA];
-    const observed = new Map<
-      string,
-      ReturnType<typeof consumeQueuedReplyCompletionHandoff>
-    >();
+    const observed = new Map<string, ReturnType<typeof consumeQueuedReplyCompletionHandoff>>();
     const done = createDeferred();
 
     state.admit.mockImplementation(async ({ queued }: { queued: FollowupRun }) => {

--- a/src/auto-reply/reply/followup-runner.handoff.test.ts
+++ b/src/auto-reply/reply/followup-runner.handoff.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import type { AdmittedFollowupTurn } from "./followup-turn-admission.js";
+import type { FollowupExecutionResult } from "./followup-turn-execution.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+
+const state = vi.hoisted(() => ({
+  account: vi.fn(),
+  admit: vi.fn(),
+  deliver: vi.fn(),
+  execute: vi.fn(),
+  resolveDecision: vi.fn(),
+}));
+
+vi.mock("../../infra/agent-run-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/agent-run-registry.js")>()),
+  clearAgentRunContext: vi.fn(),
+}));
+vi.mock("../../agents/embedded-agent-runner/delivery-evidence.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../agents/embedded-agent-runner/delivery-evidence.js")
+  >()),
+  hasCompletedSourceReplyDeliveryEvidence: () => true,
+}));
+vi.mock("./agent-runner-result-accounting.js", () => ({
+  accountFollowupTurn: (...args: unknown[]) => state.account(...args),
+}));
+vi.mock("./followup-turn-admission.js", () => ({
+  admitFollowupTurn: (...args: unknown[]) => state.admit(...args),
+  settleQueuedFollowupPresentation: vi.fn(async () => {}),
+}));
+vi.mock("./followup-turn-execution.js", () => ({
+  executeFollowupTurn: (...args: unknown[]) => state.execute(...args),
+}));
+vi.mock("./followup-delivery.js", () => ({
+  deliverFollowupDecision: (...args: unknown[]) => state.deliver(...args),
+  resolveFollowupDeliveryDecision: (...args: unknown[]) => state.resolveDecision(...args),
+}));
+vi.mock("../../runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../runtime.js")>();
+  return { ...actual, defaultRuntime: { ...actual.defaultRuntime, error: vi.fn() } };
+});
+
+const { scheduleFollowupDrainAfterReplyOperationClear } = await import("./agent-runner-core.js");
+const { createFollowupRunner } = await import("./followup-runner.js");
+const { clearSessionQueues, enqueueFollowupRun } = await import("./queue.js");
+const { createQueueTestRun } = await import("./queue.test-helpers.js");
+const {
+  consumeQueuedReplyCompletionHandoff,
+  recordReplyOperationCompletedSourceReply,
+} = await import("./reply-completion-handoff.js");
+const { createReplyOperation } = await import("./reply-run-registry.js");
+
+function createQueuedRun(key: string, prompt: string): FollowupRun {
+  const queued = createQueueTestRun({
+    prompt,
+    currentInboundEventKind: "user_request",
+    originatingChannel: "telegram",
+    originatingTo: "chat-1",
+    originatingAccountId: "primary",
+    originatingThreadId: 7,
+  });
+  queued.run.sessionKey = key;
+  queued.run.sessionId = "session-1";
+  queued.run.messageProvider = "telegram";
+  queued.run.agentAccountId = "primary";
+  queued.run.sourceReplyDeliveryMode = "message_tool_only";
+  return queued;
+}
+
+function createTypingController() {
+  return {
+    onReplyStart: vi.fn(async () => {}),
+    startTypingLoop: vi.fn(async () => {}),
+    startTypingOnText: vi.fn(async () => {}),
+    refreshTypingTtl: vi.fn(),
+    isActive: vi.fn(() => false),
+    markRunComplete: vi.fn(),
+    markDispatchIdle: vi.fn(),
+    cleanup: vi.fn(),
+  };
+}
+
+function createExecution(turn: AdmittedFollowupTurn): FollowupExecutionResult {
+  return {
+    commentaryPayloadsEnabled: false,
+    execution: {
+      runId: turn.runId,
+      outcome: {
+        kind: "settled",
+        status: "ok",
+        result: { payloads: [], meta: { durationMs: 0 } },
+        resolved: { provider: "anthropic", model: "claude" },
+        fallback: { exhausted: false, attempts: [] },
+        autoCompactionCount: 0,
+        didLogHeartbeatStrip: false,
+      },
+    },
+    runStartedAt: 1,
+    sessionCtx: {},
+    pendingToolTasks: new Set(),
+    progress: { drain: vi.fn(async () => {}) },
+  } as FollowupExecutionResult;
+}
+
+describe("queued completion handoff through FollowupRunner", () => {
+  const queueKeys = new Set<string>();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.resolveDecision.mockReturnValue({ kind: "suppress", reason: "silent" });
+    state.account.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    clearSessionQueues([...queueKeys]);
+    queueKeys.clear();
+  });
+
+  it("replaces A with B before the active drain admits prequeued C", async () => {
+    const key = `test-followup-runner-completion-chain-${Date.now()}`;
+    queueKeys.add(key);
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const source = createQueuedRun(key, "A");
+    const queuedB = createQueuedRun(key, "B");
+    const queuedC = createQueuedRun(key, "C");
+    const ownerA = createReplyOperation({
+      sessionKey: key,
+      sessionId: "session-1",
+      resetTriggered: false,
+    });
+    const operations = [ownerA];
+    const observed = new Map<
+      string,
+      ReturnType<typeof consumeQueuedReplyCompletionHandoff>
+    >();
+    const done = createDeferred();
+
+    state.admit.mockImplementation(async ({ queued }: { queued: FollowupRun }) => {
+      const operation = createReplyOperation({
+        sessionKey: key,
+        sessionId: "session-1",
+        resetTriggered: false,
+      });
+      operations.push(operation);
+      observed.set(queued.prompt, consumeQueuedReplyCompletionHandoff(queued, operation));
+      return {
+        kind: "admitted",
+        turn: {
+          runId: `run-${queued.prompt}`,
+          queued,
+          operation,
+          config: {},
+          session: {
+            kind: "detached",
+            current: () => undefined,
+            publish: vi.fn(),
+            adopt: vi.fn(),
+          },
+          sendPolicy: "allow",
+          preflightCompactionApplied: false,
+        } as AdmittedFollowupTurn,
+      };
+    });
+    state.execute.mockImplementation(async ({ turn }: { turn: AdmittedFollowupTurn }) => {
+      if (turn.queued.prompt === "B") {
+        recordReplyOperationCompletedSourceReply(turn.operation, turn.queued);
+      }
+      return createExecution(turn);
+    });
+    state.deliver.mockImplementation(async ({ turn }: { turn: AdmittedFollowupTurn }) => {
+      if (turn.queued.prompt === "C") {
+        done.resolve();
+      }
+    });
+
+    const runFollowup = createFollowupRunner({
+      typing: createTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+    enqueueFollowupRun(key, queuedB, settings);
+    enqueueFollowupRun(key, queuedC, settings);
+    recordReplyOperationCompletedSourceReply(ownerA, source);
+    scheduleFollowupDrainAfterReplyOperationClear({
+      operation: ownerA,
+      queueKey: key,
+      runFollowup,
+    });
+    ownerA.complete();
+
+    try {
+      await done.promise;
+      expect([...observed.keys()]).toEqual(["B", "C"]);
+      expect(observed.get("B")).toBeDefined();
+      expect(observed.get("C")).toBeDefined();
+      expect(observed.get("C")).not.toBe(observed.get("B"));
+    } finally {
+      for (const operation of operations) {
+        operation.complete();
+      }
+    }
+  });
+});

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -9,6 +9,7 @@ const state = vi.hoisted(() => ({
   admit: vi.fn(),
   completeLifecycle: vi.fn(),
   completedSourceDelivery: false,
+  scheduleAfterClear: vi.fn(),
   deliver: vi.fn(),
   execute: vi.fn(),
   resolveDecision: vi.fn(),
@@ -21,6 +22,11 @@ vi.mock("../../infra/agent-run-registry.js", () => ({
 
 vi.mock("../../agents/embedded-agent-runner/delivery-evidence.js", () => ({
   hasCompletedSourceReplyDeliveryEvidence: () => state.completedSourceDelivery,
+}));
+
+vi.mock("./agent-runner-core.js", () => ({
+  scheduleFollowupDrainAfterReplyOperationClear: (...args: unknown[]) =>
+    state.scheduleAfterClear(...args),
 }));
 
 vi.mock("./agent-runner-result-accounting.js", () => ({
@@ -96,6 +102,7 @@ function createTurn(
   result: AdmittedFollowupTurn["operation"]["result"] = null,
 ) {
   const operation = {
+    key: "main",
     result,
     complete: vi.fn(() => order.push("operation-complete")),
     fail: vi.fn(() => order.push("operation-failed")),
@@ -266,6 +273,7 @@ describe("createFollowupRunner", () => {
       order.push("delivered");
     });
     state.completeLifecycle.mockImplementation(() => order.push("lifecycle-complete"));
+    state.scheduleAfterClear.mockImplementation(() => order.push("handoff-registered"));
 
     await createFollowupRunner({
       typing,
@@ -279,6 +287,7 @@ describe("createFollowupRunner", () => {
     })(turn.queued);
 
     expect(order).toEqual([
+      "handoff-registered",
       "progress-drained",
       "accounted",
       "decision",
@@ -287,6 +296,11 @@ describe("createFollowupRunner", () => {
       "lifecycle-complete",
       "operation-complete",
     ]);
+    expect(state.scheduleAfterClear).toHaveBeenCalledWith({
+      operation: turn.operation,
+      queueKey: "main",
+      runFollowup: expect.any(Function),
+    });
     expect(state.clearRunContext).toHaveBeenCalledWith("run-1");
   });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -3,6 +3,7 @@ import { hasCompletedSourceReplyDeliveryEvidence } from "../../agents/embedded-a
 import { clearAgentRunContext } from "../../infra/agent-run-registry.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
+import { scheduleFollowupDrainAfterReplyOperationClear } from "./agent-runner-core.js";
 import { accountFollowupTurn } from "./agent-runner-result-accounting.js";
 import { deliverFollowupDecision, resolveFollowupDeliveryDecision } from "./followup-delivery.js";
 import {
@@ -75,6 +76,13 @@ export function createFollowupRunner(
       admittedRunId = turn.runId;
       operation = turn.operation;
       queuedFollowupAdmitted = true;
+      // Every admitted successor becomes the predecessor for the remaining queue.
+      // Register before clear so its delivery fact replaces the prior owner atomically.
+      scheduleFollowupDrainAfterReplyOperationClear({
+        operation,
+        queueKey: operation.key,
+        runFollowup,
+      });
       const execution = await executeFollowupTurn({
         turn,
         defaults,

--- a/src/auto-reply/reply/followup-turn-admission.handoff.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.handoff.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import type { FollowupRun } from "./queue.js";
+import {
+  bindReplyCompletionHandoffToQueuedRun,
+  replaceReplyCompletionQueuePredecessor,
+  type ReplyCompletionHandoff,
+} from "./reply-completion-handoff.js";
+
+const COMPLETED_SOURCE_REPLY_HANDOFF_MARKER = "immediately preceding turn already delivered";
+
+const state = vi.hoisted(() => ({
+  admitLifecycle: vi.fn(),
+  admitReply: vi.fn(),
+  buildPreflightFailureText: vi.fn(),
+  preflight: vi.fn(),
+  recheckFallbackProbe: vi.fn(),
+  refreshGoal: vi.fn(),
+  resolveConfig: vi.fn(),
+  resolveSendPolicy: vi.fn(),
+}));
+
+vi.mock("./agent-runner-auto-fallback.js", () => ({
+  resolveRunAfterAutoFallbackPrimaryProbeRecheck: (...args: unknown[]) =>
+    state.recheckFallbackProbe(...args),
+}));
+
+vi.mock("./agent-runner-memory.js", () => ({
+  runPreflightCompactionIfNeeded: (...args: unknown[]) => state.preflight(...args),
+}));
+
+vi.mock("./agent-runner-utils.js", () => ({
+  resolveQueuedReplyExecutionConfig: (...args: unknown[]) => state.resolveConfig(...args),
+  resolveQueuedReplyRuntimeConfig: (config: unknown) => config,
+}));
+
+vi.mock("./reply-turn-admission.js", () => ({
+  admitReplyTurn: (...args: unknown[]) => state.admitReply(...args),
+}));
+
+vi.mock("./queue.js", () => ({
+  admitFollowupRunLifecycle: (...args: unknown[]) => state.admitLifecycle(...args),
+  isFollowupRunAborted: (run: FollowupRun) =>
+    run.abortSignal?.aborted === true || run.queueAbortSignal?.aborted === true,
+  resolveFollowupAbortSignal: (run: FollowupRun) => run.abortSignal ?? run.queueAbortSignal,
+}));
+
+vi.mock("../../sessions/send-policy.js", () => ({
+  resolveSendPolicy: (...args: unknown[]) => state.resolveSendPolicy(...args),
+}));
+
+vi.mock("./inbound-meta.js", () => ({
+  refreshActiveGoalContext: (...args: unknown[]) => state.refreshGoal(...args),
+}));
+
+vi.mock("./compaction-notice.js", () => ({
+  createCompactionNoticePayload: ({ phase }: { phase: string }) => ({ text: phase }),
+  shouldNotifyUserAboutCompaction: () => false,
+}));
+
+vi.mock("./agent-runner-failure-reply.js", () => ({
+  buildPreflightCompactionFailureText: (...args: unknown[]) =>
+    state.buildPreflightFailureText(...args),
+}));
+
+const { admitFollowupTurn } = await import("./followup-turn-admission.js");
+
+function createRun(overrides: Partial<FollowupRun> = {}): FollowupRun {
+  return {
+    prompt: "queued prompt",
+    enqueuedAt: 1,
+    run: {
+      agentId: "agent",
+      agentDir: "/tmp/agent",
+      sessionId: "queued-session",
+      sessionKey: "main",
+      sessionFile: "/tmp/queued.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      provider: "anthropic",
+      model: "claude",
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+    ...overrides,
+  };
+}
+
+function createOperation(
+  sessionId = "queued-session",
+  overrides: { key?: string; lifecycleGeneration?: string } = {},
+) {
+  return {
+    key: overrides.key ?? "main",
+    sessionId,
+    lifecycleGeneration:
+      overrides.lifecycleGeneration === undefined
+        ? getAgentEventLifecycleGeneration()
+        : overrides.lifecycleGeneration,
+    result: null,
+    abortForRestart: vi.fn(() => true),
+    retainFailureUntilComplete: vi.fn(),
+    fail: vi.fn(),
+    complete: vi.fn(),
+    updateSessionId: vi.fn(),
+  };
+}
+
+function createCompletionHandoff(): ReplyCompletionHandoff {
+  return Object.freeze({
+    kind: "completed_source_reply",
+    ownerKey: "main",
+    ownerSessionId: "queued-session",
+    ownerLifecycleGeneration: getAgentEventLifecycleGeneration(),
+    route: Object.freeze({ channel: "telegram", to: "chat-1", accountId: "primary" }),
+  });
+}
+
+function createCompletionEligibleRun(overrides: Partial<FollowupRun> = {}): FollowupRun {
+  return createRun({
+    prompt: "What should we do next?",
+    transcriptPrompt: "What should we do next?",
+    currentInboundEventKind: "user_request",
+    currentInboundContext: { text: "Authenticated inbound context" },
+    originatingChannel: "telegram",
+    originatingTo: "chat-1",
+    originatingAccountId: "primary",
+    run: {
+      ...createRun().run,
+      sessionKey: "main",
+      sessionId: "queued-session",
+      messageProvider: "telegram",
+      agentAccountId: "primary",
+    },
+    ...overrides,
+  });
+}
+
+function bindCompletionHandoff(queued: FollowupRun) {
+  const owner = {};
+  replaceReplyCompletionQueuePredecessor(owner, createCompletionHandoff());
+  bindReplyCompletionHandoffToQueuedRun({ owner, queueKey: "main", queued });
+  return owner;
+}
+
+function createDefaults() {
+  return {
+    typing: {} as never,
+    typingMode: "never" as const,
+    defaultModel: "claude",
+    sessionKey: "main",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.resolveSendPolicy.mockReturnValue("allow");
+  state.resolveConfig.mockImplementation(async (config) => config);
+  state.buildPreflightFailureText.mockReturnValue("preflight failed");
+  state.preflight.mockImplementation(async ({ sessionEntry }) => sessionEntry);
+  state.recheckFallbackProbe.mockImplementation(({ run }) => run);
+  state.admitLifecycle.mockResolvedValue(undefined);
+  state.refreshGoal.mockImplementation((context) => context);
+});
+
+describe("admitFollowupTurn reply-completion handoff", () => {
+  it("adds one runtime-only directive while preserving and answering the current request", async () => {
+    const queued = createCompletionEligibleRun();
+    bindCompletionHandoff(queued);
+    state.admitReply.mockResolvedValue({ status: "owned", operation: createOperation() });
+
+    const result = await admitFollowupTurn({ queued, defaults: createDefaults() });
+
+    expect(result.kind).toBe("admitted");
+    if (result.kind === "admitted") {
+      expect(result.turn.queued.prompt).toBe("What should we do next?");
+      expect(result.turn.queued.transcriptPrompt).toBe("What should we do next?");
+      expect(result.turn.queued.currentInboundEventKind).toBe("user_request");
+      expect(result.turn.currentInboundContext?.text).toContain("Authenticated inbound context");
+      expect(result.turn.currentInboundContext?.text).toContain(
+        COMPLETED_SOURCE_REPLY_HANDOFF_MARKER,
+      );
+      expect(result.turn.currentInboundContext?.text).toContain(
+        "send a new reply whenever it warrants one",
+      );
+      expect(result.turn.currentInboundContext?.text).toContain(
+        "including when it explicitly asks to repeat or discuss the prior reply",
+      );
+    }
+
+    state.admitReply.mockResolvedValue({ status: "owned", operation: createOperation() });
+    const replay = await admitFollowupTurn({ queued, defaults: createDefaults() });
+    expect(replay.kind).toBe("admitted");
+    if (replay.kind === "admitted") {
+      expect(replay.turn.currentInboundContext?.text).not.toContain(
+        COMPLETED_SOURCE_REPLY_HANDOFF_MARKER,
+      );
+    }
+  });
+
+  it("retains the one-shot fact when reply admission defers and applies it on retry", async () => {
+    const queued = createCompletionEligibleRun();
+    bindCompletionHandoff(queued);
+    state.admitReply.mockResolvedValueOnce({ status: "skipped", reason: "active-run" });
+
+    await expect(admitFollowupTurn({ queued, defaults: createDefaults() })).resolves.toEqual({
+      kind: "deferred",
+      reason: "active-run",
+    });
+
+    state.admitReply.mockResolvedValueOnce({ status: "owned", operation: createOperation() });
+    const retried = await admitFollowupTurn({ queued, defaults: createDefaults() });
+    expect(retried.kind).toBe("admitted");
+    if (retried.kind === "admitted") {
+      expect(retried.turn.currentInboundContext?.text).toContain(
+        COMPLETED_SOURCE_REPLY_HANDOFF_MARKER,
+      );
+    }
+  });
+
+  it("fails closed when the successor operation belongs to a different lifecycle", async () => {
+    const queued = createCompletionEligibleRun();
+    bindCompletionHandoff(queued);
+    state.admitReply.mockResolvedValue({
+      status: "owned",
+      operation: createOperation("queued-session", { lifecycleGeneration: "stale-generation" }),
+    });
+
+    const result = await admitFollowupTurn({ queued, defaults: createDefaults() });
+
+    expect(result.kind).toBe("admitted");
+    if (result.kind === "admitted") {
+      expect(result.turn.currentInboundContext?.text).toBe("Authenticated inbound context");
+    }
+  });
+
+  it("does not inject the previous-turn directive into a room event", async () => {
+    const queued = createCompletionEligibleRun({ currentInboundEventKind: "room_event" });
+    bindCompletionHandoff(queued);
+    state.admitReply.mockResolvedValue({ status: "owned", operation: createOperation() });
+
+    const result = await admitFollowupTurn({ queued, defaults: createDefaults() });
+
+    expect(result.kind).toBe("admitted");
+    if (result.kind === "admitted") {
+      expect(result.turn.queued.currentInboundEventKind).toBe("room_event");
+      expect(result.turn.currentInboundContext?.text).toBe("Authenticated inbound context");
+    }
+  });
+
+  it("fails closed when the concrete queue owner clears after binding", async () => {
+    const queued = createCompletionEligibleRun();
+    const owner = { abortController: new AbortController() };
+    replaceReplyCompletionQueuePredecessor(owner, createCompletionHandoff());
+    bindReplyCompletionHandoffToQueuedRun({ owner, queueKey: "main", queued });
+    owner.abortController.abort();
+    state.admitReply.mockResolvedValue({ status: "owned", operation: createOperation() });
+
+    const result = await admitFollowupTurn({ queued, defaults: createDefaults() });
+
+    expect(result.kind).toBe("admitted");
+    if (result.kind === "admitted") {
+      expect(result.turn.currentInboundContext?.text).toBe("Authenticated inbound context");
+    }
+  });
+
+  it("does not let an adoption-time abort swallow the fact before the next successor", async () => {
+    const aborted = createCompletionEligibleRun({ prompt: "aborted" });
+    const owner = bindCompletionHandoff(aborted);
+    const controller = new AbortController();
+    aborted.queueAbortSignal = controller.signal;
+    state.admitReply.mockResolvedValueOnce({ status: "owned", operation: createOperation() });
+    state.admitLifecycle.mockImplementationOnce(async () => controller.abort());
+
+    await expect(
+      admitFollowupTurn({ queued: aborted, defaults: createDefaults() }),
+    ).resolves.toMatchObject({ kind: "skipped", reason: "aborted" });
+
+    const successor = createCompletionEligibleRun({ prompt: "successor" });
+    bindReplyCompletionHandoffToQueuedRun({ owner, queueKey: "main", queued: successor });
+    state.admitReply.mockResolvedValueOnce({ status: "owned", operation: createOperation() });
+    const result = await admitFollowupTurn({ queued: successor, defaults: createDefaults() });
+
+    expect(result.kind).toBe("admitted");
+    if (result.kind === "admitted") {
+      expect(result.turn.currentInboundContext?.text).toContain(
+        COMPLETED_SOURCE_REPLY_HANDOFF_MARKER,
+      );
+    }
+  });
+});

--- a/src/auto-reply/reply/followup-turn-admission.handoff.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.handoff.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import type { FollowupRun } from "./queue.js";
+import { resolveFollowupReplyDeliveryTargetKey } from "./queue/delivery-target.js";
 import {
   bindReplyCompletionHandoffToQueuedRun,
   replaceReplyCompletionQueuePredecessor,
@@ -106,13 +107,13 @@ function createOperation(
   };
 }
 
-function createCompletionHandoff(): ReplyCompletionHandoff {
+function createCompletionHandoff(source = createCompletionEligibleRun()): ReplyCompletionHandoff {
   return Object.freeze({
     kind: "completed_source_reply",
     ownerKey: "main",
     ownerSessionId: "queued-session",
     ownerLifecycleGeneration: getAgentEventLifecycleGeneration(),
-    route: Object.freeze({ channel: "telegram", to: "chat-1", accountId: "primary" }),
+    deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(source),
   });
 }
 
@@ -136,9 +137,9 @@ function createCompletionEligibleRun(overrides: Partial<FollowupRun> = {}): Foll
   });
 }
 
-function bindCompletionHandoff(queued: FollowupRun) {
+function bindCompletionHandoff(queued: FollowupRun, source?: FollowupRun) {
   const owner = {};
-  replaceReplyCompletionQueuePredecessor(owner, createCompletionHandoff());
+  replaceReplyCompletionQueuePredecessor(owner, createCompletionHandoff(source));
   bindReplyCompletionHandoffToQueuedRun({ owner, queueKey: "main", queued });
   return owner;
 }
@@ -244,6 +245,33 @@ describe("admitFollowupTurn reply-completion handoff", () => {
     expect(result.kind).toBe("admitted");
     if (result.kind === "admitted") {
       expect(result.turn.queued.currentInboundEventKind).toBe("room_event");
+      expect(result.turn.currentInboundContext?.text).toBe("Authenticated inbound context");
+    }
+  });
+
+  it.each([
+    ["reply anchor", { originatingReplyToId: "reply-2" }],
+    ["reply policy", { originatingReplyToMode: "off" as const }],
+    ["chat type", { originatingChatType: "group" }],
+  ])("does not cross a mismatched %s", async (_label, mismatch) => {
+    const source = createCompletionEligibleRun({
+      originatingReplyToId: "reply-1",
+      originatingReplyToMode: "all",
+      originatingChatType: "direct",
+    });
+    const queued = createCompletionEligibleRun({
+      originatingReplyToId: "reply-1",
+      originatingReplyToMode: "all",
+      originatingChatType: "direct",
+      ...mismatch,
+    });
+    bindCompletionHandoff(queued, source);
+    state.admitReply.mockResolvedValue({ status: "owned", operation: createOperation() });
+
+    const result = await admitFollowupTurn({ queued, defaults: createDefaults() });
+
+    expect(result.kind).toBe("admitted");
+    if (result.kind === "admitted") {
       expect(result.turn.currentInboundContext?.text).toBe("Authenticated inbound context");
     }
   });

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -26,12 +26,14 @@ import {
 } from "./compaction-notice.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import { refreshActiveGoalContext } from "./inbound-meta.js";
+import { appendCompletedSourceReplyHandoffDirective } from "./prompt-prelude.js";
 import {
   admitFollowupRunLifecycle,
   isFollowupRunAborted,
   resolveFollowupAbortSignal,
   type FollowupRun,
 } from "./queue.js";
+import { consumeQueuedReplyCompletionHandoff } from "./reply-completion-handoff.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import { admitReplyTurn } from "./reply-turn-admission.js";
 import {
@@ -468,6 +470,15 @@ export async function admitFollowupTurn(params: {
         }),
         turn,
       );
+    }
+    // This is the irreversible queue-admission boundary: lifecycle adoption and
+    // preflight succeeded, so a deferred retry can no longer restore this item.
+    // Only now consume the queue-owned one-shot fact and add runtime-only context.
+    const completionHandoff = consumeQueuedReplyCompletionHandoff(params.queued, operation);
+    if (completionHandoff) {
+      const handoffContext = appendCompletedSourceReplyHandoffDirective(turn.currentInboundContext);
+      turn.currentInboundContext = handoffContext;
+      turn.queued = { ...turn.queued, currentInboundContext: handoffContext };
     }
     return { kind: "admitted", turn };
   } catch (error) {

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -2,13 +2,39 @@
 import { describe, expect, it } from "vitest";
 import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { finalizeInboundContext } from "./inbound-context.js";
-import { buildReplyPromptEnvelope } from "./prompt-prelude.js";
+import {
+  appendCompletedSourceReplyHandoffDirective,
+  buildReplyPromptEnvelope,
+} from "./prompt-prelude.js";
+
+const COMPLETED_SOURCE_REPLY_HANDOFF_MARKER = "immediately preceding turn already delivered";
 
 function countOccurrences(text: string | undefined, needle: string): number {
   return (text?.split(needle).length ?? 1) - 1;
 }
 
 describe("buildReplyPromptEnvelope", () => {
+  it("adds the completion handoff directive to runtime context without mutating its input", () => {
+    const original = {
+      text: "Authenticated current request",
+      resumableText: "Resumable current request",
+      promptJoiner: " " as const,
+    };
+
+    const appended = appendCompletedSourceReplyHandoffDirective(original);
+
+    expect(original).toEqual({
+      text: "Authenticated current request",
+      resumableText: "Resumable current request",
+      promptJoiner: " ",
+    });
+    expect(appended).not.toBe(original);
+    expect(appended.text).toContain("Authenticated current request");
+    expect(countOccurrences(appended.text, COMPLETED_SOURCE_REPLY_HANDOFF_MARKER)).toBe(1);
+    expect(appended.resumableText).toContain("Resumable current request");
+    expect(countOccurrences(appended.resumableText, COMPLETED_SOURCE_REPLY_HANDOFF_MARKER)).toBe(1);
+  });
+
   it("keeps bare reset runtime context in the model prompt and out of transcript/current-turn context", () => {
     const sessionCtx = finalizeInboundContext({
       Body: "",

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -15,6 +15,8 @@ import { appendChannelPromptContext } from "./channel-prompt-context.js";
 const ROOM_EVENT_PROMPT = "[OpenClaw room event]";
 const ROOM_EVENT_PARTICIPATION_RULE =
   "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking.";
+const COMPLETED_SOURCE_REPLY_HANDOFF_DIRECTIVE =
+  "The immediately preceding turn already delivered its final user-visible reply via the `message` tool. Do not replay it merely to finish that preceding turn. Treat the current queued content as a fresh request, answer it normally, and send a new reply whenever it warrants one—including when it explicitly asks to repeat or discuss the prior reply.";
 const RESUMABLE_ROOM_CONTEXT_OMITTED_PREFIXES = [
   "Conversation context (chronological, selected for current message):",
   "Chat history since last reply:",
@@ -166,6 +168,19 @@ function resolvePerTurnDeliveryDirective(params: {
     return MESSAGE_TOOL_ONLY_DELIVERY_HINT;
   }
   return undefined;
+}
+
+/** Adds predecessor context to this turn only, never to transcript history. */
+export function appendCompletedSourceReplyHandoffDirective(
+  context: CurrentInboundPromptContext | undefined,
+): CurrentInboundPromptContext {
+  const append = (value?: string) =>
+    [value, COMPLETED_SOURCE_REPLY_HANDOFF_DIRECTIVE].filter(Boolean).join("\n\n");
+  return {
+    ...context,
+    text: append(context?.text),
+    ...(context?.resumableText ? { resumableText: append(context.resumableText) } : {}),
+  };
 }
 
 // The current event itself is the user turn body; the context block carries

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -1726,6 +1726,7 @@ describe("followup queue collect routing", () => {
       ownerLifecycleGeneration: generation,
       deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(
         createRun({
+          prompt: "source",
           originatingChannel: "telegram",
           originatingTo: "chat-1",
           originatingAccountId: "primary",

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -14,8 +14,10 @@ import {
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
+import { appendCompletedSourceReplyHandoffDirective } from "./prompt-prelude.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import {
   admitFollowupRunLifecycle,
@@ -31,6 +33,13 @@ import {
 } from "./queue.test-helpers.js";
 import { resolveFollowupDeliveryContextKey } from "./queue/drain.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "./queue/state.js";
+import {
+  consumeQueuedReplyCompletionHandoff,
+  type ReplyCompletionHandoff,
+} from "./reply-completion-handoff.js";
+import type { ReplyOperation } from "./reply-run-registry.js";
+
+const COMPLETED_SOURCE_REPLY_HANDOFF_MARKER = "immediately preceding turn already delivered";
 
 type InternalFollowupRun = FollowupRun & {
   currentTurnImagesPrepared?: true;
@@ -1703,6 +1712,73 @@ describe("followup queue collect routing", () => {
     expect(calls[0]?.prompt).toContain("[Queued messages while agent was busy]");
     expect(calls[0]?.prompt).toContain("Queued #1");
     expect(calls[0]?.prompt).toContain("Queued #2");
+  });
+
+  it("hands one completed predecessor to the admitted collect aggregate", async () => {
+    const key = `test-collect-completion-handoff-${Date.now()}`;
+    const settings = createQueueSettings();
+    const generation = getAgentEventLifecycleGeneration();
+    const predecessor: ReplyCompletionHandoff = Object.freeze({
+      kind: "completed_source_reply",
+      ownerKey: key,
+      ownerSessionId: "session-1",
+      ownerLifecycleGeneration: generation,
+      route: Object.freeze({ channel: "telegram", to: "chat-1", accountId: "primary" }),
+    });
+    const consumer = {
+      key,
+      sessionId: "session-1",
+      lifecycleGeneration: generation,
+      result: null,
+    } as unknown as ReplyOperation;
+    const done = createDeferred();
+    let aggregate: FollowupRun | undefined;
+    let directiveContext: ReturnType<typeof appendCompletedSourceReplyHandoffDirective> | undefined;
+
+    try {
+      for (const prompt of ["Question B?", "Question C?"]) {
+        const queued = createRun({
+          prompt,
+          currentInboundEventKind: "user_request",
+          originatingChannel: "telegram",
+          originatingTo: "chat-1",
+          originatingAccountId: "primary",
+        });
+        queued.run.sessionKey = key;
+        queued.run.sessionId = "session-1";
+        queued.run.messageProvider = "telegram";
+        queued.run.agentAccountId = "primary";
+        enqueueFollowupRun(key, queued, settings);
+      }
+
+      scheduleFollowupDrain(
+        key,
+        async (queued) => {
+          aggregate = queued;
+          const handoff = consumeQueuedReplyCompletionHandoff(queued, consumer);
+          directiveContext = handoff
+            ? appendCompletedSourceReplyHandoffDirective(queued.currentInboundContext)
+            : undefined;
+          done.resolve();
+        },
+        { predecessorHandoff: predecessor },
+      );
+
+      await done.promise;
+      if (!aggregate) {
+        throw new Error("expected collected successor");
+      }
+      expect(aggregate.prompt).toContain("Question B?");
+      expect(aggregate.prompt).toContain("Question C?");
+      // Collect uses the ordinary user-request default (undefined) rather than
+      // reclassifying the aggregate as a room event.
+      expect(aggregate.currentInboundEventKind).not.toBe("room_event");
+      expect(directiveContext?.text).toContain(COMPLETED_SOURCE_REPLY_HANDOFF_MARKER);
+      expect(directiveContext?.text.split(COMPLETED_SOURCE_REPLY_HANDOFF_MARKER)).toHaveLength(2);
+      expect(consumeQueuedReplyCompletionHandoff(aggregate, consumer)).toBeUndefined();
+    } finally {
+      clearFollowupQueue(key);
+    }
   });
 
   it("drains runtime-context followups individually instead of collecting them", async () => {

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -31,6 +31,7 @@ import {
   createQueueTestRun as createRun,
   installQueueRuntimeErrorSilencer,
 } from "./queue.test-helpers.js";
+import { resolveFollowupReplyDeliveryTargetKey } from "./queue/delivery-target.js";
 import { resolveFollowupDeliveryContextKey } from "./queue/drain.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "./queue/state.js";
 import {
@@ -1723,7 +1724,13 @@ describe("followup queue collect routing", () => {
       ownerKey: key,
       ownerSessionId: "session-1",
       ownerLifecycleGeneration: generation,
-      route: Object.freeze({ channel: "telegram", to: "chat-1", accountId: "primary" }),
+      deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(
+        createRun({
+          originatingChannel: "telegram",
+          originatingTo: "chat-1",
+          originatingAccountId: "primary",
+        }),
+      ),
     });
     const consumer = {
       key,

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -28,8 +28,8 @@ import {
   createQueueTestRun as createRun,
   installQueueRuntimeErrorSilencer,
 } from "./queue.test-helpers.js";
-import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
 import { resolveFollowupReplyDeliveryTargetKey } from "./queue/delivery-target.js";
+import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "./queue/state.js";
 import {
   consumeQueuedReplyCompletionHandoff,
@@ -63,7 +63,9 @@ function createCompletionHandoff(key: string): ReplyCompletionHandoff {
     ownerKey: key,
     ownerSessionId: "session-1",
     ownerLifecycleGeneration: getAgentEventLifecycleGeneration(),
-    deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(createCompletionEligibleRun(key, "source")),
+    deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(
+      createCompletionEligibleRun(key, "source"),
+    ),
   });
 }
 

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -63,9 +63,7 @@ function createCompletionHandoff(key: string): ReplyCompletionHandoff {
     ownerKey: key,
     ownerSessionId: "session-1",
     ownerLifecycleGeneration: getAgentEventLifecycleGeneration(),
-    deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(
-      createCompletionEligibleRun(key, "source"),
-    ),
+    deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(createCompletionEligibleRun(key, "source")),
   });
 }
 

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -29,6 +29,7 @@ import {
   installQueueRuntimeErrorSilencer,
 } from "./queue.test-helpers.js";
 import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
+import { resolveFollowupReplyDeliveryTargetKey } from "./queue/delivery-target.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "./queue/state.js";
 import {
   consumeQueuedReplyCompletionHandoff,
@@ -62,12 +63,9 @@ function createCompletionHandoff(key: string): ReplyCompletionHandoff {
     ownerKey: key,
     ownerSessionId: "session-1",
     ownerLifecycleGeneration: getAgentEventLifecycleGeneration(),
-    route: Object.freeze({
-      channel: "telegram",
-      to: "chat-1",
-      accountId: "primary",
-      threadId: "7",
-    }),
+    deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(
+      createCompletionEligibleRun(key, "source"),
+    ),
   });
 }
 

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -6,6 +6,7 @@ import {
   getPreparedModelRuntimePluginGeneration,
   withPreparedModelRuntimePluginGenerationScope,
 } from "../../agents/prepared-model-runtime-generation-scope.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -15,6 +16,7 @@ import {
 } from "../../process/gateway-work-admission.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import { scheduleFollowupDrainAfterReplyOperationClear } from "./agent-runner-core.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import {
   clearSessionQueues,
@@ -28,8 +30,61 @@ import {
 } from "./queue.test-helpers.js";
 import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "./queue/state.js";
+import {
+  consumeQueuedReplyCompletionHandoff,
+  recordReplyOperationCompletedSourceReply,
+  type ReplyCompletionHandoff,
+} from "./reply-completion-handoff.js";
+import { createReplyOperation, type ReplyOperation } from "./reply-run-registry.js";
 
 installQueueRuntimeErrorSilencer();
+
+function createCompletionEligibleRun(key: string, prompt: string): FollowupRun {
+  const queued = createRun({
+    prompt,
+    currentInboundEventKind: "user_request",
+    originatingChannel: "telegram",
+    originatingTo: "chat-1",
+    originatingAccountId: "primary",
+    originatingThreadId: 7,
+  });
+  queued.run.sessionKey = key;
+  queued.run.sessionId = "session-1";
+  queued.run.messageProvider = "telegram";
+  queued.run.agentAccountId = "primary";
+  queued.run.sourceReplyDeliveryMode = "message_tool_only";
+  return queued;
+}
+
+function createCompletionHandoff(key: string): ReplyCompletionHandoff {
+  return Object.freeze({
+    kind: "completed_source_reply",
+    ownerKey: key,
+    ownerSessionId: "session-1",
+    ownerLifecycleGeneration: getAgentEventLifecycleGeneration(),
+    route: Object.freeze({
+      channel: "telegram",
+      to: "chat-1",
+      accountId: "primary",
+      threadId: "7",
+    }),
+  });
+}
+
+function createCompletionConsumer(
+  handoff: ReplyCompletionHandoff,
+  overrides: Partial<Pick<ReplyOperation, "key" | "sessionId" | "lifecycleGeneration">> = {},
+): ReplyOperation {
+  return {
+    key: overrides.key ?? handoff.ownerKey,
+    sessionId: overrides.sessionId ?? handoff.ownerSessionId,
+    lifecycleGeneration:
+      overrides.lifecycleGeneration === undefined
+        ? handoff.ownerLifecycleGeneration
+        : overrides.lifecycleGeneration,
+    result: null,
+  } as unknown as ReplyOperation;
+}
 
 describe("followup queue drain restart after idle window", () => {
   it("keeps a detached drain on a live root after its enqueue request returns", async () => {
@@ -740,5 +795,285 @@ describe("followup queue drain restart after idle window", () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.prompt).toBe("before-idle");
+  });
+});
+
+describe("followup queue completed-reply handoff", () => {
+  it("does not let duplicate owner-clear callbacks erase the canonical handoff", async () => {
+    const key = `test-completion-owner-clear-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const source = createCompletionEligibleRun(key, "A");
+    const successor = createCompletionEligibleRun(key, "B");
+    const owner = createReplyOperation({
+      sessionKey: key,
+      sessionId: "session-1",
+      resetTriggered: false,
+    });
+    const done = createDeferred();
+    let observed: ReplyCompletionHandoff | undefined;
+    const runFollowup = async (queued: FollowupRun) => {
+      const handoff = createCompletionHandoff(key);
+      observed = consumeQueuedReplyCompletionHandoff(queued, createCompletionConsumer(handoff));
+      done.resolve();
+    };
+
+    try {
+      enqueueFollowupRun(key, successor, settings);
+      recordReplyOperationCompletedSourceReply(owner, source);
+      // Ordinary concurrent arrivals register distinct callbacks on one owner.
+      scheduleFollowupDrainAfterReplyOperationClear({
+        operation: owner,
+        queueKey: key,
+        runFollowup: async (queued) => runFollowup(queued),
+      });
+      scheduleFollowupDrainAfterReplyOperationClear({
+        operation: owner,
+        queueKey: key,
+        runFollowup: async (queued) => runFollowup(queued),
+      });
+      owner.complete();
+
+      await done.promise;
+      expect(observed).toMatchObject({
+        kind: "completed_source_reply",
+        ownerKey: key,
+        ownerSessionId: "session-1",
+      });
+    } finally {
+      owner.complete();
+      clearSessionQueues([key]);
+    }
+  });
+
+  it("drops the handoff after the owner session rotates without dropping the queued request", async () => {
+    const key = `test-completion-session-rotation-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const source = createCompletionEligibleRun(key, "A");
+    const successor = createCompletionEligibleRun(key, "B");
+    successor.run.sessionId = "session-2";
+    const owner = createReplyOperation({
+      sessionKey: key,
+      sessionId: "session-1",
+      resetTriggered: false,
+    });
+    const originalHandoff = createCompletionHandoff(key);
+    const done = createDeferred();
+    let observed: ReplyCompletionHandoff | undefined;
+
+    try {
+      enqueueFollowupRun(key, successor, settings);
+      recordReplyOperationCompletedSourceReply(owner, source);
+      scheduleFollowupDrainAfterReplyOperationClear({
+        operation: owner,
+        queueKey: key,
+        runFollowup: async (queued) => {
+          observed = consumeQueuedReplyCompletionHandoff(
+            queued,
+            createCompletionConsumer(originalHandoff, { sessionId: "session-2" }),
+          );
+          done.resolve();
+        },
+      });
+      owner.updateSessionId("session-2");
+      owner.complete();
+
+      await done.promise;
+      expect(observed).toBeUndefined();
+    } finally {
+      owner.complete();
+      clearSessionQueues([key]);
+    }
+  });
+
+  it("replaces the active drain predecessor so A's fact reaches B and B's reaches C", async () => {
+    const key = `test-completion-chain-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const predecessorA = createCompletionHandoff(key);
+    const predecessorB = createCompletionHandoff(key);
+    const observed: Array<ReplyCompletionHandoff | undefined> = [];
+    const done = createDeferred();
+
+    try {
+      enqueueFollowupRun(key, createCompletionEligibleRun(key, "B"), settings);
+      enqueueFollowupRun(key, createCompletionEligibleRun(key, "C"), settings);
+
+      scheduleFollowupDrain(
+        key,
+        async (queued) => {
+          const expected = queued.prompt === "B" ? predecessorA : predecessorB;
+          observed.push(
+            consumeQueuedReplyCompletionHandoff(queued, createCompletionConsumer(expected)),
+          );
+          if (queued.prompt === "B") {
+            // B completes while A's original drain callback still owns the loop.
+            scheduleFollowupDrain(key, async () => {}, { predecessorHandoff: predecessorB });
+          } else {
+            done.resolve();
+          }
+        },
+        { predecessorHandoff: predecessorA },
+      );
+
+      await done.promise;
+      expect(observed).toEqual([predecessorA, predecessorB]);
+    } finally {
+      clearSessionQueues([key]);
+    }
+  });
+
+  it("clears A's fact when B completes without a source reply before C runs", async () => {
+    const key = `test-completion-chain-no-delivery-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const predecessorA = createCompletionHandoff(key);
+    const observed: Array<[string, ReplyCompletionHandoff | undefined]> = [];
+    const done = createDeferred();
+    const operationB = createReplyOperation({
+      sessionKey: key,
+      sessionId: "session-1",
+      resetTriggered: false,
+    });
+
+    try {
+      enqueueFollowupRun(key, createCompletionEligibleRun(key, "B"), settings);
+      enqueueFollowupRun(key, createCompletionEligibleRun(key, "C"), settings);
+
+      scheduleFollowupDrain(
+        key,
+        async (queued) => {
+          observed.push([
+            queued.prompt,
+            consumeQueuedReplyCompletionHandoff(queued, createCompletionConsumer(predecessorA)),
+          ]);
+          if (queued.prompt === "B") {
+            // The canonical B owner-clear callback is claimed without a delivery
+            // fact, replacing A before the still-active drain selects C.
+            scheduleFollowupDrainAfterReplyOperationClear({
+              operation: operationB,
+              queueKey: key,
+              runFollowup: async () => {},
+            });
+            operationB.complete();
+          } else {
+            done.resolve();
+          }
+        },
+        { predecessorHandoff: predecessorA },
+      );
+
+      await done.promise;
+      expect(observed).toEqual([
+        ["B", predecessorA],
+        ["C", undefined],
+      ]);
+    } finally {
+      operationB.complete();
+      clearSessionQueues([key]);
+    }
+  });
+
+  it("preserves the predecessor across admission deferral and consumes it once on retry", async () => {
+    const key = `test-completion-deferred-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const predecessor = createCompletionHandoff(key);
+    const done = createDeferred();
+    let attempts = 0;
+    let observed: ReplyCompletionHandoff | undefined;
+
+    try {
+      enqueueFollowupRun(key, createCompletionEligibleRun(key, "deferred"), settings);
+      scheduleFollowupDrain(
+        key,
+        async (queued) => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new FollowupRunDeferredError("reply lane busy");
+          }
+          observed = consumeQueuedReplyCompletionHandoff(
+            queued,
+            createCompletionConsumer(predecessor),
+          );
+          done.resolve();
+        },
+        { predecessorHandoff: predecessor },
+      );
+
+      await done.promise;
+      expect(attempts).toBe(2);
+      expect(observed).toBe(predecessor);
+    } finally {
+      clearSessionQueues([key]);
+    }
+  });
+
+  it("skips an aborted queue entry and hands the fact to the first executed successor", async () => {
+    const key = `test-completion-aborted-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const predecessor = createCompletionHandoff(key);
+    const aborted = createCompletionEligibleRun(key, "aborted");
+    aborted.originatingTo = "foreign-aborted-route";
+    const controller = new AbortController();
+    controller.abort();
+    aborted.queueAbortSignal = controller.signal;
+    const observed: Array<[string, ReplyCompletionHandoff | undefined]> = [];
+    const done = createDeferred();
+
+    try {
+      enqueueFollowupRun(key, aborted, settings);
+      enqueueFollowupRun(key, createCompletionEligibleRun(key, "successor"), settings);
+      scheduleFollowupDrain(
+        key,
+        async (queued) => {
+          observed.push([
+            queued.prompt,
+            consumeQueuedReplyCompletionHandoff(queued, createCompletionConsumer(predecessor)),
+          ]);
+          if (queued.prompt === "successor") {
+            done.resolve();
+          }
+        },
+        { predecessorHandoff: predecessor },
+      );
+
+      await done.promise;
+      expect(observed).toEqual([["successor", predecessor]]);
+    } finally {
+      clearSessionQueues([key]);
+    }
+  });
+
+  it("drops a route-mismatched fact without suppressing or reclassifying either candidate", async () => {
+    const key = `test-completion-route-mismatch-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const predecessor = createCompletionHandoff(key);
+    const mismatched = createCompletionEligibleRun(key, "foreign route");
+    mismatched.originatingTo = "chat-2";
+    const observed: Array<[string, ReplyCompletionHandoff | undefined]> = [];
+    const done = createDeferred();
+
+    try {
+      enqueueFollowupRun(key, mismatched, settings);
+      enqueueFollowupRun(key, createCompletionEligibleRun(key, "later match"), settings);
+      scheduleFollowupDrain(
+        key,
+        async (queued) => {
+          observed.push([
+            queued.prompt,
+            consumeQueuedReplyCompletionHandoff(queued, createCompletionConsumer(predecessor)),
+          ]);
+          if (queued.prompt === "later match") {
+            done.resolve();
+          }
+        },
+        { predecessorHandoff: predecessor },
+      );
+
+      await done.promise;
+      expect(observed).toEqual([
+        ["foreign route", undefined],
+        ["later match", undefined],
+      ]);
+    } finally {
+      clearSessionQueues([key]);
+    }
   });
 });

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -890,6 +890,11 @@ describe("followup queue completed-reply handoff", () => {
     const predecessorB = createCompletionHandoff(key);
     const observed: Array<ReplyCompletionHandoff | undefined> = [];
     const done = createDeferred();
+    const operationB = createReplyOperation({
+      sessionKey: key,
+      sessionId: "session-1",
+      resetTriggered: false,
+    });
 
     try {
       enqueueFollowupRun(key, createCompletionEligibleRun(key, "B"), settings);
@@ -904,7 +909,14 @@ describe("followup queue completed-reply handoff", () => {
           );
           if (queued.prompt === "B") {
             // B completes while A's original drain callback still owns the loop.
-            scheduleFollowupDrain(key, async () => {}, { predecessorHandoff: predecessorB });
+            // Its after-clear path must replace A before that loop selects C.
+            recordReplyOperationCompletedSourceReply(operationB, queued);
+            scheduleFollowupDrainAfterReplyOperationClear({
+              operation: operationB,
+              queueKey: key,
+              runFollowup: async () => {},
+            });
+            operationB.complete();
           } else {
             done.resolve();
           }
@@ -915,6 +927,7 @@ describe("followup queue completed-reply handoff", () => {
       await done.promise;
       expect(observed).toEqual([predecessorA, predecessorB]);
     } finally {
+      operationB.complete();
       clearSessionQueues([key]);
     }
   });

--- a/src/auto-reply/reply/queue/delivery-target.ts
+++ b/src/auto-reply/reply/queue/delivery-target.ts
@@ -1,0 +1,40 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeChatType } from "../../../channels/chat-type.js";
+import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
+import { normalizeMessageChannel } from "../../../utils/message-channel.js";
+import type { FollowupRun } from "./types.js";
+
+export function resolveFollowupReplyAnchor(run: FollowupRun): string | undefined {
+  if (run.originatingReplyToMode === "off") {
+    return undefined;
+  }
+  const replyToId = normalizeOptionalString(run.originatingReplyToId);
+  if (replyToId || normalizeMessageChannel(run.originatingChannel) !== "slack") {
+    return replyToId;
+  }
+  const threadId = run.originatingThreadId;
+  const hasRoutedThread =
+    typeof threadId === "number"
+      ? Number.isFinite(threadId)
+      : normalizeOptionalString(threadId) !== undefined;
+  // Slack standalone turns have no parent reply id, but enabled reply policies
+  // still need the message id so collect groups cannot cross independent roots.
+  // A routed thread already owns that boundary and remains collectable across turns.
+  return hasRoutedThread ? undefined : normalizeOptionalString(run.messageId);
+}
+
+/** Canonical identity for fields that can change where or how a queued reply is delivered. */
+export function resolveFollowupReplyDeliveryTargetKey(run: FollowupRun): string {
+  return JSON.stringify([
+    channelRouteDedupeKey({
+      channel: run.originatingChannel ?? run.run.messageProvider,
+      to: run.originatingTo,
+      accountId: run.originatingAccountId ?? run.run.agentAccountId,
+      threadId: run.originatingThreadId,
+    }),
+    normalizeOptionalString(run.originatingChatId) ?? "",
+    resolveFollowupReplyAnchor(run) ?? "",
+    run.originatingReplyToMode ?? "",
+    normalizeChatType(run.originatingChatType ?? run.run.chatType) ?? "",
+  ]);
+}

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -35,6 +35,11 @@ import {
   previewQueueSummaryPrompt,
   waitForQueueDebounce,
 } from "../../../utils/queue-helpers.js";
+import {
+  bindReplyCompletionHandoffToQueuedRun,
+  replaceReplyCompletionQueuePredecessor,
+  type ReplyCompletionHandoff,
+} from "../reply-completion-handoff.js";
 import { isRoutableChannel } from "../route-reply.js";
 import { FOLLOWUP_QUEUES, trimSummaryElisionsToCap } from "./state.js";
 import {
@@ -1364,8 +1369,14 @@ async function drainOverflowSummaryGroup(params: {
 export function scheduleFollowupDrain(
   key: string,
   runFollowup: (run: FollowupRun) => Promise<void>,
+  completion?: { predecessorHandoff?: ReplyCompletionHandoff },
 ): void {
   const existingQueue = FOLLOWUP_QUEUES.get(key);
+  if (existingQueue && completion) {
+    // The concrete queue owner follows every actual predecessor, even while an
+    // older drain callback is still active for A -> B -> C execution.
+    replaceReplyCompletionQueuePredecessor(existingQueue, completion.predecessorHandoff);
+  }
   if (existingQueue?.draining) {
     // The active drain keeps its current callback, but deferred retries must
     // use the latest session/runtime context supplied by the finishing run.
@@ -1378,7 +1389,11 @@ export function scheduleFollowupDrain(
   }
   const drainOwner = {};
   queue.drainOwner = drainOwner;
-  const effectiveRunFollowup = FOLLOWUP_RUN_CALLBACKS.get(key) ?? runFollowup;
+  const baseRunFollowup = FOLLOWUP_RUN_CALLBACKS.get(key) ?? runFollowup;
+  const effectiveRunFollowup = async (run: FollowupRun) => {
+    bindReplyCompletionHandoffToQueuedRun({ owner: queue, queueKey: key, queued: run });
+    return await baseRunFollowup(run);
+  };
   const reserveOptions = {
     inFlight: queue.inFlight,
     shouldRestoreOnError: () =>
@@ -1387,7 +1402,7 @@ export function scheduleFollowupDrain(
   };
   // Cache callback only when a drain actually starts. Avoid keeping stale
   // callbacks around from finalize calls where no queue work is pending.
-  rememberFollowupDrainCallback(key, effectiveRunFollowup);
+  rememberFollowupDrainCallback(key, baseRunFollowup);
   const drainQueuedFollowups = async (): Promise<void> => {
     let retryDeferred = false;
     let waitingForSteer = false;
@@ -1640,15 +1655,16 @@ export function scheduleFollowupDrain(
         const hasPendingQueueWork = queue.items.length > 0 || queue.droppedCount > 0;
         if (waitingForSteer && hasPendingQueueWork) {
           if (!queue.items.some((item) => item.steerPending)) {
-            scheduleFollowupDrain(key, effectiveRunFollowup);
+            scheduleFollowupDrain(key, baseRunFollowup);
           }
         } else if (retryDeferred && hasPendingQueueWork) {
-          scheduleFollowupDrain(key, effectiveRunFollowup);
+          scheduleFollowupDrain(key, baseRunFollowup);
         } else if (!hasPendingQueueWork) {
+          replaceReplyCompletionQueuePredecessor(queue, undefined);
           FOLLOWUP_QUEUES.delete(key);
           clearFollowupDrainCallback(key);
         } else {
-          scheduleFollowupDrain(key, effectiveRunFollowup);
+          scheduleFollowupDrain(key, baseRunFollowup);
         }
       }
     }

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -24,7 +24,6 @@ import {
   createUserTurnTranscriptRecorder,
 } from "../../../sessions/user-turn-transcript.js";
 import { resolveGlobalMap, resolveGlobalSingleton } from "../../../shared/global-singleton.js";
-import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import {
   buildCollectPrompt,
   beginQueueDrain,
@@ -41,6 +40,10 @@ import {
   type ReplyCompletionHandoff,
 } from "../reply-completion-handoff.js";
 import { isRoutableChannel } from "../route-reply.js";
+import {
+  resolveFollowupReplyAnchor,
+  resolveFollowupReplyDeliveryTargetKey,
+} from "./delivery-target.js";
 import { FOLLOWUP_QUEUES, trimSummaryElisionsToCap } from "./state.js";
 import {
   admitFollowupRunLifecycle,
@@ -323,17 +326,8 @@ export function resolveFollowupDeliveryContextKey(run: FollowupRun): string {
   const execution = run.run;
   const provenance = execution.inputProvenance;
   return JSON.stringify([
-    channelRouteDedupeKey({
-      channel: run.originatingChannel,
-      to: run.originatingTo,
-      accountId: run.originatingAccountId,
-      threadId: run.originatingThreadId,
-    }),
+    resolveFollowupReplyDeliveryTargetKey(run),
     hasPreparedCurrentTurnImages(run),
-    run.originatingChatId ?? "",
-    resolveFollowupReplyAnchor(run) ?? "",
-    run.originatingReplyToMode ?? "",
-    normalizeChatType(run.originatingChatType) ?? "",
     resolveFollowupAuthorizationKey(run),
     run.turnAdoptionLifecycle?.ownerKey ?? "",
     normalizeOptionalString(execution.runtimePolicySessionKey ?? execution.sessionKey) ?? "",
@@ -380,25 +374,6 @@ export function resolveFollowupDeliveryContextKey(run: FollowupRun): string {
     execution.blockReplyBreak,
     resolveTurnAdoptionLifecycleDeliveryKey(run.turnAdoptionLifecycle),
   ]);
-}
-
-export function resolveFollowupReplyAnchor(run: FollowupRun): string | undefined {
-  if (run.originatingReplyToMode === "off") {
-    return undefined;
-  }
-  const replyToId = normalizeOptionalString(run.originatingReplyToId);
-  if (replyToId || normalizeMessageChannel(run.originatingChannel) !== "slack") {
-    return replyToId;
-  }
-  const threadId = run.originatingThreadId;
-  const hasRoutedThread =
-    typeof threadId === "number"
-      ? Number.isFinite(threadId)
-      : normalizeOptionalString(threadId) !== undefined;
-  // Slack standalone turns have no parent reply id, but enabled reply policies
-  // still need the message id so collect groups cannot cross independent roots.
-  // A routed thread already owns that boundary and remains collectable across turns.
-  return hasRoutedThread ? undefined : normalizeOptionalString(run.messageId);
 }
 
 function splitCollectItemsByDeliveryContext(items: FollowupRun[]): FollowupRun[][] {

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,6 +1,5 @@
 // Enqueues follow-up reply runs and schedules queue drains.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { normalizeChatType } from "../../../channels/chat-type.js";
 import { logMessageQueuedWithBacklogPolicy } from "../../../logging/diagnostic-runtime.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
 import { createDeferredCore } from "../../../shared/deferred.js";
@@ -9,13 +8,13 @@ import {
   countPendingQueueItems,
   shouldSkipQueueItem,
 } from "../../../utils/queue-helpers.js";
+import { resolveFollowupReplyDeliveryTargetKey } from "./delivery-target.js";
 import {
   clearFollowupDrainCallback,
   createOverflowSummaryRetrySource,
   kickFollowupDrainIfIdle,
   rememberFollowupDrainCallback,
   resolveFollowupDeliveryContextKey,
-  resolveFollowupReplyAnchor,
 } from "./drain.js";
 import {
   peekRecentQueueMessageId,
@@ -39,17 +38,7 @@ import {
 } from "./types.js";
 
 function followupRouteIdentityKey(run: FollowupRun): string {
-  return JSON.stringify([
-    channelRouteDedupeKey({
-      channel: run.originatingChannel,
-      to: run.originatingTo,
-      accountId: run.originatingAccountId,
-      threadId: run.originatingThreadId,
-    }),
-    resolveFollowupReplyAnchor(run) ?? "",
-    run.originatingReplyToMode ?? "",
-    normalizeChatType(run.originatingChatType) ?? "",
-  ]);
+  return resolveFollowupReplyDeliveryTargetKey(run);
 }
 
 function followupMessageRouteIdentityKey(run: FollowupRun): string {

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,5 +1,6 @@
 // Enqueues follow-up reply runs and schedules queue drains.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeChatType } from "../../../channels/chat-type.js";
 import { logMessageQueuedWithBacklogPolicy } from "../../../logging/diagnostic-runtime.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
 import { createDeferredCore } from "../../../shared/deferred.js";

--- a/src/auto-reply/reply/reply-completion-handoff-producer.ts
+++ b/src/auto-reply/reply/reply-completion-handoff-producer.ts
@@ -1,0 +1,25 @@
+import { hasCompletedSourceReplyDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import type { AgentTurnExecutionResult, AgentTurnParams } from "./agent-runner-execution.types.js";
+import { recordReplyOperationCompletedSourceReply } from "./reply-completion-handoff.js";
+
+/** Returns delivery evidence while minting a fact only for a successfully settled owner run. */
+export function recordSourceReplyEvidence(
+  params: AgentTurnParams,
+  result: AgentTurnExecutionResult | undefined,
+): boolean {
+  const outcome = result?.outcome;
+  const toolDelivered =
+    outcome?.kind === "settled" && hasCompletedSourceReplyDeliveryEvidence(outcome.result);
+  if (
+    toolDelivered &&
+    outcome.kind === "settled" &&
+    outcome.status === "ok" &&
+    !outcome.abortReason &&
+    params.replyOperation
+  ) {
+    // This runs before execution returns: owner-clear callbacks must never
+    // observe a completed operation without its source-delivery fact.
+    recordReplyOperationCompletedSourceReply(params.replyOperation, params.followupRun);
+  }
+  return toolDelivered;
+}

--- a/src/auto-reply/reply/reply-completion-handoff.ts
+++ b/src/auto-reply/reply/reply-completion-handoff.ts
@@ -1,15 +1,7 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isAgentEventLifecycleGenerationCurrent } from "../../infra/agent-events.js";
+import { resolveFollowupReplyDeliveryTargetKey } from "./queue/delivery-target.js";
 import type { FollowupRun } from "./queue/types.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
-
-type ReplyCompletionRoute = Readonly<{
-  channel?: string;
-  to?: string;
-  accountId?: string;
-  chatId?: string;
-  threadId?: string;
-}>;
 
 /** Immutable process-local fact minted by the owner that completed a source reply. */
 export type ReplyCompletionHandoff = Readonly<{
@@ -17,7 +9,7 @@ export type ReplyCompletionHandoff = Readonly<{
   ownerKey: string;
   ownerSessionId: string;
   ownerLifecycleGeneration: string;
-  route: ReplyCompletionRoute;
+  deliveryTargetKey: string;
 }>;
 
 type ReplyCompletionQueueClaim = {
@@ -39,34 +31,6 @@ type QueuedCompletionCarrier = FollowupRun & {
     owner: ReplyCompletionQueueOwner;
   };
 };
-
-function normalizeRouteChannel(value: unknown): string | undefined {
-  return normalizeOptionalString(value)?.toLowerCase();
-}
-
-function resolveReplyCompletionRoute(run: FollowupRun): ReplyCompletionRoute {
-  const threadId = run.originatingThreadId;
-  return Object.freeze({
-    channel: normalizeRouteChannel(run.originatingChannel ?? run.run.messageProvider),
-    to: normalizeOptionalString(run.originatingTo),
-    accountId: normalizeOptionalString(run.originatingAccountId ?? run.run.agentAccountId),
-    chatId: normalizeOptionalString(run.originatingChatId),
-    threadId:
-      typeof threadId === "number" && Number.isFinite(threadId)
-        ? String(threadId)
-        : normalizeOptionalString(threadId),
-  });
-}
-
-function replyCompletionRoutesMatch(left: ReplyCompletionRoute, right: ReplyCompletionRoute) {
-  return (
-    left.channel === right.channel &&
-    left.to === right.to &&
-    left.accountId === right.accountId &&
-    left.chatId === right.chatId &&
-    left.threadId === right.threadId
-  );
-}
 
 function clearReplyCompletionQueueClaim(owner: ReplyCompletionQueueOwner): void {
   completionClaimsByQueueOwner.delete(owner);
@@ -92,7 +56,7 @@ export function recordReplyOperationCompletedSourceReply(
       ownerKey: operation.key,
       ownerSessionId: operation.sessionId,
       ownerLifecycleGeneration: lifecycleGeneration,
-      route: resolveReplyCompletionRoute(source),
+      deliveryTargetKey: resolveFollowupReplyDeliveryTargetKey(source),
     }),
   );
 }
@@ -173,7 +137,7 @@ export function bindReplyCompletionHandoffToQueuedRun(params: {
     params.queued.run.sessionKey === handoff.ownerKey &&
     (params.queued.admissionSessionId ?? params.queued.run.sessionId) === handoff.ownerSessionId &&
     params.queued.currentInboundEventKind !== "room_event" &&
-    replyCompletionRoutesMatch(handoff.route, resolveReplyCompletionRoute(params.queued));
+    handoff.deliveryTargetKey === resolveFollowupReplyDeliveryTargetKey(params.queued);
   if (!eligible) {
     clearReplyCompletionQueueClaim(params.owner);
     return;
@@ -213,7 +177,7 @@ export function consumeQueuedReplyCompletionHandoff(
     queued.run.sessionKey === handoff.ownerKey &&
     (queued.admissionSessionId ?? queued.run.sessionId) === handoff.ownerSessionId &&
     queued.currentInboundEventKind !== "room_event" &&
-    replyCompletionRoutesMatch(handoff.route, resolveReplyCompletionRoute(queued))
+    handoff.deliveryTargetKey === resolveFollowupReplyDeliveryTargetKey(queued)
     ? handoff
     : undefined;
 }

--- a/src/auto-reply/reply/reply-completion-handoff.ts
+++ b/src/auto-reply/reply/reply-completion-handoff.ts
@@ -1,0 +1,219 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isAgentEventLifecycleGenerationCurrent } from "../../infra/agent-events.js";
+import type { FollowupRun } from "./queue/types.js";
+import type { ReplyOperation } from "./reply-run-registry.js";
+
+type ReplyCompletionRoute = Readonly<{
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  chatId?: string;
+  threadId?: string;
+}>;
+
+/** Immutable process-local fact minted by the owner that completed a source reply. */
+export type ReplyCompletionHandoff = Readonly<{
+  kind: "completed_source_reply";
+  ownerKey: string;
+  ownerSessionId: string;
+  ownerLifecycleGeneration: string;
+  route: ReplyCompletionRoute;
+}>;
+
+type ReplyCompletionQueueClaim = {
+  handoff: ReplyCompletionHandoff;
+};
+
+type ReplyCompletionQueueOwner = object & {
+  abortController?: AbortController;
+};
+
+const completionHandoffsByOperation = new WeakMap<ReplyOperation, ReplyCompletionHandoff>();
+const claimedCompletionUpdatesByOperation = new WeakSet<ReplyOperation>();
+const completionClaimsByQueueOwner = new WeakMap<object, ReplyCompletionQueueClaim>();
+const queuedCompletionClaim = Symbol("openclaw.queuedReplyCompletionClaim");
+
+type QueuedCompletionCarrier = FollowupRun & {
+  [queuedCompletionClaim]?: {
+    claim: ReplyCompletionQueueClaim;
+    owner: ReplyCompletionQueueOwner;
+  };
+};
+
+function normalizeRouteChannel(value: unknown): string | undefined {
+  return normalizeOptionalString(value)?.toLowerCase();
+}
+
+function resolveReplyCompletionRoute(run: FollowupRun): ReplyCompletionRoute {
+  const threadId = run.originatingThreadId;
+  return Object.freeze({
+    channel: normalizeRouteChannel(run.originatingChannel ?? run.run.messageProvider),
+    to: normalizeOptionalString(run.originatingTo),
+    accountId: normalizeOptionalString(run.originatingAccountId ?? run.run.agentAccountId),
+    chatId: normalizeOptionalString(run.originatingChatId),
+    threadId:
+      typeof threadId === "number" && Number.isFinite(threadId)
+        ? String(threadId)
+        : normalizeOptionalString(threadId),
+  });
+}
+
+function replyCompletionRoutesMatch(left: ReplyCompletionRoute, right: ReplyCompletionRoute) {
+  return (
+    left.channel === right.channel &&
+    left.to === right.to &&
+    left.accountId === right.accountId &&
+    left.chatId === right.chatId &&
+    left.threadId === right.threadId
+  );
+}
+
+function clearReplyCompletionQueueClaim(owner: ReplyCompletionQueueOwner): void {
+  completionClaimsByQueueOwner.delete(owner);
+}
+
+/** Records the completed delivery before execution can return to owner cleanup. */
+export function recordReplyOperationCompletedSourceReply(
+  operation: ReplyOperation,
+  source: FollowupRun,
+): void {
+  const lifecycleGeneration = operation.lifecycleGeneration;
+  if (
+    operation.result ||
+    !lifecycleGeneration ||
+    !isAgentEventLifecycleGenerationCurrent(lifecycleGeneration)
+  ) {
+    return;
+  }
+  completionHandoffsByOperation.set(
+    operation,
+    Object.freeze({
+      kind: "completed_source_reply",
+      ownerKey: operation.key,
+      ownerSessionId: operation.sessionId,
+      ownerLifecycleGeneration: lifecycleGeneration,
+      route: resolveReplyCompletionRoute(source),
+    }),
+  );
+}
+
+type ReplyCompletionHandoffTake =
+  | { kind: "claimed"; handoff?: ReplyCompletionHandoff }
+  | { kind: "ignored" };
+
+/**
+ * Claims the exact operation's one queue-owner update after clear.
+ * Duplicate callbacks are no-ops; the canonical no-delivery callback still
+ * returns `claimed` so it can explicitly clear any predecessor state.
+ */
+export function takeReplyOperationCompletionHandoff(params: {
+  operation: ReplyOperation;
+  queueKey: string;
+  admissionSessionId: string;
+}): ReplyCompletionHandoffTake {
+  const handoff = completionHandoffsByOperation.get(params.operation);
+  if (
+    claimedCompletionUpdatesByOperation.has(params.operation) ||
+    params.operation.key !== params.queueKey ||
+    params.operation.sessionId !== params.admissionSessionId
+  ) {
+    return { kind: "ignored" };
+  }
+  claimedCompletionUpdatesByOperation.add(params.operation);
+  completionHandoffsByOperation.delete(params.operation);
+  if (
+    params.operation.result?.kind !== "completed" ||
+    !handoff ||
+    params.operation.key !== handoff.ownerKey ||
+    params.operation.sessionId !== handoff.ownerSessionId ||
+    !isAgentEventLifecycleGenerationCurrent(handoff.ownerLifecycleGeneration)
+  ) {
+    return { kind: "claimed" };
+  }
+  return { kind: "claimed", handoff };
+}
+
+/** Replaces the queue owner's predecessor fact, including replacement by no delivery. */
+export function replaceReplyCompletionQueuePredecessor(
+  owner: ReplyCompletionQueueOwner,
+  handoff: ReplyCompletionHandoff | undefined,
+): void {
+  clearReplyCompletionQueueClaim(owner);
+  if (handoff) {
+    completionClaimsByQueueOwner.set(owner, { handoff });
+  }
+}
+
+/**
+ * Binds the queue owner's predecessor fact to the exact selected candidate.
+ * A deferred candidate retains this claim; mismatches discard it without changing the run.
+ */
+export function bindReplyCompletionHandoffToQueuedRun(params: {
+  owner: ReplyCompletionQueueOwner;
+  queueKey: string;
+  queued: FollowupRun;
+}): void {
+  const claim = completionClaimsByQueueOwner.get(params.owner);
+  if (!claim) {
+    return;
+  }
+  if (params.owner.abortController?.signal.aborted) {
+    clearReplyCompletionQueueClaim(params.owner);
+    return;
+  }
+  // Dropped/aborted queue entries never become a successor. Preserve the fact
+  // for the first non-aborted item that actually reaches reply admission.
+  if (params.queued.abortSignal?.aborted || params.queued.queueAbortSignal?.aborted) {
+    return;
+  }
+  const handoff = claim.handoff;
+  const eligible =
+    isAgentEventLifecycleGenerationCurrent(handoff.ownerLifecycleGeneration) &&
+    params.queueKey === handoff.ownerKey &&
+    params.queued.run.sessionKey === handoff.ownerKey &&
+    (params.queued.admissionSessionId ?? params.queued.run.sessionId) === handoff.ownerSessionId &&
+    params.queued.currentInboundEventKind !== "room_event" &&
+    replyCompletionRoutesMatch(handoff.route, resolveReplyCompletionRoute(params.queued));
+  if (!eligible) {
+    clearReplyCompletionQueueClaim(params.owner);
+    return;
+  }
+  Object.defineProperty(params.queued, queuedCompletionClaim, {
+    configurable: true,
+    value: { claim, owner: params.owner },
+  });
+}
+
+/** Consumes the candidate-bound fact only after its ReplyOperation admission succeeds. */
+export function consumeQueuedReplyCompletionHandoff(
+  queued: FollowupRun,
+  operation: ReplyOperation,
+): ReplyCompletionHandoff | undefined {
+  // SAFETY: the optional symbol is written only by bindReplyCompletionHandoffToQueuedRun.
+  const carrier = queued as QueuedCompletionCarrier;
+  const binding = carrier[queuedCompletionClaim];
+  if (!binding) {
+    return undefined;
+  }
+  delete carrier[queuedCompletionClaim];
+  if (completionClaimsByQueueOwner.get(binding.owner) !== binding.claim) {
+    return undefined;
+  }
+  if (binding.owner.abortController?.signal.aborted) {
+    clearReplyCompletionQueueClaim(binding.owner);
+    return undefined;
+  }
+  clearReplyCompletionQueueClaim(binding.owner);
+  const handoff = binding.claim.handoff;
+  return !operation.result &&
+    operation.key === handoff.ownerKey &&
+    operation.sessionId === handoff.ownerSessionId &&
+    operation.lifecycleGeneration === handoff.ownerLifecycleGeneration &&
+    isAgentEventLifecycleGenerationCurrent(handoff.ownerLifecycleGeneration) &&
+    queued.run.sessionKey === handoff.ownerKey &&
+    (queued.admissionSessionId ?? queued.run.sessionId) === handoff.ownerSessionId &&
+    queued.currentInboundEventKind !== "room_event" &&
+    replyCompletionRoutesMatch(handoff.route, resolveReplyCompletionRoute(queued))
+    ? handoff
+    : undefined;
+}


### PR DESCRIPTION
Fixes #126813

**Human-led, AI-assisted:** I led and actively contributed throughout this work, including problem selection, architecture, implementation, code-level decisions and review, test design, edge-case analysis, and final validation. Codex assisted with portions of code drafting and editing, test execution, and adversarial review. I reviewed and approved every material code, design, test, and evidence change.

## What Problem This Solves

A message-tool-only turn can finish a visible source reply while peer or user messages are already queued. The queued successor still receives the normal answer-expected delivery hint, but the queue clear/drain boundary currently loses the causal fact that the immediately preceding owner already completed its reply. In multi-agent rooms, the successor can therefore replay the preceding answer before handling its own queued request.

The missing owner is the ephemeral boundary from the canonical `ReplyOperation` through the concrete queue/drain owner into successor admission. Transcript text and historical session outcomes cannot safely reconstruct this fact because they do not prove current-source delivery or exact predecessor order.

## Why This Change Was Made

This adds a typed, immutable, process-local completion handoff from the canonical `ReplyOperation` to the exact next eligible queued successor. The ordinary message-tool-only guidance remains intact; admission adds narrowly scoped runtime context that the preceding reply is complete and that the current queued request must still be answered normally.

The implementation enforces these invariants:

1. **Confirmed delivery only.** A fact is minted only after a settled, successful, non-aborted run has canonical completed current-source delivery evidence. Failed, aborted, partial/progress, foreign-source, and unrelated tool sends cannot mint it.
2. **Producer-before-clear ownership.** The fact is stored against the canonical operation before execution returns. A tagged one-shot take makes duplicate after-clear callbacks no-ops while allowing a canonical no-delivery completion to replace an older predecessor.
3. **Exact queue successor.** The concrete queue owner holds one ephemeral predecessor claim. Each actual predecessor replaces it; aborted entries are skipped, admission deferral preserves it, and successful admission consumes it once. This covers A→B→C as well as B-completes-without-delivery clearing A's fact.
4. **Fail-closed fencing without request loss.** Session key/id, lifecycle generation, and one canonical reply-delivery target must match. That target includes channel/to/account/chat/thread plus the normalized reply anchor, reply-to policy, and chat type; queue identity, owner abort/reset, session rotation, and room-event class are also fenced. A mismatch drops only the fact; it never suppresses, drops, or reclassifies the queued request.
5. **Current requests remain answerable.** The runtime-only directive prevents accidental replay merely to finish the preceding turn while explicitly requiring normal handling of the current request, including an intentional request to repeat or discuss the prior answer. It is not written to the transcript.
6. **Intentionally non-durable.** WeakMap ownership keeps the causal handoff process-local. There are no session-state, queue-codec, transcript, or message-tool outcome schema changes.

This is the canonical minimum fix because it records the delivery fact at its authoritative producer and transfers it only across the owner boundary that currently drops it. Inferring from prompts or persisting the fact would broaden trust and restart semantics unnecessarily.

Compatibility was checked against active neighboring work. #119736 is complementary durable restart evidence; this handoff is immediate and process-local. Draft #113554 can broaden the canonical explicit-route predicate without changing the fencing here. The current exact-head rebase composes the narrow hook with upstream's extracted message-tool outcome module and drain-owner generation fence without widening persistence or restart semantics. #82572 persists queue state, while this claim is deliberately excluded from persistence and must not be persisted without a new trust design.

## User Impact

Queued multi-agent turns no longer need to guess whether the preceding message-tool-only owner already answered. The next eligible successor receives exact causal context, avoids an accidental duplicate, and still answers its own request normally.

Ordinary queue ordering, overflow/drop policy, automatic delivery, user-request classification, and restart behavior are unchanged. Legitimate follow-ups—including “repeat the prior answer”—remain answerable and are covered end to end.

## Evidence

### Current exact-head rebase update

Current exact head `4d3b1169f3f15fd65c6827bd362c9f357a66c080` rebases the reviewed nine-commit series once onto `main` snapshot `cddf5165ee8f153c3e4fefb6181ed0928da141e6`, which includes the repository-owned Telegram userbot harness from #131715. Range-diff maps all nine commits one-to-one. The only semantic conflict adaptation moves the same completion evidence into upstream's extracted message-tool outcome module and composes the handoff with the new drain-owner generation fence. The final surface remains 18 files, `+1540/-52`.

Exact-head hosted CI is green: [run 33261641621](https://github.com/openclaw/openclaw/actions/runs/33261641621) completed 258 check contexts with zero pending and zero failures, including `openclaw/ci-gate`. Local validation on the rebased head passed 218 related tests, the exact queue/owner-clear/collect-admission handoff E2E, `tsgo:core`, the messaging test type graph, changed-file type-aware Oxlint, formatting, runtime and Madge cycle checks, conflict-marker, max-lines, assertion-safety, and `git diff --check` guards. The only local failure is the previously documented unrelated Windows SQLite cleanup `EBUSY`, which also reproduces when its overflow-session test runs alone.

#131715 retired the old Telegram Desktop/Mantis workflows after the earlier recording. The remaining exact-head real-behavior proof must therefore use `.agents/skills/telegram-e2e-userbot`: hold A's provider response, enqueue fresh B and C requests, confirm two pending followups before drain, release the drain, and record for 90 seconds. The pass contract is exactly one visible A reply, one fresh B answer, one fresh C answer, no replay, and exactly three provider requests where B and C each contain the completed-predecessor directive once. The earlier native Mantis artifacts remain useful historical behavior evidence, but they are not claimed as proof of this exact head.
Prior reviewed integration head `138b970da9b33d1400016c4a54fd1d0477ba9bf8` combined behavior head `bb47f213255e5c7f934b20511654230a1f6a66ee` with upstream snapshot `3b0cad5d7087e08a5288f4f3d513a06571be4f9e`. Its review and hosted CI remain historical evidence; the current rebase update above supersedes that commit topology while preserving the reviewed nine-commit patch mapping and centralized reply-delivery target identity.

Validation used bundled Node v24.19.0:

- `pnpm test src/auto-reply/reply/agent-runner-execution-message-tools.test.ts src/auto-reply/reply/followup-turn-admission.test.ts src/auto-reply/reply/followup-turn-admission.handoff.test.ts src/auto-reply/reply/prompt-prelude.test.ts src/auto-reply/reply/queue.drain-restart.test.ts` — 95/95 passed.
- `pnpm test src/auto-reply/reply/queue.collect.test.ts -t "hands one completed predecessor to the admitted collect aggregate"` — 1/1 passed.
- `OPENCLAW_E2E_SKIP_BUILD=1 pnpm test src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "hands a confirmed source reply through owner clear and collect admission without suppressing the new answer"` — 1/1 passed.
- `pnpm tsgo:core` — passed.
- The messaging test type graph, runtime import-cycle check, and Madge source graph — passed with zero cycles. The completion core imports the queue leaf contract, while the delivery/agent adapter is a one-way producer module.
- Changed-file type-aware Oxlint (including max-lines), formatting, conflict-marker, assertion-safety, `check:changed --dry-run`, and `git diff --check` guards — passed.
- Pre-rebase hosted CI — `check-dependencies`, `check-test-types-core-4`, `check-additional-runtime-topology-architecture`, every remaining shard, and `openclaw/ci-gate` passed on patch-equivalent head `c3fb29731b586996ed905a244bed42a856adb3ac`: https://github.com/openclaw/openclaw/actions/runs/32584209718
- Prior exact-head hosted CI — 207 passed and 41 skipped check contexts, with zero pending and zero failures on `138b970da9b33d1400016c4a54fd1d0477ba9bf8`, including `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/32797492241

The real E2E spans confirmed current-source tool delivery → actual `ReplyOperation` completion with duplicate clear callbacks → actual collect/drain → successor admission. Its successor is message-tool-only, sees both `MESSAGE_TOOL_ONLY_DELIVERY_HINT` and the new handoff directive, answers an explicit repeat request through a new current-source final message-tool send, and emits no automatic duplicate.

A maintainer-owned native Telegram Desktop Mantis run supplied channel-visible proof on behavior head `44d8d8277f31af9d968e175420f7528dc95df905`: baseline and candidate both visibly delivered the first answer and the fresh queued successor answer; baseline provider facts lacked the completion handoff, while candidate provider facts contained it and the second Telegram answer addressed the queued request without replaying the first. Both lanes passed, with screenshots, GIFs, MP4s, and raw QA facts: https://github.com/openclaw/openclaw/actions/runs/32583508198. The current exact head preserves that matching-target behavior but additionally fences reply anchor, reply-to policy, and chat type in response to the P1 review. Because that predicate changed after the recording, the old run remains historical evidence. A fresh exact-head run through the repository-owned Telegram userbot harness described above is now the authoritative real-behavior proof step; contributor-side CI cannot substitute for that credentialed lane.

The principal regression fails when only the producer hook is removed: admitted context retains the ordinary message-tool-only hints but lacks the completion directive at `agent-runner.runreplyagent.e2e.test.ts:1664`. Restoring the hook makes the same E2E pass. Exact base does not contain the new primitive, so removing the producer is the conservative intended-cause counterfactual while keeping the integrated test harness buildable.

The suites also cover foreign/partial/progress/failed/aborted producer negatives; one-shot and deferred admission; lifecycle, route, reply-anchor, reply-policy, chat-type, room-event, owner-abort, and session-rotation rejection; duplicate clears; A→B→C replacement; a no-delivery predecessor clearing stale evidence; aborted first entries; and exactly one directive over a real B+C collect aggregate without losing either current request.

A full local `queue.collect.test.ts` run additionally passed all new handoff coverage but reproduced one pre-existing Windows-only SQLite `.shm` cleanup `EBUSY` in the unrelated overflow-session test. Exact-head hosted Linux CI ran the complete checkout and passed that suite and the aggregate gate.

ClawSweeper's earlier review rated the native Telegram behavior proof highly, while the latest review found one P1: the handoff route omitted reply anchor, reply-to policy, and chat type. Prior reviewed head `138b970da9b33d1400016c4a54fd1d0477ba9bf8` resolved that finding with one canonical delivery-target key and focused mismatch coverage. Current exact head `4d3b1169f3f15fd65c6827bd362c9f357a66c080` preserves that repair on the new upstream architecture and has fully green hosted CI. A repository-owned Telegram userbot recording is now requested; ClawSweeper re-review will follow once its exact-head artifacts are attached. No remaining contributor-side code finding is known. The repository reporter has also been invited to provide an optional production-room diagnostic with a 90-second negative observation window, outbound counts, current-request preservation, explicit-repeat handling, and strict redaction requirements: https://github.com/openclaw/openclaw/pull/127967#issuecomment-5381411670.
