### PR TITLE
fix(cli): reject conflicting read-only doctor postures

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -100,7 +100,7 @@ openclaw channels status --probe
 | `--skip <id>`                   | With `--lint`: skip a check id. Repeatable.                                                                                                                                             |
 | `--only <id>`                   | With `--lint`: run only the given check id(s). Repeatable.                                                                                                                              |
 
-`--severity-min`, `--all`, `--only`, and `--skip` are only accepted together with `--lint`. Bare `--json` uses the default read-only lint check selection but keeps Doctor's advisory exit behavior. It cannot be combined with `--repair`, `--fix`, or `--force` unless another machine mode owns the command.
+`--severity-min`, `--all`, `--only`, and `--skip` are only accepted together with `--lint`. Bare `--json` uses the default read-only lint check selection but keeps Doctor's advisory exit behavior. Both read-only postures reject `--repair`, `--fix`, `--force`, `--yes`, and `--generate-gateway-token`. Explicit `--lint` also rejects `--session-sqlite` modes and their selectors, including `--github-issue`. Other machine modes can still use `--json` for their own output.
 
 ## Lint mode
 

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -26,6 +26,24 @@ const {
   runDoctorLintCli,
 } = mocks;
 
+const DOCTOR_MUTATION_OPTIONS = [
+  "--repair",
+  "--fix",
+  "--force",
+  "--yes",
+  "--generate-gateway-token",
+] as const;
+
+const DOCTOR_SESSION_SQLITE_MODES = [
+  "inspect",
+  "dry-run",
+  "import",
+  "validate",
+  "compact",
+  "restore",
+  "recover",
+] as const;
+
 vi.mock("../../commands/doctor.js", () => ({
   doctorCommand: mocks.doctorCommand,
 }));
@@ -372,11 +390,124 @@ describe("registerMaintenanceCommands doctor action", () => {
     }
   });
 
