### PR TITLE
fix(subagents): interrupted tasks lose real user instructions after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Subagent restart recovery:** preserve the latest real user instruction after image-only turns, ignore hidden reasoning and commentary when detecting completed configuration changes, and bound resumed prompt context.
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **macOS app profiles:** isolate named app instances across state, preferences, Keychain, Gateway services, and duplicate-instance ownership while keeping host-global login and node services untouched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Subagent restart recovery:** preserve the latest real user instruction after image-only turns, ignore hidden reasoning and commentary when detecting completed configuration changes, and bound resumed prompt context.
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **macOS app profiles:** isolate named app instances across state, preferences, Keychain, Gateway services, and duplicate-instance ownership while keeping host-global login and node services untouched.

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.test.ts
@@ -10,4 +10,19 @@ describe("buildRestartRecoveryResumeMessage", () => {
         "Use the latest figures\n\nPlease continue where you left off.",
     );
   });
+
+  it.each([
+    ["original task", (value: string) => buildRestartRecoveryResumeMessage(value)],
+    [
+      "latest user direction",
+      (value: string) => buildRestartRecoveryResumeMessage("Finish the report", value),
+    ],
+  ])("bounds the %s without splitting UTF-16 surrogate pairs", (_label, buildMessage) => {
+    const retained = `${"x".repeat(1_997)}🦞`;
+    const message = buildMessage(`${retained}🚀discarded direction`);
+
+    expect(message).toContain(`${retained}...\n\n`);
+    expect(message).not.toContain("🚀");
+    expect(message).not.toContain("discarded direction");
+  });
 });

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.ts
@@ -29,12 +29,13 @@ export function isRestartRecoveryLifecycleCurrent(
 }
 
 export function buildRestartRecoveryResumeMessage(task: string, lastHumanMessage?: string): string {
-  const original = task.length > 2_000 ? `${truncateUtf16Safe(task, 2_000)}...` : task;
+  const boundContext = (text: string) =>
+    text.length > 2_000 ? `${truncateUtf16Safe(text, 2_000)}...` : text;
   return formatSystemTurnPrompt(
     `Your previous turn was interrupted by a gateway restart. ` +
-      `Your original task was:\n\n${original}\n\n` +
+      `Your original task was:\n\n${boundContext(task)}\n\n` +
       (lastHumanMessage
-        ? `The last message from the user before the interruption was:\n\n${lastHumanMessage}\n\n`
+        ? `The last message from the user before the interruption was:\n\n${boundContext(lastHumanMessage)}\n\n`
         : "") +
       `Please continue where you left off.`,
   );

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-message.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-message.ts
@@ -1,27 +1,25 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
-import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import { extractAssistantPhaseText } from "../../../shared/chat-message-content.js";
 
 export function readSubagentRecoveryTranscriptMessage(
   message: unknown,
-): { role?: string; text: string | null } | null {
+): { role?: string; text: string } | null {
   const record = asOptionalRecord(message);
   if (!record) {
     return null;
   }
-  const role = readStringValue(record.role);
-  if (typeof record.content === "string") {
-    return { role, text: record.content.trim() || null };
-  }
-  if (Array.isArray(record.content)) {
-    const text = record.content
-      .flatMap((block) => {
-        const blockText = readStringValue(asOptionalRecord(block)?.text)?.trim();
-        return blockText ? [blockText] : [];
-      })
-      .join("\n")
-      .trim();
-    return { role, text: text || null };
-  }
-  const text = readStringValue(record.text)?.trim();
-  return { role, text: text || null };
+  const role = typeof record.role === "string" ? record.role : undefined;
+  const projected =
+    role === "assistant"
+      ? record
+      : {
+          content: Array.isArray(record.content)
+            ? record.content.map((block) => ({
+                type: "text",
+                text: asOptionalRecord(block)?.text,
+              }))
+            : (record.content ?? record.text),
+        };
+  const text = extractAssistantPhaseText(projected);
+  return text ? { role, text } : null;
 }

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts
@@ -33,8 +33,6 @@ vi.mock("../../../config/sessions/session-accessor.js", () => ({
   patchSessionEntryCore: mocks.patchSessionEntryCore,
 }));
 vi.mock("../../../gateway/session-transcript-readers.js", () => ({
-  extractMessageRole: (message: { role?: string }) => message?.role,
-  extractSessionTranscriptText: (message: { content?: string }) => message?.content ?? null,
   readSessionMessagesAsync: mocks.readSessionMessages,
 }));
 
@@ -220,57 +218,109 @@ describe("subagent registry restart recovery", () => {
     mocks.readSessionMessages.mockResolvedValue([]);
   });
 
-  it("resumes a collector with transcript context and its output contract", async () => {
-    mocks.readSessionMessages.mockResolvedValue([
-      { role: "user", content: "latest user direction" },
-      { role: "assistant", content: "I updated openclaw.json" },
-    ]);
-    const entry = run({ collect: true, outputSchema: { type: "object" } });
-
-    await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
-
-    expect(dispatchAgent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionKey: childSessionKey,
-        expectedExistingSessionId: "session-id",
-        internalRuntimeHandoffId: expect.any(String),
-        lane: "subagent",
-        deliver: false,
-        swarmCollector: true,
-        swarmOutputSchema: { type: "object" },
-        sessionEffects: "internal",
-        suppressPromptPersistence: true,
-        message: expect.stringMatching(/latest user direction[\s\S]*already applied/),
-      }),
-    );
-    expect(reserveLaunch).toHaveBeenCalledWith({
-      runId: "original-run",
-      expected: entry,
-      sessionId: "session-id",
-      sessionMarker: expect.any(String),
-      idempotencyKey: expect.stringMatching(/^subagent-recovery:[a-f0-9]{64}$/),
-    });
-    expect(replaceRun).toHaveBeenCalledWith(
-      expect.objectContaining({
-        previousRunId: "original-run",
-        nextRunId: expect.stringMatching(/^subagent-recovery:[a-f0-9]{64}$/),
-        expected: entry,
-        task: "finish the restart-safe task",
-        persistenceFailure: "return-false",
-      }),
-    );
-    expect(replaceRun.mock.calls[0]?.[0].restartRecovery).toMatchObject({
-      phase: "accepted",
-      sessionId: "session-id",
-    });
-    expect(mocks.entries[childSessionKey]).toMatchObject({
-      abortedLastRun: false,
-      subagentRecovery: {
-        automaticAttempts: 1,
-        lastRunId: "original-run",
-      },
-    });
+  const signedAssistantText = (phase: "commentary" | "final_answer", text: string) => ({
+    type: "text",
+    text,
+    textSignature: JSON.stringify({ v: 1, id: `recovery-${phase}`, phase }),
   });
+
+  it.each([
+    {
+      label: "legacy scalar user text and visible assistant text",
+      userContent: "latest user direction",
+      assistantContent: "I updated openclaw.json",
+      appendImage: false,
+      configChanged: true,
+    },
+    {
+      label: "input_text user direction before an image and hidden reasoning",
+      userContent: [{ type: "input_text", text: "latest user direction" }],
+      assistantContent: [{ type: "reasoning", text: "I updated openclaw.json" }],
+      appendImage: true,
+      configChanged: false,
+    },
+    {
+      label: "legacy untyped user text and signed commentary",
+      userContent: [{ text: "latest user direction" }],
+      assistantContent: [signedAssistantText("commentary", "I will apply config.patch")],
+      appendImage: false,
+      configChanged: false,
+    },
+    {
+      label: "a final answer instead of preceding signed commentary",
+      userContent: "latest user direction",
+      assistantContent: [
+        signedAssistantText("commentary", "I will run openclaw gateway restart"),
+        signedAssistantText("final_answer", "The requested work remains pending"),
+      ],
+      appendImage: false,
+      configChanged: false,
+    },
+    {
+      label: "visible output_text after an image-only user follow-up",
+      userContent: [{ type: "input_text", text: "latest user direction" }],
+      assistantContent: [{ type: "output_text", text: "I updated openclaw.json" }],
+      appendImage: true,
+      configChanged: true,
+    },
+  ])(
+    "resumes a collector with $label",
+    async ({ userContent, assistantContent, appendImage, configChanged }) => {
+      mocks.readSessionMessages.mockResolvedValue([
+        { role: "user", content: userContent },
+        ...(appendImage ? [{ role: "user", content: [{ type: "image", image: "opaque" }] }] : []),
+        { role: "assistant", content: assistantContent },
+      ]);
+      const entry = run({ collect: true, outputSchema: { type: "object" } });
+
+      await expect(recover(entry)).resolves.toEqual({ status: "accepted" });
+
+      expect(dispatchAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: childSessionKey,
+          expectedExistingSessionId: "session-id",
+          internalRuntimeHandoffId: expect.any(String),
+          lane: "subagent",
+          deliver: false,
+          swarmCollector: true,
+          swarmOutputSchema: { type: "object" },
+          sessionEffects: "internal",
+          suppressPromptPersistence: true,
+          message: expect.stringContaining("latest user direction"),
+        }),
+      );
+      expect(String(dispatchAgent.mock.calls[0]?.[0].message).includes("already applied")).toBe(
+        configChanged,
+      );
+      expect(reserveLaunch).toHaveBeenCalledWith({
+        runId: "original-run",
+        expected: entry,
+        sessionId: "session-id",
+        sessionMarker: expect.any(String),
+        idempotencyKey: expect.stringMatching(/^subagent-recovery:[a-f0-9]{64}$/),
+      });
+      expect(replaceRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          previousRunId: "original-run",
+          nextRunId: expect.stringMatching(/^subagent-recovery:[a-f0-9]{64}$/),
+          expected: entry,
+          task: "finish the restart-safe task",
+          persistenceFailure: "return-false",
+        }),
+      );
+      expect(replaceRun.mock.calls[0]?.[0].restartRecovery).toMatchObject({
+        phase: "accepted",
+        sessionId: "session-id",
+      });
+      expect(mocks.entries[childSessionKey]).toMatchObject({
+        abortedLastRun: false,
+        subagentRecovery: {
+          automaticAttempts: 1,
+          lastRunId: "original-run",
+        },
+      });
+    },
+  );
 
   it("ignores non-aborted, yielded, steer-owned, and already-terminal rows", async () => {
     mocks.entries[childSessionKey]!.abortedLastRun = false;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where interrupted subagent tasks could resume without their latest real user direction after an image-only message, incorrectly claim hidden reasoning or commentary had already changed OpenClaw configuration, or inject an unbounded user message into the resumed prompt.

## Why This Change Was Made

Restart recovery now uses the shared assistant-visible transcript projection while preserving legacy user-message formats and dropping textless rows at the transcript owner. The existing Unicode-safe recovery-context bound applies consistently to both the original task and the latest user direction. Production code decreases by one line.

## User Impact

Subagents resumed after a Gateway restart retain the real user instruction, continue pending configuration work instead of trusting invisible model text, and receive bounded recovery prompts without breaking Unicode characters.

## Evidence

- Before the fix: the real restart recovery → session admission → Gateway dispatch suite failed four cases covering image-only follow-ups, hidden reasoning, commentary, and signed final-answer precedence; the recovery-prompt suite separately failed its oversized user-direction case.
- After the fix: `node scripts/run-vitest.mjs src/shared/chat-message-content.test.ts src/gateway/session-display-projection.test.ts src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.test.ts src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts` passed 61 tests across four Vitest shards, including actual recovery-to-dispatch behavior and shared Gateway visibility siblings.
- Core typechecking, focused lint/format checks, max-lines and assertion-safety ratchets, runtime import-cycle validation, and a fresh independent in-session review passed.
