### PR TITLE
fix(mcp): keep add from replacing existing servers

### DIFF
--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { setConfiguredMcpServer } from "../agents/mcp-config-mutation.js";
 import { withTempHome } from "../config/home-env.test-harness.js";
 import {
   cleanupMcpCliTestState,
@@ -29,7 +30,7 @@ describe("mcp cli", () => {
     await cleanupMcpCliTestState();
   });
 
-  it("sets and shows a configured MCP server", async () => {
+  it("sets, replaces, and shows a configured MCP server", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async (home) => {
       const workspaceDir = await createWorkspace();
       const configPath = path.join(home, ".openclaw", "openclaw.json");
@@ -37,10 +38,16 @@ describe("mcp cli", () => {
 
       await runMcpCommand(["mcp", "set", "context7", '{"command":"uvx","args":["context7-mcp"]}']);
       expect(lastLogLine()).toBe(`Saved MCP server "context7" to ${configPath}.`);
+      await runMcpCommand([
+        "mcp",
+        "set",
+        "context7",
+        '{"command":"uvx","args":["context7-mcp@2"]}',
+      ]);
 
       mockLog.mockClear();
       await runMcpCommand(["mcp", "show", "context7", "--json"]);
-      expect(JSON.parse(lastLogLine())).toEqual({ command: "uvx", args: ["context7-mcp"] });
+      expect(JSON.parse(lastLogLine())).toEqual({ command: "uvx", args: ["context7-mcp@2"] });
     });
   });
 
@@ -88,6 +95,84 @@ describe("mcp cli", () => {
         connectionTimeoutMs: 3_000,
         supportsParallelToolCalls: true,
         codex: { defaultToolsApprovalMode: "approve" },
+      });
+    });
+  });
+
+  it("rejects an existing MCP server before probing", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      await runMcpCommand(["mcp", "set", "docs", '{"command":"node","args":["existing.mjs"]}']);
+      const probe = vi.fn(() => {
+        throw new Error("duplicate add attempted a probe");
+      });
+      setCreateSessionMcpRuntimeOverride(probe);
+
+      await expect(runMcpCommand(["mcp", "add", "docs", "--command", "uvx"])).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      expect(probe).not.toHaveBeenCalled();
+      expect(lastErrorLine()).toBe('MCP server "docs" already exists.');
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "docs", "--json"]);
+      expect(JSON.parse(lastLogLine())).toEqual({
+        command: "node",
+        args: ["existing.mjs"],
+      });
+    });
+  });
+
+  it("does not replace an MCP server added while probing", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      let competitorWon = false;
+      setCreateSessionMcpRuntimeOverride((params) => ({
+        sessionId: params.sessionId,
+        workspaceDir: params.workspaceDir,
+        configFingerprint: "cli-probe-race",
+        createdAt: 0,
+        lastUsedAt: 0,
+        getCatalog: async () => {
+          const result = await setConfiguredMcpServer({
+            name: "docs",
+            server: { command: "node", args: ["winner.mjs"] },
+            createOnly: true,
+          });
+          competitorWon = result.ok;
+          return {
+            version: 1,
+            generatedAt: Date.now(),
+            servers: {
+              docs: {
+                serverName: "docs",
+                launchSummary: "node winner.mjs",
+                toolCount: 0,
+              },
+            },
+            tools: [],
+            diagnostics: [],
+          };
+        },
+        peekCatalog: () => null,
+        markUsed: () => {},
+        callTool: async () => ({ content: [] }),
+        dispose: async () => {},
+      }));
+
+      await expect(runMcpCommand(["mcp", "add", "docs", "--command", "uvx"])).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      expect(competitorWon).toBe(true);
+      expect(lastErrorLine()).toBe('MCP server "docs" already exists.');
+      mockLog.mockClear();
+      await runMcpCommand(["mcp", "show", "docs", "--json"]);
+      expect(JSON.parse(lastLogLine())).toEqual({
+        command: "node",
+        args: ["winner.mjs"],
       });
     });
   });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -1097,6 +1097,10 @@ export function registerMcpCli(program: Command) {
         if (!loaded.ok) {
           fail(loaded.error);
         }
+        const targetName = name.trim();
+        if (targetName && Object.hasOwn(loaded.mcpServers, targetName)) {
+          fail(`MCP server ${JSON.stringify(targetName)} already exists.`);
+        }
         const shouldProbe =
           opts.probe !== false && server.enabled !== false && server.auth !== "oauth";
         if (shouldProbe) {
@@ -1106,7 +1110,7 @@ export function registerMcpCli(program: Command) {
             servers: { [name]: server },
           });
         }
-        const result = await setConfiguredMcpServer({ name, server });
+        const result = await setConfiguredMcpServer({ name, server, createOnly: true });
         if (!result.ok) {
           fail(result.error);
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw mcp add <name>` could silently replace an already configured MCP server with the same name. A server added concurrently while the new candidate was being probed could also be overwritten.

## Why This Change Was Made

`mcp add` now rejects a visible duplicate before making probe contact and uses the config mutation owner's create-only guard for the final write. This keeps `mcp set` as the explicit replacement command while making duplicate admission race-safe.

## User Impact

Users can rely on `mcp add` to create a new named server only. Existing configuration is preserved and the command reports an error when the name is already in use.

## Evidence

- Previous-base regression: focused CLI tests failed both the visible-duplicate and probe-interleaving cases (27 passed, 2 failed).
- `node scripts/run-vitest.mjs src/cli/mcp-cli.test.ts src/config/mcp-config.test.ts src/agents/mcp-config-mutation.test.ts` — 46 passed across 3 shards on the final rebased head.
- Isolated real CLI flow — first add succeeded; duplicate add exited 1 with `MCP server "demo" already exists.`; persisted command remained the original `/bin/true`.
- `node scripts/check-changed.mjs -- src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts` — passed all selected core production/test typechecks, lint, formatting, and repository guards.
- `git diff --check origin/main...HEAD` — passed.
- Final branch autoreview — no accepted/actionable findings, 0.99 confidence.

AI-assisted: yes. Peter Steinberger reviewed the behavior, owner boundary, regression proof, and final diff. No agent transcript is included.
