### PR TITLE
fix(agents): fail closed on workspace delete guard when realpath is unresolvable

### DIFF
--- a/src/agents/agent-delete-safety.test.ts
+++ b/src/agents/agent-delete-safety.test.ts
@@ -34,12 +34,21 @@ describe("shared auth store deletion safety", () => {
 });
 
 describe("findOverlappingWorkspaceAgentIds", () => {
+  const tempRoots: string[] = [];
+
   afterEach(() => {
     vi.restoreAllMocks();
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    }
   });
 
   function makeTempWorkspace(name: string): string {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+    tempRoots.push(root);
     return fs.realpathSync.native(root);
   }
 
@@ -67,25 +76,47 @@ describe("findOverlappingWorkspaceAgentIds", () => {
     expect(findOverlappingWorkspaceAgentIds(cfg, "beta", link)).toEqual(["alpha"]);
   });
 
+  function mockRealpathError(code: string): void {
+    vi.spyOn(fs.realpathSync, "native").mockImplementation(() => {
+      throw Object.assign(new Error(`simulated realpath failure (${code})`), { code });
+    });
+  }
+
   it("reports overlap when an existing workspace path cannot be realpath-resolved", () => {
     const alpha = makeTempWorkspace("delete-safety-alpha");
     const beta = makeTempWorkspace("delete-safety-beta");
     const cfg = configWithWorkspaces({ alpha, beta });
 
-    vi.spyOn(fs.realpathSync, "native").mockImplementation(() => {
-      throw new Error("simulated transient realpath failure");
-    });
+    mockRealpathError("EACCES");
 
     // Both directories exist but their symlink relationship can no longer be
     // proven; deletion must fail closed instead of trusting lexical inequality.
     expect(findOverlappingWorkspaceAgentIds(cfg, "beta", beta)).toEqual(["alpha"]);
   });
 
-  it("keeps lexical comparison for non-existent workspace directories", () => {
-    const missingLeft = path.join(makeTempWorkspace("delete-safety-miss-a"), "gone-left");
-    const missingRight = path.join(makeTempWorkspace("delete-safety-miss-b"), "gone-right");
-    const cfg = configWithWorkspaces({ alpha: missingLeft, beta: missingRight });
+  it("fails closed for symlink-loop and other non-missing realpath errors", () => {
+    const alpha = makeTempWorkspace("delete-safety-loop-a");
+    const beta = makeTempWorkspace("delete-safety-loop-b");
+    const cfg = configWithWorkspaces({ alpha, beta });
 
-    expect(findOverlappingWorkspaceAgentIds(cfg, "beta", missingRight)).toEqual([]);
+    for (const code of ["ELOOP", "EPERM", "EIO"]) {
+      mockRealpathError(code);
+      expect(findOverlappingWorkspaceAgentIds(cfg, "beta", beta)).toEqual(["alpha"]);
+    }
+  });
+
+  it("keeps lexical comparison only for missing-path realpath errors", () => {
+    const left = makeTempWorkspace("delete-safety-miss-a");
+    const right = makeTempWorkspace("delete-safety-miss-b");
+    const missingLeft = path.join(makeTempWorkspace("delete-safety-gone-a"), "gone-left");
+    const missingRight = path.join(makeTempWorkspace("delete-safety-gone-b"), "gone-right");
+    const cfg = configWithWorkspaces({ alpha: left, beta: right });
+    const goneCfg = configWithWorkspaces({ alpha: missingLeft, beta: missingRight });
+
+    mockRealpathError("ENOENT");
+    expect(findOverlappingWorkspaceAgentIds(cfg, "beta", right)).toEqual([]);
+
+    // Genuinely absent directories keep the pre-existing lexical comparison too.
+    expect(findOverlappingWorkspaceAgentIds(goneCfg, "beta", missingRight)).toEqual([]);
   });
 });

--- a/src/agents/agent-delete-safety.test.ts
+++ b/src/agents/agent-delete-safety.test.ts
@@ -1,7 +1,9 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
-import { isSharedAuthStoreOwner } from "./agent-delete-safety.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { findOverlappingWorkspaceAgentIds, isSharedAuthStoreOwner } from "./agent-delete-safety.js";
 
 describe("shared auth store deletion safety", () => {
   const sharedAuthDbPath = path.join(os.tmpdir(), "shared-auth", "openclaw-agent.sqlite");
@@ -28,5 +30,62 @@ describe("shared auth store deletion safety", () => {
     },
   ])("$name", ({ ownership, agentAuthDbPath, expected }) => {
     expect(isSharedAuthStoreOwner({ ownership, agentAuthDbPath, sharedAuthDbPath })).toBe(expected);
+  });
+});
+
+describe("findOverlappingWorkspaceAgentIds", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeTempWorkspace(name: string): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+    return fs.realpathSync.native(root);
+  }
+
+  function configWithWorkspaces(workspaces: Record<string, string>): OpenClawConfig {
+    return {
+      agents: {
+        entries: Object.fromEntries(
+          Object.entries(workspaces).map(([id, workspace]) => [id, { workspace }]),
+        ),
+      },
+    } as unknown as OpenClawConfig;
+  }
+
+  it("flags a symlinked workspace that resolves into another agent's workspace", () => {
+    const shared = makeTempWorkspace("delete-safety-shared");
+    const link = path.join(makeTempWorkspace("delete-safety-link"), "linked");
+    // Junctions keep this reachable on Windows without elevated symlink rights.
+    fs.symlinkSync(shared, link, "junction");
+
+    const cfg = configWithWorkspaces({
+      alpha: shared,
+      beta: link,
+    });
+
+    expect(findOverlappingWorkspaceAgentIds(cfg, "beta", link)).toEqual(["alpha"]);
+  });
+
+  it("reports overlap when an existing workspace path cannot be realpath-resolved", () => {
+    const alpha = makeTempWorkspace("delete-safety-alpha");
+    const beta = makeTempWorkspace("delete-safety-beta");
+    const cfg = configWithWorkspaces({ alpha, beta });
+
+    vi.spyOn(fs.realpathSync, "native").mockImplementation(() => {
+      throw new Error("simulated transient realpath failure");
+    });
+
+    // Both directories exist but their symlink relationship can no longer be
+    // proven; deletion must fail closed instead of trusting lexical inequality.
+    expect(findOverlappingWorkspaceAgentIds(cfg, "beta", beta)).toEqual(["alpha"]);
+  });
+
+  it("keeps lexical comparison for non-existent workspace directories", () => {
+    const missingLeft = path.join(makeTempWorkspace("delete-safety-miss-a"), "gone-left");
+    const missingRight = path.join(makeTempWorkspace("delete-safety-miss-b"), "gone-right");
+    const cfg = configWithWorkspaces({ alpha: missingLeft, beta: missingRight });
+
+    expect(findOverlappingWorkspaceAgentIds(cfg, "beta", missingRight)).toEqual([]);
   });
 });

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -25,25 +25,40 @@ export function formatSharedAuthStoreOwnerDeleteError(agentId: string): string {
   return `Agent "${agentId}" owns the legacy shared auth store and cannot be deleted. Run openclaw doctor --fix to migrate shared auth, then retry.`;
 }
 
