### PR TITLE
fix(onboard): provider setup changes the wrong agent model in managed fleets

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -133,6 +133,9 @@ workspace through their normal setup flow. On a rerun with an existing agent
 roster, onboarding preserves the configured fleet workspace: the classic
 wizard shows both paths and requires explicit confirmation before moving it,
 while non-interactive setup warns and keeps the current value.
+For an explicitly managed multi-agent fleet, provider setup updates the configured
+system agent's model and aliases without replacing fleet-wide model defaults or
+another agent's model.
 
 After inference passes, onboarding checks for memories from supported local AI
 tools: Claude Code auto-memory, Codex consolidated memories, and Hermes memory

--- a/src/commands/onboard-agent-target.test.ts
+++ b/src/commands/onboard-agent-target.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
+import { applyPrimaryModel } from "../plugins/provider-model-primary.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
@@ -257,6 +258,37 @@ describe("onboarding agent target", () => {
       },
     });
     expect(updated.plugins?.entries?.fixture?.enabled).toBe(true);
+  });
+
+  it.each([
+    { selectModel: false, expectedModel: undefined, expectedModels: undefined },
+    {
+      selectModel: true,
+      expectedModel: { primary: "provider/selected" },
+      expectedModels: { "provider/selected": {} },
+    },
+  ])("keeps fleet model aliases and policy inherited (select model: $selectModel)", (scenario) => {
+    const config = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: {
+          model: "openai/global",
+          models: { "openai/global": { alias: "Global" } },
+          modelPolicy: { allow: ["openai/global"] },
+        },
+        entries: { main: { model: "openai/main" }, ops: {} },
+      },
+    };
+    const target = resolveOnboardingAgentTarget(config, "ops");
+    const updated = applyAgentModelDefaults(config, target, (projected) =>
+      scenario.selectModel ? applyPrimaryModel(projected, "provider/selected") : projected,
+    );
+
+    expect(updated.agents?.defaults).toEqual(config.agents.defaults);
+    expect(updated.agents?.entries?.ops?.model).toEqual(scenario.expectedModel);
+    expect(updated.agents?.entries?.ops?.models).toEqual(scenario.expectedModels);
+    expect(updated.agents?.entries?.ops?.modelPolicy).toBeUndefined();
+    expect(updated.agents?.entries?.main?.model).toEqual("openai/main");
   });
 
   it("preserves every list-form agent when applying the primary model", () => {

--- a/src/commands/onboard-agent-target.test.ts
+++ b/src/commands/onboard-agent-target.test.ts
@@ -198,6 +198,67 @@ describe("onboarding agent target", () => {
     expect(updated.agents?.entries?.ops).toBeUndefined();
   });
 
+  it("preserves unrelated global defaults while projecting model changes onto the authored agent", () => {
+    const config = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: {
+          model: { primary: "openai/global" },
+          models: { "openai/global": { alias: "Global" } },
+          modelPolicy: { allow: ["openai/global"] },
+        },
+        entries: {
+          main: { model: { primary: "openai/sibling" } },
+          OPS: {
+            model: { primary: "openai/old" },
+            models: { "openai/old": { alias: "Old" } },
+            modelPolicy: { allow: ["openai/old"] },
+          },
+        },
+      },
+    };
+    const target = resolveOnboardingAgentTarget(config, "ops");
+
+    const updated = applyAgentModelDefaults(config, target, (projected) => ({
+      ...projected,
+      plugins: { entries: { fixture: { enabled: true } } },
+      agents: {
+        ...projected.agents,
+        defaults: {
+          ...projected.agents?.defaults,
+          model: { primary: "provider/selected" },
+          models: {
+            ...projected.agents?.defaults?.models,
+            "provider/selected": { alias: "Selected" },
+          },
+          modelPolicy: { allow: ["provider/selected"] },
+          mediaModels: { video: { primary: "media/video" } },
+          experimental: { localModelLean: true },
+        },
+      },
+    }));
+
+    expect(updated.agents?.defaults).toEqual({
+      model: { primary: "openai/global" },
+      models: { "openai/global": { alias: "Global" } },
+      modelPolicy: { allow: ["openai/global"] },
+      mediaModels: { video: { primary: "media/video" } },
+      experimental: { localModelLean: true },
+    });
+    expect(updated.agents?.entries).toEqual({
+      main: { model: { primary: "openai/sibling" } },
+      OPS: {
+        model: { primary: "provider/selected" },
+        models: {
+          "openai/old": { alias: "Old" },
+          "provider/selected": { alias: "Selected" },
+        },
+        modelPolicy: { allow: ["provider/selected"] },
+      },
+    });
+    expect(updated.plugins?.entries?.fixture?.enabled).toBe(true);
+  });
+
   it("preserves every list-form agent when applying the primary model", () => {
     const config = {
       agents: {

--- a/src/commands/onboard-agent-target.ts
+++ b/src/commands/onboard-agent-target.ts
@@ -1,4 +1,5 @@
 // Resolves one concrete agent owner for onboarding auth, model, workspace, and session effects.
+import { isDeepStrictEqual } from "node:util";
 import {
   listAgentEntries,
   resolveAgentDir,
@@ -12,6 +13,7 @@ import {
   normalizeAgentModelMapForConfig,
   normalizeAgentModelRefForConfig,
   resolveAgentModelFallbackValues,
+  toAgentModelListLike,
 } from "../config/model-input.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
 import type { AgentEntryConfig } from "../config/types.agents.js";
@@ -183,12 +185,34 @@ export function projectAgentModelDefaults(
     return updated;
   }
   const updatedDefaults = updated.agents?.defaults;
+  const originalDefaults = config.agents?.defaults;
+  const agentModels =
+    entry?.models !== undefined
+      ? updatedDefaults?.models
+      : Object.fromEntries(
+          Object.entries(updatedDefaults?.models ?? {}).filter(
+            ([modelRef, model]) =>
+              !Object.hasOwn(originalDefaults?.models ?? {}, modelRef) ||
+              !isDeepStrictEqual(model, originalDefaults?.models?.[modelRef]),
+          ),
+        );
+  const hasAgentModel =
+    entry?.model !== undefined ||
+    !isDeepStrictEqual(
+      toAgentModelListLike(updatedDefaults?.model),
+      toAgentModelListLike(originalDefaults?.model),
+    );
+  const hasAgentModelPolicy =
+    entry?.modelPolicy !== undefined ||
+    !isDeepStrictEqual(updatedDefaults?.modelPolicy, originalDefaults?.modelPolicy);
   const { model: _model, models: _models, modelPolicy: _modelPolicy, ...entryRest } = entry ?? {};
   const nextEntry = {
     ...entryRest,
-    ...(updatedDefaults?.model !== undefined ? { model: updatedDefaults.model } : {}),
-    ...(updatedDefaults?.models !== undefined ? { models: updatedDefaults.models } : {}),
-    ...(updatedDefaults?.modelPolicy !== undefined
+    ...(hasAgentModel && updatedDefaults?.model !== undefined
+      ? { model: updatedDefaults.model }
+      : {}),
+    ...(agentModels && Object.keys(agentModels).length > 0 ? { models: agentModels } : {}),
+    ...(hasAgentModelPolicy && updatedDefaults?.modelPolicy !== undefined
       ? { modelPolicy: updatedDefaults.modelPolicy }
       : {}),
   };
@@ -198,7 +222,6 @@ export function projectAgentModelDefaults(
     modelPolicy: _updatedModelPolicy,
     ...sharedDefaults
   } = updatedDefaults ?? {};
-  const originalDefaults = config.agents?.defaults;
   const baseConfig = {
     ...config,
     agents: {

--- a/src/commands/onboard-agent-target.ts
+++ b/src/commands/onboard-agent-target.ts
@@ -139,14 +139,13 @@ export function applyOnboardingPrimaryModel(
   });
 }
 
-/** Apply a model-default mutation to one agent without flattening it globally. */
-export function applyAgentModelDefaults(
+/** Expose one agent's effective model settings through the defaults-based provider contract. */
+export function prepareAgentModelDefaults(
   config: OpenClawConfig,
   target: OnboardingAgentTarget,
-  mutate: (config: OpenClawConfig) => OpenClawConfig,
 ): OpenClawConfig {
   const entry = resolveMutableAgentEntry(config, target.agentId);
-  const projected = {
+  return {
     ...config,
     agents: {
       ...config.agents,
@@ -158,7 +157,19 @@ export function applyAgentModelDefaults(
       },
     },
   };
-  return projectAgentModelDefaults(config, target, mutate(projected));
+}
+
+/** Apply a model-default mutation to one agent without flattening it globally. */
+export function applyAgentModelDefaults(
+  config: OpenClawConfig,
+  target: OnboardingAgentTarget,
+  mutate: (config: OpenClawConfig) => OpenClawConfig,
+): OpenClawConfig {
+  return projectAgentModelDefaults(
+    config,
+    target,
+    mutate(prepareAgentModelDefaults(config, target)),
+  );
 }
 
 /** Move a defaults-based model mutation onto one agent while preserving its other config changes. */
@@ -181,5 +192,32 @@ export function projectAgentModelDefaults(
       ? { modelPolicy: updatedDefaults.modelPolicy }
       : {}),
   };
-  return replaceOnboardingAgentEntry(config, updated, target, nextEntry);
+  const {
+    model: _updatedModel,
+    models: _updatedModels,
+    modelPolicy: _updatedModelPolicy,
+    ...sharedDefaults
+  } = updatedDefaults ?? {};
+  const originalDefaults = config.agents?.defaults;
+  const baseConfig = {
+    ...config,
+    agents: {
+      ...config.agents,
+      ...(originalDefaults || updatedDefaults
+        ? {
+            defaults: {
+              ...sharedDefaults,
+              ...(originalDefaults?.model !== undefined ? { model: originalDefaults.model } : {}),
+              ...(originalDefaults?.models !== undefined
+                ? { models: originalDefaults.models }
+                : {}),
+              ...(originalDefaults?.modelPolicy !== undefined
+                ? { modelPolicy: originalDefaults.modelPolicy }
+                : {}),
+            },
+          }
+        : {}),
+    },
+  };
+  return replaceOnboardingAgentEntry(baseConfig, updated, target, nextEntry);
 }

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -49,31 +49,75 @@ function applyCustomModelConfigWithContextWindow(contextWindow?: number) {
   });
 }
 
-it("keeps explicit custom-provider model state on the authored agent entry", () => {
-  const result = applyCustomApiConfig({
-    config: {
-      agents: {
-        ownership: "explicit",
-        defaults: { systemAgent: { agentId: "ops" } },
-        entries: { main: {}, OPS: {} },
+it.each([
+  { setAsPrimary: undefined, expectedPrimary: "custom/foo-large" },
+  { setAsPrimary: false, expectedPrimary: "openai/ops" },
+])(
+  "keeps explicit custom-provider model state on its authored owner ($setAsPrimary)",
+  ({ setAsPrimary, expectedPrimary }) => {
+    const result = applyCustomApiConfig({
+      config: {
+        agents: {
+          ownership: "explicit",
+          defaults: {
+            systemAgent: { agentId: "ops" },
+            model: { primary: "anthropic/global" },
+            models: { "anthropic/global": { alias: "Global" } },
+          },
+          entries: {
+            main: { model: { primary: "anthropic/main" } },
+            OPS: {
+              model: { primary: "openai/ops" },
+              models: { "openai/ops": { alias: "Operations" } },
+              modelPolicy: { allow: ["openai/ops"] },
+            },
+          },
+        },
       },
-    },
-    baseUrl: "https://llm.example.com/v1",
-    modelId: "foo-large",
-    compatibility: "openai",
-    providerId: "custom",
-    alias: "Custom",
-    target: { agentId: "ops", agentDir: "/tmp/ops-agent", workspaceDir: "/tmp/ops-workspace" },
-  });
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "foo-large",
+      compatibility: "openai",
+      providerId: "custom",
+      alias: "Custom",
+      target: { agentId: "ops", agentDir: "/tmp/ops-agent", workspaceDir: "/tmp/ops-workspace" },
+      setAsPrimary,
+    });
 
-  expect(result.config.agents?.entries?.OPS?.model).toEqual({ primary: "custom/foo-large" });
-  expect(result.config.agents?.entries?.OPS?.models).toEqual({
-    "custom/foo-large": { alias: "Custom" },
-  });
-  expect(result.config.agents?.defaults?.model).toBeUndefined();
-  expect(result.config.models?.providers?.custom?.models?.map((model) => model.id)).toEqual([
-    "foo-large",
-  ]);
+    expect(result.config.agents?.entries?.OPS?.model).toEqual({ primary: expectedPrimary });
+    expect(result.config.agents?.entries?.OPS?.models).toEqual({
+      "openai/ops": { alias: "Operations" },
+      "custom/foo-large": { alias: "Custom" },
+    });
+    expect(result.config.agents?.entries?.OPS?.modelPolicy).toEqual({ allow: ["openai/ops"] });
+    expect(result.config.agents?.entries?.main?.model).toEqual({ primary: "anthropic/main" });
+    expect(result.config.agents?.defaults?.model).toEqual({ primary: "anthropic/global" });
+    expect(result.config.agents?.defaults?.models).toEqual({
+      "anthropic/global": { alias: "Global" },
+    });
+    expect(result.config.models?.providers?.custom?.models?.map((model) => model.id)).toEqual([
+      "foo-large",
+    ]);
+  },
+);
+
+it("rejects custom aliases already used by the selected agent", () => {
+  expect(() =>
+    applyCustomApiConfig({
+      config: {
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "ops" } },
+          entries: { ops: { models: { "openai/ops": { alias: "Operations" } } } },
+        },
+      },
+      baseUrl: "https://llm.example.com/v1",
+      modelId: "foo-large",
+      compatibility: "openai",
+      providerId: "custom",
+      alias: "Operations",
+      target: { agentId: "ops", agentDir: "/tmp/ops-agent", workspaceDir: "/tmp/ops-workspace" },
+    }),
+  ).toThrow("Alias Operations already points to openai/ops.");
 });
 
 it("preserves a list-form roster when applying custom-provider model state", () => {

--- a/src/commands/onboard-custom-config.ts
+++ b/src/commands/onboard-custom-config.ts
@@ -18,7 +18,7 @@ import { isSecretRef, type SecretInput } from "../config/types.secrets.js";
 import { applyPrimaryModel } from "../plugins/provider-model-primary.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { normalizeAlias } from "./models/alias-name.js";
-import { projectAgentModelDefaults, type OnboardingAgentTarget } from "./onboard-agent-target.js";
+import { applyAgentModelDefaults, type OnboardingAgentTarget } from "./onboard-agent-target.js";
 
 /**
  * Wizard default for non-Azure custom APIs when context length is unknown.
@@ -301,6 +301,7 @@ export function resolveCustomModelAliasError(params: {
   raw: string;
   cfg: OpenClawConfig;
   modelRef: string;
+  agentId?: string;
 }): string | undefined {
   const trimmed = params.raw.trim();
   if (!trimmed) {
@@ -315,6 +316,7 @@ export function resolveCustomModelAliasError(params: {
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
     defaultProvider: DEFAULT_PROVIDER,
+    agentId: params.agentId,
   });
   const aliasKey = normalizeLowercaseStringOrEmpty(normalized);
   const existing = aliasIndex.byAlias.get(aliasKey);
@@ -599,6 +601,7 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
     raw: alias,
     cfg: params.config,
     modelRef,
+    agentId: params.target?.agentId,
   });
   if (aliasError) {
     throw new CustomApiError("invalid_alias", aliasError);
@@ -670,7 +673,7 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
   // Azure clients use api-key headers and no bearer Authorization header.
   const azureHeaders = isAzure && normalizedApiKey ? { "api-key": normalizedApiKey } : undefined;
 
-  let config: OpenClawConfig = {
+  const config: OpenClawConfig = {
     ...params.config,
     models: {
       ...params.config.models,
@@ -690,60 +693,62 @@ export function applyCustomApiConfig(params: ApplyCustomApiConfigParams): Custom
     },
   };
 
-  if (params.setAsPrimary !== false) {
-    config = applyPrimaryModel(config, modelRef);
-  }
-  if (isAzure && isLikelyReasoningModel) {
-    const existingPerModelThinking = config.agents?.defaults?.models?.[modelRef]?.params?.thinking;
-    if (!existingPerModelThinking) {
-      // Seed a conservative reasoning effort only when the user has not already
-      // configured per-model thinking for this exact custom deployment.
-      config = {
-        ...config,
-        agents: {
-          ...config.agents,
-          defaults: {
-            ...config.agents?.defaults,
-            models: {
-              ...config.agents?.defaults?.models,
-              [modelRef]: {
-                ...config.agents?.defaults?.models?.[modelRef],
-                params: {
-                  ...config.agents?.defaults?.models?.[modelRef]?.params,
-                  thinking: "medium",
+  const applyModelDefaults = (modelConfig: OpenClawConfig): OpenClawConfig => {
+    let updated =
+      params.setAsPrimary === false ? modelConfig : applyPrimaryModel(modelConfig, modelRef);
+    if (isAzure && isLikelyReasoningModel) {
+      const existingPerModelThinking =
+        updated.agents?.defaults?.models?.[modelRef]?.params?.thinking;
+      if (!existingPerModelThinking) {
+        // Seed a conservative reasoning effort only when the user has not already
+        // configured per-model thinking for this exact custom deployment.
+        updated = {
+          ...updated,
+          agents: {
+            ...updated.agents,
+            defaults: {
+              ...updated.agents?.defaults,
+              models: {
+                ...updated.agents?.defaults?.models,
+                [modelRef]: {
+                  ...updated.agents?.defaults?.models?.[modelRef],
+                  params: {
+                    ...updated.agents?.defaults?.models?.[modelRef]?.params,
+                    thinking: "medium",
+                  },
                 },
+              },
+            },
+          },
+        };
+      }
+    }
+    if (alias) {
+      updated = {
+        ...updated,
+        agents: {
+          ...updated.agents,
+          defaults: {
+            ...updated.agents?.defaults,
+            models: {
+              ...updated.agents?.defaults?.models,
+              [modelRef]: {
+                ...updated.agents?.defaults?.models?.[modelRef],
+                alias,
               },
             },
           },
         },
       };
     }
-  }
-  if (alias) {
-    config = {
-      ...config,
-      agents: {
-        ...config.agents,
-        defaults: {
-          ...config.agents?.defaults,
-          models: {
-            ...config.agents?.defaults?.models,
-            [modelRef]: {
-              ...config.agents?.defaults?.models?.[modelRef],
-              alias,
-            },
-          },
-        },
-      },
-    };
-  }
-
-  if (params.target && params.config.agents?.ownership === "explicit") {
-    config = projectAgentModelDefaults(params.config, params.target, config);
-  }
+    return updated;
+  };
 
   return {
-    config,
+    config:
+      params.target && params.config.agents?.ownership === "explicit"
+        ? applyAgentModelDefaults(config, params.target, applyModelDefaults)
+        : applyModelDefaults(config),
     providerId,
     modelId,
     ...(providerIdResult.providerIdRenamedFrom

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -68,11 +68,13 @@ function stubFetchSequence(
 async function runPromptCustomApi(
   prompter: ReturnType<typeof createTestPrompter>,
   config: object = {},
+  target?: Parameters<typeof promptCustomApiConfig>[0]["target"],
 ) {
   return promptCustomApiConfig({
     prompter: prompter as unknown as Parameters<typeof promptCustomApiConfig>[0]["prompter"],
     runtime: { log: vi.fn() } as unknown as Parameters<typeof promptCustomApiConfig>[0]["runtime"],
     config,
+    ...(target ? { target } : {}),
   });
 }
 
@@ -106,6 +108,33 @@ describe("promptCustomApiConfig", () => {
     expect(result.config.agents?.defaults?.models?.["custom/llama3"]?.alias).toBe("local");
     expect(result.config.models?.providers?.custom?.models?.[0]?.input).toEqual(["text"]);
     expect(prompter.confirm).not.toHaveBeenCalled();
+  });
+
+  it("rejects aliases already used only by the selected agent", async () => {
+    const prompter = createTestPrompter({
+      text: ["http://localhost:11434/v1", "", "llama3", "custom", ""],
+      select: ["plaintext", "openai"],
+    });
+    stubFetchSequence([{ ok: true }]);
+
+    await runPromptCustomApi(
+      prompter,
+      {
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "ops" } },
+          entries: { ops: { models: { "openai/ops": { alias: "Operations" } } } },
+        },
+      },
+      { agentId: "ops", agentDir: "/tmp/ops-agent", workspaceDir: "/tmp/ops-workspace" },
+    );
+
+    const aliasPrompt = prompter.text.mock.calls.find(
+      ([options]) => options.message === "Model alias (optional)",
+    );
+    expect(aliasPrompt?.[0].validate("Operations")).toBe(
+      "Alias Operations already points to openai/ops.",
+    );
   });
 
   it("cancels custom provider verification response bodies", async () => {

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -394,7 +394,12 @@ export async function promptCustomApiConfig(params: {
       // Alias validation must use the post-collision provider id, otherwise a
       // renamed endpoint could incorrectly collide with the requested id.
       const modelRef = modelKey(resolvedProvider.providerId, modelId);
-      return resolveCustomModelAliasError({ raw: value, cfg: config, modelRef });
+      return resolveCustomModelAliasError({
+        raw: value,
+        cfg: config,
+        modelRef,
+        agentId: params.target?.agentId,
+      });
     },
   });
   const imageInputInference = resolveCustomModelImageInputInference(modelId);

--- a/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts
@@ -143,6 +143,7 @@ async function applyProviderModelChoice(params: {
   providerId: string;
   modelRef: string;
   nextConfig?: OpenClawConfig;
+  target?: typeof target;
 }) {
   const runtime = createRuntime();
   const nextConfig = params.nextConfig ?? { agents: { defaults: {} } };
@@ -173,13 +174,59 @@ async function applyProviderModelChoice(params: {
     opts: {} as never,
     runtime: runtime as never,
     baseConfig: nextConfig,
-    target,
+    target: params.target ?? target,
     resolveApiKey: vi.fn(),
     toApiKeyCredential: vi.fn(),
   });
 }
 
 describe("applyNonInteractivePluginProviderChoice", () => {
+  it.each(["nvidia", "google"])(
+    "keeps %s provider model selection on the configured explicit-fleet agent",
+    async (providerId) => {
+      const modelRef = `${providerId}/selected`;
+      const result = await applyProviderModelChoice({
+        providerId,
+        modelRef,
+        target: {
+          agentId: "ops",
+          agentDir: "/tmp/ops-agent",
+          workspaceDir: "/tmp/ops-workspace",
+        },
+        nextConfig: {
+          agents: {
+            ownership: "explicit",
+            defaults: {
+              systemAgent: { agentId: "ops" },
+              model: { primary: "anthropic/global" },
+              models: { "anthropic/global": { alias: "Global" } },
+            },
+            entries: {
+              main: { model: { primary: "anthropic/main" } },
+              ops: {
+                model: { primary: "openai/ops" },
+                models: { "openai/ops": { alias: "Operations" } },
+              },
+            },
+          },
+        },
+      });
+
+      expect(result?.agents?.defaults?.model).toEqual({ primary: "anthropic/global" });
+      expect(result?.agents?.defaults?.models).toEqual({
+        "anthropic/global": { alias: "Global" },
+      });
+      expect(result?.agents?.entries?.ops?.model).toEqual({ primary: modelRef });
+      expect(result?.agents?.entries?.ops?.models).toEqual({
+        "openai/ops": { alias: "Operations" },
+      });
+      expect(result?.agents?.entries?.main?.model).toEqual({ primary: "anthropic/main" });
+      expect(ensureCodexRuntimePluginForModelSelection).toHaveBeenCalledWith(
+        expect.objectContaining({ model: modelRef }),
+      );
+    },
+  );
+
   it.each([
     { providerId: "lmstudio", modelRef: "lmstudio/qwen/qwen3-1.7b" },
     { providerId: "ollama", modelRef: "ollama/qwen3:8b" },
@@ -287,51 +334,62 @@ describe("applyNonInteractivePluginProviderChoice", () => {
     expect(result).toEqual({ plugins: { allow: ["vllm"] } });
   });
 
-  it("loads a media setup provider without treating it as a text model provider", async () => {
-    const runtime = createRuntime();
-    const provider = { id: "pixverse", pluginId: "pixverse", label: "PixVerse" };
-    const initialConfig: OpenClawConfig = {
-      agents: { defaults: { model: { primary: "openai/gpt-5.6" } } },
-    };
-    const runNonInteractive = vi.fn(async ({ config }: { config: OpenClawConfig }) => ({
-      ...config,
-      agents: {
-        ...config.agents,
-        defaults: {
-          ...config.agents?.defaults,
-          mediaModels: { video: { primary: "pixverse/pixverse-v5.6" } },
+  it.each([false, true])(
+    "keeps media setup global without replacing the text model (explicit fleet: %s)",
+    async (explicitFleet) => {
+      const runtime = createRuntime();
+      const provider = { id: "pixverse", pluginId: "pixverse", label: "PixVerse" };
+      const initialConfig: OpenClawConfig = {
+        agents: {
+          defaults: { model: { primary: "openai/gpt-5.6" } },
+          ...(explicitFleet
+            ? { ownership: "explicit", entries: { main: { model: { primary: "openai/agent" } } } }
+            : {}),
         },
-      },
-    }));
-    resolvePreferredProviderForAuthChoice.mockResolvedValue("pixverse" as never);
-    resolvePluginProvidersCore.mockImplementation((...args: unknown[]) => {
-      const input = args[0] as { providerRefs?: string[] } | undefined;
-      return (input?.providerRefs?.includes("pixverse") ? [provider] : []) as never;
-    });
-    resolveProviderPluginChoice.mockImplementation((...args: unknown[]) => {
-      const input = args[0] as { providers?: unknown[] } | undefined;
-      return input?.providers?.includes(provider)
-        ? { provider, method: { runNonInteractive } }
-        : undefined;
-    });
+      };
+      const runNonInteractive = vi.fn(async ({ config }: { config: OpenClawConfig }) => ({
+        ...config,
+        agents: {
+          ...config.agents,
+          defaults: {
+            ...config.agents?.defaults,
+            mediaModels: { video: { primary: "pixverse/pixverse-v5.6" } },
+          },
+        },
+      }));
+      resolvePreferredProviderForAuthChoice.mockResolvedValue("pixverse" as never);
+      resolvePluginProvidersCore.mockImplementation((...args: unknown[]) => {
+        const input = args[0] as { providerRefs?: string[] } | undefined;
+        return (input?.providerRefs?.includes("pixverse") ? [provider] : []) as never;
+      });
+      resolveProviderPluginChoice.mockImplementation((...args: unknown[]) => {
+        const input = args[0] as { providers?: unknown[] } | undefined;
+        return input?.providers?.includes(provider)
+          ? { provider, method: { runNonInteractive } }
+          : undefined;
+      });
 
-    const result = await applyNonInteractivePluginProviderChoice({
-      nextConfig: initialConfig,
-      authChoice: "pixverse-api-key",
-      opts: { pixverseApiKey: "pixverse-test-key" } as never,
-      runtime: runtime as never,
-      baseConfig: initialConfig,
-      target,
-      resolveApiKey: vi.fn(),
-      toApiKeyCredential: vi.fn(),
-    });
+      const result = await applyNonInteractivePluginProviderChoice({
+        nextConfig: initialConfig,
+        authChoice: "pixverse-api-key",
+        opts: { pixverseApiKey: "pixverse-test-key" } as never,
+        runtime: runtime as never,
+        baseConfig: initialConfig,
+        target,
+        resolveApiKey: vi.fn(),
+        toApiKeyCredential: vi.fn(),
+      });
 
-    expect(runNonInteractive).toHaveBeenCalledOnce();
-    expect(result?.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.6" });
-    expect(result?.agents?.defaults?.mediaModels?.video).toEqual({
-      primary: "pixverse/pixverse-v5.6",
-    });
-  });
+      expect(runNonInteractive).toHaveBeenCalledOnce();
+      expect(result?.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.6" });
+      expect(result?.agents?.defaults?.mediaModels?.video).toEqual({
+        primary: "pixverse/pixverse-v5.6",
+      });
+      if (explicitFleet) {
+        expect(result?.agents?.entries?.main?.model).toEqual({ primary: "openai/agent" });
+      }
+    },
+  );
 
   it("installs an official catalog provider before applying a cold auth choice", async () => {
     const runtime = createRuntime();

--- a/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
@@ -28,7 +28,11 @@ import {
 } from "../../codex-runtime-plugin-install.js";
 import { ensureCopilotRuntimePluginForModelSelection } from "../../copilot-runtime-plugin-install.js";
 import { createNonInteractiveLoggingPrompter } from "../../non-interactive-prompter.js";
-import type { OnboardingAgentTarget } from "../../onboard-agent-target.js";
+import {
+  prepareAgentModelDefaults,
+  projectAgentModelDefaults,
+  type OnboardingAgentTarget,
+} from "../../onboard-agent-target.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 
 const PROVIDER_PLUGIN_CHOICE_PREFIX = "provider-plugin:";
@@ -231,9 +235,17 @@ export async function applyNonInteractivePluginProviderChoice(params: {
     return null;
   }
 
+  const agentScopedModels = enableResult.config.agents?.ownership === "explicit";
+  const providerConfig = agentScopedModels
+    ? prepareAgentModelDefaults(enableResult.config, params.target)
+    : enableResult.config;
+  const projectProviderResult = (updated: OpenClawConfig) =>
+    agentScopedModels
+      ? projectAgentModelDefaults(enableResult.config, params.target, updated)
+      : updated;
   const result = await method.runNonInteractive({
     authChoice: params.authChoice,
-    config: enableResult.config,
+    config: providerConfig,
     baseConfig: params.baseConfig,
     opts: params.opts as ProviderAuthOptionBag,
     runtime: params.runtime,
@@ -247,7 +259,7 @@ export async function applyNonInteractivePluginProviderChoice(params: {
   }
   const selectedModel = resolveAgentModelPrimaryValue(result.agents?.defaults?.model);
   if (!selectedModel) {
-    return result;
+    return projectProviderResult(result);
   }
   // Model selection can imply a runtime plugin even when auth setup belonged to
   // a provider plugin; install those runtimes before persisting the config.
@@ -283,17 +295,19 @@ export async function applyNonInteractivePluginProviderChoice(params: {
     runtime: params.runtime,
     workspaceDir,
   });
-  const previousModel = enableResult.config.agents?.defaults?.model;
+  const previousModel = providerConfig.agents?.defaults?.model;
   const previousAutoModel = enableResult.config.wizard?.localModelLeanAutoModel;
   const retainsAutoModelOwnership =
     previousAutoModel !== undefined &&
     previousAutoModel === resolveAgentModelPrimaryValue(previousModel) &&
     previousAutoModel === copilotInstall.cfg.wizard?.localModelLeanAutoModel;
 
-  return applyAutoLocalModelLean({
-    config: copilotInstall.cfg,
-    providerId: providerChoice.provider.id,
-    modelRef: selectedModel,
-    ...(retainsAutoModelOwnership ? { previousModelRef: previousAutoModel } : {}),
-  }).config;
+  return projectProviderResult(
+    applyAutoLocalModelLean({
+      config: copilotInstall.cfg,
+      providerId: providerChoice.provider.id,
+      modelRef: selectedModel,
+      ...(retainsAutoModelOwnership ? { previousModelRef: previousAutoModel } : {}),
+    }).config,
+  );
 }

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -270,6 +270,47 @@ describe("applyNonInteractiveAuthChoice", () => {
     expect(apiKeyParams?.secretInputMode).toBe("ref");
   });
 
+  it("keeps a custom provider model on the configured explicit-fleet system agent", async () => {
+    const runtime = createRuntime();
+    const nextConfig: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        defaults: {
+          systemAgent: { agentId: "ops" },
+          model: { primary: "anthropic/global" },
+        },
+        entries: {
+          main: { model: { primary: "anthropic/main" } },
+          ops: { model: { primary: "openai/ops" } },
+        },
+      },
+    };
+    resolveNonInteractiveApiKey.mockResolvedValueOnce(null);
+
+    const result = await applyNonInteractiveAuthChoice({
+      nextConfig,
+      authChoice: "custom-api-key",
+      opts: {
+        customBaseUrl: "https://models.custom.local/v1",
+        customModelId: "local-large",
+      } as never,
+      runtime: runtime as never,
+      baseConfig: nextConfig,
+      target: {
+        agentId: "ops",
+        agentDir: "/tmp/ops-agent",
+        workspaceDir: "/tmp/ops-workspace",
+      },
+    });
+
+    expect(result?.agents?.defaults?.model).toEqual({ primary: "anthropic/global" });
+    expect(result?.agents?.entries?.ops?.model).toEqual({
+      primary: "custom-models-custom-local/local-large",
+    });
+    expect(result?.agents?.entries?.main?.model).toEqual({ primary: "anthropic/main" });
+    expect(result?.models?.providers?.["custom-models-custom-local"]).toBeDefined();
+  });
+
   it("never commits an existing profile key as plaintext during custom secret-ref onboarding", async () => {
     const runtime = createRuntime();
     const nextConfig = { agents: { defaults: {} } } as OpenClawConfig;

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -280,6 +280,7 @@ export async function applyNonInteractiveAuthChoice(params: {
         apiKey: customApiKeyInput,
         providerId: customAuth.providerId,
         supportsImageInput: customAuth.supportsImageInput,
+        target: params.target,
       });
       if (result.providerIdRenamedFrom && result.providerId) {
         runtime.log(

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -16,6 +16,7 @@ const resolvePreferredProviderForAuthChoice = vi.hoisted(() => vi.fn());
 const promptDefaultModel = vi.hoisted(() => vi.fn());
 const applyPrimaryModel = vi.hoisted(() => vi.fn((config: unknown) => config));
 const promptAuthChoiceGrouped = vi.hoisted(() => vi.fn());
+const promptCustomApiConfig = vi.hoisted(() => vi.fn());
 const ensureAuthProfileStore = vi.hoisted(() => vi.fn(() => ({ profiles: {} })));
 const detectAvailableSetupProviderIds = vi.hoisted(() => vi.fn());
 const resolveManifestProviderAuthChoice = vi.hoisted(() =>
@@ -42,6 +43,8 @@ vi.mock("../commands/model-picker.js", () => ({
   applyPrimaryModel,
   promptDefaultModel,
 }));
+
+vi.mock("../commands/onboard-custom.js", () => ({ promptCustomApiConfig }));
 
 vi.mock("../commands/auth-choice-prompt.js", () => ({
   isKeepCurrentAuthChoice: (value: unknown) => value === "__keep-current",
@@ -232,6 +235,112 @@ describe("runSetupModelAuthStep", () => {
         workspaceDir: "/tmp/main-workspace",
       }),
     );
+  });
+
+  it("keeps provider model defaults owned by the selected explicit-fleet agent", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        defaults: {
+          systemAgent: { agentId: "ops" },
+          model: { primary: "global/current" },
+          models: { "global/current": { alias: "global" } },
+        },
+        entries: {
+          ops: {
+            model: { primary: "ops/current" },
+            models: { "ops/current": { alias: "existing" } },
+            agentDir: "/tmp/ops-agent",
+            workspace: "/tmp/ops-workspace",
+          },
+          main: { model: { primary: "main/current" } },
+        },
+      },
+    };
+    const persistAuthProfiles = vi.fn(async () => {});
+    applyAuthChoice.mockImplementationOnce(
+      async ({ config: authConfig }: { config: OpenClawConfig }) => ({
+        config: {
+          ...authConfig,
+          agents: {
+            ...authConfig.agents,
+            defaults: {
+              ...authConfig.agents?.defaults,
+              model: { primary: "provider/selected" },
+              models: {
+                ...authConfig.agents?.defaults?.models,
+                "provider/selected": { alias: "selected" },
+              },
+            },
+          },
+        },
+        authProfiles: [],
+        persistAuthProfiles,
+      }),
+    );
+
+    const result = await runSetupModelAuthStep({
+      config,
+      opts: { authChoice: "anthropic-cli" },
+      prompter: createPrompter(),
+      runtime: createRuntime(),
+    });
+
+    expect(applyAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "ops",
+        config: expect.objectContaining({
+          agents: expect.objectContaining({
+            defaults: expect.objectContaining({
+              model: { primary: "ops/current" },
+              models: { "ops/current": { alias: "existing" } },
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(result.config.agents?.defaults?.model).toEqual({ primary: "global/current" });
+    expect(result.config.agents?.defaults?.models).toEqual({
+      "global/current": { alias: "global" },
+    });
+    expect(result.config.agents?.entries?.ops?.model).toEqual({ primary: "provider/selected" });
+    expect(result.config.agents?.entries?.ops?.models).toEqual({
+      "ops/current": { alias: "existing" },
+      "provider/selected": { alias: "selected" },
+    });
+    expect(result.config.agents?.entries?.main?.model).toEqual({ primary: "main/current" });
+    expect(result.persistAuthProfiles).toBe(persistAuthProfiles);
+    expect(persistAuthProfiles).not.toHaveBeenCalled();
+  });
+
+  it("passes the explicit system agent to custom setup while preserving its existing model", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "ops" }, model: { primary: "global/current" } },
+        entries: {
+          ops: { model: { primary: "ops/current" }, workspace: "/tmp/ops-workspace" },
+        },
+      },
+    };
+    promptCustomApiConfig.mockResolvedValueOnce({ config });
+
+    const result = await runSetupModelAuthStep({
+      config,
+      opts: { authChoice: "custom-api-key" },
+      preserveExistingModelSelection: true,
+      prompter: createPrompter(),
+      runtime: createRuntime(),
+    });
+
+    expect(promptCustomApiConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ agentId: "ops", workspaceDir: "/tmp/ops-workspace" }),
+        setAsPrimary: false,
+      }),
+    );
+    expect(result.config.agents?.entries?.ops?.model).toEqual({ primary: "ops/current" });
+    expect(result.config.agents?.defaults?.model).toEqual({ primary: "global/current" });
   });
 
   it("validates an interactive skip against the configured default agent", async () => {

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -2,6 +2,8 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   applyOnboardingPrimaryModel,
+  prepareAgentModelDefaults,
+  projectAgentModelDefaults,
   resolveOnboardingSetupTarget,
 } from "../commands/onboard-agent-target.js";
 import type { AuthChoice, OnboardOptions } from "../commands/onboard-types.js";
@@ -205,6 +207,7 @@ export async function runSetupModelAuthStep(params: {
         prompter,
         runtime,
         config: nextConfig,
+        target: resolveTarget(nextConfig),
         secretInputMode: opts.secretInputMode,
         setAsPrimary: !params.preserveExistingModelSelection,
       });
@@ -254,11 +257,12 @@ export async function runSetupModelAuthStep(params: {
     ] = await Promise.all([loadAuthChoiceModule(), loadModelPickerModule()]);
     prompter.disableBackNavigation?.();
     const target = resolveTarget(nextConfig);
+    const agentScopedModels = nextConfig.agents?.ownership === "explicit";
     let authResult: PreparedAuthChoiceResult;
     try {
       authResult = await prepareAuthChoice({
         authChoice,
-        config: nextConfig,
+        config: agentScopedModels ? prepareAgentModelDefaults(nextConfig, target) : nextConfig,
         prompter,
         runtime,
         agentId: target.agentId,
@@ -285,12 +289,14 @@ export async function runSetupModelAuthStep(params: {
       );
       continue;
     }
-    nextConfig = authResult.config;
+    nextConfig = agentScopedModels
+      ? projectAgentModelDefaults(nextConfig, target, authResult.config)
+      : authResult.config;
     authProfiles = authResult.authProfiles;
     persistAuthProfiles = authResult.persistAuthProfiles;
     if (authResult.retrySelection) {
       if (authChoiceFromPrompt) {
-        replacementBaseConfig = authResult.config;
+        replacementBaseConfig = nextConfig;
         continue;
       }
       break;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where onboarding into an explicit multi-agent fleet reported success while leaving the System Agent on its old model and silently replacing the fleet-wide model default. Custom providers, Google, NVIDIA, interactive onboarding, non-interactive onboarding, and setup were affected.

## Why This Change Was Made

Prepare the selected agent model, aliases, and policy at the shared onboarding owner boundary, then project provider changes back onto that agent while restoring fleet-wide model settings. Preserve shared media settings and provider catalog updates, and apply the same ownership contract to custom-provider aliases and existing-model preservation.

## User Impact

The configured System Agent now immediately uses its selected provider while fleet defaults, sibling agents, agent-local aliases, shared media settings, and single-agent behavior remain intact.

## Evidence

- Before: real custom onboard, custom setup, NVIDIA, and Google CLI runs exited successfully while changing the global model and leaving the System Agent unchanged.
- After: all four real CLI flows succeeded, updated only the System Agent model, preserved the global and sibling models, and stored provider profiles with the System Agent.
- Review follow-up: real custom and NVIDIA CLI runs against an agent with four inherited fleet aliases confirmed unchanged inherited aliases and model policy remain fleet-owned; only newly selected model entries become agent-local.
- Focused regressions cover agent aliases, model policy, key casing, existing-model preservation, interactive and non-interactive provider setup, deferred authentication persistence, and shared media configuration.
- Changed-file formatting, lint, whitespace validation, offline secret scanning, and independent Codex review pass.
- Required CI will be verified on the exact pull-request head before landing.

Production growth supplies the missing shared asynchronous owner-preparation boundary without provider-specific fallback paths.
