### PR TITLE
fix(ollama): record differing terminal model identity as responseModel

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -927,6 +927,32 @@ describe("buildAssistantMessage", () => {
     expect(result).not.toHaveProperty("responseModel");
   });
 
+  it.each([
+    { name: "blank", model: "   " },
+    { name: "non-string", model: 42 },
+    { name: "null", model: null },
+  ])("omits responseModel for a $name terminal model", ({ model }) => {
+    const response = createAssistantResponse({ content: "Hello!" }, { model } as unknown as Partial<
+      Omit<AssistantResponse, "message">
+    >);
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.model).toBe("qwen3:32b");
+    expect(result).not.toHaveProperty("responseModel");
+  });
+
+  it("trims surrounding whitespace from a differing terminal model", () => {
+    const response = createAssistantResponse(
+      { content: "Hello!" },
+      { model: "  qwen3:latest  ", prompt_eval_count: 3, eval_count: 1 },
+    );
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "qwen3",
+    });
+    expect(result.responseModel).toBe("qwen3:latest");
+  });
+
   it("keeps thinking-only output when content is empty", () => {
     const response = createAssistantResponse({ content: "", thinking: "Thinking output" });
     const result = buildAssistantMessage(response, modelInfo);

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -893,6 +893,40 @@ describe("buildAssistantMessage", () => {
     expect(result.usage.totalTokens).toBe(15);
   });
 
+  it("keeps a differing terminal response.model as responseModel", () => {
+    const response = createAssistantResponse(
+      { content: "Hello!" },
+      { model: "qwen3:latest", prompt_eval_count: 3, eval_count: 1 },
+    );
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "qwen3",
+    });
+    expect(result.model).toBe("qwen3");
+    expect(result.responseModel).toBe("qwen3:latest");
+    expect(result.stopReason).toBe("stop");
+    expect(result.usage.totalTokens).toBe(4);
+  });
+
+  it("omits responseModel when terminal model matches the requested id", () => {
+    const response = createAssistantResponse({ content: "Hello!" }, { model: "qwen3:32b" });
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.model).toBe("qwen3:32b");
+    expect(result).not.toHaveProperty("responseModel");
+  });
+
+  it("omits responseModel when the terminal model equals the provider-stripped wire id", () => {
+    const response = createAssistantResponse({ content: "Hello!" }, { model: "kimi-k2.6:cloud" });
+    const result = buildAssistantMessage(response, {
+      api: "ollama",
+      provider: "ollama",
+      id: "ollama/kimi-k2.6:cloud",
+    });
+    expect(result.model).toBe("ollama/kimi-k2.6:cloud");
+    expect(result).not.toHaveProperty("responseModel");
+  });
+
   it("keeps thinking-only output when content is empty", () => {
     const response = createAssistantResponse({ content: "", thinking: "Thinking output" });
     const result = buildAssistantMessage(response, modelInfo);

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -377,6 +377,7 @@ function buildStreamAssistantMessage(params: {
   stopReason: StopReason;
   usage: Usage;
   timestamp?: number;
+  responseModel?: string;
 }): AssistantMessage {
   return {
     role: "assistant",
@@ -385,6 +386,7 @@ function buildStreamAssistantMessage(params: {
     api: params.model.api,
     provider: params.model.provider,
     model: params.model.id,
+    ...(params.responseModel ? { responseModel: params.responseModel } : {}),
     usage: params.usage,
     timestamp: params.timestamp ?? Date.now(),
   };
@@ -865,9 +867,18 @@ export function buildAssistantMessage(
       input: resolveUsageCount(response.prompt_eval_count, usageFallback?.input),
       output: resolveUsageCount(response.eval_count, usageFallback?.output),
     }),
+    // Ollama resolves untagged requested models to the concrete installed tag
+    // (e.g. "qwen3" -> "qwen3:latest"); keep that identity when it differs so
+    // terminal receipts and transcripts do not attribute the run to the alias.
+    // Compare against the wire id actually sent, not the descriptor id, so a
+    // provider-qualified request ("ollama/qwen3") is not misread as a reroute.
+    responseModel:
+      response.model &&
+      response.model !== normalizeOllamaWireModelId(modelInfo.id, modelInfo.provider)
+        ? response.model
+        : undefined,
   });
 }
-
 export async function* parseNdjsonStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
 ): AsyncGenerator<OllamaChatResponse> {

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -821,6 +821,23 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
   return result;
 }
 
