### PR TITLE
fix(matrix): hint at --json when --include-recovery-key is a text-mode dead end

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -342,6 +342,8 @@ openclaw matrix verify status
 openclaw matrix verify status --include-recovery-key --json
 ```
 
+With `--include-recovery-key`, text output confirms when a raw recovery key is available and directs you to add `--json`. Text output never prints the key itself; keep JSON output containing a recovery key private.
+
 `verify status` reports three independent trust signals (`--verbose` shows all of them):
 
 - `Locally trusted`: trusted by this client only

--- a/extensions/matrix/src/cli-shared.ts
+++ b/extensions/matrix/src/cli-shared.ts
@@ -313,6 +313,7 @@ type MatrixCliBackupStatus = MatrixRoomKeyBackupStatus;
 
 export type MatrixCliVerificationStatus = MatrixOwnDeviceVerificationStatus & {
   pendingVerifications: number;
+  recoveryKey?: string | null;
   recoveryKeyAccepted?: boolean;
   backupUsable?: boolean;
   deviceOwnerVerified?: boolean;
@@ -605,6 +606,13 @@ export function printVerificationStatus(
   if (backupIssue.message) {
     console.log(`Backup issue: ${backupIssue.message}`);
   }
+  console.log(`Recovery key stored: ${status.recoveryKeyStored ? "yes" : "no"}`);
+  // Only JSON output may expose the explicitly requested raw key.
+  if (status.recoveryKey) {
+    console.log(
+      "Recovery key: available (re-run with --json to include the raw key value in output)",
+    );
+  }
   if (verbose) {
     console.log("Diagnostics:");
     printVerificationIdentity(status);
@@ -613,11 +621,8 @@ export function printVerificationStatus(
     }
     printVerificationTrustDiagnostics(status);
     printVerificationBackupStatus(status);
-    console.log(`Recovery key stored: ${status.recoveryKeyStored ? "yes" : "no"}`);
     printTimestamp("Recovery key created at", status.recoveryKeyCreatedAt);
     console.log(`Pending verifications: ${status.pendingVerifications}`);
-  } else {
-    console.log(`Recovery key stored: ${status.recoveryKeyStored ? "yes" : "no"}`);
   }
   printVerificationGuidance(status, accountId);
 }

--- a/extensions/matrix/src/cli.test.ts
+++ b/extensions/matrix/src/cli.test.ts
@@ -860,6 +860,62 @@ describe("matrix CLI verification commands", () => {
     expectRecordFields(mockCallArg(getMatrixVerificationStatusMock), { readiness: "none" });
   });
 
+  describe.each([false, true])("recovery key output (verbose=%s)", (verbose) => {
+    it.each([
+      { include: false, recoveryKey: undefined },
+      { include: true, recoveryKey: null },
+      { include: true, recoveryKey: "test-recovery-key" },
+    ])(
+      "prints a safe hint for include=$include, key=$recoveryKey",
+      async ({ include, recoveryKey }) => {
+        getMatrixVerificationStatusMock.mockResolvedValue(
+          matrixVerificationStatus({ recoveryKey, recoveryKeyStored: recoveryKey !== null }),
+        );
+        await runMatrixCli([
+          "matrix",
+          "verify",
+          "status",
+          ...(include ? ["--include-recovery-key"] : []),
+          ...(verbose ? ["--verbose"] : []),
+        ]);
+
+        expectRecordFields(mockCallArg(getMatrixVerificationStatusMock), {
+          includeRecoveryKey: include,
+        });
+        const output = consoleLogMock.mock.calls.flat().join("\n");
+        expect(
+          output.includes(
+            "Recovery key: available (re-run with --json to include the raw key value in output)",
+          ),
+        ).toBe(Boolean(recoveryKey));
+        expect(output).toContain(`Recovery key stored: ${recoveryKey === null ? "no" : "yes"}`);
+        expect(output).not.toContain("test-recovery-key");
+        expect(stdoutWriteMock).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+      },
+    );
+
+    it.each([false, true])("preserves JSON recovery key opt-in=%s", async (include) => {
+      const status = matrixVerificationStatus(include ? { recoveryKey: "test-recovery-key" } : {});
+      getMatrixVerificationStatusMock.mockResolvedValue(status);
+      await runMatrixCli([
+        "matrix",
+        "verify",
+        "status",
+        "--json",
+        ...(include ? ["--include-recovery-key"] : []),
+        ...(verbose ? ["--verbose"] : []),
+      ]);
+
+      expectRecordFields(mockCallArg(getMatrixVerificationStatusMock), {
+        includeRecoveryKey: include,
+      });
+      expect(JSON.parse(String(stdoutWriteArg()))).toEqual(status);
+      expect(consoleLogMock).not.toHaveBeenCalled();
+      expect(process.exitCode).toBeUndefined();
+    });
+  });
+
   it("passes loaded cfg to all verify subcommands", async () => {
     const fakeCfg = { channels: { matrix: {} } };
     matrixRuntimeLoadConfigMock.mockReturnValue(fakeCfg);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw matrix verify status --include-recovery-key` got no indication that the requested key was available in text mode. The action already returned the opted-in key, but the text renderer only reported whether a key was stored. The same gap is present in the stable `v2026.7.1` source.

## Why This Change Was Made

Keep the existing JSON-only raw-key output contract and print a fixed availability hint in the common text renderer. The hint applies in both normal and verbose mode, never interpolates the key, and directs the operator to add `--json` to the same command.

