### PR TITLE
fix(release): repair frozen beta validation blockers

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -1350,98 +1350,106 @@ jobs:
           exit "$failed"
 
   bun_global_install_smoke:
-    needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready]
+    needs: [preflight, installer_smoke_candidate_payload]
     if: needs.preflight.outputs.run_full_install_smoke == 'true' && needs.preflight.outputs.run_bun_global_install_smoke == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    env:
-      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
       - *trusted_workflow_subdir_checkout_step
       - *trusted_workflow_subdir_identity_step
 
-      - name: Validate root Dockerfile image artifact binding
+      - name: Validate candidate payload artifact binding
         env:
-          ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
-          ARTIFACT_DIGEST: ${{ needs.root_dockerfile_image.outputs.artifact_digest }}
-          ARTIFACT_ID: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
-          ARTIFACT_NAME: ${{ needs.root_dockerfile_image.outputs.artifact_name }}
-          ARTIFACT_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
-          ARTIFACT_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          ARTIFACT_DIGEST: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
+          ARTIFACT_HARNESS_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.harness_repository }}
+          ARTIFACT_HARNESS_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.harness_sha }}
+          ARTIFACT_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
+          ARTIFACT_TARGET_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.target_sha }}
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
         run: |
           set -euo pipefail
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact ID is missing or invalid." >&2
+            echo "Candidate payload artifact ID is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Root image artifact digest is missing or invalid." >&2
-            exit 1
-          }
-          [[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Root image archive SHA-256 is missing or invalid." >&2
+            echo "Candidate payload artifact digest is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact run ID is missing or invalid." >&2
+            echo "Candidate payload artifact run ID is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact run attempt is missing or invalid." >&2
+            echo "Candidate payload artifact run attempt is missing or invalid." >&2
             exit 1
           }
-          expected_artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_REPOSITORY" == "$GITHUB_REPOSITORY" ]]
+          [[ "$ARTIFACT_TARGET_SHA" == "$TARGET_SHA" ]]
+          [[ "$ARTIFACT_HARNESS_REPOSITORY" == "$HARNESS_REPOSITORY" ]]
+          [[ "$ARTIFACT_HARNESS_SHA" == "$HARNESS_SHA" ]]
+          expected_artifact_name="install-smoke-candidate-payload-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
           [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
-            echo "Root image artifact name does not match the target and producer run attempt." >&2
+            echo "Candidate payload artifact name does not match the producer tuple." >&2
             exit 1
           }
           bash .release-harness/scripts/docker/shared-image-artifact.sh \
-            verify-upload "Root image" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            verify-upload "Candidate payload" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
-      - name: Download root Dockerfile image artifact
+      - name: Download candidate payload artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          artifact-ids: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
-          path: ${{ runner.temp }}/install-smoke-root-image
-          run-id: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          artifact-ids: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-candidate-payload
+          run-id: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
           github-token: ${{ github.token }}
-
-      - name: Verify and load root Dockerfile image artifact
-        env:
-          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
-          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
-          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
-          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
-          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
-        run: |
-          set -euo pipefail
-          bash .release-harness/scripts/docker/shared-image-artifact.sh \
-            load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root \
-            "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
-
-      - name: Require local root Dockerfile image
-        env:
-          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
-        run: docker image inspect "$IMAGE_REF" >/dev/null
 
       - name: Setup trusted release harness for Bun smoke
         uses: ./.release-harness/.github/actions/setup-release-harness
         with:
           node-version: "24.x"
 
+      - name: Verify candidate payload contents
+        env:
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
+          MANIFEST_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}
+          PACKAGE_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
+          PRODUCER_RUN_ATTEMPT: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}
+          PRODUCER_RUN_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
+          SOURCE_ARCHIVE_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}
+          TARGET_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          node .release-harness/scripts/install-smoke-candidate-payload.mts verify \
+            --payload-dir "${RUNNER_TEMP}/install-smoke-candidate-payload" \
+            --repository "$TARGET_REPOSITORY" \
+            --target-sha "$TARGET_SHA" \
+            --harness-repository "$HARNESS_REPOSITORY" \
+            --harness-sha "$HARNESS_SHA" \
+            --run-id "$PRODUCER_RUN_ID" \
+            --run-attempt "$PRODUCER_RUN_ATTEMPT" \
+            --package-version "$PACKAGE_VERSION" \
+            --manifest-sha256 "$MANIFEST_SHA256" \
+            --source-archive-sha256 "$SOURCE_ARCHIVE_SHA256"
+
       - name: Install Bun for global smoke
         run: npm install -g bun@1.3.14
 
