### PR TITLE
fix: subagent completion announces are lost for OpenAI-compat HTTP sessions (in-process dispatch has no gateway scope)

### DIFF
--- a/src/agents/agent-command-execution-identity.ts
+++ b/src/agents/agent-command-execution-identity.ts
@@ -7,6 +7,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
+  bindGatewayContextResolver,
+  getPluginRuntimeGatewayRequestScope,
+} from "../plugins/runtime/gateway-request-scope.js";
+import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
   type OperationalRunInstanceRef,
@@ -143,6 +147,14 @@ export function prepareAgentCommandExecutionIdentity(params: {
     operationalRunInstance,
     runId: prepared.runId,
     onAdmitted: async (admittedRunContext) => {
+      // Runs admitted inside a Gateway-owned runtime scope (e.g. the OpenAI-compat
+      // HTTP endpoints) inherit its lifecycle-fenced context resolver so deferred
+      // dispatches (subagent completion announces) can reach the owning instance.
+      const scopedGatewayContextResolver =
+        getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext;
+      if (scopedGatewayContextResolver) {
+        bindGatewayContextResolver(admittedRunContext, scopedGatewayContextResolver);
+      }
       await opts.onAdmittedRunContext?.(admittedRunContext);
       if (
         opts.mainRestartRecoveryAdmitted !== true ||

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -234,6 +234,34 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(scopedResolver?.()).toBeTruthy();
   });
 
+  it("fails closed for retired Gateway instances in the ingress resolver scope", async () => {
+    testState.agentsConfig = { list: [{ id: "main" }] };
+    resetConfigRuntimeState();
+    const port = await getGatewayTestPort();
+    const server = await startServer(port);
+    let scopedResolver: (() => unknown) | undefined;
+    try {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce(async () => {
+        scopedResolver = getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext;
+        return { payloads: [{ text: "hello" }] } as never;
+      });
+      const res = await postChatCompletions(port, {
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      await res.text();
+      expect(scopedResolver?.()).toBeTruthy();
+    } finally {
+      await server.close({ reason: "retired-instance custody test done" });
+    }
+    // The raw holder outlives shutdown; the fence must reject the retired
+    // instance so a late completion announce fails closed instead of
+    // dispatching against a dead Gateway generation.
+    expect(scopedResolver?.()).toBeUndefined();
+  });
+
   it("handles request validation and routing", async () => {
     const port = enabledPort;
     const mockAgentOnce = (payloads: Array<{ text: string }>) => {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -32,6 +32,7 @@ import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
 } from "../process/gateway-work-admission.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -209,6 +210,28 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       testState.agentsConfig = undefined;
       resetConfigRuntimeState();
     }
+  });
+
+  it("runs ingress agent commands inside the Gateway context-resolver scope", async () => {
+    testState.agentsConfig = { list: [{ id: "main" }] };
+    resetConfigRuntimeState();
+    agentCommandMock.mockClear();
+    let scopedResolver: (() => unknown) | undefined;
+    agentCommandMock.mockImplementationOnce(async () => {
+      scopedResolver = getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext;
+      return { payloads: [{ text: "hello" }] } as never;
+    });
+    const res = await postChatCompletions(enabledPort, {
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(res.status).toBe(200);
+    await res.text();
+    // Deferred dispatches (subagent completion announces) admitted from this run
+    // resolve the owning Gateway through this scope; without it they fail with
+    // "In-process gateway dispatch requires a gateway request scope or instance binding".
+    expect(typeof scopedResolver).toBe("function");
+    expect(scopedResolver?.()).toBeTruthy();
   });
 
   it("handles request validation and routing", async () => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -16,6 +16,7 @@ import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { toOpenAiChatCompletionsUsage, type OpenAiChatCompletionsUsage } from "../agents/usage.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
+import { withPluginRuntimeGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -44,6 +45,7 @@ import {
 } from "./agent-prompt.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
+import type { GatewayContextResolver } from "./server-methods/types.js";
 import {
   sendJson,
   sendMissingScopeForbidden,
@@ -85,6 +87,7 @@ type OpenAiHttpOptions = {
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
+  resolveGatewayContext?: GatewayContextResolver;
 };
 
 type OpenAiChatMessage = {
@@ -1095,7 +1098,13 @@ export async function handleOpenAiHttpRequest(
   if (!stream) {
     const stopWatchingDisconnect = watchClientDisconnect(req, res, abortController);
     try {
-      const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
+      const result = await (opts.resolveGatewayContext
+        ? // Deferred dispatches spawned by this run (subagent completion announces)
+          // need the owning Gateway's lifecycle-fenced context resolver at admission.
+          withPluginRuntimeGatewayContextResolver(opts.resolveGatewayContext, () =>
+            agentCommandFromIngress(commandInput, defaultRuntime, deps),
+          )
+        : agentCommandFromIngress(commandInput, defaultRuntime, deps));
 
       if (abortController.signal.aborted) {
         return true;
@@ -1380,7 +1389,13 @@ export async function handleOpenAiHttpRequest(
 
   void (async () => {
     try {
-      const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
+      const result = await (opts.resolveGatewayContext
+        ? // Deferred dispatches spawned by this run (subagent completion announces)
+          // need the owning Gateway's lifecycle-fenced context resolver at admission.
+          withPluginRuntimeGatewayContextResolver(opts.resolveGatewayContext, () =>
+            agentCommandFromIngress(commandInput, defaultRuntime, deps),
+          )
+        : agentCommandFromIngress(commandInput, defaultRuntime, deps));
       resultResolved = true;
 
       if (closed) {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -628,6 +628,31 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(scopedResolver?.()).toBeTruthy();
   });
 
+  it("fails closed for retired Gateway instances in the ingress resolver scope", async () => {
+    testState.agentsConfig = { list: [{ id: "main" }] };
+    resetConfigRuntimeState();
+    const port = await getGatewayTestPort();
+    const server = await startServer(port);
+    let scopedResolver: (() => unknown) | undefined;
+    try {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce(async () => {
+        scopedResolver = getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext;
+        return { payloads: [{ text: "hello" }] } as never;
+      });
+      const res = await postResponses(port, { model: "openclaw", input: "hi" });
+      expect(res.status).toBe(200);
+      await ensureResponseConsumed(res);
+      expect(scopedResolver?.()).toBeTruthy();
+    } finally {
+      await server.close({ reason: "retired-instance custody test done" });
+    }
+    // The raw holder outlives shutdown; the fence must reject the retired
+    // instance so a late completion announce fails closed instead of
+    // dispatching against a dead Gateway generation.
+    expect(scopedResolver?.()).toBeUndefined();
+  });
+
   it("handles OpenResponses request parsing and validation", async () => {
     const port = enabledPort;
     const mockAgentOnce = (payloads: Array<{ text: string }>, meta?: unknown) => {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../process/gateway-work-admission.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
   agentCommandMock,
@@ -606,6 +607,25 @@ describe("OpenResponses HTTP API (e2e)", () => {
 
     await expectInvalidRequest(res, /text/);
     expect(agentCommandMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("runs ingress agent commands inside the Gateway context-resolver scope", async () => {
+    testState.agentsConfig = { list: [{ id: "main" }] };
+    resetConfigRuntimeState();
+    agentCommandMock.mockClear();
+    let scopedResolver: (() => unknown) | undefined;
+    agentCommandMock.mockImplementationOnce(async () => {
+      scopedResolver = getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext;
+      return { payloads: [{ text: "hello" }] } as never;
+    });
+    const res = await postResponses(enabledPort, { model: "openclaw", input: "hi" });
+    expect(res.status).toBe(200);
+    await ensureResponseConsumed(res);
+    // Deferred dispatches (subagent completion announces) admitted from this run
+    // resolve the owning Gateway through this scope; without it they fail with
+    // "In-process gateway dispatch requires a gateway request scope or instance binding".
+    expect(typeof scopedResolver).toBe("function");
+    expect(scopedResolver?.()).toBeTruthy();
   });
 
   it("handles OpenResponses request parsing and validation", async () => {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -16,6 +16,7 @@ import { toOpenAiResponsesUsage } from "../agents/usage.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
+import { withPluginRuntimeGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
 import type { GatewayHttpResponsesConfig } from "../config/types.gateway.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
@@ -86,6 +87,7 @@ import {
 } from "./openai-tool-choice.js";
 import { wrapUntrustedFileContent } from "./openresponses-file-content.js";
 import { buildAgentPrompt } from "./openresponses-prompt.js";
+import type { GatewayContextResolver } from "./server-methods/types.js";
 import { createAssistantOutputItem, createFunctionCallOutputItem } from "./openresponses-shape.js";
 
 type OpenResponsesHttpOptions = {
@@ -95,6 +97,7 @@ type OpenResponsesHttpOptions = {
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
+  resolveGatewayContext?: GatewayContextResolver;
 };
 
 const DEFAULT_BODY_BYTES = 20 * 1024 * 1024;
@@ -392,27 +395,34 @@ async function runResponsesAgentCommand(params: {
   senderIsOwner: boolean;
   deps: CliDeps;
   abortSignal?: AbortSignal;
+  resolveGatewayContext?: GatewayContextResolver;
 }) {
-  return agentCommandFromIngress(
-    {
-      message: params.message,
-      images: params.images.length > 0 ? params.images : undefined,
-      clientTools: params.clientTools.length > 0 ? params.clientTools : undefined,
-      extraSystemPrompt: params.extraSystemPrompt || undefined,
-      model: params.modelOverride,
-      streamParams: params.streamParams ?? undefined,
-      sessionKey: params.sessionKey,
-      runId: params.runId,
-      deliver: false,
-      messageChannel: params.messageChannel,
-      senderIsOwner: params.senderIsOwner,
-      bestEffortDeliver: false,
-      allowModelOverride: params.modelOverride !== undefined,
-      abortSignal: params.abortSignal,
-    },
-    defaultRuntime,
-    params.deps,
-  );
+  const run = () =>
+    agentCommandFromIngress(
+      {
+        message: params.message,
+        images: params.images.length > 0 ? params.images : undefined,
+        clientTools: params.clientTools.length > 0 ? params.clientTools : undefined,
+        extraSystemPrompt: params.extraSystemPrompt || undefined,
+        model: params.modelOverride,
+        streamParams: params.streamParams ?? undefined,
+        sessionKey: params.sessionKey,
+        runId: params.runId,
+        deliver: false,
+        messageChannel: params.messageChannel,
+        senderIsOwner: params.senderIsOwner,
+        bestEffortDeliver: false,
+        allowModelOverride: params.modelOverride !== undefined,
+        abortSignal: params.abortSignal,
+      },
+      defaultRuntime,
+      params.deps,
+    );
+  // Deferred dispatches spawned by this run (subagent completion announces)
+  // need the owning Gateway's lifecycle-fenced context resolver at admission.
+  return params.resolveGatewayContext
+    ? withPluginRuntimeGatewayContextResolver(params.resolveGatewayContext, run)
+    : run();
 }
 
 export async function handleOpenResponsesHttpRequest(
@@ -713,6 +723,7 @@ export async function handleOpenResponsesHttpRequest(
         senderIsOwner,
         deps,
         abortSignal: abortController.signal,
+        resolveGatewayContext: opts.resolveGatewayContext,
       });
 
       if (abortController.signal.aborted) {
@@ -1179,6 +1190,7 @@ export async function handleOpenResponsesHttpRequest(
         senderIsOwner,
         deps,
         abortSignal: abortController.signal,
+        resolveGatewayContext: opts.resolveGatewayContext,
       });
 
       if (closed) {

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -60,6 +60,7 @@ import {
   type ResolvePluginNodeCapabilityRoute,
 } from "./server-http-plugin-auth.js";
 import { handleGatewayProbeRequest } from "./server-http-probes.js";
+import { fenceScheduledGatewayContextResolver } from "./scheduled-run-gateway-context.js";
 import type { HooksRequestHandler } from "./server/hooks-request-handler.js";
 import { runWithGatewayHttpWorkAdmission } from "./server/http-work-admission.js";
 import {
@@ -209,6 +210,11 @@ export function createGatewayHttpServer(opts: {
     getStartup,
   } = opts;
   const getResolvedAuth = opts.getResolvedAuth ?? (() => resolvedAuth);
+  // The raw holder outlives shutdown; the context's own lifecycle resolver is
+  // the fence, so compat ingress runs fail closed once the instance retires.
+  const resolveCompatGatewayContext = fenceScheduledGatewayContextResolver(
+    opts.getGatewayRequestContext,
+  );
   const loadGatewayConfig = opts.getRuntimeConfig ?? getRuntimeConfig;
   const openAiCompatEnabled = openAiChatCompletionsEnabled || openResponsesEnabled;
   const controlUiRouteBasePath =
@@ -454,7 +460,7 @@ export function createGatewayHttpServer(opts: {
         (await getOpenResponsesHttpModule()).handleOpenResponsesHttpRequest(req, res, {
           ...routeAuth,
           config: openResponsesConfig,
-          resolveGatewayContext: opts.getGatewayRequestContext,
+          resolveGatewayContext: resolveCompatGatewayContext,
         }),
       );
       addAdmittedStage(
@@ -463,7 +469,7 @@ export function createGatewayHttpServer(opts: {
           (await getOpenAiHttpModule()).handleOpenAiHttpRequest(req, res, {
             ...routeAuth,
             config: openAiChatCompletionsConfig,
-            resolveGatewayContext: opts.getGatewayRequestContext,
+            resolveGatewayContext: resolveCompatGatewayContext,
           }),
       );
       const approvalDocument = isControlUiApprovalDocumentPath({

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -160,6 +160,7 @@ export function createGatewayHttpServer(opts: {
   openAiChatCompletionsConfig?: import("../config/types.gateway.js").GatewayHttpChatCompletionsConfig;
   openResponsesEnabled: boolean;
   openResponsesConfig?: import("../config/types.gateway.js").GatewayHttpResponsesConfig;
+  getGatewayRequestContext?: () => import("./server-methods/types.js").GatewayRequestContext | undefined;
   strictTransportSecurityHeader?: string;
   handleHooksRequest: HooksRequestHandler;
   handleMcpOAuthCallbackRequest?: McpOAuthCallbackHandler;
@@ -453,6 +454,7 @@ export function createGatewayHttpServer(opts: {
         (await getOpenResponsesHttpModule()).handleOpenResponsesHttpRequest(req, res, {
           ...routeAuth,
           config: openResponsesConfig,
+          resolveGatewayContext: opts.getGatewayRequestContext,
         }),
       );
       addAdmittedStage(
@@ -461,6 +463,7 @@ export function createGatewayHttpServer(opts: {
           (await getOpenAiHttpModule()).handleOpenAiHttpRequest(req, res, {
             ...routeAuth,
             config: openAiChatCompletionsConfig,
+            resolveGatewayContext: opts.getGatewayRequestContext,
           }),
       );
       const approvalDocument = isControlUiApprovalDocumentPath({

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -302,6 +302,7 @@ export async function createGatewayHttpTransport(params: {
       openResponsesEnabled: params.openResponsesEnabled,
       openResponsesConfig: params.openResponsesConfig,
       strictTransportSecurityHeader: params.strictTransportSecurityHeader,
+      getGatewayRequestContext: params.getGatewayRequestContext,
       handleWatchNodeRequest: params.handleWatchNodeRequest,
       handleHooksRequest,
       handleMcpOAuthCallbackRequest,


### PR DESCRIPTION
Closes #128003

## What Problem This Solves

A session driven purely through the OpenAI-compatible HTTP endpoints (`POST /v1/responses`, `POST /v1/chat/completions`) silently loses every subagent result on current main: the spawn and the child run complete normally, but the completion announce turn never runs in the requester session — every dispatch attempt fails with `In-process gateway dispatch requires a gateway request scope or instance binding (method: agent)` and the retry ladder exhausts. The result reaches neither a channel nor the requester-session transcript, so for HTTP-only integrators the subagent's work simply vanishes. This is a regression relative to `2026.8.1-beta.2`, where the same rig produced the announce run and its transcript entry (full narrative and repro in #128003).

## Why This Change Was Made

Root cause: #125821 removed the ambient process-global Gateway fallback, and #126113 restored explicit context-resolver custody for routed channel turns, auto-reply dispatch, and harness task runtimes — but the OpenAI-compat HTTP ingress (`openai-http.ts` / `openresponses-http.ts` → `agentCommandFromIngress`) was left with no `resolveGatewayContext` custody, so runs admitted from these endpoints had no resolver bound at admission and the deferred announce dispatch found neither a request scope nor an instance binding.

The fix applies the same custody idiom those surfaces already use, at the three places the chain needs it:

- **Transport wiring** (`server-runtime-state.ts`, `server-http.ts`): the gateway HTTP transport already receives `getGatewayRequestContext` and already threads it into the hooks handler and plugin-route handlers; it now also threads it into the two compat endpoint handlers.
- **Handlers** (`openai-http.ts`, `openresponses-http.ts`): ingress agent commands run inside `withPluginRuntimeGatewayContextResolver(resolveGatewayContext, …)`, the existing scope primitive from #126113's family, so the resolver is visible for the duration of the run's admission.
- **Admission** (`agent-command-execution-identity.ts`): when a run is admitted inside such a scope, the scoped resolver is bound to the admitted run context (`bindGatewayContextResolver`) — the exact hand-off #126113 added for channel turns in `agent-runner-execution.ts`. From there the existing plumbing carries it: tool-caller identity → `sessions_spawn` → subagent registry entry → completion announce dispatch.

Boundaries: no new ambient/global state (the resolver stays contextual and lifecycle-fenced, per #125821's intent); paths that already bind an explicit resolver are unchanged (their `onAdmittedRunContext` bind runs after and wins); CLI runs outside a gateway scope see a no-op.

## User Impact

Subagent completion announces work again for HTTP-only integrations (OpenAI-compatible clients, gateway front-ends, serverless callers) on both compat endpoints: the announce turn runs in the requester session and its result follows the documented delivery lifecycle (transcript, and channel delivery when the session has a bound route). No behavior change for channel-driven sessions, the WS `agent` method, `/tools/invoke`, or CLI runs.

## Evidence

### Before (pristine main, no local modifications) — from #128003

Pristine `f70947bf`, gateway built from source, one `POST /v1/responses` spawn (scripted mock `openai-responses` provider; parent turn answers `sessions_spawn`, child answers plain text):

```
=== pristine main f70947bf: /v1/responses spawn, NO target headers ===
{"id":"resp_7597249f-…","status":"completed","output":[…"text":"PARENT_ACK_P"…]}   ← parent turn fine

Subagent completion direct announce failed for run 9a2ed3b6-…: In-process gateway dispatch requires a gateway request scope or instance binding (method: agent).
(repeats as the retry ladder runs; the announce turn never issues a provider request)
```

### After (this branch) — same rig, both endpoints

Same scenario shape, gateway built from this head, one spawn per endpoint, no delivery-target context:

```
=== fix branch: /v1/responses spawn ===
{"id":"resp_5c6e2123-…","status":"completed","output":[…"text":"PARENT_ACK_R"…]}     ← parent turn unchanged

=== /v1/chat/completions spawn ===
{"id":"chatcmpl_ca3daf20-…","choices":[{"message":{…"content":"PARENT_ACK_C"},…}]}   ← parent turn unchanged

=== dispatch failures across the whole run (gateway stdout + file log) ===
0
0

=== the announce turns now RUN — provider request sequence (scripted mock's own log) ===
n=1 SPAWN-R (tool sessions_spawn) → n=2 parent ack → n=3 child turn → n=4 "[Internal task completion event]"   ← announce reached the provider
n=5 SPAWN-C (tool sessions_spawn) → n=6 parent ack → n=7 child turn → n=8 "[Internal task completion event]"   ← announce reached the provider

=== gateway log ===
ANNOUNCE_RAN_RESPONSES
[agent] run announce:v1:agent:background-worker:subagent:4038da11-…:f91ba48e-… ended with stopReason=stop
ANNOUNCE_RAN_CHATCOMPLETIONS
[agent] run announce:v1:agent:background-worker:subagent:e99b035f-…:c63afce4-… ended with stopReason=stop
```

Both completion announce turns execute end to end (the `2026.8.1-beta.2` behavior restored); with no bound route their replies follow the documented transcript lifecycle, and delivery-routed sessions pick them up through the unchanged delivery pipeline.

### Unit tests + typecheck

- `node scripts/run-vitest.mjs src/gateway/openresponses-http.test.ts src/gateway/openai-http.test.ts` — **254 tests passed (4 test files, 0 failed)**, including two new regression tests ("runs ingress agent commands inside the Gateway context-resolver scope", one per endpoint) that assert the plugin-runtime scope carries a live Gateway context resolver inside the dispatched agent command — these fail on main before this fix.
- `tsc -p tsconfig.core.json --noEmit` — **no errors in any file this PR touches**; the four reported errors are pre-existing on `main` in untouched files (`src/gateway/server-worker-environment-startup.ts:268`, `src/gateway/worker-environments/service.test-support.ts:189`, `src/system-agent/chat-turn-router.ts:188`, `src/worker/worker-fault-injection.test-support.ts:579`).

### What was run locally vs left to CI

Vitest (2 gateway test files), strict typecheck, and the live gateway runs above: Linux `node:24` container, gateway built from source at this head. `git diff --check` clean. The full check/test matrix is left to CI.
