### PR TITLE
Fix wiki_search snippet: filter out generated marker comments (#128017)

### DIFF
--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -33,6 +33,7 @@ const QUERY_PAGE_READ_CONCURRENCY = 16;
 const RELATED_BLOCK_PATTERN =
   /<!-- openclaw:wiki:related:start -->[\s\S]*?<!-- openclaw:wiki:related:end -->/g;
 const MARKDOWN_FRONTMATTER_PATTERN = /^\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+const GENERATED_MARKER_LINE_PATTERN = /^\s*<!--\s*openclaw:[^>]*-->\s*$/;
 const ROUTE_QUESTION_STOP_WORDS = new Set([
   "a",
   "about",
@@ -330,7 +331,11 @@ function stripGeneratedRelatedBlock(raw: string): string {
 }
 
 function buildSnippetSearchText(raw: string): string {
-  return stripGeneratedRelatedBlock(raw).replace(MARKDOWN_FRONTMATTER_PATTERN, "");
+  return stripGeneratedRelatedBlock(raw)
+    .replace(MARKDOWN_FRONTMATTER_PATTERN, "")
+    .split(/\r?\n/)
+    .filter((line) => !GENERATED_MARKER_LINE_PATTERN.test(line))
+    .join("\n");
 }
 
 function buildQueryTokens(queryLower: string): string[] {


### PR DESCRIPTION
Fixes issue #128017: wiki_search snippets can return bare HTML marker comments instead of content

This PR adds a filter to remove generated marker comment lines from the snippet candidate pool in wiki_search. This prevents wiki_search from returning bare marker comments like `<!-- openclaw:human:start -->` as snippets when a page matches on metadata but the body line containing the query token is a marker comment.

Changes made:
- Added GENERATED_MARKER_LINE_PATTERN regex to identify marker comment lines
- Modified buildSnippetSearchText() to filter out marker lines before selecting snippet candidates

Impact: Low severity, cosmetic fix that improves the usefulness of wiki_search results, especially in multi-agent setups where agents read shared vaults.