### PR TITLE
fix(sessions): show collaboration details in CLI

### DIFF
--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -81,7 +81,7 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     lastInteractionAt: entry?.lastInteractionAt,
     label: entry?.label,
     status: entry?.status,
-    visibility: entry?.visibility,
+    visibility: entry?.visibility ?? "shared",
     createdActor: entry?.createdActor,
     owner: entry?.owner,
     participants: entry?.participants,

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -30,6 +30,11 @@ export type SessionDisplayRow = {
   lastInteractionAt?: number;
   label?: string;
   status?: SessionEntry["status"];
+  visibility?: SessionEntry["visibility"];
+  createdActor?: SessionEntry["createdActor"];
+  owner?: SessionEntry["owner"];
+  participants?: SessionEntry["participants"];
+  participantCount?: SessionEntry["participantCount"];
   systemSent?: boolean;
   abortedLastRun?: boolean;
   thinkingLevel?: string;
@@ -76,6 +81,11 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     lastInteractionAt: entry?.lastInteractionAt,
     label: entry?.label,
     status: entry?.status,
+    visibility: entry?.visibility,
+    createdActor: entry?.createdActor,
+    owner: entry?.owner,
+    participants: entry?.participants,
+    participantCount: entry?.participantCount,
     systemSent: entry?.systemSent,
     abortedLastRun: entry?.abortedLastRun,
     thinkingLevel: entry?.thinkingLevel,
@@ -134,6 +144,10 @@ export function formatSessionModelCell(model: string | null | undefined, rich: b
   return rich ? theme.info(label) : label;
 }
 
+function formatSessionActor(actor: NonNullable<SessionEntry["createdActor"]>): string {
+  return actor.label?.trim() || actor.id?.trim() || actor.type;
+}
+
 /** Formats compact per-session flags for table output. */
 export function formatSessionFlagsCell(
   row: Pick<
@@ -149,9 +163,25 @@ export function formatSessionFlagsCell(
     | "abortedLastRun"
     | "sessionId"
     | "runtimePolicySessionKey"
+    | "visibility"
+    | "createdActor"
+    | "owner"
+    | "participants"
+    | "participantCount"
   >,
   rich: boolean,
 ): string {
+  const owner = row.owner?.actor ?? row.createdActor;
+  // Match the canonical session-row participant preview bound.
+  const participants = (row.participants ?? []).slice(0, 4).map(formatSessionActor);
+  const remainingParticipants = Math.max(
+    0,
+    (row.participantCount ?? participants.length) - participants.length,
+  );
+  const participantSummary =
+    participants.length > 0
+      ? `${participants.join(",")}${remainingParticipants > 0 ? `,+${remainingParticipants}` : ""}`
+      : undefined;
   const flags = [
     row.thinkingLevel ? `think:${row.thinkingLevel}` : null,
     row.verboseLevel ? `verbose:${row.verboseLevel}` : null,
@@ -162,6 +192,9 @@ export function formatSessionFlagsCell(
     row.groupActivation ? `activation:${row.groupActivation}` : null,
     row.systemSent ? "system" : null,
     row.abortedLastRun ? "aborted" : null,
+    row.visibility ? `visibility:${row.visibility}` : null,
+    owner ? `owner:${formatSessionActor(owner)}` : null,
+    participantSummary ? `participants:${participantSummary}` : null,
     row.runtimePolicySessionKey ? `policy:${row.runtimePolicySessionKey}` : null,
     row.sessionId ? `id:${row.sessionId}` : null,
   ].filter(Boolean);

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -57,7 +57,7 @@ describe("sessionsCommand", () => {
 
     const row = logs.find((line) => line.includes("agent:main:+15555550123")) ?? "";
     expect(row).toBe(
-      "direct      agent:main:+15555550123    45m ago   test:opus      OpenAI Codex       2.0k/200k (1%)       id:abc123",
+      "direct      agent:main:+15555550123    45m ago   test:opus      OpenAI Codex       2.0k/200k (1%)       visibility:shared id:abc123",
     );
   });
 
@@ -115,7 +115,7 @@ describe("sessionsCommand", () => {
 
     const row = logs.find((line) => line.includes("agent:main:main")) ?? "";
     expect(row).toBe(
-      "direct      agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    id:main-session",
+      "direct      agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    visibility:shared id:main-session",
     );
   });
 
@@ -149,7 +149,7 @@ describe("sessionsCommand", () => {
 
     const row = logs.find((line) => line.includes("agent:main:main")) ?? "";
     expect(row).toBe(
-      "direct      agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    id:main-session",
+      "direct      agent:main:main            1m ago    claude-opus-4-7 Claude CLI         unknown/200k (?%)    visibility:shared id:main-session",
     );
   });
 
@@ -282,6 +282,27 @@ describe("sessionsCommand", () => {
     expect(main?.totalTokensFresh).toBe(true);
     expect(group?.totalTokens).toBeNull();
     expect(group?.totalTokensFresh).toBe(false);
+  });
+
+  it("defaults missing collaboration visibility to shared in JSON output", async () => {
+    const sessionKey = "agent:main:legacy-shared";
+    const store = await writeStore(
+      {
+        [sessionKey]: {
+          sessionId: "legacy-shared-session",
+          updatedAt: Date.now() - 60_000,
+          model: "test:opus",
+        },
+      },
+      "sessions-default-visibility",
+    );
+
+    const payload = await runSessionsJson<{
+      sessions?: Array<{ key: string; visibility?: SessionEntry["visibility"] }>;
+    }>(sessionsCommand, store);
+    expect(payload.sessions?.find((entry) => entry.key === sessionKey)).toMatchObject({
+      visibility: "shared",
+    });
   });
 
   it("preserves collaboration metadata in JSON and human output", async () => {

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -1,5 +1,10 @@
 // Sessions command tests cover listing, details, filtering, and transcript display behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assignSessionOwner,
+  recordSessionParticipant,
+} from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
 import {
   cleanupStore,
@@ -277,6 +282,78 @@ describe("sessionsCommand", () => {
     expect(main?.totalTokensFresh).toBe(true);
     expect(group?.totalTokens).toBeNull();
     expect(group?.totalTokensFresh).toBe(false);
+  });
+
+  it("preserves collaboration metadata in JSON and human output", async () => {
+    const sessionKey = "agent:main:shared";
+    const store = await writeStore(
+      {
+        [sessionKey]: {
+          sessionId: "shared-session",
+          updatedAt: Date.now() - 60_000,
+          model: "test:opus",
+          visibility: "suggest",
+          createdActor: { type: "human", id: "profile-creator", label: "Creator" },
+        },
+      },
+      "sessions-collaboration",
+    );
+    const scope = { agentId: "main", sessionKey, storePath: store };
+    assignSessionOwner(scope, {
+      owner: { type: "human", id: "profile-owner", label: "Grace" },
+      assignedBy: { type: "human", id: "profile-admin", label: "Admin" },
+      assignedAt: Date.now() - 30_000,
+    });
+    for (const [id, label] of [
+      ["profile-ada", "Ada"],
+      ["profile-ben", "Ben"],
+      ["profile-cam", "Cam"],
+      ["profile-dee", "Dee"],
+      ["profile-eli", "Eli"],
+    ] as const) {
+      recordSessionParticipant(scope, {
+        actor: { type: "human", id, label },
+        source: "profile",
+      });
+    }
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCommand({ store }, runtime);
+    const row = logs.find((line) => line.includes(sessionKey)) ?? "";
+    expect(row).toContain(
+      "visibility:suggest owner:profile-owner participants:profile-ada,profile-ben,profile-cam,profile-dee,+1",
+    );
+
+    const payload = await runSessionsJson<{
+      sessions?: Array<
+        Pick<
+          SessionEntry,
+          "visibility" | "createdActor" | "owner" | "participants" | "participantCount"
+        > & {
+          key: string;
+          sharingRole?: unknown;
+        }
+      >;
+    }>(sessionsCommand, store);
+    const shared = payload.sessions?.find((entry) => entry.key === sessionKey);
+    expect(shared).toMatchObject({
+      visibility: "suggest",
+      createdActor: { type: "human", id: "profile-creator" },
+      owner: {
+        actor: { type: "human", id: "profile-owner" },
+        assignedBy: { type: "human", id: "profile-admin" },
+        assignedAt: Date.now() - 30_000,
+      },
+      participantCount: 5,
+      participants: [
+        { type: "human", id: "profile-ada", source: "profile" },
+        { type: "human", id: "profile-ben", source: "profile" },
+        { type: "human", id: "profile-cam", source: "profile" },
+        { type: "human", id: "profile-dee", source: "profile" },
+        { type: "human", id: "profile-eli", source: "profile" },
+      ],
+    });
+    expect(shared).not.toHaveProperty("sharingRole");
   });
 
   it("reports the SQLite database and omits the retired sessionFile field", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users listing collaborative sessions with `openclaw sessions` would not see the persisted visibility, owner, or participant details. The JSON form also dropped those canonical fields entirely.

## Why This Change Was Made

The CLI now preserves the persisted collaboration fields in its shared session display projection. Missing legacy visibility is normalized to the canonical `shared` value. Human output renders terminal-sanitized visibility, effective owner, and a participant preview capped at four with a `+N` overflow count; JSON output retains the canonical persisted values.

The command deliberately does not invent viewer-relative `sharingRole`, because the local session store has no authenticated viewer identity.

## User Impact

Operators can now identify shared and suggest-mode sessions, their effective owner, and their participant roster directly from both human-readable and JSON session listings.

## Evidence

- Authentic pre-fix regression: the new SQLite-backed command test failed because the session row contained only ordinary flags and JSON omitted all collaboration metadata.
- Focused tests: `node scripts/run-vitest.mjs src/commands/sessions.test.ts src/commands/sessions-table.test.ts --maxWorkers=4` — 25 passed, covering canonical default `shared` and explicit `suggest` visibility in human and JSON output.
- Targeted typecheck: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.commands.json --builders 1` — passed.
- OXlint, formatter, and `git diff --check` — passed.
- ClawSweeper's default-visibility finding is resolved at the shared projection owner with dedicated regression coverage.
- Fresh local autoreview of the follow-up — no actionable findings (correctness confidence 0.99); the original branch review was also clean at 0.97.
- The broader local `check-changed` reached the unrelated core-test typecheck and stopped because the borrowed shared `node_modules` has `pako` 1.0.11 without `@types/pako`, while `ui/package.json` expects 3.0.1. No dependency files were changed to mask that environment mismatch; exact-head CI remains authoritative.
