### PR TITLE
fix(ui): keep visible chat messages authoritative over late snapshot hydration

### DIFF
--- a/src/agents/workspace.bootstrap-cache.test.ts
+++ b/src/agents/workspace.bootstrap-cache.test.ts
@@ -4,7 +4,7 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { loadWorkspaceBootstrapFiles, DEFAULT_AGENTS_FILENAME } from "./workspace.js";
@@ -164,9 +164,16 @@ describe("workspace bootstrap file caching", () => {
     const agentsFile1 = await loadAgentsFile(workspaceDir);
     expectAgentsContent(agentsFile1, content1);
 
-    // In-place edit: same path, same size, restore mtime — only ctime changes.
-    await fs.writeFile(filePath, content2, "utf-8");
-    await fs.utimes(filePath, originalStat.atime, originalStat.mtime);
+    // A loaded runner can complete both writes within one ctime tick. Wait for the
+    // fixture's cache identity to change before asserting the production reload.
+    await vi.waitFor(
+      async () => {
+        await fs.writeFile(filePath, content2, "utf-8");
+        await fs.utimes(filePath, originalStat.atime, originalStat.mtime);
+        expect((await fs.stat(filePath)).ctimeMs).not.toBe(originalStat.ctimeMs);
+      },
+      { interval: 1, timeout: 1_000 },
+    );
 
     const agentsFile2 = await loadAgentsFile(workspaceDir);
     expectAgentsContent(agentsFile2, content2);

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -105,12 +105,14 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
         !snapshot ||
         this.state !== state ||
         !areUiSessionKeysEquivalent(state.sessionKey, sessionKey) ||
-        readChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey })
+        readChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey }) ||
+        state.chatMessages.length > 0
       ) {
         return;
       }
-      // The memory miss is the ordering fence: any network replacement or live
-      // append that landed while IndexedDB was pending remains authoritative.
+      // The memory miss plus empty visible rows is the ordering fence: any
+      // network replacement, live append, or optimistic handoff that landed
+      // while IndexedDB was pending remains authoritative.
       cacheChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey }, snapshot);
       applyChatCacheSnapshot(state, snapshot);
       state.requestUpdate?.();

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -62,7 +62,11 @@ import { clearChatModelSearchOnEscape } from "./components/chat-model-picker.ts"
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
 import { exportChatMarkdown } from "./export.ts";
-import { admitInitialUserMessageHandoff } from "./history-merge.ts";
+import {
+  admitInitialUserMessageHandoff,
+  readChatSessionProjectionScope,
+  reduceChatSessionProjection,
+} from "./history-merge.ts";
 import { admitInitialTurnHandoff } from "./initial-turn-handoff.ts";
 import {
   applyChatCacheSnapshot,
@@ -105,16 +109,28 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
         !snapshot ||
         this.state !== state ||
         !areUiSessionKeysEquivalent(state.sessionKey, sessionKey) ||
-        readChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey }) ||
-        state.chatMessages.length > 0
+        readChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey })
       ) {
         return;
       }
-      // The memory miss plus empty visible rows is the ordering fence: any
-      // network replacement, live append, or optimistic handoff that landed
-      // while IndexedDB was pending remains authoritative.
-      cacheChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey }, snapshot);
-      applyChatCacheSnapshot(state, snapshot);
+      // The memory miss fences network replacement; the pane projection merges
+      // live and pending rows that arrived while IndexedDB was pending.
+      const projection = reduceChatSessionProjection(
+        state,
+        { type: "snapshotLoaded", messages: snapshot.messages },
+        {
+          scope: readChatSessionProjectionScope(state, {
+            sessionKey,
+            sessionId: snapshot.sessionId,
+            ...(Object.hasOwn(snapshot, "displayedLeafEntryId")
+              ? { activeLeafEntryId: snapshot.displayedLeafEntryId }
+              : {}),
+          }),
+        },
+      );
+      const mergedSnapshot = { ...snapshot, messages: [...projection.messages] };
+      cacheChatSessionSnapshot(state.chatMessagesBySession, state, { sessionKey }, mergedSnapshot);
+      applyChatCacheSnapshot(state, mergedSnapshot);
       state.requestUpdate?.();
     });
   }

