### PR TITLE
fix: allow code mode repair after preflight rejection

### DIFF
--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -84,6 +84,7 @@ import {
   formatToolExecutionErrorMessage,
   isTrustedToolExecutionPreflightError,
   protectNetworkToolExecutionError,
+  registerTrustedToolNoStartError,
 } from "./tool-result-error.js";
 import { copyToolTerminalPresentation } from "./tool-terminal-presentation.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -174,6 +175,7 @@ class BeforeToolCallFailureError extends Error {
 function tagBeforeToolCallFailure(
   error: unknown,
   signal?: AbortSignal,
+  stage?: "tool_preparation" | "before_tool_call",
 ): BeforeToolCallFailureError {
   try {
     if (error instanceof BeforeToolCallFailureError) {
@@ -184,7 +186,11 @@ function tagBeforeToolCallFailure(
   }
   const message = formatToolExecutionErrorMessage(error, "before_tool_call failed");
   const disposition = resolveToolErrorDiagnostic(error, signal).terminalReason;
-  return new BeforeToolCallFailureError(message, disposition, error);
+  const tagged = new BeforeToolCallFailureError(message, disposition, error);
+  if (stage === "tool_preparation" && isTrustedToolExecutionPreflightError(error)) {
+    registerTrustedToolNoStartError(tagged);
+  }
+  return tagged;
 }
 
 /** Return the closed terminal disposition carried by a before-tool failure. */
@@ -427,7 +433,7 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, params, "tool_preparation");
-        throw tagBeforeToolCallFailure(error, signal);
+        throw tagBeforeToolCallFailure(error, signal, "tool_preparation");
       }
       const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params: preparedParams });
       const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params: preparedParams });
