### PR TITLE
fix(ui): show busy avatar chooser as disabled

### DIFF
--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -639,6 +639,12 @@ suite.define(() => {
         await expect
           .poll(async () => (await gateway.getRequests("users.setAvatar")).length)
           .toBe(requestCountBefore + 1);
+        const chooser = page.locator(".identity-avatar-control > label");
+        await screenshot(page, "11-avatar-action-disabled.png");
+        await expect(chooser).toHaveAttribute("aria-disabled", "true");
+        await expect
+          .poll(() => chooser.evaluate((element) => getComputedStyle(element).opacity))
+          .toBe("0.5");
         await gateway.emitGatewayEvent("presence", {
           presence: [
             {

--- a/ui/src/pages/profile/identity-section.test.ts
+++ b/ui/src/pages/profile/identity-section.test.ts
@@ -132,6 +132,11 @@ describe("renderIdentitySection", () => {
     expect(input?.accept).toBe("image/png,image/jpeg,image/webp");
     expect(input?.value).toBe("");
     expect(onAvatarSelect).toHaveBeenCalledWith(file);
+
+    render(renderIdentitySection(createProps({ busy: "display-name" })), container);
+    const chooser = container.querySelector<HTMLElement>(".identity-avatar-control .btn");
+    expect(chooser?.getAttribute("aria-disabled")).toBe("true");
+    expect(container.querySelector<HTMLInputElement>('input[type="file"]')?.disabled).toBe(true);
   });
 
   it("shows verified GitHub identity and explicit co-author credit", () => {

--- a/ui/src/pages/profile/identity-section.ts
+++ b/ui/src/pages/profile/identity-section.ts
@@ -57,7 +57,7 @@ export function renderIdentitySection(props: IdentitySectionProps) {
                 .user=${avatarViewer(props.profile, props.avatarUrl)}
                 variant="profile"
               ></openclaw-viewer-avatar>
-              <label class="btn btn--sm">
+              <label class="btn btn--sm" aria-disabled=${props.busy !== null}>
                 ${props.busy === "avatar"
                   ? t("profilePage.identity.processingAvatar")
                   : t("profilePage.identity.chooseAvatar")}

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1094,7 +1094,7 @@ openclaw-session-progress-hovercard-provider {
   border-color: transparent;
 }
 
-.btn:disabled {
+.btn:is(:disabled, [aria-disabled="true"]) {
   opacity: 0.5;
   cursor: not-allowed;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Profile avatar chooser still looked enabled while another identity change was saving, even though its hidden file input was disabled. Clicking the apparently available action therefore did nothing.

## Why This Change Was Made

The visible chooser now projects the Profile form's existing busy state through `aria-disabled`, and the shared button styling treats that state like native `disabled`. This keeps the visible control, hidden input, and adjacent Save action consistent without adding a second busy-state owner.

ClawSweeper's rank-up move is applied: the shared disabled styling uses one `:is(...)` selector, keeping production LOC net-neutral.

AI-assisted: yes — implemented and reviewed with Amp. I understand the change and verified the affected source and browser paths.

## User Impact

While a Profile identity operation is in progress, the avatar chooser is now visibly and programmatically disabled instead of appearing actionable and silently ignoring input.

## Evidence

**Before:** the busy avatar action remains visually enabled while Save is disabled.

![Before: busy avatar chooser looks enabled](https://ampcode.com/user-content/artifacts/55ab7b7b580676e115d264c1632242145d9ce224f6ba580a2d06901e6dade8e4-file.png)

**After:** the avatar action matches the disabled Save state.

![After: busy avatar chooser is visibly disabled](https://ampcode.com/user-content/artifacts/104a89f48e3f188de75cac38860123d3f37e32c86d303461adea90d0547775e4-file.png)

Validated against the exact content at head `c9af299650dfa3f16cdfa9980f7599ba335d01e9` and confirmed compatible with current `origin/main` `008412212f4334bf9fe83d36d3f93364991e2302` (all four pre-change file objects are identical):

- Profile unit tests: 19/19 passed.
- Source-browser Profile E2E: 7/7 passed; asserted `aria-disabled="true"` and computed opacity `0.5` on the visible chooser.
- Full changed-file gate passed for all four touched files.
- `pnpm ui:build` passed, including Control UI performance budgets.
- Fresh Codex autoreview on the final head: clean, no accepted/actionable findings (0.99 confidence).
- Production LOC: +2/-2 (net 0). Tests: +11/-0.
