### PR TITLE
fix(compaction): keep the previous summary on a prefix-only split-turn pass

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -884,4 +884,70 @@ describe("split-turn compaction", () => {
     expect(streamFn).toHaveBeenCalledTimes(2);
     expect(maxActive).toBe(1);
   });
+  it("keeps the previous summary when only a turn prefix is summarized", async () => {
+    const model: Model = {
+      id: "summary-model",
+      name: "Summary Model",
+      api: "test-api",
+      provider: "test-provider",
+      baseUrl: "https://example.test",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 100_000,
+      maxTokens: 8_000,
+    };
+    const streamFn = vi.fn<StreamFn>(() => {
+      const stream = createAssistantMessageEventStream();
+      const message: AssistantMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: "prefix-summary" }],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      };
+      stream.push({ type: "done", reason: "stop", message });
+      stream.end();
+      return stream;
+    });
+
+    const result = await compact(
+      {
+        firstKeptEntryId: "kept-entry",
+        messagesToSummarize: [],
+        turnPrefixMessages: [{ role: "user", content: "prefix", timestamp: 2 }],
+        isSplitTurn: true,
+        tokensBefore: 100,
+        previousSummary: "Earlier compacted history.",
+        fileOps: createFileOps(),
+        settings: { enabled: true, reserveTokens: 1_000, keepRecentTokens: 100 },
+      },
+      model,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      streamFn,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(streamFn).toHaveBeenCalledTimes(1);
+    expect(result.value.summary).toContain("Earlier compacted history.");
+    expect(result.value.summary).toContain("prefix-summary");
+    expect(result.value.summary).not.toContain("No prior history.");
+  });
 });

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -897,7 +897,7 @@ export async function compact(
           streamFn,
           runtime,
         )
-      : ok<string, CompactionError>("No prior history.");
+      : ok<string, CompactionError>(previousSummary ?? "No prior history.");
   if (!historyResult.ok) {
     return err(historyResult.error);
   }


### PR DESCRIPTION
## Summary
On the default compaction mode, when the cut lands inside the first retained turn after an earlier compaction (the steady state of re-compaction on a long session whose retained tail is one large in-flight turn), the new compaction entry stores the literal string `No prior history.` as its history summary. The previous summary is discarded in one step, the turn prefix is the only context that survives, and the run reports success. Nothing in logs or UI indicates that all distilled history was thrown away.

## Root cause
`packages/agent-core/src/harness/compaction/compaction.ts:900` in `compact()`. When `messagesToSummarize` is empty and the pass is a split turn, the history summarizer is skipped and the fallback is a constant:

```ts
// before
const historyResult =
  messagesToSummarize.length > 0 || !summarizeTurnPrefix
    ? await generateSummary(..., previousSummary, ...)
    : ok<string, CompactionError>("No prior history.");
```

`previousSummary` is already destructured from the preparation a few lines above and is passed to `generateSummary` on the other branch, but the skip branch ignores it. `prepareCompaction` produces exactly this shape whenever the retained region since the previous compaction is a single turn larger than `keepRecentTokens`: `turnStartIndex === boundaryStart`, so `messagesToSummarize` is empty while `turnPrefixMessages` is not.

The two sibling implementations in `src/agents` already carry the previous summary in this case: `src/agents/compaction.ts:111` returns `params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK`, and `src/agents/agent-hooks/compaction-safeguard-quality.ts:103` uses `trimmedPreviousSummary || "No prior history."`. The agent-core implementation is the one that drops it.

## Fix
```ts
// after
    : ok<string, CompactionError>(previousSummary ?? "No prior history.");
```

The placeholder is now only used when there is genuinely no prior history. When a previous summary exists it becomes the history section, and the turn prefix summary is appended to it exactly as before.

## Why this is the right boundary
`compact()` is the single owner of the history/prefix composition and every caller routes through it. The default mode reaches it directly: `src/agents/sessions/agent-session-compaction.ts` calls `prepareCompaction` then `compact` and appends the result with `appendCompaction`; only safeguard mode registers a `session_before_compact` handler that takes over summarization. `resolveEffectiveCompactionMode` (`src/agents/agent-settings.ts:106`) returns `"default"` unless `agents.defaults.compaction.mode` is `"safeguard"` or a compaction provider is configured, so this is the path every unconfigured install runs.

