### PR TITLE
fix(mcp): dedupe blocked stdio env warnings

### DIFF
--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -140,15 +140,29 @@ describe("resolveMcpTransportConfig", () => {
         NODE_OPTIONS: "--require=./evil.js",
       },
     });
+    const firstCollidingPair = resolveMcpTransportConfig("svc", {
+      command: "node",
+      env: {
+        "LD_A:LD_B": "/tmp/workspace",
+      },
+    });
+    const secondCollidingPair = resolveMcpTransportConfig("svc:LD_A", {
+      command: "node",
+      env: {
+        LD_B: "/tmp/workspace",
+      },
+    });
 
     for (const resolved of [
       ...repeatedResolutions,
       sameKeyDifferentServer,
       sameServerDifferentKey,
+      firstCollidingPair,
+      secondCollidingPair,
     ]) {
       expect(resolved).toEqual(expect.objectContaining({ env: {} }));
     }
-    expect(logWarn).toHaveBeenCalledTimes(3);
+    expect(logWarn).toHaveBeenCalledTimes(5);
     expect(logWarn).toHaveBeenNthCalledWith(
       1,
       'bundle-mcp: server "repeat-server": env "PYTHONPATH" is blocked for stdio startup safety and was ignored.',
@@ -160,6 +174,14 @@ describe("resolveMcpTransportConfig", () => {
     expect(logWarn).toHaveBeenNthCalledWith(
       3,
       'bundle-mcp: server "repeat-server": env "NODE_OPTIONS" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenNthCalledWith(
+      4,
+      'bundle-mcp: server "svc": env "LD_A:LD_B" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenNthCalledWith(
+      5,
+      'bundle-mcp: server "svc:LD_A": env "LD_B" is blocked for stdio startup safety and was ignored.',
     );
   });
 

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -119,6 +119,22 @@ describe("resolveMcpTransportConfig", () => {
     );
   });
 
