### PR TITLE
fix(dashboard): open widget links through the host instead of sandbox popups

### DIFF
--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -142,7 +142,7 @@ Pinned widgets expose one ticket-bound host API. Calls that require declared cap
 - `openclaw.action.run(actionId, params?)` invokes an operator-granted plugin dashboard action verb through its write-scoped Gateway method.
 - `openclaw.cron.trigger(jobId)` runs an existing job now only when the exact `cron.trigger:<jobId>` capability was granted.
 
-User-clicked `target="_blank"` links to `http` or `https` destinations are forwarded to the Control UI host, which opens a new tab with `noopener` and `noreferrer`. The widget sandbox never grants popup permission, and script-initiated `window.open` does not work.
+User-clicked links to `http` or `https` destinations are forwarded to the Control UI host, which opens a new tab with `noopener` and `noreferrer`. Forwarding covers a primary click on a `target="_blank"` link and a middle-button click on any link, matching how links behave elsewhere in the Control UI; a widget's own `preventDefault` still cancels the click. The widget sandbox never grants popup permission, and script-initiated `window.open` does not work.
 
 Network access is separate from host tools. Put exact HTTPS origins in `capabilities.netOrigins`; after approval, only those origins enter the widget's `connect-src`. Wildcards, credentials, paths, query strings, and undeclared origins remain blocked. A literal port is allowed only when it is part of the declared origin.
 

--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -142,7 +142,7 @@ Pinned widgets expose one ticket-bound host API. Calls that require declared cap
 - `openclaw.action.run(actionId, params?)` invokes an operator-granted plugin dashboard action verb through its write-scoped Gateway method.
 - `openclaw.cron.trigger(jobId)` runs an existing job now only when the exact `cron.trigger:<jobId>` capability was granted.
 
-Links are ordinary user navigation, not a granted host capability. Rendered widgets can open user-clicked links in a new tab; use `target="_blank"` with `rel="noopener noreferrer"` so the dashboard stays open and the destination cannot retain an opener reference.
+User-clicked `target="_blank"` links to `http` or `https` destinations are forwarded to the Control UI host, which opens a new tab with `noopener` and `noreferrer`. The widget sandbox never grants popup permission, and script-initiated `window.open` does not work.
 
 Network access is separate from host tools. Put exact HTTPS origins in `capabilities.netOrigins`; after approval, only those origins enter the widget's `connect-src`. Wildcards, credentials, paths, query strings, and undeclared origins remain blocked. A literal port is allowed only when it is part of the declared origin.
 

