### PR TITLE
fix(web): keep short multiline user messages expanded

### DIFF
--- a/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
+++ b/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
@@ -10,73 +10,135 @@ import {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
-  it.each([
-    {
-      name: "explicit lines",
-      text: Array.from({ length: 8 }, (_, index) => `Prompt line ${index + 1}`).join("\n"),
+  it("keeps seven short lines fully visible", async () => {
+    const text = [
+      "please re-review these:",
+      "#127818",
+      "#127826",
+      "#127844",
+      "#127881",
+      "",
+      "rerun the same session we had for these",
+    ].join("\n");
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
-    },
-    {
-      name: "soft-wrapped text",
-      text: `${"This prompt remains mounted while its narrow visual preview is clamped. ".repeat(7)}Final prompt tail.`,
-      viewport: { height: 844, width: 390 },
-    },
-  ] as const)(
-    "clamps $name to five lines and toggles the complete prompt",
-    async ({ name, text, viewport }) => {
-      const context = await suite.newBrowserContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport,
-      });
-      const page = await context.newPage();
-      await installMockGateway(page, {
-        historyMessages: [{ role: "user", content: [{ type: "text", text }], timestamp: 1 }],
-      });
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      historyMessages: [{ role: "user", content: [{ type: "text", text }], timestamp: 1 }],
+    });
 
-      try {
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const bubble = page.locator(".chat-group.user .chat-bubble");
-        await bubble.waitFor({ state: "visible", timeout: 10_000 });
-        const content = bubble.locator(".chat-message-disclosure__content");
-        const toggle = bubble.getByRole("button", { name: "Show more" });
-
-        expect(await toggle.getAttribute("aria-expanded")).toBe("false");
-        expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
-          "5",
-        );
-        expect(await content.textContent()).toContain(text.slice(-18));
-        const collapsedHeight = await content.evaluate((element) => element.clientHeight);
-        expect(
-          await content.evaluate((element) => element.scrollHeight > element.clientHeight),
-        ).toBe(true);
-        const proofDir = path.join(
-          process.cwd(),
-          ".artifacts",
-          "control-ui-e2e",
-          "user-bubble-disclosure",
-        );
-        const proofName = name.replaceAll(" ", "-");
-        if (captureUiProofEnabled) {
-          await mkdir(proofDir, { recursive: true });
-          await bubble.screenshot({ path: path.join(proofDir, `${proofName}-collapsed.png`) });
-        }
-
-        await toggle.click();
-        const collapse = bubble.getByRole("button", { name: "Show less" });
-        expect(await collapse.getAttribute("aria-expanded")).toBe("true");
-        expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
-          "none",
-        );
-        expect(await content.evaluate((element) => element.clientHeight)).toBeGreaterThan(
-          collapsedHeight,
-        );
-        if (captureUiProofEnabled) {
-          await bubble.screenshot({ path: path.join(proofDir, `${proofName}-expanded.png`) });
-        }
-      } finally {
-        await suite.closeBrowserContext(context);
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const bubble = page.locator(".chat-group.user .chat-bubble");
+      await bubble.waitFor({ state: "visible", timeout: 10_000 });
+      const proofDir = path.join(
+        process.cwd(),
+        ".artifacts",
+        "control-ui-e2e",
+        "user-bubble-clamp",
+      );
+      if (captureUiProofEnabled) {
+        await mkdir(proofDir, { recursive: true });
+        await bubble.screenshot({ path: path.join(proofDir, "short-message.png") });
       }
-    },
-  );
+
+      expect(await bubble.getByRole("button", { name: "Show more" }).count()).toBe(0);
+      expect(await bubble.locator(".chat-message-disclosure").count()).toBe(0);
+      const bubbleText = await bubble.textContent();
+      for (const line of text.split("\n").filter(Boolean)) {
+        expect(bubbleText).toContain(line);
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("clamps a 1300-character prompt to five lines and toggles the complete prompt", async () => {
+    const text =
+      `${"This long prompt stays mounted while its preview is clamped. ".repeat(22)}Final prompt tail.`.slice(
+        0,
+        1_300,
+      );
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 844, width: 390 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      historyMessages: [{ role: "user", content: [{ type: "text", text }], timestamp: 1 }],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const bubble = page.locator(".chat-group.user .chat-bubble");
+      await bubble.waitFor({ state: "visible", timeout: 10_000 });
+      const content = bubble.locator(".chat-message-disclosure__content");
+      const toggle = bubble.getByRole("button", { name: "Show more" });
+
+      expect(await toggle.getAttribute("aria-expanded")).toBe("false");
+      expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
+        "5",
+      );
+      expect(await content.textContent()).toContain(text.slice(-18));
+      const collapsedHeight = await content.evaluate((element) => element.clientHeight);
+      expect(await content.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(
+        true,
+      );
+      const proofDir = path.join(
+        process.cwd(),
+        ".artifacts",
+        "control-ui-e2e",
+        "user-bubble-clamp",
+      );
+      if (captureUiProofEnabled) {
+        await mkdir(proofDir, { recursive: true });
+        await bubble.screenshot({ path: path.join(proofDir, "long-message-collapsed.png") });
+      }
+
+      await toggle.click();
+      const collapse = bubble.getByRole("button", { name: "Show less" });
+      expect(await collapse.getAttribute("aria-expanded")).toBe("true");
+      expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
+        "none",
+      );
+      expect(await content.evaluate((element) => element.clientHeight)).toBeGreaterThan(
+        collapsedHeight,
+      );
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("hides the disclosure when long markdown renders within five lines", async () => {
+    const text = `[short label](https://example.com/${"a".repeat(1_300)})`;
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 844, width: 390 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      historyMessages: [{ role: "user", content: [{ type: "text", text }], timestamp: 1 }],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const bubble = page.locator(".chat-group.user .chat-bubble");
+      await bubble.waitFor({ state: "visible", timeout: 10_000 });
+      const content = bubble.locator(".chat-message-disclosure__content");
+      const toggle = bubble.locator(".chat-message-disclosure__toggle");
+
+      expect(await content.textContent()).toContain("short label");
+      expect(
+        await content.evaluate((element) => element.scrollHeight <= element.clientHeight),
+      ).toBe(true);
+      expect(await toggle.isHidden()).toBe(true);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
 });

--- a/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
+++ b/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
@@ -112,33 +112,4 @@ suite.define(() => {
       await suite.closeBrowserContext(context);
     }
   });
-
-  it("hides the disclosure when long markdown renders within five lines", async () => {
-    const text = `[short label](https://example.com/${"a".repeat(1_300)})`;
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 844, width: 390 },
-    });
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      historyMessages: [{ role: "user", content: [{ type: "text", text }], timestamp: 1 }],
-    });
-
-    try {
-      await page.goto(`${suite.server.baseUrl}chat`);
-      const bubble = page.locator(".chat-group.user .chat-bubble");
-      await bubble.waitFor({ state: "visible", timeout: 10_000 });
-      const content = bubble.locator(".chat-message-disclosure__content");
-      const toggle = bubble.locator(".chat-message-disclosure__toggle");
-
-      expect(await content.textContent()).toContain("short label");
-      expect(
-        await content.evaluate((element) => element.scrollHeight <= element.clientHeight),
-      ).toBe(true);
-      expect(await toggle.isHidden()).toBe(true);
-    } finally {
-      await suite.closeBrowserContext(context);
-    }
-  });
 });

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -2,8 +2,9 @@
 // Contract for the full-message fetch flag: the Gateway marks every display-
 // capped projection (user rows included), but the expander that consumes this
 // flag renders loaded content for assistant rows alone.
