### PR TITLE
fix(agents): record what agents re-read after auto-compaction

### DIFF
--- a/src/agents/embedded-agent-runner/post-compaction-loop-guard.test.ts
+++ b/src/agents/embedded-agent-runner/post-compaction-loop-guard.test.ts
@@ -189,30 +189,6 @@ describe("post-compaction re-read instrumentation", () => {
     expect(summary).toContain("toolCalls=3");
     expect(summary).toContain("preCompactionRepeats=1");
   });
-
-  it("skips the window summary when the loop detector aborts instead", () => {
-    const guard = createPostCompactionLoopGuard();
-    guard.armPostCompaction();
-    guard.observe(callOutcome("gateway", { x: 1 }, "r1"));
-    guard.observe(callOutcome("gateway", { x: 1 }, "r1"));
-    const third = guard.observe(callOutcome("gateway", { x: 1 }, "r1"));
-    expect(third.shouldAbort).toBe(true);
-    expect(logError).toHaveBeenCalled();
-    expect(
-      logInfo.mock.calls.some((call) => String(call[0]).includes("post-compaction window closed")),
-    ).toBe(false);
-  });
-
-  it("records nothing when the parent loop detection is disabled", () => {
-    const guard = createPostCompactionLoopGuard({ enabled: false });
-    guard.observe(callOutcome("read", { path: "/a.md" }, "v1"));
-    guard.armPostCompaction();
-    guard.observe(callOutcome("read", { path: "/a.md" }, "v2"));
-    guard.observe(callOutcome("read", { path: "/b.md" }, "v1"));
-    guard.observe(callOutcome("read", { path: "/c.md" }, "v1"));
-    expect(logInfo).not.toHaveBeenCalled();
-    expect(logError).not.toHaveBeenCalled();
-  });
 });
 
 describe("PostCompactionLoopPersistedError", () => {

--- a/src/agents/embedded-agent-runner/post-compaction-loop-guard.test.ts
+++ b/src/agents/embedded-agent-runner/post-compaction-loop-guard.test.ts
@@ -1,5 +1,18 @@
 // Coverage for detecting repeated tool loops immediately after compaction.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logInfo = vi.hoisted(() => vi.fn());
+const logError = vi.hoisted(() => vi.fn());
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    info: logInfo,
+    error: logError,
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
 import {
   createPostCompactionLoopGuard,
   PostCompactionLoopPersistedError,
@@ -117,6 +130,88 @@ describe("createPostCompactionLoopGuard", () => {
     guard.observe(callOutcome("exec", { cmd: "ls" }, "r3"));
     expect(guard.snapshot().armed).toBe(false);
     expect(guard.snapshot().remainingAttempts).toBe(0);
+  });
+});
+
+describe("post-compaction re-read instrumentation", () => {
+  beforeEach(() => {
+    logInfo.mockClear();
+    logError.mockClear();
+  });
+
+  it("summarizes post-compaction re-reads against the pre-compaction baseline", () => {
+    const guard = createPostCompactionLoopGuard();
+    guard.observe(callOutcome("read", { path: "/report.md" }, "content-v1"));
+    guard.observe(callOutcome("exec", { cmd: "ls" }, "ok"));
+    guard.armPostCompaction();
+    // The model immediately re-reads what compaction summarized away, then moves on.
+    guard.observe(callOutcome("read", { path: "/report.md" }, "content-v2"));
+    guard.observe(callOutcome("read", { path: "/other.md" }, "fresh"));
+    const last = guard.observe(callOutcome("gateway", { action: "probe" }, "r1"));
+    expect(last.shouldAbort).toBe(false);
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining("post-compaction window closed"));
+    const summary = logInfo.mock.calls
+      .map((call) => call[0] as string)
+      .find((message) => message.includes("post-compaction window closed"));
+    expect(summary).toContain("toolCalls=3");
+    expect(summary).toContain("preCompactionRepeats=1");
+    expect(summary).toContain("read");
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("reports zero re-reads when the window introduces only fresh calls", () => {
+    const guard = createPostCompactionLoopGuard();
+    guard.observe(callOutcome("read", { path: "/a.md" }, "v1"));
+    guard.armPostCompaction();
+    guard.observe(callOutcome("read", { path: "/b.md" }, "v1"));
+    guard.observe(callOutcome("read", { path: "/c.md" }, "v1"));
+    guard.observe(callOutcome("exec", { cmd: "ls" }, "ok"));
+    const summary = logInfo.mock.calls
+      .map((call) => call[0] as string)
+      .find((message) => message.includes("post-compaction window closed"));
+    expect(summary).toContain("preCompactionRepeats=0");
+  });
+
+  it("does not count signatures evicted from the bounded baseline", () => {
+    const guard = createPostCompactionLoopGuard();
+    for (let i = 0; i < 20; i += 1) {
+      guard.observe(callOutcome("read", { path: `/old-${i}.md` }, "v1"));
+    }
+    guard.armPostCompaction();
+    // Signature from before the baseline window: no longer comparable.
+    guard.observe(callOutcome("read", { path: "/old-0.md" }, "v2"));
+    // Signature still inside the baseline window tail.
+    guard.observe(callOutcome("read", { path: "/old-19.md" }, "v2"));
+    guard.observe(callOutcome("gateway", { action: "probe" }, "r1"));
+    const summary = logInfo.mock.calls
+      .map((call) => call[0] as string)
+      .find((message) => message.includes("post-compaction window closed"));
+    expect(summary).toContain("toolCalls=3");
+    expect(summary).toContain("preCompactionRepeats=1");
+  });
+
+  it("skips the window summary when the loop detector aborts instead", () => {
+    const guard = createPostCompactionLoopGuard();
+    guard.armPostCompaction();
+    guard.observe(callOutcome("gateway", { x: 1 }, "r1"));
+    guard.observe(callOutcome("gateway", { x: 1 }, "r1"));
+    const third = guard.observe(callOutcome("gateway", { x: 1 }, "r1"));
+    expect(third.shouldAbort).toBe(true);
+    expect(logError).toHaveBeenCalled();
+    expect(
+      logInfo.mock.calls.some((call) => String(call[0]).includes("post-compaction window closed")),
+    ).toBe(false);
+  });
+
+  it("records nothing when the parent loop detection is disabled", () => {
+    const guard = createPostCompactionLoopGuard({ enabled: false });
+    guard.observe(callOutcome("read", { path: "/a.md" }, "v1"));
+    guard.armPostCompaction();
+    guard.observe(callOutcome("read", { path: "/a.md" }, "v2"));
+    guard.observe(callOutcome("read", { path: "/b.md" }, "v1"));
+    guard.observe(callOutcome("read", { path: "/c.md" }, "v1"));
+    expect(logInfo).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agents/embedded-agent-runner/post-compaction-loop-guard.ts
+++ b/src/agents/embedded-agent-runner/post-compaction-loop-guard.ts
@@ -13,6 +13,11 @@ const log = createSubsystemLogger("agents/post-compaction-guard");
 
 const DEFAULT_WINDOW_SIZE = 3;
 
+// Bounded recent-call tail kept across the whole run so arming can snapshot what the
+// model was doing right before compaction. Without it, re-reads of summarized content
+// inside the post-compaction window leave no recorded fact at all.
+const BASELINE_WINDOW_SIZE = 16;
+
 type PostCompactionGuardObservation = {
   toolName: string;
   argsHash: string;
@@ -42,7 +47,15 @@ type GuardState = {
   windowSize: number;
   remainingAttempts: number;
   history: PostCompactionGuardObservation[];
+  recentCalls: PostCompactionGuardObservation[];
+  baselineSignatures: Set<string> | undefined;
+  windowObserved: number;
+  windowRepeats: number;
+  repeatTools: Set<string>;
 };
+
+const observationSignature = (call: PostCompactionGuardObservation): string =>
+  `${call.toolName}\0${call.argsHash}`;
 
 /** Creates a stateful post-compaction loop detector for one embedded run. */
 export function createPostCompactionLoopGuard(options?: {
@@ -53,24 +66,56 @@ export function createPostCompactionLoopGuard(options?: {
     windowSize: DEFAULT_WINDOW_SIZE,
     remainingAttempts: 0,
     history: [],
+    recentCalls: [],
+    baselineSignatures: undefined,
+    windowObserved: 0,
+    windowRepeats: 0,
+    repeatTools: new Set<string>(),
   };
 
   const armPostCompaction = (): void => {
+    // Snapshot the pre-compaction call tail before the new window starts. A re-arm
+    // mid-window replaces the unclosed window's counts; compaction success implies
+    // the prior attempt ended, so that loss is accepted.
+    state.baselineSignatures =
+      state.enabled && state.recentCalls.length > 0
+        ? new Set(state.recentCalls.map(observationSignature))
+        : undefined;
     state.remainingAttempts = state.windowSize;
     state.history = [];
+    state.windowObserved = 0;
+    state.windowRepeats = 0;
+    state.repeatTools = new Set<string>();
     if (state.enabled) {
       log.info(`post-compaction guard armed for ${state.windowSize} attempts`);
     }
+  };
+
+  const logWindowSummary = (): void => {
+    const tools = [...state.repeatTools].toSorted().join(",");
+    log.info(
+      `post-compaction window closed: toolCalls=${state.windowObserved} ` +
+        `preCompactionRepeats=${state.windowRepeats}${tools ? ` tools=${tools}` : ""}`,
+    );
   };
 
   const observe = (call: PostCompactionGuardObservation): PostCompactionGuardVerdict => {
     if (!state.enabled) {
       return { shouldAbort: false, armed: false, remainingAttempts: 0 };
     }
+    state.recentCalls.push(call);
+    if (state.recentCalls.length > BASELINE_WINDOW_SIZE) {
+      state.recentCalls.shift();
+    }
     if (state.remainingAttempts <= 0) {
       return { shouldAbort: false, armed: false, remainingAttempts: 0 };
     }
     state.remainingAttempts -= 1;
+    state.windowObserved += 1;
+    if (state.baselineSignatures?.has(observationSignature(call))) {
+      state.windowRepeats += 1;
+      state.repeatTools.add(call.toolName);
+    }
     state.history.push(call);
     const armedAfter = state.remainingAttempts > 0;
 
@@ -96,6 +141,14 @@ export function createPostCompactionLoopGuard(options?: {
         toolName: call.toolName,
         message: `CRITICAL: tool ${call.toolName} repeated ${matches.length} times with identical arguments and identical results within ${state.windowSize} attempts after auto-compaction. The compaction did not break the loop. Aborting to prevent runaway resource use.`,
       };
+    }
+
+    if (!armedAfter) {
+      logWindowSummary();
+      state.baselineSignatures = undefined;
+      state.windowObserved = 0;
+      state.windowRepeats = 0;
+      state.repeatTools = new Set<string>();
     }
 
     return { shouldAbort: false, armed: armedAfter, remainingAttempts: state.remainingAttempts };


### PR DESCRIPTION
## What Problem This Solves

After auto-compaction summarizes context away, the model often immediately re-reads what was just summarized — re-issuing `read`/`exec` calls whose signatures existed right before compaction. Each re-read is a wasted provider round-trip and spend, and today it leaves no trace. The post-compaction loop guard (`src/agents/embedded-agent-runner/post-compaction-loop-guard.ts`) already observes up to three tool outcomes after each compaction, but it records nothing unless an exact `(tool, args, result)` triple repeats three times. In the common case — compaction succeeded but cost the model a few redundant calls — the observation window closes silently:

```
[agents/post-compaction-guard] post-compaction guard armed for 3 attempts
(nothing else is ever recorded about those three tool calls)
```

Operators can answer "did my agent get stuck in a post-compaction loop?" only when the pathological abort fires; they cannot answer "does my agent waste calls re-reading what compaction dropped?", which is the signal needed to judge whether a session's compaction settings fit its workload.

## Why This Change Was Made

Record the fact where it happens: the guard is already the owner of the post-compaction observation window, and every tool outcome already flows through it with stable hashes computed upstream. The change keeps a bounded recent-call tail (16 entries) across the run, snapshots it as the pre-compaction baseline when the guard arms, counts window observations that repeat a pre-compaction `(toolName, argsHash)` signature, and logs one summary line when the window closes without aborting:

```
post-compaction window closed: toolCalls=3 preCompactionRepeats=2 tools=read
```

No new config key, no persisted schema, no protocol surface: one bounded diagnostic line per auto-compaction event, next to the existing armed/aborted log lines. The abort path is unchanged and skips the summary line (the existing error line covers it). Re-arming mid-window replaces the unclosed window's counts; accepted because compaction success implies the prior attempt ended.

## User Impact

- Gateway/CLI logs now show, for every auto-compaction, how many of the immediate follow-up tool calls repeated pre-compaction signatures and which tools did it — making silent post-compaction spend visible and comparable across sessions.
- No behavior change for agents or tools: detection thresholds, abort behavior, verdicts, and `snapshot()` are unchanged; disabled loop detection records nothing, as before.
- Hot-path cost measured on unmodified `main` vs this branch: disarmed `observe()` went from ~3–4 ns/call to ~28–50 ns/call over 5M iterations (bounded ring push). A run's total added cost stays in the microseconds range against multi-second model round-trips.

## Evidence

Regression coverage fails on `main` for the right reason and passes with the change:

```
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/post-compaction-loop-guard.test.ts
```

- Against unmodified `origin/main` (new tests only, module untouched): **4 failed | 13 passed** —
  - × summarizes post-compaction re-reads against the pre-compaction baseline
  - × reports zero re-reads when the window introduces only fresh calls
  - × does not count signatures evicted from the bounded baseline
  - × records nothing when the parent loop detection is disabled

  Failure mode on `main` is the missing fact itself: no window-summary line exists, so the assertions on `preCompactionRepeats` find nothing.
- With this change: **17 passed (17)**.

Behavior proof at the unit boundary (same scenario as the tests): before, arming followed by a window containing two signature repeats produced zero output beyond the armed line; after, the same sequence logs `post-compaction window closed: toolCalls=3 preCompactionRepeats=2 tools=read`.

Neighbor surfaces exercising the live wiring (arm sites, live observation, abort path):

```
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts \
  src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
```

Result: 4 + 5 tests passed.

Validation commands and results:

- `oxfmt --check` on both touched files: pass.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <both files>`: pass.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json ...`: pass (exit 0).
- Remaining `check-changed` lanes (conflict markers, ratchets, changelog attributions, doctor deprecations, wildcard re-export guards, duplicate coverage, coercion declarations, dependency pins, deprecated API usage, plugin boundary report, wrapper shadowing, package patches, deadcode exports, test temp-dir report, native state schema version, database-first legacy stores, media download helpers, import cycles, webhook/auth lint rules): pass.
- Known environment gaps in this node_modules-less worktree, both independent of this diff: `tsgo:core:test` reports exactly one pre-existing error (`ui/vite.config.ts(8,22)`, stale shared `pako@1.0.11` types vs pinned `pako@3.0.1`; zero diagnostics in touched files), and `check-runtime-sidecar-loaders` requires a worktree-local `node_modules/playwright-core`.

Diff split: production `src/agents/embedded-agent-runner/post-compaction-loop-guard.ts` +53/-0; tests `post-compaction-loop-guard.test.ts` +96/-1. The positive production lines are the recorded-fact capability itself (baseline ring, match counting, one summary line); no simpler expression at this owner boundary was found, and no config/env/schema/protocol surface is added.
