### PR TITLE
fix(mantis): fence lost Telegram leases without a ten-second delay

### DIFF
--- a/scripts/mantis/run-with-lease-fence.sh
+++ b/scripts/mantis/run-with-lease-fence.sh
@@ -10,7 +10,7 @@ lost_marker_path="$1"
 shift 2
 
 # The marker records broker-confirmed loss of the shared-account lease; continuing
-# Telegram I/O would violate broker serialization. The <=10s poll window is accepted
+# Telegram I/O would violate broker serialization. The <=1s poll window is accepted
 # against the 20-minute lease TTL.
 # <&0: a backgrounded command's stdin defaults to /dev/null, which silently
 # swallowed the piped agent prompt. The explicit redirect keeps the caller's stdin.
@@ -48,10 +48,5 @@ while true; do
     exit 97
   fi
 
-  for _ in {1..10}; do
-    sleep 1
-    if ! kill -0 "$command_pid" 2>/dev/null; then
-      command_exit
-    fi
-  done
+  sleep 1
 done

--- a/test/scripts/run-with-lease-fence.test.ts
+++ b/test/scripts/run-with-lease-fence.test.ts
@@ -43,7 +43,7 @@ describe("run-with-lease-fence", () => {
       fs.writeFileSync(lostMarker, "lost\n");
 
       try {
-        await expect(waitForChildClose(child, 12_000)).resolves.toEqual({
+        await expect(waitForChildClose(child)).resolves.toEqual({
           code: 97,
           signal: null,
         });

--- a/test/scripts/run-with-lease-fence.test.ts
+++ b/test/scripts/run-with-lease-fence.test.ts
@@ -47,9 +47,9 @@ describe("run-with-lease-fence", () => {
           code: 97,
           signal: null,
         });
-        const ticksAfterFence = fs.readFileSync(ticksFile, "utf8");
-        await new Promise((resolve) => setTimeout(resolve, 1_200));
-        expect(fs.readFileSync(ticksFile, "utf8")).toBe(ticksAfterFence);
+        expect(() => process.kill(-commandPid, 0)).toThrow(
+          expect.objectContaining({ code: "ESRCH" }),
+        );
         expect(stderr).toContain("::error::Telegram QA lease lost mid-run; fencing proof");
       } finally {
         if (child.exitCode === null) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a Telegram Desktop proof could keep using a shared QA account for up to ten seconds after the broker reported that its lease was lost. The same delayed fence made the real-process regression test spend more than ten unnecessary seconds waiting for termination.

## Why This Change Was Made

The lease-fence owner now observes both child completion and the authoritative lease-loss marker on the same one-second cadence instead of nesting marker observation behind ten child polls. Its real-process regression now enforces the shared helper's five-second deadline and directly verifies that the fenced POSIX process group no longer exists rather than sleeping another 1.2 seconds to infer termination from an unchanged file.

## User Impact

Shared Telegram QA accounts are fenced within approximately one second after broker-confirmed lease loss instead of up to ten seconds, reducing the window in which overlapping proofs could violate account serialization. The focused real-process test also runs 58.8% faster without reducing lifecycle coverage.

## Evidence

Measured on the same Linux Blacksmith Testbox with one Vitest worker, separate module caches, import diagnostics, and `/usr/bin/time -v`; one baseline warmup and one candidate warmup were excluded.

| Retained sample | Wall time | Vitest duration | Lease-loss test | Max RSS | Imports |
| --- | ---: | ---: | ---: | ---: | ---: |
| Baseline 1 | 17.34 s | 14.45 s | 12.217 s | 305,884 KiB | 10 |
| Baseline 2 | 17.46 s | 14.44 s | 12.216 s | 297,116 KiB | 10 |
| Candidate 1 | 7.12 s | 4.24 s | 2.008 s | 310,324 KiB | 10 |
| Candidate 2 | 7.23 s | 4.23 s | 2.008 s | 300,272 KiB | 10 |

Mean scoped wall time improved from **17.400 s to 7.175 s: 10.225 s faster (58.8%)**. The original benchmark Testbox was associated with https://github.com/openclaw/openclaw/actions/runs/32616562380.

A reversible fault mutation changed the production exit code from 97 to 98 and the unchanged real-process assertion failed with `expected { code: 98, signal: null } to deeply equal { code: 97, signal: null }`; restoring exit 97 immediately restored the passing run. A second, stronger reversible proof replaced the candidate owner with the actual previous ten-second production implementation: the updated five-second regression deadline failed after 5.016 seconds with `child did not close before timeout`, while restoring the one-second owner passed in 2.008 seconds. Both synchronized files were SHA-256 verified on the Testbox before **35 real Linux owner/workflow sibling tests passed**, including process-group termination, normal child exit, stdin forwarding, and shared-account serialization. The complete `testRoot, tooling` changed gate passed again on that same verified checkout, including all guards, root-test typechecking, and scripts lint; final hosted Testbox run: https://github.com/openclaw/openclaw/actions/runs/32621413533. `bash -n`, ShellCheck, targeted formatting, `git diff --check`, and fresh independent structured review all passed. Production delta: **-5 lines**; test delta: **0 lines**.
