### PR TITLE
fix(gateway): keep rootless sessions usable after permission changes

### DIFF
--- a/src/gateway/server.sessions.permission-root.test.ts
+++ b/src/gateway/server.sessions.permission-root.test.ts
@@ -1,0 +1,133 @@
+// Session permission-root tests protect the persisted root/mode invariant across
+// patch, create, and reset owners before hooks or active-work interruption.
+import { afterEach, expect, test } from "vitest";
+import { getRuntimeConfig } from "../config/io.js";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { rpcReq, writeSessionStore } from "./test-helpers.js";
+import {
+  sessionHookMocks,
+  sessionStoreEntry,
+  setupGatewaySessionsTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir, openClient, seedActiveMainSession } =
+  setupGatewaySessionsTestHarness();
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+});
+
+test("sessions.patch rejects a rootless permission mode before persistence or hooks", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: { main: sessionStoreEntry("sess-rootless-permission") },
+  });
+  sessionHookMocks.triggerInternalHook.mockClear();
+
+  const { ws } = await openClient();
+  try {
+    const patched = await rpcReq(ws, "sessions.patch", {
+      key: "agent:main:main",
+      permissionMode: "guarded",
+    });
+
+    expect(patched).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "permission mode requires a session root; choose Default or a rooted session",
+      },
+    });
+    expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).not.toHaveProperty(
+      "permissionMode",
+    );
+    expect(sessionHookMocks.triggerInternalHook).not.toHaveBeenCalled();
+  } finally {
+    ws.close();
+  }
+});
+
+test("createGatewaySession rejects a permission mode without a prepared session root", async () => {
+  await createSessionStoreDir();
+  const { createGatewaySession } = await import("./session-create-service.js");
+
+  await expect(
+    createGatewaySession({
+      cfg: getRuntimeConfig(),
+      agentId: "main",
+      commandSource: "test",
+      permissionMode: "guarded",
+    }),
+  ).resolves.toMatchObject({
+    ok: false,
+    error: {
+      code: "INVALID_REQUEST",
+      message: "permission mode requires a session root; choose Default or a rooted session",
+    },
+  });
+});
+
+test("sessions.reset rejects a rootless permission mode without interrupting admitted work", async () => {
+  const { storePath } = await seedActiveMainSession();
+  let interrupted = false;
+  let releaseAdmission = () => {};
+  const admissionLease = await beginSessionWorkAdmission({
+    scope: storePath,
+    identities: ["agent:main:main", "sess-main"],
+    assertAllowed: () => {},
+    onInterrupt: () => {
+      interrupted = true;
+      releaseAdmission();
+    },
+  });
+  releaseAdmission = admissionLease.release;
+
+  try {
+    const { performGatewaySessionReset } = await import("./session-reset-service.js");
+    const reset = await performGatewaySessionReset({
+      key: "main",
+      reason: "reset",
+      commandSource: "gateway:agent",
+      workerPlacementContext: {},
+      permissionMode: "guarded",
+    });
+
+    expect(reset).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "permission mode requires a session root; choose Default or a rooted session",
+      },
+    });
+    expect(interrupted).toBe(false);
+  } finally {
+    admissionLease.release();
+  }
+});
+
+test("sessions.reset rejects a persisted rootless permission mode", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-legacy-rootless-permission", { permissionMode: "full" }),
+    },
+  });
+  const { performGatewaySessionReset } = await import("./session-reset-service.js");
+
+  const reset = await performGatewaySessionReset({
+    key: "main",
+    reason: "reset",
+    commandSource: "gateway:agent",
+    workerPlacementContext: {},
+  });
+
+  expect(reset).toMatchObject({
+    ok: false,
+    error: {
+      code: "INVALID_REQUEST",
+      message: "permission mode requires a session root; choose Default or a rooted session",
+    },
+  });
+});

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -1062,6 +1062,7 @@ export async function createGatewaySession(params: {
             ),
           storeKey: target.canonicalKey,
           agentId: target.agentId,
+          preparedSessionRoot: sessionRoot,
           // Patch appliers read key presence as caller intent (present = change,
           // null = clear), so omitted create fields must stay absent: a present
           // undefined model trips the selection lock and drops modelFallback,
@@ -1075,6 +1076,7 @@ export async function createGatewaySession(params: {
             ...(requestedContextWindow ? { contextWindow: requestedContextWindow } : {}),
             ...(requestedThinkingLevel ? { thinkingLevel: requestedThinkingLevel } : {}),
             ...(requestedToolOverrides ? { toolOverrides: params.toolOverrides } : {}),
+            ...(params.permissionMode ? { permissionMode: params.permissionMode } : {}),
           },
           loadGatewayModelCatalog: params.loadGatewayModelCatalog,
           authorizedAgentHarnessId: params.authorizedAgentHarnessId,
@@ -1155,8 +1157,6 @@ export async function createGatewaySession(params: {
           // Session worktrees adopt cwd only during admin-gated creation; public patching stays
           // restricted to spawned subagent and ACP lineage.
           ...(spawnedCwd ? { spawnedCwd } : {}),
-          ...(sessionRoot ? { sessionRoot } : {}),
-          ...(params.permissionMode ? { permissionMode: params.permissionMode } : {}),
           ...(preparedLifecycle?.worktree ? { worktree: preparedLifecycle.worktree } : {}),
           ...(execNode ? { execHost: "node", execNode, ...(execCwd ? { execCwd } : {}) } : {}),
           ...(createdNewEntry && params.armSessionDiffBaselineCapture && !execNode

--- a/src/gateway/session-permission-policy.ts
+++ b/src/gateway/session-permission-policy.ts
@@ -1,0 +1,27 @@
+import type { SessionPermissionMode } from "../../packages/gateway-protocol/src/index.js";
+import type { SessionEntry } from "../config/sessions.js";
+
+const SESSION_PERMISSION_ROOT_REQUIRED_MESSAGE =
+  "permission mode requires a session root; choose Default or a rooted session";
+
+export function resolveSessionPermissionRootError(
+  permissionMode: SessionPermissionMode | null | undefined,
+  sessionRoot: string | undefined,
+): string | undefined {
+  return permissionMode && !sessionRoot ? SESSION_PERMISSION_ROOT_REQUIRED_MESSAGE : undefined;
+}
+
+export function applySessionPermissionMode(
+  entry: Pick<SessionEntry, "permissionMode" | "sessionRoot">,
+  permissionMode: SessionPermissionMode | null | undefined,
+): string | undefined {
+  if (permissionMode === null) {
+    delete entry.permissionMode;
+    return undefined;
+  }
+  const error = resolveSessionPermissionRootError(permissionMode, entry.sessionRoot);
+  if (!error && permissionMode) {
+    entry.permissionMode = permissionMode;
+  }
+  return error;
+}

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -105,6 +105,7 @@ import {
   type PrepareGatewaySessionLifecycle,
   rollbackGatewaySessionPreparation,
 } from "./session-lifecycle-preparation.js";
+import { resolveSessionPermissionRootError } from "./session-permission-policy.js";
 import { resolvePluginSessionOwnershipError } from "./session-plugin-ownership.js";
 import { notifyGatewaySessionReset } from "./session-reset-notifications.js";
 import {
@@ -1202,6 +1203,20 @@ export async function performGatewaySessionReset(params: {
         return;
       }
       preparedResetSessionId = normalizeOptionalString(currentEntry?.sessionId);
+      // Lifecycle preparation can establish a worktree root unless the request clears it.
+      // Reject every other impossible tuple before active work is interrupted.
+      if (params.clearSpawnedCwd || !params.prepareLifecycle) {
+        const permissionRootError = resolveSessionPermissionRootError(
+          params.clearSpawnedCwd
+            ? undefined
+            : (params.permissionMode ?? currentEntry?.permissionMode),
+          params.clearSpawnedCwd ? undefined : (params.sessionRoot ?? currentEntry?.sessionRoot),
+        );
+        if (permissionRootError) {
+          resetPreparationError = errorShape(ErrorCodes.INVALID_REQUEST, permissionRootError);
+          return;
+        }
+      }
       admittedWorkReleased = await interruptSessionWorkAdmissions({
         scope: resetTarget.storePath,
         identities: resetLifecycleIdentities,
@@ -1219,6 +1234,19 @@ export async function performGatewaySessionReset(params: {
           return;
         }
         preparedLifecycle = prepared.value;
+      }
+      if (admittedWorkReleased) {
+        const permissionRootError = resolveSessionPermissionRootError(
+          params.clearSpawnedCwd
+            ? undefined
+            : (params.permissionMode ?? currentEntry?.permissionMode),
+          params.clearSpawnedCwd
+            ? undefined
+            : (preparedLifecycle?.sessionRoot ?? params.sessionRoot ?? currentEntry?.sessionRoot),
+        );
+        if (permissionRootError) {
+          resetPreparationError = errorShape(ErrorCodes.INVALID_REQUEST, permissionRootError);
+        }
       }
     },
     run: async () => {

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1655,6 +1655,25 @@ describe("gateway sessions patch", () => {
     expect(cleared.sessionRoot).toBe("/workspace/project");
   });
 
+  test("rejects a session permission mode without a recorded root", async () => {
+    const store = mainStoreEntry({});
+    const result = await runPatch({
+      store,
+      patch: { key: MAIN_SESSION_KEY, permissionMode: "workspace" },
+    });
+
+    expectPatchError(result, "permission mode requires a session root");
+    expect(store[MAIN_SESSION_KEY]?.permissionMode).toBeUndefined();
+
+    const recovered = expectPatchOk(
+      await runPatch({
+        store: mainStoreEntry({ permissionMode: "full" }),
+        patch: { key: MAIN_SESSION_KEY, permissionMode: null },
+      }),
+    );
+    expect(recovered.permissionMode).toBeUndefined();
+  });
+
   test("clears a node cwd when changing or clearing the node binding", async () => {
     const store = mainStoreEntry({
       execHost: "node",

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -81,6 +81,7 @@ import {
   isAgentSessionModelPatchOrigin,
   snapshotAgentModelFallback,
 } from "./session-model-patch-origin.js";
+import { applySessionPermissionMode } from "./session-permission-policy.js";
 import { applySessionContextWindowPatch } from "./sessions-patch-context-window.js";
 import { applySessionsPatchSubagentPolicy } from "./sessions-patch-subagent-policy.js";
 
@@ -175,6 +176,8 @@ export async function projectSessionsPatchEntry(params: {
   storeKey: string;
   agentId?: string;
   patch: SessionsPatchParams;
+  /** Canonical root prepared by the trusted create path; never accepted from public patches. */
+  preparedSessionRoot?: string;
   archivedBy?: SessionCreatedActor;
   loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
   providerAuthMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
@@ -237,14 +240,10 @@ export async function projectSessionsPatchEntry(params: {
   };
   let loadedModelCatalog: ModelCatalogEntry[] | undefined;
   const loadPreparedModelCatalogForPatch = async () => {
-    if (loadedModelCatalog) {
-      return loadedModelCatalog;
+    if (!loadedModelCatalog && params.loadGatewayModelCatalog) {
+      const catalog = await params.loadGatewayModelCatalog();
+      loadedModelCatalog = Array.isArray(catalog) ? catalog : [];
     }
-    if (!params.loadGatewayModelCatalog) {
-      return undefined;
-    }
-    const catalog = await params.loadGatewayModelCatalog();
-    loadedModelCatalog = Array.isArray(catalog) ? catalog : [];
     return loadedModelCatalog;
   };
 
@@ -255,6 +254,7 @@ export async function projectSessionsPatchEntry(params: {
     ...existing,
     sessionId: existing?.sessionId || randomUUID(),
     updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+    ...(params.preparedSessionRoot ? { sessionRoot: params.preparedSessionRoot } : {}),
     // Stamp only genuinely new rows; existing placeholder aliases must not be restamped.
     ...(creation && params.existingEntry === undefined ? buildSessionCreationStamp(creation) : {}),
   };
@@ -571,10 +571,9 @@ export async function projectSessionsPatchEntry(params: {
     }
   }
   if ("permissionMode" in patch) {
-    if (patch.permissionMode === null) {
-      delete next.permissionMode;
-    } else if (patch.permissionMode !== undefined) {
-      next.permissionMode = patch.permissionMode;
+    const permissionRootError = applySessionPermissionMode(next, patch.permissionMode);
+    if (permissionRootError) {
+      return invalid(permissionRootError);
     }
   }
   if ("model" in patch) {

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -244,6 +244,51 @@ describe("chat pane composer controls", () => {
     }
   });
 
+  it("surfaces a rejected permission change in the rendered error state", async () => {
+    const failure = new Error(
+      "permission mode requires a session root; choose Default or a rooted session",
+    );
+    const state = {
+      chatRunId: null,
+      connected: true,
+      client: {},
+      chatLoading: false,
+      chatModelCatalog: [],
+      sessions: {
+        state: { modelOverrides: {} },
+        patch: vi.fn(async () => {
+          throw failure;
+        }),
+      },
+      chatModelSwitchPromises: {},
+      sessionKey: "agent:main:rootless-permission-test",
+      chatModelsLoading: false,
+      chatSending: false,
+      sessionsResult: null,
+      chatStream: null,
+      lastError: null,
+      chatError: null,
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+
+    const controls = renderChatPaneComposerControls({
+      state,
+      selectedSession: undefined,
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      toastAnchor: document.createElement("div"),
+      onModelSetup: vi.fn(),
+    });
+    await controls.permissionPicker.onSelect("full");
+
+    expect(state.chatError).toContain(failure.message);
+    expect(state.lastError).toBe(state.chatError);
+    expect(state.requestUpdate).toHaveBeenCalledOnce();
+  });
+
   it("holds the session send barrier until a Full Access selection settles", async () => {
     const pending = createDeferred<Record<string, never>>();
     const state = {

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -174,7 +174,7 @@ export function renderChatPaneComposerControls(params: {
           state.connectionEpoch === connectionEpoch &&
           scopedAgentParamsForSession(state, sessionKey).agentId === agentScope.agentId;
         try {
-          state.chatError = null;
+          state.chatError = state.lastError = null;
           const patched = await patchChatSessionSettings(
             state,
             sessionKey,
@@ -203,7 +203,7 @@ export function renderChatPaneComposerControls(params: {
           if (!ownsSelection()) {
             return;
           }
-          state.chatError = t("chat.permissionControls.updateFailed", {
+          state.chatError = state.lastError = t("chat.permissionControls.updateFailed", {
             error: String(error),
           });
           state.requestUpdate?.();


### PR DESCRIPTION
Fixes #128039

## Summary

- Enforce one persisted session invariant: a non-default permission mode requires a canonical session root.
- Apply that invariant at the two authoritative persistence owners: the shared session patch/create projector and reset lifecycle commit.
- Reject impossible reset requests before interrupting admitted work, running hooks, cleanup, or writing state.
- Surface Gateway rejection text in the Control UI's rendered error state.
- Preserve current `main` authorization checks, active-run behavior, and contributor credit.

## What Problem This Solves

The public `sessions.patch` path could store `permissionMode` without `sessionRoot`. Later agent setup rejected that tuple before model execution. A fallback model/auth error could then obscure the primary session-state failure.

The reset lifecycle is a second persistence owner, so fixing only the shared patch projector was incomplete. It could also preserve or request a rootless non-default mode, and the earlier PR revision validated after active work had already been interrupted.

## Canonical behavior

- Rootless `full`, `guarded`, or `workspace` requests return `INVALID_REQUEST` with: `permission mode requires a session root; choose Default or a rooted session`.
- Rejection is side-effect free: no row write, hook, cleanup, or active-work interruption.
- `permissionMode: null` remains the recovery path for a legacy invalid row and does not require transcript deletion.
- Rooted creation and reset continue to persist the selected mode.
- Upgrades do not silently rewrite legacy rows. Validation occurs when the tuple is mutated or reset, avoiding an automatic permission-policy change during update.

## Review findings resolved

- **P1 active-run interruption:** validation now happens before admission interruption whenever lifecycle preparation cannot establish a root. A regression installs a real admission and proves its interrupt callback is not invoked.
- **Persisted legacy tuple:** reset validates the effective mode (`requested ?? persisted`), preventing a legacy rootless override from being re-committed unchanged.
- **Security/rebase risk:** the branch was rebuilt from current canonical `main`; authenticated missing-session creation checks remain intact.
- **Dirty branch:** final head is mergeable and contains current canonical `main`.

## Evidence

Final head: `d5d72cd276f5a16bcc461be018ef5168fd3cdbca`  
Canonical base: `c841a9958abc8344b37ce5c6c5a06bec4cfa6b91`

- Final-head focused Gateway suite: 9 passed, 203 skipped by the `permission` filter.
- Targeted lint/format and `git diff --check`: passed.
- Autoreview: clean, no actionable findings, 0.97 correctness confidence; secret scan clean.
- Production diff: +69/-15 across five files. Regression coverage: +197 lines across three test files.

Blacksmith Testbox `tbx_01m0xvmycd6p161xnqgpwyyb41` (stopped after proof), using official Crabbox v0.46.0:

- Hydrated `pnpm check:changed`: passed all selected core, core-test, and UI lanes, including full dead-export scans, core/core-test/UI typechecks, lint, i18n, policy, database, and runtime-cycle guards.
- Focused Gateway tests: 9 passed.
- Control UI test file: 11 passed.
- Production Control UI build and performance budget: passed.
- Full runtime build: passed.
- Run: https://github.com/openclaw/openclaw/actions/runs/32919908413

The Testbox proof ran on the identical patch tree at `4bf8e72b9265ea93755630eb4a867aa01bc6816a`. Canonical `main` then added three commits. Only restart/session-lifecycle recovery was adjacent; it did not touch the permission persistence owners. After rebasing, the full focused Gateway permission suite, including the active-admission case, passed again at final head `d5d72cd276f`.

### Source-blind runtime contract

An isolated real Gateway and the public `openclaw gateway call` CLI exercised the final patch tree:

```text
reject_status=1 reject_has_canonical_error=1 before_count=0
default_ok=true default_has_mode=false after_count=1 after_has_mode=false
contract=PASS clauses=rootless_rejected,no_write_on_reject,default_recovers,no_mode_persisted
```

Anti-cheat probes repeated the rejection with both `full` and `workspace`, reopened state through `sessions.list`, and verified Default performed a real write without a permission override.

### Original contributor evidence

The contributor's earlier exact-head browser proof remains useful visual confirmation of the same user-facing contract:

- Visible rejection: https://github.com/user-attachments/assets/998c2753-0af7-48fc-96b4-bb008f735cee
- Default recovery: https://github.com/user-attachments/assets/da89a395-057b-40d9-b68b-dfb23cf25afd

Those recordings were captured at the superseded `b728365abab7` head. Current-head correctness is established by the tests, builds, lifecycle regression, and black-box Gateway/CLI state proof above.

## Scope

No protocol, configuration, database schema/version, migration, provider, channel, dependency, or permission-default change.

