### PR TITLE
perf(plugins): share schema validation format scope

### DIFF
--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -129,17 +129,35 @@ function withPluginFormatSemantics<T>(callback: () => T): T {
   }
 }
 
-function checkSchema(validate: TypeBoxValidator, value: unknown): TypeBoxValidationError[] | null {
-  return withPluginFormatSemantics(() => {
-    if (validate.Check(value)) {
-      return null;
-    }
-    return [...validate.Errors(value)] as TypeBoxValidationError[];
-  });
+function checkSchemaWithCurrentFormats(
+  validate: TypeBoxValidator,
+  value: unknown,
+): TypeBoxValidationError[] | null {
+  if (validate.Check(value)) {
+    return null;
+  }
+  return [...validate.Errors(value)] as TypeBoxValidationError[];
 }
 
-function applyDefaultsWithPluginFormatSemantics(schema: JsonSchemaValue, value: unknown): unknown {
-  return withPluginFormatSemantics(() => applyJsonSchemaDefaults(schema, value));
+function checkSchema(validate: TypeBoxValidator, value: unknown): TypeBoxValidationError[] | null {
+  return withPluginFormatSemantics(() => checkSchemaWithCurrentFormats(validate, value));
+}
+
+function applyDefaultsAndCheckSchema(params: {
+  schema: JsonSchemaValue;
+  validate: TypeBoxValidator;
+  value: unknown;
+  applyDefaults: boolean;
+  hasDefaults: boolean;
+}): { value: unknown; errors: TypeBoxValidationError[] | null } {
+  if (!params.applyDefaults || !params.hasDefaults) {
+    return { value: params.value, errors: checkSchema(params.validate, params.value) };
+  }
+  const clonedValue = cloneValidationValue(params.value);
+  return withPluginFormatSemantics(() => {
+    const value = applyJsonSchemaDefaults(params.schema, clonedValue);
+    return { value, errors: checkSchemaWithCurrentFormats(params.validate, value) };
+  });
 }
 
 function isDefaultActivatedConditionalFailure(params: {
@@ -345,11 +363,13 @@ export function validateJsonSchemaValue(params: {
   const useCache = params.cache !== false;
   if (!useCache) {
     const validate = compileSchema(params.schema);
-    const value =
-      params.applyDefaults && schemaHasDefaults(params.schema)
-        ? applyDefaultsWithPluginFormatSemantics(params.schema, cloneValidationValue(params.value))
-        : params.value;
-    const errors = checkSchema(validate, value);
+    const { value, errors } = applyDefaultsAndCheckSchema({
+      schema: params.schema,
+      validate,
+      value: params.value,
+      applyDefaults: params.applyDefaults === true,
+      hasDefaults: params.applyDefaults === true && schemaHasDefaults(params.schema),
+    });
     if (!errors) {
       return { ok: true, value };
     }
@@ -389,11 +409,13 @@ export function validateJsonSchemaValue(params: {
     cached.schema = params.schema;
   }
 
-  const value =
-    params.applyDefaults && cached.hasDefaults
-      ? applyDefaultsWithPluginFormatSemantics(params.schema, cloneValidationValue(params.value))
-      : params.value;
-  const errors = checkSchema(cached.validate, value);
+  const { value, errors } = applyDefaultsAndCheckSchema({
+    schema: params.schema,
+    validate: cached.validate,
+    value: params.value,
+    applyDefaults: params.applyDefaults === true,
+    hasDefaults: cached.hasDefaults,
+  });
   if (!errors) {
     return { ok: true, value };
   }


### PR DESCRIPTION
## What Problem This Solves

Plugin configuration schemas that hydrate defaults entered the global TypeBox format-semantics scope twice in succession: once for default application and again for validation. This repeated a full format-registry snapshot, rewrite, clear, and restoration on every default-bearing validation.

## Why This Change Was Made

Default hydration and the immediately following validation are synchronous and require the same plugin-local format semantics. This branch performs both in one scope while retaining the existing standalone validation scope for schemas without active defaults. Cache ownership, cloning, defaults, errors, and global-format restoration remain unchanged.

## User Impact

No user-visible behavior changes. Default-bearing plugin configuration validation performs less synchronous registry work.

## Evidence

- Exact-current temporary probe: default hydration plus validation enters the format scope twice on base and once on this branch. The implementation-coupled probe was removed rather than committed.
- Base/candidate differential across cached and uncached defaults, invalid formats, conditional defaults, boolean and malformed schemas, identity/getters, and registry restoration: byte-identical 1,170-byte output (`a493bbf6395f9aed21bd5a845298987cfb581abbda7cc4628dcd47b4d1c9f704`).
- Exact-current owner benchmark, 50,000 public validations × 7 paired samples: median 1,077.840 ms on base and 1,017.487 ms on this branch (5.6% reduction); checksums identical.
- Owner/caller suites: 4 files, 308 tests passed.
- `node scripts/check-changed.mjs -- src/plugins/schema-validator.ts`
- `GIT_BRANCH=main pnpm build`
- Diff-scoped TruffleHog scan clean; Codex Sol/high autoreview reported no P0/P1 findings.