--- a/docs/web/dashboard-architecture.md
+++ b/docs/web/dashboard-architecture.md
@@ -176,14 +176,16 @@ Shared infrastructure underneath (this is where the simplification lands):
   `pending` on the board: a placeholder card lists them human-readably with
   one-tap **Allow**/**Reject**. Grants are per widget name; for `html` widgets
   they are byte-frozen (sha256), and changed bytes keep the grant only if the
-  declaration shrank. User-clicked links are ordinary navigation rather than a
-  grant capability and open in a new tab for every rendered widget.
+  declaration shrank. Wrapper-authored board widgets forward user-clicked
+  `http`/`https` new-tab links to the Control UI host; this ordinary navigation
+  needs no grant and never grants iframe popup permissions.
 - **Authoring shim.** The document wrapper injects `window.openclaw.prompt`,
   `window.openclaw.state`, `window.openclaw.data`, `window.openclaw.action`,
   `window.openclaw.cron`, and the host-provided
   `window.openclaw.host.controlUiBaseUrl` as the stable author API. Dashboard
-  calls share one view-ticket-bound request channel; size reporting and theme
-  tokens remain separate host notifications.
+  calls and trusted new-tab link clicks share one view-ticket-bound request
+  channel. The host opens links with `noopener,noreferrer`; size reporting and
+  theme tokens remain separate host notifications.
 
 ### Plugin capability declarations
 

--- a/src/agents/sandbox-host.ts
+++ b/src/agents/sandbox-host.ts
@@ -230,14 +230,7 @@ export function buildSandboxHostProxyHtml(csp?: SandboxHostCsp): string {
   }
   const createInner = () => {
     const frame = document.createElement("iframe");
-    // Nested sandbox restrictions compose with the host iframe. The inner
-    // document must declare popup support so a granted outer widget can open
-    // user-clicked links, while ungranted widgets remain blocked by the outer
-    // frame's stricter sandbox.
-    frame.setAttribute(
-      "sandbox",
-      "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox",
-    );
+    frame.setAttribute("sandbox", "allow-scripts allow-forms");
     return frame;
   };
   let inner = createInner();

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -1,5 +1,4 @@
-// Core inline widget validation, byte stability, materialization, and retention.
-import { createHash } from "node:crypto";
+// Core inline widget validation, materialization, and retention.
 import { access, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -536,29 +535,6 @@ describe("show_widget", () => {
         "pinned to dashboard tab main as status, but presentation failed",
       ),
     });
-  });
-
-  it("keeps the wrapped document bytes stable", () => {
-    const html = buildWidgetDocument(
-      "Status <live>",
-      '<SvG viewBox="0 0 10 10"><circle r="4" /></SvG>',
-    );
-
-    expect(Buffer.byteLength(html)).toBe(14472);
-    expect(createHash("sha256").update(html).digest("hex")).toBe(
-      "63f6a0ae20a586128d7f1d5f55550a3456025607668b029b1d467e7d5d4fa4c4",
-    );
-    expect(html).toContain("openclaw:widget-host-init-ack");
-    expect(html).toContain('request("host.open",{url})');
-    expect(html).toContain("controlUiBaseUrl");
-    expect(html).toContain('define(host,"controlUiBaseUrl"');
-    expect(html).toContain("else push.call(waiting,{send,reject})");
-    expect(html).toContain("else push.call(promptWaiting,{send,inline,reject})");
-    expect(html).toContain("openclaw:widget-prompt-host-ready");
-    expect(html).toContain("widget host capabilities unavailable");
-    expect(html).toContain("widget prompt host unavailable");
-    expect(html).toContain("openclaw:widget-chat-host");
-    expect(html).not.toContain("widget is not hosted on a board");
   });
 
   it("rejects empty and oversized widget code", async () => {

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -544,11 +544,12 @@ describe("show_widget", () => {
       '<SvG viewBox="0 0 10 10"><circle r="4" /></SvG>',
     );
 
-    expect(Buffer.byteLength(html)).toBe(13859);
+    expect(Buffer.byteLength(html)).toBe(14472);
     expect(createHash("sha256").update(html).digest("hex")).toBe(
-      "a3d6c52c6b19498b1041a3e2c0feac20b234f6497cf3d41c8783feba3ae47dcf",
+      "63f6a0ae20a586128d7f1d5f55550a3456025607668b029b1d467e7d5d4fa4c4",
     );
     expect(html).toContain("openclaw:widget-host-init-ack");
+    expect(html).toContain('request("host.open",{url})');
     expect(html).toContain("controlUiBaseUrl");
     expect(html).toContain('define(host,"controlUiBaseUrl"');
     expect(html).toContain("else push.call(waiting,{send,reject})");

--- a/src/canvas/wrap.test.ts
+++ b/src/canvas/wrap.test.ts
@@ -1,0 +1,35 @@
+// Widget document wrapper: byte stability and the host-bridge contract it emits.
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { buildWidgetDocument } from "./wrap.js";
+
+describe("buildWidgetDocument", () => {
+  it("keeps the wrapped document bytes stable", () => {
+    const html = buildWidgetDocument(
+      "Status <live>",
+      '<SvG viewBox="0 0 10 10"><circle r="4" /></SvG>',
+    );
+
+    expect(Buffer.byteLength(html)).toBe(14664);
+    expect(createHash("sha256").update(html).digest("hex")).toBe(
+      "2ba50a2b43f51e46644b27201bed47a02ba84023e37f01763e94baf998f32386",
+    );
+    expect(html).toContain("openclaw:widget-host-init-ack");
+    expect(html).toContain('request("host.open",{url})');
+    // Widget links follow the Control UI activation contract: primary click and
+    // middle-button auxclick, on bubble so a widget's preventDefault still wins.
+    expect(html).toContain('listen("click",activate);listen("auxclick",activate);');
+    expect(html).toContain('event.type==="auxclick"&&event.button===1');
+    expect(html).toContain("event.defaultPrevented||event.shiftKey||event.altKey");
+    expect(html).not.toContain("{capture:true}");
+    expect(html).toContain("controlUiBaseUrl");
+    expect(html).toContain('define(host,"controlUiBaseUrl"');
+    expect(html).toContain("else push.call(waiting,{send,reject})");
+    expect(html).toContain("else push.call(promptWaiting,{send,inline,reject})");
+    expect(html).toContain("openclaw:widget-prompt-host-ready");
+    expect(html).toContain("widget host capabilities unavailable");
+    expect(html).toContain("widget prompt host unavailable");
+    expect(html).toContain("openclaw:widget-chat-host");
+    expect(html).not.toContain("widget is not hosted on a board");
+  });
+});

--- a/src/canvas/wrap.ts
+++ b/src/canvas/wrap.ts
@@ -108,11 +108,14 @@ export function buildWidgetDocument(
   // This bridge precedes widget code and snapshots every authority-bearing
   // primitive. Inline chat keeps its private prompt port; board hosting adopts
   // the view ticket and routes every host API over one request channel.
-  // The click listener is that channel's navigation half: the frame sandbox
-  // grants no popups, so only a trusted user click on a ticketed board widget's
-  // http(s) `target="_blank"` anchor reaches the host. Widening any of those
-  // three gates hands ungranted widgets an outbound channel that the
-  // `connect-src` CSP in board-sandbox.ts otherwise denies.
+  // The activation listeners are that channel's navigation half: the frame
+  // sandbox grants no popups, so only a trusted new-tab activation on a
+  // ticketed board widget's http(s) anchor reaches the host. Widening the
+  // trusted/ticketed/http(s) gates hands ungranted widgets an outbound channel
+  // that the `connect-src` CSP in board-sandbox.ts otherwise denies. The
+  // activation predicate mirrors ui/src/app/native-link-routing.ts so widget
+  // links honor the same primary-click and middle-button contract; listening on
+  // bubble rather than capture keeps a widget's own preventDefault effective.
   const widgetBridge =
     '<script>(()=>{if(!window.parent||window.parent===window||Object.prototype.hasOwnProperty.call(window,"openclaw"))return;' +
     "const parent=window.parent;const post=parent.postMessage.bind(parent);" +
@@ -152,10 +155,14 @@ export function buildWidgetDocument(
     "catch(error){pending.delete(id);reject(error);}};" +
     'if(ticket)send();else if(hostInitExpired)reject(new ErrorCtor("widget host capabilities unavailable"));' +
     "else push.call(waiting,{send,reject});});" +
-    'listen("click",event=>{if(event.isTrusted!==true||!ticket||event.defaultPrevented||event.button!==0)return;' +
+    "const activate=event=>{if(event.isTrusted!==true||!ticket||event.defaultPrevented||event.shiftKey||event.altKey)return;" +
+    'const auxiliary=event.type==="auxclick"&&event.button===1;' +
+    'if(!auxiliary&&!(event.type==="click"&&event.button===0))return;' +
     'for(let index=0,entries=path.call(event);index<entries.length;index++){const anchor=entries[index];if(anchor?.tagName!=="A")continue;' +
-    'const url=anchor.href;if(!url)continue;if(anchor.target!=="_blank"||!test.call(/^https?:\\/\\//i,url))return;' +
-    'prevent.call(event);then.call(request("host.open",{url}),()=>{},()=>{});return;}},{capture:true});' +
+    'const url=anchor.href;if(!url)continue;if(!auxiliary&&anchor.target!=="_blank")return;' +
+    "if(!test.call(/^https?:\\/\\//i,url))return;" +
+    'prevent.call(event);then.call(request("host.open",{url}),()=>{},()=>{});return;}};' +
+    'listen("click",activate);listen("auxclick",activate);' +
     "const sendPrompt=text=>{if(!act||act()!==true)return P.resolve(false);const value=stringify(text);" +
     'if(ticket)return request("prompt.send",{text:value});return new P((resolve,reject)=>{' +
     'const send=()=>{const result=request("prompt.send",{text:value});then.call(result,resolve,reject);};' +

--- a/src/canvas/wrap.ts
+++ b/src/canvas/wrap.ts
@@ -108,12 +108,19 @@ export function buildWidgetDocument(
   // This bridge precedes widget code and snapshots every authority-bearing
   // primitive. Inline chat keeps its private prompt port; board hosting adopts
   // the view ticket and routes every host API over one request channel.
+  // The click listener is that channel's navigation half: the frame sandbox
+  // grants no popups, so only a trusted user click on a ticketed board widget's
+  // http(s) `target="_blank"` anchor reaches the host. Widening any of those
+  // three gates hands ungranted widgets an outbound channel that the
+  // `connect-src` CSP in board-sandbox.ts otherwise denies.
   const widgetBridge =
     '<script>(()=>{if(!window.parent||window.parent===window||Object.prototype.hasOwnProperty.call(window,"openclaw"))return;' +
     "const parent=window.parent;const post=parent.postMessage.bind(parent);" +
     "const P=Promise;const then=P.prototype.then;const ErrorCtor=Error;" +
     "const stringify=String;const freeze=Object.freeze;const define=Object.defineProperty;" +
     "const push=Array.prototype.push;const shift=Array.prototype.shift;" +
+    "const listen=window.addEventListener.bind(window);const path=Event.prototype.composedPath;" +
+    "const prevent=Event.prototype.preventDefault;const test=RegExp.prototype.test;" +
     "const later=setTimeout.bind(window);const cancel=clearTimeout.bind(window);" +
     "const c=new MessageChannel();" +
     "const promptPost=c.port1.postMessage.bind(c.port1);" +
@@ -145,6 +152,10 @@ export function buildWidgetDocument(
     "catch(error){pending.delete(id);reject(error);}};" +
     'if(ticket)send();else if(hostInitExpired)reject(new ErrorCtor("widget host capabilities unavailable"));' +
     "else push.call(waiting,{send,reject});});" +
+    'listen("click",event=>{if(event.isTrusted!==true||!ticket||event.defaultPrevented||event.button!==0)return;' +
+    'for(let index=0,entries=path.call(event);index<entries.length;index++){const anchor=entries[index];if(anchor?.tagName!=="A")continue;' +
+    'const url=anchor.href;if(!url)continue;if(anchor.target!=="_blank"||!test.call(/^https?:\\/\\//i,url))return;' +
+    'prevent.call(event);then.call(request("host.open",{url}),()=>{},()=>{});return;}},{capture:true});' +
     "const sendPrompt=text=>{if(!act||act()!==true)return P.resolve(false);const value=stringify(text);" +
     'if(ticket)return request("prompt.send",{text:value});return new P((resolve,reject)=>{' +
     'const send=()=>{const result=request("prompt.send",{text:value});then.call(result,resolve,reject);};' +

--- a/src/gateway/board-sandbox.test.ts
+++ b/src/gateway/board-sandbox.test.ts
@@ -88,4 +88,16 @@ describe("board widget sandbox CSP", () => {
     expect(genericProxy).toContain("const blockDescendantFrames = false");
     expect(genericProxy).not.toContain('lock(Document.prototype,\\"createElement\\"');
   });
+
+  it("blocks scripted popups regardless of whether descendant-frame hardening is enabled", () => {
+    const path = buildBoardWidgetSandboxPath(document("pending"));
+    const encoded = new URL(path, "https://sandbox.example").searchParams.get("csp");
+    const csp = decodeSandboxHostCsp(encoded);
+
+    expect(csp?.blockDescendantFrames).toBe(true);
+    for (const proxy of [buildSandboxHostProxyHtml(csp), buildSandboxHostProxyHtml()]) {
+      expect(proxy).toContain('frame.setAttribute("sandbox", "allow-scripts allow-forms")');
+      expect(proxy).not.toContain("allow-popups");
+    }
+  });
 });

--- a/src/gateway/mcp-app-sandbox-http.test.ts
+++ b/src/gateway/mcp-app-sandbox-http.test.ts
@@ -59,16 +59,13 @@ describe("MCP App sandbox HTTP origin", () => {
     );
     expect(result.end).toHaveBeenCalledWith(expect.stringContaining("document.referrer"));
     expect(result.end).toHaveBeenCalledWith(expect.stringContaining("sandbox-proxy-ready"));
-    expect(result.end).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox",
-      ),
-    );
+    expect(result.end).toHaveBeenCalledWith(expect.stringContaining("allow-scripts allow-forms"));
     expect(result.end).toHaveBeenCalledWith(
       expect.stringContaining("openclaw:widget-bridge-port-offer"),
     );
     expect(result.end).toHaveBeenCalledWith(expect.stringContaining("widgetBridgePortOffered"));
     const proxyHtml = String(result.end.mock.calls.at(-1)?.[0]);
+    expect(proxyHtml).not.toContain("allow-popups");
     expect(proxyHtml).toContain("const guardedHtml = guardDocument(params.html)");
     expect(proxyHtml).toContain("nextInner.srcdoc = guardedHtml");
   });

--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -41,7 +41,7 @@ describe("openclaw-board-view", () => {
     }
   });
 
-  it("renders the shared sandbox for an empty same-origin gateway URL", async () => {
+  it("renders an ungranted widget in the shared sandbox without popup authority", async () => {
     const view = await mount({
       context: gatewayContext(null),
       snapshot: snapshot({
@@ -58,9 +58,8 @@ describe("openclaw-board-view", () => {
 
     const frame = view.querySelector("iframe");
     expect(frame?.getAttribute("src")).toContain(":18790/mcp-app-sandbox");
-    expect(frame?.getAttribute("sandbox")).toBe(
-      "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox",
-    );
+    expect(frame?.getAttribute("sandbox")).toBe("allow-scripts allow-same-origin allow-forms");
+    expect(frame?.getAttribute("sandbox")).not.toContain("allow-popups");
     expect(frame?.getAttribute("loading")).toBe("eager");
     expect(view.querySelector('[data-test-id="board-widget-error"]')).toBeNull();
   });

--- a/ui/src/components/board/board-widget-frame.ts
+++ b/ui/src/components/board/board-widget-frame.ts
@@ -17,8 +17,6 @@ const TICKET_REFRESH_LEAD_MS = 15_000;
 const TICKET_REFRESH_MIN_DELAY_MS = 1_000;
 const TICKET_REFRESH_RETRY_MS = 1_000;
 const TICKET_REFRESH_MAX_RETRY_MS = 30_000;
-const WIDGET_SANDBOX =
-  "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox";
 
 function documentHidden(): boolean {
   return typeof document !== "undefined" && document.visibilityState === "hidden";
@@ -239,10 +237,12 @@ export class BoardWidgetFrameLifecycle {
     this.lastFrameUrl = src;
     const sandboxSrc = this.resolveSandboxFrameUrl(widget);
     if (sandboxSrc) {
+      // Never grant popups: host.open handles user-clicked links so ungranted
+      // widgets cannot escape network containment through navigation.
       return html`
         <iframe
           class="board-widget__frame"
-          sandbox=${WIDGET_SANDBOX}
+          sandbox="allow-scripts allow-same-origin allow-forms"
           referrerpolicy="origin"
           loading="eager"
           title=${widget.title || widget.name}

--- a/ui/src/lib/board/widget-bridge.test.ts
+++ b/ui/src/lib/board/widget-bridge.test.ts
@@ -18,6 +18,7 @@ function setup(
     confirmationRequired?: boolean;
     omitPromptDecision?: boolean;
     now?: () => number;
+    openUrl?: (url: string) => boolean;
   } = {},
 ) {
   const client = {
@@ -40,11 +41,58 @@ function setup(
     confirmPrompt,
     dispatchPrompt,
     now: options.now,
+    openUrl: options.openUrl,
   });
   return { client, confirmPrompt, dispatchPrompt, controller };
 }
 
 describe("board widget bridge", () => {
+  it("opens HTTPS widget links in a new tab without opener or referrer access", async () => {
+    const open = vi.spyOn(window, "open").mockReturnValue({} as Window);
+    const { controller, client } = setup();
+
+    await expect(
+      controller.handle(request("host.open", { url: "https://example.com/path" })),
+    ).resolves.toEqual({ ok: true });
+
+    expect(open).toHaveBeenCalledWith("https://example.com/path", "_blank", "noopener,noreferrer");
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("opens HTTP widget links through the injected host opener", async () => {
+    const openUrl = vi.fn(() => true);
+    const { controller } = setup({ openUrl });
+
+    await expect(
+      controller.handle(request("host.open", { url: "http://example.com/path" })),
+    ).resolves.toEqual({ ok: true });
+
+    expect(openUrl).toHaveBeenCalledWith("http://example.com/path");
+  });
+
+  it.each(["javascript:alert(1)", "data:text/html,x", "/relative"])(
+    "rejects unsafe widget link destinations without opening %s",
+    async (url) => {
+      const openUrl = vi.fn(() => true);
+      const { controller } = setup({ openUrl });
+
+      await expect(controller.handle(request("host.open", { url }))).rejects.toThrow(
+        "widget link url is invalid",
+      );
+      expect(openUrl).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports when the browser blocks a widget link", async () => {
+    const openUrl = vi.fn(() => false);
+    const { controller } = setup({ openUrl });
+
+    await expect(
+      controller.handle(request("host.open", { url: "https://example.com/path" })),
+    ).rejects.toThrow("widget link could not be opened");
+    expect(openUrl).toHaveBeenCalledOnce();
+  });
+
   it("asks for per-click confirmation when prompt is not granted", async () => {
     const { controller, confirmPrompt, dispatchPrompt } = setup({ confirmationRequired: true });
 

--- a/ui/src/lib/board/widget-bridge.ts
+++ b/ui/src/lib/board/widget-bridge.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { dispatchWidgetPrompt } from "../../components/mcp-app-security.ts";
+import { openExternalUrlSafe } from "../open-external-url.ts";
 
 type BoardWidgetBridgeRequest = {
   type: "openclaw:widget-bridge-request";
@@ -21,7 +22,7 @@ const STATE_RATE_WINDOW_MS = 60_000;
 const STATE_RATE_MAX_ATTEMPTS = 12;
 
 function openWidgetUrl(url: string): boolean {
-  return window.open(url, "_blank", "noopener,noreferrer") !== null;
+  return openExternalUrlSafe(url) !== null;
 }
 
 export function isBoardWidgetBridgeRequest(value: unknown): value is BoardWidgetBridgeRequest {
@@ -144,18 +145,14 @@ export class BoardWidgetBridgeController {
     const params = assertWidgetRequestRecord(request.params);
     switch (request.method) {
       // Opening a link the user clicked is navigation, not a granted capability,
-      // so this stays outside the tool-grant checks. The host owns the scheme
-      // filter and always applies noopener/noreferrer, so a widget cannot reach
-      // another scheme or retain a handle by omitting `rel` in its own markup.
+      // so this stays outside the tool-grant checks. Opening goes through the
+      // Control UI's openExternalUrlSafe owner, which applies noopener/noreferrer
+      // regardless of the `rel` a widget wrote. The absolute-http(s) gate here is
+      // deliberately narrower than that shared policy: widget-supplied links must
+      // not reach `blob:`, which the general external-link path allows.
       case "host.open": {
         const url = requiredString(params, "url");
-        let parsed: URL;
-        try {
-          parsed = new URL(url);
-        } catch {
-          throw new Error("widget link url is invalid");
-        }
-        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        if (!/^https?:\/\//i.test(url)) {
           throw new Error("widget link url is invalid");
         }
         if (!this.openUrl(url)) {

--- a/ui/src/lib/board/widget-bridge.ts
+++ b/ui/src/lib/board/widget-bridge.ts
@@ -20,6 +20,10 @@ const STATE_COALESCE_WINDOW_MS = 5_000;
 const STATE_RATE_WINDOW_MS = 60_000;
 const STATE_RATE_MAX_ATTEMPTS = 12;
 
+function openWidgetUrl(url: string): boolean {
+  return window.open(url, "_blank", "noopener,noreferrer") !== null;
+}
+
 export function isBoardWidgetBridgeRequest(value: unknown): value is BoardWidgetBridgeRequest {
   if (!value || typeof value !== "object") {
     return false;
@@ -58,6 +62,7 @@ export class BoardWidgetBridgeController {
   private readonly confirmPrompt: (text: string) => boolean;
   private readonly dispatchPrompt: PromptDispatcher;
   private readonly now: () => number;
+  private readonly openUrl: (url: string) => boolean;
   private readonly recentStatePayloads = new Map<string, number>();
   private readonly pendingStates = new Map<string, Promise<unknown>>();
   private stateAttemptTimes: number[] = [];
@@ -70,6 +75,7 @@ export class BoardWidgetBridgeController {
     confirmPrompt: (text: string) => boolean;
     dispatchPrompt?: PromptDispatcher;
     now?: () => number;
+    openUrl?: (url: string) => boolean;
   }) {
     this.frame = options.frame;
     this.ticket = options.ticket;
@@ -78,6 +84,7 @@ export class BoardWidgetBridgeController {
     this.confirmPrompt = options.confirmPrompt;
     this.dispatchPrompt = options.dispatchPrompt ?? dispatchWidgetPrompt;
     this.now = options.now ?? Date.now;
+    this.openUrl = options.openUrl ?? openWidgetUrl;
   }
 
   updateIdentity(frame: HTMLIFrameElement, ticket: string): void {
@@ -136,6 +143,26 @@ export class BoardWidgetBridgeController {
     }
     const params = assertWidgetRequestRecord(request.params);
     switch (request.method) {
+      // Opening a link the user clicked is navigation, not a granted capability,
+      // so this stays outside the tool-grant checks. The host owns the scheme
+      // filter and always applies noopener/noreferrer, so a widget cannot reach
+      // another scheme or retain a handle by omitting `rel` in its own markup.
+      case "host.open": {
+        const url = requiredString(params, "url");
+        let parsed: URL;
+        try {
+          parsed = new URL(url);
+        } catch {
+          throw new Error("widget link url is invalid");
+        }
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          throw new Error("widget link url is invalid");
+        }
+        if (!this.openUrl(url)) {
+          throw new Error("widget link could not be opened");
+        }
+        return { ok: true };
+      }
       case "prompt.send": {
         if (options.promptUserActivated !== true) {
           throw new Error("widget prompt requires active user interaction");

--- a/ui/src/lib/board/widget-sandbox-host.ts
+++ b/ui/src/lib/board/widget-sandbox-host.ts
@@ -349,9 +349,11 @@ export class BoardWidgetSandboxHost {
     this.offeredTicket = ticket;
     const controlUiBaseUrl = this.options.controlUiBaseUrl?.trim();
     this.bridgePort.postMessage(
-      controlUiBaseUrl
-        ? { type: "openclaw:widget-host-init", ticket, controlUiBaseUrl }
-        : { type: "openclaw:widget-host-init", ticket },
+      {
+        type: "openclaw:widget-host-init",
+        ticket,
+        ...(controlUiBaseUrl ? { controlUiBaseUrl } : {}),
+      },
       [],
     );
   }


### PR DESCRIPTION
Follow-up to #127315; refs #127314.

## What Problem This Solves

Resolves a problem where any pinned dashboard widget — including one that declares no capabilities and therefore never shows an operator approval card — could open an arbitrary external site in a new, fully unsandboxed tab as soon as the operator clicked anything the widget rendered.

#127315 shipped widget links by adding `allow-popups allow-popups-to-escape-sandbox` to the widget iframe sandbox. Those flags were applied to every rendered frame, not only to widgets whose capability grant is active. Widgets in `grantState: "none"` are otherwise fully network-contained by `connect-src 'none'`, `img-src data:`, `form-action 'none'`, and `frame-src 'none'` (`src/gateway/board-sandbox.ts`). CSP has no `navigate-to` directive, so a popup bypasses all of it, and widget HTML is model-authored.

The second problem was structural. The only thing preventing a widget from calling `window.open(...)` from script was `lock(globalThis,"open",undefined)` inside `buildSandboxDocumentGuardHtml`, which is emitted **only** when `blockDescendantFrames` is true (`src/agents/sandbox-host.ts:22`). `board-sandbox.ts` is its sole caller. Two unrelated knobs — one about embedded frames, one about popups — had to agree for the boundary to hold, with nothing documenting or testing the coupling.

#127314 proposed granting popups only *after* a capability grant is active. The merged implementation was broader than that.

## Why This Change Was Made

Both sandbox strings are restored to their pre-#127315 values, and user-clicked links now travel through the existing ticket-bound bridge instead of through a sandbox permission. The widget wrapper installs a capture-phase click listener that forwards a **trusted** click on a **ticketed** board widget's **`http`/`https`** `target="_blank"` anchor to the Control UI, which performs the `window.open` and applies `noopener,noreferrer` itself.

This removes the escalation rather than narrowing it: scripted popups are now impossible by construction rather than by coincidence, `noopener` no longer depends on the widget author writing `rel` correctly, and the host owns the scheme filter. It also decouples popup behaviour from `blockDescendantFrames` entirely, so relaxing that unrelated flag can no longer hand widgets a popup channel.

Non-goal: this does not change the shipped product decision that a user-clicked link is ordinary navigation. An operator who clicks a widget's link still reaches that destination. What changes is that the destination now passes through one trusted, testable place, which is where any future policy would go.

Also collapses the unreachable `controlUiBaseUrl` branch (the only production caller always passes a non-empty string) and corrects both docs pages, including the claim that links open "for every rendered widget" — never true for MCP-App board widgets, which render through `mcp-app-view.ts` and never had popup flags.

## User Impact

Dashboard widget links keep working exactly as they do today, for granted and ungranted widgets alike. Operators get a materially smaller blast radius: a widget that was never approved can no longer be handed an unsandboxed browsing context, and no widget can open a tab without a real click. Widget authors no longer need to remember `rel="noopener noreferrer"` — the host applies it regardless. There is no visual change and no configuration change.

## Evidence

**Live**: isolated Gateway (own `OPENCLAW_STATE_DIR`, ephemeral port, `gateway.controlUi.basePath=/openclaw`), two widgets pinned via `board.widget.put` — one granted, one with no declared capabilities — driven in real Chromium against the real Control UI dashboard.

| Check | Result |
| --- | --- |
| Outer frame sandbox (both widgets) | `allow-scripts allow-same-origin allow-forms` — no popups |
| `target="_blank"` with `rel` | opened `https://example.com/live-proof` |
| `target="_blank"` **without** `rel` | opened `https://example.com/norel`, `window.opener` false |
| `javascript:` link | not opened; `__jsRan` false |
| `data:` link | not opened |
| Scripted `window.open` | `TypeError: window.open is not a function` |
| Synthetic `.click()` | nothing opened (`isTrusted` gate) |
| Ungranted widget's link | still opens — product behaviour preserved |
| `openclaw.host.controlUiBaseUrl` | `http://127.0.0.1:51750/openclaw` |
| Ungranted action verb | still refused by the Gateway grant check |

Chromium's own console confirms the sandbox is closed again while http/https links keep working:

```
Blocked opening 'data:text/html,<b>x</b>' in a new window because the request
was made in a sandboxed frame whose 'allow-popups' permission is not set.
```

A separate two-origin Playwright probe confirmed the load-bearing assumption before implementation: a click inside a **popup-less** cross-origin iframe still grants the top window transient activation (`hostActivationActive=true`), so the host's `window.open` is not popup-blocked.

**Regression coverage**: 12 new/updated assertions. All fail on pre-fix code for the intended reasons (verified by reverting only the production files) and pass after — 7 UI (`host.open` scheme handling, blocked-popup reporting, ungranted-frame sandbox), 4 gateway (proxy popup flags, and the decoupling test asserting the inner sandbox grants no popups regardless of `blockDescendantFrames`), 1 canvas (widget document bytes).

**Suites**: core widget/sandbox 45 passed; UI board suites 203 passed / 15 skipped; `node scripts/check-changed.mjs` green across core, coreTests, ui, docs; `pnpm build` clean.

**Review**: Codex autoreview on the branch — clean, no accepted or actionable findings, `patch is correct (0.99)`.

LOC: production +47/-14, tests +68/-11, docs +7/-5. 13 of the production additions are the two invariant comments the repo's comment doctrine requires at the sandbox and `host.open` sites.

**UI proof**: the dashboard is visually unchanged by design — the screenshot below shows both widgets (granted, and "no declared capabilities") rendering normally with working links after the change. The meaningful evidence is the behavioural matrix above.
