### PR TITLE
fix(sessions): preserve model-run sessions when probe retention is disabled

### DIFF
--- a/src/config/sessions/cleanup-service.model-run-retention.test.ts
+++ b/src/config/sessions/cleanup-service.model-run-retention.test.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const maintenanceState = vi.hoisted(() => ({ modelRunPruneAfterMs: 24 * 60 * 60 * 1000 }));
+
+vi.mock("./store-maintenance-runtime.js", () => ({
+  resolveMaintenanceConfig: () => ({
+    mode: "enforce",
+    pruneAfterMs: 30 * DAY_MS,
+    archiveDashboardAfterMs: null,
+    modelRunPruneAfterMs: maintenanceState.modelRunPruneAfterMs,
+    maxEntries: 2,
+    preserveRecentMs: null,
+    resetArchiveRetentionMs: null,
+    maxDiskBytes: null,
+    highWaterBytes: null,
+  }),
+}));
+
+import { runSessionsCleanup } from "./cleanup-service.js";
+import { replaceSessionEntrySync } from "./session-accessor.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("sessions cleanup model-run preview", () => {
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  it.each([
+    { modelRunPruneAfterMs: DAY_MS, modelRunPruned: 1, capped: 0 },
+    { modelRunPruneAfterMs: 0, modelRunPruned: 0, capped: 1 },
+    { modelRunPruneAfterMs: -DAY_MS, modelRunPruned: 0, capped: 1 },
+  ])(
+    "previews model-run retention $modelRunPruneAfterMs before capping",
+    async ({ modelRunPruneAfterMs, modelRunPruned, capped }) => {
+      maintenanceState.modelRunPruneAfterMs = modelRunPruneAfterMs;
+      const storePath = path.join(
+        tempDirs.make("openclaw-cleanup-model-run-"),
+        "agents",
+        "main",
+        "sessions",
+        "sessions.json",
+      );
+      const modelRunSessionKey =
+        "agent:main:explicit:model-run-123e4567-e89b-12d3-a456-426614174000";
+      const oldSessionKey = "agent:main:old";
+      const now = Date.now();
+      replaceSessionEntrySync(
+        { sessionKey: modelRunSessionKey, storePath },
+        { sessionId: "session-model-run", updatedAt: now - 2 * DAY_MS },
+      );
+      replaceSessionEntrySync(
+        { sessionKey: oldSessionKey, storePath },
+        { sessionId: "session-old", updatedAt: now - 3 * DAY_MS },
+      );
+      replaceSessionEntrySync(
+        { sessionKey: "agent:main:active", storePath },
+        { sessionId: "session-active", updatedAt: now },
+      );
+
+      const result = await runSessionsCleanup({
+        cfg: {},
+        opts: { dryRun: true, enforce: true },
+        targets: [{ agentId: "main", storePath }],
+      });
+
+      const preview = result.previewResults[0];
+      expect(preview?.summary).toMatchObject({ modelRunPruned, capped, afterCount: 2 });
+      expect(preview?.modelRunPrunedKeys.has(modelRunSessionKey)).toBe(modelRunPruned === 1);
+      expect(preview?.cappedKeys.has(oldSessionKey)).toBe(capped === 1);
+    },
+  );
+});

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -341,7 +341,7 @@ export function pruneStaleModelRunEntries(
     preserveRecentMs?: number | null;
   } = {},
 ): number {
-  if (overrideMaxAgeMs == null) {
+  if (overrideMaxAgeMs == null || overrideMaxAgeMs <= 0) {
     return 0;
   }
   const cutoffMs = Date.now() - overrideMaxAgeMs;

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -329,54 +329,59 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
     });
   });
 
