### PR TITLE
fix(signal): preserve messages redelivered behind a busy lane

### DIFF
--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -47,6 +47,12 @@ the transport callback instead of dispatching an event that was not made
 durable. At claim time it decodes the versioned payload, re-runs `inspect`, and
 rejects an id or lane mismatch before delivery.
 
+`onDurableAdmission(raw, context)` runs after every durable enqueue, including
+duplicates. `context.isNew` is `true` if and only if this admission inserted the
+`(queue_name, event_id)` row. It does not indicate claim ownership or eventual
+delivery. If retention previously pruned the row, a later admission may insert
+it again and report `isNew: true`.
+
 `deliver` receives `onAdopted`, `onDeferred`, `onAdoptionFinalizing`, `onFailed`,
 `onCancelled`, `onAbandoned`, and `abortSignal`. Use `onFailed` for delivery
 errors, `onCancelled` for explicit pre-adoption cancellation that must preserve

--- a/extensions/signal/src/signal-ingress.test.ts
+++ b/extensions/signal/src/signal-ingress.test.ts
@@ -449,6 +449,46 @@ describe("Signal durable ingress", () => {
     },
   );
 
+  it("keeps a pending dual-identity message dispatchable through redelivery", async () => {
+    await withQueue(async (queue) => {
+      const sender = {
+        senderNumber: "+15550002222",
+        senderUuid: "123e4567-e89b-12d3-a456-426614174000",
+      };
+      const first = signalEvent({ ...sender, timestamp: 1_700_000_000_001, message: "first" });
+      const second = signalEvent({ ...sender, timestamp: 1_700_000_000_002, message: "second" });
+      let adoptFirst: (() => void | Promise<void>) | undefined;
+      const dispatch = vi.fn<SignalIngressDispatch>((_event, lifecycle, payload) => {
+        if (payload.envelope?.dataMessage?.message === "first") {
+          adoptFirst = lifecycle.onAdopted;
+          lifecycle.onDeferred();
+          return { kind: "deferred" } as const;
+        }
+        return undefined;
+      });
+      const started = await startMonitor(queue, dispatch);
+      try {
+        await started.monitor.receive(first);
+        await started.monitor.receive(second);
+        await started.waitForIdle();
+        expect(await queue.listPending()).toHaveLength(1);
+
+        await started.monitor.receive(second);
+        await started.waitForIdle();
+        expect(await queue.listPending()).toHaveLength(1);
+
+        await adoptFirst?.();
+        await started.waitForIdle();
+        expect(dispatch.mock.calls.map((call) => call[2].envelope?.dataMessage?.message)).toEqual([
+          "first",
+          "second",
+        ]);
+      } finally {
+        await started.monitor.stop();
+      }
+    });
+  });
+
   it("keeps identity-alias tombstones scoped to their Signal account", async () => {
     await withQueue(async (queue, stateDir) => {
       const otherQueue = createChannelIngressQueueForTests<SignalIngressPayload>({

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -198,14 +198,14 @@ export async function startSignalIngressMonitor(params: {
     },
     deliver: ([event, parsedPayload], lifecycle) =>
       parsedPayload ? params.dispatch(event, lifecycle, parsedPayload) : undefined,
-    onDurableAdmission: async (_event, { facts }) => {
+    onDurableAdmission: async (_event, { facts, isNew }) => {
       const { numberAliasEventId } = facts as SignalIngressEventFacts;
       if (!numberAliasEventId) {
         return;
       }
       // signal-cli can learn or forget a UUID between redeliveries; bridge both
       // shipped sender IDs before the monitor releases its admission/claim lock.
-      if (!(await ingressQueue.complete(numberAliasEventId))) {
+      if (!(await ingressQueue.complete(numberAliasEventId)) && isNew) {
         await ingressQueue.complete(facts.eventId);
       }
     },

--- a/src/channels/message/ingress-monitor.admission.test.ts
+++ b/src/channels/message/ingress-monitor.admission.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressMonitor } from "./ingress-monitor.js";
+import { createChannelIngressQueue } from "./ingress-queue.js";
+
+type RawEvent = { id: string; text: string };
+type StoredEvent = { version: 1; rawEvent: string };
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+describe("channel ingress monitor admission", () => {
+  it("reports whether each durable admission inserted a new row", async () => {
+    const queue = createChannelIngressQueue<StoredEvent>({
+      channelId: "test",
+      accountId: "a",
+      stateDir: tempDirs.make("openclaw-ingress-monitor-admission-"),
+    });
+    const admissions: boolean[] = [];
+    const monitor = createChannelIngressMonitor<RawEvent, string, StoredEvent>({
+      queue,
+      inspect: (raw) => ({ eventId: raw.id, laneKey: "lane:a" }),
+      payload: {
+        storage: "raw-event",
+        version: 1,
+        serialize: (raw) => JSON.stringify(raw),
+        deserialize: (body) => JSON.parse(body) as RawEvent,
+        createClaimError: (kind) => new Error(kind),
+      },
+      deliver: vi.fn(),
+      pollIntervalMs: 10,
+      retention: { pruneIntervalMs: 60_000 },
+      onDurableAdmission: (_raw, { isNew }) => {
+        admissions.push(isNew);
+      },
+    });
+
+    try {
+      await monitor.admit({ id: "event-one", text: "hello" });
+      await monitor.admit({ id: "event-one", text: "hello" });
+      expect(admissions).toEqual([true, false]);
+    } finally {
+      await monitor.stop();
+    }
+  });
+});

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -16,6 +16,7 @@ import {
   createChannelIngressMonitor,
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
+  type CreateChannelIngressMonitorOptions,
 } from "./ingress-monitor.js";
 import { createChannelIngressQueue, type ChannelIngressQueue } from "./ingress-queue.js";
 import type { IngressRetryPolicyConfig } from "./ingress-retry-policy.js";
@@ -72,6 +73,12 @@ function createMonitor(
         retryPolicy?: IngressRetryPolicyConfig;
         deferredLaneOccupancy?: "hold" | "release";
         runPumpTask?: (work: () => Promise<void>) => Promise<void>;
+        onDurableAdmission?: CreateChannelIngressMonitorOptions<
+          RawEvent,
+          string,
+          StoredEvent,
+          unknown
+        >["onDurableAdmission"];
       },
   onError?: (error: unknown) => void,
   abortSignal?: AbortSignal,
@@ -196,6 +203,23 @@ describe("channel ingress monitor", () => {
       await monitor.stop();
 
       expect(prune).not.toHaveBeenCalled();
+    });
+  });
+
+  it("reports whether each durable admission inserted a new row", async () => {
+    await withQueue(async (queue) => {
+      const admissions: boolean[] = [];
+      const monitor = createMonitor(queue, vi.fn(), {
+        onDurableAdmission: (_raw, { isNew }) => {
+          admissions.push(isNew);
+        },
+      });
+
+      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
+      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
+
+      expect(admissions).toEqual([true, false]);
+      await monitor.stop();
     });
   });
 

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -16,7 +16,6 @@ import {
   createChannelIngressMonitor,
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
-  type CreateChannelIngressMonitorOptions,
 } from "./ingress-monitor.js";
 import { createChannelIngressQueue, type ChannelIngressQueue } from "./ingress-queue.js";
 import type { IngressRetryPolicyConfig } from "./ingress-retry-policy.js";
@@ -73,12 +72,6 @@ function createMonitor(
         retryPolicy?: IngressRetryPolicyConfig;
         deferredLaneOccupancy?: "hold" | "release";
         runPumpTask?: (work: () => Promise<void>) => Promise<void>;
-        onDurableAdmission?: CreateChannelIngressMonitorOptions<
-          RawEvent,
-          string,
-          StoredEvent,
-          unknown
-        >["onDurableAdmission"];
       },
   onError?: (error: unknown) => void,
   abortSignal?: AbortSignal,
@@ -203,23 +196,6 @@ describe("channel ingress monitor", () => {
       await monitor.stop();
 
       expect(prune).not.toHaveBeenCalled();
-    });
-  });
-
-  it("reports whether each durable admission inserted a new row", async () => {
-    await withQueue(async (queue) => {
-      const admissions: boolean[] = [];
-      const monitor = createMonitor(queue, vi.fn(), {
-        onDurableAdmission: (_raw, { isNew }) => {
-          admissions.push(isNew);
-        },
-      });
-
-      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
-      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
-
-      expect(admissions).toEqual([true, false]);
-      await monitor.stop();
     });
   });
 

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -121,9 +121,10 @@ export type CreateChannelIngressMonitorOptions<TRaw, TBody, TStoredPayload, TMet
   pollIntervalMs: number;
   retention: "standard" | Partial<ChannelIngressMonitorRetention>;
   appendRetryDelaysMs?: readonly number[];
+  /** Runs after every durable enqueue; isNew distinguishes inserts from duplicates. */
   onDurableAdmission?: (
     raw: TRaw,
-    context: { facts: ChannelIngressMonitorFacts; receivedAt: number },
+    context: { facts: ChannelIngressMonitorFacts; receivedAt: number; isNew: boolean },
   ) => void | Promise<void>;
   onAdmissionFailure?: (raw: TRaw, error: unknown) => void | Promise<void>;
   /** False lets repeated requests fill drain capacity while earlier claims remain active. */
@@ -613,18 +614,19 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       }
       admitOptions.pruneTask ??= pruneIfDue("admission");
       await admitOptions.pruneTask;
-      const body = options.payload.serialize(raw, { facts, receivedAt: admitOptions.receivedAt });
+      const { receivedAt } = admitOptions;
+      const body = options.payload.serialize(raw, { facts, receivedAt });
       const payload =
         options.payload.storage === "raw-event"
           ? ({ version: options.payload.version, rawEvent: body } as TStoredPayload)
           : options.payload.encode({ version: options.payload.version, body });
-      const queueResult = await admitOnce({
-        facts,
-        payload,
-        receivedAt: admitOptions.receivedAt,
-      });
+      const queueResult = await admitOnce({ facts, payload, receivedAt });
       admitOptions.onDurablyAdmitted();
-      await options.onDurableAdmission?.(raw, { facts, receivedAt: admitOptions.receivedAt });
+      await options.onDurableAdmission?.(raw, {
+        facts,
+        receivedAt,
+        isNew: queueResult.kind === "accepted",
+      });
       return { kind: "durable", queueResult } as const;
     } catch (error) {
       await options.onAdmissionFailure?.(raw, error);

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -121,7 +121,10 @@ export type CreateChannelIngressMonitorOptions<TRaw, TBody, TStoredPayload, TMet
   pollIntervalMs: number;
   retention: "standard" | Partial<ChannelIngressMonitorRetention>;
   appendRetryDelaysMs?: readonly number[];
-  /** Runs after every durable enqueue; isNew distinguishes inserts from duplicates. */
+  /**
+   * Runs after every durable enqueue. `isNew` means this admission inserted the queue
+   * row; a pruned event can become new again. It does not imply claim or delivery.
+   */
   onDurableAdmission?: (
     raw: TRaw,
     context: { facts: ChannelIngressMonitorFacts; receivedAt: number; isNew: boolean },


### PR DESCRIPTION
Closes #128009

## What Problem This Solves

Fixes an issue where Signal users could permanently lose a message when signal-cli redelivered it while an earlier message from the same sender was still being processed. The duplicate admission could mark the real pending row completed and erase its payload before dispatch.

Reported with a production-path reproduction by @yetval in #128009.

## Why This Change Was Made

The shared durable-ingress monitor now exposes one narrow `isNew` fact after enqueue instead of leaking the full queue result through the Plugin SDK. Signal still bridges the phone-number alias on every admission, but completes the primary UUID row only when that row was freshly inserted, preserving both duplicate-redelivery safety and the existing phone-first alias dedupe.

## User Impact

Signal messages redelivered behind a busy sender lane remain pending and dispatch exactly once after the earlier message finishes, instead of being silently dropped.

## Evidence

- The boundary regression drives `startSignalIngressMonitor.receive` over the real SQLite ingress queue: a deferred first message blocks the lane, the second message remains pending, its identical redelivery leaves it pending, and releasing the first claim dispatches both messages in order.
- Before the fix, this scenario fails immediately after redelivery because the pending row count becomes zero.
- `node scripts/run-vitest.mjs extensions/signal/src/signal-ingress.test.ts src/channels/message/ingress-monitor.test.ts` — 58 passed.
- `node scripts/check-changed.mjs -- src/channels/message/ingress-monitor.ts src/channels/message/ingress-monitor.test.ts extensions/signal/src/signal-ingress.ts extensions/signal/src/signal-ingress.test.ts` — all selected core, core-test, plugin, and plugin-test gates passed.
- `node --max-old-space-size=8192 --import tsx scripts/plugin-sdk-surface-report.mts --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted ...` — clean; no accepted/actionable findings.

No live signal-cli daemon or SSE connection was attached; the regression replays the exact receive envelope through the production Signal monitor entry point and durable queue.
