### PR TITLE
fix(gateway): restore HTTP subagent completion announces [AI-assisted]

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -27,6 +27,7 @@ import {
   getAgentEventLifecycleGeneration,
   onAgentEvent,
 } from "../infra/agent-events.js";
+import { getGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
 import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -158,6 +159,7 @@ type FirstAgentCommandOptions = {
   message?: string;
   messageChannel?: string;
   model?: string;
+  onAdmittedRunContext?: (context: object) => void | Promise<void>;
   senderIsOwner?: boolean;
   sessionKey?: string;
   streamParams?: {
@@ -177,6 +179,29 @@ function firstAgentCommandOptions() {
 }
 
 describe("OpenAI-compatible HTTP API (e2e)", () => {
+  it("binds the Gateway lifecycle resolver to chat-completion runs", async () => {
+    let resolveGatewayContext: ReturnType<typeof getGatewayContextResolver>;
+    agentCommandMock.mockClear();
+    agentCommandMock.mockImplementationOnce(async (opts: unknown) => {
+      const admittedRunContext = {};
+      const onAdmittedRunContext = (opts as FirstAgentCommandOptions).onAdmittedRunContext;
+      expect(onAdmittedRunContext).toBeTypeOf("function");
+      await onAdmittedRunContext?.(admittedRunContext);
+      resolveGatewayContext = getGatewayContextResolver(admittedRunContext);
+      return { payloads: [{ text: "hello" }] } as never;
+    });
+
+    const res = await postChatCompletions(enabledPort, {
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    const context = resolveGatewayContext?.();
+    expect(context?.resolveGatewayContext).toBe(resolveGatewayContext);
+  });
+
   it("returns a typed selection error unless an ownerless fleet request selects an agent", async () => {
     try {
       testState.agentsConfig = {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -180,26 +180,40 @@ function firstAgentCommandOptions() {
 
 describe("OpenAI-compatible HTTP API (e2e)", () => {
   it("binds the Gateway lifecycle resolver to chat-completion runs", async () => {
+    const started = await startGatewayServerWithRetries({
+      port: await getGatewayTestPort(),
+      opts: {
+        host: "127.0.0.1",
+        auth: { mode: "none" },
+        controlUiEnabled: false,
+        openAiChatCompletionsEnabled: true,
+      },
+    });
     let resolveGatewayContext: ReturnType<typeof getGatewayContextResolver>;
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce(async (opts: unknown) => {
-      const admittedRunContext = {};
-      const onAdmittedRunContext = (opts as FirstAgentCommandOptions).onAdmittedRunContext;
-      expect(onAdmittedRunContext).toBeTypeOf("function");
-      await onAdmittedRunContext?.(admittedRunContext);
-      resolveGatewayContext = getGatewayContextResolver(admittedRunContext);
-      return { payloads: [{ text: "hello" }] } as never;
-    });
+    try {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce(async (opts: unknown) => {
+        const admittedRunContext = {};
+        const onAdmittedRunContext = (opts as FirstAgentCommandOptions).onAdmittedRunContext;
+        expect(onAdmittedRunContext).toBeTypeOf("function");
+        await onAdmittedRunContext?.(admittedRunContext);
+        resolveGatewayContext = getGatewayContextResolver(admittedRunContext);
+        return { payloads: [{ text: "hello" }] } as never;
+      });
 
-    const res = await postChatCompletions(enabledPort, {
-      model: "openclaw",
-      messages: [{ role: "user", content: "hi" }],
-    });
+      const res = await postChatCompletions(started.port, {
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
 
-    expect(res.status).toBe(200);
-    await res.text();
-    const context = resolveGatewayContext?.();
-    expect(context?.resolveGatewayContext).toBe(resolveGatewayContext);
+      expect(res.status).toBe(200);
+      await res.text();
+      const context = resolveGatewayContext?.();
+      expect(context?.resolveGatewayContext).toBe(resolveGatewayContext);
+    } finally {
+      await started.server.close({ reason: "chat-completion resolver lifecycle test done" });
+    }
+    expect(resolveGatewayContext?.()).toBeUndefined();
   });
 
   it("returns a typed selection error unless an ownerless fleet request selects an agent", async () => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -9,13 +9,14 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { avoidTrailingHighSurrogateBreak } from "@openclaw/normalization-core/utf16-slice";
+import type { AdmittedRunContext } from "../agents/admitted-run-context.js";
 import { isClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import type { AgentStreamParams, ClientToolDefinition } from "../agents/command/shared-types.js";
 import type { ImageContent } from "../agents/command/types.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { toOpenAiChatCompletionsUsage, type OpenAiChatCompletionsUsage } from "../agents/usage.js";
 import { createDefaultDeps } from "../cli/deps.js";
-import { agentCommandFromIngress } from "../commands/agent.js";
+import { agentCommandFromGatewayIngress } from "../commands/agent.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -30,6 +31,7 @@ import {
   type InputImageLimits,
   type InputImageSource,
 } from "../media/input-files.js";
+import { bindGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
 import { retainGatewayRootWorkAdmissionContinuation } from "../process/gateway-work-admission.js";
 import { defaultRuntime } from "../runtime.js";
 import {
@@ -77,6 +79,7 @@ import {
   toolChoiceConstraintPrompt,
   type ToolChoiceConstraint,
 } from "./openai-tool-choice.js";
+import type { GatewayContextResolver } from "./server-methods/types.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -85,6 +88,7 @@ type OpenAiHttpOptions = {
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
+  resolveGatewayContext?: GatewayContextResolver;
 };
 
 type OpenAiChatMessage = {
@@ -1091,11 +1095,23 @@ export async function handleOpenAiHttpRequest(
     abortSignal: abortController.signal,
     streamParams,
   });
+  const gatewayCommandInput = opts.resolveGatewayContext
+    ? {
+        ...commandInput,
+        onAdmittedRunContext: (context: AdmittedRunContext) =>
+          bindGatewayContextResolver(context, opts.resolveGatewayContext),
+      }
+    : commandInput;
 
   if (!stream) {
     const stopWatchingDisconnect = watchClientDisconnect(req, res, abortController);
     try {
-      const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
+      const result = await agentCommandFromGatewayIngress(
+        gatewayCommandInput,
+        defaultRuntime,
+        deps,
+        {},
+      );
 
       if (abortController.signal.aborted) {
         return true;
@@ -1380,7 +1396,12 @@ export async function handleOpenAiHttpRequest(
 
   void (async () => {
     try {
-      const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
+      const result = await agentCommandFromGatewayIngress(
+        gatewayCommandInput,
+        defaultRuntime,
+        deps,
+        {},
+      );
       resultResolved = true;
 
       if (closed) {

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -22,6 +22,7 @@ import {
   getAgentEventLifecycleGeneration,
   onAgentEvent,
 } from "../infra/agent-events.js";
+import { getGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
 import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -335,6 +336,28 @@ async function expectInvalidRequest(
 }
 
 describe("OpenResponses HTTP API (e2e)", () => {
+  it("binds the Gateway lifecycle resolver to response runs", async () => {
+    let resolveGatewayContext: ReturnType<typeof getGatewayContextResolver>;
+    agentCommandMock.mockClear();
+    agentCommandMock.mockImplementationOnce(async (opts: unknown) => {
+      const admittedRunContext = {};
+      const onAdmittedRunContext = (
+        opts as { onAdmittedRunContext?: (context: object) => void | Promise<void> }
+      ).onAdmittedRunContext;
+      expect(onAdmittedRunContext).toBeTypeOf("function");
+      await onAdmittedRunContext?.(admittedRunContext);
+      resolveGatewayContext = getGatewayContextResolver(admittedRunContext);
+      return { payloads: [{ text: "hello" }] } as never;
+    });
+
+    const res = await postResponses(enabledPort, { model: "openclaw", input: "hi" });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    const context = resolveGatewayContext?.();
+    expect(context?.resolveGatewayContext).toBe(resolveGatewayContext);
+  });
+
   it("returns a typed selection error unless an ownerless fleet request selects an agent", async () => {
     try {
       testState.agentsConfig = {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -9,13 +9,14 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import type { AdmittedRunContext } from "../agents/admitted-run-context.js";
 import { isClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import type { ImageContent } from "../agents/command/types.js";
 import type { ClientToolDefinition } from "../agents/embedded-agent-runner/run/params.js";
 import { toOpenAiResponsesUsage } from "../agents/usage.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import type { CliDeps } from "../cli/deps.types.js";
-import { agentCommandFromIngress } from "../commands/agent.js";
+import { agentCommandFromGatewayIngress } from "../commands/agent.js";
 import type { GatewayHttpResponsesConfig } from "../config/types.gateway.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
@@ -34,6 +35,7 @@ import {
   type InputImageLimits,
   type InputImageSource,
 } from "../media/input-files.js";
+import { bindGatewayContextResolver } from "../plugins/runtime/gateway-request-scope.js";
 import { retainGatewayRootWorkAdmissionContinuation } from "../process/gateway-work-admission.js";
 import { defaultRuntime } from "../runtime.js";
 import {
@@ -87,6 +89,7 @@ import {
 import { wrapUntrustedFileContent } from "./openresponses-file-content.js";
 import { buildAgentPrompt } from "./openresponses-prompt.js";
 import { createAssistantOutputItem, createFunctionCallOutputItem } from "./openresponses-shape.js";
+import type { GatewayContextResolver } from "./server-methods/types.js";
 
 type OpenResponsesHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -95,6 +98,7 @@ type OpenResponsesHttpOptions = {
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
+  resolveGatewayContext?: GatewayContextResolver;
 };
 
 const DEFAULT_BODY_BYTES = 20 * 1024 * 1024;
@@ -391,9 +395,10 @@ async function runResponsesAgentCommand(params: {
   messageChannel: string;
   senderIsOwner: boolean;
   deps: CliDeps;
+  resolveGatewayContext?: GatewayContextResolver;
   abortSignal?: AbortSignal;
 }) {
-  return agentCommandFromIngress(
+  return agentCommandFromGatewayIngress(
     {
       message: params.message,
       images: params.images.length > 0 ? params.images : undefined,
@@ -409,9 +414,16 @@ async function runResponsesAgentCommand(params: {
       bestEffortDeliver: false,
       allowModelOverride: params.modelOverride !== undefined,
       abortSignal: params.abortSignal,
+      ...(params.resolveGatewayContext
+        ? {
+            onAdmittedRunContext: (context: AdmittedRunContext) =>
+              bindGatewayContextResolver(context, params.resolveGatewayContext),
+          }
+        : {}),
     },
     defaultRuntime,
     params.deps,
+    {},
   );
 }
 
@@ -712,6 +724,7 @@ export async function handleOpenResponsesHttpRequest(
         messageChannel,
         senderIsOwner,
         deps,
+        resolveGatewayContext: opts.resolveGatewayContext,
         abortSignal: abortController.signal,
       });
 
@@ -1178,6 +1191,7 @@ export async function handleOpenResponsesHttpRequest(
         messageChannel,
         senderIsOwner,
         deps,
+        resolveGatewayContext: opts.resolveGatewayContext,
         abortSignal: abortController.signal,
       });
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -60,6 +60,7 @@ import {
   type ResolvePluginNodeCapabilityRoute,
 } from "./server-http-plugin-auth.js";
 import { handleGatewayProbeRequest } from "./server-http-probes.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 import type { HooksRequestHandler } from "./server/hooks-request-handler.js";
 import { runWithGatewayHttpWorkAdmission } from "./server/http-work-admission.js";
 import {
@@ -181,6 +182,7 @@ export function createGatewayHttpServer(opts: {
   getReadiness?: ReadinessChecker;
   getStartup?: StartupChecker;
   getRuntimeConfig?: () => OpenClawConfig;
+  getGatewayRequestContext?: () => GatewayRequestContext | undefined;
   isStartupPluginRuntimeReady?: () => boolean;
   isTerminalEnabled?: () => boolean;
   tlsOptions?: TlsOptions;
@@ -453,6 +455,7 @@ export function createGatewayHttpServer(opts: {
         (await getOpenResponsesHttpModule()).handleOpenResponsesHttpRequest(req, res, {
           ...routeAuth,
           config: openResponsesConfig,
+          resolveGatewayContext: opts.getGatewayRequestContext?.()?.resolveGatewayContext,
         }),
       );
       addAdmittedStage(
@@ -461,6 +464,7 @@ export function createGatewayHttpServer(opts: {
           (await getOpenAiHttpModule()).handleOpenAiHttpRequest(req, res, {
             ...routeAuth,
             config: openAiChatCompletionsConfig,
+            resolveGatewayContext: opts.getGatewayRequestContext?.()?.resolveGatewayContext,
           }),
       );
       const approvalDocument = isControlUiApprovalDocumentPath({

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -318,6 +318,7 @@ export async function createGatewayHttpTransport(params: {
       getReadiness: params.getReadiness,
       getStartup: params.getStartup,
       getRuntimeConfig: loadRuntimeConfig,
+      getGatewayRequestContext: params.getGatewayRequestContext,
       isStartupPluginRuntimeReady: params.isStartupPluginRuntimeReady,
       isTerminalEnabled: params.isTerminalEnabled,
       tlsOptions,


### PR DESCRIPTION
Closes #128003

Related: #128060

## What Problem This Solves

Fixes an issue where users driving agents through `POST /v1/responses` or `POST /v1/chat/completions` would silently lose every subagent completion announcement. The parent and child runs complete, but the deferred announce cannot dispatch back into the requester session because the HTTP-originated run retains no Gateway instance binding.

## Why This Change Was Made

The HTTP request boundary now captures the active Gateway context's own lifecycle-fenced resolver and passes it to both OpenAI-compatible handlers. Those handlers use the trusted `agentCommandFromGatewayIngress` entrypoint and its private `onAdmittedRunContext` hook to bind that resolver to the admitted run.

This intentionally leaves the shared `prepareAgentCommandExecutionIdentity` path and public `agentCommandFromIngress` sanitizer unchanged. It also avoids retaining the raw process-level context getter: the resolver stored by deferred work is the context's own `resolveGatewayContext`, which returns `undefined` after that Gateway instance retires.

The implementation is AI-assisted.

## User Impact

Subagent completion announces run again for HTTP-only integrations on both OpenAI-compatible endpoints. Active requests can dispatch into their owning Gateway instance, while work finishing after lifecycle retirement still fails closed instead of using a stale context.

No delivery-target behavior changes here. External channel delivery still depends on the session's existing route; this fix restores the announce run and requester-session transcript path.

## Evidence

### Rebased full-flow Gateway proof

Rebased onto `008412212f4334bf9fe83d36d3f93364991e2302`, then ran an isolated QA Gateway with the real `startQaGatewayChild` process boundary and `startQaMockOpenAiServer`. The scripted provider drove `sessions_spawn` from one `/v1/responses` request and one `/v1/chat/completions` request; proof waited for the child runs and deferred completion turns rather than accepting the parent HTTP responses alone.

```json
{
  "ok": true,
  "responsesAccepted": true,
  "chatAccepted": true,
  "providerRequests": 303,
  "announceRequests": 2,
  "dispatchFailures": 0
}
```

The two `announceRequests` are mock-provider requests containing the protected `Internal task completion event`, one for each HTTP endpoint. `dispatchFailures` counts the reported missing-scope error across the Gateway logs.

### Lifecycle and repository checks

- `node scripts/run-vitest.mjs src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts` — **254 tests passed** across four discovered test files.
  - Both endpoint suites invoke the actual Gateway-only admission hook.
  - The chat-completion regression closes its dedicated Gateway and asserts that the retained resolver returns `undefined` after retirement. This fails if the raw process-level context holder is retained.
- `node scripts/check-changed.mjs -- src/gateway/openai-http.test.ts src/gateway/openai-http.ts src/gateway/openresponses-http.test.ts src/gateway/openresponses-http.ts src/gateway/server-http.ts src/gateway/server-runtime-state.ts` — **passed** all selected formatting, lint, production/test typecheck, dependency, boundary, dead-export, database, and import-cycle gates after the rebase and lifecycle-test update.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — **clean**, no accepted/actionable findings; overall patch correctness reported as 0.97.
- `.agents/skills/autoreview/scripts/autoreview --mode local` after adding the retirement assertion — **clean**, no accepted/actionable findings; test-only change correctness reported as 0.99.
- `git diff --check` — clean.
- Diff classification: production **+45/-5** (net +40); tests **+62/-0**. The production growth supplies the missing explicit Gateway lifecycle-custody boundary for two sibling HTTP endpoints.

## AI Assistance

- [x] AI-assisted implementation and review disclosed.
- [x] The code and lifecycle ownership path were manually inspected.
- [x] Repository autoreview completed cleanly.
