### PR TITLE
perf(process): avoid rescanning exited runs

### DIFF
--- a/src/process/supervisor/registry.test.ts
+++ b/src/process/supervisor/registry.test.ts
@@ -4,12 +4,13 @@ import { createRunRegistry } from "./registry.js";
 
 type RunRegistry = ReturnType<typeof createRunRegistry>;
 
-function addRunningRecord(
+function addRecord(
   registry: RunRegistry,
   params: {
     runId: string;
     sessionId: string;
     startedAtMs: number;
+    state?: "running" | "exited";
     scopeKey?: string;
     backendId?: string;
   },
@@ -19,7 +20,7 @@ function addRunningRecord(
     sessionId: params.sessionId,
     backendId: params.backendId ?? "b1",
     scopeKey: params.scopeKey,
-    state: "running",
+    state: params.state ?? "running",
     startedAtMs: params.startedAtMs,
     lastOutputAtMs: params.startedAtMs,
     createdAtMs: params.startedAtMs,
@@ -30,7 +31,7 @@ function addRunningRecord(
 describe("process supervisor run registry", () => {
   it("finalize is idempotent and preserves first terminal metadata", () => {
     const registry = createRunRegistry();
-    addRunningRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
+    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
 
     registry.finalize("r1", {
       reason: "overall-timeout",
@@ -57,18 +58,55 @@ describe("process supervisor run registry", () => {
     });
   });
 
-  it("prunes oldest exited records once retention cap is exceeded", () => {
+  it("prunes the oldest created exited records after out-of-order exits", () => {
     const registry = createRunRegistry({ maxExitedRecords: 2 });
-    addRunningRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
-    addRunningRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2 });
-    addRunningRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
+    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
+    addRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2 });
+    addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
+    addRecord(registry, { runId: "r4", sessionId: "s4", startedAtMs: 4 });
 
-    registry.finalize("r1", { reason: "exit", exitCode: 0, exitSignal: null });
     registry.finalize("r2", { reason: "exit", exitCode: 0, exitSignal: null });
+    registry.finalize("r3", { reason: "exit", exitCode: 0, exitSignal: null });
+    registry.finalize("r1", { reason: "exit", exitCode: 0, exitSignal: null });
+
+    expect(registry.get("r1")).toBeUndefined();
+    expect(registry.get("r2")?.state).toBe("exited");
+    expect(registry.get("r3")?.state).toBe("exited");
+
+    registry.finalize("r4", { reason: "exit", exitCode: 0, exitSignal: null });
+
+    expect(registry.get("r2")).toBeUndefined();
+    expect(registry.get("r3")?.state).toBe("exited");
+    expect(registry.get("r4")?.state).toBe("exited");
+  });
+
+  it("tracks records added or transitioned into the exited state", () => {
+    const registry = createRunRegistry({ maxExitedRecords: 2 });
+    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1, state: "exited" });
+    addRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2 });
+    addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
+
+    registry.updateState("r2", "exited");
     registry.finalize("r3", { reason: "exit", exitCode: 0, exitSignal: null });
 
     expect(registry.get("r1")).toBeUndefined();
     expect(registry.get("r2")?.state).toBe("exited");
+    expect(registry.get("r3")?.state).toBe("exited");
+  });
+
+  it("tracks exited records replaced or transitioned back to a live state", () => {
+    const registry = createRunRegistry({ maxExitedRecords: 2 });
+    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1, state: "exited" });
+    addRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2, state: "exited" });
+
+    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
+    registry.updateState("r2", "running");
+    addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
+    registry.finalize("r1", { reason: "exit", exitCode: 0, exitSignal: null });
+    registry.finalize("r3", { reason: "exit", exitCode: 0, exitSignal: null });
+
+    expect(registry.get("r1")?.state).toBe("exited");
+    expect(registry.get("r2")?.state).toBe("running");
     expect(registry.get("r3")?.state).toBe("exited");
   });
 });