-import { describe, expect, it } from "vitest";
-import { resolveMessageActionDetails } from "./chat-message-markdown.ts";
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { renderUserMessageMarkdown, resolveMessageActionDetails } from "./chat-message-markdown.ts";
 
 const cappedMeta = { id: "msg-1", truncated: true, reason: "display-cap" };
 
@@ -49,5 +50,81 @@ describe("resolveMessageActionDetails full-message fetch flag", () => {
       senderLabel: "assistant",
     });
     expect(details?.shouldFetchFullMessage).toBe(false);
+  });
+});
+
+describe("user message disclosure", () => {
+  it.each([
+    {
+      name: "seven short lines",
+      markdown: [
+        "please re-review these:",
+        "#127818",
+        "#127826",
+        "#127844",
+        "#127881",
+        "",
+        "rerun the same session we had for these",
+      ].join("\n"),
+    },
+    { name: "exactly 1200 UTF-16 code units", markdown: "a".repeat(1_200) },
+    { name: "forty short lines", markdown: Array(40).fill("a").join("\n") },
+  ])("keeps $name fully visible", ({ markdown }) => {
+    const container = document.createElement("div");
+
+    render(
+      renderUserMessageMarkdown(
+        markdown,
+        "message",
+        { isStreaming: false, onToggleUserMessageExpanded: vi.fn() },
+        {},
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-message-disclosure")).toBeNull();
+    for (const line of markdown.split("\n").filter(Boolean)) {
+      expect(container.textContent).toContain(line);
+    }
+  });
+
+  it("collapses 1201 UTF-16 code units without truncating the DOM", () => {
+    const container = document.createElement("div");
+    const markdown = "a".repeat(1_201);
+    const onToggle = vi.fn();
+
+    render(
+      renderUserMessageMarkdown(
+        markdown,
+        "message",
+        { isStreaming: false, onToggleUserMessageExpanded: onToggle },
+        {},
+      ),
+      container,
+    );
+
+    const disclosure = container.querySelector(".chat-message-disclosure");
+    const toggle = disclosure?.querySelector<HTMLButtonElement>(".chat-message-disclosure__toggle");
+    expect(disclosure?.textContent).toContain(markdown);
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+
+    toggle?.click();
+    expect(onToggle).toHaveBeenCalledWith("user-message:message");
+  });
+
+  it("collapses forty-one short lines", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderUserMessageMarkdown(
+        Array(41).fill("a").join("\n"),
+        "message",
+        { isStreaming: false, onToggleUserMessageExpanded: vi.fn() },
+        {},
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-message-disclosure")).not.toBeNull();
   });
 });

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -87,44 +87,4 @@ describe("user message disclosure", () => {
       expect(container.textContent).toContain(line);
     }
   });
-
-  it("collapses 1201 UTF-16 code units without truncating the DOM", () => {
-    const container = document.createElement("div");
-    const markdown = "a".repeat(1_201);
-    const onToggle = vi.fn();
-
-    render(
-      renderUserMessageMarkdown(
-        markdown,
-        "message",
-        { isStreaming: false, onToggleUserMessageExpanded: onToggle },
-        {},
-      ),
-      container,
-    );
-
-    const disclosure = container.querySelector(".chat-message-disclosure");
-    const toggle = disclosure?.querySelector<HTMLButtonElement>(".chat-message-disclosure__toggle");
-    expect(disclosure?.textContent).toContain(markdown);
-    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
-
-    toggle?.click();
-    expect(onToggle).toHaveBeenCalledWith("user-message:message");
-  });
-
-  it("collapses forty-one short lines", () => {
-    const container = document.createElement("div");
-
-    render(
-      renderUserMessageMarkdown(
-        Array(41).fill("a").join("\n"),
-        "message",
-        { isStreaming: false, onToggleUserMessageExpanded: vi.fn() },
-        {},
-      ),
-      container,
-    );
-
-    expect(container.querySelector(".chat-message-disclosure")).not.toBeNull();
-  });
 });

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -201,8 +201,9 @@ export function renderReplyButton(
   `;
 }
 
-const USER_MESSAGE_COLLAPSED_LINE_LIMIT = 5;
-const USER_MESSAGE_COLLAPSED_CHAR_LIMIT = 700;
+// Character length owns normal disclosure; this high line cap only bounds newline-heavy prompts.
+const USER_MESSAGE_COLLAPSED_CHAR_LIMIT = 1_200;
+const USER_MESSAGE_COLLAPSED_LINE_LIMIT = 40;
 
 function shouldCollapseUserMessage(markdown: string): boolean {
   return (
@@ -253,28 +254,21 @@ export function renderUserMessageMarkdown(
   markdownRenderOptions: MarkdownRenderOptions,
   duplicateSuffix?: DuplicateSuffix,
 ) {
-  if (!opts.onToggleUserMessageExpanded) {
+  if (!opts.onToggleUserMessageExpanded || !shouldCollapseUserMessage(markdown)) {
     return renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions, duplicateSuffix);
   }
 
   const disclosureId = `user-message:${messageKey}`;
   const expanded = opts.isUserMessageExpanded?.(disclosureId) ?? false;
-  const likelyOverflow = shouldCollapseUserMessage(markdown);
   return html`
-    <div
-      class="chat-message-disclosure ${expanded
-        ? "is-expanded has-overflow"
-        : likelyOverflow
-          ? "has-overflow"
-          : ""}"
-    >
+    <div class="chat-message-disclosure ${expanded ? "is-expanded has-overflow" : ""}">
       <div class="chat-message-disclosure__content" ${ref(userMessageOverflowRef(expanded))}>
         ${renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions, duplicateSuffix)}
       </div>
       <button
         class="chat-message-disclosure__toggle"
         type="button"
