### PR TITLE
fix(config): refuse auto-restore when the clobbered snapshot cannot be written

### DIFF
--- a/src/config/io.clobber-snapshot.ts
+++ b/src/config/io.clobber-snapshot.ts
@@ -259,6 +259,14 @@ function rotateOldestClobberedSiblingsSync(
   return true;
 }
 
+export function formatClobberSnapshotSkipWarning(
+  context: string,
+  configPath: string,
+  reasons: string[],
+): string {
+  return `Config ${context} skipped: could not write the .clobbered.* copy of the current config: ${configPath} (${reasons.join(", ")})`;
+}
+
 function buildClobberedTargetPath(configPath: string, observedAt: string, attempt: number): string {
   const basePath = `${configPath}.clobbered.${formatConfigArtifactTimestamp(observedAt)}`;
   return attempt === 0 ? basePath : `${basePath}-${String(attempt).padStart(2, "0")}`;

--- a/src/config/io.context.ts
+++ b/src/config/io.context.ts
@@ -12,7 +12,7 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { DuplicateAgentDirError, findDuplicateAgentDirs } from "./agent-dirs.js";
 import { applyConfigEnvVars, cloneEnvWithPlatformSemantics } from "./config-env-vars.js";
-import { observeConfigSnapshotSync } from "./io.observe.js";
+import { type ConfigObservationOptions, observeConfigSnapshotSync } from "./io.observe.js";
 import { retainGeneratedOwnerDisplaySecret } from "./io.owner-display-secret.js";
 import { resolveConfigWidePluginMetadataSnapshot } from "./io.plugin-metadata.js";
 import {
@@ -50,7 +50,10 @@ export type ConfigIoContext = {
   pathResolution: { env: NodeJS.ProcessEnv; homedir?: () => string };
   configPath: string;
   options: ConfigIoFactoryOptions;
-  observeLoadConfigSnapshot: (snapshot: ConfigFileSnapshot) => ConfigFileSnapshot;
+  observeLoadConfigSnapshot: (
+    snapshot: ConfigFileSnapshot,
+    observation?: ConfigObservationOptions,
+  ) => ConfigFileSnapshot;
   finalizeLoadedRuntimeConfig: (config: OpenClawConfig) => OpenClawConfig;
   createValidationPluginMetadataSnapshotLoader: (params: {
     effectiveConfigRaw: unknown;
@@ -70,9 +73,12 @@ export function createConfigIoContext(options: ConfigIoFactoryOptions = {}): Con
   // resolvers need the original OS-home fallback or relative overrides expand twice.
   const pathResolution = { env: deps.env, homedir: options.homedir };
 
-  function observeLoadConfigSnapshot(snapshot: ConfigFileSnapshot): ConfigFileSnapshot {
+  function observeLoadConfigSnapshot(
+    snapshot: ConfigFileSnapshot,
+    observation?: ConfigObservationOptions,
+  ): ConfigFileSnapshot {
     if (deps.observe) {
-      observeConfigSnapshotSync(deps, snapshot);
+      observeConfigSnapshotSync(deps, snapshot, observation);
     }
     return snapshot;
   }

--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -138,6 +138,7 @@ export function loadConfigFromContext(
     if (!deps.suppressFutureVersionWarning) {
       warnIfConfigFromFuture(validated.config, deps.logger);
     }
+    let retrySuspiciousRecovery = false;
     if (
       deps.observe &&
       !options.skipSuspiciousRecovery &&
@@ -158,6 +159,7 @@ export function loadConfigFromContext(
         });
         return loadConfigFromContext(context, { skipSuspiciousRecovery: true });
       }
+      retrySuspiciousRecovery = recovery.retrySuspiciousRecovery === true;
     }
     const cfg = materializeRuntimeConfig(validated.config, {
       ...pathResolution,
@@ -178,6 +180,7 @@ export function loadConfigFromContext(
         resolutionFacts: readResolution.resolutionFacts,
         legacyIssues: [],
       }),
+      { recordSuspiciousSignature: !retrySuspiciousRecovery },
     );
     return context.finalizeLoadedRuntimeConfig(cfg);
   } catch (error) {

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -340,6 +340,30 @@ describe("config observe recovery", () => {
       },
     };
   }
+  function withClobberLockMkdirFailure(
+    deps: ObserveRecoveryDeps,
+    configPath: string,
+    error = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }),
+  ): ObserveRecoveryDeps {
+    const lockPath = `${configPath}.clobber.lock`;
+    const mkdir = deps.fs.promises.mkdir.bind(deps.fs.promises);
+    return {
+      ...deps,
+      fs: {
+        ...deps.fs,
+        promises: {
+          ...deps.fs.promises,
+          mkdir: (async (targetPath: fs.PathLike, options?: unknown) => {
+            if (targetPath === lockPath) {
+              throw error;
+            }
+            return await mkdir(targetPath, options as Parameters<typeof mkdir>[1]);
+          }) as typeof deps.fs.promises.mkdir,
+        },
+      },
+    };
+  }
+
   it("auto-restores suspicious update-channel-only roots from backup", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath, warn } = makeDeps(home);
@@ -470,6 +494,110 @@ describe("config observe recovery", () => {
       const observe = await readLastObserveEvent(auditPath);
       expect(observe?.restoredFromBackup).toBe(true);
       expectSuspiciousMatching(observe, /^size-drop-vs-last-good:/);
+    });
+  });
+
+  it("leaves the live config untouched when the async clobbered snapshot cannot be written", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, warn } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      const clobbered = await writeClobberedUpdateChannel(configPath);
+
+      const recovered = await recoverSuspiciousConfigRead({
+        deps: withClobberLockMkdirFailure(deps, configPath),
+        configPath,
+        ...clobbered,
+      });
+
+      expect(recovered.raw).toBe(clobbered.raw);
+      expect(recovered.parsed).toEqual(clobbered.parsed);
+      expect(recovered.retrySuspiciousRecovery).toBe(true);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+      expect(await listClobberFiles(configPath)).toEqual([]);
+      expectWarnContaining(
+        warn,
+        `Config backup restore skipped: could not write the .clobbered.* copy of the current config: ${configPath}`,
+      );
+      expectWarnNotContaining(warn, "Config auto-restored from backup:");
+    });
+  });
+
+  it("leaves the live config untouched when the sync clobbered snapshot cannot be written", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, warn } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      await writeClobberedUpdateChannel(configPath);
+      const lockPath = `${configPath}.clobber.lock`;
+      await fsp.mkdir(lockPath, { mode: 0o700 });
+      try {
+        const recovered = recoverClobberedUpdateChannelSync({ deps, configPath });
+
+        expect(recovered.raw).toBe(clobberedUpdateChannelRaw);
+        expect(recovered.parsed).toEqual(clobberedUpdateChannelConfig);
+        expect(recovered.retrySuspiciousRecovery).toBe(true);
+        await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobberedUpdateChannelRaw);
+        expect(await listClobberFiles(configPath)).toEqual([]);
+        expectWarnContaining(
+          warn,
+          `Config backup restore skipped: could not write the .clobbered.* copy of the current config: ${configPath}`,
+        );
+        expectWarnNotContaining(warn, "Config auto-restored from backup:");
+      } finally {
+        await fsp.rmdir(lockPath);
+      }
+    });
+  });
+
+  it("read snapshots retry backup restore after the snapshot failure clears", async () => {
+    await withSuiteHome(async (home) => {
+      const { io, configPath, warn } = createTestConfigIO(home);
+      await seedConfigBackup(configPath, largeRecoverableCoreConfig);
+      const clobbered = await writeConfigRaw(configPath, {
+        meta: { lastTouchedVersion: "2026.5.28" },
+      });
+      const lockPath = `${configPath}.clobber.lock`;
+      await fsp.mkdir(lockPath, { mode: 0o700 });
+
+      const blocked = await io.readConfigFileSnapshot({ recoverSuspicious: true });
+
+      expect(blocked.raw).toBe(clobbered.raw);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+      expect(await listClobberFiles(configPath)).toEqual([]);
+      expectWarnNotContaining(warn, "Config auto-restored from backup:");
+
+      await fsp.rmdir(lockPath);
+      const retried = await io.readConfigFileSnapshot({ recoverSuspicious: true });
+
+      expect(retried.config.gateway?.mode).toBe("local");
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.not.toBe(clobbered.raw);
+      await expect(listClobberFiles(configPath)).resolves.toHaveLength(1);
+      expectWarnContaining(warn, "Config auto-restored from backup:");
+    });
+  });
+
+  it("loadConfig retries backup restore after the snapshot failure clears", async () => {
+    await withSuiteHome(async (home) => {
+      const { io, configPath, warn } = createTestConfigIO(home);
+      await seedConfigBackup(configPath, largeRecoverableCoreConfig);
+      const clobbered = await writeConfigRaw(configPath, {
+        meta: { lastTouchedVersion: "2026.5.28" },
+      });
+      const lockPath = `${configPath}.clobber.lock`;
+      await fsp.mkdir(lockPath, { mode: 0o700 });
+
+      io.loadConfig();
+
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobbered.raw);
+      expect(await listClobberFiles(configPath)).toEqual([]);
+      expectWarnNotContaining(warn, "Config auto-restored from backup:");
+
+      await fsp.rmdir(lockPath);
+      const retried = io.loadConfig();
+
+      expect(retried.gateway?.mode).toBe("local");
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.not.toBe(clobbered.raw);
+      await expect(listClobberFiles(configPath)).resolves.toHaveLength(1);
+      expectWarnContaining(warn, "Config auto-restored from backup:");
     });
   });
 
