### PR TITLE
fix(macos): preserve externally owned Gateways in attach-only mode

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -170,8 +170,8 @@ enum GatewayLaunchAgentManager {
             self.logger.info("launchd change skipped (remote mode)")
             return nil
         }
-        if enabled, self.isLaunchAgentWriteDisabled() {
-            self.logger.info("launchd enable skipped (disable marker set)")
+        if self.isLaunchAgentWriteDisabled() {
+            self.logger.info("launchd change skipped (disable marker set)")
             return nil
         }
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -187,9 +187,19 @@ struct GatewayLaunchAgentManagerTests {
             GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
 
             let error = GatewayLaunchAgentManager.applyAttachOnlyRuntimeOverride()
+            let installError = await GatewayLaunchAgentManager.set(
+                enabled: true,
+                bundlePath: "/Applications/OpenClaw.app",
+                port: 18789)
+            let uninstallError = await GatewayLaunchAgentManager.set(
+                enabled: false,
+                bundlePath: "/Applications/OpenClaw.app",
+                port: 18789)
             let kickstartError = await GatewayLaunchAgentManager.kickstart()
 
             #expect(error == nil)
+            #expect(installError == nil)
+            #expect(uninstallError == nil)
             #expect(kickstartError == nil)
             #expect(FileManager().fileExists(atPath: marker.path))
             #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running the macOS app in documented attach-only mode could have their externally owned Gateway uninstalled when the app paused, stopped, or switched connection modes.

## Why This Change Was Made

The launch-agent lifecycle owner honored the persistent attach-only marker for installation and restart, but accidentally allowed its destructive uninstall branch through. Apply the existing ownership fence to every launch-agent mutation so an external Gateway remains outside the app's lifecycle authority.

## User Impact

Attach-only mode now preserves externally managed Gateways across app shutdown, pauses, and local-to-remote transitions. Regular app-managed Gateway installation, removal, restart, and profile ownership continue to behave as before.

## Evidence

- Existing native owner-boundary regression extended to exercise install, uninstall, and restart with the attach-only marker enabled.
- Before the fix, the real lifecycle owner issued the forbidden intercepted command `[["uninstall"]]` and the regression failed.
- After the fix, 60 tests across `GatewayLaunchAgentManagerTests`, `GatewayProcessManagerTests`, and `GatewayAutostartPolicyTests` pass, including remote-mode removal for normally managed Gateways.
- Production change: +2/-2 lines; regression coverage: +10 lines; no new configuration, compatibility path, dependency, or test-only seam.
- Independent Codex review reported no actionable findings.
