### PR TITLE
fix(ui): keep limited access status clear of session titles

### DIFF
--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -245,6 +245,7 @@ export function renderApplicationShell(host: ShellViewHost) {
     // Scope-aware to match the store: admin-only, never advertisement alone.
     canCallGatewayMethod(gatewaySnapshot, "openclaw.chat", "operator.admin");
   const activeRoute = host.routeState.routeId ?? "chat";
+  const sessionRoute = isSessionRouteId(activeRoute);
   // Chat has an offline outbox, New Session keeps a local draft, and Appearance
   // persists local preference intent for replay. Their server actions are
   // independently gated; other pages cannot submit useful disconnected work.
@@ -299,7 +300,10 @@ export function renderApplicationShell(host: ShellViewHost) {
         .props=${{
           snapshot: gatewaySnapshot,
           mobile: mobileNavLayout,
-          showTrigger: !mergedChatChrome,
+          // Device-less clients may not reach a session pane, so the shell
+          // retains the manual-repair entry until the header can own it.
+          showTrigger:
+            !sessionRoute || onboarding || gatewaySnapshot.client?.scopeUpgradeReady !== true,
         }}
       ></openclaw-device-scope-upgrade-banner>`
     : null;
@@ -347,7 +351,6 @@ export function renderApplicationShell(host: ShellViewHost) {
   const uiSettings = loadSettings();
   // The new-session draft shares the chat layout: full-height pane that owns
   // its scrolling and pins the composer dock to the bottom.
-  const sessionRoute = isSessionRouteId(activeRoute);
   const chatLikeRoute = sessionRoute || activeRoute === "new-session";
   const custodianRoute = activeRoute === "custodian";
   if (!settingsTakeover) {

--- a/ui/src/app/device-scope-upgrade-registration.ts
+++ b/ui/src/app/device-scope-upgrade-registration.ts
@@ -11,10 +11,12 @@ import {
   readScopeUpgradeAvailability,
   type ScopeUpgradeState,
 } from "./device-scope-upgrade-availability.ts";
-import { SCOPE_UPGRADE_DETAILS_EVENT } from "./device-scope-upgrade.ts";
+import {
+  SCOPE_UPGRADE_DETAILS_EVENT,
+  SCOPE_UPGRADE_TRIGGER_ID,
+  renderScopeUpgradeTrigger,
+} from "./device-scope-upgrade.ts";
 import type { ApplicationGatewaySnapshot } from "./gateway.ts";
-
-const SCOPE_UPGRADE_TRIGGER_ID = "scope-upgrade-trigger";
 
 type UpgradeOperation = {
   client: GatewayBrowserClient;
@@ -281,16 +283,10 @@ class ScopeUpgradeSurface extends OpenClawLightDomContentsElement {
       </button>
     </div>`;
     const trigger = props.showTrigger
-      ? html`<button
-          id=${SCOPE_UPGRADE_TRIGGER_ID}
-          type="button"
-          class="shell-chrome-controls__button scope-upgrade-shell-status scope-upgrade-status-trigger"
-          aria-label=${t("connection.scopeUpgrade.showDetails")}
-          aria-haspopup="dialog"
-          @click=${this.showDetailsFromTrigger}
-        >
-          ${icons.shieldQuestion}
-        </button>`
+      ? renderScopeUpgradeTrigger(
+          "shell-chrome-controls__button scope-upgrade-shell-status scope-upgrade-status-trigger",
+          this.showDetailsFromTrigger,
+        )
       : nothing;
     if (props.mobile) {
       return html`${trigger}${this.detailsOpen

--- a/ui/src/app/device-scope-upgrade.ts
+++ b/ui/src/app/device-scope-upgrade.ts
@@ -1,20 +1,45 @@
+import { html } from "lit";
+import { icons } from "../components/icons.ts";
+import { t } from "../i18n/index.ts";
 import type { ApplicationGatewaySnapshot } from "./gateway.ts";
 import { hasOperatorAdminAccess } from "./operator-access.ts";
 
 export const SCOPE_UPGRADE_DETAILS_EVENT = "openclaw:scope-upgrade-details";
+export const SCOPE_UPGRADE_TRIGGER_ID = "scope-upgrade-trigger";
 const SCOPE_UPGRADE_SURFACE_SELECTOR = "openclaw-device-scope-upgrade-banner";
 
-export function openScopeUpgradeDetails(): void {
+export function openScopeUpgradeDetails(event?: Event): void {
+  event?.stopImmediatePropagation();
   const surface = globalThis.document?.querySelector(SCOPE_UPGRADE_SURFACE_SELECTOR);
   surface?.setAttribute("data-open-requested", "");
   globalThis.dispatchEvent(new Event(SCOPE_UPGRADE_DETAILS_EVENT));
 }
 
-export function scopeUpgradeStatusVisible(snapshot: ApplicationGatewaySnapshot): boolean {
+export function renderScopeUpgradeTrigger(
+  className: string,
+  onClick: (event: Event) => void = openScopeUpgradeDetails,
+) {
+  return html`<button
+    id=${SCOPE_UPGRADE_TRIGGER_ID}
+    type="button"
+    class=${className}
+    aria-label=${t("connection.scopeUpgrade.showDetails")}
+    aria-haspopup="dialog"
+    @click=${onClick}
+  >
+    ${icons.shieldQuestion}
+  </button>`;
+}
+
+function scopeUpgradeStatusVisible(snapshot: ApplicationGatewaySnapshot): boolean {
   const auth = snapshot.hello?.auth;
   return !(
     snapshot.phase !== "connected" ||
     auth?.scopes === undefined ||
     hasOperatorAdminAccess(auth)
   );
+}
+
+export function scopeUpgradeStatusUsesSessionHeader(snapshot: ApplicationGatewaySnapshot): boolean {
+  return scopeUpgradeStatusVisible(snapshot) && snapshot.client?.scopeUpgradeReady === true;
 }

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   startControlUiE2eServer,
   type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
+import { chatSessionListResponse } from "./chat-flow.test-support.ts";
 
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
@@ -174,6 +175,68 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     } finally {
       await closeProofContext(mobile, "mobile-compact-header");
     }
+  });
+
+  it("anchors desktop chat access status in the active header actions", async () => {
+    const context = await createContext();
+    await context.addInitScript(
+      ({ settingsKey }) => {
+        localStorage.setItem(settingsKey, JSON.stringify({ navCollapsed: true }));
+      },
+      { settingsKey: controlUiBundledSettingsStorageKey(server.baseUrl) },
+    );
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": chatSessionListResponse([
+          {
+            key: "agent:main:session-a",
+            kind: "direct",
+            label: "Dashboard sessions: bulk messaging support",
+            spawnedCwd: "/repo/openclaw",
+            updatedAt: 1,
+          },
+        ]),
+      },
+      operatorScopes: LIMITED_SCOPES,
+      sessionKey: "agent:main:session-a",
+    });
+    await page.goto(`${server.baseUrl}chat`);
+
+    const header = page.locator(".chat-pane__header").first();
+    const status = page.getByRole("button", { name: "Show limited access details" });
+    await header.waitFor();
+    await status.waitFor();
+    await captureProof(page, "desktop-chat-header.png");
+
+    expect(await page.locator(".scope-upgrade-shell-status").count()).toBe(0);
+    expect(
+      await header
+        .locator(".chat-pane__actions")
+        .getByRole("button", { name: "Show limited access details" })
+        .count(),
+    ).toBe(1);
+    const geometry = await header.evaluate((root) => {
+      const rect = (selector: string) => {
+        const box = root.querySelector(selector)?.getBoundingClientRect();
+        if (!box) {
+          throw new Error(`Missing desktop header element: ${selector}`);
+        }
+        return { left: box.left, right: box.right };
+      };
+      return {
+        actions: rect(".chat-pane__actions"),
+        status: rect(".scope-upgrade-status-trigger"),
+        title: rect(".chat-pane__crumbs"),
+      };
+    });
+    expect(geometry.status.left).toBeGreaterThanOrEqual(geometry.title.right);
+    expect(geometry.status.right).toBeLessThanOrEqual(geometry.actions.right);
+
+    await status.click();
+    await page.getByText("This browser has limited access.", { exact: true }).waitFor();
+    await page.locator(".scope-upgrade-details-popover").waitFor();
+    await captureProof(page, "desktop-chat-access-details.png");
   });
 
   it("keeps Automations access status in shell chrome without moving routed content", async () => {
@@ -420,7 +483,7 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
   );
 
   it.each(HIDDEN_WEB_CHROME_HOSTS)(
-    "keeps manual guidance reachable from shell status with $label",
+    "keeps manual guidance reachable from active header status with $label",
     async ({ collapsed, rootClass }) => {
       const context = await createContext();
       await context.addInitScript(
@@ -459,12 +522,16 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
       }
       const status = page.getByRole("button", { name: "Show limited access details" });
       await status.waitFor();
-      expect(await status.evaluate((element) => getComputedStyle(element).position)).toBe("fixed");
+      expect(await status.evaluate((element) => getComputedStyle(element).position)).toBe("static");
+      expect(
+        await page
+          .locator(".chat-pane-cache__pane--active .chat-pane__actions")
+          .getByRole("button", { name: "Show limited access details" })
+          .count(),
+      ).toBe(1);
       if (rootClass === "openclaw-native-web-chrome") {
         await expect.poll(() => page.locator(".shell-chrome-controls").isVisible()).toBe(false);
-        expect((await status.boundingBox())?.x).toBe(252);
       } else {
-        expect((await status.boundingBox())?.x).toBe(10);
         expect(await page.locator(".shell-chrome-controls__search").isVisible()).toBe(false);
       }
       await status.click();
@@ -633,7 +700,10 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     const gateway = await installMockGateway(page, { operatorScopes: LIMITED_SCOPES });
 
     await page.goto(`${server.baseUrl}chat`);
-    await page.getByRole("button", { name: "Show limited access details" }).click();
+    const status = page.getByRole("button", { name: "Show limited access details" });
+    await status.waitFor();
+    expect(await page.locator(".scope-upgrade-shell-status").count()).toBe(1);
+    await status.click();
     await page.getByText(MANUAL_UPGRADE_GUIDANCE, { exact: true }).waitFor();
 
     expect(await page.getByRole("button", { name: "Request admin" }).count()).toBe(0);

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -6,7 +6,8 @@ import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
 import { resolveControlUiAuthCandidates } from "../../app/control-ui-auth.ts";
 import {
   openScopeUpgradeDetails,
-  scopeUpgradeStatusVisible,
+  renderScopeUpgradeTrigger,
+  scopeUpgradeStatusUsesSessionHeader,
 } from "../../app/device-scope-upgrade.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import {
@@ -82,7 +83,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       return [];
     }
     const actions: HeaderMenuStatusAction[] = [];
-    if (scopeUpgradeStatusVisible(this.context.gateway.snapshot)) {
+    if (scopeUpgradeStatusUsesSessionHeader(this.context.gateway.snapshot)) {
       actions.push({
         id: "access",
         label: t("connection.scopeUpgrade.status"),
@@ -272,6 +273,14 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
     const desktopEnvironmentId = resolveChatPaneDesktopTarget(row);
     const desktopPanelAvailable =
       desktopEnvironmentId !== null && isDesktopPanelAvailable(this.context.gateway.snapshot);
+    const accessStatusAction =
+      this.active &&
+      !this.narrow &&
+      scopeUpgradeStatusUsesSessionHeader(this.context.gateway.snapshot)
+        ? renderScopeUpgradeTrigger(
+            "btn btn--ghost btn--icon chat-icon-btn scope-upgrade-status-trigger",
+          )
+        : nothing;
     const openDesktopPanel = sessionWorkspace.onToggleDesktop ?? (() => undefined);
     const discussion = this.resolveSessionDiscussionAction();
     const sidePanelOpen = (sidebarLayout ?? this.state?.sidebarLayout)?.open === true;
@@ -451,7 +460,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       canReveal,
       copiedAction: this.headerCopiedAction,
       renameDisabledReason,
-      panelActions: html`${browserPanelAction}${backgroundTasksAction}${sidePanelAction}`,
+      panelActions: html`${accessStatusAction}${browserPanelAction}${backgroundTasksAction}${sidePanelAction}`,
       discussionAction: nothing,
       diffAction: nothing,
       backgroundTasksAction: nothing,


### PR DESCRIPTION
Follow-up to #127704.

## What Problem This Solves

Fixes an issue where desktop chat sessions with limited browser access rendered the access shield in the same left-side space as the project/title breadcrumb. With collapsed navigation, the fixed shell control overlapped the project chip and made the access state look like part of the session identity.

## Why This Change Was Made

Session routes now place the limited-access trigger in the active pane's existing right-aligned action cluster. Non-session routes keep the shell-owned trigger, compact mobile chat keeps access status in the overflow menu, and both placements share one canonical trigger renderer and popover anchor.

This is AI-assisted. The implementation, focused regression, visual proof, changed gate, and autoreview results were inspected before publication.

## User Impact

Desktop session titles and project breadcrumbs remain clear and unobstructed while the limited-access status stays visible and actionable with the other session controls. Mobile behavior is unchanged.

## Evidence

### Desktop

| Before | After |
| --- | --- |
| ![Limited-access shield overlapping the desktop project breadcrumb](https://github.com/user-attachments/assets/7ce05650-1000-482e-b66c-399edfe52a88) | ![Limited-access shield anchored in the desktop header action cluster](https://github.com/user-attachments/assets/831f72a9-048e-41f9-a949-be8498abc3c8) |

### Mobile (unchanged)

| Before | After |
| --- | --- |
| ![Compact mobile header before the change](https://github.com/user-attachments/assets/3646e95e-8fc6-4df1-90b4-ad6831760a07) | ![Compact mobile header after the change](https://github.com/user-attachments/assets/e8ad3411-53b1-49fe-aa60-7b447c01e8bc) |

- Pre-fix regression: `device-scope-upgrade.e2e.test.ts -t "anchors desktop chat access status in the active header actions"` failed because `.scope-upgrade-shell-status` remained outside the pane actions (AWS Crabbox `run_7029608c64c1`).
- Post-fix desktop and mobile E2E: 2/2 passed; baseline mobile: 1/1 passed (AWS Crabbox `run_63d176bf1d5c`).
- Exact-title desktop E2E: passed; targeted oxfmt: passed; core-test tsgo shards: passed (AWS Crabbox `run_9f44682098c2`).
- Full scope-upgrade owner-boundary E2E: 16/16 passed, including native headers, device-less manual recovery, lazy-load failures, and mobile/non-chat siblings (AWS Crabbox `run_fb0d5a065d19`; its subsequent formatter-only finding was applied locally).
- Changed gate: all pre-typecheck UI/core guards passed; its callback-contract finding was fixed and the failed typecheck lane then passed on `run_9f44682098c2`.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, no accepted/actionable findings.
- `git diff --check`: passed.

Production LOC: +52/-19 (net +33; includes moving the existing trigger markup into its canonical shared renderer and preserving the device-less shell fallback) | Tests: +75/-5.

Co-authored-by: Tak Hoffman <781889+Takhoffman@users.noreply.github.com>
