### PR TITLE
fix(media): attachments.ttlHours deletes inbound media that chat transcripts still reference

### DIFF
--- a/src/config/schema.help.runtime.ts
+++ b/src/config/schema.help.runtime.ts
@@ -315,7 +315,7 @@ export const RUNTIME_FIELD_HELP: Record<string, string> = {
   attachments:
     "Top-level retention behavior shared across providers and tools that persist media. Use ttlHours when general staged media needs bounded cleanup.",
   "attachments.ttlHours":
-    "Optional retention window in hours for persisted media handled by the general mtime sweep. Leave unset to disable that sweep, or set values like 24 (1 day) or 168 (7 days) to periodically remove older staged media. Managed outgoing media (chat-generated attachments) is excluded and follows its own SQLite- and transcript-aware retention.",
+    "Optional retention window in hours for persisted media handled by the general mtime sweep. Leave unset to disable that sweep, or set values like 24 (1 day) or 168 (7 days) to periodically remove older staged media. Inbound media still referenced by transcript history is retained, and managed outgoing media (chat-generated attachments) is excluded and follows its own SQLite- and transcript-aware retention.",
   bindings:
     "Top-level binding rules for routing and persistent ACP conversation ownership. Use type=route for normal routing and type=acp for persistent ACP harness bindings.",
   "bindings[].type":

--- a/src/media/inbound-transcript-refs.ts
+++ b/src/media/inbound-transcript-refs.ts
@@ -1,0 +1,92 @@
+import type { DatabaseSync } from "node:sqlite";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { listExistingAgentDatabaseTargets } from "../commands/doctor-session-sqlite-readers.js";
+import { getRuntimeConfig } from "../config/config.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import { parseInboundMediaUri } from "./media-reference.js";
+
+const INBOUND_MEDIA_URI_PATTERN = /media:\/\/inbound\/[^\s"'<>\\\]]+/gi;
+const TRANSCRIPT_SCAN_WINDOW_ROWIDS = 200;
+export const TRANSCRIPT_ROWID_BOUNDS_SQL = {
+  highest: "SELECT rowid AS rowid FROM transcript_events ORDER BY rowid DESC LIMIT 1",
+  lowest: "SELECT rowid AS rowid FROM transcript_events ORDER BY rowid ASC LIMIT 1",
+} as const;
+
+function tryParseInboundMediaId(source: string): string | undefined {
+  try {
+    return parseInboundMediaUri(source)?.id;
+  } catch {
+    return undefined;
+  }
+}
+
+function readRowidBound(database: DatabaseSync, sql: string): number | undefined {
+  const row = database.prepare(sql).get() as { rowid?: unknown } | undefined;
+  return typeof row?.rowid === "number" ? row.rowid : undefined;
+}
+
+function collectRowReferences(
+  eventJson: string,
+  candidateIds: ReadonlySet<string>,
+  referenced: Set<string>,
+): void {
+  for (const match of eventJson.matchAll(INBOUND_MEDIA_URI_PATTERN)) {
+    const id = tryParseInboundMediaId(match[0]);
+    if (id && candidateIds.has(id)) {
+      referenced.add(id);
+    }
+  }
+}
+
+export async function collectTranscriptReferencedInboundMediaIds(
+  candidateIds: ReadonlySet<string>,
+): Promise<Set<string> | null> {
+  const referenced = new Set<string>();
+  if (candidateIds.size === 0) {
+    return referenced;
+  }
+  try {
+    for (const target of listExistingAgentDatabaseTargets(getRuntimeConfig(), process.env)) {
+      const database = openNodeSqliteDatabase(target.sqlitePath, { readOnly: true });
+      try {
+        if (!tableExists(database, "transcript_events")) {
+          continue;
+        }
+        const lowestRowid = readRowidBound(database, TRANSCRIPT_ROWID_BOUNDS_SQL.lowest);
+        const highestRowid = readRowidBound(database, TRANSCRIPT_ROWID_BOUNDS_SQL.highest);
+        if (lowestRowid === undefined || highestRowid === undefined) {
+          continue;
+        }
+        const selectWindow = database.prepare(
+          "SELECT event_json AS event_json FROM transcript_events WHERE rowid >= ? AND rowid <= ? AND instr(event_json, 'media://inbound/') > 0",
+        );
+        let cursor = lowestRowid;
+        while (cursor <= highestRowid) {
+          const windowEnd = Math.min(cursor + TRANSCRIPT_SCAN_WINDOW_ROWIDS - 1, highestRowid);
+          const rows = selectWindow.all(cursor, windowEnd) as { event_json?: unknown }[];
+          for (const row of rows) {
+            if (typeof row.event_json === "string") {
+              collectRowReferences(row.event_json, candidateIds, referenced);
+            }
+          }
+          if (referenced.size === candidateIds.size) {
+            break;
+          }
+          cursor = windowEnd + 1;
+          if (cursor <= highestRowid) {
+            await yieldToEventLoop();
+          }
+        }
+      } finally {
+        database.close();
+      }
+      if (referenced.size === candidateIds.size) {
+        break;
+      }
+    }
+    return referenced;
+  } catch {
+    return null;
+  }
+}

--- a/src/media/store.cleanup.test.ts
+++ b/src/media/store.cleanup.test.ts
@@ -3,6 +3,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { listExistingAgentDatabaseTargets } from "../commands/doctor-session-sqlite-readers.js";
+import { getRuntimeConfig } from "../config/config.js";
+import {
+  appendTranscriptMessageSync,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { cleanupManagedOutgoingMediaRecords } from "../gateway/managed-image-attachments.js";
 import {
   insertManagedImageRecord,
@@ -10,6 +16,8 @@ import {
   readManagedImageRecord,
 } from "../gateway/managed-image-record-store.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { buildPersistedUserTurnMessage } from "../sessions/user-turn-transcript.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -98,6 +106,172 @@ describe("cleanOldMedia managed-subtree retention", () => {
 
     expect(cleanup.deletedFileCount).toBe(0);
     await expect(fs.stat(legacyOrphanPath)).resolves.toMatchObject({ size: 15 });
+  });
+
+  it("retains transcript-referenced inbound media while sweeping unreferenced inbound media", async () => {
+    const referenced = await store.saveMediaBuffer(Buffer.from("user photo"), "image/png");
+    const orphan = await store.saveMediaBuffer(Buffer.from("orphan"), "image/png");
+    const sessionKey = "agent:main:dm:user-1";
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey },
+      { sessionId: "session-inbound-1", updatedAt: 1 },
+    );
+    appendTranscriptMessageSync(
+      { agentId: "main", sessionId: "session-inbound-1", sessionKey },
+      {
+        message: buildPersistedUserTurnMessage({
+          text: "what is in this picture?",
+          timestamp: 1,
+          media: [
+            { url: `media://inbound/${referenced.id}`, contentType: "image/png", kind: "image" },
+          ],
+        }),
+      },
+    );
+    const stale = Date.now() - 25 * 60 * 60_000;
+    await Promise.all(
+      [referenced.path, orphan.path].map((filePath) =>
+        fs.utimes(filePath, stale / 1000, stale / 1000),
+      ),
+    );
+
+    await store.cleanOldMedia(60 * 60_000, { recursive: true, pruneEmptyDirs: true });
+
+    await expect(fs.stat(orphan.path)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(store.resolveMediaBufferPath(referenced.id, "inbound")).resolves.toBe(
+      referenced.path,
+    );
+  });
+
+  it("retains only expired candidates out of the historical inbound reference set", async () => {
+    const historical = await store.saveMediaBuffer(Buffer.from("historical"), "image/png");
+    const candidate = await store.saveMediaBuffer(Buffer.from("candidate"), "image/png");
+    const sessionKey = "agent:main:dm:user-2";
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey },
+      { sessionId: "session-inbound-2", updatedAt: 1 },
+    );
+    for (const media of [historical, candidate]) {
+      appendTranscriptMessageSync(
+        { agentId: "main", sessionId: "session-inbound-2", sessionKey },
+        {
+          message: buildPersistedUserTurnMessage({
+            text: "look at this",
+            timestamp: 1,
+            media: [
+              { url: `media://inbound/${media.id}`, contentType: "image/png", kind: "image" },
+            ],
+          }),
+        },
+      );
+    }
+
+    const { collectTranscriptReferencedInboundMediaIds } =
+      await import("./inbound-transcript-refs.js");
+
+    await expect(collectTranscriptReferencedInboundMediaIds(new Set())).resolves.toEqual(new Set());
+    const retained = await collectTranscriptReferencedInboundMediaIds(new Set([candidate.id]));
+    expect(retained).toEqual(new Set([candidate.id]));
+    expect(retained?.has(historical.id)).toBe(false);
+  });
+
+  it("discovers transcript rowid bounds with endpoint seeks instead of an aggregate scan", async () => {
+    const sessionKey = "agent:main:dm:user-4";
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey },
+      { sessionId: "session-inbound-4", updatedAt: 1 },
+    );
+    for (let index = 0; index < 5; index += 1) {
+      appendTranscriptMessageSync(
+        { agentId: "main", sessionId: "session-inbound-4", sessionKey },
+        {
+          message: buildPersistedUserTurnMessage({
+            text: `bounds ${index}`,
+            timestamp: 1,
+          }),
+        },
+      );
+    }
+
+    const { TRANSCRIPT_ROWID_BOUNDS_SQL } = await import("./inbound-transcript-refs.js");
+    const [target] = listExistingAgentDatabaseTargets(getRuntimeConfig(), process.env);
+    expect(target).toBeDefined();
+    const database = openNodeSqliteDatabase(target!.sqlitePath, { readOnly: true });
+    try {
+      const readOpcodes = (sql: string) =>
+        (database.prepare(`EXPLAIN ${sql}`).all() as { opcode?: unknown }[]).map(
+          (row) => row.opcode,
+        );
+      const lowestProgram = readOpcodes(TRANSCRIPT_ROWID_BOUNDS_SQL.lowest);
+      const highestProgram = readOpcodes(TRANSCRIPT_ROWID_BOUNDS_SQL.highest);
+      for (const program of [lowestProgram, highestProgram]) {
+        expect(program).not.toContain("AggStep");
+        expect(program).toContain("DecrJumpZero");
+      }
+      expect(lowestProgram).toContain("Rewind");
+      expect(highestProgram).toContain("Last");
+
+      const readBound = (sql: string) => (database.prepare(sql).get() as { rowid: number }).rowid;
+      const extrema = database
+        .prepare("SELECT min(rowid) AS lo, max(rowid) AS hi FROM transcript_events")
+        .get() as { hi: number; lo: number };
+      expect(readBound(TRANSCRIPT_ROWID_BOUNDS_SQL.lowest)).toBe(extrema.lo);
+      expect(readBound(TRANSCRIPT_ROWID_BOUNDS_SQL.highest)).toBe(extrema.hi);
+      expect(extrema.hi).toBeGreaterThan(extrema.lo);
+    } finally {
+      database.close();
+    }
+  });
+
+  it("sweeps an unreferenced expired candidate without blocking maintenance on a large history", async () => {
+    const orphan = await store.saveMediaBuffer(Buffer.from("unreferenced"), "image/png");
+    const sessionKey = "agent:main:dm:user-3";
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey },
+      { sessionId: "session-inbound-3", updatedAt: 1 },
+    );
+    for (let index = 0; index < 450; index += 1) {
+      appendTranscriptMessageSync(
+        { agentId: "main", sessionId: "session-inbound-3", sessionKey },
+        {
+          message: buildPersistedUserTurnMessage({
+            text: `history ${index}`,
+            timestamp: 1,
+            media: [
+              {
+                url: `media://inbound/history-${index}.png`,
+                contentType: "image/png",
+                kind: "image",
+              },
+            ],
+          }),
+        },
+      );
+    }
+
+    const { collectTranscriptReferencedInboundMediaIds } =
+      await import("./inbound-transcript-refs.js");
+
+    let eventLoopTurns = 0;
+    let counting = true;
+    const countTurn = () => {
+      if (!counting) {
+        return;
+      }
+      eventLoopTurns += 1;
+      setImmediate(countTurn);
+    };
+    setImmediate(countTurn);
+    const referenced = await collectTranscriptReferencedInboundMediaIds(new Set([orphan.id]));
+    counting = false;
+
+    expect(referenced).toEqual(new Set());
+    expect(eventLoopTurns).toBeGreaterThanOrEqual(2);
+
+    const stale = Date.now() - 25 * 60 * 60_000;
+    await fs.utimes(orphan.path, stale / 1000, stale / 1000);
+    await store.cleanOldMedia(60 * 60_000, { recursive: true, pruneEmptyDirs: true });
+    await expect(fs.stat(orphan.path)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("retires only stale outbound staging and its trusted HTML provenance", async () => {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -34,6 +34,7 @@ export const PLAYBACK_TRANSCODE_SUBDIR = "playback-transcode";
 // records/*.json files are the pre-SQLite migration barrier. An mtime-only
 // sweep would delete both out from under that reaper.
 const MANAGED_OUTGOING_SUBDIR = "outgoing";
+const INBOUND_SUBDIR = "inbound";
 const OUTBOUND_STAGING_SUBDIR = "outbound";
 // Match delivery-queue orphan grace: staged files get a full day to reach
 // every direct, streamed, fan-out, or queue-owned delivery path.
@@ -243,6 +244,10 @@ async function pruneNonPlaybackMedia(ttlMs: number, options: CleanOldMediaOption
     }
     const scopedDir = path.join(mediaDir, entry.name);
     const recursive = options.recursive === true;
+    if (entry.name === INBOUND_SUBDIR) {
+      await pruneUnreferencedInboundMedia(scopedDir, ttlMs, options);
+      continue;
+    }
     await openMediaStore(MAX_BYTES, scopedDir).pruneExpired({
       ttlMs,
       recursive,
@@ -251,6 +256,49 @@ async function pruneNonPlaybackMedia(ttlMs: number, options: CleanOldMediaOption
     });
     if (options.pruneEmptyDirs) {
       await fs.rmdir(scopedDir).catch(() => {});
+    }
+  }
+}
+
+async function pruneUnreferencedInboundMedia(
+  inboundDir: string,
+  ttlMs: number,
+  options: CleanOldMediaOptions,
+): Promise<void> {
+  const now = Date.now();
+  const entries = await fs.readdir(inboundDir, { withFileTypes: true }).catch(() => []);
+  const expired: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(inboundDir, entry.name);
+    if (entry.isDirectory()) {
+      await openMediaStore(MAX_BYTES, entryPath).pruneExpired({
+        ttlMs,
+        recursive: options.recursive === true,
+        pruneEmptyDirs: options.pruneEmptyDirs,
+      });
+      if (options.pruneEmptyDirs) {
+        await fs.rmdir(entryPath).catch(() => {});
+      }
+      continue;
+    }
+    const stat = await fs.lstat(entryPath).catch(() => null);
+    if (stat?.isFile() && now - stat.mtimeMs > ttlMs) {
+      expired.push(entry.name);
+    }
+  }
+  if (expired.length === 0) {
+    return;
+  }
+  const { collectTranscriptReferencedInboundMediaIds } =
+    await import("./inbound-transcript-refs.js");
+  const referenced = await collectTranscriptReferencedInboundMediaIds(new Set(expired));
+  if (!referenced) {
+    return;
+  }
+  const inboundStore = openMediaStore(MAX_BYTES, inboundDir);
+  for (const name of expired) {
+    if (!referenced.has(name)) {
+      await inboundStore.remove(name).catch(() => {});
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Setting `attachments.ttlHours` deletes inbound media that chat transcripts still reference. The general mtime sweep walks every media subdirectory except `playback-transcode` and `outgoing`, so `media/inbound` is retired purely on file age. Session transcripts keep `media://inbound/<id>` URIs for replay, tool use, rewind, and Control UI history, so once the sweep runs, opening that history resolves to a file that no longer exists.

This is the last durable-reference media tree the sweep still treats as disposable staging. The managed outgoing tree already has a SQLite- and transcript-aware reaper; inbound had nothing.

## Root cause

`pruneNonPlaybackMedia` in `src/media/store.ts` applies `pruneExpired({ ttlMs })` to every scoped subdirectory that is not playback cache or managed outgoing. Nothing consults transcript ownership before unlinking, so a file whose only owner is durable chat history is indistinguishable from abandoned staging.

The fix routes the `inbound` subdirectory through a retention check: expired direct files become candidates, the candidate set is matched against `media://inbound/` URIs persisted in `transcript_events`, and only candidates no transcript references are removed. Expired staging with no transcript owner is still swept, so the setting keeps bounding genuinely unowned bytes.

## Changes since the last review

The previous head discovered its scan window with `SELECT min(rowid), max(rowid) FROM transcript_events`. SQLite applies its min/max shortcut only to a query with a single aggregate, so combining both functions walks the whole table or its covering index before the loop reaches its first yield. That put an unbounded synchronous pause back on the Gateway maintenance loop, which is the one actionable finding on the last verdict.

Window discovery now reads the two endpoints with separate ordered lookups limited to one row each, so it seeks the ends of the rowid btree instead of scanning. Everything else about the lookup is unchanged.

## Real environment tested

Linux, Node v24.18.0. Patched head `4b74cf4300a8e25c1a6a1be8809475e5f2e55d1d`, rebased onto pristine base `64298c378960ecfc59ea9440ff88929777fb2aca`, with identical inputs on both sides. Each run uses an isolated OpenClaw home, writes real user turns through the SQLite transcript writer, ages the staged files, and calls the same `cleanOldMedia` entry point the Gateway maintenance timer calls with the configured TTL. The scale runs grow one real agent session store to 200,006 and 800,006 `transcript_events` rows and then call the production retention lookup directly. The previous head `f553f2e2d8c1659b381385e5679a6aa70dcc8453` is the comparison point for the window-discovery numbers, since the lookup does not exist on base.

## Evidence before fix

Pristine base `64298c378960`, one transcript-referenced inbound file and one unreferenced inbound file, both older than the configured window:

```
[before] attachments.ttlHours sweep = 1 hour
[before] transcript references media://inbound/533054d1-6a1e-447b-8ef0-b85718537930.png
[before] unreferenced staged file  media://inbound/72db6e53-dde0-4174-8b8b-6eb49f889115.png
[before] after sweep: referenced file present = false
[before] after sweep: unreferenced file present = false
[before] chat history reference FAILS to resolve: resolveMediaBufferPath: media ID does not resolve to a file: "533054d1-6a1e-447b-8ef0-b85718537930.png"
```

Window discovery on the previously reviewed head `f553f2e2d8c1`, worst case of an expired inbound file that no transcript references, measured as the time the maintenance loop is held before the lookup yields for the first time:

```
[old] transcript history rows carrying inbound URIs = 200006
[old] retention lookup returned 0 referenced id(s)
[old] event loop blocked before first yield = 27.5ms
[old] maintenance event loop turns during lookup = 1000

[old] transcript history rows carrying inbound URIs = 800006
[old] retention lookup returned 0 referenced id(s)
[old] event loop blocked before first yield = 122.6ms
[old] maintenance event loop turns during lookup = 4000
```

## Evidence after fix

Patched head `4b74cf4300a8`, same inputs:

```
[after] attachments.ttlHours sweep = 1 hour
[after] transcript references media://inbound/150176a1-17d9-4b97-9ea3-fc13fe873a1d.png
[after] unreferenced staged file  media://inbound/fcfa2727-4d04-408c-8e42-902ef554a9d6.png
[after] after sweep: referenced file present = true
[after] after sweep: unreferenced file present = false
[after] chat history reference resolves to /tmp/oc-proof-UrHUBv/.openclaw/media/inbound/150176a1-17d9-4b97-9ea3-fc13fe873a1d.png
```

```
[new] transcript history rows carrying inbound URIs = 200006
[new] retention lookup returned 0 referenced id(s)
[new] event loop blocked before first yield = 7.9ms
[new] maintenance event loop turns during lookup = 1000

[new] transcript history rows carrying inbound URIs = 800006
[new] retention lookup returned 0 referenced id(s)
[new] event loop blocked before first yield = 3.7ms
[new] maintenance event loop turns during lookup = 4000
```

The two query shapes measured directly against that same real 800,002-row session store, with the plan SQLite chose for each:

```
[plan] real session store /tmp/oc-proof-DQRBfx/.openclaw/agents/main/agent/openclaw-agent.sqlite
[plan] transcript_events rows = 800002
[plan] combined aggregate | plan: SCAN transcript_events USING COVERING INDEX sqlite_autoindex_transcript_events_1
[plan] combined aggregate | aggregate step opcode present = true
[plan] combined aggregate | 70.811ms per call
[plan] endpoint seek low  | plan: SCAN transcript_events
[plan] endpoint seek low  | aggregate step opcode present = false
[plan] endpoint seek low  | 0.004ms per call
[plan] endpoint seek high | plan: SCAN transcript_events
[plan] endpoint seek high | aggregate step opcode present = false
[plan] endpoint seek high | 0.004ms per call
```

## Observed result after fix

The inbound file a transcript still references survives the configured window and stays resolvable through the media store, while the expired inbound file no transcript references is still removed, so the setting keeps reclaiming unowned bytes.

Window discovery no longer grows with history. On the previous head the maintenance loop was held for 27.5ms at 200,006 rows and 122.6ms at 800,006 rows before the lookup yielded once; with the endpoint seeks it is 7.9ms and 3.7ms, flat as history grows by 4x. Measured on the same real session store, the combined aggregate costs 70.811ms per call at 800,002 rows and walks the covering index, while each endpoint lookup costs 0.004ms and carries no aggregate step. The remainder of the lookup is unchanged: bounded rowid windows with a yield between windows, 1000 and 4000 maintenance turns released during the two runs.

## Maintainer decisions this PR does not make

1. Retention contract. This intentionally makes live transcript references override `attachments.ttlHours` for inbound originals, so a long-lived transcript can hold inbound bytes past the configured window. That is a deliberate policy change and the reason the compatibility label is correct. If maintainers want the TTL to stay an absolute bound for all inbound originals, this PR should not land as written.

2. Ownership boundary. ClawSweeper's preferred shape is a retention fact owned by the transcript lifecycle rather than a lookup at cleanup time. That means new persisted state written on the transcript write path plus a backfill, which is a larger change than this defect warrants and a schema decision that belongs to maintainers. The bounded lookup here needs no schema change and no migration.

3. Cold-archived transcripts. `session.maintenance.coldStorage` (opt in, default off, added after this PR opened) moves aged transcript rows out of `transcript_events` into `session_transcript_cold_archives` and restores them on read. A reference living only in a cold archive is not visible to this lookup, so that media can still be swept, exactly as it is on current main. This PR does not regress that case and does not close it; closing it needs either cold-payload decoding or the transcript-owned retention fact in point 2, and is better filed separately.

## Notes on the remaining checklist items

- Config compatibility: no schema, default, or config shape changes. The only config-surface edit is the `attachments.ttlHours` help string, which now states the inbound exception. Existing configs parse and behave identically except for the retention change described above.
- Data-model compatibility: no persistent data-model change. `src/media/inbound-transcript-refs.ts` opens existing session databases read only and runs read only queries; it creates no table, writes no row, and performs no migration or backfill. There is nothing to upgrade or roll back.
- Production footprint: the lookup is one file plus one branch in the sweep.

## Coverage

`src/media/store.cleanup.test.ts` covers a transcript-referenced inbound file surviving the sweep while an unreferenced one is removed, candidate filtering against unrelated historical references, the unreferenced-candidate-at-scale case asserting the maintenance loop is released during the lookup, and window discovery: the two bounds statements are prepared against a real session store and asserted to carry no aggregate step, to seek from either end of the rowid btree under a one-row limit, and to return the same endpoints the aggregate form would.

## Local checks on this host

`node scripts/run-vitest.mjs src/media/store.cleanup.test.ts` passed, 6 of 6, and `oxfmt` is clean on both changed files. The type checker and the linter were not run on this host, which is memory constrained and was previously taken down by the type checker, so a type error in the new coverage would surface only in the repository's own checks rather than here.

https://claude.ai/code/session_0141MfnPJYgyybnqkv98rhfr
