### PR TITLE
feat(plugins): expose durable plugin session state

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -786,8 +786,10 @@ to `false`.
 ### Session extensions and next-turn injections
 
 Workflow plugins can persist small JSON-compatible session state with
-`api.session.state.registerSessionExtension(...)` and update it through the
-Gateway `sessions.pluginPatch` method. Session rows project registered
+`api.session.state.registerSessionExtension(...)`, then read, write, and clear
+their own state with `getSessionExtension(...)`, `setSessionExtension(...)`,
+and `clearSessionExtension(...)`. The host binds these operations to the
+current plugin ID. Session rows project registered
 extension state through `pluginExtensions`, letting Control UI and other
 clients render plugin-owned status without learning plugin internals.
 `api.registerSessionExtension(...)` still works but is deprecated in favor of

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -380,22 +380,23 @@ generic contracts; Plan Mode can use them, but so can approval workflows,
 workspace policy gates, background monitors, setup wizards, and UI companion
 plugins.
 
-| Method                                                                               | Contract it owns                                                                                                                                           |
-| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api.session.state.registerSessionExtension(...)`                                    | Plugin-owned, JSON-compatible session state projected through Gateway sessions                                                                             |
-| `api.session.workflow.enqueueNextTurnInjection(...)`                                 | Durable exactly-once context injected into the next agent turn for one session                                                                             |
-| `api.registerTrustedToolPolicy(...)`                                                 | Manifest-gated trusted pre-plugin tool policy that can block or rewrite tool params                                                                        |
-| `api.registerToolMetadata(...)`                                                      | Tool catalog display metadata without changing the tool implementation                                                                                     |
-| `api.registerCommand(...)`                                                           | Scoped plugin commands; command results can set `continueAgent: true` or `suppressReply: true`; Discord native commands support `descriptionLocalizations` |
-| `api.session.controls.registerControlUiDescriptor(...)`                              | Control UI contribution descriptors for session, tool, run, settings, or tab surfaces                                                                      |
-| `api.lifecycle.registerRuntimeLifecycle(...)`                                        | Cleanup callbacks for plugin-owned runtime resources on reset/delete/reload paths                                                                          |
-| `api.agent.events.registerAgentEventSubscription(...)`                               | Sanitized event subscriptions for workflow state and monitors                                                                                              |
-| `api.runContext.setRunContext(...)` / `getRunContext(...)` / `clearRunContext(...)`  | Per-run plugin scratch state cleared on terminal run lifecycle                                                                                             |
-| `api.session.workflow.registerSessionSchedulerJob(...)`                              | Cleanup metadata for plugin-owned scheduler jobs; does not schedule work or create task records                                                            |
-| `api.session.workflow.sendSessionAttachment(...)`                                    | Bundled-only host-mediated file attachment delivery to the active direct-outbound session route                                                            |
-| `api.session.workflow.scheduleSessionTurn(...)` / `unscheduleSessionTurnsByTag(...)` | Bundled-only Cron-backed scheduled session turns plus tag-based cleanup                                                                                    |
-| `api.session.controls.registerSessionAction(...)`                                    | Typed session actions clients can dispatch through the Gateway                                                                                             |
-| `api.registerBoardWidgetContentKind(...)`                                            | Sandboxed board widget source validation, renderer resources, and document composition                                                                     |
+| Method                                                                                                   | Contract it owns                                                                                                                                           |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api.session.state.registerSessionExtension(...)`                                                        | Plugin-owned, JSON-compatible session state projected through Gateway sessions                                                                             |
+| `api.session.state.getSessionExtension(...)` / `setSessionExtension(...)` / `clearSessionExtension(...)` | Read, persist, or clear session-extension state automatically scoped to the current plugin ID                                                              |
+| `api.session.workflow.enqueueNextTurnInjection(...)`                                                     | Durable exactly-once context injected into the next agent turn for one session                                                                             |
+| `api.registerTrustedToolPolicy(...)`                                                                     | Manifest-gated trusted pre-plugin tool policy that can block or rewrite tool params                                                                        |
+| `api.registerToolMetadata(...)`                                                                          | Tool catalog display metadata without changing the tool implementation                                                                                     |
+| `api.registerCommand(...)`                                                                               | Scoped plugin commands; command results can set `continueAgent: true` or `suppressReply: true`; Discord native commands support `descriptionLocalizations` |
+| `api.session.controls.registerControlUiDescriptor(...)`                                                  | Control UI contribution descriptors for session, tool, run, settings, or tab surfaces                                                                      |
+| `api.lifecycle.registerRuntimeLifecycle(...)`                                                            | Cleanup callbacks for plugin-owned runtime resources on reset/delete/reload paths                                                                          |
+| `api.agent.events.registerAgentEventSubscription(...)`                                                   | Sanitized event subscriptions for workflow state and monitors                                                                                              |
+| `api.runContext.setRunContext(...)` / `getRunContext(...)` / `clearRunContext(...)`                      | Per-run plugin scratch state cleared on terminal run lifecycle                                                                                             |
+| `api.session.workflow.registerSessionSchedulerJob(...)`                                                  | Cleanup metadata for plugin-owned scheduler jobs; does not schedule work or create task records                                                            |
+| `api.session.workflow.sendSessionAttachment(...)`                                                        | Bundled-only host-mediated file attachment delivery to the active direct-outbound session route                                                            |
+| `api.session.workflow.scheduleSessionTurn(...)` / `unscheduleSessionTurnsByTag(...)`                     | Bundled-only Cron-backed scheduled session turns plus tag-based cleanup                                                                                    |
+| `api.session.controls.registerSessionAction(...)`                                                        | Typed session actions clients can dispatch through the Gateway                                                                                             |
+| `api.registerBoardWidgetContentKind(...)`                                                                | Sandboxed board widget source validation, renderer resources, and document composition                                                                     |
 
 `registerBoardWidgetContentKind(...)` is for plugins that own a declarative
 widget source format. The registration supplies a globally unique lowercase