-  it("rejects JSON repair mode before running doctor", async () => {
-    const message =
-      "doctor --json runs read-only lint checks and cannot be combined with --repair, --fix, or --force.";
+  it.each(
+    DOCTOR_MUTATION_OPTIONS.flatMap((mutationOption) => [
+      { mode: "explicit lint", args: ["--lint", mutationOption], mutationOption },
+      {
+        mode: "explicit JSON lint",
+        args: ["--lint", "--json", mutationOption],
+        mutationOption,
+      },
+      { mode: "implicit JSON lint", args: ["--json", mutationOption], mutationOption },
+    ]),
+  )("rejects $mutationOption in $mode before running doctor", async ({ args, mutationOption }) => {
+    const mode = args.includes("--lint") ? "--lint" : "--json";
+    const conflictingOptions =
+      mutationOption === "--yes" || mutationOption === "--generate-gateway-token"
+        ? mutationOption
+        : "--repair, --fix, or --force";
+    const message = `doctor ${mode} runs read-only lint checks and cannot be combined with ${conflictingOptions}.`;
 
-    await runMaintenanceCli(["doctor", "--json", "--repair"]);
+    await runMaintenanceCli(["doctor", ...args]);
+
+    expect(doctorCommand).not.toHaveBeenCalled();
+    expect(runDoctorLintCli).not.toHaveBeenCalled();
+    expect(runtime.writeJson).toHaveBeenCalledWith(jsonFailure(message));
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
+  it.each(DOCTOR_MUTATION_OPTIONS)(
+    "keeps interactive lint mutation conflict %s on stderr",
+    async (mutationOption) => {
+      const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+      Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+
+      try {
+        await runMaintenanceCli(["doctor", "--lint", mutationOption]);
+
+        expect(doctorCommand).not.toHaveBeenCalled();
+        expect(runDoctorLintCli).not.toHaveBeenCalled();
+        expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(mutationOption));
+        expect(runtime.writeJson).not.toHaveBeenCalled();
+        expect(runtime.exit).toHaveBeenCalledWith(2);
+      } finally {
+        if (stdoutDescriptor) {
+          Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
+        } else {
+          Reflect.deleteProperty(process.stdout, "isTTY");
+        }
+      }
+    },
+  );
+
+  it.each(["--yes", "--generate-gateway-token"])(
+    "keeps %s available to mutating doctor posture",
+    async (mutationOption) => {
+      doctorCommand.mockResolvedValue(undefined);
+
+      await runMaintenanceCli(["doctor", mutationOption]);
+
+      expect(doctorCommand).toHaveBeenCalledTimes(1);
+      expect(runDoctorLintCli).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(0);
+    },
+  );
+
+  it.each(DOCTOR_SESSION_SQLITE_MODES)(
+    "rejects separate session SQLite %s posture during explicit lint",
+    async (sessionMode) => {
+      const message = `doctor --lint runs read-only lint checks and cannot be combined with --session-sqlite ${sessionMode}.`;
+
+      await runMaintenanceCli(["doctor", "--lint", "--session-sqlite", sessionMode]);
+
+      expect(doctorCommand).not.toHaveBeenCalled();
+      expect(runDoctorLintCli).not.toHaveBeenCalled();
+      expect(runtime.writeJson).toHaveBeenCalledWith(jsonFailure(message));
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(2);
+    },
+  );
+
+  it.each(DOCTOR_SESSION_SQLITE_MODES)(
+    "preserves session SQLite %s posture with its own JSON output",
+    async (sessionMode) => {
+      doctorCommand.mockResolvedValue(undefined);
+
+      await runMaintenanceCli(["doctor", "--session-sqlite", sessionMode, "--json"]);
+
+      expect(doctorCommand).toHaveBeenCalledTimes(1);
+      expect(commandCall(doctorCommand)[1]).toEqual(
+        expect.objectContaining({ sessionSqlite: sessionMode, json: true }),
+      );
+      expect(runDoctorLintCli).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(0);
+    },
+  );
+
+  it.each([
+    ["agent selector", ["--session-sqlite-agent", "main"]],
+    ["store selector", ["--session-sqlite-store", "/tmp/openclaw/sessions.json"]],
+    ["all-agents selector", ["--session-sqlite-all-agents"]],
+    ["GitHub issue creation", ["--github-issue"]],
+  ])("rejects orphan session SQLite %s during explicit lint", async (_label, options) => {
+    const message =
+      "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.";
+
+    await runMaintenanceCli(["doctor", "--lint", ...options]);
+
+    expect(doctorCommand).not.toHaveBeenCalled();
+    expect(runDoctorLintCli).not.toHaveBeenCalled();
+    expect(runtime.writeJson).toHaveBeenCalledWith(jsonFailure(message));
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
+  it("rejects GitHub issue creation from session recovery during explicit lint", async () => {
+    const message =
+      "doctor --lint runs read-only lint checks and cannot be combined with --session-sqlite recover.";
+
+    await runMaintenanceCli(["doctor", "--lint", "--session-sqlite", "recover", "--github-issue"]);
 
     expect(doctorCommand).not.toHaveBeenCalled();
     expect(runDoctorLintCli).not.toHaveBeenCalled();

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -115,20 +115,36 @@ export function registerMaintenanceCommands(program: Command) {
           opts.json === true,
         );
       }
+      if (hasSessionSqliteOnlyDoctorOptions(opts)) {
+        return exitDoctorError(
+          "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.",
+          opts.json === true || (opts.lint === true && !process.stdout.isTTY),
+        );
+      }
       const jsonImpliesLint =
         opts.json === true &&
         opts.lint !== true &&
         opts.postUpgrade !== true &&
         typeof opts.stateSqlite !== "string" &&
-        typeof opts.sessionSqlite !== "string" &&
-        !hasSessionSqliteOnlyDoctorOptions(opts);
-      if (jsonImpliesLint && (opts.repair === true || opts.fix === true || opts.force === true)) {
+        typeof opts.sessionSqlite !== "string";
+      const lintMode = opts.lint === true ? "--lint" : jsonImpliesLint ? "--json" : undefined;
+      const mutationOption =
+        opts.repair === true || opts.fix === true || opts.force === true
+          ? "--repair, --fix, or --force"
+          : opts.yes === true
+            ? "--yes"
+            : opts.generateGatewayToken === true
+              ? "--generate-gateway-token"
+              : typeof opts.sessionSqlite === "string"
+                ? `--session-sqlite ${opts.sessionSqlite}`
+                : undefined;
+      if (lintMode && mutationOption) {
         return exitDoctorError(
-          "doctor --json runs read-only lint checks and cannot be combined with --repair, --fix, or --force.",
-          true,
+          `doctor ${lintMode} runs read-only lint checks and cannot be combined with ${mutationOption}.`,
+          opts.json === true || !process.stdout.isTTY,
         );
       }
-      if (opts.lint === true || jsonImpliesLint) {
+      if (lintMode) {
         await runCommandWithRuntime(
           defaultRuntime,
           async () => {
@@ -147,12 +163,6 @@ export function registerMaintenanceCommands(program: Command) {
           (err) => exitDoctorError(formatError(err), opts.json === true || !process.stdout.isTTY),
         );
         return;
-      }
-      if (hasSessionSqliteOnlyDoctorOptions(opts)) {
-        return exitDoctorError(
-          "doctor session SQLite options require --session-sqlite. Use `openclaw doctor --session-sqlite dry-run ...`.",
-          opts.json === true,
-        );
       }
       if (hasLintOnlyDoctorOptions(opts)) {
         return exitDoctorError(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators requesting Doctor repairs, gateway-token generation, session-database maintenance, or a recovery GitHub issue alongside read-only lint would silently receive lint findings instead of the requested operation or a clear error. Bare `doctor --json` also silently ignored `--yes` and `--generate-gateway-token`, even though it already rejected the other repair flags.

## Why This Change Was Made

Doctor's maintenance-command owner now validates orphan session selectors before choosing an execution posture, then applies one canonical read-only posture guard before loading either Doctor implementation. Explicit lint rejects all seven session-maintenance modes and all four session-only selectors, while explicit lint and implicit JSON lint both reject the five mutating options. Existing standalone session-maintenance JSON output, advisory JSON behavior, the original repair-conflict error, and terminal-versus-machine-readable error channels remain unchanged. The Doctor CLI reference documents the complete compatibility contract.

## User Impact

Operators receive an immediate, actionable exit-code-2 error instead of silently skipping requested repairs, session maintenance, token generation, or recovery issue creation. Interactive terminals keep human-readable stderr, while piped lint and JSON commands preserve the canonical JSON failure envelope on stdout. No database, storage, schema, authentication, or configuration implementation changes.

## Evidence

- Regression-first proof: the initial real-Commander owner suite failed 17 cases for the five mutating flags; the expanded owner suite failed another 12 cases covering all seven session modes, four orphan session selectors, and recovery issue creation before the canonical owner repair.
- Focused owner and sibling proof: `node scripts/run-vitest.mjs src/cli/program/register.maintenance.test.ts src/cli/machine-output-modes.test.ts src/cli/failure-output.test.ts` passed 119 tests across three files and two Vitest shards.
- Real production behavior: 44 unmocked Commander invocations passed across all five mutating options, seven session modes, four session-only selectors, recovery issue creation, interactive terminals, piped lint, explicit JSON lint, and implicit advisory JSON without accessing user configuration or state.
- Architecture ratchets: `node --import tsx scripts/check-max-lines-ratchet.mts --base origin/main` and `node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main` both passed.
- Formatting and lint: `node_modules/.bin/oxfmt --check src/cli/program/register.maintenance.ts src/cli/program/register.maintenance.test.ts docs/cli/doctor.md`, `node_modules/.bin/oxlint --tsconfig=config/tsconfig/oxlint.core.json src/cli/program/register.maintenance.ts src/cli/program/register.maintenance.test.ts`, and `git diff --check` passed.
- Independent full-source review and authenticated full-branch Codex review both reported no actionable findings. Production growth is 10 lines for the missing mutually exclusive posture contract while removing the duplicated session-selector check.
