### PR TITLE
fix(mistral): retain provider-returned streaming model as responseModel

### DIFF
--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -800,6 +800,27 @@ describe("Mistral provider", () => {
       cacheWrite: 0,
       totalTokens: 110,
     });
+    expect(result.responseId).toBe("response-cache-usage");
+    expect(result.responseModel).toBe("mistral-small-latest");
+  });
+
+  it("omits responseModel when streamed model matches the requested id", async () => {
+    mistralMockState.streamResult = {
+      async *[Symbol.asyncIterator]() {
+        yield {
+          data: {
+            id: "response-same-model",
+            model: "mistral-large-latest",
+            choices: [{ finishReason: "stop", delta: { content: "ok" } }],
+          },
+        };
+      },
+    };
+
+    const result = await runMistralFixture(context, { apiKey: "fixture" });
+
+    expect(result.responseId).toBe("response-same-model");
+    expect(result).not.toHaveProperty("responseModel");
   });
 
   it("serializes structured non-image blocks in tool results as JSON text", async () => {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -584,6 +584,11 @@ async function consumeChatStream(
     // Mistral's streamed CompletionChunk carries an id field. Keep the first non-empty one,
     // mirroring how OpenAI-style streaming exposes a stable response identifier per stream.
     output.responseId ||= chunk.id;
+    // Retain the provider-returned model when it differs from the requested id so
+    // routed responses are not misattributed, matching the OpenAI sibling stream.
+    if (typeof chunk.model === "string" && chunk.model.length > 0 && chunk.model !== model.id) {
+      output.responseModel ||= chunk.model;
+    }
 
     if (chunk.usage) {
       const promptTokens = chunk.usage.promptTokens || 0;


### PR DESCRIPTION
Closes #127625

## What Problem This Solves

Mistral stream consumption preserved chunk ID, usage, finish reason, and content but discarded the required `CompletionChunk.model`. A valid routed/differing model never reached `AssistantMessage.responseModel`, so terminal receipts, transcript metadata, and effective-model/reroute diagnostics falsely attributed the response to the requested model. The provider-returned id was irretrievably lost at stream ownership.

## Why This Change Was Made

`packages/ai/src/providers/mistral.ts` consumed required `chunk.model` without retaining it. The OpenAI completions sibling preserves differing provider-returned model identity (`output.responseModel ||= chunk.model` guarded by a non-empty, differs-from-requested check), and Anthropic direct/server-fallback do the same. This mirrors that exact pattern immediately after response-ID ownership:

```ts
output.responseId ||= chunk.id;
if (typeof chunk.model === "string" && chunk.model.length > 0 && chunk.model !== model.id) {
  output.responseModel ||= chunk.model;
}
```

## User Impact

- Routed Mistral responses now record the concrete served model (e.g. requested `mistral-large-latest`, returned `mistral-small-latest`) in `responseModel`.
- Same-model streams remain byte-identical (no `responseModel` emitted).
- Additive optional field only; no config/protocol/API changes.

## Evidence

An existing fixture in `mistral.test.ts` already streamed the differing-model shape (`model: "mistral-small-latest"` under requested `mistral-large-latest`) but asserted usage only. Extended proof (Windows, Node v24.15.0):

```
node node_modules/vitest/vitest.mjs run packages/ai/src/providers/mistral.test.ts
Test Files  1 passed (1)
     Tests  29 passed (29)
```

New regression coverage:
- the cached-prompt-tokens fixture now also asserts `responseId` and `responseModel`,
- same-model omission: streamed `model` equal to requested id produces no `responseModel`.

Lint: `oxlint` clean on touched files (0 warnings, 0 errors).

## Review follow-ups (post-ClawSweeper review of 6c2f421)

- **Real SDK/SSE behavior proof** � captured: the pinned Mistral SDK consumed a real local HTTP/SSE stream (no mocks) whose chunk model differs from the requested id, driven through the changed `streamMistral`:

  ```
  LIVE_SSE_PROOF {"requested":"mistral-large-latest","responseId":"resp-live-proof","responseModel":"mistral-small-latest","stopReason":"stop","text":"ok"}
  ```

  This is the after-fix behavior through the installed SDK boundary the review asked for.
