### PR TITLE
fix(agents): warn when configured image model entries fail to resolve

### DIFF
--- a/src/agents/model-fallback-candidates.test.ts
+++ b/src/agents/model-fallback-candidates.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
+import { resolveImageFallbackCandidates } from "./model-fallback-candidates.js";
+
+describe("resolveImageFallbackCandidates", () => {
+  it("records unresolved configured entries without changing the resolved chain", async () => {
+    const warnLogs = createWarnLogCapture("openclaw-image-fallback-candidates-test");
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "openai/",
+            fallbacks: ["anthropic/claude-sonnet-4-6", "/vision"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    try {
+      expect(
+        resolveImageFallbackCandidates({
+          cfg,
+          defaultProvider: "openai",
+        }),
+      ).toEqual([
+        {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          routeOrigin: "configured-fallback",
+          routeResolution: "resolved",
+        },
+      ]);
+      expect(
+        await warnLogs.findText(
+          'Unresolved image model "openai/"; skipped configured-primary candidate.',
+        ),
+      ).toBeDefined();
+      expect(
+        await warnLogs.findText(
+          'Unresolved image model "/vision"; skipped configured-fallback candidate.',
+        ),
+      ).toBeDefined();
+    } finally {
+      warnLogs.cleanup();
+    }
+  });
+
+  it("does not warn for resolved configured entries", async () => {
+    const warnLogs = createWarnLogCapture("openclaw-image-fallback-candidates-test");
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "openai/gpt-5.4",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    try {
+      expect(
+        resolveImageFallbackCandidates({
+          cfg,
+          defaultProvider: "openai",
+        }),
+      ).toHaveLength(2);
+      expect(await warnLogs.findText("Unresolved image model")).toBeUndefined();
+    } finally {
+      warnLogs.cleanup();
+    }
+  });
+});

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 /** Resolves ordered model and image fallback candidate chains. */
 import {
   resolveAgentModelFallbackValues,
@@ -6,6 +7,7 @@ import {
 } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
@@ -41,6 +43,7 @@ import {
 
 const MAX_FALLBACK_CANDIDATE_CACHE_ENTRIES = 256;
 const fallbackCandidateCache = new Map<string, ModelFallbackCandidate[]>();
+const log = createSubsystemLogger("model-selection");
 
 function createModelCandidateCollector(): {
   candidates: ModelFallbackCandidate[];
@@ -98,6 +101,9 @@ export function resolveImageFallbackCandidates(
       manifestPlugins: params.manifestPlugins,
     });
     if (!resolved) {
+      log.warn(
+        `Unresolved image model "${sanitizeForLog(raw)}"; skipped ${routeOrigin} candidate.`,
+      );
       return;
     }
     addCandidate(resolved.ref, routeOrigin, "resolved");


### PR DESCRIPTION
## What Problem This Solves

`resolveImageFallbackCandidates` silently dropped configured `agents.defaults.imageModel` entries that fail to resolve — malformed slash refs (`openai/`, `/vision`, `/`) in any position, and blank entries in the `fallbacks` array. (A whitespace-only `primary` is a different case: canonical config normalization treats it as unset — same contract as the general model primary — so it correctly ends in the `No image model configured` error rather than a silent drop; see the ClawSweeper skip note below.) When every configured entry dropped, image/PDF processing later failed with the unrelated-looking `No image model configured. Set agents.defaults.imageModel.primary or agents.defaults.imageModel.fallbacks.` error, and nothing anywhere recorded why the configured model never became a candidate. Surfaced while diagnosing Mantis proof-run failures (run 32581065979's `Unknown model` symptom — which diagnosis showed is the *other* case: syntactically valid unknown refs are included and fail at runtime lookup; only blank/malformed refs were silently dropped).

## Why This Change Was Made

Product doctrine: every action ends in a visible outcome or a recorded, intentional non-outcome. History check confirmed the silent `return` is not a deliberate contract — it dates to the original `feat: add image model config + tool` (78998dba) and was carried through refactors unchanged, while PR #39215 established the sibling contract that unresolved configured model IDs warn through the model-selection subsystem without changing routing. This applies that same contract here: unresolved entries emit `Unresolved image model "<sanitized raw>"; skipped <routeOrigin> candidate.` via the existing `model-selection` subsystem logger + `sanitizeForLog`. Candidate construction, ordering, allowlist behavior, and return values are unchanged.

## User Impact

Operators with a malformed image model entry now get a log line naming the exact raw value and route origin (requested / configured-primary / configured-fallback) instead of a dead-end downstream error. No routing or channel-visible behavior change.

## Evidence

- Production delta +6/-0 (`src/agents/model-fallback-candidates.ts`); tests +74.
- Regression tests: `records unresolved configured entries without changing the resolved chain`, `does not warn for resolved configured entries`. Pre-fix proof: reverted the production change and reran — 1 failed / 1 passed, failing on the missing-warning assertion for the intended reason; reapplied fix — 2/2 pass.
- `node scripts/run-vitest.mjs src/agents/model-fallback-candidates.test.ts` pass; `node scripts/check-changed.mjs -- <changed files>` exit 0 (lanes: core, coreTests).
- Fresh autoreview (codex gpt-5.6-sol, branch mode): clean, `patch is correct (0.99)`.
- No Mantis dispatch: the diff adds a diagnostic log warning only — no channel-visible or harness-visible behavior change; the regression test plus pre-fix failure is the appropriate proof tier.

## ClawSweeper finding disposition

The review's P2 ("Preserve blank configured primaries for the warning") is **skipped intentionally**: `resolveAgentModelPrimaryValue` -> `normalizeOptionalString` treating whitespace-only as unset is the canonical repo-wide normalization contract, shared with the general (non-image) model primary path. A blank primary is "not configured", and the existing `No image model configured. Set agents.defaults.imageModel.primary...` error is the accurate, actionable visible outcome for that state — a recorded, intentional non-outcome, not a silent drop. Warning there would require carrying raw pre-normalization values across the canonical boundary and would diverge image-model config semantics from every sibling model config surface, spending production LOC the same review flags as merge risk. Blank *fallback* entries pass through raw and are covered by the new warning path (same `resolveModelRefFromString` null branch as `/vision`).
