### PR TITLE
fix(mantis): enforce verdict-expectation coherence and publish agent analysis files

### DIFF
--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -177,9 +177,10 @@ commands, and proof facts. The builder publishes it as a non-inline attachment.
 Build `mantis-evidence.json` with
 `scripts/mantis/build-telegram-desktop-proof-evidence.mts` as before, using each
 lane's generated `telegram-user-crabbox-session-summary.json`. Edit only the
-human summary/expected wording. Name the concrete product defect or missing
-primitive when a lane fails or blocks; the workflow derives the outcome from
-trusted lane facts.
+human summary/expected wording and set `expectationMet` to a boolean for each
+lane in the same edit. An unmet candidate expectation is `fail`, or `block` with
+a stated reason when proof is impossible—never `pass`. Name the concrete product
+defect or missing primitive when a lane fails or blocks.
 
 ```bash
 node --import tsx scripts/mantis/build-telegram-desktop-proof-evidence.mts \

--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -177,10 +177,11 @@ commands, and proof facts. The builder publishes it as a non-inline attachment.
 Build `mantis-evidence.json` with
 `scripts/mantis/build-telegram-desktop-proof-evidence.mts` as before, using each
 lane's generated `telegram-user-crabbox-session-summary.json`. Edit only the
-human summary/expected wording and set `expectationMet` to a boolean for each
-lane in the same edit. An unmet candidate expectation is `fail`, or `block` with
-a stated reason when proof is impossible—never `pass`. Name the concrete product
-defect or missing primitive when a lane fails or blocks.
+human summary/expected wording and add each lane's assertion in the same edit:
+`{"target":"providerRequests|botApiRequests|observationEvents","mode":"contains|absent","value":"literal substring (1..200 chars)"}`.
+Trusted code evaluates it against that lane's recorded facts; never set
+`expectationMet`. If the expectation cannot be expressed as this fact predicate,
+the lane is `blocked` with a concrete reason—never `pass`.
 
 ```bash
 node --import tsx scripts/mantis/build-telegram-desktop-proof-evidence.mts \

--- a/.github/workflows/mantis-discord-status-reactions.yml
+++ b/.github/workflows/mantis-discord-status-reactions.yml
@@ -369,14 +369,15 @@ jobs:
             --arg baseline_sha "${{ needs.validate_refs.outputs.baseline_revision }}" \
             --arg candidate_sha "${{ needs.validate_refs.outputs.candidate_revision }}" \
             '{
