### PR TITLE
fix(protocol): make chat history cursor types consumable

### DIFF
--- a/packages/gateway-protocol/src/schema/logs-chat.test.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.test.ts
@@ -1,12 +1,19 @@
 // Gateway Protocol tests cover typed chat stream events.
+import type { Static } from "typebox";
 import { Value } from "typebox/value";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import {
   ChatEventSchema,
   ChatHistoryCursorResultSchema,
+  ChatHistoryDeltaResultSchema,
   ChatHistoryParamsSchema,
+  ChatHistoryResetResultSchema,
   ChatSendParamsSchema,
   ChatStatusEventSchema,
+  type ChatHistoryCursorResult,
+  type ChatHistoryDeltaResult,
+  type ChatHistoryParams,
+  type ChatHistoryResetResult,
 } from "./logs-chat.js";
 
 const statusEvent = {
@@ -29,6 +36,19 @@ describe("ChatHistoryParamsSchema", () => {
 
 describe("ChatHistoryCursorResultSchema", () => {
   const sessionInfo = { key: "agent:main:main" };
+
+  it("derives the public request and cursor result types from their schemas", () => {
+    expectTypeOf<ChatHistoryParams>().toEqualTypeOf<Static<typeof ChatHistoryParamsSchema>>();
+    expectTypeOf<ChatHistoryDeltaResult>().toEqualTypeOf<
+      Static<typeof ChatHistoryDeltaResultSchema>
+    >();
+    expectTypeOf<ChatHistoryResetResult>().toEqualTypeOf<
+      Static<typeof ChatHistoryResetResultSchema>
+    >();
+    expectTypeOf<ChatHistoryCursorResult>().toEqualTypeOf<
+      Static<typeof ChatHistoryCursorResultSchema>
+    >();
+  });
 
   it("accepts only the closed delta and reset outcomes", () => {
     const delta = {

--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -272,6 +272,10 @@ export const ChatEventSchema = Type.Union([
 
 // Wire types derive directly from local schema consts so public d.ts graphs never
 // pull in the ProtocolSchemas registry.
+export type ChatHistoryParams = Static<typeof ChatHistoryParamsSchema>;
+export type ChatHistoryDeltaResult = Static<typeof ChatHistoryDeltaResultSchema>;
+export type ChatHistoryResetResult = Static<typeof ChatHistoryResetResultSchema>;
+export type ChatHistoryCursorResult = Static<typeof ChatHistoryCursorResultSchema>;
 export type ChatMetadataParams = Static<typeof ChatMetadataParamsSchema>;
 export type ChatToolTitlesParams = Static<typeof ChatToolTitlesParamsSchema>;
 export type LogsTailParams = Static<typeof LogsTailParamsSchema>;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where gateway protocol consumers could validate chat history cursor requests and responses at runtime but could not import the corresponding TypeScript types from the public protocol package.

## Why This Change Was Made

Exports schema-derived request, delta, reset, and cursor-result aliases from the schema owner. Compile-time tests keep each public alias exactly aligned with its canonical TypeBox schema; there is no wire or runtime behavior change.

## User Impact

SDK and protocol consumers can now type chat history cursor calls without recreating contracts or relying on assertions.

## Evidence

- Before: a source import probe failed with missing-export diagnostics for all four aliases.
- Focused tests: `OPENCLAW_VITEST_MAX_WORKERS=4 node scripts/run-vitest.mjs packages/gateway-protocol/src/schema/logs-chat.test.ts packages/gateway-protocol/src/index.test.ts` — 2 files / 68 tests passed.
- Changed-file gate: `node scripts/check-changed.mjs -- packages/gateway-protocol/src/schema/logs-chat.ts packages/gateway-protocol/src/schema/logs-chat.test.ts` — formatting, typecheck, lint, dead-export, boundary, cycle, and guard checks passed.
- Package build: `pnpm --filter @openclaw/gateway-protocol build` — passed; generated declarations export all four aliases.
- Built-package consumer import probe — passed.
- Autoreview: clean, no accepted/actionable findings.
