### PR TITLE
fix(agents): prevent reloads from losing queued replies or restoring stale credentials

### DIFF
--- a/src/agents/prepared-model-runtime-generation-scope.ts
+++ b/src/agents/prepared-model-runtime-generation-scope.ts
@@ -1,6 +1,14 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import type { PreparedModelRuntimePluginGeneration } from "./prepared-model-runtime.types.js";
+import type {
+  PreparedModelRuntimePluginGeneration,
+  PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.types.js";
+
+type PreparedModelRuntimeGenerationScope = Readonly<{
+  generation: PreparedModelRuntimePluginGeneration;
+  borrowSnapshot?: () => PreparedModelRuntimeSnapshot | undefined;
+}>;
 
 // Global singleton keeps one scope instance across lazy module boundaries so a
 // wrapped turn and the nested embedded runner always share the same store.
@@ -9,15 +17,22 @@ const PREPARED_MODEL_RUNTIME_PLUGIN_GENERATION_SCOPE_KEY: unique symbol = Symbol
 );
 
 const preparedModelRuntimePluginGenerationScope = resolveGlobalSingleton<
-  AsyncLocalStorage<PreparedModelRuntimePluginGeneration | undefined>
+  AsyncLocalStorage<PreparedModelRuntimeGenerationScope | undefined>
 >(PREPARED_MODEL_RUNTIME_PLUGIN_GENERATION_SCOPE_KEY, () => new AsyncLocalStorage());
 
 /** Keeps the exact admitted generation available to nested embedded agent runs. */
 export function withPreparedModelRuntimePluginGenerationScope<T>(
   generation: PreparedModelRuntimePluginGeneration,
   run: () => T,
+  borrowSnapshot?: () => PreparedModelRuntimeSnapshot | undefined,
 ): T {
-  return preparedModelRuntimePluginGenerationScope.run(generation, run);
+  const inherited = preparedModelRuntimePluginGenerationScope.getStore();
+  const borrow =
+    borrowSnapshot ?? (inherited?.generation === generation ? inherited.borrowSnapshot : undefined);
+  return preparedModelRuntimePluginGenerationScope.run(
+    { generation, ...(borrow ? { borrowSnapshot: borrow } : {}) },
+    run,
+  );
 }
 
 /** Detached queue drains re-admit on the current generation, never a predecessor's scope. */
