### PR TITLE
fix(tui): honor system-agent history limit

### DIFF
--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -208,6 +208,55 @@ describe("runSystemAgentTui", () => {
     }
   }, 240_000);
 
+  it("retains and returns only the requested latest history", async () => {
+    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+
+    await runSystemAgentTui(
+      {
+        ...verified,
+        runTui: async (opts) => {
+          const backend = opts.backend as unknown as {
+            sendChat: (opts: { sessionKey: string; message: string }) => Promise<{ runId: string }>;
+            loadHistory: (opts: { sessionKey: string; limit?: number }) => Promise<{
+              messages: Array<{ content: Array<{ text: string }> }>;
+            }>;
+            engine: {
+              handle: () => Promise<never>;
+              dispose: () => Promise<void>;
+            };
+          };
+          backend.engine.handle = () => new Promise(() => {});
+          backend.engine.dispose = async () => undefined;
+
+          for (let index = 1; index <= 201; index += 1) {
+            await backend.sendChat({
+              sessionKey: "agent:openclaw:main",
+              message: `message-${index}`,
+            });
+          }
+
+          const retained = await backend.loadHistory({
+            sessionKey: "agent:openclaw:main",
+            limit: 500,
+          });
+          expect(retained.messages).toHaveLength(200);
+          expect(retained.messages[0]?.content[0]?.text).toBe("message-2");
+
+          const tail = await backend.loadHistory({
+            sessionKey: "agent:openclaw:main",
+            limit: 2,
+          });
+          expect(tail.messages.map((entry) => entry.content[0]?.text)).toEqual([
+            "message-200",
+            "message-201",
+          ]);
+          return { exitReason: "exit" };
+        },
+      },
+      createRuntime(),
+    );
+  });
+
   it("opens the verified setup shell without preparing an unpublished model catalog", async () => {
     const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
     const catalogPreparation = vi.mocked(preparedModelCatalog.loadPreparedModelCatalog);
@@ -265,7 +314,7 @@ describe("runSystemAgentTui", () => {
         ...verified,
         runTui: async (opts) => {
           const backend = opts.backend as unknown as {
-            loadHistory: () => Promise<{ thinkingLevel: string }>;
+            loadHistory: (opts: { sessionKey: string }) => Promise<{ thinkingLevel: string }>;
             listSessions: () => Promise<{
               sessions: Array<{
                 model?: string;
@@ -275,7 +324,9 @@ describe("runSystemAgentTui", () => {
             }>;
           };
 
-          await expect(backend.loadHistory()).resolves.toMatchObject({ thinkingLevel: "high" });
+          await expect(
+            backend.loadHistory({ sessionKey: "agent:openclaw:main" }),
+          ).resolves.toMatchObject({ thinkingLevel: "high" });
           await expect(backend.listSessions()).resolves.toMatchObject({
             sessions: [
               {

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -77,6 +77,7 @@ type SystemAgentTuiRoute = {
 };
 
 const SYSTEM_AGENT_SESSION_KEY = buildAgentMainSessionKey({ agentId: SYSTEM_AGENT_ID });
+const SYSTEM_AGENT_HISTORY_LIMIT = 200;
 
 function createChatEngine(opts: SystemAgentTuiOptions): SystemAgentChatEngine {
   return new SystemAgentChatEngine({
@@ -142,7 +143,7 @@ class SystemAgentTuiBackend implements TuiBackend {
     private readonly route: SystemAgentTuiRoute,
   ) {
     this.engine = engine;
-    this.messages.push(message("assistant", welcome));
+    this.appendMessage(message("assistant", welcome));
   }
 
   setRequestExitHandler(handler: () => void): void {
@@ -171,7 +172,7 @@ class SystemAgentTuiBackend implements TuiBackend {
   async sendChat(opts: ChatSendOptions): Promise<{ runId: string }> {
     const runId = opts.runId ?? randomUUID();
     const text = opts.message.trim();
-    this.messages.push(message("user", opts.message));
+    this.appendMessage(message("user", opts.message));
     // Keep the backend queue ahead of the engine queue so a failed inference
     // turn can retire the session before an already-submitted host command runs.
     const response = this.responseQueue.then(() => this.respond(runId, opts.sessionKey, text));
@@ -183,15 +184,16 @@ class SystemAgentTuiBackend implements TuiBackend {
     return { ok: true, aborted: false };
   }
 
-  async loadHistory(): Promise<{
+  async loadHistory(opts: { sessionKey: string; agentId?: string; limit?: number }): Promise<{
     sessionId: string;
     messages: SystemAgentHistoryMessage[];
     thinkingLevel: string;
     verboseLevel: string;
   }> {
+    const limit = Math.min(opts.limit ?? SYSTEM_AGENT_HISTORY_LIMIT, SYSTEM_AGENT_HISTORY_LIMIT);
     return {
       sessionId: "openclaw",
-      messages: this.messages,
+      messages: limit > 0 ? this.messages.slice(-limit) : [],
       thinkingLevel: this.route.thinkingLevel,
       verboseLevel: "off",
     };
@@ -259,11 +261,8 @@ class SystemAgentTuiBackend implements TuiBackend {
     this.engine = createChatEngine(this.opts);
     this.engineDisposal = null;
     const overview = await loadOverviewForTui(this.opts);
-    this.messages.splice(
-      0,
-      this.messages.length,
-      message("assistant", formatSystemAgentStartupMessage(overview)),
-    );
+    this.messages.length = 0;
+    this.appendMessage(message("assistant", formatSystemAgentStartupMessage(overview)));
     return { ok: true };
   }
 
@@ -301,6 +300,13 @@ class SystemAgentTuiBackend implements TuiBackend {
     return this.engineDisposal;
   }
 
+  private appendMessage(entry: SystemAgentHistoryMessage): void {
+    this.messages.push(entry);
+    if (this.messages.length > SYSTEM_AGENT_HISTORY_LIMIT) {
+      this.messages.splice(0, this.messages.length - SYSTEM_AGENT_HISTORY_LIMIT);
+    }
+  }
+
   private nextSeq(): number {
     this.seq += 1;
     return this.seq;
@@ -324,7 +330,7 @@ class SystemAgentTuiBackend implements TuiBackend {
       "assistant",
       text || "OpenClaw listened and found nothing to change.",
     );
-    this.messages.push(assistant);
+    this.appendMessage(assistant);
     this.emit("chat", {
       runId,
       sessionKey,
@@ -497,7 +503,7 @@ export async function runSystemAgentTui(
       await runTui({
         local: true,
         session: SYSTEM_AGENT_SESSION_KEY,
-        historyLimit: 200,
+        historyLimit: SYSTEM_AGENT_HISTORY_LIMIT,
         backend,
         config: {},
         title: "openclaw setup",


### PR DESCRIPTION
<!-- AI-assisted: implemented and reviewed with Amp/Codex. -->

## What Problem This Solves

Fixes an issue where long local OpenClaw system-agent TUI conversations kept every displayed message in memory and returned the full retained transcript even though the TUI requested a 200-message history limit.

Before the repair, a boundary regression observed 202 entries after the startup message plus 201 user turns; the configured limit was only passed to the renderer and never enforced by the local backend.

## Why This Change Was Made

The system-agent backend now owns one 200-message retention invariant for its welcome, user, assistant, and reset paths. `loadHistory` returns only the requested latest entries, capped at the same canonical limit used to launch the TUI.

This is intentionally local to the in-memory system-agent backend: no protocol, persistence, or public configuration contract changes.

Production LOC: +17/-11 (net +6) | Tests: +53/-2. The small production growth creates one canonical append/eviction owner and removes the duplicated literal at the TUI launch boundary.

## User Impact

Long setup and repair conversations no longer grow the local TUI's displayed-history buffer without bound. Reloads also honor smaller caller-requested history limits while preserving the latest messages.

## Evidence

- Authentic pre-fix regression: expected 200 retained messages, received 202.
- Focused regression: `node scripts/run-vitest.mjs src/system-agent/tui-backend.test.ts -t 'retains and returns only the requested latest history'` — 1 passed.
- Full owner suite: `node scripts/run-vitest.mjs src/system-agent/tui-backend.test.ts` — 11 passed.
- Changed-file gate: `node scripts/check-changed.mjs -- src/system-agent/tui-backend.ts src/system-agent/tui-backend.test.ts` — passed, including formatting, typechecks, lint, import-cycle and policy guards.
- Fresh structured autoreview: clean; no accepted/actionable findings, patch correct (0.99).
- Codex hard gate: inspected Codex `thread/read` plus complete transcript hydration in `codex-rs/tui/src/thread_transcript.rs`, `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`, and `codex-rs/app-server-protocol/src/protocol/common.rs`; that separate persisted app-server path does not participate in this local OpenClaw backend invariant.

No live provider/channel proof was needed: this is a deterministic in-memory local backend contract covered at the `runSystemAgentTui` owner boundary.
