### PR TITLE
fix(feishu): preserve all accepted voice fallback content

### DIFF
--- a/extensions/feishu/src/reply-delivery-result.ts
+++ b/extensions/feishu/src/reply-delivery-result.ts
@@ -74,12 +74,17 @@ export function mergeFeishuReplyDeliveryResults(
   content?: string,
 ): FeishuReplyDeliveryResult {
   const visible = results.filter((result) => result.visibleReplySent === true);
+  const acceptedContent = visible.flatMap((result) =>
+    result.content === undefined ? [] : [result.content],
+  );
   return createFeishuReplyDeliveryResult({
     results: visible,
     visibleReplySent: visible.length > 0,
     content:
       content === undefined
-        ? results.find((result) => result.content !== undefined)?.content
+        ? acceptedContent.length > 0
+          ? acceptedContent.join("\n\n")
+          : undefined
         : content,
   });
 }

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2381,6 +2381,71 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("reports every accepted voice upload fallback in the successful delivery result", async () => {
+    sendMediaFeishuMock
+      .mockRejectedValueOnce(new Error("first upload failed"))
+      .mockRejectedValueOnce(new Error("second upload failed"));
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "om-first-fallback" })
+      .mockResolvedValueOnce({ messageId: "om-second-fallback" });
+    const { options } = createDispatcherHarness();
+
+    const delivery = await options.deliver(
+      {
+        text: "spoken reply",
+        mediaUrls: ["https://example.com/first.mp3", "https://example.com/second.mp3"],
+        audioAsVoice: true,
+      },
+      { kind: "final" },
+    );
+
+    expect(delivery).toMatchObject({
+      messageIds: ["om-first-fallback", "om-second-fallback"],
+      visibleReplySent: true,
+      content:
+        "spoken reply\n\n📎 https://example.com/first.mp3\n\n📎 https://example.com/second.mp3",
+    });
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains every accepted voice upload fallback when a later fallback fails", async () => {
+    sendMediaFeishuMock
+      .mockRejectedValueOnce(new Error("first upload failed"))
+      .mockRejectedValueOnce(new Error("second upload failed"))
+      .mockRejectedValueOnce(new Error("third upload failed"));
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "om-first-fallback" })
+      .mockResolvedValueOnce({ messageId: "om-second-fallback" })
+      .mockRejectedValueOnce(new Error("third fallback failed"));
+    const { options } = createDispatcherHarness();
+
+    const error = await options
+      .deliver(
+        {
+          text: "spoken reply",
+          mediaUrls: [
+            "https://example.com/first.mp3",
+            "https://example.com/second.mp3",
+            "https://example.com/third.mp3",
+          ],
+          audioAsVoice: true,
+        },
+        { kind: "final" },
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["om-first-fallback", "om-second-fallback"],
+        visibleReplySent: true,
+        content:
+          "spoken reply\n\n📎 https://example.com/first.mp3\n\n📎 https://example.com/second.mp3",
+      },
+    });
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(3);
+  });
+
   it("does not leak local media paths in the upload failure fallback", async () => {
     const mediaPath = path.join(os.tmpdir(), "openclaw-feishu-reply-local-voice.mp3");
     sendMediaFeishuMock.mockRejectedValueOnce(new Error("media failed"));

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1495,7 +1495,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           hasVoiceMedia && hasText ? { fallbackText: text } : undefined,
         );
       }
-      const result = mergeFeishuReplyDeliveryResults(deliveredResults, text);
+      const deliveredContent = hasVoiceMedia ? (deliveredResults.at(-1)?.content ?? text) : text;
+      const result = mergeFeishuReplyDeliveryResults(deliveredResults, deliveredContent);
       if (priorClosedStreamingSettlement?.error !== undefined) {
         throw createFeishuPartialReplyDeliveryError(
           isChannelPartialDeliveryError(priorClosedStreamingSettlement.error) &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu users sending voice replies with multiple attachment upload failures would receive the recovery links in chat, but downstream delivery results and `message_sent` hooks would report only the original spoken caption or the first accepted fallback message. If a later fallback also failed, the partial-delivery error similarly lost already accepted recovery content even though both provider message IDs were retained.

## Why This Change Was Made

The Feishu plugin's private delivery-result owner now aggregates every provider-visible accepted body in delivery order while preserving explicit content overrides and provider receipt identities. The final voice-delivery result uses the actual accepted fallback content when available, without changing streaming snapshots, ordinary text replies, native voice delivery, degraded voice behavior, provider retries, plugin SDK contracts, or configuration.

## User Impact

Feishu delivery events, hooks, and partial-failure diagnostics now truthfully describe every recovery message that users actually received, including multiple attachment links, without duplicate sends.

## Evidence

- Regression-first proof: two real existing Feishu dispatcher/provider boundary cases failed on unchanged `main`: successful delivery of two fallback links reported only `spoken reply`; a failed third fallback reported only the first accepted fallback body despite retaining both message IDs.
- Both new cases pass after the owner-boundary repair: `node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts -t 'voice upload fallback'`.
- Full owning and sibling suites: `node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/media.test.ts extensions/feishu/src/send-result.test.ts` — **4 files, 273 tests passed**.
- Repository max-lines and assertion-safety ratchets, focused formatting, targeted extension lint, and `git diff --check` all pass.
- Independent full-source review and fresh authenticated Codex structured review of the complete committed branch both found no actionable issues.
- Production delta: **+6 lines**, required to retain all accepted provider-visible content at its existing private ownership boundary; no public SDK, config, auth, security, or protocol changes.
- Live Feishu account proof was unavailable because this task does not have an authenticated test Feishu account; the existing real dispatcher boundary was exercised with provider fault injection instead.
- Named follow-up, intentionally outside this invariant: accepted text/card sends that lack a provider receipt currently lose their accepted chunk body at the separate chunk-delivery producer.
