### PR TITLE
fix(auth): preserve non-lock store write errors

### DIFF
--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -9,7 +9,10 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FILE_LOCK_TIMEOUT_ERROR_CODE, resetFileLockStateForTest } from "../../infra/file-lock.js";
-import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { OAuthRefreshFailureError } from "./oauth-refresh-failure.js";
 import { buildRefreshContentionError } from "./oauth-refresh-lock-errors.js";
@@ -19,6 +22,7 @@ import {
   readAuthProfileStoreForTest,
 } from "./oauth-test-utils.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
 let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile;
@@ -1026,6 +1030,35 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     });
 
     expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the OAuth diagnosis when stale lastGood cleanup fails", async () => {
+    const profileId = "openai:default";
+    saveAuthProfileStore(
+      {
+        ...createExpiredOauthStore({ profileId, provider: "openai" }),
+        lastGood: { openai: profileId },
+      },
+      agentDir,
+    );
+    const store = ensureAuthProfileStore(agentDir);
+    openOpenClawAgentDatabase({
+      agentId: "main",
+      path: resolveAuthProfileDatabasePath(agentDir),
+    }).db.exec("ALTER TABLE auth_profile_state DROP COLUMN updated_at");
+    getOAuthApiKeyMock.mockImplementationOnce(async () => {
+      throw new Error(
+        '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
+      );
+    });
+
+    const failure = await resolveApiKeyForProfile({ store, profileId, agentDir }).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(OAuthRefreshFailureError);
+    expect(String(failure)).toContain("refresh_token_reused");
+    expect(String(failure)).not.toContain("no column named updated_at");
   });
 
   it("clears stale lastGood before selecting an alternate Codex OAuth profile", async () => {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -28,6 +28,7 @@ import {
 } from "../../secrets/runtime-degraded-state.js";
 import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
+import { authProfilesLog } from "./constants.js";
 import {
   evaluateStoredCredentialEligibility,
   resolveTokenExpiryState,
@@ -505,11 +506,20 @@ export async function resolveApiKeyForProfile(
         agentDir: params.agentDir,
         profileId,
       });
-      await clearLastGoodProfileWithLock({
-        provider: cred.provider,
-        profileId,
-        agentDir: ownerAgentDir,
-      });
+      let clearedLastGood = false;
+      try {
+        await clearLastGoodProfileWithLock({
+          provider: cred.provider,
+          profileId,
+          agentDir: ownerAgentDir,
+        });
+        clearedLastGood = true;
+      } catch (cleanupError) {
+        // The refresh failure owns the operator diagnosis; stale last-good cleanup is secondary.
+        authProfilesLog.warn("failed to clear stale OAuth last-good state after refresh failure", {
+          error: formatErrorMessage(cleanupError),
+        });
+      }
       if (
         params.agentDir !== ownerAgentDir &&
         hasRuntimeAuthProfileStoreSnapshot(params.agentDir)
@@ -524,7 +534,9 @@ export async function resolveApiKeyForProfile(
           setRuntimeAuthProfileStoreSnapshot(snapshot, params.agentDir);
         }
       }
-      refreshedStore = loadAuthProfileStoreForSecretsRuntime(params.agentDir);
+      if (clearedLastGood) {
+        refreshedStore = loadAuthProfileStoreForSecretsRuntime(params.agentDir);
+      }
     }
     const fallbackProfileId =
       params.allowProfileFallback === false

--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -88,6 +88,20 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
     expect(readPersistedAuthProfileStoreRaw(agentDir)).toEqual(unreadableStore);
   });
 
