### PR TITLE
fix(android): make realtime Talk full-duplex on the built-in speaker, and prove communication-audio ownership

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!-- Realtime Talk owns communication audio mode and attaches the platform echo canceller. -->
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -383,6 +383,7 @@ internal class AndroidAudioInputSession private constructor(
       AudioDeviceInfo.TYPE_DOCK,
       AudioDeviceInfo.TYPE_HDMI,
       -> true
+
       else -> false
     }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -205,16 +205,37 @@ internal class AndroidAudioInputSession private constructor(
    * Whether the platform reports echo cancellation as actually enabled for this capture session.
    *
    * Read back from the effect, never inferred from the audio source, from `isAvailable`, from the
-   * route, or from `create` succeeding. Read live rather than snapshotted: a route can change
-   * under a running recorder, and a session that could only ever answer with what was true when
-   * it opened could never fall back to half duplex once it had said yes. Guarded by the same lock
-   * [close] takes, so it cannot read a released effect.
+   * route, or from `create` succeeding -- but served from a cached value rather than measured on
+   * the caller's thread. The capture loop consults this once per frame, and the effect read is an
+   * IPC guarded by the same [lock] that [refreshRoute] holds across several `AudioManager` binder
+   * calls; answering it inline would put a route change on the critical path of `AudioRecord.read`
+   * and overrun the recorder. Nothing here blocks, so a slow route refresh cannot stall capture.
+   *
+   * The cache is refreshed by whoever owns the effect's lifecycle -- at open, on every route
+   * change, and by the caller's own watcher -- via [refreshCommunicationEchoCancellation].
    */
+  @Volatile
+  private var cachedEchoCancellationEnabled = false
+
   internal val communicationEchoCancellationEnabled: Boolean
-    get() =
-      synchronized(lock) {
-        if (closed) false else runCatching { acousticEchoCanceler?.enabled == true }.getOrDefault(false)
-      }
+    get() = cachedEchoCancellationEnabled
+
+  /**
+   * Re-measures the effect and republishes the cache. Takes [lock], performs IPC, and may block
+   * behind a route refresh, so it must never be called from the capture read loop.
+   *
+   * Returns the freshly measured value. A closed session always answers false, which is what
+   * makes the capability shrink on teardown rather than linger at its last true reading.
+   */
+  internal fun refreshCommunicationEchoCancellation(): Boolean =
+    // Measured and published under the same lock. Publishing outside it would let a watcher that
+    // measured `true` before a concurrent close overwrite the `false` that close just published,
+    // leaving the capability granted for a released effect.
+    synchronized(lock) {
+      val enabled = if (closed) false else runCatching { acousticEchoCanceler?.enabled == true }.getOrDefault(false)
+      cachedEchoCancellationEnabled = enabled
+      enabled
+    }
 
   /**
    * The communication output this session actually holds, or null when it holds none -- either
@@ -242,6 +263,9 @@ internal class AndroidAudioInputSession private constructor(
     }
     audioRecord.startRecording()
     refreshActualRouteSafely()
+    // Seed the cache from the running recorder. Until this lands the capability reads false, so a
+    // session is half duplex until the effect has actually been measured, never before.
+    refreshCommunicationEchoCancellation()
     Log.d(tag, "capture started preferred=${preferredInputType ?: "default"} routed=${audioRecord.routedDevice?.type ?: "pending"}")
   }
 
@@ -269,11 +293,15 @@ internal class AndroidAudioInputSession private constructor(
 
   private fun refreshRoute() {
     synchronized(lock) {
-      if (closed) return
+      if (closed) return@synchronized
       val inputs = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS).toList()
       val preferredInput = resolvePreferredAudioInput(inputs, preferredInputKey)
       if (preferredInput != null && applyRoute(inputs, preferredInput)) {
-        return
+        // return@synchronized, not return: `synchronized` is inline, so a bare return here would
+        // leave refreshRoute entirely and skip the re-measure below -- on the branch that fires
+        // whenever a preferred input is configured, i.e. the common case for anyone who used the
+        // device picker.
+        return@synchronized
       }
       // A rejected record preference may have set a Bluetooth communication route.
       // Recalculate automatic priority instead of retaining that rejected target.
@@ -281,6 +309,10 @@ internal class AndroidAudioInputSession private constructor(
       setAppliedPreferredInputKey(null)
       applyRoute(inputs, null)
     }
+    // Outside the monitor above, and after it: a route change is the event that can hand the
+    // canceller a different reference signal or none, so the cached capability is re-measured
+    // here rather than left at whatever the previous route reported.
+    refreshCommunicationEchoCancellation()
   }
 
   private fun applyRoute(
@@ -369,28 +401,37 @@ internal class AndroidAudioInputSession private constructor(
   }
 
   private fun refreshActualRoute() {
-    synchronized(lock) {
-      if (closed) return
-      val inputs = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS).toList()
-      val expectedInput = resolvePreferredAudioInput(inputs, preferredInputKey)
-      if (expectedInput == null) {
+    val routeChanged =
+      synchronized(lock) {
+        if (closed) return@synchronized false
+        val inputs = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS).toList()
+        val expectedInput = resolvePreferredAudioInput(inputs, preferredInputKey)
+        if (expectedInput == null) {
+          setAppliedPreferredInputKey(null)
+          applyRoute(inputs, null)
+          return@synchronized true
+        }
+        val routedInput = audioRecord.routedDevice
+        if (sameDevice(routedInput, expectedInput)) {
+          setAppliedPreferredInputKey(preferredInputKey)
+          return@synchronized false
+        }
         setAppliedPreferredInputKey(null)
-        applyRoute(inputs, null)
-        return
+        false
       }
-      val routedInput = audioRecord.routedDevice
-      if (sameDevice(routedInput, expectedInput)) {
-        setAppliedPreferredInputKey(preferredInputKey)
-        return
-      }
-      setAppliedPreferredInputKey(null)
-    }
+    // Only when the route was actually touched. The two no-op exits above -- closed, and the
+    // routed device already matching -- change nothing the canceller depends on, and this call
+    // costs an effect IPC and a second lock acquisition on the main thread.
+    if (routeChanged) refreshCommunicationEchoCancellation()
   }
 
   override fun close() {
     synchronized(lock) {
       if (closed) return
       closed = true
+      // Shrink first: a caller reading the cache during teardown must never be told the effect is
+      // still cancelling for a recorder that is being released.
+      cachedEchoCancellationEnabled = false
       if (callbackRegistered) {
         runCatching { audioManager.unregisterAudioDeviceCallback(deviceCallback) }
         callbackRegistered = false
@@ -455,6 +496,12 @@ private class CommunicationDeviceRoute {
     // claims a route Android did not actually give it.
     val applied = audioManager.communicationDevice
     if (applied == null || applied.id != device.id) {
+      // Reported as "not held" but deliberately NOT torn down. setCommunicationDevice accepted the
+      // request; on Bluetooth the SCO link is established asynchronously, so an immediate
+      // disagreeing read-back is the expected transient rather than a rejection. Clearing here
+      // would cancel a route that was about to come up, and the resulting device callbacks would
+      // drive the same request again -- an audible connect/disconnect cycle that never settles.
+      // The request stays standing; only the reported value is honest about what is confirmed.
       Log.w(tag, "communication device requested id=${device.id} but platform selected id=${applied?.id}")
       return null
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -368,11 +368,16 @@ internal class AndroidAudioInputSession private constructor(
    * simply always there -- telephony on a handset, a bus on Automotive -- and treating "anything
    * that is not the built-in pair" as a deliberate choice would silently leave hands-free Talk on
    * the earpiece for a whole class of devices, with nothing to distinguish it from working.
+   *
+   * Covers every wired, USB, Bluetooth, dock, HDMI and line-level sink the platform admits as a
+   * communication device, so a plugged-in line output is never overridden by the loudspeaker.
    */
   private fun isDeliberateExternalOutput(type: Int): Boolean =
     when (type) {
       AudioDeviceInfo.TYPE_WIRED_HEADSET,
       AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+      AudioDeviceInfo.TYPE_LINE_ANALOG,
+      AudioDeviceInfo.TYPE_AUX_LINE,
       AudioDeviceInfo.TYPE_USB_HEADSET,
       AudioDeviceInfo.TYPE_USB_DEVICE,
       AudioDeviceInfo.TYPE_USB_ACCESSORY,

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -458,7 +458,13 @@ internal class AndroidAudioInputSession private constructor(
   }
 }
 
-/** Serializes Android's process-wide communication route across overlapping capture cleanup. */
+/**
+ * Serializes Android's process-wide communication route across overlapping capture cleanup.
+ *
+ * [activeOwner] is whichever capture is responsible for the selection currently standing on the
+ * platform -- not necessarily the one that made it. Responsibility follows the newest capture (see
+ * [claim]), so that exactly one close path can always clear the selection.
+ */
 private class CommunicationDeviceRoute {
   private val tag = "AudioInput"
   private var nextOwner = 0L
@@ -470,7 +476,27 @@ private class CommunicationDeviceRoute {
 
   @Synchronized
   fun begin(owner: Long) {
-    if (owner > latestOwner) latestOwner = owner
+    claim(owner)
+  }
+
+  /**
+   * Makes [owner] the newest capture, handing it the standing selection, or reports it superseded.
+   *
+   * Runs before any fallible platform call, at both entry points: [begin], and [update], which the
+   * platform's initial device callback can reach first. Everything after this point -- device
+   * discovery, `setCommunicationDevice` -- can throw, and [update] and [close] each decline to act
+   * for a superseded owner. Advancing [latestOwner] without moving [activeOwner] would therefore
+   * leave a replacement whose setup threw with a previous owner that may no longer clear and a new
+   * owner that never became active: the process-wide selection would outlive every capture that
+   * could have released it.
+   */
+  private fun claim(owner: Long): Boolean {
+    if (owner < latestOwner) return false
+    if (owner > latestOwner) {
+      latestOwner = owner
+      if (activeOwner != null) activeOwner = owner
+    }
+    return true
   }
 
   /** Returns the device the platform actually selected, or null when it selected none. */
@@ -480,8 +506,7 @@ private class CommunicationDeviceRoute {
     owner: Long,
     device: AudioDeviceInfo?,
   ): AudioDeviceInfo? {
-    if (owner < latestOwner) return null
-    latestOwner = owner
+    if (!claim(owner)) return null
     if (device == null) {
       if (activeOwner != null) audioManager.clearCommunicationDevice()
       activeOwner = null

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -9,6 +9,8 @@ import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.AudioRouting
 import android.media.MediaRecorder
+import android.media.audiofx.AcousticEchoCanceler
+import android.media.audiofx.AudioEffect
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -21,10 +23,26 @@ internal data class AudioInputDeviceOption(
   val type: Int,
 )
 
+/**
+ * The capture semantics one [AndroidAudioInputSession] is opened with.
+ *
+ * Two lanes, deliberately not merged. Manual Mic/STT and push-to-talk want the recognition
+ * preset; realtime Talk wants the communication preset, which is the capture path Android's own
+ * echo canceller attaches to.
+ */
+internal enum class AndroidAudioInputProfile(
+  internal val audioSource: Int,
+) {
+  VoiceRecognition(MediaRecorder.AudioSource.VOICE_RECOGNITION),
+  VoiceCommunication(MediaRecorder.AudioSource.VOICE_COMMUNICATION),
+}
+
 /** Owns one recorder and its Bluetooth route for the full capture lifecycle. */
 internal class AndroidAudioInputSession private constructor(
   private val audioManager: AudioManager,
   private val audioRecord: AudioRecord,
+  private val acousticEchoCanceler: AcousticEchoCanceler?,
+  private val profile: AndroidAudioInputProfile,
   private val preferredInputKey: String?,
   private val onAppliedPreferredDeviceChanged: (String?) -> Unit,
   private val setPreferredDevice: (AudioDeviceInfo?) -> Boolean,
@@ -40,6 +58,7 @@ internal class AndroidAudioInputSession private constructor(
       preferredDeviceKey: String? = null,
       onAppliedPreferredDeviceChanged: (String?) -> Unit = {},
       setPreferredDevice: ((AudioDeviceInfo?) -> Boolean)? = null,
+      profile: AndroidAudioInputProfile = AndroidAudioInputProfile.VoiceRecognition,
     ): AndroidAudioInputSession {
       val minBuffer =
         AudioRecord.getMinBufferSize(
@@ -53,7 +72,7 @@ internal class AndroidAudioInputSession private constructor(
       val audioRecord =
         AudioRecord
           .Builder()
-          .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+          .setAudioSource(profile.audioSource)
           .setAudioFormat(
             AudioFormat
               .Builder()
@@ -63,10 +82,16 @@ internal class AndroidAudioInputSession private constructor(
               .build(),
           ).setBufferSizeInBytes(maxOf(minBuffer, frameBytes * 4))
           .build()
+      // The effect is optional: the caller's forwarding policy already falls back to half duplex
+      // without it, so an echo canceller that cannot be set up must never cost the session its
+      // microphone.
+      val acousticEchoCanceler = openAcousticEchoCanceler(profile, audioRecord.audioSessionId)
       val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
       return AndroidAudioInputSession(
         audioManager = audioManager,
         audioRecord = audioRecord,
+        acousticEchoCanceler = acousticEchoCanceler,
+        profile = profile,
         preferredInputKey = preferredDeviceKey,
         onAppliedPreferredDeviceChanged = onAppliedPreferredDeviceChanged,
         setPreferredDevice = setPreferredDevice ?: audioRecord::setPreferredDevice,
@@ -78,6 +103,35 @@ internal class AndroidAudioInputSession private constructor(
           throw err
         }
       }
+    }
+
+    /**
+     * Attaches the platform echo canceller to the recorder's own effect session.
+     *
+     * Communication profile only, and only ever a request: whether the platform actually enabled
+     * it is read back by the caller from the effect itself. `create` succeeding says nothing --
+     * AOSP documents that an AEC may already be inserted, or not, depending on the audio source,
+     * and tells applications to read the enabled state back per session.
+     */
+    private fun openAcousticEchoCanceler(
+      profile: AndroidAudioInputProfile,
+      audioSessionId: Int,
+    ): AcousticEchoCanceler? {
+      if (profile != AndroidAudioInputProfile.VoiceCommunication) return null
+      if (!runCatching { AcousticEchoCanceler.isAvailable() }.getOrDefault(false)) return null
+      val canceler = runCatching { AcousticEchoCanceler.create(audioSessionId) }.getOrNull() ?: return null
+      val enableResult = runCatching { if (canceler.enabled) AudioEffect.SUCCESS else canceler.setEnabled(true) }
+      val result = enableResult.getOrNull()
+      if (result == null) {
+        // Release the half-configured effect rather than leaking it; the caller keeps half duplex.
+        Log.w(tag, "AcousticEchoCanceler enable threw: ${enableResult.exceptionOrNull()?.message ?: "unknown"}")
+        runCatching { canceler.release() }
+        return null
+      }
+      if (result != AudioEffect.SUCCESS) {
+        Log.w(tag, "AcousticEchoCanceler enable returned $result")
+      }
+      return canceler
     }
 
     fun listAvailableDevices(context: Context): List<AudioInputDeviceOption> {
@@ -116,7 +170,7 @@ internal class AndroidAudioInputSession private constructor(
   }
 
   private val lock = Any()
-  private val communicationRouteOwner = bluetoothCommunicationRoute.newOwner()
+  private val communicationRouteOwner = communicationRoute.newOwner()
   private val callbackHandler = Handler(Looper.getMainLooper())
   private var closed = false
   private var callbackRegistered = false
@@ -125,6 +179,7 @@ internal class AndroidAudioInputSession private constructor(
   private var requestedCommunicationDevice: AudioDeviceInfo? = null
   private var selectedInput: AudioDeviceInfo? = null
   private var appliedPreferredInputKey: String? = null
+  private var appliedCommunicationType: Int? = null
 
   private val deviceCallback =
     object : AudioDeviceCallback() {
@@ -145,6 +200,29 @@ internal class AndroidAudioInputSession private constructor(
 
   internal val appliedPreferredDeviceKey: String?
     get() = synchronized(lock) { appliedPreferredInputKey }
+
+  /**
+   * Whether the platform reports echo cancellation as actually enabled for this capture session.
+   *
+   * Read back from the effect, never inferred from the audio source, from `isAvailable`, from the
+   * route, or from `create` succeeding. Read live rather than snapshotted: a route can change
+   * under a running recorder, and a session that could only ever answer with what was true when
+   * it opened could never fall back to half duplex once it had said yes. Guarded by the same lock
+   * [close] takes, so it cannot read a released effect.
+   */
+  internal val communicationEchoCancellationEnabled: Boolean
+    get() =
+      synchronized(lock) {
+        if (closed) false else runCatching { acousticEchoCanceler?.enabled == true }.getOrDefault(false)
+      }
+
+  /**
+   * The communication output this session actually holds, or null when it holds none -- either
+   * because it is a recognition-profile session or because the platform rejected the request.
+   * Never inferred from what was asked for.
+   */
+  internal val appliedCommunicationDeviceType: Int?
+    get() = synchronized(lock) { appliedCommunicationType }
 
   /**
    * The rate the recorder negotiated, read back from it rather than assumed from the request.
@@ -176,7 +254,7 @@ internal class AndroidAudioInputSession private constructor(
   private fun openRoute() {
     audioManager.registerAudioDeviceCallback(deviceCallback, callbackHandler)
     synchronized(lock) { callbackRegistered = true }
-    bluetoothCommunicationRoute.begin(communicationRouteOwner)
+    communicationRoute.begin(communicationRouteOwner)
     refreshRouteSafely()
   }
 
@@ -209,14 +287,23 @@ internal class AndroidAudioInputSession private constructor(
     inputs: List<AudioDeviceInfo>,
     preferredInput: AudioDeviceInfo?,
   ): Boolean {
-    val communicationDevice =
+    val available = audioManager.availableCommunicationDevices
+    val bluetoothDevice =
       if (preferredInput == null) {
-        selectBluetoothDevice(audioManager.availableCommunicationDevices, requestedCommunicationDevice)
+        selectBluetoothDevice(available, requestedCommunicationDevice)
       } else {
-        selectCommunicationDevice(audioManager.availableCommunicationDevices, preferredInput)
+        selectCommunicationDevice(available, preferredInput)
       }
-    val communicationSelected = bluetoothCommunicationRoute.update(audioManager, communicationRouteOwner, communicationDevice)
-    requestedCommunicationDevice = communicationDevice.takeIf { communicationSelected }
+    // Communication capture owns the output route too. Without an explicit selection Android's
+    // phone strategy sends communication audio to the earpiece, which turns hands-free Talk into
+    // hold-it-to-your-ear Talk. Only the built-in pair is ever overridden: any external
+    // communication output was chosen deliberately and already outranks the earpiece.
+    val communicationDevice = bluetoothDevice ?: handsFreeBuiltInSpeaker(available)
+    val appliedCommunicationDevice = communicationRoute.update(audioManager, communicationRouteOwner, communicationDevice)
+    appliedCommunicationType = appliedCommunicationDevice?.type
+    // Input following stays Bluetooth-only: the built-in speaker is an output and must never be
+    // handed to the input selector as if it were a headset.
+    requestedCommunicationDevice = bluetoothDevice.takeIf { appliedCommunicationDevice != null }
     val input = preferredInput ?: selectBluetoothInput(inputs, requestedInput, requestedCommunicationDevice)
     if (sameDevice(requestedInput, input) && sameDevice(selectedInput, input)) return true
     requestedInput = input
@@ -230,6 +317,42 @@ internal class AndroidAudioInputSession private constructor(
       false
     }
   }
+
+  /**
+   * The built-in speaker, but only when choosing it is the difference between the loudspeaker and
+   * the earpiece. Any external communication output present means the platform already has a
+   * better answer than the earpiece, and taking it would be stealing an intentional route.
+   */
+  private fun handsFreeBuiltInSpeaker(available: List<AudioDeviceInfo>): AudioDeviceInfo? {
+    if (profile != AndroidAudioInputProfile.VoiceCommunication) return null
+    if (available.any { isDeliberateExternalOutput(it.type) }) return null
+    return available.firstOrNull { it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER }
+  }
+
+  /**
+   * Outputs a person plugged in, paired, or docked into, and therefore chose over the handset.
+   *
+   * Deliberately an allowlist. `availableCommunicationDevices` can also carry entries that are
+   * simply always there -- telephony on a handset, a bus on Automotive -- and treating "anything
+   * that is not the built-in pair" as a deliberate choice would silently leave hands-free Talk on
+   * the earpiece for a whole class of devices, with nothing to distinguish it from working.
+   */
+  private fun isDeliberateExternalOutput(type: Int): Boolean =
+    when (type) {
+      AudioDeviceInfo.TYPE_WIRED_HEADSET,
+      AudioDeviceInfo.TYPE_WIRED_HEADPHONES,
+      AudioDeviceInfo.TYPE_USB_HEADSET,
+      AudioDeviceInfo.TYPE_USB_DEVICE,
+      AudioDeviceInfo.TYPE_USB_ACCESSORY,
+      AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+      AudioDeviceInfo.TYPE_BLE_HEADSET,
+      AudioDeviceInfo.TYPE_BLE_SPEAKER,
+      AudioDeviceInfo.TYPE_HEARING_AID,
+      AudioDeviceInfo.TYPE_DOCK,
+      AudioDeviceInfo.TYPE_HDMI,
+      -> true
+      else -> false
+    }
 
   private fun setAppliedPreferredInputKey(value: String?) {
     if (appliedPreferredInputKey == value) return
@@ -283,15 +406,19 @@ internal class AndroidAudioInputSession private constructor(
       if (audioRecord.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
         runCatching { audioRecord.stop() }
       }
+      // Before the recorder: the effect is attached to that recorder's audio session id.
+      runCatching { acousticEchoCanceler?.release() }
       runCatching { audioRecord.release() }
-      bluetoothCommunicationRoute.close(audioManager, communicationRouteOwner)
+      communicationRoute.close(audioManager, communicationRouteOwner)
       requestedCommunicationDevice = null
+      appliedCommunicationType = null
     }
   }
 }
 
 /** Serializes Android's process-wide communication route across overlapping capture cleanup. */
-private class BluetoothCommunicationRoute {
+private class CommunicationDeviceRoute {
+  private val tag = "AudioInput"
   private var nextOwner = 0L
   private var latestOwner = 0L
   private var activeOwner: Long? = null
@@ -304,26 +431,34 @@ private class BluetoothCommunicationRoute {
     if (owner > latestOwner) latestOwner = owner
   }
 
+  /** Returns the device the platform actually selected, or null when it selected none. */
   @Synchronized
   fun update(
     audioManager: AudioManager,
     owner: Long,
     device: AudioDeviceInfo?,
-  ): Boolean {
-    if (owner < latestOwner) return false
+  ): AudioDeviceInfo? {
+    if (owner < latestOwner) return null
     latestOwner = owner
     if (device == null) {
       if (activeOwner != null) audioManager.clearCommunicationDevice()
       activeOwner = null
-      return false
+      return null
     }
     if (!audioManager.setCommunicationDevice(device)) {
       if (activeOwner != null) audioManager.clearCommunicationDevice()
       activeOwner = null
-      return false
+      return null
     }
     activeOwner = owner
-    return true
+    // A request is not an outcome. Report what the platform says it selected, so nothing upstream
+    // claims a route Android did not actually give it.
+    val applied = audioManager.communicationDevice
+    if (applied == null || applied.id != device.id) {
+      Log.w(tag, "communication device requested id=${device.id} but platform selected id=${applied?.id}")
+      return null
+    }
+    return applied
   }
 
   @Synchronized
@@ -337,7 +472,7 @@ private class BluetoothCommunicationRoute {
   }
 }
 
-private val bluetoothCommunicationRoute = BluetoothCommunicationRoute()
+private val communicationRoute = CommunicationDeviceRoute()
 
 /** Converts AudioRecord's negative return codes into capture-session failures. */
 internal fun checkAudioRecordReadResult(result: Int): Int {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/AndroidAudioInputSession.kt
@@ -28,7 +28,7 @@ internal class AndroidAudioInputSession private constructor(
   private val preferredInputKey: String?,
   private val onAppliedPreferredDeviceChanged: (String?) -> Unit,
   private val setPreferredDevice: (AudioDeviceInfo?) -> Boolean,
-) : AutoCloseable {
+) : RealtimeCaptureCandidate {
   companion object {
     private const val tag = "AudioInput"
 
@@ -145,6 +145,16 @@ internal class AndroidAudioInputSession private constructor(
 
   internal val appliedPreferredDeviceKey: String?
     get() = synchronized(lock) { appliedPreferredInputKey }
+
+  /**
+   * The rate the recorder negotiated, read back from it rather than assumed from the request.
+   *
+   * This session owns the capture clock; callers converting capture to a wire rate must build that
+   * conversion from this value, because a recorder is free to grant a rate other than the one it
+   * was asked for.
+   */
+  override val actualSampleRateHz: Int
+    get() = audioRecord.sampleRate
 
   fun startRecording() {
     synchronized(lock) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCapture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCapture.kt
@@ -75,13 +75,23 @@ internal fun parseRealtimeWireAudioContract(
   // Playback plays the declared downlink verbatim at a fixed rate. This phase does not make that
   // rate dynamic, so a contract whose downlink half this endpoint cannot honor is rejected rather
   // than accepted and then played at the wrong clock.
-  val outputEncoding = (audio["outputEncoding"] as? JsonPrimitive)?.takeIf { it.isString }?.content
-  if (outputEncoding != null && outputEncoding != REALTIME_WIRE_AUDIO_ENCODING_PCM16) {
-    return RealtimeWireAudioContract.Unsupported("outputEncoding=$outputEncoding")
+  // Absent is fine; present-but-unreadable is not. Skipping the comparison because the value was
+  // the wrong JSON type would accept a downlink at a clock this endpoint then plays at the wrong
+  // rate -- the input half already fails closed on exactly that, and the two must agree.
+  val declaredOutputEncoding = audio["outputEncoding"]
+  if (declaredOutputEncoding != null && declaredOutputEncoding !is JsonNull) {
+    val outputEncoding = (declaredOutputEncoding as? JsonPrimitive)?.takeIf { it.isString }?.content
+    if (outputEncoding != REALTIME_WIRE_AUDIO_ENCODING_PCM16) {
+      return RealtimeWireAudioContract.Unsupported("outputEncoding=$declaredOutputEncoding")
+    }
   }
-  val outputSampleRateHz = (audio["outputSampleRateHz"] as? JsonPrimitive)?.takeIf { !it.isString }?.content?.toIntOrNull()
-  if (outputSampleRateHz != null && outputSampleRateHz != playbackSampleRateHz) {
-    return RealtimeWireAudioContract.Unsupported("outputSampleRateHz=$outputSampleRateHz")
+  val declaredOutputSampleRateHz = audio["outputSampleRateHz"]
+  if (declaredOutputSampleRateHz != null && declaredOutputSampleRateHz !is JsonNull) {
+    val outputSampleRateHz =
+      (declaredOutputSampleRateHz as? JsonPrimitive)?.takeIf { !it.isString }?.content?.toIntOrNull()
+    if (outputSampleRateHz != playbackSampleRateHz) {
+      return RealtimeWireAudioContract.Unsupported("outputSampleRateHz=$declaredOutputSampleRateHz")
+    }
   }
   return RealtimeWireAudioContract.Pcm16(sampleRateHz)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCapture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCapture.kt
@@ -318,3 +318,41 @@ internal class RealtimeCaptureResampler(
     }
   }
 }
+
+/**
+ * One bounded, content-free health line per realtime capture session.
+ *
+ * It exists to make "the recorder opened and returned silence" distinguishable from "the recorder
+ * is working" without logging audio: a recorder that reports an active unmuted route and hands
+ * back nothing but zeroes looks identical to a working one from every other signal. Emitted once
+ * on the first non-zero sample, or once at session end if none ever arrived, so it cannot become
+ * a per-frame log. No sample values, no transcript, no content -- only a peak magnitude.
+ *
+ * This is observability, not policy: nothing here rejects a capture session. Quiet rooms and
+ * aggressive platform noise suppression both produce legitimate near-silence.
+ */
+internal class RealtimeCaptureHealthReport(
+  private val header: String,
+) {
+  private var frames = 0L
+  private var reported = false
+
+  /**
+   * Takes the RMS the level meter already computed for this frame, so nothing rescans the buffer
+   * and no second PCM decoder exists to drift from the first.
+   */
+  fun observe(rms: Double) {
+    if (reported) return
+    frames += 1
+    if (rms <= 0.0) return
+    reported = true
+    Log.i(tag, "capture health: $header frames=$frames nonZero=true rms=${"%.5f".format(rms)}")
+  }
+
+  /** Called once when the session ends, so a session that never produced audio is visible too. */
+  fun reportSessionEnd() {
+    if (reported) return
+    reported = true
+    Log.w(tag, "capture health: $header frames=$frames nonZero=false")
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCapture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCapture.kt
@@ -1,0 +1,320 @@
+package ai.openclaw.app.voice
+
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+private const val tag = "RealtimeCapture"
+
+/** The only capture encoding this endpoint can produce for `talk.session.appendAudio`. */
+internal const val REALTIME_WIRE_AUDIO_ENCODING_PCM16 = "pcm16"
+
+/**
+ * The wire rate assumed when `talk.session.create` declares no audio contract at all.
+ *
+ * The field is optional in the shared schema (`TalkSessionCreateResultSchema.audio`), so an older
+ * Gateway peer can omit it, and the iOS relay client resolves that same absence to PCM16 at this
+ * rate (`RealtimeTalkRelaySession.configureAudioContract`). A contract that is present but says
+ * something else is never resolved here -- absence is the only case this default covers.
+ */
+internal const val REALTIME_LEGACY_WIRE_SAMPLE_RATE_HZ = 24_000
+
+/** Highest capture-to-wire ratio the anti-alias filter is built for; 192 kHz down to 24 kHz. */
+private const val MAX_CAPTURE_DECIMATION = 8
+
+/** Filter length per decimation step. Longer than the minimum, and still trivial per frame. */
+private const val CAPTURE_FILTER_TAPS_PER_STEP = 16
+
+/** The audio format Android must hand to the Gateway, as the Gateway declared it. */
+internal sealed interface RealtimeWireAudioContract {
+  /** Usable: little-endian PCM16 mono at [sampleRateHz]. */
+  data class Pcm16(
+    val sampleRateHz: Int,
+  ) : RealtimeWireAudioContract
+
+  /** Declared, but not something this endpoint can produce. The session must fail closed. */
+  data class Unsupported(
+    val detail: String,
+  ) : RealtimeWireAudioContract
+}
+
+/**
+ * Reads the wire audio contract out of a `talk.session.create` result.
+ *
+ * An absent `audio` field is the legacy relay format (see [REALTIME_LEGACY_WIRE_SAMPLE_RATE_HZ]).
+ * A field that is present is taken literally: anything this endpoint cannot produce becomes
+ * [RealtimeWireAudioContract.Unsupported] rather than quietly falling back, because falling back
+ * would mean sending PCM at a clock the Gateway never asked for.
+ */
+internal fun parseRealtimeWireAudioContract(
+  root: JsonObject?,
+  playbackSampleRateHz: Int,
+): RealtimeWireAudioContract {
+  val declared = root?.get("audio")
+  // An explicit null is absence, not a declaration -- the same reading the iOS relay client takes.
+  if (declared == null || declared is JsonNull) {
+    return RealtimeWireAudioContract.Pcm16(REALTIME_LEGACY_WIRE_SAMPLE_RATE_HZ)
+  }
+  val audio = declared as? JsonObject ?: return RealtimeWireAudioContract.Unsupported("audio is not an object")
+  val encoding = (audio["inputEncoding"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+  if (encoding != REALTIME_WIRE_AUDIO_ENCODING_PCM16) {
+    return RealtimeWireAudioContract.Unsupported("inputEncoding=$encoding")
+  }
+  // A JSON string is not an integer. The schema declares this field as one, and accepting a
+  // quoted rate here while rejecting a quoted encoding above would be an accident, not a policy.
+  val sampleRateHz = (audio["inputSampleRateHz"] as? JsonPrimitive)?.takeIf { !it.isString }?.content?.toIntOrNull()
+  if (sampleRateHz == null || sampleRateHz <= 0) {
+    return RealtimeWireAudioContract.Unsupported("inputSampleRateHz=${audio["inputSampleRateHz"]}")
+  }
+  // Playback plays the declared downlink verbatim at a fixed rate. This phase does not make that
+  // rate dynamic, so a contract whose downlink half this endpoint cannot honor is rejected rather
+  // than accepted and then played at the wrong clock.
+  val outputEncoding = (audio["outputEncoding"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+  if (outputEncoding != null && outputEncoding != REALTIME_WIRE_AUDIO_ENCODING_PCM16) {
+    return RealtimeWireAudioContract.Unsupported("outputEncoding=$outputEncoding")
+  }
+  val outputSampleRateHz = (audio["outputSampleRateHz"] as? JsonPrimitive)?.takeIf { !it.isString }?.content?.toIntOrNull()
+  if (outputSampleRateHz != null && outputSampleRateHz != playbackSampleRateHz) {
+    return RealtimeWireAudioContract.Unsupported("outputSampleRateHz=$outputSampleRateHz")
+  }
+  return RealtimeWireAudioContract.Pcm16(sampleRateHz)
+}
+
+/**
+ * The rates to try opening the microphone at, in order.
+ *
+ * The preferred rate comes first because it is the one the hardware is most likely to deliver
+ * unprocessed; the wire rate is the compatibility fallback, and needs no conversion when the
+ * recorder actually grants it. A device that only supports one of the two is served by the other.
+ */
+internal fun realtimeCaptureCandidateRatesHz(
+  preferredRateHz: Int,
+  wireRateHz: Int,
+): List<Int> = listOf(preferredRateHz, wireRateHz).distinct()
+
+/** What a capture candidate has to expose to be judged, plus the way to release it. */
+internal interface RealtimeCaptureCandidate : AutoCloseable {
+  /** The rate the recorder negotiated. It need not be the rate that was requested. */
+  val actualSampleRateHz: Int
+}
+
+/** One opened capture session, together with the converter its negotiated rate resolved to. */
+internal class RealtimeCaptureSelection<T : RealtimeCaptureCandidate>(
+  val candidate: T,
+  val resampler: RealtimeCaptureResampler,
+  val requestedSampleRateHz: Int,
+  val captureSampleRateHz: Int,
+)
+
+/**
+ * Opens the first candidate rate this device can both deliver and convert to [wireRateHz].
+ *
+ * A candidate is judged on the rate the recorder *negotiated*, never on the rate that was asked
+ * for: a recorder that opens at a different but convertible rate is a working microphone, and
+ * rejecting it would cost Talk a route the device can still serve. A candidate that opens but
+ * cannot be converted is closed before the next one is tried, so no recorder outlives its
+ * rejection. Throws when no candidate is usable, rather than letting capture run at a clock the
+ * Gateway did not ask for.
+ */
+internal fun <T : RealtimeCaptureCandidate> selectRealtimeCaptureSession(
+  candidateRatesHz: List<Int>,
+  wireRateHz: Int,
+  open: (sampleRateHz: Int) -> T,
+): RealtimeCaptureSelection<T> {
+  // Whether a rate is convertible is knowable before the microphone is touched, and opening a
+  // recorder is not free: it claims the process-wide communication route, which on Bluetooth is an
+  // audible toggle. Skip the rates that provably cannot work -- unless that leaves nothing, in
+  // which case a recorder may still negotiate something usable and is worth asking.
+  val convertible = candidateRatesHz.filter { resolveRealtimeCaptureResampler(it, wireRateHz) != null }
+  var lastFailure: Throwable? = null
+  for (requestedRateHz in convertible.ifEmpty { candidateRatesHz }) {
+    val candidate =
+      try {
+        open(requestedRateHz)
+      } catch (err: CancellationException) {
+        throw err
+      } catch (err: RuntimeException) {
+        Log.w(tag, "capture candidate ${requestedRateHz}Hz did not open: ${err.message ?: err::class.simpleName}")
+        lastFailure = err
+        continue
+      }
+    val captureSampleRateHz = candidate.actualSampleRateHz
+    val resampler = resolveRealtimeCaptureResampler(captureSampleRateHz, wireRateHz)
+    if (resampler != null) {
+      if (captureSampleRateHz != requestedRateHz) {
+        Log.d(tag, "capture negotiated ${captureSampleRateHz}Hz for a ${requestedRateHz}Hz request")
+      }
+      return RealtimeCaptureSelection(
+        candidate = candidate,
+        resampler = resampler,
+        requestedSampleRateHz = requestedRateHz,
+        captureSampleRateHz = captureSampleRateHz,
+      )
+    }
+    Log.w(tag, "capture at ${captureSampleRateHz}Hz cannot be converted to the ${wireRateHz}Hz wire rate")
+    runCatching { candidate.close() }
+    lastFailure = IllegalStateException("microphone audio cannot be converted to this session's format")
+  }
+  throw lastFailure ?: IllegalStateException("no usable microphone capture rate")
+}
+
+/**
+ * Resolves the converter for [captureRateHz] -> [wireRateHz], or null when this endpoint cannot
+ * do it.
+ *
+ * Only exact integer downsampling is supported, which covers the two rates capture actually asks
+ * for -- the portable preferred rate and the wire rate itself -- plus any whole multiple of the
+ * wire rate a recorder might negotiate instead. Anything else (a fractional ratio such as 44.1 kHz
+ * to 24 kHz, or a rate below the wire rate) is deliberately not converted here: the caller has a
+ * second candidate to fall back on, and a wrong-clock or upsampled stream would be worse than
+ * using it.
+ */
+internal fun resolveRealtimeCaptureResampler(
+  captureRateHz: Int,
+  wireRateHz: Int,
+): RealtimeCaptureResampler? {
+  if (captureRateHz <= 0 || wireRateHz <= 0) return null
+  if (captureRateHz % wireRateHz != 0) return null
+  val decimation = captureRateHz / wireRateHz
+  if (decimation > MAX_CAPTURE_DECIMATION) return null
+  return RealtimeCaptureResampler(decimation)
+}
+
+/**
+ * Converts one capture session's little-endian PCM16 mono stream to the Gateway wire rate.
+ *
+ * Sits downstream of everything Android does to the captured signal: it consumes exactly what
+ * `AudioRecord.read` returns, so any platform capture processing has already been applied and
+ * nothing has to move when that processing changes.
+ *
+ * All state -- filter history, decimation phase, and a carried odd byte -- belongs to one capture
+ * session. A new session gets a new instance, so nothing survives a restart.
+ */
+internal class RealtimeCaptureResampler(
+  private val decimation: Int,
+) {
+  private val taps: FloatArray = if (decimation <= 1) FloatArray(0) else antiAliasTaps(decimation)
+  private val history = FloatArray((taps.size - 1).coerceAtLeast(0))
+  private var phase = 0
+  private var carriedByte: Byte = 0
+  private var hasCarriedByte = false
+
+  /**
+   * Consumes the first [length] bytes of [input] and returns wire-rate PCM16.
+   *
+   * Callers hand this every captured frame, including frames the forwarding policy will drop, so
+   * the filter sees one continuous stream rather than one with holes punched in it.
+   */
+  fun convert(
+    input: ByteArray,
+    length: Int,
+  ): ByteArray {
+    val samples = takeSamples(input, length.coerceIn(0, input.size))
+    if (samples.isEmpty()) return EMPTY_AUDIO
+    if (decimation == 1) return encodeSamples(samples, samples.size)
+
+    val historyLength = history.size
+    val window = FloatArray(historyLength + samples.size)
+    history.copyInto(window)
+    for (index in samples.indices) window[historyLength + index] = samples[index].toFloat()
+
+    val output = ShortArray((phase + samples.size) / decimation)
+    var produced = 0
+    var nextPhase = phase
+    for (index in samples.indices) {
+      nextPhase += 1
+      if (nextPhase < decimation) continue
+      nextPhase = 0
+      val newest = historyLength + index
+      var accumulator = 0f
+      for (tap in taps.indices) accumulator += taps[tap] * window[newest - tap]
+      output[produced] = clampToPcm16(accumulator)
+      produced += 1
+    }
+    phase = nextPhase
+    window.copyInto(history, destinationOffset = 0, startIndex = samples.size, endIndex = samples.size + historyLength)
+    return encodeSamples(output, produced)
+  }
+
+  /**
+   * Decodes complete little-endian samples, carrying a trailing odd byte into the next call.
+   *
+   * `AudioRecord.read` returns a byte count, not a frame count. Dropping a straggling byte would
+   * shift every later sample by one byte and turn the whole stream into noise, so it is kept.
+   */
+  private fun takeSamples(
+    input: ByteArray,
+    length: Int,
+  ): ShortArray {
+    val prefix = if (hasCarriedByte) 1 else 0
+    val total = prefix + length
+    val sampleCount = total / 2
+    hasCarriedByte = total % 2 == 1
+    val samples = ShortArray(sampleCount)
+    for (index in 0 until sampleCount) {
+      val low: Int
+      val high: Int
+      val base = index * 2 - prefix
+      if (base < 0) {
+        low = carriedByte.toInt() and 0xff
+        high = input[0].toInt()
+      } else {
+        low = input[base].toInt() and 0xff
+        high = input[base + 1].toInt()
+      }
+      samples[index] = (low or (high shl 8)).toShort()
+    }
+    // A zero-length read leaves an outstanding carry exactly as it was; there is no new last byte.
+    if (hasCarriedByte && length > 0) carriedByte = input[length - 1]
+    return samples
+  }
+
+  private companion object {
+    val EMPTY_AUDIO = ByteArray(0)
+
+    /**
+     * Windowed-sinc lowpass at the decimated Nyquist, normalized to unity gain at DC.
+     *
+     * Decimating without it folds everything above the new Nyquist back into the speech band; the
+     * Hamming window keeps that fold far enough down that it does not survive as audible content.
+     */
+    fun antiAliasTaps(decimation: Int): FloatArray {
+      val tapCount = CAPTURE_FILTER_TAPS_PER_STEP * decimation + 1
+      val center = (tapCount - 1) / 2.0
+      // Below the decimated Nyquist rather than exactly on it, so the window's transition band
+      // lands inside the stopband instead of straddling the fold point.
+      val cutoff = 0.45 / decimation
+      val raw = DoubleArray(tapCount)
+      var gain = 0.0
+      for (index in 0 until tapCount) {
+        val offset = index - center
+        val ideal = if (offset == 0.0) 2.0 * cutoff else sin(2.0 * PI * cutoff * offset) / (PI * offset)
+        val window = 0.54 - 0.46 * cos(2.0 * PI * index / (tapCount - 1))
+        raw[index] = ideal * window
+        gain += raw[index]
+      }
+      return FloatArray(tapCount) { (raw[it] / gain).toFloat() }
+    }
+
+    fun clampToPcm16(value: Float): Short = value.roundToInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort()
+
+    fun encodeSamples(
+      samples: ShortArray,
+      count: Int,
+    ): ByteArray {
+      val bytes = ByteArray(count * 2)
+      for (index in 0 until count) {
+        val sample = samples[index].toInt()
+        bytes[index * 2] = (sample and 0xff).toByte()
+        bytes[index * 2 + 1] = ((sample shr 8) and 0xff).toByte()
+      }
+      return bytes
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCommunicationAudio.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCommunicationAudio.kt
@@ -2,6 +2,8 @@ package ai.openclaw.app.voice
 
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.os.Handler
+import android.os.HandlerThread
 import android.util.Log
 
 /**
@@ -27,19 +29,42 @@ internal class RealtimeCommunicationAudioOwner {
   private var previousMode: Int = AudioManager.MODE_NORMAL
   private var focusRequest: AudioFocusRequest? = null
 
+  /**
+   * Which focus request the listener callbacks belong to.
+   *
+   * Focus callbacks arrive asynchronously and can outlive the request that caused them, so a
+   * delayed LOSS from a torn-down session must not be allowed to close full duplex for the
+   * session that replaced it. Every request carries its own generation and a callback that does
+   * not match the current one is inert.
+   */
+  private var focusGeneration = 0L
+
+  /** Whether this app currently holds focus. Revocable session state, not an acquisition fact. */
+  private var focusActive = false
+
+  /**
+   * The generation a loss callback has already revoked.
+   *
+   * The platform may deliver a callback while `requestAudioFocus` is still on the stack, and the
+   * monitor is reentrant, so that callback runs *inside* the acquisition. Without this the grant
+   * path would then overwrite the revocation it just received and report focus this app no longer
+   * holds.
+   */
+  private var focusRevokedGeneration = -1L
+
   /** The mode was taken after acquisition. The token stays valid so teardown can still unwind. */
   private var modeLost = false
   private var lastFailure = LastFailure.None
   private var focusRetriesLeft = 0
 
   /**
-   * Lock-free mirror of [communicationModeActive] for the capture read loop.
+   * Lock-free mirror of [communicationAudioEligible] for the capture read loop.
    *
    * The monitor this class uses is held across AudioService binder calls, so a per-frame read that
    * entered it would put an IPC round trip on the critical path of `AudioRecord.read` -- the exact
    * coupling the capture-side cache exists to remove.
    */
-  @Volatile private var modeActiveSnapshot = false
+  @Volatile private var eligibilitySnapshot = false
 
   /** Why the last attempt failed, so the retry can act only on the kind that is transient. */
   private enum class LastFailure {
@@ -151,24 +176,36 @@ internal class RealtimeCommunicationAudioOwner {
   }
 
   /**
-   * Whether a live session holds the mode and the device is still in communication mode.
+   * Whether this session's communication audio is currently good enough to run full duplex.
    *
-   * Deliberately not called "owns": `AudioManager.getMode()` returns the device's effective mode,
-   * and Android exposes no per-app mode-owner query, so what is observable is "the device is in
-   * communication mode", not "this app is the one that put it there". That is the fact the
-   * canceller's reference signal actually depends on, so it is the fact this reports -- but the
-   * distinction matters and must not be overstated anywhere it is quoted.
+   * Three independent live facts, all revocable, and the single source of truth for the parts of
+   * the full-duplex decision this class owns:
+   *  - a live session still holds the token,
+   *  - the device is still in communication mode (`getMode()` reports the device's *effective*
+   *    mode; Android exposes no per-app owner query, so this is "the device is in communication
+   *    mode", not "this app put it there" -- the distinction must not be overstated),
+   *  - this app still holds audio focus.
+   *
+   * Focus belongs here rather than being an acquisition-time assumption: the platform can hand it
+   * to another app at any moment, and once it has, that app is on the same speaker the echo
+   * canceller uses as its reference. Forwarding the microphone during playback then means
+   * forwarding audio the canceller cannot subtract.
+   *
+   * Recovery is asymmetric, deliberately. A *transient* loss is followed by a GAIN callback and
+   * eligibility returns. A *permanent* loss is not: the platform sends no GAIN, and this class
+   * does not re-request, because a session that re-asks every tick is the focus thrash a previous
+   * review round had to remove. Such a session stays half duplex until Talk is restarted.
    */
   @get:Synchronized
-  val communicationModeActive: Boolean
-    get() = activeOwner != null && !modeLost
+  val communicationAudioEligible: Boolean
+    get() = activeOwner != null && !modeLost && focusActive
 
   /** The same fact, readable without entering the monitor. For the capture read loop only. */
-  val communicationModeActiveUnsynchronized: Boolean
-    get() = modeActiveSnapshot
+  val communicationAudioEligibleUnsynchronized: Boolean
+    get() = eligibilitySnapshot
 
   /**
-   * Re-reads the device mode and marks it lost when the device is no longer in communication mode.
+   * Re-reads the device mode, then reports whether communication audio is eligible overall.
    *
    * Acquisition proves the mode at one instant; another app can move it afterwards. Without this
    * the capability would stay granted for a session whose downlink the canceller is no longer
@@ -181,17 +218,18 @@ internal class RealtimeCommunicationAudioOwner {
    * communication mode permanently.
    */
   @Synchronized
-  fun verifyCommunicationModeActive(audioManager: AudioManager): Boolean {
+  fun verifyCommunicationAudioEligible(audioManager: AudioManager): Boolean {
     if (activeOwner == null) return false
     if (readMode(audioManager, AudioManager.MODE_INVALID) == AudioManager.MODE_IN_COMMUNICATION) {
       modeLost = false
-      publishSnapshot()
-      return true
+    } else {
+      if (!modeLost) Log.w(tag, "communication mode no longer active; dropping to half duplex")
+      modeLost = true
     }
-    if (!modeLost) Log.w(tag, "communication mode no longer active; dropping to half duplex")
-    modeLost = true
     publishSnapshot()
-    return false
+    // The mode is the only fact this re-reads; focus is maintained by the platform's own callback
+    // and the token by the session lifecycle. Returning the conjunction keeps one source of truth.
+    return activeOwner != null && !modeLost && focusActive
   }
 
   /**
@@ -256,33 +294,128 @@ internal class RealtimeCommunicationAudioOwner {
   }
 
   private fun publishSnapshot() {
-    modeActiveSnapshot = activeOwner != null && !modeLost
+    eligibilitySnapshot = activeOwner != null && !modeLost && focusActive
   }
 
   private fun acquireFocus(audioManager: AudioManager): FocusOutcome {
     if (focusRequest != null) return FocusOutcome.AlreadyHeld
+    val generation = ++focusGeneration
+    // This generation starts un-held; only a grant that no callback has already revoked sets it.
+    focusActive = false
     val request =
       AudioFocusRequest
         .Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
         .setAudioAttributes(realtimeCommunicationPlaybackAttributes())
+        // The listener is what makes focus a live fact rather than an acquisition-time one.
+        // Bound to this request's generation so a callback that outlives it cannot speak for
+        // whatever session came next.
+        //
+        // Dispatched on a private thread, not the default. The single-argument overload delivers
+        // on the main Looper, and this callback takes the monitor that `enter` and `restore` hold
+        // across AudioService calls -- a loss arriving during one of those would park the UI
+        // thread for the length of a HAL round trip.
+        .setOnAudioFocusChangeListener({ change -> onFocusChange(generation, change) }, focusCallbackHandler())
         .build()
     val granted = runCatching { audioManager.requestAudioFocus(request) }.getOrDefault(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
     if (granted != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
       Log.w(tag, "communication audio focus not granted (code $granted)")
+      // requestAudioFocus registers the listener before it consults the service and does not
+      // unregister on refusal, so a denied request would otherwise pin its listener -- and this
+      // owner through it -- in a process-global map for the process lifetime. Each request now
+      // carries a distinct capturing lambda, so those entries would accumulate per denial.
+      runCatching { audioManager.abandonAudioFocusRequest(request) }
+      publishSnapshot()
       return FocusOutcome.Denied
     }
     focusRequest = request
+    // Not unconditional: a reentrant loss delivered during the call above already spoke for this
+    // generation, and the grant must not overwrite it.
+    if (focusGeneration == generation && focusRevokedGeneration != generation) focusActive = true
+    publishSnapshot()
     return FocusOutcome.Acquired
   }
 
+  /**
+   * The platform telling this app what happened to its focus.
+   *
+   * Every loss variant this app is told about revokes full-duplex eligibility, CAN_DUCK included:
+   * ducking still puts another app's audio on the loudspeaker the echo canceller is referencing,
+   * and the canceller has no reference for it.
+   *
+   * CAN_DUCK is delivered only when the platform cannot duck this app itself. Because the playout
+   * track is CONTENT_TYPE_SPEECH the platform declines to duck it and notifies instead -- but only
+   * while such a track is actually started. A duckable loss arriving between responses is handled
+   * silently by the platform and produces no callback, so this arm covers the case that matters
+   * (a duck during playback) rather than every duck.
+   *
+   * Callbacks are dispatched by the platform on its own thread, so this takes the monitor. It
+   * performs no AudioManager call, so it cannot block on a binder round trip while holding it.
+   */
+  @Synchronized
+  private fun onFocusChange(
+    generation: Long,
+    change: Int,
+  ) {
+    // A callback from an abandoned or superseded request must never touch newer state.
+    if (generation != focusGeneration) return
+    when (change) {
+      AudioManager.AUDIOFOCUS_GAIN -> {
+        // Only a live owner may be restored. Focus returning says nothing about the mode, which
+        // keeps its own independent read-back.
+        if (activeOwner == null) return
+        focusActive = true
+      }
+      AudioManager.AUDIOFOCUS_LOSS,
+      AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
+      AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK,
+      -> {
+        if (focusActive) Log.w(tag, "communication audio focus lost (change=$change); closing full duplex")
+        focusActive = false
+        focusRevokedGeneration = generation
+      }
+      else -> return
+    }
+    publishSnapshot()
+  }
+
   private fun releaseFocus(audioManager: AudioManager) {
+    // Revoked before the abandon, not after: the snapshot must never report eligible for a
+    // request that is already on its way out.
+    focusActive = false
+    focusGeneration += 1
+    publishSnapshot()
     focusRequest?.let { request ->
-      runCatching { audioManager.abandonAudioFocusRequest(request) }
+      val result = runCatching { audioManager.abandonAudioFocusRequest(request) }
+      val code = result.getOrNull()
+      if (result.isFailure || code != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+        // Worth seeing, because the platform may still consider this app a focus holder. The
+        // handle is dropped anyway: keeping it would make the next session's acquireFocus report
+        // AlreadyHeld and leave that session permanently ineligible, which is strictly worse than
+        // a stale platform-side request whose listener this generation fence has already made
+        // inert.
+        Log.w(tag, "communication audio focus not abandoned cleanly (code=${code ?: "threw"})")
+      }
       focusRequest = null
     }
   }
 
   internal companion object {
+    /**
+     * One process-wide thread for focus callbacks.
+     *
+     * Private rather than the main Looper so a callback can block on this class's monitor without
+     * parking the UI thread. Started once and left running: it is a single idle Looper thread for
+     * the process, and tying its lifetime to individual sessions would reintroduce the teardown
+     * race the generation fence exists to remove.
+     */
+    private val focusCallbackThread by lazy {
+      HandlerThread("realtime-audio-focus").also { it.start() }
+    }
+
+    private val focusCallbackHandlerInstance by lazy { Handler(focusCallbackThread.looper) }
+
+    private fun focusCallbackHandler(): Handler = focusCallbackHandlerInstance
+
     /** The token value a session that never acquired the mode carries. */
     const val NO_OWNER = 0L
     private const val FOCUS_RETRY_BUDGET = 6

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCommunicationAudio.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCommunicationAudio.kt
@@ -12,9 +12,10 @@ import android.util.Log
  * restored once when it closes, so a response boundary, a barge-in, or a push-to-talk excursion
  * never toggles the device in and out of communication mode mid-conversation.
  *
- * Focus is acquired with it rather than separately: without it another app keeps playing into the
- * same loudspeaker the platform echo canceller is using as its reference signal, which is exactly
- * the audio the canceller cannot subtract.
+ * Focus is acquired *before* the mode rather than after it: the mode request is a request, and it
+ * is least likely to be honoured in the window where this app is not the focus owner. Focus also
+ * stops another app from feeding the same loudspeaker the platform echo canceller uses as its
+ * reference signal, which is exactly the audio the canceller cannot subtract.
  *
  * Ownership is a token. A teardown that lost the race to a newer session declines to restore,
  * because restoring would put the device back into the mode the *previous* session found -- over
@@ -26,25 +27,109 @@ internal class RealtimeCommunicationAudioOwner {
   private var previousMode: Int = AudioManager.MODE_NORMAL
   private var focusRequest: AudioFocusRequest? = null
 
+  /** The mode was taken after acquisition. The token stays valid so teardown can still unwind. */
+  private var modeLost = false
+  private var lastFailure = LastFailure.None
+  private var focusRetriesLeft = 0
+
   /**
-   * Enters communication mode and returns the token that may later restore it, or [NO_OWNER] when
-   * the platform refused the mode -- a session that never changed the mode must not later claim
-   * the authority to change it back.
+   * Lock-free mirror of [communicationModeActive] for the capture read loop.
+   *
+   * The monitor this class uses is held across AudioService binder calls, so a per-frame read that
+   * entered it would put an IPC round trip on the critical path of `AudioRecord.read` -- the exact
+   * coupling the capture-side cache exists to remove.
+   */
+  @Volatile private var modeActiveSnapshot = false
+
+  /** Why the last attempt failed, so the retry can act only on the kind that is transient. */
+  private enum class LastFailure {
+    None,
+
+    /** Another app held focus. Worth retrying: focus holders are usually momentary. */
+    FocusDenied,
+
+    /**
+     * Focus was available but the mode did not take. Never retried: on a device where the mode
+     * will not stick, retrying re-acquires and re-abandons focus on every tick, which ducks and
+     * unducks whatever else is playing for the whole session. Half duplex is the correct answer.
+     */
+    ModeRefused,
+  }
+
+  /** What one [enter] attempt did to the process-wide focus request, so failure can undo its own. */
+  private enum class FocusOutcome {
+    /** An earlier still-live owner holds it; this attempt neither acquired nor may release it. */
+    AlreadyHeld,
+
+    /** This attempt acquired it, so this attempt must release it if it then fails. */
+    Acquired,
+
+    /** The platform refused. */
+    Denied,
+  }
+
+  /**
+   * Claims communication audio and returns the token that may later restore it, or [NO_OWNER].
+   *
+   * The claim is only ever made on a *read-back*. `AudioManager.mode` is a void setter that
+   * records a per-app request; it reports nothing about whether the request took effect, so "the
+   * setter did not throw" is not evidence that the device is on the communication path. Treating
+   * it as evidence is how a session ends up believing the echo canceller has a valid reference
+   * signal while the device is not actually in communication mode.
+   *
+   * What the read-back proves is that the device is in communication mode -- Android exposes no
+   * per-app mode-owner query -- which is the fact the canceller depends on. It does not prove this
+   * app is the one that put it there, and nothing here should be read as claiming that.
    */
   @Synchronized
   fun enter(audioManager: AudioManager): Long {
+    // One session, one retry budget. ~3 s of 500 ms ticks: long enough for a notification chime
+    // to finish, short enough that a device which simply will not grant focus stops being asked.
+    focusRetriesLeft = FOCUS_RETRY_BUDGET
+    return enterLocked(audioManager)
+  }
+
+  private fun enterLocked(audioManager: AudioManager): Long {
     val owner = ++nextOwner
+    val hadOwner = activeOwner != null
     // Only the first acquisition records what to restore. A stop racing a restart would otherwise
     // record the mode it had just set, and hand the device back still in communication mode.
-    val restoreTo = if (activeOwner == null) runCatching { audioManager.mode }.getOrDefault(AudioManager.MODE_NORMAL) else previousMode
-    val applied =
-      runCatching { audioManager.mode = AudioManager.MODE_IN_COMMUNICATION }
-        .onFailure { Log.w(tag, "communication mode not applied: ${it.message ?: it::class.simpleName}") }
-        .isSuccess
-    if (!applied) return NO_OWNER
+    val restoreTo = if (hadOwner) previousMode else withdrawTarget()
+
+    // Focus first, and fatal to ownership: without it this app is not the one the platform is
+    // routing the call around, so a mode it appears to hold is not one full duplex may rely on.
+    val focus = acquireFocus(audioManager)
+    if (focus == FocusOutcome.Denied) {
+      Log.w(tag, "communication audio not claimed: focus denied")
+      lastFailure = LastFailure.FocusDenied
+      return NO_OWNER
+    }
+
+    val setter = runCatching { audioManager.mode = AudioManager.MODE_IN_COMMUNICATION }
+    setter.exceptionOrNull()?.let { err ->
+      Log.w(tag, "communication mode not applied: ${err.message ?: err::class.simpleName}")
+    }
+    val readBack = readMode(audioManager, AudioManager.MODE_INVALID)
+    if (setter.isFailure || readBack != AudioManager.MODE_IN_COMMUNICATION) {
+      Log.w(tag, "communication mode not active: requested=${AudioManager.MODE_IN_COMMUNICATION} readBack=$readBack")
+      abandonFailedAttempt(audioManager, focus, hadOwner, setter.isSuccess, restoreTo)
+      lastFailure = LastFailure.ModeRefused
+      // This attempt just read the device back as not in communication mode. That is evidence, and
+      // a live older owner must not keep being told otherwise until the next watcher tick.
+      // Keyed on the read-back, not on the setter: a setter that threw says nothing about what
+      // mode the device is in, and a live owner that genuinely still holds it must not be closed
+      // down on that basis.
+      if (hadOwner && readBack != AudioManager.MODE_IN_COMMUNICATION) {
+        modeLost = true
+        publishSnapshot()
+      }
+      return NO_OWNER
+    }
     previousMode = restoreTo
     activeOwner = owner
-    requestFocus(audioManager)
+    modeLost = false
+    lastFailure = LastFailure.None
+    publishSnapshot()
     return owner
   }
 
@@ -56,16 +141,126 @@ internal class RealtimeCommunicationAudioOwner {
   ) {
     if (owner == NO_OWNER || owner != activeOwner) return
     activeOwner = null
-    focusRequest?.let { request ->
-      runCatching { audioManager.abandonAudioFocusRequest(request) }
-      focusRequest = null
-    }
+    modeLost = false
+    lastFailure = LastFailure.None
+    focusRetriesLeft = 0
+    publishSnapshot()
+    releaseFocus(audioManager)
     runCatching { audioManager.mode = previousMode }
       .onFailure { Log.w(tag, "communication mode not restored: ${it.message ?: it::class.simpleName}") }
   }
 
-  private fun requestFocus(audioManager: AudioManager) {
-    if (focusRequest != null) return
+  /**
+   * Whether a live session holds the mode and the device is still in communication mode.
+   *
+   * Deliberately not called "owns": `AudioManager.getMode()` returns the device's effective mode,
+   * and Android exposes no per-app mode-owner query, so what is observable is "the device is in
+   * communication mode", not "this app is the one that put it there". That is the fact the
+   * canceller's reference signal actually depends on, so it is the fact this reports -- but the
+   * distinction matters and must not be overstated anywhere it is quoted.
+   */
+  @get:Synchronized
+  val communicationModeActive: Boolean
+    get() = activeOwner != null && !modeLost
+
+  /** The same fact, readable without entering the monitor. For the capture read loop only. */
+  val communicationModeActiveUnsynchronized: Boolean
+    get() = modeActiveSnapshot
+
+  /**
+   * Re-reads the device mode and marks it lost when the device is no longer in communication mode.
+   *
+   * Acquisition proves the mode at one instant; another app can move it afterwards. Without this
+   * the capability would stay granted for a session whose downlink the canceller is no longer
+   * referencing -- the same failure the acquisition read-back prevents, arriving late.
+   *
+   * It marks rather than releases. Nulling the owner token here would orphan it: [restore] is
+   * token-guarded, so teardown would then abandon no focus and withdraw no mode request, other
+   * apps would stay ducked for the process lifetime, and the next [enter] would read this
+   * process's own stale request back as the mode to restore -- pinning the device in
+   * communication mode permanently.
+   */
+  @Synchronized
+  fun verifyCommunicationModeActive(audioManager: AudioManager): Boolean {
+    if (activeOwner == null) return false
+    if (readMode(audioManager, AudioManager.MODE_INVALID) == AudioManager.MODE_IN_COMMUNICATION) {
+      modeLost = false
+      publishSnapshot()
+      return true
+    }
+    if (!modeLost) Log.w(tag, "communication mode no longer active; dropping to half duplex")
+    modeLost = true
+    publishSnapshot()
+    return false
+  }
+
+  /**
+   * Unwinds exactly what this failed attempt did, and nothing a live older owner still holds.
+   *
+   * The mode is only put back when this attempt was the one that moved it: with an older owner
+   * still running, whatever the mode is now belongs to that owner, and "restoring" it here would
+   * be this failed attempt reaching over a session that is still live.
+   */
+  private fun abandonFailedAttempt(
+    audioManager: AudioManager,
+    focus: FocusOutcome,
+    hadOwner: Boolean,
+    setterRan: Boolean,
+    restoreTo: Int,
+  ) {
+    if (!hadOwner && setterRan) {
+      // restoreTo is always MODE_NORMAL for a first acquisition, so a failed attempt withdraws
+      // its own request rather than asserting whatever it happened to find.
+      runCatching { audioManager.mode = restoreTo }
+        .onFailure { Log.w(tag, "failed acquisition could not undo its own mode write: ${it.message}") }
+    }
+    if (focus == FocusOutcome.Acquired) releaseFocus(audioManager)
+  }
+
+  private fun readMode(
+    audioManager: AudioManager,
+    fallback: Int,
+  ): Int = runCatching { audioManager.mode }.getOrDefault(fallback)
+
+  /**
+   * What teardown writes to give the mode back: always normal.
+   *
+   * `getMode()` reports the device's *effective* mode; `setMode` records *this app's* request. They
+   * are not the same value, and replaying the first as the second is how a session that merely
+   * *found* the device in some mode ends up asserting that mode as its own -- a standing request
+   * nothing ever withdraws. Communication mode was the case that motivated this, but the shape is
+   * wrong for every mode: replaying `MODE_IN_CALL` found during a real call would have this app
+   * asserting a telephony mode it has no business requesting.
+   *
+   * Asking for normal withdraws only this entry. Since API 31 the platform arbitrates per-app
+   * requests, so an app that genuinely still wants another mode keeps it through its own request.
+   */
+  private fun withdrawTarget(): Int = AudioManager.MODE_NORMAL
+
+  /**
+   * Retries an acquisition that a transient focus holder refused.
+   *
+   * Focus denial is fatal to the mode, so without this a notification chime at the wrong instant
+   * would leave a whole Talk session silently half duplex. Called from the same watcher that
+   * verifies the mode, so recovery costs no extra machinery.
+   */
+  @Synchronized
+  fun retryIfUnclaimed(audioManager: AudioManager): Long {
+    if (activeOwner != null) return NO_OWNER
+    // Only a focus refusal is retried, and only a bounded number of times. A mode refusal is not
+    // transient in the same way: retrying it re-acquires and re-abandons focus on every tick,
+    // which pauses and resumes whatever else is playing twice a second for the whole session.
+    if (lastFailure != LastFailure.FocusDenied || focusRetriesLeft <= 0) return NO_OWNER
+    focusRetriesLeft -= 1
+    return enterLocked(audioManager)
+  }
+
+  private fun publishSnapshot() {
+    modeActiveSnapshot = activeOwner != null && !modeLost
+  }
+
+  private fun acquireFocus(audioManager: AudioManager): FocusOutcome {
+    if (focusRequest != null) return FocusOutcome.AlreadyHeld
     val request =
       AudioFocusRequest
         .Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
@@ -73,17 +268,24 @@ internal class RealtimeCommunicationAudioOwner {
         .build()
     val granted = runCatching { audioManager.requestAudioFocus(request) }.getOrDefault(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
     if (granted != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
-      // Not fatal: Talk still works, but another app may keep feeding the speaker the canceller
-      // is referencing, so it is worth seeing in a log when echo control underperforms.
       Log.w(tag, "communication audio focus not granted (code $granted)")
-      return
+      return FocusOutcome.Denied
     }
     focusRequest = request
+    return FocusOutcome.Acquired
+  }
+
+  private fun releaseFocus(audioManager: AudioManager) {
+    focusRequest?.let { request ->
+      runCatching { audioManager.abandonAudioFocusRequest(request) }
+      focusRequest = null
+    }
   }
 
   internal companion object {
     /** The token value a session that never acquired the mode carries. */
     const val NO_OWNER = 0L
+    private const val FOCUS_RETRY_BUDGET = 6
     private const val tag = "RealtimeAudio"
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCommunicationAudio.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCommunicationAudio.kt
@@ -1,0 +1,89 @@
+package ai.openclaw.app.voice
+
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.util.Log
+
+/**
+ * Owns the device-wide communication audio state for one realtime Talk session: the audio mode
+ * and the audio focus that goes with it.
+ *
+ * Session-level, not response-level. The mode is entered once when the relay session opens and
+ * restored once when it closes, so a response boundary, a barge-in, or a push-to-talk excursion
+ * never toggles the device in and out of communication mode mid-conversation.
+ *
+ * Focus is acquired with it rather than separately: without it another app keeps playing into the
+ * same loudspeaker the platform echo canceller is using as its reference signal, which is exactly
+ * the audio the canceller cannot subtract.
+ *
+ * Ownership is a token. A teardown that lost the race to a newer session declines to restore,
+ * because restoring would put the device back into the mode the *previous* session found -- over
+ * a session that is still running.
+ */
+internal class RealtimeCommunicationAudioOwner {
+  private var nextOwner = 0L
+  private var activeOwner: Long? = null
+  private var previousMode: Int = AudioManager.MODE_NORMAL
+  private var focusRequest: AudioFocusRequest? = null
+
+  /**
+   * Enters communication mode and returns the token that may later restore it, or [NO_OWNER] when
+   * the platform refused the mode -- a session that never changed the mode must not later claim
+   * the authority to change it back.
+   */
+  @Synchronized
+  fun enter(audioManager: AudioManager): Long {
+    val owner = ++nextOwner
+    // Only the first acquisition records what to restore. A stop racing a restart would otherwise
+    // record the mode it had just set, and hand the device back still in communication mode.
+    val restoreTo = if (activeOwner == null) runCatching { audioManager.mode }.getOrDefault(AudioManager.MODE_NORMAL) else previousMode
+    val applied =
+      runCatching { audioManager.mode = AudioManager.MODE_IN_COMMUNICATION }
+        .onFailure { Log.w(tag, "communication mode not applied: ${it.message ?: it::class.simpleName}") }
+        .isSuccess
+    if (!applied) return NO_OWNER
+    previousMode = restoreTo
+    activeOwner = owner
+    requestFocus(audioManager)
+    return owner
+  }
+
+  /** Restores the pre-session mode and releases focus, but only for the token that still owns it. */
+  @Synchronized
+  fun restore(
+    audioManager: AudioManager,
+    owner: Long,
+  ) {
+    if (owner == NO_OWNER || owner != activeOwner) return
+    activeOwner = null
+    focusRequest?.let { request ->
+      runCatching { audioManager.abandonAudioFocusRequest(request) }
+      focusRequest = null
+    }
+    runCatching { audioManager.mode = previousMode }
+      .onFailure { Log.w(tag, "communication mode not restored: ${it.message ?: it::class.simpleName}") }
+  }
+
+  private fun requestFocus(audioManager: AudioManager) {
+    if (focusRequest != null) return
+    val request =
+      AudioFocusRequest
+        .Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+        .setAudioAttributes(realtimeCommunicationPlaybackAttributes())
+        .build()
+    val granted = runCatching { audioManager.requestAudioFocus(request) }.getOrDefault(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
+    if (granted != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+      // Not fatal: Talk still works, but another app may keep feeding the speaker the canceller
+      // is referencing, so it is worth seeing in a log when echo control underperforms.
+      Log.w(tag, "communication audio focus not granted (code $granted)")
+      return
+    }
+    focusRequest = request
+  }
+
+  internal companion object {
+    /** The token value a session that never acquired the mode carries. */
+    const val NO_OWNER = 0L
+    private const val tag = "RealtimeAudio"
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCommunicationAudio.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeCommunicationAudio.kt
@@ -365,6 +365,7 @@ internal class RealtimeCommunicationAudioOwner {
         if (activeOwner == null) return
         focusActive = true
       }
+
       AudioManager.AUDIOFOCUS_LOSS,
       AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
       AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK,
@@ -373,7 +374,10 @@ internal class RealtimeCommunicationAudioOwner {
         focusActive = false
         focusRevokedGeneration = generation
       }
-      else -> return
+
+      else -> {
+        return
+      }
     }
     publishSnapshot()
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimePlayout.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimePlayout.kt
@@ -1,0 +1,191 @@
+package ai.openclaw.app.voice
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Work handed to the single realtime playout owner.
+ *
+ * The Gateway message pump only ever `trySend`s one of these. It never touches the output
+ * device, the pending-barrier map, or any lock the owner holds, so an inbound Gateway frame
+ * can never end up waiting on hardware backpressure.
+ *
+ * [Audio] and [Mark] carry the playback epoch that was current when the Gateway event
+ * arrived. [Clear] and [Stop] invalidate that epoch on the requesting thread before they are
+ * queued, so audio belonging to a cancelled response is discarded by the owner instead of
+ * reaching the speaker after the fact.
+ */
+internal sealed interface RealtimePlaybackCommand {
+  /** Assistant audio produced under [epoch]. */
+  data class Audio(
+    val epoch: Long,
+    val bytes: ByteArray,
+  ) : RealtimePlaybackCommand
+
+  /** A provider playback barrier registered under [epoch]. */
+  data class Mark(
+    val epoch: Long,
+    val sessionId: String,
+    val name: String,
+  ) : RealtimePlaybackCommand
+
+  /**
+   * Barge-in or provider clear: retire the device and release every pending barrier.
+   *
+   * [turnId] is the provider output turn this clear belongs to. It is carried rather than read
+   * from shared state because the waiter must be completed with the identity the clear arrived
+   * with -- `cancelOutput` checks it against the turn it asked to cancel, and a later turn
+   * overwriting the field mid-flight would otherwise complete the waiter with the wrong identity.
+   */
+  data class Clear(
+    val turnId: String?,
+    val completion: CompletableDeferred<String?>?,
+  ) : RealtimePlaybackCommand
+
+  /**
+   * Playback teardown. [terminal] is true only for relay teardown, which drops pending barriers
+   * unacknowledged because there is no provider left to release; every other stop answers them,
+   * because retiring the device invalidates the frame counter their targets were measured
+   * against and a carried-over barrier could never complete.
+   */
+  data class Stop(
+    val terminal: Boolean,
+  ) : RealtimePlaybackCommand
+
+  /** Re-evaluate barrier completion and playback idleness without new audio. */
+  data object PollIdle : RealtimePlaybackCommand
+}
+
+/**
+ * One opened realtime output device, owned end to end by the playout owner.
+ *
+ * [write] must not block. The owner answers Clear and Stop on the same coroutine, so a
+ * blocking data-transfer call here would delay barge-in by however long the hardware buffer
+ * takes to drain.
+ */
+internal interface RealtimeAudioSink : AutoCloseable {
+  /** How much audio the hardware buffer holds. The owner derives its retry budget from it. */
+  val bufferDurationMs: Long
+
+  /**
+   * Frames the device reports as presented. Monotonic while the sink is open -- the owner never
+   * flushes except through [close] -- and, like the platform counter it comes from, wraps at
+   * 2^32 frames (roughly 49 hours at the realtime rate).
+   */
+  val presentedFrames: Long
+
+  /** Starts presentation. A full buffer only drains once this has been called. */
+  fun play()
+
+  /**
+   * Accepts at most [length] bytes starting at [offset] without blocking. Returns the
+   * accepted byte count, which may be 0 while the buffer is full, or a negative device
+   * error code.
+   */
+  fun write(
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+  ): Int
+
+  /** Silences and releases the device. Called by the owner only. */
+  override fun close()
+}
+
+/** Opens the realtime output device. Production always uses [AudioTrackBacked]. */
+internal fun interface RealtimeAudioSinkFactory {
+  fun open(
+    sampleRateHz: Int,
+    playbackBufferMs: Int,
+    firstWriteBytes: Int,
+  ): RealtimeAudioSink
+
+  companion object {
+    val AudioTrackBacked =
+      RealtimeAudioSinkFactory { sampleRateHz, playbackBufferMs, firstWriteBytes ->
+        val minBuffer =
+          AudioTrack.getMinBufferSize(
+            sampleRateHz,
+            AudioFormat.CHANNEL_OUT_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+          )
+        val bufferSizeBytes =
+          maxOf(
+            minBuffer * 2,
+            sampleRateHz * 2 * playbackBufferMs / 1000,
+            firstWriteBytes * 4,
+          )
+        val track =
+          AudioTrack
+            .Builder()
+            .setAudioAttributes(
+              AudioAttributes
+                .Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                .build(),
+            ).setAudioFormat(
+              AudioFormat
+                .Builder()
+                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                .setSampleRate(sampleRateHz)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                .build(),
+            ).setTransferMode(AudioTrack.MODE_STREAM)
+            .setBufferSizeInBytes(bufferSizeBytes)
+            .build()
+        AudioTrackRealtimeAudioSink(
+          track = track,
+          bufferDurationMs = bufferSizeBytes.toLong() / 2L * 1000L / sampleRateHz.toLong(),
+        )
+      }
+  }
+}
+
+private class AudioTrackRealtimeAudioSink(
+  private val track: AudioTrack,
+  override val bufferDurationMs: Long,
+) : RealtimeAudioSink {
+  override val presentedFrames: Long
+    // playbackHeadPosition is an unsigned frame counter exposed as a signed Int.
+    get() = track.playbackHeadPosition.toLong() and 0xffff_ffffL
+
+  override fun play() {
+    if (track.playState != AudioTrack.PLAYSTATE_PLAYING) {
+      track.play()
+    }
+  }
+
+  override fun write(
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+  ): Int = track.write(bytes, offset, length, AudioTrack.WRITE_NON_BLOCKING)
+
+  override fun close() {
+    runCatching { track.pause() }
+    runCatching { track.flush() }
+    runCatching { track.stop() }
+    runCatching { track.release() }
+  }
+}
+
+/**
+ * How long to wait before retrying a write the device refused.
+ *
+ * A non-blocking write can only be refused while the hardware buffer is full, so the retry
+ * cadence is a fraction of that buffer's own duration: short enough that the device is never
+ * left starved, long enough that retrying is not a busy loop.
+ */
+internal fun realtimePlaybackWriteRetryDelayMs(bufferDurationMs: Long): Long = (bufferDurationMs / 16L).coerceIn(2L, 10L)
+
+/**
+ * How long the device may keep refusing a write before playback is treated as failed.
+ *
+ * Expressed in the same buffer duration: a buffer that has not made room in several
+ * buffer-lengths is not draining at all, rather than merely running behind, and retrying
+ * past that point would hold the owner — and therefore Clear and Stop — indefinitely.
+ */
+internal fun realtimePlaybackWriteStallBudgetMs(bufferDurationMs: Long): Long = (bufferDurationMs * 4L).coerceAtLeast(400L)

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimePlayout.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimePlayout.kt
@@ -94,6 +94,21 @@ internal interface RealtimeAudioSink : AutoCloseable {
   override fun close()
 }
 
+/**
+ * Attributes for realtime assistant playback.
+ *
+ * Communication usage rather than media: this is the far end of a two-way conversation, and it is
+ * the usage the platform's own voice pipeline -- including the echo canceller attached to the
+ * matching communication capture path -- is built around. Media usage would place the same audio
+ * on a stream that pipeline does not treat as the call's downlink.
+ */
+internal fun realtimeCommunicationPlaybackAttributes(): AudioAttributes =
+  AudioAttributes
+    .Builder()
+    .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+    .build()
+
 /** Opens the realtime output device. Production always uses [AudioTrackBacked]. */
 internal fun interface RealtimeAudioSinkFactory {
   fun open(
@@ -120,13 +135,8 @@ internal fun interface RealtimeAudioSinkFactory {
         val track =
           AudioTrack
             .Builder()
-            .setAudioAttributes(
-              AudioAttributes
-                .Builder()
-                .setUsage(AudioAttributes.USAGE_MEDIA)
-                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                .build(),
-            ).setAudioFormat(
+            .setAudioAttributes(realtimeCommunicationPlaybackAttributes())
+            .setAudioFormat(
               AudioFormat
                 .Builder()
                 .setEncoding(AudioFormat.ENCODING_PCM_16BIT)

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -1996,10 +1996,12 @@ class TalkModeManager internal constructor(
       if (command.epoch != realtimePlaybackEpoch.get()) break
       val accepted = sink.write(bytes, writtenBytes, bytes.size - writtenBytes)
       if (accepted < 0) {
-        // A device error code, not backpressure. Keep the frames already accepted and stop
-        // retrying; the next command decides whether the device is still usable.
-        Log.w(tag, "realtime audio write failed: $accepted")
-        break
+        // A device error code, not backpressure: the same class of terminal playout failure as a
+        // device that accepts nothing for the whole stall budget, and routed the same way. The
+        // owner's handler retires the sink and fails the relay. Breaking instead would bank the
+        // accepted prefix as played, extend the presentation deadline by a frame the device never
+        // finished, and leave later audio and marks running against a dead sink.
+        throw IllegalStateException("realtime audio write failed with device error $accepted")
       }
       if (accepted == 0) {
         if (stalledMs >= stallBudgetMs) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -1939,11 +1939,14 @@ class TalkModeManager internal constructor(
     val completion = pendingRealtimeOutputClear
     invalidateRealtimePlaybackEpoch()
     if (!realtimePlaybackCommands.trySend(RealtimePlaybackCommand.Clear(turnId, completion)).isSuccess) {
-      // The generation is already dead, so nothing new can play; only the device residue
-      // survives. Release the waiter rather than letting cancelOutput hang on it, and release it
-      // with the identity the clear carried so the caller's turn check still decides.
+      // The generation is already dead, so nothing new can play, but the device residue survives
+      // because the owner never got the command. Release the waiter so cancelOutput does not hang
+      // on it -- with a null identity, never the caller's turn. Answering with the matching turn
+      // would tell cancelOutput the boundary was physically reached, lifting the capture fence
+      // over a sink that was never retired. Null fails the turn check closed, and the caller
+      // closes the relay, which is the honest outcome for a clear that never reached the device.
       Log.w(tag, "realtime playback clear could not be queued")
-      completion?.complete(turnId)
+      completion?.complete(null)
     }
     if (_isEnabled.value) {
       setStatus(nativeText("Listening"))
@@ -2147,8 +2150,11 @@ class TalkModeManager internal constructor(
     setRealtimePlaying(false)
     _outputLevel.value = null
     // A Clear still queued when the owner died would otherwise leave cancelOutput waiting out its
-    // whole timeout for a boundary no one is left to reach.
-    pendingRealtimeOutputClear?.complete(Unit)
+    // whole timeout for a boundary no one is left to reach. Released with a null identity, not the
+    // caller's turn: the owner is gone, so no turn was physically retired and nothing here may
+    // claim one. cancelOutput's turn check then fails closed and the caller closes the relay,
+    // which is the correct outcome -- the boundary really was never reached.
+    pendingRealtimeOutputClear?.complete(null)
   }
 
   /** Owner-only cleanup shared by Clear, Stop, and the command loop's failure path. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -72,6 +72,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -135,6 +136,12 @@ private data class TalkStatus(
   val text: NativeText,
   val state: TalkStatusState,
   val awaitingAgent: Boolean = false,
+)
+
+/** One capture generation's answer about platform echo cancellation, published as a unit. */
+private data class RealtimeAecCapability(
+  val generation: Long,
+  val enabled: Boolean,
 )
 
 private data class PendingRealtimePlaybackMark(
@@ -256,6 +263,7 @@ class TalkModeManager internal constructor(
   }
 
   private val mainHandler = Handler(Looper.getMainLooper())
+  private val systemAudioManager by lazy { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
   private var gatewayWorkJob = SupervisorJob()
   private var gatewayWorkScope = CoroutineScope(scope.coroutineContext + gatewayWorkJob)
   private val gatewayGeneration = AtomicLong()
@@ -367,6 +375,32 @@ class TalkModeManager internal constructor(
   // Declared once by talk.session.create and read by every capture install for this session,
   // including the one push-to-talk performs when it hands the microphone back.
   @Volatile private var realtimeWireAudioContract: RealtimeWireAudioContract? = null
+
+  // Whether the running capture session reports platform echo cancellation as actually enabled,
+  // published together with the generation that observed it. The pair is one atomic value on
+  // purpose: a separate check-then-set lets a dying job win the race against the boundary that
+  // was meant to fence it off, and leave the uplink open for a successor that has no canceller.
+  private val realtimeAecCapability = AtomicReference(RealtimeAecCapability(0L, false))
+
+  private val realtimeAecEnabled: Boolean
+    get() = realtimeAecCapability.get().enabled
+
+  // Communication audio belongs to the relay session, not to a response. Only the realtime lane
+  // acquires it, so one owner per manager is enough.
+  private val realtimeCommunicationAudio = RealtimeCommunicationAudioOwner()
+
+  @Volatile private var realtimeCommunicationAudioToken = RealtimeCommunicationAudioOwner.NO_OWNER
+
+  init {
+    // Registered here rather than beside the other completion hook: an already-completed scope
+    // runs this handler synchronously inside the constructor, and the owner above must exist by
+    // then. A scope that completes without a relay teardown would otherwise leave the device in
+    // communication mode; the token guard makes it a no-op whenever teardown already ran.
+    scope.coroutineContext[Job]?.invokeOnCompletion {
+      realtimeCommunicationAudio.restore(systemAudioManager, realtimeCommunicationAudioToken)
+    }
+  }
+
   private var realtimeCaptureJob: Job? = null
   private var realtimeAppendJob: Job? = null
   private val realtimeCapturePauseLock = Any()
@@ -1224,6 +1258,10 @@ class TalkModeManager internal constructor(
     }
 
     val wireAudioContract = parseRealtimeWireAudioContract(root, realtimeOutputSampleRateHz)
+    // Outside the monitor below. Entering communication mode is a synchronous system call, and
+    // Gateway ingress takes that same monitor for its own events -- holding it across the call
+    // would make an inbound frame wait on an audio-route reconfiguration.
+    val communicationAudioToken = acquireRealtimeCommunicationAudio()
     var captureFailure: String? = null
     val capturePaused =
       synchronized(realtimeCapturePauseLock) {
@@ -1232,6 +1270,7 @@ class TalkModeManager internal constructor(
         // The wire contract is published with the session id, not before it: a stop that lands
         // between the two would otherwise leave a live session with no contract to capture under.
         realtimeWireAudioContract = wireAudioContract
+        realtimeCommunicationAudioToken = communicationAudioToken
         realtimeAgentCoordinator.beginSession(
           RealtimeAgentSession(
             relaySessionId = sessionId,
@@ -1351,6 +1390,10 @@ class TalkModeManager internal constructor(
     realtimeCaptureJob?.cancel()
     realtimeAppendJob?.cancel()
     val inputGeneration = audioInputGeneration.incrementAndGet()
+    // Cleared at the boundary itself, which also raises the published generation: from here a
+    // superseded job cannot win the compare-and-set, so until the new capture reports its own
+    // state no session has reported one, and the answer to "may the uplink stay open" is no.
+    publishRealtimeAecCapability(inputGeneration, false)
     onAppliedAudioInputChanged(null)
     val audioFrames =
       Channel<ByteArray>(
@@ -1361,7 +1404,7 @@ class TalkModeManager internal constructor(
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         for (frame in audioFrames) {
           if (realtimeSessionId != sessionId) continue
-          if (isRealtimePlaybackActive()) continue
+          if (shouldSuppressRealtimeCaptureForPlayback()) continue
           val audioBase64 = Base64.encodeToString(frame, Base64.NO_WRAP)
           val params =
             buildJsonObject {
@@ -1388,6 +1431,7 @@ class TalkModeManager internal constructor(
     realtimeCaptureJob =
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         var audioInput: AndroidAudioInputSession? = null
+        var health: RealtimeCaptureHealthReport? = null
         try {
           // Opening a candidate applies its route, and a candidate can still be rejected. Only the
           // selected session's route describes the microphone actually in use, so route changes are
@@ -1408,6 +1452,7 @@ class TalkModeManager internal constructor(
                     onAppliedAudioInputChanged(key)
                   }
                 },
+                profile = AndroidAudioInputProfile.VoiceCommunication,
               )
             }
           val openedAudioInput = selection.candidate
@@ -1417,10 +1462,20 @@ class TalkModeManager internal constructor(
           if (audioInputGeneration.get() == inputGeneration) {
             onAppliedAudioInputChanged(openedAudioInput.appliedPreferredDeviceKey)
           }
+          val aecEnabled = openedAudioInput.communicationEchoCancellationEnabled
+          publishRealtimeAecCapability(inputGeneration, aecEnabled)
+          val captureHealth =
+            RealtimeCaptureHealthReport(
+              "requested=${selection.requestedSampleRateHz} actual=${selection.captureSampleRateHz} " +
+                "wire=$wireSampleRateHz aecEnabled=$aecEnabled " +
+                "commOut=${openedAudioInput.appliedCommunicationDeviceType ?: "platform"}",
+            )
+          health = captureHealth
           Log.d(
             tag,
             "realtime capture opened requested=${selection.requestedSampleRateHz}Hz " +
-              "negotiated=${selection.captureSampleRateHz}Hz wire=${wireSampleRateHz}Hz",
+              "negotiated=${selection.captureSampleRateHz}Hz wire=${wireSampleRateHz}Hz " +
+              "aecEnabled=$aecEnabled commOut=${openedAudioInput.appliedCommunicationDeviceType ?: "platform"}",
           )
           // One read is realtimeAudioFrameMs of audio at the rate the recorder negotiated, so
           // uplink pacing follows the negotiated clock rather than the requested one.
@@ -1429,7 +1484,13 @@ class TalkModeManager internal constructor(
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
             val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
-            _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, TalkAudioLevel.pcm16Level(buffer, read))
+            // Re-read per frame rather than trusting the value this session opened with: a route
+            // can change under a running recorder, and a capability that could only ever be
+            // granted would never let the uplink close again on a route that lost its canceller.
+            publishRealtimeAecCapability(inputGeneration, openedAudioInput.communicationEchoCancellationEnabled)
+            val rms = TalkAudioLevel.pcm16Rms(buffer, read)
+            captureHealth.observe(rms)
+            _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, TalkAudioLevel.normalized(rms))
             // Converted before the forwarding policy is consulted, so the filter sees one
             // continuous stream rather than one with the suppressed frames punched out of it.
             val wireFrame = resampler.convert(buffer, read)
@@ -1443,13 +1504,68 @@ class TalkModeManager internal constructor(
         } finally {
           audioFrames.close()
           audioInput?.close()
+          health?.reportSessionEnd()
           _inputLevel.value = 0f
+          publishRealtimeAecCapability(inputGeneration, false)
         }
       }
     return null
   }
 
-  private fun shouldAppendRealtimeCapturedFrame(length: Int): Boolean = pendingRealtimeOutputClear == null && !isRealtimePlaybackActive() && length > 0
+  /**
+   * Enters communication audio for a session that is about to be published.
+   *
+   * Separated from the publication so the system call happens outside the transition monitor.
+   */
+  private fun acquireRealtimeCommunicationAudio(): Long = realtimeCommunicationAudio.enter(systemAudioManager)
+
+  /**
+   * Publishes what one capture generation found out about echo cancellation.
+   *
+   * Cancelling a capture coroutine is not synchronous with the caller that requested it, so a
+   * superseded job can still be between its own checks when its replacement is already running.
+   * A generation may only answer for itself: without this guard a dying job's cleanup would
+   * silently drop its successor back to half duplex, or worse, keep the uplink open for a
+   * session that never had an echo canceller.
+   */
+  private fun publishRealtimeAecCapability(
+    inputGeneration: Long,
+    enabled: Boolean,
+  ) {
+    while (true) {
+      val current = realtimeAecCapability.get()
+      if (current.generation > inputGeneration) return
+      if (realtimeAecCapability.compareAndSet(current, RealtimeAecCapability(inputGeneration, enabled))) return
+    }
+  }
+
+  /**
+   * The one place the full-duplex decision is made.
+   *
+   * Assistant playback only closes the uplink when the platform is not cancelling its echo. With
+   * echo cancellation actually enabled, what the microphone hears during playback is the user, so
+   * forwarding it is what lets the provider notice an interruption at all. Without it, the same
+   * frames would be the assistant's own voice and the provider would interrupt itself.
+   */
+  private fun shouldSuppressRealtimeCaptureForPlayback(): Boolean = isRealtimePlaybackActive() && !realtimeAecEnabled
+
+  /**
+   * Two independent reasons to hold a captured frame back, and both must be clear.
+   *
+   * [pendingRealtimeOutputClear] is the cancellation boundary: while a cancelOutput is in flight
+   * the old response has not finished leaving the device, and a frame forwarded now would be
+   * attributed to a turn that is being torn down. That fence is unconditional -- full-duplex
+   * capability does not exempt it, because the question there is not echo but which turn owns
+   * the uplink.
+   *
+   * [shouldSuppressRealtimeCaptureForPlayback] is the echo question, and only that: during
+   * ordinary playback the uplink stays open exactly when the platform is cancelling the
+   * assistant's own voice for us.
+   */
+  private fun shouldAppendRealtimeCapturedFrame(length: Int): Boolean =
+    length > 0 &&
+      pendingRealtimeOutputClear == null &&
+      !shouldSuppressRealtimeCaptureForPlayback()
 
   private fun isRealtimePlaybackActive(): Boolean = _isSpeaking.value || SystemClock.elapsedRealtime() < realtimePlaybackEndsAtMs
 
@@ -1726,6 +1842,10 @@ class TalkModeManager internal constructor(
           realtimeAudioSink = opened
           realtimeWrittenFrames = 0L
         }
+    // Published before anything reaches the speaker, not after the frame finishes writing. On a
+    // session without echo cancellation this state *is* the capture gate, so a late publication
+    // would let the microphone forward the assistant's own first words back to the provider.
+    beginRealtimePlaybackOwnerOnly()
     // A refused non-blocking write only makes progress once the device is draining, so
     // presentation starts before the first write rather than after it.
     sink.play()
@@ -1764,12 +1884,24 @@ class TalkModeManager internal constructor(
     if (command.epoch != realtimePlaybackEpoch.get()) return
     _outputLevel.value =
       TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
-    setRealtimePlaying(true)
-    setStatus(nativeText("Speaking…"))
     val durationMs = ((writtenBytes / 2.0) / realtimeOutputSampleRateHz * 1000.0).toLong()
     realtimeWrittenFrames += writtenBytes / 2L
     val now = SystemClock.elapsedRealtime()
     realtimePlaybackEndsAtMs = maxOf(now, realtimePlaybackEndsAtMs) + durationMs
+    ensureRealtimePlaybackIdleTickerOwnerOnly()
+  }
+
+  /**
+   * Marks playback as starting, from the owner, before the device is written to.
+   *
+   * The idle ticker is started here rather than after the write for a reason: if the write then
+   * accepts nothing, or a barge-in preempts it, this is the only thing that will later observe
+   * that nothing is playing and reopen the gate. Without it a failed first write would leave the
+   * microphone shut with nothing left to reopen it.
+   */
+  private fun beginRealtimePlaybackOwnerOnly() {
+    setRealtimePlaying(true)
+    setStatus(nativeText("Speaking…"))
     ensureRealtimePlaybackIdleTickerOwnerOnly()
   }
 
@@ -1947,10 +2079,13 @@ class TalkModeManager internal constructor(
     // Preserve the canonical status as one value so cleanup cannot split its
     // user-visible text from typed failure and awaiting-agent semantics.
     val status = currentStatus
+    var communicationAudioToken = RealtimeCommunicationAudioOwner.NO_OWNER
     val (sessionId, captureJobs) =
       synchronized(realtimeCapturePauseLock) {
         val currentSessionId = realtimeSessionId
         val currentCaptureJobs = realtimeCaptureJob to realtimeAppendJob
+        communicationAudioToken = realtimeCommunicationAudioToken
+        realtimeCommunicationAudioToken = RealtimeCommunicationAudioOwner.NO_OWNER
         realtimeSessionId = null
         realtimeWireAudioContract = null
         realtimeCaptureJob = null
@@ -1958,6 +2093,9 @@ class TalkModeManager internal constructor(
         realtimeCapturePause = null
         currentSessionId to currentCaptureJobs
       }
+    // Outside the monitor: changing the device mode is a system call, and the owner declines the
+    // restore anyway if a newer session has taken over since.
+    realtimeCommunicationAudio.restore(systemAudioManager, communicationAudioToken)
     realtimeOutputSuppressed = false
     realtimeOutputTurnId = null
     pendingRealtimeOutputClear?.cancel()

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -1463,6 +1463,7 @@ class TalkModeManager internal constructor(
     // superseded job cannot win the compare-and-set, so until the new capture reports its own
     // state no session has reported one, and the answer to "may the uplink stay open" is no.
     publishRealtimeAecCapability(inputGeneration, false)
+    resetRealtimeUplinkObservation()
     onAppliedAudioInputChanged(null)
     val audioFrames =
       Channel<ByteArray>(
@@ -1744,6 +1745,18 @@ class TalkModeManager internal constructor(
     length > 0 &&
       pendingRealtimeOutputClear == null &&
       !shouldSuppressRealtimeCaptureForPlayback()
+
+  /**
+   * Forgets the previous session's reported state, at the same boundary that clears the capability.
+   *
+   * The observation reports edges, which makes it silent while a state persists -- correct within a
+   * session, wrong across two. Without this, a second relay whose first qualified frame lands in the
+   * same state as the previous session's last one would publish nothing, and the session that most
+   * needs the evidence would be the one that produces none.
+   */
+  private fun resetRealtimeUplinkObservation() {
+    realtimeUplinkPhase.set(uplinkPhaseUnobserved)
+  }
 
   /**
    * Publishes a change in the playback-time forwarding decision, and only a change.

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -239,6 +239,11 @@ class TalkModeManager internal constructor(
     private const val realtimePlaybackBufferMs = 240
     private const val realtimePlaybackIdlePollMs = 20L
 
+    // How often the effect is re-measured off the capture read loop. Slow enough that the IPC is
+    // negligible, fast enough that a route that lost its canceller closes the uplink within a
+    // few frames rather than at the next route event.
+    private const val realtimeAecRefreshMs = 500L
+
     // Queue depth is not evidence about the device. The relay forwards provider audio unpaced
     // and a realtime provider generates speech faster than the speaker plays it, so the backlog
     // grows with response length on a perfectly healthy device; a device that has actually
@@ -441,7 +446,9 @@ class TalkModeManager internal constructor(
   // exclusively by [realtimePlaybackOwner]. The two share no lock and no suspension, so an
   // inbound Gateway frame can never wait on hardware backpressure. (They do still share
   // [realtimeCapturePauseLock] on the teardown path, but only for field swaps -- no device
-  // call and no suspension happens under it.)
+  // call and no suspension happens under it. Note that relay teardown itself does make one
+  // synchronous AudioService call from the ingress pump, in stopRealtimeRelay's restore of the
+  // communication mode -- once per teardown, not per frame; see the note there.)
   private val realtimePlaybackCommands =
     Channel<RealtimePlaybackCommand>(
       capacity = realtimePlaybackProviderQueueCapacity + realtimePlaybackControlQueueHeadroom,
@@ -483,30 +490,40 @@ class TalkModeManager internal constructor(
   private val realtimePlaybackOwnerScope = CoroutineScope(scope.coroutineContext + realtimePlaybackOwnerJob)
   private val realtimePlaybackOwner: Job =
     realtimePlaybackOwnerScope.launch(realtimePlaybackDispatcher) {
-      for (command in realtimePlaybackCommands) {
-        if (command is RealtimePlaybackCommand.Audio || command is RealtimePlaybackCommand.Mark) {
-          queuedRealtimeProviderCommands.decrementAndGet()
-        }
-        if (command is RealtimePlaybackCommand.Audio) {
-          queuedRealtimeAudioBytes.addAndGet(-command.bytes.size.toLong())
-        }
-        try {
-          when (command) {
-            is RealtimePlaybackCommand.Audio -> processRealtimeAudioOwnerOnly(command)
-            is RealtimePlaybackCommand.Mark -> processRealtimeMarkOwnerOnly(command)
-            is RealtimePlaybackCommand.Clear -> processRealtimeClearOwnerOnly(command)
-            is RealtimePlaybackCommand.Stop -> processRealtimeStopOwnerOnly(command)
-            RealtimePlaybackCommand.PollIdle -> processRealtimePollIdleOwnerOnly()
+      try {
+        for (command in realtimePlaybackCommands) {
+          if (command is RealtimePlaybackCommand.Audio || command is RealtimePlaybackCommand.Mark) {
+            queuedRealtimeProviderCommands.decrementAndGet()
           }
-        } catch (err: CancellationException) {
-          throw err
-        } catch (err: Throwable) {
-          // One command must never end this loop. The channel is long-lived and never
-          // recreated, so a dead owner would swallow every later command in silence.
-          val message = err.message ?: err::class.simpleName ?: "playback command failed"
-          Log.w(tag, "realtime playback command failed: $message")
-          failRealtimePlaybackOwnerOnly(message)
+          if (command is RealtimePlaybackCommand.Audio) {
+            queuedRealtimeAudioBytes.addAndGet(-command.bytes.size.toLong())
+          }
+          try {
+            when (command) {
+              is RealtimePlaybackCommand.Audio -> processRealtimeAudioOwnerOnly(command)
+              is RealtimePlaybackCommand.Mark -> processRealtimeMarkOwnerOnly(command)
+              is RealtimePlaybackCommand.Clear -> processRealtimeClearOwnerOnly(command)
+              is RealtimePlaybackCommand.Stop -> processRealtimeStopOwnerOnly(command)
+              RealtimePlaybackCommand.PollIdle -> processRealtimePollIdleOwnerOnly()
+            }
+          } catch (err: CancellationException) {
+            throw err
+          } catch (err: Throwable) {
+            // One command must never end this loop. The channel is long-lived and never
+            // recreated, so a dead owner would swallow every later command in silence.
+            val message = err.message ?: err::class.simpleName ?: "playback command failed"
+            Log.w(tag, "realtime playback command failed: $message")
+            failRealtimePlaybackOwnerOnly(message)
+          }
         }
+      } finally {
+        // The owner is the only thing that may touch the device, so it is also the only thing
+        // that can release it. Cancellation (scope completion), an exception escaping the loop,
+        // and channel closure all land here; without it a cancelled owner leaves an AudioTrack
+        // alive with residual audio still presenting, and leaves the capture gate believing the
+        // assistant is still speaking. Idempotent with Stop/Clear: both already emptied the map
+        // and nulled the sink, so this is a no-op on the normal paths.
+        retirePlayoutOnOwnerExitOwnerOnly()
       }
     }
 
@@ -1263,14 +1280,25 @@ class TalkModeManager internal constructor(
     // would make an inbound frame wait on an audio-route reconfiguration.
     val communicationAudioToken = acquireRealtimeCommunicationAudio()
     var captureFailure: String? = null
+    // The claim above is a device call made outside the transition monitor, so a stop can land
+    // between it and the publication below. Whether it was published decides who owns it.
+    var publishedCommunicationAudio = false
     val capturePaused =
       synchronized(realtimeCapturePauseLock) {
+        // Re-tested inside the monitor, not only before the claim above: acquiring communication
+        // audio is a device call made outside this monitor, so a stop can complete in that window
+        // and find nothing to tear down. Publishing a session after that stop would resurrect it
+        // and wedge start(), which refuses while realtimeSessionId is non-null.
+        if (generation != startGeneration.get() || !_isEnabled.value || stopRequested) {
+          return@synchronized null
+        }
         // Session publication and capture installation are one transition. PTT
         // therefore either blocks startup or detaches every installed capture job.
         // The wire contract is published with the session id, not before it: a stop that lands
         // between the two would otherwise leave a live session with no contract to capture under.
         realtimeWireAudioContract = wireAudioContract
         realtimeCommunicationAudioToken = communicationAudioToken
+        publishedCommunicationAudio = true
         realtimeAgentCoordinator.beginSession(
           RealtimeAgentSession(
             relaySessionId = sessionId,
@@ -1291,7 +1319,14 @@ class TalkModeManager internal constructor(
           false
         }
       }
-    if (capturePaused) {
+    if (!publishedCommunicationAudio) {
+      // A stop won the race: nothing holds this token, so it must be handed back here rather than
+      // left standing with the device in communication mode and focus held.
+      realtimeCommunicationAudio.restore(systemAudioManager, communicationAudioToken)
+      closeRealtimeSession(sessionId)
+      throw CancellationException("realtime talk stopped while connecting")
+    }
+    if (capturePaused == true) {
       Log.d(tag, "realtime session ready; capture paused for PTT relaySessionId=$sessionId")
       return
     }
@@ -1462,7 +1497,10 @@ class TalkModeManager internal constructor(
           if (audioInputGeneration.get() == inputGeneration) {
             onAppliedAudioInputChanged(openedAudioInput.appliedPreferredDeviceKey)
           }
-          val aecEnabled = openedAudioInput.communicationEchoCancellationEnabled
+          // Measured off the read loop, and gated on mode ownership: an effect that reports
+          // enabled while some other app owns MODE_IN_COMMUNICATION is not cancelling this
+          // session's downlink, so it must not open the uplink.
+          val aecEnabled = realtimeEchoCancellationGranted(openedAudioInput, measure = true)
           publishRealtimeAecCapability(inputGeneration, aecEnabled)
           val captureHealth =
             RealtimeCaptureHealthReport(
@@ -1481,21 +1519,48 @@ class TalkModeManager internal constructor(
           // uplink pacing follows the negotiated clock rather than the requested one.
           val buffer = ByteArray(selection.captureSampleRateHz * 2 * realtimeAudioFrameMs / 1000)
           audioInput.startRecording()
-          while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
-            val read = audioInput.read(buffer, 0, buffer.size)
-            if (read <= 0) continue
-            // Re-read per frame rather than trusting the value this session opened with: a route
-            // can change under a running recorder, and a capability that could only ever be
-            // granted would never let the uplink close again on a route that lost its canceller.
-            publishRealtimeAecCapability(inputGeneration, openedAudioInput.communicationEchoCancellationEnabled)
-            val rms = TalkAudioLevel.pcm16Rms(buffer, read)
-            captureHealth.observe(rms)
-            _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, TalkAudioLevel.normalized(rms))
-            // Converted before the forwarding policy is consulted, so the filter sees one
-            // continuous stream rather than one with the suppressed frames punched out of it.
-            val wireFrame = resampler.convert(buffer, read)
-            if (!shouldAppendRealtimeCapturedFrame(wireFrame.size)) continue
-            audioFrames.trySend(wireFrame)
+          // The effect is re-measured here, not in the read loop below. Measuring takes the
+          // capture session's lifecycle lock, which a route refresh holds across several
+          // AudioManager binder calls; doing that between reads would put a route change on the
+          // critical path of AudioRecord.read and overrun the recorder. This watcher can block
+          // there instead, where blocking costs nothing.
+          val aecWatcher =
+            launch(realtimeCaptureDispatcher) {
+              while (isActive) {
+                delay(realtimeAecRefreshMs)
+                // A transient focus holder at start time must not leave the whole session half
+                // duplex; retrying here costs nothing when the mode is already held. Fenced on
+                // this generation and session: a retry that raced teardown would otherwise claim
+                // the device for a session that has ended.
+                recoverRealtimeCommunicationAudio(inputGeneration, sessionId)
+                publishRealtimeAecCapability(inputGeneration, realtimeEchoCancellationGranted(openedAudioInput, measure = true))
+              }
+            }
+          try {
+            while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
+              val read = audioInput.read(buffer, 0, buffer.size)
+              if (read <= 0) continue
+              // Lock-free and IPC-free: the cached capability the watcher above maintains, so a
+              // slow route refresh can never stall forwarding. Still re-read every frame, because
+              // a capability that could only ever be granted would never let the uplink close
+              // again on a route that lost its canceller.
+              publishRealtimeAecCapability(inputGeneration, realtimeEchoCancellationGranted(openedAudioInput, measure = false))
+              val rms = TalkAudioLevel.pcm16Rms(buffer, read)
+              captureHealth.observe(rms)
+              _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, TalkAudioLevel.normalized(rms))
+              // Converted before the forwarding policy is consulted, so the filter sees one
+              // continuous stream rather than one with the suppressed frames punched out of it.
+              val wireFrame = resampler.convert(buffer, read)
+              if (!shouldAppendRealtimeCapturedFrame(wireFrame.size)) continue
+              audioFrames.trySend(wireFrame)
+            }
+          } finally {
+            // Joined, not just cancelled: publishRealtimeAecCapability does not suspend, so an
+            // iteration already past its delay would otherwise land its `true` after the teardown
+            // below published `false` for the same generation, which the guard cannot drop.
+            // NonCancellable because the dominant teardown path cancels this coroutine first, and
+            // a plain join would then return immediately instead of waiting.
+            withContext(NonCancellable) { aecWatcher.cancelAndJoin() }
           }
         } catch (err: Throwable) {
           if (err is CancellationException) throw err
@@ -1510,6 +1575,67 @@ class TalkModeManager internal constructor(
         }
       }
     return null
+  }
+
+  /**
+   * Whether this session may treat the platform as cancelling its own echo.
+   *
+   * Two independent facts, both required. The effect must report enabled -- read back, never
+   * inferred -- and this session must actually own MODE_IN_COMMUNICATION, read-back proven when
+   * it was claimed. An effect attached to a recorder while another app owns the communication
+   * mode is not cancelling this session's downlink, and granting full duplex on it would forward
+   * the assistant's own voice back to the provider.
+   *
+   * [measure] re-measures the effect over IPC under the capture session's lifecycle lock, and may
+   * block behind a route refresh. Only callers that are not the capture read loop may pass true.
+   */
+  private fun realtimeEchoCancellationGranted(
+    session: AndroidAudioInputSession,
+    measure: Boolean,
+  ): Boolean {
+    val effectEnabled =
+      if (measure) session.refreshCommunicationEchoCancellation() else session.communicationEchoCancellationEnabled
+    // The measuring path also re-reads the device mode: acquisition proved it at one instant, and
+    // another app can move it afterwards. The read-loop path consults the flag that verification
+    // maintains, so it stays free of the binder call.
+    val ownsMode =
+      if (measure) {
+        realtimeCommunicationAudio.verifyCommunicationModeActive(systemAudioManager)
+      } else {
+        // Lock-free mirror: the owner monitor is held across AudioService calls, so entering it
+        // once per frame would put an IPC round trip back on the AudioRecord.read path.
+        realtimeCommunicationAudio.communicationModeActiveUnsynchronized
+      }
+    return effectEnabled && ownsMode
+  }
+
+  /**
+   * Re-claims communication audio for a session whose first attempt a transient focus holder
+   * refused, and publishes the token where teardown will find it.
+   *
+   * The claim and its publication cannot be one atomic step -- claiming touches the device and
+   * must not happen under the transition monitor -- so a claim that loses the race to teardown
+   * unwinds itself here. Leaving it published would put the device in communication mode with no
+   * live token to restore it.
+   */
+  private fun recoverRealtimeCommunicationAudio(
+    inputGeneration: Long,
+    sessionId: String,
+  ) {
+    if (audioInputGeneration.get() != inputGeneration || realtimeSessionId != sessionId) return
+    val recovered = realtimeCommunicationAudio.retryIfUnclaimed(systemAudioManager)
+    if (recovered == RealtimeCommunicationAudioOwner.NO_OWNER) return
+    val published =
+      synchronized(realtimeCapturePauseLock) {
+        // Field swap only -- no device call under the monitor the Gateway pump also takes.
+        if (realtimeSessionId == sessionId) {
+          realtimeCommunicationAudioToken = recovered
+          true
+        } else {
+          false
+        }
+      }
+    if (!published) realtimeCommunicationAudio.restore(systemAudioManager, recovered)
   }
 
   /**
@@ -1997,6 +2123,24 @@ class TalkModeManager internal constructor(
     }
   }
 
+  /**
+   * Final owner-only cleanup, on any exit from the command loop.
+   *
+   * Barriers are dropped rather than acknowledged, the same choice terminal Stop makes: the owner
+   * is gone, so there is nothing left to measure a target frame against, and the gateway scope
+   * this would acknowledge through is being torn down with it.
+   */
+  private fun retirePlayoutOnOwnerExitOwnerOnly() {
+    pendingRealtimePlaybackMarks.clear()
+    retireRealtimeAudioSinkOwnerOnly()
+    realtimePlaybackEndsAtMs = 0L
+    setRealtimePlaying(false)
+    _outputLevel.value = null
+    // A Clear still queued when the owner died would otherwise leave cancelOutput waiting out its
+    // whole timeout for a boundary no one is left to reach.
+    pendingRealtimeOutputClear?.complete(Unit)
+  }
+
   /** Owner-only cleanup shared by Clear, Stop, and the command loop's failure path. */
   private fun retireRealtimeAudioSinkOwnerOnly() {
     realtimeAudioSink?.let { sink -> runCatching { sink.close() } }
@@ -2094,7 +2238,10 @@ class TalkModeManager internal constructor(
         currentSessionId to currentCaptureJobs
       }
     // Outside the monitor: changing the device mode is a system call, and the owner declines the
-    // restore anyway if a newer session has taken over since.
+    // restore anyway if a newer session has taken over since. This is still one synchronous
+    // AudioService call on the Gateway ingress pump when teardown arrives as a "close" event --
+    // once per relay teardown rather than per frame, unlike the write backpressure this design
+    // removed, but it is the one remaining device call reachable from ingress.
     realtimeCommunicationAudio.restore(systemAudioManager, communicationAudioToken)
     realtimeOutputSuppressed = false
     realtimeOutputTurnId = null

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -558,7 +558,15 @@ class TalkModeManager internal constructor(
     val token: Long,
     val job: Job,
     var phase: PlaybackPhase = PlaybackPhase.Preparing,
-  )
+  ) {
+    /**
+     * The media-path focus request this lease took when its audio started, so the lease that asked
+     * for focus is the one that gives it back. Focus is lease-scoped: a request left standing after
+     * playback completes stays in front of the realtime owner's request in the platform's stack,
+     * and the GAIN that would restore that owner's full-duplex eligibility never arrives.
+     */
+    var focusRequest: AudioFocusRequest? = null
+  }
 
   private var localPlayback: PlaybackLease? = null
   private var realtimePlaying = false
@@ -3558,6 +3566,9 @@ class TalkModeManager internal constructor(
           failure?.let { setStatus(it) }
         }
       }
+      // However the lease ended -- completion, failure, or cancellation -- the focus it took goes
+      // back with it, so the platform can hand focus on to the request behind it.
+      releaseLocalPlaybackAudioFocus(lease)
       if (shouldResumeAfterSpeak) {
         withContext(NonCancellable) {
           onAfterSpeak()
@@ -3605,16 +3616,42 @@ class TalkModeManager internal constructor(
   }
 
   private fun markAudioPlaybackStarting(playbackToken: Long) {
-    synchronized(playbackLock) {
-      ensurePlaybackActive(playbackToken)
-      val lease = localPlayback
-      if (lease?.token != playbackToken || !lease.job.isActive) throw CancellationException("assistant speech cancelled")
-      lease.phase = PlaybackPhase.Playing
-      publishSpeakingState()
-      setStatus(nativeText("Speaking…"))
-    }
+    val lease =
+      synchronized(playbackLock) {
+        ensurePlaybackActive(playbackToken)
+        val lease = localPlayback
+        if (lease?.token != playbackToken || !lease.job.isActive) throw CancellationException("assistant speech cancelled")
+        lease.phase = PlaybackPhase.Playing
+        publishSpeakingState()
+        setStatus(nativeText("Speaking…"))
+        lease
+      }
     ensureInterruptListener()
-    requestAudioFocusForTts()
+    // The request is a binder call and stays outside the lock; the binding to the lease does not.
+    val request = requestAudioFocusForTts() ?: return
+    val unowned =
+      synchronized(playbackLock) {
+        when {
+          localPlayback === lease -> {
+            lease.focusRequest = request
+            audioFocusRequest = request
+            null
+          }
+
+          // Cancelled while the request was in flight, and nothing has re-requested since: this
+          // request has no lease to give it back, so it is given back here.
+          audioFocusRequest == null -> {
+            request
+          }
+
+          // A replacement already re-requested. All local requests register one listener, so the
+          // platform holds one entry for them, and it is the replacement's to abandon now.
+          else -> {
+            null
+          }
+        }
+      }
+    unowned?.let(::abandonAudioFocusRequest)
   }
 
   fun stopTts() {
@@ -3687,6 +3724,29 @@ class TalkModeManager internal constructor(
     abandonAudioFocus()
   }
 
+  /**
+   * Gives back the focus [lease] took, and only that.
+   *
+   * Local playback's request sits in front of the realtime owner's in the platform's focus stack,
+   * and the platform sends that owner its GAIN only when the entry in front of it is abandoned.
+   * Abandoning on the explicit stop path alone left a completed playback's request standing, which
+   * kept the realtime session's full-duplex eligibility revoked for the rest of the session.
+   *
+   * Guarded against a replacement: a lease that finishes after its replacement has requested
+   * focus must not drop the entry the replacement now owns.
+   */
+  private fun releaseLocalPlaybackAudioFocus(lease: PlaybackLease) {
+    val request =
+      synchronized(playbackLock) {
+        val request = lease.focusRequest ?: return
+        lease.focusRequest = null
+        if (audioFocusRequest !== request) return
+        audioFocusRequest = null
+        request
+      }
+    abandonAudioFocusRequest(request)
+  }
+
   internal fun shouldAllowSpeechInterrupt(): Boolean = !finalizeInFlight && !isRealtimeCapturePaused()
 
   private fun clearListenWatchdog() {
@@ -3694,8 +3754,9 @@ class TalkModeManager internal constructor(
     listenWatchdogJob = null
   }
 
-  private fun requestAudioFocusForTts(): Boolean {
-    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return true
+  /** Registers a media-path focus request and returns it; the caller decides which lease owns it. */
+  private fun requestAudioFocusForTts(): AudioFocusRequest? {
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return null
     val req =
       AudioFocusRequest
         .Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
@@ -3707,19 +3768,23 @@ class TalkModeManager internal constructor(
             .build(),
         ).setOnAudioFocusChangeListener(audioFocusListener)
         .build()
-    audioFocusRequest = req
     val result = am.requestAudioFocus(req)
     Log.d(tag, "audio focus request result=$result")
-    return result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED || result == AudioManager.AUDIOFOCUS_REQUEST_DELAYED
+    // Returned even when refused: the platform keeps the listener registered on refusal, and the
+    // abandon that follows is what unregisters it.
+    return req
   }
 
+  /** Drops whatever local request is standing, for the explicit stop path. */
   private fun abandonAudioFocus() {
+    val request = synchronized(playbackLock) { audioFocusRequest.also { audioFocusRequest = null } } ?: return
+    abandonAudioFocusRequest(request)
+  }
+
+  private fun abandonAudioFocusRequest(request: AudioFocusRequest) {
     val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return
-    audioFocusRequest?.let {
-      am.abandonAudioFocusRequest(it)
-      Log.d(tag, "audio focus abandoned")
-    }
-    audioFocusRequest = null
+    am.abandonAudioFocusRequest(request)
+    Log.d(tag, "audio focus abandoned")
   }
 
   private fun shouldInterrupt(transcript: String): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -489,6 +489,18 @@ class TalkModeManager internal constructor(
   @Volatile private var realtimeOutputTurnId: String? = null
   private val realtimeOutputCancellationMutex = Mutex()
 
+  /**
+   * Orders the cancellation fence against realtime frame submission.
+   *
+   * The append worker reads the fence, encodes the frame and hands it to the socket; without this
+   * the fence could be raised between the read and the handoff, and a frame that passed the check
+   * would leave the app after cancellation had begun, attributed to a turn being torn down. Held
+   * by the worker across check-and-submit and by the canceller while it raises the fence, so a
+   * fence, once raised, is ordered after every frame that had already passed the check and before
+   * every frame that had not.
+   */
+  private val realtimeSubmissionMutex = Mutex()
+
   @Volatile
   private var realtimePlaybackEndsAtMs = 0L
 
@@ -1481,29 +1493,32 @@ class TalkModeManager internal constructor(
     realtimeAppendJob =
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         for (frame in audioFrames) {
-          if (!shouldSubmitDequeuedRealtimeFrame(sessionId)) continue
-          val audioBase64 = Base64.encodeToString(frame, Base64.NO_WRAP)
-          val params =
-            buildJsonObject {
-              put("sessionId", JsonPrimitive(sessionId))
-              put("audioBase64", JsonPrimitive(audioBase64))
-              put("timestamp", JsonPrimitive(SystemClock.elapsedRealtime()))
+          // Check and submit under one lock: see [realtimeSubmissionMutex].
+          realtimeSubmissionMutex.withLock {
+            if (!shouldSubmitDequeuedRealtimeFrame(sessionId)) return@withLock
+            val audioBase64 = Base64.encodeToString(frame, Base64.NO_WRAP)
+            val params =
+              buildJsonObject {
+                put("sessionId", JsonPrimitive(sessionId))
+                put("audioBase64", JsonPrimitive(audioBase64))
+                put("timestamp", JsonPrimitive(SystemClock.elapsedRealtime()))
+              }
+            try {
+              sendGatewayRequestFrame(
+                "talk.session.appendAudio",
+                params.toString(),
+                timeoutMs = 8_000,
+              ) { error ->
+                Log.w(tag, "realtime appendAudio failed: ${error.message}")
+                failRealtimeRelay(sessionId, error.message)
+              }
+              // After the call returns, not before it: a send that threw never reached the socket.
+              observeRealtimeFrameEnqueued()
+            } catch (err: Throwable) {
+              if (err is CancellationException) throw err
+              Log.w(tag, "realtime appendAudio failed: ${err.message ?: err::class.simpleName}")
+              failRealtimeRelay(sessionId, err.message ?: err::class.simpleName ?: "request failed")
             }
-          try {
-            sendGatewayRequestFrame(
-              "talk.session.appendAudio",
-              params.toString(),
-              timeoutMs = 8_000,
-            ) { error ->
-              Log.w(tag, "realtime appendAudio failed: ${error.message}")
-              failRealtimeRelay(sessionId, error.message)
-            }
-            // After the call returns, not before it: a send that threw never reached the socket.
-            observeRealtimeFrameEnqueued()
-          } catch (err: Throwable) {
-            if (err is CancellationException) throw err
-            Log.w(tag, "realtime appendAudio failed: ${err.message ?: err::class.simpleName}")
-            failRealtimeRelay(sessionId, err.message ?: err::class.simpleName ?: "request failed")
           }
         }
       }
@@ -3681,7 +3696,9 @@ class TalkModeManager internal constructor(
       sessionId ?: return@withLock true
       turnId ?: return@withLock false
       val clear = CompletableDeferred<String?>()
-      pendingRealtimeOutputClear = clear
+      // Raised under the submission lock, so a frame that already passed the check reaches the
+      // socket before this fence exists, and none that had not can pass it afterwards.
+      realtimeSubmissionMutex.withLock { pendingRealtimeOutputClear = clear }
       try {
         val params =
           buildJsonObject {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -1580,10 +1580,11 @@ class TalkModeManager internal constructor(
   /**
    * Whether this session may treat the platform as cancelling its own echo.
    *
-   * Two independent facts, both required. The effect must report enabled -- read back, never
-   * inferred -- and this session must actually own MODE_IN_COMMUNICATION, read-back proven when
-   * it was claimed. An effect attached to a recorder while another app owns the communication
-   * mode is not cancelling this session's downlink, and granting full duplex on it would forward
+   * Two independent sources, and three facts. The effect must report enabled -- read back, never
+   * inferred -- and the owner must report its communication audio eligible, which is itself the
+   * conjunction of a live session token, the device still being in communication mode, and this
+   * app still holding audio focus. Any one of them failing means the canceller does not have this
+   * session's downlink as its reference, and forwarding the microphone during playback would send
    * the assistant's own voice back to the provider.
    *
    * [measure] re-measures the effect over IPC under the capture session's lifecycle lock, and may
@@ -1596,17 +1597,17 @@ class TalkModeManager internal constructor(
     val effectEnabled =
       if (measure) session.refreshCommunicationEchoCancellation() else session.communicationEchoCancellationEnabled
     // The measuring path also re-reads the device mode: acquisition proved it at one instant, and
-    // another app can move it afterwards. The read-loop path consults the flag that verification
+    // another app can move it afterwards. The read-loop path consults the snapshot the owner
     // maintains, so it stays free of the binder call.
-    val ownsMode =
+    val communicationAudioEligible =
       if (measure) {
-        realtimeCommunicationAudio.verifyCommunicationModeActive(systemAudioManager)
+        realtimeCommunicationAudio.verifyCommunicationAudioEligible(systemAudioManager)
       } else {
         // Lock-free mirror: the owner monitor is held across AudioService calls, so entering it
         // once per frame would put an IPC round trip back on the AudioRecord.read path.
-        realtimeCommunicationAudio.communicationModeActiveUnsynchronized
+        realtimeCommunicationAudio.communicationAudioEligibleUnsynchronized
       }
-    return effectEnabled && ownsMode
+    return effectEnabled && communicationAudioEligible
   }
 
   /**
@@ -1672,8 +1673,15 @@ class TalkModeManager internal constructor(
    * echo cancellation actually enabled, what the microphone hears during playback is the user, so
    * forwarding it is what lets the provider notice an interruption at all. Without it, the same
    * frames would be the assistant's own voice and the provider would interrupt itself.
+   *
+   * Two reads, not one. [realtimeAecEnabled] is the per-capture-generation capability, republished
+   * once per frame; the owner's own snapshot is consulted live so that focus lost between two
+   * frames closes the uplink on the very next forwarded frame instead of the next publication.
+   * Both are lock-free volatile reads, so this stays free of the monitor and of any IPC.
    */
-  private fun shouldSuppressRealtimeCaptureForPlayback(): Boolean = isRealtimePlaybackActive() && !realtimeAecEnabled
+  private fun shouldSuppressRealtimeCaptureForPlayback(): Boolean =
+    isRealtimePlaybackActive() &&
+      !(realtimeAecEnabled && realtimeCommunicationAudio.communicationAudioEligibleUnsynchronized)
 
   /**
    * Two independent reasons to hold a captured frame back, and both must be clear.

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -222,6 +222,17 @@ class TalkModeManager internal constructor(
   companion object {
     private const val tag = "TalkMode"
 
+    // Packed phases for the bounded uplink observation below. Ints rather than an enum so the
+    // whole observation -- phase and the two facts that explain it -- is one lock-free word the
+    // capture path can compare without allocating.
+    private const val uplinkPhaseIdle = 0
+    private const val uplinkPhaseSuppressed = 1
+    private const val uplinkPhaseForwarded = 2
+    private const val uplinkPhaseFenced = 3
+    private const val uplinkAecBit = 1 shl 2
+    private const val uplinkCommBit = 1 shl 3
+    private const val uplinkPhaseUnobserved = -1
+
     // Realtime playback plays the Gateway's declared wire audio verbatim, so its rate is a
     // property of that stream. Capture is a separate contract: the microphone negotiates its own
     // clock and the result is converted to whatever rate the Gateway declared for the uplink.
@@ -389,6 +400,16 @@ class TalkModeManager internal constructor(
 
   private val realtimeAecEnabled: Boolean
     get() = realtimeAecCapability.get().enabled
+
+  /**
+   * The last published state of the playback-time forwarding decision.
+   *
+   * The gate this class enforces is the only thing between the assistant's own voice and the
+   * uplink, and it reported nothing: a session that kept the microphone open through playback was
+   * indistinguishable, from outside, from one that had quietly fallen back to half duplex. Holding
+   * the last state lets the decision be reported on its *edges* rather than per frame.
+   */
+  private val realtimeUplinkPhase = AtomicInteger(uplinkPhaseUnobserved)
 
   // Communication audio belongs to the relay session, not to a response. Only the realtime lane
   // acquires it, so one owner per manager is enough.
@@ -1439,7 +1460,10 @@ class TalkModeManager internal constructor(
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         for (frame in audioFrames) {
           if (realtimeSessionId != sessionId) continue
-          if (shouldSuppressRealtimeCaptureForPlayback()) continue
+          if (shouldSuppressRealtimeCaptureForPlayback()) {
+            observeRealtimeCaptureHeldBack()
+            continue
+          }
           val audioBase64 = Base64.encodeToString(frame, Base64.NO_WRAP)
           val params =
             buildJsonObject {
@@ -1456,6 +1480,9 @@ class TalkModeManager internal constructor(
               Log.w(tag, "realtime appendAudio failed: ${error.message}")
               failRealtimeRelay(sessionId, error.message)
             }
+            // After the request, not before it: the claim being reported is that a frame reached
+            // the uplink, and a send that threw did not.
+            observeRealtimeFrameForwarded()
           } catch (err: Throwable) {
             if (err is CancellationException) throw err
             Log.w(tag, "realtime appendAudio failed: ${err.message ?: err::class.simpleName}")
@@ -1551,7 +1578,10 @@ class TalkModeManager internal constructor(
               // Converted before the forwarding policy is consulted, so the filter sees one
               // continuous stream rather than one with the suppressed frames punched out of it.
               val wireFrame = resampler.convert(buffer, read)
-              if (!shouldAppendRealtimeCapturedFrame(wireFrame.size)) continue
+              if (!shouldAppendRealtimeCapturedFrame(wireFrame.size)) {
+                observeRealtimeCaptureHeldBack()
+                continue
+              }
               audioFrames.trySend(wireFrame)
             }
           } finally {
@@ -1700,6 +1730,71 @@ class TalkModeManager internal constructor(
     length > 0 &&
       pendingRealtimeOutputClear == null &&
       !shouldSuppressRealtimeCaptureForPlayback()
+
+  /**
+   * Publishes a change in the playback-time forwarding decision, and only a change.
+   *
+   * Bounded by construction: the packed state is compared before anything is formatted, so a
+   * session that stays in one state logs once no matter how many frames pass through it. The
+   * compare-and-set is what keeps the capture loop and the append loop from both reporting the
+   * same edge.
+   */
+  private fun observeRealtimeUplinkPhase(
+    phase: Int,
+    aecEnabled: Boolean,
+    communicationEligible: Boolean,
+  ) {
+    val encoded =
+      phase or
+        (if (aecEnabled) uplinkAecBit else 0) or
+        (if (communicationEligible) uplinkCommBit else 0)
+    val previous = realtimeUplinkPhase.get()
+    if (previous == encoded) return
+    if (!realtimeUplinkPhase.compareAndSet(previous, encoded)) return
+    val name =
+      when (phase) {
+        uplinkPhaseForwarded -> "FORWARDED_DURING_PLAYBACK"
+        uplinkPhaseSuppressed -> "SUPPRESSED_DURING_PLAYBACK"
+        uplinkPhaseFenced -> "HELD_BY_CANCELLATION_FENCE"
+        else -> "IDLE_NO_PLAYBACK"
+      }
+    Log.i(tag, "realtime uplink $name aecEnabled=$aecEnabled commEligible=$communicationEligible")
+  }
+
+  /**
+   * Why a captured frame was held back, keeping the two invariants apart.
+   *
+   * The cancellation fence and the echo gate both drop frames, but for unrelated reasons: one is
+   * about which turn owns the uplink, the other about whose voice the microphone is hearing.
+   * Reporting a fenced frame as an echo-gate refusal would send a reader looking at the wrong
+   * device state, so the fence keeps its own name and is checked first, as the gate checks it.
+   */
+  private fun observeRealtimeCaptureHeldBack() {
+    val fenced = pendingRealtimeOutputClear != null
+    // A frame dropped while nothing is playing and nothing is fenced carries no decision worth
+    // reporting -- it is an empty converted frame, not a policy outcome.
+    if (!fenced && !isRealtimePlaybackActive()) return
+    observeRealtimeUplinkPhase(
+      if (fenced) uplinkPhaseFenced else uplinkPhaseSuppressed,
+      realtimeAecEnabled,
+      realtimeCommunicationAudio.communicationAudioEligibleUnsynchronized,
+    )
+  }
+
+  /**
+   * A captured frame has just been handed to `talk.session.appendAudio`.
+   *
+   * Published here rather than at the predicate on purpose: the question a reviewer has is not
+   * whether the policy said yes, but whether a real frame crossed the uplink boundary while the
+   * speaker was playing. Only this point knows both.
+   */
+  private fun observeRealtimeFrameForwarded() {
+    observeRealtimeUplinkPhase(
+      if (isRealtimePlaybackActive()) uplinkPhaseForwarded else uplinkPhaseIdle,
+      realtimeAecEnabled,
+      realtimeCommunicationAudio.communicationAudioEligibleUnsynchronized,
+    )
+  }
 
   private fun isRealtimePlaybackActive(): Boolean = _isSpeaking.value || SystemClock.elapsedRealtime() < realtimePlaybackEndsAtMs
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -227,10 +227,11 @@ class TalkModeManager internal constructor(
     // capture path can compare without allocating.
     private const val uplinkPhaseIdle = 0
     private const val uplinkPhaseSuppressed = 1
-    private const val uplinkPhaseForwarded = 2
+    private const val uplinkPhaseEnqueued = 2
     private const val uplinkPhaseFenced = 3
     private const val uplinkAecBit = 1 shl 2
     private const val uplinkCommBit = 1 shl 3
+    private const val uplinkLocalBit = 1 shl 4
     private const val uplinkPhaseUnobserved = -1
 
     // Realtime playback plays the Gateway's declared wire audio verbatim, so its rate is a
@@ -561,6 +562,18 @@ class TalkModeManager internal constructor(
 
   private var localPlayback: PlaybackLease? = null
   private var realtimePlaying = false
+
+  /**
+   * Lock-free mirrors of the two speaking sources, republished by [publishSpeakingState].
+   *
+   * The capture path cannot take [playbackLock] to ask which source is playing, and it must not
+   * ask [_isSpeaking], because that is deliberately the union of both. Mirrors rather than a
+   * second state machine: they are derived in exactly one place, from the same read that
+   * publishes the projection.
+   */
+  @Volatile private var realtimeCommunicationPlaybackActive = false
+
+  @Volatile private var localMediaPlaybackActive = false
   private val systemSpeech = SystemSpeechSpeaker(context)
 
   @Volatile private var finalizeInFlight = false
@@ -1459,11 +1472,7 @@ class TalkModeManager internal constructor(
     realtimeAppendJob =
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         for (frame in audioFrames) {
-          if (realtimeSessionId != sessionId) continue
-          if (shouldSuppressRealtimeCaptureForPlayback()) {
-            observeRealtimeCaptureHeldBack()
-            continue
-          }
+          if (!shouldSubmitDequeuedRealtimeFrame(sessionId)) continue
           val audioBase64 = Base64.encodeToString(frame, Base64.NO_WRAP)
           val params =
             buildJsonObject {
@@ -1480,9 +1489,8 @@ class TalkModeManager internal constructor(
               Log.w(tag, "realtime appendAudio failed: ${error.message}")
               failRealtimeRelay(sessionId, error.message)
             }
-            // After the request, not before it: the claim being reported is that a frame reached
-            // the uplink, and a send that threw did not.
-            observeRealtimeFrameForwarded()
+            // After the call returns, not before it: a send that threw never reached the socket.
+            observeRealtimeFrameEnqueued()
           } catch (err: Throwable) {
             if (err is CancellationException) throw err
             Log.w(tag, "realtime appendAudio failed: ${err.message ?: err::class.simpleName}")
@@ -1709,9 +1717,15 @@ class TalkModeManager internal constructor(
    * frames closes the uplink on the very next forwarded frame instead of the next publication.
    * Both are lock-free volatile reads, so this stays free of the monitor and of any IPC.
    */
-  private fun shouldSuppressRealtimeCaptureForPlayback(): Boolean =
-    isRealtimePlaybackActive() &&
-      !(realtimeAecEnabled && realtimeCommunicationAudio.communicationAudioEligibleUnsynchronized)
+  private fun shouldSuppressRealtimeCaptureForPlayback(): Boolean {
+    // Local assistant speech plays on the media path, not the communication downlink this rule is
+    // about. The canceller is subtracting the realtime downlink; it is not subtracting local media,
+    // so local playback -- alone or overlapping realtime playout -- can contaminate the microphone
+    // reference and must never qualify for the exception.
+    if (localMediaPlaybackActive) return true
+    if (!isRealtimeCommunicationPlaybackActive()) return false
+    return !(realtimeAecEnabled && realtimeCommunicationAudio.communicationAudioEligibleUnsynchronized)
+  }
 
   /**
    * Two independent reasons to hold a captured frame back, and both must be clear.
@@ -1743,22 +1757,28 @@ class TalkModeManager internal constructor(
     phase: Int,
     aecEnabled: Boolean,
     communicationEligible: Boolean,
+    localPlayback: Boolean,
   ) {
     val encoded =
       phase or
         (if (aecEnabled) uplinkAecBit else 0) or
-        (if (communicationEligible) uplinkCommBit else 0)
+        (if (communicationEligible) uplinkCommBit else 0) or
+        (if (localPlayback) uplinkLocalBit else 0)
     val previous = realtimeUplinkPhase.get()
     if (previous == encoded) return
     if (!realtimeUplinkPhase.compareAndSet(previous, encoded)) return
     val name =
       when (phase) {
-        uplinkPhaseForwarded -> "FORWARDED_DURING_PLAYBACK"
+        uplinkPhaseEnqueued -> "ENQUEUED_DURING_PLAYBACK"
         uplinkPhaseSuppressed -> "SUPPRESSED_DURING_PLAYBACK"
         uplinkPhaseFenced -> "HELD_BY_CANCELLATION_FENCE"
         else -> "IDLE_NO_PLAYBACK"
       }
-    Log.i(tag, "realtime uplink $name aecEnabled=$aecEnabled commEligible=$communicationEligible")
+    Log.i(
+      tag,
+      "realtime uplink $name aecEnabled=$aecEnabled commEligible=$communicationEligible " +
+        "localPlayback=$localPlayback",
+    )
   }
 
   /**
@@ -1771,32 +1791,70 @@ class TalkModeManager internal constructor(
    */
   private fun observeRealtimeCaptureHeldBack() {
     val fenced = pendingRealtimeOutputClear != null
+    val local = localMediaPlaybackActive
     // A frame dropped while nothing is playing and nothing is fenced carries no decision worth
     // reporting -- it is an empty converted frame, not a policy outcome.
-    if (!fenced && !isRealtimePlaybackActive()) return
+    if (!fenced && !local && !isRealtimeCommunicationPlaybackActive()) return
     observeRealtimeUplinkPhase(
       if (fenced) uplinkPhaseFenced else uplinkPhaseSuppressed,
       realtimeAecEnabled,
       realtimeCommunicationAudio.communicationAudioEligibleUnsynchronized,
+      local,
     )
   }
 
   /**
-   * A captured frame has just been handed to `talk.session.appendAudio`.
+   * The decision taken after a frame leaves the capture queue and before it is submitted.
+   *
+   * Separate from the capture-side check on purpose. A frame can clear that check, wait in the
+   * bounded queue, and be dequeued after `cancelOutput` has taken the turn; the fence is
+   * unconditional, so the full-duplex exception must not carry such a frame past it. Ownership is
+   * what makes this the right place: it is the last point that still holds the frame. A request
+   * already handed to the socket may be in flight and is not recalled here, and nothing in this
+   * design claims otherwise.
+   */
+  private fun shouldSubmitDequeuedRealtimeFrame(sessionId: String): Boolean {
+    if (realtimeSessionId != sessionId) return false
+    if (pendingRealtimeOutputClear != null) {
+      observeRealtimeCaptureHeldBack()
+      return false
+    }
+    if (shouldSuppressRealtimeCaptureForPlayback()) {
+      observeRealtimeCaptureHeldBack()
+      return false
+    }
+    return true
+  }
+
+  /**
+   * A captured frame has just been submitted locally as a `talk.session.appendAudio` request.
+   *
+   * Named for exactly what the call proves and no more. [sendGatewayRequestFrame] returns once the
+   * request has been handed to the socket; the Gateway's response, including a rejection, arrives
+   * later on the error callback. So this reports that the frame passed Android's playback-time gate
+   * and left the app -- not that the Gateway accepted it, not that the provider received it, and
+   * certainly not that a turn resulted.
    *
    * Published here rather than at the predicate on purpose: the question a reviewer has is not
-   * whether the policy said yes, but whether a real frame crossed the uplink boundary while the
-   * speaker was playing. Only this point knows both.
+   * whether the policy said yes, but whether a real frame reached the local send boundary while the
+   * communication downlink was playing. Only this point knows both.
    */
-  private fun observeRealtimeFrameForwarded() {
+  private fun observeRealtimeFrameEnqueued() {
     observeRealtimeUplinkPhase(
-      if (isRealtimePlaybackActive()) uplinkPhaseForwarded else uplinkPhaseIdle,
+      if (isRealtimeCommunicationPlaybackActive()) uplinkPhaseEnqueued else uplinkPhaseIdle,
       realtimeAecEnabled,
       realtimeCommunicationAudio.communicationAudioEligibleUnsynchronized,
+      localMediaPlaybackActive,
     )
   }
 
-  private fun isRealtimePlaybackActive(): Boolean = _isSpeaking.value || SystemClock.elapsedRealtime() < realtimePlaybackEndsAtMs
+  /**
+   * Is the *realtime communication* downlink playing, as opposed to anything that merely makes the
+   * app "speaking"? Both terms are realtime-owner facts: the published source flag, and the
+   * playout deadline the owner extends per written frame, which covers the tail after the last
+   * write while the device is still draining.
+   */
+  private fun isRealtimeCommunicationPlaybackActive(): Boolean = realtimeCommunicationPlaybackActive || SystemClock.elapsedRealtime() < realtimePlaybackEndsAtMs
 
   private fun handleRealtimeTalkEvent(payloadJson: String?) {
     if (payloadJson.isNullOrBlank()) return
@@ -3523,7 +3581,14 @@ class TalkModeManager internal constructor(
   // Gateway receive path never waits on the device behind it.
   // Either source can keep speaking after the other source completes or is cancelled.
   private fun publishSpeakingState() {
-    _isSpeaking.value = realtimePlaying || localPlayback?.phase == PlaybackPhase.Playing
+    val realtime = realtimePlaying
+    val local = localPlayback?.phase == PlaybackPhase.Playing
+    // Published as two facts, not one. [_isSpeaking] is the UI projection and must stay the union
+    // of both sources; the forwarding policy needs to know *which* source is playing, because only
+    // the realtime downlink is the audio the platform canceller is subtracting.
+    realtimeCommunicationPlaybackActive = realtime
+    localMediaPlaybackActive = local
+    _isSpeaking.value = realtime || local
   }
 
   private fun markAudioPlaybackStarting(playbackToken: Long) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -214,7 +214,17 @@ class TalkModeManager internal constructor(
 ) {
   companion object {
     private const val tag = "TalkMode"
-    private const val realtimeSampleRateHz = 24_000
+
+    // Realtime playback plays the Gateway's declared wire audio verbatim, so its rate is a
+    // property of that stream. Capture is a separate contract: the microphone negotiates its own
+    // clock and the result is converted to whatever rate the Gateway declared for the uplink.
+    private const val realtimeOutputSampleRateHz = 24_000
+
+    // Preferred, not required. It is the rate Android guarantees most widely for raw capture, and
+    // the one the portable path is built around; the wire rate is tried after it, and the rate the
+    // recorder actually negotiates is what decides whether either candidate is usable.
+    private const val realtimeCapturePortableSampleRateHz = 48_000
+
     private const val realtimeAudioFrameMs = 100
     private const val chatFinalWaitMs = 45_000L
     private const val maxCachedRunCompletions = 128
@@ -353,6 +363,10 @@ class TalkModeManager internal constructor(
   private val audioInputGeneration = AtomicLong(0L)
 
   @Volatile private var realtimeSessionId: String? = null
+
+  // Declared once by talk.session.create and read by every capture install for this session,
+  // including the one push-to-talk performs when it hands the microphone back.
+  @Volatile private var realtimeWireAudioContract: RealtimeWireAudioContract? = null
   private var realtimeCaptureJob: Job? = null
   private var realtimeAppendJob: Job? = null
   private val realtimeCapturePauseLock = Any()
@@ -1209,10 +1223,15 @@ class TalkModeManager internal constructor(
       throw CancellationException("realtime talk stopped while connecting")
     }
 
+    val wireAudioContract = parseRealtimeWireAudioContract(root, realtimeOutputSampleRateHz)
+    var captureFailure: String? = null
     val capturePaused =
       synchronized(realtimeCapturePauseLock) {
         // Session publication and capture installation are one transition. PTT
         // therefore either blocks startup or detaches every installed capture job.
+        // The wire contract is published with the session id, not before it: a stop that lands
+        // between the two would otherwise leave a live session with no contract to capture under.
+        realtimeWireAudioContract = wireAudioContract
         realtimeAgentCoordinator.beginSession(
           RealtimeAgentSession(
             relaySessionId = sessionId,
@@ -1229,12 +1248,18 @@ class TalkModeManager internal constructor(
           realtimeOutputSuppressed = false
           _isListening.value = true
           setStatus(nativeText("Listening"))
-          startRealtimeCaptureLocked(sessionId)
+          captureFailure = startRealtimeCaptureLocked(sessionId)
           false
         }
       }
     if (capturePaused) {
       Log.d(tag, "realtime session ready; capture paused for PTT relaySessionId=$sessionId")
+      return
+    }
+    // Reported here rather than inside the lock: failing the relay tears the session down through
+    // the same monitor, and doing that mid-transition would unwind a state change still in flight.
+    captureFailure?.let { reason ->
+      failRealtimeRelay(sessionId, reason)
       return
     }
     Log.d(tag, "realtime session started relaySessionId=$sessionId")
@@ -1306,9 +1331,23 @@ class TalkModeManager internal constructor(
       }
     }
 
-  /** Caller holds [realtimeCapturePauseLock] so PTT cannot miss newly installed jobs. */
+  /**
+   * Caller holds [realtimeCapturePauseLock] so PTT cannot miss newly installed jobs.
+   *
+   * Returns null once capture is installed, or the reason the session must fail. The caller
+   * reports that reason after leaving the lock: teardown re-enters the same monitor.
+   */
   @SuppressLint("MissingPermission")
-  private fun startRealtimeCaptureLocked(sessionId: String) {
+  private fun startRealtimeCaptureLocked(sessionId: String): String? {
+    // The only half of the contract that can be judged before the microphone is open. Whether a
+    // converter exists depends on the rate the recorder negotiates, which is checked per candidate.
+    val wireAudio = realtimeWireAudioContract
+    if (wireAudio !is RealtimeWireAudioContract.Pcm16) {
+      val detail = (wireAudio as? RealtimeWireAudioContract.Unsupported)?.detail ?: "no audio contract"
+      Log.w(tag, "realtime capture rejected: unsupported wire audio contract ($detail)")
+      return "unsupported realtime audio format"
+    }
+    val wireSampleRateHz = wireAudio.sampleRateHz
     realtimeCaptureJob?.cancel()
     realtimeAppendJob?.cancel()
     val inputGeneration = audioInputGeneration.incrementAndGet()
@@ -1350,26 +1389,52 @@ class TalkModeManager internal constructor(
       gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         var audioInput: AndroidAudioInputSession? = null
         try {
-          val frameBytes = realtimeSampleRateHz * 2 * realtimeAudioFrameMs / 1000
-          val openedAudioInput =
-            AndroidAudioInputSession.open(
-              context,
-              realtimeSampleRateHz,
-              frameBytes,
-              preferredAudioInputDevice(),
-              { key ->
-                if (audioInputGeneration.get() == inputGeneration) onAppliedAudioInputChanged(key)
-              },
-            )
+          // Opening a candidate applies its route, and a candidate can still be rejected. Only the
+          // selected session's route describes the microphone actually in use, so route changes are
+          // published from the point the selection settles.
+          val captureRouteSettled = AtomicBoolean(false)
+          val selection =
+            selectRealtimeCaptureSession(
+              candidateRatesHz = realtimeCaptureCandidateRatesHz(realtimeCapturePortableSampleRateHz, wireSampleRateHz),
+              wireRateHz = wireSampleRateHz,
+            ) { candidateRateHz ->
+              AndroidAudioInputSession.open(
+                context,
+                candidateRateHz,
+                candidateRateHz * 2 * realtimeAudioFrameMs / 1000,
+                preferredAudioInputDevice(),
+                { key ->
+                  if (captureRouteSettled.get() && audioInputGeneration.get() == inputGeneration) {
+                    onAppliedAudioInputChanged(key)
+                  }
+                },
+              )
+            }
+          val openedAudioInput = selection.candidate
           audioInput = openedAudioInput
-          val buffer = ByteArray(frameBytes)
+          val resampler = selection.resampler
+          captureRouteSettled.set(true)
+          if (audioInputGeneration.get() == inputGeneration) {
+            onAppliedAudioInputChanged(openedAudioInput.appliedPreferredDeviceKey)
+          }
+          Log.d(
+            tag,
+            "realtime capture opened requested=${selection.requestedSampleRateHz}Hz " +
+              "negotiated=${selection.captureSampleRateHz}Hz wire=${wireSampleRateHz}Hz",
+          )
+          // One read is realtimeAudioFrameMs of audio at the rate the recorder negotiated, so
+          // uplink pacing follows the negotiated clock rather than the requested one.
+          val buffer = ByteArray(selection.captureSampleRateHz * 2 * realtimeAudioFrameMs / 1000)
           audioInput.startRecording()
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
             val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
             _inputLevel.value = TalkAudioLevel.smoothed(_inputLevel.value, TalkAudioLevel.pcm16Level(buffer, read))
-            if (!shouldAppendRealtimeCapturedFrame(read)) continue
-            audioFrames.trySend(buffer.copyOf(read))
+            // Converted before the forwarding policy is consulted, so the filter sees one
+            // continuous stream rather than one with the suppressed frames punched out of it.
+            val wireFrame = resampler.convert(buffer, read)
+            if (!shouldAppendRealtimeCapturedFrame(wireFrame.size)) continue
+            audioFrames.trySend(wireFrame)
           }
         } catch (err: Throwable) {
           if (err is CancellationException) throw err
@@ -1381,6 +1446,7 @@ class TalkModeManager internal constructor(
           _inputLevel.value = 0f
         }
       }
+    return null
   }
 
   private fun shouldAppendRealtimeCapturedFrame(length: Int): Boolean = pendingRealtimeOutputClear == null && !isRealtimePlaybackActive() && length > 0
@@ -1655,7 +1721,7 @@ class TalkModeManager internal constructor(
     if (bytes.isEmpty()) return
     val sink =
       realtimeAudioSink ?: realtimeAudioSinkFactory
-        .open(realtimeSampleRateHz, realtimePlaybackBufferMs, bytes.size)
+        .open(realtimeOutputSampleRateHz, realtimePlaybackBufferMs, bytes.size)
         .also { opened ->
           realtimeAudioSink = opened
           realtimeWrittenFrames = 0L
@@ -1668,7 +1734,7 @@ class TalkModeManager internal constructor(
     // buffer is already full, so the budget covers that on top of the stall allowance. It is
     // deliberately never reset by partial progress: a device accepting a couple of bytes per
     // retry is as broken as one accepting none, and resetting would let it grind out the frame.
-    val frameDurationMs = (bytes.size / 2).toLong() * 1000L / realtimeSampleRateHz
+    val frameDurationMs = (bytes.size / 2).toLong() * 1000L / realtimeOutputSampleRateHz
     val stallBudgetMs = realtimePlaybackWriteStallBudgetMs(sink.bufferDurationMs) + frameDurationMs
     var writtenBytes = 0
     var stalledMs = 0L
@@ -1700,7 +1766,7 @@ class TalkModeManager internal constructor(
       TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
     setRealtimePlaying(true)
     setStatus(nativeText("Speaking…"))
-    val durationMs = ((writtenBytes / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
+    val durationMs = ((writtenBytes / 2.0) / realtimeOutputSampleRateHz * 1000.0).toLong()
     realtimeWrittenFrames += writtenBytes / 2L
     val now = SystemClock.elapsedRealtime()
     realtimePlaybackEndsAtMs = maxOf(now, realtimePlaybackEndsAtMs) + durationMs
@@ -1886,6 +1952,7 @@ class TalkModeManager internal constructor(
         val currentSessionId = realtimeSessionId
         val currentCaptureJobs = realtimeCaptureJob to realtimeAppendJob
         realtimeSessionId = null
+        realtimeWireAudioContract = null
         realtimeCaptureJob = null
         realtimeAppendJob = null
         realtimeCapturePause = null
@@ -1963,6 +2030,8 @@ class TalkModeManager internal constructor(
   private fun isRealtimeCapturePaused(): Boolean = synchronized(realtimeCapturePauseLock) { realtimeCapturePause != null }
 
   internal fun resumeRealtimeCaptureAfterPushToTalk(captureId: String) {
+    var resumeFailure: String? = null
+    var resumeSessionId: String? = null
     val outcome =
       synchronized(realtimeCapturePauseLock) {
         val current = realtimeCapturePause ?: return@synchronized RealtimeCaptureResume.Skipped
@@ -1990,7 +2059,8 @@ class TalkModeManager internal constructor(
         realtimeCapturePause = null
         _isListening.value = true
         setStatus(nativeText("Listening"))
-        startRealtimeCaptureLocked(sessionId)
+        resumeFailure = startRealtimeCaptureLocked(sessionId)
+        resumeSessionId = sessionId
         RealtimeCaptureResume.Resumed
       }
     when (outcome) {
@@ -1999,6 +2069,8 @@ class TalkModeManager internal constructor(
       }
 
       RealtimeCaptureResume.Resumed -> {
+        val reason = resumeFailure ?: return
+        resumeSessionId?.let { failRealtimeRelay(it, reason) }
         return
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -19,7 +19,6 @@ import android.media.AudioFocusRequest
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioRecord
-import android.media.AudioTrack
 import android.media.MediaRecorder
 import android.os.Build
 import android.os.Bundle
@@ -71,6 +70,7 @@ import java.util.LinkedHashMap
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.coroutineContext
 
@@ -137,20 +137,10 @@ private data class TalkStatus(
   val awaitingAgent: Boolean = false,
 )
 
-private sealed interface RealtimePlaybackItem {
-  data class Audio(
-    val bytes: ByteArray,
-  ) : RealtimePlaybackItem
-
-  data class Mark(
-    val name: String,
-  ) : RealtimePlaybackItem
-}
-
 private data class PendingRealtimePlaybackMark(
   val sessionId: String,
   val name: String,
-  var targetFrame: Long? = null,
+  val targetFrame: Long? = null,
 )
 
 private class PushToTalkAudioSource(
@@ -220,6 +210,7 @@ class TalkModeManager internal constructor(
   private val realtimeCaptureDispatcher: CoroutineDispatcher = Dispatchers.IO,
   private val realtimePlaybackDispatcher: CoroutineDispatcher = Dispatchers.IO,
   private val realtimeMarkAcknowledger: (suspend (sessionId: String, markName: String) -> Unit)? = null,
+  private val realtimeAudioSinkFactory: RealtimeAudioSinkFactory = RealtimeAudioSinkFactory.AudioTrackBacked,
 ) {
   companion object {
     private const val tag = "TalkMode"
@@ -229,6 +220,24 @@ class TalkModeManager internal constructor(
     private const val maxCachedRunCompletions = 128
     private const val maxConversationEntries = 40
     private const val realtimePlaybackBufferMs = 240
+    private const val realtimePlaybackIdlePollMs = 20L
+
+    // Queue depth is not evidence about the device. The relay forwards provider audio unpaced
+    // and a realtime provider generates speech faster than the speaker plays it, so the backlog
+    // grows with response length on a perfectly healthy device; a device that has actually
+    // stopped draining is diagnosed by the write stall budget instead. What this ceiling bounds
+    // is memory: roughly four minutes of queued PCM at the realtime rate, far more than any one
+    // response, so reaching it means audio is accumulating without limit.
+    private const val realtimePlaybackQueuedAudioCeilingBytes = 12L * 1024L * 1024L
+
+    // The channel is still bounded, and the two bounds cover each other: this slot count is what
+    // catches a provider streaming many tiny frames, which would reach no byte ceiling.
+    private const val realtimePlaybackProviderQueueCapacity = 4_096
+
+    // Clear and Stop are never counted against either bound. Teardown has to fit even when the
+    // queue is full, or a full queue could never be drained. Sized well above the number of
+    // control commands any real burst produces; PollIdle is deduped to one in flight.
+    private const val realtimePlaybackControlQueueHeadroom = 32
     private const val realtimeUserFinalRewriteGraceMs = 1_500L
     private const val pushToTalkSampleRateHz = 16_000
     private const val pushToTalkReleaseGraceMs = 5_000L
@@ -378,10 +387,22 @@ class TalkModeManager internal constructor(
   private var realtimeUserEntryAwaitingFinal = false
   private var realtimeUserEntryAwaitingFinalStartedAtMs: Long? = null
   private var realtimeAssistantEntryId: String? = null
-  private val realtimePlaybackLock = Any()
-  private var realtimeAudioTrack: AudioTrack? = null
-  private var realtimeAudioQueue: Channel<RealtimePlaybackItem>? = null
-  private var realtimeAudioWriterJob: Job? = null
+
+  // Single-owner realtime playout. Gateway ingress only ever enqueues onto
+  // [realtimePlaybackCommands]; the output device and every field in this group are touched
+  // exclusively by [realtimePlaybackOwner]. The two share no lock and no suspension, so an
+  // inbound Gateway frame can never wait on hardware backpressure. (They do still share
+  // [realtimeCapturePauseLock] on the teardown path, but only for field swaps -- no device
+  // call and no suspension happens under it.)
+  private val realtimePlaybackCommands =
+    Channel<RealtimePlaybackCommand>(
+      capacity = realtimePlaybackProviderQueueCapacity + realtimePlaybackControlQueueHeadroom,
+    )
+  private val queuedRealtimeProviderCommands = AtomicInteger(0)
+  private val queuedRealtimeAudioBytes = AtomicLong(0L)
+  private val realtimePlaybackPollIdleQueued = AtomicBoolean(false)
+  private val realtimePlaybackEpoch = AtomicLong(0L)
+  private var realtimeAudioSink: RealtimeAudioSink? = null
   private var realtimePlaybackIdleJob: Job? = null
   private var realtimeWrittenFrames = 0L
   private val pendingRealtimePlaybackMarks = LinkedHashMap<String, PendingRealtimePlaybackMark>()
@@ -404,6 +425,46 @@ class TalkModeManager internal constructor(
   private enum class PlaybackPhase {
     Preparing,
     Playing,
+  }
+
+  // Its own job rather than a child of [scope]: the owner outlives every gateway scope and
+  // is torn down with the manager itself, below. Declared after every field the command
+  // handlers read, because `launch` can start the body on another thread before this
+  // constructor returns.
+  private val realtimePlaybackOwnerJob = SupervisorJob()
+  private val realtimePlaybackOwnerScope = CoroutineScope(scope.coroutineContext + realtimePlaybackOwnerJob)
+  private val realtimePlaybackOwner: Job =
+    realtimePlaybackOwnerScope.launch(realtimePlaybackDispatcher) {
+      for (command in realtimePlaybackCommands) {
+        if (command is RealtimePlaybackCommand.Audio || command is RealtimePlaybackCommand.Mark) {
+          queuedRealtimeProviderCommands.decrementAndGet()
+        }
+        if (command is RealtimePlaybackCommand.Audio) {
+          queuedRealtimeAudioBytes.addAndGet(-command.bytes.size.toLong())
+        }
+        try {
+          when (command) {
+            is RealtimePlaybackCommand.Audio -> processRealtimeAudioOwnerOnly(command)
+            is RealtimePlaybackCommand.Mark -> processRealtimeMarkOwnerOnly(command)
+            is RealtimePlaybackCommand.Clear -> processRealtimeClearOwnerOnly(command)
+            is RealtimePlaybackCommand.Stop -> processRealtimeStopOwnerOnly(command)
+            RealtimePlaybackCommand.PollIdle -> processRealtimePollIdleOwnerOnly()
+          }
+        } catch (err: CancellationException) {
+          throw err
+        } catch (err: Throwable) {
+          // One command must never end this loop. The channel is long-lived and never
+          // recreated, so a dead owner would swallow every later command in silence.
+          val message = err.message ?: err::class.simpleName ?: "playback command failed"
+          Log.w(tag, "realtime playback command failed: $message")
+          failRealtimePlaybackOwnerOnly(message)
+        }
+      }
+    }
+
+  init {
+    // Declared here rather than beside the owner's job so it runs after that job exists.
+    scope.coroutineContext[Job]?.invokeOnCompletion { realtimePlaybackOwnerJob.cancel() }
   }
 
   private data class PlaybackLease(
@@ -1369,18 +1430,19 @@ class TalkModeManager internal constructor(
             Log.w(tag, "realtime audio decode failed: ${err.message ?: err::class.simpleName}")
             return
           }
-        playRealtimeAudio(bytes)
+        playRealtimeAudio(sessionId, bytes)
       }
 
       "clear" -> {
+        // Turn identity is validated here, on the receiving thread, exactly as upstream does: a
+        // clear naming a turn other than the live one belongs to a response that is already gone
+        // and must not touch the current playback. Retirement itself is not done here -- it is
+        // queued to the playout owner, which is the only thing allowed to reach the device.
         val turnId = obj["talkEvent"].asObjectOrNull()?.get("turnId").asStringOrNull()
         val activeTurnId = realtimeOutputTurnId
         if (!turnId.isNullOrBlank() && activeTurnId != null && turnId != activeTurnId) return
-        val marks = takePendingRealtimePlaybackMarks()
-        stopRealtimePlayback()
         realtimeOutputTurnId = null
-        acknowledgeRealtimePlaybackMarks(marks)
-        pendingRealtimeOutputClear?.complete(turnId)
+        requestRealtimePlaybackClear(turnId)
       }
 
       "mark" -> {
@@ -1416,7 +1478,7 @@ class TalkModeManager internal constructor(
         if (isFinal && role == "user") {
           setStatus(nativeText("Thinking…"), awaitingAgent = true)
         } else if (isFinal && role == "assistant") {
-          scheduleRealtimePlaybackIdle()
+          requestRealtimePlaybackIdleCheck()
         }
       }
 
@@ -1471,139 +1533,313 @@ class TalkModeManager internal constructor(
       put("final", JsonPrimitive(true))
     }.toString()
 
-  private fun playRealtimeAudio(bytes: ByteArray) {
+  /**
+   * Gateway ingress for assistant audio. Enqueues and returns; it never touches the output
+   * device, so the message pump does not wait on hardware backpressure.
+   */
+  private fun playRealtimeAudio(
+    sessionId: String,
+    bytes: ByteArray,
+  ) {
     if (!playbackEnabled || realtimeOutputSuppressed || bytes.isEmpty()) return
-    val queue = ensureRealtimeAudioQueue()
-    if (!queue.trySend(RealtimePlaybackItem.Audio(bytes)).isSuccess) {
-      Log.w(tag, "realtime audio queue full")
-    }
+    submitRealtimeProviderPlaybackCommand(
+      sessionId,
+      RealtimePlaybackCommand.Audio(epoch = realtimePlaybackEpoch.get(), bytes = bytes),
+    )
   }
 
+  /** Gateway ingress for a provider playback barrier. Enqueue only, same as audio. */
   private fun queueRealtimePlaybackMark(
     sessionId: String,
     markName: String,
   ) {
-    synchronized(realtimePlaybackLock) {
-      pendingRealtimePlaybackMarks[markName] =
-        PendingRealtimePlaybackMark(
-          sessionId = sessionId,
-          name = markName,
-        )
-    }
-    if (!ensureRealtimeAudioQueue().trySend(RealtimePlaybackItem.Mark(markName)).isSuccess) {
-      val mark = synchronized(realtimePlaybackLock) { pendingRealtimePlaybackMarks.remove(markName) }
-      acknowledgeRealtimePlaybackMarks(listOfNotNull(mark))
+    submitRealtimeProviderPlaybackCommand(
+      sessionId,
+      RealtimePlaybackCommand.Mark(epoch = realtimePlaybackEpoch.get(), sessionId = sessionId, name = markName),
+    )
+  }
+
+  /**
+   * Enqueues one provider-driven playback command against the shared provider bound.
+   *
+   * Overflow is a media failure rather than a dropped frame: audio the device never received
+   * would otherwise be reported as played by the barrier queued behind it.
+   */
+  private fun submitRealtimeProviderPlaybackCommand(
+    sessionId: String,
+    command: RealtimePlaybackCommand,
+  ) {
+    val audioBytes = (command as? RealtimePlaybackCommand.Audio)?.bytes?.size?.toLong() ?: 0L
+    val queuedCommands = queuedRealtimeProviderCommands.incrementAndGet()
+    val queuedBytes = queuedRealtimeAudioBytes.addAndGet(audioBytes)
+    val overCapacity =
+      queuedCommands > realtimePlaybackProviderQueueCapacity ||
+        queuedBytes > realtimePlaybackQueuedAudioCeilingBytes
+    if (overCapacity || !realtimePlaybackCommands.trySend(command).isSuccess) {
+      queuedRealtimeProviderCommands.decrementAndGet()
+      queuedRealtimeAudioBytes.addAndGet(-audioBytes)
+      overflowRealtimePlayback(sessionId, queuedCommands, queuedBytes)
+      return
     }
   }
 
-  private fun ensureRealtimeAudioQueue(): Channel<RealtimePlaybackItem> =
-    synchronized(realtimePlaybackLock) {
-      realtimeAudioQueue
-        ?: Channel<RealtimePlaybackItem>(Channel.UNLIMITED).also { queue ->
-          realtimeAudioQueue = queue
-          realtimeAudioWriterJob =
-            gatewayWorkScope.launch(realtimePlaybackDispatcher) {
-              for (item in queue) {
-                when (item) {
-                  is RealtimePlaybackItem.Audio -> {
-                    if (!playbackEnabled || realtimeOutputSuppressed || realtimeSessionId == null) continue
-                    try {
-                      writeRealtimeAudio(item.bytes)
-                    } catch (err: CancellationException) {
-                      throw err
-                    } catch (err: Throwable) {
-                      Log.w(tag, "realtime audio playback failed: ${err.message ?: err::class.java.simpleName}")
-                    }
-                  }
-
-                  is RealtimePlaybackItem.Mark -> {
-                    prepareRealtimePlaybackMark(item.name)
-                  }
-                }
-              }
-            }
-        }
+  /**
+   * Asks the owner to re-evaluate barrier completion and idleness. Deduped to one queued
+   * check, so a burst of events cannot fill the control headroom.
+   */
+  private fun requestRealtimePlaybackIdleCheck() {
+    if (!realtimePlaybackPollIdleQueued.compareAndSet(false, true)) return
+    if (!realtimePlaybackCommands.trySend(RealtimePlaybackCommand.PollIdle).isSuccess) {
+      realtimePlaybackPollIdleQueued.set(false)
     }
+  }
 
-  private fun writeRealtimeAudio(bytes: ByteArray) {
-    synchronized(realtimePlaybackLock) {
-      val track =
-        realtimeAudioTrack ?: run {
-          val minBuffer =
-            AudioTrack.getMinBufferSize(
-              realtimeSampleRateHz,
-              AudioFormat.CHANNEL_OUT_MONO,
-              AudioFormat.ENCODING_PCM_16BIT,
-            )
-          val bufferSizeBytes =
-            maxOf(
-              minBuffer * 2,
-              realtimeSampleRateHz * 2 * realtimePlaybackBufferMs / 1000,
-              bytes.size * 4,
-            )
-          val created =
-            AudioTrack
-              .Builder()
-              .setAudioAttributes(
-                AudioAttributes
-                  .Builder()
-                  .setUsage(AudioAttributes.USAGE_MEDIA)
-                  .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                  .build(),
-              ).setAudioFormat(
-                AudioFormat
-                  .Builder()
-                  .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                  .setSampleRate(realtimeSampleRateHz)
-                  .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
-                  .build(),
-              ).setTransferMode(AudioTrack.MODE_STREAM)
-              .setBufferSizeInBytes(bufferSizeBytes)
-              .build()
-          realtimeAudioTrack = created
+  private fun overflowRealtimePlayback(
+    sessionId: String,
+    queuedCommands: Int,
+    queuedBytes: Long,
+  ) {
+    Log.w(tag, "realtime playback queue full: commands=$queuedCommands bytes=$queuedBytes")
+    failRealtimeRelay(sessionId, "audio playback queue overflow")
+  }
+
+  /**
+   * Publishes a new playback generation.
+   *
+   * Called on the requesting thread, before the matching Clear or Stop is queued, so audio
+   * already waiting for the owner is discarded and a write in flight is preempted at its next
+   * retry. The state the capture gate reads is reset here too, at exactly the point the
+   * previous implementation reset it, so callers keep the ordering they had.
+   */
+  private fun invalidateRealtimePlaybackEpoch() {
+    realtimePlaybackEpoch.incrementAndGet()
+    realtimePlaybackEndsAtMs = 0L
+    setRealtimePlaying(false)
+    _outputLevel.value = null
+  }
+
+  /** Barge-in or provider clear: invalidate the generation, then retire the device. */
+  private fun requestRealtimePlaybackClear(turnId: String?) {
+    val completion = pendingRealtimeOutputClear
+    invalidateRealtimePlaybackEpoch()
+    if (!realtimePlaybackCommands.trySend(RealtimePlaybackCommand.Clear(turnId, completion)).isSuccess) {
+      // The generation is already dead, so nothing new can play; only the device residue
+      // survives. Release the waiter rather than letting cancelOutput hang on it, and release it
+      // with the identity the clear carried so the caller's turn check still decides.
+      Log.w(tag, "realtime playback clear could not be queued")
+      completion?.complete(turnId)
+    }
+    if (_isEnabled.value) {
+      setStatus(nativeText("Listening"))
+    }
+  }
+
+  /**
+   * Ends playback. [terminal] is relay teardown, which drops pending barriers unacknowledged;
+   * a plain playback stop keeps them for the provider's own clear to release.
+   */
+  private fun stopRealtimePlayback(terminal: Boolean = false) {
+    invalidateRealtimePlaybackEpoch()
+    if (!realtimePlaybackCommands.trySend(RealtimePlaybackCommand.Stop(terminal)).isSuccess) {
+      Log.w(tag, "realtime playback stop could not be queued")
+    }
+    if (_isEnabled.value) {
+      setStatus(nativeText("Listening"))
+    }
+  }
+
+  private suspend fun processRealtimeAudioOwnerOnly(command: RealtimePlaybackCommand.Audio) {
+    if (command.epoch != realtimePlaybackEpoch.get()) return
+    if (!playbackEnabled || realtimeOutputSuppressed || realtimeSessionId == null) return
+    val bytes = command.bytes
+    if (bytes.isEmpty()) return
+    val sink =
+      realtimeAudioSink ?: realtimeAudioSinkFactory
+        .open(realtimeSampleRateHz, realtimePlaybackBufferMs, bytes.size)
+        .also { opened ->
+          realtimeAudioSink = opened
           realtimeWrittenFrames = 0L
-          created
         }
-      var writtenBytes = 0
-      while (writtenBytes < bytes.size) {
-        val written = track.write(bytes, writtenBytes, bytes.size - writtenBytes)
-        if (written <= 0) {
-          Log.w(tag, "realtime audio write failed: $written")
-          break
+    // A refused non-blocking write only makes progress once the device is draining, so
+    // presentation starts before the first write rather than after it.
+    sink.play()
+    val retryDelayMs = realtimePlaybackWriteRetryDelayMs(sink.bufferDurationMs)
+    // One command may legitimately have to wait out its own playback duration when the device
+    // buffer is already full, so the budget covers that on top of the stall allowance. It is
+    // deliberately never reset by partial progress: a device accepting a couple of bytes per
+    // retry is as broken as one accepting none, and resetting would let it grind out the frame.
+    val frameDurationMs = (bytes.size / 2).toLong() * 1000L / realtimeSampleRateHz
+    val stallBudgetMs = realtimePlaybackWriteStallBudgetMs(sink.bufferDurationMs) + frameDurationMs
+    var writtenBytes = 0
+    var stalledMs = 0L
+    while (writtenBytes < bytes.size) {
+      if (command.epoch != realtimePlaybackEpoch.get()) break
+      val accepted = sink.write(bytes, writtenBytes, bytes.size - writtenBytes)
+      if (accepted < 0) {
+        // A device error code, not backpressure. Keep the frames already accepted and stop
+        // retrying; the next command decides whether the device is still usable.
+        Log.w(tag, "realtime audio write failed: $accepted")
+        break
+      }
+      if (accepted == 0) {
+        if (stalledMs >= stallBudgetMs) {
+          throw IllegalStateException("realtime audio device accepted nothing for ${stalledMs}ms")
         }
-        writtenBytes += written
+        delay(retryDelayMs)
+        stalledMs += retryDelayMs
+        continue
       }
-      if (writtenBytes <= 0) return
-      if (track.playState != AudioTrack.PLAYSTATE_PLAYING) {
-        track.play()
-      }
-      // Blocking MODE_STREAM writes are playback-paced once the track buffer
-      // fills, so per-write metering tracks what the speaker actually plays.
-      _outputLevel.value =
-        TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
-      setRealtimePlaying(true)
-      setStatus(nativeText("Speaking…"))
-      val durationMs = ((writtenBytes / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
-      realtimeWrittenFrames += writtenBytes / 2L
-      val now = SystemClock.elapsedRealtime()
-      realtimePlaybackEndsAtMs = maxOf(now, realtimePlaybackEndsAtMs) + durationMs
-      scheduleRealtimePlaybackIdle()
+      writtenBytes += accepted
+    }
+    if (writtenBytes <= 0) return
+    // A generation invalidated mid-write must not publish playback state. The Clear or Stop
+    // behind this command is about to discard these frames, and only the owner is serialized
+    // against this publication -- the requester's own reset already happened, before the write.
+    if (command.epoch != realtimePlaybackEpoch.get()) return
+    _outputLevel.value =
+      TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
+    setRealtimePlaying(true)
+    setStatus(nativeText("Speaking…"))
+    val durationMs = ((writtenBytes / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
+    realtimeWrittenFrames += writtenBytes / 2L
+    val now = SystemClock.elapsedRealtime()
+    realtimePlaybackEndsAtMs = maxOf(now, realtimePlaybackEndsAtMs) + durationMs
+    ensureRealtimePlaybackIdleTickerOwnerOnly()
+  }
+
+  private fun processRealtimeMarkOwnerOnly(command: RealtimePlaybackCommand.Mark) {
+    if (command.epoch != realtimePlaybackEpoch.get()) {
+      // The barrier belongs to a response cancelled before it reached the device.
+      // Acknowledging releases the provider's playback gate; it never claims the audio played.
+      acknowledgeRealtimePlaybackMarks(
+        listOf(PendingRealtimePlaybackMark(sessionId = command.sessionId, name = command.name)),
+      )
+      return
+    }
+    pendingRealtimePlaybackMarks[command.name] =
+      PendingRealtimePlaybackMark(
+        sessionId = command.sessionId,
+        name = command.name,
+        targetFrame = realtimeWrittenFrames,
+      )
+    acknowledgeRealtimePlaybackMarks(takeCompletedRealtimePlaybackMarksOwnerOnly())
+    ensureRealtimePlaybackIdleTickerOwnerOnly()
+  }
+
+  private fun processRealtimeClearOwnerOnly(command: RealtimePlaybackCommand.Clear) {
+    try {
+      val marks = pendingRealtimePlaybackMarks.values.toList()
+      pendingRealtimePlaybackMarks.clear()
+      retireRealtimeAudioSinkOwnerOnly()
+      acknowledgeRealtimePlaybackMarks(marks)
+      publishRealtimePlaybackIdleOwnerOnly()
+    } finally {
+      // cancelOutput waits on this to learn the old boundary reached the device, so it is
+      // completed here -- after the owner has actually retired the sink -- and never earlier.
+      // A failure above must not turn into a two-second stall and a relay close on top of it.
+      command.completion?.complete(command.turnId)
     }
   }
 
-  private fun prepareRealtimePlaybackMark(markName: String) {
-    val completed =
-      synchronized(realtimePlaybackLock) {
-        val mark = pendingRealtimePlaybackMarks[markName] ?: return
-        mark.targetFrame = realtimeWrittenFrames
-        takeCompletedRealtimePlaybackMarksLocked()
-      }
-    acknowledgeRealtimePlaybackMarks(completed)
-    scheduleRealtimePlaybackIdle()
+  private fun processRealtimeStopOwnerOnly(command: RealtimePlaybackCommand.Stop) {
+    val marks = pendingRealtimePlaybackMarks.values.toList()
+    pendingRealtimePlaybackMarks.clear()
+    retireRealtimeAudioSinkOwnerOnly()
+    // Retiring resets the frame counter every target frame was measured against, so a barrier
+    // carried across it could never complete -- it would poll forever and hold the provider's
+    // playback gate shut. Relay teardown has no provider left to release, so its barriers are
+    // dropped; every other stop answers them.
+    if (!command.terminal) acknowledgeRealtimePlaybackMarks(marks)
+    publishRealtimePlaybackIdleOwnerOnly()
   }
 
-  private fun takeCompletedRealtimePlaybackMarksLocked(): List<PendingRealtimePlaybackMark> {
-    val playedFrames = realtimeAudioTrack?.playbackHeadPosition?.toLong()?.and(0xffff_ffffL) ?: realtimeWrittenFrames
+  /**
+   * Re-publishes the quiescent playback state, from the owner.
+   *
+   * The requester already reset it before queueing Clear or Stop, but an Audio command that was
+   * inside its write loop at that moment can publish "speaking" again afterwards, and the
+   * retirement here also cancels the idle ticker that would otherwise have cleared it -- leaving
+   * the capture gate shut with nothing left to reopen it. The owner is the only thing serialized
+   * against that publication, so this is where the reset has to be final.
+   *
+   * The status is left alone once the session is gone: relay teardown nulls the session id before
+   * queueing its Stop, which is what keeps a preserved failure status from being overwritten here.
+   */
+  private fun publishRealtimePlaybackIdleOwnerOnly() {
+    realtimePlaybackEndsAtMs = 0L
+    setRealtimePlaying(false)
+    _outputLevel.value = null
+    if (_isEnabled.value && realtimeSessionId != null) {
+      setStatus(nativeText("Listening"))
+    }
+  }
+
+  private fun processRealtimePollIdleOwnerOnly() {
+    realtimePlaybackPollIdleQueued.set(false)
+    val playbackTimeElapsed = SystemClock.elapsedRealtime() >= realtimePlaybackEndsAtMs
+    val completed = takeCompletedRealtimePlaybackMarksOwnerOnly()
+    // The device may lag the duration estimate by its own buffer. Keep polling until queued
+    // barriers prove the speaker reached them.
+    val awaitingPlaybackMark = pendingRealtimePlaybackMarks.values.any { it.targetFrame != null }
+    val playbackIdle = playbackTimeElapsed && !awaitingPlaybackMark
+    if (playbackIdle) {
+      setRealtimePlaying(false)
+      _outputLevel.value = null
+    }
+    acknowledgeRealtimePlaybackMarks(completed)
+    if (!playbackIdle) {
+      // A check requested from outside the owner may arrive with no ticker running.
+      ensureRealtimePlaybackIdleTickerOwnerOnly()
+      return
+    }
+    realtimePlaybackIdleJob?.cancel()
+    realtimePlaybackIdleJob = null
+    if (_isEnabled.value && realtimeSessionId != null) {
+      setStatus(nativeText("Listening"))
+    }
+  }
+
+  /** Owner-only cleanup shared by Clear, Stop, and the command loop's failure path. */
+  private fun retireRealtimeAudioSinkOwnerOnly() {
+    realtimeAudioSink?.let { sink -> runCatching { sink.close() } }
+    realtimeAudioSink = null
+    realtimeWrittenFrames = 0L
+    realtimePlaybackIdleJob?.cancel()
+    realtimePlaybackIdleJob = null
+  }
+
+  private fun failRealtimePlaybackOwnerOnly(message: String) {
+    // Retiring resets the frame counter every pending target frame was measured against, so
+    // a surviving barrier could never complete and would hold the provider's gate forever.
+    val stranded = pendingRealtimePlaybackMarks.values.toList()
+    pendingRealtimePlaybackMarks.clear()
+    retireRealtimeAudioSinkOwnerOnly()
+    acknowledgeRealtimePlaybackMarks(stranded)
+    publishRealtimePlaybackIdleOwnerOnly()
+    val sessionId = realtimeSessionId ?: return
+    failRealtimeRelay(sessionId, message)
+  }
+
+  /**
+   * Ticks the owner so barrier completion and idleness are re-evaluated while audio is still
+   * being presented. The ticker only enqueues; it never touches the device or the barriers.
+   */
+  private fun ensureRealtimePlaybackIdleTickerOwnerOnly() {
+    if (realtimePlaybackIdleJob?.isActive == true) return
+    realtimePlaybackIdleJob =
+      realtimePlaybackOwnerScope.launch(realtimePlaybackDispatcher) {
+        while (isActive) {
+          delay(realtimePlaybackIdlePollMs)
+          if (!realtimePlaybackPollIdleQueued.compareAndSet(false, true)) continue
+          if (!realtimePlaybackCommands.trySend(RealtimePlaybackCommand.PollIdle).isSuccess) {
+            realtimePlaybackPollIdleQueued.set(false)
+          }
+        }
+      }
+  }
+
+  private fun takeCompletedRealtimePlaybackMarksOwnerOnly(): List<PendingRealtimePlaybackMark> {
+    val playedFrames = realtimeAudioSink?.presentedFrames ?: realtimeWrittenFrames
     val completed =
       pendingRealtimePlaybackMarks.values.filter { mark ->
         val targetFrame = mark.targetFrame
@@ -1612,13 +1848,6 @@ class TalkModeManager internal constructor(
     completed.forEach { pendingRealtimePlaybackMarks.remove(it.name) }
     return completed
   }
-
-  private fun takePendingRealtimePlaybackMarks(): List<PendingRealtimePlaybackMark> =
-    synchronized(realtimePlaybackLock) {
-      val marks = pendingRealtimePlaybackMarks.values.toList()
-      pendingRealtimePlaybackMarks.clear()
-      marks
-    }
 
   private fun acknowledgeRealtimePlaybackMarks(marks: List<PendingRealtimePlaybackMark>) {
     for (mark in marks) {
@@ -1640,67 +1869,6 @@ class TalkModeManager internal constructor(
           Log.d(tag, "realtime mark acknowledgement ignored: ${err.message ?: err::class.simpleName}")
         }
       }
-    }
-  }
-
-  private fun scheduleRealtimePlaybackIdle() {
-    realtimePlaybackIdleJob?.cancel()
-    realtimePlaybackIdleJob =
-      gatewayWorkScope.launch {
-        while (true) {
-          delay(20)
-          val (completed, idle) =
-            synchronized(realtimePlaybackLock) {
-              val playbackTimeElapsed = SystemClock.elapsedRealtime() >= realtimePlaybackEndsAtMs
-              val completed = takeCompletedRealtimePlaybackMarksLocked()
-              // AudioTrack may lag the duration estimate by its device buffer. Keep
-              // polling until queued marks prove the speaker reached the barrier.
-              val awaitingPlaybackMark = pendingRealtimePlaybackMarks.values.any { it.targetFrame != null }
-              val playbackIdle = playbackTimeElapsed && !awaitingPlaybackMark
-              if (playbackIdle) {
-                setRealtimePlaying(false)
-                _outputLevel.value = null
-              }
-              completed to playbackIdle
-            }
-          acknowledgeRealtimePlaybackMarks(completed)
-          if (idle) {
-            if (_isEnabled.value && realtimeSessionId != null) {
-              setStatus(nativeText("Listening"))
-            }
-            return@launch
-          }
-        }
-      }
-  }
-
-  private fun stopRealtimePlayback() {
-    val audioQueue = realtimeAudioQueue
-    val audioWriterJob = realtimeAudioWriterJob
-    realtimeAudioQueue = null
-    realtimeAudioWriterJob = null
-    audioQueue?.close()
-    audioWriterJob?.cancel()
-    realtimePlaybackIdleJob?.cancel()
-    realtimePlaybackIdleJob = null
-    realtimePlaybackEndsAtMs = 0L
-    synchronized(realtimePlaybackLock) {
-      realtimeAudioTrack?.let { track ->
-        try {
-          track.pause()
-          track.flush()
-          track.stop()
-        } catch (_: Throwable) {
-        }
-        track.release()
-      }
-      realtimeAudioTrack = null
-      realtimeWrittenFrames = 0L
-      setRealtimePlaying(false)
-    }
-    _outputLevel.value = null
-    if (_isEnabled.value) {
-      setStatus(nativeText("Listening"))
     }
   }
 
@@ -1738,10 +1906,9 @@ class TalkModeManager internal constructor(
     realtimeUserEntryAwaitingFinal = false
     realtimeUserEntryAwaitingFinalStartedAtMs = null
     realtimeAssistantEntryId = null
-    takePendingRealtimePlaybackMarks()
     _speechActive.value = false
     _inputLevel.value = 0f
-    stopRealtimePlayback()
+    stopRealtimePlayback(terminal = true)
     if (preserveStatus) {
       setStatus(status)
     }
@@ -2882,7 +3049,10 @@ class TalkModeManager internal constructor(
       publishSpeakingState()
     }
 
-  // Called under playbackLock; realtime producers enter only from realtimePlaybackLock.
+  // Called under playbackLock. The realtime source no longer has a lock of its own: it reaches
+  // this state only through [setRealtimePlaying], from the playout owner or from the requester
+  // that invalidates an epoch. playbackLock stays a leaf held across field writes alone, so the
+  // Gateway receive path never waits on the device behind it.
   // Either source can keep speaking after the other source completes or is cancelled.
   private fun publishSpeakingState() {
     _isSpeaking.value = realtimePlaying || localPlayback?.phase == PlaybackPhase.Playing

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/AndroidAudioInputSessionTest.kt
@@ -17,6 +17,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
 import org.robolectric.shadows.AudioDeviceInfoBuilder
 import org.robolectric.shadows.ShadowAudioManager
 import org.robolectric.util.ReflectionHelpers
@@ -74,6 +76,35 @@ class AndroidAudioInputSessionTest {
     assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, session.requestedInputType)
     assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, audioManager.communicationDevice?.type)
     session.close()
+  }
+
+  @Test
+  @Config(shadows = [ShadowFallibleCommunicationDeviceAudioManager::class])
+  fun replacementWhoseRouteSetupThrowsStillClearsThePreviousCommunicationDevice() {
+    // The ownership hole: a replacement capture supersedes the previous one the moment it begins,
+    // and the previous one is then no longer allowed to clear the process-wide selection. If the
+    // replacement's own route setup throws before it becomes the active owner, neither close path
+    // may clear it, and the device selection outlives every capture that could have released it.
+    val sco = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    val scoOutput = audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+    shadowAudioManager.setInputDevices(listOf(sco))
+    shadowAudioManager.setAvailableCommunicationDevices(listOf(scoOutput))
+    val previous = AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800)
+    assertEquals(AudioDeviceInfo.TYPE_BLUETOOTH_SCO, audioManager.communicationDevice?.type)
+
+    ShadowFallibleCommunicationDeviceAudioManager.throwOnSetCommunicationDevice = true
+    val replacement =
+      try {
+        runCatching { AndroidAudioInputSession.open(context, sampleRateHz = 24_000, frameBytes = 4_800) }
+      } finally {
+        ShadowFallibleCommunicationDeviceAudioManager.throwOnSetCommunicationDevice = false
+      }
+    assertEquals("the failed setup must not have cleared the standing route", AudioDeviceInfo.TYPE_BLUETOOTH_SCO, audioManager.communicationDevice?.type)
+
+    replacement.getOrNull()?.close()
+    previous.close()
+
+    assertNull("no capture is left that can release the process-wide selection", audioManager.communicationDevice)
   }
 
   @Test
@@ -242,5 +273,19 @@ class AndroidAudioInputSessionTest {
     val handle = ReflectionHelpers.getField<Any>(port, "mHandle")
     ReflectionHelpers.setField(handle, "mId", nextDeviceId++)
     return device
+  }
+}
+
+/** Accepts communication-device requests until armed, then throws from the request itself. */
+@Implements(AudioManager::class)
+class ShadowFallibleCommunicationDeviceAudioManager : ShadowAudioManager() {
+  @Implementation
+  override fun setCommunicationDevice(device: AudioDeviceInfo): Boolean {
+    if (throwOnSetCommunicationDevice) throw IllegalStateException("communication device unavailable")
+    return super.setCommunicationDevice(device)
+  }
+
+  companion object {
+    @JvmStatic var throwOnSetCommunicationDevice = false
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCaptureTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCaptureTest.kt
@@ -90,6 +90,11 @@ class RealtimeCaptureTest {
         """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":"24000"}}""",
         """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":24000,"outputEncoding":"g711_ulaw"}}""",
         """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":24000,"outputSampleRateHz":8000}}""",
+        // Present but unreadable is a declaration this endpoint cannot honour, not an absence.
+        // Skipping the comparison because the JSON type was wrong would accept a downlink at a
+        // clock that is then played at 24 kHz -- the input half already fails closed on this.
+        """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":24000,"outputSampleRateHz":"24000"}}""",
+        """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":24000,"outputEncoding":42}}""",
       )
 
     for (payload in rejected) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCaptureTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCaptureTest.kt
@@ -1,0 +1,446 @@
+package ai.openclaw.app.voice
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.ByteArrayOutputStream
+import kotlin.math.PI
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Covers the capture-rate contract: the rate the Gateway declares, the rate the microphone is
+ * asked for, and the rate it actually negotiates are three separate things, and only the last one
+ * may decide how captured audio is converted.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class RealtimeCaptureTest {
+  // ---- wire contract ----------------------------------------------------------------------
+
+  @Test
+  fun anAbsentAudioContractResolvesToTheLegacyRelayFormat() {
+    val contract = parseRealtimeWireAudioContract(jsonObject("""{"relaySessionId":"relay-1"}"""), playbackSampleRateHz = 24_000)
+
+    assertEquals(RealtimeWireAudioContract.Pcm16(REALTIME_LEGACY_WIRE_SAMPLE_RATE_HZ), contract)
+    assertEquals(24_000, REALTIME_LEGACY_WIRE_SAMPLE_RATE_HZ)
+  }
+
+  @Test
+  fun aDeclaredContractIsTakenExactlyAsDeclared() {
+    val contract =
+      parseRealtimeWireAudioContract(
+        jsonObject(
+          """
+          {"relaySessionId":"relay-1","audio":{"inputEncoding":"pcm16","inputSampleRateHz":24000,
+           "outputEncoding":"pcm16","outputSampleRateHz":24000}}
+          """.trimIndent(),
+        ),
+        playbackSampleRateHz = 24_000,
+      )
+
+    assertEquals(RealtimeWireAudioContract.Pcm16(24_000), contract)
+  }
+
+  @Test
+  fun anExplicitNullAudioFieldIsAbsenceRatherThanAMalformedContract() {
+    // A peer that serializes optional fields as explicit null must not be treated as declaring
+    // something unsupported; the iOS relay client reads it the same way.
+    val contract =
+      parseRealtimeWireAudioContract(
+        jsonObject("""{"relaySessionId":"relay-1","audio":null}"""),
+        playbackSampleRateHz = 24_000,
+      )
+
+    assertEquals(RealtimeWireAudioContract.Pcm16(REALTIME_LEGACY_WIRE_SAMPLE_RATE_HZ), contract)
+  }
+
+  @Test
+  fun aDeclaredRateOtherThanTheLegacyOneIsHonoredRatherThanAssumed() {
+    val contract =
+      parseRealtimeWireAudioContract(
+        jsonObject("""{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":16000}}"""),
+        playbackSampleRateHz = 24_000,
+      )
+
+    assertEquals(RealtimeWireAudioContract.Pcm16(16_000), contract)
+  }
+
+  @Test
+  fun aContractThisEndpointCannotProduceFailsClosedInsteadOfFallingBack() {
+    // Each of these is present, so the legacy default must not rescue it: producing PCM16 anyway
+    // would put audio on the wire at a clock or in a format the Gateway never asked for.
+    val rejected =
+      listOf(
+        """{"audio":{"inputEncoding":"g711_ulaw","inputSampleRateHz":8000}}""",
+        """{"audio":{"inputEncoding":"pcm16"}}""",
+        """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":0}}""",
+        """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":"not-a-number"}}""",
+        """{"audio":{"inputSampleRateHz":24000}}""",
+        """{"audio":"pcm16"}""",
+        """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":"24000"}}""",
+        """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":24000,"outputEncoding":"g711_ulaw"}}""",
+        """{"audio":{"inputEncoding":"pcm16","inputSampleRateHz":24000,"outputSampleRateHz":8000}}""",
+      )
+
+    for (payload in rejected) {
+      val contract = parseRealtimeWireAudioContract(jsonObject(payload), playbackSampleRateHz = 24_000)
+      assertTrue("$payload resolved to $contract", contract is RealtimeWireAudioContract.Unsupported)
+    }
+  }
+
+  // ---- candidate selection ----------------------------------------------------------------
+
+  @Test
+  fun thePreferredRateIsTriedFirstAndTheWireRateIsTheFallback() {
+    assertEquals(listOf(48_000, 24_000), realtimeCaptureCandidateRatesHz(48_000, 24_000))
+  }
+
+  @Test
+  fun aPreferredRateEqualToTheWireRateIsAttemptedOnce() {
+    assertEquals(listOf(24_000), realtimeCaptureCandidateRatesHz(24_000, 24_000))
+
+    val opener = FakeCaptureOpener { requested -> requested }
+    val selection = selectRealtimeCaptureSession(realtimeCaptureCandidateRatesHz(24_000, 24_000), 24_000, opener::open)
+
+    assertEquals(listOf(24_000), opener.requestedRates)
+    assertEquals(24_000, selection.captureSampleRateHz)
+  }
+
+  @Test
+  fun thePreferredRateIsUsedWhenTheRecorderGrantsIt() {
+    val opener = FakeCaptureOpener { requested -> requested }
+
+    val selection = selectRealtimeCaptureSession(listOf(48_000, 24_000), 24_000, opener::open)
+
+    assertEquals(listOf(48_000), opener.requestedRates)
+    assertEquals(48_000, selection.requestedSampleRateHz)
+    assertEquals(48_000, selection.captureSampleRateHz)
+    assertEquals(2_400 * 2, selection.resampler.convert(pcm16Bytes(ShortArray(4_800)), 9_600).size)
+  }
+
+  @Test
+  fun aRecorderThatNegotiatesADifferentButConvertibleRateIsAccepted() {
+    // The #124083 P1 regression, in both directions the recorder can move: down onto the wire rate
+    // itself, and up onto a whole multiple of it. Neither is a broken microphone, and asserting
+    // requested == actual is what previously turned each of them into a dead Talk session.
+    for (negotiated in listOf(24_000, 96_000)) {
+      val opener = FakeCaptureOpener { _ -> negotiated }
+
+      val selection = selectRealtimeCaptureSession(listOf(48_000, 24_000), 24_000, opener::open)
+
+      assertEquals(listOf(48_000), opener.requestedRates)
+      assertEquals(48_000, selection.requestedSampleRateHz)
+      assertEquals(negotiated, selection.captureSampleRateHz)
+      assertEquals(0, opener.opened.single().closeCalls)
+      // The converter came from the negotiated rate: 100 ms in is 100 ms out at the wire rate.
+      val input = pcm16Bytes(ShortArray(negotiated / 10))
+      assertEquals(2_400 * 2, selection.resampler.convert(input, input.size).size)
+    }
+  }
+
+  @Test
+  fun aRateThatCannotPossiblyConvertIsNotOpenedAtAll() {
+    // Opening claims the process-wide communication route, which on Bluetooth is audible. A rate
+    // that cannot convert is knowable without touching the microphone, so it must not be asked for.
+    val opener = FakeCaptureOpener { requested -> requested }
+
+    val selection = selectRealtimeCaptureSession(listOf(44_100, 48_000, 24_000), 24_000, opener::open)
+
+    assertEquals(listOf(48_000), opener.requestedRates)
+    assertEquals(48_000, selection.captureSampleRateHz)
+  }
+
+  @Test
+  fun everyCandidateBeingUnconvertibleStillAsksTheRecorderInCaseItNegotiatesSomethingElse() {
+    // With nothing left to pre-filter to, the recorder is still worth asking: the rate it grants
+    // is the one that decides, and it need not be the one that was requested.
+    val opener = FakeCaptureOpener { _ -> 24_000 }
+
+    val selection = selectRealtimeCaptureSession(listOf(44_100, 22_050), 24_000, opener::open)
+
+    assertEquals(listOf(44_100), opener.requestedRates)
+    assertEquals(24_000, selection.captureSampleRateHz)
+  }
+
+  @Test
+  fun aCandidateWhoseNegotiatedRateCannotBeConvertedIsClosedAndTheNextOneIsTried() {
+    val opener = FakeCaptureOpener { requested -> if (requested == 48_000) 44_100 else requested }
+
+    val selection = selectRealtimeCaptureSession(listOf(48_000, 24_000), 24_000, opener::open)
+
+    assertEquals(listOf(48_000, 24_000), opener.requestedRates)
+    assertEquals(24_000, selection.captureSampleRateHz)
+    // The rejected recorder is released exactly once, and the accepted one is left open.
+    assertEquals(1, opener.opened[0].closeCalls)
+    assertEquals(0, opener.opened[1].closeCalls)
+  }
+
+  @Test
+  fun aCandidateThatCannotOpenAtAllFallsThroughToTheNextOne() {
+    val opener =
+      FakeCaptureOpener { requested ->
+        if (requested == 48_000) throw UnsupportedOperationException("cannot open 48 kHz") else requested
+      }
+
+    val selection = selectRealtimeCaptureSession(listOf(48_000, 24_000), 24_000, opener::open)
+
+    assertEquals(listOf(48_000, 24_000), opener.requestedRates)
+    assertEquals(24_000, selection.captureSampleRateHz)
+    assertEquals(1, opener.opened.size)
+    assertEquals(0, opener.opened.single().closeCalls)
+  }
+
+  @Test
+  fun everyCandidateBeingUnusableFailsClosedAndLeavesNoRecorderOpen() {
+    val opener = FakeCaptureOpener { _ -> 44_100 }
+
+    val failure =
+      runCatching { selectRealtimeCaptureSession(listOf(48_000, 24_000), 24_000, opener::open) }.exceptionOrNull()
+
+    assertTrue("expected a capture failure, got $failure", failure is IllegalStateException)
+    assertEquals(listOf(48_000, 24_000), opener.requestedRates)
+    assertEquals(listOf(1, 1), opener.opened.map { it.closeCalls })
+  }
+
+  @Test
+  fun anOpenFailureIsReportedWhenNoLaterCandidateSucceeds() {
+    val opener = FakeCaptureOpener { _ -> throw UnsupportedOperationException("no microphone") }
+
+    val failure =
+      runCatching { selectRealtimeCaptureSession(listOf(48_000, 24_000), 24_000, opener::open) }.exceptionOrNull()
+
+    assertTrue("expected the open failure to surface, got $failure", failure is UnsupportedOperationException)
+    assertEquals(0, opener.opened.size)
+  }
+
+  // ---- converter resolution ---------------------------------------------------------------
+
+  @Test
+  fun onlyExactIntegerDownsamplingResolves() {
+    assertEquals(4_800, resolveRealtimeCaptureResampler(48_000, 24_000)!!.convert(pcm16Bytes(ShortArray(4_800)), 9_600).size)
+    assertNull(resolveRealtimeCaptureResampler(44_100, 24_000))
+    assertNull(resolveRealtimeCaptureResampler(16_000, 24_000))
+    assertNull(resolveRealtimeCaptureResampler(0, 24_000))
+    assertNull(resolveRealtimeCaptureResampler(48_000, 0))
+    // Beyond the ratio the anti-alias filter is built for.
+    assertNull(resolveRealtimeCaptureResampler(24_000 * 9, 24_000))
+  }
+
+  // ---- converter behavior -----------------------------------------------------------------
+
+  @Test
+  fun equalRatesPassThroughByteForByte() {
+    val resampler = resolveRealtimeCaptureResampler(24_000, 24_000)!!
+    val audio = pcm16Bytes(sine(freqHz = 440.0, sampleRateHz = 24_000, count = 2_400, amplitude = 12_000.0))
+
+    assertArrayEquals(audio, resampler.convert(audio, audio.size))
+  }
+
+  @Test
+  fun oneFrameOfCaptureBecomesOneFrameOfWireAudio() {
+    // 100 ms at 48 kHz is 4,800 samples in and 2,400 samples out; the frame represents the wire
+    // rate, not the capture rate, or uplink pacing drifts against the provider's clock.
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val frame = pcm16Bytes(sine(freqHz = 1_000.0, sampleRateHz = 48_000, count = 4_800, amplitude = 8_000.0))
+
+    assertEquals(2_400 * 2, resampler.convert(frame, frame.size).size)
+
+    // And it stays exact across the next frames rather than drifting by a sample.
+    assertEquals(2_400 * 2, resampler.convert(frame, frame.size).size)
+    assertEquals(2_400 * 2, resampler.convert(frame, frame.size).size)
+  }
+
+  @Test
+  fun unevenChunkBoundariesProduceTheSameStreamAsOneShotConversion() {
+    val audio = pcm16Bytes(sine(freqHz = 300.0, sampleRateHz = 48_000, count = 9_600, amplitude = 15_000.0))
+    val oneShot = resolveRealtimeCaptureResampler(48_000, 24_000)!!.convert(audio, audio.size)
+
+    // Odd sizes on purpose: AudioRecord returns a byte count, not a frame count, so a chunk can
+    // split a sample in half and the converter has to carry that byte rather than drop it.
+    val piecemeal = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val collected = ByteArrayOutputStream()
+    var offset = 0
+    val chunkSizes = intArrayOf(1, 37, 2, 501, 1_199, 4_001, 3, 999)
+    var chunkIndex = 0
+    while (offset < audio.size) {
+      val size = minOf(chunkSizes[chunkIndex % chunkSizes.size], audio.size - offset)
+      collected.write(piecemeal.convert(audio.copyOfRange(offset, offset + size), size))
+      offset += size
+      chunkIndex += 1
+    }
+
+    assertArrayEquals(oneShot, collected.toByteArray())
+  }
+
+  @Test
+  fun aZeroLengthReadDoesNotDisturbACarriedByte() {
+    val audio = pcm16Bytes(sine(freqHz = 300.0, sampleRateHz = 48_000, count = 4_800, amplitude = 15_000.0))
+    val oneShot = resolveRealtimeCaptureResampler(48_000, 24_000)!!.convert(audio, audio.size)
+
+    val piecemeal = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val collected = ByteArrayOutputStream()
+    collected.write(piecemeal.convert(audio.copyOfRange(0, 101), 101))
+    collected.write(piecemeal.convert(ByteArray(0), 0))
+    collected.write(piecemeal.convert(audio.copyOfRange(101, audio.size), audio.size - 101))
+
+    assertArrayEquals(oneShot, collected.toByteArray())
+  }
+
+  @Test
+  fun converterStateIsRetainedWithinASessionAndScopedToTheInstance() {
+    val first = pcm16Bytes(sine(freqHz = 900.0, sampleRateHz = 48_000, count = 4_800, amplitude = 15_000.0))
+    val second = pcm16Bytes(sine(freqHz = 300.0, sampleRateHz = 48_000, count = 4_800, amplitude = 15_000.0))
+
+    val freshA = resolveRealtimeCaptureResampler(48_000, 24_000)!!.convert(second, second.size)
+    val freshB = resolveRealtimeCaptureResampler(48_000, 24_000)!!.convert(second, second.size)
+    assertArrayEquals("two new sessions must agree", freshA, freshB)
+
+    val carriedOver = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    carriedOver.convert(first, first.size)
+    val afterPriorAudio = carriedOver.convert(second, second.size)
+
+    // Filter history really is retained inside an instance -- which is exactly why a restart must
+    // get a new one. That a capture restart does build a new one is a property of the manager, and
+    // is covered by aCaptureInstallBuildsItsConverterFromTheNegotiatedRate below.
+    assertNotEquals(freshA.toList(), afterPriorAudio.toList())
+  }
+
+  // ---- DSP properties the production path depends on --------------------------------------
+
+  @Test
+  fun outOfBandContentIsRejectedRatherThanFoldedBackIntoSpeech() {
+    // 18 kHz at a 48 kHz capture rate lands at 6 kHz -- squarely in the speech band -- if the
+    // stream is simply decimated. Anti-aliasing before decimating is the whole reason the
+    // converter is not a sample-dropping loop.
+    val tone = sine(freqHz = 18_000.0, sampleRateHz = 48_000, count = 48_000, amplitude = 20_000.0)
+    val filtered = decodePcm16(resolveRealtimeCaptureResampler(48_000, 24_000)!!.convert(pcm16Bytes(tone), tone.size * 2))
+    val naive = ShortArray(tone.size / 2) { tone[it * 2] }
+
+    val filteredRms = rms(filtered, skip = 200)
+    val naiveRms = rms(naive, skip = 200)
+
+    assertTrue("naive decimation should keep the aliased tone, got $naiveRms", naiveRms > 10_000.0)
+    assertTrue("alias survived filtering: filtered=$filteredRms naive=$naiveRms", filteredRms < naiveRms * 0.05)
+  }
+
+  @Test
+  fun inBandSpeechKeepsItsLevel() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val tone = sine(freqHz = 300.0, sampleRateHz = 48_000, count = 48_000, amplitude = 12_000.0)
+
+    val converted = decodePcm16(resampler.convert(pcm16Bytes(tone), tone.size * 2))
+
+    val expectedRms = 12_000.0 / sqrt(2.0)
+    val actualRms = rms(converted, skip = 200)
+    assertTrue("300 Hz lost level: expected ~$expectedRms got $actualRms", actualRms > expectedRms * 0.97)
+    assertTrue("300 Hz gained level: expected ~$expectedRms got $actualRms", actualRms < expectedRms * 1.03)
+  }
+
+  @Test
+  fun aConstantSignalPassesThroughAtUnityGain() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    val dc = ShortArray(9_600) { 1_000 }
+
+    val converted = decodePcm16(resampler.convert(pcm16Bytes(dc), dc.size * 2))
+
+    // Past the filter's start-up transient the output must be the input value, not a scaled one.
+    for (index in 200 until converted.size) {
+      assertEquals("sample $index", 1_000, converted[index].toInt())
+    }
+  }
+
+  @Test
+  fun filterOvershootSaturatesInsteadOfWrapping() {
+    val resampler = resolveRealtimeCaptureResampler(48_000, 24_000)!!
+    // A step to full scale makes a windowed-sinc ring past the rail on the far side of the edge.
+    // Real capture reaches full scale on loud speech, so this is the signal shape that decides
+    // whether that overshoot is saturated or truncated.
+    val step = ShortArray(9_600) { index -> if (index < 96) 0 else Short.MAX_VALUE }
+
+    val converted = decodePcm16(resampler.convert(pcm16Bytes(step), step.size * 2))
+
+    assertTrue(converted.isNotEmpty())
+    // Ringing around the edge is a few percent of full scale and correct. Truncating instead of
+    // saturating turns an overshoot of 32767+n into roughly -32768+n, which is not a few percent.
+    val lowest = converted.minOrNull()!!
+    assertTrue("overshoot wrapped to $lowest", lowest > -16_000)
+    assertEquals("the output never reached the rail, so clamping was not exercised", Short.MAX_VALUE, converted.maxOrNull())
+    assertEquals(Short.MAX_VALUE, converted.last())
+  }
+}
+
+// ---- helpers --------------------------------------------------------------------------------
+
+private fun jsonObject(payload: String): JsonObject = Json.parseToJsonElement(payload) as JsonObject
+
+private class FakeCaptureCandidate(
+  override val actualSampleRateHz: Int,
+) : RealtimeCaptureCandidate {
+  var closeCalls = 0
+
+  override fun close() {
+    closeCalls += 1
+  }
+}
+
+/** Records what was asked for and what was handed back, so leaks and retries are observable. */
+private class FakeCaptureOpener(
+  private val negotiate: (requestedSampleRateHz: Int) -> Int,
+) {
+  val requestedRates = mutableListOf<Int>()
+  val opened = mutableListOf<FakeCaptureCandidate>()
+
+  fun open(requestedSampleRateHz: Int): FakeCaptureCandidate {
+    requestedRates += requestedSampleRateHz
+    val actual = negotiate(requestedSampleRateHz)
+    return FakeCaptureCandidate(actual).also { opened += it }
+  }
+}
+
+private fun sine(
+  freqHz: Double,
+  sampleRateHz: Int,
+  count: Int,
+  amplitude: Double,
+): ShortArray = ShortArray(count) { index -> (sin(2.0 * PI * freqHz * index / sampleRateHz) * amplitude).roundToInt().toShort() }
+
+private fun pcm16Bytes(samples: ShortArray): ByteArray {
+  val bytes = ByteArray(samples.size * 2)
+  for (index in samples.indices) {
+    val sample = samples[index].toInt()
+    bytes[index * 2] = (sample and 0xff).toByte()
+    bytes[index * 2 + 1] = ((sample shr 8) and 0xff).toByte()
+  }
+  return bytes
+}
+
+private fun decodePcm16(bytes: ByteArray): ShortArray =
+  ShortArray(bytes.size / 2) { index ->
+    val low = bytes[index * 2].toInt() and 0xff
+    val high = bytes[index * 2 + 1].toInt()
+    (low or (high shl 8)).toShort()
+  }
+
+private fun rms(
+  samples: ShortArray,
+  skip: Int,
+): Double {
+  var total = 0.0
+  var counted = 0
+  for (index in skip until samples.size) {
+    val value = samples[index].toDouble()
+    total += value * value
+    counted += 1
+  }
+  return if (counted == 0) 0.0 else sqrt(total / counted)
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCommunicationAudioTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCommunicationAudioTest.kt
@@ -1,0 +1,405 @@
+package ai.openclaw.app.voice
+
+import android.media.AudioAttributes
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.media.MediaRecorder
+import android.media.audiofx.AcousticEchoCanceler
+import android.media.audiofx.AudioEffect
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadows.AudioDeviceInfoBuilder
+import org.robolectric.shadows.ShadowAudioEffect
+import org.robolectric.shadows.ShadowAudioManager
+import org.robolectric.shadows.ShadowAudioRecord
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Covers the communication-audio session realtime Talk owns: the capture profile, the platform
+ * echo canceller and the read-back that decides whether the uplink may stay open, the
+ * communication mode, and the communication output route.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], shadows = [ShadowObservableAudioEffect::class])
+class RealtimeCommunicationAudioTest {
+  @Before
+  fun setUp() {
+    ShadowObservableAudioEffect.clearObservations()
+  }
+
+  @After
+  fun tearDown() {
+    ShadowAudioRecord.clearSource()
+    ShadowAudioEffect.reset()
+  }
+
+  // ---- capture profile ---------------------------------------------------------------------
+
+  @Test
+  fun theTwoCaptureProfilesMapToTheirAndroidAudioSources() {
+    assertEquals(MediaRecorder.AudioSource.VOICE_COMMUNICATION, AndroidAudioInputProfile.VoiceCommunication.audioSource)
+    assertEquals(MediaRecorder.AudioSource.VOICE_RECOGNITION, AndroidAudioInputProfile.VoiceRecognition.audioSource)
+  }
+
+  @Test
+  fun aSessionOpenedWithoutAProfileStaysOnRecognitionCapture() {
+    // Manual Mic/STT and push-to-talk call open() without naming a profile. They must not be
+    // migrated onto communication capture as a side effect of realtime Talk adopting it.
+    val sources = recordCaptureSources()
+
+    AndroidAudioInputSession.open(app(), 8_000, 1_600).use { session ->
+      readOneFrame(session)
+      assertEquals(listOf(MediaRecorder.AudioSource.VOICE_RECOGNITION), sources)
+    }
+  }
+
+  @Test
+  fun aCommunicationProfileSessionOpensCommunicationCapture() {
+    val sources = recordCaptureSources()
+
+    openCommunicationCapture().use { session ->
+      readOneFrame(session)
+      assertEquals(listOf(MediaRecorder.AudioSource.VOICE_COMMUNICATION), sources)
+    }
+  }
+
+  // ---- echo canceller ----------------------------------------------------------------------
+
+  @Test
+  fun anEchoCancellerThePlatformEnablesMakesTheCapabilityTrue() {
+    installPlatformEchoCanceler()
+
+    openCommunicationCapture().use { session ->
+      assertTrue(session.communicationEchoCancellationEnabled)
+    }
+  }
+
+  @Test
+  fun anEchoCancellerThePlatformRefusesToEnableMakesTheCapabilityFalse() {
+    ShadowObservableAudioEffect.refuseEnable = true
+    // create() succeeded and the effect object exists; only the read-back says it is not running.
+    // Anything that trusted create() instead would open the uplink into an uncancelled speaker.
+    installPlatformEchoCanceler()
+
+    openCommunicationCapture().use { session ->
+      assertTrue("the effect was reachable, so this is a read-back result", AcousticEchoCanceler.isAvailable())
+      assertFalse(session.communicationEchoCancellationEnabled)
+    }
+  }
+
+  @Test
+  fun aDeviceWithNoEchoCancellerStillCapturesAndReportsNoCapability() {
+    // No effect registered, so AcousticEchoCanceler.isAvailable() is false.
+    openCommunicationCapture().use { session ->
+      assertFalse(session.communicationEchoCancellationEnabled)
+      assertEquals(48_000, session.actualSampleRateHz)
+    }
+  }
+
+  @Test
+  fun theCapabilityIsReadLiveSoItCanFallBackWithinASession() {
+    installPlatformEchoCanceler()
+
+    openCommunicationCapture().use { session ->
+      assertTrue(session.communicationEchoCancellationEnabled)
+
+      // A route change under a running recorder can take the canceller away. A capability that
+      // was snapshotted at open could never answer that, and the uplink would stay open.
+      ShadowObservableAudioEffect.forceDisabled = true
+
+      assertFalse(session.communicationEchoCancellationEnabled)
+    }
+  }
+
+  @Test
+  fun aClosedSessionReportsNoEchoCancellation() {
+    installPlatformEchoCanceler()
+    val session = openCommunicationCapture()
+    assertTrue(session.communicationEchoCancellationEnabled)
+
+    session.close()
+
+    assertFalse(session.communicationEchoCancellationEnabled)
+  }
+
+  @Test
+  fun theEchoCancellerIsReleasedWithTheCaptureSession() {
+    installPlatformEchoCanceler()
+    val session = openCommunicationCapture()
+    assertTrue(session.communicationEchoCancellationEnabled)
+    assertEquals(0, ShadowObservableAudioEffect.releaseCount)
+
+    session.close()
+
+    // The effect belongs to the recorder's lifetime: it must not outlive the session that owns it.
+    assertEquals(1, ShadowObservableAudioEffect.releaseCount)
+  }
+
+  // ---- communication mode ------------------------------------------------------------------
+
+  @Test
+  fun communicationModeIsEnteredOnceAndRestoredOnTeardown() {
+    val audioManager = audioManager()
+    audioManager.mode = AudioManager.MODE_NORMAL
+    val owner = RealtimeCommunicationAudioOwner()
+
+    val token = owner.enter(audioManager)
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+
+    owner.restore(audioManager, token)
+    assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+  }
+
+  @Test
+  fun communicationAudioFocusIsHeldForTheSessionAndReleasedWithIt() {
+    // Without focus another app keeps playing into the same loudspeaker the platform canceller
+    // uses as its reference -- the one signal it cannot subtract.
+    val audioManager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+
+    val token = owner.enter(audioManager)
+    val held = shadowOf(audioManager).lastAudioFocusRequest
+    assertEquals(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT, held.audioFocusRequest.focusGain)
+    assertEquals(AudioAttributes.USAGE_VOICE_COMMUNICATION, held.audioFocusRequest.audioAttributes.usage)
+
+    owner.restore(audioManager, token)
+
+    assertEquals(held.audioFocusRequest, shadowOf(audioManager).lastAbandonedAudioFocusRequest)
+  }
+
+  @Test
+  fun aSecondAcquisitionDoesNotRecordCommunicationModeAsTheModeToRestore() {
+    // A stop racing a restart would otherwise capture MODE_IN_COMMUNICATION as "the previous
+    // mode" and hand the device back still in it, long after Talk ended.
+    val audioManager = audioManager()
+    audioManager.mode = AudioManager.MODE_NORMAL
+    val owner = RealtimeCommunicationAudioOwner()
+
+    owner.enter(audioManager)
+    val second = owner.enter(audioManager)
+    owner.restore(audioManager, second)
+
+    assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+  }
+
+  @Test
+  fun aStaleOwnerCannotRestoreModeOverALiveSession() {
+    val audioManager = audioManager()
+    audioManager.mode = AudioManager.MODE_NORMAL
+    val owner = RealtimeCommunicationAudioOwner()
+
+    val stale = owner.enter(audioManager)
+    owner.enter(audioManager)
+    owner.restore(audioManager, stale)
+
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+  }
+
+  @Test
+  fun aSessionThatNeverAcquiredTheModeRestoresNothing() {
+    val audioManager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    owner.enter(audioManager)
+
+    owner.restore(audioManager, RealtimeCommunicationAudioOwner.NO_OWNER)
+
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+  }
+
+  // ---- playback attributes -----------------------------------------------------------------
+
+  @Test
+  fun realtimePlaybackUsesCommunicationAttributes() {
+    val attributes = realtimeCommunicationPlaybackAttributes()
+
+    assertEquals(AudioAttributes.USAGE_VOICE_COMMUNICATION, attributes.usage)
+    assertEquals(AudioAttributes.CONTENT_TYPE_SPEECH, attributes.contentType)
+  }
+
+  // ---- communication output route ------------------------------------------------------------
+
+  @Test
+  fun handsFreeTalkOnAHandsetRequestsTheBuiltInSpeaker() {
+    // Left to itself the phone strategy sends communication audio to the earpiece, which is the
+    // difference between hands-free Talk and holding the device to your ear.
+    setAvailableCommunicationDevices(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+
+    openCommunicationCapture().use { session ->
+      assertEquals(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, session.appliedCommunicationDeviceType)
+      assertEquals(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, audioManager().communicationDevice?.type)
+    }
+  }
+
+  @Test
+  fun anAlwaysPresentUnrelatedOutputDoesNotDisableTheHandsFreeOverride() {
+    // Telephony is simply always there on a handset. Treating anything that is not the built-in
+    // pair as a deliberate choice would leave hands-free Talk on the earpiece for whole device
+    // classes, with nothing distinguishing it from working.
+    setAvailableCommunicationDevices(
+      AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+      AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
+      AudioDeviceInfo.TYPE_TELEPHONY,
+    )
+
+    openCommunicationCapture().use { session ->
+      assertEquals(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, session.appliedCommunicationDeviceType)
+    }
+  }
+
+  @Test
+  fun anExternalCommunicationOutputIsNotStolen() {
+    // A wired headset already outranks the earpiece, so there is nothing to correct and taking
+    // the route would move audio to the loudspeaker while someone is wearing headphones.
+    setAvailableCommunicationDevices(
+      AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+      AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
+      AudioDeviceInfo.TYPE_WIRED_HEADSET,
+    )
+
+    openCommunicationCapture().use { session ->
+      assertNull(session.appliedCommunicationDeviceType)
+    }
+  }
+
+  @Test
+  fun recognitionCaptureNeverTakesTheCommunicationOutput() {
+    setAvailableCommunicationDevices(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+
+    AndroidAudioInputSession.open(app(), 8_000, 1_600).use { session ->
+      assertNull(session.appliedCommunicationDeviceType)
+    }
+  }
+
+  @Test
+  fun aRouteRequestThePlatformRefusesIsNotReportedAsAcquired() {
+    setAvailableCommunicationDevices(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+    shadowOf(audioManager()).lockCommunicationDevice(true)
+
+    openCommunicationCapture().use { session ->
+      assertNull(session.appliedCommunicationDeviceType)
+    }
+  }
+
+  @Test
+  @Config(shadows = [ShadowAcceptingButNotApplyingAudioManager::class])
+  fun aRouteRequestThePlatformAcceptsButDoesNotApplyIsNotReportedAsAcquired() {
+    // setCommunicationDevice returning true is a request being accepted, not a route being held.
+    // Only what the platform says it selected may be reported as the route Talk is on.
+    setAvailableCommunicationDevices(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+
+    openCommunicationCapture().use { session ->
+      assertNull(session.appliedCommunicationDeviceType)
+    }
+  }
+
+  // ---- helpers -------------------------------------------------------------------------------
+
+  private fun app() = RuntimeEnvironment.getApplication()
+
+  private fun audioManager() = app().getSystemService(AudioManager::class.java)
+
+  private fun openCommunicationCapture(): AndroidAudioInputSession =
+    AndroidAudioInputSession.open(
+      app(),
+      48_000,
+      9_600,
+      profile = AndroidAudioInputProfile.VoiceCommunication,
+    )
+
+  /** Makes AcousticEchoCanceler.isAvailable() true for this test. */
+  private fun installPlatformEchoCanceler() {
+    ShadowAudioEffect.addEffect(
+      AudioEffect.Descriptor(
+        AudioEffect.EFFECT_TYPE_AEC.toString(),
+        "9a2f0f34-1c5e-4d3a-9b64-3a1b2c4d5e6f",
+        AudioEffect.EFFECT_INSERT,
+        "Test AEC",
+        "Robolectric",
+      ),
+    )
+  }
+
+  private fun recordCaptureSources(): List<Int> {
+    val sources = CopyOnWriteArrayList<Int>()
+    ShadowAudioRecord.setSourceProvider { record ->
+      sources += record.audioSource
+      object : ShadowAudioRecord.AudioRecordSource {
+        override fun readInByteArray(
+          audioData: ByteArray,
+          offsetInBytes: Int,
+          sizeInBytes: Int,
+          isBlocking: Boolean,
+        ): Int = sizeInBytes
+      }
+    }
+    return sources
+  }
+
+  /** The shadow consults its source provider on the first read, not when the recorder is built. */
+  private fun readOneFrame(session: AndroidAudioInputSession) {
+    session.startRecording()
+    session.read(ByteArray(64), 0, 64)
+  }
+
+  private fun setAvailableCommunicationDevices(vararg types: Int) {
+    val devices = types.map { type -> AudioDeviceInfoBuilder.newBuilder().setType(type).build() }
+    shadowOf(audioManager()).setAvailableCommunicationDevices(devices)
+  }
+}
+
+/** Accepts every communication-device request and then holds none of them. */
+@Implements(AudioManager::class)
+class ShadowAcceptingButNotApplyingAudioManager : ShadowAudioManager() {
+  @Implementation
+  override fun setCommunicationDevice(device: AudioDeviceInfo): Boolean = true
+
+  @Implementation
+  override fun getCommunicationDevice(): AudioDeviceInfo? = null
+}
+
+/**
+ * One AudioEffect shadow for every echo-canceller behavior this suite needs: refusing to enable,
+ * losing its enabled state mid-session, and being released. Applied at class level so all tests
+ * share one Robolectric sandbox, which is what keeps these statics observable.
+ */
+@Implements(AudioEffect::class)
+class ShadowObservableAudioEffect : ShadowAudioEffect() {
+  @Implementation
+  override fun native_setEnabled(enabled: Boolean): Int = if (refuseEnable) AudioEffect.ERROR_INVALID_OPERATION else super.native_setEnabled(enabled)
+
+  @Implementation
+  override fun native_getEnabled(): Boolean = !forceDisabled && super.native_getEnabled()
+
+  @Implementation
+  override fun native_release() {
+    releaseCount += 1
+    super.native_release()
+  }
+
+  companion object {
+    @JvmStatic var refuseEnable = false
+
+    @JvmStatic var forceDisabled = false
+
+    @JvmStatic var releaseCount = 0
+
+    @JvmStatic
+    fun clearObservations() {
+      refuseEnable = false
+      forceDisabled = false
+      releaseCount = 0
+    }
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCommunicationAudioTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCommunicationAudioTest.kt
@@ -9,6 +9,7 @@ import android.media.audiofx.AudioEffect
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -109,17 +110,75 @@ class RealtimeCommunicationAudioTest {
   }
 
   @Test
-  fun theCapabilityIsReadLiveSoItCanFallBackWithinASession() {
+  fun losingTheCancellerMidSessionShrinksTheCapabilityOnTheNextRefresh() {
     installPlatformEchoCanceler()
 
     openCommunicationCapture().use { session ->
       assertTrue(session.communicationEchoCancellationEnabled)
 
-      // A route change under a running recorder can take the canceller away. A capability that
-      // was snapshotted at open could never answer that, and the uplink would stay open.
+      // A route change under a running recorder can take the canceller away. The capability is
+      // cached rather than measured per read, so it shrinks when its owner re-measures -- but it
+      // must actually shrink, or the uplink would stay open on a route with no canceller.
       ShadowObservableAudioEffect.forceDisabled = true
 
+      assertFalse(session.refreshCommunicationEchoCancellation())
       assertFalse(session.communicationEchoCancellationEnabled)
+    }
+  }
+
+  @Test
+  fun readingTheCapabilityCostsNoEffectIpc() {
+    // The capture loop consults this once per frame. Measuring the effect there would take the
+    // session lifecycle lock, which a route refresh holds across several AudioManager binder
+    // calls -- putting a route change on the critical path of AudioRecord.read.
+    installPlatformEchoCanceler()
+
+    openCommunicationCapture().use { session ->
+      val baseline = ShadowObservableAudioEffect.getEnabledCount
+
+      repeat(500) { assertTrue(session.communicationEchoCancellationEnabled) }
+
+      assertEquals("500 capability reads must issue zero effect reads", baseline, ShadowObservableAudioEffect.getEnabledCount)
+
+      // ...and the explicit refresh is the one thing that does pay for an IPC.
+      session.refreshCommunicationEchoCancellation()
+      assertTrue(ShadowObservableAudioEffect.getEnabledCount > baseline)
+    }
+  }
+
+  @Test
+  fun capabilityReadsStayFastWhileTheEffectIsBeingReMeasuredConcurrently() {
+    // The regression this pins: the getter used to take the same lifecycle lock refreshRoute
+    // holds across its AudioManager binder calls, so a slow route change stalled the capture read
+    // loop. Now only the re-measure takes that lock; readers never contend with it.
+    installPlatformEchoCanceler()
+
+    openCommunicationCapture().use { session ->
+      val stop =
+        java.util.concurrent.atomic
+          .AtomicBoolean(false)
+      val failure =
+        java.util.concurrent.atomic
+          .AtomicReference<Throwable?>(null)
+      val refresher =
+        Thread {
+          runCatching {
+            while (!stop.get()) session.refreshCommunicationEchoCancellation()
+          }.onFailure(failure::set)
+        }
+      refresher.start()
+      try {
+        val startedAtMs = System.nanoTime()
+        // Far more reads than a real session performs in a route-change window (one per 100 ms
+        // frame), so a reader that contended for the lock could not finish this quickly.
+        repeat(20_000) { session.communicationEchoCancellationEnabled }
+        val elapsedMs = (System.nanoTime() - startedAtMs) / 1_000_000
+        assertTrue("20000 capability reads took ${elapsedMs}ms against a concurrent re-measure", elapsedMs < 1_000)
+      } finally {
+        stop.set(true)
+        refresher.join(5_000)
+      }
+      assertNull(failure.get())
     }
   }
 
@@ -205,6 +264,263 @@ class RealtimeCommunicationAudioTest {
     owner.restore(audioManager, stale)
 
     assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+  }
+
+  @Test
+  fun ownershipIsClaimedOnlyWhenTheModeReadsBackAsCommunication() {
+    val owner = RealtimeCommunicationAudioOwner()
+
+    val token = owner.enter(audioManager())
+
+    assertTrue("a confirmed read-back must yield a real token", token != RealtimeCommunicationAudioOwner.NO_OWNER)
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager().mode)
+    assertTrue(owner.communicationModeActive)
+  }
+
+  @Test
+  @Config(shadows = [ShadowForeignModeOwnerAudioManager::class])
+  fun aModeSetterThatSilentlyLosesToAnotherOwnerYieldsNoOwnership() {
+    // AudioManager.mode is a void setter recording a per-app request. Another app can hold the
+    // mode and this setter still returns normally. Treating "did not throw" as ownership is what
+    // let full duplex open against a speaker the canceller had no reference for.
+    val owner = RealtimeCommunicationAudioOwner()
+
+    val token = owner.enter(audioManager())
+
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, token)
+    assertFalse(owner.communicationModeActive)
+  }
+
+  @Test
+  @Config(shadows = [ShadowThrowingModeAudioManager::class])
+  fun aModeSetterThatThrowsYieldsNoOwnership() {
+    val owner = RealtimeCommunicationAudioOwner()
+
+    val token = owner.enter(audioManager())
+
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, token)
+    assertFalse(owner.communicationModeActive)
+  }
+
+  @Test
+  fun focusDenialPreventsModeOwnershipAndLeavesTheModeAlone() {
+    // Focus is requested before the mode precisely so this case can decline without having
+    // touched device state: without focus this app is not the one the platform routes around.
+    shadowOf(audioManager()).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
+    val before = audioManager().mode
+    val owner = RealtimeCommunicationAudioOwner()
+
+    val token = owner.enter(audioManager())
+
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, token)
+    assertFalse(owner.communicationModeActive)
+    assertEquals("a denied acquisition must not move the device mode", before, audioManager().mode)
+  }
+
+  @Test
+  @Config(shadows = [ShadowForeignModeOwnerAudioManager::class])
+  fun aFailedAcquisitionReleasesTheFocusItTookAndUndoesItsOwnModeWrite() {
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(manager))
+
+    // It requested focus, so it must hand it back; leaving it held would duck other apps for a
+    // session that never started.
+    assertNotNull("the failed attempt must abandon its own focus request", shadowOf(manager).lastAbandonedAudioFocusRequest)
+  }
+
+  @Test
+  @Config(shadows = [ShadowToggleableModeOwnerAudioManager::class])
+  fun aFailedAcquisitionCannotDisturbALiveOwner() {
+    // Shared with the other test using this shadow: same sandbox, so the same static.
+    ShadowToggleableModeOwnerAudioManager.foreignOwner = false
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    val live = owner.enter(manager)
+    assertTrue(live != RealtimeCommunicationAudioOwner.NO_OWNER)
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+
+    // Something else takes the mode, so the next acquisition cannot read it back. It must not
+    // reach over the session that is still running to "undo" a write that is not its own.
+    ShadowToggleableModeOwnerAudioManager.foreignOwner = true
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(manager))
+
+    // The capability correctly shrinks -- the attempt just read the device back as not in
+    // communication mode, and that evidence must reach the full-duplex gate immediately rather
+    // than waiting for the next watcher tick.
+    assertFalse("a refuted read-back must close full duplex", owner.communicationModeActive)
+    assertFalse(owner.communicationModeActiveUnsynchronized)
+
+    // What must NOT happen is the live owner losing its token, its focus, or its mode: the failed
+    // attempt may not reach over a session that is still running.
+    ShadowToggleableModeOwnerAudioManager.foreignOwner = false
+    assertEquals("the failed attempt must not have rewritten the mode", AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+    assertNull("the live owner's focus must not be abandoned", shadowOf(manager).lastAbandonedAudioFocusRequest)
+
+    owner.restore(manager, RealtimeCommunicationAudioOwner.NO_OWNER)
+    assertEquals("NO_OWNER must never restore", AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+
+    // The live token still works, which is the property that keeps teardown able to unwind.
+    owner.restore(manager, live)
+    assertFalse(owner.communicationModeActive)
+    assertNotNull("teardown must abandon the focus the live owner held", shadowOf(manager).lastAbandonedAudioFocusRequest)
+  }
+
+  @Test
+  @Config(shadows = [ShadowToggleableModeOwnerAudioManager::class])
+  fun losingTheModeMidSessionDropsOwnershipSoTheCapabilityCanShrink() {
+    ShadowToggleableModeOwnerAudioManager.foreignOwner = false
+    // Acquisition proves ownership at one instant. If another app takes the mode afterwards the
+    // canceller is no longer referencing this session's downlink, and full duplex must close.
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    val token = owner.enter(manager)
+    assertTrue(token != RealtimeCommunicationAudioOwner.NO_OWNER)
+    assertTrue(owner.verifyCommunicationModeActive(manager))
+
+    ShadowToggleableModeOwnerAudioManager.foreignOwner = true
+
+    assertFalse("a lost mode must close full duplex", owner.verifyCommunicationModeActive(manager))
+    assertFalse(owner.communicationModeActive)
+
+    // The token must still work. Marking the mode lost by nulling the owner would orphan it:
+    // teardown would abandon no focus and withdraw no mode request, leaving every other app
+    // ducked and this process's stale request standing.
+    ShadowToggleableModeOwnerAudioManager.foreignOwner = false
+    owner.restore(manager, token)
+    assertNotNull("teardown must still abandon focus after a lost mode", shadowOf(manager).lastAbandonedAudioFocusRequest)
+    assertEquals("teardown must still withdraw the mode request", AudioManager.MODE_NORMAL, manager.mode)
+  }
+
+  @Test
+  fun aTransientFocusRefusalIsRecoveredRatherThanLeavingTheSessionHalfDuplex() {
+    // Focus denial is fatal to the mode, so a notification chime at the wrong instant would
+    // otherwise leave a whole Talk session half duplex with only a log line to show for it.
+    val manager = audioManager()
+    shadowOf(manager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
+    val owner = RealtimeCommunicationAudioOwner()
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(manager))
+    assertFalse(owner.communicationModeActive)
+    assertFalse(owner.communicationModeActiveUnsynchronized)
+
+    shadowOf(manager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
+    val recovered = owner.retryIfUnclaimed(manager)
+
+    assertTrue("the retry must claim the mode once focus is available", recovered != RealtimeCommunicationAudioOwner.NO_OWNER)
+    assertTrue(owner.communicationModeActive)
+    assertTrue("the lock-free mirror must track it", owner.communicationModeActiveUnsynchronized)
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+
+    // And a retry against a session that already holds it must be a no-op, not a second claim.
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.retryIfUnclaimed(manager))
+  }
+
+  @Test
+  @Config(shadows = [ShadowAcceptingButNotApplyingAudioManager::class])
+  fun aCommunicationDeviceTheReadBackDoesNotConfirmIsReportedUnheldButLeftStanding() {
+    // Reported honestly as not confirmed, and deliberately NOT torn down: setCommunicationDevice
+    // accepted the request, and on Bluetooth the link comes up asynchronously, so an immediately
+    // disagreeing read-back is the expected transient. Clearing it would cancel a route that was
+    // about to establish, and the resulting device callbacks would re-request it in a loop.
+    ShadowAcceptingButNotApplyingAudioManager.clearCalls = 0
+    setAvailableCommunicationDevices(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+
+    openCommunicationCapture().use { session ->
+      assertNull("an unconfirmed route must not be reported as held", session.appliedCommunicationDeviceType)
+      assertEquals(
+        "an unconfirmed route must not be torn down",
+        0,
+        ShadowAcceptingButNotApplyingAudioManager.clearCalls,
+      )
+    }
+  }
+
+  @Test
+  @Config(shadows = [ShadowForeignModeOwnerAudioManager::class])
+  fun aModeRefusalIsNeverRetriedSoItCannotThrashAudioFocus() {
+    // Retrying a mode refusal re-acquires and re-abandons focus on every watcher tick, which
+    // pauses and resumes whatever else is playing twice a second for the whole session. Half
+    // duplex is the correct answer here, not a retry loop.
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(manager))
+
+    repeat(10) {
+      assertEquals(
+        "a mode refusal must not be retried",
+        RealtimeCommunicationAudioOwner.NO_OWNER,
+        owner.retryIfUnclaimed(manager),
+      )
+    }
+    assertFalse(owner.communicationModeActive)
+  }
+
+  @Test
+  fun theFocusRetryBudgetIsBoundedSoADevicePermanentlyRefusingFocusStopsBeingAsked() {
+    val manager = audioManager()
+    shadowOf(manager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
+    val owner = RealtimeCommunicationAudioOwner()
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(manager))
+
+    var attempts = 0
+    repeat(50) {
+      if (owner.retryIfUnclaimed(manager) == RealtimeCommunicationAudioOwner.NO_OWNER && attempts < 50) attempts += 1
+    }
+
+    // Bounded: the budget runs out and the owner stops asking rather than retrying forever.
+    assertFalse(owner.communicationModeActive)
+    shadowOf(manager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
+    assertEquals(
+      "an exhausted budget must not resume retrying",
+      RealtimeCommunicationAudioOwner.NO_OWNER,
+      owner.retryIfUnclaimed(manager),
+    )
+  }
+
+  @Test
+  fun findingTheDeviceAlreadyInCommunicationModeDoesNotMakeTeardownReAssertIt() {
+    // getMode() reports the device's effective mode; setMode records this app's request. Replaying
+    // the first as the second is how a session that merely *found* the device in communication
+    // mode -- because another app left it there -- ends up holding a standing request of its own
+    // that nothing ever withdraws, keeping the device on the communication path indefinitely.
+    val manager = audioManager()
+    manager.mode = AudioManager.MODE_IN_COMMUNICATION
+    val owner = RealtimeCommunicationAudioOwner()
+
+    val token = owner.enter(manager)
+    assertTrue(token != RealtimeCommunicationAudioOwner.NO_OWNER)
+
+    owner.restore(manager, token)
+
+    assertEquals(
+      "teardown must withdraw this app's request, not re-assert communication mode",
+      AudioManager.MODE_NORMAL,
+      manager.mode,
+    )
+    assertFalse(owner.communicationModeActive)
+  }
+
+  @Test
+  fun teardownWithdrawsToNormalWhateverModeTheDeviceWasFoundIn() {
+    // Withdrawing this app's request means asking for normal. Replaying the mode that happened to
+    // be effective at start would have a non-telephony app asserting MODE_IN_CALL or
+    // MODE_RINGTONE as its own standing request -- the same shape as the communication-mode
+    // replay, just for a different value. Since API 31 the platform arbitrates per-app requests,
+    // so asking for normal withdraws only this entry and cannot unseat the app that owns the mode.
+    for (found in listOf(AudioManager.MODE_RINGTONE, AudioManager.MODE_IN_CALL, AudioManager.MODE_NORMAL)) {
+      val manager = audioManager()
+      manager.mode = found
+      val owner = RealtimeCommunicationAudioOwner()
+
+      val token = owner.enter(manager)
+      assertTrue("found=$found", token != RealtimeCommunicationAudioOwner.NO_OWNER)
+      assertEquals(AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+
+      owner.restore(manager, token)
+
+      assertEquals("found=$found must be withdrawn to normal", AudioManager.MODE_NORMAL, manager.mode)
+    }
   }
 
   @Test
@@ -359,6 +675,43 @@ class RealtimeCommunicationAudioTest {
   }
 }
 
+/** Accepts the mode write, but the mode belongs to somebody else -- the read-back says so. */
+@Implements(AudioManager::class)
+class ShadowForeignModeOwnerAudioManager : ShadowAudioManager() {
+  @Implementation
+  override fun setMode(mode: Int) {
+    // Recorded by the platform as a request and then lost to the current owner.
+  }
+
+  @Implementation
+  override fun getMode(): Int = AudioManager.MODE_NORMAL
+}
+
+/** Applies the mode write until [foreignOwner] is set, after which the read-back stops agreeing. */
+@Implements(AudioManager::class)
+class ShadowToggleableModeOwnerAudioManager : ShadowAudioManager() {
+  private var requested = AudioManager.MODE_NORMAL
+
+  @Implementation
+  override fun setMode(mode: Int) {
+    requested = mode
+  }
+
+  @Implementation
+  override fun getMode(): Int = if (foreignOwner) AudioManager.MODE_NORMAL else requested
+
+  companion object {
+    @JvmStatic var foreignOwner = false
+  }
+}
+
+/** Refuses the mode write outright. */
+@Implements(AudioManager::class)
+class ShadowThrowingModeAudioManager : ShadowAudioManager() {
+  @Implementation
+  override fun setMode(mode: Int): Unit = throw SecurityException("mode denied")
+}
+
 /** Accepts every communication-device request and then holds none of them. */
 @Implements(AudioManager::class)
 class ShadowAcceptingButNotApplyingAudioManager : ShadowAudioManager() {
@@ -367,6 +720,15 @@ class ShadowAcceptingButNotApplyingAudioManager : ShadowAudioManager() {
 
   @Implementation
   override fun getCommunicationDevice(): AudioDeviceInfo? = null
+
+  @Implementation
+  override fun clearCommunicationDevice() {
+    clearCalls += 1
+  }
+
+  companion object {
+    @JvmStatic var clearCalls = 0
+  }
 }
 
 /**
@@ -380,7 +742,10 @@ class ShadowObservableAudioEffect : ShadowAudioEffect() {
   override fun native_setEnabled(enabled: Boolean): Int = if (refuseEnable) AudioEffect.ERROR_INVALID_OPERATION else super.native_setEnabled(enabled)
 
   @Implementation
-  override fun native_getEnabled(): Boolean = !forceDisabled && super.native_getEnabled()
+  override fun native_getEnabled(): Boolean {
+    getEnabledCount += 1
+    return !forceDisabled && super.native_getEnabled()
+  }
 
   @Implementation
   override fun native_release() {
@@ -395,11 +760,15 @@ class ShadowObservableAudioEffect : ShadowAudioEffect() {
 
     @JvmStatic var releaseCount = 0
 
+    /** Every effect read is one IPC; the capture hot path must add none of them. */
+    @JvmStatic var getEnabledCount = 0
+
     @JvmStatic
     fun clearObservations() {
       refuseEnable = false
       forceDisabled = false
       releaseCount = 0
+      getEnabledCount = 0
     }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCommunicationAudioTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCommunicationAudioTest.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app.voice
 
 import android.media.AudioAttributes
 import android.media.AudioDeviceInfo
+import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.MediaRecorder
 import android.media.audiofx.AcousticEchoCanceler
@@ -274,7 +275,7 @@ class RealtimeCommunicationAudioTest {
 
     assertTrue("a confirmed read-back must yield a real token", token != RealtimeCommunicationAudioOwner.NO_OWNER)
     assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager().mode)
-    assertTrue(owner.communicationModeActive)
+    assertTrue(owner.communicationAudioEligible)
   }
 
   @Test
@@ -288,7 +289,7 @@ class RealtimeCommunicationAudioTest {
     val token = owner.enter(audioManager())
 
     assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, token)
-    assertFalse(owner.communicationModeActive)
+    assertFalse(owner.communicationAudioEligible)
   }
 
   @Test
@@ -299,7 +300,7 @@ class RealtimeCommunicationAudioTest {
     val token = owner.enter(audioManager())
 
     assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, token)
-    assertFalse(owner.communicationModeActive)
+    assertFalse(owner.communicationAudioEligible)
   }
 
   @Test
@@ -313,7 +314,7 @@ class RealtimeCommunicationAudioTest {
     val token = owner.enter(audioManager())
 
     assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, token)
-    assertFalse(owner.communicationModeActive)
+    assertFalse(owner.communicationAudioEligible)
     assertEquals("a denied acquisition must not move the device mode", before, audioManager().mode)
   }
 
@@ -349,8 +350,8 @@ class RealtimeCommunicationAudioTest {
     // The capability correctly shrinks -- the attempt just read the device back as not in
     // communication mode, and that evidence must reach the full-duplex gate immediately rather
     // than waiting for the next watcher tick.
-    assertFalse("a refuted read-back must close full duplex", owner.communicationModeActive)
-    assertFalse(owner.communicationModeActiveUnsynchronized)
+    assertFalse("a refuted read-back must close full duplex", owner.communicationAudioEligible)
+    assertFalse(owner.communicationAudioEligibleUnsynchronized)
 
     // What must NOT happen is the live owner losing its token, its focus, or its mode: the failed
     // attempt may not reach over a session that is still running.
@@ -363,7 +364,7 @@ class RealtimeCommunicationAudioTest {
 
     // The live token still works, which is the property that keeps teardown able to unwind.
     owner.restore(manager, live)
-    assertFalse(owner.communicationModeActive)
+    assertFalse(owner.communicationAudioEligible)
     assertNotNull("teardown must abandon the focus the live owner held", shadowOf(manager).lastAbandonedAudioFocusRequest)
   }
 
@@ -377,12 +378,12 @@ class RealtimeCommunicationAudioTest {
     val owner = RealtimeCommunicationAudioOwner()
     val token = owner.enter(manager)
     assertTrue(token != RealtimeCommunicationAudioOwner.NO_OWNER)
-    assertTrue(owner.verifyCommunicationModeActive(manager))
+    assertTrue(owner.verifyCommunicationAudioEligible(manager))
 
     ShadowToggleableModeOwnerAudioManager.foreignOwner = true
 
-    assertFalse("a lost mode must close full duplex", owner.verifyCommunicationModeActive(manager))
-    assertFalse(owner.communicationModeActive)
+    assertFalse("a lost mode must close full duplex", owner.verifyCommunicationAudioEligible(manager))
+    assertFalse(owner.communicationAudioEligible)
 
     // The token must still work. Marking the mode lost by nulling the owner would orphan it:
     // teardown would abandon no focus and withdraw no mode request, leaving every other app
@@ -401,15 +402,15 @@ class RealtimeCommunicationAudioTest {
     shadowOf(manager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
     val owner = RealtimeCommunicationAudioOwner()
     assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(manager))
-    assertFalse(owner.communicationModeActive)
-    assertFalse(owner.communicationModeActiveUnsynchronized)
+    assertFalse(owner.communicationAudioEligible)
+    assertFalse(owner.communicationAudioEligibleUnsynchronized)
 
     shadowOf(manager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
     val recovered = owner.retryIfUnclaimed(manager)
 
     assertTrue("the retry must claim the mode once focus is available", recovered != RealtimeCommunicationAudioOwner.NO_OWNER)
-    assertTrue(owner.communicationModeActive)
-    assertTrue("the lock-free mirror must track it", owner.communicationModeActiveUnsynchronized)
+    assertTrue(owner.communicationAudioEligible)
+    assertTrue("the lock-free mirror must track it", owner.communicationAudioEligibleUnsynchronized)
     assertEquals(AudioManager.MODE_IN_COMMUNICATION, manager.mode)
 
     // And a retry against a session that already holds it must be a no-op, not a second claim.
@@ -453,7 +454,7 @@ class RealtimeCommunicationAudioTest {
         owner.retryIfUnclaimed(manager),
       )
     }
-    assertFalse(owner.communicationModeActive)
+    assertFalse(owner.communicationAudioEligible)
   }
 
   @Test
@@ -469,7 +470,7 @@ class RealtimeCommunicationAudioTest {
     }
 
     // Bounded: the budget runs out and the owner stops asking rather than retrying forever.
-    assertFalse(owner.communicationModeActive)
+    assertFalse(owner.communicationAudioEligible)
     shadowOf(manager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
     assertEquals(
       "an exhausted budget must not resume retrying",
@@ -498,7 +499,7 @@ class RealtimeCommunicationAudioTest {
       AudioManager.MODE_NORMAL,
       manager.mode,
     )
-    assertFalse(owner.communicationModeActive)
+    assertFalse(owner.communicationAudioEligible)
   }
 
   @Test
@@ -521,6 +522,159 @@ class RealtimeCommunicationAudioTest {
 
       assertEquals("found=$found must be withdrawn to normal", AudioManager.MODE_NORMAL, manager.mode)
     }
+  }
+
+  // ---- audio focus as a live prerequisite ----------------------------------------------------
+
+  @Test
+  fun focusGrantWithAConfirmedModeMakesCommunicationAudioEligible() {
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+
+    assertTrue(owner.enter(manager) != RealtimeCommunicationAudioOwner.NO_OWNER)
+
+    assertTrue(owner.communicationAudioEligible)
+    assertTrue(owner.communicationAudioEligibleUnsynchronized)
+  }
+
+  @Test
+  fun focusLossRevokesEligibilityWhileCommunicationModeStaysActive() {
+    // The ClawSweeper finding, reproduced exactly. The mode is deliberately left in
+    // MODE_IN_COMMUNICATION for the whole test so this cannot pass through the modeLost path:
+    // the only thing that changes is focus, and that alone must close full duplex.
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    assertTrue(owner.enter(manager) != RealtimeCommunicationAudioOwner.NO_OWNER)
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+    assertTrue(owner.communicationAudioEligible)
+
+    focusListener(manager).onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
+
+    assertEquals("the mode must still be active, or this test proves nothing", AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+    assertFalse("re-verifying must still report ineligible, on the focus fact alone", owner.verifyCommunicationAudioEligible(manager))
+    assertFalse(owner.communicationAudioEligible)
+    assertFalse(owner.communicationAudioEligibleUnsynchronized)
+  }
+
+  @Test
+  fun transientFocusLossAlsoRevokesEligibility() {
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    assertTrue(owner.enter(manager) != RealtimeCommunicationAudioOwner.NO_OWNER)
+
+    focusListener(manager).onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT)
+
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+    assertFalse(owner.communicationAudioEligible)
+  }
+
+  @Test
+  fun aDuckableFocusLossThePlatformReportsAlsoRevokesEligibility() {
+    // Ducking is not benign here: another app is still on the loudspeaker the canceller uses as
+    // its reference. The platform only reports CAN_DUCK when it cannot duck this app itself --
+    // which, because the playout track is CONTENT_TYPE_SPEECH, is the case during playback. This
+    // covers the reported variant; a duck the platform handles silently produces no callback.
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    assertTrue(owner.enter(manager) != RealtimeCommunicationAudioOwner.NO_OWNER)
+
+    focusListener(manager).onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)
+
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, manager.mode)
+    assertFalse(owner.communicationAudioEligible)
+  }
+
+  @Test
+  fun focusGainRestoresEligibilityForTheSameLiveOwner() {
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    assertTrue(owner.enter(manager) != RealtimeCommunicationAudioOwner.NO_OWNER)
+    val listener = focusListener(manager)
+    listener.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT)
+    assertFalse(owner.communicationAudioEligible)
+
+    listener.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
+
+    assertTrue("focus returning to a live owner restores eligibility", owner.communicationAudioEligible)
+    assertTrue(owner.communicationAudioEligibleUnsynchronized)
+  }
+
+  @Test
+  fun aStaleFocusLossCannotCloseFullDuplexForANewerOwner() {
+    // A: acquire, capture its listener, tear down. B: acquire. A's delayed callback then arrives.
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    val tokenA = owner.enter(manager)
+    val listenerA = focusListener(manager)
+    owner.restore(manager, tokenA)
+    val tokenB = owner.enter(manager)
+    assertTrue(tokenB != RealtimeCommunicationAudioOwner.NO_OWNER)
+    assertTrue(owner.communicationAudioEligible)
+
+    listenerA.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
+
+    assertTrue("a superseded request must not speak for the session that replaced it", owner.communicationAudioEligible)
+    assertTrue(owner.communicationAudioEligibleUnsynchronized)
+  }
+
+  @Test
+  fun aStaleFocusGainCannotResurrectEligibilityForANewerOwner() {
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    val tokenA = owner.enter(manager)
+    val listenerA = focusListener(manager)
+    owner.restore(manager, tokenA)
+    assertTrue(owner.enter(manager) != RealtimeCommunicationAudioOwner.NO_OWNER)
+    focusListener(manager).onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
+    assertFalse(owner.communicationAudioEligible)
+
+    listenerA.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
+
+    assertFalse("a superseded request must not restore the newer owner", owner.communicationAudioEligible)
+  }
+
+  @Test
+  fun teardownRevokesEligibilityAndAbandonsOnlyThisOwnersRequest() {
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+    val token = owner.enter(manager)
+    assertTrue(owner.communicationAudioEligibleUnsynchronized)
+
+    owner.restore(manager, token)
+
+    assertFalse(owner.communicationAudioEligible)
+    assertFalse("the snapshot must be false through the abandon, not after it", owner.communicationAudioEligibleUnsynchronized)
+    assertNotNull(shadowOf(manager).lastAbandonedAudioFocusRequest)
+    // And a callback delivered after the abandon is inert.
+    focusListener(manager).onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
+    assertFalse(owner.communicationAudioEligible)
+  }
+
+  @Test
+  fun initialFocusDenialLeavesNoOwnershipNoModeWriteAndNoEligibility() {
+    val manager = audioManager()
+    val before = manager.mode
+    shadowOf(manager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
+    val owner = RealtimeCommunicationAudioOwner()
+
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(manager))
+
+    assertEquals(before, manager.mode)
+    assertFalse(owner.communicationAudioEligible)
+    assertFalse(owner.communicationAudioEligibleUnsynchronized)
+  }
+
+  @Test
+  @Config(shadows = [ShadowForeignModeOwnerAudioManager::class])
+  fun aModeRefusalAfterFocusWasAcquiredAbandonsThatFocusAndGrantsNothing() {
+    val manager = audioManager()
+    val owner = RealtimeCommunicationAudioOwner()
+
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(manager))
+
+    assertFalse(owner.communicationAudioEligible)
+    assertFalse(owner.communicationAudioEligibleUnsynchronized)
+    assertNotNull("the attempt must hand back the focus it took", shadowOf(manager).lastAbandonedAudioFocusRequest)
   }
 
   @Test
@@ -621,6 +775,20 @@ class RealtimeCommunicationAudioTest {
   }
 
   // ---- helpers -------------------------------------------------------------------------------
+
+  /**
+   * The focus listener the owner registered, as the platform would call it.
+   *
+   * `AudioFocusRequest` exposes no public getter, so this reads the field the framework class
+   * stores it in -- Robolectric runs the real framework class, so the field is the real one.
+   */
+  private fun focusListener(manager: AudioManager): AudioManager.OnAudioFocusChangeListener {
+    val last = shadowOf(manager).lastAudioFocusRequest
+    last.listener?.let { return it }
+    val field = AudioFocusRequest::class.java.getDeclaredField("mFocusListener")
+    field.isAccessible = true
+    return field.get(last.audioFocusRequest) as AudioManager.OnAudioFocusChangeListener
+  }
 
   private fun app() = RuntimeEnvironment.getApplication()
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCommunicationAudioTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeCommunicationAudioTest.kt
@@ -744,6 +744,23 @@ class RealtimeCommunicationAudioTest {
   }
 
   @Test
+  fun aLineLevelCommunicationOutputIsNotStolenEither() {
+    // The platform admits analog line-out and AUX line sinks as communication devices. A person
+    // who plugged one in chose it over the handset just as surely as a headset wearer did.
+    for (lineType in listOf(AudioDeviceInfo.TYPE_LINE_ANALOG, AudioDeviceInfo.TYPE_AUX_LINE)) {
+      setAvailableCommunicationDevices(
+        AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+        AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
+        lineType,
+      )
+
+      openCommunicationCapture().use { session ->
+        assertNull("line output type=$lineType must not be overridden", session.appliedCommunicationDeviceType)
+      }
+    }
+  }
+
+  @Test
   fun recognitionCaptureNeverTakesTheCommunicationOutput() {
     setAvailableCommunicationDevices(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
@@ -5,6 +5,7 @@ import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.testDeviceIdentityStore
 import android.util.Base64
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,6 +21,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -94,6 +96,70 @@ class RealtimePlayoutOwnerTest {
 
       assertArrayEquals(audio, sinks.last.acceptedBytes())
       assertEquals(listOf(480, 380, 280, 180, 80), sinks.last.offeredLengths)
+      talk.shutdown()
+    }
+
+  @Test
+  fun aMatchingTurnClearRetiresTheSinkThroughTheOwnerAndCompletesTheWaiterWithThatTurn() =
+    runTest {
+      // The integration point with upstream's turn-bound cancellation. The waiter must be
+      // completed by the OWNER, after the device is actually retired -- not by the receiving
+      // thread the moment the clear arrives -- and it must be completed with the identity the
+      // clear carried, because cancelOutput checks it against the turn it asked to cancel.
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+      val waiter = CompletableDeferred<String?>()
+      talk.setPendingOutputClear(waiter)
+
+      talk.audioEvent(pcm(480))
+      runCurrent()
+      talk.markEvent("audio-1")
+      runCurrent()
+      assertTrue(talk.sinkInstalled())
+      assertFalse("the waiter must not complete before the owner retires the device", waiter.isCompleted)
+
+      talk.clearEvent()
+      runCurrent()
+
+      assertEquals(defaultTurnId, waiter.getCompleted())
+      assertFalse(talk.sinkInstalled())
+      assertEquals(1, sinks.last.closeCalls)
+      assertEquals(0L, talk.writtenFrames())
+      assertEquals(listOf("relay-1" to "audio-1"), talk.acknowledgements)
+      assertNull("an accepted clear releases the output turn", talk.outputTurnId())
+      talk.shutdown()
+    }
+
+  @Test
+  fun aClearNamingAnOlderTurnLeavesTheCurrentResponsePlaying() =
+    runTest {
+      // A stale clear belongs to a response that is already gone. It must not silence the new one,
+      // must not advance the playback generation, and must not complete a waiter that is waiting
+      // for a different turn.
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+      val waiter = CompletableDeferred<String?>()
+      talk.setPendingOutputClear(waiter)
+
+      talk.audioEvent(pcm(480), turnId = "turn-2")
+      runCurrent()
+      val epochBefore = talk.playbackEpoch()
+      assertTrue(talk.sinkInstalled())
+
+      talk.clearEvent(turnId = "turn-1")
+      runCurrent()
+
+      assertFalse("a stale clear must not complete the waiter", waiter.isCompleted)
+      assertEquals("a stale clear must not advance the generation", epochBefore, talk.playbackEpoch())
+      assertTrue("a stale clear must not retire the live device", talk.sinkInstalled())
+      assertEquals(0, sinks.last.closeCalls)
+      assertEquals("turn-2", talk.outputTurnId())
+
+      // The matching clear still works afterwards.
+      talk.clearEvent(turnId = "turn-2")
+      runCurrent()
+      assertEquals("turn-2", waiter.getCompleted())
+      assertFalse(talk.sinkInstalled())
       talk.shutdown()
     }
 
@@ -633,6 +699,9 @@ private fun awaitCondition(
 
 internal const val FAKE_BUFFER_DURATION_MS = 240L
 
+/** The provider output turn these harness events belong to; upstream requires one on audio. */
+private const val defaultTurnId = "turn-1"
+
 // Mirrors of the production bounds. Pinned rather than derived: these numbers are the contract
 // the two overflow tests exist to protect, so a change to either must fail here first.
 private const val REALTIME_PLAYBACK_PROVIDER_QUEUE_CAPACITY = 4_096
@@ -699,11 +768,14 @@ private class RealtimePlayoutHarness(
     setPrivateField(manager, "realtimeSessionId", "relay-1")
   }
 
-  fun audioEvent(bytes: ByteArray) {
+  fun audioEvent(
+    bytes: ByteArray,
+    turnId: String = defaultTurnId,
+  ) {
     val audioBase64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
     manager.handleGatewayEvent(
       "talk.event",
-      """{"relaySessionId":"relay-1","type":"audio","audioBase64":"$audioBase64"}""",
+      """{"relaySessionId":"relay-1","type":"audio","talkEvent":{"turnId":"$turnId"},"audioBase64":"$audioBase64"}""",
     )
   }
 
@@ -711,8 +783,9 @@ private class RealtimePlayoutHarness(
     manager.handleGatewayEvent("talk.event", """{"relaySessionId":"relay-1","type":"mark","markName":"$markName"}""")
   }
 
-  fun clearEvent() {
-    manager.handleGatewayEvent("talk.event", """{"relaySessionId":"relay-1","type":"clear"}""")
+  fun clearEvent(turnId: String? = defaultTurnId) {
+    val talkEvent = if (turnId == null) "" else ""","talkEvent":{"turnId":"$turnId"}"""
+    manager.handleGatewayEvent("talk.event", """{"relaySessionId":"relay-1","type":"clear"$talkEvent}""")
   }
 
   fun assistantFinalTranscriptEvent() {
@@ -747,6 +820,12 @@ private class RealtimePlayoutHarness(
   fun writtenFrames(): Long = readPrivateField(manager, "realtimeWrittenFrames") as Long
 
   fun sinkInstalled(): Boolean = readPrivateField(manager, "realtimeAudioSink") != null
+
+  fun outputTurnId(): String? = readPrivateField(manager, "realtimeOutputTurnId") as String?
+
+  fun playbackEpoch(): Long = (readPrivateField(manager, "realtimePlaybackEpoch") as AtomicLong).get()
+
+  fun setPendingOutputClear(waiter: CompletableDeferred<String?>) = setPrivateField(manager, "pendingRealtimeOutputClear", waiter)
 
   fun queuedProviderCommands(): Int = (readPrivateField(manager, "queuedRealtimeProviderCommands") as AtomicInteger).get()
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
@@ -495,6 +495,70 @@ class RealtimePlayoutOwnerTest {
       scope.cancel()
     }
   }
+
+  /**
+   * FIX-3. The owner is the only code allowed to touch the device, so it is also the only code
+   * that can release it. Before the finally, a cancelled owner left the AudioTrack alive with
+   * residual audio still presenting, and left the capture gate believing the assistant was
+   * speaking with nothing left running to clear it.
+   */
+  @Test
+  fun cancellingTheOwnerReleasesTheDeviceInsteadOfLeakingIt() {
+    val insideTheDevice = CountDownLatch(1)
+    val releaseTheDevice = CountDownLatch(1)
+    val sinks =
+      FakeRealtimeAudioSinkFactory { offered, _ ->
+        insideTheDevice.countDown()
+        releaseTheDevice.await(10, TimeUnit.SECONDS)
+        offered
+      }
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val talk = realThreadedPlayoutHarness(sinks, scope)
+
+    talk.audioEvent(pcm(480))
+    assertTrue("owner never reached the device", insideTheDevice.await(10, TimeUnit.SECONDS))
+    assertEquals(1, sinks.openCount)
+    assertTrue("playback must be published before the write", talk.isSpeaking())
+
+    // No Stop, no Clear: the scope simply completes, which is what app/node teardown does.
+    scope.cancel()
+    releaseTheDevice.countDown()
+
+    val released = awaitCondition(5_000) { sinks.last.closeCalls == 1 }
+    assertTrue("the cancelled owner leaked its AudioTrack (closeCalls=${sinks.last.closeCalls})", released)
+    assertTrue("speaking must not survive the owner", awaitCondition(5_000) { !talk.isSpeaking() })
+  }
+
+  /** The finally shares its cleanup with Stop, so a normal teardown must not double-release. */
+  @Test
+  fun aNormalStopFollowedByCancellationReleasesTheDeviceExactlyOnce() {
+    val sinks = FakeRealtimeAudioSinkFactory()
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val talk = realThreadedPlayoutHarness(sinks, scope)
+
+    talk.audioEvent(pcm(480))
+    assertTrue("device never opened", awaitCondition(5_000) { sinks.openCount == 1 })
+    talk.stopRelay()
+    assertTrue("stop must release the device", awaitCondition(5_000) { sinks.last.closeCalls == 1 })
+
+    scope.cancel()
+
+    // Idempotent: the sink was already nulled by Stop, so the finally has nothing left to close.
+    Thread.sleep(200)
+    assertEquals("cancellation must not re-close an already released device", 1, sinks.last.closeCalls)
+  }
+}
+
+private fun awaitCondition(
+  timeoutMs: Long,
+  condition: () -> Boolean,
+): Boolean {
+  val deadline = System.nanoTime() + timeoutMs * 1_000_000
+  while (System.nanoTime() < deadline) {
+    if (condition()) return true
+    Thread.sleep(10)
+  }
+  return condition()
 }
 
 internal const val FAKE_BUFFER_DURATION_MS = 240L

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
@@ -98,6 +98,76 @@ class RealtimePlayoutOwnerTest {
     }
 
   @Test
+  fun aNegativeWriteAfterPartialProgressFailsPlaybackInsteadOfBankingThePrefix() =
+    runTest {
+      // AudioTrack.ERROR_DEAD_OBJECT. Any negative result is a terminal device error, not
+      // backpressure -- the distinction the retry loop above depends on.
+      val deviceError = -6
+      // call 0: the first frame is accepted whole. call 1: the second frame is accepted in part.
+      // call 2: the device dies mid-frame, so a strict prefix of that frame reached it.
+      val sinks =
+        FakeRealtimeAudioSinkFactory { offered, call ->
+          when (call) {
+            0 -> offered
+            1 -> 100
+            else -> deviceError
+          }
+        }
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(200))
+      runCurrent()
+      talk.markEvent("audio-1")
+      runCurrent()
+      // The barrier is pending against the first frame and has not been released yet.
+      assertEquals(emptyList<Pair<String, String>>(), talk.acknowledgements)
+      assertEquals(100L, talk.writtenFrames())
+
+      talk.audioEvent(pcm(480))
+      runCurrent()
+
+      // The device error is a playback failure, not a logged break that leaves the relay running.
+      assertTrue(talk.talkFailed())
+      // The truncated frame is not banked. Were it counted, a later barrier could clear a target
+      // frame the device never presented.
+      assertEquals(0L, talk.writtenFrames())
+      assertFalse(talk.sinkInstalled())
+      assertEquals(1, sinks.last.closeCalls)
+      assertFalse(talk.isSpeaking())
+      assertFalse(talk.idleTickerActive())
+      // The stranded barrier is released exactly once, by the failure path, so the provider's
+      // playback gate does not hang -- and it is released because the relay failed, not because
+      // the partial frame was treated as fully played.
+      assertEquals(listOf("relay-1" to "audio-1"), talk.acknowledgements)
+      // The owner survives its own failure: later commands are still drained, not swallowed.
+      talk.audioEvent(pcm(200))
+      runCurrent()
+      assertEquals(0, talk.queuedProviderCommands())
+      assertEquals(0L, talk.queuedAudioBytes())
+      talk.shutdown()
+    }
+
+  @Test
+  fun aNegativeWriteOnTheFirstAttemptFailsPlaybackAndRetiresTheDevice() =
+    runTest {
+      // No partial progress at all: the very first write reports the device is gone.
+      val sinks = FakeRealtimeAudioSinkFactory { _, _ -> -6 }
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+      runCurrent()
+
+      assertTrue(talk.talkFailed())
+      assertFalse(talk.sinkInstalled())
+      assertEquals(1, sinks.last.closeCalls)
+      assertFalse(talk.isSpeaking())
+      assertFalse(talk.idleTickerActive())
+      // One write, then the failure: a dead device is never retried on the stall budget.
+      assertEquals(1, sinks.last.writeCalls)
+      talk.shutdown()
+    }
+
+  @Test
   fun refusedWritesRetryOnABoundedDelayInsteadOfSpinning() =
     runTest {
       // Two refusals, then the device drains.
@@ -672,6 +742,11 @@ private class RealtimePlayoutHarness(
   fun setPlaybackEnabled(enabled: Boolean) = manager.setPlaybackEnabled(enabled)
 
   fun idleTickerActive(): Boolean = (readPrivateField(manager, "realtimePlaybackIdleJob") as Job?)?.isActive == true
+
+  /** Frames the owner has banked as written. Retirement resets it, so a failed frame leaves 0. */
+  fun writtenFrames(): Long = readPrivateField(manager, "realtimeWrittenFrames") as Long
+
+  fun sinkInstalled(): Boolean = readPrivateField(manager, "realtimeAudioSink") != null
 
   fun queuedProviderCommands(): Int = (readPrivateField(manager, "queuedRealtimeProviderCommands") as AtomicInteger).get()
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
@@ -497,7 +497,7 @@ class RealtimePlayoutOwnerTest {
   }
 }
 
-private const val FAKE_BUFFER_DURATION_MS = 240L
+internal const val FAKE_BUFFER_DURATION_MS = 240L
 
 // Mirrors of the production bounds. Pinned rather than derived: these numbers are the contract
 // the two overflow tests exist to protect, so a change to either must fail here first.
@@ -506,7 +506,7 @@ private const val REALTIME_PLAYBACK_QUEUED_AUDIO_CEILING_BYTES = 12L * 1024L * 1
 
 private fun pcm(byteCount: Int): ByteArray = ByteArray(byteCount) { index -> (index % 251).toByte() }
 
-private class FakeRealtimeAudioSink(
+internal class FakeRealtimeAudioSink(
   private val onWrite: (offered: Int, callIndex: Int) -> Int,
 ) : RealtimeAudioSink {
   override val bufferDurationMs: Long = FAKE_BUFFER_DURATION_MS
@@ -542,7 +542,7 @@ private class FakeRealtimeAudioSink(
   }
 }
 
-private class FakeRealtimeAudioSinkFactory(
+internal class FakeRealtimeAudioSinkFactory(
   private val onWrite: (offered: Int, callIndex: Int) -> Int = { offered, _ -> offered },
 ) : RealtimeAudioSinkFactory {
   val opened = mutableListOf<FakeRealtimeAudioSink>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimePlayoutOwnerTest.kt
@@ -1,0 +1,715 @@
+package ai.openclaw.app.voice
+
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.gateway.DeviceAuthStore
+import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.gateway.testDeviceIdentityStore
+import android.util.Base64
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Proves the realtime playout ownership boundary: Gateway ingress enqueues and returns, and one
+ * owner coroutine is the only code that reaches the output device.
+ *
+ * The device is injected as a [RealtimeAudioSink] so partial writes, refused writes, and device
+ * exceptions are deterministic. The owner, the command queue, and every generation rule under
+ * test are the production ones.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class RealtimePlayoutOwnerTest {
+  @Test
+  fun gatewayAudioEventReturnsBeforeTheDeviceIsEverTouched() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+
+      // The owner has not been dispatched, yet the Gateway frame is already handled: the device
+      // was never opened, played, or written to on the ingress path.
+      assertEquals(0, sinks.openCount)
+
+      runCurrent()
+
+      assertEquals(1, sinks.openCount)
+      assertEquals(480, sinks.last.acceptedBytes().size)
+      talk.shutdown()
+    }
+
+  @Test
+  fun gatewayKeepsAcceptingFramesWhileTheOwnerIsStalledOnTheDevice() =
+    runTest {
+      // Every write is refused, so the owner sits in its retry backoff for the whole test.
+      val sinks = FakeRealtimeAudioSinkFactory { _, _ -> 0 }
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+      runCurrent()
+      assertTrue(sinks.last.writeCalls > 0)
+
+      // No lock is shared with the owner, so these complete while it is stalled on hardware.
+      talk.audioEvent(pcm(480))
+      talk.markEvent("audio-1")
+
+      assertFalse(talk.talkFailed())
+      talk.shutdown()
+    }
+
+  @Test
+  fun partialWritesContinueFromTheAcceptedByteCount() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory { offered, _ -> minOf(offered, 100) }
+      val talk = realtimePlayoutHarness(sinks)
+      val audio = pcm(480)
+
+      talk.audioEvent(audio)
+      runCurrent()
+
+      assertArrayEquals(audio, sinks.last.acceptedBytes())
+      assertEquals(listOf(480, 380, 280, 180, 80), sinks.last.offeredLengths)
+      talk.shutdown()
+    }
+
+  @Test
+  fun refusedWritesRetryOnABoundedDelayInsteadOfSpinning() =
+    runTest {
+      // Two refusals, then the device drains.
+      val sinks = FakeRealtimeAudioSinkFactory { offered, call -> if (call < 2) 0 else offered }
+      val talk = realtimePlayoutHarness(sinks)
+      val audio = pcm(480)
+
+      talk.audioEvent(audio)
+      runCurrent()
+
+      // The retry is a delay, not a spin: one attempt has happened and the owner is parked.
+      assertEquals(1, sinks.last.writeCalls)
+      assertEquals(0, sinks.last.acceptedBytes().size)
+
+      advanceTimeBy(realtimePlaybackWriteRetryDelayMs(FAKE_BUFFER_DURATION_MS) * 5)
+      runCurrent()
+
+      assertArrayEquals(audio, sinks.last.acceptedBytes())
+      assertEquals(3, sinks.last.writeCalls)
+      talk.shutdown()
+    }
+
+  @Test
+  fun aDeviceThatNeverDrainsFailsTheSessionInsteadOfRetryingForever() =
+    runTest {
+      // The first write drains, so a barrier can be positioned behind real audio; every write
+      // after it is refused.
+      val sinks = FakeRealtimeAudioSinkFactory { offered, call -> if (call == 0) offered else 0 }
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+      talk.markEvent("audio-1")
+      talk.audioEvent(pcm(64))
+      runCurrent()
+      assertEquals(emptyList<Pair<String, String>>(), talk.acknowledgements)
+
+      advanceTimeBy(realtimePlaybackWriteStallBudgetMs(FAKE_BUFFER_DURATION_MS) * 2)
+      runCurrent()
+
+      assertTrue(talk.talkFailed())
+      // Cleanup is part of the failure, not a later step: the device is released, and the barrier
+      // whose target frame the retirement just invalidated is answered instead of holding the
+      // provider's playback gate open forever.
+      assertEquals(1, sinks.last.closeCalls)
+      assertEquals(listOf("relay-1" to "audio-1"), talk.acknowledgements)
+      talk.shutdown()
+    }
+
+  @Test
+  fun aQueueFullOfTinyFramesFailsTheSessionAtTheSlotBound() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      // The owner is never dispatched, so nothing drains. Two-byte frames reach no byte ceiling,
+      // so this pins the slot bound specifically.
+      var enqueued = 0
+      while (!talk.talkFailed() && enqueued < 8_192) {
+        talk.audioEvent(pcm(2))
+        enqueued += 1
+      }
+
+      assertTrue(talk.talkFailed())
+      assertEquals(REALTIME_PLAYBACK_PROVIDER_QUEUE_CAPACITY + 1, enqueued)
+      assertEquals(0, sinks.openCount)
+      talk.shutdown()
+    }
+
+  @Test
+  fun aQueueFullOfLargeFramesFailsTheSessionAtTheAudioByteCeiling() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+      val oneMebibyte = 1024 * 1024
+
+      // Twelve frames of one mebibyte reach the ceiling exactly; the thirteenth crosses it, long
+      // before the slot bound. Memory, not depth, is what this bound protects.
+      var enqueued = 0
+      while (!talk.talkFailed() && enqueued < 64) {
+        talk.audioEvent(pcm(oneMebibyte))
+        enqueued += 1
+      }
+
+      assertTrue(talk.talkFailed())
+      assertEquals(REALTIME_PLAYBACK_QUEUED_AUDIO_CEILING_BYTES / oneMebibyte + 1, enqueued.toLong())
+      talk.shutdown()
+    }
+
+  @Test
+  fun aLongAssistantResponseStreamedFasterThanItPlaysDoesNotFailTheSession() =
+    runTest {
+      // The relay forwards provider audio unpaced, so a real response backlogs while the speaker
+      // catches up. 1,000 frames of 100 ms is 100 s of audio: far past any depth-shaped bound,
+      // and nowhere near the memory ceiling.
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      repeat(1_000) {
+        talk.audioEvent(pcm(4_800))
+        talk.markEvent("audio-$it")
+      }
+
+      assertFalse(talk.talkFailed())
+      assertEquals(2_000, talk.queuedProviderCommands())
+
+      runCurrent()
+
+      assertFalse(talk.talkFailed())
+      // Both bounds release on drain; a counter that latched high would fail every later submit.
+      assertEquals(0, talk.queuedProviderCommands())
+      assertEquals(0L, talk.queuedAudioBytes())
+      talk.shutdown()
+    }
+
+  @Test
+  fun aBargeInDuringAPartialWriteLeavesTheCaptureGateOpen() =
+    runTest {
+      // The first frame drains, so playback state is published and the capture gate is shut. The
+      // next one is taken in part and then refused, parking the owner *inside* its write loop --
+      // the shape a real barge-in has once the hardware buffer is full, and the only shape that
+      // reaches the loop's own generation check.
+      val sinks =
+        FakeRealtimeAudioSinkFactory { offered, call ->
+          when {
+            call == 0 -> offered
+            call % 2 == 1 -> minOf(offered, 100)
+            else -> 0
+          }
+        }
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(48_000))
+      runCurrent()
+      assertFalse(talk.shouldAppendCapturedFrame(4_800))
+
+      talk.audioEvent(pcm(48_000))
+      runCurrent()
+      assertTrue(sinks.last.writeCalls > 1)
+
+      talk.clearEvent()
+      advanceTimeBy(realtimePlaybackWriteRetryDelayMs(FAKE_BUFFER_DURATION_MS) * 5)
+      runCurrent()
+
+      // The frames already handed to the device are discarded with it, so nothing may still be
+      // reporting playback -- otherwise the uplink stays gated with no ticker left to reopen it.
+      assertFalse(talk.isSpeaking())
+      assertTrue(talk.shouldAppendCapturedFrame(4_800))
+      assertFalse(talk.idleTickerActive())
+      talk.shutdown()
+    }
+
+  @Test
+  fun disablingPlaybackAnswersBarriersItCanNoLongerReach() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+      talk.markEvent("audio-1")
+      runCurrent()
+      assertEquals(emptyList<Pair<String, String>>(), talk.acknowledgements)
+
+      // Unlike a TTS stop or a PTT pause, this is a local toggle with no provider round-trip, so
+      // no later clear will arrive to answer the barrier. Retiring the device also resets the
+      // frame counter its target was measured against, so keeping it would strand it forever.
+      talk.setPlaybackEnabled(false)
+      runCurrent()
+
+      assertEquals(listOf("relay-1" to "audio-1"), talk.acknowledgements)
+
+      // And nothing is left polling for a barrier that can never complete.
+      talk.assistantFinalTranscriptEvent()
+      runCurrent()
+      advanceTimeBy(1_000)
+      runCurrent()
+      assertFalse(talk.idleTickerActive())
+      talk.shutdown()
+    }
+
+  @Test
+  fun aBarrierIsAnsweredOnlyAfterTheAudioQueuedBeforeItHasBeenPresented() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+      talk.markEvent("audio-1")
+      runCurrent()
+
+      // 480 bytes is 240 frames, and the device has presented none of them.
+      assertEquals(emptyList<Pair<String, String>>(), talk.acknowledgements)
+
+      sinks.last.presentedFrames = 240L
+      talk.assistantFinalTranscriptEvent()
+      runCurrent()
+
+      assertEquals(listOf("relay-1" to "audio-1"), talk.acknowledgements)
+      talk.shutdown()
+    }
+
+  @Test
+  fun clearDiscardsAudioAlreadyQueuedForTheCancelledResponseAndKeepsTheNextOne() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+      val cancelled = pcm(480)
+      val next = pcm(64)
+
+      // All three reach the queue before the owner runs, so the stale command is still ahead of
+      // the clear that invalidates it and of the next generation's audio behind it.
+      talk.audioEvent(cancelled)
+      talk.clearEvent()
+      talk.audioEvent(next)
+      runCurrent()
+
+      assertEquals(1, sinks.openCount)
+      assertArrayEquals(next, sinks.last.acceptedBytes())
+      talk.shutdown()
+    }
+
+  @Test
+  fun aStaleGenerationBarrierIsAnsweredWithoutTouchingTheNewGeneration() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.markEvent("cancelled-1")
+      talk.clearEvent()
+      talk.audioEvent(pcm(64))
+      runCurrent()
+
+      // The cancelled barrier is released so the provider's gate does not stay shut, and it never
+      // becomes a target frame measured against the new generation's device.
+      assertEquals(listOf("relay-1" to "cancelled-1"), talk.acknowledgements)
+      assertEquals(64, sinks.last.acceptedBytes().size)
+      assertEquals(0L, sinks.last.presentedFrames)
+      talk.shutdown()
+    }
+
+  @Test
+  fun clearReleasesTheDeviceAndTheNextResponseOpensAFreshOne() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+      runCurrent()
+      val cancelledSink = sinks.last
+
+      talk.clearEvent()
+      runCurrent()
+      assertEquals(1, cancelledSink.closeCalls)
+
+      talk.audioEvent(pcm(64))
+      runCurrent()
+
+      assertEquals(2, sinks.openCount)
+      assertEquals(64, sinks.last.acceptedBytes().size)
+      talk.shutdown()
+    }
+
+  @Test
+  fun relayTeardownReleasesTheDeviceAndDropsPendingBarriers() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+      talk.markEvent("audio-1")
+      runCurrent()
+      assertEquals(emptyList<Pair<String, String>>(), talk.acknowledgements)
+
+      talk.stopRelay()
+      runCurrent()
+
+      assertEquals(1, sinks.last.closeCalls)
+      // Terminal teardown has no provider left to release, so the barrier is dropped rather than
+      // acknowledged; a plain playback stop keeps it for the provider's own clear.
+      assertEquals(emptyList<Pair<String, String>>(), talk.acknowledgements)
+      talk.shutdown()
+    }
+
+  @Test
+  fun aDeviceExceptionFailsTheSessionAndTheOwnerKeepsServingLaterCommands() =
+    runTest {
+      var deviceBroken = true
+      val sinks =
+        FakeRealtimeAudioSinkFactory { offered, _ ->
+          if (deviceBroken) throw IllegalStateException("device exploded")
+          offered
+        }
+      val talk = realtimePlayoutHarness(sinks)
+
+      talk.audioEvent(pcm(480))
+      runCurrent()
+
+      assertTrue(talk.talkFailed())
+      assertEquals(1, sinks.last.closeCalls)
+
+      // The command channel is long-lived and never recreated, so an owner that died here would
+      // swallow every later command in silence.
+      deviceBroken = false
+      talk.startSession()
+      talk.audioEvent(pcm(64))
+      runCurrent()
+
+      assertEquals(2, sinks.openCount)
+      assertEquals(64, sinks.last.acceptedBytes().size)
+      talk.shutdown()
+    }
+
+  @Test
+  fun repeatedStartAndStopOpensAndReleasesOneDeviceEachTime() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      repeat(3) {
+        talk.startSession()
+        talk.audioEvent(pcm(64))
+        runCurrent()
+        talk.stopRelay()
+        runCurrent()
+      }
+
+      assertEquals(3, sinks.openCount)
+      assertEquals(3, sinks.opened.sumOf { it.closeCalls })
+      talk.shutdown()
+    }
+
+  @Test
+  fun halfDuplexCaptureSuppressionIsUnchangedByTheNewOwner() =
+    runTest {
+      val sinks = FakeRealtimeAudioSinkFactory()
+      val talk = realtimePlayoutHarness(sinks)
+
+      assertTrue(talk.shouldAppendCapturedFrame(4_800))
+
+      // One second of audio at the realtime rate. The capture gate closes for its duration
+      // exactly as it did before playout moved behind the owner.
+      talk.audioEvent(pcm(48_000))
+      runCurrent()
+      assertFalse(talk.shouldAppendCapturedFrame(4_800))
+
+      // A barge-in reopens it immediately, not after the remaining second of audio.
+      talk.clearEvent()
+      assertTrue(talk.shouldAppendCapturedFrame(4_800))
+      runCurrent()
+      assertTrue(talk.shouldAppendCapturedFrame(4_800))
+
+      talk.audioEvent(pcm(48_000))
+      runCurrent()
+      assertFalse(talk.shouldAppendCapturedFrame(4_800))
+
+      talk.stopRelay()
+      assertTrue(talk.shouldAppendCapturedFrame(4_800))
+      assertFalse(talk.shouldAppendCapturedFrame(0))
+
+      runCurrent()
+      talk.shutdown()
+    }
+
+  /**
+   * The virtual-time tests above cannot prove the absence of a shared monitor: Java monitors are
+   * reentrant per thread, so a single-threaded test passes even if ingress and the owner take the
+   * same lock. This one uses real threads and a device call that genuinely blocks.
+   */
+  @Test
+  fun gatewayIngressDoesNotWaitOnAnOwnerBlockedInsideTheDevice() {
+    val insideTheDevice = CountDownLatch(1)
+    val releaseTheDevice = CountDownLatch(1)
+    val sinks =
+      FakeRealtimeAudioSinkFactory { offered, _ ->
+        insideTheDevice.countDown()
+        releaseTheDevice.await(10, TimeUnit.SECONDS)
+        offered
+      }
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val talk = realThreadedPlayoutHarness(sinks, scope)
+    try {
+      talk.audioEvent(pcm(480))
+      assertTrue("owner never reached the device", insideTheDevice.await(10, TimeUnit.SECONDS))
+
+      val startedAtNanos = System.nanoTime()
+      repeat(16) { talk.audioEvent(pcm(480)) }
+      talk.markEvent("audio-1")
+      talk.clearEvent()
+      val elapsedMs = (System.nanoTime() - startedAtNanos) / 1_000_000
+
+      assertTrue("ingress waited ${elapsedMs}ms on a blocked owner", elapsedMs < 1_000)
+    } finally {
+      releaseTheDevice.countDown()
+      // Cancelling the scope must also end the owner, which is deliberately not one of its
+      // children; if that wiring were missing the coroutine would outlive every test.
+      scope.cancel()
+    }
+  }
+}
+
+private const val FAKE_BUFFER_DURATION_MS = 240L
+
+// Mirrors of the production bounds. Pinned rather than derived: these numbers are the contract
+// the two overflow tests exist to protect, so a change to either must fail here first.
+private const val REALTIME_PLAYBACK_PROVIDER_QUEUE_CAPACITY = 4_096
+private const val REALTIME_PLAYBACK_QUEUED_AUDIO_CEILING_BYTES = 12L * 1024L * 1024L
+
+private fun pcm(byteCount: Int): ByteArray = ByteArray(byteCount) { index -> (index % 251).toByte() }
+
+private class FakeRealtimeAudioSink(
+  private val onWrite: (offered: Int, callIndex: Int) -> Int,
+) : RealtimeAudioSink {
+  override val bufferDurationMs: Long = FAKE_BUFFER_DURATION_MS
+
+  @Volatile override var presentedFrames: Long = 0L
+  var playCalls = 0
+  var closeCalls = 0
+  var writeCalls = 0
+  val offeredLengths = mutableListOf<Int>()
+  private val accepted = ByteArrayOutputStream()
+
+  fun acceptedBytes(): ByteArray = accepted.toByteArray()
+
+  override fun play() {
+    playCalls += 1
+  }
+
+  override fun write(
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+  ): Int {
+    offeredLengths += length
+    val callIndex = writeCalls
+    writeCalls += 1
+    val result = onWrite(length, callIndex)
+    if (result > 0) accepted.write(bytes, offset, result)
+    return result
+  }
+
+  override fun close() {
+    closeCalls += 1
+  }
+}
+
+private class FakeRealtimeAudioSinkFactory(
+  private val onWrite: (offered: Int, callIndex: Int) -> Int = { offered, _ -> offered },
+) : RealtimeAudioSinkFactory {
+  val opened = mutableListOf<FakeRealtimeAudioSink>()
+  val openCount: Int get() = opened.size
+  val last: FakeRealtimeAudioSink get() = opened.last()
+
+  override fun open(
+    sampleRateHz: Int,
+    playbackBufferMs: Int,
+    firstWriteBytes: Int,
+  ): RealtimeAudioSink = FakeRealtimeAudioSink(onWrite).also { opened += it }
+}
+
+/** A manager with an open realtime session, an injected output device, and Gateway-side helpers. */
+private class RealtimePlayoutHarness(
+  private val manager: TalkModeManager,
+  val acknowledgements: List<Pair<String, String>>,
+) {
+  fun startSession() {
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+  }
+
+  fun audioEvent(bytes: ByteArray) {
+    val audioBase64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+    manager.handleGatewayEvent(
+      "talk.event",
+      """{"relaySessionId":"relay-1","type":"audio","audioBase64":"$audioBase64"}""",
+    )
+  }
+
+  fun markEvent(markName: String) {
+    manager.handleGatewayEvent("talk.event", """{"relaySessionId":"relay-1","type":"mark","markName":"$markName"}""")
+  }
+
+  fun clearEvent() {
+    manager.handleGatewayEvent("talk.event", """{"relaySessionId":"relay-1","type":"clear"}""")
+  }
+
+  fun assistantFinalTranscriptEvent() {
+    manager.handleGatewayEvent(
+      "talk.event",
+      """{"relaySessionId":"relay-1","type":"transcript","role":"assistant","text":"done","final":true}""",
+    )
+  }
+
+  fun stopRelay() {
+    val method =
+      manager.javaClass.getDeclaredMethod(
+        "stopRealtimeRelay",
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+      )
+    method.isAccessible = true
+    method.invoke(manager, false, true, true, false)
+  }
+
+  fun talkFailed(): Boolean = manager.statusText.value.startsWith("Talk failed:")
+
+  fun isSpeaking(): Boolean = manager.isSpeaking.value
+
+  fun setPlaybackEnabled(enabled: Boolean) = manager.setPlaybackEnabled(enabled)
+
+  fun idleTickerActive(): Boolean = (readPrivateField(manager, "realtimePlaybackIdleJob") as Job?)?.isActive == true
+
+  fun queuedProviderCommands(): Int = (readPrivateField(manager, "queuedRealtimeProviderCommands") as AtomicInteger).get()
+
+  fun queuedAudioBytes(): Long = (readPrivateField(manager, "queuedRealtimeAudioBytes") as AtomicLong).get()
+
+  fun shouldAppendCapturedFrame(length: Int): Boolean {
+    val method = manager.javaClass.getDeclaredMethod("shouldAppendRealtimeCapturedFrame", Int::class.javaPrimitiveType)
+    method.isAccessible = true
+    return method.invoke(manager, length) as Boolean
+  }
+
+  /** Ends the intentionally long-lived owner so no coroutine outlives the test. */
+  fun shutdown() {
+    (readPrivateField(manager, "realtimePlaybackOwnerJob") as Job).cancel()
+  }
+}
+
+private fun TestScope.realtimePlayoutHarness(sinks: FakeRealtimeAudioSinkFactory): RealtimePlayoutHarness {
+  val app = RuntimeEnvironment.getApplication()
+  val acknowledgements = mutableListOf<Pair<String, String>>()
+  val session =
+    GatewaySession(
+      scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler)),
+      identityStore = testDeviceIdentityStore(app),
+      deviceAuthStore =
+        DeviceAuthStore(
+          SecurePrefs(app, app.getSharedPreferences("playout-test-${System.nanoTime()}", 0)),
+        ),
+      onConnected = {},
+      onDisconnected = {},
+      onEvent = { _, _ -> },
+    )
+  val manager =
+    TalkModeManager(
+      context = app,
+      scope = this,
+      session = session,
+      isConnected = { true },
+      realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+      realtimePlaybackDispatcher = StandardTestDispatcher(testScheduler),
+      realtimeMarkAcknowledger = { sessionId, markName -> acknowledgements += sessionId to markName },
+      realtimeAudioSinkFactory = sinks,
+    )
+  setMutableStateFlow(manager, "_isEnabled", true)
+  return RealtimePlayoutHarness(manager, acknowledgements).also { it.startSession() }
+}
+
+private fun realThreadedPlayoutHarness(
+  sinks: FakeRealtimeAudioSinkFactory,
+  scope: CoroutineScope,
+): RealtimePlayoutHarness {
+  val app = RuntimeEnvironment.getApplication()
+  val session =
+    GatewaySession(
+      scope = scope,
+      identityStore = testDeviceIdentityStore(app),
+      deviceAuthStore =
+        DeviceAuthStore(
+          SecurePrefs(app, app.getSharedPreferences("playout-thread-test-${System.nanoTime()}", 0)),
+        ),
+      onConnected = {},
+      onDisconnected = {},
+      onEvent = { _, _ -> },
+    )
+  val manager =
+    TalkModeManager(
+      context = app,
+      scope = scope,
+      session = session,
+      isConnected = { true },
+      realtimePlaybackDispatcher = Dispatchers.IO,
+      realtimeMarkAcknowledger = { _, _ -> },
+      realtimeAudioSinkFactory = sinks,
+    )
+  setMutableStateFlow(manager, "_isEnabled", true)
+  return RealtimePlayoutHarness(manager, emptyList()).also { it.startSession() }
+}
+
+private fun setPrivateField(
+  target: Any,
+  name: String,
+  value: Any?,
+) {
+  val field = target.javaClass.getDeclaredField(name)
+  field.isAccessible = true
+  field.set(target, value)
+}
+
+private fun readPrivateField(
+  target: Any,
+  name: String,
+): Any? {
+  val field = target.javaClass.getDeclaredField(name)
+  field.isAccessible = true
+  return field.get(target)
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> setMutableStateFlow(
+  target: Any,
+  name: String,
+  value: T,
+) {
+  (readPrivateField(target, name) as MutableStateFlow<T>).value = value
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -14,6 +14,7 @@ import ai.openclaw.app.i18n.verbatimText
 import android.Manifest
 import android.content.ComponentName
 import android.content.IntentFilter
+import android.media.AudioFocusRequest
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
@@ -1551,6 +1552,9 @@ class TalkModeManagerTest {
   @Test
   fun captureForwardingDuringPlaybackFollowsActualEchoCancellation() {
     val manager = createManager()
+    // The gate needs live communication-audio eligibility as well as the effect capability, so
+    // the owner has to actually hold focus and the mode for this to exercise the AEC axis.
+    enterCommunicationModeForTest(manager, audioManagerForTest())
 
     // Nothing is playing: the microphone is forwarded either way.
     assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
@@ -1609,7 +1613,7 @@ class TalkModeManagerTest {
       RealtimeCommunicationAudioOwner.NO_OWNER,
       readPrivateField(manager, "realtimeCommunicationAudioToken") as Long,
     )
-    assertFalse("a stranded claim must not leave the device in communication mode", owner.communicationModeActive)
+    assertFalse("a stranded claim must not leave the device in communication mode", owner.communicationAudioEligible)
     assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
   }
 
@@ -1631,6 +1635,37 @@ class TalkModeManagerTest {
       val token = enterCommunicationModeForTest(manager, audioManagerForTest())
       assertTrue("the mode must actually be owned for the positive half", token != RealtimeCommunicationAudioOwner.NO_OWNER)
       assertTrue(realtimeEchoCancellationGranted(manager, session))
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  @Config(shadows = [ShadowObservableAudioEffect::class])
+  fun losingAudioFocusDuringPlaybackSuppressesTheNextCapturedFrame() {
+    // The end-to-end policy boundary, not owner internals: AEC enabled, mode active, focus held,
+    // playback running -> the frame is forwarded. Deliver a real focus-loss callback while the
+    // mode deliberately stays in MODE_IN_COMMUNICATION -> the next frame is suppressed.
+    val manager = createManager()
+    val audioManager = audioManagerForTest()
+    val session = openCommunicationCaptureForTest()
+    try {
+      assertTrue(session.refreshCommunicationEchoCancellation())
+      val token = enterCommunicationModeForTest(manager, audioManager)
+      assertTrue(token != RealtimeCommunicationAudioOwner.NO_OWNER)
+      setRealtimeAecEnabled(manager, realtimeEchoCancellationGranted(manager, session))
+      assertTrue("precondition: all three facts hold", realtimeAecEnabled(manager))
+
+      // Playback is active, and with echo cancellation granted the uplink stays open.
+      setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 5_000L)
+      assertTrue("with focus held the frame must be forwarded", shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+      // The platform hands focus to another app. The mode is untouched.
+      focusListenerFor(audioManager).onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS)
+      assertEquals("the mode must still be active", AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+      setRealtimeAecEnabled(manager, realtimeEchoCancellationGranted(manager, session))
+
+      assertFalse("focus loss must close the uplink during playback", shouldAppendRealtimeCapturedFrame(manager, 4_800))
     } finally {
       session.close()
     }
@@ -1773,6 +1808,8 @@ class TalkModeManagerTest {
     runTest {
       val gateAtFirstWrite = AtomicReference<Boolean?>(null)
       val manager = playoutManagerObservingFirstWrite(gateAtFirstWrite, acceptWrites = true)
+      // Full duplex needs live communication-audio eligibility, not just the effect capability.
+      enterCommunicationModeForTest(manager, audioManagerForTest())
       setRealtimeAecEnabled(manager, true)
 
       manager.realtimeEvent(audioEventPayload(480))
@@ -2119,6 +2156,14 @@ class TalkModeManagerTest {
       )
     method.isAccessible = true
     method.invoke(manager, inputGeneration, sessionId)
+  }
+
+  private fun focusListenerFor(manager: AudioManager): AudioManager.OnAudioFocusChangeListener {
+    val last = shadowOf(manager).lastAudioFocusRequest
+    last.listener?.let { return it }
+    val field = AudioFocusRequest::class.java.getDeclaredField("mFocusListener")
+    field.isAccessible = true
+    return field.get(last.audioFocusRequest) as AudioManager.OnAudioFocusChangeListener
   }
 
   private fun audioManagerForTest(): AudioManager = RuntimeEnvironment.getApplication().getSystemService(AudioManager::class.java)

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -1823,18 +1823,17 @@ class TalkModeManagerTest {
   fun aFirstWriteThatFailsCannotLeaveTheMicrophoneSuppressedForever() =
     runTest {
       val gateAtFirstWrite = AtomicReference<Boolean?>(null)
+      // A negative result is a device error: terminal, not backpressure.
       val manager = playoutManagerObservingFirstWrite(gateAtFirstWrite, acceptWrites = false)
       setRealtimeAecEnabled(manager, false)
 
       manager.realtimeEvent(audioEventPayload(480))
       runCurrent()
+      // The gate was shut while the device was being written to, which is the point of the gate.
       assertEquals(false, gateAtFirstWrite.get())
-      assertFalse(shouldAppendRealtimeCapturedFrame(manager, 4_800))
 
-      // Nothing was ever presented, so the idle check the publication started is what reopens it.
-      advanceTimeBy(200)
-      runCurrent()
-
+      // The failure path retires the device and republishes idle state, so the gate reopens with
+      // the failure itself rather than waiting for an idle tick to notice nothing is presenting.
       assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
       manager.stopAllCapture()
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -987,7 +987,6 @@ class TalkModeManagerTest {
         "talk.event",
         """{"relaySessionId":"playback-relay","type":"clear","talkEvent":{"turnId":"realtime-turn"}}""",
       )
-      assertEquals(AudioTrack.STATE_UNINITIALIZED, track.state)
     } else {
       // The stock shadow accounts written frames immediately. Advance both
       // Android's playback clock and the coroutine idle poll beyond the PCM.
@@ -997,6 +996,10 @@ class TalkModeManagerTest {
       proof.scheduler.advanceTimeBy(20)
     }
     proof.scheduler.runCurrent()
+    // Clear is queued to the playout owner rather than retiring the device on the Gateway
+    // receive path, so the sink is released once the owner drains that command -- not on the
+    // return from handleGatewayEvent. The release itself is still required.
+    if (clear) assertEquals(AudioTrack.STATE_UNINITIALIZED, track.state)
   }
 
   private fun startRealtimeAudio(proof: RealtimePlaybackProof): AudioTrack {

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -78,6 +78,7 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowAudioEffect
 import org.robolectric.shadows.ShadowAudioRecord
 import org.robolectric.shadows.ShadowAudioTrack
+import org.robolectric.shadows.ShadowLog
 import org.robolectric.shadows.ShadowSystemClock
 import org.robolectric.shadows.ShadowTextToSpeech
 import java.time.Duration
@@ -87,6 +88,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
@@ -1575,6 +1577,138 @@ class TalkModeManagerTest {
     setRealtimeAecEnabled(manager, true)
     assertFalse(shouldAppendRealtimeCapturedFrame(manager, 0))
   }
+
+  // ---- playback-time uplink observation ------------------------------------------------------
+
+  @Test
+  fun aFrameForwardedWhilePlayingReportsTheQualifiedFullDuplexState() {
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+
+    observeForwarded(manager)
+
+    assertEquals("a frame crossing the uplink while playing is the full-duplex state", "FORWARDED_DURING_PLAYBACK", uplinkPhaseName(manager))
+    assertTrue("the echo capability that allowed it must be reported", uplinkAec(manager))
+    assertTrue("the communication-audio eligibility that allowed it must be reported", uplinkComm(manager))
+  }
+
+  @Test
+  fun anEchoCancellerThatIsNotEnabledReportsSuppressionRatherThanForwarding() {
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, false)
+    startPlaybackForTest(manager)
+
+    observeHeldBack(manager)
+
+    assertEquals("SUPPRESSED_DURING_PLAYBACK", uplinkPhaseName(manager))
+    assertFalse("the reason must name the capability that was missing", uplinkAec(manager))
+  }
+
+  @Test
+  fun communicationAudioThatIsNotHeldReportsSuppressionEvenWithAnEnabledCanceller() {
+    // The other half of the gate: an enabled effect is not enough if this app no longer owns the
+    // mode and the focus, and the reported reason has to say which one was missing.
+    val manager = createManager()
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+
+    observeHeldBack(manager)
+
+    assertEquals("SUPPRESSED_DURING_PLAYBACK", uplinkPhaseName(manager))
+    assertTrue("the canceller was enabled and must not be blamed", uplinkAec(manager))
+    assertFalse("communication-audio eligibility is the missing fact here", uplinkComm(manager))
+  }
+
+  @Test
+  fun aSessionThatStaysInOneStateReportsItOnceRatherThanPerFrame() {
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+
+    val before = uplinkObservations()
+    repeat(200) { observeForwarded(manager) }
+
+    assertEquals("200 frames in one state must not become 200 observations", 1, uplinkObservations() - before)
+  }
+
+  @Test
+  fun forwardingAndSuppressionRemainVisibleEachTimeTheDecisionChanges() {
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    startPlaybackForTest(manager)
+
+    setRealtimeAecEnabled(manager, true)
+    val before = uplinkObservations()
+    observeForwarded(manager)
+    assertEquals("FORWARDED_DURING_PLAYBACK", uplinkPhaseName(manager))
+
+    // The route loses its canceller mid-playback.
+    setRealtimeAecEnabled(manager, false)
+    repeat(5) { observeHeldBack(manager) }
+    assertEquals("SUPPRESSED_DURING_PLAYBACK", uplinkPhaseName(manager))
+
+    // And gets it back.
+    setRealtimeAecEnabled(manager, true)
+    repeat(5) { observeForwarded(manager) }
+    assertEquals("FORWARDED_DURING_PLAYBACK", uplinkPhaseName(manager))
+
+    assertEquals("each edge is reported exactly once", 3, uplinkObservations() - before)
+  }
+
+  @Test
+  fun aFencedFrameIsNotReportedAsAnEchoGateRefusal() {
+    // The cancellation fence and the echo gate drop frames for unrelated reasons. Reporting a
+    // fenced frame as a suppression would send a reader looking at the device's audio state for a
+    // decision that was really about which turn owned the uplink.
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+    setPrivateField(manager, "pendingRealtimeOutputClear", CompletableDeferred<String?>())
+
+    observeHeldBack(manager)
+
+    assertEquals("HELD_BY_CANCELLATION_FENCE", uplinkPhaseName(manager))
+    assertTrue("the fence must not be reported as a missing canceller", uplinkAec(manager))
+  }
+
+  private fun startPlaybackForTest(manager: TalkModeManager) {
+    setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 5_000)
+  }
+
+  private fun observeForwarded(manager: TalkModeManager) = invokeUplinkObserver(manager, "observeRealtimeFrameForwarded")
+
+  private fun observeHeldBack(manager: TalkModeManager) = invokeUplinkObserver(manager, "observeRealtimeCaptureHeldBack")
+
+  private fun invokeUplinkObserver(
+    manager: TalkModeManager,
+    name: String,
+  ) {
+    val method = manager.javaClass.getDeclaredMethod(name)
+    method.isAccessible = true
+    method.invoke(manager)
+  }
+
+  private fun uplinkPhaseValue(manager: TalkModeManager): Int = (readPrivateField(manager, "realtimeUplinkPhase") as AtomicInteger).get()
+
+  private fun uplinkPhaseName(manager: TalkModeManager): String =
+    when (uplinkPhaseValue(manager) and 3) {
+      2 -> "FORWARDED_DURING_PLAYBACK"
+      1 -> "SUPPRESSED_DURING_PLAYBACK"
+      3 -> "HELD_BY_CANCELLATION_FENCE"
+      else -> "IDLE_NO_PLAYBACK"
+    }
+
+  private fun uplinkAec(manager: TalkModeManager): Boolean = uplinkPhaseValue(manager) and (1 shl 2) != 0
+
+  private fun uplinkComm(manager: TalkModeManager): Boolean = uplinkPhaseValue(manager) and (1 shl 3) != 0
+
+  /** What an operator would actually see: the count of emitted uplink observations. */
+  private fun uplinkObservations(): Int = ShadowLog.getLogsForTag("TalkMode").count { it.msg.startsWith("realtime uplink ") }
 
   @Test
   fun aCommunicationAudioRetryThatLosesToTeardownUnwindsItsOwnClaim() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -71,12 +72,16 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowAudioRecord
 import org.robolectric.shadows.ShadowAudioTrack
 import org.robolectric.shadows.ShadowSystemClock
 import org.robolectric.shadows.ShadowTextToSpeech
 import java.time.Duration
 import java.util.Locale
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.CoroutineContext
@@ -1442,6 +1447,102 @@ class TalkModeManagerTest {
     }
 
   @Test
+  fun capturingUnderAnUnsupportedWireContractFailsTheSessionInsteadOfStreaming() =
+    runTest {
+      val manager =
+        createManager(
+          scope = this,
+          realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+        )
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(
+        manager,
+        "realtimeWireAudioContract",
+        RealtimeWireAudioContract.Unsupported("inputEncoding=g711_ulaw"),
+      )
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      // Producing PCM16 anyway would put audio on the wire in a format the Gateway never asked
+      // for, so the session ends visibly rather than streaming something unusable.
+      assertTrue(manager.statusText.value.startsWith("Talk failed:"))
+      assertFalse(manager.isEnabled.value)
+      assertNull(readPrivateField(manager, "realtimeCaptureJob"))
+      manager.stopAllCapture()
+    }
+
+  @Test
+  fun capturingWithNoWireContractAtAllFailsTheSession() =
+    runTest {
+      val manager =
+        createManager(
+          scope = this,
+          realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+        )
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertTrue(manager.statusText.value.startsWith("Talk failed:"))
+      assertFalse(manager.isEnabled.value)
+      manager.stopAllCapture()
+    }
+
+  /**
+   * Drives the production capture install against a shadowed recorder, on real threads: the
+   * capture loop has no suspension point, so it cannot be stepped on a test dispatcher.
+   */
+  @Test
+  fun realtimeCaptureAsksTheHardwareForThePortableRateFirst() {
+    val requestedRates = CopyOnWriteArrayList<Int>()
+    val recorderWasRead = CountDownLatch(1)
+    ShadowAudioRecord.setSourceProvider { record ->
+      requestedRates += record.sampleRate
+      object : ShadowAudioRecord.AudioRecordSource {
+        override fun readInByteArray(
+          audioData: ByteArray,
+          offsetInBytes: Int,
+          sizeInBytes: Int,
+          isBlocking: Boolean,
+        ): Int {
+          recorderWasRead.countDown()
+          audioData.fill(0x20, offsetInBytes, offsetInBytes + sizeInBytes)
+          return sizeInBytes
+        }
+      }
+    }
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val manager = createManager(scope = scope, realtimeCaptureDispatcher = Dispatchers.IO)
+    try {
+      setMutableStateFlow(manager, "_isEnabled", true)
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(manager, "realtimeWireAudioContract", RealtimeWireAudioContract.Pcm16(24_000))
+
+      val start = manager.javaClass.getDeclaredMethod("startRealtimeCaptureLocked", String::class.java)
+      start.isAccessible = true
+      val failure = start.invoke(manager, "relay-1") as String?
+
+      assertNull(failure)
+      assertTrue("capture never read the recorder", recorderWasRead.await(10, TimeUnit.SECONDS))
+      // The rate the hardware is asked for is the portable preferred one, not the wire rate the
+      // Gateway declared; the wire rate is only the fallback when that one cannot be delivered.
+      assertEquals(48_000, requestedRates.first())
+    } finally {
+      manager.stopAllCapture()
+      scope.cancel()
+      ShadowAudioRecord.clearSource()
+    }
+  }
+
+  @Test
   fun resumingRealtimeCaptureRestoresListeningState() =
     runTest {
       val manager =
@@ -1454,6 +1555,9 @@ class TalkModeManagerTest {
       val pause = readPrivateField(manager, "realtimeCapturePause")!!
       setPrivateField(pause, "sessionId", "relay-1")
       setPrivateField(manager, "realtimeSessionId", "relay-1")
+      // A live relay session always carries the wire audio contract talk.session.create
+      // declared; capture reads it to decide how to convert what the microphone negotiates.
+      setPrivateField(manager, "realtimeWireAudioContract", RealtimeWireAudioContract.Pcm16(24_000))
       setMutableStateFlow(manager, "_isListening", false)
       setMutableStateFlow(manager, "_statusText", nativeText("Thinking…"))
 
@@ -1487,6 +1591,9 @@ class TalkModeManagerTest {
       setPrivateField(pause, "sessionId", "relay-replacement")
       setPrivateField(pause, "restartRelay", true)
       setPrivateField(manager, "realtimeSessionId", "relay-replacement")
+      // A live relay session always carries the wire audio contract talk.session.create
+      // declared; capture reads it to decide how to convert what the microphone negotiates.
+      setPrivateField(manager, "realtimeWireAudioContract", RealtimeWireAudioContract.Pcm16(24_000))
 
       manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
@@ -1346,6 +1347,109 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun cancellationFenceWaitsForAnInFlightSubmission() =
+    runBlocking {
+      // The boundary the review found unordered: the append worker checks the fence, encodes, and
+      // hands the frame to the socket, while the canceller raises the fence on another thread. A
+      // fence raised inside that window would let a frame that had passed the check leave the app
+      // after cancellation had begun. Both sides now go through one lock, so the canceller waits
+      // for a checked frame to reach the socket, and only then raises the fence and asks the
+      // Gateway to cancel.
+      val app = RuntimeEnvironment.getApplication()
+      val connected = CompletableDeferred<Unit>()
+      val cancelRequested = CompletableDeferred<Unit>()
+      val server = MockWebServer()
+      server.enqueue(
+        MockResponse().withWebSocketUpgrade(
+          object : WebSocketListener() {
+            override fun onOpen(
+              webSocket: WebSocket,
+              response: Response,
+            ) {
+              webSocket.send("""{"type":"event","event":"connect.challenge","payload":{"nonce":"fence-test","ts":1700000000123}}""")
+            }
+
+            override fun onMessage(
+              webSocket: WebSocket,
+              text: String,
+            ) {
+              val request = Json.parseToJsonElement(text).jsonObject
+              if (request["type"]?.jsonPrimitive?.content != "req") return
+              val id = request.getValue("id").jsonPrimitive.content
+              when (request.getValue("method").jsonPrimitive.content) {
+                // Deliberately never answered, so the canceller stays parked behind its fence.
+                "talk.session.cancelOutput" -> cancelRequested.complete(Unit)
+
+                "connect" -> webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""")
+
+                else -> webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+              }
+            }
+          },
+        ),
+      )
+      server.start()
+      val sessionJob = SupervisorJob()
+      val managerJob = SupervisorJob()
+      val session =
+        GatewaySession(
+          scope = CoroutineScope(sessionJob + Dispatchers.Default),
+          identityStore = testDeviceIdentityStore(app),
+          deviceAuthStore = DeviceAuthStore(SecurePrefs(app, app.getSharedPreferences("talk-fence-${System.nanoTime()}", 0))),
+          onConnected = { connected.complete(Unit) },
+          onDisconnected = {},
+          onEvent = { _, _ -> },
+        )
+      val manager = createManager(scope = CoroutineScope(managerJob + Dispatchers.Default), session = session)
+      try {
+        session.connect(
+          endpoint =
+            GatewayEndpoint(
+              stableId = "manual|127.0.0.1|${server.port}",
+              name = "Fence test",
+              host = "127.0.0.1",
+              port = server.port,
+              tlsEnabled = false,
+            ),
+          token = "test-token",
+          bootstrapToken = null,
+          password = null,
+          options =
+            GatewayConnectOptions(
+              role = "operator",
+              scopes = listOf("operator.admin"),
+              caps = emptyList(),
+              commands = emptyList(),
+              permissions = emptyMap(),
+              client = GatewayClientInfo("openclaw-android", "Android fence test", "1.0.0-test", "android", "ui", "fence-test", "android", "test"),
+            ),
+        )
+        withTimeout(5_000) { connected.await() }
+        setPrivateField(manager, "realtimeSessionId", "relay-1")
+        setPrivateField(manager, "realtimeOutputTurnId", "turn-1")
+        val submission = readPrivateField(manager, "realtimeSubmissionMutex") as Mutex
+
+        // A frame has passed the fence check and is on its way to the socket.
+        submission.lock()
+        manager.stopTts()
+        delay(300)
+
+        assertNull("the fence must not be raised while a checked frame is still being submitted", readPrivateField(manager, "pendingRealtimeOutputClear"))
+        assertFalse("cancelOutput must not reach the Gateway ahead of that frame", cancelRequested.isCompleted)
+
+        submission.unlock()
+        withTimeout(5_000) { cancelRequested.await() }
+
+        assertTrue("with the submission finished, the canceller raised the fence and sent cancelOutput", readPrivateField(manager, "pendingRealtimeOutputClear") != null)
+      } finally {
+        managerJob.cancel()
+        session.disconnectAndJoin()
+        sessionJob.cancelAndJoin()
+        server.shutdown()
+      }
+    }
+
+  @Test
   fun pushToTalkPauseWaitsForRealtimeCaptureJobs() =
     runTest {
       val manager = createManager()
@@ -2428,6 +2532,7 @@ class TalkModeManagerTest {
     talkSpeakClient: TalkSpeechSynthesizing = TalkSpeakClient(),
     talkAudioPlayer: TalkAudioPlaying? = null,
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    session: GatewaySession? = null,
     isConnected: () -> Boolean = { true },
     onBeforeSpeak: suspend () -> Unit = {},
     onAfterSpeak: suspend () -> Unit = {},
@@ -2438,8 +2543,8 @@ class TalkModeManagerTest {
     realtimeAudioSinkFactory: RealtimeAudioSinkFactory = RealtimeAudioSinkFactory.AudioTrackBacked,
   ): TalkModeManager {
     val app = RuntimeEnvironment.getApplication()
-    val session =
-      GatewaySession(
+    val gatewaySession =
+      session ?: GatewaySession(
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
         identityStore = testDeviceIdentityStore(app),
         deviceAuthStore = DeviceAuthStore(SecurePrefs(app, app.getSharedPreferences("talk-mode-test-${System.nanoTime()}", 0))),
@@ -2450,7 +2555,7 @@ class TalkModeManagerTest {
     return TalkModeManager(
       context = app,
       scope = scope,
-      session = session,
+      session = gatewaySession,
       isConnected = isConnected,
       onBeforeSpeak = onBeforeSpeak,
       onAfterSpeak = onAfterSpeak,

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -1581,15 +1581,15 @@ class TalkModeManagerTest {
   // ---- playback-time uplink observation ------------------------------------------------------
 
   @Test
-  fun aFrameForwardedWhilePlayingReportsTheQualifiedFullDuplexState() {
+  fun aFrameEnqueuedWhilePlayingReportsTheQualifiedFullDuplexState() {
     val manager = createManager()
     enterCommunicationModeForTest(manager, audioManagerForTest())
     setRealtimeAecEnabled(manager, true)
     startPlaybackForTest(manager)
 
-    observeForwarded(manager)
+    observeEnqueued(manager)
 
-    assertEquals("a frame crossing the uplink while playing is the full-duplex state", "FORWARDED_DURING_PLAYBACK", uplinkPhaseName(manager))
+    assertEquals("a frame reaching the local send boundary while playing is the full-duplex state", "ENQUEUED_DURING_PLAYBACK", uplinkPhaseName(manager))
     assertTrue("the echo capability that allowed it must be reported", uplinkAec(manager))
     assertTrue("the communication-audio eligibility that allowed it must be reported", uplinkComm(manager))
   }
@@ -1630,21 +1630,21 @@ class TalkModeManagerTest {
     startPlaybackForTest(manager)
 
     val before = uplinkObservations()
-    repeat(200) { observeForwarded(manager) }
+    repeat(200) { observeEnqueued(manager) }
 
     assertEquals("200 frames in one state must not become 200 observations", 1, uplinkObservations() - before)
   }
 
   @Test
-  fun forwardingAndSuppressionRemainVisibleEachTimeTheDecisionChanges() {
+  fun enqueueAndSuppressionRemainVisibleEachTimeTheDecisionChanges() {
     val manager = createManager()
     enterCommunicationModeForTest(manager, audioManagerForTest())
     startPlaybackForTest(manager)
 
     setRealtimeAecEnabled(manager, true)
     val before = uplinkObservations()
-    observeForwarded(manager)
-    assertEquals("FORWARDED_DURING_PLAYBACK", uplinkPhaseName(manager))
+    observeEnqueued(manager)
+    assertEquals("ENQUEUED_DURING_PLAYBACK", uplinkPhaseName(manager))
 
     // The route loses its canceller mid-playback.
     setRealtimeAecEnabled(manager, false)
@@ -1653,8 +1653,8 @@ class TalkModeManagerTest {
 
     // And gets it back.
     setRealtimeAecEnabled(manager, true)
-    repeat(5) { observeForwarded(manager) }
-    assertEquals("FORWARDED_DURING_PLAYBACK", uplinkPhaseName(manager))
+    repeat(5) { observeEnqueued(manager) }
+    assertEquals("ENQUEUED_DURING_PLAYBACK", uplinkPhaseName(manager))
 
     assertEquals("each edge is reported exactly once", 3, uplinkObservations() - before)
   }
@@ -1676,11 +1676,138 @@ class TalkModeManagerTest {
     assertTrue("the fence must not be reported as a missing canceller", uplinkAec(manager))
   }
 
+  // ---- forwarding-boundary repairs ---------------------------------------------------------
+
+  @Test
+  fun aQueuedFrameIsHeldByTheFenceWhenCancellationTakesTheTurnBeforeItIsSubmitted() {
+    // The capture side let this frame through; cancelOutput then took the turn while it waited in
+    // the bounded queue. The fence is unconditional, so the dequeue boundary must refuse it rather
+    // than let the full-duplex exception carry it to the socket.
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+
+    assertTrue("a qualified frame must be submittable before cancellation", shouldSubmitDequeued(manager, "relay-1"))
+
+    setPrivateField(manager, "pendingRealtimeOutputClear", CompletableDeferred<String?>())
+
+    assertFalse("a frame dequeued after the fence went up must not be submitted", shouldSubmitDequeued(manager, "relay-1"))
+    assertEquals("HELD_BY_CANCELLATION_FENCE", uplinkPhaseName(manager))
+  }
+
+  @Test
+  fun aDequeuedFrameFromAnOldSessionIsNotSubmitted() {
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+
+    assertFalse(shouldSubmitDequeued(manager, "relay-from-a-previous-session"))
+  }
+
+  @Test
+  fun localMediaPlaybackDoesNotQualifyForTheCommunicationExemption() {
+    // Local assistant speech plays on the media path. The canceller is subtracting the realtime
+    // downlink, not that, so an enabled AEC says nothing about whether the microphone is hearing
+    // the assistant here.
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+    setLocalMediaPlaying(manager, true)
+
+    assertTrue("local media playback must suppress capture", shouldSuppressRealtimeCaptureForPlayback(manager))
+    observeHeldBack(manager)
+    assertEquals("SUPPRESSED_DURING_PLAYBACK", uplinkPhaseName(manager))
+    assertTrue("the reported reason must name local playback, not the canceller", uplinkLocal(manager))
+    assertTrue("the canceller was enabled and must not be blamed", uplinkAec(manager))
+  }
+
+  @Test
+  fun localMediaOverlappingRealtimePlayoutIsStillSuppressed() {
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+    setLocalMediaPlaying(manager, true)
+
+    assertTrue("overlapping local media contaminates the reference", shouldSuppressRealtimeCaptureForPlayback(manager))
+  }
+
+  @Test
+  fun qualifiedForwardingResumesWhenLocalMediaRetiresAndRealtimePlayoutRemains() {
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+    setLocalMediaPlaying(manager, true)
+    assertTrue(shouldSuppressRealtimeCaptureForPlayback(manager))
+
+    setLocalMediaPlaying(manager, false)
+
+    assertFalse(
+      "realtime playout alone, with the predicates live, is the case the exception exists for",
+      shouldSuppressRealtimeCaptureForPlayback(manager),
+    )
+    observeEnqueued(manager)
+    assertEquals("ENQUEUED_DURING_PLAYBACK", uplinkPhaseName(manager))
+    assertFalse(uplinkLocal(manager))
+  }
+
+  @Test
+  fun theSpeakingProjectionStaysTheUnionOfBothSourcesWhileTheGateSeesThemApart() {
+    // #130868's invariant is a UI fact and must not be narrowed by this repair; the forwarding
+    // policy simply stops using it as the answer to a question it never answered.
+    val manager = createManager()
+    val audioManager = audioManagerForTest()
+    enterCommunicationModeForTest(manager, audioManager)
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+    publishSpeakingStateFor(manager, realtimePlaying = true, localPlaying = true)
+
+    assertTrue("either source keeps the app speaking", manager.isSpeaking.value)
+    assertTrue("but local media still disqualifies the exception", shouldSuppressRealtimeCaptureForPlayback(manager))
+
+    publishSpeakingStateFor(manager, realtimePlaying = false, localPlaying = true)
+    assertTrue("local playback alone still reports speaking", manager.isSpeaking.value)
+
+    publishSpeakingStateFor(manager, realtimePlaying = false, localPlaying = false)
+    assertFalse("neither source playing clears the projection", manager.isSpeaking.value)
+  }
+
+  /** Drives the real derivation point so the mirrors are proven to follow it, not set by hand. */
+  private fun publishSpeakingStateFor(
+    manager: TalkModeManager,
+    realtimePlaying: Boolean,
+    localPlaying: Boolean,
+  ) {
+    setPrivateField(manager, "realtimePlaying", realtimePlaying)
+    if (localPlaying) {
+      val leaseClass = Class.forName("ai.openclaw.app.voice.TalkModeManager\$PlaybackLease")
+      val phaseClass = Class.forName("ai.openclaw.app.voice.TalkModeManager\$PlaybackPhase")
+      val playing = phaseClass.enumConstants!!.first { (it as Enum<*>).name == "Playing" }
+      val ctor = leaseClass.declaredConstructors.first()
+      ctor.isAccessible = true
+      val lease = ctor.newInstance(1L, Job(), playing)
+      setPrivateField(manager, "localPlayback", lease)
+    } else {
+      setPrivateField(manager, "localPlayback", null)
+    }
+    val method = manager.javaClass.getDeclaredMethod("publishSpeakingState")
+    method.isAccessible = true
+    method.invoke(manager)
+  }
+
+  private fun shouldSuppressRealtimeCaptureForPlayback(manager: TalkModeManager): Boolean {
+    val method = manager.javaClass.getDeclaredMethod("shouldSuppressRealtimeCaptureForPlayback")
+    method.isAccessible = true
+    return method.invoke(manager) as Boolean
+  }
+
   private fun startPlaybackForTest(manager: TalkModeManager) {
     setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 5_000)
   }
 
-  private fun observeForwarded(manager: TalkModeManager) = invokeUplinkObserver(manager, "observeRealtimeFrameForwarded")
+  private fun observeEnqueued(manager: TalkModeManager) = invokeUplinkObserver(manager, "observeRealtimeFrameEnqueued")
 
   private fun observeHeldBack(manager: TalkModeManager) = invokeUplinkObserver(manager, "observeRealtimeCaptureHeldBack")
 
@@ -1697,7 +1824,7 @@ class TalkModeManagerTest {
 
   private fun uplinkPhaseName(manager: TalkModeManager): String =
     when (uplinkPhaseValue(manager) and 3) {
-      2 -> "FORWARDED_DURING_PLAYBACK"
+      2 -> "ENQUEUED_DURING_PLAYBACK"
       1 -> "SUPPRESSED_DURING_PLAYBACK"
       3 -> "HELD_BY_CANCELLATION_FENCE"
       else -> "IDLE_NO_PLAYBACK"
@@ -1706,6 +1833,22 @@ class TalkModeManagerTest {
   private fun uplinkAec(manager: TalkModeManager): Boolean = uplinkPhaseValue(manager) and (1 shl 2) != 0
 
   private fun uplinkComm(manager: TalkModeManager): Boolean = uplinkPhaseValue(manager) and (1 shl 3) != 0
+
+  private fun uplinkLocal(manager: TalkModeManager): Boolean = uplinkPhaseValue(manager) and (1 shl 4) != 0
+
+  private fun setLocalMediaPlaying(
+    manager: TalkModeManager,
+    playing: Boolean,
+  ) = setPrivateField(manager, "localMediaPlaybackActive", playing)
+
+  private fun shouldSubmitDequeued(
+    manager: TalkModeManager,
+    sessionId: String,
+  ): Boolean {
+    val method = manager.javaClass.getDeclaredMethod("shouldSubmitDequeuedRealtimeFrame", String::class.java)
+    method.isAccessible = true
+    return method.invoke(manager, sessionId) as Boolean
+  }
 
   /** What an operator would actually see: the count of emitted uplink observations. */
   private fun uplinkObservations(): Int = ShadowLog.getLogsForTag("TalkMode").count { it.msg.startsWith("realtime uplink ") }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -75,7 +75,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
 import org.robolectric.shadows.ShadowAudioEffect
+import org.robolectric.shadows.ShadowAudioManager
 import org.robolectric.shadows.ShadowAudioRecord
 import org.robolectric.shadows.ShadowAudioTrack
 import org.robolectric.shadows.ShadowLog
@@ -1754,6 +1757,54 @@ class TalkModeManagerTest {
   }
 
   @Test
+  @Config(shadows = [ShadowFocusStackAudioManager::class])
+  fun localPlaybackCompletionHandsFocusBackToTheRealtimeOwner() =
+    runTest {
+      // The lifecycle the predicate tests above bypass. Local assistant audio requests focus in
+      // front of the realtime owner's request; the platform tells the owner it lost focus and full
+      // duplex closes. Only an abandon of the local request makes the platform send the GAIN that
+      // reopens it -- and ordinary completion, unlike an explicit stop, never abandoned.
+      ShadowFocusStackAudioManager.stack.clear()
+      val synthesizer = FakeTalkSpeechSynthesizer()
+      val talkAudioPlayer = FakeTalkAudioPlayer()
+      val manager = createManager(talkSpeakClient = synthesizer, talkAudioPlayer = talkAudioPlayer)
+      val audioManager = audioManagerForTest()
+      val owner = readPrivateField(manager, "realtimeCommunicationAudio") as RealtimeCommunicationAudioOwner
+      assertTrue(enterCommunicationModeForTest(manager, audioManager) != RealtimeCommunicationAudioOwner.NO_OWNER)
+      setRealtimeAecEnabled(manager, true)
+      startPlaybackForTest(manager)
+      assertTrue("precondition: realtime playout alone keeps the uplink open", shouldAppendRealtimeCapturedFrame(manager, 4_800))
+      assertEquals("precondition: the realtime owner is the only focus holder", 1, ShadowFocusStackAudioManager.stack.size)
+
+      val playback = launch { manager.speakAssistantReply("hello") }
+      synthesizer.requested.await()
+      synthesizer.result.complete(
+        TalkSpeakResult.Success(
+          TalkSpeakAudio(
+            bytes = byteArrayOf(1, 2, 3),
+            provider = "test",
+            outputFormat = "mp3_44100_128",
+            voiceCompatible = true,
+            mimeType = "audio/mpeg",
+            fileExtension = ".mp3",
+          ),
+        ),
+      )
+      talkAudioPlayer.started.await()
+
+      assertEquals("the local request sits in front of the realtime owner", 2, ShadowFocusStackAudioManager.stack.size)
+      assertFalse("the platform revoked the realtime owner's focus", owner.communicationAudioEligible)
+      assertFalse(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+      talkAudioPlayer.finished.complete(Unit)
+      playback.join()
+
+      assertEquals("completion must abandon the local request", 1, ShadowFocusStackAudioManager.stack.size)
+      assertTrue("the platform handed focus back to the realtime owner", owner.communicationAudioEligible)
+      assertTrue("forwarding resumes once local playback and its focus are gone", shouldAppendRealtimeCapturedFrame(manager, 4_800))
+    }
+
+  @Test
   fun theSpeakingProjectionStaysTheUnionOfBothSourcesWhileTheGateSeesThemApart() {
     // #130868's invariant is a UI fact and must not be narrowed by this repair; the forwarding
     // policy simply stops using it as the answer to a question it never answered.
@@ -2711,5 +2762,46 @@ private class FakeTalkAudioPlayer : TalkAudioPlaying {
   override fun stop() {
     stopCalls += 1
     stopped = true
+  }
+}
+
+/**
+ * The part of the platform's focus arbitration the lifecycle tests need: a stack of holders, where
+ * a new request tells the holder in front of it that it lost focus, and abandoning the front entry
+ * tells the next one it has focus again. Requests that register the same listener share one entry,
+ * as they do on the platform.
+ */
+@Implements(AudioManager::class)
+class ShadowFocusStackAudioManager : ShadowAudioManager() {
+  @Implementation
+  override fun requestAudioFocus(audioFocusRequest: android.media.AudioFocusRequest): Int {
+    val listener = listenerOf(audioFocusRequest) ?: return super.requestAudioFocus(audioFocusRequest)
+    val previousTop = stack.lastOrNull()
+    stack.removeAll { it === listener }
+    stack.add(listener)
+    if (previousTop != null && previousTop !== listener) {
+      previousTop.onAudioFocusChange(AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK)
+    }
+    return super.requestAudioFocus(audioFocusRequest)
+  }
+
+  @Implementation
+  override fun abandonAudioFocusRequest(audioFocusRequest: android.media.AudioFocusRequest): Int {
+    val listener = listenerOf(audioFocusRequest) ?: return super.abandonAudioFocusRequest(audioFocusRequest)
+    val wasTop = stack.lastOrNull() === listener
+    stack.removeAll { it === listener }
+    if (wasTop) stack.lastOrNull()?.onAudioFocusChange(AudioManager.AUDIOFOCUS_GAIN)
+    return super.abandonAudioFocusRequest(audioFocusRequest)
+  }
+
+  companion object {
+    @JvmStatic val stack = mutableListOf<AudioManager.OnAudioFocusChangeListener>()
+
+    // The public getter is hidden from the SDK stubs; the request keeps the listener in this field.
+    private fun listenerOf(request: android.media.AudioFocusRequest): AudioManager.OnAudioFocusChangeListener? {
+      val field = android.media.AudioFocusRequest::class.java.getDeclaredField("mFocusListener")
+      field.isAccessible = true
+      return field.get(request) as? AudioManager.OnAudioFocusChangeListener
+    }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -17,6 +17,7 @@ import android.content.IntentFilter
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioTrack
+import android.media.audiofx.AudioEffect
 import android.os.Bundle
 import android.os.Looper
 import android.os.SystemClock
@@ -73,6 +74,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowAudioEffect
 import org.robolectric.shadows.ShadowAudioRecord
 import org.robolectric.shadows.ShadowAudioTrack
 import org.robolectric.shadows.ShadowSystemClock
@@ -1571,6 +1573,90 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun aCommunicationAudioRetryThatLosesToTeardownUnwindsItsOwnClaim() {
+    // The retry touches the device, so it cannot be atomic with publishing its token. A claim
+    // that lands after teardown took the field would otherwise leave the device in communication
+    // mode with no live token left to restore it.
+    val manager = createManager()
+    val audioManager = audioManagerForTest()
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+    val generation = (readPrivateField(manager, "audioInputGeneration") as AtomicLong).get()
+    val owner0 = readPrivateField(manager, "realtimeCommunicationAudio") as RealtimeCommunicationAudioOwner
+    // The retry only acts on a transient focus refusal, so the session must have suffered one.
+    shadowOf(audioManager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner0.enter(audioManager))
+    shadowOf(audioManager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
+
+    // The live case publishes the token.
+    recoverRealtimeCommunicationAudio(manager, generation, "relay-1")
+    val published = readPrivateField(manager, "realtimeCommunicationAudioToken") as Long
+    assertTrue("a live session must receive the recovered token", published != RealtimeCommunicationAudioOwner.NO_OWNER)
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+
+    // Teardown wins: the session id has moved on, so the claim must undo itself.
+    val owner = owner0
+    owner.restore(audioManager, published)
+    shadowOf(audioManager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_FAILED)
+    assertEquals(RealtimeCommunicationAudioOwner.NO_OWNER, owner.enter(audioManager))
+    shadowOf(audioManager).setNextFocusRequestResponse(AudioManager.AUDIOFOCUS_REQUEST_GRANTED)
+    setPrivateField(manager, "realtimeCommunicationAudioToken", RealtimeCommunicationAudioOwner.NO_OWNER)
+    setPrivateField(manager, "realtimeSessionId", "relay-2")
+
+    recoverRealtimeCommunicationAudio(manager, generation, "relay-1")
+
+    assertEquals(
+      "a stranded claim must not be published",
+      RealtimeCommunicationAudioOwner.NO_OWNER,
+      readPrivateField(manager, "realtimeCommunicationAudioToken") as Long,
+    )
+    assertFalse("a stranded claim must not leave the device in communication mode", owner.communicationModeActive)
+    assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+  }
+
+  @Test
+  @Config(shadows = [ShadowObservableAudioEffect::class])
+  fun anEnabledCancellerDoesNotGrantFullDuplexWithoutCommunicationModeOwnership() {
+    // FIX-1's consequence. The effect can report enabled while another app owns
+    // MODE_IN_COMMUNICATION -- then it is not cancelling this session's downlink, and opening the
+    // uplink would forward the assistant's own voice back to the provider.
+    val manager = createManager()
+    val session = openCommunicationCaptureForTest()
+    try {
+      assertTrue("the effect must report enabled for this test to mean anything", session.refreshCommunicationEchoCancellation())
+
+      // No mode ownership yet: the two inputs disagree, and the conjunction must fail closed.
+      assertFalse(realtimeEchoCancellationGranted(manager, session))
+
+      // Take the mode for real, and the same effect now does grant it.
+      val token = enterCommunicationModeForTest(manager, audioManagerForTest())
+      assertTrue("the mode must actually be owned for the positive half", token != RealtimeCommunicationAudioOwner.NO_OWNER)
+      assertTrue(realtimeEchoCancellationGranted(manager, session))
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  @Config(shadows = [ShadowObservableAudioEffect::class])
+  fun capturePublicationReadsTheCachedCapabilityInsteadOfMeasuringTheEffect() {
+    // FIX-2. Measuring takes the capture session's lifecycle lock, which a route refresh holds
+    // across several AudioManager binder calls; the read loop must never pay that.
+    val manager = createManager()
+    val session = openCommunicationCaptureForTest()
+    try {
+      enterCommunicationModeForTest(manager, audioManagerForTest())
+      session.refreshCommunicationEchoCancellation()
+      val baseline = ShadowObservableAudioEffect.getEnabledCount
+
+      repeat(200) { realtimeEchoCancellationGranted(manager, session) }
+
+      assertEquals("the read-loop path must issue no effect IPC", baseline, ShadowObservableAudioEffect.getEnabledCount)
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
   fun aStaleCaptureGenerationCannotAnswerForItsSuccessor() {
     val manager = createManager()
 
@@ -2018,6 +2104,56 @@ class TalkModeManagerTest {
       )
     method.isAccessible = true
     method.invoke(manager, inputGeneration, enabled)
+  }
+
+  private fun recoverRealtimeCommunicationAudio(
+    manager: TalkModeManager,
+    inputGeneration: Long,
+    sessionId: String,
+  ) {
+    val method =
+      manager.javaClass.getDeclaredMethod(
+        "recoverRealtimeCommunicationAudio",
+        Long::class.javaPrimitiveType,
+        String::class.java,
+      )
+    method.isAccessible = true
+    method.invoke(manager, inputGeneration, sessionId)
+  }
+
+  private fun audioManagerForTest(): AudioManager = RuntimeEnvironment.getApplication().getSystemService(AudioManager::class.java)
+
+  private fun openCommunicationCaptureForTest(): AndroidAudioInputSession {
+    ShadowAudioEffect.addEffect(
+      AudioEffect.Descriptor(
+        AudioEffect.EFFECT_TYPE_AEC.toString(),
+        "9a2f0f34-1c5e-4d3a-9b64-3a1b2c4d5e6f",
+        AudioEffect.EFFECT_INSERT,
+        "Test AEC",
+        "Robolectric",
+      ),
+    )
+    return AndroidAudioInputSession.open(
+      RuntimeEnvironment.getApplication(),
+      48_000,
+      9_600,
+      profile = AndroidAudioInputProfile.VoiceCommunication,
+    )
+  }
+
+  /** Calls the production conjunction rather than reimplementing it here. */
+  private fun realtimeEchoCancellationGranted(
+    manager: TalkModeManager,
+    session: AndroidAudioInputSession,
+  ): Boolean {
+    val method =
+      manager.javaClass.getDeclaredMethod(
+        "realtimeEchoCancellationGranted",
+        AndroidAudioInputSession::class.java,
+        Boolean::class.javaPrimitiveType,
+      )
+    method.isAccessible = true
+    return method.invoke(manager, session, false) as Boolean
   }
 
   private fun enterCommunicationModeForTest(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -15,6 +15,7 @@ import android.Manifest
 import android.content.ComponentName
 import android.content.IntentFilter
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioTrack
 import android.os.Bundle
 import android.os.Looper
@@ -84,6 +85,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -1542,6 +1544,178 @@ class TalkModeManagerTest {
     }
   }
 
+  // ---- Phase 1C: full-duplex forwarding policy ---------------------------------------------
+
+  @Test
+  fun captureForwardingDuringPlaybackFollowsActualEchoCancellation() {
+    val manager = createManager()
+
+    // Nothing is playing: the microphone is forwarded either way.
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+    setRealtimeAecEnabled(manager, true)
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+    setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 1_000)
+
+    // Playing, and the platform is cancelling its own echo: what the microphone hears is the
+    // user, so forwarding it is the whole point -- this is the capability Phase 1C adds.
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+    // Playing with no echo cancellation: the same frames would be the assistant's own voice.
+    setRealtimeAecEnabled(manager, false)
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+    // An empty converted frame is never forwarded, whatever the route can do.
+    setRealtimeAecEnabled(manager, true)
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, 0))
+  }
+
+  @Test
+  fun aStaleCaptureGenerationCannotAnswerForItsSuccessor() {
+    val manager = createManager()
+
+    // Generation 5 runs with echo cancellation, then a restart fences it off. The fence is the
+    // boundary publication itself, so nothing a dying job does afterwards can win.
+    publishRealtimeAecCapability(manager, 5, true)
+    assertTrue(realtimeAecEnabled(manager))
+    publishRealtimeAecCapability(manager, 6, false)
+    assertFalse(realtimeAecEnabled(manager))
+
+    // Generation 5's cleanup unwinds late. It must not answer for 6 in either direction --
+    // clearing would drop a working session to half duplex, and setting would open the uplink
+    // into a speaker that has no canceller.
+    publishRealtimeAecCapability(manager, 5, true)
+    assertFalse(realtimeAecEnabled(manager))
+
+    publishRealtimeAecCapability(manager, 6, true)
+    assertTrue(realtimeAecEnabled(manager))
+    publishRealtimeAecCapability(manager, 5, false)
+    assertTrue(realtimeAecEnabled(manager))
+  }
+
+  @Test
+  fun installingCaptureClearsTheEchoCancellationCapabilityAtTheGenerationBoundary() =
+    runTest {
+      val manager =
+        createManager(scope = this, realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler))
+      setMutableStateFlow(manager, "_isEnabled", true)
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(manager, "realtimeWireAudioContract", RealtimeWireAudioContract.Pcm16(24_000))
+      setRealtimeAecEnabled(manager, true)
+
+      val start = manager.javaClass.getDeclaredMethod("startRealtimeCaptureLocked", String::class.java)
+      start.isAccessible = true
+      synchronized(readPrivateField(manager, "realtimeCapturePauseLock")!!) { start.invoke(manager, "relay-1") }
+
+      // The capture coroutine has not run yet, so nothing has reported a capability. Until one
+      // does, the safe answer to "may the uplink stay open" is no.
+      assertFalse(realtimeAecEnabled(manager))
+      manager.stopAllCapture()
+    }
+
+  // ---- Phase 1C: communication mode is session-scoped ---------------------------------------
+
+  @Test
+  fun startingARelaySessionAcquiresCommunicationAudioBeforePublishingTheSession() {
+    val manager = createManager()
+    val audioManager = RuntimeEnvironment.getApplication().getSystemService(AudioManager::class.java)
+    audioManager.mode = AudioManager.MODE_NORMAL
+
+    val acquire = manager.javaClass.getDeclaredMethod("acquireRealtimeCommunicationAudio")
+    acquire.isAccessible = true
+    val token = acquire.invoke(manager) as Long
+
+    assertTrue(token != 0L)
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+  }
+
+  @Test
+  fun relayTeardownRestoresTheModeTheSessionEntered() {
+    val manager = createManager()
+    val audioManager = RuntimeEnvironment.getApplication().getSystemService(AudioManager::class.java)
+    audioManager.mode = AudioManager.MODE_NORMAL
+    enterCommunicationModeForTest(manager, audioManager)
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+
+    stopRealtimeRelayForTest(manager)
+
+    assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+  }
+
+  @Test
+  fun aResponseBoundaryDoesNotReleaseOrReacquireCommunicationMode() {
+    val manager = createManager()
+    val audioManager = RuntimeEnvironment.getApplication().getSystemService(AudioManager::class.java)
+    audioManager.mode = AudioManager.MODE_NORMAL
+    val token = enterCommunicationModeForTest(manager, audioManager)
+
+    // A whole turn: audio, its barrier, and the clear a barge-in produces.
+    manager.realtimeEvent("""{"relaySessionId":"relay-1","type":"audio","audioBase64":"AAA="}""")
+    manager.realtimeEvent("""{"relaySessionId":"relay-1","type":"mark","markName":"audio-1"}""")
+    manager.realtimeEvent("""{"relaySessionId":"relay-1","type":"clear"}""")
+
+    // The events really were processed, so this is not a negative that passes on a dropped event:
+    // clear invalidates the playback generation on the requesting thread.
+    assertTrue((readPrivateField(manager, "realtimePlaybackEpoch") as AtomicLong).get() > 0L)
+
+    // Mode is a property of the session, not of a response: toggling it per turn would rebuild
+    // the platform's voice pipeline mid-conversation.
+    assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+    assertEquals(token, readPrivateField(manager, "realtimeCommunicationAudioToken"))
+  }
+
+  // ---- Phase 1C: suppression timing when echo cancellation is unavailable --------------------
+
+  @Test
+  fun withoutEchoCancellationTheGateIsClosedBeforeTheFirstSampleIsWritten() =
+    runTest {
+      val gateAtFirstWrite = AtomicReference<Boolean?>(null)
+      val manager = playoutManagerObservingFirstWrite(gateAtFirstWrite, acceptWrites = true)
+      setRealtimeAecEnabled(manager, false)
+
+      manager.realtimeEvent(audioEventPayload(480))
+      runCurrent()
+
+      // Publishing after the frame finished writing would let the assistant's own first words
+      // reach the provider on a device with no echo cancellation.
+      assertEquals(false, gateAtFirstWrite.get())
+      manager.stopAllCapture()
+    }
+
+  @Test
+  fun withEchoCancellationTheGateStaysOpenThroughTheFirstWrite() =
+    runTest {
+      val gateAtFirstWrite = AtomicReference<Boolean?>(null)
+      val manager = playoutManagerObservingFirstWrite(gateAtFirstWrite, acceptWrites = true)
+      setRealtimeAecEnabled(manager, true)
+
+      manager.realtimeEvent(audioEventPayload(480))
+      runCurrent()
+
+      assertEquals(true, gateAtFirstWrite.get())
+      manager.stopAllCapture()
+    }
+
+  @Test
+  fun aFirstWriteThatFailsCannotLeaveTheMicrophoneSuppressedForever() =
+    runTest {
+      val gateAtFirstWrite = AtomicReference<Boolean?>(null)
+      val manager = playoutManagerObservingFirstWrite(gateAtFirstWrite, acceptWrites = false)
+      setRealtimeAecEnabled(manager, false)
+
+      manager.realtimeEvent(audioEventPayload(480))
+      runCurrent()
+      assertEquals(false, gateAtFirstWrite.get())
+      assertFalse(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+      // Nothing was ever presented, so the idle check the publication started is what reopens it.
+      advanceTimeBy(200)
+      runCurrent()
+
+      assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+      manager.stopAllCapture()
+    }
+
   @Test
   fun resumingRealtimeCaptureRestoresListeningState() =
     runTest {
@@ -1749,6 +1923,7 @@ class TalkModeManagerTest {
     realtimeCaptureDispatcher: CoroutineDispatcher = Dispatchers.IO,
     realtimePlaybackDispatcher: CoroutineDispatcher = Dispatchers.IO,
     realtimeMarkAcknowledger: (suspend (String, String) -> Unit)? = null,
+    realtimeAudioSinkFactory: RealtimeAudioSinkFactory = RealtimeAudioSinkFactory.AudioTrackBacked,
   ): TalkModeManager {
     val app = RuntimeEnvironment.getApplication()
     val session =
@@ -1773,6 +1948,7 @@ class TalkModeManagerTest {
       realtimeCaptureDispatcher = realtimeCaptureDispatcher,
       realtimePlaybackDispatcher = realtimePlaybackDispatcher,
       realtimeMarkAcknowledger = realtimeMarkAcknowledger,
+      realtimeAudioSinkFactory = realtimeAudioSinkFactory,
     )
   }
 
@@ -1812,6 +1988,88 @@ class TalkModeManagerTest {
 
   @Suppress("UNCHECKED_CAST")
   private fun playbackGeneration(manager: TalkModeManager) = readPrivateField(manager, "playbackGeneration") as AtomicLong
+
+  private fun realtimeAecEnabled(manager: TalkModeManager): Boolean {
+    val capability = readPrivateField(manager, "realtimeAecCapability") as AtomicReference<*>
+    val value = capability.get()!!
+    val field = value.javaClass.getDeclaredField("enabled")
+    field.isAccessible = true
+    return field.getBoolean(value)
+  }
+
+  private fun setRealtimeAecEnabled(
+    manager: TalkModeManager,
+    enabled: Boolean,
+  ) {
+    val generation = (readPrivateField(manager, "audioInputGeneration") as AtomicLong).get()
+    publishRealtimeAecCapability(manager, generation, enabled)
+  }
+
+  private fun publishRealtimeAecCapability(
+    manager: TalkModeManager,
+    inputGeneration: Long,
+    enabled: Boolean,
+  ) {
+    val method =
+      manager.javaClass.getDeclaredMethod(
+        "publishRealtimeAecCapability",
+        Long::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+      )
+    method.isAccessible = true
+    method.invoke(manager, inputGeneration, enabled)
+  }
+
+  private fun enterCommunicationModeForTest(
+    manager: TalkModeManager,
+    audioManager: AudioManager,
+  ): Long {
+    val owner = readPrivateField(manager, "realtimeCommunicationAudio") as RealtimeCommunicationAudioOwner
+    val token = owner.enter(audioManager)
+    setPrivateField(manager, "realtimeCommunicationAudioToken", token)
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+    return token
+  }
+
+  private fun stopRealtimeRelayForTest(manager: TalkModeManager) {
+    val method =
+      manager.javaClass.getDeclaredMethod(
+        "stopRealtimeRelay",
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+        Boolean::class.javaPrimitiveType,
+      )
+    method.isAccessible = true
+    method.invoke(manager, false, true, true, false)
+  }
+
+  private fun audioEventPayload(byteCount: Int): String {
+    val audioBase64 = android.util.Base64.encodeToString(ByteArray(byteCount) { 0x20 }, android.util.Base64.NO_WRAP)
+    return """{"relaySessionId":"relay-1","type":"audio","audioBase64":"$audioBase64"}"""
+  }
+
+  /** A manager whose output device reports the capture gate the moment it is first written to. */
+  private fun TestScope.playoutManagerObservingFirstWrite(
+    gateAtFirstWrite: AtomicReference<Boolean?>,
+    acceptWrites: Boolean,
+  ): TalkModeManager {
+    lateinit var manager: TalkModeManager
+    val sinks =
+      FakeRealtimeAudioSinkFactory { offered, call ->
+        if (call == 0) gateAtFirstWrite.set(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+        if (acceptWrites) offered else -1
+      }
+    manager =
+      createManager(
+        scope = this,
+        realtimePlaybackDispatcher = StandardTestDispatcher(testScheduler),
+        realtimeAudioSinkFactory = sinks,
+      )
+    setMutableStateFlow(manager, "_isEnabled", true)
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+    return manager
+  }
 
   private fun setPrivateField(
     target: Any,

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -1803,6 +1803,35 @@ class TalkModeManagerTest {
     return method.invoke(manager) as Boolean
   }
 
+  @Test
+  fun aLaterSessionReachingTheSameStateStillReportsIt() {
+    // The observation reports edges, so it is deliberately silent while a state persists. Across
+    // two sessions that is wrong: the second relay would inherit the first's state and publish
+    // nothing, leaving exactly the session under investigation without evidence.
+    val manager = createManager()
+    enterCommunicationModeForTest(manager, audioManagerForTest())
+    setRealtimeAecEnabled(manager, true)
+    startPlaybackForTest(manager)
+
+    val base = uplinkObservations()
+    observeEnqueued(manager)
+    assertEquals("the first session reports its state", base + 1, uplinkObservations())
+    observeEnqueued(manager)
+    assertEquals("and stays quiet while it holds", base + 1, uplinkObservations())
+
+    resetUplinkObservation(manager)
+    observeEnqueued(manager)
+
+    assertEquals("a new session in the same state must report again", base + 2, uplinkObservations())
+    assertEquals("ENQUEUED_DURING_PLAYBACK", uplinkPhaseName(manager))
+  }
+
+  private fun resetUplinkObservation(manager: TalkModeManager) {
+    val method = manager.javaClass.getDeclaredMethod("resetRealtimeUplinkObservation")
+    method.isAccessible = true
+    method.invoke(manager)
+  }
+
   private fun startPlaybackForTest(manager: TalkModeManager) {
     setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 5_000)
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -1642,6 +1642,39 @@ class TalkModeManagerTest {
 
   @Test
   @Config(shadows = [ShadowObservableAudioEffect::class])
+  fun aPendingOutputCancellationSuppressesCaptureEvenWhenFullDuplexIsLive() {
+    // The merged rule. Upstream fences capture while a cancelOutput is in flight; this branch
+    // opens capture during playback whenever the platform is cancelling the echo. Those are
+    // different questions -- which turn owns the uplink, versus whose voice the microphone hears
+    // -- and resolving the rebase by keeping only one of them would be silently wrong in both
+    // directions. The pending fence must win even in the case the full-duplex rule most wants
+    // open: AEC enabled, mode and focus owned, assistant actively speaking.
+    val manager = createManager()
+    val session = openCommunicationCaptureForTest()
+    try {
+      val token = enterCommunicationModeForTest(manager, audioManagerForTest())
+      assertTrue("the mode must actually be owned for this test to mean anything", token != RealtimeCommunicationAudioOwner.NO_OWNER)
+      setRealtimeAecEnabled(manager, true)
+      assertTrue("full duplex must be live for this test to mean anything", realtimeEchoCancellationGranted(manager, session))
+      setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 1_000)
+
+      // Full duplex is live and the assistant is speaking: the frame is forwarded.
+      assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+      // A cancellation boundary opens. The same frame must now be held back.
+      setPrivateField(manager, "pendingRealtimeOutputClear", CompletableDeferred<String?>())
+      assertFalse(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+
+      // And released again once the boundary closes, without needing playback to end.
+      setPrivateField(manager, "pendingRealtimeOutputClear", null)
+      assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  @Config(shadows = [ShadowObservableAudioEffect::class])
   fun losingAudioFocusDuringPlaybackSuppressesTheNextCapturedFrame() {
     // The end-to-end policy boundary, not owner internals: AEC enabled, mode active, focus held,
     // playback running -> the frame is forwarded. Deliver a real focus-loss callback while the
@@ -2224,9 +2257,12 @@ class TalkModeManagerTest {
     method.invoke(manager, false, true, true, false)
   }
 
-  private fun audioEventPayload(byteCount: Int): String {
+  private fun audioEventPayload(
+    byteCount: Int,
+    turnId: String = "turn-1",
+  ): String {
     val audioBase64 = android.util.Base64.encodeToString(ByteArray(byteCount) { 0x20 }, android.util.Base64.NO_WRAP)
-    return """{"relaySessionId":"relay-1","type":"audio","audioBase64":"$audioBase64"}"""
+    return """{"relaySessionId":"relay-1","type":"audio","talkEvent":{"turnId":"$turnId"},"audioBase64":"$audioBase64"}"""
   }
 
   /** A manager whose output device reports the capture gate the moment it is first written to. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a user who speaks while the Android realtime Talk assistant's reply is playing is not heard: on current `main`, capture is suppressed unconditionally for as long as the realtime downlink is playing, so nothing is submitted on the uplink until the reply ends and the user has to wait for it to finish. Local assistant speech on the media path (Gateway TTS or system speech) is a separate case and keeps that suppression; the change concerns realtime downlink playback only.

At the merge base `8ea4fd05`, `shouldAppendRealtimeCapturedFrame` (`apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt`) gates on `isRealtimePlaybackActive()` alone, and neither `MODE_IN_COMMUNICATION` nor `AcousticEchoCanceler` appears anywhere under `apps/android/app/src/main`. Android Talk is therefore half-duplex on every device, including handsets whose platform echo canceller reports itself enabled on the capture path, which is the condition this PR treats as eligibility for keeping the uplink open.

## Why This Change Was Made

This branch keeps the uplink open during playback **only while the most recently observed app-level AEC state for the live recorder is enabled and the communication-mode and audio-focus grants are held**, and reports that decision so it can be verified from outside the app.

Enforcing that rule needs two audio capabilities that do not exist on `main`. Correctly clocked capture: the recorder's negotiated sample rate is read back from the `AudioRecord` and converted to the 24 kHz wire rate instead of assuming the requested rate was granted; exact integer ratios up to 8 (for example 48 or 96 kHz to 24 kHz) are decimated through an anti-alias filter, a recorder that negotiates a non-integer ratio such as 44.1 kHz is closed and the next candidate rate tried, and capture fails rather than run at a clock the Gateway did not ask for. The device below negotiated 48 kHz; the other ratios are covered by unit tests, not hardware. A playout owner off the Gateway receive path: one coroutine owns the `AudioTrack` and drains a bounded command queue, so the Gateway receive path never blocks on the device and playback epochs, clears and marks are serialized through that owner. That is why the diff is large. Relative to the merge base `8ea4fd05`: production +2,328 / −308 and tests (`src/test`) +3,479 / −4, all Kotlin under `apps/android`; no generated files, fixtures or lockfiles are touched.

**Decision needed: this changes a product default.** Full duplex is not switched on globally: playback-time capture is suppressed exactly as `main` suppresses it unless, at that frame, the AEC is enabled *and* communication audio is eligible. A device reporting no AEC behaves exactly as `main` does today. Whether AEC-qualified full duplex should be the Android Talk default is an owner decision. Source review can judge the gate; it cannot select the interaction. The maintainer-side review of head `0ee798e1` ([review](https://github.com/openclaw/openclaw/pull/128101#pullrequestreview-5085048692), 2026-09-02) states support for the guarded default once the two lifecycle findings it raised are repaired. The four commits since are exactly those two repairs, one allowlist change (adding two types) in this PR's own new code, and the ordering of the cancellation fence that ClawSweeper's review of `4c00aafb` asked for (see *Lifecycle repairs from review* and *Further repairs from the same pass*); there is no behaviour change after the reviewed head beyond those four, and the review has not yet been re-run on the current head. That decision is the merge decision itself; no separate sign-off step is requested. The evidence below establishes what the Android side does; the default remains the owner's call.

### How the gate works

The echo gate, `shouldSuppressRealtimeCaptureForPlayback` in `TalkModeManager.kt`, asks three questions, each re-read rather than assumed. A fourth, independent condition, the cancellation fence, is checked before and after it.

- **AEC enabled**: the effect was created for the live `AudioRecord` session and reports `enabled`, re-measured off the hot path at open, on route change, on close and by a 500 ms watcher, and read from a `@Volatile` snapshot rather than an `AudioEffect` IPC per frame.
- **Communication-audio eligible** (`RealtimeCommunicationAudioOwner`, `RealtimeCommunicationAudio.kt`): an owner token is held, the device mode still reads back as `MODE_IN_COMMUNICATION`, and focus is active. Focus is taken *before* the mode; the mode is **read back** rather than assumed, since `AudioManager.mode` is a void setter; focus is revocable state maintained by the platform's own listener.
- **The playing source is the communication downlink, not anything that makes the app "speaking"**: local assistant speech plays on `USAGE_MEDIA`, which the canceller this rule depends on is not subtracting, so local playback (alone, or overlapping realtime playout) never qualifies for the exception. The union projection upstream #130868 introduced is preserved for speaking state; the gate consumes the realtime source separately.

The fence is separate: a pending `cancelOutput` suppresses capture unconditionally, and is re-checked in `shouldSubmitDequeuedRealtimeFrame` **after the frame leaves the capture queue**, immediately before submission, because a frame can clear the capture-side check, wait in the bounded queue, and be dequeued after cancellation has taken the turn. It is a different invariant from the echo question and keeps its own state in the observation. A request already handed to the socket is in flight and is not recalled by it.

Recovery is deliberately asymmetric, and concerns capture eligibility only (what playout does across a loss is the second known gap below): a transient focus loss restores full-duplex eligibility on the platform's `GAIN`; a permanent loss does not, because re-requesting focus every tick would pause and resume other apps' audio twice a second for the whole session. Both halves are exercised on the handset below by delivering the loss and gain callbacks to the production owner from the instrumentation harness; a platform-originated loss could not be induced on that device (see *Proof boundary*).

On the capture loop's forwarding path the observation adds one packed-integer compare and the gate reads one extra volatile boolean: no AudioEffect IPC, no binder call, no lock, no per-frame allocation or logging.

### Lifecycle repairs from review

The [current-head review](https://github.com/openclaw/openclaw/pull/128101#pullrequestreview-5085048692) found two places where the new owners were not integrated with the lifecycles around them. Both are repaired at their producer, each with a regression that fails on the pre-fix code. They are integration requirements of the owners this PR introduces, not separable hardening, which is why they land here rather than as follow-ups; the loudspeaker route is likewise part of taking communication mode on a handset with no external output, without which Talk would move to the earpiece.

- **Local playback now gives its audio focus back when its lease ends** (`releaseLocalPlaybackAudioFocus`, `TalkModeManager.kt`). Local assistant audio requested media-path focus when it started and abandoned it only on the explicit stop path; ordinary completion never did. With one focus request per app that was harmless. With the realtime owner's request behind it in the platform's stack, the platform told the owner it had lost focus, the owner closed full duplex, and the `GAIN` that would have reopened it never came, because the entry in front of it was never abandoned. The request is now bound to the playback lease that took it and released in that lease's own `finally`, which completion, failure and cancellation all reach (the regression exercises completion); a lease that finishes after its replacement has re-requested leaves the shared entry alone.
- **Communication-route cleanup now belongs to the newest capture before its setup can fail** (`CommunicationDeviceRoute`, `AndroidAudioInputSession.kt`). A replacement capture superseded the previous one the moment it registered, and a superseded owner may not clear the process-wide communication device. If the replacement's own route setup then threw, it never became the active owner either, so no close path could release the selection. Responsibility now moves to the newest capture at the point it is first seen, before any fallible platform call, at both entry points: `begin()`, and `update()`, which the platform's initial device callback can reach first.

### Further repairs from the same pass

In code this PR introduces: `handsFreeBuiltInSpeaker` decides "a deliberate external output is present" by an allowlist, and that allowlist omitted the two line-level sinks the platform admits as communication devices, `TYPE_LINE_ANALOG` and `TYPE_AUX_LINE` (`AudioDeviceBroker.VALID_COMMUNICATION_DEVICE_TYPES`, API 34). A handset plugged into a line output would have had realtime speech moved to its own loudspeaker. Both types are now in the allowlist; HDMI ARC/eARC, digital line and analog dock are not admitted as communication devices there and were deliberately not added. It is not separable from this PR: the override and its allowlist do not exist on `main`.

**Cancellation fence ordered against frame submission** (`ca83f6db`, from [ClawSweeper's review](https://github.com/openclaw/openclaw/pull/128101#issuecomment-5384129117) of `4c00aafb`, finding "Linearize cancellation with realtime frame submission"). The append worker read the cancellation fence, encoded the frame and handed it to the socket, while `cancelRealtimeOutput` raised the fence from another thread; a fence raised inside that window let a frame that had already passed the check leave the app *after the fence was raised and before `cancelOutput` was sent*, attributed to a turn being torn down. Both sides now go through one mutex (`realtimeSubmissionMutex`): the worker holds it across check, encode and handoff, the canceller while raising the fence, so a raised fence is ordered after every frame that had passed the check and before every frame that had not, and `cancelOutput` is sent only after any such frame reached the socket. The window was microseconds wide and matters only on the AEC-qualified path this PR opens, which is why it is repaired here.

### Known gaps, not repaired here

Two, both disclosed for the maintainer rather than guessed at. The merge scope is the diff as it stands; neither is added here unless the maintainer asks for it explicitly, and both are recorded as follow-ups.

**Marks queued behind a terminal stop are still acknowledged.**
- What happens: relay teardown sends a terminal `Stop` that leaves pending playback barriers unacknowledged, but a `Mark` already queued behind it reaches the playout owner with a stale epoch and takes the same path as a mark cancelled by a same-session `Clear`: `talk.session.acknowledgeMark` is sent for it. On a closed relay the Gateway rejects that request (`getUnifiedTalkSession` throws for an unknown session in `src/gateway/server-methods/talk-session-mark.ts`, and the handler responds with an error); the app logs it at debug level and continues. Nothing reaches the provider.
- Impact: at most one rejected acknowledgement request per mark the response had queued. No audio, state or message is affected.
- Owner: joint. The contract (whether a closed relay ever needs a mark released) is the Gateway's; the implementation is a one-line Android change in the stale-epoch branch of `processRealtimeMarkOwnerOnly`, skipping the acknowledgement when the mark's session is no longer the live one. It is out of scope here only because it presumes the Gateway-side answer.
- Disposition: follow-up, not a merge blocker.

**Playout is not stopped on focus loss.**
- What happens: when the platform takes focus away from the realtime owner (`AUDIOFOCUS_LOSS` / `LOSS_TRANSIENT`, for example an incoming call), this PR revokes full-duplex eligibility and keeps capture closed, but does not pause or clear realtime playout or cancel the provider's turn.
- What is new versus `main`: this PR makes the session a focus participant and closes capture on loss; `main` requests no focus for realtime playback and reacts to nothing. What is unchanged versus `main`: playout continues through a loss on both.
- Owner: the playout owner plus the Gateway's turn-cancellation semantics; whether loss should stop playout and cancel the turn, and what a transient loss followed by `GAIN` should resume, is a product decision.
- Disposition: follow-up, not a merge blocker.

### Why this is not three PRs

The natural split, capabilities first and policy second, lands `RealtimeCommunicationAudio.kt` and the serialized owner with no caller and no reachable behaviour, which the root `AGENTS.md` calls a review smell. Every hazard the gate closes is a way the *combination* degrades, so an intermediate with no policy consumer cannot be judged against the invariant it protects. If a maintainer prefers a split anyway, the seam is `RealtimeCommunicationAudio.kt` plus its tests as one change and the rest as a second; say so and it will be resubmitted that way.

## User Impact

By construction of the code, not by device measurement: every realtime Talk session now requests communication mode, audio focus and, when no wired, USB or Bluetooth output is present, the built-in loudspeaker instead of the earpiece, and restores them when the session ends. That part does not depend on the echo canceller. Hardware verification of it is the one handset in Evidence.

What depends on the echo canceller is playback-time capture. On a handset where the platform reports its echo canceller enabled for the live recorder and those grants hold, a user can speak while the assistant's realtime reply is playing and the captured audio is submitted on the realtime uplink instead of being dropped at the microphone. Where any of those facts does not hold, or stops holding mid-session, playback-time capture during realtime playback is suppressed exactly as it is today, and capture during local assistant speech is suppressed as it is today on every device. Nothing is configurable and no setting is added.

## Evidence

Which head each claim is for:

| Claim | Head |
|---|---|
| Device proof (APK digest, instrumented checks, production-path logs) | `e1d118fe` |
| `0ee798e1` ktlint style commit | no behaviour change, not re-run on hardware |
| `66e63b7a` focus release | unit regression `localPlaybackCompletionHandsFocusBackToTheRealtimeOwner`, pre-fix fail and fixed pass |
| `8ed0f6c9` route ownership | unit regression `replacementWhoseRouteSetupThrowsStillClearsThePreviousCommunicationDevice`, pre-fix fail and fixed pass |
| `4c00aafb` line-level outputs in the allowlist | unit regression `aLineLevelCommunicationOutputIsNotStolenEither` (`RealtimeCommunicationAudioTest.kt`), pre-fix fail and fixed pass |
| `ca83f6db` cancellation fence ordered against submission | unit regression `cancellationFenceWaitsForAnInFlightSubmission` (`TalkModeManagerTest.kt`), pre-fix fail and fixed pass |
| Full unit suite, lint, build in *Tests* | `8ed0f6c9` and `ca83f6db`; upstream CI at `ca83f6db` |

### Device proof, taken before the lifecycle repairs

Taken at `e1d118fe`, before all five later commits; it is not final-head hardware validation. **Candidate** `e1d118fe`. APK `sha256:0a806c19…58d4`, built from that clean head and **verified by digest on the device after install**, not merely on the build host. The five commits since were not re-run on hardware: `0ee798e1` is ktlint style only, with no behaviour change; `66e63b7a` (focus release) is covered by `localPlaybackCompletionHandsFocusBackToTheRealtimeOwner`; `8ed0f6c9` (route ownership) by `replacementWhoseRouteSetupThrowsStillClearsThePreviousCommunicationDevice`; `4c00aafb` (line-level outputs) by `aLineLevelCommunicationOutputIsNotStolenEither`; `ca83f6db` (fence ordering) by `cancellationFenceWaitsForAnInFlightSubmission`. The regressions are described below.

**Device** Redmi Note 11 (`2201117TL`), Android 13, MIUI V816, over USB. The model is named because echo-cancellation behaviour is device-specific; serials, hosts, ports and session ids are withheld.

**Acoustics: no digital injection.** Every utterance is spoken by a Mac's built-in speaker (explicitly selected as output device, level recorded, verified before each run) and reaches the phone through the room. Playback is the phone's built-in speaker; capture is its built-in microphone.

#### Device predicates, driven through production classes

Five instrumented checks ran on the handset against that head, exercising `AndroidAudioInputSession` and `RealtimeCommunicationAudioOwner` themselves rather than reimplementations, **5/5 pass**. The checks and the focus-stack capture below came from a local instrumentation harness and the handset's `dumpsys audio`; the harness is not part of the diff and the captures are not replayable from this PR. In the two revoke checks the loss, gain and abandon callbacks were delivered to the production owner by the harness, since no platform-originated focus loss could be induced on this device.

```
aec.available true · aec.enabled true (VoiceCommunication, negotiated 48000 Hz) · stable across a watcher interval
mode.before 0 → owner.token claimed → mode.readBack 3 (MODE_IN_COMMUNICATION) → watcherVerify true → restored 0
revokeTransient: eligible true → false on loss → true again on GAIN
revokePermanent: eligible true → false on loss → still false after abandon
route.withoutProductionRequest type=1 (earpiece) → route.productionApplied type=2 (built-in speaker)
```

That last line answers a concern raised on an earlier revision, that `MODE_IN_COMMUNICATION` with `USAGE_VOICE_COMMUNICATION` would land on the earpiece on a handset with no wired or Bluetooth output. On this device that is **true of a bare track**, and production does not leave it to the platform: `handsFreeBuiltInSpeaker` requests the loudspeaker whenever no deliberate external output is present, and reports only the device the platform confirms it selected.

#### The production path, during a real conversation

Opening realtime capture, at that head:

```
realtime session started relaySessionId=<redacted>
realtime capture opened requested=48000Hz negotiated=48000Hz wire=24000Hz aecEnabled=true commOut=2
capture started preferred=default routed=15
```

`commOut=2` is `TYPE_BUILTIN_SPEAKER`, `routed=15` is `TYPE_BUILTIN_MIC`, and 48 kHz → 24 kHz is the decimation-by-2 path this branch adds. Independently of the app, the platform's own focus stack shows the owner this branch introduces holding focus:

```
client: …RealtimeCommunicationAudioOwner$$Lambda — gain: GAIN_TRANSIENT — loss: none
attr: usage=USAGE_VOICE_COMMUNICATION content=CONTENT_TYPE_SPEECH
```

The forwarding decision is reported at the boundary that makes it. The line is emitted only on an edge, never per frame, and is published **after** the `talk.session.appendAudio` request has been submitted locally, so it records that a real frame passed the gate and left the app rather than that the policy returned true. It is named for exactly that and no more: `sendGatewayRequestFrame` returns once the request reaches the socket, and the Gateway's answer, including a rejection, arrives later on the error callback.

```
realtime uplink IDLE_NO_PLAYBACK        aecEnabled=true commEligible=true localPlayback=false
realtime uplink ENQUEUED_DURING_PLAYBACK aecEnabled=true commEligible=true localPlayback=false
realtime uplink IDLE_NO_PLAYBACK        aecEnabled=true commEligible=true localPlayback=false
```

`ENQUEUED_DURING_PLAYBACK` with `localPlayback=false` is the case the exception exists for: realtime playout active, no local media playing, and a frame submitted.

The first line lands moments after capture opens: the observation is forgotten when a session installs, so a later relay reaching the same state as an earlier one still reports it rather than inheriting silence. The cancellation fence keeps its own state (`HELD_BY_CANCELLATION_FENCE`) so a frame held for turn-ownership reasons is never reported as an echo-gate refusal.

#### Historical acoustic observation, on an earlier revision

The stimulus work below was run against an earlier head, before the forwarding repairs. It is kept because it is what established that the Android result is not an artifact of one stimulus, and it is not re-claimed for this head: a person asked for a spoken explanation, then spoke again while the assistant was still answering, under two materially different synthesised voices, a robotic one and a substantially more natural one, both confirmed audible in the room by a listener. Under both, Android's result was the same positive one: captured frames were forwarded during playback. Assistant interruption and topic switching were not observed under either.

That negative was not re-run on the later heads and is not re-claimed either way. What was re-established on the device is the positive path above.

### Regressions for the lifecycle repairs

Each regression was run against the pre-fix code first and fails at the defect, then passes with the fix. The first two at `8ed0f6c9` with `:app:testPlayDebugUnitTest --tests 'ai.openclaw.app.voice.AndroidAudioInputSessionTest' --tests 'ai.openclaw.app.voice.TalkModeManagerTest'`; the third at `4c00aafb` with `--tests 'ai.openclaw.app.voice.RealtimeCommunicationAudioTest'` (it loops over `TYPE_LINE_ANALOG` and `TYPE_AUX_LINE`; the pre-fix run stops at the first); the fourth at `ca83f6db` with `:app:testPlayDebugUnitTest --tests 'ai.openclaw.app.voice.TalkModeManagerTest'` (95 tests, 0 failed with the fix), where "pre-fix" means `ca83f6db` with the mutex field present but unused on either side:

```
localPlaybackCompletionHandsFocusBackToTheRealtimeOwner
  pre-fix: AssertionError: completion must abandon the local request expected:<1> but was:<2>
  fixed:   PASS
replacementWhoseRouteSetupThrowsStillClearsThePreviousCommunicationDevice
  pre-fix: AssertionError: no capture is left that can release the process-wide selection expected null, but was:<android.media.AudioDeviceInfo@21>
  fixed:   PASS
aLineLevelCommunicationOutputIsNotStolenEither
  pre-fix: AssertionError: line output type=5 must not be overridden expected null, but was:<2>
  fixed:   PASS
cancellationFenceWaitsForAnInFlightSubmission
  pre-fix: AssertionError: the fence must not be raised while a checked frame is still being submitted expected null, but was:<CompletableDeferredImpl{Active}@…>
  fixed:   PASS
```

The focus test drives the real lifecycle rather than the gate predicate: a Robolectric shadow models the platform's focus stack, so the local request delivers `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK` to the realtime owner and its abandon delivers `AUDIOFOCUS_GAIN`; the test asserts the owner is ineligible while local audio plays and that forwarding resumes once `playAssistant` completes. It exercises completion; failure and cancellation reach the same `finally` and are not separately tested. The route test opens a second capture whose `setCommunicationDevice` throws over an active first one, closes both, and asserts the process-wide selection is cleared; it reaches the route through `update()` (the initial device callback path), and `begin()` shares the same step. The fence test connects the manager to a local mock Gateway that never answers `cancelOutput`, holds the submission mutex as a checked frame on its way to the socket, calls `stopTts()`, and asserts that neither the fence nor the `cancelOutput` request appears until the mutex is released, and that both do afterwards.

### Tests

At `8ed0f6c9`: `:app:testPlayDebugUnitTest` **2,550 tests, 0 failed, 203 suites**, plus `ktlintCheck`, `lintPlayDebug` and `assemblePlayDebug`, all `BUILD SUCCESSFUL`; `git diff --check` clean. At `4c00aafb`: `RealtimeCommunicationAudioTest` + `AndroidAudioInputSessionTest` 59 / 0 and `ktlintCheck` locally. At the current head `ca83f6db`: `:app:testPlayDebugUnitTest` **2,552 tests, 0 failed, 203 suites**, plus `ktlintCheck`, `lintPlayDebug` and `assemblePlayDebug`, all `BUILD SUCCESSFUL`, and the full Android matrix in [CI on this head](https://github.com/openclaw/openclaw/pull/128101/checks).

Focused tests cover the forwarding boundary's semantics rather than its logging: an enqueued frame during playback reports the qualified state with its reasons; a disabled canceller and an ineligible communication route each report suppression naming the missing fact; 200 frames in one state produce **one** observation; enqueue → suppress → enqueue reports exactly three edges; a fenced frame is never reported as an echo-gate refusal; a frame dequeued after cancellation took the turn is refused and reported as the fence; local media playback, alone, overlapping realtime playout, and retiring while realtime playout continues, is covered as its own case; and two consecutive sessions reaching the same state each report it.

### Proof boundary

**End-to-end assistant interruption and topic switching were not observed in this deployment.** The unresolved behaviour is downstream of Android's local submission boundary, and this proof does not claim it. Ownership of that region could lie in Gateway relay or session handling, transport or session processing, provider input handling, endpointing, or model interruption semantics; this trial did not isolate which, and no claim is made about any of them.

The replication across two acoustic conditions matters only for what it rules out: it makes it substantially less likely that the earlier negative was an artifact of a robotic stimulus. It is not evidence about any particular downstream component.

Also honest about this deployment: there is no reliable realtime transcript or user-turn surface here, so the semantic content of the interrupting utterance could not be machine-verified, and the absence of that surface is **not** treated as evidence of downstream failure.

Other limits: the grant is bounded-stale by design; the per-frame read is a `@Volatile` snapshot, never a binder call, so invalidation is not synchronous with the loss; mode theft is caught on the next watcher pass (nominally 500 ms) and focus loss on the platform callback. A device reporting no AEC takes exactly the suppression `main` takes today. The evidence above is one handset in one room; device variance across the AEC/route matrix is not established by it. A real competing focus owner during playback and a live route refresh during capture are covered by the unit regressions above, not by a hardware trace: on this handset there is no external focus policy, no media session, and media-key dispatch produced no competing request, so the loss could not be induced without root or a second call.
