### PR TITLE
fix(ui): let keyboard users choose a profile avatar

### DIFF
--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -633,9 +633,10 @@ suite.define(() => {
         await chooser.focus();
         await expect(chooser).toBeFocused();
         await screenshot(page, "11-avatar-keyboard-focus.png");
-        const fileChooserPromise = page.waitForEvent("filechooser");
-        await page.keyboard.press("Enter");
-        const fileChooser = await fileChooserPromise;
+        const [fileChooser] = await Promise.all([
+          page.waitForEvent("filechooser"),
+          chooser.press("Enter"),
+        ]);
         await fileChooser.setFiles({
           name: "avatar.png",
           mimeType: "image/png",

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -628,7 +628,15 @@ suite.define(() => {
         const updatedAtRequestCountBefore = avatarRequests.filter(
           (url) => new URL(url).searchParams.get("v") === updatedAtRevision,
         ).length;
-        await page.locator('input[type="file"]').setInputFiles({
+        const chooser = page.locator(".identity-avatar-control > button");
+        await expect(chooser).toHaveAccessibleName("Choose image");
+        await chooser.focus();
+        await expect(chooser).toBeFocused();
+        await screenshot(page, "11-avatar-keyboard-focus.png");
+        const fileChooserPromise = page.waitForEvent("filechooser");
+        await page.keyboard.press("Enter");
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles({
           name: "avatar.png",
           mimeType: "image/png",
           buffer: Buffer.from(
@@ -639,9 +647,8 @@ suite.define(() => {
         await expect
           .poll(async () => (await gateway.getRequests("users.setAvatar")).length)
           .toBe(requestCountBefore + 1);
-        const chooser = page.locator(".identity-avatar-control > label");
-        await screenshot(page, "11-avatar-action-disabled.png");
-        await expect(chooser).toHaveAttribute("aria-disabled", "true");
+        await screenshot(page, "12-avatar-action-disabled.png");
+        await expect(chooser).toBeDisabled();
         await expect
           .poll(() => chooser.evaluate((element) => getComputedStyle(element).opacity))
           .toBe("0.5");

--- a/ui/src/pages/profile/identity-section.test.ts
+++ b/ui/src/pages/profile/identity-section.test.ts
@@ -124,7 +124,13 @@ describe("renderIdentitySection", () => {
     const container = document.createElement("div");
     render(renderIdentitySection(createProps({ onAvatarSelect })), container);
 
+    const chooser = container.querySelector<HTMLButtonElement>(".identity-avatar-control .btn");
     const input = container.querySelector<HTMLInputElement>('input[type="file"]');
+    const clickInput = vi.spyOn(input!, "click");
+    chooser?.click();
+    expect(chooser?.type).toBe("button");
+    expect(clickInput).toHaveBeenCalledOnce();
+
     const file = new File(["avatar"], "avatar.webp", { type: "image/webp" });
     Object.defineProperty(input, "files", { configurable: true, value: [file] });
     input?.dispatchEvent(new Event("change", { bubbles: true }));
@@ -134,8 +140,9 @@ describe("renderIdentitySection", () => {
     expect(onAvatarSelect).toHaveBeenCalledWith(file);
 
     render(renderIdentitySection(createProps({ busy: "display-name" })), container);
-    const chooser = container.querySelector<HTMLElement>(".identity-avatar-control .btn");
-    expect(chooser?.getAttribute("aria-disabled")).toBe("true");
+    expect(
+      container.querySelector<HTMLButtonElement>(".identity-avatar-control .btn")?.disabled,
+    ).toBe(true);
     expect(container.querySelector<HTMLInputElement>('input[type="file"]')?.disabled).toBe(true);
   });
 

--- a/ui/src/pages/profile/identity-section.ts
+++ b/ui/src/pages/profile/identity-section.ts
@@ -57,25 +57,37 @@ export function renderIdentitySection(props: IdentitySectionProps) {
                 .user=${avatarViewer(props.profile, props.avatarUrl)}
                 variant="profile"
               ></openclaw-viewer-avatar>
-              <label class="btn btn--sm" aria-disabled=${props.busy !== null}>
+              <button
+                type="button"
+                class="btn btn--sm"
+                ?disabled=${props.busy !== null}
+                @click=${(event: Event) => {
+                  const button = event.currentTarget;
+                  const input =
+                    button instanceof HTMLButtonElement ? button.nextElementSibling : null;
+                  if (input instanceof HTMLInputElement) {
+                    input.click();
+                  }
+                }}
+              >
                 ${props.busy === "avatar"
                   ? t("profilePage.identity.processingAvatar")
                   : t("profilePage.identity.chooseAvatar")}
-                <input
-                  type="file"
-                  accept="image/png,image/jpeg,image/webp"
-                  hidden
-                  ?disabled=${props.busy !== null}
-                  @change=${(event: Event) => {
-                    const input = event.currentTarget as HTMLInputElement;
-                    const file = input.files?.[0];
-                    input.value = "";
-                    if (file) {
-                      props.onAvatarSelect(file);
-                    }
-                  }}
-                />
-              </label>
+              </button>
+              <input
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                hidden
+                ?disabled=${props.busy !== null}
+                @change=${(event: Event) => {
+                  const input = event.currentTarget as HTMLInputElement;
+                  const file = input.files?.[0];
+                  input.value = "";
+                  if (file) {
+                    props.onAvatarSelect(file);
+                  }
+                }}
+              />
             </span>
           `,
         })}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where keyboard-only users could not choose a profile avatar because the visible image picker responded only to pointer activation. The control also exposed a custom disabled attribute instead of native button state while an avatar update was processing.

## Why This Change Was Made

The picker is now a native button that activates the existing hidden file input, preserving the accepted image formats and upload flow while gaining built-in Enter/Space behavior and native disabled semantics. Focused unit and browser regressions cover click delegation, keyboard file selection, file forwarding/reset, focus, and busy state.

## User Impact

Keyboard and assistive-technology users can focus the profile avatar control, activate it with Enter or Space, choose an image, and receive truthful disabled state while processing. Pointer behavior and upload semantics are unchanged.

## Evidence

- Pre-fix browser regression: focusing a button named “Choose image” timed out because the control was a mouse-oriented label.
- `node scripts/run-vitest.mjs ui/src/pages/profile/identity-section.test.ts ui/src/pages/profile/profile-page.test.ts` — 19/19 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/profile-page.e2e.test.ts` — 7/7 passed, including Enter-driven `filechooser` upload.
- `node scripts/check-changed.mjs -- ui/src/pages/profile/identity-section.ts ui/src/pages/profile/identity-section.test.ts ui/src/e2e/profile-page.e2e.test.ts` — passed all changed-file gates.
- `pnpm ui:build` — passed; startup JavaScript 337.1 KiB gzip under the 337.5 KiB budget.
- Fresh final-head autoreview — no actionable findings, patch-correct confidence 0.99.

**Keyboard focus**

![Profile avatar Choose image button with visible keyboard focus](https://ampcode.com/user-content/artifacts/08a6168effbe5d552f557f7d1708af2930f882cc7f57f11452c0c6213530a829-file.png)

**Native disabled processing state**

![Profile avatar action disabled while processing](https://ampcode.com/user-content/artifacts/a497dd7440c98afd310a52cd0a0e4a74a30ddff261d79773eccb69169e139166-file.png)

AI-assisted: Codex investigated, implemented, tested, and reviewed this change under maintainer supervision. No agent transcript is attached.
