### PR TITLE
perf(logging): reuse log level thresholds

### DIFF
--- a/src/logging/levels.ts
+++ b/src/logging/levels.ts
@@ -11,6 +11,18 @@ export const ALLOWED_LOG_LEVELS = [
 
 export type LogLevel = (typeof ALLOWED_LOG_LEVELS)[number];
 
+// tslog v4 logLevelId (src/index.ts): silly=0, trace=1, debug=2, info=3, warn=4, error=5, fatal=6
+// tslog filters: logLevelId < minLevel is dropped, so higher minLevel = more restrictive.
+const MIN_LEVEL_BY_LOG_LEVEL: Record<LogLevel, number> = {
+  trace: 1,
+  debug: 2,
+  info: 3,
+  warn: 4,
+  error: 5,
+  fatal: 6,
+  silent: Number.POSITIVE_INFINITY,
+};
+
 export function tryParseLogLevel(level?: string): LogLevel | undefined {
   if (typeof level !== "string") {
     return undefined;
@@ -24,16 +36,5 @@ export function normalizeLogLevel(level?: string, fallback: LogLevel = "info") {
 }
 
 export function levelToMinLevel(level: LogLevel): number {
-  // tslog v4 logLevelId (src/index.ts): silly=0, trace=1, debug=2, info=3, warn=4, error=5, fatal=6
-  // tslog filters: logLevelId < minLevel is dropped, so higher minLevel = more restrictive.
-  const map: Record<LogLevel, number> = {
-    trace: 1,
-    debug: 2,
-    info: 3,
-    warn: 4,
-    error: 5,
-    fatal: 6,
-    silent: Number.POSITIVE_INFINITY,
-  };
-  return map[level];
+  return MIN_LEVEL_BY_LOG_LEVEL[level];
 }


### PR DESCRIPTION
## What Problem This Solves

Every subsystem log emission checks console and file thresholds. Those checks called `levelToMinLevel`, which rebuilt the same seven-entry tslog threshold object on every invocation, including disabled-log fast paths.

## Why This Change Was Made

The logging-level owner now constructs that immutable lookup once at module initialization and reuses it for every threshold check. The function signature, accepted levels, numeric thresholds, filtering behavior, redaction, and transports are unchanged.

This change was AI-assisted. I reviewed the logging owner, all callers, threshold/filter tests, and benchmark path and understand the resulting behavior.

## User Impact

Logging-heavy workloads should spend less CPU and allocation pressure checking thresholds, especially when debug or trace calls are disabled. Log contents, severity decisions, destinations, redaction, and configuration behavior are unchanged.

## Evidence

- Exact head: `17b8ec181ddcf9dc9ef74292d381abed23257805`; parent/current-main baseline: `8f18edfa10ab52b83083da4d1fd4e0f7e2d2e43f`.
- Existing owner tests assert all seven exact threshold outputs, including `silent` → `Infinity`.
- Fresh Node 24 benchmark: 10,000,000 disabled debug calls/sample, 7 alternating fresh-process samples per variant after warmup and GC. Median fell from 42.831 to 27.468 ns/call (**35.87% lower**); median user CPU fell **33.70%**; median measured heap growth fell from 51,431,048 bytes to 18,288 bytes. This is owner-stage evidence, not an end-to-end throughput claim.
- Final focused logging suite: 5 files / 89 tests passed.
- `node scripts/check-changed.mjs -- src/logging/levels.ts`: passed formatting, production/test typechecks, lint, dead exports, guards, and import-cycle checks at the exact head.
- `pnpm build`: passed all core, package, plugin, SDK, postbuild, and Control UI phases before the final unrelated-main rebase; the rebased commits do not touch logging or build ownership.
- Exact committed-head Codex Sol/high autoreview: clean at 0.99 confidence, with no accepted/actionable P0/P1 findings; TruffleHog preflight clean.
- Fresh live overlap searches found no open PR or issue for `levelToMinLevel` or logging-threshold reuse, and no exact `src/logging/levels.ts` overlap among the 100 open logging-related PR search results.