--- a/src/process/supervisor/registry.ts
+++ b/src/process/supervisor/registry.ts
@@ -41,36 +41,34 @@ type RunRegistry = {
 export function createRunRegistry(options?: { maxExitedRecords?: number }): RunRegistry {
   const records = new Map<string, RunRecord>();
   const maxExitedRecords = resolveMaxExitedRecords(options?.maxExitedRecords);
+  // Keep this exact across every write path so ordinary finalization never scans all records.
+  let exitedRecords = 0;
 
   const pruneExitedRecords = () => {
-    if (!records.size) {
+    if (exitedRecords <= maxExitedRecords) {
       return;
     }
-    let exited = 0;
-    for (const record of records.values()) {
-      if (record.state === "exited") {
-        exited += 1;
-      }
-    }
-    if (exited <= maxExitedRecords) {
-      return;
-    }
-    let remove = exited - maxExitedRecords;
     // Map insertion order is the retention policy: oldest exited records leave first.
     for (const [runId, record] of records.entries()) {
-      if (remove <= 0) {
+      if (exitedRecords <= maxExitedRecords) {
         break;
       }
       if (record.state !== "exited") {
         continue;
       }
       records.delete(runId);
-      remove -= 1;
+      exitedRecords -= 1;
     }
   };
 
   const add: RunRegistry["add"] = (record) => {
+    if (records.get(record.runId)?.state === "exited") {
+      exitedRecords -= 1;
+    }
     records.set(record.runId, { ...record });
+    if (record.state === "exited") {
+      exitedRecords += 1;
+    }
   };
 
   const get: RunRegistry["get"] = (runId) => {
@@ -82,6 +80,11 @@ export function createRunRegistry(options?: { maxExitedRecords?: number }): RunR
     const current = records.get(runId);
     if (!current) {
       return undefined;
+    }
+    if (current.state !== "exited" && state === "exited") {
+      exitedRecords += 1;
+    } else if (current.state === "exited" && state !== "exited") {
+      exitedRecords -= 1;
     }
     const updatedAtMs = nowMs();
     const next: RunRecord = {
@@ -125,6 +128,7 @@ export function createRunRegistry(options?: { maxExitedRecords?: number }): RunR
       updatedAtMs: ts,
     };
     records.set(runId, next);
+    exitedRecords += 1;
     pruneExitedRecords();
   };
 


### PR DESCRIPTION
## What Problem This Solves

The process supervisor retains exited run records for diagnostics. Every completed run currently rescans the entire registry solely to recount those exited records, making repeated process completion quadratic before the 2,000-record retention cap and leaving an unnecessary full retained-set scan afterward.

## Why This Change Was Made

The registry now maintains one exact private exited-record count across additions, replacements, state transitions, effective finalization, and pruning. Pruning still follows `Map` insertion order, so the oldest created exited records leave first; live records, detached snapshots, first terminal metadata, the default cap, and all public types remain unchanged.

## User Impact

Long-running OpenClaw processes that supervise many commands spend less CPU finalizing completed runs. There is no user-visible behavior or configuration change.

## Evidence

- Deterministic complexity probe on exact current `main`: 500/1,000 completions visited 125,250/500,500 registry values before the change and 0 after it.
- Exact base/candidate semantic differential: 1,934-byte snapshots were byte-identical (SHA-256 `530bb25abb5d22d3f8f4becdd42b0e6c4cf1006421950e533b7d698644bf098c`) across out-of-order exits, repeated pruning, replacements, state transitions, detached snapshots, missing IDs, output touches, and idempotent finalization.
- Node 24.15 owner microbenchmark, 250,000 add/finalize operations × 9 alternating rounds: median 2,085.947 ms → 286.546 ms (7.28×, 86.26% reduction). This is a registry-owner microbenchmark, not an end-to-end throughput claim.
- Full process-supervisor suite: 11 files / 149 tests passed (exact base: 11 files / 147 tests passed).
- `node scripts/check-changed.mjs -- src/process/supervisor/registry.ts src/process/supervisor/registry.test.ts`
- `pnpm build`
- Fresh bundled Codex Sol/high autoreview after a clean TruffleHog scan: no accepted/actionable P1+ findings, patch correctness 0.97.
- Test-audit retained behavior-level coverage for insertion-order retention and every count-maintenance path; the implementation-coupled iteration-count probe remains external evidence rather than a committed test.

AI-assisted: yes. @steipete reviewed the owner path, invariant, diff, and verification evidence and understands the change.
