### PR TITLE
fix(cli): reject malformed usage-cost --days instead of silently defaulting

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -341,14 +341,17 @@ describe("gateway-cli coverage", () => {
     expect(runtimeErrors).toHaveLength(0);
   });
 
-  it.each(["abc", "7d", "1.5"])("rejects malformed usage-cost --days %s", async (days) => {
-    callGateway.mockClear();
+  it.each(["abc", "7d", "1.5", "", "  "])(
+    "rejects malformed usage-cost --days %j",
+    async (days) => {
+      callGateway.mockClear();
 
-    await expectGatewayExit(["gateway", "usage-cost", "--days", days, "--json"]);
+      await expectGatewayExit(["gateway", "usage-cost", "--days", days, "--json"]);
 
-    expect(callGateway).not.toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("Invalid --days");
-  });
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(runtimeErrors.join("\n")).toContain("Invalid --days");
+    },
+  );
 
   it("rejects a malformed --timeout before the health auth diagnostic", async () => {
     callGateway.mockClear();

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -349,17 +349,25 @@ describe("gateway-cli coverage", () => {
       await expectGatewayExit(["gateway", "usage-cost", "--days", days, "--json"]);
 
       expect(callGateway).not.toHaveBeenCalled();
-      expect(runtimeErrors.join("\n")).toContain("Invalid --days");
+      expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+        ok: false,
+        error: { type: "cli_error", message: expect.stringContaining("Invalid --days") },
+      });
+      expect(runtimeErrors).toHaveLength(0);
     },
   );
 
