### PR TITLE
fix(plugins): reload replaced setup modules after lifecycle resets

### DIFF
--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -560,6 +560,41 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(fs.existsSync(fullMarker)).toBe(false);
   });
 
+  it("reloads replaced installed channel setup modules and their dependencies", () => {
+    const { pluginDir } = writeExternalSetupChannelPlugin();
+    const setupPath = path.join(pluginDir, "setup-entry.cjs");
+    const dependencyPath = path.join(pluginDir, "setup-dependency.cjs");
+    const initialSource = fs
+      .readFileSync(setupPath, "utf8")
+      .replace('blurb: "setup entry",', 'blurb: require("./setup-dependency.cjs"),');
+    fs.writeFileSync(dependencyPath, 'module.exports = "before";\n', "utf8");
+    fs.writeFileSync(setupPath, initialSource, "utf8");
+    const cfg = createExternalChannelTestConfig({ pluginDir });
+    const options = {
+      includePersistedAuthState: false,
+      includeSetupFallbackPlugins: true,
+    };
+
+    const first = listReadOnlyChannelPluginsForConfig(cfg, options);
+    expect(first.find((plugin) => plugin.id === "external-chat")?.meta.blurb).toBe("before");
+
+    fs.writeFileSync(dependencyPath, 'module.exports = "after";\n', "utf8");
+    fs.writeFileSync(
+      setupPath,
+      initialSource.replace(
+        'blurb: require("./setup-dependency.cjs"),',
+        'blurb: "updated:" + require("./setup-dependency.cjs"),',
+      ),
+      "utf8",
+    );
+    clearPluginMetadataLifecycleCaches();
+
+    const second = listReadOnlyChannelPluginsForConfig(cfg, options);
+    expect(second.find((plugin) => plugin.id === "external-chat")?.meta.blurb).toBe(
+      "updated:after",
+    );
+  });
+
   it("matches setup-only plugins by manifest-owned channel ids when plugin id differs", () => {
     const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
       pluginId: "external-chat-plugin",

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -31,6 +31,7 @@ import { registerPluginMetadataProcessMemoLifecycleClear } from "../../plugins/p
 import { resolvePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
+  clearPluginModuleLoaderLifecycleCache,
   getCachedPluginModuleLoader,
   type PluginModuleLoaderCache,
 } from "../../plugins/plugin-module-loader-cache.js";
@@ -53,6 +54,7 @@ import { listChannelPlugins } from "./registry.js";
 import type { ChannelPlugin } from "./types.plugin.js";
 
 const moduleLoaders: PluginModuleLoaderCache = new Map();
+const moduleRoots = new Map<string, string>();
 const log = createSubsystemLogger("channels");
 
 type ReadOnlyChannelPluginOptions = {
@@ -87,6 +89,7 @@ let nextReadOnlyChannelPluginObjectId = 1;
 
 registerPluginMetadataProcessMemoLifecycleClear(() => {
   readOnlyChannelPluginResolutionCache.clear();
+  clearPluginModuleLoaderLifecycleCache({ moduleLoaders, moduleRoots });
 });
 
 function cloneReadOnlyChannelPluginResolution(
@@ -432,6 +435,7 @@ function loadSetupChannelPluginFromManifestRecord(params: {
     return {};
   }
   try {
+    moduleRoots.set(params.record.setupSource, params.record.rootDir);
     const moduleLoader = getCachedPluginModuleLoader({
       cache: moduleLoaders,
       modulePath: params.record.setupSource,

--- a/src/plugins/setup-registry-loader-state.ts
+++ b/src/plugins/setup-registry-loader-state.ts
@@ -6,5 +6,6 @@ import {
 
 export const pluginSetupRegistryLoaderState = {
   moduleLoaders: createPluginModuleLoaderCache(),
+  moduleRoots: new Map<string, string>(),
   moduleLoaderFactory: undefined as PluginModuleLoaderFactory | undefined,
 };

--- a/src/plugins/setup-registry.lifecycle.test.ts
+++ b/src/plugins/setup-registry.lifecycle.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { resolvePluginSetupRegistry } from "./setup-registry.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+describe("plugin setup registry artifact lifecycle", () => {
+  it("reloads replaced installed setup modules and their dependencies", () => {
+    const rootDir = fs.realpathSync(makeTrackedTempDir("openclaw-setup-lifecycle", tempDirs));
+    const setupSource = path.join(rootDir, "setup-api.cjs");
+    const dependencyPath = path.join(rootDir, "setup-dependency.cjs");
+    const writeSetupArtifact = (version: string) => {
+      fs.writeFileSync(dependencyPath, `module.exports = "dependency-${version}";\n`, "utf8");
+      fs.writeFileSync(
+        setupSource,
+        `module.exports = { register(api) { api.registerProvider({ id: "setup-lifecycle", label: "entry-${version}:" + require("./setup-dependency.cjs") }); } };\n`,
+        "utf8",
+      );
+    };
+    const manifestRegistry = {
+      plugins: [
+        {
+          id: "setup-lifecycle",
+          rootDir,
+          source: setupSource,
+          setupSource,
+          manifestPath: path.join(rootDir, "openclaw.plugin.json"),
+          origin: "global",
+          channels: [],
+          providers: ["setup-lifecycle"],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          setup: { requiresRuntime: true, providers: [{ id: "setup-lifecycle" }] },
+        },
+      ],
+      diagnostics: [],
+    } satisfies PluginManifestRegistry;
+
+    writeSetupArtifact("before");
+    expect(resolvePluginSetupRegistry({ manifestRegistry }).providers[0]?.provider.label).toBe(
+      "entry-before:dependency-before",
+    );
+
+    writeSetupArtifact("after");
+    clearPluginMetadataLifecycleCaches();
+
+    expect(resolvePluginSetupRegistry({ manifestRegistry }).providers[0]?.provider.label).toBe(
+      "entry-after:dependency-after",
+    );
+  });
+
+  it.each(["dist", "dist-runtime"])(
+    "reloads bundled setup artifacts and their dependencies from %s",
+    (artifactRootName) => {
+      const packageRoot = fs.realpathSync(
+        makeTrackedTempDir("openclaw-bundled-setup-lifecycle", tempDirs),
+      );
+      const rootDir = path.join(packageRoot, "extensions", "bundled-setup");
+      const artifactRoot = path.join(packageRoot, artifactRootName, "extensions", "bundled-setup");
+      fs.mkdirSync(rootDir, { recursive: true });
+      fs.mkdirSync(artifactRoot, { recursive: true });
+      const sourcePath = path.join(rootDir, "setup-api.ts");
+      const artifactPath = path.join(artifactRoot, "setup-api.js");
+      const dependencyPath =
+        artifactRootName === "dist"
+          ? path.join(packageRoot, artifactRootName, "setup-dependency.cjs")
+          : path.join(artifactRoot, "setup-dependency.cjs");
+      const dependencyImport =
+        artifactRootName === "dist" ? "../../setup-dependency.cjs" : "./setup-dependency.cjs";
+      fs.writeFileSync(sourcePath, "export {};\n", "utf8");
+      const writeBundledArtifact = (version: string) => {
+        fs.writeFileSync(dependencyPath, `module.exports = "dependency-${version}";\n`, "utf8");
+        fs.writeFileSync(
+          artifactPath,
+          `module.exports = { register(api) { api.registerProvider({ id: "bundled-setup", label: "entry-${version}:" + require(${JSON.stringify(dependencyImport)}) }); } };\n`,
+          "utf8",
+        );
+      };
+      const manifestRegistry = {
+        plugins: [
+          {
+            id: "bundled-setup",
+            rootDir,
+            source: sourcePath,
+            setupSource: sourcePath,
+            manifestPath: path.join(rootDir, "openclaw.plugin.json"),
+            origin: "bundled",
+            channels: [],
+            providers: ["bundled-setup"],
+            cliBackends: [],
+            skills: [],
+            hooks: [],
+            setup: { requiresRuntime: true, providers: [{ id: "bundled-setup" }] },
+          },
+        ],
+        diagnostics: [],
+      } satisfies PluginManifestRegistry;
+
+      writeBundledArtifact("before");
+      expect(resolvePluginSetupRegistry({ manifestRegistry }).providers[0]?.provider.label).toBe(
+        "entry-before:dependency-before",
+      );
+
+      writeBundledArtifact("after");
+      clearPluginMetadataLifecycleCaches();
+
+      expect(resolvePluginSetupRegistry({ manifestRegistry }).providers[0]?.provider.label).toBe(
+        "entry-after:dependency-after",
+      );
+    },
+  );
+});

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -15,7 +15,8 @@ import {
 // falling back to jiti. These tests script plugin-loading behavior through the
 // source-transform mock, so force the fallback path and keep the fixture
 // transformer authoritative.
-vi.mock("./native-module-require.js", () => ({
+vi.mock("./native-module-require.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./native-module-require.js")>()),
   isJavaScriptModulePath: (_modulePath: string) => false,
   tryNativeRequireJavaScriptModule: (_modulePath: string) => ({ ok: false }),
 }));

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -17,7 +17,10 @@ import { createPluginCacheKey, PluginLruCache } from "./plugin-cache-primitives.
 import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataEnvFingerprint } from "./plugin-metadata-snapshot.js";
-import { getCachedPluginModuleLoader } from "./plugin-module-loader-cache.js";
+import {
+  clearPluginModuleLoaderLifecycleCache,
+  getCachedPluginModuleLoader,
+} from "./plugin-module-loader-cache.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { listSetupCliBackendIds, listSetupProviderIds } from "./setup-descriptors.js";
@@ -108,14 +111,15 @@ const pluginSetupRegistryCache = new PluginLruCache<PluginSetupRegistry>(
 );
 
 function clearPluginSetupRegistryCache(): void {
-  pluginSetupRegistryLoaderState.moduleLoaders.clear();
+  clearPluginModuleLoaderLifecycleCache(pluginSetupRegistryLoaderState);
   setupRegistrySnapshotIds = new WeakMap();
   setupManifestRegistryCache.clear();
   pluginSetupRegistryCache.clear();
 }
 
 registerPluginMetadataProcessMemoLifecycleClear(clearPluginSetupRegistryCache);
-function getModuleLoader(modulePath: string) {
+function getModuleLoader(modulePath: string, rootDir: string) {
+  pluginSetupRegistryLoaderState.moduleRoots.set(modulePath, rootDir);
   return getCachedPluginModuleLoader({
     cache: pluginSetupRegistryLoaderState.moduleLoaders,
     modulePath,
@@ -227,41 +231,44 @@ function resolveRegister(mod: OpenClawPluginModule): {
 function rewriteBundledSetupSourceToBuiltArtifact(
   source: string,
   record: PluginManifestRecord,
-): string {
+): { source: string; rootDir: string } {
+  const sourceArtifact = { source, rootDir: record.rootDir };
   if (record.origin !== "bundled") {
-    return source;
+    return sourceArtifact;
   }
   const rootDir = path.resolve(record.rootDir);
   const sourcePath = path.resolve(source);
   const extensionsDir = path.dirname(rootDir);
   if (path.basename(extensionsDir) !== "extensions") {
-    return source;
+    return sourceArtifact;
   }
   const packageRoot = path.dirname(extensionsDir);
   if (path.basename(packageRoot) === "dist" || path.basename(packageRoot) === "dist-runtime") {
-    return source;
+    return sourceArtifact;
   }
   const relativeSource = path.relative(rootDir, sourcePath);
   if (relativeSource === "" || relativeSource.startsWith("..") || path.isAbsolute(relativeSource)) {
-    return source;
+    return sourceArtifact;
   }
   const artifactRelativePath = relativeSource.replace(/\.[^.]+$/u, ".js");
   for (const artifactRootName of ["dist-runtime", "dist"] as const) {
-    const candidate = path.join(
+    const artifactRoot = path.join(
       packageRoot,
       artifactRootName,
       "extensions",
       path.basename(rootDir),
-      artifactRelativePath,
     );
+    const candidate = path.join(artifactRoot, artifactRelativePath);
     if (fs.existsSync(candidate)) {
-      return candidate;
+      return { source: candidate, rootDir: artifactRoot };
     }
   }
-  return source;
+  return sourceArtifact;
 }
 
-function resolveLoadableSetupRuntimeSource(record: PluginManifestRecord): string | null {
+function resolveLoadableSetupRuntimeSource(
+  record: PluginManifestRecord,
+): { source: string; rootDir: string } | null {
   const source = record.setupSource ?? resolveSetupApiPath(record.rootDir);
   return source ? rewriteBundledSetupSourceToBuiltArtifact(source, record) : null;
 }
@@ -285,14 +292,15 @@ function resolveSetupRegistration(
   if (record.setup?.requiresRuntime === false) {
     return null;
   }
-  const setupSource = resolveLoadableSetupRuntimeSource(record);
-  if (!setupSource) {
+  const setupArtifact = resolveLoadableSetupRuntimeSource(record);
+  if (!setupArtifact) {
     return null;
   }
+  const setupSource = setupArtifact.source;
 
   let mod: OpenClawPluginModule;
   try {
-    mod = getModuleLoader(setupSource)(setupSource) as OpenClawPluginModule;
+    mod = getModuleLoader(setupSource, setupArtifact.rootDir)(setupSource) as OpenClawPluginModule;
   } catch (error) {
     // A broken setup entry silently removes the plugin's providers/CLI
     // backends/migrations from onboarding; record why instead of vanishing.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users updating or replacing installed plugins would continue seeing stale provider setup and channel information after OpenClaw explicitly refreshed plugin metadata. The same stale behavior affected bundled setup artifacts and their packaged dependencies in both distribution layouts.

## Why This Change Was Made

Both setup-registry and read-only channel owners cleared metadata results without retiring their executable loader closures and native Node module/dependency caches. Associate each loaded setup artifact with its actual package root and reuse the existing canonical lifecycle invalidator introduced in #126719, preserving strict package containment and correctly handling dependencies hoisted into `dist` versus package-local `dist-runtime` artifacts. This completes the same lifecycle invariant previously applied to web runtime artifacts in #126867; it introduces no public configuration, SDK, protocol, persistence, or security contract change.

## User Impact

After an explicit plugin metadata refresh, replaced provider setup modules, channel setup modules, and their owned dependencies are reloaded from disk immediately. Installed plugins and bundled `dist`/`dist-runtime` packages now consistently expose their updated behavior instead of silently serving the previous version.

## Evidence

- Before the fix, the installed setup regression returned `entry-before:dependency-before` instead of `entry-after:dependency-after`; the independent channel regression returned `before` instead of `updated:after`.
- After the owner-boundary repair, ten focused plugin, channel, SDK, doctor, provider discovery, facade, and native-loader suites pass: **189 tests**, including installed plugin replacement, bundled `dist` hoisted dependencies, bundled `dist-runtime` package-contained dependencies, and replaced channel setup modules.
- Validation: `node scripts/run-vitest.mjs src/plugins/setup-registry.lifecycle.test.ts src/plugins/setup-registry.test.ts src/plugins/setup-registry.runtime.test.ts src/plugins/plugin-module-loader-cache.test.ts src/plugins/native-module-require.test.ts src/plugins/doctor-contract-registry.test.ts src/plugins/provider-discovery.runtime.test.ts src/plugins/public-surface-loader.test.ts src/channels/plugins/read-only.test.ts src/plugin-sdk/facade-loader.test.ts`.
- Both max-lines and assertion-safety ratchets, targeted formatting/lint, and `git diff --check` pass. An independent full source/security review and authenticated Codex review reported no actionable findings. Production delta: **+13 lines** for authoritative owner/root lifecycle tracking; regression tests are counted separately.
- Live third-party provider credentials are not needed: boundary tests execute actual installed CommonJS setup artifacts and dependencies through the real loader before and after replacement.