@@ -1395,6 +1523,45 @@ describe("config observe recovery", () => {
       await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(brokenRaw);
       await expect(listClobberFiles(configPath)).resolves.toHaveLength(0);
       expectWarnContaining(warn, "candidate cannot converge under the current schema");
+    });
+  });
+
+  it("refuses last-known-good recovery when the clobbered snapshot cannot be written", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, auditPath, warn } = makeDeps(home);
+      const snapshot = await makeSnapshot(configPath, {
+        gateway: { mode: "local", auth: { mode: "token", token: "secret-token" } },
+        channels: { discord: { enabled: true, dmPolicy: "pairing" } },
+      });
+      await expect(
+        promoteConfigSnapshotToLastKnownGoodCore({ deps, snapshot, logger: deps.logger }),
+      ).resolves.toBe(true);
+
+      const brokenRaw = "{ gateway: { mode: 123 } }\n";
+      await fsp.writeFile(configPath, brokenRaw, "utf-8");
+      const restored = await recoverConfigFromLastKnownGoodCore({
+        deps: withClobberLockMkdirFailure(deps, configPath),
+        snapshot: {
+          ...snapshot,
+          raw: brokenRaw,
+          parsed: { gateway: { mode: 123 } },
+          valid: false,
+          issues: [{ path: "gateway.mode", message: "Expected string" }],
+        },
+        reason: "test-invalid-config",
+        prepareCandidate: approveRecoveryCandidate,
+      });
+
+      expect(restored).toBe(false);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(brokenRaw);
+      expect(await listClobberFiles(configPath)).toEqual([]);
+      expectWarnContaining(
+        warn,
+        `Config last-known-good recovery skipped: could not write the .clobbered.* copy of the current config: ${configPath} (test-invalid-config)`,
+      );
+      expectWarnNotContaining(warn, "Config auto-restored from last-known-good:");
+      const observe = await readLastObserveEvent(auditPath);
+      expect(observe?.restoredFromBackup).not.toBe(true);
     });
   });
 

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -5,6 +5,7 @@ import { replaceFileAtomic, replaceFileAtomicSync } from "../infra/replace-file.
 import { isRecord } from "../utils.js";
 import { appendConfigAuditRecord, appendConfigAuditRecordSync } from "./io.audit.js";
 import {
+  formatClobberSnapshotSkipWarning,
   persistBoundedClobberedConfigSnapshot,
   persistBoundedClobberedConfigSnapshotSync,
 } from "./io.clobber-snapshot.js";
