### PR TITLE
fix: keep Code Mode restricted after an unrelated failed wait

### DIFF
--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
@@ -437,11 +437,7 @@ export function resolveMainSessionResumePolicy(
     return { action: "resume", forceRestartSafeTools: true };
   }
   if (isRestartAbortedWaitFailure(lastMeaningful)) {
-    const waitCall = readCodeModeWaitCall(meaningfulMessages[1]);
-    const checkpoint = readCodeModeCheckpoint(meaningfulMessages[2]);
-    return waitCall && checkpoint?.replaySafe === true && checkpoint.runId === waitCall.runId
-      ? { action: "resume", forceRestartSafeTools: true, forceCodeModeTools: true }
-      : { action: "resume", forceRestartSafeTools: true };
+    return { action: "resume", forceRestartSafeTools: true };
   }
   const waitCall = readCodeModeWaitCall(lastMeaningful);
   if (waitCall) {

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -5102,31 +5102,57 @@ describe("main-session-restart-recovery", () => {
     });
   });
 
-  it("keeps an unmatched failed wait restricted when its checkpoint is replay-safe", async () => {
-    await writeMainSessionTranscript([
-      { role: "user", content: "do the thing" },
-      codeModeCheckpointMessage(),
-      codeModeWaitCallMessage(),
-      {
-        role: "toolResult",
-        toolName: "wait",
-        toolCallId: "call-other",
-        content: [{ type: "text", text: "Error: The operation was aborted." }],
-        details: {
-          status: "failed",
-          error: "Error: The operation was aborted.",
-          code: "internal_error",
-        },
-        isError: true,
-      },
-    ]);
+  it.each([
+    {
+      label: "matching failed-wait result identity",
+      toolCallIds: ["call-wait-1"],
+      restoresCodeModeTools: true,
+    },
+    {
+      label: "mismatched failed-wait result identity",
+      toolCallIds: ["call-other"],
+      restoresCodeModeTools: false,
+    },
+    {
+      label: "missing failed-wait result identity",
+      toolCallIds: [undefined],
+      restoresCodeModeTools: false,
+    },
+    {
+      label: "duplicate failed-wait result identities",
+      toolCallIds: ["call-wait-1", "call-wait-1"],
+      restoresCodeModeTools: false,
+    },
+  ])(
+    "restores Code Mode tools only for exactly one $label",
+    async ({ toolCallIds, restoresCodeModeTools }) => {
+      await writeMainSessionTranscript([
+        { role: "user", content: "do the thing" },
+        codeModeCheckpointMessage(),
+        codeModeWaitCallMessage(),
+        ...toolCallIds.map((toolCallId) => ({
+          role: "toolResult",
+          toolName: "wait",
+          ...(toolCallId ? { toolCallId } : {}),
+          content: [{ type: "text", text: "Error: The operation was aborted." }],
+          details: {
+            status: "failed",
+            error: "Error: The operation was aborted.",
+            code: "internal_error",
+          },
+          isError: true,
+        })),
+      ]);
 
-    await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
-    expect(gatewayParams()).toMatchObject({
-      forceRestartSafeTools: true,
-      forceCodeModeTools: true,
-    });
-  });
+      await expectRecovery({ recovered: 1, failed: 0, skipped: 0 });
+      expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+      if (restoresCodeModeTools) {
+        expect(gatewayParams()).toMatchObject({ forceCodeModeTools: true });
+      } else {
+        expect(gatewayParams()).not.toHaveProperty("forceCodeModeTools");
+      }
+    },
+  );
 
   it.each([
     {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users recovering after a Gateway restart could have Code Mode tools re-enabled by an unrelated failed wait result when a replay-safe checkpoint for the same run was nearby.

## Why This Change Was Made

Exact tool-call identity is authoritative when deciding whether a failed wait belongs to the preceding Code Mode wait. Remove the duplicate run-ID-only restoration path so the existing identity-checked artifact handling and canonical checkpoint path remain the sole owners of Code Mode restoration.

## User Impact

Unrelated, missing, and duplicate failed wait identities remain restart-safe and restricted after recovery. Exactly one matching failed wait still restores Code Mode tools when its checkpoint is replay-safe.

## Evidence

Before the fix, the focused regression failed because `forceCodeModeTools` was unexpectedly `true`:

```sh
node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts -t 'mismatched failed-wait result identity'
```

After the fix:

```sh
node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts -t 'mismatched failed-wait result identity' # passed
node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery.test.ts # 163 passed
node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts # 18 passed
node scripts/check-changed.mjs -- src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts src/agents/main-session-recovery/main-session-restart-recovery.test.ts # all gates passed
git diff --check # passed
```

Production: `+1/-5` (net `-4`); tests: `+50/-24` (net `+26`). No live provider or UI proof is applicable: this is deterministic transcript recovery policy with owner-boundary regression coverage across matching, mismatched, missing, and duplicate identities.

AI-assisted. The author reviewed and understands the change; fresh automated code review reported no actionable findings.