@@ -29,5 +44,13 @@ export function runOutsidePreparedModelRuntimePluginGenerationScope<T>(run: () =
 export function getPreparedModelRuntimePluginGeneration():
   | PreparedModelRuntimePluginGeneration
   | undefined {
-  return preparedModelRuntimePluginGenerationScope.getStore();
+  return preparedModelRuntimePluginGenerationScope.getStore()?.generation;
+}
+
+/** Borrows the exact parent snapshot only while its owning turn lease remains open. */
+export function getPreparedModelRuntimeBorrowedSnapshot(
+  generation: PreparedModelRuntimePluginGeneration,
+): PreparedModelRuntimeSnapshot | undefined {
+  const current = preparedModelRuntimePluginGenerationScope.getStore();
+  return current?.generation === generation ? current.borrowSnapshot?.() : undefined;
 }

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -1,6 +1,7 @@
 /** Agent-run lease admission for lifecycle-owned prepared model runtimes. */
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
+import { getPreparedModelRuntimeBorrowedSnapshot } from "./prepared-model-runtime-generation-scope.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimePublicationSupersededError,
@@ -9,6 +10,7 @@ import {
   normalizePreparedModelRuntimeInput,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
+  resolveConfiguredOwner,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeLease,
   type PreparedModelRuntimeOwner,
@@ -77,6 +79,42 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         key = ownerKey(input);
       }
       continue;
+    }
+    if (provenance === "run" && context.getGatewayLifecycleActive() && options.pluginGeneration) {
+      const configuredOwner = resolveConfiguredOwner(context.owners, input);
+      if (configuredOwner?.pending) {
+        await configuredOwner.pending.catch(() => undefined);
+        continue;
+      }
+      if (
+        configuredOwner &&
+        (configuredOwner.needsRefresh ||
+          configuredOwner.pluginGeneration !== options.pluginGeneration)
+      ) {
+        const borrowed = getPreparedModelRuntimeBorrowedSnapshot(options.pluginGeneration);
+        if (
+          !configuredOwner.needsRefresh &&
+          borrowed &&
+          borrowed.metadataSnapshot === options.pluginGeneration.pluginMetadataSnapshot &&
+          borrowed.config === input.config &&
+          borrowed.agentId === input.agentId &&
+          borrowed.agentDir === input.agentDir &&
+          borrowed.inheritedAuthDir === input.inheritedAuthDir &&
+          borrowed.workspaceDir === input.workspaceDir &&
+          (!input.allowGatewaySubagentBinding || borrowed.allowGatewaySubagentBinding) &&
+          !input.readOnly &&
+          !input.loadRuntimePlugins &&
+          !input.skipCredentials &&
+          !input.env
+        ) {
+          // A turn may finish under its still-open parent lease after reload. Its historic
+          // generation must never publish over the configured owner for newly admitted work.
+          return { snapshot: borrowed, release: () => {} };
+        }
+        throw new PreparedModelRuntimeOwnerNotPublishedError(
+          `prepared model runtime plugin generation was superseded for ${input.agentDir}`,
+        );
+      }
     }
     let existing = context.owners.get(key);
     let staleDynamicOwner =

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -8,6 +8,7 @@ import {
   hasConfiguredOwnerMatching,
   ownerKey,
   normalizePreparedModelRuntimeInput,
+  preparedModelRuntimeConfigsMatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
   resolveConfiguredOwner,
@@ -96,7 +97,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
           !configuredOwner.needsRefresh &&
           borrowed &&
           borrowed.metadataSnapshot === options.pluginGeneration.pluginMetadataSnapshot &&
-          borrowed.config === input.config &&
+          preparedModelRuntimeConfigsMatch(borrowed.config, input.config) &&
           borrowed.agentId === input.agentId &&
           borrowed.agentDir === input.agentDir &&
           borrowed.inheritedAuthDir === input.inheritedAuthDir &&

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { withPreparedModelRuntimePluginGenerationScope } from "./prepared-model-runtime-generation-scope.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
@@ -246,7 +247,7 @@ describe("prepared model runtime owner selection", () => {
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
   });
 
-  it("sequences pending owners by their explicit plugin generation", async () => {
+  it("rejects unpublished plugin generations while matching pending callers share their owner", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
@@ -281,24 +282,164 @@ describe("prepared model runtime owner selection", () => {
     });
     const pendingB = acquireAgentRunPreparedModelRuntime(input, {
       pluginGeneration: generationB,
-    });
+    }).catch((error: unknown) => error);
     await Promise.resolve();
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
     finishGenerationA();
-    const [leaseA, matchingLeaseA, leaseB] = await Promise.all([
+    const [leaseA, matchingLeaseA, rejectedGeneration] = await Promise.all([
       pendingA,
       matchingPendingA,
       pendingB,
     ]);
 
     expect(matchingLeaseA.snapshot).toBe(leaseA.snapshot);
-    expect(leaseB.snapshot).not.toBe(leaseA.snapshot);
+    expect(rejectedGeneration).toEqual(
+      expect.objectContaining({ message: expect.stringContaining("superseded") }),
+    );
     expect(leaseA.snapshot.metadataSnapshot).toBe(generationA!.pluginMetadataSnapshot);
-    expect(leaseB.snapshot.metadataSnapshot).toBe(generationB.pluginMetadataSnapshot);
+    await expect(prepareModelRuntimeSnapshot(input)).resolves.toBe(leaseA.snapshot);
     leaseA.release();
     matchingLeaseA.release();
-    await expect(prepareModelRuntimeSnapshot(input)).resolves.toBe(leaseB.snapshot);
-    leaseB.release();
+  });
+
+  it("keeps a committed gateway owner current when an admitted turn resumes on its older generation", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const defaults = {
+      model: "openai/gpt-5",
+      models: {
+        "openai/gpt-5": { params: { transport: "sse" as const, openaiWsWarmup: false } },
+      },
+    };
+    const previousConfig = {
+      agents: { defaults },
+      messages: { responsePrefix: "previous" },
+    };
+    const committedConfig = {
+      agents: { defaults },
+      messages: { responsePrefix: "committed" },
+    };
+    const publicationOptions = {
+      allowGatewaySubagentBinding: true,
+      catalogMode: "static" as const,
+      gatewayLifecycle: true,
+    };
+    const runInput = (config: typeof previousConfig) => ({
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      allowGatewaySubagentBinding: true,
+      config,
+      runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5", runtime: "openclaw" }],
+      workspaceDir: "/tmp/unused-workspace",
+    });
+
+    await refreshPreparedModelRuntimeSnapshots(previousConfig, publicationOptions);
+    const admitted = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    const previousSnapshot = getPreparedModelRuntimeSnapshot(runInput(previousConfig));
+    expect(admitted?.pluginGeneration).toBeDefined();
+    expect(previousSnapshot).toBeDefined();
+
+    const outerLease = await acquireAgentRunPreparedModelRuntime(runInput(previousConfig), {
+      catalogMode: "static",
+      pluginGeneration: admitted!.pluginGeneration,
+    });
+    expect(outerLease.snapshot).toBe(previousSnapshot);
+    let outerLeaseActive = true;
+
+    await refreshPreparedModelRuntimeSnapshots(committedConfig, publicationOptions);
+    const committedSnapshot = getPreparedModelRuntimeSnapshot(runInput(committedConfig));
+    const registryLoads = mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.length;
+    expect(committedSnapshot).toBeDefined();
+    expect(committedSnapshot).not.toBe(previousSnapshot);
+    let releaseDetachedAdmission!: () => void;
+    const detachedAdmissionGate = new Promise<void>((resolve) => {
+      releaseDetachedAdmission = resolve;
+    });
+    let detachedAdmission!: Promise<unknown>;
+
+    try {
+      await withPreparedModelRuntimePluginGenerationScope(
+        admitted!.pluginGeneration,
+        async () => {
+          const resumed = await withPreparedModelRuntimePluginGenerationScope(
+            admitted!.pluginGeneration,
+            async () =>
+              await acquireAgentRunPreparedModelRuntime(runInput(previousConfig), {
+                catalogMode: "static",
+                pluginGeneration: admitted!.pluginGeneration,
+              }),
+          );
+
+          expect(resumed.snapshot).toBe(previousSnapshot);
+          expect(getPreparedModelRuntimeSnapshot(runInput(committedConfig))).toBe(
+            committedSnapshot,
+          );
+          expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(registryLoads);
+          resumed.release();
+          await expect(
+            acquireAgentRunPreparedModelRuntime(
+              { ...runInput(previousConfig), workspaceDir: "/tmp/different-workspace" },
+              { pluginGeneration: admitted!.pluginGeneration },
+            ),
+          ).rejects.toThrow("plugin generation was superseded");
+          await expect(
+            acquireAgentRunPreparedModelRuntime(runInput(previousConfig), {
+              pluginGeneration: { ...admitted!.pluginGeneration },
+            }),
+          ).rejects.toThrow("plugin generation was superseded");
+          detachedAdmission = detachedAdmissionGate.then(async () =>
+            acquireAgentRunPreparedModelRuntime(runInput(previousConfig), {
+              pluginGeneration: admitted!.pluginGeneration,
+            }),
+          );
+        },
+        () => (outerLeaseActive ? outerLease.snapshot : undefined),
+      );
+    } finally {
+      outerLeaseActive = false;
+      outerLease.release();
+    }
+    releaseDetachedAdmission();
+    await expect(detachedAdmission).rejects.toThrow("plugin generation was superseded");
+
+    await expect(
+      acquireAgentRunPreparedModelRuntime(runInput(previousConfig), {
+        pluginGeneration: admitted!.pluginGeneration,
+      }),
+    ).rejects.toThrow("plugin generation was superseded");
+    expect(getPreparedModelRuntimeSnapshot(runInput(committedConfig))).toBe(committedSnapshot);
+
+    const next = await acquireAgentRunPreparedModelRuntime(runInput(committedConfig));
+    expect(next.snapshot).toBe(committedSnapshot);
+    next.release();
+  });
+
+  it("does not let a stale pinned generation replace an owner awaiting auth refresh", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const admitted = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    expect(admitted).toBeDefined();
+
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+
+    await expect(
+      acquireAgentRunPreparedModelRuntime(
+        {
+          agentId: "default",
+          agentDir: "/tmp/unused-agent",
+          config,
+          workspaceDir: "/tmp/unused-workspace",
+        },
+        { pluginGeneration: { ...admitted!.pluginGeneration } },
+      ),
+    ).rejects.toThrow("plugin generation was superseded");
+
+    await vi.waitFor(async () => {
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ).resolves.toMatchObject({ config });
+    });
   });
 
   it("bounds retained gateway run owners while reusing recent selections", async () => {

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -375,6 +375,12 @@ describe("prepared model runtime owner selection", () => {
           );
           expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(registryLoads);
           resumed.release();
+          const clonedConfigLease = await acquireAgentRunPreparedModelRuntime(
+            runInput(structuredClone(previousConfig)),
+            { pluginGeneration: admitted!.pluginGeneration },
+          );
+          expect(clonedConfigLease.snapshot).toBe(previousSnapshot);
+          clonedConfigLease.release();
           await expect(
             acquireAgentRunPreparedModelRuntime(
               { ...runInput(previousConfig), workspaceDir: "/tmp/different-workspace" },

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -148,6 +148,14 @@ export function hasConfiguredOwnerMatching(
   return findConfiguredOwnerCandidates(owners, rawInput).length > 0;
 }
 
+export function resolveConfiguredOwner(
+  owners: Map<string, PreparedModelRuntimeOwner>,
+  rawInput: PreparedModelRuntimeInput,
+): PreparedModelRuntimeOwner | undefined {
+  const candidates = findConfiguredOwnerCandidates(owners, rawInput);
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
 function resolveCommittedConfiguredOwner(
   owners: Map<string, PreparedModelRuntimeOwner>,
   rawInput: PreparedModelRuntimeInput,

--- a/src/auto-reply/reply/get-reply-run.prepared-metadata.test.ts
+++ b/src/auto-reply/reply/get-reply-run.prepared-metadata.test.ts
@@ -103,9 +103,10 @@ describe("runPreparedReply prepared metadata", () => {
         config,
         agentId: "main",
         agentDir: "/tmp/openclaw-reply-agent",
+        allowGatewaySubagentBinding: true,
         workspaceDir,
       },
-      { pluginGeneration },
+      { catalogMode: "static", pluginGeneration },
     );
     expect(admissionSnapshot).toBe(metadataSnapshot);
     expect(executionSnapshot).toBe(metadataSnapshot);

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -40,10 +40,12 @@ export async function runPreparedReply(
       config: dispatchRuntime.config,
       agentId: dispatchRuntime.agentId,
       agentDir: dispatchRuntime.agentDir,
+      allowGatewaySubagentBinding: true,
       workspaceDir: context.workspaceDir,
     },
-    { pluginGeneration: dispatchRuntime.pluginGeneration },
+    { catalogMode: "static", pluginGeneration: dispatchRuntime.pluginGeneration },
   );
+  let leaseActive = true;
   try {
     return await withPreparedModelRuntimePluginGenerationScope(
       dispatchRuntime.pluginGeneration,
@@ -51,8 +53,10 @@ export async function runPreparedReply(
         withPluginRuntimeGenerationScope(lease.snapshot, () =>
           executePreparedReplyContext(context),
         ),
+      () => (leaseActive ? lease.snapshot : undefined),
     );
   } finally {
+    leaseActive = false;
     lease.release();
   }
 }

--- a/test/e2e/qa-lab/runtime/fixtures/worker-inference-generation-provider/index.js
+++ b/test/e2e/qa-lab/runtime/fixtures/worker-inference-generation-provider/index.js
@@ -15,7 +15,7 @@ function requireConfig(pluginConfig) {
   const barrierPath = pluginConfig?.barrierPath;
   const mockProviderBaseUrl = pluginConfig?.mockProviderBaseUrl;
   if (
-    (generation !== "A" && generation !== "B" && generation !== "C") ||
+    (generation !== "A" && generation !== "B" && generation !== "C" && generation !== "D") ||
     typeof tracePath !== "string" ||
     !tracePath ||
     typeof barrierPath !== "string" ||

--- a/test/e2e/qa-lab/runtime/fixtures/worker-inference-generation-provider/index.js
+++ b/test/e2e/qa-lab/runtime/fixtures/worker-inference-generation-provider/index.js
@@ -15,7 +15,7 @@ function requireConfig(pluginConfig) {
   const barrierPath = pluginConfig?.barrierPath;
   const mockProviderBaseUrl = pluginConfig?.mockProviderBaseUrl;
   if (
-    (generation !== "A" && generation !== "B" && generation !== "C" && generation !== "D") ||
+    (generation !== "A" && generation !== "B" && generation !== "C") ||
     typeof tracePath !== "string" ||
     !tracePath ||
     typeof barrierPath !== "string" ||
@@ -68,8 +68,6 @@ export default definePluginEntry({
     if (typeof sourceCredential !== "string" || !sourceCredential) {
       throw new Error("qa worker generation provider requires a direct credential");
     }
-    const runtimeCredential = `qa-worker-runtime-${generation}`;
-
     trace("registered", { registrationMode: api.registrationMode });
     api.registerReload({
       hotPrefixes: [`plugins.entries.${PLUGIN_ID}.config`],
@@ -101,7 +99,10 @@ export default definePluginEntry({
           await waitForBarrierRelease(barrierPath);
           trace("auth-prepare-released", { waited: true });
         }
-        trace("auth-ready", { runtimeCredentialGeneration: generation });
+        const runtimeGeneration =
+          typeof apiKey === "string" ? apiKey.slice(apiKey.lastIndexOf("-") + 1) : generation;
+        const runtimeCredential = `qa-worker-runtime-${runtimeGeneration}`;
+        trace("auth-ready", { runtimeCredentialGeneration: runtimeGeneration });
         return { apiKey: runtimeCredential };
       },
       createStreamFn: ({ model }) => {

--- a/test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts
+++ b/test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts
@@ -6,7 +6,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
 import {
+  createQaBusState,
+  createQaChannelTransport,
   QA_EVIDENCE_FILENAME,
+  startQaBusServer,
   startQaGatewayChild,
   startQaMockOpenAiServer,
   type QaEvidenceSummaryJson,
@@ -43,7 +46,7 @@ const GENERATION_B_REPLY = "WORKER-GENERATION-B-OK";
 const GENERATION_C_REPLY = "WORKER-GENERATION-C-OK";
 const OWNERSHIP_STAGES = ["factory", "policy", "wrapper", "execution"] as const;
 
-type Generation = "A" | "B" | "C";
+type Generation = "A" | "B" | "C" | "D";
 type ProducerOptions = { artifactBase: string; repoRoot: string };
 type TraceEvent = {
   event: string;
@@ -81,7 +84,7 @@ async function readTrace(tracePath: string): Promise<TraceEvent[]> {
 
 function classifyAuthorization(value: string | undefined): Generation | "unknown" {
   const credential = value?.replace(/^Bearer\s+/iu, "");
-  for (const generation of ["A", "B", "C"] as const) {
+  for (const generation of ["A", "B", "C", "D"] as const) {
     if (credential === `qa-worker-runtime-${generation}`) {
       return generation;
     }
@@ -210,6 +213,7 @@ function buildGenerationConfig(params: {
       ...config.agents,
       defaults: {
         ...config.agents?.defaults,
+        maxConcurrent: 1,
         model: { primary: MODEL_REF, fallbacks: [] },
         models: {
           ...config.agents?.defaults?.models,
@@ -398,6 +402,8 @@ async function runProof(options: ProducerOptions) {
     options.repoRoot,
     "test/e2e/qa-lab/runtime/fixtures/worker-inference-generation-provider",
   );
+  const channelState = createQaBusState();
+  const channelBus = await startQaBusServer({ state: channelState });
   const mock = await startQaMockOpenAiServer({ modelRefs: [MODEL_REF] });
   const authProxy = await startAuthInspectingProxy(mock.baseUrl);
   let gateway: WireGateway | undefined;
@@ -418,10 +424,11 @@ async function runProof(options: ProducerOptions) {
       providerMode: "mock-openai",
       primaryModel: MODEL_REF,
       alternateModel: DEFAULT_MOCK_MODEL_REF,
-      transportBaseUrl: "http://127.0.0.1",
+      transport: createQaChannelTransport(channelState),
+      transportBaseUrl: channelBus.baseUrl,
       controlUiEnabled: false,
-      mutateConfig: (config) =>
-        buildGenerationConfig({
+      mutateConfig: (config) => ({
+        ...buildGenerationConfig({
           config,
           generation: "A",
           pluginDir,
@@ -429,6 +436,8 @@ async function runProof(options: ProducerOptions) {
           barrierPath,
           mockProviderBaseUrl: `${authProxy.baseUrl}/v1`,
         }),
+        session: { ...config.session, dmScope: "per-peer" },
+      }),
     });
     await waitFor("generation A provider registration", async () => {
       const registrations = (await readTrace(tracePath)).filter(
@@ -528,16 +537,86 @@ async function runProof(options: ProducerOptions) {
       throw new Error(`worker history reply counts were not exact: ${JSON.stringify(replyCounts)}`);
     }
 
+    const channelTraceCursor = (await readTrace(tracePath)).length;
+    const channelReplies = {
+      blocker: "CHANNEL-GENERATION-C-BLOCKER-OK",
+      admitted: "CHANNEL-GENERATION-C-ADMITTED-OK",
+      current: "CHANNEL-GENERATION-D-CURRENT-OK",
+    };
+    const sendChannelTurn = (conversationId: string, reply: string) =>
+      channelState.addInboundMessage({
+        conversation: { id: conversationId, kind: "direct" },
+        senderId: conversationId,
+        text: `Reply exactly: ${reply}`,
+      });
+    const waitForChannelReply = async (conversationId: string, reply: string) =>
+      await waitFor(`${reply} channel delivery`, () =>
+        channelState
+          .getSnapshot()
+          .messages.find(
+            (message) =>
+              message.direction === "outbound" &&
+              message.conversation.id === conversationId &&
+              message.text.includes(reply),
+          ),
+      );
+
+    await fs.writeFile(barrierPath, "armed\n", "utf8");
+    sendChannelTurn("generation-blocker", channelReplies.blocker);
+    await waitFor("generation C channel blocker auth barrier", async () =>
+      (await readTrace(tracePath))
+        .slice(channelTraceCursor)
+        .find(
+          (event) =>
+            event.event === "auth-prepare" && event.generation === "C" && event.waited === true,
+        ),
+    );
+    sendChannelTurn("generation-admitted", channelReplies.admitted);
+    const activeGateway = gateway;
+    const queuedMainLane = await waitFor(
+      "admitted generation C turn waiting for the global lane",
+      async () => {
+        const diagnostics = (await activeGateway.call("diagnostics.lanes", {})) as {
+          lanes?: Array<{ lane?: string; activeCount?: number; queuedCount?: number }>;
+        };
+        return diagnostics.lanes?.find(
+          (lane) => lane.lane === "main" && lane.activeCount === 1 && (lane.queuedCount ?? 0) >= 1,
+        );
+      },
+    );
+    const hotPublishD = await hotPublishGeneration({ gateway, tracePath, generation: "D" });
+    await fs.writeFile(barrierPath, "released\n", "utf8");
+    await waitForChannelReply("generation-blocker", channelReplies.blocker);
+    await waitForChannelReply("generation-admitted", channelReplies.admitted);
+    sendChannelTurn("generation-current", channelReplies.current);
+    await waitForChannelReply("generation-current", channelReplies.current);
+
+    const channelAuthGenerations = authProxy.authGenerations.slice(3);
+    if (JSON.stringify(channelAuthGenerations) !== JSON.stringify(["C", "C", "D"])) {
+      throw new Error(
+        `admitted channel turn replaced the committed runtime owner: ${JSON.stringify(channelAuthGenerations)}`,
+      );
+    }
+
     verdict = {
       status: "pass",
       providerMode: "mock-openai",
       sessionKey: SESSION_KEY,
       placement: dispatched.placement,
-      hotPublishes: { generationB: hotPublishB, generationC: hotPublishC },
+      hotPublishes: {
+        generationB: hotPublishB,
+        generationC: hotPublishC,
+        generationD: hotPublishD,
+      },
       generationA: { reply: GENERATION_A_REPLY, stages: stagesA },
       generationB: { reply: GENERATION_B_REPLY, stages: stagesB },
       generationC: { reply: GENERATION_C_REPLY, stages: stagesC },
       runtimeCredentialGenerations: authProxy.authGenerations,
+      channelGenerationOwnership: {
+        replies: channelReplies,
+        queuedMainLane,
+        channelAuthGenerations,
+      },
       replyCounts,
       requestFacts,
       tracePath,
@@ -558,6 +637,7 @@ async function runProof(options: ProducerOptions) {
     published ? closeWireServer(published.server) : Promise.resolve(),
     authProxy.stop(),
     mock.stop(),
+    channelBus.stop(),
     fs.rm(root, { recursive: true, force: true }),
   ]);
   const cleanupFailures = cleanup.flatMap((result) =>

--- a/test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts
+++ b/test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts
@@ -279,6 +279,49 @@ async function hotPublishGeneration(params: {
   return { pidBefore: before.pid!, pidAfter: after.pid! };
 }
 
+async function hotPublishChannelCredential(params: {
+  gateway: WireGateway;
+  generation: Generation;
+}): Promise<{ pidBefore: number; pidAfter: number }> {
+  const before = (await params.gateway.call("system.info", {})) as { pid?: number };
+  const previous = (await params.gateway.call("config.get", {})) as { hash?: string };
+  const config = JSON.parse(await fs.readFile(params.gateway.configPath, "utf8")) as OpenClawConfig;
+  const providerConfig = config.models?.providers?.[PROVIDER_ID];
+  if (!providerConfig) {
+    throw new Error("worker generation provider was missing before credential reload");
+  }
+  const next: OpenClawConfig = {
+    ...config,
+    models: {
+      ...config.models,
+      providers: {
+        ...config.models?.providers,
+        [PROVIDER_ID]: {
+          ...providerConfig,
+          apiKey: `${SOURCE_CREDENTIAL_PREFIX}-${params.generation}`,
+        },
+      },
+    },
+  };
+  await fs.writeFile(params.gateway.configPath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  await waitFor(`generation ${params.generation} credential publication`, async () => {
+    const current = (await params.gateway.call("config.get", {})) as {
+      hash?: string;
+      appliedConfigHash?: string;
+      configRevisionHash?: string;
+    };
+    return current.hash !== previous.hash &&
+      current.appliedConfigHash === current.configRevisionHash
+      ? current
+      : undefined;
+  });
+  const after = (await params.gateway.call("system.info", {})) as { pid?: number };
+  if (!Number.isSafeInteger(before.pid) || after.pid !== before.pid) {
+    throw new Error(`credential hot publish replaced the Gateway: ${before.pid} -> ${after.pid}`);
+  }
+  return { pidBefore: before.pid!, pidAfter: after.pid! };
+}
+
 async function startTurn(operator: GatewayClient, reply: string): Promise<string> {
   const runId = `${SCENARIO_ID}-${randomUUID()}`;
   const started = await operator.request<TurnResult>("chat.send", {
@@ -419,7 +462,12 @@ async function runProof(options: ProducerOptions) {
     published = await createPublishedWireWorkspace(root);
     gateway = await startQaGatewayChild({
       repoRoot: options.repoRoot,
-      useRepoCli: true,
+      command: {
+        executablePath: process.execPath,
+        argsPrefix: [path.join(options.repoRoot, "dist", "index.js")],
+        cwd: options.repoRoot,
+        usePackagedPlugins: true,
+      },
       providerBaseUrl: `${authProxy.baseUrl}/v1`,
       providerMode: "mock-openai",
       primaryModel: MODEL_REF,
@@ -436,6 +484,15 @@ async function runProof(options: ProducerOptions) {
           barrierPath,
           mockProviderBaseUrl: `${authProxy.baseUrl}/v1`,
         }),
+        channels: {
+          ...config.channels,
+          "qa-channel": {
+            ...config.channels?.["qa-channel"],
+            accounts: {
+              parallel: { enabled: true, baseUrl: channelBus.baseUrl, allowFrom: ["*"] },
+            },
+          },
+        },
         session: { ...config.session, dmScope: "per-peer" },
       }),
     });
@@ -543,8 +600,9 @@ async function runProof(options: ProducerOptions) {
       admitted: "CHANNEL-GENERATION-C-ADMITTED-OK",
       current: "CHANNEL-GENERATION-D-CURRENT-OK",
     };
-    const sendChannelTurn = (conversationId: string, reply: string) =>
+    const sendChannelTurn = (conversationId: string, reply: string, accountId = "default") =>
       channelState.addInboundMessage({
+        accountId,
         conversation: { id: conversationId, kind: "direct" },
         senderId: conversationId,
         text: `Reply exactly: ${reply}`,
@@ -571,7 +629,9 @@ async function runProof(options: ProducerOptions) {
             event.event === "auth-prepare" && event.generation === "C" && event.waited === true,
         ),
     );
-    sendChannelTurn("generation-admitted", channelReplies.admitted);
+    // Each QA account serializes its own inbound stream, so use a second account
+    // to admit the victim while the first account's turn still holds the main lane.
+    sendChannelTurn("generation-admitted", channelReplies.admitted, "parallel");
     const activeGateway = gateway;
     const queuedMainLane = await waitFor(
       "admitted generation C turn waiting for the global lane",
@@ -584,7 +644,9 @@ async function runProof(options: ProducerOptions) {
         );
       },
     );
-    const hotPublishD = await hotPublishGeneration({ gateway, tracePath, generation: "D" });
+    // A provider-only config reload replaces prepared owners without stopping
+    // the active channel accounts, unlike a whole plugin-generation reload.
+    const hotPublishD = await hotPublishChannelCredential({ gateway, generation: "D" });
     await fs.writeFile(barrierPath, "released\n", "utf8");
     await waitForChannelReply("generation-blocker", channelReplies.blocker);
     await waitForChannelReply("generation-admitted", channelReplies.admitted);
@@ -688,7 +750,7 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
         { filePath: `${SCENARIO_ID}-trace.jsonl`, kind: "trace" },
       ],
       details:
-        "A baseline worker turn established the placement lifecycle; generation B then retained factory, policy, wrapper, and execution ownership while C hot-published, and the next turn used C",
+        "Worker generations A, B, and C preserved provider ownership across plugin reload; two concurrent channel turns retained C while credential generation D committed, and the next channel turn used D",
       durationMs: Math.max(1, Date.now() - startedAt),
       status: "pass",
     });


### PR DESCRIPTION
Related: #127217

## What Problem This Solves

Fixes an issue where users sending messages during a provider or credential hot reload could lose an already-admitted reply or silently restore the previous runtime configuration for later turns. The original generation-pinning fix preserved a copied generation identifier, but a queued turn could use that identifier to publish its retired configuration over the newly committed Gateway owner.

## Why This Change Was Made

The prepared-runtime owner now fences retired or refreshing configured generations and permits old-generation reuse only through the exact outer reply lease while that lease remains open. Borrowing validates the generation, canonical configuration, agent, directories, workspace, metadata, and binding capability; equivalent cloned configurations are accepted through the existing canonical comparison, while expired, copied, mismatched, and auth-refresh admissions fail closed.

The existing worker-generation QA producer now also drives two real QA-channel accounts through a one-slot Gateway command lane, changes provider credentials while the second already-admitted turn is queued, and verifies that the existing Gateway process preserves old-turn ownership without rolling back the current owner.

## User Impact

Messages already accepted before a config or credential reload complete with their original provider state, newly accepted messages use the new state, and stale generations cannot resurrect retired credentials or policy.

## Evidence

- Red owner-boundary regression reproduced stale runtime republication before the fix.
- `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.owner-selection.test.ts src/agents/prepared-model-runtime.lifecycle.test.ts src/auto-reply/reply/get-reply-run.prepared-metadata.test.ts src/auto-reply/reply/queue.drain-restart.test.ts` — **95 tests passed**.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed.
- `OPENCLAW_BUILD_PRIVATE_QA=1 node --import tsx test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts --artifact-base /tmp/openclaw-runtime-generation-proof` — **passed** against a real isolated Gateway, paired worker, local fixture provider, and two QA-channel accounts. Gateway PID stayed unchanged across three reloads; all six replies arrived; observed provider credentials were `A, B, C, C, C, D`; the saturated main lane reported one active and one queued turn; overlapping channel turns used `C, C`, and the next fresh turn used `D`.
- Independent structured security/code reviews: clean.
- Production: `+79/-5` (net `+74`), required for the closure-bound lease/security ownership boundary. Tests and existing QA fixtures: `+310/-19`; no new standalone harness.