-      - name: Run Bun global install image-provider smoke
+      - name: Run Bun global install candidate-payload smoke
         working-directory: .release-harness
         env:
-          OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
-          OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0"
+          OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ: ${{ runner.temp }}/install-smoke-candidate-payload/candidate.tgz
         run: bash scripts/e2e/bun-global-install-smoke.sh
 
   docker-e2e-fast:

--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -479,7 +479,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.preflight.outputs.checkout_revision }}
-          fetch-depth: 1
+          fetch-depth: ${{ inputs.full_release_validation && '0' || '1' }}
           fetch-tags: false
           persist-credentials: false
           submodules: false

--- a/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
+++ b/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
@@ -96,24 +96,58 @@ function readSharedAuthProfileStoreText(stateDir) {
   }
 }
 
+function assertNoLegacyPrimaryAuthRows(stateDir) {
+  const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  if (!fs.existsSync(dbPath)) {
+    return;
+  }
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const legacyRows = [
+      {
+        table: "auth_profile_store",
+        query: "SELECT 1 AS present FROM auth_profile_store WHERE store_key = ? LIMIT 1",
+      },
+      {
+        table: "auth_profile_state",
+        query: "SELECT 1 AS present FROM auth_profile_state WHERE state_key = ? LIMIT 1",
+      },
+    ];
+    for (const entry of legacyRows) {
+      const schema = db
+        .prepare("SELECT type FROM sqlite_schema WHERE name = ? LIMIT 1")
+        .get(entry.table);
+      if (!schema) {
+        continue;
+      }
+      if (schema.type !== "table") {
+        throw new Error(`${entry.table} is ${String(schema.type)}, not a table`);
+      }
+      if (db.prepare(entry.query).get("primary")) {
+        throw new Error(`onboard preserved a retired primary row in ${entry.table}`);
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("onboard preserved a retired")) {
+      throw error;
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`could not validate the main-agent auth database: ${detail}`);
+  } finally {
+    db?.close();
+  }
+}
+
 function assertOnboardState() {
   const home = process.argv[3];
   const stateDir = path.join(home, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
-  const legacyAuthDatabase = path.join(
-    stateDir,
-    "agents",
-    "main",
-    "agent",
-    "openclaw-agent.sqlite",
-  );
 
   if (!fs.existsSync(configPath)) {
     throw new Error("onboard did not write openclaw.json");
   }
-  if (fs.existsSync(legacyAuthDatabase)) {
-    throw new Error("onboard created the retired main-agent auth database");
-  }
+  assertNoLegacyPrimaryAuthRows(stateDir);
   const authStoreText = readSharedAuthProfileStoreText(stateDir);
   if (!authStoreText) {
     throw new Error("onboard did not persist auth profile store");

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -184,10 +184,13 @@ function requiredReviewedFindingsForPackage(
   return [...commonFindings, ...sourceLayout];
 }
 
-function isReviewedPublishableCriticalFinding(key: string): boolean {
+function isReviewedPublishableCriticalFinding(key: string, evidence: string): boolean {
+  const sourceContract = OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_CONTRACTS.get(key);
+  if (sourceContract) {
+    return evidence === sourceContract.evidence;
+  }
   return (
     REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
-    OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_CONTRACTS.has(key) ||
     REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
     OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
   );
@@ -369,7 +372,7 @@ async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): P
     }
     const packedPath = normalizePackedFindingPath(toRepoPath(relative(stageDir, finding.file)));
     const key = `${plugin.packageName}:${finding.ruleId}:${packedPath}`;
-    if (isReviewedPublishableCriticalFinding(key)) {
+    if (isReviewedPublishableCriticalFinding(key, finding.evidence)) {
       reviewedCriticalFindings.push(key);
       continue;
     }
@@ -479,12 +482,30 @@ describe("publishable plugin npm package install security scan", () => {
       count: 1,
       evidence: "const child = spawn(invocation.command, invocation.argv, {",
     });
-    expect(isReviewedPublishableCriticalFinding(`${openCodeFinding}.relocated`)).toBe(false);
+    expect(
+      isReviewedPublishableCriticalFinding(
+        openCodeFinding,
+        "const child = spawn(invocation.command, invocation.argv, {",
+      ),
+    ).toBe(true);
+    expect(
+      isReviewedPublishableCriticalFinding(
+        openCodeFinding,
+        "const child = spawn(other.command, other.argv, {",
+      ),
+    ).toBe(false);
+    expect(
+      isReviewedPublishableCriticalFinding(
+        `${openCodeFinding}.relocated`,
+        "const child = spawn(invocation.command, invocation.argv, {",
+      ),
+    ).toBe(false);
   });
 
-  it("accepts only one occurrence of an optional reviewed source boundary", () => {
+  it("rejects a decoy contract string paired with a different dangerous spawn", () => {
     const packageDir = mkdtempSync(join(tmpdir(), "openclaw-reviewed-source-"));
     const packedPath = "session-catalog.ts";
+    const finding = "@openclaw/opencode-provider:dangerous-exec:session-catalog.ts";
     const evidence = "const child = spawn(invocation.command, invocation.argv, {";
     try {
       fs.writeFileSync(join(packageDir, packedPath), "export {};\n");
@@ -496,14 +517,24 @@ describe("publishable plugin npm package install security scan", () => {
         ),
       ).toEqual([]);
 
-      fs.writeFileSync(join(packageDir, packedPath), `${evidence}\n`);
+      fs.writeFileSync(
+        join(packageDir, packedPath),
+        `const reviewedBoundaryDecoy = ${JSON.stringify(evidence)};\n` +
+          "const child = spawn(other.command, other.argv, {\n",
+      );
       expect(
         expectedReviewedSourceFindingsForPackedPath(
           packageDir,
           "@openclaw/opencode-provider",
           packedPath,
         ),
-      ).toEqual(["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts"]);
+      ).toEqual([finding]);
+      expect(
+        isReviewedPublishableCriticalFinding(
+          finding,
+          "const child = spawn(other.command, other.argv, {",
+        ),
+      ).toBe(false);
 
       fs.writeFileSync(join(packageDir, packedPath), `${evidence}\n${evidence}\n`);
       expect(() =>

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -602,7 +602,12 @@ describe("publishable plugin npm package install security scan", () => {
     const relocatedFinding =
       "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/relocated.ts";
 
-    expect(isReviewedPublishableCriticalFinding(relocatedFinding)).toBe(false);
+    expect(
+      isReviewedPublishableCriticalFinding(
+        relocatedFinding,
+        "const child = spawn(other.command, other.argv, {",
+      ),
+    ).toBe(false);
     expect(resolveReviewedCodexSourceLayout([relocatedFinding])).toBeUndefined();
   });
 

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -38,6 +38,26 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/voice-call:dangerous-exec:src/tunnel.ts", 1],
 ]);
 
+const OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_CONTRACTS = new Map<
+  string,
+  { count: number; evidence: string }
+>([
+  [
+    "@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts",
+    {
+      count: 1,
+      evidence: "const child = spawn(invocation.command, invocation.args, {",
+    },
+  ],
+  [
+    "@openclaw/opencode-provider:dangerous-exec:session-catalog.ts",
+    {
+      count: 1,
+      evidence: "const child = spawn(invocation.command, invocation.argv, {",
+    },
+  ],
+]);
+
 const REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/processes.ts", 1],
@@ -167,6 +187,7 @@ function requiredReviewedFindingsForPackage(
 function isReviewedPublishableCriticalFinding(key: string): boolean {
   return (
     REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
+    OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_CONTRACTS.has(key) ||
     REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
     OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
   );
@@ -184,6 +205,27 @@ function expectedOptionalReviewedFindingsForPackedPath(
       ? Array.from({ length: count }, () => key)
       : [],
   );
+}
+
+function expectedReviewedSourceFindingsForPackedPath(
+  packageDir: string,
+  packageName: string,
+  packedPath: string,
+): string[] {
+  const key = `${packageName}:dangerous-exec:${packedPath}`;
+  const contract = OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_CONTRACTS.get(key);
+  if (!contract) {
+    return [];
+  }
+  const source = readFileSync(resolve(packageDir, packedPath), "utf8");
+  const count = source.split(contract.evidence).length - 1;
+  if (count === 0) {
+    return [];
+  }
+  if (count !== contract.count) {
+    throw new Error(`${key}: reviewed execution evidence count changed from ${contract.count}.`);
+  }
+  return Array.from({ length: contract.count }, () => key);
 }
 
 function stageScannerRelevantPackedFiles(
@@ -296,6 +338,13 @@ async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): P
   const unexpectedCriticalFindings: string[] = [];
   const packedFiles = await collectNpmPackedFiles(plugin.packageDir, plugin.packageName);
   for (const packedFile of packedFiles) {
+    expectedReviewedCriticalFindings.push(
+      ...expectedReviewedSourceFindingsForPackedPath(
+        plugin.packageDir,
+        plugin.packageName,
+        packedFile,
+      ),
+    );
     for (const key of expectedOptionalReviewedFindingsForPackedPath(
       plugin.packageName,
       packedFile,
@@ -412,6 +461,61 @@ describe("publishable plugin npm package install security scan", () => {
     expect(
       expectedOptionalReviewedFindingsForPackedPath("@openclaw/codex", "dist/client-retired.js"),
     ).toEqual([]);
+  });
+
+  it("requires exact count-one reviewed CLI execution boundaries", () => {
+    const codexFinding = "@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts";
+    const openCodeFinding = "@openclaw/opencode-provider:dangerous-exec:session-catalog.ts";
+
+    expect(
+      OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_CONTRACTS.get(codexFinding),
+    ).toEqual({
+      count: 1,
+      evidence: "const child = spawn(invocation.command, invocation.args, {",
+    });
+    expect(
+      OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_CONTRACTS.get(openCodeFinding),
+    ).toEqual({
+      count: 1,
+      evidence: "const child = spawn(invocation.command, invocation.argv, {",
+    });
+    expect(isReviewedPublishableCriticalFinding(`${openCodeFinding}.relocated`)).toBe(false);
+  });
+
+  it("accepts only one occurrence of an optional reviewed source boundary", () => {
+    const packageDir = mkdtempSync(join(tmpdir(), "openclaw-reviewed-source-"));
+    const packedPath = "session-catalog.ts";
+    const evidence = "const child = spawn(invocation.command, invocation.argv, {";
+    try {
+      fs.writeFileSync(join(packageDir, packedPath), "export {};\n");
+      expect(
+        expectedReviewedSourceFindingsForPackedPath(
+          packageDir,
+          "@openclaw/opencode-provider",
+          packedPath,
+        ),
+      ).toEqual([]);
+
+      fs.writeFileSync(join(packageDir, packedPath), `${evidence}\n`);
+      expect(
+        expectedReviewedSourceFindingsForPackedPath(
+          packageDir,
+          "@openclaw/opencode-provider",
+          packedPath,
+        ),
+      ).toEqual(["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts"]);
+
+      fs.writeFileSync(join(packageDir, packedPath), `${evidence}\n${evidence}\n`);
+      expect(() =>
+        expectedReviewedSourceFindingsForPackedPath(
+          packageDir,
+          "@openclaw/opencode-provider",
+          packedPath,
+        ),
+      ).toThrow("reviewed execution evidence count changed from 1");
+    } finally {
+      rmSync(packageDir, { recursive: true, force: true });
+    }
   });
 
   it("accepts either complete reviewed Codex source layout", () => {

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -305,7 +305,7 @@ describe("install smoke no-push root image transport", () => {
 
   it("verifies and loads the immutable artifact in every consumer", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
-    for (const jobName of ["root_dockerfile_smokes", "bun_global_install_smoke"]) {
+    for (const jobName of ["root_dockerfile_smokes"]) {
       const consumer = job(workflow, jobName);
       expect(consumer.needs, jobName).toContain("root_dockerfile_image_ready");
       expect(consumer.env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE, jobName).toBe("1");
@@ -367,7 +367,7 @@ describe("install smoke no-push root image transport", () => {
     }
 
     const text = readFileSync(INSTALL_SMOKE_REUSABLE, "utf8");
-    expect(text.match(/verify-upload "Root image"/g)).toHaveLength(2);
+    expect(text.match(/verify-upload "Root image"/g)).toHaveLength(1);
     expect(text).not.toContain("gh api");
   });
 
@@ -507,15 +507,54 @@ describe("install smoke no-push root image transport", () => {
     }
 
     const bunConsumer = job(workflow, "bun_global_install_smoke");
+    expect(bunConsumer.needs).toEqual(["preflight", "installer_smoke_candidate_payload"]);
+    const bunBinding = step(bunConsumer, "Validate candidate payload artifact binding");
+    expect(bunBinding.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ needs.installer_smoke_candidate_payload.outputs.artifact_digest }}",
+      ARTIFACT_ID: "${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}",
+      ARTIFACT_RUN_ATTEMPT:
+        "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}",
+      ARTIFACT_HARNESS_SHA: "${{ needs.installer_smoke_candidate_payload.outputs.harness_sha }}",
+      ARTIFACT_TARGET_SHA: "${{ needs.installer_smoke_candidate_payload.outputs.target_sha }}",
+      HARNESS_SHA: "${{ steps.workflow.outputs.sha }}",
+      TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
+    });
+    expect(bunBinding.run).toContain('[[ "$ARTIFACT_HARNESS_SHA" == "$HARNESS_SHA" ]]');
+    expect(bunBinding.run).toContain("verify-upload");
+    expect(step(bunConsumer, "Download candidate payload artifact").with).toMatchObject({
+      "artifact-ids": "${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}",
+      "run-id": "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}",
+    });
     expect(step(bunConsumer, "Setup trusted release harness for Bun smoke")).toMatchObject({
       uses: "./.release-harness/.github/actions/setup-release-harness",
       with: { "node-version": "24.x" },
     });
+    const bunVerify = step(bunConsumer, "Verify candidate payload contents");
+    expect(bunVerify.env).toMatchObject({
+      MANIFEST_SHA256: "${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}",
+      PACKAGE_VERSION: "${{ needs.installer_smoke_candidate_payload.outputs.package_version }}",
+      PRODUCER_RUN_ATTEMPT:
+        "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}",
+      PRODUCER_RUN_ID: "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}",
+      SOURCE_ARCHIVE_SHA256:
+        "${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}",
+    });
+    expect(bunVerify.run).toContain("install-smoke-candidate-payload.mts verify");
+    expect(bunVerify.run).toContain('--run-id "$PRODUCER_RUN_ID"');
+    expect(bunVerify.run).toContain('--run-attempt "$PRODUCER_RUN_ATTEMPT"');
     expect(step(bunConsumer, "Install Bun for global smoke").run).toBe("npm install -g bun@1.3.14");
-    expect(step(bunConsumer, "Run Bun global install image-provider smoke")).toMatchObject({
+    expect(step(bunConsumer, "Run Bun global install candidate-payload smoke")).toMatchObject({
       "working-directory": ".release-harness",
+      env: {
+        OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0",
+        OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ:
+          "${{ runner.temp }}/install-smoke-candidate-payload/candidate.tgz",
+      },
       run: "bash scripts/e2e/bun-global-install-smoke.sh",
     });
+    expect(JSON.stringify(bunConsumer)).not.toContain("root_dockerfile_image");
+    expect(JSON.stringify(bunConsumer)).not.toContain("OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE");
     expect(JSON.stringify(bunConsumer)).not.toContain(
       "./.release-harness/.github/actions/setup-node-env",
     );
@@ -658,7 +697,7 @@ describe("install smoke no-push root image transport", () => {
     });
   });
 
-  it("passes package changelog intent only to current-tree smoke scripts", () => {
+  it("passes package changelog intent only to the candidate packager", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
     expect(
       step(
@@ -668,12 +707,8 @@ describe("install smoke no-push root image transport", () => {
     ).toMatchObject({
       ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
     });
-    expect(
-      step(job(workflow, "bun_global_install_smoke"), "Run Bun global install image-provider smoke")
-        .env,
-    ).toMatchObject({
-      OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG:
-        "${{ inputs.allow_unreleased_changelog }}",
-    });
+    expect(JSON.stringify(job(workflow, "bun_global_install_smoke"))).not.toContain(
+      "OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG",
+    );
   });
 });

--- a/test/scripts/npm-onboard-channel-agent-assertions.test.ts
+++ b/test/scripts/npm-onboard-channel-agent-assertions.test.ts
@@ -60,6 +60,42 @@ function writeSharedAuthProfileStoreSqlite(home: string, store: unknown): void {
   }
 }
 
+function writeAgentAuthDatabase(
+  home: string,
+  rows: {
+    stateKeys?: string[];
+    storeKeys?: string[];
+  } = {},
+): string {
+  const agentDir = path.join(home, ".openclaw", "agents", "main", "agent");
+  fs.mkdirSync(agentDir, { recursive: true });
+  const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE auth_profile_store (
+        store_key TEXT NOT NULL PRIMARY KEY,
+        store_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      ) STRICT;
+      CREATE TABLE auth_profile_state (
+        state_key TEXT NOT NULL PRIMARY KEY,
+        state_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      ) STRICT;
+    `);
+    for (const key of rows.storeKeys ?? []) {
+      db.prepare("INSERT INTO auth_profile_store VALUES (?, '{}', ?)").run(key, Date.now());
+    }
+    for (const key of rows.stateKeys ?? []) {
+      db.prepare("INSERT INTO auth_profile_state VALUES (?, '{}', ?)").run(key, Date.now());
+    }
+  } finally {
+    db.close();
+  }
+  return dbPath;
+}
+
 function runAssert(home: string, channel: string, ...tokens: string[]) {
   return spawnSync(
     process.execPath,
@@ -298,9 +334,8 @@ describe("npm onboard channel agent assertions", () => {
     }
   });
 
-  it("rejects a fresh install that recreates the retired main-agent auth database", () => {
+  it("accepts a main-agent database without retired primary auth rows", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
-    const legacyAgentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
 
     try {
       writeOnboardConfig(tempDir);
@@ -314,13 +349,117 @@ describe("npm onboard channel agent assertions", () => {
           },
         },
       });
-      fs.mkdirSync(legacyAgentDir, { recursive: true });
-      new DatabaseSync(path.join(legacyAgentDir, "openclaw-agent.sqlite")).close();
+      writeAgentAuthDatabase(tempDir, {
+        stateKeys: ["last-good"],
+        storeKeys: ["workspace"],
+      });
+
+      const result = runOnboardAssert(tempDir);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  for (const legacyRow of [
+    { key: "primary", table: "auth_profile_store" },
+    { key: "primary", table: "auth_profile_state" },
+  ] as const) {
+    it(`rejects a retired primary row in ${legacyRow.table}`, () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+      try {
+        writeOnboardConfig(tempDir);
+        writeSharedAuthProfileStoreSqlite(tempDir, {
+          version: 1,
+          profiles: {
+            "openai:api-key": {
+              type: "api_key",
+              provider: "openai",
+              keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+            },
+          },
+        });
+        writeAgentAuthDatabase(tempDir, {
+          stateKeys: legacyRow.table === "auth_profile_state" ? [legacyRow.key] : [],
+          storeKeys: legacyRow.table === "auth_profile_store" ? [legacyRow.key] : [],
+        });
+
+        const result = runOnboardAssert(tempDir);
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          `onboard preserved a retired primary row in ${legacyRow.table}`,
+        );
+      } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+      }
+    });
+  }
+
+  it("fails closed when the main-agent database is unreadable", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+    try {
+      writeOnboardConfig(tempDir);
+      writeSharedAuthProfileStoreSqlite(tempDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
+      fs.mkdirSync(agentDir, { recursive: true });
+      fs.writeFileSync(path.join(agentDir, "openclaw-agent.sqlite"), "not sqlite");
 
       const result = runOnboardAssert(tempDir);
 
       expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("onboard created the retired main-agent auth database");
+      expect(result.stderr).toContain("could not validate the main-agent auth database");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("fails closed when a retired auth table is replaced by a view", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+    try {
+      writeOnboardConfig(tempDir);
+      writeSharedAuthProfileStoreSqlite(tempDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      const dbPath = writeAgentAuthDatabase(tempDir);
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.exec(`
+          DROP TABLE auth_profile_store;
+          CREATE VIEW auth_profile_store AS
+            SELECT 'primary' AS store_key, '{}' AS store_json, 1 AS updated_at;
+        `);
+      } finally {
+        db.close();
+      }
+
+      const result = runOnboardAssert(tempDir);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "could not validate the main-agent auth database: auth_profile_store is view, not a table",
+      );
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
     }

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -739,6 +739,11 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       "${{ fromJson(needs.preflight.outputs.plugin_prerelease_extension_matrix) }}",
     );
     expect(
+      extensionShard.steps.find((step: WorkflowStep) => step.name === "Checkout").with?.[
+        "fetch-depth"
+      ],
+    ).toBe("${{ inputs.full_release_validation && '0' || '1' }}");
+    expect(
       extensionShard.steps.find((step: WorkflowStep) => step.name === "Run extension shard").run,
     ).toContain("--retry=1");
     expect(inspector.name).toBe("plugin-prerelease-inspector");

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2173,13 +2173,17 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     expect(workflow).toContain("uses: ./.release-harness/.github/actions/setup-release-harness");
     expect(workflow).toContain("npm install -g bun@1.3.14");
     expect(workflow).toContain('install-bun: "false"');
-    expect(workflow).toContain("Run Bun global install image-provider smoke");
+    expect(workflow).toContain("Validate candidate payload artifact binding");
+    expect(workflow).toContain("Verify candidate payload contents");
+    expect(workflow).toContain("install-smoke-candidate-payload.mts verify");
+    expect(workflow).toContain("Run Bun global install candidate-payload smoke");
     expect(workflow).toContain("working-directory: .release-harness");
     expect(workflow).toContain("bash scripts/e2e/bun-global-install-smoke.sh");
     expect(workflow).not.toContain("uses: ./.release-harness/.github/actions/setup-node-env");
     expect(workflow).toContain(
-      "OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}",
+      "OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ: ${{ runner.temp }}/install-smoke-candidate-payload/candidate.tgz",
     );
+    expect(workflow).not.toContain("OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE:");
     expect(workflow).toContain("group: ${{ github.workflow }}-workflow-call-${{ github.run_id }}");
     expect(workflow).toContain("cancel-in-progress: false");
     expect(workflow).not.toContain(


### PR DESCRIPTION
## What Problem This Solves

Resolves four tooling failures that prevented the frozen beta candidate
`ee5ead24b1b46a3560f28f8d57e0afcd911acacb` from completing release validation:

- the release scanner rejected the candidate's reviewed Codex and OpenCode CLI execution boundaries;
- the full-release plugin extension shard used a shallow checkout and could not inspect the frozen base commit;
- the Bun install smoke repacked the tooling checkout instead of consuming the sealed candidate package;
- the npm onboarding smoke rejected any agent database, including valid databases with no legacy auth rows.

## Why This Change Was Made

The repair stays on tooling base `c96e8137501421b2dc81f208edcb827a728a01aa`.
It records only the two exact count-one reviewed execution findings and requires
the scanner's actual finding evidence to match each reviewed boundary, gives
the full-release extension shard full history, binds Bun smoke to the existing
sealed candidate artifact and its complete producer tuple, and checks the agent
SQLite database read-only for the retired `primary` rows while failing closed
on unreadable or malformed schemas. The workflow contract tests assert that Bun
uses the verified candidate tarball rather than the retired image-provider path.

The Codex boundary was checked directly against `openai/codex` tag
`rust-v0.149.0` at commit `758ef40f50c1a458425c7cfbf1eb12cbc07af0b0`:
`codex-rs/cli/src/main.rs:343-367`, `2702-2725`, and `3825-3851` confirm the
explicit resume session-id argument contract and its conflict behavior.

## User Impact

No candidate product bytes change. Release validation can qualify the frozen
beta package without repacking it from tooling, weakening the plugin security
scanner, or rejecting valid migrated onboarding state.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/npm-install-security-scan.release.test.ts`
  - exact head: 104/104 passed, including decoy-string/mismatched-spawn rejection
  - frozen candidate with this trusted scanner overlay: 104/104 passed
- `node scripts/run-vitest.mjs test/scripts/test-install-sh-docker.test.ts test/scripts/install-smoke-no-push-workflow.test.ts test/scripts/install-smoke-candidate-payload.test.ts`
  - exact head: 105/105 passed
- prior exact-head workflow/onboarding proof remains green: 48/48 passed
- `node --import tsx scripts/check-workflows.mts`
  - actionlint, zizmor, composite-action interpolation, and conflict-marker checks passed
- focused test type graphs
  - the corrected two-argument scanner call emits no touched-file diagnostic
  - the frozen base/shared install still stops tsgo at
    `packages/terminal-core/src/ansi.ts:194` and a missing `pako` declaration
- `OPENCLAW_CODEX_REPO=<clean rust-v0.149.0 checkout> node scripts/run-vitest.mjs extensions/codex/src/app-server/approval-policy-v0.149.proof.test.ts`
  - frozen candidate: 2/2 passed
- `git diff --check`
  - passed
- `node scripts/check-changed.mjs -- <changed files>`
  - all guards through dead-export scan passed
  - unrelated base/shared-install typecheck failure remains at
    `packages/terminal-core/src/ansi.ts:194` (`TS2554`, expected 1 argument but got 2)

Production/tooling delta: +100/-58 (net +42). Test delta: +344/-21. The
positive tooling delta enforces the sealed-artifact trust boundary, exact
reviewed scanner inventory, and fail-closed read-only SQLite validation.
