### PR TITLE
improve(cli): speed up config help startup

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -385,6 +385,7 @@ const LAUNCHER_PRECOMPUTED_COMMAND_HELP = {
   nodes: { command: "nodes", metadataKey: "nodesHelpText" },
 };
 const LAUNCHER_PRECOMPUTED_SUBCOMMAND_HELP = new Set([
+  "config",
   "doctor",
   "gateway",
   "models",

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -46,6 +46,7 @@ const COMMAND_HELP_RENDER_KILL_GRACE_MS = 5_000;
 // proxy for module-loading throughput on a disk-contended host.
 const COMMAND_HELP_RENDER_CONCURRENCY = 2;
 const PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS = [
+  "config",
   "doctor",
   "gateway",
   "models",
@@ -282,6 +283,7 @@ function resolveSubcommandHelpSourceSignature(sourceRootDir: string = rootDir): 
       path.join(sourceRootDir, "src/cli/program/context.ts"),
       path.join(sourceRootDir, "src/cli/banner.ts"),
       path.join(sourceRootDir, "src/cli/help-format.ts"),
+      path.join(sourceRootDir, "src/cli/config-cli.ts"),
       path.join(sourceRootDir, "src/cli/daemon-cli/register-service-commands.ts"),
       path.join(sourceRootDir, "src/cli/program/register.maintenance.ts"),
       path.join(sourceRootDir, "src/cli/program/register.status-health-sessions.ts"),

--- a/src/cli/precomputed-help.ts
+++ b/src/cli/precomputed-help.ts
@@ -3,6 +3,7 @@ import { getCommandPathWithRootOptions, isSimpleCommandHelpInvocation } from "./
 import type { RootHelpRenderOptions } from "./program/root-help.js";
 
 type PrecomputedSubcommandHelpName =
+  | "config"
   | "doctor"
   | "gateway"
   | "models"
@@ -27,6 +28,7 @@ export type PrecomputedCommandHelpDeps = {
 };
 
 const PRECOMPUTED_SUBCOMMAND_HELP_COMMANDS = new Set<PrecomputedSubcommandHelpName>([
+  "config",
   "doctor",
   "gateway",
   "models",

--- a/src/cli/root-help-metadata.ts
+++ b/src/cli/root-help-metadata.ts
@@ -2,6 +2,7 @@
 import { readCliStartupMetadata } from "./startup-metadata.js";
 
 export type PrecomputedSubcommandHelpName =
+  | "config"
   | "doctor"
   | "gateway"
   | "models"
@@ -142,6 +143,7 @@ function isPrecomputedSubcommandHelpName(
   commandName: string,
 ): commandName is PrecomputedSubcommandHelpName {
   return (
+    commandName === "config" ||
     commandName === "doctor" ||
     commandName === "gateway" ||
     commandName === "models" ||

--- a/src/entry.test.ts
+++ b/src/entry.test.ts
@@ -248,7 +248,7 @@ describe("entry precomputed command help fast path", () => {
     expect(outputPrecomputedNodesHelpTextCalls).toBe(1);
   });
 
-  it.each(["doctor", "gateway", "plugins", "sessions", "tasks"])(
+  it.each(["config", "doctor", "gateway", "plugins", "sessions", "tasks"])(
     "renders precomputed %s help from startup metadata without importing the full program",
     async (commandName) => {
       const outputPrecomputedSubcommandHelpTextCalls: string[] = [];

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -414,7 +414,7 @@ describe("openclaw launcher", () => {
     expect(result.stdout).toBe(`PRECOMPUTED ${params.command} help\n`);
   });
 
-  it.each(["doctor", "gateway", "models", "plugins", "sessions", "tasks"])(
+  it.each(["config", "doctor", "gateway", "models", "plugins", "sessions", "tasks"])(
     "uses precomputed %s help before loading the runtime entry",
     async (command) => {
       const fixtureRoot = await makeLauncherFixture(fixtureRoots);

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -22,6 +22,7 @@ const DEFAULT_COMMAND_HELP_NAMES = [
   "browser",
   "secrets",
   "nodes",
+  "config",
   "doctor",
   "gateway",
   "models",
@@ -51,6 +52,7 @@ function writeStartupMetadataSourceSignatureFixture(rootDir: string): void {
     ["src/cli/gateway-cli/register.ts", "export const gatewayRegister = 'gateway';\n"],
     ["src/cli/gateway-cli/run-command.ts", "export const gatewayRun = 'gateway';\n"],
     ["src/cli/help-format.ts", "export const helpFormat = 'help';\n"],
+    ["src/cli/config-cli.ts", "export const configHelp = 'config';\n"],
     ["src/cli/models-cli.ts", "export const modelsHelp = 'models';\n"],
     ["src/cli/nodes-cli/register.ts", "export const nodesHelp = 'nodes';\n"],
     ["src/cli/program/register.maintenance.ts", "export const maintenanceHelp = 'maintenance';\n"],
@@ -415,6 +417,7 @@ describe("write-cli-startup-metadata", () => {
           renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
           renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
           renderSourceSubcommandHelpTextRecord: () => ({
+            config: "Usage: openclaw config\n",
             doctor: "Usage: openclaw doctor\n",
             gateway: "Usage: openclaw gateway\n",
             models: "Usage: openclaw models\n",
@@ -698,6 +701,7 @@ describe("write-cli-startup-metadata", () => {
           `  renderSourceSecretsHelpText: renderCommand(${JSON.stringify(commandPath)}, 'render failed'),`,
           "  renderSourceNodesHelpText: () => 'Usage: openclaw nodes\\n',",
           "  renderSourceSubcommandHelpTextRecord: () => ({",
+          "    config: 'Usage: openclaw config\\n',",
           "    doctor: 'Usage: openclaw doctor\\n', gateway: 'Usage: openclaw gateway\\n',",
           "    models: 'Usage: openclaw models\\n', plugins: 'Usage: openclaw plugins\\n',",
           "    sessions: 'Usage: openclaw sessions\\n', tasks: 'Usage: openclaw tasks\\n',",
@@ -782,6 +786,7 @@ describe("write-cli-startup-metadata", () => {
       renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
       renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
       renderSourceSubcommandHelpTextRecord: () => ({
+        config: "Usage: openclaw config\n",
         doctor: "Usage: openclaw doctor\n",
         gateway: "Usage: openclaw gateway\n",
         models: "Usage: openclaw models\n",
@@ -799,6 +804,7 @@ describe("write-cli-startup-metadata", () => {
       rootHelpText: string;
       secretsHelpText: string;
       subcommandHelpText: {
+        config: string;
         doctor: string;
         gateway: string;
         models: string;
@@ -817,6 +823,7 @@ describe("write-cli-startup-metadata", () => {
     expect(written.nodesHelpText).toContain("openclaw nodes");
     expect(written.rootHelpText).toContain("Usage:");
     expect(written.rootHelpText).toContain("openclaw");
+    expect(written.subcommandHelpText.config).toContain("openclaw config");
     expect(written.subcommandHelpText.doctor).toContain("openclaw doctor");
     expect(written.subcommandHelpText.gateway).toContain("openclaw gateway");
     expect(written.subcommandHelpText.models).toContain("openclaw models");
@@ -849,6 +856,7 @@ describe("write-cli-startup-metadata", () => {
         renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
         renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
         renderSourceSubcommandHelpTextRecord: () => ({
+          config: "Usage: openclaw config\n",
           doctor: "Usage: openclaw doctor\n",
           gateway: "Usage: openclaw gateway\n",
           models: "Usage: openclaw models\n",
@@ -898,6 +906,7 @@ describe("write-cli-startup-metadata", () => {
       renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
       renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
       renderSourceSubcommandHelpTextRecord: () => ({
+        config: "Usage: openclaw config\n",
         doctor: "Usage: openclaw doctor\n",
         gateway: "Usage: openclaw gateway\n",
         models: "Usage: openclaw models\n",
@@ -965,6 +974,7 @@ describe("write-cli-startup-metadata", () => {
           unblockers.set("subcommands", resolve);
         });
         return {
+          config: "Usage: openclaw config\n",
           doctor: "Usage: openclaw doctor\n",
           gateway: "Usage: openclaw gateway\n",
           models: "Usage: openclaw models\n",
@@ -1034,6 +1044,7 @@ describe("write-cli-startup-metadata", () => {
       },
       renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
       renderSourceSubcommandHelpTextRecord: () => ({
+        config: "Usage: openclaw config\n",
         doctor: "Usage: openclaw doctor\n",
         gateway: "Usage: openclaw gateway\n",
         models: "Usage: openclaw models\n",
@@ -1093,6 +1104,7 @@ describe("write-cli-startup-metadata", () => {
           renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
           renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
           renderSourceSubcommandHelpTextRecord: () => ({
+            config: "Usage: openclaw config\n",
             doctor: "Usage: openclaw doctor\n",
             gateway: "Usage: openclaw gateway\n",
             models: "Usage: openclaw models\n",
@@ -1141,6 +1153,7 @@ describe("write-cli-startup-metadata", () => {
           return `Usage: openclaw nodes ${nodesRenderCount}\n`;
         },
         renderSourceSubcommandHelpTextRecord: () => ({
+          config: "Usage: openclaw config\n",
           doctor: "Usage: openclaw doctor\n",
           gateway: "Usage: openclaw gateway\n",
           models: "Usage: openclaw models\n",
@@ -1196,6 +1209,7 @@ describe("write-cli-startup-metadata", () => {
       };
       const banner = `OpenClaw ${buildInfo.version} (${buildInfo.commit.slice(0, 7)})`;
       return {
+        config: `${banner}\nUsage: openclaw config\n`,
         doctor: `${banner}\nUsage: openclaw doctor\n`,
         gateway: `${banner}\nUsage: openclaw gateway\n`,
         models: `${banner}\nUsage: openclaw models\n`,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users running `openclaw config --help` would wait for the full CLI runtime to load even though this stable parent-command help can be served from generated startup metadata like sibling commands.

## Why This Change Was Made

Adds `config` to the existing generated subcommand-help contract and keeps the packaged launcher and direct runtime-entry consumers aligned. The metadata signature now includes the config command owner so help changes invalidate the generated record; config parsing, execution, and nested help remain on their existing runtime paths.

## User Impact

`openclaw config --help` now starts substantially faster and with lower peak memory while producing byte-identical help output. Other config commands and help shapes are unchanged.

## Evidence

- Deterministic regression: the packaged-launcher config row failed on current main because the runtime entry loaded, then passed after the repair.
- Exact current-main/candidate output differential: status, stdout, and stderr are identical; stdout is 1,935 bytes with SHA-256 `50bf78014102ee8d2ec430bc21bb75385e0741c0e853bcfa91bc6cbfe5beb6e2`.
- Node 24.15.0 packaged-launcher benchmark, 9 alternating measured rounds after warmup: p50 1,464.565 ms → 40.016 ms (36.60×, 97.27% lower).
- Peak RSS, 5 alternating `/usr/bin/time` samples: median 332,576 KiB → 46,852 KiB (85.91% lower).
- `test/openclaw-launcher.e2e.test.ts`: 39 passed, 1 skipped.
- Metadata, entry, and parser suites: 56 passed.
- `node scripts/check-changed.mjs -- <7 changed paths>`: all lanes passed.
- `GIT_BRANCH=main pnpm build`: passed, including 48 plugin control-plane modules, all 147 public plugin SDK subpaths, and Control UI budgets.
- Codex Sol/high autoreview through the bundled helper: clean, no P0/P1 findings (0.97 confidence); TruffleHog scan clean.
