### PR TITLE
fix(mantis): surface lane block reasons in proof verdicts

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -1158,7 +1158,7 @@ jobs:
             --scenario-label telegram-desktop-proof
           trusted_manifest="${manifest}.trusted"
           sudo jq --slurpfile judgment "$judgment" '
-            .summary = $judgment[0].summary |
+            .summary = (if .comparison.outcome == "pass" then $judgment[0].summary else .summary end) |
             .comparison.baseline.expected = $judgment[0].baselineExpected |
             .comparison.candidate.expected = $judgment[0].candidateExpected
           ' "$manifest" | sudo tee "$trusted_manifest" >/dev/null

--- a/scripts/mantis/build-telegram-desktop-proof-evidence.mts
+++ b/scripts/mantis/build-telegram-desktop-proof-evidence.mts
@@ -7,6 +7,10 @@ import { fileURLToPath } from "node:url";
 type CliArgs = Record<string, string>;
 type LaneName = "baseline" | "candidate";
 type LaneStatus = "blocked" | "fail" | "pass";
+type LaneFacts = {
+  blocked?: { reason?: string };
+  error?: string;
+};
 type SessionSummary = {
   artifacts?: Partial<
     Record<
@@ -19,6 +23,7 @@ type SessionSummary = {
   sutAttestation?: { lane?: string; sha?: string };
 };
 type LoadedLane = {
+  facts: LaneFacts;
   factsPath: string;
   outputDir: string;
   repoRoot: string;
@@ -44,13 +49,20 @@ type TelegramDesktopProofManifest = {
   summary: string;
   scenario: string;
   comparison: {
-    baseline: { expected: string; status: string; ref?: string; sha?: string };
-    candidate: { expected: string; status: string; ref?: string; sha?: string };
+    baseline: { detail?: string; expected: string; status: string; ref?: string; sha?: string };
+    candidate: { detail?: string; expected: string; status: string; ref?: string; sha?: string };
     outcome: LaneStatus;
     pass: boolean;
   };
   artifacts: EvidenceArtifact[];
 };
+
+const MAX_LANE_DETAIL_LENGTH = 300;
+const GRAPHEME_SEGMENTER = new Intl.Segmenter("en", { granularity: "grapheme" });
+const PASS_SUMMARY =
+  "Mantis captured native Telegram Desktop before/after GIF evidence with Convex-leased Telegram credentials.";
+const INCOMPLETE_SUMMARY =
+  "Mantis did not capture native Telegram Desktop before/after GIF proof. See the Baseline and Candidate lane details below.";
 
 const LANES = [
   {
@@ -95,7 +107,11 @@ function requireArg(args: CliArgs, name: string): string {
   return value;
 }
 
-function readJson(filePath: string): SessionSummary {
+function readSessionSummary(filePath: string): SessionSummary {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function readLaneFacts(filePath: string): LaneFacts {
   return JSON.parse(readFileSync(filePath, "utf8"));
 }
 
@@ -142,9 +158,11 @@ function loadLane({
   status?: string;
 }): LoadedLane {
   const summaryPath = path.join(outputDir, "telegram-user-crabbox-session-summary.json");
-  const summary = readJson(summaryPath);
+  const factsPath = path.join(outputDir, "mantis-lane-facts.json");
+  const summary = readSessionSummary(summaryPath);
   return {
-    factsPath: path.join(outputDir, "mantis-lane-facts.json"),
+    facts: readLaneFacts(factsPath),
+    factsPath,
     outputDir,
     repoRoot,
     status: status || summary.status || "unknown",
@@ -208,6 +226,30 @@ function copyLaneArtifacts({
 
 function laneStatus(lane: LoadedLane): LaneStatus {
   return lane.status === "pass" || lane.status === "blocked" ? lane.status : "fail";
+}
+
+function sanitizeLaneDetail(value: string | undefined): string | undefined {
+  const escaped = value
+    ?.trim()
+    .replace(/\s+/gu, " ")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("`", "&#96;");
+  if (!escaped) {
+    return undefined;
+  }
+  const characters = Array.from(GRAPHEME_SEGMENTER.segment(escaped), ({ segment }) => segment);
+  return characters.length > MAX_LANE_DETAIL_LENGTH
+    ? `${characters.slice(0, MAX_LANE_DETAIL_LENGTH - 1).join("")}…`
+    : escaped;
+}
+
+function laneDetail(lane: LoadedLane, status: LaneStatus): string | undefined {
+  if (status === "blocked") {
+    return sanitizeLaneDetail(lane.facts.blocked?.reason);
+  }
+  return status === "fail" ? sanitizeLaneDetail(lane.facts.error) : undefined;
 }
 
 function requireLaneAttestation(lane: LoadedLane, expectedLane: LaneName, expectedSha: string) {
@@ -305,6 +347,8 @@ function buildTelegramDesktopProofManifest({
 }): TelegramDesktopProofManifest {
   const baselineStatus = laneStatus(baseline);
   const candidateStatus = laneStatus(candidate);
+  const baselineDetail = laneDetail(baseline, baselineStatus);
+  const candidateDetail = laneDetail(candidate, candidateStatus);
   const outcome =
     baselineStatus === "fail" || candidateStatus === "fail"
       ? "fail"
@@ -315,17 +359,18 @@ function buildTelegramDesktopProofManifest({
     schemaVersion: 1,
     id: "telegram-desktop-proof",
     title: "Mantis Telegram Desktop Proof",
-    summary:
-      "Mantis captured native Telegram Desktop before/after GIF evidence with Convex-leased Telegram credentials.",
+    summary: outcome === "pass" ? PASS_SUMMARY : INCOMPLETE_SUMMARY,
     scenario: scenarioLabel || "telegram-desktop-proof",
     comparison: {
       baseline: {
+        ...(baselineDetail ? { detail: baselineDetail } : {}),
         ...(baselineSha ? { sha: baselineSha } : {}),
         ...(baselineRef ? { ref: baselineRef } : {}),
         expected: "baseline visual proof captured",
         status: baselineStatus,
       },
       candidate: {
+        ...(candidateDetail ? { detail: candidateDetail } : {}),
         ...(candidateSha ? { sha: candidateSha } : {}),
         ...(candidateRef ? { ref: candidateRef } : {}),
         expected: "candidate visual proof captured",

--- a/scripts/mantis/publish-pr-evidence.mjs
+++ b/scripts/mantis/publish-pr-evidence.mjs
@@ -9,7 +9,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 
-/** @typedef {Record<string, unknown> & { expected?: string, fixed?: boolean, ref?: string, sha?: string, status?: string }} EvidenceLane */
+/** @typedef {Record<string, unknown> & { detail?: string, expected?: string, fixed?: boolean, ref?: string, sha?: string, status?: string }} EvidenceLane */
 /**
  * @typedef {{
  *   alt?: string,
@@ -366,7 +366,9 @@ function laneLine(label, lane) {
   } else if (lane.ref) {
     pieces.push(` at \`${lane.ref}\``);
   }
-  if (lane.expected) {
+  if (lane.detail) {
+    pieces.push(` — ${lane.detail}`);
+  } else if (lane.expected) {
     pieces.push(`, expected ${lane.expected}`);
   }
   return pieces.join("");

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -21,7 +21,9 @@ function makeLane(
   name: "baseline" | "candidate",
   sha: string,
   options: {
+    blockedReason?: string;
     diagnosticOnly?: boolean;
+    error?: string;
     status?: "blocked" | "fail" | "pass";
     withGif?: boolean;
   } = {},
@@ -72,6 +74,8 @@ function makeLane(
       lane: name,
       providerRequests: [],
       schemaVersion: 2,
+      ...(options.blockedReason ? { blocked: { reason: options.blockedReason } } : {}),
+      ...(options.error ? { error: options.error } : {}),
     }),
   );
   return { outputDir, repo };
@@ -245,12 +249,21 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
   it("preserves a blocked lane as a distinct non-failure outcome", () => {
     const baselineSha = "a".repeat(40);
     const candidateSha = "b".repeat(40);
-    const baseline = makeLane("baseline", baselineSha, { status: "blocked", withGif: false });
-    const candidate = makeLane("candidate", candidateSha, { status: "blocked", withGif: false });
+    const unsafeReason = `  The lane\nblocked <unsafe> & \`inline\` ${"x".repeat(400)}  `;
+    const baseline = makeLane("baseline", baselineSha, {
+      blockedReason: unsafeReason,
+      status: "blocked",
+      withGif: false,
+    });
+    const candidate = makeLane("candidate", candidateSha, {
+      blockedReason: "The queued successor steered instead of queueing.",
+      status: "blocked",
+      withGif: false,
+    });
     const outputDir = mkdtempSync(path.join(tmpdir(), "mantis-telegram-blocked-proof-"));
     tempDirs.push(outputDir);
 
-    const { manifest } = writeTelegramDesktopProofEvidence([
+    const result = writeTelegramDesktopProofEvidence([
       "--output-dir",
       outputDir,
       "--baseline-repo-root",
@@ -271,23 +284,49 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       "blocked",
     ]);
 
-    expect(manifest.comparison).toMatchObject({
+    expect(result.manifest.comparison).toMatchObject({
       baseline: { status: "blocked" },
-      candidate: { status: "blocked" },
+      candidate: {
+        detail: "The queued successor steered instead of queueing.",
+        status: "blocked",
+      },
       outcome: "blocked",
       pass: false,
     });
+    expect(result.manifest.summary).toBe(
+      "Mantis did not capture native Telegram Desktop before/after GIF proof. See the Baseline and Candidate lane details below.",
+    );
+    expect(result.manifest.comparison.baseline.detail).toHaveLength(300);
+    expect(result.manifest.comparison.baseline.detail).toMatch(
+      /^The lane blocked &lt;unsafe&gt; &amp; &#96;inline&#96; /u,
+    );
+    expect(result.manifest.comparison.baseline.detail).toMatch(/…$/u);
+    expect(result.manifest.comparison.baseline.detail).not.toMatch(/[<>`\n\r]/u);
+
+    const manifest = loadEvidenceManifest(result.manifestPath);
+    const body = renderEvidenceComment({
+      manifest,
+      marker: "<!-- mantis-telegram-desktop-proof -->",
+      rawBase: "https://qa.openclaw.ai/mantis/telegram-desktop/pr-1/run-1",
+    });
+    expect(body).toContain(
+      `- Candidate (PR merged onto main): \`blocked\` at \`${candidateSha}\` — The queued successor steered instead of queueing.`,
+    );
+    expect(body).toContain(`- Baseline: \`blocked\` at \`${baselineSha}\` — The lane blocked`);
   });
 
   it("preserves an unattested diagnostic-only startup failure", () => {
     const baselineSha = "a".repeat(40);
     const candidateSha = "b".repeat(40);
-    const baseline = makeLane("baseline", baselineSha, { diagnosticOnly: true });
+    const baseline = makeLane("baseline", baselineSha, {
+      diagnosticOnly: true,
+      error: "  recorder <failed>\nwith `exit 1` & no frames  ",
+    });
     const candidate = makeLane("candidate", candidateSha);
     const outputDir = mkdtempSync(path.join(tmpdir(), "mantis-telegram-startup-failure-"));
     tempDirs.push(outputDir);
 
-    const { manifest } = writeTelegramDesktopProofEvidence([
+    const result = writeTelegramDesktopProofEvidence([
       "--output-dir",
       outputDir,
       "--baseline-repo-root",
@@ -306,14 +345,26 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       candidateSha,
     ]);
 
-    expect(manifest.comparison).toMatchObject({
-      baseline: { status: "fail" },
+    expect(result.manifest.comparison).toMatchObject({
+      baseline: {
+        detail: "recorder &lt;failed&gt; with &#96;exit 1&#96; &amp; no frames",
+        status: "fail",
+      },
       candidate: { status: "pass" },
       pass: false,
     });
     expect(
       JSON.parse(readFileSync(path.join(outputDir, "baseline", "summary.json"), "utf8")),
     ).toEqual({ artifacts: {}, status: "infra-error" });
+    const manifest = loadEvidenceManifest(result.manifestPath);
+    const body = renderEvidenceComment({
+      manifest,
+      marker: "<!-- mantis-telegram-desktop-proof -->",
+      rawBase: "https://qa.openclaw.ai/mantis/telegram-desktop/pr-1/run-1",
+    });
+    expect(body).toContain(
+      `- Baseline: \`fail\` at \`${baselineSha}\` — recorder &lt;failed&gt; with &#96;exit 1&#96; &amp; no frames`,
+    );
   });
 
   it("publishes an optional recipe suggestion as a non-inline attachment", () => {

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -369,7 +369,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(gate).toContain("build-telegram-desktop-proof-evidence.mts");
     expect(gate).toContain('--baseline-status "$baseline_status"');
     expect(gate).toContain('--candidate-status "$candidate_status"');
-    expect(gate).toContain(".summary = $judgment[0].summary");
+    expect(gate).toContain(
+      '.summary = (if .comparison.outcome == "pass" then $judgment[0].summary else .summary end)',
+    );
     expect(gate).toContain('sudo mv "$trusted_manifest" "$manifest"');
     expect(gate.indexOf('"$trusted_output/$lane/summary.json"')).toBeLessThan(
       gate.indexOf("build-telegram-desktop-proof-evidence.mts"),


### PR DESCRIPTION
## What Problem This Solves

When a Mantis Telegram Desktop proof lane ends `blocked` or `fail`, the posted PR verdict comment says only "`blocked` at `<sha>`, expected baseline visual proof captured" — no reason. The lane runner already records the agent's stop-report in `mantis-lane-facts.json` (`blocked: { reason }` from the lane CLI `block --reason`, plus a redacted `error` for infra failures), but the evidence builder never surfaced it. Maintainers had to fetch raw artifacts to learn why a run blocked.

Real example (run 32589119827, PR #127950): both lanes blocked with the recorded reason "The queued successor was answered while the long turn was still running, so the scenario steered instead of queueing." — invisible in the posted comment.

## Why This Change Was Made

The evidence builder (`scripts/mantis/build-telegram-desktop-proof-evidence.mts`) owns lane-fact interpretation, and the comment renderer (`scripts/mantis/publish-pr-evidence.mjs`) owns lane lines — the fix lands at those owners:

- `loadLane` now reads `mantis-lane-facts.json`; a `blocked` lane's `blocked.reason` (or a `fail` lane's `error`) becomes an additive optional `detail` field on the manifest comparison lanes (schemaVersion stays 1 — consumers ignore unknown fields; workflow jq validations and `publish-pr-evidence` checked).
- Detail text is agent-authored free text landing in a public comment: whitespace collapsed, `&`/`<`/`>`/backticks HTML-escaped, hard-capped at 300 graphemes with an ellipsis. Lane facts are secret-redacted upstream; that path is unchanged.
- Lane lines render the reason: `- Baseline: \`blocked\` at \`<sha>\` — <reason>` (falling back to the existing `expected` text when no detail exists).
- The static summary claimed "Mantis captured … GIF evidence" even on blocked runs; the summary is now outcome-aware, and the workflow's trusted-manifest jq only overwrites it with the agent judgment summary on `pass`.
- Sibling check: the web-ui-chat evidence builder consumes no lane-facts schema with `blocked`/`error`, so it is unchanged.

## User Impact

Maintainer/CI-only. A blocked or failed Mantis verdict comment now states the concrete per-lane reason inline; no more raw-artifact archaeology to understand a non-pass run.

## Evidence

- Regression tests in `test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts`: blocked-lane fixture with `blocked.reason` and fail-lane fixture with `error` assert the sanitized, capped detail appears in the manifest; verified failing on pre-change code (2 failures for the intended reason).
- `node scripts/run-vitest.mjs test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts test/scripts/mantis-publish-pr-evidence.test.ts test/scripts/mantis-telegram-desktop-proof-workflow.test.ts` — 49/49 pass (verified independently by the reviewing agent).
- `node scripts/check-changed.mjs -- <changed files>` — exit 0 (verified independently).
- Autoreview (Codex gpt-5.6-sol, high): clean, `patch is correct (0.99)`, no findings.
- LOC: production/tooling +57/-10; tests +63/-10.
