### PR TITLE
fix(gateway): prevent silent delivery loss on closing connections

### DIFF
--- a/src/gateway/device-pair-setup-completion.test.ts
+++ b/src/gateway/device-pair-setup-completion.test.ts
@@ -93,6 +93,7 @@ describe("device pair setup completion", () => {
   it("keeps the completion recoverable when a slow subscriber drops the frame", async () => {
     const baseDir = await tempDirs.make("openclaw-setup-completion-slow-");
     const slowSocket = {
+      readyState: 1,
       bufferedAmount: MAX_BUFFERED_BYTES + 1,
       send: vi.fn(),
       close: vi.fn(),

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -55,6 +55,7 @@ const wsMockState = vi.hoisted(() => ({
 
 vi.mock("ws", () => ({
   WebSocket: class MockWebSocket {
+    static readonly OPEN = 1;
     on = vi.fn();
     close = vi.fn();
     send = vi.fn();
@@ -272,6 +273,7 @@ describe("GatewayClient", () => {
 });
 
 type TestSocket = {
+  readyState: number;
   bufferedAmount: number;
   send: (payload: string) => void;
   close: (code: number, reason: string) => void;
@@ -291,6 +293,7 @@ type RecordingSocket = TestSocket & {
 function makeRecordingSocket(): RecordingSocket {
   const sent: EventFrame[] = [];
   return {
+    readyState: 1,
     bufferedAmount: 0,
     send: vi.fn((payload: string) => {
       sent.push(JSON.parse(payload) as EventFrame);
@@ -592,8 +595,8 @@ describe("gateway broadcaster", () => {
   });
 
   it("requires operator.questions for question broadcasts", () => {
-    const questionSocket: TestSocket = { bufferedAmount: 0, send: vi.fn(), close: vi.fn() };
-    const readSocket: TestSocket = { bufferedAmount: 0, send: vi.fn(), close: vi.fn() };
+    const questionSocket = makeRecordingSocket();
+    const readSocket = makeRecordingSocket();
     const clients = new Set<GatewayWsClient>([
       makeOperatorWsClient("c-questions", questionSocket, ["operator.questions"]),
       makeOperatorWsClient("c-read", readSocket, ["operator.read"]),

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -47,7 +47,7 @@ import {
   type PendingSystemRunEvent,
 } from "./node-registry.invoke-stream.js";
 import { normalizeNodeSkillDescriptors } from "./node-skill-descriptors.js";
-import { MAX_BUFFERED_BYTES } from "./server-constants.js";
+import { MAX_BUFFERED_BYTES, WEBSOCKET_OPEN_READY_STATE } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 /** Connected node session advertised over Gateway websocket. */
@@ -135,7 +135,6 @@ type PingableSocket = {
 
 const SERIALIZED_EVENT_PAYLOAD = Symbol("openclaw.serializedEventPayload");
 const AUTHORIZED_SYSTEM_RUN_EVENT_GRACE_MS = 5 * 60 * 1000;
-const WEBSOCKET_OPEN_READY_STATE = 1;
 const SLOW_CONSUMER_CLOSE_CODE = 1008;
 const FAILED_EVENT_LOG_INTERVAL_MS = 30_000;
 const log = createSubsystemLogger("gateway/nodes");

--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_IDS,
@@ -14,6 +15,7 @@ import { createSessionObserverAudience } from "./session-observer-audience.js";
 import { resolveSessionSubscriptionKeys } from "./session-subscription-keys.js";
 
 type RecordingSocket = {
+  readyState: number;
   bufferedAmount: number;
   close: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
@@ -27,6 +29,7 @@ function makeClient(
 ): { client: GatewayWsClient; socket: RecordingSocket } {
   const events: string[] = [];
   const socket: RecordingSocket = {
+    readyState: WebSocket.OPEN,
     bufferedAmount: 0,
     close: vi.fn(),
     send: vi.fn((payload: string) => {

--- a/src/gateway/server-broadcast.serialization.test.ts
+++ b/src/gateway/server-broadcast.serialization.test.ts
@@ -3,6 +3,7 @@
 // cause a synchronized reconnect storm) and must leave a server-side record.
 import { once } from "node:events";
 import type { AddressInfo } from "node:net";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { setVerbose } from "../global-state.js";
@@ -100,7 +101,7 @@ describe("broadcast serialization failures", () => {
     const healthy = await connectPeer();
     const delivered: Array<{ event: string; seq: number }> = [];
     healthy.peer.on("message", (data: RawData) => {
-      delivered.push(JSON.parse(data.toString()) as { event: string; seq: number });
+      delivered.push(JSON.parse(rawDataToString(data)) as { event: string; seq: number });
     });
     const makeRealClient = (connId: string, socket: WebSocket): GatewayWsClient => ({
       connId,

--- a/src/gateway/server-broadcast.serialization.test.ts
+++ b/src/gateway/server-broadcast.serialization.test.ts
@@ -1,7 +1,10 @@
 // Covers broadcast frame-serialization failure: an unserializable payload must
 // not consume per-client seqs (which would fire every client's gap detector and
 // cause a synchronized reconnect storm) and must leave a server-side record.
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { setVerbose } from "../global-state.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
@@ -24,6 +27,7 @@ vi.mock("../logging/subsystem.js", async (importOriginal) => {
 });
 
 type RecordingSocket = {
+  readyState: number;
   bufferedAmount: number;
   close: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
@@ -33,6 +37,7 @@ type RecordingSocket = {
 function makeClient(connId: string): { client: GatewayWsClient; socket: RecordingSocket } {
   const frames: Array<{ event: string; seq: number }> = [];
   const socket: RecordingSocket = {
+    readyState: WebSocket.OPEN,
     bufferedAmount: 0,
     close: vi.fn(),
     send: vi.fn((payload: string) => {
@@ -59,6 +64,89 @@ afterEach(() => {
 });
 
 describe("broadcast serialization failures", () => {
+  it.each([
+    { state: "closing", readyState: WebSocket.CLOSING },
+    { state: "closed", readyState: WebSocket.CLOSED },
+  ])("skips $state sockets without disrupting healthy broadcast sequences", ({ readyState }) => {
+    const retired = makeClient("retired");
+    const healthy = makeClient("healthy");
+    const clients = new Set([retired.client, healthy.client]);
+    const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
+
+    retired.socket.readyState = readyState;
+    broadcast("skills.changed", { reason: "first" });
+    broadcastToConnIds("skills.changed", { reason: "second" }, new Set(["healthy", "retired"]));
+
+    expect(retired.socket.send).not.toHaveBeenCalled();
+    expect(clients.has(retired.client)).toBe(true);
+    expect(healthy.socket.frames).toEqual([
+      { event: "skills.changed", seq: 1 },
+      { event: "skills.changed", seq: 2 },
+    ]);
+  });
+
+  it("keeps a real healthy peer delivering while skipping a silently closing peer", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const address = server.address() as AddressInfo;
+    const connectPeer = async () => {
+      const accepted = once(server, "connection");
+      const peer = new WebSocket(`ws://127.0.0.1:${address.port}`);
+      await once(peer, "open");
+      const [socket] = (await accepted) as [WebSocket];
+      return { peer, socket };
+    };
+    const retired = await connectPeer();
+    const healthy = await connectPeer();
+    const delivered: Array<{ event: string; seq: number }> = [];
+    healthy.peer.on("message", (data: RawData) => {
+      delivered.push(JSON.parse(data.toString()) as { event: string; seq: number });
+    });
+    const makeRealClient = (connId: string, socket: WebSocket): GatewayWsClient => ({
+      connId,
+      socket,
+      connect: { role: "operator", scopes: ["operator.read"] } as GatewayWsClient["connect"],
+      usesSharedGatewayAuth: false,
+    });
+    const retiredClient = makeRealClient("real-retired", retired.socket);
+    const healthyClient = makeRealClient("real-healthy", healthy.socket);
+    const clients = new Set([retiredClient, healthyClient]);
+    const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
+
+    try {
+      retired.socket.close(1000, "retiring peer");
+      expect(retired.socket.readyState).toBe(WebSocket.CLOSING);
+      const bufferedAtClose = retired.socket.bufferedAmount;
+
+      broadcast("skills.changed", { reason: "fanout" });
+      broadcastToConnIds("skills.changed", { reason: "targeted" }, new Set(["real-healthy"]));
+      await vi.waitFor(() => expect(delivered).toHaveLength(2));
+
+      expect(retired.socket.bufferedAmount).toBe(bufferedAtClose);
+      expect(clients.has(retiredClient)).toBe(true);
+      expect(delivered.map(({ event, seq }) => ({ event, seq }))).toEqual([
+        { event: "skills.changed", seq: 1 },
+        { event: "skills.changed", seq: 2 },
+      ]);
+
+      let callbackError: Error | undefined;
+      retired.socket.send("dependency-callback-proof", (error) => {
+        callbackError = error;
+      });
+      expect(callbackError).toBeUndefined();
+      await vi.waitFor(() => expect(callbackError).toBeInstanceOf(Error));
+    } finally {
+      retired.peer.terminate();
+      healthy.peer.terminate();
+      for (const activeSocket of server.clients) {
+        activeSocket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("drops the event without consuming seqs when the payload cannot serialize", () => {
     warnSpy.mockClear();
     const first = makeClient("first");

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -1,4 +1,3 @@
-import { WebSocket } from "ws";
 import {
   GATEWAY_CLIENT_CAPS,
   hasGatewayClientCap,
@@ -32,7 +31,7 @@ import type {
   GatewayPluginEventScope,
 } from "./server-broadcast-types.js";
 import type { SessionMessageSubscriberRegistry } from "./server-chat-state.js";
-import { MAX_BUFFERED_BYTES } from "./server-constants.js";
+import { MAX_BUFFERED_BYTES, WEBSOCKET_OPEN_READY_STATE } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { logWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
@@ -271,7 +270,7 @@ export function createGatewayBroadcaster(params: {
     let sessionSubscriberConnIdsByKey: Array<ReadonlySet<string> | undefined> | undefined;
     for (const c of params.clients) {
       // Closing nodes remain discoverable until their owner drains admitted lifecycle work.
-      if (c.invalidated === true || c.socket.readyState !== WebSocket.OPEN) {
+      if (c.invalidated === true || c.socket.readyState !== WEBSOCKET_OPEN_READY_STATE) {
         continue;
       }
       if (targetConnIds && !targetConnIds.has(c.connId)) {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -1,3 +1,4 @@
+import { WebSocket } from "ws";
 import {
   GATEWAY_CLIENT_CAPS,
   hasGatewayClientCap,
@@ -269,7 +270,8 @@ export function createGatewayBroadcaster(params: {
     const sessionMessageSubscribers = params.sessionMessageSubscribers;
     let sessionSubscriberConnIdsByKey: Array<ReadonlySet<string> | undefined> | undefined;
     for (const c of params.clients) {
-      if (c.invalidated === true) {
+      // Closing nodes remain discoverable until their owner drains admitted lifecycle work.
+      if (c.invalidated === true || c.socket.readyState !== WebSocket.OPEN) {
         continue;
       }
       if (targetConnIds && !targetConnIds.has(c.connId)) {

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -3,6 +3,7 @@
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
 export const MAX_PREAUTH_PAYLOAD_BYTES = 64 * 1024;
+export const WEBSOCKET_OPEN_READY_STATE = 1;
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 const maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;

--- a/src/gateway/server-methods/portals.test.ts
+++ b/src/gateway/server-methods/portals.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import type {
   PortalOpenResult,
   PortalSummary,
@@ -175,6 +176,7 @@ describe("portal gateway methods", () => {
         usesSharedGatewayAuth: false,
         connect: { role, scopes } as GatewayWsClient["connect"],
         socket: {
+          readyState: WebSocket.OPEN,
           bufferedAmount: 0,
           close: vi.fn(),
           send: (value: string) =>

--- a/src/gateway/server/ws-connection.test-helpers.ts
+++ b/src/gateway/server/ws-connection.test-helpers.ts
@@ -17,6 +17,7 @@ export type GatewayWsTestSocket = EventEmitter & {
     localAddress: string;
     localPort: number;
   };
+  readyState: number;
   bufferedAmount: number;
   send: ReturnType<typeof vi.fn>;
   ping?: ReturnType<typeof vi.fn>;
@@ -66,6 +67,7 @@ export function createGatewayWsTestSocket(
       localAddress: "127.0.0.1",
       localPort: 5678,
     },
+    readyState: 1,
     bufferedAmount: 0,
     send: vi.fn((data: string, cb?: (err?: Error) => void) => {
       params.onSend?.(data);

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -1,6 +1,10 @@
 // Gateway WebSocket connection tests cover handshake auth, shared sessions, and message-handler attachment.
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
 import type { ResolvedGatewayAuth } from "../auth.js";
+import { createGatewayBroadcaster } from "../server-broadcast.js";
 import { MAX_BUFFERED_BYTES } from "../server-constants.js";
 import {
   attachGatewayWsForTest,
@@ -53,6 +57,7 @@ import { markPublicWorkerIngress } from "./public-worker-ingress-context.js";
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js";
 import { GATEWAY_WS_CONNECTION_KIND_PROPERTY } from "./ws-types.js";
+import type { GatewayWsClient } from "./ws-types.js";
 
 async function waitForLazyMessageHandler() {
   await vi.dynamicImportSettled();
@@ -406,6 +411,168 @@ describe("attachGatewayWsConnectionHandler", () => {
 
     expect(socket.send).not.toHaveBeenCalled();
     expect(socket.close).toHaveBeenCalledWith(1008, "slow consumer");
+  });
+
+  it.each([
+    { state: "closing", readyState: WebSocket.CLOSING },
+    { state: "closed", readyState: WebSocket.CLOSED },
+  ])(
+    "rejects direct responses on a $state socket before its close event",
+    async ({ readyState }) => {
+      const socket = createGatewayWsTestSocket();
+      const { clients, passed } = await connectTestWs({ socket });
+      const handlerParams = passed as {
+        send: (frame: unknown) => { kind: string };
+        setClient: (client: unknown) => boolean;
+      };
+      handlerParams.setClient({
+        socket,
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+        connId: "closing-client",
+        usesSharedGatewayAuth: false,
+      });
+      socket.send.mockClear();
+      socket.readyState = readyState;
+
+      expect(handlerParams.send({ type: "res", id: "closing-request", ok: true })).toEqual({
+        kind: "unavailable",
+      });
+      expect(socket.send).not.toHaveBeenCalled();
+      expect(clients.size).toBe(0);
+    },
+  );
+
+  it("rejects a real closing WebSocket before ws can silently buffer a lost response", async () => {
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const accepted = once(server, "connection");
+    const peer = new WebSocket(`ws://127.0.0.1:${(server.address() as AddressInfo).port}`);
+    await once(peer, "open");
+    const [socket] = (await accepted) as [WebSocket];
+
+    try {
+      const { clients, passed } = await connectTestWs({
+        socket: socket as unknown as GatewayWsTestSocket,
+      });
+      const handlerParams = passed as {
+        send: (frame: unknown) => { kind: string };
+        setClient: (client: unknown) => boolean;
+      };
+      handlerParams.setClient({
+        socket,
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+        connId: "real-closing-client",
+        usesSharedGatewayAuth: false,
+      });
+
+      socket.close(1000, "real close race");
+      expect(socket.readyState).toBe(WebSocket.CLOSING);
+      const bufferedAtClose = socket.bufferedAmount;
+
+      expect(handlerParams.send({ type: "res", id: "real-closing-request", ok: true })).toEqual({
+        kind: "unavailable",
+      });
+      expect(socket.bufferedAmount).toBe(bufferedAtClose);
+      expect(clients.size).toBe(0);
+    } finally {
+      peer.terminate();
+      for (const activeSocket of server.clients) {
+        activeSocket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("keeps a closing node discoverable throughout pending lifecycle dispatch and fanout", async () => {
+    const unregister = vi.fn(() => "draining-node");
+    const get = vi.fn(() => undefined);
+    const clients = new Set<GatewayWsClient>();
+    const socket = createGatewayWsTestSocket();
+    const { passed } = await connectTestWs({
+      clients,
+      socket,
+      options: {
+        buildRequestContext: () =>
+          createGatewayWsTestRequestContext({
+            nodeRegistry: { get, unregister } as never,
+          }) as never,
+      },
+    });
+    const handler = passed as {
+      connId: string;
+      send: (frame: unknown) => { kind: string };
+      setClient: (client: GatewayWsClient) => boolean;
+      nodeLifecycleDispatch: {
+        dispatch: (method: string, run: () => Promise<void>) => Promise<void>;
+      };
+    };
+    const nodeClient: GatewayWsClient = {
+      socket: socket as unknown as GatewayWsClient["socket"],
+      connect: {
+        minProtocol: 1,
+        maxProtocol: 1,
+        role: "node",
+        client: {
+          id: "openclaw-macos",
+          version: "1.0.0",
+          platform: "darwin",
+          mode: "node",
+        },
+        device: {
+          id: "draining-device",
+          publicKey: "draining-public-key",
+          signature: "draining-signature",
+          signedAt: 1,
+          nonce: "draining-nonce",
+        },
+      },
+      connId: handler.connId,
+      usesSharedGatewayAuth: false,
+    };
+    expect(handler.setClient(nodeClient)).toBe(true);
+    const healthySocket = createGatewayWsTestSocket();
+    clients.add({
+      socket: healthySocket as unknown as GatewayWsClient["socket"],
+      connect: { role: "operator", scopes: ["operator.read"] } as GatewayWsClient["connect"],
+      connId: "healthy-during-node-drain",
+      usesSharedGatewayAuth: false,
+    });
+    let releaseDispatch!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    const dispatch = handler.nodeLifecycleDispatch.dispatch("node.invoke.result", () => pending);
+    socket.send.mockClear();
+    socket.readyState = WebSocket.CLOSING;
+
+    expect(handler.send({ type: "res", id: "pending-node-result", ok: true })).toEqual({
+      kind: "unavailable",
+    });
+    expect(clients.has(nodeClient)).toBe(true);
+    const broadcaster = createGatewayBroadcaster({ clients });
+    broadcaster.broadcast("tick", { source: "before-node-close" });
+
+    socket.emit("close", 1000, Buffer.from("node draining"));
+    expect(clients.has(nodeClient)).toBe(true);
+    expect(unregister).not.toHaveBeenCalled();
+
+    broadcaster.broadcast("tick", { source: "during-node-drain" });
+
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(healthySocket.send).toHaveBeenCalledTimes(2);
+    const revocableNode = [...clients].find(
+      (client) => client.connect.device?.id === "draining-device",
+    );
+    expect(revocableNode).toBe(nodeClient);
+    revocableNode!.invalidated = true;
+    expect(nodeClient.invalidated).toBe(true);
+
+    releaseDispatch();
+    await dispatch;
+    await vi.waitFor(() => expect(unregister).toHaveBeenCalledOnce());
+    expect(clients.has(nodeClient)).toBe(false);
   });
 
   it("distinguishes serialization failure from unavailable transports", async () => {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,7 +1,7 @@
 // Gateway WebSocket connection handler owns pre-auth limits, handshake auth, presence, and message-handler attachment.
 import { randomUUID } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import type { RawData, WebSocket, WebSocketServer } from "ws";
+import { WebSocket, type RawData, type WebSocketServer } from "ws";
 import { WORKER_PROTOCOL_MAX_PAYLOAD_BYTES } from "../../../packages/gateway-protocol/src/index.js";
 import { GATEWAY_STARTUP_PENDING_CLOSE_CAUSE } from "../../../packages/gateway-protocol/src/startup-unavailable.js";
 import { getRuntimeConfig } from "../../config/io.js";
@@ -347,6 +347,14 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     const send = (obj: unknown) => {
       if (closed) {
+        return { kind: "unavailable" } as const;
+      }
+      if (socket.readyState !== WebSocket.OPEN) {
+        // Keep pending node results revocable until their close handler drains admitted work.
+        if (client?.connect.role === "node" && nodeLifecycleDispatch.hasActive()) {
+          retainClientUntilNodeDrain = true;
+        }
+        close();
         return { kind: "unavailable" } as const;
       }
       if (socket.bufferedAmount > MAX_BUFFERED_BYTES) {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,7 +1,7 @@
 // Gateway WebSocket connection handler owns pre-auth limits, handshake auth, presence, and message-handler attachment.
 import { randomUUID } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { WebSocket, type RawData, type WebSocketServer } from "ws";
+import type { RawData, WebSocket, WebSocketServer } from "ws";
 import { WORKER_PROTOCOL_MAX_PAYLOAD_BYTES } from "../../../packages/gateway-protocol/src/index.js";
 import { GATEWAY_STARTUP_PENDING_CLOSE_CAUSE } from "../../../packages/gateway-protocol/src/startup-unavailable.js";
 import { getRuntimeConfig } from "../../config/io.js";
@@ -25,6 +25,7 @@ import {
   MAX_BUFFERED_BYTES,
   MAX_PAYLOAD_BYTES,
   MAX_PREAUTH_PAYLOAD_BYTES,
+  WEBSOCKET_OPEN_READY_STATE,
 } from "../server-constants.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
@@ -349,7 +350,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       if (closed) {
         return { kind: "unavailable" } as const;
       }
-      if (socket.readyState !== WebSocket.OPEN) {
+      if (socket.readyState !== WEBSOCKET_OPEN_READY_STATE) {
         // Keep pending node results revocable until their close handler drains admitted work.
         if (client?.connect.role === "node" && nodeLifecycleDispatch.hasActive()) {
           retainClientUntilNodeDrain = true;

--- a/src/gateway/server/ws-connection/message-handler.worker.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker.test.ts
@@ -188,6 +188,7 @@ function attachHarness(
   options: {
     admissionFailure?: WorkerAdmissionFailureReason;
     commitFailure?: WorkerTranscriptCommitErrorReason;
+    closeDuringHello?: boolean;
     identity?: WorkerConnectionIdentity;
     liveFailure?: WorkerLiveEventErrorDetails;
     omitPublicAdmission?: boolean;
@@ -200,7 +201,11 @@ function attachHarness(
 ) {
   const socket = createGatewayWsTestSocket();
   const responses: unknown[] = [];
-  const close = vi.fn();
+  let closed = false;
+  const close = vi.fn(() => {
+    closed = true;
+    cleanup();
+  });
   const service = {
     admitWorker: vi.fn(async () =>
       options.admissionFailure
@@ -254,6 +259,7 @@ function attachHarness(
   const logWsControl = createLogger();
   const setCloseCause = vi.fn();
   const setLastFrameMeta = vi.fn();
+  const advanceHandshakePhase = vi.fn();
   const cleanup = attachWorkerWsMessageHandler({
     socket: socket as unknown as WebSocket,
     connId: "worker-connection",
@@ -262,14 +268,19 @@ function attachHarness(
     publicAdmission: options.omitPublicAdmission
       ? undefined
       : { clientIp: "203.0.113.10", rateLimiter: options.rateLimiter },
-    send: (frame) => responses.push(frame),
+    send: (frame) => {
+      responses.push(frame);
+      if (options.closeDuringHello) {
+        close();
+      }
+    },
     close,
-    isClosed: () => false,
+    isClosed: () => closed,
     clearHandshakeTimer: vi.fn(),
     getClient: () => client,
     setClient,
     setHandshakeState: vi.fn(),
-    advanceHandshakePhase: vi.fn(),
+    advanceHandshakePhase,
     setCloseCause,
     setLastFrameMeta,
     logGateway,
@@ -281,6 +292,7 @@ function attachHarness(
     client: () => client,
     cleanup,
     close,
+    advanceHandshakePhase,
     logGateway,
     logWsControl,
     responses,
@@ -302,6 +314,7 @@ async function admit(harness: ReturnType<typeof attachHarness>): Promise<void> {
 
 describe("dedicated worker websocket protocol", () => {
   afterEach(() => {
+    vi.useRealTimers();
     resetGatewayWorkAdmission();
     for (const cleanup of cleanups.splice(0)) {
       cleanup();
@@ -318,6 +331,19 @@ describe("dedicated worker websocket protocol", () => {
       connectionKind: "worker",
       connect: { role: "worker" },
     });
+  });
+
+  it("does not mark a synchronously closed hello ready or recreate its expiry timer", async () => {
+    vi.useFakeTimers();
+    const harness = attachHarness({ closeDuringHello: true });
+
+    harness.sendConnect();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(harness.responses).toHaveLength(1);
+    expect(harness.close).toHaveBeenCalledOnce();
+    expect(harness.advanceHandshakePhase).not.toHaveBeenCalledWith("ready");
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("keeps unrelated worker admission closed while startup is pending", async () => {

--- a/src/gateway/server/ws-connection/worker-connection.ts
+++ b/src/gateway/server/ws-connection/worker-connection.ts
@@ -493,6 +493,9 @@ export function attachWorkerWsMessageHandler(params: WorkerWsMessageHandlerParam
     setSocketMaxPayload(params.socket, workerMaxPayload(admission.identity));
     params.advanceHandshakePhase("hello_payload_prepared");
     params.send({ type: "res", id, ok: true, payload: buildWorkerHello(admission.identity) });
+    if (disposed || params.isClosed()) {
+      return;
+    }
     params.advanceHandshakePhase("ready");
     expiryTimer = setTimeout(
       () => {

--- a/src/gateway/talk-transcription-relay.test.ts
+++ b/src/gateway/talk-transcription-relay.test.ts
@@ -2,6 +2,7 @@
  * Tests talk transcription relay behavior between realtime events and clients.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import type { RealtimeTranscriptionProviderPlugin } from "../plugins/types.js";
 import type { RealtimeTranscriptionSessionCreateRequest } from "../realtime-transcription/provider-types.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
@@ -560,6 +561,7 @@ describe("talk transcription gateway relay", () => {
 
   it("closes a backpressured owner for final transcripts while healthy owners still receive them", async () => {
     const createSocket = () => ({
+      readyState: WebSocket.OPEN,
       bufferedAmount: 0,
       send: vi.fn<(payload: string) => void>(),
       close: vi.fn<(code: number, reason: string) => void>(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using the Gateway or Control UI would silently lose responses, live updates, and worker connection handshakes when a WebSocket entered its closing state before the close event reached the Gateway. The existing WebSocket dependency accepts those send calls without throwing even though it never delivers the frames, so callers previously reported successful delivery and broadcasts consumed misleading sequence numbers.

## Why This Change Was Made

Admit direct responses and fanout only while the actual WebSocket is OPEN, stop worker handshake progression before recreating a credential-expiry timer after synchronous transport closure, and keep unavailable broadcasts from advancing healthy-client sequencing. Connection ownership remains with the Gateway: closing nodes with admitted lifecycle work stay discoverable throughout their existing drain so device-pairing and token revocation can still fence the exact live node before the owner retires it.

## User Impact

Operators receive truthful delivery outcomes when a Gateway connection disappears, healthy peers continue receiving ordered live updates, and workers no longer appear connected or leave expiry timers behind after their hello cannot be delivered. Existing node result delivery and pairing/token revocation behavior remain intact while disconnect cleanup drains pending work.

## Evidence

- Regression-first proof on the unmodified owners failed for both CLOSING and CLOSED transports, including real loopback WebSocket peers: direct responses incorrectly returned `sent`, broadcast silently accumulated 79 discarded bytes, and closed worker hellos still advanced to ready.
- A separate regression proved that prematurely deleting a closing node prevents pairing/token revocation from finding it while an admitted node result is still draining. The repaired owner retains that exact node through both pre-close and close-drain fanout and removes it only after the lifecycle work completes.
- Final focused and sibling proof: **20 Vitest project files, 340 tests passed**, including real healthy/closing peers, async WebSocket callbacks, direct responses, targeted and global fanout, sequence continuity, slow-consumer backpressure, worker timer cleanup, and the existing real pairing-revocation-during-node-drain integration:

  ```text
  node scripts/run-vitest.mjs src/gateway/server/ws-connection.test.ts src/gateway/server-broadcast.serialization.test.ts src/gateway/server/ws-connection/message-handler.worker.test.ts src/gateway/server-broadcast.board.test.ts src/gateway/gateway-misc.test.ts src/gateway/device-pair-setup-completion.test.ts src/gateway/server-methods/portals.test.ts src/gateway/talk-transcription-relay.test.ts src/gateway/node-registry.ws-lifecycle.test.ts src/gateway/server.node-result-close.test.ts
  ```

- Core production typecheck, assertion-safety ratchet, max-lines ratchet, focused oxlint, formatting, `git diff --check`, independent source review, and authenticated committed-branch Codex review all passed.
- The broader core-test typecheck reaches only pre-existing shared-install dependency gaps unrelated to this change: missing `@panzoom/panzoom` and `@types/pako`. Focused Gateway tests and touched-source lint are green; no dependency install or reconciliation was performed in the linked worktree.
