### PR TITLE
improve(outbound): reduce chunk planning overhead

### DIFF
--- a/src/infra/outbound/message-plan.ts
+++ b/src/infra/outbound/message-plan.ts
@@ -83,15 +83,6 @@ function withPlannedReplyTo(
   return consumeReplyTo ? consumeReplyTo({ ...overrides }) : { ...overrides };
 }
 
-function withChunkedTextFormatting(
-  overrides: OutboundMessageSendOverrides,
-  formatting?: OutboundDeliveryFormattingOptions,
-): OutboundMessageSendOverrides {
-  return formatting
-    ? { ...overrides, formatting: { ...overrides.formatting, ...formatting } }
-    : overrides;
-}
-
 function chunkTextForPlan(params: {
   text: string;
   limit: number;
@@ -117,28 +108,32 @@ export function planOutboundTextMessageUnits(params: {
   formatting?: OutboundDeliveryFormattingOptions;
   consumeReplyTo?: PlanReplyToConsumption;
 }): OutboundMessageUnit[] {
-  const planTextUnit = (text: string, deliveryPartIndex: number): OutboundMessageUnit => ({
-    kind: "text",
-    text,
-    overrides: {
+  const planTextUnit = (
+    text: string,
+    deliveryPartIndex: number,
+    chunkedTextFormatting?: OutboundDeliveryFormattingOptions,
+  ): OutboundMessageUnit => {
+    const overrides = {
       ...withPlannedReplyTo(params.overrides, params.consumeReplyTo),
       deliveryPartIndex,
-    },
-  });
-  const planChunkedTextUnit = (text: string, deliveryPartIndex: number): OutboundMessageUnit => {
-    const unit = planTextUnit(text, deliveryPartIndex);
+    };
     return {
-      ...unit,
-      overrides: withChunkedTextFormatting(unit.overrides, params.chunkedTextFormatting),
+      kind: "text",
+      text,
+      overrides: chunkedTextFormatting
+        ? { ...overrides, formatting: { ...overrides.formatting, ...chunkedTextFormatting } }
+        : overrides,
     };
   };
 
   const withDeliveryTopology = (units: OutboundMessageUnit[]): OutboundMessageUnit[] => {
     const deliveryPartCount = units.length;
-    return units.map((unit) => ({
-      ...unit,
-      overrides: { ...unit.overrides, deliveryPartCount },
-    }));
+    // These units are planner-owned until return; finalize them in place rather
+    // than cloning every chunk solely to attach the shared fan-out count.
+    for (const unit of units) {
+      unit.overrides.deliveryPartCount = deliveryPartCount;
+    }
+    return units;
   };
 
   if (!params.chunker || params.textLimit === undefined) {
@@ -167,7 +162,7 @@ export function planOutboundTextMessageUnits(params: {
         chunks.push(blockChunk);
       }
       for (const chunk of chunks) {
-        units.push(planChunkedTextUnit(chunk, units.length));
+        units.push(planTextUnit(chunk, units.length, params.chunkedTextFormatting));
       }
     }
     return withDeliveryTopology(units);
@@ -179,7 +174,7 @@ export function planOutboundTextMessageUnits(params: {
       limit: params.textLimit,
       chunker: params.chunker,
       formatting: params.formatting,
-    }).map(planChunkedTextUnit),
+    }).map((chunk, index) => planTextUnit(chunk, index, params.chunkedTextFormatting)),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Large or heavily chunked outbound messages performed two avoidable object-copy passes per planned text unit. The shared outbound planner first rebuilt formatted units and then cloned every unit and overrides object again solely to attach the common delivery-part count, increasing CPU time and garbage-collection pressure on reply and channel delivery paths.

## Why This Change Was Made

The planner now builds each chunk's final formatting overrides once and attaches the common part count directly to its fresh, planner-owned units before returning them. Caller-owned overrides remain cloned, each returned unit and overrides object remains independent, and chunking, reply consumption, delivery topology, errors, and output property order are unchanged.

Open PR #110402 also touches the newline-planning branch, but proposes a separate visible paragraph-grouping policy change. This PR preserves the current newline packing contract and only removes redundant planner-owned copies.

## User Impact

Chunk-heavy outbound replies use less CPU and temporary memory while producing the same sends. There is no user-visible formatting, grouping, reply, media, or delivery behavior change.

## Evidence

- Current-main owner benchmark, 100,000 formatted text units, 9 measured rounds with GC between rounds:
  - before: 16.600 ms median, 47,407,584 B median measured allocation
  - after: 13.099 ms median, 33,063,408 B
  - 21.1% lower median planning time and 30.3% lower measured allocation
- Exact pre/post differential: byte-identical 3,948-byte semantic snapshot, SHA-256 `c80835529d03f96fe0e68e3c83ec3c1107e74058ef4eb948d480936c4d3bc8cd`. It covers unchunked, ordinary/newline/Markdown chunking, formatting context and ownership, empty chunk output/fallback, single-use reply callback order, thrown callback errors, getter reads, media topology, and unit/override uniqueness.
- `pnpm test src/infra/outbound/message-plan.test.ts` — 4/4 passed on the final rebased head.
- `pnpm test src/infra/outbound/deliver.test.ts src/plugin-sdk/reply-payload.test.ts src/channels/plugins/contracts/outbound-payload.contract.test.ts` — 255/255 sibling and boundary tests passed.
- `node scripts/check-changed.mjs -- src/infra/outbound/message-plan.ts` — passed core production/test typechecks, Oxlint, format, dead-export, import-cycle, storage/media/runtime, and repository guard lanes.
- `pnpm build` — passed all phases.
- Bundled autoreview: TruffleHog clean; Codex `gpt-5.6-sol`/high; no P0/P1 findings; correctness 0.96.
- Test-audit disposition: no allocation/call-count test was retained because it would couple behavior coverage to this implementation. Existing output contracts plus the exact differential protect the public behavior.

Production LOC: +20/-25 (net -5). Tests: +0/-0.

AI-assisted: yes. The patch was reproduced, benchmarked, behavior-differentially checked, reviewed, and validated against the owner and delivery boundaries.