--- a/ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts
@@ -1,0 +1,197 @@
+/* @vitest-environment jsdom */
+
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { loadChatHistory } from "./chat-history.ts";
+import {
+  createInitializationContext,
+  nativeHistoryMessage,
+  type TestChatPane,
+} from "./chat-pane.test-support.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
+import { observeChatCache, type ChatMessageCache } from "./session-message-cache.ts";
+import { clearStoredChatSnapshots } from "./session-snapshot-invalidation.ts";
+import { SessionSnapshotStore } from "./session-snapshot-store.ts";
+import "./chat-pane.ts";
+
+describe("stored chat snapshot hydration", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function createMountedPane(targetSessionKey: string, sharedMessages: ChatMessageCache) {
+    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
+    vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
+    vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
+    pane.sessionKey = targetSessionKey;
+    pane.chatMessagesBySession = sharedMessages;
+    pane.context = createInitializationContext();
+    return pane;
+  }
+
+  async function writeStoredSnapshot(
+    targetSessionKey: string,
+    messages: ReturnType<typeof nativeHistoryMessage>[],
+  ) {
+    const writer = new SessionSnapshotStore();
+    writer.write(targetSessionKey, {
+      messages,
+      pagination: { hasMore: false, completeSnapshot: true },
+      sessionId: "persistent-session",
+    });
+    await writer.flush();
+  }
+
+  it("paints a persistent snapshot while the network refresh is already in flight", async () => {
+    vi.stubGlobal("indexedDB", new IDBFactory());
+    const targetSessionKey = "agent:main:persistent";
+    const cachedMessages = [nativeHistoryMessage(1, "persistent history")];
+    const networkMessages = [nativeHistoryMessage(1, "network history")];
+    await writeStoredSnapshot(targetSessionKey, cachedMessages);
+    const response = createDeferred<Record<string, unknown>>();
+    const request = vi.fn(() => response.promise);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const sharedMessages: ChatMessageCache = new Map();
+    const store = new SessionSnapshotStore(sharedMessages);
+    store.connect();
+    observeChatCache(sharedMessages, store);
+    const pane = createMountedPane(targetSessionKey, sharedMessages);
+    pane.sessionSnapshotStore = store;
+    const stopAfterAttach = new Error("stop after attach");
+    let attachedState: ChatPageHost | undefined;
+    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
+      attachedState = state;
+      state.client = client;
+      state.connected = true;
+      state.connectionEpoch = 1;
+      void loadChatHistory(state);
+      throw stopAfterAttach;
+    });
+
+    try {
+      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
+      expect(request).toHaveBeenCalledWith(
+        "chat.history",
+        expect.objectContaining({ sessionKey: targetSessionKey }),
+      );
+      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(cachedMessages));
+
+      response.resolve({ messages: networkMessages, sessionId: "network-session" });
+      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(networkMessages));
+    } finally {
+      pane.disconnectedCallback();
+      store.disconnect();
+      await store.whenIdle();
+      await clearStoredChatSnapshots();
+    }
+  });
+
+  it("discards persistent hydration when the network snapshot lands first", async () => {
+    vi.stubGlobal("indexedDB", new IDBFactory());
+    const targetSessionKey = "agent:main:network-first";
+    await writeStoredSnapshot(targetSessionKey, [
+      nativeHistoryMessage(1, "stale persistent history"),
+    ]);
+    const networkMessages = [nativeHistoryMessage(1, "authoritative network history")];
+    const request = vi.fn(async () => ({
+      messages: networkMessages,
+      sessionId: "network-session",
+    }));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const sharedMessages: ChatMessageCache = new Map();
+    const store = new SessionSnapshotStore(sharedMessages);
+    store.connect();
+    observeChatCache(sharedMessages, store);
+    const pane = createMountedPane(targetSessionKey, sharedMessages);
+    pane.sessionSnapshotStore = store;
+    const stopAfterAttach = new Error("stop after attach");
+    let attachedState: ChatPageHost | undefined;
+    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
+      attachedState = state;
+      state.client = client;
+      state.connected = true;
+      state.connectionEpoch = 1;
+      void loadChatHistory(state);
+      throw stopAfterAttach;
+    });
+
+    try {
+      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
+      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(networkMessages));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(attachedState?.chatMessages).toEqual(networkMessages);
+    } finally {
+      pane.disconnectedCallback();
+      store.disconnect();
+      await store.whenIdle();
+      await clearStoredChatSnapshots();
+    }
+  });
+
+  it("keeps an admitted first-turn prompt visible when stored hydration resolves late", async () => {
+    const targetSessionKey = "agent:main:first-turn-retry";
+    const client = {
+      addEventListener: vi.fn(() => vi.fn()),
+      request: vi.fn(),
+    } as unknown as GatewayBrowserClient;
+    const context = createInitializationContext();
+    context.gateway.snapshot.client = client;
+    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
+    vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
+    vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
+    pane.sessionKey = targetSessionKey;
+    pane.chatMessagesBySession = new Map();
+    let deliverStoredSnapshot: ((snapshot: unknown) => void) | undefined;
+    pane.sessionSnapshotStore = {
+      read: () =>
+        new Promise((resolve) => {
+          deliverStoredSnapshot = resolve;
+        }),
+    } as never;
+    pane.context = context;
+    prepareInitialUserMessageHandoff(
+      context.initialUserMessage,
+      targetSessionKey,
+      { attachments: [], createdAt: 1, text: "retry the rejected prompt" },
+      client,
+      { runId: "initial-run" },
+    );
+    const stopAfterAttach = new Error("stop after attach");
+    let attachedState: ChatPageHost | undefined;
+    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
+      attachedState = state;
+      throw stopAfterAttach;
+    });
+
+    try {
+      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
+      expect(attachedState?.chatMessages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: [expect.objectContaining({ type: "text", text: "retry the rejected prompt" })],
+        }),
+      ]);
+      deliverStoredSnapshot?.({
+        messages: [nativeHistoryMessage(1, "stale stored transcript")],
+        pagination: { hasMore: false, completeSnapshot: true },
+        sessionId: "stored-session",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(deliverStoredSnapshot).toBeDefined();
+      expect(attachedState?.chatMessages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: [expect.objectContaining({ type: "text", text: "retry the rejected prompt" })],
+        }),
+      ]);
+    } finally {
+      pane.disconnectedCallback();
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts
@@ -12,7 +12,11 @@ import {
 } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
-import { observeChatCache, type ChatMessageCache } from "./session-message-cache.ts";
+import {
+  observeChatCache,
+  readChatSessionSnapshot,
+  type ChatMessageCache,
+} from "./session-message-cache.ts";
 import { clearStoredChatSnapshots } from "./session-snapshot-invalidation.ts";
 import { SessionSnapshotStore } from "./session-snapshot-store.ts";
 import "./chat-pane.ts";
@@ -133,7 +137,7 @@ describe("stored chat snapshot hydration", () => {
     }
   });
 
