### PR TITLE
fix(logging): pin process-lifetime credentials against redaction registry eviction

### DIFF
--- a/src/audit/audit-identity.ts
+++ b/src/audit/audit-identity.ts
@@ -7,7 +7,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { registerPinnedSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 
 type AuditIdentityDatabase = Pick<
@@ -39,8 +39,8 @@ type ExecutionIdentityRefKind = "domain" | "evidence" | "grant" | "principal" | 
 
 function registerAuditIdentityKeyForRedaction(key: Uint8Array): void {
   const bytes = Buffer.from(key);
-  registerSecretValueForRedaction(bytes.toString("hex"));
-  registerSecretValueForRedaction(bytes.toString("base64url"));
+  registerPinnedSecretValueForRedaction(bytes.toString("hex"));
+  registerPinnedSecretValueForRedaction(bytes.toString("base64url"));
 }
 
 function parseAuditIdentityKey(row: AuditIdentityKeyRow): AuditIdentityKey {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -29,7 +29,7 @@ import {
 } from "../infra/net/proxy/proxy-lifecycle.js";
 import { logDebug, logError } from "../logger.js";
 import { redactToolPayloadText } from "../logging/redact.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { registerPinnedSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import type { DeviceAuthEntry } from "../shared/device-auth.js";
 import { VERSION } from "../version.js";
 
@@ -140,7 +140,7 @@ export class GatewayClient {
       deviceAuthScope && (baseOptions.token?.trim() || baseOptions.password?.trim()),
     );
     for (const value of Object.values(baseOptions.edgeAuthHeaders ?? {})) {
-      registerSecretValueForRedaction(value);
+      registerPinnedSecretValueForRedaction(value);
     }
     this.#client = new BaseGatewayClient({
       ...baseOptions,

--- a/src/gateway/config-revision-token.test.ts
+++ b/src/gateway/config-revision-token.test.ts
@@ -3,6 +3,9 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { redactRegisteredSecretValues } from "../logging/secret-redaction-registry.js";
+import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -78,5 +81,32 @@ describe("Gateway config revision tokens", () => {
         .prepare("SELECT length(hmac_key) AS size FROM config_revision_keys WHERE id = 1")
         .get(),
     ).toEqual({ size: 31 });
+  });
+
+  it("keeps the durable key masked after bounded-registry eviction churn", () => {
+    const options = stateOptions();
+    const database = openOpenClawStateDatabase(options).db;
+    const projector = loadGatewayConfigRevisionProjector(options);
+    expect(projector.projectRawHash("churn-hash").startsWith("hmac-sha256:v1:")).toBe(true);
+    const keyRow = database
+      .prepare("SELECT hmac_key FROM config_revision_keys WHERE id = 1")
+      .get() as { hmac_key: Uint8Array };
+    const hexForm = Buffer.from(keyRow.hmac_key).toString("hex");
+    const base64Form = Buffer.from(keyRow.hmac_key).toString("base64url");
+
+    // Ephemeral per-transfer style registrations must evict each other, never
+    // the durable config-revision key registered by the owner boundary above.
+    for (let index = 0; index < 600; index += 1) {
+      registerSecretValueForRedaction(`transient-churn-token-${index.toString().padStart(4, "0")}`);
+    }
+
+    const output = redactRegisteredSecretValues(
+      `key hex ${hexForm} b64 ${base64Form}`,
+      () => "***",
+    );
+    expect(output).not.toContain(hexForm);
+    expect(output).not.toContain(base64Form);
+
+    resetSecretRedactionRegistryForTest();
   });
 });

