### PR TITLE
fix(gateway): avoid failed worker cleanup blocking startup

### DIFF
--- a/src/gateway/server-worker-placement-reconcile-guard.test.ts
+++ b/src/gateway/server-worker-placement-reconcile-guard.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import { installWorkerPlacementReconcileGuard } from "./server-worker-placement-reconcile-guard.js";
+
+const localClaim = {
+  owner: "local" as const,
+  claimId: "claim-cleanup",
+  runId: "run-cleanup",
+  generation: 1,
+  ownerEpoch: null,
+};
+
+function createFailedPlacementGuard(params: {
+  turnClaim: typeof localClaim | null;
+  activeOwnerEpoch: number | null;
+  destroyRequestedAtMs: number | null;
+}) {
+  let guard:
+    | ((environmentId: string, reconcileCore: () => Promise<void>) => Promise<void>)
+    | undefined;
+  const resumeProvisioning = vi.fn();
+  installWorkerPlacementReconcileGuard({
+    placements: {
+      list: () => [
+        {
+          sessionId: "session-cleanup",
+          state: "failed",
+          environmentId: "worker-cleanup",
+          turnClaim: params.turnClaim,
+          activeOwnerEpoch: params.activeOwnerEpoch,
+        },
+      ],
+    } as never,
+    environments: {
+      get: (environmentId: string) => ({
+        environmentId,
+        state: "provisioning",
+        destroyRequestedAtMs: params.destroyRequestedAtMs,
+      }),
+      installReconcileEnvironmentGuard: (installed: typeof guard) => {
+        guard = installed;
+        return async () => {};
+      },
+    } as never,
+    dispatch: { resumeProvisioning } as never,
+    isStopping: () => false,
+  });
+  if (!guard) {
+    throw new Error("worker placement reconciliation guard was not installed");
+  }
+  return { guard, resumeProvisioning };
+}
+
+describe("worker placement reconciliation teardown authority", () => {
+  it("allows destruction only after its exact failed owner has released all authority", async () => {
+    const { guard, resumeProvisioning } = createFailedPlacementGuard({
+      turnClaim: null,
+      activeOwnerEpoch: null,
+      destroyRequestedAtMs: 1,
+    });
+    const reconcileCore = vi.fn(async () => {});
+
+    await guard("worker-cleanup", reconcileCore);
+
+    expect(reconcileCore).toHaveBeenCalledOnce();
+    expect(resumeProvisioning).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      reason: "a retained local turn claim",
+      turnClaim: localClaim,
+      activeOwnerEpoch: null,
+      destroyRequestedAtMs: 1,
+    },
+    {
+      reason: "an active owner epoch",
+      turnClaim: null,
+      activeOwnerEpoch: 2,
+      destroyRequestedAtMs: 1,
+    },
+    {
+      reason: "no durable destruction request",
+      turnClaim: null,
+      activeOwnerEpoch: null,
+      destroyRequestedAtMs: null,
+    },
+  ])("keeps failed-placement cleanup fenced with $reason", async ({ reason: _, ...params }) => {
+    const { guard, resumeProvisioning } = createFailedPlacementGuard(params);
+    const reconcileCore = vi.fn(async () => {});
+
+    await expect(guard("worker-cleanup", reconcileCore)).rejects.toThrow(
+      "provisioning owner is failed",
+    );
+
+    expect(reconcileCore).not.toHaveBeenCalled();
+    expect(resumeProvisioning).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-worker-placement-reconcile-guard.ts
+++ b/src/gateway/server-worker-placement-reconcile-guard.ts
@@ -29,7 +29,11 @@ export function installWorkerPlacementReconcileGuard(params: {
         owner &&
         (environment?.state === "requested" ||
           environment?.state === "provisioning" ||
-          environment?.state === "bootstrapping")
+          environment?.state === "bootstrapping") &&
+        (owner.state !== "failed" ||
+          owner.turnClaim !== null ||
+          owner.activeOwnerEpoch !== null ||
+          environment.destroyRequestedAtMs === null)
       ) {
         throw new Error(`Worker environment ${environmentId} provisioning owner is ${owner.state}`);
       }

--- a/src/gateway/server-worker-placement-recovery-events.test.ts
+++ b/src/gateway/server-worker-placement-recovery-events.test.ts
@@ -98,6 +98,7 @@ describe("worker placement recovery session events", () => {
         }
 
         await vi.advanceTimersByTimeAsync(60_000);
+        await vi.dynamicImportSettled();
         expect(context.broadcastToConnIds).not.toHaveBeenCalled();
         expect(readSessionsMutationVersion(context)).toBe(initialMutationVersion);
 

--- a/src/gateway/server-worker-placement-recovery-events.test.ts
+++ b/src/gateway/server-worker-placement-recovery-events.test.ts
@@ -97,8 +97,8 @@ describe("worker placement recovery session events", () => {
           throw new Error("worker placement runtime did not start");
         }
 
-        await vi.advanceTimersByTimeAsync(60_000);
         await vi.dynamicImportSettled();
+        await vi.advanceTimersByTimeAsync(60_000);
         expect(context.broadcastToConnIds).not.toHaveBeenCalled();
         expect(readSessionsMutationVersion(context)).toBe(initialMutationVersion);
 

--- a/src/gateway/server-worker-placement-startup-cleanup.test.ts
+++ b/src/gateway/server-worker-placement-startup-cleanup.test.ts
@@ -20,11 +20,141 @@ vi.mock("./worker-environments/placement-disk-space.js", async (importOriginal) 
 });
 
 import { createGatewayWorkerPlacementRuntime } from "./server-worker-placement-startup.js";
+import { seedActivePlacement } from "./worker-environments/placement-dispatch-test-fixtures.js";
 import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import * as workerEnvironmentSupport from "./worker-environments/service.test-support.js";
 
 describe("worker placement startup cleanup ownership", () => {
   workerEnvironmentSupport.setupWorkerEnvironmentServiceSuite();
+
+  it.each([
+    { retainedAuthority: "a local turn claim", claimLocalTurn: true },
+    { retainedAuthority: "an active owner epoch", claimLocalTurn: false },
+  ])(
+    "never reaches worker providers during startup while a failed placement retains $retainedAuthority",
+    async ({ claimLocalTurn }) => {
+      const environmentId = "worker-startup-fenced";
+      const provision = vi.fn(async () => ({
+        leaseId: "lease-startup-fenced",
+        ssh: workerEnvironmentSupport.SSH_ENDPOINT,
+      }));
+      const inspect = vi.fn(async () => ({ status: "active" as const }));
+      const destroy = vi.fn(async () => {});
+      const environments = workerEnvironmentSupport.createService(
+        workerEnvironmentSupport.createProvider({ provision, inspect, destroy }),
+      );
+      const requestedEnvironment = workerEnvironmentSupport.testState.store.createIntent({
+        environmentId,
+        providerId: "fake",
+        profileId: "development",
+        profileSnapshot: { settings: { region: "test" } },
+        provisionOperationId: "provision:startup-fenced",
+      });
+      workerEnvironmentSupport.testState.store.transition({
+        environmentId,
+        from: requestedEnvironment.state,
+        to: "provisioning",
+      });
+      workerEnvironmentSupport.testState.store.requestDestroy({
+        environmentId,
+        state: "provisioning",
+      });
+      const placements = createWorkerSessionPlacementStore({
+        database: workerEnvironmentSupport.testState.stateDb,
+        now: () => workerEnvironmentSupport.testState.nowMs,
+      });
+      let failed;
+      if (claimLocalTurn) {
+        const identity = {
+          sessionId: "session-startup-fenced",
+          sessionKey: "agent:main:startup-fenced",
+          agentId: "main",
+        };
+        placements.claimTurn({
+          ...identity,
+          owner: { kind: "local" },
+          claimId: "startup-fenced-local-claim",
+          runId: "startup-fenced-local-run",
+        });
+        const requested = placements.startDispatch({ ...identity, executionMode: "remote-exec" });
+        failed = placements.fail({
+          sessionId: requested.sessionId,
+          expectedGeneration: requested.generation,
+          recoveryError: "startup worker placement failed before its local claim was released",
+        });
+        // Current dispatch binds environments only after its local turn drains; preserve a
+        // crash-era terminal environment reference in SQLite without fabricating record shapes.
+        workerEnvironmentSupport.testState.stateDb.db
+          .prepare("UPDATE worker_session_placements SET environment_id = ? WHERE session_id = ?")
+          .run(environmentId, failed.sessionId);
+        failed = placements.get(failed.sessionId);
+      } else {
+        const active = seedActivePlacement(placements, {
+          environmentId,
+          ownerEpoch: 1,
+          executionMode: "remote-exec",
+        });
+        if (active.state !== "active") {
+          throw new Error("startup authority fixture did not produce an active placement");
+        }
+        const draining = placements.startDrain({
+          sessionId: active.sessionId,
+          environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+          expectedGeneration: active.generation,
+        });
+        const reconciling = placements.startReconcile({
+          sessionId: draining.sessionId,
+          environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+          expectedGeneration: draining.generation,
+        });
+        failed = placements.fail({
+          sessionId: reconciling.sessionId,
+          expectedGeneration: reconciling.generation,
+          recoveryError: "startup worker placement failed before its owner epoch was released",
+        });
+      }
+      expect(failed).toMatchObject({
+        state: "failed",
+        environmentId,
+        activeOwnerEpoch: claimLocalTurn ? null : 1,
+        turnClaim: claimLocalTurn ? expect.objectContaining({ owner: "local" }) : null,
+      });
+      runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValue(async () => "current");
+      runtimeFactoryMocks.createDiskSpace.mockReturnValue({
+        read: vi.fn(),
+        version: vi.fn(() => 0),
+        sweep: vi.fn().mockResolvedValue(undefined),
+      });
+      const runtime = createGatewayWorkerPlacementRuntime({
+        placements,
+        environments,
+        gatewayNamespace: "gateway-test",
+        revokeSessionAuthority: vi.fn(),
+        warn: vi.fn(),
+      });
+      const sidecar = await runtime.startRuntime({
+        isClosePreludeStarted: () => false,
+        registerSidecar: vi.fn(),
+        unregisterSidecar: vi.fn(),
+      });
+      try {
+        expect(sidecar).not.toBeNull();
+        await environments.reconcileOnce();
+        expect(provision).not.toHaveBeenCalled();
+        expect(inspect).not.toHaveBeenCalled();
+        expect(destroy).not.toHaveBeenCalled();
+        expect(workerEnvironmentSupport.testState.store.get(environmentId)).toMatchObject({
+          state: "provisioning",
+          leaseId: null,
+          destroyRequestedAtMs: expect.any(Number),
+        });
+      } finally {
+        await sidecar?.stop();
+      }
+    },
+  );
 
   it("becomes ready before failed-placement lease adoption and drains its exact teardown", async () => {
     const environmentId = "worker-startup-indeterminate";

--- a/src/gateway/server-worker-placement-startup-cleanup.test.ts
+++ b/src/gateway/server-worker-placement-startup-cleanup.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
+
+const runtimeFactoryMocks = vi.hoisted(() => ({
+  createDiskSpace: vi.fn(),
+  createSessionEvidenceResolver: vi.fn(),
+}));
+
+vi.mock("./server-worker-placement-session-evidence.js", () => ({
+  createWorkerPlacementSessionEvidenceResolver: runtimeFactoryMocks.createSessionEvidenceResolver,
+}));
+
+vi.mock("./worker-environments/placement-disk-space.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./worker-environments/placement-disk-space.js")>();
+  return {
+    ...actual,
+    createWorkerPlacementDiskSpaceMonitor: runtimeFactoryMocks.createDiskSpace,
+  };
+});
+
+import { createGatewayWorkerPlacementRuntime } from "./server-worker-placement-startup.js";
+import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
+import * as workerEnvironmentSupport from "./worker-environments/service.test-support.js";
+
+describe("worker placement startup cleanup ownership", () => {
+  workerEnvironmentSupport.setupWorkerEnvironmentServiceSuite();
+
+  it("becomes ready before failed-placement lease adoption and drains its exact teardown", async () => {
+    const environmentId = "worker-startup-indeterminate";
+    const operationId = "provision:startup-indeterminate";
+    const releaseProvision = createDeferredCore();
+    const provisionStarted = createDeferredCore();
+    const provision = vi.fn(async () => {
+      provisionStarted.resolve();
+      await releaseProvision.promise;
+      return { leaseId: "lease-startup-adopted", ssh: workerEnvironmentSupport.SSH_ENDPOINT };
+    });
+    const destroy = vi.fn(async () => {});
+    const environments = workerEnvironmentSupport.createService(
+      workerEnvironmentSupport.createProvider({ provision, destroy }),
+    );
+    const intent = workerEnvironmentSupport.testState.store.createIntent({
+      environmentId,
+      providerId: "fake",
+      profileId: "development",
+      profileSnapshot: { settings: { region: "test" } },
+      provisionOperationId: operationId,
+    });
+    workerEnvironmentSupport.testState.store.transition({
+      environmentId,
+      from: intent.state,
+      to: "provisioning",
+    });
+    workerEnvironmentSupport.testState.store.requestDestroy({
+      environmentId,
+      state: "provisioning",
+    });
+    const placements = createWorkerSessionPlacementStore({
+      database: workerEnvironmentSupport.testState.stateDb,
+      now: () => workerEnvironmentSupport.testState.nowMs,
+    });
+    const requested = placements.startDispatch({
+      sessionId: "session-startup-indeterminate",
+      sessionKey: "agent:main:startup-indeterminate",
+      agentId: "main",
+      executionMode: "remote-exec",
+    });
+    const provisioning = placements.transition({
+      sessionId: requested.sessionId,
+      from: "requested",
+      to: "provisioning",
+      expectedGeneration: requested.generation,
+      patch: { environmentId },
+    });
+    const failed = placements.fail({
+      sessionId: provisioning.sessionId,
+      expectedGeneration: provisioning.generation,
+      recoveryError: "startup worker placement failed",
+    });
+    expect(failed).toMatchObject({
+      state: "failed",
+      environmentId,
+      turnClaim: null,
+      activeOwnerEpoch: null,
+    });
+    runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValue(async () => "current");
+    runtimeFactoryMocks.createDiskSpace.mockReturnValue({
+      read: vi.fn(),
+      version: vi.fn(() => 0),
+      sweep: vi.fn().mockResolvedValue(undefined),
+    });
+    const runtime = createGatewayWorkerPlacementRuntime({
+      placements,
+      environments,
+      gatewayNamespace: "gateway-test",
+      revokeSessionAuthority: vi.fn(),
+      warn: vi.fn(),
+    });
+    let registeredSidecar: { stop: () => Promise<void> } | undefined;
+    const starting = runtime.startRuntime({
+      isClosePreludeStarted: () => false,
+      registerSidecar: (sidecar) => {
+        registeredSidecar = sidecar;
+      },
+      unregisterSidecar: vi.fn(),
+    });
+
+    try {
+      const first = await Promise.race([
+        starting.then((sidecar) => ({ kind: "ready" as const, sidecar })),
+        provisionStarted.promise.then(() => ({ kind: "provision" as const })),
+      ]);
+      expect(first.kind).toBe("ready");
+      if (first.kind !== "ready" || !first.sidecar) {
+        throw new Error("worker startup did not reach readiness before provider adoption");
+      }
+      await provisionStarted.promise;
+      expect(provision).toHaveBeenCalledWith({ region: "test" }, operationId, undefined);
+      expect(workerEnvironmentSupport.testState.store.get(environmentId)).toMatchObject({
+        state: "provisioning",
+        leaseId: null,
+        destroyRequestedAtMs: expect.any(Number),
+      });
+
+      let stopped = false;
+      const stopping = first.sidecar.stop().then(() => {
+        stopped = true;
+      });
+      await Promise.resolve();
+      expect(stopped).toBe(false);
+      expect(destroy).not.toHaveBeenCalled();
+
+      releaseProvision.resolve();
+      await stopping;
+
+      expect(destroy).toHaveBeenCalledWith({
+        leaseId: "lease-startup-adopted",
+        profile: { region: "test" },
+      });
+      expect(workerEnvironmentSupport.testState.store.get(environmentId)).toMatchObject({
+        state: "destroyed",
+        leaseId: "lease-startup-adopted",
+      });
+    } finally {
+      releaseProvision.resolve();
+      await starting.catch(() => undefined);
+      await registeredSidecar?.stop();
+    }
+  });
+});

--- a/src/gateway/server-worker-placement-startup.test.ts
+++ b/src/gateway/server-worker-placement-startup.test.ts
@@ -212,6 +212,8 @@ describe("worker placement startup health lifetime", () => {
       });
 
       expect(sidecar).not.toBeNull();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reconcileActive).toHaveBeenCalledOnce();
       expect(diskSpace.sweep).toHaveBeenCalledOnce();
       await vi.advanceTimersByTimeAsync(60_000);
       expect(reconcileActive).toHaveBeenCalledOnce();
@@ -236,7 +238,84 @@ describe("worker placement startup health lifetime", () => {
     }
   });
 
-  it("drains deferred startup session evidence before stopping environments", async () => {
+  it.each(["provisioning", "active"] as const)(
+    "waits for %s placement authority recovery before exposing readiness",
+    async (state) => {
+      const releaseRecovery = createDeferredCore();
+      const reconcile = vi.fn(async () => await releaseRecovery.promise);
+      runtimeFactoryMocks.createDiskSpace.mockReturnValue({
+        read: vi.fn(),
+        version: vi.fn(() => 0),
+        sweep: vi.fn().mockResolvedValue(undefined),
+      });
+      runtimeFactoryMocks.createDispatch.mockReturnValue({
+        dispatch: vi.fn(),
+        forceDestroyEnvironment: vi.fn(),
+        reclaim: vi.fn(),
+        reconcile,
+        reconcileActive: vi.fn().mockResolvedValue(undefined),
+      });
+      runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValue(async () => "current");
+      const placement = {
+        sessionId: `session-startup-${state}`,
+        sessionKey: `agent:main:startup-${state}`,
+        agentId: "main",
+        state,
+        generation: 1,
+        environmentId: `worker-startup-${state}`,
+        activeOwnerEpoch: state === "active" ? 1 : null,
+        turnClaim: null,
+      };
+      const environments = {
+        installReconcileEnvironmentGuard: vi.fn(() => vi.fn()),
+        start: vi.fn(),
+        stop: vi.fn().mockResolvedValue(undefined),
+      };
+      const runtime = createGatewayWorkerPlacementRuntime({
+        placements: {
+          workspaceResultInstanceId: () => "gateway-test",
+          get: () => placement,
+          list: () => [placement],
+          retireSessionPlacement: vi.fn(),
+          pruneOrphanedWorkspaceReconciliations: () => [],
+          listWorkspaceReconciliationOwners: () => [],
+          listPendingWorkspaceResults: () => [],
+        } as never,
+        environments: environments as never,
+        gatewayNamespace: "gateway-test",
+        revokeSessionAuthority: vi.fn(),
+        warn: vi.fn(),
+      });
+      const starting = runtime.startRuntime({
+        isClosePreludeStarted: () => false,
+        registerSidecar: vi.fn(),
+        unregisterSidecar: vi.fn(),
+      });
+
+      try {
+        await vi.waitFor(() => expect(reconcile).toHaveBeenCalledWith("startup"));
+        expect(environments.start).not.toHaveBeenCalled();
+
+        let ready = false;
+        void starting.then(() => {
+          ready = true;
+        });
+        await Promise.resolve();
+        expect(ready).toBe(false);
+
+        releaseRecovery.resolve();
+        const sidecar = await starting;
+        expect(sidecar).not.toBeNull();
+        expect(environments.start).toHaveBeenCalledOnce();
+        await sidecar?.stop();
+      } finally {
+        releaseRecovery.resolve();
+        await starting.catch(() => undefined);
+      }
+    },
+  );
+
+  it("drains post-readiness session evidence before stopping environments", async () => {
     const evidence = createDeferredCore<"current">();
     runtimeFactoryMocks.resolveSessionEvidence.mockImplementation(async () => evidence.promise);
     runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValue(
@@ -307,6 +386,7 @@ describe("worker placement startup health lifetime", () => {
       unregisterSidecar,
     });
     await vi.waitFor(() => expect(runtimeFactoryMocks.resolveSessionEvidence).toHaveBeenCalled());
+    await expect(starting).resolves.toBe(sidecar);
     closeStarted = true;
     const stopping = sidecar?.stop();
     const repeatedStop = sidecar?.stop();
@@ -324,11 +404,9 @@ describe("worker placement startup health lifetime", () => {
     expect(environments.stopNodeEnrollmentWaits).toHaveBeenCalledOnce();
     expect(environments.stop).not.toHaveBeenCalled();
     evidence.resolve("current");
-    await expect(starting).resolves.toBeNull();
     await Promise.all([stopping, repeatedStop]);
     expect(environments.stop).toHaveBeenCalledOnce();
-    expect(unregisterSidecar).toHaveBeenCalledOnce();
-    expect(unregisterSidecar).toHaveBeenCalledWith(sidecar);
+    expect(unregisterSidecar).not.toHaveBeenCalled();
   });
 
   it("retries worker environment cleanup after a failed stop attempt", async () => {
@@ -492,6 +570,7 @@ describe("worker placement startup health lifetime", () => {
     const releaseRecovery = createDeferredCore();
     const environmentStopStarted = createDeferredCore();
     const events: string[] = [];
+    const reconcileActive = vi.fn().mockResolvedValue(undefined);
     let installedGuard: ReconcileGuard | undefined;
     const placement = {
       sessionId: "session-close-guard",
@@ -508,7 +587,7 @@ describe("worker placement startup health lifetime", () => {
       forceDestroyEnvironment: vi.fn(),
       reclaim: vi.fn(),
       reconcile: vi.fn().mockResolvedValue(undefined),
-      reconcileActive: vi.fn().mockResolvedValue(undefined),
+      reconcileActive,
       resumeProvisioning: vi.fn(async (_placement, reconcileCore) => {
         events.push("recovery:start");
         recoveryStarted.resolve();
@@ -557,6 +636,8 @@ describe("worker placement startup health lifetime", () => {
     if (!sidecar || !guard) {
       throw new Error("worker placement reconcile guard was not installed");
     }
+    await vi.waitFor(() => expect(reconcileActive).toHaveBeenCalledOnce());
+    await runtime.dispatchService.reconcileActive();
     const reconcileCore = vi.fn(async () => {
       events.push("reconcile:core");
     });

--- a/src/gateway/server-worker-placement-startup.test.ts
+++ b/src/gateway/server-worker-placement-startup.test.ts
@@ -314,10 +314,12 @@ describe("worker placement startup health lifetime", () => {
     },
   );
 
-  it("drains periodic post-readiness session evidence before stopping environments", async () => {
-    const evidence = createDeferredCore<"current">();
-    runtimeFactoryMocks.resolveSessionEvidence.mockImplementation(async () => evidence.promise);
-    runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValue(
+  it("immediately retires absent sessions after readiness and drains retirement on stop", async () => {
+    const evidence = createDeferredCore<"absent">();
+    const reconcileActive = vi.fn().mockResolvedValue(undefined);
+    const retireSessionPlacement = vi.fn();
+    runtimeFactoryMocks.resolveSessionEvidence.mockImplementationOnce(async () => evidence.promise);
+    runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValueOnce(
       runtimeFactoryMocks.resolveSessionEvidence,
     );
     runtimeFactoryMocks.createDiskSpace.mockReturnValue({
@@ -330,7 +332,7 @@ describe("worker placement startup health lifetime", () => {
       forceDestroyEnvironment: vi.fn(),
       reclaim: vi.fn(),
       reconcile: vi.fn().mockResolvedValue(undefined),
-      reconcileActive: vi.fn().mockResolvedValue(undefined),
+      reconcileActive,
     });
     const placement = {
       sessionId: "session-startup",
@@ -364,7 +366,7 @@ describe("worker placement startup health lifetime", () => {
         workspaceResultInstanceId: () => "gateway-test",
         get: () => placement,
         list: () => [placement],
-        retireSessionPlacement: vi.fn(),
+        retireSessionPlacement,
         pruneOrphanedWorkspaceReconciliations: () => [],
         listWorkspaceReconciliationOwners: () => [],
         listPendingWorkspaceResults: () => [],
@@ -376,7 +378,6 @@ describe("worker placement startup health lifetime", () => {
     });
     let sidecar: { stop: () => Promise<void> } | undefined;
     const unregisterSidecar = vi.fn();
-    vi.useFakeTimers();
     try {
       const starting = runtime.startRuntime({
         isClosePreludeStarted: () => false,
@@ -386,9 +387,9 @@ describe("worker placement startup health lifetime", () => {
         unregisterSidecar,
       });
       await expect(starting).resolves.toBe(sidecar);
-      expect(runtimeFactoryMocks.resolveSessionEvidence).not.toHaveBeenCalled();
-      await vi.advanceTimersByTimeAsync(60_000);
       expect(runtimeFactoryMocks.resolveSessionEvidence).toHaveBeenCalledOnce();
+      expect(reconcileActive).not.toHaveBeenCalled();
+      expect(retireSessionPlacement).not.toHaveBeenCalled();
 
       const stopping = sidecar?.stop();
       const repeatedStop = sidecar?.stop();
@@ -400,14 +401,14 @@ describe("worker placement startup health lifetime", () => {
       expect(repeatedStop).toBe(stopping);
       expect(environments.stopNodeEnrollmentWaits).toHaveBeenCalledOnce();
       expect(environments.stop).not.toHaveBeenCalled();
-      evidence.resolve("current");
+      evidence.resolve("absent");
       await Promise.all([stopping, repeatedStop]);
+      expect(retireSessionPlacement).toHaveBeenCalledOnce();
       expect(environments.stop).toHaveBeenCalledOnce();
       expect(unregisterSidecar).not.toHaveBeenCalled();
     } finally {
-      evidence.resolve("current");
+      evidence.resolve("absent");
       await sidecar?.stop();
-      vi.useRealTimers();
     }
   });
 

--- a/src/gateway/server-worker-placement-startup.test.ts
+++ b/src/gateway/server-worker-placement-startup.test.ts
@@ -212,8 +212,7 @@ describe("worker placement startup health lifetime", () => {
       });
 
       expect(sidecar).not.toBeNull();
-      await vi.advanceTimersByTimeAsync(0);
-      expect(reconcileActive).toHaveBeenCalledOnce();
+      expect(reconcileActive).not.toHaveBeenCalled();
       expect(diskSpace.sweep).toHaveBeenCalledOnce();
       await vi.advanceTimersByTimeAsync(60_000);
       expect(reconcileActive).toHaveBeenCalledOnce();
@@ -315,7 +314,7 @@ describe("worker placement startup health lifetime", () => {
     },
   );
 
-  it("drains post-readiness session evidence before stopping environments", async () => {
+  it("drains periodic post-readiness session evidence before stopping environments", async () => {
     const evidence = createDeferredCore<"current">();
     runtimeFactoryMocks.resolveSessionEvidence.mockImplementation(async () => evidence.promise);
     runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValue(
@@ -375,38 +374,41 @@ describe("worker placement startup health lifetime", () => {
       revokeSessionAuthority: vi.fn(),
       warn: vi.fn(),
     });
-    let closeStarted = false;
     let sidecar: { stop: () => Promise<void> } | undefined;
     const unregisterSidecar = vi.fn();
-    const starting = runtime.startRuntime({
-      isClosePreludeStarted: () => closeStarted,
-      registerSidecar: (registered) => {
-        sidecar = registered;
-      },
-      unregisterSidecar,
-    });
-    await vi.waitFor(() => expect(runtimeFactoryMocks.resolveSessionEvidence).toHaveBeenCalled());
-    await expect(starting).resolves.toBe(sidecar);
-    closeStarted = true;
-    const stopping = sidecar?.stop();
-    const repeatedStop = sidecar?.stop();
-    if (!stopping || !repeatedStop) {
-      throw new Error("startup did not register its placement sidecar");
-    }
-    let repeatedStopSettled = false;
-    void repeatedStop.then(() => {
-      repeatedStopSettled = true;
-    });
+    vi.useFakeTimers();
+    try {
+      const starting = runtime.startRuntime({
+        isClosePreludeStarted: () => false,
+        registerSidecar: (registered) => {
+          sidecar = registered;
+        },
+        unregisterSidecar,
+      });
+      await expect(starting).resolves.toBe(sidecar);
+      expect(runtimeFactoryMocks.resolveSessionEvidence).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(runtimeFactoryMocks.resolveSessionEvidence).toHaveBeenCalledOnce();
 
-    await Promise.resolve();
-    expect(repeatedStop).toBe(stopping);
-    expect(repeatedStopSettled).toBe(false);
-    expect(environments.stopNodeEnrollmentWaits).toHaveBeenCalledOnce();
-    expect(environments.stop).not.toHaveBeenCalled();
-    evidence.resolve("current");
-    await Promise.all([stopping, repeatedStop]);
-    expect(environments.stop).toHaveBeenCalledOnce();
-    expect(unregisterSidecar).not.toHaveBeenCalled();
+      const stopping = sidecar?.stop();
+      const repeatedStop = sidecar?.stop();
+      if (!stopping || !repeatedStop) {
+        throw new Error("startup did not register its placement sidecar");
+      }
+
+      await Promise.resolve();
+      expect(repeatedStop).toBe(stopping);
+      expect(environments.stopNodeEnrollmentWaits).toHaveBeenCalledOnce();
+      expect(environments.stop).not.toHaveBeenCalled();
+      evidence.resolve("current");
+      await Promise.all([stopping, repeatedStop]);
+      expect(environments.stop).toHaveBeenCalledOnce();
+      expect(unregisterSidecar).not.toHaveBeenCalled();
+    } finally {
+      evidence.resolve("current");
+      await sidecar?.stop();
+      vi.useRealTimers();
+    }
   });
 
   it("retries worker environment cleanup after a failed stop attempt", async () => {
@@ -570,7 +572,6 @@ describe("worker placement startup health lifetime", () => {
     const releaseRecovery = createDeferredCore();
     const environmentStopStarted = createDeferredCore();
     const events: string[] = [];
-    const reconcileActive = vi.fn().mockResolvedValue(undefined);
     let installedGuard: ReconcileGuard | undefined;
     const placement = {
       sessionId: "session-close-guard",
@@ -587,7 +588,7 @@ describe("worker placement startup health lifetime", () => {
       forceDestroyEnvironment: vi.fn(),
       reclaim: vi.fn(),
       reconcile: vi.fn().mockResolvedValue(undefined),
-      reconcileActive,
+      reconcileActive: vi.fn().mockResolvedValue(undefined),
       resumeProvisioning: vi.fn(async (_placement, reconcileCore) => {
         events.push("recovery:start");
         recoveryStarted.resolve();
@@ -636,8 +637,6 @@ describe("worker placement startup health lifetime", () => {
     if (!sidecar || !guard) {
       throw new Error("worker placement reconcile guard was not installed");
     }
-    await vi.waitFor(() => expect(reconcileActive).toHaveBeenCalledOnce());
-    await runtime.dispatchService.reconcileActive();
     const reconcileCore = vi.fn(async () => {
       events.push("reconcile:core");
     });

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -646,6 +646,11 @@ export function createGatewayWorkerPlacementRuntime(
       if (hooks.isClosePreludeStarted()) {
         return await stopBeforeReady();
       }
+      void trackOperation(
+        placementReconcile,
+        sessionRetirement.reconcile(),
+        "Worker placement reconcile sweep failed",
+      );
       void sweepDiskSpace();
       placementReconcileInterval = setInterval(
         sweepActivePlacements,

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -623,8 +623,7 @@ export function createGatewayWorkerPlacementRuntime(
       return await stopBeforeReady();
     }
     const startupReconcile = (async () => {
-      await dispatchService.reconcile();
-      await sessionRetirement.reconcile();
+      await dispatchService.reconcile("startup");
       await reconcilePublications();
     })();
     placementReconcile.current = startupReconcile;
@@ -647,6 +646,7 @@ export function createGatewayWorkerPlacementRuntime(
       if (hooks.isClosePreludeStarted()) {
         return await stopBeforeReady();
       }
+      void reconcileActivePlacements();
       void sweepDiskSpace();
       placementReconcileInterval = setInterval(
         sweepActivePlacements,

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -646,7 +646,6 @@ export function createGatewayWorkerPlacementRuntime(
       if (hooks.isClosePreludeStarted()) {
         return await stopBeforeReady();
       }
-      void reconcileActivePlacements();
       void sweepDiskSpace();
       placementReconcileInterval = setInterval(
         sweepActivePlacements,

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -175,7 +175,7 @@ export function coordinateWorkerPlacementDispatch(
     },
     reclaim: async (request, authorize) =>
       await runExclusivePlacementOperation(() => service.reclaim(request, authorize)),
-    reconcile: () => runReconciliation(service.reconcile),
+    reconcile: (mode) => runReconciliation(() => service.reconcile(mode)),
     reconcileActive: (environmentId) =>
       environmentId === undefined
         ? runReconciliation(() => service.reconcileActive())

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -77,6 +77,7 @@ export type WorkerDispatchEnvironmentService = Pick<
   | "createFromProfileSnapshot"
   | "destroy"
   | "get"
+  | "reconcileEnvironment"
   | "reconcileOnce"
   | "startTunnel"
   | "stopTunnel"

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -181,7 +181,8 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         continue;
       }
       if (isFailedPlacement(placement)) {
-        if (mode !== "startup" || placement.turnClaim || placement.activeOwnerEpoch !== null) {
+        // Terminal cleanup never gates readiness; tracked post-start owners resume it safely.
+        if (mode !== "startup") {
           await failure.retryFailedTeardown(placement);
         }
         continue;

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -121,8 +121,17 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
     }
   };
 
-  const reconcile = async (): Promise<void> => {
-    await environments.reconcileOnce();
+  const reconcile = async (mode?: "startup"): Promise<void> => {
+    if (mode === "startup") {
+      // Readiness fences live owners; unowned teardown remains in the service-owned sweep.
+      for (const { environmentId, state } of placements.listForReconcile()) {
+        if (environmentId && state !== "failed" && state !== "reclaimed") {
+          await environments.reconcileEnvironment(environmentId);
+        }
+      }
+    } else {
+      await environments.reconcileOnce();
+    }
     const pendingResultOwners = await recoverPendingWorkspaceResults(deps, true);
     const journalOwners = blockingWorkspaceJournalSessions(placements);
     const moveOwners = (await deps.recoverPlacementMoves?.()) ?? new Set<string>();
@@ -172,7 +181,9 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         continue;
       }
       if (isFailedPlacement(placement)) {
-        await failure.retryFailedTeardown(placement);
+        if (mode !== "startup" || placement.turnClaim || placement.activeOwnerEpoch !== null) {
+          await failure.retryFailedTeardown(placement);
+        }
         continue;
       }
       const error = new Error(`Worker dispatch interrupted in ${placement.state}`);

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -367,6 +367,9 @@ export function createHarness(
     reconcileOnce: vi.fn(async () => {
       log.push("environment:reconcile");
     }),
+    reconcileEnvironment: vi.fn(async () => {
+      log.push("environment:reconcile");
+    }),
   };
   const service = createWorkerPlacementDispatchService({
     placements,

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -203,6 +203,7 @@ describe("worker turn launcher failure recovery", () => {
         throw new Error("unexpected inherited worker environment creation");
       }),
       reconcileOnce,
+      reconcileEnvironment: vi.fn(),
     };
     const workspaceOperations = createWorkerWorkspaceOperationCoordinator();
     const dispatch = createWorkerPlacementDispatchService({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Gateway restart could remain unready while retrying cleanup for an already-failed cloud worker. If provider allocation had an indeterminate result, startup synchronously replayed the durable operation and waited for teardown even though that failed placement no longer held serving authority.

## Why This Change Was Made

Startup now waits only for nonterminal placement authority that must be recovered or fenced before serving. Failed-placement cleanup keeps its existing provider lease-adoption safety, but begins immediately after readiness through the existing tracked reconciliation owner and is still drained during shutdown.

The guard permits this deferred cleanup only for one exact failed placement with no turn claim, no active owner epoch, and durable destruction intent. Ambiguous or authority-retaining states remain fenced.

AI-assisted; the implementation was independently reviewed and the final rebased patch was unchanged from the reviewed diff.

## User Impact

Gateway restarts no longer remain unavailable while a terminal cloud-worker cleanup waits on a slow provider. Potentially live paid leases are still adopted and destroyed rather than being hidden or abandoned.

## Evidence

- Regression before the fix: the startup cleanup test observed provider replay before readiness and failed with `expected 'provision' to be 'ready'`.
- Boundary regression after the fix: readiness completes first, the exact provider replay starts through tracked post-readiness reconciliation, shutdown waits for it, and the adopted lease is destroyed.
- Focused suite after rebase: 26 test-file executions, 418 tests passed.
- Production-boundary provider spies prove failed placements retaining a local claim or active owner epoch cannot invoke provisioning, inspection, or destruction during startup.
- Absent-session retirement starts immediately after readiness in the existing tracked reconciliation slot; shutdown drains it while active placement recovery remains periodic.
- The failed CI shard exposed a duplicate immediate placement sweep; the correction removes that duplicate owner and preserves the established periodic recovery/event cadence.
- `git diff --check origin/main...HEAD` passed.
- Targeted oxlint and oxfmt checks passed for all changed files.
- Autoreview ran on both the working diff and final rebased branch; no accepted/actionable blocker findings.
- Production delta: +28/-7 lines. The +21 net lines define the internal startup authority/cleanup boundary; provider, protocol, schema, config, and public SDK contracts are unchanged.





### Real provider-transport proof

At exact head `e3278e24860cc5b831b85e5e3c44b4274c29d583`, I ran a local, secretless provider-transport proof twice using the actual bundled Crabbox plugin through its public top-level entry, the production `runCommandWithTimeout` OS-process path, the real SQLite-backed worker environment service/store, and the real Gateway placement startup runtime. Both runs passed and produced byte-identical sanitized artifacts (SHA-256 `7a94cf634455579395c0c78b1fa5d952738336c14f4f5501cc858fea06f671f1`).

- Failed placement retaining a local turn claim: `gateway-ready -> immediate-reconcile-complete`; zero Crabbox `warmup/inspect/run/stop` process invocations.
- Failed placement retaining an active owner epoch: `gateway-ready -> immediate-reconcile-complete`; zero Crabbox process invocations.
- Authority-free failed placement: readiness completed first, then the actual provider subprocess sequence was `warmup -> inspect -> run (node enrollment via stdin) -> inspect -> stop`. `sidecar.stop()` remained pending while warmup was held and completed only after provider stop; the SQLite environment finished `destroyed` with the adopted fixed lease.

The proof used a deterministic local fake Crabbox executable as the process transport peer; it created no network or paid cloud lease. Temporary paths, IDs, hostnames, and credentials were redacted. Runs completed as 6/6 tests in 18.95s and 17.48s.