-function normalizeWorkspacePathForComparison(input: string): string {
+type NormalizedWorkspacePath = {
+  path: string;
+  /** True when realpath failed but the path still exists, so symlink overlap cannot be ruled out. */
+  unverifiable: boolean;
+};
+
+function normalizeWorkspacePathForComparison(input: string): NormalizedWorkspacePath {
   const resolved = path.resolve(input.replaceAll("\0", ""));
   let normalized = resolved;
+  let unverifiable = false;
   try {
     normalized = fs.realpathSync.native(resolved);
   } catch {
-    // Keep lexical path for non-existent directories.
+    // Keep lexical path for non-existent directories. An existing directory whose
+    // realpath cannot be resolved may still reach another workspace through symlinks,
+    // so mark it unverifiable and let the overlap check fail closed rather than
+    // trusting lexical inequality for a live deletion-safety decision.
+    unverifiable = fs.existsSync(resolved);
   }
   if (process.platform === "win32") {
-    return lowercasePreservingWhitespace(normalized);
+    return { path: lowercasePreservingWhitespace(normalized), unverifiable };
   }
-  return normalized;
+  return { path: normalized, unverifiable };
 }
 
 function workspacePathsOverlap(left: string, right: string): boolean {
   const normalizedLeft = normalizeWorkspacePathForComparison(left);
   const normalizedRight = normalizeWorkspacePathForComparison(right);
+  if (normalizedLeft.unverifiable || normalizedRight.unverifiable) {
+    return true;
+  }
   return (
-    isPathInside(normalizedRight, normalizedLeft) || isPathInside(normalizedLeft, normalizedRight)
+    isPathInside(normalizedRight.path, normalizedLeft.path) ||
+    isPathInside(normalizedLeft.path, normalizedRight.path)
   );
 }
 

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -43,6 +43,7 @@ function normalizeWorkspacePathForComparison(input: string): NormalizedWorkspace
     // filesystem errors may still reach another workspace through symlinks,
     // so the overlap check must fail closed instead of trusting lexical
     // inequality for a live deletion-safety decision.
+    // SAFETY: filesystem errors carry a string errno code; read-only narrowing.
     const code = (error as NodeJS.ErrnoException | null)?.code;
     if (code !== "ENOENT" && code !== "ENOTDIR") {
       unverifiable = true;

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -27,7 +27,7 @@ export function formatSharedAuthStoreOwnerDeleteError(agentId: string): string {
 
 type NormalizedWorkspacePath = {
   path: string;
-  /** True when realpath failed but the path still exists, so symlink overlap cannot be ruled out. */
+  /** True when realpath failed for any reason other than a missing path. */
   unverifiable: boolean;
 };
 
@@ -37,12 +37,16 @@ function normalizeWorkspacePathForComparison(input: string): NormalizedWorkspace
   let unverifiable = false;
   try {
     normalized = fs.realpathSync.native(resolved);
-  } catch {
-    // Keep lexical path for non-existent directories. An existing directory whose
-    // realpath cannot be resolved may still reach another workspace through symlinks,
-    // so mark it unverifiable and let the overlap check fail closed rather than
-    // trusting lexical inequality for a live deletion-safety decision.
-    unverifiable = fs.existsSync(resolved);
+  } catch (error) {
+    // Only a definitively missing path is safe for lexical comparison: a
+    // workspace that cannot be resolved because of access, loop, or other
+    // filesystem errors may still reach another workspace through symlinks,
+    // so the overlap check must fail closed instead of trusting lexical
+    // inequality for a live deletion-safety decision.
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (code !== "ENOENT" && code !== "ENOTDIR") {
+      unverifiable = true;
+    }
   }
   if (process.platform === "win32") {
     return { path: lowercasePreservingWhitespace(normalized), unverifiable };


### PR DESCRIPTION
Closes #106558

## What Problem This Solves

`normalizeWorkspacePathForComparison` in `src/agents/agent-delete-safety.ts` falls back to lexical `path.resolve` whenever `fs.realpathSync.native` fails. For a path that still exists (transient permission/traversal errors, reparse-point quirks), that fallback silently skips symlink resolution. Two workspaces that share storage through a symlink but differ lexically then compare as non-overlapping, so the delete guard reports no shared agents and recursive workspace deletion proceeds against the shared host directory.

## Why This Change Was Made

The lexical fallback is only sound for directories that do not exist (not-yet-created workspaces). For an existing directory whose realpath cannot be resolved, inequality of lexical paths proves nothing about overlap, and the failure direction of this guard is catastrophic data loss. The fix keeps the fallback for missing paths and fails closed otherwise:

- normalization now returns `{ path, unverifiable }`; `unverifiable` is set when realpath fails but `fs.existsSync(resolved)` confirms the path is live;
- `workspacePathsOverlap` returns `true` when either side is unverifiable-existing, so callers retain the workspace exactly as they already do for proven overlap (`agents.commands.delete.ts`, gateway agent delete, claw lifecycle delete).

No legitimate workflow deletes through an unresolvable-but-live workspace path; worst case is a retained workspace with a retry after the transient condition clears.

## User Impact

- Deleting an agent can no longer destroy a shared host directory just because symlink resolution failed at check time; the guard now errs toward retention.
- Non-existent workspace directories keep today's lexical comparison, so normal create/delete flows are unaffected.
- No config surface or public API changes; internal helper signature only.

## Evidence

Focused proof (Windows, Node v24.15.0):

```
node node_modules/vitest/vitest.mjs run src/agents/agent-delete-safety.test.ts
Test Files  2 passed (2)
     Tests  12 passed (12)
```

New regression coverage:
- a junction/symlinked workspace resolving into another agent's workspace is flagged (baseline behavior preserved cross-platform),
- with `realpathSync.native` forced to fail on existing directories, overlap is conservatively reported (fail-closed),
- non-existent distinct directories still compare lexically with no false overlap.

Lint: `oxlint` clean on touched files (0 warnings, 0 errors).

## Review follow-ups (post-ClawSweeper review of f066e76)

- **[P1]/[high] Fail closed on every non-missing realpath failure** � fixed in 02e43f7. The partial `existsSync` second probe is gone: normalization now classifies the realpath error itself. Only `ENOENT`/`ENOTDIR` (definitively missing path) keep the lexical fallback; every other code (`EACCES`, `EPERM`, `ELOOP` symlink loops, `EIO`, unknown) marks the path unverifiable and reports overlap so deletion is refused. New regression covers `ELOOP`/`EPERM`/`EIO` explicitly; the access-error case now mocks an `EACCES`-coded error.
- **[P2] Temporary workspace cleanup** � fixed in the same commit; tests track temp roots and `rmSync` them in `afterEach`.
- **Real deletion-flow proof** � not attached: simulating realpath failures inside a live deletion process requires fault injection at the same seam the unit tests use; a CLI-run variant would exercise only the success path on a healthy filesystem. Focused proof remains 14/14 across both vitest projects for this file.
