### PR TITLE
fix(ui): stop terminal panel teardown from leaking liveness probes

### DIFF
--- a/ui/src/components/terminal/terminal-connection.test.ts
+++ b/ui/src/components/terminal/terminal-connection.test.ts
@@ -970,4 +970,33 @@ describe("TerminalConnection", () => {
     expect(client.listenerCount()).toBe(0);
     expect(conn.size).toBe(0);
   });
+
+  // A reply that lands after panel teardown races a dead owner. Registering its
+  // stream would retain the sink forever and arm the liveness probe loop
+  // against the replaced client, so the owner must refuse post-dispose work.
+  it.each([
+    ["attach", "terminal.attach"],
+    ["open", "terminal.open"],
+  ] as const)(
+    "a late %s reply after dispose() leaves no resurrected stream or liveness probes",
+    (kind, method) =>
+      withFakeTimers(async () => {
+        const { client, conn } = makeHarness();
+        const response = createDeferred<TestSessionResult & { buffer: string }>();
+        deferRequest(client, method, response);
+        const settle =
+          kind === "attach"
+            ? conn.attach("s1", testSink())
+            : conn.open({ cols: 80, rows: 24 }, testSink());
+        // Panel teardown (reconnect or element removal) discards the connection
+        // while the RPC is still in flight.
+        conn.dispose();
+        response.resolve({ ...sessionResult(), buffer: "replayed\n" });
+        await expect(settle).resolves.toMatchObject({ sessionId: "s1" });
+        expect(conn.size).toBe(0);
+        expect(client.listenerCount()).toBe(0);
+        await vi.advanceTimersByTimeAsync(IDLE_PLUS_PROBE_MS);
+        expect(client.requests.filter((request) => request.method === "terminal.list")).toEqual([]);
+      }),
+  );
 });

--- a/ui/src/components/terminal/terminal-connection.ts
+++ b/ui/src/components/terminal/terminal-connection.ts
@@ -140,6 +140,10 @@ export class TerminalConnection {
   // capped buffer becomes a detectable gap instead of silent output loss.
   private readonly pending = new Map<string, BoundedBuffer<PendingEvent>>();
   private unsubscribe: (() => void) | null = null;
+  // Fence for replies that outlive dispose(): without it a late open/attach
+  // would resurrect stream state and re-arm the liveness loop on a connection
+  // whose panel is gone or was replaced by a reconnect.
+  private disposed = false;
   private pendingOpenCount = 0;
   private livenessTimer: ReturnType<typeof setTimeout> | null = null;
   private livenessProbeInFlight = false;
@@ -244,6 +248,9 @@ export class TerminalConnection {
       }
       throw new TerminalOpenUnusableSessionError(missingField);
     }
+    if (this.disposed) {
+      return result;
+    }
     const stream = this.setStream(result.sessionId, sink, {
       seqMode: "unknown",
       expectedSeq: 0,
@@ -268,6 +275,9 @@ export class TerminalConnection {
     }
     const offset =
       typeof result.seq === "number" && Number.isSafeInteger(result.seq) ? result.seq : null;
+    if (this.disposed) {
+      return result;
+    }
     const stream = this.setStream(sessionId, sink, {
       seqMode: offset === null ? "counter" : "offset",
       expectedSeq: offset,
@@ -640,6 +650,7 @@ export class TerminalConnection {
   }
 
   dispose(): void {
+    this.disposed = true;
     for (const stream of this.streams.values()) {
       stream.abort.abort();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an operator who closes the terminal panel (or loses/replaces the gateway connection) exactly while a terminal `open`/`attach` reply is still in flight would keep a background probe loop running for the rest of the page session.

The reply lands after `TerminalConnection.dispose()` and re-registered its stream on the torn-down connection. Nothing routes events into that resurrected stream anymore, but it retains the tab sink and arms the 20-second liveness watchdog, which then probes `terminal.list` against the replaced client roughly every 25 seconds until reload, and can escalate to a reconnect request on a client the panel already discarded.

## Why This Change Was Made

`dispose()` now records that the connection is closed, and `open()`/`attach()` refuse to register sinks, flush buffered events, or schedule liveness checks once a reply outlives that teardown. The session result is still returned normally, so the panel's existing lifecycle guards keep owning server-side cleanup (closing a freshly opened-but-cancelled session, dropping the failed tab). No consumer behavior changed; only the owner no longer resurrects state after disposal.

## User Impact

No visible UI change by design: this removes silent background network chatter and retained references after terminal panel teardown during a gateway reconnect. Operators on long-lived dashboards stop accumulating dead probe loops per raced teardown.

## Evidence

Regression test fails on current `main` and passes with the fix (`ui/src/components/terminal/terminal-connection.test.ts`, "a late attach/open reply after dispose() leaves no resurrected stream or liveness probes"):

Failing on `main` before the fix:

```
× a late attach reply after dispose() leaves no resurrected stream or liveness probes
× a late open reply after dispose() leaves no resurrected stream or liveness probes
AssertionError: expected 1 to be +0
      expect(conn.size).toBe(0);
Tests  2 failed | 45 passed (47)
```

After the fix:

```
Test Files  1 passed (1)
Tests  47 passed (47)
```

Validation commands run:

```
node scripts/run-vitest.mjs ui/src/components/terminal/terminal-connection.test.ts
node scripts/run-vitest.mjs ui/src/components/terminal/terminal-panel.test.ts   # 25 passed
oxfmt --check <touched files>
node scripts/run-tsgo.mjs -p tsconfig.ui.json ...                                # only pre-existing unrelated pako shim error in ui/vite.config.ts; zero errors in touched files
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <touched files>
node --import tsx scripts/run-stylelint.mts <touched files>
node --import tsx scripts/check-max-lines-ratchet.mts                            # OK
node --import tsx scripts/check-assertion-safety-ratchet.mts                     # OK
```

Diff: production `ui/src/components/terminal/terminal-connection.ts` +11/-0 (lifecycle fence at the owner); tests `ui/src/components/terminal/terminal-connection.test.ts` +29/-0.