@@ -15,8 +16,10 @@ import {
   type ConfigHealthFingerprint,
 } from "./io.health-state.js";
 import {
+  createBackupRestoreAuditAppendParams,
   createConfigHealthFingerprint,
-  createConfigObserveAuditRecord,
+  createConfigObserveAuditAppendParams,
+  extractRestoreErrorDetails,
   readConfigFingerprintForPath,
   readConfigFingerprintForPathSync,
   readConfigHealthEntry,
@@ -84,9 +87,10 @@ type ConfigReadRecoveryParams = {
   allowBackupRecovery?: () => Promise<boolean>;
 };
 
-type ConfigReadRecoveryResult = {
+export type ConfigReadRecoveryResult = {
   raw: string;
   parsed: unknown;
+  retrySuspiciousRecovery?: boolean;
 };
 
 function createRecoveryCommitEffect(params: {
@@ -131,34 +135,12 @@ function createRecoveryCommitEffect(params: {
   };
 }
 
-type ConfigObserveAuditRecordParams = Parameters<typeof createConfigObserveAuditRecord>[0];
-
-function createConfigObserveAuditAppendParams(
-  deps: ObserveRecoveryDeps,
-  params: ConfigObserveAuditRecordParams,
-) {
-  return {
-    env: deps.env,
-    homedir: deps.homedir,
-    record: createConfigObserveAuditRecord(params),
-  };
-}
-
-function extractRestoreErrorDetails(error: unknown): {
-  code: string | null;
-  message: string | null;
-} {
-  if (!error || typeof error !== "object") {
-    return { code: null, message: typeof error === "string" ? error : null };
-  }
-  return {
-    code: "code" in error && typeof error.code === "string" ? error.code : null,
-    message: "message" in error && typeof error.message === "string" ? error.message : null,
-  };
-}
-
 function returnOriginalConfigRead(params: ConfigReadRecoveryParams): ConfigReadRecoveryResult {
   return { raw: params.raw, parsed: params.parsed };
+}
+
+function returnRetryableConfigRead(params: ConfigReadRecoveryParams): ConfigReadRecoveryResult {
+  return { raw: params.raw, parsed: params.parsed, retrySuspiciousRecovery: true };
 }
 
 function parseBackupConfigRaw(
@@ -170,33 +152,6 @@ function parseBackupConfigRaw(
   } catch {
     return null;
   }
-}
-
-function createBackupRestoreAuditAppendParams(params: {
-  deps: ObserveRecoveryDeps;
-  configPath: string;
-  restoredFromBackup: boolean;
-  current: ConfigHealthFingerprint;
-  suspicious: string[];
-  entry: ConfigHealthEntry;
-  backup: ConfigHealthFingerprint | null | undefined;
-  clobberedPath: string | null;
-  backupPath: string;
-  restoreErrorDetails: { code: string | null; message: string | null };
-}) {
-  return createConfigObserveAuditAppendParams(params.deps, {
-    configPath: params.configPath,
-    valid: params.restoredFromBackup,
-    current: params.current,
-    suspicious: params.suspicious,
-    lastKnownGood: params.entry.lastKnownGood,
-    backup: params.backup,
-    clobberedPath: params.clobberedPath,
-    restoredFromBackup: params.restoredFromBackup,
-    restoredBackupPath: params.backupPath,
-    restoreErrorCode: params.restoreErrorDetails.code,
-    restoreErrorMessage: params.restoreErrorDetails.message,
-  });
 }
 
 function isRecoverableConfigReadSuspiciousReason(reason: string): boolean {
@@ -316,7 +271,7 @@ type SuspiciousConfigRecoveryPlan = {
   assertUnchanged: () => void;
   apply: (
     beforeCommit?: () => void,
-  ) => ConfigRecoveryOperation<{ restored: boolean; error: unknown }>;
+  ) => ConfigRecoveryOperation<{ restored: boolean; error: unknown; preserved: boolean }>;
 };
 
 /** Prepare the existing recovery without observing or writing the selected config. */
@@ -359,7 +314,10 @@ function* recoverSuspiciousConfigRead(
       return returnOriginalConfigRead(params);
     }
   }
-  yield* plan.apply();
+  const applied = yield* plan.apply();
+  if (!applied.preserved) {
+    return returnRetryableConfigRead(params);
+  }
   return plan.candidate;
 }
 
@@ -496,6 +454,11 @@ function* planSuspiciousConfigRead(
         sync: () => persistBoundedClobberedConfigSnapshotSync(snapshotParams),
         async: () => persistBoundedClobberedConfigSnapshot(snapshotParams),
       }) as string | null;
+      if (!clobberedPath) {
+        const skipped = formatClobberSnapshotSkipWarning("backup restore", configPath, suspicious);
+        deps.logger.warn(skipped);
+        return { restored: false, error: new Error(skipped), preserved: false };
+      }
       let restoredFromBackup = false;
       let restoreError: unknown;
       try {
@@ -557,7 +520,7 @@ function* planSuspiciousConfigRead(
           }),
         );
       }
