### PR TITLE
fix(commands): skip retired catalog rows in auth probe fallback selection

### DIFF
--- a/src/commands/models/list.probe.models.ts
+++ b/src/commands/models/list.probe.models.ts
@@ -1,5 +1,5 @@
 /** Model candidate normalization and catalog selection for auth probes. */
-import { expectDefined } from "@openclaw/normalization-core";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { normalizeProviderId, parseModelRef } from "../../agents/model-selection.js";
 import { DEFAULT_PROVIDER } from "./shared.js";
 
@@ -20,7 +20,7 @@ export function buildProbeCandidateMap(modelCandidates: string[]): Map<string, s
   return map;
 }
 
-function catalogProbePriority(provider: string, modelId: string): number {
+function probePriority(provider: string, modelId: string): number {
   const id = modelId.trim().toLowerCase();
   if (provider !== "anthropic") {
     return 50;
@@ -50,21 +50,20 @@ function catalogProbePriority(provider: string, modelId: string): number {
 export function selectProbeModel(params: {
   provider: string;
   candidates: Map<string, string[]>;
-  catalog: Array<{ provider: string; id: string }>;
+  catalog: Array<Pick<ModelCatalogEntry, "provider" | "id" | "status">>;
 }): { provider: string; model: string } | null {
   const { provider, candidates, catalog } = params;
-  const direct = candidates.get(provider);
-  if (direct && direct.length > 0) {
-    return { provider, model: expectDefined(direct[0], "direct entry at 0") };
+  const direct = candidates.get(provider)?.[0];
+  if (direct) {
+    return { provider, model: direct };
   }
   const fromCatalog = catalog
-    .map((entry, index) => ({ entry, index }))
-    .filter(({ entry }) => normalizeProviderId(entry.provider) === provider)
-    .toSorted((left, right) => {
-      const priority =
-        catalogProbePriority(provider, left.entry.id) -
-        catalogProbePriority(provider, right.entry.id);
-      return priority || left.index - right.index;
-    })[0]?.entry;
+    .filter(
+      (entry) =>
+        normalizeProviderId(entry.provider) === provider &&
+        entry.status !== "deprecated" &&
+        entry.status !== "disabled",
+    )
+    .toSorted((a, b) => probePriority(provider, a.id) - probePriority(provider, b.id))[0];
   return fromCatalog ? { provider, model: fromCatalog.id } : null;
 }

--- a/src/commands/models/list.probe.ollama.test.ts
+++ b/src/commands/models/list.probe.ollama.test.ts
@@ -1,11 +1,15 @@
 // Ollama probe planning tests cover keyless runtime auth and provider-scoped catalog reads.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildProbeCandidateMap, selectProbeModel } from "./list.probe.models.js";
 
-const loadPreparedModelCatalog = vi.fn(async () => [
-  { provider: "ollama", id: "llama3.2:latest" },
-  { provider: "ollama", id: "gemma4:latest" },
-]);
+const loadPreparedModelCatalog = vi.fn(
+  async (): Promise<Array<Pick<ModelCatalogEntry, "provider" | "id" | "status">>> => [
+    { provider: "ollama", id: "llama3.2:latest" },
+    { provider: "ollama", id: "gemma4:latest" },
+  ],
+);
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({ loadPreparedModelCatalog }));
 vi.mock("../../agents/auth-profiles.js", () => ({
@@ -141,5 +145,144 @@ describe("Ollama probe targets", () => {
         useRuntimeAuth: true,
       }),
     ]);
+  });
+
+  it("builds an automatic Ollama probe with the first non-retired catalog model", async () => {
+    loadPreparedModelCatalog.mockResolvedValueOnce([
+      { provider: "ollama", id: "kimi-k2.5", status: "deprecated" },
+      { provider: "ollama", id: "kimi-k2.6" },
+    ]);
+
+    const plan = await buildProbeTargets({
+      cfg: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://127.0.0.1:11434",
+              api: "ollama",
+              models: [],
+            },
+          },
+        },
+      },
+      providers: ["ollama"],
+      modelCandidates: [],
+      options,
+    });
+
+    expect(plan.results).toEqual([]);
+    expect(plan.targets).toEqual([
+      expect.objectContaining({
+        provider: "ollama",
+        model: { provider: "ollama", model: "kimi-k2.6" },
+      }),
+    ]);
+  });
+});
+
+type ProbeModelScenario = {
+  name: string;
+  provider: string;
+  catalog: Array<Pick<ModelCatalogEntry, "provider" | "id" | "status">>;
+  requestedModels?: string[];
+  expectedModel: string | null;
+};
+
+const probeModelScenarios: ProbeModelScenario[] = [
+  {
+    name: "skips the retired Ollama Cloud catalog model",
+    provider: "ollama-cloud",
+    catalog: [
+      { provider: "ollama-cloud", id: "kimi-k2.5", status: "deprecated" },
+      { provider: "ollama-cloud", id: "kimi-k2.6" },
+    ],
+    expectedModel: "kimi-k2.6",
+  },
+  {
+    name: "skips the retired Tencent preview in favor of its replacement",
+    provider: "tencent-tokenhub",
+    catalog: [
+      { provider: "tencent-tokenhub", id: "hy3-preview", status: "deprecated" },
+      { provider: "tencent-tokenhub", id: "hy3" },
+    ],
+    expectedModel: "hy3",
+  },
+  {
+    name: "skips disabled automatic catalog candidates",
+    provider: "ollama",
+    catalog: [
+      { provider: "ollama", id: "disabled-model", status: "disabled" },
+      { provider: "ollama", id: "available-model", status: "available" },
+    ],
+    expectedModel: "available-model",
+  },
+  {
+    name: "keeps available preview models eligible",
+    provider: "ollama",
+    catalog: [
+      { provider: "ollama", id: "preview-model", status: "preview" },
+      { provider: "ollama", id: "available-model", status: "available" },
+    ],
+    expectedModel: "preview-model",
+  },
+  {
+    name: "reports no model when every automatic candidate is retired",
+    provider: "ollama",
+    catalog: [
+      { provider: "ollama", id: "deprecated-model", status: "deprecated" },
+      { provider: "ollama", id: "disabled-model", status: "disabled" },
+    ],
+    expectedModel: null,
+  },
+  {
+    name: "preserves an explicitly selected retired model",
+    provider: "ollama-cloud",
+    requestedModels: ["ollama-cloud/kimi-k2.5"],
+    catalog: [
+      { provider: "ollama-cloud", id: "kimi-k2.5", status: "deprecated" },
+      { provider: "ollama-cloud", id: "kimi-k2.6" },
+    ],
+    expectedModel: "kimi-k2.5",
+  },
+  {
+    name: "does not prioritize a retired Anthropic Haiku over a live Sonnet",
+    provider: "anthropic",
+    catalog: [
+      { provider: "anthropic", id: "claude-haiku-4-5-20251001", status: "deprecated" },
+      { provider: "anthropic", id: "claude-sonnet-4-6", status: "available" },
+    ],
+    expectedModel: "claude-sonnet-4-6",
+  },
+  {
+    name: "preserves the Anthropic Haiku probe priority among eligible models",
+    provider: "anthropic",
+    catalog: [
+      { provider: "anthropic", id: "claude-sonnet-4-6" },
+      { provider: "anthropic", id: "claude-haiku-4-5" },
+      { provider: "anthropic", id: "claude-haiku-4-5-20251001" },
+    ],
+    expectedModel: "claude-haiku-4-5-20251001",
+  },
+  {
+    name: "preserves catalog order for equally prioritized eligible models",
+    provider: "ollama",
+    catalog: [
+      { provider: "ollama", id: "retired-model", status: "deprecated" },
+      { provider: "ollama", id: "first-live-model" },
+      { provider: "ollama", id: "second-live-model" },
+    ],
+    expectedModel: "first-live-model",
+  },
+];
+
+describe("automatic probe model lifecycle", () => {
+  it.each(probeModelScenarios)("$name", ({ provider, catalog, requestedModels, expectedModel }) => {
+    expect(
+      selectProbeModel({
+        provider,
+        candidates: buildProbeCandidateMap(requestedModels ?? []),
+        catalog,
+      }),
+    ).toEqual(expectedModel === null ? null : { provider, model: expectedModel });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Automatic provider health probes select the first retired model in the real Ollama Cloud and Tencent catalogs. A valid credential can therefore be reported as unhealthy or sign-in-required because the probe asks the provider for a model that no longer exists.

Related to #124689; that report also includes independent model-picker/session behavior that this probe fix does not resolve.

## Why This Change Was Made

The shared probe selector narrowed complete catalog rows to only provider and model identifiers, losing their lifecycle status. Both affected providers currently place a deprecated model before their first available model. The selector also maintained unnecessary indexed wrappers even though stable sorting already preserves catalog order.

The canonical selector now retains model lifecycle status and excludes deprecated or disabled rows only when choosing an automatic fallback. Explicitly configured retired models remain selectable, preview models remain eligible, Anthropic model prioritization is unchanged, and equally ranked models retain manifest order. Removing redundant indexed wrappers makes the production change net negative.

## User Impact

Ollama Cloud probes now choose `kimi-k2.6` instead of retired `kimi-k2.5`; Tencent probes choose `hy3` instead of retired `hy3-preview`. Existing explicitly pinned retired models remain unchanged. No Gateway protocol, public error shape, provider configuration, or authentication contract is changed.

## Evidence

- Seven authentic owner/caller regressions failed on the pre-fix selector.
- `node scripts/run-vitest.mjs src/commands/models/list.probe.ollama.test.ts src/commands/models/list.probe.targets.test.ts` passed all 45 tests.
- Coverage includes real Ollama/Tencent manifest ordering, deprecated and disabled rows, preview models, all-retired catalogs, explicitly selected retired models, Anthropic priority, stable manifest order, and the actual probe-target caller.
- Focused type-aware lint, formatting, and diff checks passed; independent structured review reported no actionable findings.
- Production delta: +13/-14 lines, net -1; tests are counted separately.

### Live authenticated probe output (redacted)

Two live `openclaw models status --probe --probe-provider ollama-cloud` runs against a real Ollama server (127.0.0.1:11434, real HTTP/inference; credentials redacted by the CLI). The server serves `kimi-k2.6` and `tinyllama`; the retired catalog entry `kimi-k2.5` is absent, so the provider answers with its real model-not-found error — the same response shape the cloud API returns for a retired model.

**Pre-fix head `dcb23a6c7cc` (unmodified `main`)** — the probe selects the first catalog row, retired `kimi-k2.5`, and a valid credential is reported broken:

```
Auth probes
┌────────────────────────┬────────────────────────┬────────────────────────────────────────────────────────────────────┐
│ Model                  │ Profile                │ Status                                                             │
├────────────────────────┼────────────────────────┼────────────────────────────────────────────────────────────────────┤
│ ollama-cloud/kimi-k2.5 │ models.json (api_key)  │ format · 47.4s                                                     │
│                        │                        │ ↳ The selected model was not found by the provider. Check the      │
│                        │                        │ model id or choose a different model.                              │
└────────────────────────┴────────────────────────┴────────────────────────────────────────────────────────────────────┘
Probed 1 target in 47.5s
```

**This PR's head `8e0177b34c3`** — the selector skips deprecated/disabled rows and probes the first live model, `kimi-k2.6`, which the same credential reaches:

```
Auth probes
┌────────────────────────┬────────────────────────┬────────────┐
│ Model                  │ Profile                │ Status     │
├────────────────────────┼────────────────────────┼────────────┤
│ ollama-cloud/kimi-k2.6 │ models.json (api_key)  │ ok · 49.6s │
└────────────────────────┴────────────────────────┴────────────┘
Probed 1 target in 49.7s
```

The two runs are the same binary invocation with the same provider config and credential; the only difference is the head. Pre-fix targets the retired model and fails; this PR targets the live model and succeeds.

Original diagnosis and contributor credit: @Finn763.
