### PR TITLE
feat(mantis): add long-held active turn recipe

### DIFF
--- a/.github/codex/prompts/mantis-recipes/README.md
+++ b/.github/codex/prompts/mantis-recipes/README.md
@@ -6,6 +6,7 @@ even when Telegram Desktop pixels match.
 
 - `send-failure-injection.md`: outbound Bot API failures and retry behavior
 - `busy-queue-scripted-provider.md`: ordered slow/fast multi-turn responses
+- `long-held-active-turn.md`: queued turn behind a >300-second active turn
 - `callback-data-payload-proof.md`: byte-level callback payload differences
 - `staged-media-provider-proof.md`: staged Telegram media proven through provider content facts
 

--- a/.github/codex/prompts/mantis-recipes/long-held-active-turn.md
+++ b/.github/codex/prompts/mantis-recipes/long-held-active-turn.md
@@ -1,0 +1,59 @@
+# Long-held active turn
+
+Use when a second Telegram turn must wait behind an active turn for more than 300 seconds.
+
+Write `public-config.json`:
+
+```text
+{"mockResponse":"unused","configPatch":{"agents":{"defaults":{"timeoutSeconds":600}},"models":{"providers":{"openai":{"timeoutSeconds":600}}}}}
+```
+
+Write `long-exec-events.json`:
+
+```text
+[{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_long","call_id":"call_long","name":"exec","arguments":""}},{"type":"response.function_call_arguments.delta","delta":"{\"language\":\"javascript\",\"code\":\"return \\\"MANTIS-FIRST-EXEC-DONE\\\";\"}"},{"type":"response.output_item.done","item":{"type":"function_call","id":"fc_long","call_id":"call_long","name":"exec","arguments":"{\"language\":\"javascript\",\"code\":\"return \\\"MANTIS-FIRST-EXEC-DONE\\\";\"}"}},{"type":"response.completed","response":{"id":"resp_long","status":"completed","output":[{"type":"function_call","id":"fc_long","call_id":"call_long","name":"exec","arguments":"{\"language\":\"javascript\",\"code\":\"return \\\"MANTIS-FIRST-EXEC-DONE\\\";\"}"}],"usage":{"input_tokens":64,"output_tokens":16,"total_tokens":80,"input_tokens_details":{"cached_tokens":0}}}}]
+```
+
+Write `provider-script.json` beside the events file:
+
+```text
+{"responses":[{"eventsFile":"long-exec-events.json"},{"text":"MANTIS-FIRST-LONG-START MANTIS-FIRST-LONG-DONE","chunkDelayMs":330000},{"text":"MANTIS-SECOND-SURVIVED"}],"default":{"text":"MANTIS-UNEXPECTED-EXTRA"}}
+```
+
+- Do not ask `observe` for more than 60 seconds; loop up to eight 60-second calls.
+- Do not put `chunkDelayMs` on a `/v1/responses` request with `body.stream === false`; that JSON branch bypasses `writeDefaultResponseEvents`, whose delay runs only before streamed `response.output_text.delta` events after the first.
+- Do not use an unawaited Code Mode `setTimeout` to hold the turn; pending timers do not keep `exec` alive.
+- Do not rely on timeout defaults; pin both keys to 600 through `start --config` (current main: 48-hour agent-run default, 120-second cloud-model idle default).
+
+Then run both lanes:
+
+```bash
+out="$MANTIS_OUTPUT_DIR"; lane="$OPENCLAW_TELEGRAM_MANTIS_LANE_CMD"
+config="$out/public-config.json"; script="$out/provider-script.json"
+sha="$(sha256sum "$script" | cut -d ' ' -f1)"
+run_lane() {
+  local name="$1" root="$2" second_id i
+  $lane start --lane "$name" --repo-root "$root" --config "$config"
+  $lane mock --lane "$name" --script "$script" "$sha"
+  $lane send --lane "$name" --text '@{sut} MANTIS queue proof turn one'
+  sleep 2
+  second_id="$($lane send --lane "$name" --text '@{sut} MANTIS queue proof turn two' | jq -er '.revealedMessageId')"
+  $lane observe --lane "$name" --seconds 30 --until-provider-requests 1
+  for i in {1..8}; do
+    $lane observe --lane "$name" --seconds 60 --until-provider-requests 2 --until-text 'MANTIS-SECOND-SURVIVED' >"$out/$name-observe-$i.json"
+    $lane requests --lane "$name" >"$out/$name-requests-current.json"
+    $lane observe --lane "$name" --seconds 0 --since 0 >"$out/$name-full-current.json"
+    jq -e '(.requests | length) >= 3' "$out/$name-requests-current.json" >/dev/null && jq -e '(.events | tostring | contains("MANTIS-SECOND-SURVIVED"))' "$out/$name-full-current.json" >/dev/null && break
+  done
+  $lane requests --lane "$name"
+  $lane botapi-requests --lane "$name" --method sendMessage
+  $lane exec --lane "$name" --command "grep -E 'claim.*adoption stalled|queued behind an active turn|spooled update|retry limit|MANTIS' gateway.log | tail -n 80 || true"
+  $lane view --lane "$name" --message-id "$second_id"
+  $lane screenshot --lane "$name"
+  $lane finish --lane "$name" --focus-message-id "$second_id"
+}
+run_lane baseline "$MANTIS_BASELINE_ROOT"
+run_lane candidate "$MANTIS_CANDIDATE_ROOT"
+```
+
+Proof facts: three ordered provider requests show the `exec` call, its follow-up, and the queued turn; the long response holds the active turn for about 333 seconds. Provider requests, `sendMessage` records, gateway log lines, and the focused second message show whether `MANTIS-SECOND-SURVIVED` arrived after the 300-second watchdog window.

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -170,9 +170,9 @@ near the bottom and the recording covers the behavior—not only its final state
 If `start` reports `desktop-unavailable`, record that fact and use `block`; never
 retry that lane. Iterate as needed; all attempts remain recorded.
 
