### PR TITLE
perf(slack): reuse thread history text projection

### DIFF
--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -239,7 +239,7 @@ export async function resolveSlackThreadHistory(params: {
 
   // Slack recommends no more than 200 per page.
   const fetchLimit = 200;
-  const retained: SlackRepliesPageMessage[] = [];
+  const retained: Array<[message: SlackRepliesPageMessage, text: string | undefined]> = [];
   let cursor: string | undefined;
   let pagesFetched = 0;
 
@@ -263,7 +263,7 @@ export async function resolveSlackThreadHistory(params: {
         if (params.currentMessageTs && msg.ts === params.currentMessageTs) {
           continue;
         }
-        retained.push(msg);
+        retained.push([msg, text]);
       }
       if (retained.length > maxMessages) {
         retained.splice(0, retained.length - maxMessages);
@@ -282,13 +282,13 @@ export async function resolveSlackThreadHistory(params: {
       return [];
     }
 
-    return retained.map((msg) => ({
+    return retained.map(([message, text]) => ({
       // For file-only messages, create a placeholder showing attached filenames.
-      text: resolveSlackMessageText(msg) ?? formatSlackFilePlaceholder(msg.files),
-      userId: msg.user,
-      botId: msg.bot_id,
-      ts: msg.ts,
-      files: msg.files,
+      text: text ?? formatSlackFilePlaceholder(message.files),
+      userId: message.user,
+      botId: message.bot_id,
+      ts: message.ts,
+      files: message.files,
     }));
   } catch (err) {
     logVerbose(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where seeding context for a Slack thread projected each retained reply's Block Kit and attachment fallback text twice. Rich or long thread histories therefore repeated the most CPU-intensive owner-local text scan before an inbound turn could start.

## Why This Change Was Made

`resolveSlackThreadHistory` now retains each admitted message together with the text it already resolved, then reuses that text when building the final bounded history. The tuple stays private to the Slack owner and preserves pagination, trimming, file placeholders, response order, errors, and the public result shape. Production size is unchanged: +8/-8 in one Slack file.

No regression test was committed because the only deterministic failing assertion available counted property reads inside the implementation. That temporary probe was useful red/green evidence but not durable behavioral coverage; existing owner/sibling tests plus the exact-output differential protect the shipped behavior without adding a test-only seam.

## User Impact

Slack thread replies with rich Block Kit or attachment fallback content can start processing with less local projection work. Message content, history selection, ordering, and delivery behavior are unchanged.

## Evidence

- Deterministic pre-fix/fixed probe on the current base: one retained rich message read its Block Kit text twice before the change and once after it, with identical `"Projected once"` output.
- Nine-case exact base/candidate differential covered rich, attachment, file-only, empty, paginated/current-excluded, bounded-discard, malformed, rejected, zero-limit, and infinite-limit paths. Outputs and API call records were byte-identical: 1,462 bytes, SHA-256 `b855bc881f2e3ef58602d3c0e8a554b861c08e9a1088dbfe4baa97cd69e03335`.
- Owner benchmark: 120 rich replies × six blocks, 100 calls/sample × seven samples. Median fell from 30,814,976 ns to 16,714,787 ns with identical checksum 42,294,000: 45.76% lower projection time (1.844×). This is an owner microbenchmark, not an end-to-end throughput claim.
- Focused owner/sibling suites: 6 files / 313 tests passed.
- Full Slack extension: 136 files / 2,428 tests passed.
- `node scripts/check-changed.mjs -- extensions/slack/src/monitor/thread.ts` passed all selected format, type, lint, boundary, guard, dead-code, and cycle checks.
- `GIT_BRANCH=main pnpm build` passed; UI startup gzip 345,123 B, below the limit.
- `git diff --check`, `git show --check`, and focused formatting passed.
- Fresh authenticated Codex Sol/high autoreview on the exact one-file patch found no actionable P0/P1 findings (correctness 0.98); TruffleHog 3.97.0 was clean.
- Slack Web API 8.0.0 source was inspected: ordinary replies arrive as plain JSON-parsed objects. No live Slack API call was made because this changes only reuse of an already computed local projection.
- Exhaustive current open-PR file overlap inspection found no viable logical owner overlap. PR #121576 mechanically deletes this file only as part of a malformed 31,428-file branch; its stated owner is unrelated shared model-token stripping.
