### PR TITLE
fix(agent-core): requeue undelivered steers when a run aborts

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1189,6 +1189,107 @@ describe("agentLoop tool termination", () => {
     expect(skippedEnd).not.toHaveProperty("errorKind");
   });
 
+  it("requeues a drained steer when the run aborts before delivering it", async () => {
+    const firstReleased = createDeferred();
+    const firstStarted = createDeferred();
+    const secondExecute = vi.fn(async () => ({ content: [], details: {} }));
+    const requestMessages: Message[][] = [];
+    const agent = new Agent({
+      initialState: {
+        model,
+        tools: [
+          {
+            ...makeTool("first", []),
+            execute: async () => {
+              firstStarted.resolve();
+              await firstReleased.promise;
+              return { content: [{ type: "text", text: "first result" }], details: {} };
+            },
+          },
+          { ...makeTool("second", []), execute: secondExecute },
+        ],
+      },
+      streamFn: createTurnSequenceStream(
+        [
+          [
+            { type: "toolCall", id: "call-first", name: "first", arguments: {} },
+            { type: "toolCall", id: "call-second", name: "second", arguments: {} },
+          ],
+          [{ type: "text", text: "handled steer" }],
+        ],
+        requestMessages,
+      ),
+      toolExecution: "sequential",
+    });
+    agent.subscribe(async (event) => {
+      if (event.type === "turn_end" && event.toolResults.length > 0) {
+        await Promise.resolve();
+        agent.abort();
+      }
+    });
+    const steer = { role: "user" as const, content: "actually, stop", timestamp: 2 };
+
+    const run = agent.prompt("start");
+    await firstStarted.promise;
+    agent.steer(steer);
+    firstReleased.resolve();
+    await run;
+
+    expect(secondExecute).not.toHaveBeenCalled();
+    expect(agent.state.messages).not.toContain(steer);
+    expect(agent.hasQueuedMessages()).toBe(true);
+
+    await agent.prompt("again");
+
+    expect(requestMessages).toHaveLength(2);
+    expect(requestMessages[1]?.at(-1)).toBe(steer);
+    expect(agent.hasQueuedMessages()).toBe(false);
+  });
+
+  it("delivers a steer exactly once when the run is not aborted", async () => {
+    const firstReleased = createDeferred();
+    const firstStarted = createDeferred();
+    const requestMessages: Message[][] = [];
+    const agent = new Agent({
+      initialState: {
+        model,
+        tools: [
+          {
+            ...makeTool("first", []),
+            execute: async () => {
+              firstStarted.resolve();
+              await firstReleased.promise;
+              return { content: [{ type: "text", text: "first result" }], details: {} };
+            },
+          },
+          makeTool("second", []),
+        ],
+      },
+      streamFn: createTurnSequenceStream(
+        [
+          [
+            { type: "toolCall", id: "call-first", name: "first", arguments: {} },
+            { type: "toolCall", id: "call-second", name: "second", arguments: {} },
+          ],
+          [{ type: "text", text: "handled steer" }],
+        ],
+        requestMessages,
+      ),
+      toolExecution: "sequential",
+    });
+    const steer = { role: "user" as const, content: "one change", timestamp: 2 };
+
+    const run = agent.prompt("start");
+    await firstStarted.promise;
+    agent.steer(steer);
+    firstReleased.resolve();
+    await run;
+
+    expect(requestMessages).toHaveLength(2);
+    expect(agent.state.messages.filter((message) => message === steer)).toHaveLength(1);
+    expect(agent.hasQueuedMessages()).toBe(false);
+  });
+
   it("uses a private synchronous steer at the scheduler without invoking the public fallback", async () => {
     const steer = { role: "user" as const, content: "redirect", timestamp: 2 };
     let steerReady = false;

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -321,6 +321,10 @@ async function runLoop(
     if (!signal?.aborted) {
       return false;
     }
+    if (pendingMessages.length > 0) {
+      config.restoreUndeliveredMessages?.(pendingMessages);
+      pendingMessages = [];
+    }
     // Persist an aborted assistant outcome so session post-processing does not
     // compact or continue from the preceding toolUse message.
     const abortedMessage = withAssistantTurnTaint(

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -194,6 +194,10 @@ class PendingMessageQueue {
     return [first];
   }
 
+  restore(messages: AgentMessage[]): void {
+    this.messages = [...messages, ...this.messages];
+  }
+
   clear(): void {
     this.messages = [];
   }
@@ -546,6 +550,7 @@ export class Agent {
       getApiKey: this.getApiKey,
       getSteeringMessages,
       getFollowUpMessages: async () => this.followUpQueue.drain(),
+      restoreUndeliveredMessages: (messages) => this.steeringQueue.restore(messages),
     };
   }
 

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -320,6 +320,8 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
    */
   getFollowUpMessages?: () => Promise<AgentMessage[]>;
 
+  restoreUndeliveredMessages?: (messages: AgentMessage[]) => void;
+
   /**
    * Tool execution mode.
    * - "sequential": execute tool calls one by one, checking for steering before each starts


### PR DESCRIPTION
## Summary
Typing a steering message during a multi-tool batch and then aborting the run (Ctrl+C, `/stop`) destroys the steer. The loop has already skipped the remaining tool calls with "Skipped due to queued user message." on that steer's behalf, then the abort lands and the message is gone: not in the transcript, not in the queue, nowhere to recover. The session's display queue still advertises it as pending because `retireQueuedUserMessage` only fires on `message_start`, so the user sees a ghost entry that is never delivered.

Callers that pass `waitForTranscriptCommit: true` (gateway chat send, channel steer adoption, `sessions_send`) are protected by their own commit wait. The direct `AgentSession.steer()` / SDK path and the follow-up queue are not.

## Root cause
`packages/agent-core/src/agent-loop.ts` drains steering messages out of the queue during the tool batch and keeps them only in the loop-local `pendingMessages` variable. `PendingMessageQueue.drain()` in `agent.ts` is destructive. When the abort signal fires before the loop injects them (the window spans every awaited `turn_end` listener, including session persistence), `stopIfAborted` emits the aborted outcome and returns without doing anything with `pendingMessages`:

```ts
// before
const stopIfAborted = async (): Promise<boolean> => {
  if (!signal?.aborted) {
    return false;
  }
  const abortedMessage = withAssistantTurnTaint(
    createFailureMessage(...),
```

```ts
        pendingMessages = executedToolBatch.steeringMessages;
        ...
      await emit({ type: "turn_end", message, toolResults });
      turnOpen = false;
      if (await stopIfAborted()) {
        return;
      }
```

All four `stopIfAborted` call sites that can hold drained messages route through the same closure, so the loss is a single missing step rather than four.

## Fix
`stopIfAborted` hands any undelivered pending messages back before emitting the aborted outcome, through a new optional `restoreUndeliveredMessages` callback on `AgentLoopConfig`. `Agent` wires that callback to put the messages at the front of its steering queue, so `hasQueuedMessages()` is true after the abort and the next `prompt()` / `continue()` delivers them.

```ts
// after
const stopIfAborted = async (): Promise<boolean> => {
  if (!signal?.aborted) {
    return false;
  }
  if (pendingMessages.length > 0) {
    config.restoreUndeliveredMessages?.(pendingMessages);
    pendingMessages = [];
  }
```

```ts
  restore(messages: AgentMessage[]): void {
    this.messages = [...messages, ...this.messages];
  }
  ...
      getFollowUpMessages: async () => this.followUpQueue.drain(),
      restoreUndeliveredMessages: (messages) => this.steeringQueue.restore(messages),
```

## Why this is the right boundary
The loop is the only code that knows a drained message was never injected, and `stopIfAborted` is the one choke point every abort return passes through, so the restore lives there. The queue is owned by `Agent`, so putting messages back is its job via the same config seam it already uses to hand them out (`getSteeringMessages` / `getFollowUpMessages`). The callback is optional, so `runAgentLoop` callers with their own steering getters are unchanged. Follow-up messages drained at the end of a turn go through the same path; they are restored to the steering queue, which delivers no later than the follow-up queue would have. Non-aborted runs never reach the restore, so a steer is still injected exactly once (covered by the second new test). `AgentSession.clearQueue()` already documents that queued messages should survive an abort so they can be returned to the editor; this makes the agent queue agree with the session's display queue.

## Verification
- `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts`: 69 passed (67 existing + 2 new)
- New test `requeues a drained steer when the run aborts before delivering it` fails on pristine main (`expected false to be true` for `agent.hasQueuedMessages()`) and passes with the patch; `delivers a steer exactly once when the run is not aborted` passes on both
- `oxlint` on the four changed files: 0 diagnostics (229 rules)
- `./node_modules/.bin/oxfmt --check` on the four changed files: clean
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: clean
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`: not run locally (machine contention); relying on CI for the test-project typecheck

## Real behavior proof
Behavior addressed: a steer queued during a sequential tool batch is lost when the run aborts during the `turn_end` listener fan-out, after the loop already skipped the remaining tool on its behalf.
Real environment tested: the real `Agent` class from `packages/agent-core/src/index.ts` driven with `tsx`, real `PendingMessageQueue`, real sequential tool execution with two real tool implementations, a real `subscribe` listener that writes the tool results to disk and then calls `agent.abort()` during `turn_end`; on pristine main 31ce436b5f69e3343144f55b4a7cba9a656da1a9 and on the patched tree with identical inputs. The only seam replaced is the provider stream (`streamFn`), which returns a scripted two-tool assistant turn followed by a text turn.
Exact steps or command run after this patch: `TSX_TSCONFIG_PATH=./tsconfig.json node_modules/.bin/tsx .proof/steer-abort-proof.mts` (driver: `agent.prompt("start")`, `agent.steer({ content: "actually, stop" })` while the first tool is blocked, release the tool, abort inside the `turn_end` listener, await the run, then `agent.prompt("again")` and inspect the provider request)
Evidence after fix:
```
# BEFORE (pristine main 31ce436b5f69e3343144f55b4a7cba9a656da1a9)
steered (second tool skipped for the steer): Skipped due to queued user message.
stillQueued after abort: false
inTranscript after abort: false
delivered on next prompt: false
last request tail: [[{"type":"text","text":"<turn_aborted>\nThe previous turn was interrupted. Any running background processes may still be active. If any tools or commands were aborted, they may have partially executed.\n</turn_aborted>"}],[{"type":"text","text":"again"}]]

# AFTER (this patch, identical inputs)
steered (second tool skipped for the steer): Skipped due to queued user message.
stillQueued after abort: true
inTranscript after abort: false
delivered on next prompt: true
last request tail: [[{"type":"text","text":"again"}],"actually, stop"]
```
Observed result after fix: the second tool is still skipped for the steer in both runs, but on main the steer is gone after the abort (not queued, not in the transcript, absent from the next provider request), while with the patch it stays queued and is delivered as the last message of the next provider request.
What was not tested: no live provider request; the gateway chat-send path with `waitForTranscriptCommit` was not exercised since it is already protected; full `pnpm build` and the full test suite were not run.
