### PR TITLE
perf: stop /models from rescanning plugin manifests several times per invocation

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -83,7 +83,15 @@ function hasSlashFormModelRef(raw: string): boolean {
   return slash > 0 && slash < trimmed.length - 1;
 }
 
-function resolveManifestPluginsForModelIdNormalization(params: {
+/**
+ * Resolves manifest plugin metadata for model-id normalization.
+ *
+ * Loading the manifest snapshot rescans every installed plugin, so callers that
+ * build several normalization-aware structures (policy, alias index, ref
+ * resolution) should resolve once and thread the result through
+ * `manifestPlugins` instead of letting each structure resolve it again.
+ */
+export function resolveManifestPluginsForModelIdNormalization(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
   manifestPlugins?: ModelManifestPlugins;

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -40,10 +40,12 @@ import {
   resolveBareModelDefaultProvider,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveManifestPluginsForModelIdNormalization,
   resolveModelAliasFromPair,
   resolveModelRefFromString,
   type ModelAliasIndex,
 } from "./model-selection-shared.js";
+export { resolveManifestPluginsForModelIdNormalization };
 export {
   resolveThinkingDefault,
   resolveThinkingDefaultWithRuntimeCatalog,

--- a/src/auto-reply/reply/commands-models.browse-policy.test.ts
+++ b/src/auto-reply/reply/commands-models.browse-policy.test.ts
@@ -1,0 +1,81 @@
+// Guards that /models browse builds the visibility policy once per invocation.
+// Each build reloads plugin manifest metadata, which rescans every installed plugin.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { buildModelsProviderData } from "./commands-models.js";
+
+const catalogMocks = vi.hoisted(() => ({ loadModelCatalog: vi.fn() }));
+const createVisibilityPolicy = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/prepared-model-catalog.js", () => ({
+  loadProviderScopedThinkingCatalog: vi.fn(async () => []),
+  loadPreparedModelCatalog: catalogMocks.loadModelCatalog,
+  loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
+    const entries = await catalogMocks.loadModelCatalog(...args);
+    return { entries, routeVariants: entries };
+  },
+}));
+
+vi.mock("../../agents/model-provider-auth.js", () => ({
+  createProviderAuthChecker: () =>
+    Object.assign(() => true, {
+      evaluateModelAuth: async () => ({ availability: true, routeResolution: null }),
+    }),
+  hasAuthForModelProvider: () => true,
+  getCurrentProviderAuthState: () => null,
+  clearCurrentProviderAuthState: () => undefined,
+}));
+
+vi.mock("../../agents/model-visibility-policy.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/model-visibility-policy.js")>();
+  return {
+    ...actual,
+    createModelVisibilityPolicy: (
+      params: Parameters<typeof actual.createModelVisibilityPolicy>[0],
+    ) => {
+      createVisibilityPolicy(params);
+      return actual.createModelVisibilityPolicy(params);
+    },
+  };
+});
+
+beforeEach(() => {
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupRegistry: () => ({
+      providers: [],
+      cliBackends: [],
+      configMigrations: [],
+      autoEnableProbes: [],
+      diagnostics: [],
+    }),
+    resolveRuntimeCliBackends: () => [],
+  });
+  catalogMocks.loadModelCatalog.mockReset();
+  catalogMocks.loadModelCatalog.mockResolvedValue([
+    { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
+  ]);
+  createVisibilityPolicy.mockClear();
+  setActivePluginRegistry(createTestRegistry([]));
+});
+
+describe("buildModelsProviderData", () => {
+  it("builds the visibility policy once per browse", async () => {
+    await buildModelsProviderData({
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+    } as OpenClawConfig);
+
+    expect(createVisibilityPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses one manifest plugin snapshot across browse normalization", async () => {
+    await buildModelsProviderData({
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+    } as OpenClawConfig);
+
+    const [params] = createVisibilityPolicy.mock.calls.at(0) ?? [];
+    expect(params).toHaveProperty("manifestPlugins");
+  });
+});

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -26,6 +26,7 @@ import {
   normalizeProviderId,
   resolveBareModelDefaultProvider,
   resolveDefaultModelForAgent,
+  resolveManifestPluginsForModelIdNormalization,
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import {
@@ -181,13 +182,28 @@ export async function buildModelsProviderData(
       }),
   });
   const catalog = snapshot.entries;