-      return { restored: restoredFromBackup, error: restoreError };
+      return { restored: restoredFromBackup, error: restoreError, preserved: true };
     },
   };
 }
@@ -685,6 +648,12 @@ export async function recoverConfigFromLastKnownGoodCore(params: {
     raw: snapshot.raw,
     observedAt: now,
   });
+  if (!clobberedPath) {
+    deps.logger.warn(
+      formatClobberSnapshotSkipWarning("last-known-good recovery", snapshot.path, [params.reason]),
+    );
+    return false;
+  }
   if (recoveryCandidate.raw !== backupRaw) {
     warnIfJSON5CommentsWillBeStripped({
       raw: backupRaw,

--- a/src/config/io.observe-state.ts
+++ b/src/config/io.observe-state.ts
@@ -165,3 +165,56 @@ export function createConfigObserveAuditRecord(params: {
     restoreErrorMessage: params.restoreErrorMessage ?? null,
   };
 }
+
+type ConfigObserveAuditDeps = Pick<NormalizedConfigIoDeps, "env" | "homedir">;
+
+export function createConfigObserveAuditAppendParams(
+  deps: ConfigObserveAuditDeps,
+  params: Parameters<typeof createConfigObserveAuditRecord>[0],
+) {
+  return {
+    env: deps.env,
+    homedir: deps.homedir,
+    record: createConfigObserveAuditRecord(params),
+  };
+}
+
+export function extractRestoreErrorDetails(error: unknown): {
+  code: string | null;
+  message: string | null;
+} {
+  if (!error || typeof error !== "object") {
+    return { code: null, message: typeof error === "string" ? error : null };
+  }
+  return {
+    code: "code" in error && typeof error.code === "string" ? error.code : null,
+    message: "message" in error && typeof error.message === "string" ? error.message : null,
+  };
+}
+
+export function createBackupRestoreAuditAppendParams(params: {
+  deps: ConfigObserveAuditDeps;
+  configPath: string;
+  restoredFromBackup: boolean;
+  current: ConfigHealthFingerprint;
+  suspicious: string[];
+  entry: ConfigHealthEntry;
+  backup: ConfigHealthFingerprint | null | undefined;
+  clobberedPath: string | null;
+  backupPath: string;
+  restoreErrorDetails: { code: string | null; message: string | null };
+}) {
+  return createConfigObserveAuditAppendParams(params.deps, {
+    configPath: params.configPath,
+    valid: params.restoredFromBackup,
+    current: params.current,
+    suspicious: params.suspicious,
+    lastKnownGood: params.entry.lastKnownGood,
+    backup: params.backup,
+    clobberedPath: params.clobberedPath,
+    restoredFromBackup: params.restoredFromBackup,
+    restoredBackupPath: params.backupPath,
+    restoreErrorCode: params.restoreErrorDetails.code,
+    restoreErrorMessage: params.restoreErrorDetails.message,
+  });
+}

--- a/src/config/io.observe.ts
+++ b/src/config/io.observe.ts
@@ -54,6 +54,10 @@ function createObservedFingerprint(snapshot: ConfigFileSnapshot, stat: fs.Stats 
   });
 }
 
+export type ConfigObservationOptions = {
+  recordSuspiciousSignature?: boolean;
+};
+
 function resolveObservation(params: {
   snapshot: ConfigFileSnapshot;
   current: ConfigHealthFingerprint;
@@ -95,6 +99,7 @@ function updateHealthyObservation(params: {
 export async function observeConfigSnapshot(
   deps: NormalizedConfigIoDeps,
   snapshot: ConfigFileSnapshot,
+  options?: ConfigObservationOptions,
 ): Promise<void> {
   if (!snapshot.exists || typeof snapshot.raw !== "string") {
     return;
@@ -140,6 +145,9 @@ export async function observeConfigSnapshot(
       backup,
     }),
   });
+  if (options?.recordSuspiciousSignature === false) {
+    return;
+  }
   healthState = updateConfigHealthEntry(healthState, snapshot.path, {
     ...entry,
     lastObservedSuspiciousSignature: signature,
@@ -150,6 +158,7 @@ export async function observeConfigSnapshot(
 export function observeConfigSnapshotSync(
   deps: NormalizedConfigIoDeps,
   snapshot: ConfigFileSnapshot,
+  options?: ConfigObservationOptions,
 ): void {
   if (!snapshot.exists || typeof snapshot.raw !== "string") {
     return;
@@ -193,6 +202,9 @@ export function observeConfigSnapshotSync(
       backup,
     }),
   });
+  if (options?.recordSuspiciousSignature === false) {
+    return;
+  }
   healthState = updateConfigHealthEntry(healthState, snapshot.path, {
     ...entry,
     lastObservedSuspiciousSignature: signature,

--- a/src/config/io.recovery.ts
+++ b/src/config/io.recovery.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { replaceFileAtomic } from "../infra/replace-file.js";
-import { persistBoundedClobberedConfigSnapshot } from "./io.clobber-snapshot.js";
+import {
+  formatClobberSnapshotSkipWarning,
+  persistBoundedClobberedConfigSnapshot,
+} from "./io.clobber-snapshot.js";
 import type { ConfigIoContext } from "./io.context.js";
 import {
   parseConfigJson5,
@@ -37,7 +40,7 @@ async function persistPrefixedConfigRecovery(params: {
   context: ConfigIoContext;
   originalRaw: string;
   recoveredRaw: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const { context } = params;
   const observedAt = new Date().toISOString();
   const clobberedPath = await persistBoundedClobberedConfigSnapshot({
@@ -46,6 +49,12 @@ async function persistPrefixedConfigRecovery(params: {
     raw: params.originalRaw,
     observedAt,
   });
+  if (!clobberedPath) {
+    context.deps.logger.warn(
+      formatClobberSnapshotSkipWarning("prefix recovery", context.configPath, ["non-JSON prefix"]),
+    );
+    return false;
+  }
   // Recovery must publish by rename; a copy fallback can truncate the live config.
   await replaceFileAtomic({
     filePath: context.configPath,
@@ -56,9 +65,9 @@ async function persistPrefixedConfigRecovery(params: {
     fileSystem: context.deps.fs,
   });
   context.deps.logger.warn(
-    `Config auto-stripped non-JSON prefix: ${context.configPath}` +
-      (clobberedPath ? ` (original saved as ${clobberedPath})` : ""),
+    `Config auto-stripped non-JSON prefix: ${context.configPath} (original saved as ${clobberedPath})`,
   );
+  return true;
 }
 
 export async function recoverConfigFromJsonRootSuffixWithContext(
@@ -97,10 +106,9 @@ export async function recoverConfigFromJsonRootSuffixWithContext(
   if (!validated.ok) {
     return false;
   }
-  await persistPrefixedConfigRecovery({
+  return await persistPrefixedConfigRecovery({
     context,
     originalRaw: snapshot.raw,
     recoveredRaw: suffixRecovery.raw,
   });
-  return true;
 }

--- a/src/config/io.snapshot-shared.ts
+++ b/src/config/io.snapshot-shared.ts
@@ -72,10 +72,12 @@ export function createConfigFileSnapshot(params: {
 export async function finalizeReadConfigSnapshotInternalResult(
   deps: NormalizedConfigIoDeps,
   result: ReadConfigFileSnapshotInternalResult,
-  options?: { observe?: boolean },
+  options?: { observe?: boolean; recordSuspiciousSignature?: boolean },
 ): Promise<ReadConfigFileSnapshotInternalResult> {
   if (deps.observe && options?.observe !== false) {
-    await observeConfigSnapshot(deps, result.snapshot);
+    await observeConfigSnapshot(deps, result.snapshot, {
+      recordSuspiciousSignature: options?.recordSuspiciousSignature,
+    });
   }
   return result;
 }

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -285,6 +285,7 @@ export async function readConfigFileSnapshotInternal(
       warnIfConfigFromFuture(validated.config, deps.logger);
     }
     let callerRejectedSuspiciousRecovery = false;
+    let retrySuspiciousRecovery = false;
     if (
       options.recoverSuspicious === true &&
       deps.observe &&
@@ -317,6 +318,7 @@ export async function readConfigFileSnapshotInternal(
             : {}),
         }),
       );
+      retrySuspiciousRecovery = recovery.retrySuspiciousRecovery === true;
       if (recovery.raw !== raw) {
         restoreEnvChangesIfUnchanged({
           env: deps.env,
@@ -366,7 +368,10 @@ export async function readConfigFileSnapshotInternal(
           includeFileTargetsForWrite,
           pluginMetadataSnapshot: pluginMetadata.getSnapshot(),
         },
-        { observe: !callerRejectedSuspiciousRecovery },
+        {
+          observe: !callerRejectedSuspiciousRecovery,
+          recordSuspiciousSignature: !retrySuspiciousRecovery,
+        },
       ),
     );
   } catch (error) {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -829,6 +829,46 @@ describe("config io write", () => {
     ]);
   });
 
+  itWithHome(
+    "leaves the prefixed config untouched when the clobbered snapshot cannot be written",
+    async (home) => {
+      const configPath = configPathForHome(home);
+      const cleanConfig = {
+        gateway: { mode: "local" },
+        agents: { entries: { main: { default: true } } },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `Found and updated: False\n${formatConfig(cleanConfig)}`;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const warn = vi.fn();
+      const io = createHomeConfigIO(home, {
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        logger: { warn, error: vi.fn() },
+      });
+
+      const initialSnapshot = await io.readConfigFileSnapshot();
+      expect(initialSnapshot.valid).toBe(false);
+
+      const lockPath = `${configPath}.clobber.lock`;
+      await fs.mkdir(lockPath, { mode: 0o700 });
+      try {
+        await expect(io.recoverConfigFromJsonRootSuffix(initialSnapshot)).resolves.toBe(false);
+        await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+        const entries = await fs.readdir(path.dirname(configPath));
+        expect(entries.filter((entry) => entry.includes(".clobbered."))).toEqual([]);
+        expectWarnContaining(
+          warn,
+          `Config prefix recovery skipped: could not write the .clobbered.* copy of the current config: ${configPath} (non-JSON prefix)`,
+        );
+        expect(warnMessages(warn).join("\n")).not.toContain(
+          "Config auto-stripped non-JSON prefix:",
+        );
+      } finally {
+        await fs.rmdir(lockPath);
+      }
+    },
+  );
+
   for (const failure of ["write", "chmod", "rename"] as const) {
     itWithHome(`prefix recovery preserves the config after a failed ${failure}`, async (home) => {
       const configPath = configPathForHome(home);


### PR DESCRIPTION
## Summary
Config auto-restore overwrites the live config file even when the forensic `.clobbered.*` copy of the bytes being replaced could not be written. All three recovery paths call the bounded clobber-snapshot helper, which is best-effort and returns `null` on lock-acquire failure, rotation failure, or write failure. None of them checked that result before committing the overwrite. The restore paths never call `maintainConfigBackups`, so the `.clobbered.*` file is the only preservation of the replaced bytes.

Realistic trigger: hand-trim your config (size-drop-vs-last-good), with a stale `openclaw.json.clobber.lock` directory left behind by a killed process (the lock is only reaped after 30s). The next `loadConfig` replaces the trimmed file with the backup, and the trimmed bytes are gone with no copy. An unwritable config directory hits the same `null`. The same held lock makes `doctor --fix` strip the non-JSON prefix from a config with no forensic copy of the removed bytes.

Still live on current main: the three production call sites are unchanged. #137713 made prefix recovery publish by rename and stopped it claiming a snapshot it did not write, but it still writes over the live config when the snapshot is missing, so the operator bytes are still lost. That is an adjacent fix, not this one.

## Root cause
Three destructive config rewrites shared one unchecked precondition.

`src/config/io.observe-recovery.ts`, in the suspicious-read plan's `apply` and in `recoverConfigFromLastKnownGoodCore`. The clobbered path is captured and later written to the audit record, but it was never checked before the recovery commit:

```ts
// before (suspicious-read plan.apply)
const clobberedPath = (yield {
  sync: () => persistBoundedClobberedConfigSnapshotSync(snapshotParams),
  async: () => persistBoundedClobberedConfigSnapshot(snapshotParams),
}) as string | null;
let restoredFromBackup = false;
```

```ts
// before (recoverConfigFromLastKnownGoodCore)
const clobberedPath = await persistBoundedClobberedConfigSnapshot({ ... });
if (recoveryCandidate.raw !== backupRaw) { ... }
await createRecoveryCommitEffect({ deps, configPath: snapshot.path, raw: recoveryCandidate.raw }).async();
```

`src/config/io.recovery.ts`, in `persistPrefixedConfigRecovery`. This is the path `doctor --fix` reaches first for an invalid config, before last-known-good recovery. It wrote the stripped suffix unconditionally and only mentioned the snapshot in the past-tense success message:

```ts
// before (persistPrefixedConfigRecovery)
const clobberedPath = await persistBoundedClobberedConfigSnapshot({ ... });
await replaceFileAtomic({ filePath: context.configPath, content: params.recoveredRaw, ... });
context.deps.logger.warn(
  `Config auto-stripped non-JSON prefix: ${context.configPath}` +
    (clobberedPath ? ` (original saved as ${clobberedPath})` : ""),
);
```

The non-JSON prefix is operator bytes that exist nowhere else once the suffix is published over the file, so the ternary was reporting the data loss rather than preventing it.

`persistBoundedClobberedConfigSnapshot` / `...Sync` in `src/config/io.clobber-snapshot.ts` return `null` from eight paths (lock not acquired, rotation failed, non-EEXIST write error, all attempt slots taken). A destructive overwrite proceeded on the strength of a guard that silently did not run.

## Fix
Make a successful snapshot a precondition for every destructive config rewrite, using each file's existing logger and one shared message. `formatClobberSnapshotSkipWarning` lives in `src/config/io.clobber-snapshot.ts` next to the helper whose failure it describes, so both recovery modules import it instead of duplicating the string.

```ts
// after (suspicious-read plan.apply)
if (!clobberedPath) {
  const skipped = formatClobberSnapshotSkipWarning("backup restore", configPath, suspicious);
  deps.logger.warn(skipped);
  return { restored: false, error: new Error(skipped), preserved: false };
}
```

```ts
// after (recoverConfigFromLastKnownGoodCore)
if (!clobberedPath) {
  deps.logger.warn(
    formatClobberSnapshotSkipWarning("last-known-good recovery", snapshot.path, [params.reason]),
  );
  return false;
}
```

```ts
// after (persistPrefixedConfigRecovery)
if (!clobberedPath) {
  context.deps.logger.warn(
    formatClobberSnapshotSkipWarning("prefix recovery", context.configPath, ["non-JSON prefix"]),
  );
  return false;
}
```

The last-known-good path returns `false`, the same outcome as every other "recovery skipped" branch in that function, and it already clears `lastObservedSuspiciousSignature` only on success, so a later Doctor run retries by itself. Prefix recovery now propagates its result: `persistPrefixedConfigRecovery` returns a boolean and `recoverConfigFromJsonRootSuffixWithContext` returns it, so `doctor --fix` falls through from prefix recovery to last-known-good recovery to its existing invalid-config reporting, exactly as it already does when the suffix does not parse or does not validate. Because the write no longer happens without a snapshot, the `clobberedPath ? ... : ""` ternary in the success message is dead and is replaced by the unconditional form.

## Keeping a failed preservation retryable
A refusal on the suspicious-read path must not look like an anomaly that has already been handled. Returning the unchanged bytes let `io.load.ts` and `io.snapshot.ts` fall through into ordinary observation, which persists `lastObservedSuspiciousSignature`. The next read then exits at `resolveConfigReadRecoveryContext` before it ever reaches the snapshot lock, so a transient preservation failure disabled recovery for those exact bytes permanently, across restarts. `config_health_entries` has no expiry, and the only clears are a healthy observation, a last-known-good promotion, and a successful last-known-good recovery.

The refusal now carries a retryable outcome instead:

- the plan's `apply` reports `preserved: false`, and `recoverSuspiciousConfigRead` returns the original read tagged `retrySuspiciousRecovery`;
- `io.load.ts` and `io.snapshot.ts` pass that through to observation as `recordSuspiciousSignature: false`;
- `observeConfigSnapshot` / `...Sync` still emit `Config observe anomaly` and still append the audit record, and only skip persisting the signature.

So the operator still gets the anomaly warning and the audit trail for the blocked read, and the next read retries the restore once the lock clears or the directory becomes writable. Both public read paths are covered, and both are exercised by the two-read behavior proof below and by regression tests.

## Why this is the right boundary
The recovery functions are the only owners of the "preserve, then overwrite" sequence; the clobber-snapshot helper is deliberately best-effort, so the decision to abort belongs to the callers that overwrite. All three production callers of the helper are now guarded, so the preserve-before-overwrite invariant is uniform rather than per-path. The retry signal is one optional field on the existing recovery result plus one optional field on the existing observation call, rather than a new recovery coordinator or a new stored state column. Audit, health-state, rotation, and permission-hardening behavior on the success path are unchanged, and no caller of the helper is left unguarded.

## Maintainer decision still open
Behavior change to note for review: with an unwritable config directory or a held clobber lock, `doctor --fix` now reports the config as still invalid instead of silently repairing it, and a suspicious read is served from the bytes on disk instead of the backup. That is the intended tradeoff, it is retryable rather than terminal after this revision, and it matches what the other two recovery paths already did before this branch. Accepting that recovery-availability change is a maintainer call and is not resolved by this branch.

Novelty: #76483 and #82012 bounded and rotated the clobbered copies, #75441 logged write failures, #137713 made prefix recovery atomic and stopped it over-reporting the snapshot, and #126932 (open) changes which configs count as clobbered; none of them check the helper result before the commit. #126806 / #90551 are about which configs should be restored, not about restoring without a forensic copy.

## Regression coverage
6 new cases across `src/config/io.observe-recovery.test.ts` and `src/config/io.write-config.test.ts`: async suspicious read, sync suspicious read, last-known-good recovery, held-lock prefix recovery, and the two-read retry sequence through both public read paths (`readConfigFileSnapshot({ recoverSuspicious: true })` and `loadConfig()`).

They assert no `.clobbered.*` file is written, the live bytes are unchanged, the original read (or `false`) is returned, the auto-restored / auto-stripped warning is not emitted, and that the second read after the lock clears does restore and does write exactly one `.clobbered.*` file. Each fails on the original defect. Suite validation is left to CI on this head.

## Real behavior proof
Behavior addressed: config auto-restore (the every-load backup restore, last-known-good recovery, and doctor's prefix-strip recovery) replaced the live config file while the forensic .clobbered.* copy of the replaced bytes was never written, because the helper returned null and the result was never checked; and, once refused, the anomaly was recorded as already handled so recovery never ran again for those bytes.
Real environment tested: real `loadConfig()`, `readConfigFileSnapshot()`, `promoteConfigSnapshotToLastKnownGood()`, `recoverConfigFromLastKnownGood()` and `recoverConfigFromJsonRootSuffix()` from `src/config/io.runtime.ts`, driven with `tsx` against a temp HOME / `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH`, real fs, real SQLite health state, real audit log; nothing mocked. Before run on pristine main c38897f5544081974bc13632c2f1a17337b52ba7, after run on this head 5f927e84f3b24a6959ce3bc78c148b6671b5df8d with identical inputs. Inputs: a 979 byte config promoted as last-known-good and copied to `openclaw.json.bak`, then `openclaw.json` trimmed to 35 bytes; for last-known-good, a 31 byte invalid config; for prefix recovery, a 60 byte config whose first line is `Found and updated: False`. In every scenario an `openclaw.json.clobber.lock` directory is present with a fresh mtime, as left behind by a killed process. The fourth scenario holds that lock for the first read, removes it, and reads again.
Exact steps or command run after this patch: `./node_modules/.bin/tsx clobber-proof.mts` (script seeds the temp dirs above, calls `loadConfig()`, then `recoverConfigFromLastKnownGood`, then `recoverConfigFromJsonRootSuffix`, then the two-read sequence, and reports the live file bytes, the `.clobbered.*` file count, and the `Config ...` warnings emitted)
Evidence after fix:
```
# BEFORE (pristine main c38897f55440)
[loadConfig size-drop + held clobber.lock] live config bytes replaced: true (before=35B after=979B)
[loadConfig size-drop + held clobber.lock] .clobbered.* files: 0
[loadConfig size-drop + held clobber.lock] warn: Config auto-restored from backup: /tmp/clobber-proof-suspicious-MFN4Aj/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)
[recoverConfigFromLastKnownGood + held clobber.lock] returned: true
[recoverConfigFromLastKnownGood + held clobber.lock] live config bytes replaced: true (before=31B after=979B)
[recoverConfigFromLastKnownGood + held clobber.lock] .clobbered.* files: 0
[recoverConfigFromLastKnownGood + held clobber.lock] warn: Config auto-restored from last-known-good: /tmp/clobber-proof-lkg-g951hA/.openclaw/openclaw.json (invalid-config); Rejected validation details: gateway.mode: Invalid input (allowed: "local", "remote").
[doctor prefix-strip recovery + held clobber.lock] returned: true
[doctor prefix-strip recovery + held clobber.lock] live config bytes replaced: true (before=60B after=35B)
[doctor prefix-strip recovery + held clobber.lock] non-JSON prefix still present: false
[doctor prefix-strip recovery + held clobber.lock] .clobbered.* files: 0
[doctor prefix-strip recovery + held clobber.lock] warn: Config auto-stripped non-JSON prefix: /tmp/clobber-proof-prefix-Uwn1sk/.openclaw/openclaw.json
[two-read retry after the lock clears] read 1 (lock held) live config bytes replaced: true (before=35B after=979B)
[two-read retry after the lock clears] read 1 (lock held) .clobbered.* files: 0
[two-read retry after the lock clears] read 1 warn: Config auto-restored from backup: /tmp/clobber-proof-retry-Y6uBlI/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)
[two-read retry after the lock clears] read 2 (lock released) live config bytes restored: false (before=979B after=979B)
[two-read retry after the lock clears] read 2 (lock released) .clobbered.* files: 0

# AFTER (this patch 5f927e84f3b2, identical inputs)
[loadConfig size-drop + held clobber.lock] live config bytes replaced: false (before=35B after=35B)
[loadConfig size-drop + held clobber.lock] .clobbered.* files: 0
[loadConfig size-drop + held clobber.lock] warn: Config backup restore skipped: could not write the .clobbered.* copy of the current config: /tmp/clobber-proof-suspicious-3Pz9hJ/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)
[loadConfig size-drop + held clobber.lock] warn: Config observe anomaly: /tmp/clobber-proof-suspicious-3Pz9hJ/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)
[recoverConfigFromLastKnownGood + held clobber.lock] returned: false
[recoverConfigFromLastKnownGood + held clobber.lock] live config bytes replaced: false (before=31B after=31B)
[recoverConfigFromLastKnownGood + held clobber.lock] .clobbered.* files: 0
[recoverConfigFromLastKnownGood + held clobber.lock] warn: Config last-known-good recovery skipped: could not write the .clobbered.* copy of the current config: /tmp/clobber-proof-lkg-t1AS80/.openclaw/openclaw.json (invalid-config)
[doctor prefix-strip recovery + held clobber.lock] returned: false
[doctor prefix-strip recovery + held clobber.lock] live config bytes replaced: false (before=60B after=60B)
[doctor prefix-strip recovery + held clobber.lock] non-JSON prefix still present: true
[doctor prefix-strip recovery + held clobber.lock] .clobbered.* files: 0
[doctor prefix-strip recovery + held clobber.lock] warn: Config prefix recovery skipped: could not write the .clobbered.* copy of the current config: /tmp/clobber-proof-prefix-UyfPvw/.openclaw/openclaw.json (non-JSON prefix)
[two-read retry after the lock clears] read 1 (lock held) live config bytes replaced: false (before=35B after=35B)
[two-read retry after the lock clears] read 1 (lock held) .clobbered.* files: 0
[two-read retry after the lock clears] read 1 warn: Config backup restore skipped: could not write the .clobbered.* copy of the current config: /tmp/clobber-proof-retry-K4e0qd/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)
[two-read retry after the lock clears] read 1 warn: Config observe anomaly: /tmp/clobber-proof-retry-K4e0qd/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)
[two-read retry after the lock clears] read 2 (lock released) live config bytes restored: true (before=35B after=979B)
[two-read retry after the lock clears] read 2 (lock released) .clobbered.* files: 1
[two-read retry after the lock clears] read 2 warn: Config auto-restored from backup: /tmp/clobber-proof-retry-K4e0qd/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)

# INTERMEDIATE (this patch with the retry signal disabled, reproducing the previously reviewed behavior)
[two-read retry after the lock clears] read 1 (lock held) live config bytes replaced: false (before=35B after=35B)
[two-read retry after the lock clears] read 1 (lock held) .clobbered.* files: 0
[two-read retry after the lock clears] read 1 warn: Config backup restore skipped: could not write the .clobbered.* copy of the current config: /tmp/clobber-proof-retry-SRaeHc/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)
[two-read retry after the lock clears] read 1 warn: Config observe anomaly: /tmp/clobber-proof-retry-SRaeHc/.openclaw/openclaw.json (size-drop-vs-last-good:979->35)
[two-read retry after the lock clears] read 2 (lock released) live config bytes restored: false (before=35B after=35B)
[two-read retry after the lock clears] read 2 (lock released) .clobbered.* files: 0
```
Observed result after fix: with the clobber lock held and zero .clobbered.* files written, the live config bytes are no longer replaced on any of the three paths (35B stays 35B, 31B stays 31B, 60B stays 60B and keeps its non-JSON prefix), last-known-good recovery and prefix recovery both return false, and a skip warning names the reason instead of an auto-restored or auto-stripped message. The fourth scenario shows the refusal is not terminal: read 1 under the held lock preserves the 35 byte file and still reports the anomaly, and read 2 after the lock is removed restores the 979 byte config and writes exactly one .clobbered.* copy. The intermediate block is the same head with the retry signal disabled, which reproduces the reported regression: read 2 leaves the file at 35 bytes and writes no copy.
What was not tested: no run against a real gateway process or the doctor CLI end to end; rotation-failure and unwritable-directory variants of the snapshot helper were not driven separately, only the held-lock variant that produces the same null result; the full suite was left to CI.
