### PR TITLE
perf(ui): stop running full setup detection on every Control UI connect

### DIFF
--- a/packages/gateway-protocol/src/schema/snapshot.ts
+++ b/packages/gateway-protocol/src/schema/snapshot.ts
@@ -213,6 +213,7 @@ const HealthSnapshotSchema = closedObject({
 /** Default session routing keys included in initial gateway snapshots. */
 const SessionDefaultsSchema = closedObject({
   defaultAgentId: NonEmptyString,
+  modelConfigured: Type.Optional(Type.Boolean()),
   ownership: Type.Optional(AgentOwnershipSchema),
   selectionRequired: Type.Optional(Type.Boolean()),
   mainKey: NonEmptyString,

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -87,6 +87,20 @@ async function loadHealthState() {
 
 describe("buildGatewaySnapshot update metadata", () => {
   it.each([
+    { agent: { model: "openai/gpt-5.6-luna" }, expected: true },
+    { agent: {}, expected: false },
+  ])("advertises modelConfigured=$expected for the default agent", async ({ agent, expected }) => {
+    const healthState = await loadHealthState();
+    getRuntimeConfigMock.mockReturnValue({
+      agents: { entries: { main: agent } },
+    });
+
+    const snapshot = healthState.buildGatewaySnapshot({ revisionProjector });
+
+    expect(snapshot.sessionDefaults?.modelConfigured).toBe(expected);
+  });
+
+  it.each([
     { role: "operator", scopes: ["operator.pairing"], allowed: false },
     { role: "node", scopes: ["operator.read", "operator.admin"], allowed: false },
     { role: "operator", scopes: ["operator.read"], allowed: true },

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -1,5 +1,6 @@
 // Gateway health state builds snapshots, caches health probes, and broadcasts health/presence version changes.
 import type { Snapshot } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveAgentEffectiveModelPrimary } from "../../agents/agent-scope.js";
 import { createConfigIO, getRuntimeConfig } from "../../config/io.js";
 import { STATE_DIR } from "../../config/paths.js";
 import { getRuntimeConfigAppliedHash } from "../../config/runtime-snapshot.js";
@@ -78,6 +79,7 @@ export function buildGatewaySnapshot(opts: {
       : null,
     sessionDefaults: {
       defaultAgentId,
+      modelConfigured: Boolean(resolveAgentEffectiveModelPrimary(cfg, defaultAgentId)),
       ownership: selection.ownership,
       selectionRequired: selection.selectionRequired,
       mainKey,

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -427,10 +427,14 @@ describe("normalizeInitialApplicationLocation", () => {
       hello: {
         auth: { role: "operator", scopes: ["operator.admin"] },
         features: { methods: ["openclaw.setup.detect"] },
+        snapshot: {
+          sessionDefaults: { defaultAgentId: "main", modelConfigured: false },
+        },
       },
     } as Parameters<GatewayListener>[0];
     connectedListener(gateway.snapshot);
-    await vi.waitFor(() => expect(replaceRoute).toHaveBeenCalledOnce(), STARTUP_STEP_WAIT);
+    expect(request).not.toHaveBeenCalled();
+    expect(replaceRoute).toHaveBeenCalledOnce();
     expect(replaceRoute).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
   });
 

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -613,15 +613,15 @@ function normalizeCanvasPluginSurfaceUrl(value: string | undefined): string | nu
   return trimmed ? trimmed : null;
 }
 
-function readSessionDefaults(
+export function readSessionDefaults(
   hello: GatewayHelloOk,
-): { defaultAgentId?: string | null } | undefined {
+): { defaultAgentId?: string | null; modelConfigured?: boolean } | undefined {
   const snapshot = hello.snapshot;
   if (!snapshot || typeof snapshot !== "object" || !("sessionDefaults" in snapshot)) {
     return undefined;
   }
   const defaults = snapshot.sessionDefaults;
   return defaults && typeof defaults === "object"
-    ? (defaults as { defaultAgentId?: string | null })
+    ? (defaults as { defaultAgentId?: string | null; modelConfigured?: boolean })
     : undefined;
 }

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -212,7 +212,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     expect(await loginGateMounted()).toBe(false);
   });
 
-  it("does not load the discarded workspace before a first-run setup redirect", async () => {
+  it("redirects before setup detection without loading the discarded workspace", async () => {
     const page = await createPage();
     const workspaceModules = new Set([
       "/src/components/app-sidebar.ts",
@@ -230,6 +230,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       }
     });
     const gateway = await installMockGateway(page, {
+      agentModel: null,
       deferredMethods: ["openclaw.setup.detect"],
       featureMethods: [
         "browser.request",
@@ -242,9 +243,17 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     });
 
     await page.goto(server.baseUrl);
+    await page.waitForURL("**/settings/model-setup?firstRun=1");
+    expect(new URL(page.url()).pathname).toBe("/settings/model-setup");
     await gateway.waitForRequest("openclaw.setup.detect");
-    await page.locator(".connect-splash").waitFor();
+    expect(await gateway.getRequests("openclaw.setup.detect")).toHaveLength(1);
+    const loading = page.getByText("Checking this Gateway for available AI access…", {
+      exact: true,
+    });
+    await loading.waitFor();
+    expect(await page.locator(".connect-splash").count()).toBe(0);
     expect([...requestedWorkspaceModules]).toEqual([]);
+    await captureProof(page, "06-first-run-routed-before-detection");
 
     await gateway.resolveDeferred("openclaw.setup.detect", {
       candidates: [],
@@ -252,9 +261,10 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       setupComplete: false,
       workspace: "/tmp/openclaw-e2e",
     });
+    await loading.waitFor({ state: "detached" });
     await page.getByRole("heading", { name: "Connect a verified AI model" }).waitFor();
-    expect(new URL(page.url()).pathname).toBe("/settings/model-setup");
     expect([...requestedWorkspaceModules]).toEqual([]);
+    await captureProof(page, "07-first-run-model-setup-ready");
   });
 
   it("falls back to the login gate when stored credentials are rejected", async () => {

--- a/ui/src/pages/model-setup/detect-cache.ts
+++ b/ui/src/pages/model-setup/detect-cache.ts
@@ -9,13 +9,6 @@ let cached:
   | { connection: ModelSetupDetectionConnection; result: SystemAgentSetupDetectResult }
   | undefined;
 
-export function cacheModelSetupDetection(
-  connection: ModelSetupDetectionConnection,
-  result: SystemAgentSetupDetectResult,
-): void {
-  cached = { connection, result };
-}
-
 export function consumeCachedModelSetupDetection(
   connection: ModelSetupDetectionConnection,
 ): SystemAgentSetupDetectResult | null {

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { routeIdFromPath } from "../../app-routes.ts";
 import type { RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { consumeCachedModelSetupDetection } from "./detect-cache.ts";
 import { isDefaultChatLanding, startModelSetupFirstRunRedirectAfterLocation } from "./first-run.ts";
 
 const defaultLanding = { pathname: "/chat/main", search: "", hash: "" };
@@ -18,6 +16,49 @@ async function startRedirect(
     history: { location: () => currentLocation, replace: () => undefined },
     initialLocationReady: Promise.resolve(defaultLanding),
   });
+}
+
+function createConnectedContext(
+  options: {
+    selectedId?: string | null;
+    defaultAgentId?: string;
+    modelConfigured?: boolean;
+    includeModelConfigured?: boolean;
+    admin?: boolean;
+    advertised?: boolean;
+  } = {},
+) {
+  const request = vi.fn();
+  const replace = vi.fn();
+  const sessionDefaults = {
+    defaultAgentId: options.defaultAgentId ?? "main",
+    ...(options.includeModelConfigured === false
+      ? {}
+      : { modelConfigured: options.modelConfigured ?? false }),
+  };
+  const snapshot = {
+    phase: "connected" as const,
+    client: { request },
+    hello: {
+      auth: {
+        role: "operator",
+        scopes: [options.admin === false ? "operator.read" : "operator.admin"],
+      },
+      features: { methods: options.advertised === false ? [] : ["openclaw.setup.detect"] },
+      snapshot: { sessionDefaults },
+    },
+  };
+  const context = {
+    gateway: {
+      snapshot,
+      subscribe: () => () => undefined,
+    },
+    agentSelection: {
+      state: { selectedId: options.selectedId === undefined ? "main" : options.selectedId },
+    },
+    replace,
+  } as unknown as ApplicationContext<RouteId>;
+  return { context, replace, request };
 }
 
 describe("model setup first-run redirect", () => {
@@ -61,7 +102,7 @@ describe("model setup first-run redirect", () => {
     ).toBe(false);
   });
 
-  it("installs a released session deep link without registering first-run detection", async () => {
+  it("installs a released session deep link without registering the first-run gate", async () => {
     const releasedLocation = {
       pathname: "/chat",
       search: "?session=agent%3Aresearch%3Atelegram%3A12345",
@@ -79,21 +120,7 @@ describe("model setup first-run redirect", () => {
     const subscribe = vi.fn(() => () => undefined);
     const replaceRoute = vi.fn();
     const context = {
-      gateway: {
-        snapshot: {
-          phase: "connected",
-          client: { request: vi.fn() },
-          hello: {
-            auth: { role: "operator", scopes: ["operator.admin"] },
-            features: { methods: ["openclaw.setup.detect"] },
-          },
-        },
-        subscribe,
-      },
-      agentSelection: {
-        state: { selectedId: "main" },
-        subscribe: () => () => undefined,
-      },
+      gateway: { snapshot: {}, subscribe },
       replace: replaceRoute,
     } as unknown as ApplicationContext<RouteId>;
 
@@ -109,307 +136,97 @@ describe("model setup first-run redirect", () => {
     expect(replaceRoute).not.toHaveBeenCalled();
   });
 
-  it("detects once, caches the result, and redirects once", async () => {
-    const result = {
-      candidates: [],
-      manualProviders: [],
-      workspace: "/tmp/workspace",
-      setupComplete: false,
-    };
-    const request = vi.fn().mockResolvedValue(result);
-    const client = { request } as unknown as GatewayBrowserClient;
-    type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
-    let listener: GatewayListener | null = null;
-    const snapshot = {
-      phase: "connected",
-      client,
-      hello: {
-        type: "hello-ok" as const,
-        protocol: 1,
-        auth: { role: "operator", scopes: ["operator.admin"] },
-        features: { methods: ["openclaw.setup.detect"] },
-      },
-    };
-    const replace = vi.fn();
-    const context = {
-      gateway: {
-        snapshot,
-        subscribe: (next: GatewayListener) => {
-          listener = next;
-          return () => undefined;
-        },
-      },
-      agentSelection: {
-        state: { selectedId: "main" },
-        subscribe: () => () => undefined,
-      },
-      replace,
-    } as unknown as ApplicationContext<RouteId>;
+  it.each([
+    {
+      name: "the default agent has no configured model",
+      options: {},
+      shouldRedirect: true,
+    },
+    {
+      name: "agent selection is unset",
+      options: { selectedId: null },
+      shouldRedirect: true,
+    },
+    {
+      name: "the selected agent is the custom default",
+      options: { selectedId: "research", defaultAgentId: "research" },
+      shouldRedirect: true,
+    },
+    {
+      name: "the default agent already has a configured model",
+      options: { modelConfigured: true },
+      shouldRedirect: false,
+    },
+    {
+      name: "a non-default agent is explicitly selected",
+      options: { selectedId: "research" },
+      shouldRedirect: false,
+    },
+    {
+      name: "the operator lacks admin access",
+      options: { admin: false },
+      shouldRedirect: false,
+    },
+    {
+      name: "the setup method is not advertised",
+      options: { advertised: false },
+      shouldRedirect: false,
+    },
+    {
+      name: "the handshake omits the model fact",
+      options: { includeModelConfigured: false },
+      shouldRedirect: false,
+    },
+  ])("decides synchronously when $name", async ({ options, shouldRedirect }) => {
+    const { context, replace, request } = createConnectedContext(options);
 
-    await startRedirect(context);
-    expect(listener).not.toBeNull();
-    listener!(snapshot as Parameters<GatewayListener>[0]);
-    listener!(snapshot as Parameters<GatewayListener>[0]);
-    await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
+    const dispose = await startRedirect(context);
 
-    expect(request).toHaveBeenCalledOnce();
-    expect(request).toHaveBeenCalledWith(
-      "openclaw.setup.detect",
-      { agentId: "main" },
-      expect.objectContaining({ timeoutMs: 40_000 }),
-    );
-    expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
-    expect(
-      consumeCachedModelSetupDetection({ client, hello: snapshot.hello, agentId: "main" }),
-    ).toEqual(result);
-  });
-
-  it("retries one transient detection failure without duplicating either attempt", async () => {
-    const result = {
-      candidates: [],
-      manualProviders: [],
-      workspace: "/tmp/workspace",
-      setupComplete: false,
-    };
-    let rejectFirst!: (error: Error) => void;
-    const request = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise((_, reject) => {
-            rejectFirst = reject;
-          }),
-      )
-      .mockResolvedValueOnce(result);
-    const client = { request } as unknown as GatewayBrowserClient;
-    type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
-    let listener: GatewayListener | null = null;
-    const snapshot = {
-      phase: "connected" as const,
-      client,
-      hello: {
-        auth: { role: "operator", scopes: ["operator.admin"] },
-        features: { methods: ["openclaw.setup.detect"] },
-      },
-    };
-    const replace = vi.fn();
-    const context = {
-      gateway: {
-        snapshot,
-        subscribe: (next: GatewayListener) => {
-          listener = next;
-          return () => undefined;
-        },
-      },
-      agentSelection: {
-        state: { selectedId: "main" },
-        subscribe: () => () => undefined,
-      },
-      replace,
-    } as unknown as ApplicationContext<RouteId>;
-
-    await startRedirect(context);
-    listener!(snapshot as Parameters<GatewayListener>[0]);
-    expect(request).toHaveBeenCalledOnce();
-
-    rejectFirst(new Error("temporary gateway failure"));
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    listener!(snapshot as Parameters<GatewayListener>[0]);
-    await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
-
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
-  });
-
-  it("stops after the same connection rejects detection twice", async () => {
-    const request = vi.fn().mockRejectedValue(new Error("gateway unavailable"));
-    const client = { request } as unknown as GatewayBrowserClient;
-    type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
-    let listener: GatewayListener | null = null;
-    const snapshot = {
-      phase: "connected" as const,
-      client,
-      hello: {
-        auth: { role: "operator", scopes: ["operator.admin"] },
-        features: { methods: ["openclaw.setup.detect"] },
-      },
-    };
-    const context = {
-      gateway: {
-        snapshot,
-        subscribe: (next: GatewayListener) => {
-          listener = next;
-          return () => undefined;
-        },
-      },
-      agentSelection: {
-        state: { selectedId: "main" },
-        subscribe: () => () => undefined,
-      },
-      replace: vi.fn(),
-    } as unknown as ApplicationContext<RouteId>;
-
-    await startRedirect(context);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    listener!(snapshot as Parameters<GatewayListener>[0]);
-    await Promise.resolve();
-
-    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).not.toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledTimes(shouldRedirect ? 1 : 0);
+    if (shouldRedirect) {
+      expect(replace).toHaveBeenCalledWith("model-setup", { search: "?firstRun=1" });
+    }
+    dispose();
   });
 
   it("does not redirect after the operator leaves the default landing", async () => {
-    const result = {
-      candidates: [],
-      manualProviders: [],
-      workspace: "/tmp/workspace",
-      setupComplete: false,
-    };
-    const request = vi.fn().mockResolvedValue(result);
-    const client = { request } as unknown as GatewayBrowserClient;
-    type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
-    let listener: GatewayListener | null = null;
-    const snapshot = {
-      phase: "connected",
-      client,
-      hello: {
-        type: "hello-ok" as const,
-        protocol: 1,
-        auth: { role: "operator", scopes: ["operator.admin"] },
-        features: { methods: ["openclaw.setup.detect"] },
-      },
-    };
-    const replace = vi.fn();
-    const context = {
-      gateway: {
-        snapshot,
-        subscribe: (next: GatewayListener) => {
-          listener = next;
-          return () => undefined;
-        },
-      },
-      agentSelection: {
-        state: { selectedId: "main" },
-        subscribe: () => () => undefined,
-      },
-      replace,
-    } as unknown as ApplicationContext<RouteId>;
+    const { context, replace, request } = createConnectedContext();
 
-    await startRedirect(context, { pathname: "/chat/other", search: "", hash: "" });
-    listener!(snapshot as Parameters<GatewayListener>[0]);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-
-    expect(replace).not.toHaveBeenCalled();
-    expect(
-      consumeCachedModelSetupDetection({ client, hello: snapshot.hello, agentId: "main" }),
-    ).toEqual(result);
-  });
-
-  it("rejects stale detection and retries first-run guidance after a same-client reconnect", async () => {
-    const stale = {
-      candidates: [],
-      manualProviders: [],
-      workspace: "/tmp/stale-workspace",
-      setupComplete: false,
-    };
-    const current = {
-      ...stale,
-      workspace: "/tmp/current-workspace",
-    };
-    let resolveStale!: (result: typeof stale) => void;
-    const request = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise<typeof stale>((resolve) => {
-            resolveStale = resolve;
-          }),
-      )
-      .mockResolvedValueOnce(current);
-    const client = { request } as unknown as GatewayBrowserClient;
-    type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
-    let listener: GatewayListener | null = null;
-    const firstHello = {
-      type: "hello-ok" as const,
-      protocol: 1,
-      auth: { role: "operator", scopes: ["operator.admin"] },
-      features: { methods: ["openclaw.setup.detect"] },
-    };
-    const gateway = {
-      snapshot: { phase: "connected", client, hello: firstHello as typeof firstHello | null },
-      subscribe: (next: GatewayListener) => {
-        listener = next;
-        return () => undefined;
-      },
-    };
-    const replace = vi.fn();
-    const context = {
-      gateway,
-      agentSelection: {
-        state: { selectedId: "main" },
-        subscribe: () => () => undefined,
-      },
-      replace,
-    } as unknown as ApplicationContext<RouteId>;
-    await startRedirect(context);
-    expect(request).toHaveBeenCalledOnce();
-
-    gateway.snapshot = { phase: "reconnecting", client, hello: null };
-    listener!(gateway.snapshot as Parameters<GatewayListener>[0]);
-    const nextHello = { ...firstHello };
-    gateway.snapshot = { phase: "connected", client, hello: nextHello };
-    listener!(gateway.snapshot as Parameters<GatewayListener>[0]);
-    await vi.waitFor(() => expect(replace).toHaveBeenCalledOnce());
-    resolveStale(stale);
-    await Promise.resolve();
-
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(consumeCachedModelSetupDetection({ client, hello: nextHello, agentId: "main" })).toEqual(
-      current,
-    );
-    expect(
-      consumeCachedModelSetupDetection({ client, hello: firstHello, agentId: "main" }),
-    ).toBeNull();
-    expect(replace).toHaveBeenCalledOnce();
-  });
-
-  it("does not detect without admin scope or an advertised setup method", async () => {
-    const request = vi.fn();
-    const client = { request } as unknown as GatewayBrowserClient;
-    type GatewayListener = Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0];
-    let listener: GatewayListener | null = null;
-    const context = {
-      gateway: {
-        snapshot: {},
-        subscribe: (next: GatewayListener) => {
-          listener = next;
-          return () => undefined;
-        },
-      },
-      agentSelection: {
-        state: { selectedId: "main" },
-        subscribe: () => () => undefined,
-      },
-      replace: vi.fn(),
-    } as unknown as ApplicationContext<RouteId>;
-
-    await startRedirect(context);
-    listener!({
-      phase: "connected" as const,
-      client,
-      hello: {
-        auth: { role: "operator", scopes: ["operator.read"] },
-        features: { methods: ["openclaw.setup.detect"] },
-      },
-    } as Parameters<GatewayListener>[0]);
-    listener!({
-      phase: "connected" as const,
-      client,
-      hello: {
-        auth: { role: "operator", scopes: ["operator.admin"] },
-        features: { methods: [] },
-      },
-    } as unknown as Parameters<GatewayListener>[0]);
+    const dispose = await startRedirect(context, {
+      pathname: "/settings/appearance",
+      search: "",
+      hash: "",
+    });
 
     expect(request).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+    dispose();
   });
+
+  it.each(["reload-required", "stopped"] as const)(
+    "settles the initial decision on a terminal %s snapshot",
+    async (phase) => {
+      const onInitialDecision = vi.fn();
+      const context = {
+        gateway: {
+          snapshot: { phase, client: null, hello: null },
+          subscribe: () => () => undefined,
+        },
+        agentSelection: { state: { selectedId: "main" } },
+        replace: vi.fn(),
+      } as unknown as ApplicationContext<RouteId>;
+
+      const dispose = await startModelSetupFirstRunRedirectAfterLocation({
+        context,
+        enabled: true,
+        history: { location: () => defaultLanding, replace: () => undefined },
+        initialLocationReady: Promise.resolve(defaultLanding),
+        onInitialDecision,
+      });
+
+      expect(onInitialDecision).toHaveBeenCalledOnce();
+      dispose();
+    },
+  );
 });

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -2,10 +2,9 @@ import type { RouteLocation, RouterHistory } from "@openclaw/uirouter";
 import { sessionRouteNamespaceFromPath } from "../../app-route-paths.ts";
 import type { RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { readSessionDefaults } from "../../app/gateway-store.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
-import { cacheModelSetupDetection, type ModelSetupDetectionConnection } from "./detect-cache.ts";
-import { detectModelSetup } from "./rpc.ts";
 
 export function isDefaultChatLanding(
   location: RouteLocation,
@@ -72,15 +71,6 @@ function startModelSetupFirstRunRedirect(params: {
   redirect: () => void;
   onInitialDecision: () => void;
 }): () => void {
-  let detection:
-    | {
-        connection: ModelSetupDetectionConnection;
-        attempts: number;
-        phase: "in-flight" | "retry-ready" | "settled";
-      }
-    | undefined;
-  let redirected = false;
-  let disposed = false;
   let initialDecisionSettled = false;
   const settleInitialDecision = () => {
     if (!initialDecisionSettled) {
@@ -91,10 +81,10 @@ function startModelSetupFirstRunRedirect(params: {
   const handleSnapshot: Parameters<ApplicationContext<RouteId>["gateway"]["subscribe"]>[0] = (
     snapshot,
   ) => {
-    if (redirected) {
+    if (initialDecisionSettled) {
       return;
     }
-    if (snapshot.phase !== "connected" || !snapshot.client) {
+    if (snapshot.phase !== "connected") {
       // A build fence can move a previously authenticated client straight into
       // reconnecting or reload-required, while a terminal first attempt returns
       // to stopped. Do not hold the router when the shell needs to present recovery.
@@ -103,73 +93,25 @@ function startModelSetupFirstRunRedirect(params: {
       }
       return;
     }
+    const defaults = snapshot.hello ? readSessionDefaults(snapshot.hello) : undefined;
+    const selectedAgentId = params.context.agentSelection.state.selectedId?.trim() || null;
+    const defaultAgentId = defaults?.defaultAgentId?.trim() || null;
+    const usesDefaultAgent = selectedAgentId === null || selectedAgentId === defaultAgentId;
     if (
-      !hasOperatorAdminAccess(snapshot.hello?.auth ?? null) ||
-      isGatewayMethodAdvertised(snapshot, "openclaw.setup.detect") !== true
+      hasOperatorAdminAccess(snapshot.hello?.auth ?? null) &&
+      isGatewayMethodAdvertised(snapshot, "openclaw.setup.detect") === true &&
+      defaults?.modelConfigured === false &&
+      usesDefaultAgent &&
+      params.isStillDefaultLanding()
     ) {
-      settleInitialDecision();
-      return;
+      params.redirect();
     }
-    const agentId = params.context.agentSelection.state.selectedId;
-    const connection = { client: snapshot.client, hello: snapshot.hello, agentId };
-    const previous = detection;
-    const sameGeneration =
-      connection.client === previous?.connection.client &&
-      connection.hello === previous?.connection.hello &&
-      connection.agentId === previous?.connection.agentId;
-    if (sameGeneration && previous?.phase !== "retry-ready") {
-      return;
-    }
-    detection =
-      sameGeneration && previous
-        ? { connection, attempts: previous.attempts + 1, phase: "in-flight" }
-        : { connection, attempts: 1, phase: "in-flight" };
-    const attempt = detection;
-    void detectModelSetup(snapshot.client, agentId ?? undefined)
-      .then((result) => {
-        if (disposed || detection !== attempt) {
-          return;
-        }
-        const current = params.context.gateway.snapshot;
-        if (
-          current.phase !== "connected" ||
-          current.client !== connection.client ||
-          current.hello !== connection.hello ||
-          params.context.agentSelection.state.selectedId !== connection.agentId
-        ) {
-          return;
-        }
-        detection = { ...attempt, phase: "settled" };
-        cacheModelSetupDetection(connection, result);
-        if (!result.setupComplete && !redirected && params.isStillDefaultLanding()) {
-          redirected = true;
-          params.redirect();
-        }
-        settleInitialDecision();
-      })
-      .catch(() => {
-        if (disposed || detection !== attempt) {
-          return;
-        }
-        // One same-generation retry absorbs a transient startup race without
-        // turning first-run guidance into a background retry loop.
-        detection = { ...attempt, phase: attempt.attempts < 2 ? "retry-ready" : "settled" };
-        if (detection.phase === "retry-ready" && params.isStillDefaultLanding()) {
-          handleSnapshot(params.context.gateway.snapshot);
-        } else {
-          settleInitialDecision();
-        }
-      });
+    settleInitialDecision();
   };
   const unsubscribe = params.context.gateway.subscribe(handleSnapshot);
-  const unsubscribeSelection = params.context.agentSelection.subscribe(() =>
-    handleSnapshot(params.context.gateway.snapshot),
-  );
   handleSnapshot(params.context.gateway.snapshot);
   return () => {
-    disposed = true;
     unsubscribe();
-    unsubscribeSelection();
     settleInitialDecision();
   };
 }

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1708,6 +1708,7 @@ function installControlUiMockGateway(
               defaultAgentId: scenario.defaultAgentId,
               mainKey: "main",
               mainSessionKey: scenario.sessionKey,
+              modelConfigured: Boolean(scenario.agentModel),
               scope: "agent",
             },
           },


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where opening the Control UI on its default chat landing ran full native and ambient provider discovery on every Gateway connection before initial routing could continue.

On the measured live Gateway, that unnecessary discovery took 5.5 seconds warm and 16.8 seconds cold, with RSS increasing by 239 MB at peak and retaining 216 MB after the call. The redirect gate only needed to know whether the default agent already had a configured model.

## Why This Change Was Made

The Gateway now records that config-owned fact as an additive `sessionDefaults.modelConfigured` field in the hello snapshot. The first-run gate combines it synchronously with admin access, method availability, the selected/default agent, and the current landing route. Full setup detection remains unchanged and runs only on the Model Setup page itself.

The protocol field is optional so newer clients safely treat an omitted fact as unknown, while the current Gateway always emits a boolean. The obsolete connect-time RPC, retry/generation machinery, agent-selection subscription, and cache writer were removed.

## User Impact

Returning users with a configured default model no longer wait for provider discovery before the normal chat route starts. Fresh users are redirected to Model Setup immediately from the hello snapshot; that page then performs its existing detailed detection. Explicitly selected non-default agents are not treated as first-run defaults.

## Evidence

- Regression proof before the fix: the first-run gate issued one `openclaw.setup.detect` request, and both configured/unconfigured snapshot assertions observed `modelConfigured` as absent.
- `node scripts/run-vitest.mjs ui/src/pages/model-setup/first-run.test.ts` — 13 passed.
- `node scripts/run-vitest.mjs src/gateway/server/health-state.test.ts` — 46 passed across both selected projects.
- `node scripts/run-vitest.mjs ui/src/app/bootstrap.test.ts` — 42 passed.
- Focused Chromium E2E — 1 passed: the URL changed to `/settings/model-setup?firstRun=1` before the page-owned deferred detection resolved, exactly one detection request was issued, and no discarded workspace/chat modules loaded.
- `node scripts/check-changed.mjs -- <touched files>` — core, coreTests, and UI plan passed, including typechecks, lint, formatting, dead exports, i18n, and architecture guards.
- Branch autoreview: clean, with no accepted/actionable findings.

Immediate Model Setup routing while detailed detection is still pending:

![Model Setup route visible before detailed detection completes](https://github.com/user-attachments/assets/c3469383-ee1c-46e1-b138-7592373ae73c)

The unchanged Model Setup flow after detailed detection completes:

![Model Setup ready after detailed detection](https://github.com/user-attachments/assets/6b90c38b-ca27-4f99-820b-107c4ad0617d)

Browser recording:

https://github.com/user-attachments/assets/f13349cf-3b09-4745-a903-c8654f143ca5

AI-assisted: yes. The implementation, focused proof, and code review were completed with Codex; the code and behavior were inspected directly.
