### PR TITLE
fix(signal): keep a redelivered dual-identity message pending until it is delivered

### DIFF
--- a/extensions/signal/src/signal-ingress.test.ts
+++ b/extensions/signal/src/signal-ingress.test.ts
@@ -449,6 +449,71 @@ describe("Signal durable ingress", () => {
     },
   );
 
+  it("keeps a pending dual-identity message dispatchable when it is redelivered behind a busy lane", async () => {
+    await withQueue(async (queue) => {
+      const sender = {
+        senderNumber: "+15550002222",
+        senderUuid: "123e4567-e89b-12d3-a456-426614174000",
+      };
+      const first = signalEvent({ ...sender, timestamp: 1_700_000_000_001, message: "first" });
+      const second = signalEvent({ ...sender, timestamp: 1_700_000_000_002, message: "second" });
+      let adopt: (() => void | Promise<void>) | undefined;
+      const dispatch = vi.fn<SignalIngressDispatch>((_event, lifecycle, payload) => {
+        if (payload.envelope?.dataMessage?.message === "first") {
+          adopt = lifecycle.onAdopted;
+          lifecycle.onDeferred();
+          return { kind: "deferred" } as const;
+        }
+        return undefined;
+      });
+      const started = await startMonitor(queue, dispatch);
+      try {
+        await started.monitor.receive(first);
+        await started.monitor.receive(second);
+        await started.waitForIdle();
+        expect(await queue.listPending()).toHaveLength(1);
+
+        await started.monitor.receive(second);
+        await started.waitForIdle();
+        expect(await queue.listPending()).toHaveLength(1);
+
+        await adopt?.();
+        await started.waitForIdle();
+        expect(dispatch.mock.calls.map((call) => call[2].envelope?.dataMessage?.message)).toEqual([
+          "first",
+          "second",
+        ]);
+        expect(await queue.listPending()).toHaveLength(0);
+      } finally {
+        await started.monitor.stop();
+      }
+    });
+  });
+
+  it("completes a fresh UUID row for a message already delivered under the phone identity", async () => {
+    await withQueue(async (queue) => {
+      const phoneOnly = signalEvent({ senderNumber: "+15550002222" });
+      const withUuid = signalEvent({
+        senderNumber: "+15550002222",
+        senderUuid: "123e4567-e89b-12d3-a456-426614174000",
+      });
+      const dispatch = vi.fn().mockResolvedValue(undefined);
+      const started = await startMonitor(queue, dispatch);
+      try {
+        await started.monitor.receive(phoneOnly);
+        await started.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+
+        await started.monitor.receive(withUuid);
+        await started.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+        expect(await queue.listPending()).toHaveLength(0);
+      } finally {
+        await started.monitor.stop();
+      }
+    });
+  });
+
   it("keeps identity-alias tombstones scoped to their Signal account", async () => {
     await withQueue(async (queue, stateDir) => {
       const otherQueue = createChannelIngressQueueForTests<SignalIngressPayload>({

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -198,14 +198,15 @@ export async function startSignalIngressMonitor(params: {
     },
     deliver: ([event, parsedPayload], lifecycle) =>
       parsedPayload ? params.dispatch(event, lifecycle, parsedPayload) : undefined,
-    onDurableAdmission: async (_event, { facts }) => {
+    onDurableAdmission: async (_event, { facts, queueResult }) => {
       const { numberAliasEventId } = facts as SignalIngressEventFacts;
       if (!numberAliasEventId) {
         return;
       }
       // signal-cli can learn or forget a UUID between redeliveries; bridge both
       // shipped sender IDs before the monitor releases its admission/claim lock.
-      if (!(await ingressQueue.complete(numberAliasEventId))) {
+      const aliasCompleted = await ingressQueue.complete(numberAliasEventId);
+      if (!aliasCompleted && queueResult.kind === "accepted") {
         await ingressQueue.complete(facts.eventId);
       }
     },

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -16,6 +16,7 @@ import {
   createChannelIngressMonitor,
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
+  type CreateChannelIngressMonitorOptions,
 } from "./ingress-monitor.js";
 import { createChannelIngressQueue, type ChannelIngressQueue } from "./ingress-queue.js";
 import type { IngressRetryPolicyConfig } from "./ingress-retry-policy.js";
@@ -71,6 +72,12 @@ function createMonitor(
         waitForDeliveryIdleOnStop?: boolean;
         retryPolicy?: IngressRetryPolicyConfig;
         runPumpTask?: (work: () => Promise<void>) => Promise<void>;
+        onDurableAdmission?: CreateChannelIngressMonitorOptions<
+          RawEvent,
+          string,
+          StoredEvent,
+          unknown
+        >["onDurableAdmission"];
       },
   onError?: (error: unknown) => void,
   abortSignal?: AbortSignal,
@@ -185,6 +192,22 @@ describe("channel ingress monitor", () => {
       await monitor.stop();
 
       expect(prune).not.toHaveBeenCalled();
+    });
+  });
+
+  it("reports the durable enqueue outcome to onDurableAdmission on every admission", async () => {
+    await withQueue(async (queue) => {
+      const outcomes: string[] = [];
+      const monitor = createMonitor(queue, vi.fn(), {
+        onDurableAdmission: (_raw, { queueResult }) => {
+          outcomes.push(queueResult.kind);
+        },
+      });
+
+      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
+      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
+      expect(outcomes).toEqual(["accepted", "pending"]);
+      await monitor.stop();
     });
   });
 

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -158,7 +158,11 @@ export type CreateChannelIngressMonitorOptions<TRaw, TBody, TStoredPayload, TMet
   appendRetryDelaysMs?: readonly number[];
   onDurableAdmission?: (
     raw: TRaw,
-    context: { facts: ChannelIngressMonitorFacts; receivedAt: number },
+    context: {
+      facts: ChannelIngressMonitorFacts;
+      receivedAt: number;
+      queueResult: Awaited<ReturnType<ChannelIngressQueue<TStoredPayload, TMetadata>["enqueue"]>>;
+    },
   ) => void | Promise<void>;
   onAdmissionFailure?: (raw: TRaw, error: unknown) => void | Promise<void>;
   /** False lets repeated requests fill drain capacity while earlier claims remain active. */
@@ -633,18 +637,15 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       }
       admitOptions.pruneTask ??= pruneIfDue("admission");
       await admitOptions.pruneTask;
-      const body = options.payload.serialize(raw, { facts, receivedAt: admitOptions.receivedAt });
+      const { receivedAt } = admitOptions;
+      const body = options.payload.serialize(raw, { facts, receivedAt });
       const payload =
         options.payload.storage === "raw-event"
           ? ({ version: options.payload.version, rawEvent: body } as TStoredPayload)
           : options.payload.encode({ version: options.payload.version, body });
-      const queueResult = await admitOnce({
-        facts,
-        payload,
-        receivedAt: admitOptions.receivedAt,
-      });
+      const queueResult = await admitOnce({ facts, payload, receivedAt });
       admitOptions.onDurablyAdmitted();
-      await options.onDurableAdmission?.(raw, { facts, receivedAt: admitOptions.receivedAt });
+      await options.onDurableAdmission?.(raw, { facts, receivedAt, queueResult });
       return { kind: "durable", queueResult } as const;
     } catch (error) {
       await options.onAdmissionFailure?.(raw, error);


### PR DESCRIPTION
## Summary
A Signal message from a sender whose envelope carries both `sourceUuid` and `sourceNumber` is silently and permanently lost when signal-cli redelivers it while the durable row is still pending. The common way a row sits pending is an earlier message from the same sender still in flight: `claimNext` blocks the sender's lane while that claim is held, so the next message waits. If the SSE stream redelivers the waiting message in that window (reconnect, restart, slow drain), the redelivery marks the real row `completed` and nulls its payload. The drain never dispatches it, later redeliveries hit a completed tombstone, and the message is gone.

## Root cause
`extensions/signal/src/signal-ingress.ts` bridges the UUID and phone identities of one message inside `onDurableAdmission`, which the shared monitor fires after every durable append, including a duplicate append of an already pending id (`src/channels/message/ingress-monitor.ts`, `admitRaw`).

```ts
// before
onDurableAdmission: async (_event, { facts }) => {
  const { numberAliasEventId } = facts as SignalIngressEventFacts;
  if (!numberAliasEventId) {
    return;
  }
  if (!(await ingressQueue.complete(numberAliasEventId))) {
    await ingressQueue.complete(facts.eventId);
  }
},
```

`complete(id)` without a claim token only flips a pending row to completed (wiping `payload_json`) or inserts a completed tombstone; it returns `false` when the row already exists in any non-pending state. On the first admission of a dual-identity envelope the alias tombstone is inserted (`true`). On a redelivery of the same envelope the alias is already tombstoned, so `complete(alias)` returns `false`, and the hook treats that as "this message was already handled under the phone identity" and completes the primary UUID row, which is the still-pending real message. The intent of #118970 was to dedupe a UUID delivery against a phone-only delivery that was already processed; the same `false` is produced by the hook's own earlier tombstone.

## Fix
The monitor already has the enqueue outcome for the row it just appended, so it now passes it to `onDurableAdmission`. Signal only completes the primary row when that row was freshly accepted, which is the only case where an already-bridged alias means the message was processed under the other identity. A duplicate append (`pending`, `claimed`, `completed`, `failed`) leaves the existing row alone.

```ts
// after (src/channels/message/ingress-monitor.ts)
onDurableAdmission?: (
  raw: TRaw,
  context: {
    facts: ChannelIngressMonitorFacts;
    receivedAt: number;
    queueResult: Awaited<ReturnType<ChannelIngressQueue<TStoredPayload, TMetadata>["enqueue"]>>;
  },
) => void | Promise<void>;
...
await options.onDurableAdmission?.(raw, { facts, receivedAt, queueResult });

// after (extensions/signal/src/signal-ingress.ts)
onDurableAdmission: async (_event, { facts, queueResult }) => {
  const { numberAliasEventId } = facts as SignalIngressEventFacts;
  if (!numberAliasEventId) {
    return;
  }
  const aliasCompleted = await ingressQueue.complete(numberAliasEventId);
  if (!aliasCompleted && queueResult.kind === "accepted") {
    await ingressQueue.complete(facts.eventId);
  }
},
```

## Why this is the right boundary
The hook cannot tell "alias already bridged by me" from "alias already processed under the phone identity" using the boolean from `complete` alone; the missing fact is whether the primary row is new, and the monitor is the owner of that fact because it performed the append. Exposing `queueResult` on the hook context is additive: the other two consumers (`extensions/imessage/src/monitor/ingress.ts` advances its recovery cursor, `extensions/slack/src/monitor/ingress.ts` acks the HTTP request) ignore it and keep running on every admission, which they need. The phone-first dedupe from #118970 is preserved: a UUID envelope for a message already completed or claimed under the phone identity still enqueues as `accepted`, sees `complete(alias) === false`, and is completed without a second dispatch.

## Verification
- `node scripts/run-vitest.mjs extensions/signal/src/signal-ingress.test.ts src/channels/message/ingress-monitor.test.ts`: 30 + 29 passed with the patch.
- With the three production files reverted to `origin/main` and the new tests kept, `keeps a pending dual-identity message dispatchable when it is redelivered behind a busy lane` fails with `expected [] to have a length of 1 but got +0` (the pending row was wiped by the redelivery).
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/channels/message/ingress-monitor.ts src/channels/message/ingress-monitor.test.ts`: clean.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/signal/src/signal-ingress.ts extensions/signal/src/signal-ingress.test.ts`: clean.
- `oxfmt --check` on the changed files: clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: clean. `-p test/tsconfig/tsconfig.core.test.json`: no errors in the changed files; the only errors reported are in `ui/` and come from missing `@panzoom/panzoom` and `pako` type packages in the local install.

## Real behavior proof
Behavior addressed: A pending dual-identity Signal message is marked completed with its payload wiped when signal-cli redelivers it behind a busy sender lane, so it is never dispatched.
Real environment tested: `startSignalIngressMonitor` from `extensions/signal/src/signal-ingress.ts` driven through its `receive` entry point over the real `createChannelIngressQueue` SQLite store in a fresh state directory, on pristine main 31ce436b5f69e3343144f55b4a7cba9a656da1a9 and on the patched tree. The durable queue, the shared ingress monitor, lane blocking in `claimNext`, and the drain are all the production code; the only substituted piece is the dispatch callback, which holds the first message as a deferred claim and records what reaches it.
Exact steps or command run after this patch: `./node_modules/.bin/tsx proof-sigdual.mts` from the checkout root. The script sends message `first` (uuid+number, ts 1700000000777) whose dispatch defers and keeps its claim, sends `second` (same sender, ts 1700000000778) which parks behind the busy lane, redelivers `second` unchanged, then adopts `first` and lets the drain run. It prints the pending ids and the raw `status`/`payload_json` of the `second` row after each step from the SQLite file.
Evidence after fix:
```
# BEFORE (pristine main 31ce436b5f)
1 first message dispatched and deferred (claim held, lane busy): ["first"]
2 second message admitted, pending behind busy lane: ["[\"uuid:123e4567-e89b-12d3-a456-426614174099\",1700000000778]"]
  second primary row: status=pending payload_json={"version":1,"receivedAt":1787416619723,"event":{"event":"receive","data":"{\"envelope\":{\"sourceNumber\":\"+15550009999\",\"sourceUuid\":\"123e4567-e89b-12d3-a456-426614174099\",\"timestamp\":1700000000778,\"dataMessage\":{\"timestamp\":1700000000778,\"message\":\"second\"}}}"}}
3 second message redelivered (same uuid+number envelope), pending now: []
  second primary row: status=completed payload_json=null
4 first message adopted, lane free, drained; dispatched: ["first"]
   pending: [] claims: 0
RESULT second message dispatched 0 time(s)

# AFTER (this patch, identical inputs)
1 first message dispatched and deferred (claim held, lane busy): ["first"]
2 second message admitted, pending behind busy lane: ["[\"uuid:123e4567-e89b-12d3-a456-426614174099\",1700000000778]"]
  second primary row: status=pending payload_json={"version":1,"receivedAt":1787416686294,"event":{"event":"receive","data":"{\"envelope\":{\"sourceNumber\":\"+15550009999\",\"sourceUuid\":\"123e4567-e89b-12d3-a456-426614174099\",\"timestamp\":1700000000778,\"dataMessage\":{\"timestamp\":1700000000778,\"message\":\"second\"}}}"}}
3 second message redelivered (same uuid+number envelope), pending now: ["[\"uuid:123e4567-e89b-12d3-a456-426614174099\",1700000000778]"]
  second primary row: status=pending payload_json={"version":1,"receivedAt":1787416686294,"event":{"event":"receive","data":"{\"envelope\":{\"sourceNumber\":\"+15550009999\",\"sourceUuid\":\"123e4567-e89b-12d3-a456-426614174099\",\"timestamp\":1700000000778,\"dataMessage\":{\"timestamp\":1700000000778,\"message\":\"second\"}}}"}}
4 first message adopted, lane free, drained; dispatched: ["first","second"]
   pending: [] claims: 0
RESULT second message dispatched 1 time(s)
```
Observed result after fix: On main the redelivery flips the pending `second` row to `status=completed payload_json=null` and the drain dispatches only `first`; with the patch the row stays `status=pending` with its payload intact through the redelivery and `second` is dispatched exactly once after the lane frees.
What was not tested: No live signal-cli daemon or SSE stream was attached; the redelivery was replayed by calling `receive` with the identical envelope. Full `pnpm build` and the full check suite were not run.