-  it("rejects a malformed --timeout before the health auth diagnostic", async () => {
+  it("rejects a malformed health --timeout before calling Gateway", async () => {
     callGateway.mockClear();
-    callGateway.mockRejectedValueOnce(new Error("unauthorized"));
 
     await expectGatewayExit(["gateway", "health", "--timeout", "abc", "--json"]);
 
-    expect(runtimeErrors.join("\n")).toContain("Invalid --timeout");
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: expect.stringContaining("Invalid --timeout") },
+    });
+    expect(runtimeErrors).toHaveLength(0);
   });
 
   it("writes JSON for gateway health transport failures in JSON mode", async () => {

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -341,6 +341,24 @@ describe("gateway-cli coverage", () => {
     expect(runtimeErrors).toHaveLength(0);
   });
 
+  it.each(["abc", "7d", "1.5"])("rejects malformed usage-cost --days %s", async (days) => {
+    callGateway.mockClear();
+
+    await expectGatewayExit(["gateway", "usage-cost", "--days", days, "--json"]);
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(runtimeErrors.join("\n")).toContain("Invalid --days");
+  });
+
+  it("rejects a malformed --timeout before the health auth diagnostic", async () => {
+    callGateway.mockClear();
+    callGateway.mockRejectedValueOnce(new Error("unauthorized"));
+
+    await expectGatewayExit(["gateway", "health", "--timeout", "abc", "--json"]);
+
+    expect(runtimeErrors.join("\n")).toContain("Invalid --timeout");
+  });
+
   it("writes JSON for gateway health transport failures in JSON mode", async () => {
     const error = new Error("gateway closed (1006)");
     const payload = {

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -353,19 +353,19 @@ describe("gateway register option collisions", () => {
         expectLocalGatewayCall("diagnostics.stability", 19095, { limit: 25 });
       },
     },
-    {
-      name: "falls back for non-decimal usage-cost --days values",
-      argv: ["gateway", "usage-cost", "--days", "1e3", "--json"],
-      assert: () => {
-        expect(callGatewayCli).toHaveBeenCalledTimes(1);
-        const [method, _opts, params] = firstGatewayCall();
-        expect(method).toBe("usage.cost");
-        expect(params).toEqual({ days: 30 });
-      },
-    },
   ])("$name", async ({ argv, assert }) => {
     await sharedProgram.parseAsync(argv, { from: "user" });
     assert();
+  });
+
+  it("rejects non-decimal usage-cost --days values instead of silently defaulting", async () => {
+    await sharedProgram.parseAsync(["gateway", "usage-cost", "--days", "1e3", "--json"], {
+      from: "user",
+    });
+
+    expect(callGatewayCli).not.toHaveBeenCalled();
+    expect(defaultRuntime.error).toHaveBeenCalledWith(expect.stringContaining("Invalid --days"));
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
   it.each([

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -364,7 +364,11 @@ describe("gateway register option collisions", () => {
     });
 
     expect(callGatewayCli).not.toHaveBeenCalled();
-    expect(defaultRuntime.error).toHaveBeenCalledWith(expect.stringContaining("Invalid --days"));
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: expect.stringContaining("Invalid --days") },
+    });
+    expect(defaultRuntime.error).not.toHaveBeenCalled();
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
@@ -396,21 +400,22 @@ describe("gateway register option collisions", () => {
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("uses the effective local port override for gateway health auth diagnostics", async () => {
+  it("uses the effective local port and timeout for gateway health auth diagnostics", async () => {
     const authError = new Error("gateway auth required");
     callGatewayCli.mockRejectedValueOnce(authError);
     emitReachableGatewayAuthDiagnostic.mockResolvedValueOnce(true);
 
-    await sharedProgram.parseAsync(["gateway", "health", "--port", "19081", "--json"], {
-      from: "user",
-    });
+    await sharedProgram.parseAsync(
+      ["gateway", "health", "--port", "19081", "--timeout", "1234", "--json"],
+      { from: "user" },
+    );
 
     expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledTimes(1);
     expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledWith({
       error: authError,
       config: {},
       runtime: defaultRuntime,
-      timeoutMs: 10000,
+      timeoutMs: 1234,
       token: undefined,
       password: undefined,
       localPortOverride: 19081,

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -166,13 +166,14 @@ function parseDaysOption(raw: unknown, fallback = 30): number {
   if (typeof raw === "number" && Number.isFinite(raw)) {
     return Math.max(1, Math.floor(raw));
   }
-  if (typeof raw === "string" && raw.trim() !== "") {
+  if (typeof raw === "string") {
     const parsed = parseStrictPositiveInteger(raw);
     if (parsed !== undefined) {
       return parsed;
     }
-    // A present-but-unparseable value is operator error; the main RPC path
-    // rejects malformed --timeout the same way instead of silently defaulting.
+    // A present-but-unparseable value (including an explicit empty one) is
+    // operator error; the main RPC path rejects malformed --timeout the same
+    // way instead of silently defaulting.
     throw new Error(`Invalid --days. Use a positive integer, e.g. --days 30. Received: "${raw}".`);
   }
   return fallback;

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -24,6 +24,7 @@ import { formatCliJsonFailure, rethrowExpectedCliError } from "../failure-output
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 import { addGatewayClientOptions, callGatewayFromCliWithTransport } from "../gateway-rpc.js";
 import { formatHelpExamples } from "../help-format.js";
+import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import { setCommandJsonMode } from "../program/json-mode.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import { isGatewayMachineOutput } from "./output-mode.js";
@@ -170,19 +171,9 @@ function parseDaysOption(raw: unknown, fallback = 30): number {
     if (parsed !== undefined) {
       return parsed;
     }
-  }
-  return fallback;
-}
-
-function parseGatewayRpcTimeoutOption(raw: unknown, fallback = 10_000): number {
-  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
-    return Math.floor(raw);
-  }
-  if (typeof raw === "string" && raw.trim() !== "") {
-    const parsed = parseStrictPositiveInteger(raw);
-    if (parsed !== undefined) {
-      return parsed;
-    }
+    // A present-but-unparseable value is operator error; the main RPC path
+    // rejects malformed --timeout the same way instead of silently defaulting.
+    throw new Error(`Invalid --days. Use a positive integer, e.g. --days 30. Received: "${raw}".`);
   }
   return fallback;
 }
@@ -699,7 +690,9 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
                 error,
                 config: rpcOpts.config ?? (await readNonObservingHealthConfig()),
                 runtime: defaultRuntime,
-                timeoutMs: parseGatewayRpcTimeoutOption(rpcOpts.timeout),
+                timeoutMs: parseTimeoutMsWithFallback(rpcOpts.timeout, 10_000, {
+                  invalidType: "error",
+                }),
                 token: rpcOpts.token,
                 password: rpcOpts.password,
                 localPortOverride: rpcOpts.localPortOverride,


### PR DESCRIPTION
Closes #127975. Same operator-input class as #127875 (backup `--limit`).

## What Problem This Solves

`openclaw gateway usage-cost --days abc` (also `7d`, `1e3`, `1.5`, or an explicit empty `--days ""`) silently fell back to 30 and rendered a valid-looking cost report for the wrong window — the operator gets no signal their input was rejected. `parseDaysOption` predates the strict-parsing convention established by #127875 (`parseStrictPositiveIntOption`) and the shared `--timeout` handling (`parseTimeoutMsWithFallback(..., { invalidType: "error" })`, which already rejects malformed `--timeout` in `callGatewayFromCliRuntime`), so `--days` was the last lenient numeric outlier on this surface. Its silent fallback was even pinned by a test ("falls back for non-decimal usage-cost --days values"), updated here to the strict contract.

`parseDaysOption` now throws on any present-but-unparseable string (including empty/whitespace), surfacing through the existing `runGatewayCommand` failure path (`Gateway usage cost failed: Invalid --days ...`, exit 1, no RPC). Absent `--days` keeps the 30-day default. The duplicate lenient timeout parser in the health auth-diagnostic path is collapsed onto the canonical `parseTimeoutMsWithFallback` so both `--timeout` sites share one policy — no reachable behavior change there, since the RPC layer rejects malformed `--timeout` first.

## Evidence

Real CLI runs against this branch's build (`4e36c093a4a`, temp HOME/state dir; nothing private to redact):

```text
$ pnpm openclaw gateway usage-cost --days abc
exit=1
--- stdout ---
(empty)
--- stderr ---
Gateway usage cost failed: Invalid --days. Use a positive integer, e.g. --days 30. Received: "abc".
```

```text
$ pnpm openclaw gateway usage-cost --days ""
exit=1
--- stdout ---
(empty)
--- stderr ---
Gateway usage cost failed: Invalid --days. Use a positive integer, e.g. --days 30. Received: "".
```

No gateway connection is attempted: the rejection happens before the `usage.cost` RPC.

Regression tests:

- `gateway-cli.coverage.test.ts` "rejects malformed usage-cost --days" (`abc`, `7d`, `1.5`, `""`, whitespace-only) — verified red pre-fix (RPC ran with `days: 30`), green after.
- `register.option-collisions.test.ts` `--days 1e3` case updated from "falls back" to asserting rejection (error + exit 1, no gateway call).
- Green: `gateway-cli.coverage.test.ts` (37), `register.option-collisions.test.ts` (26), `health-route.test.ts`, `parse-timeout.test.ts`. `oxlint` / `oxfmt --check` clean; `pnpm tsgo:core` clean.
- Production delta net-negative: `register.ts` +9/−15 (duplicate timeout parser deleted, one throw + comment added).
