### PR TITLE
perf(sessions): skip duplicate transcript root preparation

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -97,7 +97,7 @@ export function appendTranscriptMessageInTransaction<TMessage>(
   const messageId = options.eventId ?? randomUUID();
   const now = options.now ?? Date.now();
   const finalMessage = serializeForStorage(prepared);
-  ensureTranscriptHeader(database, resolved, options.cwd, now);
+  ensureTranscriptHeader(database, resolved, options.cwd);
   const parentId = resolveTranscriptMessageAppendParent(database, resolved.sessionId, options);
   const event = {
     type: "message",

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -241,7 +241,6 @@ export function ensureTranscriptHeader(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   cwd: string | undefined,
-  now: number,
 ): void {
   const db = getSessionKysely(database.db);
   const existing = executeSqliteQueryTakeFirstSync(
@@ -260,7 +259,6 @@ export function ensureTranscriptHeader(
     scope,
     createSessionTranscriptHeader({ cwd, sessionId: scope.sessionId }),
   );
-  ensureTranscriptSessionRoot(database, scope, now);
 }
 
 export function readActiveTranscriptAppendParentId(


### PR DESCRIPTION
## What Problem This Solves

Fresh SQLite transcript sessions redundantly prepared the same session root between writing the header event and writing the first message event. This added avoidable statements to every first-message append.

## Why This Change Was Made

Header and message event appends already ensure their session root synchronously inside the same SQLite transaction. This removes only the duplicate middle preparation and its now-unused timestamp argument; event order, persistence shape, timestamps, rollback, and publication behavior remain unchanged.

## User Impact

No user-visible behavior changes. New transcript sessions perform less synchronous SQLite work on their first message.

## Evidence

- Exact-current temporary probe: fresh first-message append executes 29 statements on base and 24 on this branch. The call-count probe was removed rather than committing an implementation-coupled test.
- Base and candidate owner/conformance/rollback suites: 5 files, 252 tests passed on each head.
- `node scripts/check-changed.mjs -- src/config/sessions/session-accessor.sqlite-transcript-message-append.ts src/config/sessions/session-accessor.sqlite-transcript-store.ts`
- `GIT_BRANCH=main pnpm build`
- Diff-scoped TruffleHog scan clean; Codex Sol/high autoreview reported no P0/P1 findings.