+  it("warns once per blocked stdio env key and server", () => {
+    for (let index = 0; index < 3; index += 1) {
+      resolveMcpTransportConfig("repeat-server", {
+        command: "node",
+        env: {
+          PYTHONPATH: "/tmp/workspace",
+        },
+      });
+    }
+
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(logWarn).toHaveBeenCalledWith(
+      'bundle-mcp: server "repeat-server": env "PYTHONPATH" is blocked for stdio startup safety and was ignored.',
+    );
+  });
+
   it("uses an explicit empty stdio env when all configured env keys are blocked", () => {
     const resolved = resolveMcpTransportConfig("probe", {
       command: "node",

--- a/src/agents/mcp-transport-config.test.ts
+++ b/src/agents/mcp-transport-config.test.ts
@@ -120,18 +120,46 @@ describe("resolveMcpTransportConfig", () => {
   });
 
   it("warns once per blocked stdio env key and server", () => {
-    for (let index = 0; index < 3; index += 1) {
+    const repeatedResolutions = Array.from({ length: 3 }, () =>
       resolveMcpTransportConfig("repeat-server", {
         command: "node",
         env: {
           PYTHONPATH: "/tmp/workspace",
         },
-      });
-    }
+      }),
+    );
+    const sameKeyDifferentServer = resolveMcpTransportConfig("other-server", {
+      command: "node",
+      env: {
+        PYTHONPATH: "/tmp/other-workspace",
+      },
+    });
+    const sameServerDifferentKey = resolveMcpTransportConfig("repeat-server", {
+      command: "node",
+      env: {
+        NODE_OPTIONS: "--require=./evil.js",
+      },
+    });
 
-    expect(logWarn).toHaveBeenCalledTimes(1);
-    expect(logWarn).toHaveBeenCalledWith(
+    for (const resolved of [
+      ...repeatedResolutions,
+      sameKeyDifferentServer,
+      sameServerDifferentKey,
+    ]) {
+      expect(resolved).toEqual(expect.objectContaining({ env: {} }));
+    }
+    expect(logWarn).toHaveBeenCalledTimes(3);
+    expect(logWarn).toHaveBeenNthCalledWith(
+      1,
       'bundle-mcp: server "repeat-server": env "PYTHONPATH" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenNthCalledWith(
+      2,
+      'bundle-mcp: server "other-server": env "PYTHONPATH" is blocked for stdio startup safety and was ignored.',
+    );
+    expect(logWarn).toHaveBeenNthCalledWith(
+      3,
+      'bundle-mcp: server "repeat-server": env "NODE_OPTIONS" is blocked for stdio startup safety and was ignored.',
     );
   });
 

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -74,7 +74,7 @@ const warnedDroppedStdioEnvKeys = createDedupeCache({
 function warnDroppedStdioEnvOnce(serverName: string, key: string): void {
   const logServerName = sanitizeForLog(serverName);
   const logKey = sanitizeForLog(key);
-  if (warnedDroppedStdioEnvKeys.check(`${logServerName}:${logKey}`)) {
+  if (warnedDroppedStdioEnvKeys.check(JSON.stringify([serverName, key]))) {
     return;
   }
   logWarn(

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -9,6 +9,7 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveOpenClawMcpTransportAlias } from "../config/mcp-config-normalize.js";
+import { createDedupeCache } from "../infra/dedupe.js";
 import { logWarn } from "../logger.js";
 import { readTrimmedStringAlias } from "../utils/string-readers.js";
 import {
@@ -62,6 +63,24 @@ type ResolvedMcpTransportConfig = ResolvedStdioMcpTransportConfig | ResolvedHttp
 
 const DEFAULT_CONNECTION_TIMEOUT_MS = 30_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+const MAX_WARNED_DROPPED_STDIO_ENV_KEYS = 4096;
+// Warning state spans repeated MCP transport resolutions in one gateway process;
+// bounding it means evicted server/env pairs can re-warn instead of growing unbounded.
+const warnedDroppedStdioEnvKeys = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_DROPPED_STDIO_ENV_KEYS,
+});
+
+function warnDroppedStdioEnvOnce(serverName: string, key: string): void {
+  const logServerName = sanitizeForLog(serverName);
+  const logKey = sanitizeForLog(key);
+  if (warnedDroppedStdioEnvKeys.check(`${logServerName}:${logKey}`)) {
+    return;
+  }
+  logWarn(
+    `bundle-mcp: server "${logServerName}": env "${logKey}" is blocked for stdio startup safety and was ignored.`,
+  );
+}
 
 function getPositiveNumber(rawServer: unknown, keys: readonly string[]): number | undefined {
   if (!rawServer || typeof rawServer !== "object") {
@@ -205,7 +224,6 @@ export function resolveMcpTransportConfig(
   rawServer: unknown,
   options?: { logWarnings?: boolean },
 ): ResolvedMcpTransportConfig | null {
-  const logServerName = sanitizeForLog(serverName);
   const logWarnings = options?.logWarnings !== false;
   const requestedTransport = getRequestedTransport(rawServer);
   const requestedTransportAlias = requestedTransport ? "" : getRequestedTransportAlias(rawServer);
@@ -215,9 +233,7 @@ export function resolveMcpTransportConfig(
     logWarnings
       ? {
           onDroppedEnv: (key: string) => {
-            logWarn(
-              `bundle-mcp: server "${logServerName}": env "${sanitizeForLog(key)}" is blocked for stdio startup safety and was ignored.`,
-            );
+            warnDroppedStdioEnvOnce(serverName, key);
           },
         }
       : undefined,
@@ -246,7 +262,7 @@ export function resolveMcpTransportConfig(
   ) {
     if (logWarnings) {
       logWarn(
-        `bundle-mcp: skipped server "${logServerName}" because transport "${sanitizeForLog(effectiveTransport)}" is not supported.`,
+        `bundle-mcp: skipped server "${sanitizeForLog(serverName)}" because transport "${sanitizeForLog(effectiveTransport)}" is not supported.`,
       );
     }
     return null;
@@ -273,7 +289,7 @@ export function resolveMcpTransportConfig(
   const httpReason = httpLaunch.ok ? "not an HTTP MCP server" : httpLaunch.reason;
   if (logWarnings) {
     logWarn(
-      `bundle-mcp: skipped server "${logServerName}" because ${stdioLaunch.reason} and ${httpReason}.`,
+      `bundle-mcp: skipped server "${sanitizeForLog(serverName)}" because ${stdioLaunch.reason} and ${httpReason}.`,
     );
   }
   return null;


### PR DESCRIPTION
Closes #92474

## What Problem This Solves

MCP servers configured with blocked stdio environment keys such as `PYTHONPATH`
could log the same safety warning on every transport resolution, flooding
gateway logs even though the key was still removed.

## Fix

The shared transport resolver keeps the existing blocked-key filter and routes
the warning through its bounded process-local cache. The cache identity is the
JSON encoding of the raw `[serverName, key]` tuple, so different pairs cannot
collide through delimiter text. Sanitization remains limited to log output.

This is the resolver-owned fix: callers that use the default warning behavior
share the same dedupe boundary, while callers that explicitly pass
`logWarnings: false` remain silent.

## Evidence

Exact head: `7842329d69a14a5e21ccfb3f40e9b92fbf399a6f`

- Fresh max-P1 autoreview with `gpt-5.6-sol` at high reasoning: clean, no
  actionable P0/P1 findings.
- Sanitized direct AWS Crabbox proof used a fresh head-bound checkout, public
  networking, no Tailscale, no hydrated credentials, and no IAM role
  credentials.
- A full package build completed before the proof imported the emitted
  `dist/mcp-transport-config-*.js` resolver chunk.
- Focused resolver test: `13/13` passed.
- Exact-head changed gate: exit `0`, including core and core-test typechecks,
  formatting, lint, dead-code, boundary, and repository guards.
- Targeted `oxfmt --check` and `git diff --check`: passed.
- Hosted exact-head CI: `207` success, `47` skipped, `1` neutral, no failures
  or pending checks.

Sanitized unmocked resolver transcript:

```text
old head c4e94b27f3b23796d920b254b01e129266452158:
  resolutions=7 warning_count=4 empty_env_count=7

fixed built dist 7842329d69a14a5e21ccfb3f40e9b92fbf399a6f:
  resolutions=7 warning_count=5 empty_env_count=7
```

The seven resolutions cover:

- the same server/key pair three times;
- another server with the same key;
- the original server with another blocked key;
- the previously colliding raw pairs `(svc, LD_A:LD_B)` and
  `(svc:LD_A, LD_B)`.

The old delimiter identity aliases the final two pairs and emits only four
warnings. The built fixed resolver emits five distinct warnings, while every
blocked value is removed (`env={}` in all seven results).

## Caller Audit

Not every inspection caller uses `logWarnings: false`. Selected bundle and
OAuth request paths suppress warnings, while `src/cli/mcp-cli.ts`,
`src/agents/mcp-config-mutation.ts`, `src/agents/mcp-auth-profile.ts`, and
`src/agents/mcp-transport.ts` use the resolver's default warning behavior.
Resolver-boundary dedupe therefore covers the shared warning owner without
adding caller policy or changing global logger behavior.

## Scope

- Whole PR production: `+22/-6` (net `+16`) for the bounded resolver-owned
  dedupe state.
- Whole PR tests: `+66/-0`.
- Collision repair relative to the previously reviewed head: production
  `+1/-1` (net `0`); tests `+23/-1`.
- No config/default, SDK, protocol, migration, dependency, capacity,
  lifecycle, reset, or logger-policy changes.
- No persistent data-model change; the cache is bounded process-local state.

Punchcard-Session: quiet-valley-harbor-ep

AI-assisted implementation; I reviewed the changed code and validation output.