+  it("returns null for classified SQLite lock contention", async () => {
+    const { agentDir } = await withAgentStore({});
+    const lockError = Object.assign(new Error("database is locked"), { errcode: 5 });
+
+    await expect(
+      updateAuthProfileStoreWithLock({
+        agentDir,
+        updater: () => {
+          throw lockError;
+        },
+      }),
+    ).resolves.toBeNull();
+  });
+
   it("detects a legacy credential source that appears after an earlier clean load", async () => {
     const { agentDir } = await withAgentStore({});
     expect(loadAuthProfileStoreForRuntime(agentDir).profiles).toEqual({});

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -7,6 +7,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isSecretRef } from "../../config/types.secrets.js";
+import { isSqliteLockError } from "../../infra/sqlite-transaction.js";
 import { isRecord } from "../../utils.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import { AUTH_STORE_VERSION, authProfilesLog } from "./constants.js";
@@ -862,7 +863,7 @@ function mergeRuntimeExternalProfileState(params: {
   return merged;
 }
 
-/** Apply an auth store update inside the SQLite write lock; null on write failure, rethrows credential-boundary errors. */
+/** Apply an auth store update inside the SQLite write lock; null only on lock contention. */
 export async function updateAuthProfileStoreWithLock(params: {
   agentDir?: string;
   sharedStoreWrite?: boolean;
@@ -896,19 +897,14 @@ export async function updateAuthProfileStoreWithLock(params: {
       { sharedStoreWrite: params.sharedStoreWrite, stateDir: params.stateDir },
     );
   } catch (error) {
-    // Credential-boundary failures name their own remediation; collapsing them
-    // into `null` makes callers report a lock-contention retry that never clears.
-    const isCredentialBoundaryFailure =
-      error instanceof AuthProfileMigrationRequiredError ||
-      error instanceof AuthProfileStoreUnreadableError;
-    if (isCredentialBoundaryFailure) {
-      throw error;
-    }
     const message = error instanceof Error ? error.message : String(error);
     authProfilesLog.warn(`auth profile store update failed: ${message}`, {
       agentDir,
       error: message,
     });
+    if (!isSqliteLockError(error)) {
+      throw error;
+    }
     return null;
   }
   publishRuntimeSnapshotsAfterCommit(publishRuntimeSnapshots);

--- a/src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts
@@ -194,6 +194,29 @@ describe("auth profile batch persistence", () => {
     });
   });
 
+  it("reports a schema write failure instead of lock-contention retry advice", async () => {
+    await withAgentDir(async (agentDir) => {
+      await upsertAuthProfileWithLockOrThrow({
+        agentDir,
+        profileId: "openai:existing",
+        credential: apiKey("sk-existing"),
+      });
+      openOpenClawAgentDatabase({
+        agentId: "work",
+        path: resolveAuthProfileDatabasePath(agentDir),
+      }).db.exec("ALTER TABLE auth_profile_store DROP COLUMN updated_at");
+
+      const failure = await upsertAuthProfileWithLockOrThrow({
+        agentDir,
+        profileId: "openai:new",
+        credential: apiKey("sk-new"),
+      }).catch((error: unknown) => error);
+
+      expect(String(failure)).toContain("no column named updated_at");
+      expect(String(failure)).not.toContain("lock may be busy");
+    });
+  });
+
   it("leaves no partial profile batch when the SQLite state write fails", async () => {
     await withAgentDir(async (agentDir) => {
       const database = openOpenClawAgentDatabase({

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -779,7 +779,7 @@ describe("terminal resolution", () => {
     expect(resolved.result.payloads).toEqual([{ text: "Chart attached" }]);
   });
 
-  it("still reports an incomplete turn when the output budget ends with no text", async () => {
+  it("still reports an incomplete turn when auth failure bookkeeping rejects", async () => {
     const assistant = emptyAssistant({ stopReason: "length" });
     const attempt = makeEmbeddedRunnerAttempt({
       assistantTexts: [],
@@ -787,8 +787,17 @@ describe("terminal resolution", () => {
       currentAttemptAssistant: assistant,
       currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
     });
+    const maybeMarkAuthProfileFailure = vi.fn(async () => {
+      throw new Error("injected auth store write failure");
+    });
     const resolved = await resolveEmbeddedRunTerminal(
-      makeTerminalInput({ attempt, attemptAssistant: assistant }),
+      makeTerminalInput({
+        attempt,
+        attemptAssistant: assistant,
+        authProfileId: "openai:default",
+        assistantProfileFailureReason: "unknown",
+        maybeMarkAuthProfileFailure,
+      }),
     );
 
     expect(resolved.action).toBe("complete");
@@ -798,5 +807,10 @@ describe("terminal resolution", () => {
     expect(resolved.result.payloads?.[0]).toMatchObject({ isError: true });
     expect(resolved.result.meta.error?.kind).toBe("incomplete_turn");
     expect(resolved.result.meta.livenessState).toBe("abandoned");
+    expect(maybeMarkAuthProfileFailure).toHaveBeenCalledWith({
+      profileId: "openai:default",
+      reason: "unknown",
+      modelId: "gpt-5.6-luna",
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -496,11 +496,15 @@ async function surfaceIncompleteTurn(
   });
   input.setTerminalLifecycleMeta({ replayInvalid, livenessState });
   if (input.authProfileId) {
-    await input.maybeMarkAuthProfileFailure({
-      profileId: input.authProfileId,
-      reason: input.assistantProfileFailureReason,
-      modelId: input.modelId,
-    });
+    try {
+      await input.maybeMarkAuthProfileFailure({
+        profileId: input.authProfileId,
+        reason: input.assistantProfileFailureReason,
+        modelId: input.modelId,
+      });
+    } catch (error) {
+      log.warn(`terminal auth bookkeeping failed; preserving result: ${String(error)}`);
+    }
   }
   return {
     action: "complete",

--- a/src/plugin-sdk/provider-auth-api-key.ts
+++ b/src/plugin-sdk/provider-auth-api-key.ts
@@ -6,9 +6,9 @@ export type { SecretInput } from "../config/types.secrets.js";
 
 export {
   upsertAuthProfile,
-  upsertAuthProfileWithLock,
   upsertAuthProfileWithLockOrThrow,
 } from "../agents/auth-profiles/profiles.js";
+export { upsertAuthProfileWithLockCompat as upsertAuthProfileWithLock } from "./provider-auth-write-compat.js";
 export {
   formatApiKeyPreview,
   normalizeApiKeyInput,

--- a/src/plugin-sdk/provider-auth-write-compat.test.ts
+++ b/src/plugin-sdk/provider-auth-write-compat.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
+import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { upsertAuthProfileWithLock as upsertApiKeyProfileWithLock } from "./provider-auth-api-key.js";
+import {
+  removeProviderAuthProfilesWithLock,
+  updateAuthProfileStoreWithLock,
+} from "./provider-auth.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+});
+
+describe("provider auth write compatibility", () => {
+  it("preserves nullable failures on both shipped Plugin SDK subpaths", async () => {
+    const root = tempDirs.make("openclaw-provider-auth-sdk-");
+    const agentDir = path.join(root, "agents", "work", "agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openai:existing": { type: "api_key", provider: "openai", key: "sk-existing" },
+        },
+      },
+      agentDir,
+    );
+    openOpenClawAgentDatabase({
+      agentId: "work",
+      path: resolveAuthProfileDatabasePath(agentDir),
+    }).db.exec("ALTER TABLE auth_profile_store DROP COLUMN updated_at");
+
+    await expect(
+      updateAuthProfileStoreWithLock({
+        agentDir,
+        updater: (store) => {
+          store.profiles["openai:existing"] = {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-updated",
+          };
+          return true;
+        },
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      removeProviderAuthProfilesWithLock({
+        agentDir,
+        provider: "openai",
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      upsertApiKeyProfileWithLock({
+        agentDir,
+        profileId: "openai:new",
+        credential: { type: "api_key", provider: "openai", key: "sk-new" },
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/plugin-sdk/provider-auth-write-compat.ts
+++ b/src/plugin-sdk/provider-auth-write-compat.ts
@@ -1,0 +1,36 @@
+import { removeProviderAuthProfilesWithLock as removeProviderAuthProfilesWithLockStrict } from "../agents/auth-profiles/profiles.js";
+import { updateAuthProfileStoreWithLock as updateAuthProfileStoreWithLockStrict } from "../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import { upsertAuthProfileWithLock as upsertAuthProfileWithLockStrict } from "../agents/auth-profiles/upsert-with-lock.js";
+
+// These Plugin SDK exports shipped with nullable failure semantics. Core callers use the
+// strict helpers directly so plugins retain the stable contract without masking core failures.
+export async function updateAuthProfileStoreWithLockCompat(
+  params: Parameters<typeof updateAuthProfileStoreWithLockStrict>[0],
+): Promise<AuthProfileStore | null> {
+  try {
+    return await updateAuthProfileStoreWithLockStrict(params);
+  } catch {
+    return null;
+  }
+}
+
+export async function upsertAuthProfileWithLockCompat(
+  params: Parameters<typeof upsertAuthProfileWithLockStrict>[0],
+): Promise<AuthProfileStore | null> {
+  try {
+    return await upsertAuthProfileWithLockStrict(params);
+  } catch {
+    return null;
+  }
+}
+
+export async function removeProviderAuthProfilesWithLockCompat(
+  params: Parameters<typeof removeProviderAuthProfilesWithLockStrict>[0],
+): Promise<AuthProfileStore | null> {
+  try {
+    return await removeProviderAuthProfilesWithLockStrict(params);
+  } catch {
+    return null;
+  }
+}

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -60,14 +60,13 @@ export { CLAUDE_CLI_PROFILE_ID, CODEX_CLI_PROFILE_ID } from "../agents/auth-prof
 export {
   ensureAuthProfileStore,
   ensureAuthProfileStoreForLocalUpdate,
-  updateAuthProfileStoreWithLock,
 } from "../agents/auth-profiles/store.js";
+export { listProfilesForProvider, upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
 export {
-  listProfilesForProvider,
-  removeProviderAuthProfilesWithLock,
-  upsertAuthProfile,
-  upsertAuthProfileWithLock,
-} from "../agents/auth-profiles/profiles.js";
+  removeProviderAuthProfilesWithLockCompat as removeProviderAuthProfilesWithLock,
+  updateAuthProfileStoreWithLockCompat as updateAuthProfileStoreWithLock,
+  upsertAuthProfileWithLockCompat as upsertAuthProfileWithLock,
+} from "./provider-auth-write-compat.js";
 export { resolveEnvApiKey } from "../agents/model-auth-env.js";
 export {
   readClaudeCliCredentialsCached,


### PR DESCRIPTION
Closes #128025

## What Problem This Solves

Fixes an issue where users who successfully authenticate with a provider would be told that the auth store lock might be busy when persistence actually failed for a permanent reason such as an incompatible SQLite schema. The misleading retry advice hid the real failure and could send operators through repeated login attempts that could never save credentials.

## Why This Change Was Made

The shared auth-store write boundary now returns its existing `null` sentinel only for errors classified by the canonical SQLite lock predicate (`SQLITE_BUSY` or `SQLITE_LOCKED`). Every other write failure is logged and rethrown unchanged, so required credential writes retain the real diagnosis while genuine contention keeps the existing retry behavior.

Best-effort incomplete-turn bookkeeping explicitly catches those propagated failures at the terminal-resolution boundary. A secondary persistence failure is logged but cannot replace the already-prepared user-visible terminal result. There is no schema, config, or public API change; production code is net-neutral across the complete PR.

## User Impact

Operators now see the actionable underlying auth-store error after a provider login fails to persist. Genuine SQLite lock contention still produces the existing wait-and-retry guidance, and auth-health bookkeeping failures no longer suppress an incomplete-turn response.

## Evidence

- Current-main credential reproduction: remove `auth_profile_store.updated_at`, then call `upsertAuthProfileWithLockOrThrow`. Before the fix, the regression received only `Failed to update auth profile store; the auth store lock may be busy`; after the fix it receives `no column named updated_at` and no lock advice.
- ClawSweeper P1 regression: make terminal auth-failure bookkeeping reject after an incomplete turn has been prepared. Before the follow-up fix, `resolveEmbeddedRunTerminal` rejected with the bookkeeping error; after the fix it returns `action: "complete"` with the expected incomplete-turn payload.
- `node scripts/run-vitest.mjs src/agents/auth-profiles/upsert-with-lock.test.ts src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts src/agents/auth-profiles/source-check.test.ts src/agents/embedded-agent-runner/run/terminal-resolution.test.ts` — 51/51 passed.
- `node scripts/check-changed.mjs -- src/agents/auth-profiles/store.ts src/agents/auth-profiles/source-check.test.ts src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts src/agents/embedded-agent-runner/run/terminal-resolution.ts src/agents/embedded-agent-runner/run/terminal-resolution.test.ts` — passed, including core production/test typechecks, lint, format, import-cycle, schema, dependency, and architecture guards.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings (`gpt-5.6-sol`, high reasoning).
- `git diff --check` — passed.

AI-assisted: yes. The issue, current source, required credential path, best-effort terminal caller, persistence owner, relevant history, and focused tests were reviewed directly. ClawSweeper's P1 was reproduced before the follow-up repair and its requested terminal-delivery invariant is now covered.
