### PR TITLE
fix(ui): make Settings Escape contextual

### DIFF
--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -113,7 +113,7 @@ describe("OpenClaw native shell", () => {
     expect(navigate).toHaveBeenCalledWith("appearance", undefined);
   });
 
-  it("clears a focused Settings input before Escape exits Settings", () => {
+  it("keeps the raw config editor unchanged when Escape is pressed", () => {
     const navigate = vi.fn();
     const shell = document.createElement(
       "openclaw-app-shell",
@@ -127,28 +127,24 @@ describe("OpenClaw native shell", () => {
     shell.lastWorkspaceLocation = { routeId: "usage", pathname: "/usage", search: "" };
     shell.navDrawerOpen = false;
     shell.routeState = { routeId: "appearance" };
-    const input = document.body.appendChild(document.createElement("input"));
-    input.type = "search";
-    input.value = "search query";
-    input.focus();
-    input.addEventListener("keydown", (event) => shell.handleDocumentKeydown(event));
+    const rawField = document.body.appendChild(document.createElement("label"));
+    rawField.className = "config-raw-field";
+    const rawEditor = rawField.appendChild(document.createElement("textarea"));
+    rawEditor.value = '{ "gateway": { "port": 18789 } }';
+    rawEditor.focus();
+    const onInput = vi.fn();
+    rawEditor.addEventListener("input", onInput);
+    rawEditor.addEventListener("keydown", (event) => shell.handleDocumentKeydown(event));
 
     try {
-      const clearEvent = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
-      input.dispatchEvent(clearEvent);
+      const event = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+      rawEditor.dispatchEvent(event);
 
-      expect(clearEvent.defaultPrevented).toBe(true);
-      expect(input.value).toBe("");
-      expect(document.activeElement).toBe(input);
+      expect(rawEditor.value).toBe('{ "gateway": { "port": 18789 } }');
+      expect(onInput).not.toHaveBeenCalled();
       expect(navigate).not.toHaveBeenCalled();
-
-      const exitEvent = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
-      input.dispatchEvent(exitEvent);
-
-      expect(exitEvent.defaultPrevented).toBe(true);
-      expect(navigate).toHaveBeenCalledWith("usage", { pathname: "/usage" });
     } finally {
-      input.remove();
+      rawField.remove();
     }
   });
 

--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -20,6 +20,12 @@ type ShellNavigationState = {
   updated: () => void;
 };
 
+type ShellSettingsEscapeState = ShellKeyboardState & {
+  lastWorkspaceLocation: { routeId: "usage"; pathname: string; search: string };
+  navDrawerOpen: boolean;
+  routeState: { routeId: "appearance" };
+};
+
 type TestWebKitWindow = Window & {
   webkit?: {
     messageHandlers: {
@@ -105,6 +111,45 @@ describe("OpenClaw native shell", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(navigate).toHaveBeenCalledWith("appearance", undefined);
+  });
+
+  it("clears a focused Settings input before Escape exits Settings", () => {
+    const navigate = vi.fn();
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellSettingsEscapeState;
+    shell.runtime = {
+      context: {
+        navigate,
+        overlays: { snapshot: { devicePairSetupOpen: false } },
+      } as unknown as ApplicationContext,
+    };
+    shell.lastWorkspaceLocation = { routeId: "usage", pathname: "/usage", search: "" };
+    shell.navDrawerOpen = false;
+    shell.routeState = { routeId: "appearance" };
+    const input = document.body.appendChild(document.createElement("input"));
+    input.type = "search";
+    input.value = "search query";
+    input.focus();
+    input.addEventListener("keydown", (event) => shell.handleDocumentKeydown(event));
+
+    try {
+      const clearEvent = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+      input.dispatchEvent(clearEvent);
+
+      expect(clearEvent.defaultPrevented).toBe(true);
+      expect(input.value).toBe("");
+      expect(document.activeElement).toBe(input);
+      expect(navigate).not.toHaveBeenCalled();
+
+      const exitEvent = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+      input.dispatchEvent(exitEvent);
+
+      expect(exitEvent.defaultPrevented).toBe(true);
+      expect(navigate).toHaveBeenCalledWith("usage", { pathname: "/usage" });
+    } finally {
+      input.remove();
+    }
   });
 
   it("toggles the navigation sidebar when the native macOS titlebar button fires", () => {

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -420,6 +420,9 @@ export class ShellChromeOwner {
       if (this.shouldIgnoreSettingsEscape(event)) {
         return;
       }
+      if (this.clearSettingsTextInput(event)) {
+        return;
+      }
       event.preventDefault();
       host.exitSettings();
       return;
@@ -447,7 +450,7 @@ export class ShellChromeOwner {
     this.requestLazyElement(DEBUG_OVERLAY_ELEMENT, descriptor);
   };
 
-  /** Open overlays and editable controls own Escape before settings can exit. */
+  /** Open overlays and rich controls own Escape before settings can exit. */
   shouldIgnoreSettingsEscape(event: KeyboardEvent): boolean {
     const host = this.host;
     const overlaySnapshot = host.context?.overlays.snapshot;
@@ -463,9 +466,24 @@ export class ShellChromeOwner {
     return (
       target instanceof Element &&
       target.closest(
-        "input, textarea, select, [contenteditable], dialog, [role='dialog'], [role='menu'], [role='listbox']",
+        "select, [contenteditable], dialog, [role='dialog'], [role='menu'], [role='listbox']",
       ) !== null
     );
+  }
+
+  private clearSettingsTextInput(event: KeyboardEvent): boolean {
+    const target = event.target;
+    const isTextInput =
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLInputElement &&
+        ["email", "number", "password", "search", "tel", "text", "url"].includes(target.type));
+    if (!isTextInput || target.disabled || target.readOnly || target.value.length === 0) {
+      return false;
+    }
+    event.preventDefault();
+    target.value = "";
+    target.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    return true;
   }
 
   private readonly handleCommandPaletteOpen = (event: Event, replay?: () => void): void => {

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -420,9 +420,6 @@ export class ShellChromeOwner {
       if (this.shouldIgnoreSettingsEscape(event)) {
         return;
       }
-      if (this.clearSettingsTextInput(event)) {
-        return;
-      }
       event.preventDefault();
       host.exitSettings();
       return;
@@ -450,7 +447,7 @@ export class ShellChromeOwner {
     this.requestLazyElement(DEBUG_OVERLAY_ELEMENT, descriptor);
   };
 
-  /** Open overlays and rich controls own Escape before settings can exit. */
+  /** Open overlays and editable controls own Escape before settings can exit. */
   shouldIgnoreSettingsEscape(event: KeyboardEvent): boolean {
     const host = this.host;
     const overlaySnapshot = host.context?.overlays.snapshot;
@@ -466,24 +463,9 @@ export class ShellChromeOwner {
     return (
       target instanceof Element &&
       target.closest(
-        "select, [contenteditable], dialog, [role='dialog'], [role='menu'], [role='listbox']",
+        "input, textarea, select, [contenteditable], dialog, [role='dialog'], [role='menu'], [role='listbox']",
       ) !== null
     );
-  }
-
-  private clearSettingsTextInput(event: KeyboardEvent): boolean {
-    const target = event.target;
-    const isTextInput =
-      target instanceof HTMLTextAreaElement ||
-      (target instanceof HTMLInputElement &&
-        ["email", "number", "password", "search", "tel", "text", "url"].includes(target.type));
-    if (!isTextInput || target.disabled || target.readOnly || target.value.length === 0) {
-      return false;
-    }
-    event.preventDefault();
-    target.value = "";
-    target.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
-    return true;
   }
 
   private readonly handleCommandPaletteOpen = (event: Event, replay?: () => void): void => {

--- a/ui/src/components/settings-sidebar.test.ts
+++ b/ui/src/components/settings-sidebar.test.ts
@@ -440,6 +440,54 @@ describe("settings sidebar search", () => {
     expect(onNavigate).toHaveBeenCalledWith("channels");
   });
 
+  it("clears a focused search before Escape exits Settings", () => {
+    let searchQuery = "gateway";
+    const onExit = vi.fn();
+    const rerender = () => {
+      render(
+        renderSettingsSidebar({
+          basePath: "",
+          activeRouteId: "appearance",
+          offline: false,
+          lastError: null,
+          gatewayVersion: "",
+          updateAvailable: null,
+          updateBusy: false,
+          onUpdate: vi.fn(),
+          ...inactiveRefresh,
+          searchQuery,
+          onExit,
+          onRetryConnect: vi.fn(),
+          onNavigate: vi.fn(),
+          onSearchQueryChange: (nextQuery) => {
+            searchQuery = nextQuery;
+            rerender();
+          },
+          preloadTimers: new Map(),
+          saveIndicator: saveIndicator(),
+        }),
+        container,
+      );
+    };
+
+    rerender();
+    const input = container.querySelector<HTMLInputElement>(".settings-sidebar__search-input");
+    expect(input).not.toBeNull();
+    input?.focus();
+
+    input?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    expect(searchQuery).toBe("");
+    expect(document.activeElement).toBe(input);
+    expect(onExit).not.toHaveBeenCalled();
+
+    input?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    expect(onExit).toHaveBeenCalledOnce();
+  });
+
   it("renders refreshed settings route titles from the active locale", async () => {
     i18n.registerTranslation("pt-BR", {
       routeTitles: {

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -272,11 +272,15 @@ export function renderSettingsSidebar(props: SettingsSidebarProps) {
           @input=${(event: Event) =>
             props.onSearchQueryChange((event.currentTarget as HTMLInputElement).value)}
           @keydown=${(event: KeyboardEvent) => {
-            if (event.key !== "Escape" || !props.searchQuery) {
+            if (event.key !== "Escape") {
               return;
             }
             event.preventDefault();
-            props.onSearchQueryChange("");
+            if (props.searchQuery) {
+              props.onSearchQueryChange("");
+              return;
+            }
+            props.onExit();
           }}
         />
         ${props.searchQuery


### PR DESCRIPTION
## What Problem This Solves

The Settings search clears itself on Escape, but an empty focused search was still classified as an editable control by the shell. A second Escape therefore could not return to the app until the user manually blurred the field.

## Why This Change Was Made

- Keep contextual Escape handling at the Settings search owner.
- Clear a non-empty search on the first press while preserving focus.
- Invoke the existing Settings exit action when the focused search is already empty.
- Keep the shell's established Escape protection for every other input, textarea, select, content-editable control, dialog, menu, and listbox.

## User Impact

With focus in Settings search, the first Escape clears the query and the second immediately returns to the app. Escape in draft-bearing Settings controls such as the raw configuration editor does not clear the draft or exit Settings.

## Evidence

- Pre-fix regressions failed for both missing search exit and raw-config draft clearing.
- `node scripts/run-vitest.mjs ui/src/components/settings-sidebar.test.ts ui/src/app/app-host-native-shell.test.ts`: 39 tests passed.
- `node scripts/check-changed.mjs -- ui/src/components/settings-sidebar.ts ui/src/components/settings-sidebar.test.ts ui/src/app/app-shell-chrome.ts ui/src/app/app-host-native-shell.test.ts`: passed all selected UI/core gates.
- Repository-standard mock-gateway browser proof: first Escape cleared search and retained focus; second Escape navigated to `/chat/main`; Escape in the enabled raw-config textarea retained its value and `/settings/advanced` route.
- Structured autoreview at P1: clean, no accepted/actionable findings.

