### PR TITLE
fix(agents): recover when providers cap message history

### DIFF
--- a/packages/ai/src/utils/overflow.test.ts
+++ b/packages/ai/src/utils/overflow.test.ts
@@ -65,6 +65,7 @@ describe("provider overflow messages", () => {
     'HTTP 400: {"type":"error","error":{"type":"invalid_request_error","message":"input length and `max_tokens` exceed context limit: 176312 + 32000 > 200000"}}',
     "code 1210: tokens in request more than max tokens allowed",
     "code 1261: Prompt exceeds max length",
+    "413 Chat history exceeds the 800-message limit; compact the conversation and retry.",
   ])("detects %s", (text) => {
     expect(isContextOverflow(errorMessage(text), 262_144)).toBe(true);
   });
@@ -75,6 +76,15 @@ describe("scoped overflow messages", () => {
     expect(
       matchesContextOverflowMessage(
         "input length 14295 tokens exceeds the model limit",
+        "failover-explicit",
+      ),
+    ).toBe(true);
+  });
+
+  it("recognizes message-count admission overflow in the strict failover scope", () => {
+    expect(
+      matchesContextOverflowMessage(
+        "Chat history exceeds the 1,200 message limit; compact the conversation and retry.",
         "failover-explicit",
       ),
     ).toBe(true);

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -3,6 +3,8 @@ import type { AssistantMessage } from "../types.js";
 
 const CONFIGURED_CONTEXT_SIZE_OVERFLOW_RE =
   /prompt has [\d,]+ tokens?, but the configured context size is [\d,]+ tokens?/i;
+const MESSAGE_COUNT_OVERFLOW_RE =
+  /\b(?:chat\s+)?history\s+exceeds\s+(?:the\s+)?[\d,]+(?:-|\s+)messages?\s+limit\b/i;
 
 /** Detects DS4-style raw token-count context overflow errors. */
 export function isConfiguredContextSizeOverflowError(errorMessage: string): boolean {
@@ -68,6 +70,7 @@ const ASSISTANT_OVERFLOW_PATTERNS = [
   /context[_ ]length[_ ]exceeded/i, // Generic fallback
   /too many tokens/i, // Generic fallback
   /token limit exceeded/i, // Generic fallback
+  MESSAGE_COUNT_OVERFLOW_RE, // Provider message-count admission limits
   /^413\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 413 with no body
 ];
 
@@ -95,6 +98,7 @@ const FAILOVER_EXPLICIT_OVERFLOW_PATTERNS = [
   /context_window_exceeded/i,
   // FIXED(refactor-06): PR 2 removed the embedded-429 false positive; this is provider overflow.
   /input length [\d,]+\s+tokens? exceeds the model limit/i,
+  MESSAGE_COUNT_OVERFLOW_RE, // Provider message-count admission limits
   /上下文过长|上下文超出|上下文长度超|超出最大上下文|请压缩上下文/,
 ];
 

--- a/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
@@ -190,7 +190,8 @@ describe("recoverEmbeddedRunOverflow", () => {
   it("uses the canonical assistant classifier when the text heuristic misses", async () => {
     const assistantOverflowCandidate = makeAssistantMessage({
       stopReason: "error",
-      errorMessage: "400 Your input exceeds the context window of this model",
+      errorMessage:
+        "413 Chat history exceeds the 800-message limit; compact the conversation and retry.",
     });
     const result = await recoverEmbeddedRunOverflow(
       makeInput({ promptError: null, assistantOverflowCandidate }),
@@ -199,6 +200,18 @@ describe("recoverEmbeddedRunOverflow", () => {
     expect(result).toEqual({ action: "retry" });
     expect(mocks.compact).toHaveBeenCalledOnce();
     expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining("source=assistantError"));
+  });
+
+  it("recovers message-count admission overflow reported as a prompt error", async () => {
+    const promptError = new Error(
+      "413 Chat history exceeds the 800-message limit; compact the conversation and retry.",
+    );
+
+    const result = await recoverEmbeddedRunOverflow(makeInput({ promptError }));
+
+    expect(result).toEqual({ action: "retry" });
+    expect(mocks.compact).toHaveBeenCalledOnce();
+    expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining("source=promptError"));
   });
 
   it("does not compact after an ambiguous bodyless 400", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sessions routed through providers with a message-count admission cap would surface `LLM request failed` instead of entering OpenClaw's existing compact-and-retry recovery path. OmniRoute DS4F returns `413 Chat history exceeds the 800-message limit; compact the conversation and retry.`, but neither canonical overflow scope recognized that wording.

AI-assisted: Codex.

## Why This Change Was Made

The shared overflow-pattern owner now recognizes bounded `history exceeds <count>-message limit` wording in both assistant-error and strict failover scopes. Registering one shared pattern in both scopes covers providers that surface the rejection as an assistant error and providers that throw it at the prompt boundary without broadening the fuzzy overflow heuristic.

This change does not alter compaction itself. A session whose compaction summary fails safeguard quality checks can still surface that separate compaction failure, and the missing context meter after a rejected provider turn remains outside this classifier repair.

Production LOC: +4/-0. Tests: +24/-1. The positive production delta is the provider error contract plus registrations in the two existing canonical ingress scopes; there is no duplicate recovery path or new fallback.

## User Impact

Message-count overflow responses now reach the existing bounded auto-compaction and retry path instead of immediately failing classification. Operators do not need provider-specific configuration for this error family.

## Evidence

Exact head: `4bc0b247c8c221abc78935aa398f6983db5f19c0` on upstream base `7d95cff39d61a583e976b9d2492462bcbb48aab0`.

- Before the production edit, the focused matcher suite failed 2/19 assertions and the embedded recovery suite failed 2/26 assertions on the exact OmniRoute response. Both assistant and prompt-error recovery returned `{ action: "none" }`.
- `node --import tsx scripts/test-projects.mts --changed upstream/main` — 45/45 tests passed across the canonical matcher and embedded recovery suites on the exact head.
- Exact response probe — `assistantError: true`, `failoverExplicit: true`, `likelyOverflow: true`; the broad `failoverHint` remains `false`, proving the precise canonical table owns the result.
- `node scripts/check-changed.mjs --base upstream/main` — passed formatting, architecture guards, dead-export checks, production/test typechecks, lint, import-cycle checks, and database-first guards.
- `pnpm build` — passed on the exact head, including runtime bundles, built plugin control-plane loads, SDK export validation, and Control UI build.
- Branch autoreview with Codex `gpt-5.6-sol`, high reasoning — clean, 0.99 correctness; TruffleHog clean.
- Provider contract evidence: OmniRoute's admission middleware returns HTTP 413 with `code: chat_history_too_large`, `reason: message_limit`, and the exact captured message when `messages.length` exceeds its configured default of 800.
- Live recovery limitation: the TrueNAS route was unreachable from this development host during exact-head verification, so this PR does not claim a fresh provider-to-gateway end-to-end success. The reported dead session also fails manual `/compact` with `Compaction safeguard finalized summary failed quality checks`; that downstream failure is explicitly not claimed fixed here.
- Context-meter observation: the composer hides its context view model when no finite session token total or context limit is available. A provider-rejected turn can leave that usage snapshot unavailable; no UI behavior is changed in this PR.
- Codex sibling contract audit (not changed): [`ContextWindowExceeded`](https://github.com/openai/codex/blob/d1d51f6315f84a1737c655cb4d78104d030d5102/codex-rs/protocol/src/error.rs#L94-L97) remains a structured error, its [turn owner propagates it](https://github.com/openai/codex/blob/d1d51f6315f84a1737c655cb4d78104d030d5102/codex-rs/core/src/session/turn.rs#L1386-L1389), and Codex's [compaction owner trims and retries overflow](https://github.com/openai/codex/blob/d1d51f6315f84a1737c655cb4d78104d030d5102/codex-rs/core/src/compact.rs#L309-L323). This repair therefore stays in OpenClaw's provider-message classifier.