-  it("keeps an admitted first-turn prompt visible when stored hydration resolves late", async () => {
+  it("merges stored history with an admitted prompt when hydration resolves late", async () => {
     const targetSessionKey = "agent:main:first-turn-retry";
     const client = {
       addEventListener: vi.fn(() => vi.fn()),
@@ -145,7 +149,8 @@ describe("stored chat snapshot hydration", () => {
     vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
     vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
     pane.sessionKey = targetSessionKey;
-    pane.chatMessagesBySession = new Map();
+    const sharedMessages: ChatMessageCache = new Map();
+    pane.chatMessagesBySession = sharedMessages;
     let deliverStoredSnapshot: ((snapshot: unknown) => void) | undefined;
     pane.sessionSnapshotStore = {
       read: () =>
@@ -176,20 +181,41 @@ describe("stored chat snapshot hydration", () => {
           content: [expect.objectContaining({ type: "text", text: "retry the rejected prompt" })],
         }),
       ]);
+      const storedMessage = nativeHistoryMessage(1, "stored transcript");
+      const storedPagination = { hasMore: true as const, nextOffset: 1, totalMessages: 3 };
       deliverStoredSnapshot?.({
-        messages: [nativeHistoryMessage(1, "stale stored transcript")],
-        pagination: { hasMore: false, completeSnapshot: true },
+        deltaCursor: "stored-cursor",
+        displayedLeafEntryId: "stored-leaf",
+        messages: [storedMessage],
+        pagination: storedPagination,
         sessionId: "stored-session",
       });
       await Promise.resolve();
       await Promise.resolve();
       expect(deliverStoredSnapshot).toBeDefined();
       expect(attachedState?.chatMessages).toEqual([
+        storedMessage,
         expect.objectContaining({
           role: "user",
           content: [expect.objectContaining({ type: "text", text: "retry the rejected prompt" })],
         }),
       ]);
+      expect(attachedState).toMatchObject({
+        chatDisplayedLeafEntryId: "stored-leaf",
+        chatHistoryPagination: storedPagination,
+        currentSessionId: "stored-session",
+      });
+      expect(
+        readChatSessionSnapshot(sharedMessages, pane.state, {
+          sessionKey: targetSessionKey,
+        }),
+      ).toEqual({
+        deltaCursor: "stored-cursor",
+        displayedLeafEntryId: "stored-leaf",
+        messages: attachedState?.chatMessages,
+        pagination: storedPagination,
+        sessionId: "stored-session",
+      });
     } finally {
       pane.disconnectedCallback();
     }

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -177,6 +177,67 @@ export function createGatewayBrowserClientFixture(
   return overrides as typeof overrides & GatewayBrowserClient;
 }
 
+export function createInitializationContext(): ApplicationContext {
+  return {
+    basePath: "",
+    gateway: {
+      snapshot: {
+        client: null,
+        phase: "stopped",
+        offlineStable: false,
+        hello: null,
+        canvasPluginSurfaceUrl: null,
+        assistantAgentId: null,
+        sessionKey: "",
+        lastError: null,
+        lastErrorCode: null,
+      },
+      subscribe: () => () => {},
+      subscribeEvents: () => () => {},
+    },
+    config: {
+      current: {
+        assistantIdentity: {
+          agentId: null,
+          name: "Assistant",
+          avatar: null,
+          avatarSource: null,
+          avatarStatus: null,
+          avatarReason: null,
+        },
+        serverVersion: null,
+        localMediaPreviewRoots: [],
+        embedSandboxMode: "strict",
+        allowExternalEmbedUrls: false,
+        terminalEnabled: false,
+      },
+    },
+    agentSelection: { state: { selectedId: "main" } },
+    agents: { state: { agentsList: null } },
+    runtimeConfig: {
+      state: { configNeedsApply: false, configSnapshot: null },
+      subscribe: () => () => {},
+    },
+    placementStartup: {
+      get: () => null,
+      retry: () => undefined,
+      subscribe: () => () => {},
+    },
+    navigate: () => undefined,
+    initialUserMessage: createInitialUserMessageHandoff(),
+    chatAttachmentHandoff: createChatAttachmentHandoff(),
+    sessions: { state: { modelOverrides: {} } },
+  } as unknown as ApplicationContext;
+}
+
+export function nativeHistoryMessage(seq: number, text = `message ${seq}`) {
+  return {
+    role: seq % 2 === 0 ? "assistant" : "user",
+    content: [{ type: "text", text }],
+    __openclaw: { seq },
+  };
+}
+
 type SessionCapabilityFixtureOverrides = Omit<Partial<SessionCapability>, "patch" | "state"> & {
   patch?: (...args: Parameters<NonNullable<SessionCapability["patch"]>>) => unknown;
   state?: Partial<SessionCapability["state"]>;

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
+import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import {
   cacheChatSessionSnapshot,
   observeChatCache,
@@ -674,6 +675,68 @@ describe("chat pane initialization", () => {
       store.disconnect();
       await store.whenIdle();
       await clearStoredChatSnapshots();
+    }
+  });
+
+  it("keeps an admitted first-turn prompt visible when stored hydration resolves late", async () => {
+    const targetSessionKey = "agent:main:first-turn-retry";
+    const client = {
+      addEventListener: vi.fn(() => vi.fn()),
+      request: vi.fn(),
+    } as unknown as GatewayBrowserClient;
+    const context = createInitializationContext();
+    context.gateway.snapshot.client = client;
+    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
+    vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
+    vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
+    pane.sessionKey = targetSessionKey;
+    pane.chatMessagesBySession = new Map();
+    let deliverStoredSnapshot: ((snapshot: unknown) => void) | undefined;
+    pane.sessionSnapshotStore = {
+      read: () =>
+        new Promise((resolve) => {
+          deliverStoredSnapshot = resolve;
+        }),
+    } as never;
+    pane.context = context;
+    prepareInitialUserMessageHandoff(
+      context.initialUserMessage,
+      targetSessionKey,
+      { attachments: [], createdAt: 1, text: "retry the rejected prompt" },
+      client,
+      { runId: "initial-run" },
+    );
+    const stopAfterAttach = new Error("stop after attach");
+    let attachedState: ChatPageHost | undefined;
+    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
+      attachedState = state;
+      throw stopAfterAttach;
+    });
+
+    try {
+      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
+      expect(attachedState?.chatMessages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: [expect.objectContaining({ type: "text", text: "retry the rejected prompt" })],
+        }),
+      ]);
+      deliverStoredSnapshot?.({
+        messages: [nativeHistoryMessage(1, "stale stored transcript")],
+        pagination: { hasMore: false, completeSnapshot: true },
+        sessionId: "stored-session",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(deliverStoredSnapshot).toBeDefined();
+      expect(attachedState?.chatMessages).toEqual([
+        expect.objectContaining({
+          role: "user",
+          content: [expect.objectContaining({ type: "text", text: "retry the rejected prompt" })],
+        }),
+      ]);
+    } finally {
+      pane.disconnectedCallback();
     }
   });
 

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -1,11 +1,8 @@
 /* @vitest-environment jsdom */
 
-import { IDBFactory } from "fake-indexeddb";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
-import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import { t } from "../../i18n/index.ts";
@@ -18,21 +15,16 @@ import { loadChatHistory } from "./chat-history.ts";
 import { subscribeChatPaneSnapshotInvalidation } from "./chat-pane-startup-subscriptions.ts";
 import {
   createGatewayBrowserClientFixture,
+  createInitializationContext,
   createSessionCapabilityFixture,
   createSessionContext,
   createTestChatPane,
+  nativeHistoryMessage,
   type TestChatPane,
 } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
-import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
-import {
-  cacheChatSessionSnapshot,
-  observeChatCache,
-  type ChatMessageCache,
-} from "./session-message-cache.ts";
-import { clearStoredChatSnapshots } from "./session-snapshot-invalidation.ts";
-import { SessionSnapshotStore } from "./session-snapshot-store.ts";
+import { cacheChatSessionSnapshot, type ChatMessageCache } from "./session-message-cache.ts";
 import { openSlot } from "./sidebar-layout.ts";
 
 vi.mock("../../lib/toast.ts", () => ({ showToast: vi.fn() }));
@@ -51,67 +43,6 @@ function dispatchSidebarShortcut(pane: TestChatPane, shiftKey = true) {
   });
   pane.handleDocumentKeydown(event);
   return event;
-}
-
-function createInitializationContext(): ApplicationContext {
-  return {
-    basePath: "",
-    gateway: {
-      snapshot: {
-        client: null,
-        phase: "stopped",
-        offlineStable: false,
-        hello: null,
-        canvasPluginSurfaceUrl: null,
-        assistantAgentId: null,
-        sessionKey: "",
-        lastError: null,
-        lastErrorCode: null,
-      },
-      subscribe: () => () => {},
-      subscribeEvents: () => () => {},
-    },
-    config: {
-      current: {
-        assistantIdentity: {
-          agentId: null,
-          name: "Assistant",
-          avatar: null,
-          avatarSource: null,
-          avatarStatus: null,
-          avatarReason: null,
-        },
-        serverVersion: null,
-        localMediaPreviewRoots: [],
-        embedSandboxMode: "strict",
-        allowExternalEmbedUrls: false,
-        terminalEnabled: false,
-      },
-    },
-    agentSelection: { state: { selectedId: "main" } },
-    agents: { state: { agentsList: null } },
-    runtimeConfig: {
-      state: { configNeedsApply: false, configSnapshot: null },
-      subscribe: () => () => {},
-    },
-    placementStartup: {
-      get: () => null,
-      retry: () => undefined,
-      subscribe: () => () => {},
-    },
-    navigate: () => undefined,
-    initialUserMessage: createInitialUserMessageHandoff(),
-    chatAttachmentHandoff: createChatAttachmentHandoff(),
-    sessions: { state: { modelOverrides: {} } },
-  } as unknown as ApplicationContext;
-}
-
-function nativeHistoryMessage(seq: number, text = `message ${seq}`) {
-  return {
-    role: seq % 2 === 0 ? "assistant" : "user",
-    content: [{ type: "text", text }],
-    __openclaw: { seq },
-  };
 }
 
 describe("chat pane header state", () => {
@@ -565,176 +496,6 @@ describe("chat pane initialization", () => {
         totalMessages: 2,
       });
       expect(attachedState?.currentSessionId).toBe("split-session");
-    } finally {
-      pane.disconnectedCallback();
-    }
-  });
-
-  it("paints a persistent snapshot while the network refresh is already in flight", async () => {
-    vi.stubGlobal("indexedDB", new IDBFactory());
-    const targetSessionKey = "agent:main:persistent";
-    const cachedMessages = [nativeHistoryMessage(1, "persistent history")];
-    const networkMessages = [nativeHistoryMessage(1, "network history")];
-    const writer = new SessionSnapshotStore();
-    writer.write(targetSessionKey, {
-      messages: cachedMessages,
-      pagination: { hasMore: false, completeSnapshot: true },
-      sessionId: "persistent-session",
-    });
-    await writer.flush();
-    const response = createDeferred<Record<string, unknown>>();
-    const request = vi.fn(() => response.promise);
-    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
-    vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
-    vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
-    const sharedMessages: ChatMessageCache = new Map();
-    const store = new SessionSnapshotStore(sharedMessages);
-    store.connect();
-    observeChatCache(sharedMessages, store);
-    pane.sessionKey = targetSessionKey;
-    pane.chatMessagesBySession = sharedMessages;
-    pane.sessionSnapshotStore = store;
-    pane.context = createInitializationContext();
-    const client = { request } as unknown as GatewayBrowserClient;
-    const stopAfterAttach = new Error("stop after attach");
-    let attachedState: ChatPageHost | undefined;
-    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
-      attachedState = state;
-      state.client = client;
-      state.connected = true;
-      state.connectionEpoch = 1;
-      void loadChatHistory(state);
-      throw stopAfterAttach;
-    });
-
-    try {
-      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
-      expect(request).toHaveBeenCalledWith(
-        "chat.history",
-        expect.objectContaining({ sessionKey: targetSessionKey }),
-      );
-      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(cachedMessages));
-
-      response.resolve({ messages: networkMessages, sessionId: "network-session" });
-      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(networkMessages));
-    } finally {
-      pane.disconnectedCallback();
-      store.disconnect();
-      await store.whenIdle();
-      await clearStoredChatSnapshots();
-    }
-  });
-
-  it("discards persistent hydration when the network snapshot lands first", async () => {
-    vi.stubGlobal("indexedDB", new IDBFactory());
-    const targetSessionKey = "agent:main:network-first";
-    const writer = new SessionSnapshotStore();
-    writer.write(targetSessionKey, {
-      messages: [nativeHistoryMessage(1, "stale persistent history")],
-      pagination: { hasMore: false, completeSnapshot: true },
-      sessionId: "persistent-session",
-    });
-    await writer.flush();
-    const networkMessages = [nativeHistoryMessage(1, "authoritative network history")];
-    const request = vi.fn(async () => ({
-      messages: networkMessages,
-      sessionId: "network-session",
-    }));
-    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
-    vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
-    vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
-    const sharedMessages: ChatMessageCache = new Map();
-    const store = new SessionSnapshotStore(sharedMessages);
-    store.connect();
-    observeChatCache(sharedMessages, store);
-    pane.sessionKey = targetSessionKey;
-    pane.chatMessagesBySession = sharedMessages;
-    pane.sessionSnapshotStore = store;
-    pane.context = createInitializationContext();
-    const client = { request } as unknown as GatewayBrowserClient;
-    const stopAfterAttach = new Error("stop after attach");
-    let attachedState: ChatPageHost | undefined;
-    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
-      attachedState = state;
-      state.client = client;
-      state.connected = true;
-      state.connectionEpoch = 1;
-      void loadChatHistory(state);
-      throw stopAfterAttach;
-    });
-
-    try {
-      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
-      await vi.waitFor(() => expect(attachedState?.chatMessages).toEqual(networkMessages));
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 0);
-      });
-      expect(attachedState?.chatMessages).toEqual(networkMessages);
-    } finally {
-      pane.disconnectedCallback();
-      store.disconnect();
-      await store.whenIdle();
-      await clearStoredChatSnapshots();
-    }
-  });
-
-  it("keeps an admitted first-turn prompt visible when stored hydration resolves late", async () => {
-    const targetSessionKey = "agent:main:first-turn-retry";
-    const client = {
-      addEventListener: vi.fn(() => vi.fn()),
-      request: vi.fn(),
-    } as unknown as GatewayBrowserClient;
-    const context = createInitializationContext();
-    context.gateway.snapshot.client = client;
-    const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
-    vi.spyOn(pane, "requestUpdate").mockImplementation(() => undefined);
-    vi.spyOn(pane, "performUpdate").mockImplementation(() => undefined);
-    pane.sessionKey = targetSessionKey;
-    pane.chatMessagesBySession = new Map();
-    let deliverStoredSnapshot: ((snapshot: unknown) => void) | undefined;
-    pane.sessionSnapshotStore = {
-      read: () =>
-        new Promise((resolve) => {
-          deliverStoredSnapshot = resolve;
-        }),
-    } as never;
-    pane.context = context;
-    prepareInitialUserMessageHandoff(
-      context.initialUserMessage,
-      targetSessionKey,
-      { attachments: [], createdAt: 1, text: "retry the rejected prompt" },
-      client,
-      { runId: "initial-run" },
-    );
-    const stopAfterAttach = new Error("stop after attach");
-    let attachedState: ChatPageHost | undefined;
-    vi.spyOn(pane.chatState, "attach").mockImplementation((state) => {
-      attachedState = state;
-      throw stopAfterAttach;
-    });
-
-    try {
-      expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
-      expect(attachedState?.chatMessages).toEqual([
-        expect.objectContaining({
-          role: "user",
-          content: [expect.objectContaining({ type: "text", text: "retry the rejected prompt" })],
-        }),
-      ]);
-      deliverStoredSnapshot?.({
-        messages: [nativeHistoryMessage(1, "stale stored transcript")],
-        pagination: { hasMore: false, completeSnapshot: true },
-        sessionId: "stored-session",
-      });
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(deliverStoredSnapshot).toBeDefined();
-      expect(attachedState?.chatMessages).toEqual([
-        expect.objectContaining({
-          role: "user",
-          content: [expect.objectContaining({ type: "text", text: "retry the rejected prompt" })],
-        }),
-      ]);
     } finally {
       pane.disconnectedCallback();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a prompt admitted while IndexedDB hydration was pending could either disappear behind the late stored snapshot or, with the first fence, remain visible without the session's stored history.

## Why This Change Was Made

The in-memory cache miss remains the fence against a network snapshot that landed first. If live or pending rows exist, the late stored rows now pass through the pane's existing scoped `snapshotLoaded` projection merge; the merged messages are cached and applied with the stored snapshot's session and pagination metadata unchanged.

## User Impact

Stored transcript history and a newly admitted prompt remain visible together while the Gateway refresh is still in flight. Cold hydration and network-first replacement remain unchanged.

## Evidence

- CI repair: `workspace.bootstrap-cache.test.ts` could rewrite and restore mtime within one filesystem ctime tick, so the fixture now waits for the cache identity to observably change; the focused test passed 20/20, its 10-file agents-core sibling slice passed 55 tests, and `node scripts/check-changed.mjs` passed.
- Regression proof: the test failed before the repair because only the admitted prompt remained; it now requires both the stored row and prompt, plus unchanged cursor, leaf, pagination, and session metadata.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts ui/src/pages/chat/chat-pane.test.ts ui/src/pages/chat/chat-pane-lifecycle.test.ts ui/src/pages/chat/history-merge.test.ts ui/src/pages/chat/chat-history-cursor.test.ts ui/src/pages/chat/session-message-cache.test.ts ui/src/pages/chat/initial-turn-handoff.test.ts` -> 107 passed.
- `node scripts/check-changed.mjs -- ui/src/pages/chat/chat-pane-lifecycle.ts ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts ui/src/pages/chat/chat-pane.test-support.ts ui/src/pages/chat/chat-pane.test.ts` -> passed, including formatting, types, lint, and i18n verification.
- Persistent data model: no change. IndexedDB remains version 2 with the same stores, key paths, serialized snapshot fields, and migration behavior; the detector matched moved hydration fixtures rather than a schema edit.
- Rank-up, stored history: addressed through the existing scoped projection; both stored and pending rows are asserted.
- Rank-up, session-state risk: addressed by caching and applying the merged rows with all stored metadata preserved.
- Rank-up, visual proof: not captured because the IndexedDB/network race cannot be staged deterministically in the running UI without a test-only hook; the owner-boundary test drives the exact execution order instead.
- Rank-up, stale head: proof was refreshed and exact-head CI was triggered for `b1c0e719a33`; landing remains separate.
- Rank-up, maintainer handling: revised this existing branch only; no queue or landing action was taken.
- Rank-up, patch quality: changed-surface checks and focused sibling tests are green.

Production LOC: +23/-5 (net +18). Tests: +226/-179; test support: +61.

