### PR TITLE
fix(channels): audit msteams and feishu DM policy via declarative dm security adapter

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -2468,9 +2468,9 @@ describe("feishuPlugin security", () => {
     const resolveDmPolicy = feishuPlugin.security?.resolveDmPolicy;
     expect(resolveDmPolicy).toBeTypeOf("function");
     const policy = resolveDmPolicy!({ cfg, accountId: "default", account });
-    expect(policy.policy).toBe("open");
-    expect(policy.allowFrom).toEqual([" ou_Bob "]);
-    expect(policy.normalizeEntry?.(" OU_X ")).toBe("ou_x");
+    expect(policy?.policy).toBe("open");
+    expect(policy?.allowFrom).toEqual([" ou_Bob "]);
+    expect(policy?.normalizeEntry?.(" OU_X ")).toBe("ou_x");
   });
 
   it("falls back to the pairing default when no DM policy is configured", () => {

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -2475,7 +2475,7 @@ describe("feishuPlugin security", () => {
 
   it("normalizes DM allowlist entries with the runtime canonical identity form", () => {
     const cfg = { channels: { feishu: { enabled: true } } } as OpenClawConfig;
-    const account = { accountId: "default", config: {} };
+    const account = { accountId: "default", config: {} } as never;
 
     const normalizeEntry = feishuPlugin.security?.resolveDmPolicy?.({
       cfg,

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -2457,20 +2457,39 @@ describe("feishuPlugin security", () => {
         feishu: {
           enabled: true,
           dmPolicy: "open",
+          allowFrom: [" ou_bob123 ", "feishu:user:ou_alice9", "*"],
         },
       },
     } as OpenClawConfig;
     const account = {
       accountId: "default",
-      config: { dmPolicy: "open", allowFrom: [" ou_Bob "] },
+      config: { dmPolicy: "open", allowFrom: [" ou_bob123 ", "feishu:user:ou_alice9", "*"] },
     } as never;
 
     const resolveDmPolicy = feishuPlugin.security?.resolveDmPolicy;
     expect(resolveDmPolicy).toBeTypeOf("function");
     const policy = resolveDmPolicy!({ cfg, accountId: "default", account });
     expect(policy?.policy).toBe("open");
-    expect(policy?.allowFrom).toEqual([" ou_Bob "]);
-    expect(policy?.normalizeEntry?.(" OU_X ")).toBe("ou_x");
+    expect(policy?.allowFrom).toEqual([" ou_bob123 ", "feishu:user:ou_alice9", "*"]);
+  });
+
+  it("normalizes DM allowlist entries with the runtime canonical identity form", () => {
+    const cfg = { channels: { feishu: { enabled: true } } } as OpenClawConfig;
+    const account = { accountId: "default", config: {} };
+
+    const normalizeEntry = feishuPlugin.security?.resolveDmPolicy?.({
+      cfg,
+      accountId: "default",
+      account,
+    })?.normalizeEntry;
+    expect(normalizeEntry).toBeTypeOf("function");
+
+    // Bare open-id entries canonicalize to the typed runtime form.
+    expect(normalizeEntry?.(" ou_bob123 ")).toBe("user:ou_bob123");
+    // Provider-prefixed typed-user entries strip to the same runtime form.
+    expect(normalizeEntry?.("feishu:user:ou_alice9")).toBe("user:ou_alice9");
+    // Wildcards survive so audit open-policy route analysis matches runtime.
+    expect(normalizeEntry?.("*")).toBe("*");
   });
 
   it("falls back to the pairing default when no DM policy is configured", () => {

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -2449,3 +2449,43 @@ describe("looksLikeFeishuId", () => {
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+
+describe("feishuPlugin security", () => {
+  it("resolves the configured DM policy for audit instead of skipping the channel", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          dmPolicy: "open",
+        },
+      },
+    } as OpenClawConfig;
+    const account = {
+      accountId: "default",
+      config: { dmPolicy: "open", allowFrom: [" ou_Bob "] },
+    } as never;
+
+    const resolveDmPolicy = feishuPlugin.security?.resolveDmPolicy;
+    expect(resolveDmPolicy).toBeTypeOf("function");
+    const policy = resolveDmPolicy!({ cfg, accountId: "default", account });
+    expect(policy.policy).toBe("open");
+    expect(policy.allowFrom).toEqual([" ou_Bob "]);
+    expect(policy.normalizeEntry?.(" OU_X ")).toBe("ou_x");
+  });
+
+  it("falls back to the pairing default when no DM policy is configured", () => {
+    const cfg = {
+      channels: {
+        feishu: { enabled: true },
+      },
+    } as OpenClawConfig;
+    const account = { accountId: "default", config: {} } as never;
+
+    const policy = feishuPlugin.security?.resolveDmPolicy?.({
+      cfg,
+      accountId: "default",
+      account,
+    });
+    expect(policy?.policy).toBe("pairing");
+  });
+});

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -89,7 +89,7 @@ import { feishuDoctor } from "./doctor.js";
 import { chunkFeishuMarkdown } from "./markdown.js";
 import { messageActionTargetAliases } from "./message-action-contract.js";
 import { readNativeFeishuCardJson } from "./native-card.js";
-import { resolveFeishuGroupToolPolicy } from "./policy.js";
+import { normalizeFeishuAllowEntry, resolveFeishuGroupToolPolicy } from "./policy.js";
 import {
   assertFeishuCardWithinEnvelope,
   buildFeishuPresentationCard,
@@ -1822,7 +1822,10 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
         resolvePolicy: (account) => account.config?.dmPolicy,
         resolveAllowFrom: (account) => account.config?.allowFrom,
         allowFromPathSuffix: "",
-        normalizeEntry: (raw) => raw.trim().toLowerCase(),
+        // Canonical runtime identity form: provider prefixes stripped, typed
+        // prefixes preserved, wildcards kept as "*", so audit wildcard and
+        // route analysis matches runtime DM admission instead of diverging.
+        normalizeEntry: normalizeFeishuAllowEntry,
       },
       collectWarnings: ({ cfg, accountId }) => collectFeishuOpenGroupFindings({ cfg, accountId }),
       collectAuditFindings: ({ cfg }) => collectFeishuSecurityAuditFindings({ cfg }),

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1814,6 +1814,16 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       message: feishuMessageAdapter,
     },
     security: {
+      // Declarative dm block: the SDK normalizes it into resolveDmPolicy so
+      // security audit/doctor evaluate channels.feishu.dmPolicy instead of
+      // silently skipping DM findings for this channel.
+      dm: {
+        channelKey: "feishu",
+        resolvePolicy: (account) => account.config?.dmPolicy,
+        resolveAllowFrom: (account) => account.config?.allowFrom,
+        allowFromPathSuffix: "",
+        normalizeEntry: (raw) => raw.trim().toLowerCase(),
+      },
       collectWarnings: ({ cfg, accountId }) => collectFeishuOpenGroupFindings({ cfg, accountId }),
       collectAuditFindings: ({ cfg }) => collectFeishuSecurityAuditFindings({ cfg }),
     },

--- a/extensions/msteams/src/channel-config.ts
+++ b/extensions/msteams/src/channel-config.ts
@@ -14,6 +14,8 @@ export type ResolvedMSTeamsAccount = {
     ReturnType<typeof tryReadSecretFileSync>,
     { status: "configured_unavailable" }
   >["diagnostic"][];
+  dmPolicy?: string;
+  allowFrom?: Array<string | number>;
 };
 
 export const msteamsMeta = {
@@ -48,6 +50,10 @@ export function resolveMSTeamsAccount(cfg: OpenClawConfig): ResolvedMSTeamsAccou
     configured: Boolean(credentials),
     tokenStatus: !credentials ? "missing" : unavailable ? "configured_unavailable" : "available",
     ...(unavailable ? { credentialDiagnostics: [certificate.diagnostic] } : {}),
+    // Exposed so the security adapter can audit the DM policy that runtime
+    // access enforcement (monitor-handler/access.ts) applies to inbound DMs.
+    ...(config?.dmPolicy !== undefined ? { dmPolicy: config.dmPolicy } : {}),
+    ...(config?.allowFrom !== undefined ? { allowFrom: config.allowFrom } : {}),
   };
 }
 

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { MSTeamsConfigSchema } from "../config-api.js";
 import { msteamsDirectoryContractPlugin } from "../directory-contract-api.js";
 import { msTeamsApprovalAuth } from "./approval-auth.js";
+import { resolveMSTeamsAccount } from "./channel-config.js";
 import { msteamsPlugin } from "./channel.js";
 import { msteamsSetupPlugin } from "./channel.setup.js";
 
@@ -91,6 +92,7 @@ describe("msteamsPlugin", () => {
         enabled: true,
         configured: true,
         tokenStatus: "available",
+        allowFrom: ["OWNER", "  Team.Member  "],
       });
       expect(plugin.config.resolveAllowFrom?.({ cfg, accountId: "default" })).toEqual([
         "OWNER",
@@ -463,5 +465,66 @@ describe("msTeamsApprovalAuth", () => {
 
   it("preserves implicit same-chat fallback for display-name-only allowlists", () => {
     expect(authorizeApproval(["Owner Display"], "attacker-aad")).toEqual({ authorized: true });
+  });
+});
+
+describe("msteamsPlugin security", () => {
+  it("resolves the configured DM policy for audit instead of skipping the channel", () => {
+    const cfg = {
+      channels: {
+        msteams: {
+          appId: "app-id",
+          appPassword: "secret",
+          tenantId: "tenant-id",
+          dmPolicy: "open",
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolveDmPolicy = msteamsPlugin.security?.resolveDmPolicy;
+    expect(resolveDmPolicy).toBeTypeOf("function");
+
+    const openAccount = resolveMSTeamsAccount(cfg);
+    const openPolicy = resolveDmPolicy!({
+      cfg,
+      accountId: openAccount.accountId,
+      account: openAccount,
+    });
+    expect(openPolicy.policy).toBe("open");
+  });
+
+  it("falls back to the pairing default and passes allowFrom through", () => {
+    const cfg = {
+      channels: {
+        msteams: {
+          appId: "app-id",
+          appPassword: "secret",
+          tenantId: "tenant-id",
+          dmPolicy: "allowlist",
+          allowFrom: [" MSTEAMS:user:Bob@Example.com "],
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveMSTeamsAccount(cfg);
+    const policy = msteamsPlugin.security?.resolveDmPolicy?.({
+      cfg,
+      accountId: account.accountId,
+      account,
+    });
+    expect(policy?.policy).toBe("allowlist");
+    expect(policy?.allowFrom).toEqual([" MSTEAMS:user:Bob@Example.com "]);
+    expect(policy?.normalizeEntry?.(" MSTEAMS:user:Bob@Example.com ")).toBe(
+      "msteams:user:bob@example.com",
+    );
+
+    const unsetCfg = createConfiguredMSTeamsCfg();
+    const unsetAccount = resolveMSTeamsAccount(unsetCfg);
+    const unsetPolicy = msteamsPlugin.security?.resolveDmPolicy?.({
+      cfg: unsetCfg,
+      accountId: unsetAccount.accountId,
+      account: unsetAccount,
+    });
+    expect(unsetPolicy?.policy).toBe("pairing");
   });
 });

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -490,7 +490,7 @@ describe("msteamsPlugin security", () => {
       accountId: openAccount.accountId,
       account: openAccount,
     });
-    expect(openPolicy.policy).toBe("open");
+    expect(openPolicy?.policy).toBe("open");
   });
 
   it("falls back to the pairing default and passes allowFrom through", () => {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1078,6 +1078,16 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
       },
     },
     security: {
+      // Declarative dm block: the SDK normalizes it into resolveDmPolicy so
+      // security audit/doctor evaluate channels.msteams.dmPolicy instead of
+      // silently skipping DM findings for this channel.
+      dm: {
+        channelKey: "msteams",
+        resolvePolicy: (account) => account.dmPolicy,
+        resolveAllowFrom: (account) => account.allowFrom,
+        allowFromPathSuffix: "",
+        normalizeEntry: (raw) => raw.trim().toLowerCase(),
+      },
       collectWarnings: ({ cfg }) => collectMSTeamsSecurityFindings({ cfg }),
     },
     pairing: {


### PR DESCRIPTION
Closes #115410

## What Problem This Solves

`openclaw security audit` emits a critical `channels.<id>.dm.open` finding when a channel allows anyone to DM the agent, but that check is reachable only through the optional `plugin.security.resolveDmPolicy` hook. Channels without it are skipped silently - no finding, no warning, no indication the channel was never evaluated. `msteams` and `feishu` both accept `dmPolicy` configuration and enforce it at runtime, yet declared neither the hook nor a declarative `dm:` block, so their DM policy was never audited: absence of a finding read as evidence of safety. `googlechat` already wires this correctly.

## Why This Change Was Made

Same mechanism, three channels, one wired up - omission rather than intent. Both plugins now use the same declarative seam googlechat uses, which the SDK normalizes into `resolveDmPolicy` via `createChatChannelPlugin`:

- `extensions/msteams`: `security.dm` block reading account-level `dmPolicy`/`allowFrom`; `ResolvedMSTeamsAccount` now carries both from `channels.msteams.*`, matching what runtime access enforcement applies (`dmPolicy ?? "pairing"` in `monitor-handler/access.ts`). One pre-existing deep-equality assertion updated to expect the new resolved-account fields.
- `extensions/feishu`: `security.dm` block reading merged account `config.dmPolicy`/`config.allowFrom`, alongside the existing group-warning and doc-tool audit collectors. Runtime default (`bot.ts`: `dmPolicy ?? "pairing"`) matches the shared SDK default (`buildAccountScopedDmSecurityPolicy` -> `"pairing"`).

Both adapters normalize allowlist entries with trim+lowercase, consistent with each plugin's existing allowFrom formatting (`formatAllowFromLowercase` / pairing strippers).

## User Impact

- `openclaw security audit` and doctor now report `channels.msteams.dm.open` / `channels.feishu.dm.open` critical findings when those channels are configured with `dmPolicy: "open"`, instead of reporting nothing.
- Runtime enforcement, defaults, pairing flows, and config schemas are unchanged; audit-only seam plus two additive optional fields on msteams' resolved account type.

## Evidence

Focused proof (Windows, Node v24.15.0):

```
node node_modules/vitest/vitest.mjs run extensions/msteams/src/channel.test.ts
Test Files  1 passed (1)
     Tests  40 passed (40), 1 skipped

node node_modules/vitest/vitest.mjs run extensions/feishu/src/channel.test.ts
Test Files  1 passed (1)
     Tests  107 passed (107)
```

New regression coverage per plugin:
- `resolveDmPolicy` resolves the configured policy for audit (no longer absent), passes `allowFrom` through, and exposes entry normalization,
- unset policy falls back to the shared `"pairing"` default.

Lint: `oxlint` clean on touched files (0 warnings, 0 errors).

## Review follow-ups (post-ClawSweeper review of b423893)

- **[P2] Feishu canonical DM identity normalization** � fixed in 4f080c1. The Feishu adapter now uses the runtime canonical normalizer (`normalizeFeishuAllowEntry` from `extensions/feishu/src/policy.ts`) instead of naive trim+lowercase: provider prefixes (`feishu:`/`lark:`) are stripped, typed prefixes are preserved (`user:`/`chat:`), open-ids canonicalize to `user:<id>`, and wildcards survive as `*` so audit open-policy route analysis matches runtime DM admission. New regressions cover provider-prefixed typed-user entries and wildcard entries.
- **Real security-audit CLI transcript** � attempted on this machine but not attachable: `openclaw security audit --json` against an isolated state dir hangs probing plugin/live surfaces in this Windows environment (25+ min with no output; source CLI itself works - version banner verified). Adapter-level proof stands at 3 new green tests for the seam plus the full feishu/msteams suites.
