### PR TITLE
perf(cron): skip history checks for future jobs

### DIFF
--- a/src/cron/service/timer-runnable.ts
+++ b/src/cron/service/timer-runnable.ts
@@ -67,6 +67,12 @@ export function isRunnableJob(params: {
   if (hasActiveCronRun(job)) {
     return false;
   }
+  const next = job.state.nextRunAtMs;
+  // Ordinary ticks cannot recover a missed cron slot before a future wake.
+  // Keep their dominant no-due path ahead of run-history normalization.
+  if (!params.allowCronMissedRunByLastRun && hasScheduledNextRunAtMs(next) && nowMs < next) {
+    return false;
+  }
   const lastRunStatus = resolveJobLastRunStatus(job);
   if (params.skipAtIfAlreadyRan && job.schedule.kind === "at" && lastRunStatus) {
     const lastRun = job.state.lastRunAtMs;
@@ -88,8 +94,7 @@ export function isRunnableJob(params: {
     }
     return false;
   }
-  const next = job.state.nextRunAtMs;
-  if (isErrorBackoffPending(params.state, job, nowMs)) {
+  if (isErrorBackoffPending(job, nowMs, lastRunStatus)) {
     // Error retry windows are anchored at run end; persisted start-based
     // retry timestamps from older state must not bypass active backoff.
     return false;
@@ -122,8 +127,12 @@ export function isRunnableJob(params: {
   return hasMissedCronSlotSinceLastRun(job, nowMs);
 }
 
-function isErrorBackoffPending(_state: CronServiceState, job: CronJob, nowMs: number): boolean {
-  if (job.schedule.kind === "at" || resolveJobLastRunStatus(job) !== "error") {
+function isErrorBackoffPending(
+  job: CronJob,
+  nowMs: number,
+  lastRunStatus: ReturnType<typeof resolveJobLastRunStatus>,
+): boolean {
+  if (job.schedule.kind === "at" || lastRunStatus !== "error") {
     return false;
   }
   const backoffUntilMs = resolveJobErrorBackoffUntilMs(job, DEFAULT_ERROR_BACKOFF_SCHEDULE_MS);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where ordinary Cron scheduler ticks normalized run history for every enabled, inactive job even when its finite `nextRunAtMs` already proved that the job was strictly in the future. Large resident job stores paid this avoidable work on every no-due or small-due scan.

## Why This Change Was Made

The runnable-job owner now checks the already-persisted next wake before run-history normalization, but only for ordinary ticks. Startup missed-run recovery retains the existing history-aware path, and due/error paths reuse the status already resolved by the owner.

This change was AI-assisted. I reviewed the complete owner, caller, recovery, backoff, and one-shot paths and understand the resulting behavior.

## User Impact

Operators with large Cron job stores should see lower scheduler CPU and due-selection latency when most jobs are scheduled in the future. Runnable selection, ordering, startup catch-up, retries, persistence, and delivery behavior are unchanged.

## Evidence

- Exact head: `dfdbbd3339cb38e7c529cb1a03628cd363d2908c`; parent/current-main baseline: `b7cafbe7e82686b14c0f7c8e7af83194fd05ad42`.
- Deterministic current-main red/green probe: three ordinary future jobs performed 7 irrelevant history reads before the repair and 0 after it, while selecting no jobs in both cases. The getter-count probe was removed before commit under test-audit because it is implementation-coupled rather than a persisted-data behavior contract.
- Independent base/head differential: 22,680 combinations covering missing/zero/NaN/past/exact/future/infinite next wakes, every/at/cron schedules, canonical and legacy statuses, enabled/active states, skip IDs, one-shot handling, and startup missed-run options. Results, returned identity, and ordering were exact across 4,932,085 bytes at SHA-256 `75defa96e5f60caaebc78515088b78b4c05df29a1856f3afc3269c9d251806be`.
- Current-base owner benchmark: 100,000 future jobs, 10 scans/sample × 9 alternating samples after warmup. Median fell from 203.192 ms to 145.023 ms (**28.63% lower**) with identical zero-selection checksums; instrumented history reads fell from 2,500 to 0 for 1,000 representative jobs. This is owner-stage evidence, not an end-to-end throughput claim.
- Focused owner/recovery/backoff proof: 5 files / 97 tests passed after the final rebase.
- Full Cron suite: 183 files / 2,348 tests passed.
- `node scripts/check-changed.mjs -- src/cron/service/timer-runnable.ts`: passed formatting, typechecks, lint, dead exports, guards, and import-cycle checks.
- `pnpm build`: passed all core, package, plugin, SDK, postbuild, and Control UI phases.
- Exact committed-head Codex Sol/high autoreview: clean, no accepted/actionable P0/P1 findings; TruffleHog preflight clean.
- Exact-head CI [run 32602232212](https://github.com/openclaw/openclaw/actions/runs/32602232212): passed at `dfdbbd3339cb38e7c529cb1a03628cd363d2908c`.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 128048`: passed in `hosted_exact_or_recent_parent` mode without changing the PR head.
- ClawSweeper exact-head review [run 32602306206](https://github.com/openclaw/clawsweeper/actions/runs/32602306206): `keep_open`, patch correct at 0.93 confidence, no review/security findings, and no rank-up moves. Its terminal proof used the nonexistent path `src/cron/service/restart-catchup.test.ts`; rerunning the repository-native command against the actual exact-head file, `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts`, passed 1 file / 26 tests.
- Live GitHub overlap search found no open PR for `collectRunnableJobs`, due selection, or this performance cause. Open #112375 adds a separate pre-execution shell gate and does not touch `timer-runnable.ts`.
