### PR TITLE
feat(mantis): publish trusted lane fact digests and a differential line

### DIFF
--- a/scripts/mantis/build-telegram-desktop-proof-evidence.mts
+++ b/scripts/mantis/build-telegram-desktop-proof-evidence.mts
@@ -3,13 +3,40 @@
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { sanitizeCommentText } from "./publish-pr-evidence.mjs";
 
 type CliArgs = Record<string, string>;
 type LaneName = "baseline" | "candidate";
 type LaneStatus = "blocked" | "fail" | "pass";
 type LaneFacts = {
+  attempt: number;
   blocked?: { reason?: string };
+  botApiRequests: unknown[];
   error?: string;
+  observation: { events: unknown[]; observedSeconds: number };
+  providerRequests: unknown[];
+  sendCount: number;
+};
+type LaneDigestCounts = {
+  sent: number;
+  botMessages: number;
+  edits: number;
+  deletes: number;
+  providerRequests: number;
+  injectedBotApiFaults: number;
+};
+type LaneDigest = {
+  counts: LaneDigestCounts;
+  text: string;
+};
+type ManifestLane = {
+  detail?: string;
+  digest?: string;
+  expected: string;
+  status: string;
+  ref?: string;
+  sha?: string;
 };
 type SessionSummary = {
   artifacts?: Partial<
@@ -49,8 +76,9 @@ type TelegramDesktopProofManifest = {
   summary: string;
   scenario: string;
   comparison: {
-    baseline: { detail?: string; expected: string; status: string; ref?: string; sha?: string };
-    candidate: { detail?: string; expected: string; status: string; ref?: string; sha?: string };
+    baseline: ManifestLane;
+    candidate: ManifestLane;
+    differential?: string;
     outcome: LaneStatus;
     pass: boolean;
   };
@@ -58,7 +86,8 @@ type TelegramDesktopProofManifest = {
 };
 
 const MAX_LANE_DETAIL_LENGTH = 300;
-const GRAPHEME_SEGMENTER = new Intl.Segmenter("en", { granularity: "grapheme" });
+const MAX_SENT_INPUT_LENGTH = 80;
+const MAX_SENT_INPUTS = 4;
 const PASS_SUMMARY =
   "Mantis captured native Telegram Desktop before/after GIF evidence with Convex-leased Telegram credentials.";
 const INCOMPLETE_SUMMARY =
@@ -229,20 +258,7 @@ function laneStatus(lane: LoadedLane): LaneStatus {
 }
 
 function sanitizeLaneDetail(value: string | undefined): string | undefined {
-  const escaped = value
-    ?.trim()
-    .replace(/\s+/gu, " ")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll("`", "&#96;");
-  if (!escaped) {
-    return undefined;
-  }
-  const characters = Array.from(GRAPHEME_SEGMENTER.segment(escaped), ({ segment }) => segment);
-  return characters.length > MAX_LANE_DETAIL_LENGTH
-    ? `${characters.slice(0, MAX_LANE_DETAIL_LENGTH - 1).join("")}…`
-    : escaped;
+  return sanitizeCommentText(value, MAX_LANE_DETAIL_LENGTH);
 }
 
 function laneDetail(lane: LoadedLane, status: LaneStatus): string | undefined {
@@ -250,6 +266,122 @@ function laneDetail(lane: LoadedLane, status: LaneStatus): string | undefined {
     return sanitizeLaneDetail(lane.facts.blocked?.reason);
   }
   return status === "fail" ? sanitizeLaneDetail(lane.facts.error) : undefined;
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function sentInput(event: Record<string, unknown>): string | undefined {
+  const contentType = typeof event.contentType === "string" ? event.contentType : undefined;
+  if (contentType && contentType !== "messageText") {
+    const recordedType = contentType.startsWith("message")
+      ? contentType.slice("message".length)
+      : contentType;
+    const label = recordedType
+      ? `${recordedType.slice(0, 1).toLowerCase()}${recordedType.slice(1)}`
+      : contentType;
+    const sanitized = sanitizeCommentText(label, MAX_SENT_INPUT_LENGTH);
+    return sanitized ? `[${sanitized}]` : undefined;
+  }
+  return typeof event.text === "string"
+    ? sanitizeCommentText(event.text, MAX_SENT_INPUT_LENGTH)
+    : undefined;
+}
+
+function laneDigest(facts: LaneFacts): LaneDigest | undefined {
+  const { attempt, botApiRequests, observation, providerRequests, sendCount } = facts;
+  const hasRecordedFacts =
+    sendCount > 0 ||
+    observation.events.length > 0 ||
+    botApiRequests.length > 0 ||
+    providerRequests.length > 0 ||
+    observation.observedSeconds > 0;
+  if (!hasRecordedFacts) {
+    return undefined;
+  }
+
+  const counts: LaneDigestCounts = {
+    sent: sendCount,
+    botMessages: 0,
+    edits: 0,
+    deletes: 0,
+    providerRequests: providerRequests.length,
+    injectedBotApiFaults: botApiRequests.filter(
+      (request) => isRecord(request) && request.injected === true,
+    ).length,
+  };
+  const inputs: string[] = [];
+  for (const event of observation.events) {
+    if (!isRecord(event)) {
+      continue;
+    }
+    if (event.actor === "bot") {
+      if (event.kind === "message") {
+        counts.botMessages += 1;
+      } else if (event.kind === "edit") {
+        counts.edits += 1;
+      } else if (event.kind === "delete") {
+        counts.deletes += 1;
+      }
+    } else if (
+      event.actor === "user" &&
+      event.kind === "message" &&
+      inputs.length <= MAX_SENT_INPUTS
+    ) {
+      const input = sentInput(event);
+      if (input) {
+        inputs.push(input);
+      }
+    }
+  }
+
+  const pieces = [
+    `${counts.sent} sent`,
+    countLabel(counts.botMessages, "bot message"),
+    countLabel(counts.edits, "edit"),
+    countLabel(counts.deletes, "delete"),
+    countLabel(counts.providerRequests, "provider request"),
+    ...(counts.injectedBotApiFaults > 0
+      ? [countLabel(counts.injectedBotApiFaults, "injected Bot API fault")]
+      : []),
+    `${Math.round(observation.observedSeconds)}s observed`,
+    `attempt ${attempt}`,
+  ];
+  if (inputs.length > 0) {
+    const renderedInputs = inputs.slice(0, MAX_SENT_INPUTS).map((input) => `\`${input}\``);
+    if (inputs.length > MAX_SENT_INPUTS) {
+      renderedInputs.push("…");
+    }
+    pieces.push(`sent: ${renderedInputs.join(", ")}`);
+  }
+  return { counts, text: pieces.join(" · ") };
+}
+
+function laneDifferential(
+  baseline: LaneDigest,
+  candidate: LaneDigest,
+  outcome: LaneStatus,
+): string {
+  const fields = [
+    ["sent", "sent"],
+    ["botMessages", "bot messages"],
+    ["edits", "edits"],
+    ["deletes", "deletes"],
+    ["providerRequests", "provider requests"],
+    ["injectedBotApiFaults", "injected Bot API faults"],
+  ] as const;
+  const differences = fields.flatMap(([field, label]) => {
+    const before = baseline.counts[field];
+    const after = candidate.counts[field];
+    return before === after ? [] : [`${label} ${before}→${after}`];
+  });
+  if (differences.length > 0) {
+    return differences.join(" · ");
+  }
+  return outcome === "pass"
+    ? "no count differences; pass rests on payload facts and the lane judgments"
+    : "no count differences";
 }
 
 function requireLaneAttestation(lane: LoadedLane, expectedLane: LaneName, expectedSha: string) {
@@ -355,6 +487,8 @@ function buildTelegramDesktopProofManifest({
       : baselineStatus === "blocked" || candidateStatus === "blocked"
         ? "blocked"
         : "pass";
+  const baselineDigest = laneDigest(baseline.facts);
+  const candidateDigest = laneDigest(candidate.facts);
   return {
     schemaVersion: 1,
     id: "telegram-desktop-proof",
@@ -364,6 +498,7 @@ function buildTelegramDesktopProofManifest({
     comparison: {
       baseline: {
         ...(baselineDetail ? { detail: baselineDetail } : {}),
+        ...(baselineDigest ? { digest: baselineDigest.text } : {}),
         ...(baselineSha ? { sha: baselineSha } : {}),
         ...(baselineRef ? { ref: baselineRef } : {}),
         expected: "baseline visual proof captured",
@@ -371,11 +506,15 @@ function buildTelegramDesktopProofManifest({
       },
       candidate: {
         ...(candidateDetail ? { detail: candidateDetail } : {}),
+        ...(candidateDigest ? { digest: candidateDigest.text } : {}),
         ...(candidateSha ? { sha: candidateSha } : {}),
         ...(candidateRef ? { ref: candidateRef } : {}),
         expected: "candidate visual proof captured",
         status: candidateStatus,
       },
+      ...(baselineDigest && candidateDigest
+        ? { differential: laneDifferential(baselineDigest, candidateDigest, outcome) }
+        : {}),
       outcome,
       pass: outcome === "pass",
     },

--- a/scripts/mantis/publish-pr-evidence.mjs
+++ b/scripts/mantis/publish-pr-evidence.mjs
@@ -9,7 +9,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 
-/** @typedef {Record<string, unknown> & { detail?: string, expected?: string, fixed?: boolean, ref?: string, sha?: string, status?: string }} EvidenceLane */
+/** @typedef {Record<string, unknown> & { detail?: string, digest?: string, expected?: string, fixed?: boolean, ref?: string, sha?: string, status?: string }} EvidenceLane */
 /**
  * @typedef {{
  *   alt?: string,
@@ -27,7 +27,7 @@ import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 /**
  * @typedef {{
  *   artifacts: EvidenceArtifact[],
- *   comparison: { baseline?: EvidenceLane, candidate: EvidenceLane, outcome?: "blocked" | "fail" | "pass", pass?: boolean },
+ *   comparison: { baseline?: EvidenceLane, candidate: EvidenceLane, differential?: string, outcome?: "blocked" | "fail" | "pass", pass?: boolean },
  *   id: string,
  *   manifestDir: string,
  *   scenario: string,
@@ -70,6 +70,31 @@ import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 const MANTIS_ARTIFACT_UPLOAD_TIMEOUT_MS = 300_000;
 // Untrusted storage error bodies are for diagnostics only; keep them small.
 const MANTIS_UPLOAD_ERROR_BODY_MAX_BYTES = 64 * 1024;
+const COMMENT_GRAPHEME_SEGMENTER = new Intl.Segmenter("en", { granularity: "grapheme" });
+
+/**
+ * @param {string | undefined} value
+ * @param {number} maxLength
+ * @returns {string | undefined}
+ */
+export function sanitizeCommentText(value, maxLength) {
+  const escaped = value
+    ?.trim()
+    .replace(/\s+/gu, " ")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("`", "&#96;");
+  if (!escaped) {
+    return undefined;
+  }
+  const graphemes = Array.from(
+    COMMENT_GRAPHEME_SEGMENTER.segment(escaped),
+    ({ segment }) => segment,
+  );
+  return graphemes.length > maxLength ? `${graphemes.slice(0, maxLength - 1).join("")}…` : escaped;
+}
+
 function parseArgs(argv) {
   const args = {};
   for (let index = 0; index < argv.length; index += 1) {
@@ -366,7 +391,13 @@ function laneLine(label, lane) {
   } else if (lane.ref) {
     pieces.push(` at \`${lane.ref}\``);
   }
-  if (lane.detail) {
+  if (lane.digest) {
+    const judgment = lane.detail ?? sanitizeCommentText(lane.expected, 1_000);
+    if (judgment) {
+      pieces.push(` — ${judgment}`);
+    }
+    pieces.push(` · facts: ${lane.digest}`);
+  } else if (lane.detail) {
     pieces.push(` — ${lane.detail}`);
   } else if (lane.expected) {
     pieces.push(`, expected ${lane.expected}`);
@@ -456,6 +487,9 @@ export function renderEvidenceComment({
   const candidateLine = laneLine("Candidate (PR merged onto main)", candidate);
   if (candidateLine) {
     lines.push(candidateLine);
+  }
+  if (comparison.differential) {
+    lines.push(`- Differential (trusted facts): ${comparison.differential}`);
   }
   const overall = overallStatus(manifest);
   if (overall) {

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -24,6 +24,7 @@ function makeLane(
     blockedReason?: string;
     diagnosticOnly?: boolean;
     error?: string;
+    facts?: Record<string, unknown>;
     status?: "blocked" | "fail" | "pass";
     withGif?: boolean;
   } = {},
@@ -66,16 +67,20 @@ function makeLane(
   writeFileSync(
     path.join(outputDir, "mantis-lane-facts.json"),
     JSON.stringify({
-      botApiRequests: [{ injected: true, method: "sendMessage", status: 429 }],
+      attempt: 1,
+      botApiRequests: [],
       invocations: [
         { command: "botapi-fail" },
         { args: { scriptFile: "provider-script.json" }, command: "mock" },
       ],
       lane: name,
+      observation: { events: [], observedSeconds: 0 },
       providerRequests: [],
       schemaVersion: 2,
+      sendCount: 0,
       ...(options.blockedReason ? { blocked: { reason: options.blockedReason } } : {}),
       ...(options.error ? { error: options.error } : {}),
+      ...options.facts,
     }),
   );
   return { outputDir, repo };
@@ -85,8 +90,62 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
   it("builds paired native Telegram Desktop GIF evidence for PR comments", () => {
     const baselineSha = "a".repeat(40);
     const candidateSha = "b".repeat(40);
-    const baseline = makeLane("baseline", baselineSha);
-    const candidate = makeLane("candidate", candidateSha);
+    const sentEvents = [
+      {
+        actor: "user",
+        contentType: "messageText",
+        isOutgoing: true,
+        kind: "message",
+        messageId: "101",
+        text: "/queue <followup> `now`",
+      },
+      {
+        actor: "user",
+        contentType: "messageDocument",
+        isOutgoing: true,
+        kind: "message",
+        messageId: "102",
+        text: "proof caption",
+      },
+    ];
+    const baseline = makeLane("baseline", baselineSha, {
+      facts: {
+        attempt: 1,
+        botApiRequests: [{ injected: true, method: "sendMessage", status: 429 }],
+        observation: {
+          events: [
+            ...sentEvents,
+            { actor: "bot", kind: "message", messageId: "201", text: "draft" },
+            { actor: "bot", kind: "message", messageId: "202", text: "second" },
+            { actor: "bot", kind: "edit", messageId: "201", text: "final" },
+            { actor: "bot", kind: "delete", messageId: "202" },
+            { actor: "bot", kind: "typing" },
+          ],
+          observedSeconds: 133.534,
+        },
+        providerRequests: [{ seq: 1 }, { seq: 2 }, { seq: 3 }],
+        sendCount: 2,
+      },
+    });
+    const candidate = makeLane("candidate", candidateSha, {
+      facts: {
+        attempt: 1,
+        botApiRequests: [{ injected: true, method: "sendMessage", status: 429 }],
+        observation: {
+          events: [
+            ...sentEvents,
+            { actor: "bot", kind: "message", messageId: "201", text: "draft" },
+            { actor: "bot", kind: "message", messageId: "202", text: "second" },
+            { actor: "bot", kind: "message", messageId: "203", text: "third" },
+            { actor: "bot", kind: "edit", messageId: "201", text: "final" },
+            { actor: "bot", kind: "typing" },
+          ],
+          observedSeconds: 134.2,
+        },
+        providerRequests: [{ seq: 1 }, { seq: 2 }, { seq: 3 }],
+        sendCount: 2,
+      },
+    });
     const outputDir = mkdtempSync(path.join(tmpdir(), "mantis-telegram-proof-"));
     tempDirs.push(outputDir);
 
@@ -123,6 +182,13 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       ref: candidateSha,
       sha: candidateSha,
     });
+    expect(manifest.comparison.baseline?.digest).toBe(
+      "2 sent · 2 bot messages · 1 edit · 1 delete · 3 provider requests · 1 injected Bot API fault · 134s observed · attempt 1 · sent: `/queue &lt;followup&gt; &#96;now&#96;`, `[document]`",
+    );
+    expect(manifest.comparison.candidate.digest).toBe(
+      "2 sent · 3 bot messages · 1 edit · 0 deletes · 3 provider requests · 1 injected Bot API fault · 134s observed · attempt 1 · sent: `/queue &lt;followup&gt; &#96;now&#96;`, `[document]`",
+    );
+    expect(manifest.comparison.differential).toBe("bot messages 2→3 · deletes 1→0");
     expect(manifest.comparison.candidate).not.toHaveProperty("fixed");
     expect(manifest.artifacts.map((artifact) => artifact.targetPath)).toContain(
       "candidate/telegram-desktop-proof.gif",
@@ -158,10 +224,13 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(body).toContain("<!-- mantis-telegram-desktop-proof -->");
     expect(body).toContain("## Mantis Telegram Desktop Proof");
     expect(body).toContain(
-      `- Baseline: \`pass\` at \`${baselineSha}\`, expected baseline visual proof captured`,
+      `- Baseline: \`pass\` at \`${baselineSha}\` — baseline visual proof captured · facts: ${manifest.comparison.baseline?.digest}`,
     );
     expect(body).toContain(
-      `- Candidate (PR merged onto main): \`pass\` at \`${candidateSha}\`, expected candidate visual proof captured`,
+      `- Candidate (PR merged onto main): \`pass\` at \`${candidateSha}\` — candidate visual proof captured · facts: ${manifest.comparison.candidate.digest}`,
+    );
+    expect(body).toContain(
+      "- Differential (trusted facts): bot messages 2→3 · deletes 1→0\n- Overall: `pass`",
     );
     expect(body).toContain(`- Artifact: ${artifactUrl}`);
     expect(body).toContain('<table width="100%">');

--- a/test/scripts/mantis-publish-pr-evidence.test.ts
+++ b/test/scripts/mantis-publish-pr-evidence.test.ts
@@ -112,6 +112,45 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     expect(body).toContain("- Overall: `true`");
   });
 
+  it("renders trusted lane digests and their count differential", () => {
+    const manifest = loadEvidenceManifest(writeFixtureManifest());
+    manifest.comparison = {
+      baseline: {
+        digest:
+          "2 sent · 2 bot messages · 1 edit · 1 delete · 3 provider requests · 134s observed · attempt 1 · sent: `/queue followup`",
+        expected: "baseline behavior",
+        sha: "aaa",
+        status: "pass",
+      },
+      candidate: {
+        digest:
+          "2 sent · 3 bot messages · 1 edit · 0 deletes · 3 provider requests · 134s observed · attempt 1 · sent: `/queue followup`",
+        expected: "candidate behavior",
+        sha: "bbb",
+        status: "pass",
+      },
+      differential: "bot messages 2→3 · deletes 1→0",
+      outcome: "pass",
+      pass: true,
+    };
+
+    const body = renderEvidenceComment({
+      manifest,
+      marker: "<!-- mantis-telegram-desktop-proof -->",
+      rawBase: "https://qa.openclaw.ai/mantis/telegram/pr-1/run-1",
+    });
+
+    expect(body).toContain(
+      "- Baseline: `pass` at `aaa` — baseline behavior · facts: 2 sent · 2 bot messages · 1 edit · 1 delete · 3 provider requests · 134s observed · attempt 1 · sent: `/queue followup`",
+    );
+    expect(body).toContain(
+      "- Candidate (PR merged onto main): `pass` at `bbb` — candidate behavior · facts: 2 sent · 3 bot messages · 1 edit · 0 deletes · 3 provider requests · 134s observed · attempt 1 · sent: `/queue followup`",
+    );
+    expect(body).toContain(
+      "- Differential (trusted facts): bot messages 2→3 · deletes 1→0\n- Overall: `pass`",
+    );
+  });
+
   it("uploads manifest artifacts to R2-compatible object storage", async () => {
     const manifest = loadEvidenceManifest(writeFixtureManifest());
     const requests: Array<{


### PR DESCRIPTION
## What Problem This Solves

A Mantis Telegram Desktop proof `pass` verdict rested on agent prose only. Example (PR #127967, run 32583508198):

```
- Baseline: `pass` at `6917a15…`, expected Baseline captures the pre-fix queued successor path: …
- Candidate (PR merged onto main): `pass` at `a2f491b…`, expected Candidate captures the same queued successor path with …
- Overall: `pass`
```

Nothing in that comment is a trusted recorded fact: a maintainer cannot see what was sent, how many bot messages / edits / deletes each lane produced, how many provider requests were made, or how the two lanes actually differed — without opening raw artifacts. The lane runner already records all of it in `mantis-lane-facts.json`.

## Why This Change Was Made

The evidence builder (`scripts/mantis/build-telegram-desktop-proof-evidence.mts`) owns lane-fact interpretation and the comment renderer (`scripts/mantis/publish-pr-evidence.mjs`) owns lane lines, so the change lands at those owners:

- Builder: per-lane `digest` (additive optional manifest field, schemaVersion stays 1) computed from trusted facts — `sendCount`, bot `message`/`edit`/`delete` events (`actor === "bot"`), provider request count, injected Bot API faults (`injected === true`), observed seconds, attempt, and the user-sent inputs (sanitized, 80 graphemes each, max 4). Request/provider bodies are never rendered — counts and user-sent text only.
- Builder: `comparison.differential` — the counts that differ between baseline and candidate (`bot messages 2→3 · deletes 1→0`), or an explicit "no count differences" sentence, emitted whenever both lanes have facts.
- Renderer: lane lines gain ` · facts: <digest>` after the judgment text; a `- Differential (trusted facts): …` line renders before `- Overall:`. The existing `detail` sanitizer moved to the renderer as `sanitizeCommentText(value, maxLength)` so builder and renderer share one public-comment text bound.
- Consumers checked: workflow jq only rewrites summary/expected and validates outcome/status; `index.json` publication carries the full manifest; older manifests without digest keep the legacy lane line. The web-ui-chat evidence builder consumes no lane-facts schema and is unchanged.

Rendered example:

```
- Baseline: `pass` at `<sha>` — baseline visual proof captured · facts: 2 sent · 2 bot messages · 1 edit · 1 delete · 3 provider requests · 1 injected Bot API fault · 134s observed · attempt 1 · sent: `/queue followup`, `[document]`
- Candidate (PR merged onto main): `pass` at `<sha>` — candidate visual proof captured · facts: 2 sent · 3 bot messages · 1 edit · 0 deletes · 3 provider requests · 1 injected Bot API fault · 134s observed · attempt 1 · sent: `/queue followup`, `[document]`
- Differential (trusted facts): bot messages 2→3 · deletes 1→0
- Overall: `pass`
```

## User Impact

Maintainer/CI-only. Every Mantis verdict comment now states, from trusted recorded facts, what was sent, what each lane produced, and what changed between baseline and candidate — a pass is verifiable at a glance.

## Evidence

- Regression tests in `test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts` and `test/scripts/mantis-publish-pr-evidence.test.ts` (pass fixture with user/bot message, edit, delete, typing events, injected 429 Bot API fault, provider requests → exact digest strings and differential line; legacy manifest without digest keeps old formatting). Pre-change: `2 failed | 17 passed` (builder returned `undefined` for `digest`; renderer kept legacy lines).
- `node scripts/run-vitest.mjs test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts test/scripts/mantis-publish-pr-evidence.test.ts test/scripts/mantis-telegram-desktop-proof-workflow.test.ts` — 50/50 pass.
- `node scripts/check-changed.mjs -- <changed files>` — clean.
- LOC: production/tooling +193/-20 (new trusted capability: fact projection, shared sanitizer, digest + differential formatting, comment plumbing); tests +113/-5.
- Live Mantis proof from this branch (`--ref t3code/mantis-verdict-digest`): run [32615326176](https://github.com/openclaw/openclaw/actions/runs/32615326176) on #127849 — verdict comment https://github.com/openclaw/openclaw/pull/127849 renders `· facts: 2 sent · 1 bot message · 0 edits · 0 deletes · 2 provider requests · 12s observed · attempt 2 · sent: …` per lane and `- Differential (trusted facts): provider requests 2→3`.
