### PR TITLE
docs(providers): add MindsHub inference gateway page

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1850,5 +1850,13 @@
   {
     "source": "Built-in memory",
     "target": "内置记忆"
+  },
+  {
+    "source": "MindsHub (unified gateway)",
+    "target": "MindsHub (unified gateway)"
+  },
+  {
+    "source": "MindsHub",
+    "target": "MindsHub"
   }
 ]

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -511,6 +511,20 @@ Synthetic provides Anthropic-compatible models behind the `synthetic` provider:
 }
 ```
 
+### MindsHub
+
+MindsHub is a unified inference gateway that reaches Claude, GPT, Kimi, DeepSeek, Gemini, and
+more through one API key, in either OpenAI-compatible or Anthropic-compatible form. It is not a
+bundled provider plugin, so configure it via `models.providers`:
+
+- Auth: `MINDSHUB_API_KEY`
+- Example model: `mindshub/sonnet`
+- Base URL (OpenAI-compatible): `https://api.mindshub.ai/v1`
+- Base URL (Anthropic-compatible): `https://api.mindshub.ai` (host only, `authHeader: true` required)
+
+See [/providers/mindshub](/providers/mindshub) for full config examples and the auth-header
+caveat on the Anthropic-compatible path.
+
 ### MiniMax
 
 MiniMax is configured via `models.providers` because it uses custom endpoints:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1557,6 +1557,7 @@
                   "providers/lmstudio",
                   "providers/longcat",
                   "providers/meta",
+                  "providers/mindshub",
                   "providers/minimax",
                   "providers/mistral",
                   "providers/moonshot",

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -56,6 +56,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [llama.cpp (managed or existing server)](/plugins/llama-cpp)
 - [LM Studio (local models)](/providers/lmstudio)
 - [LongCat](/providers/longcat)
+- [MindsHub (unified gateway)](/providers/mindshub)
 - [MiniMax](/providers/minimax)
 - [Mistral](/providers/mistral)
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)

--- a/docs/providers/mindshub.md
+++ b/docs/providers/mindshub.md
@@ -56,9 +56,9 @@ plugin; configure it like any other custom OpenAI/Anthropic-compatible endpoint 
 This is the more thoroughly exercised custom-provider path in OpenClaw and the one to reach for
 first:
 
