### PR TITLE
fix(onboard): emit JSON for remaining non-interactive option rejections

### DIFF
--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -276,6 +276,33 @@ describe("registerOnboardCommand", () => {
     },
   );
 
+  it.each([
+    {
+      rejection: "modern onboarding without risk acknowledgement",
+      args: ["--modern", "--non-interactive"],
+      message: "Non-interactive setup requires explicit risk acknowledgement.",
+    },
+    {
+      rejection: "modern onboarding with unsupported setup flags",
+      args: ["--modern", "--classic"],
+      message: "--modern cannot be combined with: --classic.",
+    },
+  ])("emits one options JSON object for $rejection", async ({ args, message }) => {
+    await runCli(["onboard", "--json", ...args]);
+
+    expect(runtime.log).toHaveBeenCalledOnce();
+    const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0]));
+    expect(payload).toEqual({
+      ok: false,
+      phase: "options",
+      message: expect.stringContaining(message),
+    });
+    expect(runtime.error).toHaveBeenCalledWith(payload.message);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runSystemAgentWithInference).not.toHaveBeenCalled();
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+  });
+
   it("parses --mistral-api-key and forwards mistralApiKey", async () => {
     await runCli(["onboard", "--mistral-api-key", "sk-mistral-test"]);
     expect(setupWizardOptions().mistralApiKey).toBe("sk-mistral-test"); // pragma: allowlist secret

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -374,30 +374,30 @@ export function registerOnboardCommand(program: Command): void {
   command.action(async (opts, commandRuntime: Command) => {
     const { defaultRuntime } = await import("../../runtime.js");
     await runCommandWithRuntime(defaultRuntime, async () => {
+      const rejectOption = (message: string) =>
+        rejectOnboardingOption({ json: Boolean(opts.json) }, defaultRuntime, message);
       if (opts.modern) {
         const unsupportedOptions = listExplicitOptionFlagsExcept(
           commandRuntime,
           MODERN_ONBOARD_OPTION_KEYS,
         );
         if (unsupportedOptions.length > 0) {
-          defaultRuntime.error(
+          rejectOption(
             [
               `--modern cannot be combined with: ${unsupportedOptions.join(", ")}.`,
               "Run those setup options without --modern, or remove them to open OpenClaw.",
             ].join("\n"),
           );
-          defaultRuntime.exit(1);
           return;
         }
         if (opts.nonInteractive && opts.acceptRisk !== true) {
-          defaultRuntime.error(
+          rejectOption(
             [
               "Non-interactive setup requires explicit risk acknowledgement.",
               "Read: https://docs.openclaw.ai/security",
               `Re-run with: ${formatCliCommand("openclaw onboard --modern --non-interactive --accept-risk ...")}`,
             ].join("\n"),
           );
-          defaultRuntime.exit(1);
           return;
         }
         const { runSystemAgentWithInference } =

--- a/src/commands/onboard-non-interactive/api-keys.test.ts
+++ b/src/commands/onboard-non-interactive/api-keys.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
 
 function createRuntime() {
   return {
+    log: vi.fn(),
     error: vi.fn(),
     exit: vi.fn(),
   };
@@ -339,5 +340,55 @@ describe("resolveNonInteractiveApiKey", () => {
     expect(result).toBeNull();
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      rejection: "a missing required key",
+      expectedMessage: "Missing --fixture-api-key",
+    },
+    {
+      rejection: "a command-shaped key",
+      flagValue: "openclaw onboard --non-interactive --auth-choice fixture-api-key",
+      expectedMessage: "Paste the API key value",
+    },
+    {
+      rejection: "a literal key in reference mode",
+      flagValue: "fixture-api-key",
+      secretInputMode: "ref" as const,
+      expectedMessage: "cannot be used with --secret-input-mode ref",
+    },
+    {
+      rejection: "a provider-discovered key without an environment name",
+      envVar: "",
+      secretInputMode: "ref" as const,
+      resolvedEnv: { apiKey: "fixture-api-key", source: "provider discovery" },
+      expectedMessage: "requires an explicit environment variable",
+    },
+  ])("emits one options JSON object for $rejection", async (testCase) => {
+    const runtime = createRuntime();
+    resolveEnvApiKey.mockReturnValue(testCase.resolvedEnv ?? null);
+
+    const result = await resolveNonInteractiveApiKey({
+      provider: "fixture",
+      cfg: {},
+      flagName: "--fixture-api-key",
+      envVar: testCase.envVar ?? "OPENCLAW_ONBOARD_MISSING_FIXTURE_KEY",
+      flagValue: testCase.flagValue,
+      secretInputMode: testCase.secretInputMode,
+      runtime,
+      json: true,
+    });
+
+    expect(result).toBeNull();
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.log).toHaveBeenCalledOnce();
+    const payload = JSON.parse(String(runtime.log.mock.calls[0]?.[0]));
+    expect(payload).toEqual({
+      ok: false,
+      phase: "options",
+      message: expect.stringContaining(testCase.expectedMessage),
+    });
+    expect(runtime.error).toHaveBeenCalledWith(payload.message);
   });
 });

--- a/src/commands/onboard-non-interactive/api-keys.ts
+++ b/src/commands/onboard-non-interactive/api-keys.ts
@@ -15,6 +15,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
+import { rejectOnboardingOption } from "../onboard-options.js";
 import type { SecretInputMode } from "../onboard-types.js";
 
 /** Source that supplied a non-interactive provider API key. */
@@ -73,7 +74,12 @@ export async function resolveNonInteractiveApiKey(params: {
   allowProfile?: boolean;
   required?: boolean;
   secretInputMode?: SecretInputMode;
+  json?: boolean;
 }): Promise<{ key: string; source: NonInteractiveApiKeySource; envVarName?: string } | null> {
+  const reject = (message: string): null => {
+    rejectOnboardingOption(params, params.runtime, message);
+    return null;
+  };
   const flagKey = normalizeOptionalSecretInput(params.flagValue);
   const explicitEnvVar = params.envVarName?.trim() || params.envVar.trim();
   const resolveExplicitEnvKey = () => normalizeOptionalSecretInput(process.env[explicitEnvVar]);
@@ -95,9 +101,7 @@ export async function resolveNonInteractiveApiKey(params: {
       return envVarName ? { key, source, envVarName } : { key, source };
     }
     const envHint = source === "env" ? ` Check ${envVarName ?? params.envVar}.` : "";
-    params.runtime.error(`Paste the API key value, not an OpenClaw onboarding command.${envHint}`);
-    params.runtime.exit(1);
-    return null;
+    return reject(`Paste the API key value, not an OpenClaw onboarding command.${envHint}`);
   };
 
   const useSecretRefMode = params.secretInputMode === "ref"; // pragma: allowlist secret
@@ -108,14 +112,12 @@ export async function resolveNonInteractiveApiKey(params: {
     }
     // A literal flag value cannot be converted into a durable secret reference;
     // require an env var so the stored config can reference a stable name.
-    params.runtime.error(
+    return reject(
       [
         `${params.flagName} cannot be used with --secret-input-mode ref unless ${params.envVar} is set in env.`,
         `Set ${params.envVar} in env and omit ${params.flagName}, or use --secret-input-mode plaintext.`,
       ].join("\n"),
     );
-    params.runtime.exit(1);
-    return null;
   }
 
   if (useSecretRefMode) {
@@ -124,14 +126,12 @@ export async function resolveNonInteractiveApiKey(params: {
       if (!resolvedEnv.envVarName) {
         // Provider auto-detection can return a key without a concrete env var
         // name; ref mode needs the name because the config stores the reference.
-        params.runtime.error(
+        return reject(
           [
             `--secret-input-mode ref requires an explicit environment variable for provider "${params.provider}".`,
             `Set ${params.envVar} in env and retry, or use --secret-input-mode plaintext.`,
           ].join("\n"),
         );
-        params.runtime.exit(1);
-        return null;
       }
       return returnOperatorKey(resolvedEnv.key, "env", resolvedEnv.envVarName);
     }
@@ -165,9 +165,7 @@ export async function resolveNonInteractiveApiKey(params: {
 
   const profileHint =
     params.allowProfile === false ? "" : `, or existing ${params.provider} API-key profile`;
-  params.runtime.error(
+  return reject(
     `Missing ${params.flagName} (or ${params.envVar} in env${profileHint}). Export ${params.envVar}, pass ${params.flagName}, or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
   );
-  params.runtime.exit(1);
-  return null;
 }

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -104,6 +104,7 @@ export async function applyNonInteractiveAuthChoice(params: {
       agentDir: params.target.agentDir,
       workspaceDir: params.target.workspaceDir,
       secretInputMode: requestedSecretInputMode,
+      json: opts.json,
     });
   const toApiKeyCredential = (paramsLocal: {
     provider: string;

--- a/src/commands/onboard-options.ts
+++ b/src/commands/onboard-options.ts
@@ -5,11 +5,10 @@
  * non-interactive handlers reject options, and every one of them must honor --json.
  */
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
-import type { OnboardOptions } from "./onboard-types.js";
 
 /** Reports an invalid option and exits; returns false so validators can `return` it directly. */
 export function rejectOnboardingOption(
-  opts: OnboardOptions,
+  opts: { json?: boolean },
   runtime: RuntimeEnv,
   message: string,
 ): false {

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -378,6 +378,7 @@ async function validateResetAuthChoice(params: {
         allowProfile: params.resetScope === "config",
         required: false,
         secretInputMode: params.opts.secretInputMode,
+        json: params.opts.json,
       });
       if (params.opts.customApiKey?.trim() && !customCredential) {
         return false;
@@ -448,6 +449,7 @@ async function validateResetAuthChoice(params: {
           workspaceDir: params.workspaceDir,
           allowProfile: input.allowProfile === false ? false : params.resetScope === "config",
           secretInputMode: params.opts.secretInputMode,
+          json: params.opts.json,
         }),
     });
     if (!valid) {


### PR DESCRIPTION
Closes #127974. Follow-up to #127794 and #128542.

## What Problem This Solves

`openclaw onboard --json` must emit one machine-readable result even when
onboarding rejects an option. The existing shared rejection owner covered many
validators, but API-key resolution and modern onboarding option checks still
exited with empty stdout. #128542 independently fixed ambiguous provider flags
and shared `onboard`/`setup` capability validation; this change deliberately
preserves that newer architecture and fixes only the remaining generic gaps.

Provider-plugin rejection paths from the original version of this PR are being
repaired together with their plugin owner in #128574 instead of maintaining
overlapping changes here.

## Why This Change Was Made

Route every affected generic onboarding rejection through the existing
`rejectOnboardingOption` owner. Forward JSON intent into ordinary and reset
API-key validation, and reuse the same rejection owner for modern onboarding.
Keep human-facing diagnostics, non-JSON behavior, exit codes, and pre-write
rejection ordering unchanged.

The generic production diff is size-neutral and introduces no alternate error
path or fallback.

## User Impact

Automation now receives exactly one `{ ok: false, phase: "options", message }`
object for missing or malformed API keys, secret-reference validation failures,
and invalid modern-onboarding options. Interactive/text-mode errors stay
unchanged. Existing ambiguous-option and custom-input behavior remains covered
by the current-main regression suites.

## Evidence

Failing-first proof reproduced the four API-key rejection families and modern
onboarding failures. Those remaining rejection owners are unchanged between the
original baseline and the refreshed current-main baseline; every failure
occurred because stdout received zero JSON objects.

The refreshed focused suites now pass: **114 tests across four files**.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 \
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-onboard-json-cache \
node scripts/run-vitest.mjs run --configLoader runner \
  src/commands/onboard-non-interactive/api-keys.test.ts \
  src/commands/onboard-non-interactive/local.default-agent.test.ts \
  src/cli/program/register.onboard.test.ts \
  src/cli/program/register.setup.test.ts

CLI parser: 90 passed
Onboarding command owners: 24 passed
```

Three source-backed processes exercised the actual Commander command
registrations and production runtime:

```text
onboard --modern --json --non-interactive
  exit=1; exactly one options JSON object; matching missing-risk diagnostic; configWritten=false

onboard --modern --json --classic
  exit=1; exactly one options JSON object; matching invalid-option diagnostic; configWritten=false

onboard --modern --non-interactive
  exit=1; stdout=<empty>; existing stderr unchanged; configWritten=false
```

All seven touched files pass `oxfmt --check`, and `git diff --check` is clean.
Independent structured review reported no actionable findings. The provider
API-key owner is proved by four failing-first/passing regression cases; a full
source-backed provider startup was stopped after its bounded TypeScript plugin
compilation timeout instead of claiming that incomplete run as live proof.

Production LOC: net 0; test coverage increases independently.
