### PR TITLE
fix(code-mode): pending-call overflow no longer commits partial batches

### DIFF
--- a/src/agents/code-mode.bridge.test.ts
+++ b/src/agents/code-mode.bridge.test.ts
@@ -155,6 +155,50 @@ describe("Code Mode bridge settlement and cancellation", () => {
     expect(testing.activeRuns.size).toBe(0);
   });
 
+  it("rejects an over-cap bridge frontier before dispatching its admitted prefix", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const config = {
+      tools: { codeMode: { enabled: true, maxPendingToolCalls: 2 } },
+    } as never;
+    const ctx = {
+      config,
+      runtimeConfig: config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    };
+    const codeModeTools = createCodeModeTools(ctx);
+    const mutation = pluginTool("fake_mutation", "Record a side effect");
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, mutation],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const details = resultDetails(
+      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
+        "code-call-frontier-overflow",
+        {
+          code: `return await Promise.all(
+            Array.from({ length: 3 }, (_, index) => fake_mutation({ index })),
+          );`,
+        },
+      ),
+    );
+
+    expect(mutation.execute).not.toHaveBeenCalled();
+    expect(details).toMatchObject({
+      status: "failed",
+      code: "invalid_input",
+      bridgeDispatchStarted: false,
+    });
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
   it("yields nested exec before the Code Mode deadline when continuation args are omitted", async () => {
     const catalogRef = createToolSearchCatalogRef();
     const config = {

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -34,8 +34,9 @@ type VmRun = {
   didTimeout: () => boolean;
 };
 
-// Each worker handles exactly one exec/resume payload, so cancellations are run-scoped.
+// Each worker handles exactly one exec/resume payload, so bridge state is run-scoped.
 const canceledBridgeRequestIds: string[] = [];
+let bridgeAdmissionFailure: CodeModeWorkerFailure | undefined;
 
 // QuickJS error stacks are backtrace frames only ("    at file:line:col"), with
 // no leading "Name: message" header like V8. Returning .stack alone therefore
@@ -76,7 +77,11 @@ function createHostRequestHandler(params: {
 ) => JSValueHandle {
   return (methodHandle, argsHandle, bridgeIdHandle) => {
     if (params.pendingRequests.length >= params.config.maxPendingToolCalls) {
-      throw new Error("too many pending code mode tool calls");
+      bridgeAdmissionFailure ??= new CodeModeWorkerFailure(
+        "invalid_input",
+        "too many pending code mode tool calls",
+      );
+      throw bridgeAdmissionFailure;
     }
     const method = methodHandle.toString();
     if (
@@ -363,6 +368,9 @@ async function runVmExecution(params: {
   try {
     params.prepare();
     params.vm.executePendingJobs();
+    if (bridgeAdmissionFailure) {
+      throw bridgeAdmissionFailure;
+    }
     output = takeOutput(params.vm);
     const resultHandle = params.vm.global.getProp("__openclawResult");
     try {


### PR DESCRIPTION
Closes #128012

## What Problem This Solves

Fixes an issue where a Code Mode batch exceeding `maxPendingToolCalls` could execute the admitted prefix of side-effecting nested calls and then return an opaque parent failure. The production incident in #128012 requested 23 mutations, committed the first 16, and left no nested call/result projections for the operator to determine what had happened.

Reported with production ledger and transcript evidence by @hannesrudolph.

## Why This Change Was Made

The QuickJS host callback rejected the first over-cap registration, but the already-registered prefix remained in the worker's pending frontier. After the rejected guest promise settled, the worker prioritized that non-empty frontier, returned `waiting`, and allowed the host to dispatch the prefix before the resumed guest exposed the overflow failure.

The worker now records pending-call overflow as a run-scoped admission failure and checks that fact immediately after draining QuickJS jobs, before it can return a waiting frontier. Because one worker owns exactly one exec/resume payload, this keeps the fact at the lifecycle owner without adding cross-module state. Valid frontiers, sequential calls, detached-call draining, snapshots, and ordinary bridge settlement are unchanged.

Alternatives considered:

- Persisting receipts for the partial prefix would improve auditability but would still commit an unintended partial batch.
- Teaching every caller to split batches would be a consumer workaround and would leave the worker boundary unsafe.
- Draft #119056 covers a broader, stale stacked admission change and does not provide a focused current-main repair for the observed count overflow.

## User Impact

An over-cap Code Mode frontier now fails as `invalid_input` before any nested host call starts. Users no longer get a failed parent result after an unknown partial mutation batch.

## Evidence

- **Pre-fix regression:** with `maxPendingToolCalls=2`, a three-call mutation frontier executed calls 0 and 1, then returned `internal_error` with `bridgeDispatchStarted: true`.
- **Post-fix regression:** the same real QuickJS-WASI worker/bridge path executes zero mutations and returns `invalid_input` with `bridgeDispatchStarted: false`.
- `node scripts/run-vitest.mjs src/agents/code-mode.bridge.test.ts` — 23 passed.
- `node scripts/run-vitest.mjs src/agents/code-mode*.test.ts src/agents/embedded-agent-runner/run/code-mode-repair.test.ts` — 652 passed across 20 files.
- `node scripts/check-changed.mjs -- src/agents/code-mode.worker.ts src/agents/code-mode.bridge.test.ts` — passed all scoped guards, production/test typechecks, lint, dead-code scan, and import-cycle checks.
- `pnpm build` — passed; the finalized `dist/agents/code-mode.worker.js` contains the admission latch and passes `node --check`.
- Focused Codex autoreview (`gpt-5.6-sol`, high) — clean, no accepted/actionable findings; correctness confidence 0.98.
- Production LOC: +10/-2 (net +8). Tests: +44/-0.

Dependency contract checked directly against `quickjs-wasi@3.2.0` types and README: host callbacks are synchronous, `executePendingJobs()` drains promise reactions, and snapshots retain pending promises. No dependency change is included.

Provenance: the pending-call cap originated in #80600; #114884's concurrent frontier draining made the admitted-prefix behavior reachable. This repair preserves #114884's valid detached and concurrent-call semantics while making cap overflow atomic at admission.

AI-assisted: implemented and verified with Codex. The author reviewed the worker, bridge, state, snapshot/resume, tool-surface, build, and dependency paths directly.

Co-authored-by: Tak Hoffman <781889+Takhoffman@users.noreply.github.com>
