### PR TITLE
[Windows] Right-click paste in terminal panel

### DIFF
--- a/ui/src/components/terminal/terminal-runtime.ts
+++ b/ui/src/components/terminal/terminal-runtime.ts
@@ -1,9 +1,14 @@
 import type { CreateGhosttyTerminalOptions } from "@openclaw/libterminal/browser";
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 
-function isEventListener(value: unknown): value is EventListener {
-  return typeof value === "function";
-}
+/**
+ * Whether the browser is running on Windows. Right-click-to-paste is a
+ * Windows terminal convention (cmd.exe / PowerShell / Windows Terminal), so we
+ * only enable the behavior there and leave other platforms' default
+ * right-click semantics (word selection / context menu) untouched.
+ */
+const IS_WINDOWS =
+  typeof navigator !== "undefined" &&
+  /Windows/i.test(navigator.userAgent);
 
 /** Creates a terminal whose WASM memory is never reused by another tab. */
 export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTerminalOptions) {
@@ -16,10 +21,49 @@ export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTermin
   const runtime = await loadGhosttyRuntime({ module: ghosttyModule });
   const controller = await createGhosttyTerminal({ ...options, runtime });
   const dispose = controller.dispose.bind(controller);
-  const terminal = controller.terminal;
-  const mouseUpCandidate = asOptionalRecord(terminal)?.handleMouseUp;
-  let handleMouseUp = isEventListener(mouseUpCandidate) ? mouseUpCandidate : undefined;
+  const terminal = controller.terminal as unknown as { handleMouseUp?: unknown };
+  let handleMouseUp =
+    typeof terminal.handleMouseUp === "function"
+      ? (terminal.handleMouseUp as EventListener)
+      : undefined;
   let disposed = false;
+
+  /**
+   * Windows right-click paste: reads the clipboard and inserts it into the
+   * terminal, matching the muscle memory of cmd.exe / PowerShell / Windows
+   * Terminal users. The listener is scoped to the terminal's own host element
+   * (capture phase) so other surfaces' context menus are untouched, and on
+   * non-Windows platforms the browser default (word selection / context menu)
+   * is preserved.
+   */
+  let handleContextMenu: ((event: MouseEvent) => void) | undefined;
+  if (IS_WINDOWS && typeof navigator.clipboard?.readText === "function") {
+    const host = options.parent;
+    handleContextMenu = (event: MouseEvent) => {
+      if (!host.contains(event.target as Node)) {
+        return;
+      }
+      event.preventDefault();
+      navigator.clipboard
+        .readText()
+        .then((text) => {
+          if (text) {
+            // Ghostty preserves bracketed-paste mode: pasted text is inserted
+            // as editable input and never auto-executes a command.
+            terminal.paste(text);
+            terminal.focus();
+          }
+        })
+        .catch(() => {
+          // Clipboard read can be denied by permissions; fall back to the
+          // default behavior instead of silently swallowing the click.
+          document.removeEventListener("contextmenu", handleContextMenu, true);
+          handleContextMenu = undefined;
+        });
+    };
+    document.addEventListener("contextmenu", handleContextMenu, true);
+  }
+
   controller.dispose = () => {
     if (disposed) {
       return;
@@ -29,6 +73,10 @@ export async function createIsolatedGhosttyTerminal(options: CreateGhosttyTermin
     if (handleMouseUp) {
       document.removeEventListener("mouseup", handleMouseUp);
       handleMouseUp = undefined;
+    }
+    if (handleContextMenu) {
+      document.removeEventListener("contextmenu", handleContextMenu, true);
+      handleContextMenu = undefined;
     }
     dispose();
   };


### PR DESCRIPTION
## Summary

On Windows, the OpenClaw terminal panel does not respond to right-click as paste, conflicting with cmd.exe / PowerShell / Windows Terminal conventions. This adds Windows right-click-to-paste, scoped to the terminal host element, while preserving other platforms' default context menu behavior.

## Changes
- `ui/src/components/terminal/terminal-runtime.ts`: add capture-phase contextmenu listener (Windows only) that reads the clipboard via `navigator.clipboard.readText()` and inserts it with `terminal.paste()`, matching the existing file-upload paste path. Listener is removed on dispose.
- Non-Windows platforms keep browser default right-click (word selection / context menu).

Closes #128120