@@ -462,6 +463,9 @@ api.session.controls.registerControlUiDescriptor({
 Use the grouped namespaces for new plugin code:
 
 - `api.session.state.registerSessionExtension(...)`
+- `api.session.state.getSessionExtension(...)`
+- `api.session.state.setSessionExtension(...)`
+- `api.session.state.clearSessionExtension(...)`
 - `api.session.workflow.enqueueNextTurnInjection(...)`
 - `api.session.workflow.registerSessionSchedulerJob(...)`
 - `api.session.workflow.sendSessionAttachment(...)`

--- a/docs/reference/pr-127982-real-gateway-proof.md
+++ b/docs/reference/pr-127982-real-gateway-proof.md
@@ -79,3 +79,33 @@ Focused shutdown, registry, and persistent-state tests passed 73/73, formatting
 passed, and the full OpenClaw build passed. The disposable proof directory was
 moved to Trash after the run. No production profile, credential, session,
 connector, model call, message, or non-loopback endpoint was used.
+
+## Active-generation authority proof
+
+ClawSweeper's exact-head review identified a staged-replacement window that the
+earlier Gateway trace did not exercise. The correction binds every retained
+session-state closure to the exact active registry object and passes the same
+assertion to the SQLite accessor's synchronous final-commit hook.
+
+The regression fixture uses two registries containing the same plugin ID. The
+original closure begins a write while its registry is active. Its projection
+callback then stages the replacement registry after the initial authorization
+check but before the SQLite transaction's final write. The final-commit fence
+rejects the original closure, and direct store inspection confirms that neither
+the plugin extension nor its promoted slot was written.
+
+```text
+[registry] original owner active: PASS
+[session] retained original closure begins write: PASS
+[registry] same-ID replacement staged before commit: PASS
+[authority] retained closure rejected at final commit: PASS
+[sqlite] plugin extension absent after rejection: PASS
+[sqlite] promoted slot absent after rejection: PASS
+[authority] subsequent retained-closure read rejected: PASS
+```
+
+The fixture is
+`src/plugins/contracts/plugin-session-state-api.contract.test.ts` and runs
+against a disposable session store. Combined with the real Gateway lifecycle
+trace above, it covers both durable restart behavior and the replacement-stage
+authority boundary without using production data.

--- a/docs/reference/pr-127982-real-gateway-proof.md
+++ b/docs/reference/pr-127982-real-gateway-proof.md
@@ -1,0 +1,53 @@
+# PR #127982 real Gateway proof
+
+Date: 2026-08-22
+
+This is the redacted runtime trace for the plugin-scoped session-state API in
+PR #127982. The test used a disposable OpenClaw profile, a loopback-only
+Gateway, a synthetic session, and two test plugins. It used no production
+credentials, sessions, connectors, model calls, messages, phone numbers,
+public endpoints, or non-loopback IP addresses.
+
+## Environment
+
+- OpenClaw base: `v2026.7.1-2` (`0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c`)
+- Host correction commit tested: `7287b6ad`
+- Candidate plugin: `@kanary/active-project-anchor` `0.1.1`
+- Gateway binding: loopback, disposable port (redacted)
+- Backend service: local fixture only
+
+## Trace
+
+```text
+[gateway] started with disposable profile
+[plugin-owner] registered namespace active-project-anchor
+[plugin-owner] write: PASS
+[plugin-owner] exact readback: PASS
+[plugin-other] cross-plugin read rejected: PASS
+[gateway] stopped cleanly
+[gateway] restarted with the same disposable profile
+[plugin-owner] persisted readback after restart: PASS
+[suite] governed continuity cases before restart: 18/18 PASS
+[suite] governed continuity cases after restart: 18/18 PASS
+[plugin-owner] clear: PASS
+[plugin-owner] empty readback after clear: PASS
+[gateway] stopped cleanly
+```
+
+The 18-case suite covered valid continuation, fresh-session clarification,
+same-session reuse, transcript rotation, compaction, restart persistence,
+stale and malformed anchors, identity mismatch, conversation mismatch,
+ambiguous projects, explicit project switches, missing authority, and
+cross-plugin isolation.
+
+## Supporting verification
+
+- Focused OpenClaw contract and loader tests: 184/184 passed.
+- Candidate plugin tests: 22/22 passed.
+- Full OpenClaw build: passed.
+- Two independent plugin package builds were byte-identical:
+  `0c21657863a2214b5bba51f07613b39959c611aab84b6a2f7252882d33a7a5d5`.
+- The disposable profiles and package artifacts were removed after the run.
+
+This artifact proves behavior of the API through a real Gateway lifecycle. It
+does not authorize production installation or deployment.

--- a/docs/reference/pr-127982-real-gateway-proof.md
+++ b/docs/reference/pr-127982-real-gateway-proof.md
@@ -51,3 +51,31 @@ cross-plugin isolation.
 
 This artifact proves behavior of the API through a real Gateway lifecycle. It
 does not authorize production installation or deployment.
+
+## Exact-head rerun after review corrections
+
+The proof was rerun on 2026-08-22 against behavior commit
+`a1562db1d62274cf55a2a56e705fd1fd76fcbf0b` using a new disposable state
+directory, a loopback-only Gateway, one synthetic session, and two locally
+linked proof plugins. The first run exposed that normal Gateway shutdown was
+incorrectly treating every loaded plugin as disabled and deleting its durable
+session extensions. The shutdown path was corrected to preserve persistent
+plugin session state while retaining normal in-process cleanup.
+
+```text
+[gateway] exact behavior commit: a1562db1d62274cf55a2a56e705fd1fd76fcbf0b
+[gateway] loaded proof-owner and proof-other from disposable paths
+[proof-owner] write {"checkpoint":"exact-head"}: PASS
+[proof-owner] exact readback: PASS
+[proof-other] same session and namespace returned no owner value: PASS
+[gateway] graceful stop: PASS
+[gateway] restart with same disposable state: PASS
+[proof-owner] persisted readback after restart: PASS
+[proof-owner] clear: PASS
+[proof-owner] empty readback after clear: PASS
+```
+
+Focused shutdown, registry, and persistent-state tests passed 73/73, formatting
+passed, and the full OpenClaw build passed. The disposable proof directory was
+moved to Trash after the run. No production profile, credential, session,
+connector, model call, message, or non-loopback endpoint was used.

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -342,6 +342,7 @@ function resolveSessionEntryStoreTarget(
 export async function updateResolvedSessionEntry<T>(
   scope: LogicalSessionAccessScope,
   update: (entry: SessionEntry, context: ResolvedSessionEntryUpdateContext) => Promise<T> | T,
+  options: { assertCommitAllowed?: () => void } = {},
 ): Promise<ResolvedSessionEntryUpdateResult<T>> {
   const target = resolveSessionEntryStoreTarget(scope);
   if (!target.entry) {
@@ -364,6 +365,7 @@ export async function updateResolvedSessionEntry<T>(
     {
       replaceEntry: true,
       skipMaintenance: true,
+      ...(options.assertCommitAllowed ? { assertCommitAllowed: options.assertCommitAllowed } : {}),
     },
   );
   if (!updated) {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -1096,7 +1096,11 @@ export function createGatewayCloseHandler(
         warnings,
       });
     } finally {
-      await shutdownStep("plugin-host-registry", clearActivePluginRegistry, warnings);
+      await shutdownStep(
+        "plugin-host-registry",
+        () => clearActivePluginRegistry({ preservePersistentSessionState: true }),
+        warnings,
+      );
       // Rent: plugin cleanup may still read ambient slots, so drain their shared
       // lifecycle only after the registry owner has finished retiring plugins.
       await shutdownStep(

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -23,6 +23,7 @@ import { createLazyGatewayCronState } from "./server-cron-lazy.js";
 import { createGatewayCronReconciliation } from "./server-cron-reconciled.js";
 import { applyGatewayLaneConcurrency, resolveGatewayLaneConcurrency } from "./server-lanes.js";
 import { createGatewayServerLiveState } from "./server-live-state.js";
+import { emitSessionsChanged } from "./server-methods/session-change-event.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import {
   createGatewayPluginRuntimeGeneration,
@@ -362,6 +363,17 @@ export async function prepareGatewayLifecycle(params: {
   const pluginHostServices = {
     get cron() {
       return runtimeState.cronState.cron;
+    },
+    sessionChanged(event: { sessionKey: string; reason: string }) {
+      emitSessionsChanged(
+        {
+          broadcastToConnIds,
+          chatAbortControllers,
+          getRuntimeConfig,
+          getSessionEventSubscriberConnIds: () => sessionEventSubscribers.getAll(),
+        },
+        event,
+      );
     },
   };
 

--- a/src/gateway/server-shutdown.runtime.test.ts
+++ b/src/gateway/server-shutdown.runtime.test.ts
@@ -90,7 +90,10 @@ describe("gateway shutdown runtime", () => {
     expect(runtime.createGatewayCloseHandler).toBe(state.close);
     expect(runtime.flushPendingSessionsChangedEvents).toBe(state.flushSessionChanges);
     expect(runtime.runGlobalGatewayStopSafely).toBe(state.stopPlugins);
-    expect(runtime.clearActivePluginRegistry).toBe(state.clearPluginRegistry);
+    await runtime.clearActivePluginRegistry();
+    expect(state.clearPluginRegistry).toHaveBeenCalledWith({
+      preservePersistentSessionState: true,
+    });
     expect(state.preparePluginRegistryShutdown).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/server-shutdown.runtime.ts
+++ b/src/gateway/server-shutdown.runtime.ts
@@ -42,7 +42,8 @@ export async function prepareGatewayShutdownRuntime() {
     stopGmailWatcher,
     disposeAllCodeModeRuns,
     closeProviderTransportDispatcherPool,
-    clearActivePluginRegistry,
+    clearActivePluginRegistry: () =>
+      clearActivePluginRegistry({ preservePersistentSessionState: true }),
   };
 }
 

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -65,6 +65,9 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     registerAgentToolResultMiddleware() {},
     registerDetachedTaskRuntime() {},
     registerSessionExtension() {},
+    getSessionExtension: () => undefined,
+    setSessionExtension: async ({ value }) => value,
+    clearSessionExtension: async () => {},
     enqueueNextTurnInjection: async (injection) => ({
       enqueued: false,
       id: "",

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -65,9 +65,6 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     registerAgentToolResultMiddleware() {},
     registerDetachedTaskRuntime() {},
     registerSessionExtension() {},
-    getSessionExtension: () => undefined,
-    setSessionExtension: async ({ value }) => value,
-    clearSessionExtension: async () => {},
     enqueueNextTurnInjection: async (injection) => ({
       enqueued: false,
       id: "",
@@ -101,7 +98,12 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
   // Facades derive nested `agent`, `lifecycle`, `runContext`, and `session`
   // views from the flat API; explicit overrides below let tests replace only
   // the nested surface under test without rebuilding every no-op method.
-  const withFacades = attachPluginApiFacades(mergedApi);
+  const withFacades = attachPluginApiFacades(mergedApi, {
+    registerSessionExtension: mergedApi.registerSessionExtension,
+    getSessionExtension: session?.state.getSessionExtension ?? (() => undefined),
+    setSessionExtension: session?.state.setSessionExtension ?? (async ({ value }) => value),
+    clearSessionExtension: session?.state.clearSessionExtension ?? (async () => {}),
+  });
   return {
     ...withFacades,
     ...(agent ? { agent } : {}),

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -64,9 +64,6 @@ type BuildPluginApiParams = {
       | "registerCodexAppServerExtensionFactory"
       | "registerAgentToolResultMiddleware"
       | "registerSessionExtension"
-      | "getSessionExtension"
-      | "setSessionExtension"
-      | "clearSessionExtension"
       | "enqueueNextTurnInjection"
       | "registerTrustedToolPolicy"
       | "registerToolMetadata"
@@ -89,7 +86,8 @@ type BuildPluginApiParams = {
       | "registerMemoryPromptPreparation"
       | "registerMemoryCorpusSupplement"
       | "on"
-    >
+    > &
+      OpenClawPluginApi["session"]["state"]
   >;
 };
 
@@ -151,10 +149,12 @@ const noopRegisterCodexAppServerExtensionFactory: OpenClawPluginApi["registerCod
 const noopRegisterAgentToolResultMiddleware: OpenClawPluginApi["registerAgentToolResultMiddleware"] =
   () => {};
 const noopRegisterSessionExtension: OpenClawPluginApi["registerSessionExtension"] = () => {};
-const noopGetSessionExtension: OpenClawPluginApi["getSessionExtension"] = () => undefined;
-const noopSetSessionExtension: OpenClawPluginApi["setSessionExtension"] = async ({ value }) =>
-  value;
-const noopClearSessionExtension: OpenClawPluginApi["clearSessionExtension"] = async () => {};
+const noopGetSessionExtension: OpenClawPluginApi["session"]["state"]["getSessionExtension"] = () =>
+  undefined;
+const noopSetSessionExtension: OpenClawPluginApi["session"]["state"]["setSessionExtension"] =
+  async ({ value }) => value;
+const noopClearSessionExtension: OpenClawPluginApi["session"]["state"]["clearSessionExtension"] =
+  async () => {};
 const noopEnqueueNextTurnInjection: OpenClawPluginApi["enqueueNextTurnInjection"] = async (
   injection,
 ) => ({ enqueued: false, id: "", sessionKey: injection.sessionKey });
@@ -274,9 +274,6 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     registerAgentToolResultMiddleware:
       handlers.registerAgentToolResultMiddleware ?? noopRegisterAgentToolResultMiddleware,
     registerSessionExtension: handlers.registerSessionExtension ?? noopRegisterSessionExtension,
-    getSessionExtension: handlers.getSessionExtension ?? noopGetSessionExtension,
-    setSessionExtension: handlers.setSessionExtension ?? noopSetSessionExtension,
-    clearSessionExtension: handlers.clearSessionExtension ?? noopClearSessionExtension,
     enqueueNextTurnInjection: handlers.enqueueNextTurnInjection ?? noopEnqueueNextTurnInjection,
     registerTrustedToolPolicy: handlers.registerTrustedToolPolicy ?? noopRegisterTrustedToolPolicy,
     registerToolMetadata: handlers.registerToolMetadata ?? noopRegisterToolMetadata,
@@ -310,5 +307,10 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     resolvePath: params.resolvePath,
     on: handlers.on ?? noopOn,
   };
-  return attachPluginApiFacades(api);
+  return attachPluginApiFacades(api, {
+    registerSessionExtension: api.registerSessionExtension,
+    getSessionExtension: handlers.getSessionExtension ?? noopGetSessionExtension,
+    setSessionExtension: handlers.setSessionExtension ?? noopSetSessionExtension,
+    clearSessionExtension: handlers.clearSessionExtension ?? noopClearSessionExtension,
+  });
 }

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -64,6 +64,9 @@ type BuildPluginApiParams = {
       | "registerCodexAppServerExtensionFactory"
       | "registerAgentToolResultMiddleware"
       | "registerSessionExtension"
+      | "getSessionExtension"
+      | "setSessionExtension"
+      | "clearSessionExtension"
       | "enqueueNextTurnInjection"
       | "registerTrustedToolPolicy"
       | "registerToolMetadata"
@@ -148,6 +151,10 @@ const noopRegisterCodexAppServerExtensionFactory: OpenClawPluginApi["registerCod
 const noopRegisterAgentToolResultMiddleware: OpenClawPluginApi["registerAgentToolResultMiddleware"] =
   () => {};
 const noopRegisterSessionExtension: OpenClawPluginApi["registerSessionExtension"] = () => {};
+const noopGetSessionExtension: OpenClawPluginApi["getSessionExtension"] = () => undefined;
+const noopSetSessionExtension: OpenClawPluginApi["setSessionExtension"] = async ({ value }) =>
+  value;
+const noopClearSessionExtension: OpenClawPluginApi["clearSessionExtension"] = async () => {};
 const noopEnqueueNextTurnInjection: OpenClawPluginApi["enqueueNextTurnInjection"] = async (
   injection,
 ) => ({ enqueued: false, id: "", sessionKey: injection.sessionKey });
@@ -267,6 +274,9 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     registerAgentToolResultMiddleware:
       handlers.registerAgentToolResultMiddleware ?? noopRegisterAgentToolResultMiddleware,
     registerSessionExtension: handlers.registerSessionExtension ?? noopRegisterSessionExtension,
+    getSessionExtension: handlers.getSessionExtension ?? noopGetSessionExtension,
+    setSessionExtension: handlers.setSessionExtension ?? noopSetSessionExtension,
+    clearSessionExtension: handlers.clearSessionExtension ?? noopClearSessionExtension,
     enqueueNextTurnInjection: handlers.enqueueNextTurnInjection ?? noopEnqueueNextTurnInjection,
     registerTrustedToolPolicy: handlers.registerTrustedToolPolicy ?? noopRegisterTrustedToolPolicy,
     registerToolMetadata: handlers.registerToolMetadata ?? noopRegisterToolMetadata,

--- a/src/plugins/api-facades.ts
+++ b/src/plugins/api-facades.ts
@@ -10,9 +10,11 @@ export type OpenClawPluginApiWithoutFacades = Omit<OpenClawPluginApi, keyof Plug
 type PluginApiFacadeSource = Pick<
   OpenClawPluginApi,
   | "clearRunContext"
+  | "clearSessionExtension"
   | "emitAgentEvent"
   | "enqueueNextTurnInjection"
   | "getRunContext"
+  | "getSessionExtension"
   | "registerAgentEventSubscription"
   | "registerControlUiDescriptor"
   | "registerRuntimeLifecycle"
@@ -22,6 +24,7 @@ type PluginApiFacadeSource = Pick<
   | "scheduleSessionTurn"
   | "sendSessionAttachment"
   | "setRunContext"
+  | "setSessionExtension"
   | "unscheduleSessionTurnsByTag"
 >;
 
@@ -32,6 +35,9 @@ export function attachPluginApiFacades<T extends object>(
   api.session = {
     state: {
       registerSessionExtension: (...args) => api.registerSessionExtension(...args),
+      getSessionExtension: (...args) => api.getSessionExtension(...args),
+      setSessionExtension: (...args) => api.setSessionExtension(...args),
+      clearSessionExtension: (...args) => api.clearSessionExtension(...args),
     },
     workflow: {
       enqueueNextTurnInjection: (...args) => api.enqueueNextTurnInjection(...args),

--- a/src/plugins/api-facades.ts
+++ b/src/plugins/api-facades.ts
@@ -10,11 +10,9 @@ export type OpenClawPluginApiWithoutFacades = Omit<OpenClawPluginApi, keyof Plug
 type PluginApiFacadeSource = Pick<
   OpenClawPluginApi,
   | "clearRunContext"
-  | "clearSessionExtension"
   | "emitAgentEvent"
   | "enqueueNextTurnInjection"
   | "getRunContext"
-  | "getSessionExtension"
   | "registerAgentEventSubscription"
   | "registerControlUiDescriptor"
   | "registerRuntimeLifecycle"
@@ -24,20 +22,22 @@ type PluginApiFacadeSource = Pick<
   | "scheduleSessionTurn"
   | "sendSessionAttachment"
   | "setRunContext"
-  | "setSessionExtension"
   | "unscheduleSessionTurnsByTag"
 >;
+
+type PluginSessionStateFacadeSource = OpenClawPluginApi["session"]["state"];
 
 /** Attaches nested facade namespaces to the flat plugin API implementation. */
 export function attachPluginApiFacades<T extends object>(
   api: T & PluginApiFacadeSource & Partial<PluginApiFacadeFields>,
+  sessionState: PluginSessionStateFacadeSource,
 ): T & PluginApiFacadeFields {
   api.session = {
     state: {
       registerSessionExtension: (...args) => api.registerSessionExtension(...args),
-      getSessionExtension: (...args) => api.getSessionExtension(...args),
-      setSessionExtension: (...args) => api.setSessionExtension(...args),
-      clearSessionExtension: (...args) => api.clearSessionExtension(...args),
+      getSessionExtension: (...args) => sessionState.getSessionExtension(...args),
+      setSessionExtension: (...args) => sessionState.setSessionExtension(...args),
+      clearSessionExtension: (...args) => sessionState.clearSessionExtension(...args),
     },
     workflow: {
       enqueueNextTurnInjection: (...args) => api.enqueueNextTurnInjection(...args),

--- a/src/plugins/api-lifecycle.test.ts
+++ b/src/plugins/api-lifecycle.test.ts
@@ -76,4 +76,35 @@ describe("plugin api lifecycle", () => {
     expect(result).toBeUndefined();
     expect(registerSessionExtension).not.toHaveBeenCalled();
   });
+
+  it("keeps plugin-owned session state access callable after registration", async () => {
+    const getSessionExtension = vi.fn(() => ({ checkpoint: "PR117" }));
+    const setSessionExtension = vi.fn(async ({ value }) => value);
+    const clearSessionExtension = vi.fn(async () => {});
+    const api = captureRegisteredPluginApi({
+      getSessionExtension,
+      setSessionExtension,
+      clearSessionExtension,
+    });
+
+    expect(
+      api.session.state.getSessionExtension({
+        sessionKey: "agent:main:main",
+        namespace: "workflow",
+      }),
+    ).toEqual({ checkpoint: "PR117" });
+    await expect(
+      api.session.state.setSessionExtension({
+        sessionKey: "agent:main:main",
+        namespace: "workflow",
+        value: { checkpoint: "PR118" },
+      }),
+    ).resolves.toEqual({ checkpoint: "PR118" });
+    await expect(
+      api.session.state.clearSessionExtension({
+        sessionKey: "agent:main:main",
+        namespace: "workflow",
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/src/plugins/api-lifecycle.ts
+++ b/src/plugins/api-lifecycle.ts
@@ -19,12 +19,15 @@ type PluginApiLifecyclePolicy = {
 
 const PLUGIN_API_METHOD_POLICIES: Partial<Record<PluginApiMethodName, PluginApiLifecyclePolicy>> = {
   clearRunContext: { phase: "runtime", lateCallable: true },
+  clearSessionExtension: { phase: "runtime", lateCallable: true },
   emitAgentEvent: { phase: "runtime", lateCallable: true },
   enqueueNextTurnInjection: { phase: "runtime", lateCallable: true },
   getRunContext: { phase: "runtime", lateCallable: true },
+  getSessionExtension: { phase: "runtime", lateCallable: true },
   sendSessionAttachment: { phase: "runtime", lateCallable: true },
   scheduleSessionTurn: { phase: "runtime", lateCallable: true },
   setRunContext: { phase: "runtime", lateCallable: true },
+  setSessionExtension: { phase: "runtime", lateCallable: true },
   unscheduleSessionTurnsByTag: { phase: "runtime", lateCallable: true },
 };
 

--- a/src/plugins/api-lifecycle.ts
+++ b/src/plugins/api-lifecycle.ts
@@ -19,15 +19,12 @@ type PluginApiLifecyclePolicy = {
 
 const PLUGIN_API_METHOD_POLICIES: Partial<Record<PluginApiMethodName, PluginApiLifecyclePolicy>> = {
   clearRunContext: { phase: "runtime", lateCallable: true },
-  clearSessionExtension: { phase: "runtime", lateCallable: true },
   emitAgentEvent: { phase: "runtime", lateCallable: true },
   enqueueNextTurnInjection: { phase: "runtime", lateCallable: true },
   getRunContext: { phase: "runtime", lateCallable: true },
-  getSessionExtension: { phase: "runtime", lateCallable: true },
   sendSessionAttachment: { phase: "runtime", lateCallable: true },
   scheduleSessionTurn: { phase: "runtime", lateCallable: true },
   setRunContext: { phase: "runtime", lateCallable: true },
-  setSessionExtension: { phase: "runtime", lateCallable: true },
   unscheduleSessionTurnsByTag: { phase: "runtime", lateCallable: true },
 };
 

--- a/src/plugins/captured-registration.ts
+++ b/src/plugins/captured-registration.ts
@@ -313,6 +313,13 @@ export function createCapturedPluginRegistration(params?: {
         registerSessionExtension(extension: PluginSessionExtensionRegistration) {
           sessionExtensions.push(extension);
         },
+        getSessionExtension() {
+          return undefined;
+        },
+        async setSessionExtension({ value }) {
+          return value;
+        },
+        async clearSessionExtension() {},
         registerTrustedToolPolicy(policy: PluginTrustedToolPolicyRegistration) {
           const matcher = normalizePluginToolMatcher(policy.matcher);
           trustedToolPolicies.push({ ...policy, ...(matcher ? { matcher } : {}) });

--- a/src/plugins/contracts/plugin-session-state-api.contract.test.ts
+++ b/src/plugins/contracts/plugin-session-state-api.contract.test.ts
@@ -6,12 +6,15 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
-import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  replaceSessionEntry,
+  resolveSessionEntryAccessTarget,
+} from "../../config/sessions/session-accessor.js";
 import { withTempConfig } from "../../gateway/test-temp-config.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { createEmptyPluginRegistry } from "../registry-empty.js";
-import { setActivePluginRegistry } from "../runtime.js";
+import { setActivePluginRegistry, stageActivePluginRegistry } from "../runtime.js";
 import { createPluginRecord } from "../status.test-fixtures.js";
 import type { OpenClawPluginApi } from "../types.js";
 
@@ -92,6 +95,87 @@ describe("plugin session state API contract", () => {
               ownerApi?.session.state.setSessionExtension({ ...extension, value: { stale: true } }),
             ).rejects.toThrow("plugin session state API is no longer active: owner-plugin");
             await expect(ownerApi?.session.state.clearSessionExtension(extension)).rejects.toThrow(
+              "plugin session state API is no longer active: owner-plugin",
+            );
+          },
+        }),
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a retained closure during staged replacement and again at the commit edge", async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-plugin-session-state-generation-"),
+    );
+    const storePath = path.join(stateDir, "sessions.json");
+    const config = {
+      agents: { entries: { main: { default: true } } },
+      session: { store: storePath },
+    };
+    const original = createPluginRegistryFixture(config);
+    const replacement = createPluginRegistryFixture(config);
+    let originalApi: OpenClawPluginApi | undefined;
+    let stageReplacementDuringProjection = false;
+    registerTestPlugin({
+      registry: original.registry,
+      config,
+      record: createPluginRecord({ id: "owner-plugin", name: "Owner" }),
+      register(api) {
+        originalApi = api;
+        api.session.state.registerSessionExtension({
+          namespace: "workflow",
+          description: "owner workflow",
+          sessionEntrySlotKey: "approvalSnapshot",
+          sessionEntrySlotSchema: { type: "object" },
+          project: (context) => {
+            if (stageReplacementDuringProjection) {
+              stageActivePluginRegistry(replacement.registry.registry, null, "default");
+            }
+            return context.state;
+          },
+        });
+      },
+    });
+    registerTestPlugin({
+      registry: replacement.registry,
+      config,
+      record: createPluginRecord({ id: "owner-plugin", name: "Owner replacement" }),
+      register(api) {
+        api.session.state.registerSessionExtension({
+          namespace: "workflow",
+          description: "replacement owner workflow",
+        });
+      },
+    });
+    setActivePluginRegistry(original.registry.registry);
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () =>
+        withTempConfig({
+          cfg: config,
+          run: async () => {
+            await replaceSessionEntry({ sessionKey: "agent:main:main", storePath }, {
+              sessionId: "session-id",
+              updatedAt: Date.now(),
+            } as SessionEntry);
+            const extension = { sessionKey: "agent:main:main", namespace: "workflow" };
+            stageReplacementDuringProjection = true;
+            await expect(
+              originalApi?.session.state.setSessionExtension({
+                ...extension,
+                value: { stale: true },
+              }),
+            ).rejects.toThrow("plugin session state API is no longer active: owner-plugin");
+            const persisted = resolveSessionEntryAccessTarget({
+              cfg: config,
+              sessionKey: extension.sessionKey,
+            }).entry;
+            expect(persisted?.pluginExtensions?.["owner-plugin"]).toBeUndefined();
+            expect(
+              (persisted as (SessionEntry & Record<string, unknown>) | undefined)?.approvalSnapshot,
+            ).toBeUndefined();
+            expect(() => originalApi?.session.state.getSessionExtension(extension)).toThrow(
               "plugin session state API is no longer active: owner-plugin",
             );
           },

--- a/src/plugins/contracts/plugin-session-state-api.contract.test.ts
+++ b/src/plugins/contracts/plugin-session-state-api.contract.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  createPluginRegistryFixture,
+  registerTestPlugin,
+} from "openclaw/plugin-sdk/plugin-test-contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { withTempConfig } from "../../gateway/test-temp-config.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { createEmptyPluginRegistry } from "../registry-empty.js";
+import { setActivePluginRegistry } from "../runtime.js";
+import { createPluginRecord } from "../status.test-fixtures.js";
+import type { OpenClawPluginApi } from "../types.js";
+
+describe("plugin session state API contract", () => {
+  afterEach(() => setActivePluginRegistry(createEmptyPluginRegistry()));
+
+  it("isolates ownership, publishes writes, and rejects retained retired APIs", async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-plugin-session-state-api-"),
+    );
+    const storePath = path.join(stateDir, "sessions.json");
+    const config = {
+      agents: { entries: { main: { default: true } } },
+      session: { store: storePath },
+    };
+    const sessionChanged = vi.fn();
+    const { registry } = createPluginRegistryFixture(config, {
+      hostServices: { sessionChanged },
+    });
+    let ownerApi: OpenClawPluginApi | undefined;
+    let otherApi: OpenClawPluginApi | undefined;
+    for (const [id, capture] of [
+      ["owner-plugin", (api: OpenClawPluginApi) => (ownerApi = api)],
+      ["other-plugin", (api: OpenClawPluginApi) => (otherApi = api)],
+    ] as const) {
+      registerTestPlugin({
+        registry,
+        config,
+        record: createPluginRecord({ id, name: id }),
+        register(api) {
+          capture(api);
+          api.session.state.registerSessionExtension({
+            namespace: "workflow",
+            description: `${id} workflow`,
+          });
+        },
+      });
+    }
+    setActivePluginRegistry(registry.registry);
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () =>
+        withTempConfig({
+          cfg: config,
+          run: async () => {
+            await replaceSessionEntry({ sessionKey: "agent:main:main", storePath }, {
+              sessionId: "session-id",
+              updatedAt: Date.now(),
+            } as SessionEntry);
+            const extension = { sessionKey: "agent:main:main", namespace: "workflow" };
+            await expect(
+              ownerApi?.session.state.setSessionExtension({
+                ...extension,
+                value: { checkpoint: "PR117" },
+              }),
+            ).resolves.toEqual({ checkpoint: "PR117" });
+            expect(ownerApi?.session.state.getSessionExtension(extension)).toEqual({
+              checkpoint: "PR117",
+            });
+            expect(otherApi?.session.state.getSessionExtension(extension)).toBeUndefined();
+            expect(sessionChanged).toHaveBeenLastCalledWith({
+              sessionKey: "agent:main:main",
+              reason: "plugin-patch",
+            });
+            await expect(
+              ownerApi?.session.state.clearSessionExtension(extension),
+            ).resolves.toBeUndefined();
+            expect(sessionChanged).toHaveBeenCalledTimes(2);
+
+            setActivePluginRegistry(createEmptyPluginRegistry());
+            expect(() => ownerApi?.session.state.getSessionExtension(extension)).toThrow(
+              "plugin session state API is no longer active: owner-plugin",
+            );
+            await expect(
+              ownerApi?.session.state.setSessionExtension({ ...extension, value: { stale: true } }),
+            ).rejects.toThrow("plugin session state API is no longer active: owner-plugin");
+            await expect(ownerApi?.session.state.clearSessionExtension(extension)).rejects.toThrow(
+              "plugin session state API is no longer active: owner-plugin",
+            );
+          },
+        }),
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/plugins/contracts/plugin-session-state-api.contract.test.ts
+++ b/src/plugins/contracts/plugin-session-state-api.contract.test.ts
@@ -61,9 +61,13 @@ describe("plugin session state API contract", () => {
               updatedAt: Date.now(),
             } as SessionEntry);
             const extension = { sessionKey: "agent:main:main", namespace: "workflow" };
+            expect("getSessionExtension" in (ownerApi as object)).toBe(false);
+            expect("setSessionExtension" in (ownerApi as object)).toBe(false);
+            expect("clearSessionExtension" in (ownerApi as object)).toBe(false);
             await expect(
               ownerApi?.session.state.setSessionExtension({
                 ...extension,
+                namespace: " workflow ",
                 value: { checkpoint: "PR117" },
               }),
             ).resolves.toEqual({ checkpoint: "PR117" });

--- a/src/plugins/contracts/session-entry-projection.contract.test.ts
+++ b/src/plugins/contracts/session-entry-projection.contract.test.ts
@@ -23,6 +23,7 @@ import { createEmptyPluginRegistry } from "../registry-empty.js";
 import { setActivePluginRegistry } from "../runtime.js";
 import { createPluginRecord } from "../status.test-fixtures.js";
 import { runTrustedToolPolicies } from "../trusted-tool-policy.js";
+import type { OpenClawPluginApi } from "../types.js";
 
 const requireRecord = createRequireRecord("object", "expected-label");
 
@@ -103,6 +104,72 @@ describe("plugin session extension SessionEntry projection", () => {
   afterEach(() => {
     setActivePluginRegistry(createEmptyPluginRegistry());
     clearPluginHostRuntimeState();
+  });
+
+  it("lets a plugin access only its own durable session extension", async () => {
+    const { config, registry } = createPluginRegistryFixture();
+    let ownerApi: OpenClawPluginApi | undefined;
+    let otherApi: OpenClawPluginApi | undefined;
+    for (const [id, capture] of [
+      ["owner-plugin", (api: OpenClawPluginApi) => (ownerApi = api)],
+      ["other-plugin", (api: OpenClawPluginApi) => (otherApi = api)],
+    ] as const) {
+      registerTestPlugin({
+        registry,
+        config,
+        record: createPluginRecord({ id, name: id }),
+        register(api) {
+          capture(api);
+          api.session.state.registerSessionExtension({
+            namespace: "workflow",
+            description: `${id} workflow`,
+          });
+        },
+      });
+    }
+    setActivePluginRegistry(registry.registry);
+
+    await withProjectionSessionStore(
+      "openclaw-host-hooks-plugin-access-",
+      async ({ storePath, tempConfig }) => {
+        Object.assign(config, tempConfig);
+        await updateSessionStore(storePath, (store) => {
+          store["agent:main:main"] = {
+            sessionId: "session-id",
+            updatedAt: Date.now(),
+          } as unknown as SessionEntry;
+        });
+        await expect(
+          ownerApi?.session.state.setSessionExtension({
+            sessionKey: "agent:main:main",
+            namespace: "workflow",
+            value: { checkpoint: "PR117" },
+          }),
+        ).resolves.toEqual({ checkpoint: "PR117" });
+        expect(
+          ownerApi?.session.state.getSessionExtension({
+            sessionKey: "agent:main:main",
+            namespace: "workflow",
+          }),
+        ).toEqual({ checkpoint: "PR117" });
+        expect(
+          otherApi?.session.state.getSessionExtension({
+            sessionKey: "agent:main:main",
+            namespace: "workflow",
+          }),
+        ).toBeUndefined();
+        await ownerApi?.session.state.clearSessionExtension({
+          sessionKey: "agent:main:main",
+          namespace: "workflow",
+        });
+        expect(
+          ownerApi?.session.state.getSessionExtension({
+            sessionKey: "agent:main:main",
+            namespace: "workflow",
+          }),
+        ).toBeUndefined();
+      },
+    );
   });
 
   it("mirrors projected values to SessionEntry[slotKey] and clears them on unset", async () => {

--- a/src/plugins/contracts/session-entry-projection.contract.test.ts
+++ b/src/plugins/contracts/session-entry-projection.contract.test.ts
@@ -137,7 +137,7 @@ describe("plugin session extension SessionEntry projection", () => {
           store["agent:main:main"] = {
             sessionId: "session-id",
             updatedAt: Date.now(),
-          } as unknown as SessionEntry;
+          } as SessionEntry;
         });
         await expect(
           ownerApi?.session.state.setSessionExtension({
@@ -146,28 +146,16 @@ describe("plugin session extension SessionEntry projection", () => {
             value: { checkpoint: "PR117" },
           }),
         ).resolves.toEqual({ checkpoint: "PR117" });
-        expect(
-          ownerApi?.session.state.getSessionExtension({
-            sessionKey: "agent:main:main",
-            namespace: "workflow",
-          }),
-        ).toEqual({ checkpoint: "PR117" });
-        expect(
-          otherApi?.session.state.getSessionExtension({
-            sessionKey: "agent:main:main",
-            namespace: "workflow",
-          }),
-        ).toBeUndefined();
+        const extension = { sessionKey: "agent:main:main", namespace: "workflow" };
+        expect(ownerApi?.session.state.getSessionExtension(extension)).toEqual({
+          checkpoint: "PR117",
+        });
+        expect(otherApi?.session.state.getSessionExtension(extension)).toBeUndefined();
         await ownerApi?.session.state.clearSessionExtension({
           sessionKey: "agent:main:main",
           namespace: "workflow",
         });
-        expect(
-          ownerApi?.session.state.getSessionExtension({
-            sessionKey: "agent:main:main",
-            namespace: "workflow",
-          }),
-        ).toBeUndefined();
+        expect(ownerApi?.session.state.getSessionExtension(extension)).toBeUndefined();
       },
     );
   });

--- a/src/plugins/contracts/session-entry-projection.contract.test.ts
+++ b/src/plugins/contracts/session-entry-projection.contract.test.ts
@@ -23,7 +23,6 @@ import { createEmptyPluginRegistry } from "../registry-empty.js";
 import { setActivePluginRegistry } from "../runtime.js";
 import { createPluginRecord } from "../status.test-fixtures.js";
 import { runTrustedToolPolicies } from "../trusted-tool-policy.js";
-import type { OpenClawPluginApi } from "../types.js";
 
 const requireRecord = createRequireRecord("object", "expected-label");
 
@@ -104,60 +103,6 @@ describe("plugin session extension SessionEntry projection", () => {
   afterEach(() => {
     setActivePluginRegistry(createEmptyPluginRegistry());
     clearPluginHostRuntimeState();
-  });
-
-  it("lets a plugin access only its own durable session extension", async () => {
-    const { config, registry } = createPluginRegistryFixture();
-    let ownerApi: OpenClawPluginApi | undefined;
-    let otherApi: OpenClawPluginApi | undefined;
-    for (const [id, capture] of [
-      ["owner-plugin", (api: OpenClawPluginApi) => (ownerApi = api)],
-      ["other-plugin", (api: OpenClawPluginApi) => (otherApi = api)],
-    ] as const) {
-      registerTestPlugin({
-        registry,
-        config,
-        record: createPluginRecord({ id, name: id }),
-        register(api) {
-          capture(api);
-          api.session.state.registerSessionExtension({
-            namespace: "workflow",
-            description: `${id} workflow`,
-          });
-        },
-      });
-    }
-    setActivePluginRegistry(registry.registry);
-
-    await withProjectionSessionStore(
-      "openclaw-host-hooks-plugin-access-",
-      async ({ storePath, tempConfig }) => {
-        Object.assign(config, tempConfig);
-        await updateSessionStore(storePath, (store) => {
-          store["agent:main:main"] = {
-            sessionId: "session-id",
-            updatedAt: Date.now(),
-          } as SessionEntry;
-        });
-        await expect(
-          ownerApi?.session.state.setSessionExtension({
-            sessionKey: "agent:main:main",
-            namespace: "workflow",
-            value: { checkpoint: "PR117" },
-          }),
-        ).resolves.toEqual({ checkpoint: "PR117" });
-        const extension = { sessionKey: "agent:main:main", namespace: "workflow" };
-        expect(ownerApi?.session.state.getSessionExtension(extension)).toEqual({
-          checkpoint: "PR117",
-        });
-        expect(otherApi?.session.state.getSessionExtension(extension)).toBeUndefined();
-        await ownerApi?.session.state.clearSessionExtension({
-          sessionKey: "agent:main:main",
-          namespace: "workflow",
-        });
-        expect(ownerApi?.session.state.getSessionExtension(extension)).toBeUndefined();
-      },
-    );
   });
 
   it("mirrors projected values to SessionEntry[slotKey] and clears them on unset", async () => {

--- a/src/plugins/host-hook-cleanup.ts
+++ b/src/plugins/host-hook-cleanup.ts
@@ -415,6 +415,7 @@ export async function cleanupReplacedPluginHostRegistry(params: {
   previousRegistry?: PluginRegistry | null;
   nextRegistry?: PluginRegistry | null;
   shouldCleanup?: () => boolean;
+  skipPersistentSessionState?: boolean;
 }): Promise<PluginHostCleanupResult> {
   const previousRegistry = params.previousRegistry;
   const shouldCleanup = params.shouldCleanup ?? (() => true);
@@ -445,6 +446,7 @@ export async function cleanupReplacedPluginHostRegistry(params: {
         ? collectSchedulerJobIds(params.nextRegistry, pluginId)
         : undefined,
       shouldCleanup,
+      skipPersistentSessionState: params.skipPersistentSessionState,
       restartPromotedSessionEntrySlotKeys: restarted
         ? collectRestartPromotedSessionEntrySlotKeys(
             previousRegistry,

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -383,6 +383,7 @@ export async function patchPluginSessionExtension(params: {
       entry.updatedAt = Date.now();
       return pluginState[namespace] as PluginJsonValue | undefined;
     },
+    params.assertCurrent ? { assertCommitAllowed: params.assertCurrent } : {},
   );
   if (!updated.found) {
     return { ok: false, error: `unknown session key: ${params.sessionKey}` };

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -65,6 +65,7 @@ function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
         };
       },
     }),
+    api.session.state,
   );
   return {
     api: guardedApi,

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -101,6 +101,19 @@ export type PluginTextTransformRegistration = PluginTextTransforms;
 type OpenClawPluginSessionStateApi = {
   /** Register plugin-owned session state projected into Gateway session rows. */
   registerSessionExtension: (extension: PluginSessionExtensionRegistration) => void;
+  /** Read one JSON-compatible session extension owned by the current plugin. */
+  getSessionExtension: (params: {
+    sessionKey: string;
+    namespace: string;
+  }) => PluginJsonValue | undefined;
+  /** Persist one JSON-compatible session extension owned by the current plugin. */
+  setSessionExtension: (params: {
+    sessionKey: string;
+    namespace: string;
+    value: PluginJsonValue;
+  }) => Promise<PluginJsonValue>;
+  /** Clear one session extension owned by the current plugin. */
+  clearSessionExtension: (params: { sessionKey: string; namespace: string }) => Promise<void>;
 };
 
 type OpenClawPluginSessionWorkflowApi = {
@@ -337,6 +350,19 @@ export type OpenClawPluginApi = {
    * @deprecated Use `api.session.state.registerSessionExtension(...)`.
    */
   registerSessionExtension: (extension: PluginSessionExtensionRegistration) => void;
+  /** @deprecated Use `api.session.state.getSessionExtension(...)`. */
+  getSessionExtension: (params: {
+    sessionKey: string;
+    namespace: string;
+  }) => PluginJsonValue | undefined;
+  /** @deprecated Use `api.session.state.setSessionExtension(...)`. */
+  setSessionExtension: (params: {
+    sessionKey: string;
+    namespace: string;
+    value: PluginJsonValue;
+  }) => Promise<PluginJsonValue>;
+  /** @deprecated Use `api.session.state.clearSessionExtension(...)`. */
+  clearSessionExtension: (params: { sessionKey: string; namespace: string }) => Promise<void>;
   /**
    * Queue one plugin-owned context injection for the next agent turn in a session.
    * @deprecated Use `api.session.workflow.enqueueNextTurnInjection(...)`.

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -350,19 +350,6 @@ export type OpenClawPluginApi = {
    * @deprecated Use `api.session.state.registerSessionExtension(...)`.
    */
   registerSessionExtension: (extension: PluginSessionExtensionRegistration) => void;
-  /** @deprecated Use `api.session.state.getSessionExtension(...)`. */
-  getSessionExtension: (params: {
-    sessionKey: string;
-    namespace: string;
-  }) => PluginJsonValue | undefined;
-  /** @deprecated Use `api.session.state.setSessionExtension(...)`. */
-  setSessionExtension: (params: {
-    sessionKey: string;
-    namespace: string;
-    value: PluginJsonValue;
-  }) => Promise<PluginJsonValue>;
-  /** @deprecated Use `api.session.state.clearSessionExtension(...)`. */
-  clearSessionExtension: (params: { sessionKey: string; namespace: string }) => Promise<void>;
   /**
    * Queue one plugin-owned context injection for the next agent turn in a session.
    * @deprecated Use `api.session.workflow.enqueueNextTurnInjection(...)`.

--- a/src/plugins/plugin-command-runtime.test.ts
+++ b/src/plugins/plugin-command-runtime.test.ts
@@ -80,9 +80,12 @@ describe("plugin command runtime", () => {
     registry.plugins.push({ status: "loaded" } as never);
     setActivePluginRegistry(registry);
 
-    await clearActivePluginRegistry();
+    await clearActivePluginRegistry({ preservePersistentSessionState: true });
 
     expect(cleanupReplacedPluginHostRegistry).toHaveBeenCalledOnce();
+    expect(cleanupReplacedPluginHostRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({ skipPersistentSessionState: true }),
+    );
   });
 
   it("binds the request-scoped registry and scopes provider aliases", async () => {

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -149,7 +149,7 @@ export function createPluginApiFactory(
     setPluginRuntimeRecord(record);
     const sideEffectGuard = createPluginSideEffectGuard(record.id);
     const isLoadedRecordInRegistry = () =>
-      registry.plugins.some((plugin) => plugin.id === record.id && plugin.status === "loaded");
+      registry.plugins.some((plugin) => plugin === record && plugin.status === "loaded");
     const isLoadedRecordInLiveRegistry = () =>
       sideEffectGuard.active &&
       isPluginRegistryActivated(registry) &&
@@ -165,6 +165,11 @@ export function createPluginApiFactory(
       !isPluginRegistryRetired(registry) &&
       (isActivatingLoadedRecord() ||
         (isPluginRegistryActivated(registry) && isLoadedRecordInRegistry()));
+    const assertLoadedRecordInLiveRegistry = () => {
+      if (!isLoadedRecordInLiveRegistry()) {
+        throw new Error(`plugin session state API is no longer active: ${record.id}`);
+      }
+    };
     const resolveCurrentConfig = () => registryParams.runtime.config?.current?.() ?? params.config;
     return buildPluginApi({
       id: record.id,
@@ -249,6 +254,7 @@ export function createPluginApiFactory(
               },
               registerSessionExtension: (extension) => registerSessionExtension(record, extension),
               getSessionExtension: ({ sessionKey, namespace }) => {
+                assertLoadedRecordInLiveRegistry();
                 const pluginState = getPluginSessionExtensionStateSync({
                   // SAFETY: DeepReadonly preserves the OpenClawConfig structure required by the read-only session resolver.
                   cfg: resolveCurrentConfig() as OpenClawConfig,
@@ -258,6 +264,7 @@ export function createPluginApiFactory(
                 return pluginState?.[namespace];
               },
               setSessionExtension: async ({ sessionKey, namespace, value }) => {
+                assertLoadedRecordInLiveRegistry();
                 const result = await patchPluginSessionExtension({
                   // SAFETY: The session patcher reads config routing fields and does not mutate the runtime config object.
                   cfg: resolveCurrentConfig() as OpenClawConfig,
@@ -265,13 +272,19 @@ export function createPluginApiFactory(
                   sessionKey,
                   namespace,
                   value,
+                  assertCurrent: assertLoadedRecordInLiveRegistry,
                 });
                 if (!result.ok || result.value === undefined) {
                   throw new Error(result.ok ? "session extension write failed" : result.error);
                 }
+                registryParams.hostServices?.sessionChanged?.({
+                  sessionKey: result.key,
+                  reason: "plugin-patch",
+                });
                 return result.value;
               },
               clearSessionExtension: async ({ sessionKey, namespace }) => {
+                assertLoadedRecordInLiveRegistry();
                 const result = await patchPluginSessionExtension({
                   // SAFETY: The session patcher reads config routing fields and does not mutate the runtime config object.
                   cfg: resolveCurrentConfig() as OpenClawConfig,
@@ -279,10 +292,15 @@ export function createPluginApiFactory(
                   sessionKey,
                   namespace,
                   unset: true,
+                  assertCurrent: assertLoadedRecordInLiveRegistry,
                 });
                 if (!result.ok) {
                   throw new Error(result.error);
                 }
+                registryParams.hostServices?.sessionChanged?.({
+                  sessionKey: result.key,
+                  reason: "plugin-patch",
+                });
               },
               enqueueNextTurnInjection: (injection) => {
                 if (params.hookPolicy?.allowPromptInjection === false) {

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -14,7 +14,11 @@ import {
   schedulePluginSessionTurn,
   unschedulePluginSessionTurnsByTag,
 } from "./host-hook-scheduled-turns.js";
-import { enqueuePluginNextTurnInjection } from "./host-hook-state.js";
+import {
+  enqueuePluginNextTurnInjection,
+  getPluginSessionExtensionStateSync,
+  patchPluginSessionExtension,
+} from "./host-hook-state.js";
 import { isPluginRegistryActivated, isPluginRegistryRetired } from "./registry-lifecycle.js";
 import type { PluginRegistrars } from "./registry-registrars.js";
 import type { PluginRuntimeResolver } from "./registry-runtime.js";
@@ -161,6 +165,7 @@ export function createPluginApiFactory(
       !isPluginRegistryRetired(registry) &&
       (isActivatingLoadedRecord() ||
         (isPluginRegistryActivated(registry) && isLoadedRecordInRegistry()));
+    const resolveCurrentConfig = () => registryParams.runtime.config?.current?.() ?? params.config;
     return buildPluginApi({
       id: record.id,
       name: record.name,
@@ -243,6 +248,37 @@ export function createPluginApiFactory(
                 registerAgentToolResultMiddleware(record, handler, options, params.hookPolicy);
               },
               registerSessionExtension: (extension) => registerSessionExtension(record, extension),
+              getSessionExtension: ({ sessionKey, namespace }) => {
+                const pluginState = getPluginSessionExtensionStateSync({
+                  cfg: resolveCurrentConfig() as OpenClawConfig,
+                  pluginId: record.id,
+                  sessionKey,
+                });
+                return pluginState?.[namespace];
+              },
+              setSessionExtension: async ({ sessionKey, namespace, value }) => {
+                const result = await patchPluginSessionExtension({
+                  cfg: resolveCurrentConfig() as OpenClawConfig,
+                  pluginId: record.id,
+                  sessionKey,
+                  namespace,
+                  value,
+                });
+                if (!result.ok || result.value === undefined) {
+                  throw new Error(result.ok ? "session extension write failed" : result.error);
+                }
+                return result.value;
+              },
+              clearSessionExtension: async ({ sessionKey, namespace }) => {
+                const result = await patchPluginSessionExtension({
+                  cfg: resolveCurrentConfig() as OpenClawConfig,
+                  pluginId: record.id,
+                  sessionKey,
+                  namespace,
+                  unset: true,
+                });
+                if (!result.ok) throw new Error(result.error);
+              },
               enqueueNextTurnInjection: (injection) => {
                 if (params.hookPolicy?.allowPromptInjection === false) {
                   pushDiagnostic({

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -259,12 +259,13 @@ export function createPluginApiFactory(
               registerSessionExtension: (extension) => registerSessionExtension(record, extension),
               getSessionExtension: ({ sessionKey, namespace }) => {
                 assertLoadedRecordInLiveRegistry();
+                const normalizedNamespace = namespace.trim();
                 const pluginState = getPluginSessionExtensionStateSync({
                   cfg: mutableConfigView(resolveCurrentConfig()),
                   pluginId: record.id,
                   sessionKey,
                 });
-                return pluginState?.[namespace];
+                return pluginState?.[normalizedNamespace];
               },
               setSessionExtension: async ({ sessionKey, namespace, value }) => {
                 assertLoadedRecordInLiveRegistry();

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -31,6 +31,10 @@ import {
 import type { PluginRecord } from "./registry-types.js";
 import type { OpenClawPluginApi, PluginLogger, PluginRegistrationMode } from "./types.js";
 
+function mutableConfigView(config: unknown): OpenClawConfig {
+  return config as OpenClawConfig; // SAFETY: Runtime config snapshots are deeply readonly views of OpenClawConfig.
+}
+
 function normalizeLogger(logger: PluginLogger): PluginLogger {
   return {
     info: logger.info,
@@ -256,8 +260,7 @@ export function createPluginApiFactory(
               getSessionExtension: ({ sessionKey, namespace }) => {
                 assertLoadedRecordInLiveRegistry();
                 const pluginState = getPluginSessionExtensionStateSync({
-                  // SAFETY: DeepReadonly preserves the OpenClawConfig structure required by the read-only session resolver.
-                  cfg: resolveCurrentConfig() as OpenClawConfig,
+                  cfg: mutableConfigView(resolveCurrentConfig()),
                   pluginId: record.id,
                   sessionKey,
                 });
@@ -266,8 +269,7 @@ export function createPluginApiFactory(
               setSessionExtension: async ({ sessionKey, namespace, value }) => {
                 assertLoadedRecordInLiveRegistry();
                 const result = await patchPluginSessionExtension({
-                  // SAFETY: The session patcher reads config routing fields and does not mutate the runtime config object.
-                  cfg: resolveCurrentConfig() as OpenClawConfig,
+                  cfg: mutableConfigView(resolveCurrentConfig()),
                   pluginId: record.id,
                   sessionKey,
                   namespace,
@@ -286,8 +288,7 @@ export function createPluginApiFactory(
               clearSessionExtension: async ({ sessionKey, namespace }) => {
                 assertLoadedRecordInLiveRegistry();
                 const result = await patchPluginSessionExtension({
-                  // SAFETY: The session patcher reads config routing fields and does not mutate the runtime config object.
-                  cfg: resolveCurrentConfig() as OpenClawConfig,
+                  cfg: mutableConfigView(resolveCurrentConfig()),
                   pluginId: record.id,
                   sessionKey,
                   namespace,

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -250,6 +250,7 @@ export function createPluginApiFactory(
               registerSessionExtension: (extension) => registerSessionExtension(record, extension),
               getSessionExtension: ({ sessionKey, namespace }) => {
                 const pluginState = getPluginSessionExtensionStateSync({
+                  // SAFETY: DeepReadonly preserves the OpenClawConfig structure required by the read-only session resolver.
                   cfg: resolveCurrentConfig() as OpenClawConfig,
                   pluginId: record.id,
                   sessionKey,
@@ -258,6 +259,7 @@ export function createPluginApiFactory(
               },
               setSessionExtension: async ({ sessionKey, namespace, value }) => {
                 const result = await patchPluginSessionExtension({
+                  // SAFETY: The session patcher reads config routing fields and does not mutate the runtime config object.
                   cfg: resolveCurrentConfig() as OpenClawConfig,
                   pluginId: record.id,
                   sessionKey,
@@ -271,13 +273,16 @@ export function createPluginApiFactory(
               },
               clearSessionExtension: async ({ sessionKey, namespace }) => {
                 const result = await patchPluginSessionExtension({
+                  // SAFETY: The session patcher reads config routing fields and does not mutate the runtime config object.
                   cfg: resolveCurrentConfig() as OpenClawConfig,
                   pluginId: record.id,
                   sessionKey,
                   namespace,
                   unset: true,
                 });
-                if (!result.ok) throw new Error(result.error);
+                if (!result.ok) {
+                  throw new Error(result.error);
+                }
               },
               enqueueNextTurnInjection: (injection) => {
                 if (params.hookPolicy?.allowPromptInjection === false) {

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -29,6 +29,7 @@ import {
   type PluginSideEffectGuard,
 } from "./registry-state.js";
 import type { PluginRecord } from "./registry-types.js";
+import { getActivePluginRegistry } from "./runtime.js";
 import type { OpenClawPluginApi, PluginLogger, PluginRegistrationMode } from "./types.js";
 
 function mutableConfigView(config: unknown): OpenClawConfig {
@@ -156,6 +157,7 @@ export function createPluginApiFactory(
       registry.plugins.some((plugin) => plugin === record && plugin.status === "loaded");
     const isLoadedRecordInLiveRegistry = () =>
       sideEffectGuard.active &&
+      getActivePluginRegistry() === registry &&
       isPluginRegistryActivated(registry) &&
       !isPluginRegistryRetired(registry) &&
       isLoadedRecordInRegistry();

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -604,6 +604,8 @@ export type PluginRegistryParams = {
   hostServices?: {
     /** May be a live accessor; plugin APIs must read it at call time. */
     cron?: import("../cron/service-contract.js").CronServiceContract;
+    /** Publishes canonical session-row invalidation after host-owned plugin state changes. */
+    sessionChanged?: (event: { sessionKey: string; reason: string }) => void;
   };
   activateGlobalSideEffects?: boolean;
 };

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -74,6 +74,7 @@ const loadPluginHostCleanupRuntime = createLazyRuntimeModule(async () => {
 
 async function cleanupPreviousPluginHostRegistry(params: {
   previousRegistry: PluginRegistry;
+  preservePersistentSessionState?: boolean;
 }): Promise<void> {
   const { getRuntimeConfig, cleanupReplacedPluginHostRegistry } =
     await loadPluginHostCleanupRuntime();
@@ -89,6 +90,7 @@ async function cleanupPreviousPluginHostRegistry(params: {
     previousRegistry: params.previousRegistry,
     nextRegistry,
     shouldCleanup,
+    skipPersistentSessionState: params.preservePersistentSessionState,
   });
   // Per-hook cleanup errors are collected instead of thrown (host-hook-cleanup
   // must finish every plugin); dropping them here would hide broken
@@ -396,7 +398,11 @@ function clearActivePluginRegistryState(): PluginRegistry | null {
   return previousRegistry;
 }
 
-export async function clearActivePluginRegistry(): Promise<void> {
+export async function clearActivePluginRegistry(
+  options: {
+    preservePersistentSessionState?: boolean;
+  } = {},
+): Promise<void> {
   const previousRegistry = clearActivePluginRegistryState();
   const clearVersion = state.activeVersion;
   const clearRegistries = (state.commandRegistryClearRegistries ??= new Map());
@@ -411,7 +417,10 @@ export async function clearActivePluginRegistry(): Promise<void> {
         if (previousRegistry) {
           await waitForPluginCommandExecutions(previousRegistry);
           if (registryHasPluginHostCleanupWork(previousRegistry)) {
-            await cleanupPreviousPluginHostRegistry({ previousRegistry });
+            await cleanupPreviousPluginHostRegistry({
+              previousRegistry,
+              preservePersistentSessionState: options.preservePersistentSessionState,
+            });
           }
         }
       } finally {


### PR DESCRIPTION
Closes #127977

## What Problem This Solves

Resolves a problem where external plugins that register durable session
extensions cannot read their own state on later turns or after a Gateway
restart. Without readback, continuity and workflow plugins must fail closed or
maintain a duplicate store that can drift from Gateway session lifecycle.

## Why This Change Was Made

Adds plugin-ID-bound read, write, and clear methods under
`api.session.state`. The host automatically supplies the current plugin ID and
reuses the existing registered-extension persistence path, so no plugin can
request another plugin's state and no new Gateway RPC is exposed.

## User Impact

External plugin authors can safely persist and verify their own registered
session state across turns and Gateway restarts. Existing plugin APIs and
session projections remain backward-compatible.

## Evidence

- Current upstream `main` (`31ce436b` base):
  - session-entry projection contracts: 14/14 passed
  - plugin API lifecycle tests: 3/3 passed
  - complete `corepack pnpm build` passed
- Original `v2026.7.1-2` compatibility proof:
  - 14 contract tests passed
  - 170 loader tests passed
- `corepack pnpm build` passed
- Real isolated Gateway proof passed:
  - write and exact readback
  - full Gateway restart and persisted readback
  - clear and empty readback
  - second plugin could not read the owning plugin's state
- Inspectable redacted trace: [`docs/reference/pr-127982-real-gateway-proof.md`](https://github.com/openclaw/openclaw/blob/9f6fd5642eedfbe247a00d6b80d0ded493f43f40/docs/reference/pr-127982-real-gateway-proof.md)
- Diff check and formatter passed on both bases