Related prior reports: #120663 and #122617 described this family and were closed as already implemented on main citing bde1602e6e86 (#117482). That commit touches `src/agents/**` and `src/context-engine/**` only, zero files under `packages/agent-core`, so it repaired the safeguard fallback and left this default-path branch unchanged. Current main still reproduces, see the proof below.

Neighbouring open PRs, all partial overlap, none superseding:
- #120467 and #125210 both rewrite this same line, but couple it to removing the "last entry is a compaction record, skip" guard in `prepareCompaction`, which ClawSweeper labelled merge-risk: session-state. #120467 needs real behavior proof and a rebase; #125210 is merge-conflicted. This PR is the separable minimal data-loss fix and can land independently. Whichever lands first makes the other's hunk on this line a trivial rebase.
- #117585 is a 21-file usage-accounting change that restructures this block as a side effect; it does not target this defect.

This PR intentionally does not touch the `prepareCompaction` guard or anything else from those PRs. It changes one expression and adds one regression test.

## Verification
- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts`: 38 passed with the patch. With `compaction.ts` reverted to pristine upstream/main the new case `keeps the previous summary when only a turn prefix is summarized` fails with `expected 'No prior history.\n\n---\n\n**Turn Co…' to contain 'Earlier compacted history.'` (1 failed, 37 passed).
- `node scripts/run-oxlint.mjs` on both changed files: passed with `--tsconfig config/tsconfig/oxlint.core.json` (exit 0).
- `./node_modules/.bin/oxfmt --check` on both changed files: passed (`All matched files use the correct format`).
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`: passed (exit 0).
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`: not awaited locally (still running when the PR was opened). Relying on CI for the test-project typecheck.
- Full build not run; the change is a single expression inside an existing function with no module boundary impact.

## Real behavior proof
Behavior addressed: re-compaction whose cut lands inside the first retained turn replaces the stored previous summary with the literal `No prior history.` on the default compaction mode.
Real environment tested: a real in-memory `SessionManager` transcript (user turn, assistant reply, a second user turn with six large assistant messages, a real `appendCompaction` carrying the previous summary, then two more assistant messages continuing that turn) fed through the real `prepareCompaction` planner and the real agent-core `compact()`, with the resulting entry appended through the real `appendCompaction` and read back from `getBranch()`. Driven with a standalone tsx driver on pristine upstream/main 222a212e782 and on the patched tree with identical inputs. The only substituted seam is the model stream: `compact()` received a `streamFn` that answers every summarization request with a fixed text, so the planner, the cut selection, the history/prefix composition, the entry validation and the stored transcript are all production code.
Exact steps or command run after this patch: `TSX_TSCONFIG_PATH=$PWD/tsconfig.json ./node_modules/.bin/tsx /tmp/proof-driver.mts` from the repository root, once with `packages/agent-core/src/harness/compaction/compaction.ts` checked out from upstream/main and once with this patch applied.
Evidence after fix:
```
# BEFORE (pristine upstream/main 222a212e782)
planner: isSplitTurn=true messagesToSummarize=0 turnPrefixMessages=7 previousSummary="Earlier compacted history: database is SQLite at data/app.db with WAL mode."
summarizer calls: 1
stored compaction summary (first line): "No prior history."
previous summary retained: false
# AFTER (this patch, identical inputs)
planner: isSplitTurn=true messagesToSummarize=0 turnPrefixMessages=7 previousSummary="Earlier compacted history: database is SQLite at data/app.db with WAL mode."
summarizer calls: 1
stored compaction summary (first line): "Earlier compacted history: database is SQLite at data/app.db with WAL mode."
previous summary retained: true
```
Observed result after fix: with the same transcript and the same planner output, the stored compaction entry now begins with the previous summary instead of the placeholder, while the summarizer is still invoked exactly once for the turn prefix.
What was not tested: no live provider request was made for the summary text; the safeguard mode path and the manual `/compact` path were not exercised since they either own their own summarizer or share this exact function; full build not run.
