### PR TITLE
fix(ollama): start local services for native chat

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import type { ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
 // Ollama tests cover index plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
@@ -125,7 +126,7 @@ function registerProvidersWithPluginConfig(pluginConfig: Record<string, unknown>
       source: "test",
       config: {},
       pluginConfig,
-      runtime: {} as never,
+      runtime: createPluginRuntimeMock(),
       registerProvider: registerProviderMock,
     }),
   );
@@ -461,6 +462,7 @@ describe("ollama plugin", () => {
         id: "ollama",
         name: "Ollama",
         source: "test",
+        runtime: createPluginRuntimeMock(),
         registerNodeHostCommand,
         registerNodeInvokePolicy,
         registerTool,
@@ -491,6 +493,7 @@ describe("ollama plugin", () => {
         name: "Ollama",
         source: "test",
         pluginConfig: { nodeInference: { enabled: false } },
+        runtime: createPluginRuntimeMock(),
         registerNodeHostCommand,
         registerNodeInvokePolicy,
         registerTool,
@@ -2531,7 +2534,7 @@ describe("ollama plugin", () => {
         source: "test",
         config: {},
         pluginConfig: {},
-        runtime: {} as never,
+        runtime: createPluginRuntimeMock(),
         registerProvider() {},
         registerMediaUnderstandingProvider(provider) {
           mediaProviders.push(provider);

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -2453,6 +2453,37 @@ describe("ollama plugin", () => {
     expect(requireConfiguredStreamParams().providerBaseUrl).toBe(expectedBaseUrl);
   });
 
+  it("preserves the configured provider key for local-service acquisition", () => {
+    const provider = registerProvider();
+    provider.createStreamFn?.({
+      config: {
+        models: {
+          providers: {
+            "Ollama-GPU": {
+              api: "ollama",
+              baseUrl: "http://127.0.0.1:11435",
+              models: [],
+            },
+          },
+        },
+      },
+      model: {
+        id: "llama3.2",
+        provider: "ollama-gpu",
+        api: "ollama",
+      },
+      provider: "ollama-gpu",
+    } as never);
+
+    expect(requireConfiguredStreamParams()).toMatchObject({
+      providerBaseUrl: "http://127.0.0.1:11435",
+      localService: {
+        providerId: "Ollama-GPU",
+        acquire: expect.any(Function),
+      },
+    });
+  });
+
   it.each([
     {
       name: "wraps native Ollama payloads with top-level think=false when thinking is off",

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -806,42 +806,46 @@ async function augmentConfiguredOllamaCatalogModels(params: {
 }
 
 // Local and cloud own distinct auth/catalog policy but share native transport and replay rules.
-const OLLAMA_SHARED_PROVIDER_HOOKS = {
-  ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
-  createStreamFn: ({ config, model, provider }) => {
-    if (model.api !== "ollama") {
-      return undefined;
-    }
-    return createLazyConfiguredOllamaStreamFn({
-      model,
-      providerBaseUrl:
-        readProviderBaseUrl(
-          resolveConfiguredOllamaProviderConfig({ config, providerId: provider }),
-        ) ?? (provider === OLLAMA_CLOUD_PROVIDER_ID ? OLLAMA_CLOUD_BASE_URL : undefined),
-    });
-  },
-  buildReplayPolicy: ({ modelApi }) =>
-    modelApi === "ollama"
-      ? buildNativeOllamaReplayPolicy()
-      : buildOpenAICompatibleReplayPolicy(modelApi),
-  resolveReasoningOutputMode: () => "native",
-  resolveThinkingProfile: resolveOllamaThinkingProfile,
-  wrapStreamFn: createConfiguredOllamaCompatStreamWrapper,
-  matchesContextOverflowError: ({ errorMessage }) =>
-    matchesOllamaContextOverflowError(errorMessage),
-  classifyFailoverReason: ({ errorMessage }) => classifyOllamaFailoverReason(errorMessage),
-} satisfies Pick<
-  ProviderPlugin,
-  | "createStreamFn"
-  | "normalizeToolSchemas"
-  | "inspectToolSchemas"
-  | "buildReplayPolicy"
-  | "resolveReasoningOutputMode"
-  | "resolveThinkingProfile"
-  | "wrapStreamFn"
-  | "matchesContextOverflowError"
-  | "classifyFailoverReason"
->;
+const createOllamaSharedProviderHooks = (
+  acquireLocalService: OpenClawPluginApi["runtime"]["llm"]["acquireLocalService"],
+) =>
+  ({
+    ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
+    createStreamFn: ({ config, model, provider }) => {
+      if (model.api !== "ollama") {
+        return undefined;
+      }
+      return createLazyConfiguredOllamaStreamFn({
+        model,
+        localService: { providerId: provider, acquire: acquireLocalService },
+        providerBaseUrl:
+          readProviderBaseUrl(
+            resolveConfiguredOllamaProviderConfig({ config, providerId: provider }),
+          ) ?? (provider === OLLAMA_CLOUD_PROVIDER_ID ? OLLAMA_CLOUD_BASE_URL : undefined),
+      });
+    },
+    buildReplayPolicy: ({ modelApi }) =>
+      modelApi === "ollama"
+        ? buildNativeOllamaReplayPolicy()
+        : buildOpenAICompatibleReplayPolicy(modelApi),
+    resolveReasoningOutputMode: () => "native",
+    resolveThinkingProfile: resolveOllamaThinkingProfile,
+    wrapStreamFn: createConfiguredOllamaCompatStreamWrapper,
+    matchesContextOverflowError: ({ errorMessage }) =>
+      matchesOllamaContextOverflowError(errorMessage),
+    classifyFailoverReason: ({ errorMessage }) => classifyOllamaFailoverReason(errorMessage),
+  }) satisfies Pick<
+    ProviderPlugin,
+    | "createStreamFn"
+    | "normalizeToolSchemas"
+    | "inspectToolSchemas"
+    | "buildReplayPolicy"
+    | "resolveReasoningOutputMode"
+    | "resolveThinkingProfile"
+    | "wrapStreamFn"
+    | "matchesContextOverflowError"
+    | "classifyFailoverReason"
+  >;
 
 export default definePluginEntry({
   id: "ollama",
@@ -849,6 +853,7 @@ export default definePluginEntry({
   description: "Bundled Ollama provider plugin",
   register(api: OpenClawPluginApi) {
     const startupPluginConfig = (api.pluginConfig ?? {}) as OllamaPluginConfig;
+    const providerHooks = createOllamaSharedProviderHooks(api.runtime.llm.acquireLocalService);
     if (api.registrationMode === "full") {
       void checkWsl2CrashLoopRiskLazily(api);
     }
@@ -926,7 +931,7 @@ export default definePluginEntry({
           provider: buildStaticOllamaCloudProvider(),
         }),
       },
-      ...OLLAMA_SHARED_PROVIDER_HOOKS,
+      ...providerHooks,
       resolveDynamicModel: ({ provider, modelId }) => {
         const cloudProvider = buildStaticOllamaCloudProvider();
         const model = cloudProvider.models?.find((entry) => entry.id === modelId);
@@ -1090,7 +1095,7 @@ export default definePluginEntry({
         const { ensureOllamaModelPulled } = await loadOllamaSetup();
         await ensureOllamaModelPulled({ config, model, prompter });
       },
-      ...OLLAMA_SHARED_PROVIDER_HOOKS,
+      ...providerHooks,
       augmentModelCatalog: async (ctx) =>
         await augmentConfiguredOllamaCatalogModels({
           config: ctx.config,

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -1,5 +1,6 @@
 // Ollama plugin entrypoint registers its OpenClaw integration.
 import { collectConfiguredModelRefValues } from "@openclaw/model-catalog-core/configured-model-refs";
+import { findNormalizedProviderKey } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
@@ -815,12 +816,14 @@ const createOllamaSharedProviderHooks = (
       if (model.api !== "ollama") {
         return undefined;
       }
+      const configuredProviderId =
+        findNormalizedProviderKey(config?.models?.providers, provider) ?? provider;
       return createLazyConfiguredOllamaStreamFn({
         model,
-        localService: { providerId: provider, acquire: acquireLocalService },
+        localService: { providerId: configuredProviderId, acquire: acquireLocalService },
         providerBaseUrl:
           readProviderBaseUrl(
-            resolveConfiguredOllamaProviderConfig({ config, providerId: provider }),
+            resolveConfiguredOllamaProviderConfig({ config, providerId: configuredProviderId }),
           ) ?? (provider === OLLAMA_CLOUD_PROVIDER_ID ? OLLAMA_CLOUD_BASE_URL : undefined),
       });
     },

--- a/extensions/ollama/lazy-import.test.ts
+++ b/extensions/ollama/lazy-import.test.ts
@@ -35,6 +35,7 @@ describe("ollama lazy imports", () => {
     let nodeInferenceImports = 0;
     let setupImports = 0;
     let streamImports = 0;
+    let streamParams: Record<string, unknown> | undefined;
     let webSearchImports = 0;
     let wslImports = 0;
     let wslChecks = 0;
@@ -114,7 +115,10 @@ describe("ollama lazy imports", () => {
     vi.doMock("./src/stream.runtime.js", () => {
       streamImports += 1;
       return {
-        createConfiguredOllamaStreamFn: () => async () => ({ transport: "ollama" }),
+        createConfiguredOllamaStreamFn: (params: Record<string, unknown>) => {
+          streamParams = params;
+          return async () => ({ transport: "ollama" });
+        },
       };
     });
     vi.doMock("./src/web-search-provider.runtime.js", () => {
@@ -144,13 +148,14 @@ describe("ollama lazy imports", () => {
     const providers: ProviderPlugin[] = [];
     let nodeInferenceTool: AnyAgentTool | undefined;
     let webSearchProvider: WebSearchProviderPlugin | undefined;
+    const runtime = createPluginRuntimeMock();
     ollamaPlugin.register(
       createTestPluginApi({
         id: "ollama",
         name: "Ollama",
         source: "test",
         config: {},
-        runtime: createPluginRuntimeMock(),
+        runtime,
         registerEmbeddingProvider: (adapter) => {
           embeddingAdapter = adapter;
         },
@@ -229,9 +234,9 @@ describe("ollama lazy imports", () => {
       config: {
         models: {
           providers: {
-            ollama: {
+            "ollama-gpu": {
               api: "ollama",
-              baseUrl: "http://127.0.0.1:11434",
+              baseUrl: "http://127.0.0.1:11435",
               models: [],
             },
           },
@@ -240,12 +245,19 @@ describe("ollama lazy imports", () => {
       model: {
         api: "ollama",
         id: "qwen3:32b",
-        provider: "ollama",
+        provider: "ollama-gpu",
       },
-      provider: "ollama",
+      provider: "ollama-gpu",
     } as never);
     await expect(streamFn?.({} as never, {} as never, {})).resolves.toEqual({
       transport: "ollama",
+    });
+    expect(streamParams).toMatchObject({
+      providerBaseUrl: "http://127.0.0.1:11435",
+      localService: {
+        providerId: "ollama-gpu",
+        acquire: runtime.llm.acquireLocalService,
+      },
     });
 
     expect({

--- a/extensions/ollama/src/stream-registration.ts
+++ b/extensions/ollama/src/stream-registration.ts
@@ -1,10 +1,17 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 
 const loadOllamaStreamRuntime = createLazyRuntimeModule(() => import("./stream.runtime.js"));
 
+export type OllamaLocalService = {
+  providerId: string;
+  acquire: OpenClawPluginApi["runtime"]["llm"]["acquireLocalService"];
+};
+
 export function createLazyConfiguredOllamaStreamFn(params: {
   model: { baseUrl?: string; headers?: unknown };
+  localService?: OllamaLocalService;
   providerBaseUrl?: string;
 }): StreamFn {
   const streamFnPromise = loadOllamaStreamRuntime().then((runtime) =>

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1611,12 +1611,62 @@ async function createOllamaTestStream(params: {
   );
 }
 
+type OllamaLocalService = NonNullable<
+  Parameters<typeof createConfiguredOllamaStreamFn>[0]["localService"]
+>;
+
+async function createManagedOllamaTestStream(params: {
+  baseUrl: string;
+  providerId?: string;
+  defaultHeaders?: Record<string, string>;
+  model?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  options?: Parameters<ReturnType<typeof createConfiguredOllamaStreamFn>>[2];
+  acquire: OllamaLocalService["acquire"];
+}) {
+  const streamFn = createConfiguredOllamaStreamFn({
+    model: {
+      baseUrl: params.baseUrl,
+      headers: params.defaultHeaders,
+    },
+    providerBaseUrl: params.baseUrl,
+    localService: {
+      providerId: params.providerId ?? "custom-ollama",
+      acquire: params.acquire,
+    },
+  });
+  return streamFn(
+    {
+      id: "qwen3:32b",
+      api: "ollama",
+      provider: params.providerId ?? "custom-ollama",
+      contextWindow: 131072,
+      ...params.model,
+    } as unknown as Parameters<typeof streamFn>[0],
+    (params.context ?? {
+      messages: [{ role: "user", content: "hello" }],
+    }) as unknown as Parameters<typeof streamFn>[1],
+    (params.options ?? {}) as unknown as Parameters<typeof streamFn>[2],
+  );
+}
+
 async function collectStreamEvents<T>(stream: AsyncIterable<T>): Promise<T[]> {
   const events: T[] = [];
   for await (const event of stream) {
     events.push(event);
   }
   return events;
+}
+
+function rejectWhenAborted(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    const rejectWithReason = () => reject(signal.reason ?? new Error("aborted"));
+    if (signal.aborted) {
+      rejectWithReason();
+      return;
+    }
+    signal.addEventListener("abort", rejectWithReason, { once: true });
+  });
 }
 
 type OllamaStreamEvent =
@@ -3303,6 +3353,390 @@ describe("createConfiguredOllamaStreamFn", () => {
         expect(requireHeaders(requestInit.headers).Authorization).toBe("Bearer proxy-token");
       },
     );
+  });
+
+  it("acquires the exact provider service after final payload and headers, before fetch", async () => {
+    const signal = new AbortController().signal;
+    const leaseRelease = vi.fn();
+    const acquire = vi.fn(async () => ({ release: leaseRelease }));
+    const guardRelease = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        [
+          '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+          '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+        ].join("\n"),
+        { status: 200 },
+      ),
+      release: guardRelease,
+    });
+
+    const stream = await createManagedOllamaTestStream({
+      baseUrl: "http://provider-host:11434",
+      providerId: "ollama-gpu",
+      defaultHeaders: { "X-Provider": "provider" },
+      options: {
+        apiKey: "real-token", // pragma: allowlist secret
+        headers: { "X-Request": "request" },
+        onPayload: async (payload) => ({ ...requireRecord(payload, "payload"), model: "patched" }),
+        signal,
+      },
+      acquire,
+    });
+    await collectStreamEvents(stream);
+
+    expect(acquire).toHaveBeenCalledWith(
+      {
+        providerId: "ollama-gpu",
+        baseUrl: "http://provider-host:11434",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer real-token",
+          "X-Provider": "provider",
+          "X-Request": "request",
+        },
+      },
+      signal,
+    );
+    expect(getGuardedFetchJsonBody(fetchWithSsrFGuardMock).model).toBe("patched");
+    expect(acquire.mock.invocationCallOrder[0]).toBeLessThan(
+      expectDefined(fetchWithSsrFGuardMock.mock.invocationCallOrder[0], "fetch call order"),
+    );
+    expect(guardRelease).toHaveBeenCalledOnce();
+    expect(leaseRelease).toHaveBeenCalledOnce();
+    expect(guardRelease.mock.invocationCallOrder[0]).toBeLessThan(
+      expectDefined(leaseRelease.mock.invocationCallOrder[0], "lease release call order"),
+    );
+  });
+
+  it("times out pending local-service acquisition before fetch", async () => {
+    vi.useFakeTimers();
+    try {
+      let acquisitionSignal: AbortSignal | undefined;
+      const acquire = vi.fn((_request, signal) => {
+        acquisitionSignal = expectDefined(signal, "acquisition timeout signal");
+        return rejectWhenAborted(acquisitionSignal);
+      });
+      const eventsPromise = collectStreamEvents(
+        await createManagedOllamaTestStream({
+          baseUrl: "http://provider-host:11434",
+          options: { requestTimeoutMs: 25 },
+          acquire,
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(acquire).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(25);
+      const events = await eventsPromise;
+
+      expect(acquisitionSignal?.reason).toMatchObject({
+        name: "TimeoutError",
+        message: "request timed out",
+      });
+      expect(events).toMatchObject([
+        { type: "error", reason: "error", error: { errorMessage: "request timed out" } },
+      ]);
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps caller aborts classified as aborted during acquisition", async () => {
+    const caller = new AbortController();
+    let acquisitionSignal: AbortSignal | undefined;
+    const acquire = vi.fn((_request, signal) => {
+      acquisitionSignal = expectDefined(signal, "combined acquisition signal");
+      return rejectWhenAborted(acquisitionSignal);
+    });
+    const eventsPromise = collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        options: { requestTimeoutMs: 5_000, signal: caller.signal },
+        acquire,
+      }),
+    );
+    await vi.waitFor(() => expect(acquire).toHaveBeenCalledOnce());
+
+    const reason = new Error("caller stopped");
+    caller.abort(reason);
+    const events = await eventsPromise;
+
+    expect(acquisitionSignal?.reason).toBe(reason);
+    expect(events).toMatchObject([{ type: "error", reason: "aborted" }]);
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("cleans the acquisition timer before a long progressing stream", async () => {
+    vi.useFakeTimers();
+    try {
+      const encoder = new TextEncoder();
+      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const body = new ReadableStream<Uint8Array>({
+        start(streamController) {
+          controller = streamController;
+        },
+      });
+      let acquisitionSignal: AbortSignal | undefined;
+      const acquire = vi.fn(async (_request, signal) => {
+        acquisitionSignal = expectDefined(signal, "acquisition timeout signal");
+        return { release: vi.fn() };
+      });
+      const refreshTimeout = vi.fn();
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(body, { status: 200 }),
+        release: vi.fn(async () => undefined),
+        refreshTimeout,
+      });
+      const eventsPromise = collectStreamEvents(
+        await createManagedOllamaTestStream({
+          baseUrl: "http://provider-host:11434",
+          options: { requestTimeoutMs: 25 },
+          acquire,
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+      const fetchCall = getGuardedFetchCall(fetchWithSsrFGuardMock);
+      expect(fetchCall.signal).toBeUndefined();
+      expect(fetchCall.timeoutMs).toBe(25);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(acquisitionSignal?.aborted).toBe(false);
+
+      expectDefined(controller, "controlled NDJSON stream").enqueue(
+        encoder.encode(
+          '{"model":"m","created_at":"t","message":{"role":"assistant","content":"partial"},"done":false}\n',
+        ),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+      expect(refreshTimeout).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(acquisitionSignal?.aborted).toBe(false);
+
+      expectDefined(controller, "controlled NDJSON stream").enqueue(
+        encoder.encode(
+          '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}\n',
+        ),
+      );
+      expectDefined(controller, "controlled NDJSON stream").close();
+      const events = await eventsPromise;
+
+      expect(events.at(-1)).toMatchObject({ type: "done" });
+      expect(refreshTimeout).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("holds the local-service lease through incomplete NDJSON handling", async () => {
+    const encoder = new TextEncoder();
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController;
+      },
+    });
+    const leaseRelease = vi.fn();
+    const acquire = vi.fn(async () => ({ release: leaseRelease }));
+    const guardRelease = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(body, { status: 200 }),
+      release: guardRelease,
+    });
+
+    const eventsPromise = collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        acquire,
+      }),
+    );
+    await vi.waitFor(() => expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce());
+    expectDefined(controller, "controlled NDJSON stream").enqueue(
+      encoder.encode(
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"partial"},"done":false}\n',
+      ),
+    );
+    await vi.waitFor(() => expect(leaseRelease).not.toHaveBeenCalled());
+    expectDefined(controller, "controlled NDJSON stream").close();
+    const events = await eventsPromise;
+
+    expect(events.at(-1)).toMatchObject({ type: "error", reason: "error" });
+    expect(guardRelease).toHaveBeenCalledOnce();
+    expect(leaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "success",
+      response: new Response(
+        [
+          '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+          '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+        ].join("\n"),
+        { status: 200 },
+      ),
+    },
+    { name: "non-2xx", response: new Response("unavailable", { status: 503 }) },
+    { name: "empty body", response: new Response(null, { status: 200 }) },
+    { name: "malformed NDJSON", response: new Response("not-json\n", { status: 200 }) },
+    {
+      name: "incomplete NDJSON",
+      response: new Response(
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"partial"},"done":false}\n',
+        { status: 200 },
+      ),
+    },
+  ])("releases the service exactly once after $name", async ({ response }) => {
+    const leaseRelease = vi.fn();
+    const acquire = vi.fn(async () => ({ release: leaseRelease }));
+    const guardRelease = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({ response, release: guardRelease });
+
+    await collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        acquire,
+      }),
+    );
+
+    expect(acquire).toHaveBeenCalledOnce();
+    expect(guardRelease).toHaveBeenCalledOnce();
+    expect(leaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the service exactly once when guarded fetch rejects", async () => {
+    const leaseRelease = vi.fn();
+    const acquire = vi.fn(async () => ({ release: leaseRelease }));
+    fetchWithSsrFGuardMock.mockRejectedValue(new Error("connect failed"));
+
+    const events = await collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        acquire,
+      }),
+    );
+
+    expect(events).toMatchObject([{ type: "error", reason: "error" }]);
+    expect(leaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the service after a response hook failure", async () => {
+    const leaseRelease = vi.fn();
+    const acquire = vi.fn(async () => ({ release: leaseRelease }));
+    const guardRelease = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":true}\n',
+        { status: 200 },
+      ),
+      release: guardRelease,
+    });
+
+    const events = await collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        options: {
+          onResponse: () => {
+            throw new Error("response hook failed");
+          },
+        },
+        acquire,
+      }),
+    );
+
+    expect(events).toMatchObject([{ type: "error", reason: "error" }]);
+    expect(guardRelease).toHaveBeenCalledOnce();
+    expect(leaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the service exactly once when the request signal aborts", async () => {
+    const controller = new AbortController();
+    const leaseRelease = vi.fn();
+    const acquire = vi.fn(async () => ({ release: leaseRelease }));
+    const guardRelease = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"partial"},"done":false}\n',
+        { status: 200 },
+      ),
+      release: guardRelease,
+    });
+    controller.abort();
+
+    const events = await collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        options: { signal: controller.signal },
+        acquire,
+      }),
+    );
+
+    expect(events).toMatchObject([{ type: "error", reason: "aborted" }]);
+    expect(guardRelease).toHaveBeenCalledOnce();
+    expect(leaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("skips fetch and emits a terminal stream error when acquisition rejects", async () => {
+    const acquire = vi.fn(async () => {
+      throw new Error("local service failed");
+    });
+
+    const events = await collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        acquire,
+      }),
+    );
+
+    expect(events).toMatchObject([
+      { type: "error", reason: "error", error: { errorMessage: "local service failed" } },
+    ]);
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("does not acquire or fetch when payload preparation rejects", async () => {
+    const acquire = vi.fn();
+
+    const events = await collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        options: {
+          onPayload: () => {
+            throw new Error("payload rejected");
+          },
+        },
+        acquire,
+      }),
+    );
+
+    expect(events).toMatchObject([{ type: "error", reason: "error" }]);
+    expect(acquire).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves successful chat behavior when acquisition returns no lease", async () => {
+    const acquire = vi.fn(async () => undefined);
+    const guardRelease = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":true}\n',
+        { status: 200 },
+      ),
+      release: guardRelease,
+    });
+
+    const events = await collectStreamEvents(
+      await createManagedOllamaTestStream({
+        baseUrl: "http://provider-host:11434",
+        acquire,
+      }),
+    );
+
+    expect(events.at(-1)).toMatchObject({ type: "done" });
+    expect(acquire).toHaveBeenCalledOnce();
+    expect(guardRelease).toHaveBeenCalledOnce();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -3353,6 +3353,40 @@ describe("createConfiguredOllamaStreamFn", () => {
     );
   });
 
+  it("acquires the provider service when model baseUrl is whitespace", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const acquire = vi.fn(async () => ({ release: vi.fn() }));
+        const streamFn = createConfiguredOllamaStreamFn({
+          model: { baseUrl: "   " },
+          localService: { providerId: "ollama-gpu", acquire },
+        });
+        const stream = await Promise.resolve(
+          streamFn(
+            {
+              id: "qwen3:32b",
+              api: "ollama",
+              provider: "ollama-gpu",
+              contextWindow: 131072,
+            } as never,
+            { messages: [{ role: "user", content: "hello" }] } as never,
+            {} as never,
+          ),
+        );
+
+        const events = await collectStreamEvents(stream);
+
+        expect(events.at(-1)).toMatchObject({ type: "done" });
+        expect(acquire).toHaveBeenCalledOnce();
+        expect(getGuardedFetchCall(fetchMock).url).toBe("http://127.0.0.1:11434/api/chat");
+      },
+    );
+  });
+
   it("uses provider-level baseUrl when model baseUrl is absent", async () => {
     await withMockNdjsonFetch(
       [

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1615,13 +1615,19 @@ type OllamaLocalService = NonNullable<
   Parameters<typeof createConfiguredOllamaStreamFn>[0]["localService"]
 >;
 
+type ManagedOllamaTestOptions = NonNullable<
+  Parameters<ReturnType<typeof createConfiguredOllamaStreamFn>>[2]
+> & {
+  requestTimeoutMs?: number;
+};
+
 async function createManagedOllamaTestStream(params: {
   baseUrl: string;
   providerId?: string;
   defaultHeaders?: Record<string, string>;
   model?: Record<string, unknown>;
   context?: Record<string, unknown>;
-  options?: Parameters<ReturnType<typeof createConfiguredOllamaStreamFn>>[2];
+  options?: ManagedOllamaTestOptions;
   acquire: OllamaLocalService["acquire"];
 }) {
   const streamFn = createConfiguredOllamaStreamFn({
@@ -3414,8 +3420,9 @@ describe("createConfiguredOllamaStreamFn", () => {
     try {
       let acquisitionSignal: AbortSignal | undefined;
       const acquire = vi.fn((_request, signal) => {
-        acquisitionSignal = expectDefined(signal, "acquisition timeout signal");
-        return rejectWhenAborted(acquisitionSignal);
+        const timeoutSignal = expectDefined(signal, "acquisition timeout signal");
+        acquisitionSignal = timeoutSignal;
+        return rejectWhenAborted(timeoutSignal);
       });
       const eventsPromise = collectStreamEvents(
         await createManagedOllamaTestStream({
@@ -3447,8 +3454,9 @@ describe("createConfiguredOllamaStreamFn", () => {
     const caller = new AbortController();
     let acquisitionSignal: AbortSignal | undefined;
     const acquire = vi.fn((_request, signal) => {
-      acquisitionSignal = expectDefined(signal, "combined acquisition signal");
-      return rejectWhenAborted(acquisitionSignal);
+      const combinedSignal = expectDefined(signal, "combined acquisition signal");
+      acquisitionSignal = combinedSignal;
+      return rejectWhenAborted(combinedSignal);
     });
     const eventsPromise = collectStreamEvents(
       await createManagedOllamaTestStream({

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -3317,6 +3317,42 @@ describe("resolveOllamaBaseUrlForRun", () => {
 });
 
 describe("createConfiguredOllamaStreamFn", () => {
+  it("streams model-specific remote endpoints without acquiring the provider service", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const acquire = vi.fn();
+        const streamFn = createConfiguredOllamaStreamFn({
+          model: { baseUrl: "https://remote-ollama.example.test" },
+          localService: { providerId: "ollama-gpu", acquire },
+        });
+        const stream = await Promise.resolve(
+          streamFn(
+            {
+              id: "qwen3:32b",
+              api: "ollama",
+              provider: "ollama-gpu",
+              contextWindow: 131072,
+            } as never,
+            { messages: [{ role: "user", content: "hello" }] } as never,
+            {} as never,
+          ),
+        );
+
+        const events = await collectStreamEvents(stream);
+
+        expect(events.at(-1)).toMatchObject({ type: "done" });
+        expect(acquire).not.toHaveBeenCalled();
+        expect(getGuardedFetchCall(fetchMock).url).toBe(
+          "https://remote-ollama.example.test/api/chat",
+        );
+      },
+    );
+  });
+
   it("uses provider-level baseUrl when model baseUrl is absent", async () => {
     await withMockNdjsonFetch(
       [

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1615,19 +1615,13 @@ type OllamaLocalService = NonNullable<
   Parameters<typeof createConfiguredOllamaStreamFn>[0]["localService"]
 >;
 
-type ManagedOllamaTestOptions = NonNullable<
-  Parameters<ReturnType<typeof createConfiguredOllamaStreamFn>>[2]
-> & {
-  requestTimeoutMs?: number;
-};
-
 async function createManagedOllamaTestStream(params: {
   baseUrl: string;
   providerId?: string;
   defaultHeaders?: Record<string, string>;
   model?: Record<string, unknown>;
   context?: Record<string, unknown>;
-  options?: ManagedOllamaTestOptions;
+  options?: Parameters<ReturnType<typeof createConfiguredOllamaStreamFn>>[2];
   acquire: OllamaLocalService["acquire"];
 }) {
   const streamFn = createConfiguredOllamaStreamFn({
@@ -1666,7 +1660,8 @@ async function collectStreamEvents<T>(stream: AsyncIterable<T>): Promise<T[]> {
 
 function rejectWhenAborted(signal: AbortSignal): Promise<never> {
   return new Promise((_, reject) => {
-    const rejectWithReason = () => reject(signal.reason ?? new Error("aborted"));
+    const rejectWithReason = () =>
+      reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
     if (signal.aborted) {
       rejectWithReason();
       return;
@@ -3427,7 +3422,7 @@ describe("createConfiguredOllamaStreamFn", () => {
       const eventsPromise = collectStreamEvents(
         await createManagedOllamaTestStream({
           baseUrl: "http://provider-host:11434",
-          options: { requestTimeoutMs: 25 },
+          model: { requestTimeoutMs: 25 },
           acquire,
         }),
       );
@@ -3461,7 +3456,8 @@ describe("createConfiguredOllamaStreamFn", () => {
     const eventsPromise = collectStreamEvents(
       await createManagedOllamaTestStream({
         baseUrl: "http://provider-host:11434",
-        options: { requestTimeoutMs: 5_000, signal: caller.signal },
+        model: { requestTimeoutMs: 5_000 },
+        options: { signal: caller.signal },
         acquire,
       }),
     );
@@ -3500,7 +3496,7 @@ describe("createConfiguredOllamaStreamFn", () => {
       const eventsPromise = collectStreamEvents(
         await createManagedOllamaTestStream({
           baseUrl: "http://provider-host:11434",
-          options: { requestTimeoutMs: 25 },
+          model: { requestTimeoutMs: 25 },
           acquire,
         }),
       );

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -1419,7 +1419,7 @@ export function createConfiguredOllamaStreamFn(params: {
   localService?: OllamaLocalService;
   providerBaseUrl?: string;
 }): StreamFn {
-  const modelBaseUrl = readStringValue(params.model.baseUrl);
+  const modelBaseUrl = readStringValue(params.model.baseUrl)?.trim();
   const baseUrl = resolveOllamaBaseUrlForRun({
     modelBaseUrl,
     providerBaseUrl: params.providerBaseUrl,

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -1066,7 +1066,7 @@ function createRawOllamaStreamFn(
           ...(options?.signal ? { signal: options.signal } : {}),
           timeoutMs: requestTimeoutMs,
           auditContext: "ollama-stream.chat",
-        }).catch((error) => {
+        }).catch((error: unknown) => {
           localServiceLease?.release();
           throw error;
         });

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -1,6 +1,7 @@
 // Ollama stream runtime implements native transport behavior.
 import { randomUUID } from "node:crypto";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import {
   parseJsonObjectPreservingUnsafeIntegers,
   parseJsonPreservingUnsafeIntegers,
@@ -52,6 +53,7 @@ import {
 } from "./stream-compat.js";
 import { OLLAMA_INCOMPLETE_STREAM_ERROR } from "./stream-contract.js";
 import { checkNdjsonRecordCap } from "./stream-ndjson-cap.js";
+import type { OllamaLocalService } from "./stream-registration.js";
 
 export {
   createConfiguredOllamaCompatStreamWrapper,
@@ -964,6 +966,7 @@ function resolveOllamaRequestTimeoutMs(
 function createRawOllamaStreamFn(
   baseUrl: string,
   defaultHeaders?: Record<string, string>,
+  localService?: OllamaLocalService,
 ): StreamFn {
   const chatUrl = resolveOllamaChatUrl(baseUrl);
   const ssrfPolicy = buildOllamaBaseUrlSsrFPolicy(chatUrl);
@@ -1032,8 +1035,27 @@ function createRawOllamaStreamFn(
         ) {
           headers.Authorization = `Bearer ${options.apiKey}`;
         }
+        const requestTimeoutMs = resolveOllamaRequestTimeoutMs(
+          model,
+          options as { requestTimeoutMs?: unknown; timeoutMs?: unknown } | undefined,
+        );
 
-        const { response, release, refreshTimeout } = await fetchWithSsrFGuard({
+        // Acquire after request composition and release after guarded cleanup;
+        // reversing either boundary can leak the lease or stop inference mid-stream.
+        const acquisitionDeadline = localService
+          ? buildTimeoutAbortSignal({
+              timeoutMs: requestTimeoutMs,
+              signal: options?.signal,
+              operation: "ollama-stream.local-service",
+            })
+          : undefined;
+        const localServiceLease = await localService
+          ?.acquire(
+            { providerId: localService.providerId, baseUrl, headers },
+            acquisitionDeadline?.signal,
+          )
+          .finally(acquisitionDeadline?.cleanup);
+        const guardedFetch = await fetchWithSsrFGuard({
           url: chatUrl,
           init: {
             method: "POST",
@@ -1042,12 +1064,13 @@ function createRawOllamaStreamFn(
           },
           policy: ssrfPolicy,
           ...(options?.signal ? { signal: options.signal } : {}),
-          timeoutMs: resolveOllamaRequestTimeoutMs(
-            model,
-            options as { requestTimeoutMs?: unknown; timeoutMs?: unknown } | undefined,
-          ),
+          timeoutMs: requestTimeoutMs,
           auditContext: "ollama-stream.chat",
+        }).catch((error) => {
+          localServiceLease?.release();
+          throw error;
         });
+        const { response, release, refreshTimeout } = guardedFetch;
 
         try {
           await notifyProviderHttpResponse({ options, response, model });
@@ -1355,7 +1378,11 @@ function createRawOllamaStreamFn(
             message: assistantMessage,
           });
         } finally {
-          await release();
+          try {
+            await release();
+          } finally {
+            localServiceLease?.release();
+          }
         }
       } catch (err) {
         const stopReason = options?.signal?.aborted ? "aborted" : "error";
@@ -1389,14 +1416,15 @@ export function createOllamaStreamFn(
 
 export function createConfiguredOllamaStreamFn(params: {
   model: { baseUrl?: string; headers?: unknown };
+  localService?: OllamaLocalService;
   providerBaseUrl?: string;
 }): StreamFn {
-  return createOllamaStreamFn(
-    resolveOllamaBaseUrlForRun({
-      modelBaseUrl: readStringValue(params.model.baseUrl),
-      providerBaseUrl: params.providerBaseUrl,
-    }),
-    resolveOllamaModelHeaders(params.model),
+  const baseUrl = resolveOllamaBaseUrlForRun({
+    modelBaseUrl: readStringValue(params.model.baseUrl),
+    providerBaseUrl: params.providerBaseUrl,
+  });
+  return createPlainTextToolCallCompatWrapper(
+    createRawOllamaStreamFn(baseUrl, resolveOllamaModelHeaders(params.model), params.localService),
   );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -1419,12 +1419,17 @@ export function createConfiguredOllamaStreamFn(params: {
   localService?: OllamaLocalService;
   providerBaseUrl?: string;
 }): StreamFn {
+  const modelBaseUrl = readStringValue(params.model.baseUrl);
   const baseUrl = resolveOllamaBaseUrlForRun({
-    modelBaseUrl: readStringValue(params.model.baseUrl),
+    modelBaseUrl,
     providerBaseUrl: params.providerBaseUrl,
   });
   return createPlainTextToolCallCompatWrapper(
-    createRawOllamaStreamFn(baseUrl, resolveOllamaModelHeaders(params.model), params.localService),
+    createRawOllamaStreamFn(
+      baseUrl,
+      resolveOllamaModelHeaders(params.model),
+      params.providerBaseUrl?.trim() || !modelBaseUrl ? params.localService : undefined,
+    ),
   );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native Ollama chat requests failed when a configured
`models.providers.<id>.localService` was responsible for starting the Ollama
server. Embedding requests already acquired that service, but native `/api/chat`
requests bypassed it and fetched the stopped endpoint directly.

## Why This Change Was Made

The Ollama plugin now carries the exact configured provider alias and the
host-owned local-service acquirer through its lazy stream registration. Native
chat acquires the service after final payload and header composition, holds the
lease through complete NDJSON response handling, and releases it after guarded
HTTP cleanup.

Acquisition is limited to provider-owned or default endpoints. When a provider
has no `baseUrl` and the selected model supplies a remote `baseUrl`, native chat
preserves that model endpoint and streams it without trying to start the
provider's local service. This matches the existing embedding `remote-config`
ownership boundary.

Root cause: the native Ollama transport issued `/api/chat` directly while the
generic OpenAI-compatible and Ollama embedding transports already honored the
provider local-service lifecycle.

Architectural owner: the bundled Ollama provider transport.

Production source LOC: +98/-50 (net +48) | Tests: +562/-8

## User Impact

Operators can configure an on-demand Ollama server once and expect native chat
and embedding requests to start and lease the same provider-owned service.
Configured provider aliases remain distinct, idle shutdown waits until the full
chat response has been consumed, and model-specific remote endpoints remain
independent of the provider's local service.

## Evidence

- Exact head: `22327a53cab44a1be2d71a30b38a62473e08793e`
- Focused Ollama regression tests: 278 passed across
  `extensions/ollama/index.test.ts`, `extensions/ollama/lazy-import.test.ts`,
  and `extensions/ollama/src/stream-runtime.test.ts`
- Remote model regression: provider local service configured, provider
  `baseUrl` absent, model remote `baseUrl` selected; acquisition stayed at zero,
  `/api/chat` used the remote endpoint, and the stream completed
- Whitespace model regression: a whitespace-only model `baseUrl` normalizes to
  the default provider-owned endpoint, acquires the configured local service,
  and completes the native stream
- Changed-file format, focused extension oxlint, `git diff --check`, and all
  `check:changed` lanes before the extension-wide typecheck passed
- Local extension-wide typecheck reached unrelated existing `acpx` and
  `cua-computer` dependency/type drift; exact-head hosted CI is the fresh
  dependency authority for this head
- Prior code-equivalent full Ollama plugin lane: 650 passed
- TruffleHog exact-diff scan: clean

### Configured local-service smoke

Redacted Crabbox proof at production predecessor
`b4578c98b5f2a96f994e1c0b26bd338da93849a4`:

- Lease `cbx_52c2e5d28478`; artifact SHA-256
  `3b73bbefe115aad752034f0024c440ed78bb389e6a131f50ec3cc661f89fc3ad`
- Confirmed the endpoint was cold before the request and the configured
  nondefault provider alias matched exactly
- Managed startup reached ready state in 267 ms (PID 11683)
- The service lease stayed retained through the streamed response, then idle
  shutdown stopped the managed process
- A 1-second request timeout terminated pending local-service acquisition
  before fetch
- Exact lease accounting returned `0 -> 1 -> 0`

That live proof remains applicable to the provider-owned local endpoint path.
The current repair only omits acquisition when a model-specific endpoint wins
because the provider has no `baseUrl`; provider-owned local selection,
acquisition, timeout, streaming retention, cleanup, and release ordering are
unchanged.

## ClawSweeper Review Response

The latest endpoint-ownership findings are resolved at the Ollama transport owner. Local-service
acquisition now follows endpoint ownership: provider/default endpoints retain
the managed lifecycle, while model-specific remote endpoints skip acquisition.
The regressions prove both zero acquisition for a real remote endpoint and
acquisition for a whitespace-only model endpoint that falls back to the native
default.

Earlier review findings remain resolved: acquisition is bounded by the request
timeout and caller signal, its timer is cleaned when acquisition settles, the
progressing fetch keeps the refreshable timeout, mixed-case configured aliases
are preserved, guarded response cleanup precedes exactly-once lease release,
and the release-owned changelog entry remains absent.

Fresh exact-head CI and ClawSweeper review are required before landing.