+/**
+ * Resolves the concrete terminal model identity for receipt metadata.
+ * Terminal records come from parsed NDJSON, so the value is coerced to a
+ * non-empty trimmed string first; blank or non-string models resolve to
+ * undefined so malformed records cannot enter persisted metadata.
+ */
+function resolveOllamaTerminalResponseModel(
+  terminalModel: unknown,
+  modelInfo: StreamModelDescriptor,
+): string | undefined {
+  const normalized = typeof terminalModel === "string" ? terminalModel.trim() : "";
+  if (!normalized || normalized === normalizeOllamaWireModelId(modelInfo.id, modelInfo.provider)) {
+    return undefined;
+  }
+  return normalized;
+}
+
 export function buildAssistantMessage(
   response: OllamaChatResponse,
   modelInfo: StreamModelDescriptor,
@@ -872,11 +889,9 @@ export function buildAssistantMessage(
     // terminal receipts and transcripts do not attribute the run to the alias.
     // Compare against the wire id actually sent, not the descriptor id, so a
     // provider-qualified request ("ollama/qwen3") is not misread as a reroute.
-    responseModel:
-      response.model &&
-      response.model !== normalizeOllamaWireModelId(modelInfo.id, modelInfo.provider)
-        ? response.model
-        : undefined,
+    // Terminal records come from parsed NDJSON, so coerce before copying: a
+    // non-string or blank model must never enter receipt/transcript metadata.
+    responseModel: resolveOllamaTerminalResponseModel(response.model, modelInfo),
   });
 }
 export async function* parseNdjsonStream(


### PR DESCRIPTION
Closes #127626

## What Problem This Solves

Ollama terminal responses carry a concrete `model` (e.g. `qwen3:latest` after untagged-to-`:latest` resolution), but `buildAssistantMessage` ignored it and emitted only the requested model id with `rerouted:false`. Ordinary alias/tag resolution was falsely recorded as if no effective model change occurred, so terminal receipts, transcripts, and effective-model diagnostics attributed the run to the requested alias instead of the concrete local model.

## Why This Change Was Made

`extensions/ollama/src/stream.runtime.ts` finalized the raw stream via a builder that consumes content/reasoning/usage but not the required terminal `response.model`. Sibling providers (Anthropic direct/server-fallback, OpenAI completions) already retain differing provider-returned model identity in `AssistantMessage.responseModel` (`packages/llm-core/src/types.ts` documents the contract).

The fix retains the first nonempty terminal `response.model` when it differs from the requested identity, and omits the field when equal. The comparison uses the wire id actually sent (`normalizeOllamaWireModelId`), so a provider-qualified request such as `ollama/qwen3` is not misread as a reroute when Ollama echoes the stripped local tag.

## User Impact

- Terminal receipts and transcript metadata now show the concrete resolved model (e.g. `qwen3` -> `responseModel: "qwen3:latest"`).
- Same-model responses are unchanged (no `responseModel` field), preserving existing prompt-cache/transcript bytes.
- No config, protocol, or API surface changes; additive optional field on an existing message contract that siblings already populate.

## Evidence

Root cause verified on current `main` (`10c774cf38e`): `OllamaChatResponse.model` exists in the type but is never read by the terminal builder.

Focused proof (Windows, Node v24.15.0):

```
node node_modules/vitest/vitest.mjs run extensions/ollama/src/stream-runtime.test.ts
Test Files  1 passed (1)
     Tests  159 passed (159)
```

New regression coverage:
- keeps a differing terminal `response.model` as `responseModel` (`qwen3` -> `qwen3:latest`) while preserving stop reason and token totals,
- omits `responseModel` when terminal model matches the requested id,
- omits `responseModel` when the terminal model equals the provider-stripped wire id (`ollama/kimi-k2.6:cloud` request, `kimi-k2.6:cloud` echo).

Lint: `oxlint` clean on touched files (0 warnings, 0 errors).

## Review follow-ups (post-ClawSweeper review of 17ab741)

- **[P2] Normalize the terminal model before copying** � fixed in bdfadf3. Terminal `response.model` now goes through an optional-string coercion (`resolveOllamaTerminalResponseModel`): non-string or blank values resolve to no `responseModel`, whitespace is trimmed, and the comparison uses the provider-stripped wire id. New regressions cover blank, non-string (`42`), and `null` terminal models plus whitespace trimming (163/163 focused tests green).
- **Real Ollama-server proof** � captured against a real local Ollama server (`http://127.0.0.1:11434`) by driving a live `/api/chat` completion through the changed terminal builder:

  ```
  LIVE_PROOF {"requested":"qwen3.5","terminalModel":"qwen3.5","responseModel":null,"stopReason":"stop","totalTokens":209}
  ```

  This server build echoes the requested tag verbatim for untagged requests, so the truthful outcome is `responseModel` absent - exactly what the code produced (no false reroute attribution). The differing-tag sequence from the issue (`qwen3` -> `qwen3:latest`, as emitted by Ollama builds that normalize untagged to `:latest`) is covered by the unit fixtures asserting `responseModel: "qwen3:latest"`.