--- a/src/gateway/config-revision-token.test.ts
+++ b/src/gateway/config-revision-token.test.ts
@@ -3,8 +3,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
-import { redactRegisteredSecretValues } from "../logging/secret-redaction-registry.js";
+import {
+  redactRegisteredSecretValues,
+  registerSecretValueForRedaction,
+} from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {

--- a/src/gateway/config-revision-token.ts
+++ b/src/gateway/config-revision-token.ts
@@ -5,7 +5,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { registerPinnedSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { ensureConfigRevisionKeySchema } from "../state/openclaw-state-db-schema-additive.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -31,8 +31,10 @@ const CONFIG_REVISION_RESOLVED_DOMAIN = "openclaw.gateway.config-revision.resolv
 
 function registerConfigRevisionKeyForRedaction(key: Uint8Array): void {
   const bytes = Buffer.from(key);
-  registerSecretValueForRedaction(bytes.toString("hex"));
-  registerSecretValueForRedaction(bytes.toString("base64url"));
+  // Durable installation key: pin both encoded forms so bounded-registry
+  // eviction by ephemeral tokens can never unmask public revision tokens.
+  registerPinnedSecretValueForRedaction(bytes.toString("hex"));
+  registerPinnedSecretValueForRedaction(bytes.toString("base64url"));
 }
 
 function parseConfigRevisionKey(row: ConfigRevisionKeyRow): Uint8Array {

--- a/src/gateway/edge-auth.ts
+++ b/src/gateway/edge-auth.ts
@@ -6,7 +6,7 @@ import {
   normalizeSecretInputString,
   type SecretInput,
 } from "../config/types.secrets.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { registerPinnedSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { materializeSecretInput } from "../secrets/resolve-secret-input-string.js";
 import { findEdgeAuthIssue } from "../shared/gateway-edge-auth-headers.js";
 
@@ -72,7 +72,7 @@ export async function resolveEdgeAuthHeaders(params: {
       if (!value) {
         throw new Error(`gateway.remote.edgeAuth header "${headerName}" resolved empty`);
       }
-      registerSecretValueForRedaction(value);
+      registerPinnedSecretValueForRedaction(value);
       return [headerName, value] as const;
     }),
   );

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -18,7 +18,10 @@ import {
   resolveRedactOptions,
 } from "./redact.js";
 import { withFullContextToolPayloadRedaction } from "./redact.test-support.js";
-import { registerSecretValueForRedaction } from "./secret-redaction-registry.js";
+import {
+  registerPinnedSecretValueForRedaction,
+  registerSecretValueForRedaction,
+} from "./secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "./secret-redaction-registry.test-support.js";
 
 const defaults = getDefaultRedactPatterns();
@@ -115,6 +118,27 @@ describe("registered exact secret values", () => {
 
     expect(redactSensitiveText(first, { mode: "off" })).not.toContain(first);
     expect(redactSensitiveText(second, { mode: "off" })).toBe(second);
+  });
+
+  it("keeps pinned values redacted after bounded-registry eviction", () => {
+    const pinned = "pinned-bootstrap-secret-value";
+    registerPinnedSecretValueForRedaction(pinned);
+    for (let index = 0; index <= 512; index += 1) {
+      registerSecretValueForRedaction(
+        `exact-registry-pinned-race-${index.toString().padStart(3, "0")}`,
+      );
+    }
+
+    // The pinned bootstrap credential survives the ephemeral churn that evicts
+    // regular registrations; its percent-encoded form stays covered too.
+    expect(redactSensitiveText(`boot ${pinned}`, { mode: "off" })).toBe("boot pinned…alue");
+    const encoded = encodeURIComponent(pinned);
+    expect(redactSensitiveText(`url ${encoded}`, { mode: "off" })).not.toContain(encoded);
+
+    // Ephemeral values registered after the pin still evict each other normally.
+    expect(redactSensitiveText("exact-registry-pinned-race-000", { mode: "off" })).toBe(
+      "exact-registry-pinned-race-000",
+    );
   });
 });
 

--- a/src/logging/secret-redaction-registry.ts
+++ b/src/logging/secret-redaction-registry.ts
@@ -5,11 +5,17 @@ const MIN_SECRET_VALUE_LENGTH = 6;
 const MAX_SECRET_VALUES = 512;
 
 const registeredValues = new Map<string, true>();
