### PR TITLE
perf(qa-lab): avoid quadratic lane exclusions

### DIFF
--- a/extensions/qa-lab/src/runtime-pair-lane-selection.ts
+++ b/extensions/qa-lab/src/runtime-pair-lane-selection.ts
@@ -68,8 +68,9 @@ export function resolveQaRuntimePairLaneScenarioIds(params: {
       ),
     }),
   );
+  const laneCompatibleScenarioSet = new Set(laneCompatibleScenarios);
   const excludedLaneScenarios = compatibleScenarios.filter(
-    (scenario) => !laneCompatibleScenarios.includes(scenario),
+    (scenario) => !laneCompatibleScenarioSet.has(scenario),
   );
   const excludedNonFlowScenarios = params.runtimePair
     ? matchingScenarios.filter((scenario) => scenario.execution.kind !== "flow")


### PR DESCRIPTION
## What Problem This Solves

Large QA Lab runtime-pair lane plans repeatedly scanned the full selected-scenario array for every compatible scenario while deriving lane exclusions. This made that owner-local planning step quadratic as scenario catalogs grew.

## Why This Change Was Made

The canonical runtime-pair lane selector now builds one identity-preserving `Set` from selected scenarios and uses constant-time membership checks when deriving the ordered exclusion list. `Set.has` and the previous `Array.includes` both use SameValueZero, so scenario identity semantics and exclusion ordering are unchanged. Provider behavior, run plans, artifacts, configuration, and errors are unchanged.

The quadratic scan originated with the runtime-pair lane selector introduced in #112838. This change was AI-assisted. I reviewed the selector owner, CLI and run-plan callers, catalog behavior, proof harness, and benchmark and understand the resulting behavior.

## User Impact

QA Lab developers and operators should see faster runtime-pair suite planning for large scenario catalogs. Current catalog selections and exclusions remain byte-for-byte equivalent.

## Evidence

- Exact head: `d06cbd3778fb3efb2edb491383cf6418cb361557`; parent/current-main proof baseline: `fc80a1d2998d00650b346290bbb71c4a0f0398f3`.
- Deterministic 4,096-scenario proof: selected IDs and exclusions were identical; identity probes fell from **8,390,656 to 0**.
- Current real catalog differential for `mock-openai` and live-frontier core lanes matched exactly (2,276-byte canonical JSON; SHA-256 `869ae0db46ee5e267a56f010dd408cbbe04972b0762ee88c6c8419839fa6cc6a`).
- Fresh Node 24 benchmark with 16,384 scenarios: median planning time fell from 52.685 ms to 7.848 ms (**6.71× faster / 85.10% lower**) with identical checksums. This is owner-stage evidence, not an end-to-end suite-runtime claim.
- Focused catalog, run-config, and CLI coverage: 3 files / 179 tests passed.
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/runtime-pair-lane-selection.ts`: passed formatting, boundaries, dead exports, production/test typechecks, Oxlint, storage/media/runtime guards, and import-cycle checks.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: passed all build phases.
- Mock-provider product smoke: `runtime-tool-fs-read` completed with 1 scenario / 1 pass / 0 failures using `mock-openai/gpt-5.6-luna`.
- No test was added: a membership-call/complexity assertion would couple tests to this implementation; existing catalog, run-plan, and CLI tests protect the behavior contract.
- Exact final-diff Codex Sol/high autoreview: clean at 0.99 confidence; TruffleHog preflight clean.
- Fresh live overlap searches found no open PR for runtime-pair lane selection or exclusion performance.