### PR TITLE
fix(backup): keep lagging-schema agents in Git backup --all scope

### DIFF
--- a/src/commands/backup-git.test.ts
+++ b/src/commands/backup-git.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
 import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
@@ -111,6 +112,45 @@ describe("Git backup command agent selection", () => {
 
     expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
     expect(mocks.createGitBackup).toHaveBeenCalledOnce();
+  });
+
+  it("keeps agents with a lagging registry schema version in the --all scope", async () => {
+    const registered = [
+      {
+        agentId: "main",
+        path: "/tmp/state/agents/main/agent/openclaw-agent.sqlite",
+        schemaVersion: OPENCLAW_AGENT_SCHEMA_VERSION,
+      },
+      {
+        agentId: "legacy",
+        path: "/tmp/state/agents/legacy/agent/openclaw-agent.sqlite",
+        schemaVersion: OPENCLAW_AGENT_SCHEMA_VERSION - 1,
+      },
+    ];
+    mocks.listRegisteredAgentDatabases.mockImplementation(
+      (options?: { includeIncompatibleSchemaVersions?: boolean }) =>
+        registered.filter(
+          (entry) =>
+            options?.includeIncompatibleSchemaVersions === true ||
+            entry.schemaVersion === OPENCLAW_AGENT_SCHEMA_VERSION,
+        ),
+    );
+
+    await backupGitCreateCommand(createTestRuntime(), {
+      repository: "/tmp/repository",
+      all: true,
+    });
+
+    expect(mocks.createGitBackup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        all: true,
+        databases: [
+          expect.objectContaining({ identity: { role: "global" } }),
+          expect.objectContaining({ identity: { role: "agent", agentId: "legacy" } }),
+          expect.objectContaining({ identity: { role: "agent", agentId: "main" } }),
+        ],
+      }),
+    );
   });
 
   it("keeps the --all plus explicit-scope conflict ahead of agent validation", async () => {

--- a/src/commands/backup-git.ts
+++ b/src/commands/backup-git.ts
@@ -85,7 +85,13 @@ async function resolveCreateDatabases(runtime: RuntimeEnv, options: BackupGitCre
   // canonical database under the current state dir and skips absent files
   // instead of aborting the whole scheduled run on one dead registration.
   const allAgentIds = options.all
-    ? [...new Set(listOpenClawRegisteredAgentDatabases().map((entry) => entry.agentId))].toSorted()
+    ? [
+        ...new Set(
+          listOpenClawRegisteredAgentDatabases({ includeIncompatibleSchemaVersions: true }).map(
+            (entry) => entry.agentId,
+          ),
+        ),
+      ].toSorted()
     : agents;
   for (const agentId of allAgentIds) {
     const canonicalPath = resolveOpenClawAgentSqlitePath({ agentId });


### PR DESCRIPTION
## Summary
`openclaw backup git create --all` (the scope the scheduled backup cron runs by default, see `src/commands/backup-schedule.ts`) deletes the backup copy of every agent whose registry row carries a schema version that lags the running build. After any upgrade that bumps `OPENCLAW_AGENT_SCHEMA_VERSION`, every agent row lags until that agent database is reopened by the new build, so the next unattended `--all` run prunes those agent scopes from the backup repository and commits the deletion. Later runs never re-add them until the agent happens to be reopened. Live agent databases on disk are untouched; only the backup copy is destroyed.

## Root cause
`src/commands/backup-git.ts` enumerates the `--all` agent set through `listOpenClawRegisteredAgentDatabases()` with no options:

```ts
// before
const allAgentIds = options.all
  ? [...new Set(listOpenClawRegisteredAgentDatabases().map((entry) => entry.agentId))].toSorted()
  : agents;
```

Without `includeIncompatibleSchemaVersions`, `src/state/openclaw-agent-db-registry-listing.ts` filters the rows to `entry.schemaVersion === OPENCLAW_AGENT_SCHEMA_VERSION`, which is the right default for runtime listings but silently narrows what `--all` means. `createGitBackup` in `src/snapshot/git-backup.ts` then runs `removeStaleAgentScopes(repositoryPath)` whenever `params.all` is set, wiping every `agents/<id>` scope in the repository, and re-copies only the enumerated databases. Any agent dropped by the schema filter is pruned from the backup and committed away.

`registerOpenClawAgentDatabase` stamps the running build's constant at registration, so a schema bump leaves every existing row lagging until reopen. The two other callers that need a complete list, `src/commands/doctor-agent-memory-schema.ts` and `src/infra/state-migrations.media-persistence-targets.ts`, already pass `includeIncompatibleSchemaVersions: true`. Backup was the only completeness consumer that did not, and it is the one that deletes.

## Fix
```ts
// after
const allAgentIds = options.all
  ? [
      ...new Set(
        listOpenClawRegisteredAgentDatabases({ includeIncompatibleSchemaVersions: true }).map(
          (entry) => entry.agentId,
        ),
      ),
    ].toSorted()
  : agents;
```

`--all` now means every registered agent regardless of the schema version stamped on its registry row. The existing per-agent canonical-path resolution and ENOENT skip below it are unchanged, so dead registrations are still skipped rather than aborting the run.

## Why this is the right boundary
The registry listing's compatible-only default is deliberate for runtime consumers (`openclaw-agent-db.test.ts` pins "keeps incompatible schema versions maintenance-only"), so changing the default would widen every runtime listing. The scope resolver in `backup-git.ts` is the one place that decides what `--all` enumerates, and it is the only call site that feeds the pruning path: `backup-schedule.ts` builds the `--all` CLI invocation and goes through the same `backupGitCreateCommand`, so the scheduled path is covered by this single change. Explicit `--agent <id>` and `--global` scopes never consulted the registry and are unaffected. `removeStaleAgentScopes` is left as is; pruning agents that were genuinely unregistered is still correct once the enumeration is complete.

## Verification
- `node scripts/run-vitest.mjs src/commands/backup-git.test.ts`: 9 passed with the patch; with `src/commands/backup-git.ts` reverted to pristine `origin/main` the new test `keeps agents with a lagging registry schema version in the --all scope` fails (`createGitBackup` receives only the global and `main` databases) and the other 8 pass.
- The regression test models the registry listing's real schema filter in the mock and asserts the `legacy` agent whose row is stamped `OPENCLAW_AGENT_SCHEMA_VERSION - 1` still reaches `createGitBackup` under `--all`.
- Scoped oxlint, oxfmt, and tsgo were not run locally on this host (shared 2-CPU box under load); CI covers them.

## Real behavior proof
Behavior addressed: `backup git create --all` prunes the backup scope of every agent whose registry row schema version lags the running build, so a scheduled backup after a schema-bumping upgrade deletes agents from the backup repository.
Real environment tested: real `backupGitCreateCommand` driven through `defaultRuntime` with `OPENCLAW_STATE_DIR` pointed at a temp state dir, on pristine main 222a212e78 (the touched files are byte-identical through the rebase base 70c2be7e6a) and on this patch at 233d87a7c8. Everything is real: the state SQLite registry created by `openOpenClawStateDatabase`, two agent databases created and registered by `openOpenClawAgentDatabase`, the real `initializeGitBackupRepository` and `createGitBackup` Git repository in a temp dir, and the real `registerOpenClawAgentDatabase` re-stamp of the `ops` row with `OPENCLAW_AGENT_SCHEMA_VERSION - 1` to reproduce the post-upgrade state. Nothing mocked.
Exact steps or command run after this patch: `node_modules/.bin/tsx proof.mts` from the worktree root, where the script opens the state db, opens and registers agents `main` and `ops`, runs `backupGitCreateCommand(defaultRuntime, { repository, all: true })` once with both rows current, re-stamps the `ops` registry row to schema version 16 via `registerOpenClawAgentDatabase`, runs the identical `--all` command again, and prints `git ls-tree --name-only HEAD agents/` after each run.
Evidence after fix:
```
# BEFORE (pristine main 222a212e78)
running build agent schema version: 17
run1 (all current) registry rows: main@v17, ops@v17
Git backup committed: d9e422adcfa6c4cf1b53b4fd5211542c2f50b5ce
run1 result: {"commit":"d9e422adcf","noChanges":false}
run1 agent scopes in HEAD: ["agents/main","agents/ops"]
run2 (ops row lags) registry rows: main@v17, ops@v16
Git backup committed: 4878d89a9516b1345e2beb0b748ebe06d8edbd3e
run2 result: {"commit":"4878d89a95","noChanges":false}
run2 agent scopes in HEAD: ["agents/main"]
live ops database still on disk: true

# AFTER (this patch 233d87a7c8, identical inputs)
running build agent schema version: 17
run1 (all current) registry rows: main@v17, ops@v17
Git backup committed: 0789252db7840c59cf15111282fa615fd2e4c6c6
run1 result: {"commit":"0789252db7","noChanges":false}
run1 agent scopes in HEAD: ["agents/main","agents/ops"]
run2 (ops row lags) registry rows: main@v17, ops@v16
Git backup committed: 0796c90e9f34f6bdd86085908eb8d696fd3c96ed
run2 result: {"commit":"0796c90e9f","noChanges":false}
run2 agent scopes in HEAD: ["agents/main","agents/ops"]
live ops database still on disk: true
```
Observed result after fix: with the `ops` registry row lagging the running build, the second `--all` run on pristine main commits a tree with only `agents/main`, deleting the `agents/ops` backup scope; with this patch the identical run keeps both `agents/main` and `agents/ops` in HEAD while the live `ops` database is untouched in both cases.
What was not tested: no real push to a remote; the scheduled path was verified by reading `backup-schedule.ts` (it shells out to the same `--all` command) rather than by running the scheduler; a real upgrade that bumps the schema constant was simulated by re-stamping one registry row through `registerOpenClawAgentDatabase`; full build, typecheck, and lint were not run on this host.