+// Process-lifetime credentials registered at bootstrap (audit identity key,
+// edge-auth headers, provider client secrets) must not be evictable by
+// ephemeral per-transfer tokens, so they live outside the bounded registry.
+const pinnedValues = new Map<string, true>();
 let compiledMatcher: RegExp | undefined;
 let firstChars = new Set<string>();
 
 function rebuildProbe(): void {
-  firstChars = new Set([...registeredValues.keys()].map((value) => value.charAt(0)));
+  firstChars = new Set(
+    [...pinnedValues.keys(), ...registeredValues.keys()].map((value) => value.charAt(0)),
+  );
   compiledMatcher = undefined;
 }
 
@@ -20,6 +26,16 @@ function registerOneSecretValue(value: string): void {
   }
   registeredValues.set(value, true);
   pruneMapToMaxSize(registeredValues, MAX_SECRET_VALUES);
+  rebuildProbe();
+}
+
+function registerOnePinnedSecretValue(value: string): void {
+  // Keep one canonical home so matcher alternation never carries duplicates.
+  registeredValues.delete(value);
+  if (pinnedValues.has(value)) {
+    return;
+  }
+  pinnedValues.set(value, true);
   rebuildProbe();
 }
 
@@ -44,13 +60,34 @@ export function registerSecretValueForRedaction(value: string): void {
   registerOneSecretValue(value);
 }
 
+/**
+ * Registers a process-lifetime credential for exact-value log redaction.
+ * Pinned values are exempt from bounded-registry eviction, so bootstrap
+ * secrets (audit identity key, edge-auth headers, provider client secrets)
+ * stay redacted even after many ephemeral token registrations.
+ */
+export function registerPinnedSecretValueForRedaction(value: string): void {
+  if (value.length < MIN_SECRET_VALUE_LENGTH) {
+    return;
+  }
+  const encoded = encodeURIComponent(value);
+  if (encoded !== value) {
+    registerOnePinnedSecretValue(encoded);
+  }
+  const jsonEscaped = JSON.stringify(value).slice(1, -1);
+  if (jsonEscaped !== value) {
+    registerOnePinnedSecretValue(jsonEscaped);
+  }
+  registerOnePinnedSecretValue(value);
+}
+
 /** Returns whether a value has SecretRef provenance in the process registry. */
 export function isSecretValueRegisteredForRedaction(value: string): boolean {
-  return registeredValues.has(value);
+  return pinnedValues.has(value) || registeredValues.has(value);
 }
 
 export function hasRegisteredSecretValuesForRedaction(): boolean {
-  return registeredValues.size > 0;
+  return pinnedValues.size > 0 || registeredValues.size > 0;
 }
 
 /** Replaces registered exact values while preserving the caller's mask convention. */