-```json5 validate=false
+```json5
 {
-  env: { MINDSHUB_API_KEY: "mdb_..." },
+  env: { vars: { MINDSHUB_API_KEY: "mdb_..." } },
   agents: {
     defaults: { model: { primary: "mindshub/sonnet" } },
   },
@@ -109,9 +109,9 @@ endpoint. `GET /v1/models` is the authoritative live catalog; see
 MindsHub also speaks the Anthropic Messages API, so Claude-specific request/response shapes
 (`cache_control` prompt-cache breakpoints, `tool_use`/`tool_result` blocks) round-trip natively:
 
-```json5 validate=false
+```json5
 {
-  env: { MINDSHUB_API_KEY: "mdb_..." },
+  env: { vars: { MINDSHUB_API_KEY: "mdb_..." } },
   agents: {
     defaults: { model: { primary: "mindshub-anthropic/sonnet" } },
   },
@@ -143,9 +143,12 @@ provider. If you still see `401`s on this path, use the OpenAI-compatible config
 </Warning>
 
 <Warning>
-The Anthropic base URL is the **host only**, no `/v1`. OpenClaw's Anthropic client appends
-`/v1/messages` itself, so `https://api.mindshub.ai/v1` here would resolve to
-`/v1/v1/messages`.
+Use the **host only** for the Anthropic base URL, no `/v1` — OpenClaw's Anthropic client appends
+`/v1/messages` itself. If you do include a trailing `/v1` or `/v1/`, OpenClaw's model-compat
+normalization strips it from `anthropic-messages` base URLs before building the request, so a
+value like `https://api.mindshub.ai/v1` is normalized back down to `https://api.mindshub.ai`
+rather than producing a double-appended `/v1/v1/messages`. The host-only form above is still the
+one to use; don't rely on the normalization as a substitute for setting it correctly.
 </Warning>
 
 ## Model catalog

--- a/docs/providers/mindshub.md
+++ b/docs/providers/mindshub.md
@@ -1,0 +1,217 @@
+---
+summary: "Configure OpenClaw against MindsHub's OpenAI- and Anthropic-compatible inference gateway"
+read_when:
+  - You want a single API key and bill for Claude, GPT, Kimi, DeepSeek, and other models
+  - You want to configure OpenClaw against MindsHub's OpenAI-compatible or Anthropic-compatible endpoint
+title: "MindsHub"
+---
+
+[MindsHub](https://mindshub.ai) is an LLM inference gateway: one API key and one bill reach
+Claude, GPT, Kimi, DeepSeek, Gemini, and the rest of its
+[model catalog](https://docs.mindshub.ai/inference/models) through either an OpenAI-compatible
+or an Anthropic-compatible wire format. MindsHub does not ship as a bundled OpenClaw provider
+plugin; configure it like any other custom OpenAI/Anthropic-compatible endpoint via
+`models.providers` (see [Model providers](/concepts/model-providers)).
+
+| Property             | Value                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| Provider id          | Your choice (this page uses `mindshub`)                                                           |
+| Auth                 | `MINDSHUB_API_KEY`                                                                                |
+| API                  | OpenAI-compatible (`openai-completions`) or Anthropic-compatible (`anthropic-messages`)           |
+| Base URL (OpenAI)    | `https://api.mindshub.ai/v1`                                                                      |
+| Base URL (Anthropic) | `https://api.mindshub.ai` (host only — OpenClaw's Anthropic client appends `/v1/messages` itself) |
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create a key at [console.mindshub.ai](https://console.mindshub.ai).
+  </Step>
+  <Step title="Onboard a single model">
+    ```bash
+    openclaw onboard --auth-choice custom-api-key \
+      --custom-provider-id mindshub \
+      --custom-base-url https://api.mindshub.ai/v1 \
+      --custom-model-id sonnet \
+      --custom-compatibility openai \
+      --custom-api-key "$MINDSHUB_API_KEY"
+    ```
+
+    This wires up one model ref, `mindshub/sonnet`. To expose more of the
+    [catalog](https://docs.mindshub.ai/inference/models) at once, use the manual config below
+    instead.
+
+  </Step>
+  <Step title="Set the default model">
+    ```json5
+    {
+      agents: { defaults: { model: { primary: "mindshub/sonnet" } } },
+    }
+    ```
+  </Step>
+</Steps>
+
+## Config example (OpenAI-compatible)
+
+This is the more thoroughly exercised custom-provider path in OpenClaw and the one to reach for
+first:
+
+```json5 validate=false
+{
+  env: { MINDSHUB_API_KEY: "mdb_..." },
+  agents: {
+    defaults: { model: { primary: "mindshub/sonnet" } },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      mindshub: {
+        baseUrl: "https://api.mindshub.ai/v1",
+        apiKey: "${MINDSHUB_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "sonnet",
+            name: "Claude Sonnet 5",
+            reasoning: true,
+            input: ["text", "image"],
+            contextWindow: 200000,
+            maxTokens: 64000,
+          },
+          {
+            id: "opus",
+            name: "Claude Opus 5",
+            reasoning: true,
+            input: ["text", "image"],
+            contextWindow: 200000,
+            maxTokens: 64000,
+          },
+          { id: "gpt", name: "GPT 5.6 Sol", input: ["text", "image"] },
+          { id: "gpt-codex", name: "GPT 5.3 Codex", input: ["text"] },
+          { id: "kimi", name: "Kimi K3", reasoning: true, input: ["text"] },
+          { id: "deepseek", name: "DeepSeek V4-Pro-0813", input: ["text"] },
+          { id: "gemini-flash", name: "Gemini 3.7 Flash", input: ["text", "image"] },
+          { id: "mindshub_air", name: "MindsHub Air", input: ["text"] },
+        ],
+      },
+    },
+  },
+}
+```
+
+Add or remove rows to match the aliases you actually use. Send the bare alias as `id`
+(`sonnet`, not `claude-sonnet-5`); raw provider model IDs return `404 model_not_found` on this
+endpoint. `GET /v1/models` is the authoritative live catalog; see
+[Models](https://docs.mindshub.ai/inference/models).
+
+## Config example (Anthropic-compatible)
+
+MindsHub also speaks the Anthropic Messages API, so Claude-specific request/response shapes
+(`cache_control` prompt-cache breakpoints, `tool_use`/`tool_result` blocks) round-trip natively:
+
+```json5 validate=false
+{
+  env: { MINDSHUB_API_KEY: "mdb_..." },
+  agents: {
+    defaults: { model: { primary: "mindshub-anthropic/sonnet" } },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      "mindshub-anthropic": {
+        baseUrl: "https://api.mindshub.ai",
+        apiKey: "${MINDSHUB_API_KEY}",
+        api: "anthropic-messages",
+        authHeader: true,
+        models: [
+          { id: "sonnet", name: "Claude Sonnet 5", reasoning: true, input: ["text", "image"] },
+          { id: "opus", name: "Claude Opus 5", reasoning: true, input: ["text", "image"] },
+        ],
+      },
+    },
+  },
+}
+```
+
+<Warning>
+Set `authHeader: true` on the provider entry. Without it, OpenClaw's Anthropic transport
+authenticates custom endpoints with an `x-api-key` header, and MindsHub's Anthropic-compatible
+endpoint accepts only `Authorization: Bearer` (see
+[Anthropic compatibility](https://docs.mindshub.ai/inference/anthropic-compatibility)).
+`authHeader: true` makes OpenClaw add an explicit `Authorization: Bearer` header for this
+provider. If you still see `401`s on this path, use the OpenAI-compatible config above instead.
+</Warning>
+
+<Warning>
+The Anthropic base URL is the **host only**, no `/v1`. OpenClaw's Anthropic client appends
+`/v1/messages` itself, so `https://api.mindshub.ai/v1` here would resolve to
+`/v1/v1/messages`.
+</Warning>
+
+## Model catalog
+
+MindsHub's alias catalog changes over time; the table below is a snapshot (August 2026) of
+commonly used aliases. Confirm the current list with:
+
+```bash
+curl https://api.mindshub.ai/v1/models -H "Authorization: Bearer $MINDSHUB_API_KEY"
+```
+
+| Alias          | Model                  | Notes                              |
+| -------------- | ---------------------- | ---------------------------------- |
+| `mindshub_air` | MindsHub Air           | Covered by monthly included tokens |
+| `sonnet`       | Claude Sonnet 5        |                                    |
+| `opus`         | Claude Opus 5          |                                    |
+| `haiku`        | Claude Haiku 4.5       |                                    |
+| `gpt`          | GPT 5.6 Sol            |                                    |
+| `gpt-codex`    | GPT 5.3 Codex          | Tuned for code                     |
+| `kimi`         | Kimi K3                | Agentic coding at lower cost       |
+| `deepseek`     | DeepSeek V4-Pro-0813   |                                    |
+| `qwen`         | Qwen3.8-2.4T-A95B      |                                    |
+| `glm`          | GLM 5.2                |                                    |
+| `grok`         | Grok 4.6               |                                    |
+| `gemini`       | Gemini 3.1 Pro Preview |                                    |
+
+See [Models](https://docs.mindshub.ai/inference/models) for the full, current catalog and
+frozen-version aliases.
+
+<AccordionGroup>
+  <Accordion title="Model refs">
+    Model refs use the form `<provider-id>/<alias>` (`mindshub/sonnet` for the config above).
+    The provider id is whatever you name the key under `models.providers` — it does not have to
+    be `mindshub`.
+  </Accordion>
+  <Accordion title="Model allowlist">
+    If you enable a model allowlist (`agents.defaults.models`), add every MindsHub alias you
+    plan to use; anything left out is hidden from the agent.
+  </Accordion>
+  <Accordion title="Daemon-managed gateways">
+    If the OpenClaw Gateway runs as a daemon (launchd/systemd), make sure `MINDSHUB_API_KEY` is
+    visible to that process — for example via `~/.openclaw/.env` or `env.shellEnv` — not just
+    your interactive shell.
+  </Accordion>
+  <Accordion title="Cost and usage reporting">
+    OpenClaw does not know MindsHub's per-model pricing unless you set `cost` on each model
+    entry, and any dollar figure OpenClaw or an underlying CLI harness displays is its own
+    estimate. MindsHub's
+    [usage summary endpoint](https://docs.mindshub.ai/inference/billing#checking-usage-and-balance-from-code)
+    is the authoritative source for spend, grouped by model, across every key on the account.
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Provider rules, model refs, custom-provider config, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config schema including provider settings.
+  </Card>
+  <Card title="MindsHub inference docs" href="https://docs.mindshub.ai/inference/" icon="arrow-up-right-from-square">
+    Chat Completions, Responses, Anthropic Messages, and model catalog reference.
+  </Card>
+  <Card title="MindsHub console" href="https://console.mindshub.ai" icon="key">
+    Create and manage API keys.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Problem: OpenClaw has no documentation for [MindsHub](https://mindshub.ai), a multi-model inference gateway (Claude, GPT, Kimi, DeepSeek, Gemini, and more behind one API key/bill) that speaks both OpenAI-compatible chat completions and the Anthropic Messages API.
- Why it matters: MindsHub is already fully usable in OpenClaw today via the existing generic `models.providers.<id>` custom-endpoint mechanism (confirmed in `src/commands/onboard-custom-config.ts` / `src/config/types.models.ts`) — no code change is needed, only documentation, matching how `docs/providers/synthetic.md` and the "Local proxies" section of `docs/concepts/model-providers.md` document other generic OpenAI/Anthropic-compatible endpoints.
- What changed: Added `docs/providers/mindshub.md` with config examples for both wire formats, linked it from `docs/providers/index.md`, added it to the Mintlify nav in `docs/docs.json` (alphabetized next to `providers/meta` / `providers/minimax`), added a short cross-reference entry in `docs/concepts/model-providers.md`, and added the required i18n glossary entries (`docs/.i18n/glossary.zh-CN.json`) for the new page title/link label.
- What did NOT change (scope boundary): No provider plugin, onboarding auth-choice, or model-catalog code was added. Per `CONTRIBUTING.md`, new provider features should go through an issue/Discord discussion first and are steered toward the plugin SDK; since the generic custom-provider path already covers MindsHub end-to-end, a docs-only PR is the appropriately scoped contribution here.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A — docs only, no behavior change.

## User-visible / Behavior Changes

New docs page `/providers/mindshub` and nav entry. No runtime behavior changes.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A (docs)
- Model/provider: MindsHub (documented, not code-integrated)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Configure `models.providers.mindshub` per the new doc, using a MindsHub API key.
2. Set `agents.defaults.model.primary` to `mindshub/<alias>` and run a chat.
3. Repeat with the Anthropic-compatible variant and `authHeader: true`.

### Expected

- OpenClaw resolves and calls the MindsHub endpoint successfully for both wire formats.

### Actual

- Verified by reading `src/commands/onboard-custom-config.ts`, `src/config/types.models.ts`, `src/agents/anthropic-transport-stream.ts`, and `src/agents/model-auth.ts` to confirm the `models.providers` schema, the `openai-completions`/`anthropic-messages` `api` modes, and the `authHeader` behavior (OpenClaw's Anthropic transport defaults to an `x-api-key` header, which MindsHub's Anthropic-compatible endpoint does not accept per [MindsHub's Anthropic compatibility docs](https://docs.mindshub.ai/inference/anthropic-compatibility) — `authHeader: true` is required to force `Authorization: Bearer`). This PR documents that gotcha explicitly. I do not have a live MindsHub API key in this environment, so the config examples are verified against source and MindsHub's own API docs rather than a live end-to-end run; happy to adjust if a maintainer spots a mismatch. The two full example config fences use `validate=false` (per the pattern in `docs/AGENTS.md`) since they illustrate the custom env var name `MINDSHUB_API_KEY`, which — being a non-bundled, generic custom provider — isn't in any plugin's declared env-var allowlist that `docs:check-config-examples` validates against.

## Evidence

- [x] Trace/log snippets (source citations above)

## Human Verification (required)

- Verified scenarios: doc content checked against `src/commands/onboard-custom-config.ts`, `src/config/types.models.ts`, `src/config/zod-schema.core.ts`, `src/agents/anthropic-transport-stream.ts`, `src/agents/model-auth.ts`, `src/agents/provider-request-config.ts`, and the existing `docs/providers/synthetic.md` / `docs/concepts/model-providers.md` "Local proxies" section as templates. Ran `pnpm run check:docs` (format:docs:check, lint:docs, docs:check-mdx, docs:check-i18n-glossary, docs:check-links, docs:check-config-examples) plus codespell on the changed files, all against a fresh checkout of current `main` — all pass with zero issues.
- Edge cases checked: base-URL `/v1` suffix nuance for the Anthropic path (OpenClaw appends `/v1/messages` itself), and the `x-api-key` vs `Authorization: Bearer` auth-header gotcha for the Anthropic-compatible path.
- What you did **not** verify: an actual live request against `api.mindshub.ai` (no API key available in this environment).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (documents existing config surface only)
- Migration needed? No

## Risks and Mitigations

- Risk: The Anthropic-compatible auth-header guidance (`authHeader: true`) is based on source-code reading, not a live test against MindsHub.
  - Mitigation: The doc frames the OpenAI-compatible path as the primary/recommended one and calls out the Anthropic path's caveat explicitly with a fallback suggestion if it doesn't work as documented.

---

This PR is AI-assisted (Claude, via Claude Code). Degree of testing: lightly tested — `pnpm run check:docs` and codespell pass cleanly against a fresh `main` checkout, and the documented config shape was cross-checked directly against the relevant source files, but no live call was made against MindsHub's API from this environment. I understand the change: it adds a documentation page describing how to use OpenClaw's existing generic custom-provider config against a third-party inference gateway; it introduces no new code paths.

More on MindsHub: https://docs.mindshub.ai/inference/