+  // Manifest metadata rescans every installed plugin, so resolve it once here and
+  // thread it through every normalization-aware structure below. Otherwise the
+  // policy, the second policy inside the catalog resolver, the alias index, and
+  // each configured-ref resolution reload the same snapshot.
+  // No workspaceDir here on purpose: the callees below resolve it from active
+  // plugin-registry state, so passing the browse workspace would change which
+  // manifests are read.
+  const manifestPlugins = resolveManifestPluginsForModelIdNormalization({
+    cfg,
+    ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+  });
+  const browseNormalization = {
+    ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+    manifestPlugins,
+  };
   const visibilityPolicy = createModelVisibilityPolicy({
     cfg,
     catalog,
     defaultProvider: resolvedDefault.provider,
     defaultModel: resolvedDefault.model,
     agentId,
-    ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+    ...browseNormalization,
   });
   const authChecker = createProviderAuthChecker({
     cfg,
@@ -206,6 +222,8 @@ export async function buildModelsProviderData(
   const visibleCatalog = await resolveLogicalVisibleModelCatalog({
     cfg,
     catalog,
+    // Reuse the policy built above; otherwise the callee rebuilds an identical one.
+    policy: visibilityPolicy,
     defaultProvider: resolvedDefault.provider,
     defaultModel: resolvedDefault.model,
     agentId,
@@ -238,6 +256,7 @@ export async function buildModelsProviderData(
     cfg,
     defaultProvider: resolvedDefault.provider,
     agentId,
+    ...browseNormalization,
   });
   const restrictToProviderWildcards =
     options.view !== "all" && visibilityPolicy.hasProviderWildcards;
@@ -280,6 +299,7 @@ export async function buildModelsProviderData(
       raw: trimmed,
       defaultProvider,
       aliasIndex,
+      ...browseNormalization,
     });
     if (!resolved) {
       return;


### PR DESCRIPTION
Closes #127379

## What Problem This Solves

Resolves a problem where `/models` from a chat channel could pin the gateway main thread long enough to starve unrelated work. On gateways with a non-trivial number of installed plugins, the browse handler spent minutes of synchronous CPU, Control UI `models.list`/`models.authStatus` calls stacked up for 60-115s, and outbound channel HTTP (`getMe`, `sendMessage`) timed out, which made the ingress spool retry the same `/models` update.

## Why This Change Was Made

`buildModelsProviderData` built the model visibility policy with manifest and plugin normalization enabled, and every normalization-aware structure it built resolved plugin manifest metadata independently. Loading that metadata rescans every installed plugin (realpath, hash, pinned-file open) and then deep-clones the snapshot, so the cost was paid several times per invocation:

- the visibility policy built in `buildModelsProviderData`
- an identical second policy built inside `resolveLogicalVisibleModelCatalog`, because the caller never passed its `policy` parameter
- the alias index
- each configured-ref resolution in `addRawModelRef`

This change resolves manifest plugins once and threads the result through all of them, and passes the already-built policy into `resolveLogicalVisibleModelCatalog`.

Non-goal: normalization semantics. Manifest and plugin normalization stay enabled on browse. Simply dropping `RUNTIME_MODEL_VISIBILITY_NORMALIZATION` from the browse path (a tempting one-line "fix") regresses existing coverage: `shows plugin-normalized allowlist models in browse data` starts listing both the legacy and modern ids for a plugin-normalized provider.

Also out of scope: the underlying `hasStalePersistedPluginFiles` cache-miss behavior in `src/plugins/plugin-registry-snapshot.ts`. That is upstream of `/models` and deserves its own change; this PR stops the browse path from triggering it repeatedly.

## User Impact

`/models` from a channel does the plugin-manifest scan once instead of once per normalization-aware structure. Gateways with many installed plugins should see the main-thread stall and the resulting Control UI latency and channel send timeouts drop proportionally.

## Evidence

- `pnpm run tsgo:core` clean.
- `pnpm vitest run src/auto-reply/reply/commands-models.test.ts src/agents/model-catalog-visibility.test.ts src/agents/model-visibility-policy.test.ts`: 66 passed, including the plugin-normalized allowlist case that guards the normalization semantics.
- New `src/auto-reply/reply/commands-models.browse-policy.test.ts` asserts the visibility policy is constructed exactly once per browse and that resolved manifest plugins are threaded into it. It fails on `main` (policy built twice).
- `pnpm exec oxlint` clean on the touched files.
