### PR TITLE
docs(install): surface desktop app download links for normal-app installs

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -24,7 +24,7 @@ Prefer a normal app download over the CLI? OpenClaw ships desktop companions:
   - All Hub releases: [Windows Hub releases page](https://github.com/openclaw/openclaw-windows-node/releases/latest)
 - **macOS**: the [macOS menu bar app](/platforms/macos) — download the `OpenClaw-<version>.dmg` (preferred) or `.zip` asset from [OpenClaw GitHub releases](https://github.com/openclaw/openclaw/releases), then install and launch **OpenClaw.app**. See the [macOS app page](/platforms/macos) for details, including what to do when the newest release ships no macOS asset.
 
-The desktop apps connect to a local or remote Gateway; the installer script below (or the Hub's built-in setup) provisions that Gateway for you.
+Both desktop apps can provision a local Gateway during first-run setup, or connect to an existing remote Gateway.
 
 ## Recommended: installer script
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,7 +1,8 @@
 ---
-summary: "Install OpenClaw - installer script, npm/pnpm/bun, from source, Docker, and more"
+summary: "Install OpenClaw - desktop app downloads, installer script, npm/pnpm/bun, from source, Docker, and more"
 read_when:
   - You need an install method other than the Getting Started quickstart
+  - You want to download the Windows Hub or macOS desktop app instead of the CLI
   - You want to deploy to a cloud platform
   - You need to update, migrate, or uninstall
 title: "Install"
@@ -12,6 +13,18 @@ title: "Install"
 - **Node 22.22.3+, 24.15+, or 25.9+** - Node 26 is the recommended default; the installer script provisions it automatically when Node is missing.
 - **macOS, Linux, or Windows** - Windows users can start with the native Windows Hub app, the PowerShell CLI installer, or a WSL2 Gateway. See [Windows](/platforms/windows).
 - `pnpm` is only needed if you build from source.
+
+## Download the desktop app
+
+Prefer a normal app download over the CLI? OpenClaw ships desktop companions:
+
+- **Windows**: the [Windows Hub](/platforms/windows#recommended-windows-hub) companion app — a signed installer you download and run like any Windows app, with setup, tray status, chat, and node mode:
+  - [OpenClawCompanion-Setup-x64.exe](https://github.com/openclaw/openclaw-windows-node/releases/latest/download/OpenClawCompanion-Setup-x64.exe)
+  - [OpenClawCompanion-Setup-arm64.exe](https://github.com/openclaw/openclaw-windows-node/releases/latest/download/OpenClawCompanion-Setup-arm64.exe)
+  - All Hub releases: [Windows Hub releases page](https://github.com/openclaw/openclaw-windows-node/releases/latest)
+- **macOS**: the [macOS menu bar app](/platforms/macos) — download the `OpenClaw-<version>.dmg` (preferred) or `.zip` asset from [OpenClaw GitHub releases](https://github.com/openclaw/openclaw/releases), then install and launch **OpenClaw.app**. See the [macOS app page](/platforms/macos) for details, including what to do when the newest release ships no macOS asset.
+
+The desktop apps connect to a local or remote Gateway; the installer script below (or the Hub's built-in setup) provisions that Gateway for you.
 
 ## Recommended: installer script
 


### PR DESCRIPTION
## What Problem This Solves

Docs feedback on `/install`: users arriving at the install page looking for "a link to just download like a normal app" found only installer scripts and CLI methods. The desktop app downloads (Windows Hub, macOS menu bar app) existed on separate platform pages but were not surfaced on the install landing page.

Closes #126694

## Why This Change Was Made

The `/install` page is the natural landing point for "how do I install this like a normal app". The Windows Hub and macOS app are both first-class install paths, but the page only mentioned the Hub in a Note and linked the macOS app nowhere. The fix adds a "Download the desktop app" section directly above the installer script with direct download links, so both audiences (app-first and CLI-first) find their path immediately.

## User Impact

Visitors to `/install` now see direct download links for the Windows Hub (x64/arm64 `releases/latest/download` links + releases page) and the macOS app (dmg/zip assets from GitHub releases) without navigating to platform subpages.

## Evidence

- `git diff --check` clean.
- Link sanity: `/platforms/windows#recommended-windows-hub` and `/platforms/macos` anchors verified against the source docs; download URLs and asset names copied from `docs/platforms/windows.md` and `docs/platforms/macos.md` (the canonical pages), so the install page cannot drift ahead of the platform pages.
- Docs-only change; no code, tests, or generated files touched.