Maintainer rewrite of @hartmark's contribution: put the optional field on `MatrixCliVerificationStatus`, whose action result can contain the opted-in value, not on `MatrixOwnDeviceVerificationStatus`, whose producer never returns the raw key. Remove the duplicated stored-key output branch instead of adding a new helper. Reuse the existing real-command-parser tests rather than creating a second renderer-only fixture. Retrieval, crypto, persistence, configuration, and JSON serialization are unchanged.

Production LOC: **+8/-3 (net +5)**; tests: **+56/-0**; docs: **+2/-0**. The remaining production growth is the missing operator-visible hint plus its accurate CLI type and non-disclosure comment; no extra helper, new option, fallback, or low-level SDK field remains.

## User Impact

An explicitly requested recovery key no longer appears to be silently ignored. Text output confirms availability without exposing it; JSON still returns it only through the existing explicit opt-in. The Matrix guide explains both modes and reminds operators to keep recovery-key JSON private. Thanks @hartmark for the report, original fix, and real-account reproduction.

## Evidence

- Baseline `b7d9be02093061e7879bea571b5ef6fd2605c909`: the two new normal/verbose positive-hint cases failed for the missing hint; the other eight new opt-in/absent-key/JSON cases passed. Command: `node scripts/run-vitest.mjs extensions/matrix/src/cli.test.ts -t 'recovery key output'`.
- Rewritten source: `node scripts/run-vitest.mjs extensions/matrix/src/cli.test.ts extensions/matrix/src/matrix/actions/verification.test.ts extensions/matrix/src/matrix/sdk/crypto-facade.test.ts extensions/matrix/src/matrix/sdk/recovery-key-store.test.ts` — **110 tests passed**.
- `env -u OPENCLAW_TESTBOX OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs --base b7d9be02093061e7879bea571b5ef6fd2605c909 -- extensions/matrix/src/cli-shared.ts extensions/matrix/src/cli.test.ts docs/channels/matrix.md` — passed: formatting, production/test types, lint, dead exports (zero), plugin boundaries, database-first/sidecar guards, runtime cycles (zero), and five doctor-contract guard tests.
- `env -u OPENCLAW_TESTBOX pnpm build` — passed, including actual Matrix plugin build, SDK exports, and CLI bootstrap guards. Existing unrelated dependency `eval`, browser-externalized `node:path`, and plugin timing warnings were emitted; no build errors.
- Fresh Codex autoreview: no accepted/actionable findings. Independent source review also confirmed the CLI result boundary and unchanged secret access.
- Owner evidence: `cli-verification.ts` forwards the explicit flag; `matrix/actions/verification.ts` only adds `recoveryKey` after that opt-in; `matrix/sdk/client-verification.ts` returns metadata only; `cli-shared.ts` dispatches JSON separately from text. Encryption setup and device-verification sibling commands do not acquire this raw-key field.
- History: the July 25 CLI split in #113664 (author and merger @steipete, commit `4aa4ff72501c68fc815163a50e3234d75ac8f152`) carried the existing renderer forward. Stable `v2026.7.1` already has the same missing hint; shallow-history boundaries do not establish the original introducing commit.

### Fresh maintainer terminal proof

Ran the real built `dist/entry.js matrix verify status` command in a fresh temporary HOME/config/state directory against a synthetic local HTTP homeserver. No action, renderer, or SDK mocks: the actual Matrix SDK initialized Rust WASM crypto, persisted/reopened its local state, and used the existing recovery-key fixture migration into SQLite. An OS-level network policy permitted loopback only. The homeserver rejected non-GET requests.

All six commands exited 0: opted-in normal text, opted-in verbose text, opted-in JSON, text without opt-in, opted-in text without a stored key, and opted-in JSON without a key. Both text modes printed the hint exactly once and no raw key. Only opted-in JSON contained the synthetic key; absent-key JSON returned null. All **36 HTTP requests were GETs; zero writes were attempted**. No real account or credentials were used. Temporary HOME/state and server were cleaned up.

Observed operator output (diagnostics omitted):

```text
$ openclaw matrix verify status --include-recovery-key
Account: default
Verified by owner: no
Backup: missing on server
Backup issue: no room-key backup exists on the homeserver
Recovery key stored: yes
Recovery key: available (re-run with --json to include the raw key value in output)
```

This deliberately unverified fixture has no server backup: the proof covers real CLI loading, normal crypto preparation, stored-key retrieval, output selection, and non-disclosure, not real-server identity trust or backup restoration. Renderer SHA-256: `ddae1cf1a16f92977376b1e4bf43f93183c5659361fae5269fd7e6a59d08ad5f`.

### Contributor real-account evidence

The original contributor reported a redacted real-account before/after run: text mode printed `Recovery key stored: yes` without an opt-in hint on main, and added the safe availability hint on the original PR. The contributor also programmatically checked that `--include-recovery-key --json` returned a nonempty key without printing it into the PR. This is contributor-provided evidence, not a claim that the maintainer used that account.

### Review follow-through

The earlier ClawSweeper production-growth concern is addressed by removing the new helper and misplaced SDK field, reducing production growth from +14 to +5 and extending stronger existing command-level coverage. This PR continues to own the repair. Exact rewritten-head CI and fresh terminal proof are recorded in the landing comment before merge.

Known scope boundary: this fixes presentation of an already returned key. The existing best-effort `--allow-degraded-local-state` path can return no raw key when crypto has not been initialized; changing that retrieval behavior is a separate owner-level follow-up, not hidden in this presentation fix.

AI-assisted maintainer rewrite and validation.
