### PR TITLE
fix(ui): preserve other chat transcripts when deleting a session

### DIFF
--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { IDBFactory } from "fake-indexeddb";
+import { IDBFactory, IDBObjectStore } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import {
@@ -312,6 +312,81 @@ describe("persistent chat session snapshots", () => {
     const reader = new SessionSnapshotStore();
     expect(await reader.read("agent:main:deleted")).toBeNull();
     expect(await reader.read("agent:main:retained")).not.toBeNull();
+  });
+
+  it("preserves an unrelated in-flight transcript while deleting another session", async () => {
+    const writer = new SessionSnapshotStore();
+    writer.connect();
+    try {
+      const retainedSession = "agent:main:retained";
+      writer.write(retainedSession, snapshot("important transcript"));
+
+      await Promise.all([writer.flush(), writer.delete("agent:main:deleted")]);
+
+      expect(await new SessionSnapshotStore().read(retainedSession)).toEqual(
+        snapshot("important transcript"),
+      );
+      expect(writer.readSavedAt(retainedSession)).not.toBeNull();
+    } finally {
+      writer.disconnect();
+      await writer.whenIdle();
+    }
+  });
+
+  it.each(["session", "all"])(
+    "does not restore an in-flight transcript after %s invalidation",
+    async (scope) => {
+      const sessionKey = "agent:main:deleted";
+      const writer = new SessionSnapshotStore();
+      writer.connect();
+      try {
+        writer.write(sessionKey, snapshot("deleted transcript"));
+
+        await Promise.all([
+          writer.flush(),
+          scope === "session" ? writer.delete(sessionKey) : clearStoredChatSnapshots(),
+        ]);
+
+        expect(await new SessionSnapshotStore().read(sessionKey)).toBeNull();
+        expect(writer.readSavedAt(sessionKey)).toBeNull();
+      } finally {
+        writer.disconnect();
+        await writer.whenIdle();
+      }
+    },
+  );
+
+  it("does not restore deleted metadata while seeding the snapshot index", async () => {
+    const sessionKey = "agent:main:deleted-during-seed";
+    const writer = new SessionSnapshotStore();
+    writer.write(sessionKey, snapshot("deleted transcript"));
+    await writer.flush();
+
+    const reader = new SessionSnapshotStore();
+    reader.connect();
+    try {
+      let deletion: Promise<void> | undefined;
+      const originalGetAll = Reflect.get(
+        IDBObjectStore.prototype,
+        "getAll",
+      ) as IDBObjectStore["getAll"];
+      vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementationOnce(function (...args) {
+        const request = originalGetAll.apply(this, args);
+        request.addEventListener("success", () => {
+          deletion = writer.delete(sessionKey);
+        });
+        return request;
+      });
+
+      await reader.loadSavedAtIndex();
+      expect(deletion).toBeDefined();
+      await deletion;
+
+      expect(reader.readSavedAt(sessionKey)).toBeNull();
+    } finally {
+      reader.disconnect();
+      await reader.whenIdle();
+    }
   });
 
   it("upgrades a version one database before deleting an invalidated snapshot", async () => {

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -370,7 +370,10 @@ describe("persistent chat session snapshots", () => {
         IDBObjectStore.prototype,
         "getAll",
       ) as IDBObjectStore["getAll"];
-      vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementationOnce(function (...args) {
+      vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementationOnce(function (
+        this: IDBObjectStore,
+        ...args
+      ) {
         const request = originalGetAll.apply(this, args);
         request.addEventListener("success", () => {
           deletion = writer.delete(sessionKey);

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -338,8 +338,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
   }
 
   async delete(sessionKey: string): Promise<void> {
-    this.pending.delete(sessionKey);
-    this.savedAtBySession.delete(sessionKey);
+    this.forget(sessionKey);
     await deleteStoredChatSnapshot(sessionKey);
   }
 
@@ -356,6 +355,9 @@ export class SessionSnapshotStore implements ChatCacheObserver {
       this.writeTimer = null;
     }
     const pending = [...this.pending.entries()];
+    const pendingRevisions = new Map(
+      pending.map(([sessionKey]) => [sessionKey, this.revisions.get(sessionKey) ?? 0]),
+    );
     this.pending.clear();
     const records: SessionSnapshotRecord[] = [];
     for (const [sessionKey, state] of pending) {
@@ -368,7 +370,11 @@ export class SessionSnapshotStore implements ChatCacheObserver {
     }
     const generation = snapshotStoreGeneration;
     this.writeChain = this.writeChain.then(async () => {
-      const evicted = await writeSnapshotRecords(records, generation);
+      const currentRecords = records.filter(
+        ({ sessionKey }) =>
+          pendingRevisions.get(sessionKey) === (this.revisions.get(sessionKey) ?? 0),
+      );
+      const evicted = await writeSnapshotRecords(currentRecords, generation);
       if (evicted === null) {
         this.resetSavedAtIndex();
         return;
@@ -416,6 +422,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
 
   private async seedSavedAtIndex(): Promise<void> {
     const generation = snapshotStoreGeneration;
+    const revisions = new Map(this.revisions);
     const records = await readSnapshotRecords();
     if (generation !== snapshotStoreGeneration) {
       return;
@@ -425,6 +432,11 @@ export class SessionSnapshotStore implements ChatCacheObserver {
       return;
     }
     for (const record of records) {
+      if (
+        (revisions.get(record.sessionKey) ?? 0) !== (this.revisions.get(record.sessionKey) ?? 0)
+      ) {
+        continue;
+      }
       const current = this.savedAtBySession.get(record.sessionKey) ?? 0;
       this.savedAtBySession.set(record.sessionKey, Math.max(current, record.savedAt));
     }
@@ -439,7 +451,10 @@ export class SessionSnapshotStore implements ChatCacheObserver {
 }
 
 subscribeSnapshotInvalidation(async ({ sessionKey }) => {
-  snapshotStoreGeneration += 1;
+  // Scoped deletes fence only their session; whole-cache clears retire every pending operation.
+  if (!sessionKey) {
+    snapshotStoreGeneration += 1;
+  }
   for (const store of activeStores) {
     if (sessionKey) {
       store.forget(sessionKey);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deleting one Control UI chat session silently discards another session's in-flight transcript save. The affected session continues claiming it was cached, so background prefetch can skip recovery and reopening that conversation can show missing history.

## Why This Change Was Made

The snapshot owner treated every single-session deletion as a whole-cache generation change, invalidating unrelated queued IndexedDB writes after their pending state had already been removed. Keep the global generation fence only for whole-cache resets and use the owner's existing per-session revisions to fence scoped writes, deletes, and concurrent metadata-index seeding. This preserves same-session deletion and whole-cache clearing without dropping independent sessions. The positive production delta is required because scoped ownership must independently protect both asynchronous transcript writes and metadata seeding; removing either fence demonstrably loses or resurrects data.

## User Impact

Deleting one conversation no longer erases another conversation's unsaved transcript or leaves the UI falsely believing missing history was persisted. Deleted conversations stay deleted, full Gateway/cache resets still remove every snapshot, and stale metadata cannot reappear after a scoped delete.

## Evidence

- The new real IndexedDB-owner regression fails on unchanged `main`: deleting session B while session A flushes returns `null` for A's expected transcript.
- A second regression was independently red-proven by removing only the new scoped metadata fence: a deleted session's `savedAt` value reappears during concurrent index seeding.
- All 24 focused snapshot-store, Gateway invalidation, and session-prefetch tests pass, including concurrent unrelated delete, same-session delete, full-cache clear, and metadata-seeding races.
- Real installed Google Chrome running the actual production modules against native browser IndexedDB produced `{ "nativeIndexedDb": true, "unrelatedTranscript": ["important transcript"], "sameSessionDeleted": true, "fullClearDeleted": true }` in an isolated local origin. The full mocked-Gateway browser lane could not build because this linked checkout's existing shared dependencies lack the newly added `@panzoom/panzoom`; the direct Chrome proof avoids changing shared dependencies or touching the operator's Gateway.
- Targeted TypeScript lint, repository formatting, whitespace checks, and independent Codex review pass. Production: +19/-4 (net +15; two required scoped ownership fences); tests: +76/-1.