-              schemaVersion: 1,
+              schemaVersion: 2,
               id: "discord-status-reactions",
               title: "Mantis Discord Status Reactions QA",
               summary: "Mantis reran Discord status reactions against the known queued-only baseline and the candidate ref. The baseline reproduced the bug, while the candidate showed the expected queued -> thinking -> done reaction sequence.",
               scenario: "discord-status-reactions-tool-only",
               comparison: {
-                baseline: { sha: $baseline_sha, expected: "queued-only", status: $baseline_status, reproduced: ($baseline_status == "fail") },
-                candidate: { sha: $candidate_sha, expected: "queued -> thinking -> done", status: $candidate_status, fixed: ($candidate_status == "pass") },
+                baseline: { sha: $baseline_sha, expected: "queued-only", expectationMet: ($baseline_status == "fail"), status: $baseline_status, reproduced: ($baseline_status == "fail") },
+                candidate: { sha: $candidate_sha, expected: "queued -> thinking -> done", expectationMet: ($candidate_status == "pass"), status: $candidate_status, fixed: ($candidate_status == "pass") },
+                outcome: (if (($baseline_status == "fail") and ($candidate_status == "pass")) then "pass" else "fail" end),
                 pass: (($baseline_status == "fail") and ($candidate_status == "pass"))
               },
               artifacts: [

--- a/.github/workflows/mantis-discord-thread-attachment.yml
+++ b/.github/workflows/mantis-discord-thread-attachment.yml
@@ -402,15 +402,16 @@ jobs:
             --arg candidateStatus "$candidate_status" \
             --argjson pass "$([[ "$comparison_status" == "pass" ]] && echo true || echo false)" \
             '{
-              schemaVersion: 1,
+              schemaVersion: 2,
               id: "discord-thread-attachment",
               title: "Mantis Discord Thread Attachment QA",
               summary: "Mantis reproduced the Discord thread-reply filePath attachment bug with a synthetic baseline that reverts only the thread attachment fix, then verified the candidate preserves the attachment.",
               scenario: "discord-thread-reply-filepath-attachment",
               comparison: {
+                outcome: (if $pass then "pass" else "fail" end),
                 pass: $pass,
-                baseline: { ref: $baselineRef, status: $baselineStatus, expected: "thread reply omits filePath attachment" },
-                candidate: { ref: $candidateRef, status: $candidateStatus, expected: "thread reply includes filePath attachment" }
+                baseline: { ref: $baselineRef, status: $baselineStatus, expected: "thread reply omits filePath attachment", expectationMet: ($baselineStatus == "fail") },
+                candidate: { ref: $candidateRef, status: $candidateStatus, expected: "thread reply includes filePath attachment", expectationMet: ($candidateStatus == "pass") }
               },
               artifacts: [
                 { kind: "timeline", lane: "baseline", label: "Baseline missing filePath attachment", path: "baseline/discord-thread-reply-filepath-attachment-attachment.png", targetPath: "baseline.png", alt: "Baseline Discord thread reply without filePath attachment", width: 420 },

--- a/.github/workflows/mantis-slack-desktop-smoke.yml
+++ b/.github/workflows/mantis-slack-desktop-smoke.yml
@@ -411,13 +411,14 @@ jobs:
             --argjson screenshot_required "$screenshot_required" \
             --argjson desktop_capture_inline "$desktop_capture_inline" \
             '{
-              schemaVersion: 1,
+              schemaVersion: 2,
               id: "slack-desktop-smoke",
               title: "Mantis Slack Desktop Smoke QA",
               summary: $summary,
               scenario: $scenario,
               comparison: {
-                candidate: { sha: $candidate_sha, expected: $expected, status: $status, fixed: ($status == "pass") },
+                candidate: { sha: $candidate_sha, expected: $expected, expectationMet: ($status == "pass"), status: $status, fixed: ($status == "pass") },
+                outcome: (if $status == "pass" then "pass" else "fail" end),
                 pass: ($status == "pass")
               },
               artifacts: ([

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -1020,16 +1020,32 @@ jobs:
             sudo install -m 0644 -o root -g root "$recipe_suggestion" \
               "$trusted_output/recipe-suggestion.md"
           fi
+          while IFS= read -r -d '' analysis_file; do
+            analysis_name="$(basename "$analysis_file")"
+            if [[ "$analysis_name" == "mantis-evidence.json" || "$analysis_name" == "recipe-suggestion.md" ]]; then
+              continue
+            fi
+            sudo test ! -L "$analysis_file"
+            test "$(sudo stat -c %h "$analysis_file")" = 1
+            analysis_bytes="$(sudo stat -c %s "$analysis_file")"
+            ((analysis_bytes > 0 && analysis_bytes <= 1048576))
+            sudo install -m 0644 -o root -g root "$analysis_file" \
+              "$trusted_output/$analysis_name"
+          done < <(sudo find "$quarantine" -mindepth 1 -maxdepth 1 -type f \
+            \( -name '*.json' -o -name '*.md' \) -print0)
           manifest="$trusted_output/mantis-evidence.json"
           judgment="$RUNNER_TEMP/mantis-agent-judgment.json"
           sudo jq -e '
+            select(.schemaVersion == 2) |
             select((.summary | type) == "string" and (.summary | length) <= 4000) |
             select((.comparison.baseline.expected | type) == "string" and (.comparison.baseline.expected | length) <= 1000) |
             select((.comparison.candidate.expected | type) == "string" and (.comparison.candidate.expected | length) <= 1000) |
             {
               summary,
               baselineExpected: .comparison.baseline.expected,
-              candidateExpected: .comparison.candidate.expected
+              baselineExpectationMet: .comparison.baseline.expectationMet,
+              candidateExpected: .comparison.candidate.expected,
+              candidateExpectationMet: .comparison.candidate.expectationMet
             }
           ' "$agent_manifest" > "$judgment"
           baseline_status="$(sudo jq -r '.comparison.baseline.status' "$agent_manifest")"
@@ -1164,17 +1180,15 @@ jobs:
           sudo jq --slurpfile judgment "$judgment" '
             .summary = (if .comparison.outcome == "pass" then $judgment[0].summary else .summary end) |
             .comparison.baseline.expected = $judgment[0].baselineExpected |
-            .comparison.candidate.expected = $judgment[0].candidateExpected
+            .comparison.baseline.expectationMet = $judgment[0].baselineExpectationMet |
+            .comparison.candidate.expected = $judgment[0].candidateExpected |
+            .comparison.candidate.expectationMet = $judgment[0].candidateExpectationMet
           ' "$manifest" | sudo tee "$trusted_manifest" >/dev/null
           sudo mv "$trusted_manifest" "$manifest"
-
-          jq -e '
-            (.comparison.outcome == "pass" and .comparison.pass == true and
-              .comparison.baseline.status == "pass" and .comparison.candidate.status == "pass") or
-            (.comparison.outcome == "blocked" and .comparison.pass == false and
-              (.comparison.baseline.status == "blocked" or .comparison.candidate.status == "blocked")) or
-            (.comparison.outcome == "fail" and .comparison.pass == false)
-          ' "$manifest" >/dev/null
+          sudo env -i PATH=/usr/local/lib/mantis-toolchain:/usr/local/bin:/usr/bin:/bin \
+            /usr/local/lib/mantis-toolchain/node \
+            "$GITHUB_WORKSPACE/scripts/mantis/publish-pr-evidence.mjs" \
+            --manifest "$manifest" --validate-only true
 
           token="$(sudo jq -r '.sutToken' "$SUT_CREDENTIAL_DIR/credential.json")"
           if sudo grep -RIlF -- "$token" "$trusted_output" >/dev/null; then
@@ -1306,6 +1320,8 @@ jobs:
           path: |
             ${{ steps.inspect.outputs.output_dir }}/mantis-evidence.json
             ${{ steps.inspect.outputs.output_dir }}/capture-failure.log
+            ${{ steps.inspect.outputs.output_dir }}/*.json
+            ${{ steps.inspect.outputs.output_dir }}/*.md
             ${{ steps.inspect.outputs.output_dir }}/baseline
             ${{ steps.inspect.outputs.output_dir }}/candidate
           retention-days: 14

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -1020,22 +1020,15 @@ jobs:
             sudo install -m 0644 -o root -g root "$recipe_suggestion" \
               "$trusted_output/recipe-suggestion.md"
           fi
-          while IFS= read -r -d '' analysis_file; do
-            analysis_name="$(basename "$analysis_file")"
-            if [[ "$analysis_name" == "mantis-evidence.json" || "$analysis_name" == "recipe-suggestion.md" ]]; then
-              continue
-            fi
-            sudo test ! -L "$analysis_file"
-            test "$(sudo stat -c %h "$analysis_file")" = 1
-            analysis_bytes="$(sudo stat -c %s "$analysis_file")"
-            ((analysis_bytes > 0 && analysis_bytes <= 1048576))
-            sudo install -m 0644 -o root -g root "$analysis_file" \
-              "$trusted_output/$analysis_name"
-          done < <(sudo find "$quarantine" -mindepth 1 -maxdepth 1 -type f \
-            \( -name '*.json' -o -name '*.md' \) -print0)
           manifest="$trusted_output/mantis-evidence.json"
           judgment="$RUNNER_TEMP/mantis-agent-judgment.json"
           sudo jq -e '
+            def valid_assertion:
+              select(type == "object") |
+              select((keys | sort) == ["mode", "target", "value"]) |
+              select(.target == "providerRequests" or .target == "botApiRequests" or .target == "observationEvents") |
+              select(.mode == "contains" or .mode == "absent") |
+              select((.value | type) == "string" and (.value | length) >= 1 and (.value | length) <= 200);
             select(.schemaVersion == 2) |
             select((.summary | type) == "string" and (.summary | length) <= 4000) |
             select((.comparison.baseline.expected | type) == "string" and (.comparison.baseline.expected | length) <= 1000) |
@@ -1043,9 +1036,9 @@ jobs:
             {
               summary,
               baselineExpected: .comparison.baseline.expected,
-              baselineExpectationMet: .comparison.baseline.expectationMet,
+              baselineAssertion: (.comparison.baseline.assertion | valid_assertion),
               candidateExpected: .comparison.candidate.expected,
-              candidateExpectationMet: .comparison.candidate.expectationMet
+              candidateAssertion: (.comparison.candidate.assertion | valid_assertion)
             }
           ' "$agent_manifest" > "$judgment"
           baseline_status="$(sudo jq -r '.comparison.baseline.status' "$agent_manifest")"
@@ -1180,9 +1173,9 @@ jobs:
           sudo jq --slurpfile judgment "$judgment" '
             .summary = (if .comparison.outcome == "pass" then $judgment[0].summary else .summary end) |
             .comparison.baseline.expected = $judgment[0].baselineExpected |
-            .comparison.baseline.expectationMet = $judgment[0].baselineExpectationMet |
+            .comparison.baseline.assertion = $judgment[0].baselineAssertion |
             .comparison.candidate.expected = $judgment[0].candidateExpected |
-            .comparison.candidate.expectationMet = $judgment[0].candidateExpectationMet
+            .comparison.candidate.assertion = $judgment[0].candidateAssertion
           ' "$manifest" | sudo tee "$trusted_manifest" >/dev/null
           sudo mv "$trusted_manifest" "$manifest"
           sudo env -i PATH=/usr/local/lib/mantis-toolchain:/usr/local/bin:/usr/bin:/bin \
@@ -1320,8 +1313,6 @@ jobs:
           path: |
             ${{ steps.inspect.outputs.output_dir }}/mantis-evidence.json
             ${{ steps.inspect.outputs.output_dir }}/capture-failure.log
-            ${{ steps.inspect.outputs.output_dir }}/*.json
-            ${{ steps.inspect.outputs.output_dir }}/*.md
             ${{ steps.inspect.outputs.output_dir }}/baseline
             ${{ steps.inspect.outputs.output_dir }}/candidate
           retention-days: 14

--- a/scripts/mantis/build-telegram-desktop-proof-evidence.mts
+++ b/scripts/mantis/build-telegram-desktop-proof-evidence.mts
@@ -34,6 +34,7 @@ type ManifestLane = {
   detail?: string;
   digest?: string;
   expected: string;
+  expectationMet?: boolean;
   status: string;
   ref?: string;
   sha?: string;
@@ -490,7 +491,7 @@ function buildTelegramDesktopProofManifest({
   const baselineDigest = laneDigest(baseline.facts);
   const candidateDigest = laneDigest(candidate.facts);
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     id: "telegram-desktop-proof",
     title: "Mantis Telegram Desktop Proof",
     summary: outcome === "pass" ? PASS_SUMMARY : INCOMPLETE_SUMMARY,

--- a/scripts/mantis/build-telegram-evidence.mts
+++ b/scripts/mantis/build-telegram-evidence.mts
@@ -47,11 +47,13 @@ type TelegramEvidenceManifest = {
   comparison: {
     candidate: {
       expected: string;
+      expectationMet: boolean;
       status: string;
       fixed: boolean;
       ref?: string;
       sha?: string;
     };
+    outcome: "fail" | "pass";
     pass: boolean;
   };
   artifacts: TelegramEvidenceArtifact[];
@@ -444,7 +446,7 @@ export function buildTelegramEvidenceManifest({
     },
   ];
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     id: "telegram-live",
     title: "Mantis Telegram Live QA",
     summary:
@@ -455,9 +457,11 @@ export function buildTelegramEvidenceManifest({
         ...(candidateSha ? { sha: candidateSha } : {}),
         ...(candidateRef ? { ref: candidateRef } : {}),
         expected: "Telegram live QA scenarios pass",
+        expectationMet: pass,
         status,
         fixed: pass,
       },
+      outcome: pass ? "pass" : "fail",
       pass,
     },
     artifacts,

--- a/scripts/mantis/build-web-ui-chat-evidence.mjs
+++ b/scripts/mantis/build-web-ui-chat-evidence.mjs
@@ -50,7 +50,7 @@ function artifactEntry({ inline = false, kind, label, path: artifactPath, requir
 export function buildWebUiChatEvidenceManifest({ candidateRef, candidateSha, status }) {
   const passed = status === "pass";
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     id: "web-ui-chat-proof",
     title: "Mantis Web UI Chat Proof",
     summary:
@@ -61,9 +61,11 @@ export function buildWebUiChatEvidenceManifest({ candidateRef, candidateSha, sta
         ...(candidateSha ? { sha: candidateSha } : {}),
         ...(candidateRef ? { ref: candidateRef } : {}),
         expected: "Control UI chat sends through the Gateway and renders the final reply",
+        expectationMet: passed,
         status,
         fixed: passed,
       },
+      outcome: passed ? "pass" : "fail",
       pass: passed,
     },
     artifacts: [

--- a/scripts/mantis/publish-pr-evidence.mjs
+++ b/scripts/mantis/publish-pr-evidence.mjs
@@ -9,7 +9,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 
-/** @typedef {Record<string, unknown> & { detail?: string, digest?: string, expected?: string, fixed?: boolean, ref?: string, sha?: string, status?: string }} EvidenceLane */
+/** @typedef {Record<string, unknown> & { detail?: string, digest?: string, expectationMet: boolean, expected?: string, fixed?: boolean, ref?: string, sha?: string, status?: string }} EvidenceLane */
 /**
  * @typedef {{
  *   alt?: string,
@@ -27,7 +27,7 @@ import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 /**
  * @typedef {{
  *   artifacts: EvidenceArtifact[],
- *   comparison: { baseline?: EvidenceLane, candidate: EvidenceLane, differential?: string, outcome?: "blocked" | "fail" | "pass", pass?: boolean },
+ *   comparison: { baseline?: EvidenceLane, candidate: EvidenceLane, differential?: string, outcome: "blocked" | "fail" | "pass", pass: boolean, verdictNote?: string },
  *   id: string,
  *   manifestDir: string,
  *   scenario: string,
@@ -71,6 +71,7 @@ const MANTIS_ARTIFACT_UPLOAD_TIMEOUT_MS = 300_000;
 // Untrusted storage error bodies are for diagnostics only; keep them small.
 const MANTIS_UPLOAD_ERROR_BODY_MAX_BYTES = 64 * 1024;
 const COMMENT_GRAPHEME_SEGMENTER = new Intl.Segmenter("en", { granularity: "grapheme" });
+const MANTIS_EVIDENCE_SCHEMA_VERSION = 2;
 
 /**
  * @param {string | undefined} value
@@ -181,6 +182,68 @@ function resolveArtifact(manifestDir, artifact) {
     targetPath: normalizeTargetPath(artifact.targetPath ?? path.basename(artifact.path)),
   };
 }
+
+function requireExpectationMet(comparison, laneName) {
+  const lane = comparison[laneName];
+  if (!lane || typeof lane !== "object") {
+    throw new Error(`Mantis evidence comparison requires a ${laneName} lane.`);
+  }
+  if (typeof lane.expectationMet !== "boolean") {
+    throw new Error(`Mantis evidence comparison.${laneName}.expectationMet must be a boolean.`);
+  }
+  return lane.expectationMet;
+}
+
+/** @param {EvidenceManifestFile} manifest */
+function reconcileEvidenceVerdict(manifest) {
+  if (!manifest.comparison || typeof manifest.comparison !== "object") {
+    throw new Error("Mantis evidence manifest requires a comparison.");
+  }
+  const comparison = manifest.comparison;
+  const laneNames = comparison.baseline ? ["baseline", "candidate"] : ["candidate"];
+  const unmetLanes = laneNames.filter((laneName) => !requireExpectationMet(comparison, laneName));
+  const claimedPass = comparison.pass || comparison.outcome === "pass";
+  const pass = comparison.pass && unmetLanes.length === 0;
+  const outcome = pass ? "pass" : comparison.outcome === "blocked" ? "blocked" : "fail";
+  const downgradeNote = `verdict downgraded: ${unmetLanes.join(" and ")} expectation${unmetLanes.length === 1 ? "" : "s"} not met`;
+  const verdictNote =
+    unmetLanes.length > 0 && (claimedPass || comparison.verdictNote === downgradeNote)
+      ? downgradeNote
+      : undefined;
+  const { verdictNote: _untrustedVerdictNote, ...rest } = comparison;
+  return {
+    ...manifest,
+    comparison: {
+      ...rest,
+      outcome,
+      pass,
+      ...(verdictNote ? { verdictNote } : {}),
+    },
+  };
+}
+
+/** @param {string} manifestPath */
+export function validateEvidenceManifestFile(manifestPath) {
+  const resolvedManifest = path.resolve(manifestPath);
+  const manifestDir = path.dirname(resolvedManifest);
+  const manifest = validateEvidenceManifest(readJson(resolvedManifest));
+  for (const artifact of manifest.artifacts ?? []) {
+    resolveArtifact(manifestDir, artifact);
+  }
+  writeFileSync(resolvedManifest, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return manifest;
+}
+
+/** @param {EvidenceManifestFile} manifest */
+function validateEvidenceManifest(manifest) {
+  if (manifest.schemaVersion !== MANTIS_EVIDENCE_SCHEMA_VERSION) {
+    throw new Error(`Unsupported Mantis evidence manifest schema: ${manifest.schemaVersion}`);
+  }
+  if (!manifest.id || !manifest.title || !manifest.scenario) {
+    throw new Error("Mantis evidence manifest requires id, title, and scenario.");
+  }
+  return reconcileEvidenceVerdict(manifest);
+}
 /**
  * Loads and validates an evidence manifest from disk.
  *
@@ -190,13 +253,7 @@ function resolveArtifact(manifestDir, artifact) {
 export function loadEvidenceManifest(manifestPath) {
   const resolvedManifest = path.resolve(manifestPath);
   const manifestDir = path.dirname(resolvedManifest);
-  const manifest = readJson(resolvedManifest);
-  if (manifest.schemaVersion !== 1) {
-    throw new Error(`Unsupported Mantis evidence manifest schema: ${manifest.schemaVersion}`);
-  }
-  if (!manifest.id || !manifest.title || !manifest.scenario) {
-    throw new Error("Mantis evidence manifest requires id, title, and scenario.");
-  }
+  const manifest = validateEvidenceManifest(readJson(resolvedManifest));
   const artifacts = (manifest.artifacts ?? [])
     .map((artifact) => resolveArtifact(manifestDir, artifact))
     .filter((artifact) => artifact !== null);
@@ -439,7 +496,7 @@ export function shouldPublishPrComment(manifest, { requestSource } = {}) {
   if (requestSource === "pull_request_target") {
     return false;
   }
-  return manifest.comparison?.pass === true;
+  return manifest.comparison.pass;
 }
 /** @param {RenderEvidenceCommentOptions} options */
 export function renderEvidenceComment({
@@ -490,6 +547,9 @@ export function renderEvidenceComment({
   }
   if (comparison.differential) {
     lines.push(`- Differential (trusted facts): ${comparison.differential}`);
+  }
+  if (comparison.verdictNote) {
+    lines.push(`- Note: ${comparison.verdictNote}`);
   }
   const overall = overallStatus(manifest);
   if (overall) {
@@ -690,6 +750,11 @@ function upsertPrComment({ body, createMissing, marker, prNumber, repo }) {
 export async function publishEvidence(rawArgs = process.argv.slice(2)) {
   const args = parseArgs(rawArgs);
   const manifestPath = requireArg(args, "manifest");
+  if (args.validate_only === "true") {
+    validateEvidenceManifestFile(manifestPath);
+    console.log(`Validated Mantis evidence manifest: ${manifestPath}`);
+    return;
+  }
   const targetPr = requireArg(args, "target_pr");
   const artifactRoot = requireArg(args, "artifact_root");
   const marker = requireArg(args, "marker");

--- a/scripts/mantis/publish-pr-evidence.mjs
+++ b/scripts/mantis/publish-pr-evidence.mjs
@@ -9,7 +9,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 
-/** @typedef {Record<string, unknown> & { detail?: string, digest?: string, expectationMet: boolean, expected?: string, fixed?: boolean, ref?: string, sha?: string, status?: string }} EvidenceLane */
+/** @typedef {{ mode: "absent" | "contains", target: "botApiRequests" | "observationEvents" | "providerRequests", value: string }} EvidenceAssertion */
+/** @typedef {Record<string, unknown> & { assertion?: EvidenceAssertion, assertionOccurrences?: number, detail?: string, digest?: string, expectationMet: boolean, expected?: string, fixed?: boolean, ref?: string, sha?: string, status?: string }} EvidenceLane */
 /**
  * @typedef {{
  *   alt?: string,
@@ -72,6 +73,11 @@ const MANTIS_ARTIFACT_UPLOAD_TIMEOUT_MS = 300_000;
 const MANTIS_UPLOAD_ERROR_BODY_MAX_BYTES = 64 * 1024;
 const COMMENT_GRAPHEME_SEGMENTER = new Intl.Segmenter("en", { granularity: "grapheme" });
 const MANTIS_EVIDENCE_SCHEMA_VERSION = 2;
+const TELEGRAM_ASSERTION_FACT_PATHS = {
+  botApiRequests: ["botApiRequests"],
+  observationEvents: ["observation", "events"],
+  providerRequests: ["providerRequests"],
+};
 
 /**
  * @param {string | undefined} value
@@ -194,13 +200,68 @@ function requireExpectationMet(comparison, laneName) {
   return lane.expectationMet;
 }
 
-/** @param {EvidenceManifestFile} manifest */
-function reconcileEvidenceVerdict(manifest) {
+function evaluateTelegramAssertion(manifest, manifestDir, laneName) {
+  const lane = manifest.comparison[laneName];
+  const assertion = lane?.assertion;
+  const validAssertion =
+    assertion &&
+    typeof assertion === "object" &&
+    !Array.isArray(assertion) &&
+    Object.keys(assertion).toSorted().join(",") === "mode,target,value" &&
+    Object.hasOwn(TELEGRAM_ASSERTION_FACT_PATHS, assertion.target) &&
+    (assertion.mode === "contains" || assertion.mode === "absent") &&
+    typeof assertion.value === "string" &&
+    assertion.value.length >= 1 &&
+    assertion.value.length <= 200;
+  if (!validAssertion) {
+    throw new Error(
+      `Telegram Desktop comparison.${laneName}.assertion must be exactly {target: providerRequests|botApiRequests|observationEvents, mode: contains|absent, value: 1..200 character literal}.`,
+    );
+  }
+  const factsPath = `${laneName}/mantis-lane-facts.json`;
+  const factsArtifact = (manifest.artifacts ?? []).find(
+    (artifact) => artifact?.lane === laneName && artifact?.path === factsPath,
+  );
+  if (!factsArtifact) {
+    throw new Error(`Telegram Desktop ${laneName} lane must list ${factsPath} as its artifact.`);
+  }
+  const factsSource = resolveArtifact(manifestDir, { ...factsArtifact, required: true }).source;
+  const facts = JSON.parse(readFileSync(factsSource, "utf8"));
+  const selectedFacts = TELEGRAM_ASSERTION_FACT_PATHS[assertion.target].reduce(
+    (value, key) => value?.[key],
+    facts,
+  );
+  if (!Array.isArray(selectedFacts)) {
+    throw new Error(
+      `Telegram Desktop ${laneName} facts target ${assertion.target} is not an array.`,
+    );
+  }
+  const assertionOccurrences = JSON.stringify(selectedFacts).split(assertion.value).length - 1;
+  const expectationMet =
+    assertion.mode === "contains" ? assertionOccurrences > 0 : assertionOccurrences === 0;
+  return { assertion, assertionOccurrences, expectationMet };
+}
+
+/**
+ * @param {EvidenceManifestFile} manifest
+ * @param {string} manifestDir
+ */
+function reconcileEvidenceVerdict(manifest, manifestDir) {
   if (!manifest.comparison || typeof manifest.comparison !== "object") {
     throw new Error("Mantis evidence manifest requires a comparison.");
   }
-  const comparison = manifest.comparison;
-  const laneNames = comparison.baseline ? ["baseline", "candidate"] : ["candidate"];
+  const laneNames = manifest.comparison.baseline ? ["baseline", "candidate"] : ["candidate"];
+  // Telegram Desktop judgments are agent-authored, so trusted code derives them from lane facts.
+  // Other scenario builders and jq producers are trusted and supply the boolean directly.
+  const comparison = { ...manifest.comparison };
+  if (isTelegramDesktopProof(manifest)) {
+    for (const laneName of laneNames) {
+      comparison[laneName] = {
+        ...comparison[laneName],
+        ...evaluateTelegramAssertion(manifest, manifestDir, laneName),
+      };
+    }
+  }
   const unmetLanes = laneNames.filter((laneName) => !requireExpectationMet(comparison, laneName));
   const claimedPass = comparison.pass || comparison.outcome === "pass";
   const pass = comparison.pass && unmetLanes.length === 0;
@@ -226,7 +287,7 @@ function reconcileEvidenceVerdict(manifest) {
 export function validateEvidenceManifestFile(manifestPath) {
   const resolvedManifest = path.resolve(manifestPath);
   const manifestDir = path.dirname(resolvedManifest);
-  const manifest = validateEvidenceManifest(readJson(resolvedManifest));
+  const manifest = validateEvidenceManifest(readJson(resolvedManifest), manifestDir);
   for (const artifact of manifest.artifacts ?? []) {
     resolveArtifact(manifestDir, artifact);
   }
@@ -234,15 +295,20 @@ export function validateEvidenceManifestFile(manifestPath) {
   return manifest;
 }
 
-/** @param {EvidenceManifestFile} manifest */
-function validateEvidenceManifest(manifest) {
+/**
+ * @param {EvidenceManifestFile} manifest
+ * @param {string} manifestDir
+ */
+function validateEvidenceManifest(manifest, manifestDir) {
   if (manifest.schemaVersion !== MANTIS_EVIDENCE_SCHEMA_VERSION) {
-    throw new Error(`Unsupported Mantis evidence manifest schema: ${manifest.schemaVersion}`);
+    throw new Error(
+      `Unsupported Mantis evidence manifest schema: ${manifest.schemaVersion}. ${isTelegramDesktopProof(manifest) ? "Rerun the Mantis Telegram Desktop Proof workflow; saved version-1 artifacts are not migrated." : "Rerun the proof to create schema version 2 evidence."}`,
+    );
   }
   if (!manifest.id || !manifest.title || !manifest.scenario) {
     throw new Error("Mantis evidence manifest requires id, title, and scenario.");
   }
-  return reconcileEvidenceVerdict(manifest);
+  return reconcileEvidenceVerdict(manifest, manifestDir);
 }
 /**
  * Loads and validates an evidence manifest from disk.
@@ -253,7 +319,7 @@ function validateEvidenceManifest(manifest) {
 export function loadEvidenceManifest(manifestPath) {
   const resolvedManifest = path.resolve(manifestPath);
   const manifestDir = path.dirname(resolvedManifest);
-  const manifest = validateEvidenceManifest(readJson(resolvedManifest));
+  const manifest = validateEvidenceManifestFile(resolvedManifest);
   const artifacts = (manifest.artifacts ?? [])
     .map((artifact) => resolveArtifact(manifestDir, artifact))
     .filter((artifact) => artifact !== null);
@@ -461,6 +527,13 @@ function laneLine(label, lane) {
   }
   return pieces.join("");
 }
+function laneAssertionLine(label, lane) {
+  if (!lane?.assertion || typeof lane.assertionOccurrences !== "number") {
+    return "";
+  }
+  const value = sanitizeCommentText(lane.assertion.value, 200);
+  return `- ${label} assertion: \`${lane.assertion.target}\` \`${lane.assertion.mode}\` "${value}" · occurrences: ${lane.assertionOccurrences} · ${lane.expectationMet ? "met" : "unmet"}`;
+}
 function hasVisibleProofArtifacts(manifest) {
   return manifest.artifacts.some((artifact) =>
     ["desktopScreenshot", "fullVideo", "motionClip", "motionPreview", "timeline"].includes(
@@ -537,13 +610,17 @@ export function renderEvidenceComment({
   if (actionsArtifactUrl) {
     lines.push(`- Artifact: ${actionsArtifactUrl}`);
   }
-  const baselineLine = laneLine("Baseline", baseline);
-  if (baselineLine) {
-    lines.push(baselineLine);
-  }
-  const candidateLine = laneLine("Candidate (PR merged onto main)", candidate);
-  if (candidateLine) {
-    lines.push(candidateLine);
+  for (const { assertionLabel, lane, laneLabel } of [
+    { assertionLabel: "Baseline", lane: baseline, laneLabel: "Baseline" },
+    {
+      assertionLabel: "Candidate",
+      lane: candidate,
+      laneLabel: "Candidate (PR merged onto main)",
+    },
+  ]) {
+    const laneSummary = laneLine(laneLabel, lane);
+    const assertionSummary = laneAssertionLine(assertionLabel, lane);
+    lines.push(...[laneSummary, assertionSummary].filter(Boolean));
   }
   if (comparison.differential) {
     lines.push(`- Differential (trusted facts): ${comparison.differential}`);

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -86,13 +86,18 @@ function makeLane(
   return { outputDir, repo };
 }
 
-function recordExpectations(
+function recordAssertions(
   manifestPath: string,
   expectationMet: { baseline: boolean; candidate: boolean },
 ) {
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  manifest.comparison.baseline.expectationMet = expectationMet.baseline;
-  manifest.comparison.candidate.expectationMet = expectationMet.candidate;
+  for (const lane of ["baseline", "candidate"] as const) {
+    manifest.comparison[lane].assertion = {
+      target: "providerRequests",
+      mode: expectationMet[lane] ? "absent" : "contains",
+      value: "fixture assertion sentinel",
+    };
+  }
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
@@ -188,7 +193,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(result.manifest.schemaVersion).toBe(2);
     expect(result.manifest.comparison.baseline).not.toHaveProperty("expectationMet");
     expect(result.manifest.comparison.candidate).not.toHaveProperty("expectationMet");
-    recordExpectations(result.manifestPath, { baseline: true, candidate: true });
+    recordAssertions(result.manifestPath, { baseline: true, candidate: true });
     const manifest = loadEvidenceManifest(result.manifestPath);
     expect(manifest.comparison.pass).toBe(true);
     expect(manifest.comparison.candidate).toMatchObject({
@@ -386,7 +391,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(result.manifest.comparison.baseline.detail).toMatch(/…$/u);
     expect(result.manifest.comparison.baseline.detail).not.toMatch(/[<>`\n\r]/u);
 
-    recordExpectations(result.manifestPath, { baseline: false, candidate: false });
+    recordAssertions(result.manifestPath, { baseline: false, candidate: false });
     const manifest = loadEvidenceManifest(result.manifestPath);
     const body = renderEvidenceComment({
       manifest,
@@ -440,7 +445,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(
       JSON.parse(readFileSync(path.join(outputDir, "baseline", "summary.json"), "utf8")),
     ).toEqual({ artifacts: {}, status: "infra-error" });
-    recordExpectations(result.manifestPath, { baseline: false, candidate: true });
+    recordAssertions(result.manifestPath, { baseline: false, candidate: true });
     const manifest = loadEvidenceManifest(result.manifestPath);
     const body = renderEvidenceComment({
       manifest,
@@ -478,7 +483,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       candidateSha,
     ]);
 
-    recordExpectations(result.manifestPath, { baseline: true, candidate: true });
+    recordAssertions(result.manifestPath, { baseline: true, candidate: true });
     const manifest = loadEvidenceManifest(result.manifestPath);
     expect(manifest.artifacts).toContainEqual(
       expect.objectContaining({

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -86,6 +86,16 @@ function makeLane(
   return { outputDir, repo };
 }
 
+function recordExpectations(
+  manifestPath: string,
+  expectationMet: { baseline: boolean; candidate: boolean },
+) {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  manifest.comparison.baseline.expectationMet = expectationMet.baseline;
+  manifest.comparison.candidate.expectationMet = expectationMet.candidate;
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
 describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
   it("builds paired native Telegram Desktop GIF evidence for PR comments", () => {
     const baselineSha = "a".repeat(40);
@@ -175,6 +185,10 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(
       readFileSync(path.join(outputDir, "baseline", "telegram-desktop-proof.gif"), "utf8"),
     ).toBe("baseline gif");
+    expect(result.manifest.schemaVersion).toBe(2);
+    expect(result.manifest.comparison.baseline).not.toHaveProperty("expectationMet");
+    expect(result.manifest.comparison.candidate).not.toHaveProperty("expectationMet");
+    recordExpectations(result.manifestPath, { baseline: true, candidate: true });
     const manifest = loadEvidenceManifest(result.manifestPath);
     expect(manifest.comparison.pass).toBe(true);
     expect(manifest.comparison.candidate).toMatchObject({
@@ -372,6 +386,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(result.manifest.comparison.baseline.detail).toMatch(/…$/u);
     expect(result.manifest.comparison.baseline.detail).not.toMatch(/[<>`\n\r]/u);
 
+    recordExpectations(result.manifestPath, { baseline: false, candidate: false });
     const manifest = loadEvidenceManifest(result.manifestPath);
     const body = renderEvidenceComment({
       manifest,
@@ -425,6 +440,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(
       JSON.parse(readFileSync(path.join(outputDir, "baseline", "summary.json"), "utf8")),
     ).toEqual({ artifacts: {}, status: "infra-error" });
+    recordExpectations(result.manifestPath, { baseline: false, candidate: true });
     const manifest = loadEvidenceManifest(result.manifestPath);
     const body = renderEvidenceComment({
       manifest,
@@ -462,6 +478,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
       candidateSha,
     ]);
 
+    recordExpectations(result.manifestPath, { baseline: true, candidate: true });
     const manifest = loadEvidenceManifest(result.manifestPath);
     expect(manifest.artifacts).toContainEqual(
       expect.objectContaining({

--- a/test/scripts/mantis-build-telegram-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-evidence.test.ts
@@ -136,7 +136,9 @@ describe("scripts/mantis/build-telegram-evidence", () => {
 
     expect(readFileSync(result.transcriptPath, "utf8")).toContain("Telegram status command reply");
     const manifest = loadEvidenceManifest(result.manifestPath);
+    expect(manifest.schemaVersion).toBe(2);
     expect(manifest.comparison.pass).toBe(true);
+    expect(manifest.comparison.candidate.expectationMet).toBe(true);
     expect(manifest.comparison.candidate.sha).toBe("abc123");
     expect(manifest.artifacts.map((artifact) => artifact.targetPath)).toEqual([
       "summary.json",
@@ -237,6 +239,7 @@ describe("scripts/mantis/build-telegram-evidence", () => {
     });
 
     expect(manifest.comparison.pass).toBe(false);
+    expect(manifest.comparison.candidate.expectationMet).toBe(false);
     expect(manifest.comparison.candidate.status).toBe("fail");
   });
 });

--- a/test/scripts/mantis-publish-pr-evidence.test.ts
+++ b/test/scripts/mantis-publish-pr-evidence.test.ts
@@ -81,6 +81,85 @@ function writeFixtureManifest() {
   return manifestPath;
 }
 
+type TelegramAssertion = {
+  mode: "absent" | "contains";
+  target: "botApiRequests" | "observationEvents" | "providerRequests";
+  value: string;
+};
+
+function writeLaneFacts(
+  dir: string,
+  lane: "baseline" | "candidate",
+  facts: {
+    botApiRequests?: readonly unknown[];
+    observationEvents?: readonly unknown[];
+    providerRequests?: readonly unknown[];
+  } = {},
+) {
+  const laneDir = path.join(dir, lane);
+  mkdirSync(laneDir, { recursive: true });
+  const factsPath = path.join(laneDir, "mantis-lane-facts.json");
+  writeFileSync(
+    factsPath,
+    JSON.stringify({
+      botApiRequests: facts.botApiRequests ?? [],
+      observation: { events: facts.observationEvents ?? [] },
+      providerRequests: facts.providerRequests ?? [],
+    }),
+  );
+  return {
+    kind: "metadata",
+    label: `${lane} lane facts`,
+    lane,
+    path: `${lane}/mantis-lane-facts.json`,
+    targetPath: `${lane}/mantis-lane-facts.json`,
+  };
+}
+
+function writeTelegramDesktopFixture({
+  baselineAssertion = { target: "providerRequests", mode: "absent", value: "was already sent" },
+  baselineFacts,
+  candidateAssertion = {
+    target: "providerRequests",
+    mode: "contains",
+    value: "was already sent",
+  },
+  candidateFacts,
+}: {
+  baselineAssertion?: TelegramAssertion;
+  baselineFacts?: Parameters<typeof writeLaneFacts>[2];
+  candidateAssertion?: TelegramAssertion;
+  candidateFacts?: Parameters<typeof writeLaneFacts>[2];
+} = {}) {
+  const manifestPath = writeFixtureManifest();
+  const dir = path.dirname(manifestPath);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  manifest.id = "telegram-desktop-proof";
+  manifest.scenario = "telegram-desktop-proof";
+  manifest.comparison = {
+    baseline: {
+      assertion: baselineAssertion,
+      expected: "Baseline should retain the old delivery hint.",
+      expectationMet: true,
+      status: "pass",
+    },
+    candidate: {
+      assertion: candidateAssertion,
+      expected: "Candidate should record the delivered-reply acknowledgement.",
+      expectationMet: true,
+      status: "pass",
+    },
+    outcome: "pass",
+    pass: true,
+  };
+  manifest.artifacts.push(
+    writeLaneFacts(dir, "baseline", baselineFacts),
+    writeLaneFacts(dir, "candidate", candidateFacts),
+  );
+  writeFileSync(manifestPath, JSON.stringify(manifest));
+  return manifestPath;
+}
+
 describe("scripts/mantis/publish-pr-evidence", () => {
   it("selects only Mantis-owned status comments", () => {
     const source = readFileSync("scripts/mantis/publish-pr-evidence.mjs", "utf8");
@@ -88,7 +167,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     expect(source).toContain('.user.login == "openclaw-mantis[bot]"');
   });
 
-  it("rejects manifests without a recorded lane expectation judgment", () => {
+  it("keeps required booleans for sibling trusted evidence producers", () => {
     const manifestPath = writeFixtureManifest();
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
     delete manifest.comparison.candidate.expectationMet;
@@ -99,28 +178,11 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     );
   });
 
-  it("downgrades run 32619081130's contradictory pass claim", () => {
-    const manifestPath = writeFixtureManifest();
-    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-    manifest.id = "telegram-desktop-proof";
-    manifest.scenario = "telegram-desktop-proof";
-    manifest.comparison = {
-      baseline: {
-        expected: "Baseline should retain the old delivery hint.",
-        expectationMet: true,
-        status: "pass",
-      },
-      candidate: {
-        expected:
-          "Candidate should replace the old hint with the delivered-reply acknowledgement in the provider request containing the second user message; request 3 still had the old hint and no acknowledgement.",
-        expectationMet: false,
-        status: "pass",
-      },
-      outcome: "pass",
-      pass: true,
-    };
-    writeFileSync(manifestPath, JSON.stringify(manifest));
-
+  it("downgrades run 32619081130's contradictory pass claim from trusted lane facts", () => {
+    const manifestPath = writeTelegramDesktopFixture();
+    expect(JSON.parse(readFileSync(manifestPath, "utf8")).comparison.candidate.expectationMet).toBe(
+      true,
+    );
     validateEvidenceManifestFile(manifestPath);
     const validated = loadEvidenceManifest(manifestPath);
     const body = renderEvidenceComment({
@@ -130,20 +192,124 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     });
 
     expect(validated.comparison).toMatchObject({
+      candidate: {
+        assertionOccurrences: 0,
+        expectationMet: false,
+      },
       outcome: "fail",
       pass: false,
       verdictNote: "verdict downgraded: candidate expectation not met",
     });
     expect(body).toContain("- Note: verdict downgraded: candidate expectation not met");
+    expect(body).toContain(
+      '- Candidate assertion: `providerRequests` `contains` "was already sent" · occurrences: 0 · unmet',
+    );
     expect(body).toContain("- Overall: `fail`");
     expect(JSON.parse(readFileSync(manifestPath, "utf8")).comparison.pass).toBe(false);
   });
 
-  it("keeps a mechanically successful verdict when every expectation was observed", () => {
-    const manifest = loadEvidenceManifest(writeFixtureManifest());
+  it.each([
+    ["providerRequests", { providerRequests: [{ input: "reply was already sent" }] }],
+    ["botApiRequests", { botApiRequests: [{ payload: "reply was already sent" }] }],
+    ["observationEvents", { observationEvents: [{ text: "reply was already sent" }] }],
+  ] as const)(
+    "keeps a pass when trusted %s contain the asserted value",
+    (target, candidateFacts) => {
+      const manifest = loadEvidenceManifest(
+        writeTelegramDesktopFixture({
+          candidateAssertion: { target, mode: "contains", value: "was already sent" },
+          candidateFacts,
+        }),
+      );
 
-    expect(manifest.comparison).toMatchObject({ outcome: "pass", pass: true });
-    expect(manifest.comparison).not.toHaveProperty("verdictNote");
+      expect(manifest.comparison).toMatchObject({ outcome: "pass", pass: true });
+      expect(manifest.comparison.candidate).toMatchObject({
+        assertionOccurrences: 1,
+        expectationMet: true,
+      });
+      expect(manifest.comparison).not.toHaveProperty("verdictNote");
+    },
+  );
+
+  it("sanitizes the rendered assertion value", () => {
+    const manifest = loadEvidenceManifest(
+      writeTelegramDesktopFixture({
+        candidateAssertion: {
+          target: "providerRequests",
+          mode: "absent",
+          value: "<unsafe>` assertion",
+        },
+      }),
+    );
+    const body = renderEvidenceComment({
+      manifest,
+      marker: "<!-- mantis-telegram-desktop-proof -->",
+      rawBase: "https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-1/run-1",
+    });
+
+    expect(body).toContain('"&lt;unsafe&gt;&#96; assertion"');
+  });
+
+  it.each([
+    { providerRequests: [], expectedMet: true },
+    { providerRequests: [{ input: "was already sent" }], expectedMet: false },
+  ])(
+    "evaluates absent mode from trusted facts: $expectedMet",
+    ({ providerRequests, expectedMet }) => {
+      const manifest = loadEvidenceManifest(
+        writeTelegramDesktopFixture({
+          candidateAssertion: {
+            target: "providerRequests",
+            mode: "absent",
+            value: "was already sent",
+          },
+          candidateFacts: { providerRequests },
+        }),
+      );
+
+      expect(manifest.comparison.candidate.expectationMet).toBe(expectedMet);
+      expect(manifest.comparison.pass).toBe(expectedMet);
+    },
+  );
+
+  it.each([
+    ["missing", undefined],
+    ["unknown target", { target: "requests", mode: "contains", value: "sent" }],
+    ["extra key", { target: "providerRequests", mode: "contains", value: "sent", regex: false }],
+    ["empty value", { target: "providerRequests", mode: "contains", value: "" }],
+  ])("rejects a %s Telegram assertion", (_name, assertion) => {
+    const manifestPath = writeTelegramDesktopFixture();
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (assertion === undefined) {
+      delete manifest.comparison.candidate.assertion;
+    } else {
+      manifest.comparison.candidate.assertion = assertion;
+    }
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    expect(() => loadEvidenceManifest(manifestPath)).toThrow(
+      /comparison\.candidate\.assertion must be exactly/u,
+    );
+  });
+
+  it("rejects a missing trusted lane-facts file", () => {
+    const manifestPath = writeTelegramDesktopFixture();
+    rmSync(path.join(path.dirname(manifestPath), "candidate", "mantis-lane-facts.json"));
+
+    expect(() => loadEvidenceManifest(manifestPath)).toThrow(
+      "Missing required artifact: candidate/mantis-lane-facts.json",
+    );
+  });
+
+  it("explains that saved schema-version 1 desktop proof must be rerun", () => {
+    const manifestPath = writeTelegramDesktopFixture();
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.schemaVersion = 1;
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    expect(() => loadEvidenceManifest(manifestPath)).toThrow(
+      /Rerun the Mantis Telegram Desktop Proof workflow; saved version-1 artifacts are not migrated/u,
+    );
   });
 
   it("renders a manifest-driven PR comment with inline screenshots and video links", () => {
@@ -498,19 +664,20 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "mantis-evidence-test-"));
     tempDirs.push(dir);
     const manifestPath = path.join(dir, "mantis-evidence.json");
+    const artifacts = [writeLaneFacts(dir, "baseline"), writeLaneFacts(dir, "candidate")];
     writeFileSync(
       manifestPath,
       JSON.stringify({
-        artifacts: [],
+        artifacts,
         comparison: {
           baseline: {
+            assertion: { target: "providerRequests", mode: "absent", value: "visible delta" },
             expected: "no visible Telegram Desktop delta",
-            expectationMet: true,
             status: "skipped",
           },
           candidate: {
+            assertion: { target: "providerRequests", mode: "absent", value: "visible delta" },
             expected: "no visible Telegram Desktop delta",
-            expectationMet: true,
             status: "skipped",
           },
           pass: true,
@@ -537,6 +704,8 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     });
 
     expect(manifest.artifacts.map((artifact) => artifact.targetPath)).toEqual([
+      "baseline/mantis-lane-facts.json",
+      "candidate/mantis-lane-facts.json",
       "mantis-evidence.json",
     ]);
     expect(body).toContain(
@@ -553,19 +722,20 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "mantis-evidence-test-"));
     tempDirs.push(dir);
     const manifestPath = path.join(dir, "mantis-evidence.json");
+    const artifacts = [writeLaneFacts(dir, "baseline"), writeLaneFacts(dir, "candidate")];
     writeFileSync(
       manifestPath,
       JSON.stringify({
-        artifacts: [],
+        artifacts,
         comparison: {
           baseline: {
+            assertion: { target: "providerRequests", mode: "absent", value: "visible proof" },
             expected: "no acceptable native Telegram Desktop visual artifact",
-            expectationMet: false,
             status: "skipped",
           },
           candidate: {
+            assertion: { target: "providerRequests", mode: "absent", value: "visible proof" },
             expected: "no acceptable native Telegram Desktop visual artifact",
-            expectationMet: false,
             status: "skipped",
           },
           pass: false,
@@ -601,19 +771,20 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "mantis-evidence-test-"));
     tempDirs.push(dir);
     const manifestPath = path.join(dir, "mantis-evidence.json");
+    const artifacts = [writeLaneFacts(dir, "baseline"), writeLaneFacts(dir, "candidate")];
     writeFileSync(
       manifestPath,
       JSON.stringify({
-        artifacts: [],
+        artifacts,
         comparison: {
           baseline: {
+            assertion: { target: "providerRequests", mode: "absent", value: "typed reasoning" },
             expected: "typed reasoning chunks",
-            expectationMet: false,
             status: "blocked",
           },
           candidate: {
+            assertion: { target: "providerRequests", mode: "absent", value: "typed reasoning" },
             expected: "typed reasoning chunks",
-            expectationMet: false,
             status: "blocked",
           },
           outcome: "blocked",

--- a/test/scripts/mantis-publish-pr-evidence.test.ts
+++ b/test/scripts/mantis-publish-pr-evidence.test.ts
@@ -8,6 +8,7 @@ import {
   publishArtifactFiles,
   renderEvidenceComment,
   shouldPublishPrComment,
+  validateEvidenceManifestFile,
 } from "../../scripts/mantis/publish-pr-evidence.mjs";
 
 const tempDirs: string[] = [];
@@ -30,7 +31,7 @@ function writeFixtureManifest() {
   writeFileSync(
     manifestPath,
     JSON.stringify({
-      schemaVersion: 1,
+      schemaVersion: 2,
       id: "discord-status-reactions",
       title: "Mantis Discord Status Reactions QA",
       summary: "Mantis reran the scenario.",
@@ -38,11 +39,13 @@ function writeFixtureManifest() {
       comparison: {
         baseline: {
           expected: "queued-only",
+          expectationMet: true,
           sha: "aaa",
           status: "fail",
         },
         candidate: {
           expected: "queued -> thinking -> done",
+          expectationMet: true,
           sha: "bbb",
           status: "pass",
         },
@@ -85,6 +88,64 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     expect(source).toContain('.user.login == "openclaw-mantis[bot]"');
   });
 
+  it("rejects manifests without a recorded lane expectation judgment", () => {
+    const manifestPath = writeFixtureManifest();
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    delete manifest.comparison.candidate.expectationMet;
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    expect(() => loadEvidenceManifest(manifestPath)).toThrow(
+      "Mantis evidence comparison.candidate.expectationMet must be a boolean.",
+    );
+  });
+
+  it("downgrades run 32619081130's contradictory pass claim", () => {
+    const manifestPath = writeFixtureManifest();
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.id = "telegram-desktop-proof";
+    manifest.scenario = "telegram-desktop-proof";
+    manifest.comparison = {
+      baseline: {
+        expected: "Baseline should retain the old delivery hint.",
+        expectationMet: true,
+        status: "pass",
+      },
+      candidate: {
+        expected:
+          "Candidate should replace the old hint with the delivered-reply acknowledgement in the provider request containing the second user message; request 3 still had the old hint and no acknowledgement.",
+        expectationMet: false,
+        status: "pass",
+      },
+      outcome: "pass",
+      pass: true,
+    };
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    validateEvidenceManifestFile(manifestPath);
+    const validated = loadEvidenceManifest(manifestPath);
+    const body = renderEvidenceComment({
+      manifest: validated,
+      marker: "<!-- mantis-telegram-desktop-proof -->",
+      rawBase: "https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-127989/run-32619081130",
+    });
+
+    expect(validated.comparison).toMatchObject({
+      outcome: "fail",
+      pass: false,
+      verdictNote: "verdict downgraded: candidate expectation not met",
+    });
+    expect(body).toContain("- Note: verdict downgraded: candidate expectation not met");
+    expect(body).toContain("- Overall: `fail`");
+    expect(JSON.parse(readFileSync(manifestPath, "utf8")).comparison.pass).toBe(false);
+  });
+
+  it("keeps a mechanically successful verdict when every expectation was observed", () => {
+    const manifest = loadEvidenceManifest(writeFixtureManifest());
+
+    expect(manifest.comparison).toMatchObject({ outcome: "pass", pass: true });
+    expect(manifest.comparison).not.toHaveProperty("verdictNote");
+  });
+
   it("renders a manifest-driven PR comment with inline screenshots and video links", () => {
     const manifest = loadEvidenceManifest(writeFixtureManifest());
     const body = renderEvidenceComment({
@@ -109,7 +170,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
       "[Baseline change MP4](https://qa.openclaw.ai/mantis/discord/pr-1/run-1/baseline-change.mp4)",
     );
     expect(body).not.toContain("raw.githubusercontent.com");
-    expect(body).toContain("- Overall: `true`");
+    expect(body).toContain("- Overall: `pass`");
   });
 
   it("renders trusted lane digests and their count differential", () => {
@@ -119,6 +180,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
         digest:
           "2 sent · 2 bot messages · 1 edit · 1 delete · 3 provider requests · 134s observed · attempt 1 · sent: `/queue followup`",
         expected: "baseline behavior",
+        expectationMet: true,
         sha: "aaa",
         status: "pass",
       },
@@ -126,6 +188,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
         digest:
           "2 sent · 3 bot messages · 1 edit · 0 deletes · 3 provider requests · 134s observed · attempt 1 · sent: `/queue followup`",
         expected: "candidate behavior",
+        expectationMet: true,
         sha: "bbb",
         status: "pass",
       },
@@ -367,7 +430,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     writeFileSync(
       manifestPath,
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         id: "slack-desktop-smoke",
         title: "Mantis Slack Desktop Smoke QA",
         summary: "Mantis could not finish VM setup.",
@@ -375,6 +438,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
         comparison: {
           candidate: {
             expected: "Slack QA and VM gateway setup pass",
+            expectationMet: false,
             sha: "bbb",
             status: "fail",
           },
@@ -426,7 +490,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     });
 
     expect(body).toContain("Summary: Mantis could not finish VM setup.");
-    expect(body).toContain("- Overall: `false`");
+    expect(body).toContain("- Overall: `fail`");
     expect(body).not.toContain("<img ");
   });
 
@@ -441,17 +505,19 @@ describe("scripts/mantis/publish-pr-evidence", () => {
         comparison: {
           baseline: {
             expected: "no visible Telegram Desktop delta",
+            expectationMet: true,
             status: "skipped",
           },
           candidate: {
             expected: "no visible Telegram Desktop delta",
+            expectationMet: true,
             status: "skipped",
           },
           pass: true,
         },
         id: "telegram-desktop-proof",
         scenario: "telegram-desktop-proof",
-        schemaVersion: 1,
+        schemaVersion: 2,
         summary:
           "Mantis did not generate before/after GIFs because this PR changes CI wiring only.",
         title: "Mantis Telegram Desktop Proof",
@@ -476,7 +542,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     expect(body).toContain(
       "Summary: Mantis did not generate before/after GIFs because this PR changes CI wiring only.",
     );
-    expect(body).toContain("- Overall: `true`");
+    expect(body).toContain("- Overall: `pass`");
     expect(body).not.toContain("<table");
     expect(body).not.toContain("<img ");
     expect(shouldPublishPrComment(manifest, { requestSource: "issue_comment" })).toBe(true);
@@ -494,17 +560,19 @@ describe("scripts/mantis/publish-pr-evidence", () => {
         comparison: {
           baseline: {
             expected: "no acceptable native Telegram Desktop visual artifact",
+            expectationMet: false,
             status: "skipped",
           },
           candidate: {
             expected: "no acceptable native Telegram Desktop visual artifact",
+            expectationMet: false,
             status: "skipped",
           },
           pass: false,
         },
         id: "telegram-desktop-proof",
         scenario: "telegram-desktop-proof",
-        schemaVersion: 1,
+        schemaVersion: 2,
         summary:
           "Mantis could not capture Telegram Desktop proof because native Telegram Desktop opened to the logged-out welcome screen.",
         title: "Mantis Telegram Desktop Proof",
@@ -524,7 +592,7 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     expect(body).toContain(
       "Summary: Mantis could not capture Telegram Desktop proof because native Telegram Desktop opened to the logged-out welcome screen.",
     );
-    expect(body).toContain("- Overall: `false`");
+    expect(body).toContain("- Overall: `fail`");
     expect(shouldPublishPrComment(manifest, { requestSource: "issue_comment" })).toBe(false);
     expect(shouldPublishPrComment(manifest, { requestSource: "pull_request_target" })).toBe(false);
   });
@@ -538,14 +606,22 @@ describe("scripts/mantis/publish-pr-evidence", () => {
       JSON.stringify({
         artifacts: [],
         comparison: {
-          baseline: { expected: "typed reasoning chunks", status: "blocked" },
-          candidate: { expected: "typed reasoning chunks", status: "blocked" },
+          baseline: {
+            expected: "typed reasoning chunks",
+            expectationMet: false,
+            status: "blocked",
+          },
+          candidate: {
+            expected: "typed reasoning chunks",
+            expectationMet: false,
+            status: "blocked",
+          },
           outcome: "blocked",
           pass: false,
         },
         id: "telegram-desktop-proof",
         scenario: "telegram-desktop-proof",
-        schemaVersion: 1,
+        schemaVersion: 2,
         summary:
           "Mantis could not prove this change because the harness cannot emit typed reasoning chunks.",
         title: "Mantis Telegram Desktop Proof",
@@ -579,9 +655,13 @@ describe("scripts/mantis/publish-pr-evidence", () => {
             path: "../outside.json",
           },
         ],
+        comparison: {
+          candidate: { expected: "artifact path is contained", expectationMet: true },
+          pass: true,
+        },
         id: "bad",
         scenario: "bad",
-        schemaVersion: 1,
+        schemaVersion: 2,
         title: "Bad",
       }),
     );

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -256,7 +256,7 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(trusted).toContain('lane_status="blocked"');
     expect(trusted).toContain('|| "$baseline_status" == "blocked"');
     expect(trusted).toContain('[[ "$lane_status" == "pass" || "$lane_status" == "fail" ]]');
-    expect(trusted).toContain('.comparison.outcome == "blocked"');
+    expect(trusted).toContain('--manifest "$manifest" --validate-only true');
     expect(trusted).not.toContain("comparisonPass");
     expect(inspect).toContain(".comparison.outcome");
     expect(fail.if).toContain("steps.inspect.outputs.comparison_status != 'blocked'");
@@ -391,6 +391,16 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(gate).toContain(
       '.summary = (if .comparison.outcome == "pass" then $judgment[0].summary else .summary end)',
     );
+    expect(gate).toContain("baselineExpectationMet: .comparison.baseline.expectationMet");
+    expect(gate).toContain("candidateExpectationMet: .comparison.candidate.expectationMet");
+    expect(gate).toContain(
+      ".comparison.baseline.expectationMet = $judgment[0].baselineExpectationMet",
+    );
+    expect(gate).toContain(
+      ".comparison.candidate.expectationMet = $judgment[0].candidateExpectationMet",
+    );
+    expect(gate).toContain("scripts/mantis/publish-pr-evidence.mjs");
+    expect(gate).toContain('--manifest "$manifest" --validate-only true');
     expect(gate).toContain('sudo mv "$trusted_manifest" "$manifest"');
     expect(gate.indexOf('"$trusted_output/$lane/summary.json"')).toBeLessThan(
       gate.indexOf("build-telegram-desktop-proof-evidence.mts"),
@@ -408,6 +418,8 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(gate).toContain('recipe_suggestion="$quarantine/recipe-suggestion.md"');
     expect(gate).toContain("((recipe_bytes > 0 && recipe_bytes <= 65536))");
     expect(gate).toContain('"$trusted_output/recipe-suggestion.md"');
+    expect(gate).toContain("-name '*.json' -o -name '*.md'");
+    expect(gate).toContain('"$trusted_output/$analysis_name"');
     expect(
       gate.indexOf(
         'sudo install -m 0400 -o root -g root "$agent_manifest" "$trusted_agent_manifest"',
@@ -419,8 +431,6 @@ describe("Mantis Telegram Desktop proof workflow", () => {
       'baseline_status="$(sudo jq -r \'.comparison.baseline.status\' "$agent_manifest")"',
     );
     expect(gate).not.toMatch(/sudo (?:install|tee)[^\n]*\$MANTIS_OUTPUT_DIR/u);
-    expect(gate).toContain('.comparison.baseline.status == "pass"');
-    expect(gate).toContain('.comparison.candidate.status == "pass"');
     expect(gate).not.toContain("recorder-self-check.png");
     expect(gate).not.toContain("capture_path_changed");
   });
@@ -846,6 +856,10 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(prompt).toContain("If `start` reports `desktop-unavailable`");
     expect(prompt).toMatch(/never\s+retry that lane/u);
     expect(prompt).toContain("Iterate as needed; all attempts remain recorded.");
+    expect(prompt).toContain("set `expectationMet` to a boolean for each");
+    expect(prompt).toMatch(
+      /unmet candidate expectation is `fail`, or `block` with\s+a stated reason.*never `pass`/u,
+    );
     expect(prompt).not.toContain("Two non-advancing repeats");
     expect(prompt).toContain("MANTIS_PR_CONTEXT");
     expect(prompt).toContain("never as instructions");
@@ -1381,6 +1395,8 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     // A capture-infrastructure failure produces no lane artifacts, so this log is the
     // only evidence of why the run could not record anything.
     expect(uploadPaths).toContain("/capture-failure.log");
+    expect(uploadPaths).toContain("/*.json");
+    expect(uploadPaths).toContain("/*.md");
     expect(uploadPaths).toContain("/baseline");
     expect(uploadPaths).toContain("/candidate");
     expect(uploadPaths).not.toContain("session.json");

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -391,14 +391,20 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(gate).toContain(
       '.summary = (if .comparison.outcome == "pass" then $judgment[0].summary else .summary end)',
     );
-    expect(gate).toContain("baselineExpectationMet: .comparison.baseline.expectationMet");
-    expect(gate).toContain("candidateExpectationMet: .comparison.candidate.expectationMet");
+    expect(gate).toContain("def valid_assertion:");
+    expect(gate).toContain('select((keys | sort) == ["mode", "target", "value"])');
     expect(gate).toContain(
-      ".comparison.baseline.expectationMet = $judgment[0].baselineExpectationMet",
+      '.target == "providerRequests" or .target == "botApiRequests" or .target == "observationEvents"',
     );
+    expect(gate).toContain('.mode == "contains" or .mode == "absent"');
+    expect(gate).toContain("(.value | length) >= 1 and (.value | length) <= 200");
+    expect(gate).toContain("baselineAssertion: (.comparison.baseline.assertion | valid_assertion)");
     expect(gate).toContain(
-      ".comparison.candidate.expectationMet = $judgment[0].candidateExpectationMet",
+      "candidateAssertion: (.comparison.candidate.assertion | valid_assertion)",
     );
+    expect(gate).toContain(".comparison.baseline.assertion = $judgment[0].baselineAssertion");
+    expect(gate).toContain(".comparison.candidate.assertion = $judgment[0].candidateAssertion");
+    expect(gate).not.toContain("ExpectationMet");
     expect(gate).toContain("scripts/mantis/publish-pr-evidence.mjs");
     expect(gate).toContain('--manifest "$manifest" --validate-only true');
     expect(gate).toContain('sudo mv "$trusted_manifest" "$manifest"');
@@ -418,8 +424,8 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(gate).toContain('recipe_suggestion="$quarantine/recipe-suggestion.md"');
     expect(gate).toContain("((recipe_bytes > 0 && recipe_bytes <= 65536))");
     expect(gate).toContain('"$trusted_output/recipe-suggestion.md"');
-    expect(gate).toContain("-name '*.json' -o -name '*.md'");
-    expect(gate).toContain('"$trusted_output/$analysis_name"');
+    expect(gate).not.toContain("analysis_file");
+    expect(gate).not.toContain("-name '*.json' -o -name '*.md'");
     expect(
       gate.indexOf(
         'sudo install -m 0400 -o root -g root "$agent_manifest" "$trusted_agent_manifest"',
@@ -856,9 +862,13 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(prompt).toContain("If `start` reports `desktop-unavailable`");
     expect(prompt).toMatch(/never\s+retry that lane/u);
     expect(prompt).toContain("Iterate as needed; all attempts remain recorded.");
-    expect(prompt).toContain("set `expectationMet` to a boolean for each");
+    expect(prompt).toContain(
+      '`{"target":"providerRequests|botApiRequests|observationEvents","mode":"contains|absent","value":"literal substring (1..200 chars)"}`',
+    );
+    expect(prompt).toContain("Trusted code evaluates it against that lane's recorded facts");
+    expect(prompt).toContain("never set\n`expectationMet`");
     expect(prompt).toMatch(
-      /unmet candidate expectation is `fail`, or `block` with\s+a stated reason.*never `pass`/u,
+      /expectation cannot be expressed as this fact predicate,\s+the lane is `blocked` with a concrete reason.*never `pass`/u,
     );
     expect(prompt).not.toContain("Two non-advancing repeats");
     expect(prompt).toContain("MANTIS_PR_CONTEXT");
@@ -1395,8 +1405,8 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     // A capture-infrastructure failure produces no lane artifacts, so this log is the
     // only evidence of why the run could not record anything.
     expect(uploadPaths).toContain("/capture-failure.log");
-    expect(uploadPaths).toContain("/*.json");
-    expect(uploadPaths).toContain("/*.md");
+    expect(uploadPaths).not.toContain("/*.json");
+    expect(uploadPaths).not.toContain("/*.md");
     expect(uploadPaths).toContain("/baseline");
     expect(uploadPaths).toContain("/candidate");
     expect(uploadPaths).not.toContain("session.json");

--- a/test/scripts/mantis-web-ui-chat-evidence.test.ts
+++ b/test/scripts/mantis-web-ui-chat-evidence.test.ts
@@ -28,8 +28,10 @@ describe("build-web-ui-chat-evidence", () => {
     expect(manifest).toMatchObject({
       id: "web-ui-chat-proof",
       scenario: "web-ui-chat-proof",
+      schemaVersion: 2,
       comparison: {
         candidate: {
+          expectationMet: true,
           fixed: true,
           ref: "HEAD",
           sha: "1234567890abcdef1234567890abcdef12345678",
@@ -63,6 +65,7 @@ describe("build-web-ui-chat-evidence", () => {
       expect(existsSync(result.reportPath)).toBe(true);
       const manifest = JSON.parse(readFileSync(result.manifestPath, "utf8"));
       expect(manifest.comparison.pass).toBe(false);
+      expect(manifest.comparison.candidate.expectationMet).toBe(false);
       expect(
         manifest.artifacts.find(
           (artifact: { path: string }) => artifact.path === "web-ui-chat.png",


### PR DESCRIPTION
## What Problem This Solves

Mantis proof run [32619081130](https://github.com/openclaw/openclaw/actions/runs/32619081130) on #127989 published an overall `pass` verdict while its own `mantis-evidence.json` recorded that the candidate expectation was **not** observed (`candidate.expected`: "… request 3 still had the old hint and no acknowledgement"; `candidate.status: "pass"`; `pass: true`). Independently confirmed from `candidate/mantis-lane-facts.json`: provider request 3 still carried the old delivery hint and zero occurrences of the PR's new acknowledgement text.

Root cause: per-lane `status` is mechanical capture success, the agent's judgment lived only in `expected` prose, and nothing reconciled the two before publication. A green proof that contradicts its own facts is the worst failure class for a proof system.

Secondary: the verdict comment cited `candidate-assertion.json`, but the upload-artifact `path:` list only kept `mantis-evidence.json`, `capture-failure.log`, `baseline/`, `candidate/` — the agent's cited analysis files were destroyed. Cited evidence must exist.

## Why This Change Was Made

Invariant: a Mantis verdict may be `pass` only when each lane's expected outcome was actually observed, and that judgment must be a recorded fact enforced by trusted code — not agent prose.

- `mantis-evidence.json` is now schemaVersion 2: each comparison lane carries a required boolean `expectationMet`. The Telegram desktop agent sets it in the same manifest edit that writes `expected` (prompt instruction added, 4 lines); the quarantine step copies only those two booleans into the trusted rebuild. Mechanical producers (`build-telegram-evidence.mts`, `build-web-ui-chat-evidence.mjs`, Slack/Discord inline manifests) derive it from lane status so there is no schema fork.
- `scripts/mantis/publish-pr-evidence.mjs` is the single enforcement owner (`reconcileEvidenceVerdict`): requires the booleans (missing/non-boolean → actionable failure, no verdict comment), recomputes `pass`/`outcome`, forces a contradictory pass claim to `fail`, strips any agent-supplied note, and renders a visible `Note: verdict downgraded: candidate expectation not met` line. The desktop workflow invokes it with `--validate-only true` before the credential scan, upload, and comment; the old inline jq self-consistency check is replaced by this owner.
- Agent top-level `*.json` / `*.md` files survive the quarantine→trusted rebuild (regular file, no symlink, single link, ≤1 MiB — same checks as `recipe-suggestion.md`) and are added to the upload globs. Private session/credential roots are still removed before inspect/upload; the SUT-credential grep still runs after the copy.

## User Impact

Maintainers reading a Mantis verdict on a PR can trust `Overall: pass` again: an unmet expectation can no longer publish as green, and when the agent claims pass anyway the comment says so explicitly. The analysis files the verdict cites are now in the run artifact.

## Evidence

- Regression fixture uses the run 32619081130 shape (candidate `status: pass`, agent-claimed pass, `candidateExpectationMet: false`) and must come out `fail` with the downgrade note; missing judgment is rejected; both-met keeps pass.
- `node scripts/run-vitest.mjs` on the five touched Mantis script suites: 5 files, 64 tests passed.
- `node scripts/check-changed.mjs -- <14 files>`: format, erasability, script/test typecheck, script lint green.
- Autoreview (gpt-5.6-sol, high) on the commit: see land-ready comment.
- No live Mantis run yet; first live exercise of the guard will be the re-dispatch on #127989 after this lands.
