### PR TITLE
fix(memory): isolate sqlite-vec KNN from the event loop

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -768,7 +768,7 @@ extensions/memory-core/src/memory/manager-embedding-ops.ts	2
 extensions/memory-core/src/memory/manager-keyword-retrieval.ts	1
 extensions/memory-core/src/memory/manager-reindex-lock.ts	1
 extensions/memory-core/src/memory/manager-search-orchestration.ts	3
-extensions/memory-core/src/memory/manager-search.ts	13
+extensions/memory-core/src/memory/manager-search.ts	12
 extensions/memory-core/src/memory/manager-source-state.ts	2
 extensions/memory-core/src/memory/manager-sync-base.ts	5
 extensions/memory-core/src/memory/manager-vector-rebuild-state.ts	1

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -433,6 +433,9 @@ const config = {
     "extensions/signal/src/setup-core.ts": ["exports"],
     // Focused CLI tests exercise plan construction through this explicit test seam.
     "extensions/onepassword/src/secret-ref-cli.ts": ["exports"],
+    // Focused subprocess tests consume lifecycle injection and exit contracts; production uses
+    // the public runner while the full-tree companion scan audits these explicit test seams.
+    "extensions/memory-core/src/memory/manager-search-knn-subprocess.ts": ["exports", "types"],
     // Mirror config parsing, redaction mapping, cap fitting, and the runner are
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],
@@ -753,7 +756,10 @@ const config = {
       "src/matrix/send.ts!",
     ]),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/microsoft`]: bundledPluginWorkspace(),
-    [`${BUNDLED_PLUGIN_ROOT_DIR}/memory-core`]: bundledPluginWorkspace(),
+    [`${BUNDLED_PLUGIN_ROOT_DIR}/memory-core`]: bundledPluginWorkspace([
+      // The subprocess boundary tests spawn this fixture by computed URL.
+      "src/memory/fixtures/manager-search-knn-child.fixture.mjs!",
+    ]),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/memory-lancedb`]: {
       ...bundledPluginWorkspace(),
       // LanceDB declares Arrow as a peer; the plugin provides it for runtime table values.

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -433,9 +433,6 @@ const config = {
     "extensions/signal/src/setup-core.ts": ["exports"],
     // Focused CLI tests exercise plan construction through this explicit test seam.
     "extensions/onepassword/src/secret-ref-cli.ts": ["exports"],
-    // Focused subprocess tests consume lifecycle injection and exit contracts; production uses
-    // the public runner while the full-tree companion scan audits these explicit test seams.
-    "extensions/memory-core/src/memory/manager-search-knn-subprocess.ts": ["exports", "types"],
     // Mirror config parsing, redaction mapping, cap fitting, and the runner are
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],

--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -23,6 +23,10 @@ started.
 - **CJK support** via trigram tokenization for Chinese, Japanese, and Korean.
 - **sqlite-vec acceleration** for in-database vector queries (optional).
 
+Native sqlite-vec queries run in a separate, read-only process so a slow query
+does not block the Gateway event loop. Cancelling a search terminates its query
+process; OpenClaw does not retry that native query on the Gateway thread.
+
 ## Getting started
 
 By default, the builtin engine uses OpenAI embeddings. If `OPENAI_API_KEY` or
@@ -110,6 +114,10 @@ which support selective deletion after promotion. For coverage and limits, see
 - **Auto-reindex:** the index rebuilds automatically when the embedding
   provider, model, chunking config, configured sources, or scope change.
 - **Reindex on demand:** `openclaw memory index --force`
+
+Full reindexes build a replacement in a temporary database and publish the
+memory tables atomically. Concurrent searches and status reads keep using the
+published index; a failed rebuild leaves that index intact.
 
 <Info>
 You can also index Markdown files outside the workspace with

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -28,6 +28,7 @@ import {
   writeMemoryCoreWorkspaceEntry,
 } from "./src/dreaming-state.js";
 import { bm25RankToScore, buildFtsQuery } from "./src/memory/hybrid.js";
+import { runVectorKnnQuery } from "./src/memory/manager-search-knn.js";
 import { searchKeyword, searchVector } from "./src/memory/manager-search.js";
 import {
   dreamingTestState as dreamingTesting,
@@ -447,6 +448,7 @@ async function searchMigratedVectorRows(agentPath: string) {
       limit: 1,
       snippetMaxChars: 200,
       ensureVectorReady: async () => true,
+      runVectorKnn: async (request) => runVectorKnnQuery(db, request),
       sourceFilterVec: { sql: "", params: [] },
       sourceFilterChunks: { sql: "", params: [] },
     });

--- a/extensions/memory-core/src/memory/fixtures/manager-search-knn-child.fixture.mjs
+++ b/extensions/memory-core/src/memory/fixtures/manager-search-knn-child.fixture.mjs
@@ -1,0 +1,30 @@
+import process from "node:process";
+
+process.on("SIGTERM", () => {
+  // Force the parent test through its SIGKILL path.
+});
+
+const chunks = [];
+process.stdin.on("data", (chunk) => chunks.push(chunk));
+process.stdin.once("end", () => {
+  const input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  if (input.databasePath === "fixture:malformed") {
+    process.stdout.write("not-json");
+    return;
+  }
+  if (input.databasePath === "fixture:oversized") {
+    process.stdout.write(Buffer.alloc(2 * 1024 * 1024 + 1024, 120));
+    return;
+  }
+  if (input.databasePath === "fixture:early-exit") {
+    process.exit(7);
+  }
+  const deadline = performance.now() + Math.max(0, Number(input.request?.limit ?? 0));
+  while (performance.now() < deadline) {
+    // Model a synchronous native SQLite call that cannot service messages.
+  }
+  process.stdout.write(
+    JSON.stringify({ status: "ok", value: { rows: [], fallbackScanRequired: false } }),
+  );
+});
+process.stdin.resume();

--- a/extensions/memory-core/src/memory/fixtures/manager-search-knn-child.fixture.mjs
+++ b/extensions/memory-core/src/memory/fixtures/manager-search-knn-child.fixture.mjs
@@ -19,6 +19,7 @@ process.stdin.once("end", () => {
   if (input.databasePath === "fixture:early-exit") {
     process.exit(7);
   }
+  process.stderr.write("ready\n");
   const deadline = performance.now() + Math.max(0, Number(input.request?.limit ?? 0));
   while (performance.now() < deadline) {
     // Model a synchronous native SQLite call that cannot service messages.

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -80,7 +80,7 @@ describe("memory index", () => {
     const vector = Reflect.get(manager, "vector") as VectorState;
     vector.available = true;
     vector.dims = 4;
-    Reflect.set(manager, "vectorReady", Promise.resolve(true));
+    Reflect.set(Reflect.get(manager, "database"), "vectorReady", Promise.resolve(true));
 
     await expect(
       Reflect.apply(Reflect.get(manager, "runInPlaceReindex"), manager, [

--- a/extensions/memory-core/src/memory/manager-database-context.ts
+++ b/extensions/memory-core/src/memory/manager-database-context.ts
@@ -1,0 +1,69 @@
+// Owns the published index state and the isolated lifetime of shadow reindex work.
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { DatabaseSync } from "node:sqlite";
+
+export class MemoryIndexDatabase {
+  readonly vector: {
+    enabled: boolean;
+    available: boolean | null;
+    semanticAvailable?: boolean;
+    extensionPath?: string;
+    loadError?: string;
+    dims?: number;
+  } = { enabled: false, available: null };
+  readonly fts: {
+    enabled: boolean;
+    available: boolean;
+    loadError?: string;
+  } = { enabled: false, available: false };
+  vectorReady: Promise<boolean> | null = null;
+  lastMetaSerialized: string | null = null;
+  vectorDegradedWriteWarningShown = false;
+  closed = false;
+
+  constructor(readonly db: DatabaseSync) {}
+}
+
+// One process-lifetime container; stores belong only to their awaited rebuild.
+const reindexDatabase = new AsyncLocalStorage<{
+  manager: MemoryManagerDatabaseContext;
+  database: MemoryIndexDatabase;
+}>();
+
+export abstract class MemoryManagerDatabaseContext {
+  protected abstract publishedDatabase: MemoryIndexDatabase;
+
+  protected get database(): MemoryIndexDatabase {
+    const context = reindexDatabase.getStore();
+    const shadow = context?.manager === this ? context.database : undefined;
+    if (shadow?.closed) {
+      throw new Error("Memory reindex database context is closed");
+    }
+    return shadow ?? this.publishedDatabase;
+  }
+
+  protected get db(): DatabaseSync {
+    return this.database.db;
+  }
+
+  protected get vector() {
+    return this.database.vector;
+  }
+
+  protected get fts() {
+    return this.database.fts;
+  }
+
+  protected withPublishedDatabase<T>(run: () => T): T {
+    // Public calls can originate in reindex progress/provider callbacks. They
+    // must never inherit the temporary writer or outlive its connection.
+    return reindexDatabase.exit(run);
+  }
+
+  protected withReindexDatabase<T>(
+    database: MemoryIndexDatabase,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    return reindexDatabase.run({ manager: this, database }, run);
+  }
+}

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -1069,11 +1069,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         this.markVectorRebuildRequired();
       }
     });
-    this.vectorDegradedWriteWarningShown = logMemoryVectorDegradedWrite({
+    this.database.vectorDegradedWriteWarningShown = logMemoryVectorDegradedWrite({
       vectorEnabled: this.vector.enabled,
       vectorReady,
       chunkCount: chunks.length,
-      warningShown: this.vectorDegradedWriteWarningShown,
+      warningShown: this.database.vectorDegradedWriteWarningShown,
       loadError: this.vector.loadError,
       warn: (message) => log.warn(message),
     });

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
@@ -487,7 +487,7 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
     }
     this.activeManagerOperations += 1;
     try {
-      return await run();
+      return await this.withPublishedDatabase(run);
     } finally {
       this.activeManagerOperations -= 1;
       if (this.activeManagerOperations === 0) {

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
@@ -23,20 +23,26 @@ function request(limit: number): VectorKnnRequest {
     providerModels: ["test-model"],
     queryVec: [1, 0],
     limit,
+    snippetMaxChars: 700,
     sourceFilter: { sql: "", params: [] },
   };
 }
 
 function insertVectorRow(
   db: DatabaseSync,
-  params: { id: string; source: "memory" | "sessions"; vector: [number, number] },
+  params: {
+    id: string;
+    source: "memory" | "sessions";
+    vector: [number, number];
+    text?: string;
+  },
 ): void {
   db.prepare(
     "INSERT INTO memory_index_chunks (id, path, start_line, end_line, text, source, model) VALUES (?, ?, 1, 1, ?, ?, ?)",
   ).run(
     params.id,
     `${params.source}/${params.id}.md`,
-    `text ${params.id}`,
+    params.text ?? `text ${params.id}`,
     params.source,
     "test-model",
   );
@@ -276,6 +282,35 @@ describe("memory vector KNN subprocess boundary", () => {
       try {
         fixture.db.exec("ROLLBACK");
       } catch {}
+      fixture.cleanup();
+    }
+  });
+
+  it("bounds an oversized stored row before child protocol serialization", async () => {
+    const fixture = await createFileBackedVectorDatabase();
+    try {
+      const oversizedText = `${"x".repeat(63)}😀${"y".repeat(3 * 1024 * 1024)}`;
+      insertVectorRow(fixture.db, {
+        id: "oversized",
+        source: "memory",
+        vector: [1, 0],
+        text: oversizedText,
+      });
+
+      const result = await runVectorKnnInSubprocess({
+        databasePath: fixture.databasePath,
+        request: {
+          ...request(1),
+          snippetMaxChars: 64,
+        },
+      });
+
+      expect(result).toMatchObject({
+        fallbackScanRequired: false,
+        rows: [{ id: "oversized", text: "x".repeat(63) }],
+      });
+      expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(2 * 1024 * 1024);
+    } finally {
       fixture.cleanup();
     }
   });

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
@@ -1,21 +1,45 @@
+import * as childProcess from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
 import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  runVectorKnnInSubprocess,
-  testing as subprocessTesting,
-  type VectorKnnSubprocessExit,
-} from "./manager-search-knn-subprocess.js";
-import { runVectorKnnQuery, type VectorKnnRequest } from "./manager-search-knn.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runVectorKnnInSubprocess } from "./manager-search-knn-subprocess.js";
+import { type VectorKnnRequest } from "./manager-search-knn.js";
 import { searchVector } from "./manager-search.js";
 import { buildMemorySourceFilter } from "./source-filter.js";
 import { vectorToBlob } from "./vector-blob.js";
 
 const fixtureChildUrl = new URL("./fixtures/manager-search-knn-child.fixture.mjs", import.meta.url);
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: vi.fn(actual.spawn) };
+});
+
+const { spawn } = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+beforeEach(() => {
+  vi.mocked(childProcess.spawn).mockReset().mockImplementation(spawn);
+});
+
+function useFixtureChild() {
+  const children: childProcess.ChildProcessWithoutNullStreams[] = [];
+  const ready: Promise<unknown[]>[] = [];
+  vi.mocked(childProcess.spawn).mockImplementation((_command, _args, options) => {
+    const child = spawn(process.execPath, [fileURLToPath(fixtureChildUrl)], {
+      ...options,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    children.push(child);
+    ready.push(once(child.stderr, "data"));
+    return child;
+  });
+  return { children, ready };
+}
 
 function request(limit: number): VectorKnnRequest {
   return {
@@ -102,143 +126,84 @@ afterEach(() => {
 });
 
 describe("memory vector KNN subprocess boundary", () => {
-  it("demonstrates that same-thread synchronous KNN delays a timer", async () => {
-    const blockMs = 120;
-    const startedAt = performance.now();
-    let timerFiredAt = 0;
-    const timer = new Promise<void>((resolve) => {
-      setTimeout(() => {
-        timerFiredAt = performance.now();
-        resolve();
-      }, 0);
-    });
-    const fakeDb = {
-      prepare: () => ({
-        all: () => {
-          const deadline = performance.now() + blockMs;
-          while (performance.now() < deadline) {}
-          return [
-            {
-              id: "hit",
-              path: "memory/hit.md",
-              start_line: 1,
-              end_line: 1,
-              text: "hit",
-              source: "memory",
-              dist: 0,
-            },
-          ];
-        },
-      }),
-    } as unknown as Pick<DatabaseSync, "prepare">;
-
-    const result = runVectorKnnQuery(fakeDb, request(1));
-    expect(result.rows).toHaveLength(1);
-    expect(timerFiredAt).toBe(0);
-    await timer;
-    expect(timerFiredAt - startedAt).toBeGreaterThanOrEqual(blockMs - 10);
-  });
-
-  it("keeps the parent event loop responsive during equivalent synchronous child work", async () => {
+  it("keeps the parent event loop responsive during synchronous child work", async () => {
+    const fixture = useFixtureChild();
     let childFinished = false;
-    let timerBeatChild = false;
-    const timer = new Promise<void>((resolve) => {
-      setTimeout(() => {
-        timerBeatChild = !childFinished;
-        resolve();
-      }, 20);
-    });
     const resultPromise = runVectorKnnInSubprocess({
       databasePath: "fixture:ok",
       request: request(250),
-      childUrl: fixtureChildUrl,
     }).finally(() => {
       childFinished = true;
     });
-
-    const [result] = await Promise.all([resultPromise, timer]);
-    expect(result).toEqual({ rows: [], fallbackScanRequired: false });
-    expect(timerBeatChild).toBe(true);
+    await vi.waitFor(() => expect(fixture.ready).toHaveLength(1));
+    await fixture.ready[0];
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(childFinished).toBe(false);
+    await expect(resultPromise).resolves.toEqual({ rows: [], fallbackScanRequired: false });
   });
 
-  it("hard-kills and reaps a synchronous child on caller abort", async () => {
+  it("hard-kills and reaps a busy child on caller abort, then admits another query", async () => {
+    const fixture = useFixtureChild();
     const controller = new AbortController();
-    let pid: number | undefined;
-    let exit: VectorKnnSubprocessExit | undefined;
-    let abortedAt = 0;
-    const resultPromise = runVectorKnnInSubprocess({
+    const result = runVectorKnnInSubprocess({
       databasePath: "fixture:ok",
-      request: request(5_000),
+      request: request(30_000),
       signal: controller.signal,
-      childUrl: fixtureChildUrl,
-      onSpawn: (spawnedPid) => {
-        pid = spawnedPid;
-      },
-      onExit: (value) => {
-        exit = value;
-      },
     });
-    setTimeout(() => {
-      abortedAt = performance.now();
-      controller.abort(new Error("test KNN deadline"));
-    }, 250);
-
-    await expect(resultPromise).rejects.toThrow("test KNN deadline");
-    expect(performance.now() - abortedAt).toBeLessThan(1_000);
-    expect(pid).toBeTypeOf("number");
-    expect(exit).toMatchObject({ pid, code: null, signal: "SIGKILL", pidAlive: false });
-    expect(subprocessTesting.isProcessAlive(pid)).toBe(false);
+    const rejected = expect(result).rejects.toThrow("test KNN deadline");
+    await vi.waitFor(() => expect(fixture.ready).toHaveLength(1));
+    await fixture.ready[0];
+    const closed = once(fixture.children[0]!, "close");
+    controller.abort(new Error("test KNN deadline"));
+    await rejected;
+    expect(await closed).toEqual([null, "SIGKILL"]);
+    await expect(
+      runVectorKnnInSubprocess({ databasePath: "fixture:ok", request: request(1) }),
+    ).resolves.toEqual({ rows: [], fallbackScanRequired: false });
   });
 
-  it("keeps cleanup ownership and bounds admission after terminal cleanup timeout", async () => {
-    const admission = subprocessTesting.createVectorKnnAdmission(1);
+  it("retains both admission slots after cleanup timeout until children close", async () => {
+    const fixture = useFixtureChild();
     const controller = new AbortController();
-    let firstExited = false;
-    const first = subprocessTesting.runVectorKnnWithAdmission(
-      {
+    const results = [0, 1].map(() =>
+      runVectorKnnInSubprocess({
         databasePath: "fixture:ok",
-        request: request(250),
+        request: request(30_000),
         signal: controller.signal,
-        childUrl: fixtureChildUrl,
-        onExit: () => {
-          firstExited = true;
-        },
-      },
-      admission,
-      0,
-      () => {},
+      }),
     );
-    setTimeout(() => controller.abort(new Error("terminal cleanup test")), 10);
-
-    await expect(first).rejects.toMatchObject({ code: "termination-timeout" });
-    expect(firstExited).toBe(false);
-    expect(admission.active()).toBe(1);
-
-    const queuedController = new AbortController();
-    let queuedSpawned = false;
-    const queued = subprocessTesting.runVectorKnnWithAdmission(
-      {
+    const rejected = results.map((result) =>
+      expect(result).rejects.toMatchObject({ code: "termination-timeout" }),
+    );
+    await vi.waitFor(() => expect(fixture.children).toHaveLength(2));
+    await Promise.all(fixture.ready);
+    const realKills = fixture.children.map((child) => child.kill.bind(child));
+    const closed = fixture.children.map((child) => once(child, "close"));
+    const killMocks = fixture.children.map((child) =>
+      vi.spyOn(child, "kill").mockReturnValue(false),
+    );
+    try {
+      controller.abort(new Error("terminal cleanup test"));
+      await Promise.all(rejected);
+      const queuedController = new AbortController();
+      const queued = runVectorKnnInSubprocess({
         databasePath: "fixture:ok",
         request: request(1),
         signal: queuedController.signal,
-        childUrl: fixtureChildUrl,
-        onSpawn: () => {
-          queuedSpawned = true;
-        },
-      },
-      admission,
-      0,
-    );
-    expect(admission.queued()).toBe(1);
-    queuedController.abort(new Error("queued KNN deadline"));
-    await expect(queued).rejects.toThrow("queued KNN deadline");
-    expect(queuedSpawned).toBe(false);
-
-    await vi.waitFor(() => {
-      expect(firstExited).toBe(true);
-      expect(admission.active()).toBe(0);
-      expect(admission.queued()).toBe(0);
-    });
+      });
+      const queuedRejection = expect(queued).rejects.toThrow("queued KNN deadline");
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(fixture.children).toHaveLength(2);
+      queuedController.abort(new Error("queued KNN deadline"));
+      await queuedRejection;
+    } finally {
+      killMocks.forEach((mock) => mock.mockRestore());
+      realKills.forEach((kill) => kill("SIGKILL"));
+      await Promise.all(closed);
+    }
+    await expect(
+      runVectorKnnInSubprocess({ databasePath: "fixture:ok", request: request(1) }),
+    ).resolves.toEqual({ rows: [], fallbackScanRequired: false });
   });
 
   it("queries the real source child across WAL writer visibility and source filters", async () => {
@@ -316,25 +281,23 @@ describe("memory vector KNN subprocess boundary", () => {
   });
 
   it("fails closed on malformed output, oversized output, and early exit", async () => {
+    useFixtureChild();
     await expect(
       runVectorKnnInSubprocess({
         databasePath: "fixture:malformed",
         request: request(1),
-        childUrl: fixtureChildUrl,
       }),
     ).rejects.toThrow("malformed JSON");
     await expect(
       runVectorKnnInSubprocess({
         databasePath: "fixture:oversized",
         request: request(1),
-        childUrl: fixtureChildUrl,
       }),
     ).rejects.toThrow("stdout exceeded its limit");
     await expect(
       runVectorKnnInSubprocess({
         databasePath: "fixture:early-exit",
         request: request(1),
-        childUrl: fixtureChildUrl,
       }),
     ).rejects.toThrow("exited before returning a result");
   });
@@ -360,16 +323,5 @@ describe("memory vector KNN subprocess boundary", () => {
       }),
     ).rejects.toThrow("subprocess unavailable");
     expect(prepare).not.toHaveBeenCalled();
-  });
-
-  it("resolves source and hashed-dist child artifacts exactly", () => {
-    expect(
-      subprocessTesting.resolveVectorKnnChildUrl(
-        "file:///repo/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts",
-      ).pathname,
-    ).toBe("/repo/extensions/memory-core/src/memory/manager-search-knn.child.ts");
-    expect(
-      subprocessTesting.resolveVectorKnnChildUrl("file:///pkg/dist/manager-hashed.js").pathname,
-    ).toBe("/pkg/dist/extensions/memory-core/memory-search-knn.child.js");
   });
 });

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
@@ -1,0 +1,340 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  runVectorKnnInSubprocess,
+  testing as subprocessTesting,
+  type VectorKnnSubprocessExit,
+} from "./manager-search-knn-subprocess.js";
+import { runVectorKnnQuery, type VectorKnnRequest } from "./manager-search-knn.js";
+import { searchVector } from "./manager-search.js";
+import { buildMemorySourceFilter } from "./source-filter.js";
+import { vectorToBlob } from "./vector-blob.js";
+
+const fixtureChildUrl = new URL("./fixtures/manager-search-knn-child.fixture.mjs", import.meta.url);
+
+function request(limit: number): VectorKnnRequest {
+  return {
+    vectorTable: "memory_index_chunks_vec",
+    providerModels: ["test-model"],
+    queryVec: [1, 0],
+    limit,
+    sourceFilter: { sql: "", params: [] },
+  };
+}
+
+function insertVectorRow(
+  db: DatabaseSync,
+  params: { id: string; source: "memory" | "sessions"; vector: [number, number] },
+): void {
+  db.prepare(
+    "INSERT INTO memory_index_chunks (id, path, start_line, end_line, text, source, model) VALUES (?, ?, 1, 1, ?, ?, ?)",
+  ).run(
+    params.id,
+    `${params.source}/${params.id}.md`,
+    `text ${params.id}`,
+    params.source,
+    "test-model",
+  );
+  db.prepare("INSERT INTO memory_index_chunks_vec (id, embedding) VALUES (?, ?)").run(
+    params.id,
+    vectorToBlob(params.vector),
+  );
+}
+
+async function createFileBackedVectorDatabase(): Promise<{
+  db: DatabaseSync;
+  databasePath: string;
+  cleanup: () => void;
+}> {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-memory-knn-"));
+  const databasePath = path.join(directory, "memory.sqlite");
+  const db = openNodeSqliteDatabase(databasePath, { allowExtension: true });
+  try {
+    const loaded = await loadSqliteVecExtension({ db });
+    if (!loaded.ok) {
+      throw new Error(loaded.error ?? "sqlite-vec unavailable in test");
+    }
+    db.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA busy_timeout = 5000;
+      CREATE TABLE memory_index_chunks (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        start_line INTEGER NOT NULL,
+        end_line INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        source TEXT NOT NULL,
+        model TEXT NOT NULL
+      );
+      CREATE VIRTUAL TABLE memory_index_chunks_vec USING vec0(
+        id TEXT PRIMARY KEY,
+        embedding FLOAT[2]
+      );
+    `);
+    return {
+      db,
+      databasePath,
+      cleanup: () => {
+        db.close();
+        fs.rmSync(directory, { force: true, recursive: true });
+      },
+    };
+  } catch (error) {
+    db.close();
+    fs.rmSync(directory, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("memory vector KNN subprocess boundary", () => {
+  it("demonstrates that same-thread synchronous KNN delays a timer", async () => {
+    const blockMs = 120;
+    const startedAt = performance.now();
+    let timerFiredAt = 0;
+    const timer = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        timerFiredAt = performance.now();
+        resolve();
+      }, 0);
+    });
+    const fakeDb = {
+      prepare: () => ({
+        all: () => {
+          const deadline = performance.now() + blockMs;
+          while (performance.now() < deadline) {}
+          return [
+            {
+              id: "hit",
+              path: "memory/hit.md",
+              start_line: 1,
+              end_line: 1,
+              text: "hit",
+              source: "memory",
+              dist: 0,
+            },
+          ];
+        },
+      }),
+    } as unknown as Pick<DatabaseSync, "prepare">;
+
+    const result = runVectorKnnQuery(fakeDb, request(1));
+    expect(result.rows).toHaveLength(1);
+    expect(timerFiredAt).toBe(0);
+    await timer;
+    expect(timerFiredAt - startedAt).toBeGreaterThanOrEqual(blockMs - 10);
+  });
+
+  it("keeps the parent event loop responsive during equivalent synchronous child work", async () => {
+    let childFinished = false;
+    let timerBeatChild = false;
+    const timer = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        timerBeatChild = !childFinished;
+        resolve();
+      }, 20);
+    });
+    const resultPromise = runVectorKnnInSubprocess({
+      databasePath: "fixture:ok",
+      request: request(250),
+      childUrl: fixtureChildUrl,
+    }).finally(() => {
+      childFinished = true;
+    });
+
+    const [result] = await Promise.all([resultPromise, timer]);
+    expect(result).toEqual({ rows: [], fallbackScanRequired: false });
+    expect(timerBeatChild).toBe(true);
+  });
+
+  it("hard-kills and reaps a synchronous child on caller abort", async () => {
+    const controller = new AbortController();
+    let pid: number | undefined;
+    let exit: VectorKnnSubprocessExit | undefined;
+    let abortedAt = 0;
+    const resultPromise = runVectorKnnInSubprocess({
+      databasePath: "fixture:ok",
+      request: request(5_000),
+      signal: controller.signal,
+      childUrl: fixtureChildUrl,
+      onSpawn: (spawnedPid) => {
+        pid = spawnedPid;
+      },
+      onExit: (value) => {
+        exit = value;
+      },
+    });
+    setTimeout(() => {
+      abortedAt = performance.now();
+      controller.abort(new Error("test KNN deadline"));
+    }, 250);
+
+    await expect(resultPromise).rejects.toThrow("test KNN deadline");
+    expect(performance.now() - abortedAt).toBeLessThan(1_000);
+    expect(pid).toBeTypeOf("number");
+    expect(exit).toMatchObject({ pid, code: null, signal: "SIGKILL", pidAlive: false });
+    expect(subprocessTesting.isProcessAlive(pid)).toBe(false);
+  });
+
+  it("keeps cleanup ownership and bounds admission after terminal cleanup timeout", async () => {
+    const admission = subprocessTesting.createVectorKnnAdmission(1);
+    const controller = new AbortController();
+    let firstExited = false;
+    const first = subprocessTesting.runVectorKnnWithAdmission(
+      {
+        databasePath: "fixture:ok",
+        request: request(250),
+        signal: controller.signal,
+        childUrl: fixtureChildUrl,
+        onExit: () => {
+          firstExited = true;
+        },
+      },
+      admission,
+      0,
+      () => {},
+    );
+    setTimeout(() => controller.abort(new Error("terminal cleanup test")), 10);
+
+    await expect(first).rejects.toMatchObject({ code: "termination-timeout" });
+    expect(firstExited).toBe(false);
+    expect(admission.active()).toBe(1);
+
+    const queuedController = new AbortController();
+    let queuedSpawned = false;
+    const queued = subprocessTesting.runVectorKnnWithAdmission(
+      {
+        databasePath: "fixture:ok",
+        request: request(1),
+        signal: queuedController.signal,
+        childUrl: fixtureChildUrl,
+        onSpawn: () => {
+          queuedSpawned = true;
+        },
+      },
+      admission,
+      0,
+    );
+    expect(admission.queued()).toBe(1);
+    queuedController.abort(new Error("queued KNN deadline"));
+    await expect(queued).rejects.toThrow("queued KNN deadline");
+    expect(queuedSpawned).toBe(false);
+
+    await vi.waitFor(() => {
+      expect(firstExited).toBe(true);
+      expect(admission.active()).toBe(0);
+      expect(admission.queued()).toBe(0);
+    });
+  });
+
+  it("queries the real source child across WAL writer visibility and source filters", async () => {
+    const fixture = await createFileBackedVectorDatabase();
+    try {
+      insertVectorRow(fixture.db, { id: "committed", source: "memory", vector: [1, 0] });
+      fixture.db.exec("BEGIN IMMEDIATE");
+      insertVectorRow(fixture.db, { id: "pending", source: "sessions", vector: [0.9, 0.1] });
+
+      const memoryResult = await runVectorKnnInSubprocess({
+        databasePath: fixture.databasePath,
+        request: {
+          ...request(2),
+          sourceFilter: buildMemorySourceFilter("c", ["memory"]),
+        },
+      });
+      expect(memoryResult.rows.map((row) => row.id)).toEqual(["committed"]);
+
+      const beforeCommit = await runVectorKnnInSubprocess({
+        databasePath: fixture.databasePath,
+        request: {
+          ...request(2),
+          sourceFilter: buildMemorySourceFilter("c", ["sessions"]),
+        },
+      });
+      expect(beforeCommit.rows).toEqual([]);
+
+      fixture.db.exec("COMMIT");
+      const afterCommit = await runVectorKnnInSubprocess({
+        databasePath: fixture.databasePath,
+        request: {
+          ...request(2),
+          sourceFilter: buildMemorySourceFilter("c", ["sessions"]),
+        },
+      });
+      expect(afterCommit.rows.map((row) => row.id)).toEqual(["pending"]);
+      expect(fixture.db.prepare("PRAGMA journal_mode").get()).toMatchObject({
+        journal_mode: "wal",
+      });
+    } finally {
+      try {
+        fixture.db.exec("ROLLBACK");
+      } catch {}
+      fixture.cleanup();
+    }
+  });
+
+  it("fails closed on malformed output, oversized output, and early exit", async () => {
+    await expect(
+      runVectorKnnInSubprocess({
+        databasePath: "fixture:malformed",
+        request: request(1),
+        childUrl: fixtureChildUrl,
+      }),
+    ).rejects.toThrow("malformed JSON");
+    await expect(
+      runVectorKnnInSubprocess({
+        databasePath: "fixture:oversized",
+        request: request(1),
+        childUrl: fixtureChildUrl,
+      }),
+    ).rejects.toThrow("stdout exceeded its limit");
+    await expect(
+      runVectorKnnInSubprocess({
+        databasePath: "fixture:early-exit",
+        request: request(1),
+        childUrl: fixtureChildUrl,
+      }),
+    ).rejects.toThrow("exited before returning a result");
+  });
+
+  it("fails vector recall closed when the subprocess is unavailable", async () => {
+    const prepare = vi.fn(() => {
+      throw new Error("same-thread SQLite must not run");
+    });
+    await expect(
+      searchVector({
+        db: { prepare } as unknown as DatabaseSync,
+        vectorTable: "memory_index_chunks_vec",
+        providerModel: "test-model",
+        queryVec: [1, 0],
+        limit: 1,
+        snippetMaxChars: 200,
+        ensureVectorReady: async () => true,
+        runVectorKnn: async () => {
+          throw new Error("subprocess unavailable");
+        },
+        sourceFilterVec: { sql: "", params: [] },
+        sourceFilterChunks: { sql: "", params: [] },
+      }),
+    ).rejects.toThrow("subprocess unavailable");
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it("resolves source and hashed-dist child artifacts exactly", () => {
+    expect(
+      subprocessTesting.resolveVectorKnnChildUrl(
+        "file:///repo/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts",
+      ).pathname,
+    ).toBe("/repo/extensions/memory-core/src/memory/manager-search-knn.child.ts");
+    expect(
+      subprocessTesting.resolveVectorKnnChildUrl("file:///pkg/dist/manager-hashed.js").pathname,
+    ).toBe("/pkg/dist/extensions/memory-core/memory-search-knn.child.js");
+  });
+});

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
@@ -9,7 +9,7 @@ import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-eng
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runVectorKnnInSubprocess } from "./manager-search-knn-subprocess.js";
-import { type VectorKnnRequest } from "./manager-search-knn.js";
+import type { VectorKnnRequest } from "./manager-search-knn.js";
 import { searchVector } from "./manager-search.js";
 import { buildMemorySourceFilter } from "./source-filter.js";
 import { vectorToBlob } from "./vector-blob.js";
@@ -137,7 +137,9 @@ describe("memory vector KNN subprocess boundary", () => {
     });
     await vi.waitFor(() => expect(fixture.ready).toHaveLength(1));
     await fixture.ready[0];
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(childFinished).toBe(false);
     await expect(resultPromise).resolves.toEqual({ rows: [], fallbackScanRequired: false });
   });
@@ -192,7 +194,9 @@ describe("memory vector KNN subprocess boundary", () => {
         signal: queuedController.signal,
       });
       const queuedRejection = expect(queued).rejects.toThrow("queued KNN deadline");
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(fixture.children).toHaveLength(2);
       queuedController.abort(new Error("queued KNN deadline"));
       await queuedRejection;

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
@@ -7,7 +7,11 @@ import {
   resolveRuntimeWorkerUrl,
 } from "openclaw/plugin-sdk/process-runtime";
 import type { VectorKnnChildInput, VectorKnnChildResult } from "./manager-search-knn.child.js";
-import type { VectorKnnRequest, VectorKnnResponse, VectorKnnRow } from "./manager-search-knn.js";
+import {
+  isVectorKnnRow,
+  type VectorKnnRequest,
+  type VectorKnnResponse,
+} from "./manager-search-knn.js";
 
 const MAX_STDIN_BYTES = 1024 * 1024;
 const MAX_STDOUT_BYTES = 2 * 1024 * 1024;
@@ -130,23 +134,6 @@ function createVectorKnnAdmission(maxConcurrent: number): VectorKnnAdmission {
 
 const vectorKnnAdmission = createVectorKnnAdmission(MAX_CONCURRENT_VECTOR_KNN_CHILDREN);
 
-function isVectorKnnRow(value: unknown): value is VectorKnnRow {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const row = value as Partial<VectorKnnRow>;
-  return (
-    typeof row.id === "string" &&
-    typeof row.path === "string" &&
-    typeof row.start_line === "number" &&
-    typeof row.end_line === "number" &&
-    typeof row.text === "string" &&
-    typeof row.source === "string" &&
-    typeof row.dist === "number" &&
-    Number.isFinite(row.dist)
-  );
-}
-
 function parseChildResult(output: Buffer, maxRows: number): VectorKnnResponse {
   let parsed: unknown;
   try {
@@ -163,6 +150,7 @@ function parseChildResult(output: Buffer, maxRows: number): VectorKnnResponse {
       "protocol",
     );
   }
+  // SAFETY: the envelope object/status guard above narrows the only protocol discriminator.
   const result = parsed as VectorKnnChildResult;
   if (result.status === "failed") {
     throw new VectorKnnSubprocessError(result.error || "memory vector KNN child failed", "failed");

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
@@ -1,0 +1,414 @@
+// Parent-side subprocess boundary for synchronous sqlite-vec KNN work.
+import { spawn } from "node:child_process";
+import {
+  isPidAlive,
+  killProcessTree,
+  resolveRuntimeWorkerArgv,
+  resolveRuntimeWorkerUrl,
+} from "openclaw/plugin-sdk/process-runtime";
+import type { VectorKnnChildInput, VectorKnnChildResult } from "./manager-search-knn.child.js";
+import type { VectorKnnRequest, VectorKnnResponse, VectorKnnRow } from "./manager-search-knn.js";
+
+const MAX_STDIN_BYTES = 1024 * 1024;
+const MAX_STDOUT_BYTES = 2 * 1024 * 1024;
+const MAX_STDERR_BYTES = 64 * 1024;
+const GRACEFUL_KILL_GRACE_MS = 50;
+const KILL_EXIT_TIMEOUT_MS = 2_000;
+const MAX_CONCURRENT_VECTOR_KNN_CHILDREN = 2;
+
+class VectorKnnSubprocessError extends Error {
+  constructor(
+    message: string,
+    readonly code: "unavailable" | "failed" | "protocol" | "termination-timeout",
+  ) {
+    super(message);
+    this.name = "VectorKnnSubprocessError";
+  }
+}
+
+export type VectorKnnSubprocessExit = {
+  pid: number | undefined;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  pidAlive: boolean;
+};
+
+function resolveVectorKnnChildUrl(currentModuleUrl = import.meta.url): URL {
+  return resolveRuntimeWorkerUrl({
+    currentModuleUrl,
+    sourceWorkerName: "manager-search-knn.child",
+    distWorkerPath: "extensions/memory-core/memory-search-knn.child.js",
+  });
+}
+
+function buildChildEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = {};
+  for (const name of ["PATH", "SystemRoot", "SYSTEMROOT", "WINDIR", "TEMP", "TMP", "TMPDIR"]) {
+    if (env[name]) {
+      childEnv[name] = env[name];
+    }
+  }
+  return childEnv;
+}
+
+function toAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error("memory vector KNN aborted");
+}
+
+type VectorKnnAdmission = {
+  acquire: (signal?: AbortSignal) => Promise<() => void>;
+  active: () => number;
+  queued: () => number;
+};
+
+function createVectorKnnAdmission(maxConcurrent: number): VectorKnnAdmission {
+  let active = 0;
+  const waiters: Array<{
+    signal?: AbortSignal;
+    resolve: (release: () => void) => void;
+    reject: (error: Error) => void;
+    abort: () => void;
+  }> = [];
+
+  const releaseNext = (): void => {
+    while (waiters.length > 0) {
+      const next = waiters.shift()!;
+      next.signal?.removeEventListener("abort", next.abort);
+      if (next.signal?.aborted) {
+        next.reject(toAbortError(next.signal));
+        continue;
+      }
+      next.resolve(createRelease());
+      return;
+    }
+    active -= 1;
+  };
+  const createRelease = (): (() => void) => {
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      releaseNext();
+    };
+  };
+
+  return {
+    acquire: async (signal) => {
+      if (signal?.aborted) {
+        throw toAbortError(signal);
+      }
+      if (active < maxConcurrent) {
+        active += 1;
+        return createRelease();
+      }
+      return await new Promise<() => void>((resolve, reject) => {
+        const waiter = {
+          signal,
+          resolve,
+          reject,
+          abort: () => {
+            const index = waiters.indexOf(waiter);
+            if (index >= 0) {
+              waiters.splice(index, 1);
+            }
+            reject(toAbortError(signal!));
+          },
+        };
+        waiters.push(waiter);
+        signal?.addEventListener("abort", waiter.abort, { once: true });
+        if (signal?.aborted) {
+          waiter.abort();
+        }
+      });
+    },
+    active: () => active,
+    queued: () => waiters.length,
+  };
+}
+
+const vectorKnnAdmission = createVectorKnnAdmission(MAX_CONCURRENT_VECTOR_KNN_CHILDREN);
+
+function isVectorKnnRow(value: unknown): value is VectorKnnRow {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const row = value as Partial<VectorKnnRow>;
+  return (
+    typeof row.id === "string" &&
+    typeof row.path === "string" &&
+    typeof row.start_line === "number" &&
+    typeof row.end_line === "number" &&
+    typeof row.text === "string" &&
+    typeof row.source === "string" &&
+    typeof row.dist === "number" &&
+    Number.isFinite(row.dist)
+  );
+}
+
+function parseChildResult(output: Buffer, maxRows: number): VectorKnnResponse {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output.toString("utf8"));
+  } catch {
+    throw new VectorKnnSubprocessError(
+      "memory vector KNN child returned malformed JSON",
+      "protocol",
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || !("status" in parsed)) {
+    throw new VectorKnnSubprocessError(
+      "memory vector KNN child returned an invalid envelope",
+      "protocol",
+    );
+  }
+  const result = parsed as VectorKnnChildResult;
+  if (result.status === "failed") {
+    throw new VectorKnnSubprocessError(result.error || "memory vector KNN child failed", "failed");
+  }
+  if (
+    result.status !== "ok" ||
+    !result.value ||
+    !Array.isArray(result.value.rows) ||
+    result.value.rows.length > maxRows ||
+    result.value.rows.some((row) => !isVectorKnnRow(row)) ||
+    typeof result.value.fallbackScanRequired !== "boolean"
+  ) {
+    throw new VectorKnnSubprocessError(
+      "memory vector KNN child returned an invalid result",
+      "protocol",
+    );
+  }
+  return result.value;
+}
+
+type VectorKnnSubprocessParams = {
+  databasePath: string;
+  extensionPath?: string;
+  request: VectorKnnRequest;
+  signal?: AbortSignal;
+  childUrl?: URL;
+  onSpawn?: (pid: number | undefined) => void;
+  onExit?: (exit: VectorKnnSubprocessExit) => void;
+};
+
+async function runVectorKnnWithAdmission(
+  params: VectorKnnSubprocessParams,
+  admission: VectorKnnAdmission,
+  killExitTimeoutMs: number,
+  terminateProcess: typeof killProcessTree = killProcessTree,
+): Promise<VectorKnnResponse> {
+  if (params.signal?.aborted) {
+    throw toAbortError(params.signal);
+  }
+  const input: VectorKnnChildInput = {
+    databasePath: params.databasePath,
+    extensionPath: params.extensionPath,
+    request: params.request,
+  };
+  const inputPayload = Buffer.from(JSON.stringify(input), "utf8");
+  if (inputPayload.byteLength > MAX_STDIN_BYTES) {
+    throw new VectorKnnSubprocessError("memory vector KNN child input is too large", "protocol");
+  }
+
+  const releaseAdmission = await admission.acquire(params.signal);
+  if (params.signal?.aborted) {
+    releaseAdmission();
+    throw toAbortError(params.signal);
+  }
+  const childUrl = params.childUrl ?? resolveVectorKnnChildUrl();
+  let child;
+  try {
+    child = spawn(process.execPath, resolveRuntimeWorkerArgv(childUrl), {
+      detached: process.platform !== "win32",
+      env: buildChildEnv(),
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+  } catch (error) {
+    releaseAdmission();
+    throw new VectorKnnSubprocessError(
+      error instanceof Error ? error.message : String(error),
+      "unavailable",
+    );
+  }
+  params.onSpawn?.(child.pid);
+
+  return await new Promise<VectorKnnResponse>((resolve, reject) => {
+    const stdoutChunks: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let closed = false;
+    let callerSettled = false;
+    let terminationReason: Error | undefined;
+    let protocolFailure: Error | undefined;
+    let killExitTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearKillExitTimer = () => {
+      if (killExitTimer) {
+        clearTimeout(killExitTimer);
+        killExitTimer = undefined;
+      }
+    };
+    const settleCaller = (action: () => void) => {
+      if (callerSettled) {
+        return;
+      }
+      callerSettled = true;
+      params.signal?.removeEventListener("abort", abort);
+      action();
+    };
+    const releaseClosedChild = () => {
+      clearKillExitTimer();
+      params.signal?.removeEventListener("abort", abort);
+      releaseAdmission();
+    };
+    const requestTermination = (reason: Error) => {
+      if (terminationReason || closed) {
+        return;
+      }
+      terminationReason = reason;
+      child.stdin.destroy();
+      if (typeof child.pid === "number") {
+        terminateProcess(child.pid, {
+          detached: process.platform !== "win32",
+          graceMs: GRACEFUL_KILL_GRACE_MS,
+        });
+      } else {
+        child.kill("SIGKILL");
+      }
+      killExitTimer = setTimeout(() => {
+        if (!closed) {
+          if (typeof child.pid === "number") {
+            terminateProcess(child.pid, {
+              detached: process.platform !== "win32",
+              force: true,
+            });
+          } else {
+            child.kill("SIGKILL");
+          }
+          // The caller may return, but this child keeps its admission slot until
+          // close. Destroying pipes and unref'ing prevents one unkillable OS task
+          // from pinning the Gateway while the slot bounds future accumulation.
+          child.stdin.destroy();
+          child.stdout.destroy();
+          child.stderr.destroy();
+          child.unref();
+          settleCaller(() =>
+            reject(
+              new VectorKnnSubprocessError(
+                "memory vector KNN child did not exit after SIGKILL",
+                "termination-timeout",
+              ),
+            ),
+          );
+        }
+      }, GRACEFUL_KILL_GRACE_MS + killExitTimeoutMs);
+    };
+    const abort = () => {
+      requestTermination(toAbortError(params.signal!));
+    };
+
+    params.signal?.addEventListener("abort", abort, { once: true });
+    if (params.signal?.aborted) {
+      abort();
+    }
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBytes += chunk.byteLength;
+      if (stdoutBytes > MAX_STDOUT_BYTES) {
+        protocolFailure = new VectorKnnSubprocessError(
+          "memory vector KNN child stdout exceeded its limit",
+          "protocol",
+        );
+        stdoutChunks.length = 0;
+        requestTermination(protocolFailure);
+        return;
+      }
+      stdoutChunks.push(chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrBytes += chunk.byteLength;
+      if (stderrBytes > MAX_STDERR_BYTES) {
+        protocolFailure = new VectorKnnSubprocessError(
+          "memory vector KNN child stderr exceeded its limit",
+          "protocol",
+        );
+        requestTermination(protocolFailure);
+      }
+    });
+    child.stdin.on("error", (error: NodeJS.ErrnoException) => {
+      if (!terminationReason && error.code !== "EPIPE") {
+        protocolFailure = new VectorKnnSubprocessError(error.message, "failed");
+        requestTermination(protocolFailure);
+      }
+    });
+    child.once("error", (error) => {
+      protocolFailure = new VectorKnnSubprocessError(error.message, "unavailable");
+      requestTermination(protocolFailure);
+    });
+    child.once("close", (code, signal) => {
+      closed = true;
+      const pidAlive = typeof child.pid === "number" && isPidAlive(child.pid);
+      params.onExit?.({ pid: child.pid, code, signal, pidAlive });
+      releaseClosedChild();
+      settleCaller(() => {
+        if (pidAlive) {
+          reject(
+            new VectorKnnSubprocessError(
+              "memory vector KNN child PID remained alive after close",
+              "termination-timeout",
+            ),
+          );
+          return;
+        }
+        if (terminationReason) {
+          reject(terminationReason);
+          return;
+        }
+        if (protocolFailure) {
+          reject(protocolFailure);
+          return;
+        }
+        if (code !== 0 || signal) {
+          reject(
+            new VectorKnnSubprocessError(
+              `memory vector KNN child exited before returning a result (code ${code}, signal ${signal ?? "none"})`,
+              "failed",
+            ),
+          );
+          return;
+        }
+        try {
+          resolve(parseChildResult(Buffer.concat(stdoutChunks), params.request.limit));
+        } catch (error) {
+          reject(
+            error instanceof Error
+              ? error
+              : new VectorKnnSubprocessError(String(error), "protocol"),
+          );
+        }
+      });
+    });
+    child.stdin.end(inputPayload);
+  });
+}
+
+/** Run one file-backed KNN query in a bounded, OS-killable child process. */
+export async function runVectorKnnInSubprocess(
+  params: VectorKnnSubprocessParams,
+): Promise<VectorKnnResponse> {
+  return await runVectorKnnWithAdmission(params, vectorKnnAdmission, KILL_EXIT_TIMEOUT_MS);
+}
+
+export const testing = {
+  createVectorKnnAdmission,
+  gracefulKillGraceMs: GRACEFUL_KILL_GRACE_MS,
+  isProcessAlive: (pid: number | undefined) => (typeof pid === "number" ? isPidAlive(pid) : false),
+  maxConcurrentChildren: MAX_CONCURRENT_VECTOR_KNN_CHILDREN,
+  maxStderrBytes: MAX_STDERR_BYTES,
+  maxStdoutBytes: MAX_STDOUT_BYTES,
+  resolveVectorKnnChildUrl,
+  runVectorKnnWithAdmission,
+};

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
@@ -1,8 +1,6 @@
 // Parent-side subprocess boundary for synchronous sqlite-vec KNN work.
 import { spawn } from "node:child_process";
 import {
-  isPidAlive,
-  killProcessTree,
   resolveRuntimeWorkerArgv,
   resolveRuntimeWorkerUrl,
 } from "openclaw/plugin-sdk/process-runtime";
@@ -16,7 +14,6 @@ import {
 const MAX_STDIN_BYTES = 1024 * 1024;
 const MAX_STDOUT_BYTES = 2 * 1024 * 1024;
 const MAX_STDERR_BYTES = 64 * 1024;
-const GRACEFUL_KILL_GRACE_MS = 50;
 const KILL_EXIT_TIMEOUT_MS = 2_000;
 const MAX_CONCURRENT_VECTOR_KNN_CHILDREN = 2;
 
@@ -30,16 +27,9 @@ class VectorKnnSubprocessError extends Error {
   }
 }
 
-export type VectorKnnSubprocessExit = {
-  pid: number | undefined;
-  code: number | null;
-  signal: NodeJS.Signals | null;
-  pidAlive: boolean;
-};
-
-function resolveVectorKnnChildUrl(currentModuleUrl = import.meta.url): URL {
+function resolveVectorKnnChildUrl(): URL {
   return resolveRuntimeWorkerUrl({
-    currentModuleUrl,
+    currentModuleUrl: import.meta.url,
     sourceWorkerName: "manager-search-knn.child",
     distWorkerPath: "extensions/memory-core/memory-search-knn.child.js",
   });
@@ -59,13 +49,7 @@ function toAbortError(signal: AbortSignal): Error {
   return signal.reason instanceof Error ? signal.reason : new Error("memory vector KNN aborted");
 }
 
-type VectorKnnAdmission = {
-  acquire: (signal?: AbortSignal) => Promise<() => void>;
-  active: () => number;
-  queued: () => number;
-};
-
-function createVectorKnnAdmission(maxConcurrent: number): VectorKnnAdmission {
+function createVectorKnnAdmission(maxConcurrent: number) {
   let active = 0;
   const waiters: Array<{
     signal?: AbortSignal;
@@ -99,7 +83,7 @@ function createVectorKnnAdmission(maxConcurrent: number): VectorKnnAdmission {
   };
 
   return {
-    acquire: async (signal) => {
+    acquire: async (signal?: AbortSignal) => {
       if (signal?.aborted) {
         throw toAbortError(signal);
       }
@@ -127,8 +111,6 @@ function createVectorKnnAdmission(maxConcurrent: number): VectorKnnAdmission {
         }
       });
     },
-    active: () => active,
-    queued: () => waiters.length,
   };
 }
 
@@ -176,16 +158,11 @@ type VectorKnnSubprocessParams = {
   extensionPath?: string;
   request: VectorKnnRequest;
   signal?: AbortSignal;
-  childUrl?: URL;
-  onSpawn?: (pid: number | undefined) => void;
-  onExit?: (exit: VectorKnnSubprocessExit) => void;
 };
 
-async function runVectorKnnWithAdmission(
+/** Run one file-backed KNN query in a bounded, OS-killable child process. */
+export async function runVectorKnnInSubprocess(
   params: VectorKnnSubprocessParams,
-  admission: VectorKnnAdmission,
-  killExitTimeoutMs: number,
-  terminateProcess: typeof killProcessTree = killProcessTree,
 ): Promise<VectorKnnResponse> {
   if (params.signal?.aborted) {
     throw toAbortError(params.signal);
@@ -200,16 +177,15 @@ async function runVectorKnnWithAdmission(
     throw new VectorKnnSubprocessError("memory vector KNN child input is too large", "protocol");
   }
 
-  const releaseAdmission = await admission.acquire(params.signal);
+  const releaseAdmission = await vectorKnnAdmission.acquire(params.signal);
   if (params.signal?.aborted) {
     releaseAdmission();
     throw toAbortError(params.signal);
   }
-  const childUrl = params.childUrl ?? resolveVectorKnnChildUrl();
   let child;
   try {
+    const childUrl = resolveVectorKnnChildUrl();
     child = spawn(process.execPath, resolveRuntimeWorkerArgv(childUrl), {
-      detached: process.platform !== "win32",
       env: buildChildEnv(),
       shell: false,
       stdio: ["pipe", "pipe", "pipe"],
@@ -222,8 +198,6 @@ async function runVectorKnnWithAdmission(
       "unavailable",
     );
   }
-  params.onSpawn?.(child.pid);
-
   return await new Promise<VectorKnnResponse>((resolve, reject) => {
     const stdoutChunks: Buffer[] = [];
     let stdoutBytes = 0;
@@ -231,7 +205,6 @@ async function runVectorKnnWithAdmission(
     let closed = false;
     let callerSettled = false;
     let terminationReason: Error | undefined;
-    let protocolFailure: Error | undefined;
     let killExitTimer: ReturnType<typeof setTimeout> | undefined;
 
     const clearKillExitTimer = () => {
@@ -259,24 +232,11 @@ async function runVectorKnnWithAdmission(
       }
       terminationReason = reason;
       child.stdin.destroy();
-      if (typeof child.pid === "number") {
-        terminateProcess(child.pid, {
-          detached: process.platform !== "win32",
-          graceMs: GRACEFUL_KILL_GRACE_MS,
-        });
-      } else {
-        child.kill("SIGKILL");
-      }
+      // This read-only Node child creates no descendants. Kill the owned handle:
+      // native SQLite cannot service graceful shutdown while its query is busy.
+      child.kill("SIGKILL");
       killExitTimer = setTimeout(() => {
         if (!closed) {
-          if (typeof child.pid === "number") {
-            terminateProcess(child.pid, {
-              detached: process.platform !== "win32",
-              force: true,
-            });
-          } else {
-            child.kill("SIGKILL");
-          }
           // The caller may return, but this child keeps its admission slot until
           // close. Destroying pipes and unref'ing prevents one unkillable OS task
           // from pinning the Gateway while the slot bounds future accumulation.
@@ -293,7 +253,7 @@ async function runVectorKnnWithAdmission(
             ),
           );
         }
-      }, GRACEFUL_KILL_GRACE_MS + killExitTimeoutMs);
+      }, KILL_EXIT_TIMEOUT_MS);
     };
     const abort = () => {
       requestTermination(toAbortError(params.signal!));
@@ -306,12 +266,12 @@ async function runVectorKnnWithAdmission(
     child.stdout.on("data", (chunk: Buffer) => {
       stdoutBytes += chunk.byteLength;
       if (stdoutBytes > MAX_STDOUT_BYTES) {
-        protocolFailure = new VectorKnnSubprocessError(
+        const failure = new VectorKnnSubprocessError(
           "memory vector KNN child stdout exceeded its limit",
           "protocol",
         );
         stdoutChunks.length = 0;
-        requestTermination(protocolFailure);
+        requestTermination(failure);
         return;
       }
       stdoutChunks.push(chunk);
@@ -319,44 +279,29 @@ async function runVectorKnnWithAdmission(
     child.stderr.on("data", (chunk: Buffer) => {
       stderrBytes += chunk.byteLength;
       if (stderrBytes > MAX_STDERR_BYTES) {
-        protocolFailure = new VectorKnnSubprocessError(
+        const failure = new VectorKnnSubprocessError(
           "memory vector KNN child stderr exceeded its limit",
           "protocol",
         );
-        requestTermination(protocolFailure);
+        requestTermination(failure);
       }
     });
     child.stdin.on("error", (error: NodeJS.ErrnoException) => {
       if (!terminationReason && error.code !== "EPIPE") {
-        protocolFailure = new VectorKnnSubprocessError(error.message, "failed");
-        requestTermination(protocolFailure);
+        requestTermination(new VectorKnnSubprocessError(error.message, "failed"));
       }
     });
     child.once("error", (error) => {
-      protocolFailure = new VectorKnnSubprocessError(error.message, "unavailable");
-      requestTermination(protocolFailure);
+      requestTermination(new VectorKnnSubprocessError(error.message, "unavailable"));
     });
     child.once("close", (code, signal) => {
       closed = true;
-      const pidAlive = typeof child.pid === "number" && isPidAlive(child.pid);
-      params.onExit?.({ pid: child.pid, code, signal, pidAlive });
+      // close is the authoritative process/stdio completion; a recycled numeric
+      // PID must not turn a successful query into a false cleanup failure.
       releaseClosedChild();
       settleCaller(() => {
-        if (pidAlive) {
-          reject(
-            new VectorKnnSubprocessError(
-              "memory vector KNN child PID remained alive after close",
-              "termination-timeout",
-            ),
-          );
-          return;
-        }
         if (terminationReason) {
           reject(terminationReason);
-          return;
-        }
-        if (protocolFailure) {
-          reject(protocolFailure);
           return;
         }
         if (code !== 0 || signal) {
@@ -382,21 +327,3 @@ async function runVectorKnnWithAdmission(
     child.stdin.end(inputPayload);
   });
 }
-
-/** Run one file-backed KNN query in a bounded, OS-killable child process. */
-export async function runVectorKnnInSubprocess(
-  params: VectorKnnSubprocessParams,
-): Promise<VectorKnnResponse> {
-  return await runVectorKnnWithAdmission(params, vectorKnnAdmission, KILL_EXIT_TIMEOUT_MS);
-}
-
-export const testing = {
-  createVectorKnnAdmission,
-  gracefulKillGraceMs: GRACEFUL_KILL_GRACE_MS,
-  isProcessAlive: (pid: number | undefined) => (typeof pid === "number" ? isPidAlive(pid) : false),
-  maxConcurrentChildren: MAX_CONCURRENT_VECTOR_KNN_CHILDREN,
-  maxStderrBytes: MAX_STDERR_BYTES,
-  maxStdoutBytes: MAX_STDOUT_BYTES,
-  resolveVectorKnnChildUrl,
-  runVectorKnnWithAdmission,
-};

--- a/extensions/memory-core/src/memory/manager-search-knn.child.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.child.ts
@@ -24,6 +24,7 @@ function isChildInput(value: unknown): value is VectorKnnChildInput {
   if (!value || typeof value !== "object") {
     return false;
   }
+  // SAFETY: the object guard above permits explicit validation of every field read below.
   const input = value as Partial<VectorKnnChildInput>;
   return (
     typeof input.databasePath === "string" &&

--- a/extensions/memory-core/src/memory/manager-search-knn.child.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.child.ts
@@ -1,0 +1,103 @@
+// Child-process entrypoint for one hard-cancellable sqlite-vec KNN query.
+import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-schema";
+import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  runVectorKnnQuery,
+  type VectorKnnRequest,
+  type VectorKnnResponse,
+} from "./manager-search-knn.js";
+
+const MAX_STDIN_BYTES = 1024 * 1024;
+const MAX_STDOUT_BYTES = 2 * 1024 * 1024;
+
+export type VectorKnnChildInput = {
+  databasePath: string;
+  extensionPath?: string;
+  request: VectorKnnRequest;
+};
+
+export type VectorKnnChildResult =
+  | { status: "ok"; value: VectorKnnResponse }
+  | { status: "failed"; error: string };
+
+function isChildInput(value: unknown): value is VectorKnnChildInput {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const input = value as Partial<VectorKnnChildInput>;
+  return (
+    typeof input.databasePath === "string" &&
+    input.databasePath.length > 0 &&
+    Boolean(input.request) &&
+    typeof input.request === "object"
+  );
+}
+
+async function run(input: unknown): Promise<VectorKnnChildResult> {
+  if (!isChildInput(input)) {
+    return { status: "failed", error: "invalid memory vector KNN child input" };
+  }
+  const db = openNodeSqliteDatabase(input.databasePath, {
+    allowExtension: true,
+    readOnly: true,
+  });
+  try {
+    db.exec("PRAGMA query_only = ON; PRAGMA busy_timeout = 5000");
+    const loaded = await loadSqliteVecExtension({
+      db,
+      extensionPath: input.extensionPath,
+    });
+    if (!loaded.ok) {
+      throw new Error(loaded.error ?? "sqlite-vec unavailable in memory search child");
+    }
+    return { status: "ok", value: runVectorKnnQuery(db, input.request) };
+  } catch (error) {
+    return { status: "failed", error: error instanceof Error ? error.message : String(error) };
+  } finally {
+    db.close();
+  }
+}
+
+function writeResult(result: VectorKnnChildResult): void {
+  let payload = Buffer.from(JSON.stringify(result), "utf8");
+  if (payload.byteLength > MAX_STDOUT_BYTES) {
+    payload = Buffer.from(
+      JSON.stringify({ status: "failed", error: "memory vector KNN child result is too large" }),
+      "utf8",
+    );
+  }
+  process.stdout.write(payload);
+}
+
+const chunks: Buffer[] = [];
+let inputBytes = 0;
+let inputTooLarge = false;
+process.stdin.on("data", (chunk: Buffer) => {
+  inputBytes += chunk.byteLength;
+  if (inputBytes > MAX_STDIN_BYTES) {
+    inputTooLarge = true;
+    chunks.length = 0;
+    return;
+  }
+  chunks.push(chunk);
+});
+process.stdin.once("end", () => {
+  if (inputTooLarge) {
+    writeResult({ status: "failed", error: "memory vector KNN child input is too large" });
+    return;
+  }
+  let input: unknown;
+  try {
+    input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    writeResult({ status: "failed", error: "invalid memory vector KNN child JSON" });
+    return;
+  }
+  void run(input).then(writeResult, (error: unknown) => {
+    writeResult({
+      status: "failed",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+});
+process.stdin.resume();

--- a/extensions/memory-core/src/memory/manager-search-knn.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.ts
@@ -9,7 +9,7 @@ const MAX_VECTOR_KNN_K = 4096;
 const SQL_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 const SOURCE_FILTER_RE = /^(?:| AND c\.source IN \(\?(?:, \?)*\))$/u;
 
-export type VectorKnnRow = {
+type VectorKnnRow = {
   id: string;
   path: string;
   start_line: number;
@@ -32,14 +32,41 @@ export type VectorKnnResponse = {
   fallbackScanRequired: boolean;
 };
 
-function readCount(row: Record<string, unknown> | undefined): number {
-  if (typeof row?.count === "bigint") {
-    return Number(row.count);
+function readCount(row: unknown): number {
+  if (!row || typeof row !== "object") {
+    return 0;
   }
-  if (typeof row?.count === "number") {
-    return row.count;
+  const count = Reflect.get(row, "count");
+  if (typeof count === "bigint") {
+    return Number(count);
+  }
+  if (typeof count === "number") {
+    return count;
   }
   return 0;
+}
+
+export function isVectorKnnRow(value: unknown): value is VectorKnnRow {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const id = Reflect.get(value, "id");
+  const path = Reflect.get(value, "path");
+  const startLine = Reflect.get(value, "start_line");
+  const endLine = Reflect.get(value, "end_line");
+  const text = Reflect.get(value, "text");
+  const source = Reflect.get(value, "source");
+  const dist = Reflect.get(value, "dist");
+  return (
+    typeof id === "string" &&
+    typeof path === "string" &&
+    typeof startLine === "number" &&
+    typeof endLine === "number" &&
+    typeof text === "string" &&
+    (source === "memory" || source === "sessions") &&
+    typeof dist === "number" &&
+    Number.isFinite(dist)
+  );
 }
 
 function buildModelFilter(column: string, models: string[]): string {
@@ -84,8 +111,8 @@ export function runVectorKnnQuery(
   validateRequest(request);
   const vectorModelFilter = buildModelFilter("c.model", request.providerModels);
   const qBlob = vectorToBlob(request.queryVec);
-  const runVectorQuery = (candidateLimit: number) =>
-    db
+  const runVectorQuery = (candidateLimit: number) => {
+    const queryRows = db
       .prepare(
         `SELECT c.id, c.path, c.start_line, c.end_line, c.text,\n` +
           `       c.source,\n` +
@@ -103,26 +130,29 @@ export function runVectorKnnQuery(
         ...request.providerModels,
         ...request.sourceFilter.params,
         request.limit,
-      ) as VectorKnnRow[];
+      );
+    return queryRows.map((row) => {
+      if (!isVectorKnnRow(row)) {
+        throw new Error("memory vector KNN query returned an invalid row");
+      }
+      return row;
+    });
+  };
 
   const candidateLimit = Math.min(request.limit * VECTOR_KNN_OVERSAMPLE_FACTOR, MAX_VECTOR_KNN_K);
   let rows = runVectorQuery(candidateLimit);
   if (rows.length < request.limit) {
-    const matchingChunkCount = readCount(
-      db
-        .prepare(
-          `SELECT COUNT(*) AS count FROM memory_index_chunks c WHERE ${vectorModelFilter}${request.sourceFilter.sql}`,
-        )
-        .get(...request.providerModels, ...request.sourceFilter.params) as
-        | Record<string, unknown>
-        | undefined,
-    );
+    const matchingChunkCountRow = db
+      .prepare(
+        `SELECT COUNT(*) AS count FROM memory_index_chunks c WHERE ${vectorModelFilter}${request.sourceFilter.sql}`,
+      )
+      .get(...request.providerModels, ...request.sourceFilter.params);
+    const matchingChunkCount = readCount(matchingChunkCountRow);
     if (matchingChunkCount > rows.length) {
-      const vectorCount = readCount(
-        db.prepare(`SELECT COUNT(*) AS count FROM ${request.vectorTable}`).get() as
-          | Record<string, unknown>
-          | undefined,
-      );
+      const vectorCountRow = db
+        .prepare(`SELECT COUNT(*) AS count FROM ${request.vectorTable}`)
+        .get();
+      const vectorCount = readCount(vectorCountRow);
       const widenedLimit = Math.min(vectorCount, MAX_VECTOR_KNN_K);
       if (widenedLimit > candidateLimit) {
         rows = runVectorQuery(widenedLimit);

--- a/extensions/memory-core/src/memory/manager-search-knn.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.ts
@@ -1,0 +1,138 @@
+// Memory Core plugin module implements the synchronous sqlite-vec KNN query body.
+import type { DatabaseSync } from "node:sqlite";
+import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { vectorToBlob } from "./vector-blob.js";
+
+const VECTOR_KNN_OVERSAMPLE_FACTOR = 8;
+// sqlite-vec v0.1.9 rejects KNN queries with k above 4096.
+const MAX_VECTOR_KNN_K = 4096;
+const SQL_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+const SOURCE_FILTER_RE = /^(?:| AND c\.source IN \(\?(?:, \?)*\))$/u;
+
+export type VectorKnnRow = {
+  id: string;
+  path: string;
+  start_line: number;
+  end_line: number;
+  text: string;
+  source: MemorySource;
+  dist: number;
+};
+
+export type VectorKnnRequest = {
+  vectorTable: string;
+  providerModels: string[];
+  queryVec: number[];
+  limit: number;
+  sourceFilter: { sql: string; params: string[] };
+};
+
+export type VectorKnnResponse = {
+  rows: VectorKnnRow[];
+  fallbackScanRequired: boolean;
+};
+
+function readCount(row: Record<string, unknown> | undefined): number {
+  if (typeof row?.count === "bigint") {
+    return Number(row.count);
+  }
+  if (typeof row?.count === "number") {
+    return row.count;
+  }
+  return 0;
+}
+
+function buildModelFilter(column: string, models: string[]): string {
+  return models.length === 1
+    ? `${column} = ?`
+    : `${column} IN (${models.map(() => "?").join(", ")})`;
+}
+
+function validateRequest(request: VectorKnnRequest): void {
+  if (!SQL_IDENTIFIER_RE.test(request.vectorTable)) {
+    throw new Error("invalid memory vector table identifier");
+  }
+  if (
+    request.providerModels.length === 0 ||
+    request.providerModels.some((model) => typeof model !== "string" || model.length === 0)
+  ) {
+    throw new Error("memory vector KNN requires at least one provider model");
+  }
+  if (!SOURCE_FILTER_RE.test(request.sourceFilter.sql)) {
+    throw new Error("invalid memory vector source filter");
+  }
+  const placeholderCount = request.sourceFilter.sql.match(/\?/gu)?.length ?? 0;
+  if (placeholderCount !== request.sourceFilter.params.length) {
+    throw new Error("memory vector source filter parameter mismatch");
+  }
+  if (!Number.isSafeInteger(request.limit) || request.limit <= 0) {
+    throw new Error("invalid memory vector KNN limit");
+  }
+}
+
+/**
+ * Execute the complete synchronous sqlite-vec KNN/count sequence.
+ *
+ * This function must run outside the Gateway event loop for file-backed
+ * indexes. It remains separately testable so the worker and query semantics do
+ * not diverge.
+ */
+export function runVectorKnnQuery(
+  db: Pick<DatabaseSync, "prepare">,
+  request: VectorKnnRequest,
+): VectorKnnResponse {
+  validateRequest(request);
+  const vectorModelFilter = buildModelFilter("c.model", request.providerModels);
+  const qBlob = vectorToBlob(request.queryVec);
+  const runVectorQuery = (candidateLimit: number) =>
+    db
+      .prepare(
+        `SELECT c.id, c.path, c.start_line, c.end_line, c.text,\n` +
+          `       c.source,\n` +
+          `       vec_distance_cosine(v.embedding, ?) AS dist\n` +
+          `  FROM ${request.vectorTable} v\n` +
+          `  JOIN memory_index_chunks c ON c.id = v.id\n` +
+          ` WHERE v.embedding MATCH ? AND k = ? AND ${vectorModelFilter}${request.sourceFilter.sql}\n` +
+          ` ORDER BY dist ASC\n` +
+          ` LIMIT ?`,
+      )
+      .all(
+        qBlob,
+        qBlob,
+        candidateLimit,
+        ...request.providerModels,
+        ...request.sourceFilter.params,
+        request.limit,
+      ) as VectorKnnRow[];
+
+  const candidateLimit = Math.min(request.limit * VECTOR_KNN_OVERSAMPLE_FACTOR, MAX_VECTOR_KNN_K);
+  let rows = runVectorQuery(candidateLimit);
+  if (rows.length < request.limit) {
+    const matchingChunkCount = readCount(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS count FROM memory_index_chunks c WHERE ${vectorModelFilter}${request.sourceFilter.sql}`,
+        )
+        .get(...request.providerModels, ...request.sourceFilter.params) as
+        | Record<string, unknown>
+        | undefined,
+    );
+    if (matchingChunkCount > rows.length) {
+      const vectorCount = readCount(
+        db.prepare(`SELECT COUNT(*) AS count FROM ${request.vectorTable}`).get() as
+          | Record<string, unknown>
+          | undefined,
+      );
+      const widenedLimit = Math.min(vectorCount, MAX_VECTOR_KNN_K);
+      if (widenedLimit > candidateLimit) {
+        rows = runVectorQuery(widenedLimit);
+      }
+      const requiredMatches = Math.min(request.limit, matchingChunkCount);
+      if (vectorCount > MAX_VECTOR_KNN_K && rows.length < requiredMatches) {
+        return { rows: [], fallbackScanRequired: true };
+      }
+    }
+  }
+
+  return { rows, fallbackScanRequired: false };
+}

--- a/extensions/memory-core/src/memory/manager-search-knn.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.ts
@@ -1,5 +1,6 @@
 // Memory Core plugin module implements the synchronous sqlite-vec KNN query body.
 import type { DatabaseSync } from "node:sqlite";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { vectorToBlob } from "./vector-blob.js";
 
@@ -24,6 +25,7 @@ export type VectorKnnRequest = {
   providerModels: string[];
   queryVec: number[];
   limit: number;
+  snippetMaxChars: number;
   sourceFilter: { sql: string; params: string[] };
 };
 
@@ -95,6 +97,9 @@ function validateRequest(request: VectorKnnRequest): void {
   if (!Number.isSafeInteger(request.limit) || request.limit <= 0) {
     throw new Error("invalid memory vector KNN limit");
   }
+  if (!Number.isSafeInteger(request.snippetMaxChars) || request.snippetMaxChars <= 0) {
+    throw new Error("invalid memory vector KNN snippet limit");
+  }
 }
 
 /**
@@ -135,6 +140,7 @@ export function runVectorKnnQuery(
       if (!isVectorKnnRow(row)) {
         throw new Error("memory vector KNN query returned an invalid row");
       }
+      row.text = truncateUtf16Safe(row.text, request.snippetMaxChars);
       return row;
     });
   };

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -2,8 +2,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
-import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import {
   createManagerIndexFixture,

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -350,7 +350,7 @@ describe("memory index", () => {
     );
     await fs.writeFile(
       path.join(fixture.paths.memory, "alpha.md"),
-      "Unrelated path-only candidate.",
+      "Unrelated beta path-only candidate.",
     );
     await manager.sync({ reason: "test" });
 

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -3,11 +3,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import {
   createManagerIndexFixture,
   type ManagerIndexFixtureConfig,
 } from "./manager-index.test-support.js";
+import * as knnSubprocess from "./manager-search-knn-subprocess.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
 
@@ -61,6 +63,82 @@ describe("memory index", () => {
     },
   ])("finds keyword matches via hybrid search when $name", async ({ config }) => {
     await expectHybridKeywordSearchFindsMemory(createCfg(config));
+  });
+
+  it("preserves semantic results when a concurrent reindex publishes before KNN returns", async () => {
+    const manager = await getPersistentManager(
+      createCfg({
+        vectorEnabled: true,
+        minScore: 0,
+        hybrid: { enabled: true, vectorWeight: 1, textWeight: 0 },
+      }),
+    );
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      db: DatabaseSync;
+      provider: EmbeddingProvider;
+      syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+    };
+    const queryStarted = createDeferred<void>();
+    const releaseQuery = createDeferred<void>();
+    const shadowReady = createDeferred<void>();
+    const releaseReindex = createDeferred<void>();
+    const childReady = createDeferred<void>();
+    const releaseChild = createDeferred<void>();
+    const publishedDb = fields.db;
+    const publishedChunks = manager.status().chunks;
+    let shadowDb: DatabaseSync | undefined;
+    const syncMemoryFiles = fields.syncMemoryFiles.bind(manager);
+    const runKnn = knnSubprocess.runVectorKnnInSubprocess;
+    const querySpy = vi.spyOn(fields.provider, "embed").mockImplementation(async () => {
+      queryStarted.resolve();
+      await releaseQuery.promise;
+      return [1, 0, 0, 0];
+    });
+    const syncSpy = vi.spyOn(fields, "syncMemoryFiles").mockImplementation(async (params) => {
+      shadowDb = fields.db;
+      expect(manager.status().chunks).toBe(publishedChunks);
+      const lexical = await manager.search("zebra", { lexicalOnly: true, minScore: 0 });
+      expect(lexical.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+      const result = await syncMemoryFiles(params);
+      shadowReady.resolve();
+      await releaseReindex.promise;
+      return result;
+    });
+    const childSpy = vi
+      .spyOn(knnSubprocess, "runVectorKnnInSubprocess")
+      .mockImplementation(async (params) => {
+        const result = await runKnn(params);
+        expect(result.rows.length).toBeGreaterThan(0);
+        childReady.resolve();
+        await releaseChild.promise;
+        return result;
+      });
+    let search: ReturnType<typeof manager.search> | undefined;
+    let reindex: ReturnType<typeof manager.sync> | undefined;
+    try {
+      search = manager.search("semantic needle without lexical overlap");
+      await queryStarted.promise;
+      reindex = manager.sync({ reason: "test", force: true });
+      await shadowReady.promise;
+      expect(fields.db).toBe(publishedDb);
+      releaseQuery.resolve();
+      await childReady.promise;
+      releaseReindex.resolve();
+      await reindex;
+      expect(shadowDb?.isOpen).toBe(false);
+      releaseChild.resolve();
+      const results = await search;
+      expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+    } finally {
+      releaseQuery.resolve();
+      releaseReindex.resolve();
+      releaseChild.resolve();
+      await Promise.allSettled([search, reindex]);
+      childSpy.mockRestore();
+      syncSpy.mockRestore();
+      querySpy.mockRestore();
+    }
   });
 
   it("retries transient query embedding transport failures during search", async () => {

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -1,7 +1,10 @@
 // Memory Core plugin module owns public search orchestration.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import {
+  createSubsystemLogger,
+  resolveUserPath,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   MEMORY_INDEX_FTS_TABLE,
   MEMORY_INDEX_VECTOR_TABLE,
@@ -19,6 +22,7 @@ import {
 import { applyImportanceMultiplier } from "./importance.js";
 import { startAsyncSearchSync } from "./manager-async-state.js";
 import { MemoryKeywordRetrieval, type KeywordSearchHit } from "./manager-keyword-retrieval.js";
+import { runVectorKnnInSubprocess } from "./manager-search-knn-subprocess.js";
 import { resolveMemorySearchPreflight } from "./manager-search-preflight.js";
 import { resolveExactPathSpecificity, searchVector } from "./manager-search.js";
 import { applyProjectRanking } from "./project-ranking.js";
@@ -439,6 +443,13 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       snippetMaxChars: SNIPPET_MAX_CHARS,
       signal,
       ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),
+      runVectorKnn: async (request, knnSignal) =>
+        await runVectorKnnInSubprocess({
+          databasePath: resolveUserPath(this.settings.store.databasePath),
+          extensionPath: this.vector.extensionPath,
+          request,
+          signal: knnSignal,
+        }),
       sourceFilterVec: this.buildSourceFilter("c", sourceFilterList),
       sourceFilterChunks: this.buildSourceFilter(undefined, sourceFilterList),
     });

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it, vi } from "vitest";
 import { bm25RankToScore, buildFtsQuery } from "./hybrid.js";
+import { runVectorKnnQuery } from "./manager-search-knn.js";
 import { searchKeyword, searchPathKeyword, searchVector } from "./manager-search.js";
 import { runMemorySearchWithDeadline } from "./search-deadline.js";
 import { vectorToBlob } from "./vector-blob.js";
@@ -106,6 +107,7 @@ function searchVectorFixture(db: DatabaseSync, options: Partial<VectorSearchOpti
     limit: 5,
     snippetMaxChars: 200,
     ensureVectorReady: async () => false,
+    runVectorKnn: async (request) => runVectorKnnQuery(db, request),
     sourceFilterVec: { sql: "", params: [] },
     sourceFilterChunks: { sql: "", params: [] },
     ...options,

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -14,15 +14,12 @@ import {
   normalizeStringEntriesLower,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { vectorToBlob } from "./vector-blob.js";
+import type { VectorKnnRequest, VectorKnnResponse } from "./manager-search-knn.js";
 
 const FTS_QUERY_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
 const SHORT_CJK_TRIGRAM_RE = /[\u3040-\u30ff\u3400-\u9fff\uac00-\ud7af\u3131-\u3163]/u;
 const EXACT_PATH_SPECIFICITY_SQL_FUNCTION = "openclaw_memory_exact_path_specificity";
 const NORMALIZED_PATH_CONTAINS_SQL_FUNCTION = "openclaw_memory_normalized_path_contains";
-const VECTOR_KNN_OVERSAMPLE_FACTOR = 8;
-// sqlite-vec v0.1.9 rejects KNN queries with k above 4096.
-const MAX_VECTOR_KNN_K = 4096;
 
 // Scan fallback vector rows in bounded batches so large chunk tables (no usable
 // vec0 index) cannot pin the main thread for multi-second windows and starve
@@ -339,16 +336,6 @@ function buildMatchQueryFromTerms(terms: string[]): string | null {
   return quoted.join(" AND ");
 }
 
-function readCount(row: Record<string, unknown> | undefined): number {
-  if (typeof row?.count === "bigint") {
-    return Number(row.count);
-  }
-  if (typeof row?.count === "number") {
-    return row.count;
-  }
-  return 0;
-}
-
 function resolveProviderModels(primary: string, aliases: string[] | undefined): string[] {
   return Array.from(new Set([primary, ...(aliases ?? []).filter(Boolean)]));
 }
@@ -451,6 +438,7 @@ export async function searchVector(params: {
   snippetMaxChars: number;
   signal?: AbortSignal;
   ensureVectorReady: (dimensions: number) => Promise<boolean>;
+  runVectorKnn?: (request: VectorKnnRequest, signal?: AbortSignal) => Promise<VectorKnnResponse>;
   sourceFilterVec: { sql: string; params: SearchSource[] };
   sourceFilterChunks: { sql: string; params: SearchSource[] };
 }): Promise<SearchRowResult[]> {
@@ -459,7 +447,6 @@ export async function searchVector(params: {
   }
   params.signal?.throwIfAborted();
   const providerModels = resolveProviderModels(params.providerModel, params.providerModelAliases);
-  const vectorModelFilter = buildModelFilter("c.model", providerModels);
   const searchFallback = () =>
     searchChunksByEmbedding({
       db: params.db,
@@ -474,71 +461,23 @@ export async function searchVector(params: {
   const vectorReady = await params.ensureVectorReady(params.queryVec.length);
   params.signal?.throwIfAborted();
   if (vectorReady) {
-    // Use sqlite-vec's native KNN (MATCH ? AND k = ?) for candidate selection,
-    // which runs in ~O(log N + k) via the vec0 index, instead of the previous
-    // full-table scan over vec_distance_cosine(). Keep vec_distance_cosine() in
-    // the SELECT so `score = 1 - dist` stays in the cosine [0, 1] range the
-    // downstream merge/minScore pipeline expects. (memory_index_chunks_vec is created with
-    // sqlite-vec's default L2 distance, so v.distance cannot be used directly
-    // for scoring.)
-    const qBlob = vectorToBlob(params.queryVec);
-    const runVectorQuery = (candidateLimit: number) =>
-      params.db
-        .prepare(
-          `SELECT c.id, c.path, c.start_line, c.end_line, c.text,\n` +
-            `       c.source,\n` +
-            `       vec_distance_cosine(v.embedding, ?) AS dist\n` +
-            `  FROM ${params.vectorTable} v\n` +
-            `  JOIN memory_index_chunks c ON c.id = v.id\n` +
-            ` WHERE v.embedding MATCH ? AND k = ? AND ${vectorModelFilter}${params.sourceFilterVec.sql}\n` +
-            ` ORDER BY dist ASC\n` +
-            ` LIMIT ?`,
-        )
-        .all(
-          qBlob,
-          qBlob,
-          candidateLimit,
-          ...providerModels,
-          ...params.sourceFilterVec.params,
-          params.limit,
-        ) as Array<{
-        id: string;
-        path: string;
-        start_line: number;
-        end_line: number;
-        text: string;
-        source: SearchSource;
-        dist: number;
-      }>;
-
-    const candidateLimit = Math.min(params.limit * VECTOR_KNN_OVERSAMPLE_FACTOR, MAX_VECTOR_KNN_K);
-    let rows = runVectorQuery(candidateLimit);
-    if (rows.length < params.limit) {
-      const matchingChunkCount = readCount(
-        params.db
-          .prepare(
-            `SELECT COUNT(*) AS count FROM memory_index_chunks c WHERE ${vectorModelFilter}${params.sourceFilterVec.sql}`,
-          )
-          .get(...providerModels, ...params.sourceFilterVec.params),
-      );
-      if (matchingChunkCount > rows.length) {
-        const vectorCount = readCount(
-          params.db.prepare(`SELECT COUNT(*) AS count FROM ${params.vectorTable}`).get(),
-        );
-        const widenedLimit = Math.min(vectorCount, MAX_VECTOR_KNN_K);
-        if (widenedLimit > candidateLimit) {
-          rows = runVectorQuery(widenedLimit);
-        }
-        const requiredMatches = Math.min(params.limit, matchingChunkCount);
-        if (vectorCount > MAX_VECTOR_KNN_K && rows.length < requiredMatches) {
-          // Post-KNN model/source filters can hide every eligible row beyond
-          // sqlite-vec's ceiling; the bounded scan preserves filtered recall.
-          return await searchFallback();
-        }
-      }
+    if (!params.runVectorKnn) {
+      throw new Error("memory vector KNN subprocess is unavailable");
     }
-
-    return rows.map((row) =>
+    const response = await params.runVectorKnn(
+      {
+        vectorTable: params.vectorTable,
+        providerModels,
+        queryVec: params.queryVec,
+        limit: params.limit,
+        sourceFilter: params.sourceFilterVec,
+      },
+      params.signal,
+    );
+    if (response.fallbackScanRequired) {
+      return await searchFallback();
+    }
+    return response.rows.map((row) =>
       Object.assign(
         {
           id: row.id,

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -470,6 +470,7 @@ export async function searchVector(params: {
         providerModels,
         queryVec: params.queryVec,
         limit: params.limit,
+        snippetMaxChars: params.snippetMaxChars,
         sourceFilter: params.sourceFilterVec,
       },
       params.signal,

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -1,5 +1,4 @@
 // Memory Core plugin module owns shared manager synchronization state.
-import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import type { FSWatcher } from "chokidar";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -29,6 +28,7 @@ import {
   type EmbeddingProviderId,
   type EmbeddingProviderRuntime,
 } from "./embeddings.js";
+import { MemoryManagerDatabaseContext } from "./manager-database-context.js";
 import { openMemoryDatabaseAtPath } from "./manager-db.js";
 import {
   resolveMemoryPrimaryProviderRequest,
@@ -92,28 +92,6 @@ type MemoryReindexRetryState = {
   sessionsDirtyFiles: Set<string>;
 };
 
-export class MemoryIndexDatabase {
-  readonly vector: {
-    enabled: boolean;
-    available: boolean | null;
-    semanticAvailable?: boolean;
-    extensionPath?: string;
-    loadError?: string;
-    dims?: number;
-  } = { enabled: false, available: null };
-  readonly fts: {
-    enabled: boolean;
-    available: boolean;
-    loadError?: string;
-  } = { enabled: false, available: false };
-  vectorReady: Promise<boolean> | null = null;
-  lastMetaSerialized: string | null = null;
-  vectorDegradedWriteWarningShown = false;
-  closed = false;
-
-  constructor(readonly db: DatabaseSync) {}
-}
-
 export const MEMORY_INDEX_META_KEY = "memory_index_meta_v1";
 const META_KEY = MEMORY_INDEX_META_KEY;
 const VECTOR_TABLE = MEMORY_INDEX_VECTOR_TABLE;
@@ -122,13 +100,8 @@ const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const EMBEDDING_CACHE_SEED_BATCH_SIZE = 1_000;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const log = createSubsystemLogger("memory");
-// One process-lifetime container; stores belong only to their awaited rebuild.
-const reindexDatabase = new AsyncLocalStorage<{
-  manager: MemoryManagerSyncBase;
-  database: MemoryIndexDatabase;
-}>();
 
-export abstract class MemoryManagerSyncBase {
+export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext {
   protected readonly acquireLocalService?: MemoryCoreAcquireLocalService;
   protected abstract readonly cfg: OpenClawConfig;
   protected abstract readonly agentId: string;
@@ -152,41 +125,6 @@ export abstract class MemoryManagerSyncBase {
     { eligible: number | null; issues: string[] }
   >();
   protected providerKey: string | null = null;
-  protected abstract publishedDatabase: MemoryIndexDatabase;
-
-  protected get database(): MemoryIndexDatabase {
-    const context = reindexDatabase.getStore();
-    const shadow = context?.manager === this ? context.database : undefined;
-    if (shadow?.closed) {
-      throw new Error("Memory reindex database context is closed");
-    }
-    return shadow ?? this.publishedDatabase;
-  }
-
-  protected get db(): DatabaseSync {
-    return this.database.db;
-  }
-
-  protected get vector() {
-    return this.database.vector;
-  }
-
-  protected get fts() {
-    return this.database.fts;
-  }
-
-  protected withPublishedDatabase<T>(run: () => T): T {
-    // Public calls can originate in reindex progress/provider callbacks. They
-    // must never inherit the temporary writer or outlive its connection.
-    return reindexDatabase.exit(run);
-  }
-
-  protected withReindexDatabase<T>(
-    database: MemoryIndexDatabase,
-    run: () => Promise<T>,
-  ): Promise<T> {
-    return reindexDatabase.run({ manager: this, database }, run);
-  }
   protected watcher: FSWatcher | null = null;
   protected watchTimer: NodeJS.Timeout | null = null;
   protected sessionWatchTimer: NodeJS.Timeout | null = null;

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -47,6 +47,7 @@ import {
   memoryTableExists,
   requiresMemoryVectorRebuild,
 } from "./manager-vector-rebuild-state.js";
+import { buildMemorySourceFilter } from "./source-filter.js";
 import type { MemoryWatchSettleQueue } from "./watch-settle.js";
 
 export type MemorySyncProgressState = {
@@ -622,12 +623,7 @@ export abstract class MemoryManagerSyncBase {
     sourcesOverride?: MemorySource[],
   ): { sql: string; params: MemorySource[] } {
     const sources = sourcesOverride ?? Array.from(this.sources);
-    if (sources.length === 0) {
-      return { sql: "", params: [] };
-    }
-    const column = alias ? `${alias}.source` : "source";
-    const placeholders = sources.map(() => "?").join(", ");
-    return { sql: ` AND ${column} IN (${placeholders})`, params: sources };
+    return buildMemorySourceFilter(alias, sources);
   }
 
   protected openDatabase(): DatabaseSync {

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -1,4 +1,5 @@
 // Memory Core plugin module owns shared manager synchronization state.
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import type { FSWatcher } from "chokidar";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -91,6 +92,28 @@ type MemoryReindexRetryState = {
   sessionsDirtyFiles: Set<string>;
 };
 
+export class MemoryIndexDatabase {
+  readonly vector: {
+    enabled: boolean;
+    available: boolean | null;
+    semanticAvailable?: boolean;
+    extensionPath?: string;
+    loadError?: string;
+    dims?: number;
+  } = { enabled: false, available: null };
+  readonly fts: {
+    enabled: boolean;
+    available: boolean;
+    loadError?: string;
+  } = { enabled: false, available: false };
+  vectorReady: Promise<boolean> | null = null;
+  lastMetaSerialized: string | null = null;
+  vectorDegradedWriteWarningShown = false;
+  closed = false;
+
+  constructor(readonly db: DatabaseSync) {}
+}
+
 export const MEMORY_INDEX_META_KEY = "memory_index_meta_v1";
 const META_KEY = MEMORY_INDEX_META_KEY;
 const VECTOR_TABLE = MEMORY_INDEX_VECTOR_TABLE;
@@ -99,6 +122,11 @@ const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const EMBEDDING_CACHE_SEED_BATCH_SIZE = 1_000;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const log = createSubsystemLogger("memory");
+// One process-lifetime container; stores belong only to their awaited rebuild.
+const reindexDatabase = new AsyncLocalStorage<{
+  manager: MemoryManagerSyncBase;
+  database: MemoryIndexDatabase;
+}>();
 
 export abstract class MemoryManagerSyncBase {
   protected readonly acquireLocalService?: MemoryCoreAcquireLocalService;
@@ -124,20 +152,41 @@ export abstract class MemoryManagerSyncBase {
     { eligible: number | null; issues: string[] }
   >();
   protected providerKey: string | null = null;
-  protected abstract readonly vector: {
-    enabled: boolean;
-    available: boolean | null;
-    semanticAvailable?: boolean;
-    extensionPath?: string;
-    loadError?: string;
-    dims?: number;
-  };
-  protected readonly fts: {
-    enabled: boolean;
-    available: boolean;
-    loadError?: string;
-  } = { enabled: false, available: false };
-  protected vectorReady: Promise<boolean> | null = null;
+  protected abstract publishedDatabase: MemoryIndexDatabase;
+
+  protected get database(): MemoryIndexDatabase {
+    const context = reindexDatabase.getStore();
+    const shadow = context?.manager === this ? context.database : undefined;
+    if (shadow?.closed) {
+      throw new Error("Memory reindex database context is closed");
+    }
+    return shadow ?? this.publishedDatabase;
+  }
+
+  protected get db(): DatabaseSync {
+    return this.database.db;
+  }
+
+  protected get vector() {
+    return this.database.vector;
+  }
+
+  protected get fts() {
+    return this.database.fts;
+  }
+
+  protected withPublishedDatabase<T>(run: () => T): T {
+    // Public calls can originate in reindex progress/provider callbacks. They
+    // must never inherit the temporary writer or outlive its connection.
+    return reindexDatabase.exit(run);
+  }
+
+  protected withReindexDatabase<T>(
+    database: MemoryIndexDatabase,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    return reindexDatabase.run({ manager: this, database }, run);
+  }
   protected watcher: FSWatcher | null = null;
   protected watchTimer: NodeJS.Timeout | null = null;
   protected sessionWatchTimer: NodeJS.Timeout | null = null;
@@ -162,11 +211,8 @@ export abstract class MemoryManagerSyncBase {
   protected sessionsDirtyFiles = new Set<string>();
   protected sessionPendingFiles = new Set<string>();
   protected sessionPendingTargets = new Map<string, MemorySessionSyncTarget>();
-  protected vectorDegradedWriteWarningShown = false;
-  protected lastMetaSerialized: string | null = null;
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
-  protected abstract db: DatabaseSync;
   protected abstract computeProviderKey(): string;
   protected abstract resolveProviderIndexIdentities(): MemoryIndexProviderIdentity[];
   protected abstract sync(params?: MemorySyncParams): Promise<void>;
@@ -444,20 +490,20 @@ export abstract class MemoryManagerSyncBase {
   }
 
   protected resetVectorState(): void {
-    this.vectorReady = null;
+    this.database.vectorReady = null;
     this.vector.available = null;
     this.vector.semanticAvailable = undefined;
     this.vector.loadError = undefined;
     this.vector.dims = undefined;
-    this.vectorDegradedWriteWarningShown = false;
+    this.database.vectorDegradedWriteWarningShown = false;
   }
 
   protected async ensureVectorReady(dimensions?: number): Promise<boolean> {
     if (!this.vector.enabled) {
       return false;
     }
-    if (!this.vectorReady) {
-      this.vectorReady = this.withTimeout(
+    if (!this.database.vectorReady) {
+      this.database.vectorReady = this.withTimeout(
         this.loadVectorExtension(),
         VECTOR_LOAD_TIMEOUT_MS,
         `sqlite-vec load timed out after ${Math.round(VECTOR_LOAD_TIMEOUT_MS / 1000)}s`,
@@ -465,12 +511,12 @@ export abstract class MemoryManagerSyncBase {
     }
     let ready;
     try {
-      ready = (await this.vectorReady) || false;
+      ready = (await this.database.vectorReady) || false;
     } catch (err) {
       const message = formatErrorMessage(err);
       this.vector.available = false;
       this.vector.loadError = message;
-      this.vectorReady = null;
+      this.database.vectorReady = null;
       log.warn(`sqlite-vec unavailable: ${message}`);
       return false;
     }
@@ -717,22 +763,22 @@ export abstract class MemoryManagerSyncBase {
       .prepare(`SELECT value FROM memory_index_meta WHERE key = ?`)
       .get(META_KEY) as { value: string } | undefined;
     if (!row?.value) {
-      this.lastMetaSerialized = null;
+      this.database.lastMetaSerialized = null;
       return null;
     }
     try {
       const parsed = JSON.parse(row.value) as MemoryIndexMeta;
-      this.lastMetaSerialized = row.value;
+      this.database.lastMetaSerialized = row.value;
       return parsed;
     } catch {
-      this.lastMetaSerialized = null;
+      this.database.lastMetaSerialized = null;
       return null;
     }
   }
 
   protected writeMeta(meta: MemoryIndexMeta) {
     const value = JSON.stringify(meta);
-    if (this.lastMetaSerialized === value) {
+    if (this.database.lastMetaSerialized === value) {
       return;
     }
     this.db
@@ -740,6 +786,6 @@ export abstract class MemoryManagerSyncBase {
         `INSERT INTO memory_index_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value`,
       )
       .run(META_KEY, value);
-    this.lastMetaSerialized = value;
+    this.database.lastMetaSerialized = value;
   }
 }

--- a/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
@@ -7,7 +7,7 @@ import type {
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MemoryIndexDatabase } from "./manager-sync-base.js";
+import { MemoryIndexDatabase } from "./manager-database-context.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {

--- a/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
@@ -7,6 +7,7 @@ import type {
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryIndexDatabase } from "./manager-sync-base.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
@@ -30,11 +31,10 @@ class IntervalSyncHarness extends MemoryManagerSyncOps {
     pollIntervalMs: 0,
     timeoutMs: 0,
   };
-  protected readonly vector = { enabled: false, available: false };
   protected readonly cache = { enabled: false };
   protected providerUnavailableReason?: string;
   protected providerLifecycle = { mode: "active" as const, providerId: "test" };
-  protected db = {} as DatabaseSync;
+  protected publishedDatabase = new MemoryIndexDatabase({} as DatabaseSync);
 
   constructor(params: { intervalMinutes?: number; batchTimeoutMinutes?: number }) {
     super();

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -36,6 +36,7 @@ import {
   resolveConfiguredScopeHash,
   type MemoryIndexMeta,
 } from "./manager-reindex-state.js";
+import { MemoryIndexDatabase } from "./manager-sync-base.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
@@ -170,11 +171,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     pollIntervalMs: 0,
     timeoutMs: 0,
   };
-  protected readonly vector = { enabled: false, available: false };
   protected readonly cache = { enabled: false };
   protected providerUnavailableReason?: string;
   protected providerLifecycle = { mode: "active" as const, providerId: "test" };
-  protected db: DatabaseSync;
+  protected publishedDatabase: MemoryIndexDatabase;
 
   readonly syncCalls: SyncParams[] = [];
   readonly indexedPaths: string[] = [];
@@ -193,7 +193,9 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   ) {
     super();
     this.sources.add("sessions");
-    this.db = database ?? createStartupHarnessDatabase(sourceRows);
+    this.publishedDatabase = new MemoryIndexDatabase(
+      database ?? createStartupHarnessDatabase(sourceRows),
+    );
   }
 
   restartForStartup(): SessionStartupCatchupHarness {

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -31,12 +31,12 @@ import {
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryIndexDatabase } from "./manager-database-context.js";
 import {
   MEMORY_INDEX_PROVENANCE_VERSION,
   resolveConfiguredScopeHash,
   type MemoryIndexMeta,
 } from "./manager-reindex-state.js";
-import { MemoryIndexDatabase } from "./manager-sync-base.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
@@ -193,9 +193,8 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   ) {
     super();
     this.sources.add("sessions");
-    this.publishedDatabase = new MemoryIndexDatabase(
-      database ?? createStartupHarnessDatabase(sourceRows),
-    );
+    const db = database ?? createStartupHarnessDatabase(sourceRows);
+    this.publishedDatabase = new MemoryIndexDatabase(db);
   }
 
   restartForStartup(): SessionStartupCatchupHarness {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -19,6 +19,7 @@ import {
   type EmbeddingProvider,
   type EmbeddingProviderRuntime,
 } from "./embeddings.js";
+import { MemoryIndexDatabase } from "./manager-database-context.js";
 import {
   cleanupAgedMemoryReindexTempFiles,
   closeMemoryDatabase,
@@ -43,11 +44,7 @@ import {
   type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
 import { MemoryManagerSourceSyncOps } from "./manager-source-sync-ops.js";
-import {
-  MEMORY_INDEX_META_KEY,
-  MemoryIndexDatabase,
-  type MemorySyncProgressState,
-} from "./manager-sync-base.js";
+import { MEMORY_INDEX_META_KEY, type MemorySyncProgressState } from "./manager-sync-base.js";
 import {
   markMemoryTargetArchiveFilesDirty,
   runMemoryTargetedSessionSync,
@@ -532,7 +529,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       shadow.fts.enabled = this.fts.enabled;
       // Only the awaited rebuild inherits the shadow. Concurrent searches and
       // status keep the published handle and its vector/FTS/metadata state.
-      const { nextMeta, vectorIndexComplete } = await this.withReindexDatabase(shadow, async () => {
+      const rebuilt = await this.withReindexDatabase(shadow, async () => {
         try {
           this.ensureSchema();
           await this.seedEmbeddingCache(originalDb);
@@ -622,7 +619,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         }),
       );
 
-      if (vectorIndexComplete) {
+      if (rebuilt.vectorIndexComplete) {
         // Publish completeness only after the shadow tables committed. A crash
         // before this point leaves the rebuild marker conservative and retryable.
         markMemoryVectorIndexClean(originalDb);
@@ -631,7 +628,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       this.resetVectorState();
       this.fts.available = shadow.fts.available;
       this.fts.loadError = shadow.fts.loadError;
-      this.vector.dims = nextMeta.vectorDims;
+      this.vector.dims = rebuilt.nextMeta.vectorDims;
     } catch (err) {
       if (tempDb && !tempDbClosed) {
         try {

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -43,7 +43,11 @@ import {
   type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
 import { MemoryManagerSourceSyncOps } from "./manager-source-sync-ops.js";
-import { MEMORY_INDEX_META_KEY, type MemorySyncProgressState } from "./manager-sync-base.js";
+import {
+  MEMORY_INDEX_META_KEY,
+  MemoryIndexDatabase,
+  type MemorySyncProgressState,
+} from "./manager-sync-base.js";
 import {
   markMemoryTargetArchiveFilesDirty,
   runMemoryTargetedSessionSync,
@@ -517,110 +521,94 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       { reason: params.reason, force: params.force },
       true,
     );
-    const originalState = {
-      ftsAvailable: this.fts.available,
-      ftsError: this.fts.loadError,
-      lastMetaSerialized: this.lastMetaSerialized,
-      vectorAvailable: this.vector.available,
-      vectorLoadError: this.vector.loadError,
-      vectorDims: this.vector.dims,
-      vectorDegradedWriteWarningShown: this.vectorDegradedWriteWarningShown,
-      vectorReady: this.vectorReady,
-    };
-    const restoreOriginalState = () => {
-      this.db = originalDb;
-      this.fts.available = originalState.ftsAvailable;
-      this.fts.loadError = originalState.ftsError;
-      this.lastMetaSerialized = originalState.lastMetaSerialized;
-      this.vector.available = originalState.vectorAvailable;
-      this.vector.loadError = originalState.vectorLoadError;
-      this.vector.dims = originalState.vectorDims;
-      this.vectorDegradedWriteWarningShown = originalState.vectorDegradedWriteWarningShown;
-      this.vectorReady = originalState.vectorReady;
-    };
     try {
       cleanupAgedMemoryReindexTempFiles(dbPath);
       reindexLock = acquireMemoryReindexLock(dbPath);
       const originalRevision = readMemoryDatabaseRevision(originalDb);
       tempDb = openMemoryDatabaseAtPath(tempDbPath, this.settings.store.vector.enabled);
-      this.db = tempDb;
-      this.lastMetaSerialized = null;
-      this.resetVectorState();
-      this.fts.available = false;
-      this.fts.loadError = undefined;
-      this.ensureSchema();
-      await this.seedEmbeddingCache(originalDb);
+      const shadow = new MemoryIndexDatabase(tempDb);
+      shadow.vector.enabled = this.vector.enabled;
+      shadow.vector.extensionPath = this.vector.extensionPath;
+      shadow.fts.enabled = this.fts.enabled;
+      // Only the awaited rebuild inherits the shadow. Concurrent searches and
+      // status keep the published handle and its vector/FTS/metadata state.
+      const { nextMeta, vectorIndexComplete } = await this.withReindexDatabase(shadow, async () => {
+        try {
+          this.ensureSchema();
+          await this.seedEmbeddingCache(originalDb);
 
-      const shouldSyncMemory = shouldRetryMemoryOnFailure;
-      const shouldSyncSessions = shouldRetrySessionsOnFailure;
+          const shouldSyncMemory = shouldRetryMemoryOnFailure;
+          const shouldSyncSessions = shouldRetrySessionsOnFailure;
 
-      if (this.shouldDeferSourceWideBatch()) {
-        await this.executeSourceWideSync({
-          shouldSyncMemory,
-          shouldSyncSessions,
-          needsFullReindex: true,
-          progress: params.progress,
-        });
-        if (shouldSyncMemory) {
-          this.clearMemoryRetryState();
-        }
-        if (shouldSyncSessions) {
-          this.clearSessionRetryState();
-        } else {
-          this.refreshSessionDirtyFlag();
-        }
-      } else {
-        if (shouldSyncMemory) {
-          await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
-          this.clearMemoryRetryState();
-        }
+          if (this.shouldDeferSourceWideBatch()) {
+            await this.executeSourceWideSync({
+              shouldSyncMemory,
+              shouldSyncSessions,
+              needsFullReindex: true,
+              progress: params.progress,
+            });
+            if (shouldSyncMemory) {
+              this.clearMemoryRetryState();
+            }
+            if (shouldSyncSessions) {
+              this.clearSessionRetryState();
+            } else {
+              this.refreshSessionDirtyFlag();
+            }
+          } else {
+            if (shouldSyncMemory) {
+              await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
+              this.clearMemoryRetryState();
+            }
 
-        if (shouldSyncSessions) {
-          await this.syncArchiveFiles({ needsFullReindex: true, progress: params.progress });
-          this.clearSessionRetryState();
-        } else {
-          this.refreshSessionDirtyFlag();
-        }
-      }
-      if (!shouldSyncMemory) {
-        this.clearMemoryRetryState();
-      }
-      const vectorIndexComplete = this.vector.available === true;
-      const syncProvider = this.syncProviderGeneration
-        ? this.syncProviderGeneration.provider
-        : this.provider;
-      const nextMeta: MemoryIndexMeta = {
-        model: syncProvider?.model ?? "fts-only",
-        provider: syncProvider?.id ?? "none",
-        providerKey: this.syncProviderGeneration
-          ? this.syncProviderGeneration.providerKey
-          : this.providerKey!,
-        sources: resolveConfiguredSourcesForMeta(this.sources),
-        scopeHash: resolveConfiguredScopeHash({
-          workspaceDir: this.workspaceDir,
-          extraPaths: this.settings.extraPaths,
-          multimodal: {
-            enabled: this.settings.multimodal.enabled,
-            modalities: this.settings.multimodal.modalities,
-            maxFileBytes: this.settings.multimodal.maxFileBytes,
-          },
-        }),
-        chunkTokens: this.settings.chunking.tokens,
-        chunkOverlap: this.settings.chunking.overlap,
-        chunkingVersion: MEMORY_CHUNKING_VERSION,
-        ftsTokenizer: this.settings.store.fts.tokenizer,
-        provenanceVersion: MEMORY_INDEX_PROVENANCE_VERSION,
-      };
-      if (this.vector.available && this.vector.dims) {
-        nextMeta.vectorDims = this.vector.dims;
-      }
+            if (shouldSyncSessions) {
+              await this.syncArchiveFiles({ needsFullReindex: true, progress: params.progress });
+              this.clearSessionRetryState();
+            } else {
+              this.refreshSessionDirtyFlag();
+            }
+          }
+          if (!shouldSyncMemory) {
+            this.clearMemoryRetryState();
+          }
+          const vectorIndexComplete = this.vector.available === true;
+          const syncProvider = this.syncProviderGeneration
+            ? this.syncProviderGeneration.provider
+            : this.provider;
+          const nextMeta: MemoryIndexMeta = {
+            model: syncProvider?.model ?? "fts-only",
+            provider: syncProvider?.id ?? "none",
+            providerKey: this.syncProviderGeneration
+              ? this.syncProviderGeneration.providerKey
+              : this.providerKey!,
+            sources: resolveConfiguredSourcesForMeta(this.sources),
+            scopeHash: resolveConfiguredScopeHash({
+              workspaceDir: this.workspaceDir,
+              extraPaths: this.settings.extraPaths,
+              multimodal: {
+                enabled: this.settings.multimodal.enabled,
+                modalities: this.settings.multimodal.modalities,
+                maxFileBytes: this.settings.multimodal.maxFileBytes,
+              },
+            }),
+            chunkTokens: this.settings.chunking.tokens,
+            chunkOverlap: this.settings.chunking.overlap,
+            chunkingVersion: MEMORY_CHUNKING_VERSION,
+            ftsTokenizer: this.settings.store.fts.tokenizer,
+            provenanceVersion: MEMORY_INDEX_PROVENANCE_VERSION,
+          };
+          if (this.vector.available && this.vector.dims) {
+            nextMeta.vectorDims = this.vector.dims;
+          }
 
-      this.writeMeta(nextMeta);
-      this.pruneEmbeddingCacheIfNeeded?.();
-      const nextFtsState = {
-        available: this.fts.available,
-        loadError: this.fts.loadError,
-      };
+          this.writeMeta(nextMeta);
+          this.pruneEmbeddingCacheIfNeeded?.();
+          return { nextMeta, vectorIndexComplete };
+        } finally {
+          // Escaped continuations must fail closed, never write to the live DB.
+          shadow.closed = true;
+        }
+      });
 
       closeMemoryDatabase(tempDb);
       tempDbClosed = true;
@@ -630,19 +618,19 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
           sourcePath: tempDbPath,
           metaKey: MEMORY_INDEX_META_KEY,
           expectedRevision: originalRevision,
-          vectorExtensionPath: this.vector.extensionPath,
+          vectorExtensionPath: shadow.vector.extensionPath,
         }),
       );
 
-      this.db = originalDb;
       if (vectorIndexComplete) {
         // Publish completeness only after the shadow tables committed. A crash
         // before this point leaves the rebuild marker conservative and retryable.
         markMemoryVectorIndexClean(originalDb);
       }
+      this.database.lastMetaSerialized = null;
       this.resetVectorState();
-      this.fts.available = nextFtsState.available;
-      this.fts.loadError = nextFtsState.loadError;
+      this.fts.available = shadow.fts.available;
+      this.fts.loadError = shadow.fts.loadError;
       this.vector.dims = nextMeta.vectorDims;
     } catch (err) {
       if (tempDb && !tempDbClosed) {
@@ -651,7 +639,6 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
           tempDbClosed = true;
         } catch {}
       }
-      restoreOriginalState();
       this.restoreReindexRetryState(originalRetryState);
       this.markFailedFullReindexRetry({
         memory: shouldRetryMemoryOnFailure,

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -82,7 +82,7 @@ vi.mock("./embeddings.js", () => ({
   createEmbeddingProvider: vi.fn(),
 }));
 
-import { MemoryIndexDatabase } from "./manager-sync-base.js";
+import { MemoryIndexDatabase } from "./manager-database-context.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -82,6 +82,7 @@ vi.mock("./embeddings.js", () => ({
   createEmbeddingProvider: vi.fn(),
 }));
 
+import { MemoryIndexDatabase } from "./manager-sync-base.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 
 type MemoryIndexEntry = {
@@ -123,11 +124,10 @@ class SessionSyncYieldHarness extends MemoryManagerSyncOps {
     pollIntervalMs: 0,
     timeoutMs: 0,
   };
-  protected readonly vector = { enabled: false, available: false };
   protected readonly cache = { enabled: false };
   protected providerUnavailableReason?: string;
   protected providerLifecycle = { mode: "active" as const, providerId: "test" };
-  protected db = createDbMock();
+  protected publishedDatabase = new MemoryIndexDatabase(createDbMock());
 
   readonly indexedPaths: string[] = [];
   private corpusFiles: string[] = [];
@@ -199,11 +199,10 @@ class SessionSyncYieldHarness extends MemoryManagerSyncOps {
 
 class EmbeddingCacheSeedHarness extends SessionSyncYieldHarness {
   protected override readonly cache = { enabled: true };
-  protected override db: DatabaseSync;
 
   constructor(db: DatabaseSync) {
     super(() => {});
-    this.db = db;
+    this.publishedDatabase = new MemoryIndexDatabase(db);
   }
 
   async seedCache(sourceDb: DatabaseSync): Promise<void> {

--- a/extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts
+++ b/extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts
@@ -261,11 +261,11 @@ describe("memory legacy migration cleanup", () => {
     });
     expect(managerLoaded.ok, managerLoaded.error).toBe(true);
     db.close();
-    Reflect.set(manager, "db", vectorDb);
+    Reflect.set(Reflect.get(manager, "database"), "db", vectorDb);
     vectorState.enabled = true;
     vectorState.available = true;
     vectorState.extensionPath = vectorExtensionPath;
-    Reflect.set(manager, "vectorReady", null);
+    Reflect.set(Reflect.get(manager, "database"), "vectorReady", null);
     await expect(
       (
         manager as unknown as {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -23,6 +23,7 @@ import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js
 import type { EmbeddingProvider, EmbeddingProviderRequest } from "./embeddings.js";
 import { awaitPendingManagerWork } from "./manager-async-state.js";
 import { MEMORY_BATCH_FAILURE_LIMIT } from "./manager-batch-state.js";
+import { MemoryIndexDatabase } from "./manager-database-context.js";
 import { closeMemoryDatabase } from "./manager-db.js";
 import {
   clearMemoryEmbeddingProbeCache,
@@ -47,7 +48,6 @@ import {
   resolveInitialMemoryDirty,
   resolveStatusProviderInfo,
 } from "./manager-status-state.js";
-import { MemoryIndexDatabase } from "./manager-sync-base.js";
 import { enqueueMemoryTargetedSessionSync } from "./manager-sync-control.js";
 import { resolvePersistedMemoryVectorIndexState } from "./manager-vector-rebuild-state.js";
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1,5 +1,4 @@
 // Memory Core plugin module implements the concrete memory index manager.
-import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import {
   createSubsystemLogger,
@@ -48,6 +47,7 @@ import {
   resolveInitialMemoryDirty,
   resolveStatusProviderInfo,
 } from "./manager-status-state.js";
+import { MemoryIndexDatabase } from "./manager-sync-base.js";
 import { enqueueMemoryTargetedSessionSync } from "./manager-sync-control.js";
 import { resolvePersistedMemoryVectorIndexState } from "./manager-vector-rebuild-state.js";
 
@@ -110,16 +110,8 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   protected batchFailureLastError?: string;
   protected batchFailureLastProvider?: string;
   protected batchFailureLock: Promise<void> = Promise.resolve();
-  protected db: DatabaseSync;
+  protected publishedDatabase: MemoryIndexDatabase;
   protected readonly cache: { enabled: boolean; maxEntries?: number };
-  protected readonly vector: {
-    enabled: boolean;
-    available: boolean | null;
-    semanticAvailable?: boolean;
-    extensionPath?: string;
-    loadError?: string;
-    dims?: number;
-  };
   protected indexIdentityDirty = false;
   protected sessionWarm = new Set<string>();
   private syncing: Promise<void> | null = null;
@@ -218,7 +210,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     for (const source of effectiveSettings.sources) {
       this.sources.add(source);
     }
-    this.db = this.openDatabase();
+    this.publishedDatabase = new MemoryIndexDatabase(this.openDatabase());
     try {
       this.providerKey = this.computeProviderKey();
       this.cache = {
@@ -227,11 +219,8 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       };
       this.fts.enabled = effectiveSettings.query.hybrid.enabled;
       this.ensureSchema();
-      this.vector = {
-        enabled: effectiveSettings.store.vector.enabled,
-        available: null,
-        extensionPath: effectiveSettings.store.vector.extensionPath,
-      };
+      this.vector.enabled = effectiveSettings.store.vector.enabled;
+      this.vector.extensionPath = effectiveSettings.store.vector.extensionPath;
       const meta = this.readMeta();
       if (meta?.vectorDims) {
         this.vector.dims = meta.vectorDims;
@@ -285,6 +274,10 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   }
 
   async sync(params?: MemorySyncParams): Promise<void> {
+    return await this.withPublishedDatabase(() => this.syncPublished(params));
+  }
+
+  private async syncPublished(params?: MemorySyncParams): Promise<void> {
     if (this.closing || this.closed) {
       return;
     }
@@ -449,6 +442,10 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   }
 
   status(): MemoryProviderStatus {
+    return this.withPublishedDatabase(() => this.publishedStatus());
+  }
+
+  private publishedStatus(): MemoryProviderStatus {
     if (this.embeddingBootstrapFailure) {
       this.refreshKeywordFallbackIndexIdentity();
     } else {
@@ -570,7 +567,9 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       await existingClose;
       return;
     }
-    const closeOperation = this.closeTeardownComplete ? this.retryFailedClose() : this.closeOnce();
+    const closeOperation = this.withPublishedDatabase(() =>
+      this.closeTeardownComplete ? this.retryFailedClose() : this.closeOnce(),
+    );
     this.closePromise = closeOperation;
     try {
       await closeOperation;

--- a/extensions/memory-core/src/memory/source-filter.ts
+++ b/extensions/memory-core/src/memory/source-filter.ts
@@ -1,0 +1,14 @@
+// Memory Core source filtering shared by the manager and subprocess request validation tests.
+import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+
+export function buildMemorySourceFilter(
+  alias: string | undefined,
+  sources: readonly MemorySource[],
+): { sql: string; params: MemorySource[] } {
+  if (sources.length === 0) {
+    return { sql: "", params: [] };
+  }
+  const column = alias ? `${alias}.source` : "source";
+  const placeholders = sources.map(() => "?").join(", ");
+  return { sql: ` AND ${column} IN (${placeholders})`, params: [...sources] };
+}

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -108,6 +108,7 @@ const requiredPathGroups = [
   "dist/agents/compaction-planning.worker.js",
   "dist/agents/model-provider-auth.worker.js",
   "dist/agents/prepared-model-catalog.worker.js",
+  "dist/extensions/memory-core/memory-search-knn.child.js",
   "dist/config/sessions/session-accessor.sqlite-archive.worker.js",
   "dist/config/sessions/session-transcript-reconcile.worker.js",
   "dist/state/openclaw-database-verify.worker.js",

--- a/src/plugin-sdk/process-runtime.ts
+++ b/src/plugin-sdk/process-runtime.ts
@@ -12,5 +12,6 @@ export {
 } from "../process/exec.js";
 export { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 export type { OomScoreAdjustedSpawn, OomWrapOptions } from "../process/linux-oom-score.js";
+export { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 export { killProcessTree } from "../process/kill-tree.js";
 export { isPidAlive } from "../shared/pid-alive.js";

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -755,6 +755,7 @@ describe("collectMissingPackPaths", () => {
         "dist/agents/compaction-planning.worker.js",
         "dist/agents/model-provider-auth.worker.js",
         "dist/agents/prepared-model-catalog.worker.js",
+        "dist/extensions/memory-core/memory-search-knn.child.js",
         "dist/config/sessions/session-accessor.sqlite-archive.worker.js",
         "dist/config/sessions/session-transcript-reconcile.worker.js",
         "dist/state/openclaw-database-verify.worker.js",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -596,6 +596,8 @@ function buildUnifiedDistEntries(): Record<string, string> {
           "plugin-sdk/qa-runtime": "src/plugin-sdk/qa-runtime.ts",
         }
       : {}),
+    "extensions/memory-core/memory-search-knn.child":
+      "extensions/memory-core/src/memory/manager-search-knn.child.ts",
     ...listBundledPluginEntrySources(rootBundledPluginBuildEntries),
     "extensions/browser/native-host-entry": "extensions/browser/native-host-entry.ts",
     ...bundledHookEntries,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where builtin memory search can freeze the Gateway while a cold sqlite-vec query runs. The native KNN/count/widening sequence uses synchronous SQLite, so the same event loop cannot service the search deadline until it returns. Related: #81172; #83758 repaired the separate JavaScript fallback, not native KNN.

Review also reproduced a reader-lifetime regression exposed by asynchronous KNN: forced reindex temporarily made its shadow database the manager's global database. A query could receive real child results and then lose them when provenance enrichment touched the now-closed shadow connection.

## Why This Change Was Made

The native query runs in a bounded, one-shot read-only child. The Gateway retains its event loop and can terminate the owned child on cancellation. There are at most two admitted children; only the authoritative close event releases admission, including when the caller's cleanup timeout expires. The child launches no descendants. Detached process groups, graceful tree termination, recycled-PID probes, and production-only test hooks were removed.

Published database state now has one stable owner. An owner-scoped async context selects the shadow database only inside the awaited rebuild; public operations leave that context. Closed shadow work fails rather than redirecting writes into the published database. Reindex publishes atomically under the existing workspace lock and invalidates the published metadata/vector/FTS state. No schema, schema version, config, migration, or provider API changes are introduced. The maintainer explicitly accepted this concurrency design.

The child reuses the runtime-worker resolver and SQLite opener, uses no shell, excludes parent credentials/Gateway variables, bounds its input/output and result rows, and never retries native KNN on the Gateway thread. Non-abort failures are logged and leave an empty vector stage so existing keyword/hybrid retrieval can continue.

## User Impact

Search cancellation can run while native SQLite is busy, and concurrent reindexing no longer exposes temporary shadow connections to public search/status operations. Existing source filtering, provenance, hybrid search, keyword/path search, and JavaScript fallback remain in place. One-shot process startup adds latency; this is cancellation isolation, not a claim that cold native queries become faster.

## Evidence

Candidate: `5f101607d482c81cb049075788b6c095a3d44b1f`. The stack was first rebased onto `18c801daa1165f0bb7f30576b52f6642ff023233`, preserving the newer embedding interface and workspace publication lock. After its green CI, GitHub rejected the merge because new main changes conflicted. The final mechanical rebase onto `b581ff0be723060b5b03d3de5cebfd04db643006` preserves the moved shared table-existence helper and dynamic-provider status fixes. Range-diff shows only helper-move context; all 33 tests in five affected suites and fresh Codex review passed afterward.

**Regression and local verification:** The real SQLite reindex/search interleaving failed on the submitted head and passes after the owner repair. It verifies that real child hits survive shadow closure/publication and that public status and lexical searches invoked from a rebuild callback use the published index. Twelve memory suites passed 202/202 on Node 24.19.0. After the final context-module extraction and CI lint/import repairs, three focused memory suites passed 31/31 and the plugin-boundary suite passed 10/10. Targeted typed lint, the extension import guard, formatting, and fresh Codex review passed. The automated review threshold was P0; manual source/lifecycle review and the reproduced P1 repair provide the broader review evidence.

**Installed Linux package, real provider and Gateway:** A clean package built from `b868cb292ddc1e3e3c988ab36dbde79289815f59` passed package integrity and was installed into a disposable npm prefix on Node 24.19.0. Real OpenAI `text-embedding-3-small` indexed a synthetic note. The packaged CLI returned it for a semantic query with no meaningful lexical overlap. Authenticated Gateway `memory_search` returned it before, during, and after forced CLI reindex. During overlapping searches/publication, 236 Gateway health requests completed; maximum observed latency was 154 ms. Run `run_1b28f50adf85` exited 0. The subsequent commit only extracts the same context owner and repairs lint/test imports; it does not alter the verified query or publication behavior.

```json
{"platform":"linux","node":"v24.19.0","provider":"openai","model":"text-embedding-3-small","cliSemanticRecall":"pass","gatewayRecallBeforeDuringAfterReindex":"pass","healthChecks":236,"maxHealthLatencyMs":154}
```

**Windows lifecycle and native SQLite:** Windows 11 ARM64, official Node 24.19.0 x64 under emulation, sqlite-vec 0.1.9 / SQLite 3.53.3. Exact built parent code plus the actual packaged child were re-bundled for an isolated harness; this is not full npm/Gateway installation proof. Three readiness-confirmed synchronous-work fixture cancellations reaped in 17.66/7.54/10.44 ms with responsive parent heartbeats. Two-slot admission and queued abort spawned no extra child. Three subsequent real SQLite children verified source filtering and WAL visibility before/after commit. Eight children total, zero left alive. The first isolated bundle attempt lacked a dynamic package dependency; staging the exact dependency files fixed that harness issue.

```json
{"platform":"win32","node":"v24.19.0","abortReapMs":[17.66,7.54,10.44],"queuedAbortSpawnedExtraChild":false,"nativeQueriesPassed":3,"totalChildren":8,"liveChildrenAtEnd":0}
```

The Linux machine was stopped; temporary credential handling was closed; Windows task files were removed and the VM returned to its original suspended state. No real user memory was used.

**CI:** [Previous-head CI](https://github.com/openclaw/openclaw/actions/runs/33033737084) completed successfully at `c5e7d99fbb048c9c38dfbb859911c043ce9b5bf1`. [Rebased-head CI](https://github.com/openclaw/openclaw/actions/runs/33035356574) also completed successfully at `5f101607d482c81cb049075788b6c095a3d44b1f`, with no pending or failing PR checks. The previous run exposed typed lint and a forbidden test-helper import; both were fixed and locally verified. An earlier local all-changed gate was invalidated by the review checkout and is not counted as passing.

**Limits:** No Gateway-parent-death proof, full Windows Gateway installation, or production-scale cold-cache recall improvement is claimed. The contributor's earlier packaged benchmark measured approximately 0.53 s per one-shot child versus 2.32 ms for a warm direct native query; those are earlier-head measurements, not a fresh benchmark of this candidate. The full-corpus JSON fallback discussed in #113360 remains separate.

## Review disposition

Best-fix verdict: the process boundary is necessary to cancel synchronous native work; published-reader ownership is the canonical place to repair the reindex race. A filename-only change would still allow a shadow file to disappear. Waiting for every public operation inside sync could deadlock searches that themselves call sync. Retrying native work on the main thread would restore the original freeze.

Production/build LOC: +852/-241 (net +611); tests/support +458/-13; docs +8/-0; assertion metadata +1/-1. The database-context extraction is a move, not another runtime path. Net production growth is 34 lines below the submitted PR; the remaining growth implements the actual child/protocol/package boundary and reader ownership rather than an avoidable fallback stack.

Latest ClawSweeper review (`c5e7d99fbb04`, August 27 02:47 UTC): no actionable code findings; its real subprocess suite passed 7/7 twice. Its remaining rank-up move was successful exact-head native/package checks, now satisfied by CI33033737084. Windows abort/reap/WAL proof and the actual-conflict rebase were also completed. The stored-data heuristic does not represent a schema change: this repairs connection/context lifetime only.

Named follow-up: **CLI startup should surface invalid-config diagnostics before plugin-command ownership checks.** The initial live harness supplied unsupported internal config keys and received a misleading “unknown memory command”; correcting it to the documented public config made the installed flow pass. This is a separate CLI diagnostic issue, not a KNN workaround.

Provenance: #69680 added the native MATCH optimization (author @aalekh-sarvam, merged by @steipete on April 23, 2026); synchronous SQLite predates that optimization. The shadow-reader race was made visible by this PR's asynchronous query boundary. Thanks @anyech for the original implementation and SQLite proof; original commit credit is preserved.
