### PR TITLE
refactor(backup): unify required path resolution

### DIFF
--- a/src/commands/backup-git.ts
+++ b/src/commands/backup-git.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import path from "node:path";
 import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -18,7 +17,8 @@ import { recordBackupRunOutcome } from "../state/backup-run-records.js";
 import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { resolveUserPath, shortenHomePath } from "../utils.js";
+import { shortenHomePath } from "../utils.js";
+import { resolveRequiredBackupPath } from "./backup-shared.js";
 
 type BackupGitCreateOptions = {
   repository?: string;
@@ -37,14 +37,6 @@ type BackupGitScopeOptions = {
 
 export const GIT_BACKUP_PUSH_CREDENTIAL_WARNING =
   "Warning: pushed backup history contains credential material; keep the Git remote private.";
-
-function resolveRequiredPath(value: string | undefined, label: string): string {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    throw new Error(`Missing required ${label} value.`);
-  }
-  return path.resolve(resolveUserPath(trimmed));
-}
 
 async function resolveCreateDatabases(runtime: RuntimeEnv, options: BackupGitCreateOptions) {
   const normalizedAgents = [
@@ -151,7 +143,7 @@ export async function backupGitInitCommand(
   options: { repository?: string; remote?: string; json?: boolean },
 ): Promise<{ repositoryPath: string }> {
   const result = await initializeGitBackupRepository({
-    repositoryPath: resolveRequiredPath(options.repository, "--repository"),
+    repositoryPath: resolveRequiredBackupPath(options.repository, "--repository"),
     stateDir: resolveStateDir(),
     remote: options.remote,
   });
@@ -164,7 +156,7 @@ export async function backupGitInitCommand(
 }
 
 export async function backupGitCreateCommand(runtime: RuntimeEnv, options: BackupGitCreateOptions) {
-  const repositoryPath = resolveRequiredPath(options.repository, "--repository");
+  const repositoryPath = resolveRequiredBackupPath(options.repository, "--repository");
   if (options.push && !options.excludeSecrets) {
     runtime.error(GIT_BACKUP_PUSH_CREDENTIAL_WARNING);
   }
@@ -211,7 +203,7 @@ export async function backupGitLogCommand(
   runtime: RuntimeEnv,
   options: { repository?: string; limit?: number; json?: boolean },
 ) {
-  const repositoryPath = resolveRequiredPath(options.repository, "--repository");
+  const repositoryPath = resolveRequiredBackupPath(options.repository, "--repository");
   const limit = options.limit ?? 20;
   if (!Number.isSafeInteger(limit) || limit < 1) {
     throw new Error("--limit must be a positive integer.");
@@ -234,7 +226,7 @@ export async function backupGitVerifyCommand(
   options: BackupGitScopeOptions & { repository?: string; ref?: string; json?: boolean },
 ) {
   const result = await verifyGitBackupRef({
-    repositoryPath: resolveRequiredPath(options.repository, "--repository"),
+    repositoryPath: resolveRequiredBackupPath(options.repository, "--repository"),
     identity: resolveOneIdentity(options),
     ref: options.ref,
   });
@@ -259,10 +251,10 @@ export async function backupGitRestoreCommand(
   },
 ) {
   const result = await restoreGitBackupRef({
-    repositoryPath: resolveRequiredPath(options.repository, "--repository"),
+    repositoryPath: resolveRequiredBackupPath(options.repository, "--repository"),
     identity: resolveOneIdentity(options),
     ref: options.ref,
-    targetPath: resolveRequiredPath(options.target, "--target"),
+    targetPath: resolveRequiredBackupPath(options.target, "--target"),
   });
   if (options.json) {
     writeRuntimeJson(runtime, result);

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -5,8 +5,12 @@ import * as tar from "tar";
 import { resolveStateDir } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
-import { resolveUserPath, shortenHomePath } from "../utils.js";
-import { BACKUP_MAX_DECOMPRESSION_RATIO, canonicalizePathForContainment } from "./backup-shared.js";
+import { shortenHomePath } from "../utils.js";
+import {
+  BACKUP_MAX_DECOMPRESSION_RATIO,
+  canonicalizePathForContainment,
+  resolveRequiredBackupPath,
+} from "./backup-shared.js";
 import { verifyBackupArchive } from "./backup-verify.js";
 import { isPathWithin } from "./cleanup-utils.js";
 
@@ -36,14 +40,6 @@ type BackupRestoreResult = {
   symlinkCount: number;
   warnings: string[];
 };
-
-function resolveRequiredTarget(value: string | undefined): string {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    throw new Error("Missing required --target value.");
-  }
-  return path.resolve(resolveUserPath(trimmed));
-}
 
 async function assertTargetOutsideLiveState(targetPath: string): Promise<void> {
   const [canonicalTarget, canonicalStateDir] = await Promise.all([
@@ -127,7 +123,7 @@ export async function backupRestoreCommand(
   runtime: RuntimeEnv,
   options: BackupRestoreOptions,
 ): Promise<BackupRestoreResult> {
-  const targetPath = resolveRequiredTarget(options.target);
+  const targetPath = resolveRequiredBackupPath(options.target, "--target");
   await assertTargetOutsideLiveState(targetPath);
   const verified = await verifyBackupArchive(options.archive);
   const target = await prepareRestoreTarget(targetPath);

--- a/src/commands/backup-schedule.ts
+++ b/src/commands/backup-schedule.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
 import {
   callGatewayFromCli,
@@ -11,8 +10,9 @@ import type { CronJob } from "../cron/types.js";
 import { executeGitCommand } from "../infra/git-exec.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { resolveUserPath, shortenHomePath } from "../utils.js";
+import { shortenHomePath } from "../utils.js";
 import { GIT_BACKUP_PUSH_CREDENTIAL_WARNING } from "./backup-git.js";
+import { resolveRequiredBackupPath } from "./backup-shared.js";
 
 const BACKUP_CRON_JOB_NAME = "openclaw-backup-scheduled";
 const LOCAL_GATEWAY_REQUIRED_ERROR =
@@ -42,14 +42,6 @@ function resolveScheduledRedaction(options: BackupScheduleOptions): boolean {
     return options.excludeSecrets === true;
   }
   return options.includeSecrets !== true;
-}
-
-function resolveRepository(value: string | undefined): string {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    throw new Error("Missing required --repository value.");
-  }
-  return path.resolve(resolveUserPath(trimmed));
 }
 
 function buildScheduledArgv(
@@ -106,7 +98,7 @@ export async function backupEnableCommand(
   options: BackupScheduleOptions,
 ): Promise<{ id: string; updated: boolean }> {
   await assertLocalGatewayScheduleTarget(options);
-  const repositoryPath = resolveRepository(options.repository);
+  const repositoryPath = resolveRequiredBackupPath(options.repository, "--repository");
   const every = options.every?.trim() || "24h";
   const everyMs = parseDurationMs(every, { defaultUnit: "ms" });
   if (!Number.isSafeInteger(everyMs) || everyMs <= 0) {

--- a/src/commands/backup-shared.test.ts
+++ b/src/commands/backup-shared.test.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveRequiredBackupPath } from "./backup-shared.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolveRequiredBackupPath", () => {
+  it.each([
+    [undefined, "--repository"],
+    ["", "--target"],
+    ["   ", "<snapshot>"],
+    ["\t", "--scratch"],
+  ] as const)("rejects %j for %s", (value, label) => {
+    expect(() => resolveRequiredBackupPath(value, label)).toThrow(
+      `Missing required ${label} value.`,
+    );
+  });
+
+  it("trims and resolves relative paths from cwd", () => {
+    expect(resolveRequiredBackupPath("  backups/archive  ", "--target")).toBe(
+      path.resolve("backups/archive"),
+    );
+  });
+
+  it("expands tilde from the effective home", () => {
+    const home = path.resolve("effective-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    expect(resolveRequiredBackupPath("~/backups", "--repository")).toBe(path.join(home, "backups"));
+  });
+
+  it("preserves absolute paths", () => {
+    const absolute = path.resolve("absolute-backup");
+    expect(resolveRequiredBackupPath(`  ${absolute}  `, "--scratch")).toBe(absolute);
+  });
+});

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -7,13 +7,24 @@ import {
   resolveOAuthDir,
   resolveStateDir,
 } from "../config/config.js";
-import { pathExists, shortenHomePath } from "../utils.js";
+import { pathExists, resolveUserPath, shortenHomePath } from "../utils.js";
 import { buildCleanupPlan, isPathWithin } from "./cleanup-utils.js";
 import { planUpgradeConfigRepair } from "./doctor/shared/automatic-upgrade-config-repair.js";
 
 // DEFLATE can legitimately encode zero-filled sparse ranges just over 1000:1.
 // Keep bounded headroom without disabling node-tar's decompression bomb guard.
 export const BACKUP_MAX_DECOMPRESSION_RATIO = 1100;
+
+export function resolveRequiredBackupPath(
+  value: string | undefined,
+  label: "--repository" | "--target" | "<snapshot>" | "--scratch",
+): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new Error(`Missing required ${label} value.`);
+  }
+  return resolveUserPath(trimmed);
+}
 
 type BackupAssetKind = "state" | "config" | "credentials" | "workspace";
 type BackupSkipReason = "covered" | "missing";

--- a/src/commands/backup-sqlite.ts
+++ b/src/commands/backup-sqlite.ts
@@ -15,7 +15,8 @@ import type {
 import { recordBackupRunOutcome } from "../state/backup-run-records.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { resolveUserPath, shortenHomePath } from "../utils.js";
+import { shortenHomePath } from "../utils.js";
+import { resolveRequiredBackupPath } from "./backup-shared.js";
 
 type BackupSqliteCreateOptions = {
   global?: boolean;
@@ -76,7 +77,7 @@ export async function backupSqliteCreateCommand(
   runtime: RuntimeEnv,
   options: BackupSqliteCreateOptions,
 ): Promise<BackupSqliteCreateResult> {
-  const repositoryPath = resolveRequiredPath(options.repository, "--repository");
+  const repositoryPath = resolveRequiredBackupPath(options.repository, "--repository");
   try {
     const database = await resolveSnapshotDatabase(options);
     const result = await createLocalSqliteSnapshotProvider({ repositoryPath }).create(database);
@@ -118,7 +119,7 @@ export async function backupSqliteListCommand(
   runtime: RuntimeEnv,
   options: BackupSqliteRepositoryOptions,
 ): Promise<BackupSqliteListResult> {
-  const repositoryPath = resolveRequiredPath(options.repository, "--repository");
+  const repositoryPath = resolveRequiredBackupPath(options.repository, "--repository");
   const snapshots = await createLocalSqliteSnapshotProvider({
     repositoryPath,
     ...OPENCLAW_SNAPSHOT_READ_OPTIONS,
@@ -154,7 +155,7 @@ export async function backupSqliteRestoreCommand(
   options: BackupSqliteRestoreOptions,
 ): Promise<BackupSqliteRestoreResult> {
   const resolved = resolveSnapshot(snapshot);
-  const targetPath = resolveRequiredPath(options.target, "--target");
+  const targetPath = resolveRequiredBackupPath(options.target, "--target");
   const restored = await resolved.provider.restoreFresh(resolved.ref, targetPath);
   const report: BackupSqliteRestoreResult = {
     ok: true,
@@ -202,10 +203,10 @@ function resolveSnapshot(
   provider: ReturnType<typeof createLocalSqliteSnapshotProvider>;
   ref: SnapshotRef;
 } {
-  const snapshotPath = resolveRequiredPath(snapshot, "<snapshot>");
+  const snapshotPath = resolveRequiredBackupPath(snapshot, "<snapshot>");
   const repositoryPath = path.dirname(snapshotPath);
   const validationRootPath = scratch
-    ? resolveRequiredPath(scratch, "--scratch")
+    ? resolveRequiredBackupPath(scratch, "--scratch")
     : path.dirname(repositoryPath);
   return {
     provider: createLocalSqliteSnapshotProvider({
@@ -215,14 +216,6 @@ function resolveSnapshot(
     }),
     ref: { path: snapshotPath },
   };
-}
-
-function resolveRequiredPath(value: string | undefined, label: string): string {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    throw new Error(`Missing required ${label} value.`);
-  }
-  return path.resolve(resolveUserPath(trimmed));
 }
 
 function formatDatabaseIdentity(database: SnapshotDatabaseManifest): string {


### PR DESCRIPTION
## What Problem This Solves

Backup commands independently normalized required repository, target, snapshot, and scratch paths. The duplicate policy could drift across Git backup, SQLite backup, whole-archive restore, and scheduled backup flows.

## Why This Change Was Made

`backup-shared.ts` now owns required backup path validation and user-path resolution. All four command surfaces call that canonical helper in their existing order, preserving exact missing-value errors, whitespace trimming, effective-home expansion, relative-path resolution, and absolute paths.

This removes four local wrappers without changing CLI, configuration, storage, or backup behavior. Production delta: +37/-53 (net -16).

## User Impact

No intended user-visible change. Backup path handling remains consistent while the duplicated policy is removed.

## Evidence

- `node scripts/run-vitest.mjs src/commands/backup-shared.test.ts` - 7 passed
- `node scripts/run-vitest.mjs src/commands/backup-git.test.ts` - 8 passed
- `node scripts/run-vitest.mjs src/commands/backup-sqlite.test.ts` - 10 passed
- `node scripts/run-vitest.mjs src/commands/backup-restore.test.ts` - 7 passed
- `node scripts/run-vitest.mjs src/commands/backup-schedule.test.ts` - 9 passed
- Targeted `oxfmt` and `git diff --check` passed
- Autoreview passed with no actionable findings
- `check-changed` passed its source guards, formatting, dead-export scan, core typecheck, and lint. Its core-test typecheck stopped on missing shared-install UI dependencies (`@panzoom/panzoom` and `pako` typings), unrelated to these backup command files; repository policy forbids dependency installation inside this GWT.
