### PR TITLE
fix(memory-wiki): ignore structural markers in query text

### DIFF
--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -345,6 +345,169 @@ describe("searchMemoryWiki", () => {
     expect(results.map((result) => result.path)).toEqual(["entities/needle-person.md"]);
   });
 
+  it("filters standalone structural markers from matching, snippets, and ranking", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await Promise.all([
+      fs.writeFile(
+        path.join(rootDir, "entities", "marker-only.md"),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "entity",
+            id: "entity.marker-only",
+            title: "Marker Only",
+          },
+          body: [
+            "<!-- openclaw:wiki:generated:start -->",
+            "<!-- openclaw:wiki:generated:end -->",
+            "<!-- openclaw:human:start -->",
+            "<!-- openclaw:human:end -->",
+            "<!-- openclaw:wiki:raw-source -->",
+            "",
+          ].join("\n"),
+        }),
+        "utf8",
+      ),
+      fs.writeFile(
+        path.join(rootDir, "entities", "evidence.md"),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "entity",
+            id: "entity.evidence",
+            title: "Evidence Page",
+            description: "openclaw release evidence",
+            claims: [
+              {
+                id: "claim.evidence",
+                text: "Neutral release note.",
+                status: "supported",
+                confidence: 0.8,
+                evidence: [{ note: "supporting reference" }],
+              },
+            ],
+          },
+          body: [
+            "<!-- openclaw:human:start -->",
+            "# Evidence Page",
+            "",
+            "Readable release evidence summary.",
+            "<!-- openclaw:human:end -->",
+            "",
+          ].join("\n"),
+        }),
+        "utf8",
+      ),
+      fs.writeFile(
+        path.join(rootDir, "entities", "marker-heavy.md"),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "entity",
+            id: "entity.marker-heavy",
+            title: "Marker Heavy",
+          },
+          body: [
+            "# Marker Heavy",
+            "",
+            "<!-- openclaw:wiki:generated:start -->",
+            "openclaw body reference",
+            "<!-- openclaw:wiki:generated:end -->",
+            "<!-- openclaw:human:start -->",
+            "<!-- openclaw:human:end -->",
+            "<!-- openclaw:wiki:raw-source -->",
+            "",
+          ].join("\n"),
+        }),
+        "utf8",
+      ),
+      fs.writeFile(
+        path.join(rootDir, "entities", "clean.md"),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "entity",
+            id: "entity.clean",
+            title: "Clean",
+          },
+          body: "# Clean\n\nopenclaw openclaw body reference\n",
+        }),
+        "utf8",
+      ),
+    ]);
+
+    const evidenceResults = await searchMemoryWiki({
+      config,
+      query: "openclaw release",
+      maxResults: 10,
+    });
+    expect(evidenceResults.map((result) => result.path)).toEqual(["entities/evidence.md"]);
+    expect(evidenceResults[0]?.snippet).toBe("Readable release evidence summary.");
+
+    const openClawResults = await searchMemoryWiki({
+      config,
+      query: "openclaw",
+      maxResults: 10,
+    });
+    const paths = openClawResults.map((result) => result.path);
+    expect(paths).not.toContain("entities/marker-only.md");
+    expect(
+      openClawResults.find((result) => result.path === "entities/clean.md")?.score,
+    ).toBeGreaterThan(
+      openClawResults.find((result) => result.path === "entities/marker-heavy.md")?.score ?? 0,
+    );
+  });
+
+  it("keeps managed-block content and inline marker prose searchable", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    await Promise.all([
+      fs.writeFile(
+        path.join(rootDir, "entities", "managed-content.md"),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "entity",
+            id: "entity.managed-content",
+            title: "Managed Content",
+          },
+          body: [
+            "# Managed Content",
+            "",
+            "<!-- openclaw:wiki:generated:start -->",
+            "Cobalt content remains searchable.",
+            "<!-- openclaw:wiki:generated:end -->",
+            "",
+          ].join("\n"),
+        }),
+        "utf8",
+      ),
+      fs.writeFile(
+        path.join(rootDir, "entities", "inline-marker.md"),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "entity",
+            id: "entity.inline-marker",
+            title: "Inline Marker",
+          },
+          body: [
+            "# Inline Marker",
+            "",
+            "The literal <!-- openclaw:wiki:generated:start --> inline-needle stays searchable.",
+            "",
+          ].join("\n"),
+        }),
+        "utf8",
+      ),
+    ]);
+
+    const managedResults = await searchMemoryWiki({ config, query: "cobalt" });
+    expect(managedResults.map((result) => result.path)).toEqual(["entities/managed-content.md"]);
+    expect(managedResults[0]?.snippet).toBe("Cobalt content remains searchable.");
+
+    const inlineResults = await searchMemoryWiki({ config, query: "inline-needle" });
+    expect(inlineResults.map((result) => result.path)).toEqual(["entities/inline-marker.md"]);
+    expect(inlineResults[0]?.snippet).toContain("<!-- openclaw:wiki:generated:start -->");
+  });
+
   it("matches pages when all query terms appear without an exact phrase", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -35,6 +35,7 @@ const WIKI_SNIPPET_MAX_CHARS = 700;
 const RELATED_BLOCK_PATTERN =
   /<!-- openclaw:wiki:related:start -->[\s\S]*?<!-- openclaw:wiki:related:end -->/g;
 const MARKDOWN_FRONTMATTER_PATTERN = /^\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+const STRUCTURAL_MARKER_LINE_PATTERN = /^\s*<!--\s*openclaw:(?:wiki|human):[^>]*-->\s*$/;
 const ROUTE_QUESTION_STOP_WORDS = new Set([
   "a",
   "about",
@@ -256,7 +257,7 @@ async function readQueryDigestBundle(
 function buildSnippet(raw: string, query: string): string {
   const queryLower = normalizeLowercaseStringOrEmpty(query);
   const queryTokens = buildQueryTokens(queryLower);
-  const searchable = buildSnippetSearchText(raw);
+  const searchable = buildSearchableBody(raw);
   const lines = searchable.split(/\r?\n/).filter((line) => line.trim().length > 0);
   const matchingLine =
     lines.find((line) =>
@@ -278,6 +279,7 @@ function buildPageSearchText(page: QueryableWikiPage): string {
     page.title,
     page.relativePath,
     page.id ?? "",
+    JSON.stringify(parseWikiMarkdown(page.raw).frontmatter),
     page.pageType ?? "",
     page.entityType ?? "",
     page.canonicalId ?? "",
@@ -331,8 +333,12 @@ function stripGeneratedRelatedBlock(raw: string): string {
   return raw.replace(RELATED_BLOCK_PATTERN, "");
 }
 
-function buildSnippetSearchText(raw: string): string {
-  return stripGeneratedRelatedBlock(raw).replace(MARKDOWN_FRONTMATTER_PATTERN, "");
+function buildSearchableBody(raw: string): string {
+  return stripGeneratedRelatedBlock(raw)
+    .replace(MARKDOWN_FRONTMATTER_PATTERN, "")
+    .split(/\r?\n/)
+    .filter((line) => !STRUCTURAL_MARKER_LINE_PATTERN.test(line))
+    .join("\n");
 }
 
 function buildQueryTokens(queryLower: string): string[] {
@@ -834,7 +840,7 @@ function scorePage(page: QueryableWikiPage, query: string, mode: WikiSearchMode)
   const pathLower = normalizeLowercaseStringOrEmpty(page.relativePath);
   const idLower = normalizeLowercaseStringOrEmpty(page.id);
   const metadataLower = normalizeLowercaseStringOrEmpty(buildPageSearchText(page));
-  const rawLower = normalizeLowercaseStringOrEmpty(stripGeneratedRelatedBlock(page.raw));
+  const rawLower = normalizeLowercaseStringOrEmpty(buildSearchableBody(page.raw));
   const combinedLower = [titleLower, pathLower, idLower, metadataLower, rawLower].join("\n");
   const hasExactMatch =
     titleLower.includes(queryLower) ||


### PR DESCRIPTION
## Summary

- build one canonical searchable body for memory-wiki queries
- remove frontmatter, generated Related blocks, and standalone structural marker lines from both scoring and snippets
- preserve managed-block content and inline marker prose

Fixes #128017

Reported by @mrdcn.

## Testing

- red repro: `node scripts/run-vitest.mjs extensions/memory-wiki/src/query.test.ts` failed because the snippet was `<!-- openclaw:human:start -->`
- exact-head focused: query, OKF, and CLI tests (`90/90` passed)
- full memory-wiki source suite: `450/450` passed
- prior Blacksmith Testbox focused: `58/58` passed
- changed gate: all checks through dead-export scan passed; local extension typecheck was blocked by unrelated stale shared dependency errors in `extensions/acpx` and `extensions/cua-computer`
- autoreview: clean, no P0/P1 findings
- production LOC: `+10/-4` (net `+6`); tests: `+163/-0`



Punchcard-Session: crisp-timber-harbor-p1
