### PR TITLE
feat(ui): configure capabilities before session start [AI-assisted]

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -9005,6 +9005,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let contextwindow: String?
     public let thinkinglevel: String?
     public let permissionmode: SessionPermissionMode?
+    public let tooloverrides: [String: AnyCodable]?
     public let incognito: Bool?
     public let visibility: SessionVisibility?
     public let catalogid: String?
@@ -9034,6 +9035,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         contextwindow: String? = nil,
         thinkinglevel: String? = nil,
         permissionmode: SessionPermissionMode? = nil,
+        tooloverrides: [String: AnyCodable]? = nil,
         incognito: Bool? = nil,
         visibility: SessionVisibility? = nil,
         catalogid: String? = nil,
@@ -9062,6 +9064,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.contextwindow = contextwindow
         self.thinkinglevel = thinkinglevel
         self.permissionmode = permissionmode
+        self.tooloverrides = tooloverrides
         self.incognito = incognito
         self.visibility = visibility
         self.catalogid = catalogid
@@ -9092,6 +9095,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case contextwindow = "contextWindow"
         case thinkinglevel = "thinkingLevel"
         case permissionmode = "permissionMode"
+        case tooloverrides = "toolOverrides"
         case incognito
         case visibility
         case catalogid = "catalogId"

--- a/packages/gateway-protocol/src/schema/sessions-create.test.ts
+++ b/packages/gateway-protocol/src/schema/sessions-create.test.ts
@@ -40,4 +40,24 @@ describe("sessions.create schema", () => {
     );
     expect(validateSessionsCreateParams({ agentId: "main", idempotencyKey: "" })).toBe(false);
   });