-        ?hidden=${!expanded && !likelyOverflow}
+        ?hidden=${!expanded}
         aria-label=${t(expanded ? "chat.messages.showLess" : "chat.messages.showMore")}
         aria-expanded=${String(expanded)}
         @click=${() => opts.onToggleUserMessageExpanded?.(disclosureId)}

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1007,10 +1007,7 @@ describe("grouped chat rendering", () => {
 
   it("collapses long user messages and toggles their disclosure state", () => {
     const container = document.createElement("div");
-    const collapsedLines = [
-      "Inspect AGENTS.md:188 first.",
-      ...Array.from({ length: 11 }, (_, index) => `Prompt line ${index}`),
-    ];
+    const collapsedLines = ["Inspect AGENTS.md:188 first.", "a".repeat(1_201)];
     const expandedTail = "Full prompt tail after the disclosure boundary.";
     const markdownContent = [...collapsedLines, expandedTail].join("\n");
     const onToggleUserMessageExpanded = vi.fn();
@@ -1074,7 +1071,7 @@ describe("grouped chat rendering", () => {
 
   it("collapses a long single-line user message without truncating its DOM", () => {
     const container = document.createElement("div");
-    const markdownContent = `${"a".repeat(699)}😀`;
+    const markdownContent = `${"a".repeat(1_199)}😀`;
 
     renderGroupedMessage(
       container,
@@ -1088,20 +1085,29 @@ describe("grouped chat rendering", () => {
     expect(expectElement(disclosure, ".chat-text", HTMLDivElement).textContent).toContain("😀");
   });
 
-  it("does not add prompt disclosure controls to short user or assistant messages", () => {
+  it("does not add prompt disclosure controls to short multiline user or assistant messages", () => {
     const container = document.createElement("div");
     const onToggleUserMessageExpanded = vi.fn();
+    const shortMultilinePrompt = [
+      "please re-review these:",
+      "#127818",
+      "#127826",
+      "#127844",
+      "#127881",
+      "",
+      "rerun the same session we had for these",
+    ].join("\n");
 
     renderGroupedMessage(
       container,
-      { role: "user", content: "Short prompt", timestamp: 1001 },
+      { role: "user", content: shortMultilinePrompt, timestamp: 1001 },
       "user",
       { onToggleUserMessageExpanded },
     );
-    expect(container.querySelector(".chat-message-disclosure")).not.toBeNull();
-    expect(
-      container.querySelector<HTMLButtonElement>(".chat-message-disclosure__toggle")?.hidden,
-    ).toBe(true);
+    expect(container.querySelector(".chat-message-disclosure")).toBeNull();
+    for (const line of shortMultilinePrompt.split("\n").filter(Boolean)) {
+      expect(container.textContent).toContain(line);
+    }
 
     renderAssistantMessage(
       container,


### PR DESCRIPTION
Closes #128083

## What Problem This Solves

Fixes an issue where short multiline messages in the Control UI were collapsed after five visual lines, hiding part of a roughly 90-character prompt behind a chevron.

## Why This Change Was Made

Web Control UI prompts become eligible for disclosure above 1,200 UTF-16 code units, while an exceptional 40-line cap prevents newline-heavy prompts from creating effectively unbounded bubbles. The web only installs the five-line preview for eligible messages and retains rendered-overflow measurement so long Markdown that renders short does not get a no-op toggle.

## User Impact

Short Control UI prompts remain fully readable even when they contain several explicit line breaks. Long prompts still show a bounded preview with working expand/collapse controls.

## Mobile Follow-up

iOS/OpenClawKit and Android are intentionally unchanged in this PR. Aligning their disclosure thresholds remains a separately scoped mobile follow-up; no new issue was opened per maintainer direction.

## Evidence

### Playwright before/after

| Scenario | Before | After |
| --- | --- | --- |
| Seven-line reported prompt | ![Before: the short message is cut after five lines](https://github.com/user-attachments/assets/11703a45-2230-4db6-9b2d-80ce198b9717) | ![After: the complete short message is visible without a toggle](https://github.com/user-attachments/assets/670427f4-7e2d-4887-8d8f-b47f9b551c8e) |
| 1,300-character prompt | ![Before: long prompt is clamped to five lines](https://github.com/user-attachments/assets/dd3bb4bb-9240-4fd2-b125-ca71a3bb6285) | ![After: long prompt remains clamped with its toggle](https://github.com/user-attachments/assets/5e9f361b-4191-4ed1-8a91-7e908705c105) |

The same isolated mocked-Gateway flow also proves that a source over 1,200 characters whose Markdown renders within five lines gets no disclosure control.

### Tests and checks

- Pre-fix reproduction: the seven-line unit, grouped-render, and Playwright cases all failed because the disclosure wrapper/toggle was present.
- `pnpm test ui/src/pages/chat/components/chat-message-markdown` — 9 passed.
- `pnpm test ui/src/pages/chat/components/chat-message` — 199 passed.
- Control UI mocked-Gateway Playwright lane — 3 passed; both final captures inspected.
- `node scripts/check-changed.mjs` — passed the web-only `coreTests, ui` lanes, including formatting, dead-code, i18n, core/UI typechecks, and lint.
- Final Codex autoreview against `origin/main`: zero accepted/actionable findings on the web-only bundle.
- `pnpm docs:list` plus targeted search found no user-facing documentation for this internal threshold, so no docs update is needed.

### Scope and LOC

- Architectural owner: Control UI user-message disclosure policy; CSS remains presentation-only.
- Removed normal-path trigger: the web's five-line eligibility trigger. The five-line clamp remains only as the eligible long-message preview.
- Production: +6 / -12, net -6 lines.
- Tests: +222 / -77, net +145 lines.