@@ -444,7 +450,7 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, hookParams, "before_tool_call");
-        throw tagBeforeToolCallFailure(error, signal);
+        throw tagBeforeToolCallFailure(error, signal, "before_tool_call");
       }
       if (outcome.blocked) {
         if (outcome.kind !== "veto") {
@@ -487,7 +493,7 @@ export function wrapToolWithBeforeToolCallHook(
         });
       } catch (error) {
         recordPreExecutionError(error, outcome.params ?? hookParams, "tool_preparation");
-        throw tagBeforeToolCallFailure(error, signal);
+        throw tagBeforeToolCallFailure(error, signal, "tool_preparation");
       }
       let onImplementationStart: (() => void) | undefined;
       if (prepareControl) {

--- a/src/agents/bash-tools.exec-request-preparation.ts
+++ b/src/agents/bash-tools.exec-request-preparation.ts
@@ -26,6 +26,7 @@ import { buildSandboxEnv, coerceEnv } from "./bash-tools.shared.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import { prepareGitHubToolEnvironment } from "./github-tool-identity.js";
 import { sanitizeEnvVars } from "./sandbox/sanitize-env-vars.js";
+import { ToolInputError } from "./tools/common.js";
 
 export type ExecToolArgs = Record<string, unknown> & {
   command: string;
@@ -73,6 +74,14 @@ const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
   "ask",
   "node",
 ] as const;
+
+export function assertSupportedExecParams(args: unknown): void {
+  if (isRecord(args) && Object.hasOwn(args, "timeout")) {
+    throw new ToolInputError(
+      'exec parameter "timeout" is unsupported; use "timeoutSeconds" instead',
+    );
+  }
+}
 
 function buildSubprocessChannelContext(
   channelContext: PluginHookChannelContext | undefined,
@@ -286,6 +295,7 @@ export function createExecRequestPreparation(params: {
     args: unknown,
     context: { hookContext?: unknown },
   ): Promise<ExecToolArgs> => {
+    assertSupportedExecParams(args);
     const execParams = await prepareParamsWithResolvedExecWorkdir(args);
     const workdirState = getResolvedExecWorkdirPreparedState(execParams);
     if (workdirState?.resolution.kind === "unavailable") {

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -32,6 +32,7 @@ import { describeExecTool } from "./bash-tools.descriptions.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
 import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
 import {
+  assertSupportedExecParams,
   createExecRequestPreparation,
   type ExecToolArgs,
   resolveExecPreparedRunEnvironment,
@@ -176,9 +177,7 @@ export function createExecTool(
     finalizeBeforeToolCallParams: requestPreparation.finalizeBeforeToolCallParams,
     execute: async (toolCallId, args, signal, onUpdate) => {
       signal?.throwIfAborted();
-      if (Object.hasOwn(args, "timeout")) {
-        throw new Error('exec parameter "timeout" is unsupported; use "timeoutSeconds" instead');
-      }
+      assertSupportedExecParams(args);
       // Review cancellation belongs to this execution, never another call on the shared tool.
       const autoReviewer =
         defaults?.autoReviewer ??

--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -26,6 +26,10 @@ import {
   SWARM_CODE_MODE_REQUEST_FINGERPRINT,
 } from "./subagents/swarm/swarm-code-mode.js";
 import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
+import {
+  consumeTrustedToolNoStartError,
+  registerTrustedToolNoStartError,
+} from "./tool-result-error.js";
 import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
 import {
   waitForCollectorCompletion,
@@ -579,10 +583,14 @@ export async function runBridgeRequest(params: {
       value: boundCodeModeValue(value, params.maxOutputBytes),
     };
   } catch (error) {
-    return {
+    const settled: SettledBridgeRequest = {
       id: params.request.id,
       ok: false,
       error: redactCodeModeCatalogIds(formatErrorMessage(error), catalogProjection.bindings),
     };
+    if (consumeTrustedToolNoStartError(error)) {
+      registerTrustedToolNoStartError(settled);
+    }
+    return settled;
   }
 }

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -79,7 +79,7 @@ export async function runCodeModeExec(params: {
     throw new ToolInputError("code mode is disabled.");
   }
   const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config), {
-    validateInput: true,
+    prepareInput: true,
   });
   params.onRuntime?.(runtime);
   const bridgeDispatch = createCodeModeBridgeDispatchState();

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -10,6 +10,7 @@ import {
   createCodeModeNamespaceRuntime,
   type CodeModeNamespaceRuntime,
 } from "./code-mode-namespaces.js";
+import { registerRepairableCodeModeFailure } from "./code-mode-repair-provenance.js";
 import {
   CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
   codeModeFailureCode,
@@ -31,8 +32,10 @@ import {
   cancelPendingBridgeStates,
   cancelPendingBridgeStatesById,
   codeModeWaitingReason,
+  createCodeModeBridgeDispatchState,
   createPendingBridgeStates,
   disposeCodeModeRun,
+  isCodeModeBridgeRepairEligible,
   pendingBridgeRequestsReplaySafe,
   pendingBridgeStatesForSettlement,
   pendingToolCalls,
@@ -46,6 +49,7 @@ import {
   telemetry,
   waitForPendingBridgeSettlement,
   type PendingBridgeState,
+  type CodeModeBridgeDispatchState,
 } from "./code-mode-state.js";
 import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
@@ -74,9 +78,11 @@ export async function runCodeModeExec(params: {
   if (config.enabled === false) {
     throw new ToolInputError("code mode is disabled.");
   }
-  const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config));
+  const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config), {
+    validateInput: true,
+  });
   params.onRuntime?.(runtime);
-  const bridgeDispatch = { started: false };
+  const bridgeDispatch = createCodeModeBridgeDispatchState();
   if (params.signal?.aborted) {
     return {
       status: "failed" as const,
@@ -241,7 +247,7 @@ async function settleCodeModeResult(params: {
   pending?: PendingBridgeState[];
   activeRunId?: string;
   reservedActiveRunSlot?: boolean;
-  bridgeDispatch: { started: boolean };
+  bridgeDispatch: CodeModeBridgeDispatchState;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
 }) {
@@ -320,11 +326,6 @@ async function settleCodeModeResult(params: {
       const newPendingRequests = result.pendingRequests.filter(
         (request) => !pendingIds.has(request.id),
       );
-      if (newPendingRequests.some((request) => request.method !== "sleep")) {
-        // createPendingBridgeStates starts host calls synchronously. Flip the
-        // evidence first so every later failure is permanently non-retryable.
-        params.bridgeDispatch.started = true;
-      }
       pending.push(
         ...createPendingBridgeStates({
           pendingRequests: newPendingRequests,
@@ -339,6 +340,7 @@ async function settleCodeModeResult(params: {
           ctx: params.ctx,
           signal: params.signal,
           onUpdate: params.onUpdate,
+          bridgeDispatch: params.bridgeDispatch,
         }),
       );
       const ready = await waitForPending(
@@ -375,6 +377,7 @@ async function settleCodeModeResult(params: {
           namespaceRuntime: params.namespaceRuntime,
           output,
           deliveredOutputCount,
+          bridgeDispatch: params.bridgeDispatch,
         });
       }
       // Deliver the settled frontier only. Unresolved sibling promises remain
@@ -458,9 +461,6 @@ async function settleCodeModeResult(params: {
         const newPendingRequests = result.pendingRequests.filter(
           (request) => !pendingIds.has(request.id),
         );
-        if (newPendingRequests.some((request) => request.method !== "sleep")) {
-          params.bridgeDispatch.started = true;
-        }
         pending.push(
           ...createPendingBridgeStates({
             pendingRequests: newPendingRequests,
@@ -475,6 +475,7 @@ async function settleCodeModeResult(params: {
             ctx: params.ctx,
             signal: params.signal,
             onUpdate: params.onUpdate,
+            bridgeDispatch: params.bridgeDispatch,
           }),
         );
         return storeSnapshotState({
@@ -492,6 +493,7 @@ async function settleCodeModeResult(params: {
           namespaceRuntime: params.namespaceRuntime,
           output,
           deliveredOutputCount,
+          bridgeDispatch: params.bridgeDispatch,
         });
       } catch (error) {
         cancelPendingBridgeStates(pending);
@@ -499,9 +501,6 @@ async function settleCodeModeResult(params: {
       } finally {
         releaseReservation?.();
       }
-    }
-    if (result.pendingRequests.some((request) => request.method !== "sleep")) {
-      params.bridgeDispatch.started = true;
     }
     return snapshotState({
       pendingRequests: result.pendingRequests,
@@ -521,6 +520,7 @@ async function settleCodeModeResult(params: {
       settlementMode: result.settlementMode,
       signal: params.signal,
       onUpdate: params.onUpdate,
+      bridgeDispatch: params.bridgeDispatch,
     });
   }
   // Defensive cleanup covers aborts or terminal failures; successful runs have
@@ -531,7 +531,7 @@ async function settleCodeModeResult(params: {
     ...(result.status === "completed" ? { value: result.value } : {}),
     maxOutputBytes: params.config.maxOutputBytes,
   });
-  return {
+  const finalized = {
     ...result,
     ...(result.status === "completed" ? { value: bounded.value } : {}),
     ...(result.status === "failed"
@@ -544,6 +544,10 @@ async function settleCodeModeResult(params: {
     replaySafe: params.replaySafe,
     telemetry: telemetry(params.runtime),
   };
+  if (finalized.status === "failed" && isCodeModeBridgeRepairEligible(params.bridgeDispatch)) {
+    registerRepairableCodeModeFailure(finalized);
+  }
+  return finalized;
 }
 
 export async function runWait(params: {
@@ -596,7 +600,7 @@ export async function runWait(params: {
           error: "code mode execution aborted",
           code: "aborted" as const,
           failurePhase: "bridge" as const,
-          bridgeDispatchStarted: true,
+          bridgeDispatchStarted: state.bridgeDispatch.started,
           output: takeUndeliveredCodeModeRunOutput(state),
           replaySafe: state.replaySafe,
           telemetry: telemetry(state.runtime),
@@ -657,7 +661,7 @@ export async function runWait(params: {
       runtime: state.runtime,
       catalogProjection: state.catalogProjection,
       namespaceRuntime: state.namespaceRuntime,
-      bridgeDispatch: { started: true },
+      bridgeDispatch: state.bridgeDispatch,
       deliveredOutputCount: outputTruncated ? 0 : state.deliveredOutputCount,
       pending,
       activeRunId: state.runId,
@@ -676,7 +680,7 @@ export async function runWait(params: {
       error: codeModeFailureMessage(error),
       code: codeModeFailureCode(error),
       failurePhase: "bridge" as const,
-      bridgeDispatchStarted: true,
+      bridgeDispatchStarted: state.bridgeDispatch.started,
       output: takeUndeliveredCodeModeRunOutput(state),
       replaySafe: state.replaySafe,
       telemetry: telemetry(state.runtime),

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -219,7 +219,7 @@ export async function runCodeModeScriptHeadless(params: {
     const swarmEnabled = false;
     const codeModeRunId = `cm_headless_${randomUUID()}`;
     const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config), {
-      validateInput: true,
+      prepareInput: true,
     });
     const bridgeDispatch = createCodeModeBridgeDispatchState();
     const namespaceCatalog = runtime.namespaceEntries();

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -30,6 +30,7 @@ import {
 } from "./code-mode-runtime.js";
 import {
   cancelPendingBridgeStates,
+  createCodeModeBridgeDispatchState,
   createPendingBridgeStates,
   pendingBridgeStatesForSettlement,
   settledBridgeRequestsInCompletionOrder,
@@ -217,7 +218,10 @@ export async function runCodeModeScriptHeadless(params: {
     // Headless runs publish no resumable snapshot/handle, so collector globals stay unavailable.
     const swarmEnabled = false;
     const codeModeRunId = `cm_headless_${randomUUID()}`;
-    const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config));
+    const runtime = new ToolSearchRuntime(params.ctx, toToolSearchConfig(config), {
+      validateInput: true,
+    });
+    const bridgeDispatch = createCodeModeBridgeDispatchState();
     const namespaceCatalog = runtime.namespaceEntries();
     const namespaceRuntime = createCodeModeNamespaceRuntime(namespaceCatalog);
     const preparedSource = await awaitCodeModeDeadline({
@@ -310,6 +314,7 @@ export async function runCodeModeScriptHeadless(params: {
           deadlineMs: deadline,
           ctx: params.ctx,
           signal: abortScope.signal,
+          bridgeDispatch,
         }),
       );
       // Preserve the waiting frontier before the lazy deadline callback;

--- a/src/agents/code-mode-repair-provenance.ts
+++ b/src/agents/code-mode-repair-provenance.ts
@@ -1,0 +1,13 @@
+const repairableFailureDetails = new WeakSet<object>();
+
+/** Attach host-only repair authority to one finalized Code Mode failure payload. */
+export function registerRepairableCodeModeFailure(details: object): void {
+  repairableFailureDetails.add(details);
+}
+
+/** Consume repair authority from the exact host-created failure payload. */
+export function consumeRepairableCodeModeFailure(details: unknown): boolean {
+  return (
+    typeof details === "object" && details !== null && repairableFailureDetails.delete(details)
+  );
+}

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -15,8 +15,15 @@ import {
   type SettledBridgeRequest,
 } from "./code-mode-runtime.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
+import { consumeTrustedToolNoStartError } from "./tool-result-error.js";
 import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
 import { ToolInputError } from "./tools/common.js";
+
+export type CodeModeBridgeDispatchState = {
+  started: boolean;
+  trackedDispatches: number;
+  repairProvenance: "clean" | "eligible" | "invalid";
+};
 
 export type PendingBridgeState = PendingBridgeRequest & {
   promise: Promise<SettledBridgeRequest>;
@@ -44,6 +51,7 @@ type CodeModeRunState = {
   runtime: ToolSearchRuntime;
   catalogProjection: CodeModeCatalogProjection;
   namespaceRuntime: CodeModeNamespaceRuntime;
+  bridgeDispatch: CodeModeBridgeDispatchState;
 };
 
 const MAX_ACTIVE_CODE_MODE_RUNS = 64;
@@ -54,6 +62,15 @@ export const resumingRunIds = new Set<string>();
 let activeRunReservations = 0;
 let nextPendingBridgeSettlementSequence = 0;
 let activeRunExpiryTimer: ReturnType<typeof setTimeout> | undefined;
+
+export function createCodeModeBridgeDispatchState(): CodeModeBridgeDispatchState {
+  return { started: false, trackedDispatches: 0, repairProvenance: "clean" };
+}
+
+/** Read the monotonic host-only repair classification for one Code Mode run. */
+export function isCodeModeBridgeRepairEligible(state: CodeModeBridgeDispatchState): boolean {
+  return state.repairProvenance === "eligible";
+}
 
 // One unreferenced timer owns parked snapshots even when no later exec or wait
 // arrives; otherwise expired runs keep their VM bytes and live tool calls.
@@ -245,6 +262,7 @@ export function snapshotState(params: {
   settlementMode: CodeModeSettlementMode;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
+  bridgeDispatch: CodeModeBridgeDispatchState;
 }) {
   enforceSnapshotStateLimits(params);
   const runId = `cm_${randomUUID()}`;
@@ -327,6 +345,7 @@ export function createPendingBridgeStates(params: {
   ctx: ToolSearchToolContext;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
+  bridgeDispatch: CodeModeBridgeDispatchState;
 }): PendingBridgeState[] {
   return params.pendingRequests.map((request) => {
     // Bridge calls start immediately while the VM snapshot is stored. Their
@@ -335,6 +354,14 @@ export function createPendingBridgeStates(params: {
     const signal = params.signal
       ? AbortSignal.any([params.signal, abortController.signal])
       : abortController.signal;
+    const tracksDispatch = request.method !== "sleep";
+    if (tracksDispatch) {
+      params.bridgeDispatch.started = true;
+      params.bridgeDispatch.trackedDispatches += 1;
+      if (params.bridgeDispatch.trackedDispatches > 1) {
+        params.bridgeDispatch.repairProvenance = "invalid";
+      }
+    }
     const state: PendingBridgeState = {
       ...request,
       promise: runBridgeRequest({
@@ -350,6 +377,13 @@ export function createPendingBridgeStates(params: {
         signal,
         onUpdate: params.onUpdate,
       }).then((settled) => {
+        const trustedNoStart = tracksDispatch && consumeTrustedToolNoStartError(settled);
+        if (tracksDispatch && params.bridgeDispatch.repairProvenance !== "invalid") {
+          params.bridgeDispatch.repairProvenance =
+            params.bridgeDispatch.trackedDispatches === 1 && trustedNoStart
+              ? "eligible"
+              : "invalid";
+        }
         state.settledSequence = ++nextPendingBridgeSettlementSequence;
         state.settled = settled;
         if (state.method === "agentWait" && params.activeRunId) {
@@ -388,6 +422,7 @@ export function storeSnapshotState(params: {
   namespaceRuntime: CodeModeNamespaceRuntime;
   output: unknown[];
   deliveredOutputCount?: number;
+  bridgeDispatch: CodeModeBridgeDispatchState;
 }) {
   const now = Date.now();
   const expiresAt = resolveCodeModeSnapshotExpiresAt(now, params.config.snapshotTtlSeconds);
@@ -420,6 +455,7 @@ export function storeSnapshotState(params: {
     runtime: params.runtime,
     catalogProjection: params.catalogProjection,
     namespaceRuntime: params.namespaceRuntime,
+    bridgeDispatch: params.bridgeDispatch,
   });
   scheduleActiveRunExpiry();
   return {

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import { resolveCodeModeConfig, toToolSearchConfig } from "./code-mode-runtime.js";
 import {
   activeRuns,
+  createCodeModeBridgeDispatchState,
   disposeAllCodeModeRuns,
   disposeCodeModeRun,
   reserveActiveRunSlot,
@@ -56,6 +57,7 @@ function parkExpiringRun(
     catalogProjection: createCodeModeCatalogProjection([]),
     namespaceRuntime: createCodeModeNamespaceRuntime(),
     output: [],
+    bridgeDispatch: createCodeModeBridgeDispatchState(),
   });
   return cancel;
 }

--- a/src/agents/code-mode.bridge.test.ts
+++ b/src/agents/code-mode.bridge.test.ts
@@ -140,7 +140,7 @@ describe("Code Mode bridge settlement and cancellation", () => {
           code: `
             const ids = [];
             for (let index = 0; index < 5; index += 1) {
-              const called = await fake_create_ticket({ value: index });
+              const called = await fake_create_ticket({ value: String(index) });
               ids.push(called.input.value);
             }
             return ids;
@@ -150,7 +150,7 @@ describe("Code Mode bridge settlement and cancellation", () => {
     );
 
     expect(details.status).toBe("completed");
-    expect(details.value).toEqual([0, 1, 2, 3, 4]);
+    expect(details.value).toEqual(["0", "1", "2", "3", "4"]);
     expect(ticket.execute).toHaveBeenCalledTimes(5);
     expect(testing.activeRuns.size).toBe(0);
   });
@@ -818,40 +818,6 @@ describe("Code Mode bridge settlement and cancellation", () => {
     expect(slowCompleted).toBe(true);
     expect(slowAborted).toBe(false);
     expect(testing.activeRuns.size).toBe(0);
-  });
-
-  it("marks failures after nested tool dispatch as non-retryable bridge failures", async () => {
-    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
-    const sideEffect = pluginToolWithExecute("fake_side_effect", "Side effect", async () =>
-      jsonResult({ ok: true }),
-    );
-    applyCodeModeCatalog({
-      tools: [...codeModeTools, sideEffect],
-      config,
-      sessionId: "session-code-mode",
-      sessionKey: "agent:main:main",
-      runId: "run-code-mode",
-      catalogRef,
-    });
-
-    const details = resultDetails(
-      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
-        "code-call-post-dispatch-failure",
-        {
-          code: `
-            await fake_side_effect({});
-            throw new Error("after dispatch");
-          `,
-        },
-      ),
-    );
-
-    expect(sideEffect.execute).toHaveBeenCalledOnce();
-    expect(details).toMatchObject({
-      status: "failed",
-      failurePhase: "bridge",
-      bridgeDispatchStarted: true,
-    });
   });
 
   it("returns an actionable bounded result when a nested tool result exceeds the output budget", async () => {

--- a/src/agents/code-mode.preflight-repair.test.ts
+++ b/src/agents/code-mode.preflight-repair.test.ts
@@ -1,0 +1,99 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createExecTool } from "./bash-tools.exec-run.js";
+import { applyCodeModeCatalog } from "./code-mode.js";
+import {
+  createCodeModeHarness,
+  pluginToolWithExecute,
+  resetCodeModeTestState,
+  resultDetails,
+} from "./code-mode.test-support.js";
+import { jsonResult, ToolInputError, type AnyAgentTool } from "./tools/common.js";
+
+async function runCode(code: string, targets: AnyAgentTool[]) {
+  const { config, catalogRef, tools } = createCodeModeHarness();
+  applyCodeModeCatalog({
+    tools: [...tools, ...targets],
+    config,
+    sessionId: "session-code-mode",
+    sessionKey: "agent:main:main",
+    runId: "run-code-mode",
+    catalogRef,
+  });
+  return resultDetails(
+    await expectDefined(tools[0], "Code Mode exec test invariant").execute(
+      "code-call-preflight-repair",
+      { code },
+    ),
+  );
+}
+
+describe("Code Mode preflight repair", () => {
+  afterEach(() => resetCodeModeTestState());
+
+  it("rejects stale exec timeout input before starting the command", async () => {
+    const exec = createExecTool({ host: "gateway", security: "full", ask: "off" });
+    const execute = vi.spyOn(exec, "execute");
+
+    const details = await runCode('await exec({ command: "printf ok", timeout: 5 });', [exec]);
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(details).toMatchObject({
+      status: "failed",
+      failurePhase: "bridge",
+      bridgeDispatchStarted: true,
+    });
+    expect(details.error).toContain("timeout");
+  });
+
+  it("keeps mixed bridge settlements non-retryable", async () => {
+    const completed = pluginToolWithExecute("fake_completed", "Complete", async () =>
+      jsonResult({ ok: true }),
+    );
+    const preflight = pluginToolWithExecute("fake_preflight", "Reject input", async () =>
+      jsonResult({ unexpected: true }),
+    );
+    preflight.prepareBeforeToolCallParams = () => {
+      throw new ToolInputError("input needs repair");
+    };
+
+    const details = await runCode("await Promise.all([fake_completed({}), fake_preflight({})]);", [
+      completed,
+      preflight,
+    ]);
+
+    expect(completed.execute).toHaveBeenCalledOnce();
+    expect(preflight.execute).not.toHaveBeenCalled();
+    expect(details).toMatchObject({
+      status: "failed",
+      failurePhase: "bridge",
+      bridgeDispatchStarted: true,
+    });
+  });
+
+  it.each([
+    {
+      label: "guest failure after a successful call",
+      execute: async () => jsonResult({ ok: true }),
+      code: 'await fake_post_dispatch({}); throw new Error("after dispatch");',
+    },
+    {
+      label: "ToolInputError after implementation start",
+      execute: async () => {
+        throw new ToolInputError("implementation already started");
+      },
+      code: "await fake_post_dispatch({});",
+    },
+  ])("keeps $label non-retryable", async ({ execute, code }) => {
+    const target = pluginToolWithExecute("fake_post_dispatch", "Post-dispatch failure", execute);
+
+    const details = await runCode(code, [target]);
+
+    expect(target.execute).toHaveBeenCalledOnce();
+    expect(details).toMatchObject({
+      status: "failed",
+      failurePhase: "bridge",
+      bridgeDispatchStarted: true,
+    });
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -132,8 +132,9 @@ function createSubscriptionMock(): SubscriptionMock {
     getLatestMcpAppChannelView: () => undefined,
     getLatestMcpConnectAction: () => undefined,
     toolMetas: [] as Array<{ toolName: string; meta?: string; asyncStarted?: boolean }>,
-    runToolLifecycle: async <T>(toolParams: { execute: () => Promise<T> }) =>
-      await toolParams.execute(),
+    runToolLifecycle: async <T>(toolParams: {
+      execute: (onImplementationStart: () => void) => Promise<T>;
+    }) => await toolParams.execute(() => undefined),
     unsubscribe: () => {},
     setTerminalLifecycleMeta: () => {},
     waitForCompactionRetry: async () => {},

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -103,7 +103,7 @@ describe("prepareEmbeddedAttemptStream", () => {
     vi.clearAllMocks();
     mocks.subscribe.mockReturnValue({
       toolMetas: [],
-      runToolLifecycle: vi.fn(async ({ execute }) => await execute()),
+      runToolLifecycle: vi.fn(async ({ execute }) => await execute(() => undefined)),
       isCompacting: vi.fn(() => false),
     });
     mocks.runBeforeFinalizeHook.mockResolvedValue({ action: "continue" });

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -30,6 +30,7 @@ import {
   isAgentRunRestartAbortReason,
 } from "../../run-termination.js";
 import type { AgentMessage } from "../../runtime/index.js";
+import { getInternalToolExecutionPreparer } from "../../runtime/internal-hooks.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { isToolResultError } from "../../tool-result-error.js";
 import {
@@ -349,14 +350,37 @@ export function prepareEmbeddedAttemptStream(input: {
         hideFromChannelProgress:
           "hideFromChannelProgress" in toolParams.tool &&
           toolParams.tool.hideFromChannelProgress === true,
-        execute: async () =>
-          await toolParams.tool.execute(
-            toolParams.toolCallId,
-            toolParams.input,
-            toolParams.signal ?? input.runAbortController.signal,
-            toolParams.onUpdate,
-            undefined as never,
-          ),
+        execute: async (onImplementationStart) => {
+          const signal = toolParams.signal ?? input.runAbortController.signal;
+          const preparer = getInternalToolExecutionPreparer(toolParams.tool);
+          if (!preparer) {
+            onImplementationStart();
+            return await toolParams.tool.execute(
+              toolParams.toolCallId,
+              toolParams.input,
+              signal,
+              toolParams.onUpdate,
+              undefined as never,
+            );
+          }
+          const prepared = await preparer({
+            toolCallId: toolParams.toolCallId,
+            args: toolParams.input,
+            signal,
+            onUpdate: toolParams.onUpdate,
+          });
+          try {
+            if (prepared.kind === "immediate") {
+              if (prepared.outcome.kind === "error") {
+                throw prepared.outcome.error;
+              }
+              return prepared.outcome.result;
+            }
+            return await prepared.execute(onImplementationStart);
+          } finally {
+            prepared.dispose();
+          }
+        },
       });
       // Settlement persists every queued projection. Validate the final result
       // first so a rejected hidden-tool value never enters session history.

--- a/src/agents/embedded-agent-runner/run/code-mode-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-repair.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { registerRepairableCodeModeFailure } from "../../code-mode-repair-provenance.js";
 import type { AfterToolOutcomeContext, Agent, AgentToolResult } from "../../runtime/index.js";
 import { installCodeModeRepairHook } from "./code-mode-repair.js";
 
@@ -38,6 +39,7 @@ function failedResult(params?: {
   failurePhase?: "input" | "guest" | "bridge" | "host";
   bridgeDispatchStarted?: boolean;
   output?: unknown[];
+  repairable?: boolean;
 }): AgentToolResult<unknown> {
   const details = {
     status: "failed",
@@ -47,10 +49,14 @@ function failedResult(params?: {
     bridgeDispatchStarted: params?.bridgeDispatchStarted ?? false,
     ...(params?.output ? { output: params.output } : {}),
   };
-  return {
+  const result: AgentToolResult<unknown> = {
     content: [{ type: "text", text: JSON.stringify(details) }],
     details,
   };
+  if (params?.repairable) {
+    registerRepairableCodeModeFailure(details);
+  }
+  return result;
 }
 
 function completedResult(): AgentToolResult<unknown> {
@@ -165,7 +171,7 @@ describe("installCodeModeRepairHook", () => {
     });
   });
 
-  it("does not consume the repair on sibling execs from the originating turn", async () => {
+  it("consumes the repair when a sibling exec follows in the originating turn", async () => {
     const agent = createAgent();
     const assistantMessage = {
       role: "assistant",
@@ -183,8 +189,8 @@ describe("installCodeModeRepairHook", () => {
     const correctionFailure = await agent.afterToolOutcome?.(outcome({ result: failedResult() }));
 
     expect(siblingFailure).toMatchObject({
-      terminate: false,
-      details: { repair: { allowed: true, remainingAttempts: 1 } },
+      terminate: true,
+      details: { repair: { allowed: false, remainingAttempts: 0 } },
     });
     expect(correctionFailure).toMatchObject({
       terminate: true,
@@ -194,14 +200,16 @@ describe("installCodeModeRepairHook", () => {
 
   it("never offers a retry after bridge dispatch", async () => {
     const agent = createAgent();
+    const failure = failedResult({
+      failurePhase: "bridge",
+      bridgeDispatchStarted: true,
+      output: [{ type: "text", text: "before dispatch failure" }],
+    });
+    (failure.details as Record<string, unknown>).repairableNoStart = true;
 
     const result = await agent.afterToolOutcome?.(
       outcome({
-        result: failedResult({
-          failurePhase: "bridge",
-          bridgeDispatchStarted: true,
-          output: [{ type: "text", text: "before dispatch failure" }],
-        }),
+        result: failure,
       }),
     );
     const payload = JSON.parse(
@@ -217,6 +225,29 @@ describe("installCodeModeRepairHook", () => {
       },
     });
     expect(payload.output).toEqual([{ type: "text", text: "before dispatch failure" }]);
+  });
+
+  it("offers one repair for an authenticated nested no-start bridge failure", async () => {
+    const agent = createAgent();
+
+    const result = await agent.afterToolOutcome?.(
+      outcome({
+        result: failedResult({
+          failurePhase: "bridge",
+          bridgeDispatchStarted: true,
+          repairable: true,
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      terminate: false,
+      details: {
+        bridgeDispatchStarted: true,
+        repair: { allowed: true, remainingAttempts: 1 },
+      },
+    });
   });
 
   it("preserves dispatch evidence replaced by an earlier outcome hook", async () => {

--- a/src/agents/embedded-agent-runner/run/code-mode-repair.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-repair.ts
@@ -3,6 +3,7 @@ import {
   CODE_MODE_EXEC_TOOL_NAME,
   CODE_MODE_WAIT_TOOL_NAME,
 } from "../../code-mode-control-tools.js";
+import { consumeRepairableCodeModeFailure } from "../../code-mode-repair-provenance.js";
 import type {
   AfterToolCallResult,
   AfterToolOutcomeContext,
@@ -18,6 +19,7 @@ type CodeModeFailure = {
   failurePhase: CodeModeFailurePhase;
   bridgeDispatchStarted: boolean;
   bridgeDispatchKnown: boolean;
+  repairableNoStart: boolean;
   details: Record<string, unknown>;
 };
 
@@ -58,6 +60,7 @@ function codeModeFailureFromOutcome(context: AfterToolOutcomeContext): CodeModeF
       ),
       bridgeDispatchStarted,
       bridgeDispatchKnown: typeof details.bridgeDispatchStarted === "boolean",
+      repairableNoStart: consumeRepairableCodeModeFailure(details),
       details,
     };
   }
@@ -72,6 +75,7 @@ function codeModeFailureFromOutcome(context: AfterToolOutcomeContext): CodeModeF
     failurePhase: argumentValidation ? "input" : "host",
     bridgeDispatchStarted: context.executionStarted,
     bridgeDispatchKnown: argumentValidation,
+    repairableNoStart: false,
     details,
   };
 }
@@ -117,6 +121,7 @@ function preserveOriginalDispatchEvidence(
       failurePhase: "bridge",
       bridgeDispatchStarted: true,
       bridgeDispatchKnown: true,
+      repairableNoStart: original.repairableNoStart || preserved.repairableNoStart,
     };
   }
   if (!original.bridgeDispatchKnown || preserved.bridgeDispatchKnown) {
@@ -127,6 +132,7 @@ function preserveOriginalDispatchEvidence(
     failurePhase: original.failurePhase,
     bridgeDispatchStarted: original.bridgeDispatchStarted,
     bridgeDispatchKnown: true,
+    repairableNoStart: original.repairableNoStart || preserved.repairableNoStart,
   };
 }
 
@@ -206,6 +212,7 @@ function hookFailure(
         : "input",
     bridgeDispatchStarted: original?.bridgeDispatchStarted ?? context.executionStarted,
     bridgeDispatchKnown: original?.bridgeDispatchKnown ?? !context.executionStarted,
+    repairableNoStart: false,
     details: original?.details ?? {},
   };
 }
@@ -215,6 +222,7 @@ export function installCodeModeRepairHook(params: { agent: Agent }): void {
   const previousAfterToolOutcome = params.agent.afterToolOutcome?.bind(params.agent);
   let repairState: RepairState = "ready";
   let repairOfferedBy: AfterToolOutcomeContext["assistantMessage"] | undefined;
+  let repairOfferedFor: AfterToolOutcomeContext["toolCall"] | undefined;
 
   params.agent.afterToolOutcome = async (context, signal) => {
     const codeModeTool =
@@ -264,7 +272,7 @@ export function installCodeModeRepairHook(params: { agent: Agent }): void {
       if (
         effective.toolCall.name === CODE_MODE_EXEC_TOOL_NAME &&
         repairState === "offered" &&
-        effective.assistantMessage !== repairOfferedBy
+        (effective.assistantMessage !== repairOfferedBy || effective.toolCall !== repairOfferedFor)
       ) {
         repairState = "consumed";
       }
@@ -282,7 +290,10 @@ export function installCodeModeRepairHook(params: { agent: Agent }): void {
       });
     }
 
-    if (failure.bridgeDispatchStarted || effective.toolCall.name === CODE_MODE_WAIT_TOOL_NAME) {
+    if (
+      (failure.bridgeDispatchStarted && !failure.repairableNoStart) ||
+      effective.toolCall.name === CODE_MODE_WAIT_TOOL_NAME
+    ) {
       repairState = "consumed";
       return renderFailure({
         failure,
@@ -295,19 +306,10 @@ export function installCodeModeRepairHook(params: { agent: Agent }): void {
     }
 
     const repairable =
-      failure.bridgeDispatchKnown &&
-      (failure.failurePhase === "input" || failure.failurePhase === "guest") &&
-      (failure.code === "invalid_input" || failure.code === "internal_error");
-    if (repairState === "offered" && effective.assistantMessage === repairOfferedBy && repairable) {
-      return renderFailure({
-        failure,
-        allowed: true,
-        remainingAttempts: 1,
-        reason:
-          "Retry exec once with corrected JavaScript or TypeScript. Do not repeat unchanged input.",
-        terminate: false,
-      });
-    }
+      failure.repairableNoStart ||
+      (failure.bridgeDispatchKnown &&
+        (failure.failurePhase === "input" || failure.failurePhase === "guest") &&
+        (failure.code === "invalid_input" || failure.code === "internal_error"));
 
     if (repairState === "offered" || repairState === "consumed") {
       repairState = "consumed";
@@ -333,6 +335,7 @@ export function installCodeModeRepairHook(params: { agent: Agent }): void {
 
     repairState = "offered";
     repairOfferedBy = effective.assistantMessage;
+    repairOfferedFor = effective.toolCall;
     return renderFailure({
       failure,
       allowed: true,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -691,4 +691,5 @@ export async function handleToolExecutionEnd(
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);
       });
   }
+  return { executionStarted: terminal.executionStarted };
 }

--- a/src/agents/embedded-agent-subscribe.handlers.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.ts
@@ -123,8 +123,8 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
       case "tool_execution_end":
         void scheduleEvent(
           evt,
-          () => {
-            return handleToolExecutionEnd(ctx, evt as never);
+          async () => {
+            await handleToolExecutionEnd(ctx, evt as never);
           },
           { detach: true },
         );

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -38,6 +38,10 @@ import { buildToolLifecycleErrorResult } from "./embedded-agent-tool-results.js"
 import { stripDowngradedToolCallText } from "./embedded-agent-utils.js";
 import type { AgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 import type { AgentMessage } from "./runtime/index.js";
+import {
+  consumeTrustedToolNoStartError,
+  registerTrustedToolNoStartError,
+} from "./tool-result-error.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const embeddedLog = createSubsystemLogger("agent/embedded");
@@ -607,7 +611,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       args: unknown;
       replaySafe?: boolean;
       hideFromChannelProgress?: boolean;
-      execute: () => Promise<T>;
+      execute: (onImplementationStart: () => void) => Promise<T>;
     }): Promise<T> => {
       await handleToolExecutionStart(ctx, {
         type: "tool_execution_start",
@@ -617,28 +621,36 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         replaySafe: toolParams.replaySafe,
         hideFromChannelProgress: toolParams.hideFromChannelProgress,
       } as never);
+      let executionStarted = false;
+      const onImplementationStart = () => {
+        executionStarted = true;
+      };
       try {
-        const result = await toolParams.execute();
+        const result = await toolParams.execute(onImplementationStart);
         await handleToolExecutionEnd(ctx, {
           type: "tool_execution_end",
           toolName: toolParams.toolName,
           toolCallId: toolParams.toolCallId,
           isError: false,
-          executionStarted: true,
+          executionStarted,
           result,
           hideFromChannelProgress: toolParams.hideFromChannelProgress,
         } as never);
         return result;
       } catch (error) {
-        await handleToolExecutionEnd(ctx, {
+        const trustedNoStart = consumeTrustedToolNoStartError(error);
+        const terminal = await handleToolExecutionEnd(ctx, {
           type: "tool_execution_end",
           toolName: toolParams.toolName,
           toolCallId: toolParams.toolCallId,
           isError: true,
-          executionStarted: true,
+          executionStarted,
           result: buildToolLifecycleErrorResult(error),
           hideFromChannelProgress: toolParams.hideFromChannelProgress,
         } as never);
+        if (trustedNoStart && !terminal.executionStarted) {
+          registerTrustedToolNoStartError(error);
+        }
         throw error;
       }
     },

--- a/src/agents/tool-result-error.ts
+++ b/src/agents/tool-result-error.ts
@@ -18,6 +18,7 @@ const NETWORK_TOOL_ERROR_MAX_CHARS = 4_000;
 const protectedNetworkToolErrors = new WeakSet<object>();
 const protectedNetworkToolTimeoutErrors = new WeakSet<object>();
 const trustedToolInputErrors = new WeakSet<object>();
+const trustedToolNoStartErrors = new WeakSet<object>();
 
 function readToolErrorField(error: object, key: string): unknown {
   try {
@@ -151,6 +152,18 @@ export function isTrustedToolExecutionPreflightError(error: unknown): boolean {
 /** Records canonical host-created input failures without loading heavyweight tool implementations. */
 export function registerTrustedToolInputError(error: object): void {
   trustedToolInputErrors.add(error);
+}
+
+/** Authenticate a wrapper-owned failure that settled before tool implementation start. */
+export function registerTrustedToolNoStartError(error: unknown): void {
+  if (typeof error === "object" && error !== null) {
+    trustedToolNoStartErrors.add(error);
+  }
+}
+
+/** Consume one private no-start fact at the next authoritative lifecycle boundary. */
+export function consumeTrustedToolNoStartError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && trustedToolNoStartErrors.delete(error);
 }
 
 /** Format a redacted tool error without allowing hostile getters to escape observability. */

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -462,7 +462,7 @@ export class ToolSearchRuntime {
   constructor(
     private readonly ctx: ToolSearchToolContext,
     private readonly config: ToolSearchConfig,
-    private readonly options: { validateInput?: boolean } = {},
+    private readonly options: { prepareInput?: boolean; validateInput?: boolean } = {},
   ) {}
 
   search = async (query: string, options?: { limit?: number } & CatalogVisibilityOptions) => {
@@ -644,8 +644,13 @@ export class ToolSearchRuntime {
       return snapshot;
     };
     const validateInput = this.options.validateInput && entry.source === "openclaw";
+    const prepareInput =
+      this.options.prepareInput &&
+      entry.source === "openclaw" &&
+      "prepareBeforeToolCallParams" in entry.tool &&
+      typeof entry.tool.prepareBeforeToolCallParams === "function";
     const executionTool =
-      validateInput && !isToolWrappedWithBeforeToolCallHook(entry.tool as never)
+      (prepareInput || validateInput) && !isToolWrappedWithBeforeToolCallHook(entry.tool as never)
         ? wrapToolWithBeforeToolCallHook(entry.tool as never)
         : entry.tool;
     const runExecution = async () => {


### PR DESCRIPTION
Fixes #128021

## What Problem This Solves

Fixes an issue where Code Mode would terminate instead of offering a safe correction when a nested tool rejected stale or invalid input before its implementation started. The failure was treated like a potentially side-effecting bridge call even though no target operation ran.

## Why This Change Was Made

Nested execution now uses the existing two-phase tool preparation boundary and carries one-shot host-private no-start provenance through bridge settlement. Repair remains disabled for successful, mixed, unknown, forged, cancelled, waiting, or post-start outcomes, and stale `exec.timeout` input is rejected during preparation while direct exec callers retain the same validation contract. Code Mode only requests wrapping for tools that declare preparation, preserving existing post-start network error behavior.

## User Impact

Code Mode can offer one correction attempt after a proven nested preflight rejection without weakening the existing no-retry protection for calls that may have produced side effects.

## Evidence

- Reproduced current-main behavior with stale `exec.timeout`: target execution was entered and the outer result was classified as a side-effecting bridge failure.
- Blacksmith Testbox: 700 tests passed across Code Mode guest, wait, bridge, preflight repair, headless, embedded lifecycle, repair-hook, and exec timeout suites.
- `node scripts/check-changed.mjs -- <changed files>` passed all core and core-test gates.
- Fresh uncommitted autoreview: no accepted/actionable findings.
- Testbox lease `tbx_01m0nw2f2t7aqjeg8e5qc1vp46` stopped after success.