-If you design a novel working scenario worth reusing, optionally write
-`MANTIS_OUTPUT_DIR/recipe-suggestion.md` with its trigger, exact commands, and
-proof facts. The builder publishes it as a non-inline attachment.
+If you change scenario mechanics after a failed attempt that was not a product
+defect, write `MANTIS_OUTPUT_DIR/recipe-suggestion.md` with its trigger, exact
+commands, and proof facts. The builder publishes it as a non-inline attachment.
 
 Build `mantis-evidence.json` with
 `scripts/mantis/build-telegram-desktop-proof-evidence.mts` as before, using each

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -824,8 +824,17 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(stagedMediaRecipe.indexOf("--until-provider-requests 4")).toBeLessThan(
       stagedMediaRecipe.lastIndexOf("finish --lane baseline"),
     );
+    const longHeldActiveTurnRecipe = readFileSync(
+      ".github/codex/prompts/mantis-recipes/long-held-active-turn.md",
+      "utf8",
+    );
+    const recipesReadme = readFileSync(".github/codex/prompts/mantis-recipes/README.md", "utf8");
+    expect(longHeldActiveTurnRecipe).toContain("MANTIS-SECOND-SURVIVED");
+    expect(recipesReadme).toContain("`long-held-active-turn.md`");
     expect(prompt).toContain("mantis-recipes/");
-    expect(prompt).toContain("recipe-suggestion.md");
+    expect(prompt).toMatch(
+      /change scenario mechanics after a failed attempt that was not a product\s+defect, write `MANTIS_OUTPUT_DIR\/recipe-suggestion\.md`/u,
+    );
     expect(prompt).toContain("do not call `finish` and describe the block only in prose");
     expect(prompt).toContain("`block --reason TEXT [--missing-primitive NAME]`");
     expect(prompt).toContain("`@{sut}`");


### PR DESCRIPTION
## What Problem This Solves

Mantis proof run [32616859410](https://github.com/openclaw/openclaw/actions/runs/32616859410) (PR #127950) spent ~17 of its 40 minutes rediscovering how to hold a Telegram turn open past the 300 s ingress adoption watchdog: the `observe --seconds` 60 cap, `chunkDelayMs` being bypassed on non-streaming requests, Code Mode `setTimeout` not holding an exec turn, and the 48 h agent / 120 s idle timeout defaults that must be pinned via `configPatch`. None of that was recorded anywhere a future agent would find it — the same rediscovery cost would recur on every long-turn scenario.

## Why This Change Was Made

Speed is a requirement for Mantis. The largest reducible slice of the 40-minute run was mechanics rediscovery, so the proven scenario mechanics become a recipe (`.github/codex/prompts/mantis-recipes/long-held-active-turn.md`): the dual 600 s timeout config patch, the Code Mode exec events file, the streamed `chunkDelayMs: 330000` hold, and the observe-loop pattern, plus the four gotchas as explicit "Do not" bullets. The agent prompt now also *requires* writing `MANTIS_OUTPUT_DIR/recipe-suggestion.md` whenever scenario mechanics changed after a non-defect failed attempt, so future discoveries persist instead of dying with the run.

## User Impact

Maintainers dispatching Mantis proofs on long-turn / queueing PRs get materially faster runs: the next agent starts from working mechanics instead of ~5 scenario reruns. No runtime, workflow, or lane CLI behavior changes — the diff is prompt text, recipe docs, and their workflow test.

## Evidence

- Recipe mechanics are transcribed from the final working scenario of run 32616859410 (pass/pass verdict on both lanes, screenshots inspected); config defaults it overrides verified on main: 48 h agent-run default (`src/agents/timeout.ts:13`), 120 s cloud-model idle default (`src/agents/embedded-agent-runner/run/llm-idle-timeout.ts:23`); streaming-only delay condition verified in `scripts/e2e/mock-openai-server.mjs` (`writeDefaultResponseEvents`); `setTimeout` exec behavior verified against `../codex/codex-rs/code-mode-protocol/src/description.rs:33`.
- `node scripts/run-vitest.mjs test/scripts/mantis-telegram-desktop-proof-workflow.test.ts` — 32/32 green after a fresh `pnpm install`.
- `node scripts/check-changed.mjs -- <4 changed files>` — green.
- Autoreview (`gpt-5.6-sol`, high): clean, "patch is correct (0.99)".
- No live Mantis dispatch: prompt/docs/test-only diff, no channel-visible runtime change; the recipe is exercised by the next long-turn proof run.
