### PR TITLE
fix(agents): cap local inference context so tool-loop compaction can fire

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  DEFAULT_LOCAL_USABLE_CONTEXT_TOKENS,
   evaluateContextWindowGuard,
   formatContextWindowBlockMessage,
   formatContextWindowWarningMessage,
@@ -270,6 +271,89 @@ describe("context-window-guard", () => {
     });
     expect(mediumGuard.hardMinTokens).toBe(6_400);
     expect(mediumGuard.warnBelowTokens).toBe(12_800);
+  });
+
+  it("caps advertised omlx 256k windows so tool-loop compaction can fire", () => {
+    const cfg = {
+      models: {
+        providers: {
+          omlx: {
+            baseUrl: "http://127.0.0.1:8000/v1",
+            apiKey: "x",
+            models: [
+              {
+                id: "Qwen3.8-27B-4bit",
+                name: "Qwen3.8-27B-4bit",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 262_144,
+                contextTokens: 262_144,
+                maxTokens: 32_768,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "omlx",
+      modelId: "Qwen3.8-27B-4bit",
+      modelContextWindow: 262_144,
+      defaultTokens: 200_000,
+    });
+
+    expect(info.source).toBe("modelsConfig");
+    expect(info.tokens).toBe(DEFAULT_LOCAL_USABLE_CONTEXT_TOKENS);
+    expect(info.referenceTokens).toBe(262_144);
+  });
+
+  it("does not cap cloud providers with large advertised windows", () => {
+    const info = resolveContextWindowInfo({
+      cfg: undefined,
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      modelContextWindow: 1_048_576,
+      defaultTokens: 200_000,
+    });
+    expect(info.tokens).toBe(1_048_576);
+    expect(info.referenceTokens).toBeUndefined();
+  });
+
+  it("lets operators disable the local usable-context cap", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { localUsableContextTokens: 0 } } },
+      models: {
+        providers: {
+          omlx: {
+            baseUrl: "http://127.0.0.1:8000/v1",
+            apiKey: "x",
+            models: [
+              {
+                id: "Qwen3.8-27B-4bit",
+                name: "Qwen3.8-27B-4bit",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 262_144,
+                maxTokens: 32_768,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "omlx",
+      modelId: "Qwen3.8-27B-4bit",
+      modelContextWindow: 262_144,
+      defaultTokens: 200_000,
+    });
+    expect(info.tokens).toBe(262_144);
   });
 
   it("adds a local-model hint to warning messages for localhost endpoints", () => {

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -13,6 +13,24 @@ const CONTEXT_WINDOW_WARN_BELOW_TOKENS = 8_000;
 const CONTEXT_WINDOW_HARD_MIN_RATIO = 0.1;
 const CONTEXT_WINDOW_WARN_BELOW_RATIO = 0.2;
 
+/**
+ * Local MLX/llama.cpp-class servers often advertise the model's theoretical
+ * context (256k+) even though unified memory cannot hold that KV cache.
+ * Compaction keyed off the advertised window never fires, and the backend
+ * crawls through multi-minute prefills instead. Cap unless the operator
+ * opts out with `localUsableContextTokens: 0`.
+ */
+export const DEFAULT_LOCAL_USABLE_CONTEXT_TOKENS = 65_536;
+const LOCAL_INFERENCE_PROVIDERS = new Set([
+  "omlx",
+  "ollama",
+  "lmstudio",
+  "llamacpp",
+  "llama.cpp",
+  "mlx",
+  "vllm",
+]);
+
 type ContextWindowSource = "model" | "modelsConfig" | "agentContextTokens" | "default";
 
 export type ContextWindowInfo = {
@@ -50,6 +68,21 @@ function modelIdMatchesProviderScope(params: {
   return stripProvider(configuredId) === stripProvider(params.modelId);
 }
 
+function localUsableContextCap(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): number | null {
+  if (!LOCAL_INFERENCE_PROVIDERS.has(provider)) {
+    return null;
+  }
+  const raw = cfg?.agents?.defaults?.compaction?.localUsableContextTokens;
+  if (raw === 0) {
+    return null;
+  }
+  const override = normalizePositiveInt(raw);
+  return override ?? DEFAULT_LOCAL_USABLE_CONTEXT_TOKENS;
+}
+
 /** Resolve the effective context window and source for one provider/model. */
 export function resolveContextWindowInfo(params: {
   cfg: OpenClawConfig | undefined;
@@ -82,11 +115,16 @@ export function resolveContextWindowInfo(params: {
     normalizePositiveInt(params.modelContextWindow);
   const defaultTokens =
     normalizePositiveInt(params.defaultTokens) ?? CONTEXT_WINDOW_WARN_BELOW_TOKENS;
-  return fromModelsConfig
+  const resolved = fromModelsConfig
     ? { tokens: fromModelsConfig, source: "modelsConfig" as const }
     : fromModel
       ? { tokens: fromModel, source: "model" as const }
       : { tokens: defaultTokens, source: "default" as const };
+  const cap = localUsableContextCap(params.cfg, params.provider);
+  if (cap && resolved.tokens > cap) {
+    return { ...resolved, tokens: cap, referenceTokens: resolved.tokens };
+  }
+  return resolved;
 }
 
 type ContextWindowGuardResult = ContextWindowInfo & {

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -146,6 +146,8 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
     "Optional embedded OpenClaw tool-loop precheck that detects context pressure after a tool result is appended and before the next model call. When enabled, OpenClaw reuses existing precheck recovery to truncate tool results or compact before retrying.",
   "agents.defaults.compaction.midTurnPrecheck.enabled":
     "Enable structured mid-turn context pressure checks for embedded OpenClaw tool loops. Default: false. Keep disabled unless long tool-heavy sessions hit context overflow before normal turn-end compaction can run.",
+  "agents.defaults.compaction.localUsableContextTokens":
+    "Usable context cap in tokens for local inference providers (omlx, ollama, lmstudio, llama.cpp, mlx, vllm). Those servers often advertise a 256k theoretical window that unified memory cannot hold, so compaction never fires during tool loops. Default: 65536. Set 0 to honor the advertised window unchanged.",
   "agents.defaults.compaction.postIndexSync":
     'Controls post-compaction session memory reindex mode: "off", "async", or "await" (default: "async"). Use "await" for strongest freshness, "async" for lower compaction latency, and "off" only when session-memory sync is handled elsewhere.',
   "agents.defaults.compaction.postCompactionSections":

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -317,6 +317,10 @@ describe("config help copy quality", () => {
           [/mid-turn|tool loop|default:\s*false/i],
         ],
         [
+          "agents.defaults.compaction.localUsableContextTokens",
+          [/omlx|ollama|lmstudio|65536|advertised/i],
+        ],
+        [
           "agents.defaults.compaction.model",
           [/provider\/model|different model|primary agent model/i, /alias/i],
         ],

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -629,6 +629,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.qualityGuard.maxRetries": "Compaction Quality Guard Max Retries",
   "agents.defaults.compaction.midTurnPrecheck": "Compaction Mid-turn Precheck",
   "agents.defaults.compaction.midTurnPrecheck.enabled": "Compaction Mid-turn Precheck Enabled",
+  "agents.defaults.compaction.localUsableContextTokens": "Local Usable Context Tokens",
   "agents.defaults.compaction.postIndexSync": "Compaction Post-Index Sync",
   "agents.defaults.compaction.postCompactionSections": "Post-Compaction Context Sections",
   "agents.defaults.compaction.timeoutSeconds": "Compaction Timeout (Seconds)",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -396,6 +396,13 @@ export type AgentCompactionConfig = {
   qualityGuard?: AgentCompactionQualityGuardConfig;
   /** Mid-turn precheck for tool-loop context pressure. Default: disabled. */
   midTurnPrecheck?: AgentCompactionMidTurnPrecheckConfig;
+  /**
+   * Usable context cap for local inference providers (omlx, ollama, lmstudio,
+   * llama.cpp, mlx, vllm). Theoretical model windows (256k+) exceed unified
+   * memory, so compaction never fires. Default: 65536. Set 0 to use the
+   * advertised window unchanged.
+   */
+  localUsableContextTokens?: number;
   /** Post-compaction session memory index sync mode. */
   postIndexSync?: AgentCompactionPostIndexSyncMode;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -387,6 +387,26 @@ describe("agent defaults schema", () => {
     ).toBe(false);
   });
 
+  it("accepts compaction.localUsableContextTokens including 0 to disable the cap", () => {
+    const capped = AgentDefaultsSchema.parse({
+      compaction: { localUsableContextTokens: 65536 },
+    })!;
+    expect(capped.compaction?.localUsableContextTokens).toBe(65536);
+
+    const disabled = AgentDefaultsSchema.parse({
+      compaction: { localUsableContextTokens: 0 },
+    })!;
+    expect(disabled.compaction?.localUsableContextTokens).toBe(0);
+  });
+
+  it("rejects a negative compaction.localUsableContextTokens", () => {
+    expect(
+      AgentDefaultsSchema.safeParse({
+        compaction: { localUsableContextTokens: -1 },
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts compaction.midTurnPrecheck.enabled", () => {
     const result = AgentDefaultsSchema.parse({
       compaction: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -158,6 +158,7 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        localUsableContextTokens: z.number().int().nonnegative().optional(),
         postIndexSync: z.enum(["off", "async", "await"]).optional(),
         postCompactionSections: z.array(z.string()).optional(),
         model: z.string().optional(),


### PR DESCRIPTION
## Problem

Local inference providers (omlx, ollama, lmstudio, llama.cpp, mlx, vllm) often advertise a **theoretical** 256k context window. Compaction and the 90% preemptive overflow guard (`#29371`) key off that number, so they never fire while the backend is already choking.

Repro from a live OpenClaw 2026.7.1-2 + oMLX 0.6.0rc1 session on a Mac Mini M4 Pro 64 GB (WeChat direct chat, `Qwen3.8-27B-4bit`):

- Config: `models.providers.omlx.contextWindow = 262144`, `compaction.mode = safeguard`, `reserveTokensFloor = 32768`
- Session `c82f67e3-…`: **4 user** / **98 assistant** / **88 toolResult**, **80 `exec` calls**, **compactionCount: 0**
- oMLX log: prompt grew `2994 → 76149`; `323/375` completions were `finish_reason=tool_calls`
- Preemptive overflow threshold was `0.9 * 262144 ≈ 236k`, so compaction never ran
- Prefills throttled for 30–80s each and the Mini ran hot

`midTurnPrecheck` default remains false; even if enabled, it still uses the same inflated window.

## Change

`resolveContextWindowInfo` now clamps local inference providers to **65536** tokens by default (keeps `referenceTokens` as the advertised value).

New config:

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "localUsableContextTokens": 65536
      }
    }
  }
}
```

- unset → 65536 for omlx/ollama/lmstudio/llama.cpp/mlx/vllm
- `0` → honor the advertised window
- any positive int → that cap
- cloud providers are unchanged

With a 64k usable window, the existing 90% preemptive overflow path fires around **59k**, before Metal starts crawling 76k prefills.

## Tests

`node scripts/run-vitest.mjs src/agents/context-window-guard.test.ts src/config/zod-schema.agent-defaults.test.ts src/config/schema.help.quality.test.ts`

- 21 + 24 + 47 passed (unit-fast / tooling / runtime-config shards)
