### PR TITLE
fix(doctor): show disabled automations during authority reauthorization

### DIFF
--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -311,6 +311,41 @@ describe("collectLegacyCronStoreHealthFindings", () => {
     ).resolves.toEqual([]);
   });
 
+  it("includes disabled authority debt in the remediation inventory", async () => {
+    const storePath = await makeTempStorePath();
+    const legacyAuthorityJob = {
+      owner: { agentId: "main", sessionKey: "agent:main:discord:group:ops" },
+      payload: { kind: "agentTurn", message: "run", toolsAllow: ["write"] },
+    };
+    await writeCurrentCronStore(storePath, [
+      createCurrentCronJob({
+        ...legacyAuthorityJob,
+        id: "legacy-authority-enabled",
+        name: "Enabled authority debt",
+      }),
+      createCurrentCronJob({
+        ...legacyAuthorityJob,
+        id: "legacy-authority-disabled",
+        name: "Disabled authority debt",
+        enabled: false,
+      }),
+    ]);
+
+    const findings = await collectLegacyCronStoreHealthFindings({
+      cfg: createCronConfig(storePath),
+    });
+    const finding = findings.find(
+      ({ requirement }) => requirement === "cron-scheduled-authority-reauthorization",
+    );
+
+    expect(finding).toEqual(
+      expect.objectContaining({
+        message: "2 tool-bearing automations require explicit scheduled authority reauthorization.",
+        fixHint: expect.stringContaining("openclaw automations list --all"),
+      }),
+    );
+  });
+
   it("reports a legacy quarantine sidecar without creating or modifying a SQLite database", async () => {
     const storePath = await makeTempStorePath();
     vi.stubEnv("OPENCLAW_STATE_DIR", path.dirname(path.dirname(storePath)));

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -299,7 +299,7 @@ export async function collectLegacyCronStoreHealthFindings(params: {
           message: `${pluralize(names.length, "tool-bearing automation")} ${description}.`,
           path: sqliteStorePath,
           requirement,
-          fixHint: `Review with ${formatCliCommand("openclaw automations list")} and reauthorize with ${formatCliCommand("openclaw automations edit <id> --tools <tool,...>")}.`,
+          fixHint: `Review with ${formatCliCommand("openclaw automations list --all")} and reauthorize with ${formatCliCommand("openclaw automations edit <id> --tools <tool,...>")}.`,
         }),
       );
     }


### PR DESCRIPTION
Closes #127858

## What Problem This Solves

Doctor counts disabled automations when reporting scheduled-authority reauthorization debt, but its remediation command previously hid those disabled rows. Operators could therefore see a count larger than the inventory they were told to review.

## Why This Change Was Made

Doctor now recommends `openclaw automations list --all`, matching the all-row authority classification while preserving the established enabled-only default list behavior.

The regression test exercises the Doctor boundary with one enabled and one disabled affected automation. This is the canonical hint-only repair: filtering disabled rows out of Doctor would hide real authority debt, while changing the default list behavior would alter existing CLI semantics.

## User Impact

Operators following Doctor's remediation can enumerate every automation included in its warning count, including disabled automations retained in history.

## Evidence

- **Pre-fix regression:** the new Doctor-boundary test failed because Doctor reported 2 affected automations but returned `openclaw automations list` instead of `openclaw automations list --all`.
- **Focused post-fix tests:** 4 shards passed, 267 tests total, covering Doctor, scheduled-tool-policy migration, cron service list filtering, and the automation CLI.
- **Changed-file validation:** the repository changed-file gate passed, including formatting, lint, type checks, architecture guards, database-first checks, and import-cycle checks.
- **Inspectable real-behavior proof:** [redacted terminal transcript](https://github.com/openclaw/openclaw/pull/127998#issuecomment-5381841720) from reviewed head `8973e8d` uses the built CLI, production SQLite store, and real loopback Gateway. Doctor reports both affected rows and recommends `list --all`; the default list returns only the enabled affected row, while `list --all` returns both and marks the disabled row `disabled`.
- **Review:** the single draft autoreview pass found no actionable issues and rated the patch correct (0.99 confidence).
- **Production LOC:** +1/-1 (net 0). Test LOC: +35/-0.
