### PR TITLE
test(infra): stop the ssh tunnel stderr cases hanging the suite

### DIFF
--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -255,7 +255,10 @@ describe("startSshPortForward", () => {
   it.each(["active", "teardown"] as const)(
     "does not crash when stderr errors while the tunnel is %s",
     async (phase) => {
-      vi.useFakeTimers();
+      // Real timers only. The fake spawn opens a real socket, and
+      // waitForLocalListener retries on setTimeout against a Date.now() deadline.
+      // Under fake timers neither advances, so a listener that loses the race on the
+      // first probe hangs to the suite timeout instead of failing on its own budget.
       spawnFakeSshListening();
 
       const tunnel = await startSshPortForward({


### PR DESCRIPTION
## What Problem This Solves

`src/infra/ssh-tunnel.test.ts > startSshPortForward > does not crash when stderr errors while the tunnel is active` intermittently hangs in CI and dies on the 120s suite timeout rather than failing an assertion. It surfaced today on an unrelated PR in the `checks-node-compact-small-19` shard.

The two `it.each(["active", "teardown"])` cases enable fake timers and then call `spawnFakeSshListening()`, whose fake `spawn` opens a **real** loopback socket with `server.listen(...)`. `startSshPortForward` waits for that listener in `waitForLocalListener`:

```js
while (Date.now() - startedAt < timeoutMs) {
  ...probe...
  await new Promise((r) => setTimeout(r, 50));
}
throw new Error(`ssh tunnel did not start listening on localhost:${port}`);
```

Under `vi.useFakeTimers()` neither half advances. The 50ms retry never resolves, and the `Date.now()` deadline never moves, so the loop can neither retry nor give up. If the real `listen` has not completed by the first probe, the case deadlocks permanently.

On an idle machine the listener wins that race, which is why the file passes locally and only fails occasionally under CI load.

## Why This Change Was Made

The cases do not need fake time. They assert that a stderr `error` event does not throw and that `stop()` resolves, and the fake child emits its `exit` from a `queueMicrotask`. Dropping `vi.useFakeTimers()` removes the deadlock entirely and lets the production timeout do its job.

This is the only place in the file that mixes fake timers with a real socket. The sibling case at line 194 already uses `spawnFakeSshListening()` on real timers, and the fake-timer case at line 215 uses a spawn that fails immediately and explicitly advances timers. Those are untouched.

Test-only change. Production LOC delta is 0, and `waitForLocalListener` is not at fault: it behaves correctly on real timers.

## User Impact

None at runtime. This removes a CI hang that costs 120s per occurrence and reds unrelated PRs at random.

## Evidence

Injected the exact failure the race produces, by making the fake spawn skip `server.listen` so the listener never comes up. Same injection, before and after, `--testTimeout=8000`:

Before, on `a4dbe235f84`:

```
 × does not crash when stderr errors while the tunnel is active    8004ms
 × does not crash when stderr errors while the tunnel is teardown  8001ms
Error: Test timed out in 8000ms.
```

After:

```
 × does not crash when stderr errors while the tunnel is active    1045ms
 × does not crash when stderr errors while the tunnel is teardown  1050ms
Error: ssh tunnel did not start listening on localhost:43210
```

Same missing listener, and the fix turns a suite-timeout hang into a fast failure on the production budget with the real error text. The real-timer sibling case in the same run already failed cleanly in 1063ms both times, which is what isolated fake timers as the cause rather than the socket or the port.

Normal runs, no injection:

- `node scripts/run-vitest.mjs src/infra/ssh-tunnel.test.ts` : 12 passed in 469ms. Real timers add no measurable time.
- `node scripts/run-vitest.mjs src/infra` : 8918 passed, 22 skipped, 1 failed.
- `node scripts/check-changed.mjs` : exit 0.

The one `src/infra` failure is `provider-usage.auth.plugin.test.ts > resolves SecretRef-backed profiles before provider credential classification`. It is pre-existing and unrelated: I stashed this change and reran it on a clean tree at `d0700b3bc26`, and it fails identically there (`1 failed | 11 passed`). I have not touched it.

Proof gap: I could not make the original CI hang reproduce on demand on this machine, because the listener always wins the race locally. The injection above reproduces the same deadlock deterministically, but the trigger under real CI load is timing I did not directly observe.

---
AI-assisted: diagnosis, patch and the before/after injection were produced with AI help, then reviewed and run locally by me. If you would rather keep fake timers here and advance them explicitly around the call, I am happy to redo it that way.