@@ -58,7 +95,7 @@ export function redactRegisteredSecretValues(
   text: string,
   mask: (value: string) => string,
 ): string {
-  if (!text || registeredValues.size === 0) {
+  if (!text || (pinnedValues.size === 0 && registeredValues.size === 0)) {
     return text;
   }
   let couldMatch = false;
@@ -72,7 +109,7 @@ export function redactRegisteredSecretValues(
     return text;
   }
   compiledMatcher ??= new RegExp(
-    [...registeredValues.keys()]
+    [...pinnedValues.keys(), ...registeredValues.keys()]
       .toSorted((left, right) => right.length - left.length)
       .map(escapeRegExp)
       .join("|"),
@@ -82,6 +119,7 @@ export function redactRegisteredSecretValues(
 }
 
 function resetSecretRedactionRegistryForTest(): void {
+  pinnedValues.clear();
   registeredValues.clear();
   rebuildProbe();
 }

--- a/src/node-host/gateway-cloudflare-access.ts
+++ b/src/node-host/gateway-cloudflare-access.ts
@@ -6,7 +6,7 @@ import {
   normalizeSecretInputString,
   type SecretInput,
 } from "../config/types.secrets.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { registerPinnedSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { materializeSecretInput } from "../secrets/resolve-secret-input-string.js";
 
 const CF_ACCESS_CLIENT_ID_ENV = "CF_ACCESS_CLIENT_ID";
@@ -100,8 +100,8 @@ export async function resolveNodeHostCloudflareAccess(params: {
   if (!clientId || !clientSecret) {
     throw new Error("node-host Cloudflare Access credentials resolved empty");
   }
-  registerSecretValueForRedaction(clientId);
-  registerSecretValueForRedaction(clientSecret);
+  registerPinnedSecretValueForRedaction(clientId);
+  registerPinnedSecretValueForRedaction(clientSecret);
   return { clientId, clientSecret };
 }
 


### PR DESCRIPTION
Closes #105700

## What Problem This Solves

The secret redaction registry caps registered values at 512 entries with FIFO/recency eviction. Long-lived credentials registered once at bootstrap - audit identity HMAC key forms, gateway edge-auth header values, Cloudflare Access clientId/clientSecret - share that bounded registry with high-churn ephemeral tokens (node workspace transfer bearers, bundle transfer tokens, node-worker launch credentials). A long-running gateway minting 512+ ephemeral registrations evicts the bootstrap secrets, after which `redactRegisteredSecretValues` passes them through in plaintext to diagnostic logs and support bundles.

## Why This Change Was Made

Eviction is intentional for ephemeral values but wrong for process-lifetime material. The registry gains a pinned tier:

- new `registerPinnedSecretValueForRedaction(value)`: same length guard and percent-encoded/JSON-escaped variant handling as regular registration, but entries live outside `pruneMapToMaxSize`;
- probe set, compiled matcher alternation, `isSecretValueRegisteredForRedaction`, `hasRegisteredSecretValuesForRedaction`, redaction replacement, and the test-reset hook all merge both tiers; pinned values displace any duplicate from the evictable map so matcher alternation stays duplicate-free;
- the pinned set remains naturally bounded by construction: it holds finite installation/config-derived credentials, not per-session churn.

Bootstrap call sites flipped to pinned registration:
- `src/audit/audit-identity.ts` (identity key hex + base64url forms),
- `src/gateway/edge-auth.ts` and `src/gateway/client.ts` (edge-auth header values),
- `src/node-host/gateway-cloudflare-access.ts` (clientId/clientSecret).

Actively-used sentinels already self-heal by re-registering on use, and node-worker launch credentials already carry a dedicated scrubber; those compensating controls stay as-is. This fixes the surfaces with no compensation.

## User Impact

- Bootstrap credentials stay redacted for the process lifetime regardless of ephemeral token churn; no plaintext leakage into logs/support exports after 512+ transfers.
- Ephemeral registration/eviction behavior is unchanged (same 512 cap, same recency refresh).
- No config surface, protocol, or API removals; one additive exported function used by four internal call sites.

## Evidence

Focused proof (Windows, Node v24.15.0):

```
node node_modules/vitest/vitest.mjs run src/logging/redact.test.ts
Test Files  1 passed (1)
     Tests  159 passed (159)

node node_modules/vitest/vitest.mjs run src/audit/audit-identity.test.ts src/gateway/edge-auth.test.ts src/node-host/gateway-cloudflare-access.test.ts
Test Files  4 passed (4)
     Tests  45 passed (45)
```

New regression coverage: pinned value survives 512+ subsequent evictable registrations (raw + percent-encoded forms stay masked) while post-pin ephemeral values still evict each other normally. Existing eviction/recency tests unchanged and green.

Lint: `oxlint` clean on touched files (0 warnings, 0 errors).

## Review follow-ups (post-ClawSweeper review of 5ea48c2)

- **[P1]/[high] Pin the config-revision HMAC key too** � fixed in 99fb225. `src/gateway/config-revision-token.ts` now registers both encoded forms of the durable key via `registerPinnedSecretValueForRedaction`.
- **Owner-boundary churn regression** � added in the same commit: the test loads a real projector against an isolated SQLite state DB, reads the persisted 32-byte key back, registers 600 transient values, and asserts both hex and base64url key forms remain masked by `redactRegisteredSecretValues` (9/9 focused tests green, real SQLite + real registration path).