+
+  it("accepts initial session tool overrides", () => {
+    expect(
+      validateSessionsCreateParams({
+        agentId: "main",
+        toolOverrides: {
+          mcpServers: { github: false },
+          skills: { release: true },
+          webSearch: false,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it.each([null, { webSearch: "yes" }, { skills: { release: "yes" } }, { unknown: true }])(
+    "rejects malformed initial tool overrides %#",
+    (toolOverrides) => {
+      expect(validateSessionsCreateParams({ agentId: "main", toolOverrides })).toBe(false);
+    },
+  );
 });

--- a/packages/gateway-protocol/src/schema/sessions-create.ts
+++ b/packages/gateway-protocol/src/schema/sessions-create.ts
@@ -2,7 +2,7 @@ import { Type } from "typebox";
 import { closedObject } from "./closed-object.js";
 import { ChatAttachmentsSchema } from "./logs-chat.js";
 import { NonEmptyString, SessionLabelString } from "./primitives.js";
-import { SessionPermissionModeSchema } from "./sessions-row.js";
+import { SessionPermissionModeSchema, SessionToolOverridesSchema } from "./sessions-row.js";
 import { SessionVisibilitySchema } from "./sessions-sharing-values.js";
 
 export const SESSION_CREATE_RETRY_WINDOW_MS = 4 * 60_000;
@@ -19,6 +19,7 @@ export const SessionsCreateParamsSchema = closedObject({
   contextWindow: Type.Optional(NonEmptyString),
   thinkingLevel: Type.Optional(NonEmptyString),
   permissionMode: Type.Optional(SessionPermissionModeSchema),
+  toolOverrides: Type.Optional(SessionToolOverridesSchema),
   incognito: Type.Optional(Type.Boolean()),
   visibility: Type.Optional(SessionVisibilitySchema),
   catalogId: Type.Optional(NonEmptyString),

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -528,7 +528,7 @@ describe("method scope resolution", () => {
     );
   });
 
-  it("requires admin for incognito session creation and inheritance", () => {
+  it("requires admin for sensitive session creation parameters", () => {
     const incognitoKey = "agent:main:dashboard:incognito-parent";
     for (const params of [
       { agentId: "main", incognito: true },
@@ -537,6 +537,7 @@ describe("method scope resolution", () => {
       { parentSessionKey: incognitoKey, fork: true },
       { parentSessionKey: incognitoKey, spawnDepth: 1 },
       { parentSessionKey: incognitoKey, succeedsParent: false, emitCommandHooks: true },
+      { agentId: "main", toolOverrides: { skills: { release: false } } },
     ]) {
       expect(resolveLeastPrivilegeOperatorScopesForMethod("sessions.create", params)).toEqual([
         "operator.admin",

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -539,9 +539,8 @@ describe("method scope resolution", () => {
       { parentSessionKey: incognitoKey, succeedsParent: false, emitCommandHooks: true },
       { agentId: "main", toolOverrides: { skills: { release: false } } },
     ]) {
-      expect(resolveLeastPrivilegeOperatorScopesForMethod("sessions.create", params)).toEqual([
-        "operator.admin",
-      ]);
+      const required = resolveLeastPrivilegeOperatorScopesForMethod("sessions.create", params);
+      expect(required).toEqual(["operator.admin"]);
       expect(
         authorizeOperatorScopesForMethod("sessions.create", ["operator.write"], params),
       ).toEqual({ allowed: false, missingScope: "operator.admin" });

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -541,6 +541,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       spawnedCwd: p.worktree === true ? undefined : sessionCwd,
       sessionRoot: p.worktree === true ? undefined : sessionRoot,
       permissionMode: p.permissionMode ?? (p.worktree === true ? "workspace" : undefined),
+      ...(p.toolOverrides !== undefined ? { toolOverrides: p.toolOverrides } : {}),
       prepareLifecycle,
       onLifecycleCleanupError: (error) => {
         sessionLog.warn(

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1433,6 +1433,86 @@ test("sessions.create rejects draft visibility when policy disables drafts", asy
   });
 });
 
+test("sessions.create persists explicit tool overrides before the first turn", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const parentSessionKey = "agent:main:main";
+  const sessionKey = "agent:main:dashboard:create-tool-overrides";
+  await writeSessionStore({
+    entries: {
+      [parentSessionKey]: sessionStoreEntry("tool-overrides-parent", {
+        toolOverrides: { skills: { inherited: false } },
+      }),
+    },
+  });
+  const requested = {
+    mcpServers: { zeta: false, alpha: true },
+    mcpToolsDeny: { github: ["write", "read", "write"] },
+    skills: { release: false },
+    webSearch: false,
+  };
+  const normalized = {
+    mcpServers: { alpha: true, zeta: false },
+    mcpToolsDeny: { github: ["read", "write"] },
+    skills: { release: false },
+    webSearch: false,
+  };
+  const { chatHandlers } = await import("./server-methods/chat.js");
+  const observed: Array<unknown> = [];
+  const chatSend = vi.spyOn(chatHandlers, "chat.send").mockImplementation(async ({ respond }) => {
+    observed.push(loadSessionEntry({ agentId: "main", sessionKey, storePath })?.toolOverrides);
+    respond(true, { runId: "create-tool-overrides-run", status: "started" });
+  });
+  const client = { client: { connect: { scopes: ["operator.admin"] } } as never };
+
+  try {
+    const created = await directSessionReq<{
+      entry?: { toolOverrides?: unknown };
+      runStarted?: boolean;
+    }>(
+      "sessions.create",
+      {
+        agentId: "main",
+        key: sessionKey,
+        parentSessionKey,
+        message: "run with the selected capabilities",
+        toolOverrides: requested,
+      },
+      client,
+    );
+
+    expect(created).toMatchObject({
+      ok: true,
+      payload: { entry: { toolOverrides: normalized }, runStarted: true },
+    });
+    expect(observed).toEqual([normalized]);
+    expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })?.toolOverrides).toEqual(
+      normalized,
+    );
+
+    const retried = await directSessionReq(
+      "sessions.create",
+      { agentId: "main", key: sessionKey, toolOverrides: requested },
+      client,
+    );
+    expect(retried.ok).toBe(true);
+
+    const mismatch = await directSessionReq(
+      "sessions.create",
+      { agentId: "main", key: sessionKey, toolOverrides: { skills: { release: true } } },
+      client,
+    );
+    expect(mismatch).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "sessions.create toolOverrides requires a new session",
+      },
+    });
+  } finally {
+    chatSend.mockRestore();
+  }
+});
+
 test("sessions.create rolls back failed provisioning before a same-key creator proceeds", async () => {
   const openClawState = await createOpenClawTestState({
     layout: "state-only",

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -27,7 +28,11 @@ import {
   forkSessionFromParentWithDecision,
   MODEL_SELECTION_LOCKED_PARENT_FORK_MESSAGE,
 } from "../auto-reply/reply/session-fork.js";
-import type { InternalSessionEntry, SessionEntry } from "../config/sessions.js";
+import type {
+  InternalSessionEntry,
+  SessionEntry,
+  SessionToolOverrides,
+} from "../config/sessions.js";
 import { resolveAgentMainSessionKey } from "../config/sessions/main-session.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import {
@@ -314,6 +319,7 @@ export async function createGatewaySession(params: {
   spawnedCwd?: string;
   sessionRoot?: string;
   permissionMode?: SessionEntry["permissionMode"];
+  toolOverrides?: SessionToolOverrides;
   /** Prepares session-owned resources while the target lifecycle fence is held. */
   prepareLifecycle?: PrepareGatewaySessionLifecycle;
   onLifecycleCleanupError?: (error: unknown) => void;
@@ -360,6 +366,7 @@ export async function createGatewaySession(params: {
   const requestedKey = normalizeOptionalString(params.key);
   const parentSessionKey = normalizeOptionalString(params.parentSessionKey);
   const projectId = normalizeOptionalString(params.projectId);
+  const requestedToolOverrides = params.toolOverrides !== undefined;
   const explicitAgentId = params.agentId;
   const normalizedExplicitAgentId = normalizeOptionalString(explicitAgentId);
   const explicitKeyAgentId = parseAgentSessionKey(requestedKey)?.agentId;
@@ -679,6 +686,7 @@ export async function createGatewaySession(params: {
     params.emitCommandHooks === true &&
     !requestedKey &&
     params.resetMainWhenUnspecified === true &&
+    !requestedToolOverrides &&
     !parentIncognito &&
     // Catalog targets need a fresh locked row; resetting main would return before
     // the catalog-owned model/runtime pair is persisted.
@@ -1066,12 +1074,27 @@ export async function createGatewaySession(params: {
             ...((catalogModel ?? requestedModel) ? { model: catalogModel ?? requestedModel } : {}),
             ...(requestedContextWindow ? { contextWindow: requestedContextWindow } : {}),
             ...(requestedThinkingLevel ? { thinkingLevel: requestedThinkingLevel } : {}),
+            ...(requestedToolOverrides ? { toolOverrides: params.toolOverrides } : {}),
           },
           loadGatewayModelCatalog: params.loadGatewayModelCatalog,
           authorizedAgentHarnessId: params.authorizedAgentHarnessId,
         });
         if (!patched.ok) {
           return patched;
+        }
+        if (
+          requestedToolOverrides &&
+          existingEntry !== undefined &&
+          stableStringify(existingEntry.toolOverrides) !==
+            stableStringify(patched.entry.toolOverrides)
+        ) {
+          return {
+            ok: false,
+            error: errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              "sessions.create toolOverrides requires a new session",
+            ),
+          };
         }
         sessionEntries[target.canonicalKey] = patched.entry;
         const execNode = normalizeOptionalString(params.execNode);
@@ -1202,6 +1225,9 @@ export async function createGatewaySession(params: {
           !canonicalParentSessionKey || catalogModel || normalizeOptionalString(params.model)
             ? {}
             : inheritSessionSelection(currentParentSessionEntry);
+        if (requestedToolOverrides) {
+          delete inheritedSelection.toolOverrides;
+        }
         const entry: SessionEntry = {
           ...initializedEntry,
           ...inheritedSelection,

--- a/src/shared/session-method-scopes-base.ts
+++ b/src/shared/session-method-scopes-base.ts
@@ -68,6 +68,7 @@ function resolveSessionsCreateRequiredScope(params: unknown): SessionMutationOpe
     (typeof params.parentSessionKey === "string" &&
       isIncognitoSessionKey(params.parentSessionKey)) ||
     Object.hasOwn(params, "execNode") ||
+    Object.hasOwn(params, "toolOverrides") ||
     params.permissionMode === "full"
   ) {
     return "operator.admin";

--- a/ui/src/e2e/new-session-page.capability-menu.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.capability-menu.e2e.test.ts
@@ -1,0 +1,106 @@
+import { expect, it } from "vitest";
+import {
+  createNewSessionPageE2eSuite,
+  installMockGateway,
+} from "./new-session-page.test-support.ts";
+
+const suite = createNewSessionPageE2eSuite();
+
+suite.define(() => {
+  it("creates the first turn with Draft and selected capabilities atomically", async () => {
+    await suite.withPage({ viewport: { width: 555, height: 1200 } }, async ({ page }) => {
+      const config = {
+        mcp: {
+          servers: {
+            github: { enabled: true, url: "https://mcp.example.test" },
+          },
+        },
+        tools: { web: { search: { provider: "brave" } } },
+      };
+      const gateway = await installMockGateway(page, {
+        allowedSessionVisibilities: ["shared", "draft"],
+        hasMultipleSessionSharingIdentities: true,
+        operatorScopes: ["operator.read", "operator.write", "operator.admin"],
+        methodResponses: {
+          "config.get": {
+            raw: JSON.stringify(config),
+            hash: "new-session-capabilities",
+            sourceConfig: config,
+            runtimeConfig: config,
+            config,
+          },
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [
+              {
+                name: "Release",
+                description: "Prepare a release",
+                source: "test",
+                filePath: "/tmp/openclaw-e2e/skills/release/SKILL.md",
+                baseDir: "/tmp/openclaw-e2e/skills/release",
+                skillKey: "release",
+                always: false,
+                disabled: false,
+                blockedByAllowlist: false,
+                eligible: true,
+                requirements: { anyBins: [], bins: [], env: [], config: [], os: [] },
+                missing: { anyBins: [], bins: [], env: [], config: [], os: [] },
+                configChecks: [],
+                install: [],
+              },
+            ],
+          },
+          "sessions.create": {
+            key: "agent:main:new-session-capabilities",
+            runStarted: true,
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}new`);
+      const composer = page.locator(".new-session-page__composer");
+      const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+      await composer.getByRole("button", { name: "Add attachment" }).click();
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("root");
+
+      await menu.getByRole("menuitem", { name: "Draft" }).click();
+      await menu.getByRole("menuitem", { name: /^Skills/ }).click();
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("skills");
+      const release = menu.getByRole("menuitem", { name: "Release" });
+      await expect.poll(() => release.isEnabled()).toBe(true);
+      await release.click();
+      await menu.getByRole("menuitem", { name: "Back" }).click();
+
+      await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("connectors");
+      await menu.getByRole("menuitem", { name: /^github/ }).click();
+      await menu.getByRole("menuitem", { name: "Back" }).click();
+      await menu.getByRole("menuitemcheckbox", { name: "Web search" }).click();
+
+      await expect
+        .poll(async () =>
+          (await composer.locator(".new-session-page__selection-status").allTextContents()).map(
+            (text) => text.replace(/\s+/g, " ").trim(),
+          ),
+        )
+        .toEqual(["Draft", "3 session overrides"]);
+      await page.locator(".new-session-page__message").fill("prepare the release");
+      await composer.getByRole("button", { name: "Start session" }).click();
+
+      const create = await gateway.waitForRequest("sessions.create");
+      expect(create.params).toMatchObject({
+        agentId: "main",
+        message: "prepare the release",
+        visibility: "draft",
+        toolOverrides: {
+          mcpServers: { github: false },
+          skills: { release: false },
+          webSearch: false,
+        },
+      });
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
+      expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+    });
+  });
+});

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -290,13 +290,22 @@ suite.define(() => {
       });
     });
     const worktreePath = "/home/peter/.openclaw/worktrees/terminal-e2e";
+    const config = { tools: { web: { search: { provider: "brave" } } } };
     const gateway = await installMockGateway(page, {
       cliAgentsEnabled: true,
       terminalEnabled: true,
+      operatorScopes: ["operator.read", "operator.write", "operator.admin"],
       workspace: WORKSPACE,
       workspaceGit: true,
       featureMethods: [...TERMINAL_START_FEATURE_METHODS],
       methodResponses: {
+        "config.get": {
+          raw: JSON.stringify(config),
+          hash: "terminal-capability-overrides",
+          sourceConfig: config,
+          runtimeConfig: config,
+          config,
+        },
         "agents.list": {
           agents: [
             {
@@ -362,6 +371,23 @@ suite.define(() => {
       await placePopover.getByLabel("Worktree name").fill("terminal-task");
       await page.locator("#new-session-detail-trigger").click();
       await page.locator(".new-session-page__message").fill("  inspect the checkout  ");
+
+      const composer = page.locator(".new-session-page__composer");
+      const capabilityMenu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+      await composer.getByRole("button", { name: "Add attachment" }).click();
+      await capabilityMenu.getByRole("menuitemcheckbox", { name: "Web search" }).click();
+      await page.keyboard.press("Escape");
+      const terminalTrigger = page.getByRole("button", { name: "Start in terminal" });
+      await expect.poll(() => terminalTrigger.isDisabled()).toBe(true);
+      const terminalTooltip = page.locator("openclaw-tooltip").filter({ has: terminalTrigger });
+      await expect
+        .poll(() => terminalTooltip.evaluate((element) => element.getAttribute("content")))
+        .toBe("Clear session capability overrides before starting in a terminal.");
+      expect(await gateway.getRequests("sessions.catalog.startTerminal")).toHaveLength(0);
+      await composer.getByRole("button", { name: /session options/ }).click();
+      await capabilityMenu.getByRole("menuitemcheckbox", { name: "Web search" }).click();
+      await page.keyboard.press("Escape");
+      await expect.poll(() => terminalTrigger.isEnabled()).toBe(true);
 
       if (captureCliAgentsProof) {
         await page.screenshot({

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -297,6 +297,21 @@ export async function replaceGatewayClient(page: Page) {
   });
 }
 
+export async function openNewSessionPlusMenu(page: Page) {
+  const composer = page.locator(".new-session-page__composer");
+  const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+  await composer.getByRole("button", { name: "Add attachment" }).click();
+  await expect.poll(() => menu.getAttribute("data-view")).toBe("root");
+  return menu;
+}
+
+export async function selectNewSessionDraft(page: Page) {
+  const menu = await openNewSessionPlusMenu(page);
+  await menu.getByRole("menuitem", { name: "Draft" }).click();
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Draft", exact: true }).waitFor();
+}
+
 export async function navigateInApp(page: Page, routeId: string, search = "") {
   await page.evaluate(
     ({ targetRouteId, targetSearch }) => {

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -101,7 +101,7 @@ async function withNewSessionPage(
 }
 
 suite.define(() => {
-  it("keeps rail privacy visible and reveals the mobile footer mode on hover or focus", async () => {
+  it("keeps rail privacy visible and exposes Draft from Plus on mobile", async () => {
     await withNewSessionPage(MOBILE_CONTEXT, async (page) => {
       await installMockGateway(page, {
         models: [
@@ -124,37 +124,14 @@ suite.define(() => {
       const footer = page.locator(".new-session-page__composer .agent-chat__composer-footer");
       const attach = page.getByRole("button", { name: "Add attachment" });
       const takePhoto = page.getByRole("menuitem", { name: "Take photo" });
-      const draft = page.getByRole("switch", { name: "Draft" });
       const incognito = page.getByRole("switch", { name: "Incognito" });
       const model = page.locator(".new-session-page__composer .chat-composer-model-control");
-      const message = page.locator(".new-session-page__message");
-      await Promise.all([
-        footer.waitFor(),
-        attach.waitFor(),
-        draft.waitFor({ state: "attached" }),
-        incognito.waitFor(),
-        model.waitFor(),
-      ]);
+      await Promise.all([footer.waitFor(), attach.waitFor(), incognito.waitFor(), model.waitFor()]);
 
       await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
       await page.mouse.move(0, 0);
       await expect
         .poll(() => incognito.evaluate((element) => getComputedStyle(element).opacity))
-        .toBe("1");
-      await expect
-        .poll(() => draft.evaluate((element) => getComputedStyle(element).opacity))
-        .toBe("0");
-      await footer.hover();
-      await expect
-        .poll(() => draft.evaluate((element) => getComputedStyle(element).opacity))
-        .toBe("1");
-      await page.mouse.move(0, 0);
-      await expect
-        .poll(() => draft.evaluate((element) => getComputedStyle(element).opacity))
-        .toBe("0");
-      await message.focus();
-      await expect
-        .poll(() => draft.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
       expect(
         await incognito.evaluate(
@@ -162,25 +139,21 @@ suite.define(() => {
         ),
       ).toBe(true);
 
-      const [footerBox, attachBox, draftBox, modelBox] = await Promise.all([
+      const [footerBox, attachBox, modelBox] = await Promise.all([
         footer.boundingBox(),
         attach.boundingBox(),
-        draft.boundingBox(),
         model.boundingBox(),
       ]);
       expect(footerBox).not.toBeNull();
       expect(attachBox).not.toBeNull();
-      expect(draftBox).not.toBeNull();
       expect(modelBox).not.toBeNull();
-      expect((attachBox?.x ?? 0) + (attachBox?.width ?? 0)).toBeLessThanOrEqual(draftBox?.x ?? 0);
-      for (const control of [attachBox, draftBox, modelBox]) {
+      expect((attachBox?.x ?? 0) + (attachBox?.width ?? 0)).toBeLessThanOrEqual(modelBox?.x ?? 0);
+      for (const control of [attachBox, modelBox]) {
         expect(control?.x ?? 0).toBeGreaterThanOrEqual(footerBox?.x ?? 0);
         expect((control?.x ?? 0) + (control?.width ?? 0)).toBeLessThanOrEqual(
           (footerBox?.x ?? 0) + (footerBox?.width ?? 0),
         );
       }
-      // The new-session footer keeps flex (not the shared chat mobile grid), so
-      // its transient mode switches can wrap before the model picker overflows.
       const controlsOverflow = await footer.evaluate(
         (element) => element.scrollWidth - element.clientWidth,
       );
@@ -188,6 +161,7 @@ suite.define(() => {
 
       await attach.click();
       await expect.poll(() => takePhoto.isVisible()).toBe(true);
+      await expect.poll(() => page.getByRole("menuitem", { name: "Draft" }).isVisible()).toBe(true);
       await page.keyboard.press("Escape");
       await incognito.click();
       await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -183,6 +183,21 @@ async function replaceGatewayClient(targetPage: Page) {
   });
 }
 
+async function openNewSessionPlusMenu(targetPage: Page) {
+  const composer = targetPage.locator(".new-session-page__composer");
+  const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+  await composer.getByRole("button", { name: "Add attachment" }).click();
+  await expect.poll(() => menu.getAttribute("data-view")).toBe("root");
+  return menu;
+}
+
+async function selectNewSessionDraft(targetPage: Page) {
+  const menu = await openNewSessionPlusMenu(targetPage);
+  await menu.getByRole("menuitem", { name: "Draft" }).click();
+  await targetPage.keyboard.press("Escape");
+  await targetPage.getByRole("button", { name: "Draft", exact: true }).waitFor();
+}
+
 suite.define(() => {
   afterEach(async () => {
     await page
@@ -604,11 +619,12 @@ suite.define(() => {
     });
 
     await currentPage.goto(`${suite.server?.baseUrl ?? ""}new`);
-    // Playwright check()/isChecked() support role="switch" buttons via aria-checked.
-    const draftToggle = currentPage.getByRole("switch", { name: "Draft", exact: true });
-    await draftToggle.waitFor();
+    const menu = await openNewSessionPlusMenu(currentPage);
+    await menu.getByRole("menuitem", { name: "Draft" }).waitFor();
     await captureUiProof(currentPage, "02-create-draft-available.png");
-    await draftToggle.check();
+    await menu.getByRole("menuitem", { name: "Draft" }).click();
+    await currentPage.keyboard.press("Escape");
+    await currentPage.getByRole("button", { name: "Draft", exact: true }).waitFor();
     await currentPage.locator(".new-session-page__message").fill("work privately first");
     await captureUiProof(currentPage, "03-create-draft-selected.png");
     await currentPage.getByRole("button", { name: "Start session" }).click();
@@ -1020,22 +1036,24 @@ suite.define(() => {
     });
 
     await currentPage.goto(`${suite.server?.baseUrl ?? ""}new`);
-    const draftToggle = currentPage.getByRole("switch", { name: "Draft", exact: true });
-    await draftToggle.check();
+    await selectNewSessionDraft(currentPage);
     await gateway.setSessionSharingPolicy({
       allowedSessionVisibilities: ["shared"],
       hasMultipleSessionSharingIdentities: false,
     });
     await replaceGatewayClient(currentPage);
-    await expect.poll(() => draftToggle.count()).toBe(0);
+    await expect
+      .poll(() => currentPage.getByRole("button", { name: "Draft", exact: true }).count())
+      .toBe(0);
 
     await gateway.setSessionSharingPolicy({
       allowedSessionVisibilities: ["shared", "draft"],
       hasMultipleSessionSharingIdentities: true,
     });
     await replaceGatewayClient(currentPage);
-    await draftToggle.waitFor();
-    expect(await draftToggle.isChecked()).toBe(false);
+    const menu = await openNewSessionPlusMenu(currentPage);
+    await menu.getByRole("menuitem", { name: "Draft" }).waitFor();
+    expect(await currentPage.getByRole("button", { name: "Draft", exact: true }).count()).toBe(0);
   });
 
   it("keeps create-as-draft dormant for one owner", async () => {
@@ -1049,7 +1067,7 @@ suite.define(() => {
     });
 
     await currentPage.goto(`${suite.server?.baseUrl ?? ""}new`);
-    await currentPage.locator(".new-session-page__message").waitFor();
-    expect(await currentPage.getByRole("switch", { name: "Draft", exact: true }).count()).toBe(0);
+    const menu = await openNewSessionPlusMenu(currentPage);
+    expect(await menu.getByRole("menuitem", { name: "Draft" }).count()).toBe(0);
   });
 });

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -6,6 +6,11 @@ import { expect as expectBrowser } from "playwright/test";
 import { afterEach, expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  openNewSessionPlusMenu,
+  replaceGatewayClient,
+  selectNewSessionDraft,
+} from "./new-session-page.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI session ownership",
@@ -169,33 +174,6 @@ async function openSidebarSortMenu(targetPage: Page) {
   const menu = targetPage.locator(".sidebar-session-sort-menu");
   await menu.waitFor();
   return menu;
-}
-
-async function replaceGatewayClient(targetPage: Page) {
-  await targetPage.evaluate(() => {
-    const app = document.querySelector("openclaw-app") as HTMLElement & {
-      runtime?: { context: { gateway: { connect: () => void } } };
-    };
-    if (!app.runtime) {
-      throw new Error("OpenClaw application runtime is unavailable");
-    }
-    app.runtime.context.gateway.connect();
-  });
-}
-
-async function openNewSessionPlusMenu(targetPage: Page) {
-  const composer = targetPage.locator(".new-session-page__composer");
-  const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
-  await composer.getByRole("button", { name: "Add attachment" }).click();
-  await expect.poll(() => menu.getAttribute("data-view")).toBe("root");
-  return menu;
-}
-
-async function selectNewSessionDraft(targetPage: Page) {
-  const menu = await openNewSessionPlusMenu(targetPage);
-  await menu.getByRole("menuitem", { name: "Draft" }).click();
-  await targetPage.keyboard.press("Escape");
-  await targetPage.getByRole("button", { name: "Draft", exact: true }).waitFor();
 }
 
 suite.define(() => {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -968,6 +968,8 @@ export const en: TranslationMap = {
     agentsUnavailable: "No agents are available on this Gateway yet.",
     nodeUnavailable: "The selected device is unavailable. Pick another place.",
     terminalNeedsFolder: "Pick a folder before starting in a terminal.",
+    terminalCapabilityOverridesUnsupported:
+      "Clear session capability overrides before starting in a terminal.",
     what: "What",
     detail: "Detail",
     local: "Local",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -948,6 +948,7 @@ export const en: TranslationMap = {
     incognitoDescription: "Keep this session only until the Gateway restarts",
     draft: "Draft",
     draftDescription: "Keep this session to yourself until you publish it",
+    composerOptionsSelected: "Add attachments or session options ({count} selected)",
     messagePlaceholder: "What should this session work on?",
     readingAttachment: "Reading attachment",
     start: "Start session",

--- a/ui/src/lib/sessions/session-placement-recovery.ts
+++ b/ui/src/lib/sessions/session-placement-recovery.ts
@@ -1,5 +1,7 @@
+import { SessionToolOverridesSchema } from "@openclaw/gateway-protocol";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { hasNonEmptyString as isNonEmptyString } from "@openclaw/normalization-core/string-coerce";
+import { Value } from "typebox/value";
 import type { SessionCreateParams } from "./create.ts";
 import {
   sessionPlacementRecoveryExactStorageKey,
@@ -52,6 +54,7 @@ const PLACEMENT_CREATE_FIELDS = new Set<string>([
   "worktree",
   "incognito",
   "visibility",
+  "toolOverrides",
   ...PLACEMENT_CREATE_STRING_FIELDS,
 ]);
 
@@ -72,6 +75,8 @@ export function parseSessionPlacementCreateParams(
     record.worktree !== true ||
     (record.incognito !== undefined && record.incognito !== true) ||
     (record.visibility !== undefined && record.visibility !== "draft") ||
+    (record.toolOverrides !== undefined &&
+      !Value.Check(SessionToolOverridesSchema, record.toolOverrides)) ||
     (record.projectId !== undefined && record.cwd !== undefined) ||
     PLACEMENT_CREATE_STRING_FIELDS.some(
       (key) => record[key] !== undefined && !isNonEmptyString(record[key]),

--- a/ui/src/pages/chat/chat-composer-capability-host.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.ts
@@ -1,12 +1,7 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type {
-  ConfigSnapshot,
-  GatewaySessionRow,
-  SkillStatusEntry,
-  ToolsEffectiveResult,
-} from "../../api/types.ts";
+import type { ConfigSnapshot, GatewaySessionRow, ToolsEffectiveResult } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import "../../components/modal-dialog.ts";
@@ -33,23 +28,21 @@ import {
 } from "../../lib/sessions/index.ts";
 import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
-import { nextBooleanToolOverrides, readOwnEntry } from "../../lib/sessions/tool-overrides.ts";
-import { loadSkillStatusReport } from "../../lib/skills/index.ts";
+import { nextBooleanToolOverrides } from "../../lib/sessions/tool-overrides.ts";
 import { refreshCurrentChatSessionList } from "./chat-session.ts";
 import { patchChatSessionSettings } from "./chat-settings-patches.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import type { ChatComposerMenuSkill } from "./components/chat-composer-plus-menu.ts";
 import type { CapabilityMenuProps } from "./components/chat-composer-types.ts";
+import {
+  ComposerSkillCatalog,
+  composerWebSearchBaseEnabled,
+} from "./composer-capability-catalog.ts";
 
 type ComposerMcpServerScope = "session" | "everywhere";
 
 type CapabilityMutationResult =
   | { ok: true }
   | { ok: false; error: string; stage: "config" | "session" };
-
-function webSearchBaseEnabled(config: Record<string, unknown> | null): boolean {
-  return asRecord(asRecord(asRecord(config?.tools)?.web)?.search)?.enabled !== false;
-}
 
 function activeConfigFingerprint(snapshot: ConfigSnapshot | null): string {
   const revision =
@@ -62,24 +55,8 @@ function activeConfigFingerprint(snapshot: ConfigSnapshot | null): string {
   return JSON.stringify(asRecord(asRecord(snapshot?.runtimeConfig)?.mcp)?.servers ?? null);
 }
 
-function toComposerSkill(skill: SkillStatusEntry): ChatComposerMenuSkill {
-  const missingDeps = Object.values(skill.missing).some((values) => values.length > 0);
-  const blocked = skill.blockedByAllowlist || skill.blockedByAgentFilter === true;
-  const baseEnabled = !skill.disabled;
-  return {
-    key: skill.skillKey,
-    name: skill.name,
-    enabled: baseEnabled && !missingDeps && !blocked,
-    baseEnabled,
-    ...(missingDeps ? { missingDeps: true } : {}),
-    ...(blocked ? { blocked: true } : {}),
-  };
-}
-
 export class ChatComposerCapabilityHost {
-  private readonly skills = new Map<string, ChatComposerMenuSkill[]>();
-  private readonly loading = new Set<string>();
-  private readonly loadErrors = new Set<string>();
+  private readonly skillCatalog: ComposerSkillCatalog;
   private readonly patchTokens = new Map<string, symbol>();
   private effectiveTools: { key: string; result: ToolsEffectiveResult } | null = null;
   private effectiveToolsErrorKey: string | null = null;
@@ -91,7 +68,9 @@ export class ChatComposerCapabilityHost {
   private addBusy = false;
   private addError: string | null = null;
 
-  constructor(private readonly notify: () => void) {}
+  constructor(private readonly notify: () => void) {
+    this.skillCatalog = new ComposerSkillCatalog(notify);
+  }
 
   static async addMcpServer(options: {
     scope: ComposerMcpServerScope;
@@ -165,41 +144,13 @@ export class ChatComposerCapabilityHost {
       void context.runtimeConfig.ensureLoaded().catch(() => undefined);
     }
     const client = state.client;
-    if (!state.connected || !client || this.skills.has(agentId) || this.loading.has(agentId)) {
-      return;
-    }
     const connectionEpoch = state.connectionEpoch;
-    const isCurrent = () =>
-      state.client === client &&
-      this.client === client &&
-      state.connected &&
-      state.connectionEpoch === connectionEpoch &&
-      this.connectionEpoch === connectionEpoch;
-    this.loadErrors.delete(agentId);
-    this.loading.add(agentId);
-    this.notify();
-    void loadSkillStatusReport(client, agentId)
-      .then((report) => {
-        if (report && isCurrent()) {
-          this.skills.set(
-            agentId,
-            report.skills
-              .map(toComposerSkill)
-              .toSorted((left, right) => left.name.localeCompare(right.name)),
-          );
-        }
-      })
-      .catch(() => {
-        if (isCurrent()) {
-          this.loadErrors.add(agentId);
-        }
-      })
-      .finally(() => {
-        if (isCurrent()) {
-          this.loading.delete(agentId);
-          this.notify();
-        }
-      });
+    this.skillCatalog.load(
+      client,
+      connectionEpoch,
+      agentId,
+      () => state.connected && state.client === client && state.connectionEpoch === connectionEpoch,
+    );
   }
 
   private effectiveToolsKeys(
@@ -571,9 +522,7 @@ export class ChatComposerCapabilityHost {
     if (this.client !== state.client || this.connectionEpoch !== state.connectionEpoch) {
       this.client = state.client;
       this.connectionEpoch = state.connectionEpoch;
-      this.skills.clear();
-      this.loading.clear();
-      this.loadErrors.clear();
+      this.skillCatalog.synchronize(state.client, state.connectionEpoch);
       this.patchTokens.clear();
       this.effectiveTools = null;
       this.effectiveToolsErrorKey = null;
@@ -625,23 +574,15 @@ export class ChatComposerCapabilityHost {
         : null;
     return {
       basePath: state.basePath,
-      skills:
-        this.skills.get(agentId)?.map((skill) =>
-          Object.assign({}, skill, {
-            enabled:
-              skill.missingDeps || skill.blocked
-                ? false
-                : (readOwnEntry(session?.toolOverrides?.skills, skill.key) ?? skill.baseEnabled),
-          }),
-        ) ?? null,
-      skillsLoading: this.loading.has(agentId),
-      skillsError: this.loadErrors.has(agentId),
+      skills: this.skillCatalog.rows(agentId, session?.toolOverrides),
+      skillsLoading: this.skillCatalog.isLoading(agentId),
+      skillsError: this.skillCatalog.hasError(agentId),
       mcpServers: summarizeMcpServers(runtimeConfig) ?? [],
       toolsEffectiveResult,
       toolsEffectiveLoading,
       toolsEffectiveError,
       toolAccessMutationBlockedReason,
-      webSearchBaseEnabled: webSearchBaseEnabled(runtimeConfig),
+      webSearchBaseEnabled: composerWebSearchBaseEnabled(runtimeConfig),
       mutationBlockedReason,
       canAdmin: access.canAdmin && gatewayAvailable,
       adminBlockedReason,

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -504,15 +504,20 @@ export function handleChatAttachmentMenuSelection(
   return true;
 }
 
-export function renderChatAttachmentMenuTrigger(disabled: boolean | undefined) {
+export function renderChatAttachmentMenuTrigger(
+  disabled: boolean | undefined,
+  selection?: { active: boolean; label: string },
+) {
   return html`
     <button
       slot="trigger"
       type="button"
-      class="agent-chat__input-btn agent-chat__input-btn--attach"
-      aria-label=${t("chat.composer.addAttachment")}
+      class="agent-chat__input-btn agent-chat__input-btn--attach ${selection?.active
+        ? "agent-chat__input-btn--selected"
+        : ""}"
+      aria-label=${selection?.active ? selection.label : t("chat.composer.addAttachment")}
       ?disabled=${disabled}
-      title=${t("chat.composer.addAttachment")}
+      title=${selection?.active ? selection.label : t("chat.composer.addAttachment")}
     >
       ${icons.plus}
     </button>
@@ -533,19 +538,6 @@ export function renderChatAttachmentMenuOptions(fileIcon = icons.folder) {
       <span slot="icon" aria-hidden="true">${fileIcon}</span>
       <span>${t("chat.composer.attachFileOption")}</span>
     </wa-dropdown-item>
-  `;
-}
-
-export function renderChatAttachmentMenu(props: ChatAttachmentControlsProps) {
-  return html`
-    <wa-dropdown
-      class="agent-chat__attach-menu"
-      placement="top-start"
-      aria-label=${t("chat.composer.addAttachment")}
-      @wa-select=${handleChatAttachmentMenuSelection}
-    >
-      ${renderChatAttachmentMenuTrigger(props.disabled)} ${renderChatAttachmentMenuOptions()}
-    </wa-dropdown>
   `;
 }
 

--- a/ui/src/pages/chat/components/chat-composer-plus-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-plus-menu.ts
@@ -35,9 +35,19 @@ export type ChatComposerMenuSkill = {
   blocked?: boolean;
 };
 
+type ChatComposerRootToggle = {
+  value: string;
+  label: string;
+  icon?: unknown;
+  checked: boolean;
+  disabled: boolean;
+  title?: string;
+  onChange: (checked: boolean) => void;
+};
+
 type MenuRoute = "mcp" | "plugins" | "skills";
 
-export type ChatComposerPlusMenuProps = {
+type ChatComposerPlusMenuProps = {
   attachments: ChatAttachmentControlsProps;
   showCapabilities: boolean;
   basePath: string;
@@ -57,6 +67,8 @@ export type ChatComposerPlusMenuProps = {
   mutationBlockedReason: string | null;
   canAdmin: boolean;
   adminBlockedReason: string | null;
+  rootToggles?: readonly ChatComposerRootToggle[];
+  selectedLabel?: string;
   addServerDialog?: TemplateResult | typeof nothing;
   onOpenChange: (open: boolean) => void;
   onViewChange: (view: ChatComposerPlusMenuView) => void;
@@ -67,6 +79,20 @@ export type ChatComposerPlusMenuProps = {
   onEnsureToolAccess?: (serverName: string) => void;
   onOpenToolAccess?: (serverName: string) => void;
 };
+
+export type ChatComposerCapabilityMenuProps = Omit<
+  ChatComposerPlusMenuProps,
+  | "attachments"
+  | "disabled"
+  | "open"
+  | "view"
+  | "toolOverrides"
+  | "onOpenChange"
+  | "onViewChange"
+  | "showCapabilities"
+  | "rootToggles"
+  | "selectedLabel"
+>;
 
 function menuDivider(): TemplateResult {
   return html`<div class="agent-chat__capability-menu-divider" role="separator"></div>`;
@@ -98,6 +124,7 @@ function renderCapabilityToggleRow(options: {
   checked: boolean;
   disabled: boolean;
   title: string | null | undefined;
+  icon?: unknown;
   note?: TemplateResult | typeof nothing;
 }) {
   return html`
@@ -107,6 +134,7 @@ function renderCapabilityToggleRow(options: {
       ?disabled=${options.disabled}
       title=${options.title ?? ""}
     >
+      ${options.icon ? html`<span slot="icon" aria-hidden="true">${options.icon}</span>` : nothing}
       <span class="agent-chat__capability-menu-label">
         <span>${options.label}</span>
         ${options.note ?? nothing}
@@ -138,58 +166,71 @@ function renderRootView(props: ChatComposerPlusMenuProps) {
     props.toolOverrides?.webSearch,
   );
   const attachments = renderChatAttachmentMenuOptions(icons.paperclip);
-  if (!props.showCapabilities) {
+  const rootToggles = props.rootToggles ?? [];
+  if (!props.showCapabilities && rootToggles.length === 0) {
     return attachments;
   }
   // Core gates managed and Codex-native search. Config sniffing misses env/native providers;
   // without a provider, this session override is a harmless no-op.
   return html`
     ${attachments} ${menuDivider()}
-    <wa-dropdown-item class="agent-chat__capability-menu-item" value="open-skills">
-      <span slot="icon" aria-hidden="true">${icons.book}</span>
-      <span>${t("chat.composer.menu.skills")}</span>
-      <span slot="details" class="agent-chat__capability-menu-details">
-        ${hasSkillOverrides
-          ? html`<span class="agent-chat__capability-menu-badge"
-              >${t("chat.composer.menu.enabledCount", {
-                count: String(enabledSkillCount),
-              })}</span
-            >`
-          : nothing}
-        <span class="agent-chat__capability-menu-chevron" aria-hidden="true"
-          >${icons.chevronRight}</span
-        >
-      </span>
-    </wa-dropdown-item>
-    <wa-dropdown-item class="agent-chat__capability-menu-item" value="open-connectors">
-      <span slot="icon" aria-hidden="true">${icons.puzzle}</span>
-      <span>${t("chat.composer.menu.connectors")}</span>
-      <span slot="details" class="agent-chat__capability-menu-details">
-        <span class="agent-chat__capability-menu-badge">${connectorCount}</span>
-        <span class="agent-chat__capability-menu-chevron" aria-hidden="true"
-          >${icons.chevronRight}</span
-        >
-      </span>
-    </wa-dropdown-item>
-    <wa-dropdown-item
-      class="agent-chat__capability-menu-item"
-      type="checkbox"
-      value="toggle-web-search"
-      .checked=${webSearchEnabled}
-      ?disabled=${props.mutationBlockedReason !== null}
-      title=${props.mutationBlockedReason ?? ""}
-    >
-      <span slot="icon" aria-hidden="true">${icons.globe}</span>
-      <span>${t("chat.composer.menu.webSearch")}</span>
-    </wa-dropdown-item>
-    ${menuDivider()}
-    <wa-dropdown-item class="agent-chat__capability-menu-item" value="manage-plugins">
-      <span slot="icon" aria-hidden="true">${icons.puzzle}</span>
-      ${internalLink(
-        pathForRoute("plugins", props.basePath),
-        t("chat.composer.menu.managePlugins"),
-      )}
-    </wa-dropdown-item>
+    ${rootToggles.map((toggle) =>
+      renderCapabilityToggleRow({
+        value: toggle.value,
+        label: toggle.label,
+        icon: toggle.icon,
+        checked: toggle.checked,
+        disabled: toggle.disabled,
+        title: toggle.title,
+      }),
+    )}
+    ${props.showCapabilities
+      ? html`<wa-dropdown-item class="agent-chat__capability-menu-item" value="open-skills">
+            <span slot="icon" aria-hidden="true">${icons.book}</span>
+            <span>${t("chat.composer.menu.skills")}</span>
+            <span slot="details" class="agent-chat__capability-menu-details">
+              ${hasSkillOverrides
+                ? html`<span class="agent-chat__capability-menu-badge"
+                    >${t("chat.composer.menu.enabledCount", {
+                      count: String(enabledSkillCount),
+                    })}</span
+                  >`
+                : nothing}
+              <span class="agent-chat__capability-menu-chevron" aria-hidden="true"
+                >${icons.chevronRight}</span
+              >
+            </span>
+          </wa-dropdown-item>
+          <wa-dropdown-item class="agent-chat__capability-menu-item" value="open-connectors">
+            <span slot="icon" aria-hidden="true">${icons.puzzle}</span>
+            <span>${t("chat.composer.menu.connectors")}</span>
+            <span slot="details" class="agent-chat__capability-menu-details">
+              <span class="agent-chat__capability-menu-badge">${connectorCount}</span>
+              <span class="agent-chat__capability-menu-chevron" aria-hidden="true"
+                >${icons.chevronRight}</span
+              >
+            </span>
+          </wa-dropdown-item>
+          <wa-dropdown-item
+            class="agent-chat__capability-menu-item"
+            type="checkbox"
+            value="toggle-web-search"
+            .checked=${webSearchEnabled}
+            ?disabled=${props.mutationBlockedReason !== null}
+            title=${props.mutationBlockedReason ?? ""}
+          >
+            <span slot="icon" aria-hidden="true">${icons.globe}</span>
+            <span>${t("chat.composer.menu.webSearch")}</span>
+          </wa-dropdown-item>
+          ${menuDivider()}
+          <wa-dropdown-item class="agent-chat__capability-menu-item" value="manage-plugins">
+            <span slot="icon" aria-hidden="true">${icons.puzzle}</span>
+            ${internalLink(
+              pathForRoute("plugins", props.basePath),
+              t("chat.composer.menu.managePlugins"),
+            )}
+          </wa-dropdown-item>`
+      : nothing}
   `;
 }
 
@@ -403,6 +444,14 @@ function handleMenuSelection(
   if (handleChatAttachmentMenuSelection(event)) {
     return;
   }
+  const rootToggle = props.rootToggles?.find((toggle) => toggle.value === value);
+  if (rootToggle) {
+    event.preventDefault();
+    if (!rootToggle.disabled) {
+      rootToggle.onChange(!rootToggle.checked);
+    }
+    return;
+  }
   const menu = event.currentTarget as HTMLElement;
   const changeView = (view: ChatComposerPlusMenuView) => {
     props.onViewChange(view);
@@ -515,7 +564,7 @@ function handleMenuSelection(
   }
 }
 
-export function renderChatComposerPlusMenu(props: ChatComposerPlusMenuProps) {
+function renderChatComposerPlusMenuContent(props: ChatComposerPlusMenuProps) {
   const view = props.showCapabilities ? props.view : "root";
   if (view.startsWith("tools:")) {
     props.onEnsureToolAccess?.(view.slice("tools:".length));
@@ -549,8 +598,64 @@ export function renderChatComposerPlusMenu(props: ChatComposerPlusMenuProps) {
       }}
       data-view=${view}
     >
-      ${renderChatAttachmentMenuTrigger(props.disabled)} ${content}
+      ${renderChatAttachmentMenuTrigger(
+        props.disabled,
+        props.selectedLabel
+          ? {
+              active: true,
+              label: props.selectedLabel,
+            }
+          : undefined,
+      )}
+      ${content}
     </wa-dropdown>
     ${props.addServerDialog ?? nothing}
   `;
+}
+
+export function renderChatComposerPlusMenu(props: {
+  attachments: ChatAttachmentControlsProps;
+  capabilityMenu?: ChatComposerCapabilityMenuProps;
+  disabled: boolean;
+  open: boolean;
+  view: ChatComposerPlusMenuView;
+  toolOverrides: SessionToolOverrides | null | undefined;
+  rootToggles?: readonly ChatComposerRootToggle[];
+  selectedLabel?: string;
+  onOpenChange: (open: boolean) => void;
+  onViewChange: (view: ChatComposerPlusMenuView) => void;
+}) {
+  const capabilityMenu = props.capabilityMenu;
+  return renderChatComposerPlusMenuContent({
+    attachments: props.attachments,
+    showCapabilities: capabilityMenu !== undefined,
+    basePath: capabilityMenu?.basePath ?? "",
+    disabled: props.disabled,
+    open: props.open,
+    view: props.view,
+    toolOverrides: props.toolOverrides,
+    skills: capabilityMenu?.skills ?? null,
+    skillsLoading: capabilityMenu?.skillsLoading ?? false,
+    skillsError: capabilityMenu?.skillsError ?? false,
+    mcpServers: capabilityMenu?.mcpServers ?? [],
+    toolsEffectiveResult: capabilityMenu?.toolsEffectiveResult ?? null,
+    toolsEffectiveLoading: capabilityMenu?.toolsEffectiveLoading ?? false,
+    toolsEffectiveError: capabilityMenu?.toolsEffectiveError ?? false,
+    toolAccessMutationBlockedReason: capabilityMenu?.toolAccessMutationBlockedReason ?? null,
+    webSearchBaseEnabled: capabilityMenu?.webSearchBaseEnabled ?? true,
+    mutationBlockedReason: capabilityMenu?.mutationBlockedReason ?? null,
+    canAdmin: capabilityMenu?.canAdmin ?? false,
+    adminBlockedReason: capabilityMenu?.adminBlockedReason ?? null,
+    rootToggles: props.rootToggles,
+    selectedLabel: props.selectedLabel,
+    addServerDialog: capabilityMenu?.addServerDialog,
+    onOpenChange: props.onOpenChange,
+    onViewChange: props.onViewChange,
+    onLoadSkills: capabilityMenu?.onLoadSkills ?? (() => {}),
+    onPatchToolOverrides: capabilityMenu?.onPatchToolOverrides ?? (() => {}),
+    onNavigate: capabilityMenu?.onNavigate ?? (() => {}),
+    onAddServer: capabilityMenu?.onAddServer,
+    onEnsureToolAccess: capabilityMenu?.onEnsureToolAccess,
+    onOpenToolAccess: capabilityMenu?.onOpenToolAccess,
+  });
 }

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -23,7 +23,7 @@ import type { ChatRunUiStatus } from "../run-lifecycle.ts";
 import type { CompactionStatus, FallbackStatus } from "../tool-stream.ts";
 import type { ChatAttachmentControlsProps } from "./chat-attachments.ts";
 import type {
-  ChatComposerPlusMenuProps,
+  ChatComposerCapabilityMenuProps,
   ChatComposerPlusMenuView,
 } from "./chat-composer-plus-menu.ts";
 import type { SkillMenuState } from "./chat-composer-skill-menu.ts";
@@ -40,17 +40,7 @@ export type ChatQueuedEditProps = {
   onCancel: () => void;
 };
 
-export type CapabilityMenuProps = Omit<
-  ChatComposerPlusMenuProps,
-  | "attachments"
-  | "disabled"
-  | "open"
-  | "view"
-  | "toolOverrides"
-  | "onOpenChange"
-  | "onViewChange"
-  | "showCapabilities"
->;
+export type CapabilityMenuProps = ChatComposerCapabilityMenuProps;
 
 type ChatComposerDisabledBannerContent = {
   title?: string;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -342,26 +342,11 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
             <div class="agent-chat__composer-input-row">
               ${renderChatComposerPlusMenu({
                 attachments: props,
-                showCapabilities: props.capabilityMenu !== undefined,
-                basePath: props.capabilityMenu?.basePath ?? "",
+                capabilityMenu: props.capabilityMenu,
                 disabled: !canCompose || props.suggestionComposer === true,
                 open: state.capabilityMenuOpen,
                 view: state.capabilityMenuView,
                 toolOverrides: props.toolOverrides,
-                skills: props.capabilityMenu?.skills ?? null,
-                skillsLoading: props.capabilityMenu?.skillsLoading ?? false,
-                skillsError: props.capabilityMenu?.skillsError ?? false,
-                mcpServers: props.capabilityMenu?.mcpServers ?? [],
-                toolsEffectiveResult: props.capabilityMenu?.toolsEffectiveResult ?? null,
-                toolsEffectiveLoading: props.capabilityMenu?.toolsEffectiveLoading ?? false,
-                toolsEffectiveError: props.capabilityMenu?.toolsEffectiveError ?? false,
-                toolAccessMutationBlockedReason:
-                  props.capabilityMenu?.toolAccessMutationBlockedReason ?? null,
-                webSearchBaseEnabled: props.capabilityMenu?.webSearchBaseEnabled ?? true,
-                mutationBlockedReason: props.capabilityMenu?.mutationBlockedReason ?? null,
-                canAdmin: props.capabilityMenu?.canAdmin ?? false,
-                adminBlockedReason: props.capabilityMenu?.adminBlockedReason ?? null,
-                addServerDialog: props.capabilityMenu?.addServerDialog,
                 onOpenChange: (open) => {
                   state.capabilityMenuOpen = open;
                   if (!open) {
@@ -373,12 +358,6 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                   state.capabilityMenuView = view;
                   requestUpdate();
                 },
-                onLoadSkills: props.capabilityMenu?.onLoadSkills ?? (() => {}),
-                onPatchToolOverrides: props.capabilityMenu?.onPatchToolOverrides ?? (() => {}),
-                onNavigate: props.capabilityMenu?.onNavigate ?? (() => {}),
-                onAddServer: props.capabilityMenu?.onAddServer,
-                onEnsureToolAccess: props.capabilityMenu?.onEnsureToolAccess,
-                onOpenToolAccess: props.capabilityMenu?.onOpenToolAccess,
               })}
               <div class="agent-chat__composer-combobox">
                 <textarea

--- a/ui/src/pages/chat/composer-capability-catalog.ts
+++ b/ui/src/pages/chat/composer-capability-catalog.ts
@@ -1,0 +1,111 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SkillStatusEntry } from "../../api/types.ts";
+import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
+import { readOwnEntry } from "../../lib/sessions/tool-overrides.ts";
+import { loadSkillStatusReport } from "../../lib/skills/index.ts";
+import type { ChatComposerMenuSkill } from "./components/chat-composer-plus-menu.ts";
+
+export function composerWebSearchBaseEnabled(config: Record<string, unknown> | null): boolean {
+  return asRecord(asRecord(asRecord(config?.tools)?.web)?.search)?.enabled !== false;
+}
+
+function toComposerSkill(skill: SkillStatusEntry): ChatComposerMenuSkill {
+  const missingDeps = Object.values(skill.missing).some((values) => values.length > 0);
+  const blocked = skill.blockedByAllowlist || skill.blockedByAgentFilter === true;
+  const baseEnabled = !skill.disabled;
+  return {
+    key: skill.skillKey,
+    name: skill.name,
+    enabled: baseEnabled && !missingDeps && !blocked,
+    baseEnabled,
+    ...(missingDeps ? { missingDeps: true } : {}),
+    ...(blocked ? { blocked: true } : {}),
+  };
+}
+
+export class ComposerSkillCatalog {
+  private readonly skills = new Map<string, ChatComposerMenuSkill[]>();
+  private readonly loading = new Set<string>();
+  private readonly loadErrors = new Set<string>();
+  private client: GatewayBrowserClient | null = null;
+  private connectionEpoch: number | undefined;
+
+  constructor(private readonly notify: () => void) {}
+
+  synchronize(client: GatewayBrowserClient | null, connectionEpoch: number | undefined) {
+    if (this.client === client && this.connectionEpoch === connectionEpoch) {
+      return;
+    }
+    this.client = client;
+    this.connectionEpoch = connectionEpoch;
+    this.skills.clear();
+    this.loading.clear();
+    this.loadErrors.clear();
+  }
+
+  load(
+    client: GatewayBrowserClient | null,
+    connectionEpoch: number | undefined,
+    agentId: string,
+    isCurrentConnection: () => boolean,
+  ): void {
+    this.synchronize(client, connectionEpoch);
+    if (
+      !client ||
+      !isCurrentConnection() ||
+      this.skills.has(agentId) ||
+      this.loading.has(agentId)
+    ) {
+      return;
+    }
+    const isCurrent = () =>
+      this.client === client && this.connectionEpoch === connectionEpoch && isCurrentConnection();
+    this.loadErrors.delete(agentId);
+    this.loading.add(agentId);
+    this.notify();
+    void loadSkillStatusReport(client, agentId)
+      .then((report) => {
+        if (report && isCurrent()) {
+          this.skills.set(
+            agentId,
+            report.skills
+              .map(toComposerSkill)
+              .toSorted((left, right) => left.name.localeCompare(right.name)),
+          );
+        }
+      })
+      .catch(() => {
+        if (isCurrent()) {
+          this.loadErrors.add(agentId);
+        }
+      })
+      .finally(() => {
+        if (isCurrent()) {
+          this.loading.delete(agentId);
+          this.notify();
+        }
+      });
+  }
+
+  rows(agentId: string, toolOverrides: SessionToolOverrides | null | undefined) {
+    return (
+      this.skills.get(agentId)?.map((skill) =>
+        Object.assign({}, skill, {
+          enabled:
+            skill.missingDeps || skill.blocked
+              ? false
+              : (readOwnEntry(toolOverrides?.skills, skill.key) ?? skill.baseEnabled),
+        }),
+      ) ?? null
+    );
+  }
+
+  isLoading(agentId: string): boolean {
+    return this.loading.has(agentId);
+  }
+
+  hasError(agentId: string): boolean {
+    return this.loadErrors.has(agentId);
+  }
+}

--- a/ui/src/pages/new-session/capability-controller.ts
+++ b/ui/src/pages/new-session/capability-controller.ts
@@ -9,6 +9,7 @@ import {
   ComposerSkillCatalog,
   composerWebSearchBaseEnabled,
 } from "../chat/composer-capability-catalog.ts";
+import { canStartSessionAsDraft } from "./create-params.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
 
 export class NewSessionCapabilityController {
@@ -46,6 +47,14 @@ export class NewSessionCapabilityController {
     if (toolOverrides !== undefined) {
       this.setToolOverrides(toolOverrides);
     }
+  }
+
+  canStartAsDraft(context: ApplicationContext | undefined): boolean {
+    return canStartSessionAsDraft({
+      allowedVisibilities: context?.gateway.snapshot.hello?.policy?.allowedSessionVisibilities,
+      hasMultipleIdentities:
+        context?.gateway.snapshot.hello?.policy?.hasMultipleSessionSharingIdentities,
+    });
   }
 
   composerProps(

--- a/ui/src/pages/new-session/capability-controller.ts
+++ b/ui/src/pages/new-session/capability-controller.ts
@@ -1,0 +1,117 @@
+import type { ApplicationContext } from "../../app/context.ts";
+import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
+import { t } from "../../i18n/index.ts";
+import { summarizeMcpServers } from "../../lib/config/mcp-servers.ts";
+import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
+import { countSessionToolOverrides } from "../../lib/sessions/tool-overrides.ts";
+import type { CapabilityMenuProps } from "../chat/components/chat-composer-types.ts";
+import {
+  ComposerSkillCatalog,
+  composerWebSearchBaseEnabled,
+} from "../chat/composer-capability-catalog.ts";
+import type { DraftGatewayState } from "./draft-gateway-state.ts";
+
+export class NewSessionCapabilityController {
+  private readonly skillCatalog: ComposerSkillCatalog;
+  private toolOverridesValue: SessionToolOverrides | null = null;
+  private onMutation = () => {};
+
+  constructor(private readonly notify: () => void) {
+    this.skillCatalog = new ComposerSkillCatalog(notify);
+  }
+
+  setMutationCallback(onMutation: () => void) {
+    this.onMutation = onMutation;
+  }
+
+  get toolOverrides(): SessionToolOverrides | null {
+    return this.toolOverridesValue;
+  }
+
+  setToolOverrides(toolOverrides: SessionToolOverrides | null) {
+    const next = countSessionToolOverrides(toolOverrides) > 0 ? toolOverrides : null;
+    if (next === this.toolOverridesValue) {
+      return;
+    }
+    this.onMutation();
+    this.toolOverridesValue = next;
+    this.notify();
+  }
+
+  reset() {
+    this.toolOverridesValue = null;
+  }
+
+  restoreToolOverrides(toolOverrides: SessionToolOverrides | null | undefined) {
+    if (toolOverrides !== undefined) {
+      this.setToolOverrides(toolOverrides);
+    }
+  }
+
+  composerProps(
+    context: ApplicationContext | undefined,
+    gateway: DraftGatewayState,
+    agentId: string,
+  ) {
+    return {
+      toolOverrides: this.toolOverridesValue,
+      capabilityMenu: context ? this.props(context, gateway, agentId) : undefined,
+    };
+  }
+
+  props(
+    context: ApplicationContext,
+    gateway: DraftGatewayState,
+    agentId: string,
+  ): CapabilityMenuProps {
+    this.skillCatalog.synchronize(gateway.client, gateway.connectionEpoch);
+    const config = context.runtimeConfig.state;
+    if (!config.configSnapshot && !config.configLoading) {
+      void context.runtimeConfig.ensureLoaded().finally(this.notify);
+    }
+    const runtimeConfig = config.configSnapshot?.runtimeConfig ?? null;
+    const gatewayAvailable = gateway.connected && Boolean(gateway.client);
+    const access = readGatewayOperatorAccess(context.gateway.snapshot);
+    const mutationBlockedReason = !gatewayAvailable
+      ? t("chat.composer.menu.offlineBlocked")
+      : !runtimeConfig
+        ? t("common.loading")
+        : !access.canAdmin
+          ? t("chat.composer.menu.adminBlocked")
+          : null;
+    return {
+      basePath: context.basePath,
+      skills: this.skillCatalog.rows(agentId, this.toolOverridesValue),
+      skillsLoading: this.skillCatalog.isLoading(agentId),
+      skillsError: this.skillCatalog.hasError(agentId),
+      mcpServers: summarizeMcpServers(runtimeConfig) ?? [],
+      toolsEffectiveResult: null,
+      toolsEffectiveLoading: false,
+      toolsEffectiveError: false,
+      toolAccessMutationBlockedReason: mutationBlockedReason,
+      webSearchBaseEnabled: composerWebSearchBaseEnabled(runtimeConfig),
+      mutationBlockedReason,
+      canAdmin: access.canAdmin && gatewayAvailable,
+      adminBlockedReason: access.canAdmin
+        ? gatewayAvailable
+          ? null
+          : t("chat.composer.menu.offlineBlocked")
+        : t("chat.composer.menu.adminBlocked"),
+      onLoadSkills: () => {
+        const client = gateway.client;
+        const connectionEpoch = gateway.connectionEpoch;
+        this.skillCatalog.load(
+          client,
+          connectionEpoch,
+          agentId,
+          () =>
+            gateway.connected &&
+            gateway.client === client &&
+            gateway.connectionEpoch === connectionEpoch,
+        );
+      },
+      onPatchToolOverrides: (next) => this.setToolOverrides(next),
+      onNavigate: (routeId, options) => context.navigate(routeId, options),
+    };
+  }
+}

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -3,6 +3,7 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildFallbackSlashCommands, replaceSlashCommands } from "../../lib/chat/commands.ts";
+import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { adjustTextareaHeight } from "../chat/components/chat-composer-dom.ts";
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
@@ -28,6 +29,7 @@ function renderComposer(
     messageLocked?: boolean;
     visibility?: NewSessionVisibility;
     draftAvailable?: boolean;
+    toolOverrides?: SessionToolOverrides | null;
     onVisibilityChange?: (visibility: NewSessionVisibility) => void;
     message?: string;
     onInput?: (message: string) => void;
@@ -58,6 +60,7 @@ function renderComposer(
         message,
         visibility: overrides.visibility,
         draftAvailable: overrides.draftAvailable,
+        toolOverrides: overrides.toolOverrides,
         modelControl: new NewSessionModelControl(() => undefined),
         requiresModifier: overrides.requiresModifier ?? false,
         requestUpdate: renderCurrent,
@@ -418,20 +421,31 @@ describe("new-session composer attachment drops", () => {
     expect(switches).toHaveLength(0);
   });
 
-  it("lets the draft pill replace page-level incognito", () => {
+  it("moves Draft into Plus and keeps active selections visible", () => {
     const onVisibilityChange = vi.fn();
     const { composer } = renderComposer({
       draftAvailable: true,
-      visibility: "incognito",
+      visibility: "draft",
+      toolOverrides: { skills: { release: false } },
       onVisibilityChange,
     });
-    const draftPill = composer.querySelector<HTMLButtonElement>('[role="switch"]');
+    const menu = composer.querySelector<HTMLElement>("wa-dropdown.agent-chat__capability-menu");
+    const draftToggle = menu?.querySelector<HTMLElement>(
+      'wa-dropdown-item[value="new-session-draft"]',
+    );
 
-    expect(draftPill?.textContent).toContain("Draft");
-    expect(draftPill?.getAttribute("aria-checked")).toBe("false");
+    expect(
+      (draftToggle?.querySelector("wa-switch") as HTMLElement & { checked?: boolean })?.checked,
+    ).toBe(true);
+    expect(composer.querySelectorAll(".new-session-page__selection-status")).toHaveLength(2);
+    expect(composer.textContent).toContain("Draft");
+    expect(composer.textContent).toContain("1 session override");
+    expect(composer.querySelector(".agent-chat__input-btn--selected")).not.toBeNull();
 
-    draftPill?.click();
-    expect(onVisibilityChange).toHaveBeenCalledWith("draft");
+    menu?.dispatchEvent(
+      new CustomEvent("wa-select", { bubbles: true, detail: { item: draftToggle } }),
+    );
+    expect(onVisibilityChange).toHaveBeenCalledWith("normal");
   });
 
   it("adds a dropped file through the shared attachment handling", async () => {

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -7,13 +7,14 @@ import { t } from "../../i18n/index.ts";
 import "../../components/tooltip.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
+import { countSessionToolOverrides } from "../../lib/sessions/tool-overrides.ts";
 import { refreshSlashCommands } from "../chat/chat-commands.ts";
 import {
   createChatAttachmentDropHandlers,
   handleChatAttachmentPaste,
   renderAttachmentPreview,
   renderChatAttachmentInputs,
-  renderChatAttachmentMenu,
 } from "../chat/components/chat-attachments.ts";
 import {
   adjustTextareaHeight,
@@ -22,6 +23,10 @@ import {
   paneDomId,
   scheduleTextareaHeightAdjustment,
 } from "../chat/components/chat-composer-dom.ts";
+import {
+  renderChatComposerPlusMenu,
+  type ChatComposerPlusMenuView,
+} from "../chat/components/chat-composer-plus-menu.ts";
 import {
   createSkillMenuState,
   getActiveSkillMenuOptionId,
@@ -33,6 +38,7 @@ import {
   updateSkillMenu,
   type SkillMenuHost,
 } from "../chat/components/chat-composer-skill-menu.ts";
+import type { CapabilityMenuProps } from "../chat/components/chat-composer-types.ts";
 import type { NewSessionAttachmentDraft } from "./attachment-draft.ts";
 import type { NewSessionVisibility } from "./create-params.ts";
 import type { NewSessionModelControl } from "./model-control.ts";
@@ -61,6 +67,8 @@ type NewSessionComposerOptions = {
   messageLocked?: boolean;
   visibility?: NewSessionVisibility;
   draftAvailable?: boolean;
+  capabilityMenu?: CapabilityMenuProps;
+  toolOverrides?: SessionToolOverrides | null;
   onAttachmentsChange: (attachments: ChatAttachment[]) => void;
   onPendingReadsChange: (delta: 1 | -1) => void;
   onInput: (message: string) => void;
@@ -141,6 +149,8 @@ function renderStartControl(options: NewSessionComposerOptions) {
 export class NewSessionComposerTextareaController {
   private textarea: HTMLTextAreaElement | null = null;
   readonly skillMenuState = createSkillMenuState();
+  capabilityMenuOpen = false;
+  capabilityMenuView: ChatComposerPlusMenuView = "root";
 
   readonly ref = (element?: Element) => {
     const nextTextarea = element instanceof HTMLTextAreaElement ? element : null;
@@ -166,36 +176,13 @@ export class NewSessionComposerTextareaController {
 
   disconnect() {
     resetSkillMenuState(this.skillMenuState);
+    this.capabilityMenuOpen = false;
+    this.capabilityMenuView = "root";
     if (this.textarea) {
       disconnectTextareaOverflowObserver(this.textarea);
       this.textarea = null;
     }
   }
-}
-
-/** Draft visibility pill: selecting it clears incognito, re-click returns to normal. */
-function renderVisibilityPill(params: {
-  mode: Exclude<NewSessionVisibility, "normal">;
-  icon: unknown;
-  label: string;
-  description: string;
-  options: NewSessionComposerOptions;
-}) {
-  const active = params.options.visibility === params.mode;
-  const disabled = params.options.submitting || params.options.messageLocked;
-  return html`
-    <button
-      type="button"
-      class="new-session-page__visibility ${active ? "new-session-page__visibility--active" : ""}"
-      role="switch"
-      aria-checked=${String(active)}
-      ?disabled=${disabled}
-      title=${params.description}
-      @click=${() => params.options.onVisibilityChange?.(active ? "normal" : params.mode)}
-    >
-      <span aria-hidden="true">${params.icon}</span>${params.label}
-    </button>
-  `;
 }
 
 export function renderDraftError(message: string) {
@@ -240,6 +227,95 @@ function handleComposerKeydown(
     event.preventDefault();
     submitNewSession(options, options.textareaController.skillMenuState);
   }
+}
+
+function renderNewSessionPlusMenu(
+  options: NewSessionComposerOptions,
+  attachments: Parameters<typeof renderChatComposerPlusMenu>[0]["attachments"],
+) {
+  const capabilityMenu = options.capabilityMenu;
+  const draftEnabled = options.visibility === "draft";
+  const overrideCount = countSessionToolOverrides(options.toolOverrides);
+  const selectedCount = overrideCount + (draftEnabled ? 1 : 0);
+  const disabled = options.submitting || options.messageLocked === true;
+  const controller = options.textareaController;
+  return renderChatComposerPlusMenu({
+    attachments,
+    capabilityMenu,
+    disabled,
+    open: controller.capabilityMenuOpen,
+    view: controller.capabilityMenuView,
+    toolOverrides: options.toolOverrides,
+    rootToggles: options.draftAvailable
+      ? [
+          {
+            value: "new-session-draft",
+            label: t("newSession.draft"),
+            icon: icons.pencil,
+            checked: draftEnabled,
+            disabled,
+            title: t("newSession.draftDescription"),
+            onChange: (checked) => options.onVisibilityChange?.(checked ? "draft" : "normal"),
+          },
+        ]
+      : undefined,
+    selectedLabel:
+      selectedCount > 0
+        ? t("newSession.composerOptionsSelected", { count: String(selectedCount) })
+        : undefined,
+    onOpenChange: (open) => {
+      controller.capabilityMenuOpen = open;
+      if (!open) {
+        controller.capabilityMenuView = "root";
+      }
+      options.requestUpdate();
+    },
+    onViewChange: (view) => {
+      controller.capabilityMenuView = view;
+      options.requestUpdate();
+    },
+  });
+}
+
+function renderNewSessionSelectionStatus(options: NewSessionComposerOptions) {
+  const draftEnabled = options.visibility === "draft";
+  const overrideCount = countSessionToolOverrides(options.toolOverrides);
+  if (!draftEnabled && overrideCount === 0) {
+    return nothing;
+  }
+  const disabled = options.submitting || options.messageLocked === true;
+  const openMenu = () => {
+    options.textareaController.capabilityMenuView = "root";
+    options.textareaController.capabilityMenuOpen = true;
+    options.requestUpdate();
+  };
+  return html`
+    ${draftEnabled
+      ? html`<button
+          type="button"
+          class="new-session-page__selection-status"
+          ?disabled=${disabled}
+          @click=${openMenu}
+        >
+          ${icons.pencil}${t("newSession.draft")}
+        </button>`
+      : nothing}
+    ${overrideCount > 0
+      ? html`<button
+          type="button"
+          class="new-session-page__selection-status"
+          ?disabled=${disabled}
+          @click=${openMenu}
+        >
+          ${t(
+            overrideCount === 1
+              ? "chat.composer.overrides.countOne"
+              : "chat.composer.overrides.count",
+            { count: String(overrideCount) },
+          )}
+        </button>`
+      : nothing}
+  `;
 }
 
 /** Draft message box styled as the chat composer shell so both pickers match. */
@@ -345,19 +421,11 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
         </div>
         <div class="agent-chat__composer-footer">
           <div class="agent-chat__composer-controls">
-            ${renderChatAttachmentMenu(attachmentProps)}
+            ${renderNewSessionPlusMenu(options, attachmentProps)}
             ${options.modelControl && options.modelControl !== nothing
               ? html`<div class="chat-composer-model-control">${options.modelControl}</div>`
               : nothing}
-            ${options.draftAvailable
-              ? renderVisibilityPill({
-                  mode: "draft",
-                  icon: icons.pencil,
-                  label: t("newSession.draft"),
-                  description: t("newSession.draftDescription"),
-                  options,
-                })
-              : nothing}
+            ${renderNewSessionSelectionStatus(options)}
           </div>
         </div>
         ${options.blockedSubmitNotice
@@ -383,6 +451,8 @@ export function renderNewSessionDraftComposer(options: {
   message: string;
   visibility?: NewSessionVisibility;
   draftAvailable?: boolean;
+  capabilityMenu?: CapabilityMenuProps;
+  toolOverrides?: SessionToolOverrides | null;
   modelControl: NewSessionModelControl;
   textareaController: NewSessionComposerTextareaController;
   requiresModifier: boolean;
@@ -411,6 +481,8 @@ export function renderNewSessionDraftComposer(options: {
     message: options.message,
     visibility: options.visibility,
     draftAvailable: options.draftAvailable,
+    capabilityMenu: options.capabilityMenu,
+    toolOverrides: options.toolOverrides,
     modelControl: options.isCatalogTarget
       ? nothing
       : options.modelControl.render({

--- a/ui/src/pages/new-session/create-params.test.ts
+++ b/ui/src/pages/new-session/create-params.test.ts
@@ -105,6 +105,26 @@ describe("buildDraftSessionCreateParams", () => {
     });
   });
 
+  it("includes selected capability overrides in the atomic create request", () => {
+    const toolOverrides = {
+      mcpServers: { github: false },
+      skills: { release: false },
+      webSearch: false,
+    };
+    expect(
+      buildDraftSessionCreateParams({
+        agentId: "main",
+        message: "use these capabilities",
+        toolOverrides,
+        worktree: false,
+      }),
+    ).toEqual({
+      agentId: "main",
+      message: "use these capabilities",
+      toolOverrides,
+    });
+  });
+
   it("does not combine a catalog target with a draft model override", () => {
     expect(
       buildDraftSessionCreateParams({

--- a/ui/src/pages/new-session/create-params.ts
+++ b/ui/src/pages/new-session/create-params.ts
@@ -32,6 +32,7 @@ export function buildDraftSessionCreateParams(draft: {
   model?: string;
   contextWindow?: string;
   thinkingLevel?: string;
+  toolOverrides?: SessionCreateParams["toolOverrides"] | null;
   visibility?: NewSessionVisibility;
   attachments?: SessionCreateParams["attachments"];
   projectId?: string;
@@ -64,6 +65,7 @@ export function buildDraftSessionCreateParams(draft: {
     ...(!catalogId && model ? { model } : {}),
     ...(!catalogId && contextWindow ? { contextWindow } : {}),
     ...(!catalogId && thinkingLevel ? { thinkingLevel } : {}),
+    ...(draft.toolOverrides ? { toolOverrides: draft.toolOverrides } : {}),
     ...(projectId ? { projectId } : {}),
     ...(customFolder ? { cwd: customFolder } : {}),
     ...(draft.worktree

--- a/ui/src/pages/new-session/draft-persistence.test.ts
+++ b/ui/src/pages/new-session/draft-persistence.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { NewSessionCapabilityController } from "./capability-controller.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
 import type { DraftPlaceState } from "./draft-place-state.ts";
 import { DraftSubmissionFlow } from "./draft-submission-flow.ts";
@@ -70,6 +71,7 @@ function createFlow() {
   return new DraftSubmissionFlow(
     {} as DraftGatewayState,
     {} as DraftPlaceState,
+    new NewSessionCapabilityController(vi.fn()),
     () => ({ context: undefined, data: undefined, isConnected: false }),
     { requestUpdate: vi.fn(), closeTransientUi: vi.fn() },
   );

--- a/ui/src/pages/new-session/draft-persistence.test.ts
+++ b/ui/src/pages/new-session/draft-persistence.test.ts
@@ -1,7 +1,6 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { NewSessionCapabilityController } from "./capability-controller.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
 import type { DraftPlaceState } from "./draft-place-state.ts";
 import { DraftSubmissionFlow } from "./draft-submission-flow.ts";
@@ -71,7 +70,6 @@ function createFlow() {
   return new DraftSubmissionFlow(
     {} as DraftGatewayState,
     {} as DraftPlaceState,
-    new NewSessionCapabilityController(vi.fn()),
     () => ({ context: undefined, data: undefined, isConnected: false }),
     { requestUpdate: vi.fn(), closeTransientUi: vi.fn() },
   );

--- a/ui/src/pages/new-session/draft-place-browser.test.ts
+++ b/ui/src/pages/new-session/draft-place-browser.test.ts
@@ -1,24 +1,17 @@
-import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApplicationContext } from "../../app/context.ts";
 import { DraftGatewayState } from "./draft-gateway-state.ts";
 import { DraftPlaceBrowser } from "./draft-place-browser.ts";
 import type { NewSessionRouteData } from "./location.ts";
 import { loadNewSessionPreference, patchNewSessionPreference } from "./preferences.ts";
-
-class ControllerHost implements ReactiveControllerHost {
-  readonly updateComplete = Promise.resolve(true);
-  addController(_controller: ReactiveController) {}
-  removeController(_controller: ReactiveController) {}
-  requestUpdate() {}
-}
+import { TestReactiveControllerHost } from "./reactive-controller-host.test-support.ts";
 
 afterEach(() => {
   localStorage.clear();
 });
 
 function createBrowser(request: (method: string) => Promise<unknown>, data?: NewSessionRouteData) {
-  const host = new ControllerHost();
+  const host = new TestReactiveControllerHost();
   const client = { request, recoveryScope: "principal-a", recoveryScopeReady: true };
   const context = {
     gateway: {

--- a/ui/src/pages/new-session/draft-session-placement.test.ts
+++ b/ui/src/pages/new-session/draft-session-placement.test.ts
@@ -41,4 +41,32 @@ describe("new-session placement target", () => {
       draft: { message: "continue on the runner" },
     });
   });
+
+  it("restores draft visibility and capability choices from a creating recovery", () => {
+    expect(
+      projectDraftSessionPlacementRecovery({
+        sessionKey: "agent:main:cloud",
+        messageId: "message-cloud",
+        message: "continue in the cloud",
+        target: { kind: "profile", profileId: "aws" },
+        agentId: "main",
+        gatewayUrl: "ws://gateway.example",
+        recoveryScope: "principal-a",
+        phase: "creating",
+        createParams: {
+          key: "agent:main:cloud",
+          agentId: "main",
+          message: "",
+          visibility: "draft",
+          toolOverrides: { skills: { release: false } },
+          worktree: true,
+        },
+      }),
+    ).toMatchObject({
+      draft: {
+        visibility: "draft",
+        toolOverrides: { skills: { release: false } },
+      },
+    });
+  });
 });

--- a/ui/src/pages/new-session/draft-session-placement.ts
+++ b/ui/src/pages/new-session/draft-session-placement.ts
@@ -1,5 +1,6 @@
 import type { SessionPlacementRecovery } from "../../lib/sessions/session-placement-recovery.ts";
 import { restoreChatApiAttachments } from "../chat/attachment-api.ts";
+import type { NewSessionVisibility } from "./create-params.ts";
 import type { PendingSessionPlacementRecoveryState } from "./session-placement-recovery-state.ts";
 
 export type PendingPlacementPlace = {
@@ -32,8 +33,11 @@ export function resolveDraftSessionPlacement(
 }
 
 export function projectDraftSessionPlacementRecovery(recovery: SessionPlacementRecovery) {
-  const visibility: "normal" | "incognito" =
-    recovery.createParams?.incognito === true ? "incognito" : "normal";
+  const visibility: NewSessionVisibility = recovery.createParams?.incognito
+    ? "incognito"
+    : recovery.createParams?.visibility === "draft"
+      ? "draft"
+      : "normal";
   const placement: PendingPlacementPlace = {
     agentId: recovery.agentId,
     profileId: recovery.target.kind === "profile" ? recovery.target.profileId : "",
@@ -50,6 +54,7 @@ export function projectDraftSessionPlacementRecovery(recovery: SessionPlacementR
       message: recovery.message,
       attachments: restoreChatApiAttachments(recovery.attachments),
       visibility,
+      toolOverrides: recovery.createParams?.toolOverrides ?? null,
     },
   };
 }

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -9,6 +9,7 @@ import {
   getChatAttachmentDataUrl,
   registerChatAttachmentPayload,
 } from "../chat/attachment-payload-store.ts";
+import { NewSessionCapabilityController } from "./capability-controller.ts";
 import { buildDraftSessionCreateParams } from "./create-params.ts";
 import { DraftGatewayState } from "./draft-gateway-state.ts";
 import { DraftPlaceBrowser } from "./draft-place-browser.ts";
@@ -165,16 +166,19 @@ function createDraftFixture(options: FixtureOptions = {}) {
     },
   );
   const requestUpdate = vi.fn();
+  const capabilities = new NewSessionCapabilityController(requestUpdate);
   const flow = new DraftSubmissionFlow(
     gateway,
     place,
+    capabilities,
     () => ({ context, data: options.data, isConnected: phase === "connected" }),
     { requestUpdate, closeTransientUi: vi.fn() },
   );
+  capabilities.setMutationCallback(flow.retireStartedSession);
   gateway.synchronize(context.gateway);
   place.setAgentsHydrated(true);
   place.adoptAgentDefaults();
-  return { context, flow, gateway, place, request, requestUpdate };
+  return { capabilities, context, flow, gateway, place, request, requestUpdate };
 }
 
 function registerTextPayload(id: string) {
@@ -267,6 +271,7 @@ describe("DraftSubmissionFlow submit gates", () => {
     });
     let resolveBranches!: (value: unknown) => void;
     const fixture = createDraftFixture({
+      scopes: ["operator.admin", "operator.read", "operator.write"],
       agents: [
         {
           id: "main",
@@ -509,6 +514,11 @@ describe("DraftSubmissionFlow", () => {
       retire: ({ flow }: ReturnType<typeof createDraftFixture>) => flow.setVisibility("draft"),
     },
     {
+      scenario: "the requested session capabilities change",
+      retire: ({ capabilities }: ReturnType<typeof createDraftFixture>) =>
+        capabilities.setToolOverrides({ skills: { release: false } }),
+    },
+    {
       scenario: "another session becomes selected",
       retire: ({ context }: ReturnType<typeof createDraftFixture>) => {
         context.gateway.snapshot.sessionKey = "agent:main:dashboard:elsewhere";
@@ -529,6 +539,7 @@ describe("DraftSubmissionFlow", () => {
     },
   ])("never retries a committed session after $scenario", async ({ retire }) => {
     const fixture = createDraftFixture({
+      scopes: ["operator.admin", "operator.read", "operator.write"],
       agents: [
         { id: "main", workspace: "/workspace", model: { primary: "openai/test" } },
         { id: "other", workspace: "/workspace", model: { primary: "openai/test" } },
@@ -782,6 +793,7 @@ describe("DraftSubmissionFlow", () => {
     const flow = new DraftSubmissionFlow(
       gateway,
       place,
+      new NewSessionCapabilityController(vi.fn()),
       () => ({ context, data: undefined, isConnected: true }),
       { requestUpdate: vi.fn(), closeTransientUi: vi.fn() },
     );
@@ -980,6 +992,7 @@ describe("DraftSubmissionFlow", () => {
     const flow = new DraftSubmissionFlow(
       gateway,
       place,
+      new NewSessionCapabilityController(vi.fn()),
       () => ({ context, data: undefined, isConnected: true }),
       { requestUpdate: vi.fn(), closeTransientUi: vi.fn() },
     );

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -1,4 +1,3 @@
-import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SESSION_CREATE_RETRY_WINDOW_MS } from "../../../../packages/gateway-protocol/src/index.js";
 import type { ApplicationContext } from "../../app/context.ts";
@@ -9,7 +8,6 @@ import {
   getChatAttachmentDataUrl,
   registerChatAttachmentPayload,
 } from "../chat/attachment-payload-store.ts";
-import { NewSessionCapabilityController } from "./capability-controller.ts";
 import { buildDraftSessionCreateParams } from "./create-params.ts";
 import { DraftGatewayState } from "./draft-gateway-state.ts";
 import { DraftPlaceBrowser } from "./draft-place-browser.ts";
@@ -17,18 +15,12 @@ import { DraftPlaceState } from "./draft-place-state.ts";
 import { DraftSubmissionFlow } from "./draft-submission-flow.ts";
 import type { NewSessionRouteData } from "./location.ts";
 import { patchNewSessionPreference } from "./preferences.ts";
+import { TestReactiveControllerHost } from "./reactive-controller-host.test-support.ts";
 
 // The closed list of gates allowed to block without a visible reason: the busy
 // Start button and an empty draft explain themselves. Growing it is a product
 // decision — edit this list and the matching one in submit-gates.ts together.
 const SILENT_SUBMIT_GATES = ["submitting", "empty-draft"];
-
-class ControllerHost implements ReactiveControllerHost {
-  readonly updateComplete = Promise.resolve(true);
-  addController(_controller: ReactiveController) {}
-  removeController(_controller: ReactiveController) {}
-  requestUpdate() {}
-}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -102,7 +94,7 @@ function createDraftFixture(options: FixtureOptions = {}) {
   vi.mocked(context.gateway.setSessionKey).mockImplementation((sessionKey) => {
     context.gateway.snapshot.sessionKey = sessionKey;
   });
-  const host = new ControllerHost();
+  const host = new TestReactiveControllerHost();
   const gateway = new DraftGatewayState(
     host,
     () => ({
@@ -110,7 +102,7 @@ function createDraftFixture(options: FixtureOptions = {}) {
       data: options.data,
       isConnected: phase === "connected",
       isAdmin: place?.isAdmin() ?? false,
-      canStartAsDraft: flow?.canStartAsDraft() ?? false,
+      canStartAsDraft: flow?.capabilities.canStartAsDraft(context) ?? false,
       visibility: flow?.visibility ?? "normal",
       cloudProfileId: place?.cloudProfileId ?? "",
       pendingPlacement: flow?.pendingPlacement ?? {
@@ -166,19 +158,16 @@ function createDraftFixture(options: FixtureOptions = {}) {
     },
   );
   const requestUpdate = vi.fn();
-  const capabilities = new NewSessionCapabilityController(requestUpdate);
   const flow = new DraftSubmissionFlow(
     gateway,
     place,
-    capabilities,
     () => ({ context, data: options.data, isConnected: phase === "connected" }),
     { requestUpdate, closeTransientUi: vi.fn() },
   );
-  capabilities.setMutationCallback(flow.retireStartedSession);
   gateway.synchronize(context.gateway);
   place.setAgentsHydrated(true);
   place.adoptAgentDefaults();
-  return { capabilities, context, flow, gateway, place, request, requestUpdate };
+  return { capabilities: flow.capabilities, context, flow, gateway, place, request, requestUpdate };
 }
 
 function registerTextPayload(id: string) {
@@ -727,7 +716,7 @@ describe("DraftSubmissionFlow", () => {
       sessions: { state: { result: null }, createResult: vi.fn() },
       config: { current: {} },
     } as unknown as ApplicationContext;
-    const host = new ControllerHost();
+    const host = new TestReactiveControllerHost();
     const gateway = new DraftGatewayState(
       host,
       () => ({
@@ -735,7 +724,7 @@ describe("DraftSubmissionFlow", () => {
         data: undefined,
         isConnected: true,
         isAdmin: place?.isAdmin() ?? false,
-        canStartAsDraft: flow?.canStartAsDraft() ?? false,
+        canStartAsDraft: flow?.capabilities.canStartAsDraft(context) ?? false,
         visibility: flow?.visibility ?? "normal",
         cloudProfileId: place?.cloudProfileId ?? "",
         pendingPlacement: flow?.pendingPlacement ?? {
@@ -793,7 +782,6 @@ describe("DraftSubmissionFlow", () => {
     const flow = new DraftSubmissionFlow(
       gateway,
       place,
-      new NewSessionCapabilityController(vi.fn()),
       () => ({ context, data: undefined, isConnected: true }),
       { requestUpdate: vi.fn(), closeTransientUi: vi.fn() },
     );
@@ -926,7 +914,7 @@ describe("DraftSubmissionFlow", () => {
       navigateAndWait,
       preload,
     } as unknown as ApplicationContext;
-    const host = new ControllerHost();
+    const host = new TestReactiveControllerHost();
     const gateway = new DraftGatewayState(
       host,
       () => ({
@@ -934,7 +922,7 @@ describe("DraftSubmissionFlow", () => {
         data: undefined,
         isConnected: true,
         isAdmin: place?.isAdmin() ?? false,
-        canStartAsDraft: flow?.canStartAsDraft() ?? false,
+        canStartAsDraft: flow?.capabilities.canStartAsDraft(context) ?? false,
         visibility: flow?.visibility ?? "normal",
         cloudProfileId: place?.cloudProfileId ?? "",
         pendingPlacement: flow?.pendingPlacement ?? {
@@ -992,7 +980,6 @@ describe("DraftSubmissionFlow", () => {
     const flow = new DraftSubmissionFlow(
       gateway,
       place,
-      new NewSessionCapabilityController(vi.fn()),
       () => ({ context, data: undefined, isConnected: true }),
       { requestUpdate: vi.fn(), closeTransientUi: vi.fn() },
     );

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -19,6 +19,7 @@ import { requiresChatModelSetup } from "../chat/chat-model-setup.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "../chat/composer-persistence.ts";
 import { prepareInitialUserMessageHandoff } from "../chat/initial-turn-handoff.ts";
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
+import type { NewSessionCapabilityController } from "./capability-controller.ts";
 import * as catalog from "./catalog-target.ts";
 import { NewSessionComposerTextareaController } from "./composer.ts";
 import {
@@ -69,6 +70,7 @@ export class DraftSubmissionFlow {
   constructor(
     private readonly gateway: DraftGatewayState,
     private readonly place: DraftPlaceState,
+    private readonly capabilities: NewSessionCapabilityController,
     private readonly read: () => DraftSubmissionSnapshot,
     private readonly callbacks: DraftSubmissionCallbacks,
   ) {
@@ -140,10 +142,12 @@ export class DraftSubmissionFlow {
     message: string;
     attachments: ChatAttachment[];
     visibility: NewSessionVisibility;
+    toolOverrides?: NewSessionCapabilityController["toolOverrides"];
   }) {
     this.draftPersistence.noteDraftReplaced();
     this.messageValue = state.message;
     this.visibilityValue = state.visibility;
+    this.capabilities.restoreToolOverrides(state.toolOverrides);
     this.attachmentDraft.restore(state.attachments);
   }
 
@@ -154,6 +158,8 @@ export class DraftSubmissionFlow {
     this.visibilityValue = visibility;
     this.draftPersistence.transitionIncognito(wasIncognito, visibility === "incognito", publish);
   }
+
+  retireStartedSession = () => (this.startedSession.current = null);
 
   setError(error: string | null) {
     if (error === null && this.error === t("newSession.cloudRecoveryUnavailable")) {
@@ -234,6 +240,7 @@ export class DraftSubmissionFlow {
       model: this.place.modelControl.selected,
       contextWindow: this.place.modelControl.contextWindow,
       thinkingLevel: this.place.modelControl.thinkingLevel,
+      toolOverrides: this.capabilities.toolOverrides,
       visibility: options.visibility ?? this.visibilityValue,
       attachments: options.attachments,
       projectId: this.place.browser.remoteProject?.projectId ?? this.place.browser.projectId,
@@ -389,6 +396,7 @@ export class DraftSubmissionFlow {
       ? (this.submissionOutcomeUnknownValue ?? "placement-interrupted")
       : null;
     this.visibilityValue = "normal";
+    this.capabilities.reset();
     this.attachmentDraft.reset({ release: true });
     if (preservePendingPlacement) {
       if (!this.pendingPlacement.restored) {

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -19,12 +19,11 @@ import { requiresChatModelSetup } from "../chat/chat-model-setup.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "../chat/composer-persistence.ts";
 import { prepareInitialUserMessageHandoff } from "../chat/initial-turn-handoff.ts";
 import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
-import type { NewSessionCapabilityController } from "./capability-controller.ts";
+import { NewSessionCapabilityController } from "./capability-controller.ts";
 import * as catalog from "./catalog-target.ts";
 import { NewSessionComposerTextareaController } from "./composer.ts";
 import {
   buildDraftSessionCreateParams as assembleDraftSessionCreateParams,
-  canStartSessionAsDraft,
   type NewSessionVisibility,
 } from "./create-params.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
@@ -66,14 +65,16 @@ export class DraftSubmissionFlow {
   readonly attachmentDraft: NewSessionAttachmentDraft;
   readonly composerTextarea = new NewSessionComposerTextareaController();
   readonly draftPersistence: NewSessionDraftPersistence;
+  readonly capabilities: NewSessionCapabilityController;
 
   constructor(
     private readonly gateway: DraftGatewayState,
     private readonly place: DraftPlaceState,
-    private readonly capabilities: NewSessionCapabilityController,
     private readonly read: () => DraftSubmissionSnapshot,
     private readonly callbacks: DraftSubmissionCallbacks,
   ) {
+    this.capabilities = new NewSessionCapabilityController(callbacks.requestUpdate);
+    this.capabilities.setMutationCallback(() => (this.startedSession.current = null));
     this.sessionStartup = new DraftSessionStartup(gateway);
     this.draftPersistence = new NewSessionDraftPersistence(
       () => ({
@@ -159,8 +160,6 @@ export class DraftSubmissionFlow {
     this.draftPersistence.transitionIncognito(wasIncognito, visibility === "incognito", publish);
   }
 
-  retireStartedSession = () => (this.startedSession.current = null);
-
   setError(error: string | null) {
     if (error === null && this.error === t("newSession.cloudRecoveryUnavailable")) {
       this.error = null;
@@ -200,15 +199,6 @@ export class DraftSubmissionFlow {
       return undefined;
     }
     return PAGE_RENDERED_GATES.has(block.gate) ? undefined : block.reason;
-  }
-
-  canStartAsDraft(): boolean {
-    return canStartSessionAsDraft({
-      allowedVisibilities:
-        this.read().context?.gateway.snapshot.hello?.policy?.allowedSessionVisibilities,
-      hasMultipleIdentities:
-        this.read().context?.gateway.snapshot.hello?.policy?.hasMultipleSessionSharingIdentities,
-    });
   }
 
   showStartInTerminal(): boolean {
@@ -499,7 +489,8 @@ export class DraftSubmissionFlow {
         this.buildDraftSessionCreateParams({
           message: placementTarget ? "" : message,
           visibility:
-            this.visibilityValue === "draft" && !this.canStartAsDraft()
+            this.visibilityValue === "draft" &&
+            !this.capabilities.canStartAsDraft(this.read().context)
               ? "normal"
               : this.visibilityValue,
           attachments: placementTarget ? undefined : draftAttachments,

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -282,10 +282,6 @@ export class DraftSubmissionFlow {
     return this.submitBlock()?.reason;
   }
 
-  terminalStartDisabledReason(): string | undefined {
-    return this.submitBlock("terminal")?.reason;
-  }
-
   incognitoDisabledReason(): string | undefined {
     const access = readSessionMethodAccess(this.read().context?.gateway.snapshot, {
       method: "sessions.create",
@@ -317,6 +313,7 @@ export class DraftSubmissionFlow {
         submissionOutcomeUnknown: this.submissionOutcomeUnknownValue,
         pendingAttachmentReads: this.attachmentDraft.pendingReads,
         hasDraftAttachments: this.attachmentDraft.attachments.length > 0,
+        hasCapabilityOverrides: this.capabilities.toolOverrides !== null,
         submissionSnapshot: () => this.read(),
         requiresModelSetup: () => this.requiresModelSetup(),
         submissionAccess: () => this.submissionAccess(),

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -614,7 +614,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
           terminalAction: this.submission.showStartInTerminal()
             ? {
                 canStart: !this.submission.submitting && this.submission.canSubmit("terminal"),
-                disabledReason: this.submission.terminalStartDisabledReason(),
+                disabledReason: this.submission.submitBlock("terminal")?.reason,
                 onStart: () => void this.submission.startInTerminal(),
               }
             : undefined,

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -20,7 +20,6 @@ import "../../styles/chat.css";
 import "../../styles/new-session.css";
 import { renderChatImageLightbox } from "../chat/components/chat-image-lightbox.ts";
 import { renderWelcomeState } from "../chat/components/chat-welcome.ts";
-import { NewSessionCapabilityController } from "./capability-controller.ts";
 import * as catalog from "./catalog-target.ts";
 import { renderDraftError, renderNewSessionDraftComposer } from "./composer.ts";
 import { renderConnectMachineDialog } from "./connect-machine-dialog.ts";
@@ -74,7 +73,6 @@ export class NewSessionPage extends OpenClawLightDomElement {
   private readonly browser: DraftPlaceBrowser;
   private readonly place: DraftPlaceState;
   private readonly submission: DraftSubmissionFlow;
-  private readonly capabilities: NewSessionCapabilityController;
   private readonly subscriptions: SubscriptionsController;
   private readonly flushDraft = () => this.submission.draftPersistence.persistNow();
 
@@ -88,7 +86,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
         data: this.data,
         isConnected: this.isConnected,
         isAdmin: this.place?.isAdmin() ?? false,
-        canStartAsDraft: this.submission?.canStartAsDraft() ?? false,
+        canStartAsDraft: this.submission?.capabilities.canStartAsDraft(this.context) ?? false,
         visibility: this.submission?.visibility ?? "normal",
         cloudProfileId: this.place?.cloudProfileId ?? "",
         pendingPlacement: this.submission?.pendingPlacement ?? {
@@ -149,18 +147,15 @@ export class NewSessionPage extends OpenClawLightDomElement {
         onClearError: (error) => this.submission.clearErrorIf(error),
       },
     );
-    this.capabilities = new NewSessionCapabilityController(() => this.requestUpdate());
     this.submission = new DraftSubmissionFlow(
       this.gateway,
       this.place,
-      this.capabilities,
       () => ({ context: this.context, data: this.data, isConnected: this.isConnected }),
       {
         requestUpdate: () => this.requestUpdate(),
         closeTransientUi: () => closeSessionMenus(this),
       },
     );
-    this.capabilities.setMutationCallback(this.submission.retireStartedSession);
     this.subscriptions = new SubscriptionsController(this)
       .watch(
         () => this.context?.gateway,
@@ -582,6 +577,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
   private renderDraftBlock() {
     const worktreeNameInvalid =
       this.place.worktree && !isWorktreeNameValid(this.place.worktreeName);
+    const capabilities = this.submission.capabilities;
     return html`
       <div class="new-session-page__draft" aria-busy=${String(this.submission.submitting)}>
         ${this.renderTargetBar()}
@@ -607,8 +603,8 @@ export class NewSessionPage extends OpenClawLightDomElement {
           isCatalogTarget: catalog.isTarget(this.data),
           message: this.submission.message,
           visibility: this.submission.visibility,
-          draftAvailable: this.submission.canStartAsDraft(),
-          ...this.capabilities.composerProps(this.context, this.gateway, this.place.agentId),
+          draftAvailable: capabilities.canStartAsDraft(this.context),
+          ...capabilities.composerProps(this.context, this.gateway, this.place.agentId),
           modelControl: this.place.modelControl,
           requiresModifier: loadSettings().chatSendShortcut === "modifier-enter",
           requestUpdate: () => this.requestUpdate(),

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -20,6 +20,7 @@ import "../../styles/chat.css";
 import "../../styles/new-session.css";
 import { renderChatImageLightbox } from "../chat/components/chat-image-lightbox.ts";
 import { renderWelcomeState } from "../chat/components/chat-welcome.ts";
+import { NewSessionCapabilityController } from "./capability-controller.ts";
 import * as catalog from "./catalog-target.ts";
 import { renderDraftError, renderNewSessionDraftComposer } from "./composer.ts";
 import { renderConnectMachineDialog } from "./connect-machine-dialog.ts";
@@ -73,6 +74,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
   private readonly browser: DraftPlaceBrowser;
   private readonly place: DraftPlaceState;
   private readonly submission: DraftSubmissionFlow;
+  private readonly capabilities: NewSessionCapabilityController;
   private readonly subscriptions: SubscriptionsController;
   private readonly flushDraft = () => this.submission.draftPersistence.persistNow();
 
@@ -147,15 +149,18 @@ export class NewSessionPage extends OpenClawLightDomElement {
         onClearError: (error) => this.submission.clearErrorIf(error),
       },
     );
+    this.capabilities = new NewSessionCapabilityController(() => this.requestUpdate());
     this.submission = new DraftSubmissionFlow(
       this.gateway,
       this.place,
+      this.capabilities,
       () => ({ context: this.context, data: this.data, isConnected: this.isConnected }),
       {
         requestUpdate: () => this.requestUpdate(),
         closeTransientUi: () => closeSessionMenus(this),
       },
     );
+    this.capabilities.setMutationCallback(this.submission.retireStartedSession);
     this.subscriptions = new SubscriptionsController(this)
       .watch(
         () => this.context?.gateway,
@@ -603,6 +608,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
           message: this.submission.message,
           visibility: this.submission.visibility,
           draftAvailable: this.submission.canStartAsDraft(),
+          ...this.capabilities.composerProps(this.context, this.gateway, this.place.agentId),
           modelControl: this.place.modelControl,
           requiresModifier: loadSettings().chatSendShortcut === "modifier-enter",
           requestUpdate: () => this.requestUpdate(),

--- a/ui/src/pages/new-session/reactive-controller-host.test-support.ts
+++ b/ui/src/pages/new-session/reactive-controller-host.test-support.ts
@@ -1,0 +1,8 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+
+export class TestReactiveControllerHost implements ReactiveControllerHost {
+  readonly updateComplete = Promise.resolve(true);
+  addController(_controller: ReactiveController) {}
+  removeController(_controller: ReactiveController) {}
+  requestUpdate() {}
+}

--- a/ui/src/pages/new-session/session-placement-recovery.test.ts
+++ b/ui/src/pages/new-session/session-placement-recovery.test.ts
@@ -279,6 +279,11 @@ describe("session placement recovery", () => {
         category: "Client work",
         projectId: "openclaw",
         thinkingLevel: "high",
+        toolOverrides: {
+          mcpServers: { github: false },
+          skills: { release: false },
+          webSearch: false,
+        },
         visibility: "draft" as const,
         worktree: true as const,
       },
@@ -314,6 +319,7 @@ describe("session placement recovery", () => {
       value: { projectId: "openclaw", execNode: "macbook" },
     },
     { name: "an unsupported visibility", value: { visibility: "shared" } },
+    { name: "malformed tool overrides", value: { toolOverrides: { webSearch: "yes" } } },
     { name: "an unknown field", value: { unknown: true } },
   ])("rejects $name in creating parameters", ({ value }) => {
     expect(

--- a/ui/src/pages/new-session/submit-gates.ts
+++ b/ui/src/pages/new-session/submit-gates.ts
@@ -37,6 +37,7 @@ type ReasonedSubmitGate =
   | "cloud"
   | "worktree-unavailable"
   | "worktree-name"
+  | "terminal-capabilities"
   | "terminal-folder";
 export type NewSessionSubmitBlock =
   | { gate: SilentSubmitGate; reason?: undefined }
@@ -59,6 +60,7 @@ type SubmitGateHost = {
   readonly submissionOutcomeUnknown: SubmissionOutcomeReason | null;
   readonly pendingAttachmentReads: number;
   readonly hasDraftAttachments: boolean;
+  readonly hasCapabilityOverrides: boolean;
   submissionSnapshot(): DraftSubmissionSnapshot;
   requiresModelSetup(): boolean;
   submissionAccess(): SessionMethodAccess;
@@ -122,6 +124,12 @@ export function resolveNewSessionSubmitBlock(
   const access = kind === "terminal" ? host.terminalStartAccess() : host.submissionAccess();
   if (!access.allowed) {
     return { gate: "access", reason: access.reason };
+  }
+  if (kind === "terminal" && host.hasCapabilityOverrides) {
+    return {
+      gate: "terminal-capabilities",
+      reason: t("newSession.terminalCapabilityOverridesUnsupported"),
+    };
   }
   if (place.folderSubmissionBlocked()) {
     return { gate: "folder", reason: t("newSession.checkingPlace") };

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3157,6 +3157,24 @@ button.chat-pr__diff {
   background: var(--bg-hover);
 }
 
+.agent-chat__input-btn--selected:not(:disabled) {
+  position: relative;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.agent-chat__input-btn--selected::after {
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+  width: 5px;
+  height: 5px;
+  border: 1px solid var(--bg);
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
 .agent-chat__input-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -71,7 +71,7 @@ html.openclaw-native-macos .new-session-page__incognito-rail {
   text-align: left;
 }
 
-.new-session-page__visibility {
+.new-session-page__selection-status {
   display: inline-flex;
   align-items: center;
   gap: 5px;
@@ -79,40 +79,23 @@ html.openclaw-native-macos .new-session-page__incognito-rail {
   padding: 2px 8px;
   border: 0;
   border-radius: var(--radius-full);
-  background: transparent;
-  color: var(--muted);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
   font: inherit;
   font-size: 11px;
   cursor: var(--cursor-action);
-  opacity: 0;
-  transition: opacity 120ms ease;
 }
 
-.new-session-page__visibility:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
-  color: var(--text);
+.new-session-page__selection-status:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
-.new-session-page__composer:hover .new-session-page__visibility,
-.new-session-page__composer:focus-within .new-session-page__visibility,
-.new-session-page__visibility--active {
-  opacity: 1;
-}
-
-/* Active mode must read as toggled-on even while hovered: hover on an
-   inactive pill already shows a neutral fill, so active gets an accent
-   tint to stay distinguishable under the cursor. */
-.new-session-page__visibility--active,
-.new-session-page__visibility--active:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
-  color: var(--accent);
-}
-
-.new-session-page__visibility:disabled {
+.new-session-page__selection-status:disabled {
   cursor: default;
+  opacity: 0.5;
 }
 
-.new-session-page__visibility svg {
+.new-session-page__selection-status svg {
   width: 12px;
   height: 12px;
   fill: none;
@@ -709,8 +692,7 @@ wa-dropdown.new-session-page__start-menu {
   }
 
   .new-session-page__composer::after,
-  .new-session-page__composer > *,
-  .new-session-page__visibility {
+  .new-session-page__composer > * {
     transition-duration: 0ms;
   }
 }


### PR DESCRIPTION
Closes #128079

## What Problem This Solves

The new-session composer only exposed attachment actions in Plus, while Skills, Connectors, Web Search, and plugin management were available only after a session started. Operators could not choose the first turn's capabilities before launch, and Draft permanently occupied footer space despite being a secondary session option.

## Why This Change Was Made

This reuses the active-chat Plus renderer for new sessions, moves Draft into that menu, and keeps active Draft/capability state visible after the menu closes. An additive, admin-scoped `toolOverrides` field now flows through `sessions.create`, canonical normalization, SQLite session persistence, and placement recovery before the initial `chat.send`; there is no create-then-patch race.

The shared capability catalog replaces the duplicated skill-loading policy, and the obsolete standalone attachment-menu renderer was removed. Pre-session per-tool MCP access remains intentionally absent because `tools.effective` requires a persisted session.

## User Impact

Operators can select Draft, Skills, Connectors, and Web Search before starting a session. The first model turn receives those exact capabilities atomically. Model and reasoning controls remain visible, while Draft moves into Plus and leaves a compact active-state chip.

## Evidence

### Before

At the PR base SHA, the real mocked-Gateway Control UI stopped after the three attachment actions:

![Before: attachment-only new-session Plus](https://github.com/user-attachments/assets/66fb89ae-8667-49d5-9ffc-4b76a22a2306)

### After

At the PR head SHA, the same real mocked-Gateway Control UI at 555×1200 exposes Draft and the active-chat capability stack. Its responsive model/effort controls align to the composer's right content edge:

![After: unified new-session Plus](https://github.com/user-attachments/assets/938266f6-8d95-4899-9e47-5c8466b9d0d9)

Draft stays visible after the menu closes, Plus shows a selection indicator, and the model/effort controls remain right-aligned:

![After: Draft active state](https://github.com/user-attachments/assets/19fdac75-61b6-43fb-99d7-571256b05987)

### Automated proof

- `node scripts/run-vitest.mjs packages/gateway-protocol/src/schema/sessions-create.test.ts src/gateway/method-scopes.test.ts src/gateway/server.sessions.create.test.ts` — 588 tests passed. The Gateway test reads the persisted row inside the mocked initial `chat.send` and proves explicit overrides beat parent inheritance.
- `node scripts/run-vitest.mjs ui/src/pages/new-session/composer.test.ts ui/src/pages/new-session/create-params.test.ts ui/src/pages/new-session/draft-persistence.test.ts ui/src/pages/new-session/draft-session-placement.test.ts ui/src/pages/new-session/draft-submission-flow.test.ts ui/src/pages/new-session/session-placement-recovery.test.ts ui/src/pages/chat/chat-composer-capability-host.test.ts ui/src/pages/chat/chat-composer.test.ts` — 127 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.capability-menu.e2e.test.ts ui/src/e2e/chat-composer-capability-menu.e2e.test.ts` — 11 Chromium E2E tests passed; the new-session case asserts one `sessions.create` with Draft and three overrides, and zero `sessions.patch` calls.
- `pnpm build` — exact-head production build passed; Control UI startup JS remained within budget at 337.1 KiB gzip / 337.5 KiB limit.
- Protocol registry, Swift check, Kotlin generation, and protocol-since guard passed.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json ...`, `node scripts/run-tsgo-core-test-shards.mjs`, focused oxlint, i18n verification, and `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.

The broad `node scripts/check-changed.mjs` gate passed every changed-surface format, dead-code, i18n, typecheck, lint, and style phase. Its unrelated macOS packaging fixture `test/scripts/package-mac-app.test.ts` still fails on this Linux host because the host's pnpm/corepack shim exits with empty stderr; neither that test nor `scripts/package-mac-app.sh` differs from `origin/main`.

### Dependency contract

Personally inspected sibling Codex commit `66919805ea080053d1933b6b43afeb0d8bf70c91`: `ThreadStartParams.config` is accepted before thread creation (`../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:58`, `../codex/codex-rs/app-server/src/request_processors/thread_processor.rs:1072`, `../codex/codex-rs/app-server/src/request_processors/thread_processor.rs:1310`). This confirms OpenClaw must persist session capability overrides before the first turn starts.

### Diff shape

- Production: +613/-247, net +366. Growth is the new create-time capability contract, shared menu/catalog state, recovery handling, and active-state UI; the old attachment renderer and duplicated skill loader were removed.
- Tests: +299/-9, net +290.
- Generated protocol: +4.

AI-assisted. I reviewed the owner boundaries, protocol/security implications, generated clients, and final behavior.