-  it("forced cleanup prunes stale model-run probes before the cap evicts real sessions", async () => {
-    const now = Date.now();
-    const staleProbe = "agent:main:explicit:model-run-123e4567-e89b-12d3-a456-426614174099";
-    const store: Record<string, SessionEntry> = {
-      [staleProbe]: makeEntry(now - 2 * DAY_MS),
-    };
-    for (let i = 0; i < 50; i++) {
-      store[`agent:main:explicit:real-${i}`] = makeEntry(now - 3 * DAY_MS);
-    }
-    let report: { modelRunPruned: number; pruned: number; capped: number } | undefined;
+  it.each([
+    { modelRunPruneAfterMs: DAY_MS, modelRunPruned: 1, capped: 0, probePresent: false },
+    { modelRunPruneAfterMs: 0, modelRunPruned: 0, capped: 1, probePresent: true },
+    { modelRunPruneAfterMs: -DAY_MS, modelRunPruned: 0, capped: 1, probePresent: true },
+  ])(
+    "applies model-run retention $modelRunPruneAfterMs before forced capping",
+    async ({ modelRunPruneAfterMs, modelRunPruned, capped, probePresent }) => {
+      const now = Date.now();
+      const staleProbe = "agent:main:explicit:model-run-123e4567-e89b-12d3-a456-426614174099";
+      const store: Record<string, SessionEntry> = {
+        [staleProbe]: makeEntry(now - 2 * DAY_MS),
+      };
+      for (let i = 0; i < 50; i++) {
+        store[`agent:main:explicit:real-${i}`] = makeEntry(now - 3 * DAY_MS);
+      }
+      let report: { modelRunPruned: number; pruned: number; capped: number } | undefined;
 
-    const result = await applyFileBackedSessionStoreMaintenance({
-      storePath: "/tmp/openclaw-sessions/sessions.json",
-      store,
-      maintenanceConfig: {
-        mode: "enforce",
-        pruneAfterMs: 7 * DAY_MS,
-        maxEntries: 50,
-        modelRunPruneAfterMs: DAY_MS,
-        resetArchiveRetentionMs: null,
-        maxDiskBytes: null,
-        highWaterBytes: null,
-      },
-      maintenanceOverride: { mode: "enforce" },
-      onMaintenanceApplied: (applied) => {
-        report = {
-          modelRunPruned: applied.modelRunPruned,
-          pruned: applied.pruned,
-          capped: applied.capped,
-        };
-      },
-      log: { warn: () => {}, info: () => {} },
-      artifacts: {
-        archiveRemovedSessionTranscripts: async () => new Set(),
-        removeRemovedSessionTrajectoryArtifacts: async () => {},
-        cleanupArchivedSessionTranscripts: async () => {},
-      },
-    });
+      const result = await applyFileBackedSessionStoreMaintenance({
+        storePath: "/tmp/openclaw-sessions/sessions.json",
+        store,
+        maintenanceConfig: {
+          mode: "enforce",
+          pruneAfterMs: 7 * DAY_MS,
+          maxEntries: 50,
+          modelRunPruneAfterMs,
+          resetArchiveRetentionMs: null,
+          maxDiskBytes: null,
+          highWaterBytes: null,
+        },
+        maintenanceOverride: { mode: "enforce" },
+        onMaintenanceApplied: (applied) => {
+          report = {
+            modelRunPruned: applied.modelRunPruned,
+            pruned: applied.pruned,
+            capped: applied.capped,
+          };
+        },
+        log: { warn: () => {}, info: () => {} },
+        artifacts: {
+          archiveRemovedSessionTranscripts: async () => new Set(),
+          removeRemovedSessionTrajectoryArtifacts: async () => {},
+          cleanupArchivedSessionTranscripts: async () => {},
+        },
+      });
 
-    expect(result.changedStore).toBe(true);
-    expect(report?.modelRunPruned).toBe(1);
-    expect(report?.capped).toBe(0);
-    expect(store[staleProbe]).toBeUndefined();
-    expect(Object.keys(store)).toHaveLength(50);
-    for (let i = 0; i < 50; i++) {
-      expect(store).toHaveProperty(`agent:main:explicit:real-${i}`);
-    }
-  });
+      expect(result.changedStore).toBe(true);
+      expect(report?.modelRunPruned).toBe(modelRunPruned);
+      expect(report?.capped).toBe(capped);
+      expect(store[staleProbe] != null).toBe(probePresent);
+      expect(Object.keys(store)).toHaveLength(50);
+      expect(Object.keys(store).filter((key) => key.includes(":real-"))).toHaveLength(50 - capped);
+    },
+  );
 
   it("counts protected sessions when triggering capping but never evicts them", async () => {
     const now = Date.now();

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -605,6 +605,10 @@ describe("pruneStaleModelRunEntries", () => {
     expect(store).toHaveProperty(staleModelRun);
     expect(pruneStaleModelRunEntries(store, null)).toBe(0);
     expect(store).toHaveProperty(staleModelRun);
+    expect(pruneStaleModelRunEntries(store, 0)).toBe(0);
+    expect(store).toHaveProperty(staleModelRun);
+    expect(pruneStaleModelRunEntries(store, -DAY_MS)).toBe(0);
+    expect(store).toHaveProperty(staleModelRun);
   });
 
   it("preserves model-locked harness sessions from model-run pruning", () => {

--- a/src/infra/state-migrations.legacy-session-store.test.ts
+++ b/src/infra/state-migrations.legacy-session-store.test.ts
@@ -8,6 +8,50 @@ import {
   saveLegacySessionStore,
 } from "./state-migrations.legacy-session-store.js";
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+it.each([
+  { modelRunPruneAfterMs: DAY_MS, modelRunSessionPresent: false },
+  { modelRunPruneAfterMs: 0, modelRunSessionPresent: true },
+  { modelRunPruneAfterMs: -DAY_MS, modelRunSessionPresent: true },
+])(
+  "applies model-run retention $modelRunPruneAfterMs during legacy maintenance",
+  async ({ modelRunPruneAfterMs, modelRunSessionPresent }) => {
+    await withTestDir({ prefix: "openclaw-legacy-session-maintenance-" }, async (root) => {
+      const storePath = path.join(root, "sessions.json");
+      const modelRunSessionKey =
+        "agent:main:explicit:model-run-123e4567-e89b-12d3-a456-426614174000";
+      const now = Date.now();
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [modelRunSessionKey]: { sessionId: "session-model-run", updatedAt: now - 2 * DAY_MS },
+          "agent:main:old": { sessionId: "session-old", updatedAt: now - 3 * DAY_MS },
+          "agent:main:active": { sessionId: "session-active", updatedAt: now },
+        }),
+      );
+
+      const store = loadLegacySessionStore(storePath, {
+        runMaintenance: true,
+        maintenanceConfig: {
+          mode: "enforce",
+          pruneAfterMs: 30 * DAY_MS,
+          archiveDashboardAfterMs: null,
+          modelRunPruneAfterMs,
+          maxEntries: 2,
+          preserveRecentMs: null,
+          resetArchiveRetentionMs: null,
+          maxDiskBytes: null,
+          highWaterBytes: null,
+        },
+      });
+
+      expect(store[modelRunSessionKey] != null).toBe(modelRunSessionPresent);
+      expect(Object.keys(store)).toHaveLength(2);
+    });
+  },
+);
+
 it("stages prompt blobs after a recreated session directory", async () => {
   await withTestDir({ prefix: "openclaw-legacy-session-store-" }, async (root) => {
     const storeDir = path.join(root, "sessions");

--- a/src/plugin-sdk/session-store-runtime.maintenance.test.ts
+++ b/src/plugin-sdk/session-store-runtime.maintenance.test.ts
@@ -1,0 +1,54 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { getSessionEntry, patchSessionEntry, upsertSessionEntry } from "./session-store-runtime.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("plugin session store maintenance", () => {
+  it.each([
+    { modelRunPruneAfterMs: DAY_MS, modelRunSessionPresent: false },
+    { modelRunPruneAfterMs: 0, modelRunSessionPresent: true },
+    { modelRunPruneAfterMs: -DAY_MS, modelRunSessionPresent: true },
+  ])(
+    "applies model-run retention $modelRunPruneAfterMs through entry patches",
+    async ({ modelRunPruneAfterMs, modelRunSessionPresent }) => {
+      const storePath = path.join(tempDirs.make("openclaw-sdk-maintenance-"), "sessions.json");
+      const modelRunSessionKey =
+        "agent:main:explicit:model-run-123e4567-e89b-12d3-a456-426614174000";
+      const oldSessionKey = "agent:main:old";
+      const activeSessionKey = "agent:main:active";
+      const now = Date.now();
+      const seed = (sessionKey: string, sessionId: string, updatedAt: number) =>
+        upsertSessionEntry({
+          agentId: "main",
+          sessionKey,
+          storePath,
+          entry: { sessionId, updatedAt },
+        });
+      await seed(modelRunSessionKey, "session-model-run", now - 2 * DAY_MS);
+      await seed(oldSessionKey, "session-old", now - 3 * DAY_MS);
+      await seed(activeSessionKey, "session-active", now);
+
+      await patchSessionEntry({
+        sessionKey: activeSessionKey,
+        storePath,
+        maintenanceConfig: {
+          mode: "enforce",
+          pruneAfterMs: 30 * DAY_MS,
+          modelRunPruneAfterMs,
+          maxEntries: 2,
+          resetArchiveRetentionMs: 7 * DAY_MS,
+          maxDiskBytes: null,
+          highWaterBytes: null,
+        },
+        update: () => ({ model: "gpt-5.5" }),
+      });
+
+      expect(getSessionEntry({ sessionKey: modelRunSessionKey, storePath }) != null).toBe(
+        modelRunSessionPresent,
+      );
+    },
+  );
+});

--- a/src/plugin-sdk/session-store-runtime.maintenance.test.ts
+++ b/src/plugin-sdk/session-store-runtime.maintenance.test.ts
@@ -43,7 +43,7 @@ describe("plugin session store maintenance", () => {
           maxDiskBytes: null,
           highWaterBytes: null,
         },
-        update: () => ({ model: "gpt-5.5" }),
+        update: () => ({ model: "gpt-5.6-luna" }),
       });
 
       expect(getSessionEntry({ sessionKey: modelRunSessionKey, storePath }) != null).toBe(


### PR DESCRIPTION
## What Problem This Solves

A plugin can pass `modelRunPruneAfterMs` through the Plugin SDK session-store API. A value of `0` or less should disable model-run retention, but the next pressure-triggered maintenance pass deleted every eligible old model-run session instead.

## Why This Change Was Made

`pruneStaleModelRunEntries` treated only `null` as disabled. It computed a cutoff at the current time for `0` and in the future for a negative value, so old unprotected model-run rows matched the deletion rule.

The pruning owner now returns before cutoff calculation when the value is null, zero, or negative. This matches the existing ordinary session-retention contract from #127277. Positive retention and the fixed 24-hour default are unchanged.

The fix stays in the single pruning owner. SQLite maintenance, cleanup preview, file-backed maintenance operations, and legacy migration all use that owner. No caller-specific fallback or new configuration option was added.

## User Impact

- Plugins can disable model-run retention without losing old unprotected model-run sessions.
- Positive retention still removes expired model-run sessions before ordinary count capping.
- Ordinary pruning and count capping still run when model-run retention is disabled.
- Production code is +1/-1, net zero.

## Evidence

### Real behavior proof

I ran the real Plugin SDK `patchSessionEntry` path against disposable on-disk SQLite stores with identical three-row inputs on frozen current main `0294c7fdc9f3f62b64c1a48ddd3504e2575fef27` and repaired head `ddd1542f2f31a1b254e4dfae032529ad599e55b5`.

| `modelRunPruneAfterMs` | Current main | Repaired head |
| --- | --- | --- |
| `86400000` | Old model-run row pruned | Old model-run row pruned |
| `0` | Old model-run row wrongly deleted | Old model-run row preserved |
| `-86400000` | Old model-run row wrongly deleted | Old model-run row preserved |

For the disabled cases, ordinary capping still removed the oldest plain session. Each run verified the physical SQLite file and read the final rows back through the Plugin SDK.

### Regression and caller coverage

- The Plugin SDK regression test failed for zero and negative retention on pre-fix main and passed on the repaired head.
- 70 focused tests passed across the pruning owner, Plugin SDK and SQLite maintenance, cleanup preview, file-backed operations, and legacy migration.
- Formatting and type-aware lint passed on all five changed files.
- Changed-scope repository ratchets and type checks passed in the dependency-ready validation environment.

No build was needed because the change does not affect build output, package boundaries, dependencies, schemas, or protocol versions.
