### PR TITLE
refactor(context-engine): remove owner cleanup helper

### DIFF
--- a/src/context-engine/quarantine-health.test.ts
+++ b/src/context-engine/quarantine-health.test.ts
@@ -12,11 +12,7 @@ import {
   clearPersistedContextEngineQuarantineForProcess,
   recordPersistedContextEngineQuarantine,
 } from "./quarantine-health.js";
-import {
-  clearContextEnginesForOwner,
-  listContextEngineQuarantines,
-  registerContextEngineForOwner,
-} from "./registry.js";
+import { listContextEngineQuarantines } from "./registry.js";
 import { resetContextEngineRuntimeQuarantineForTests } from "./registry.test-support.js";
 
 const CONTEXT_ENGINE_QUARANTINE_OWNER_ID = "core:context-engine-quarantine-health";
@@ -242,39 +238,6 @@ describe("context engine quarantine health", () => {
 
         expect(listContextEngineQuarantines()).toEqual([]);
       });
-    });
-  });
-
-  it("clears persisted quarantine records when owner engines unload", async () => {
-    await withStateDirEnv("openclaw-context-engine-quarantine-owner-", async () => {
-      const owner = "plugin:lossless-claw";
-      registerContextEngineForOwner(
-        "lossless-claw",
-        () => ({
-          info: { id: "lossless-claw", name: "Lossless Claw", version: "1" },
-          async ingest() {
-            return { ingested: true };
-          },
-          async assemble({ messages }) {
-            return { messages, estimatedTokens: 0 };
-          },
-          async compact() {
-            return { ok: true, compacted: false };
-          },
-        }),
-        owner,
-      );
-      recordPersistedContextEngineQuarantine({
-        engineId: "lossless-claw",
-        owner,
-        operation: "bootstrap",
-        reason: "plugin disabled",
-        failedAt: new Date(123),
-      });
-
-      clearContextEnginesForOwner(owner);
-
-      expect(listContextEngineQuarantines()).toEqual([]);
     });
   });
 });

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -442,19 +442,9 @@ function listContextEngineIds(): string[] {
   return [...getContextEngines().keys()].toSorted();
 }
 
-export function clearContextEnginesForOwner(owner: string): void {
-  const normalizedOwner = requireContextEngineOwner(owner);
-  const registry = getContextEngines();
-  for (const [id, entry] of registry.entries()) {
-    if (entry.owner === normalizedOwner) {
-      registry.delete(id);
-      clearContextEngineRuntimeQuarantine(id);
-    }
-  }
-}
-
 /**
  * Return the trusted plugin id that registered a resolved context engine.
+ * Downgraded engines intentionally report no plugin owner.
  */
 export function resolveContextEngineOwnerPluginId(
   engine: ContextEngine | undefined | null,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -15,11 +15,13 @@ import { HEARTBEAT_PROMPT } from "../../auto-reply/heartbeat.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { registerLegacyContextEngine } from "../../context-engine/legacy.registration.js";
 import {
-  clearContextEnginesForOwner,
   registerContextEngineForOwner,
   resolveContextEngine,
 } from "../../context-engine/registry.js";
-import { resetContextEngineRuntimeQuarantineForTests } from "../../context-engine/registry.test-support.js";
+import {
+  captureContextEngineRegistryStateForTests,
+  resetContextEngineRuntimeQuarantineForTests,
+} from "../../context-engine/registry.test-support.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.js";
 import {
@@ -4410,6 +4412,7 @@ describe("gateway healthHandlers.status scope handling", () => {
 
 describe("gateway healthHandlers.health cache freshness", () => {
   let healthHandlers: typeof import("./health.js").healthHandlers;
+  let restoreContextEngineRegistryState: () => void;
   const contextEngineTestOwner = "plugin:health-test";
 
   function createHealthSnapshot<T extends Record<string, unknown>>(overrides: T) {
@@ -4508,15 +4511,14 @@ describe("gateway healthHandlers.health cache freshness", () => {
   });
 
   beforeEach(() => {
+    restoreContextEngineRegistryState = captureContextEngineRegistryStateForTests();
     registerLegacyContextEngine();
-    clearContextEnginesForOwner(contextEngineTestOwner);
     resetContextEngineRuntimeQuarantineForTests();
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    clearContextEnginesForOwner(contextEngineTestOwner);
-    resetContextEngineRuntimeQuarantineForTests();
+    restoreContextEngineRegistryState();
   });
 
   it("rate-limits request-driven refreshes for fresh cached health", async () => {


### PR DESCRIPTION
## What Problem This Solves

Context-engine registry production code exported an owner-specific cleanup helper solely for test fixture cleanup. Gateway health tests used that helper to delete selected registrations instead of restoring the complete registry state they inherited.

## Why This Change Was Made

The owner cleanup export and its quarantine-lifecycle test are removed. Gateway health tests now capture the complete context-engine registry state before registering the legacy engine and resetting quarantine state, then restore that snapshot after each test.

This keeps fixture ownership in the existing test-support boundary without changing runtime context-engine registration, selection, or quarantine behavior. Production delta: +1/-11 (net -10). Test delta: +8/-43 (net -35).

## User Impact

No intended user-visible change. Context-engine registry production surface is smaller, and gateway health tests restore shared registry state instead of applying owner-specific cleanup.

## Evidence

- `node scripts/run-vitest.mjs src/context-engine/quarantine-health.test.ts` - 3 passed, 3 Linux-only skipped
- `node scripts/run-vitest.mjs src/context-engine/context-engine.test.ts` - 65 passed
- `node scripts/run-vitest.mjs src/context-engine/host-param-projection.test.ts` - 7 passed
- `node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts -t "merges live context-engine quarantine state into cached health responses"` - 2 passed, 422 skipped; 12.55s wall time
- Full `server-methods.test.ts` run: 422 passed in 655.46s; two unrelated exec-approval tests failed before the changed health block. The timeout reproduced alone in 669.94s without touching the changed fixture.
- Targeted `oxfmt`, `git diff --check`, privacy scan, and autoreview passed
- `check-changed` passed source guards, formatting, dead-export scanning, core typecheck, and lint. Core-test typecheck stopped on missing shared-install UI dependencies (`@panzoom/panzoom` and `pako` typings).
