### PR TITLE
perf(cli): lazy-load infer command domains

### DIFF
--- a/src/cli/capability-cli.lazy.test.ts
+++ b/src/cli/capability-cli.lazy.test.ts
@@ -1,0 +1,45 @@
+import { Command } from "commander";
+import { expect, it, vi } from "vitest";
+
+const loaded = vi.hoisted(() => {
+  const modules = new Set<string>();
+  return {
+    modules,
+    mock(name: string, exportName: string) {
+      modules.add(name);
+      return { [exportName]: vi.fn() };
+    },
+  };
+});
+
+vi.mock("./capability-cli/audio.js", () => loaded.mock("audio", "registerAudioCapabilityCommands"));
+vi.mock("./capability-cli/embedding.js", () =>
+  loaded.mock("embedding", "registerEmbeddingCapabilityCommands"),
+);
+vi.mock("./capability-cli/image.js", () => loaded.mock("image", "registerImageCapabilityCommands"));
+vi.mock("./capability-cli/model.js", () => loaded.mock("model", "registerModelCapabilityCommands"));
+vi.mock("./capability-cli/tts.js", () => loaded.mock("tts", "registerTtsCapabilityCommands"));
+vi.mock("./capability-cli/video.js", () => loaded.mock("video", "registerVideoCapabilityCommands"));
+vi.mock("./capability-cli/web.js", () => loaded.mock("web", "registerWebCapabilityCommands"));
+
+it("loads only the selected capability command domain", async () => {
+  const { registerCapabilityCli } = await import("./capability-cli.js");
+  const metadataProgram = new Command();
+
+  await registerCapabilityCli(metadataProgram, ["node", "openclaw", "infer", "list", "--json"]);
+
+  const capability = metadataProgram.commands.find((command) => command.name() === "infer");
+  expect(capability?.commands.map((command) => command.name())).toEqual(["list", "inspect"]);
+  expect(loaded.modules).toEqual(new Set());
+
+  await registerCapabilityCli(new Command(), [
+    "node",
+    "openclaw",
+    "infer",
+    "image",
+    "providers",
+    "--json",
+  ]);
+
+  expect(loaded.modules).toEqual(new Set(["image"]));
+});

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -7,15 +7,17 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { inspectLocalAudioSelection } from "../media-understanding/local-audio.js";
-import { runRegisteredCli } from "../test-utils/command-runner.js";
-import { CAPABILITY_METADATA, registerCapabilityCli } from "./capability-cli.js";
+import { registerCapabilityCli } from "./capability-cli.js";
+import { CAPABILITY_METADATA } from "./capability-cli/metadata.js";
 
 const PNG_1X1_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+yf7kAAAAASUVORK5CYII=";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-function runCap(...argv: string[]): Promise<void> {
-  return runRegisteredCli({ register: registerCapabilityCli as (program: Command) => void, argv });
+async function runCap(...argv: string[]): Promise<void> {
+  const program = new Command();
+  await registerCapabilityCli(program, ["node", "openclaw", ...argv]);
+  await program.parseAsync(argv, { from: "user" });
 }
 
 function runCapability(domain: string, action: string, ...argv: string[]): Promise<void> {
@@ -2474,9 +2476,9 @@ describe("capability cli", () => {
     ]);
   });
 
-  it("keeps capability inspect metadata flags in sync with each command's registered options", () => {
+  it("keeps capability inspect metadata flags in sync with each command's registered options", async () => {
     const program = new Command();
-    registerCapabilityCli(program);
+    await registerCapabilityCli(program, ["node", "openclaw", "infer", "--help"]);
     const capability =
       program.commands.find((command) => command.name() === "infer") ??
       program.commands.find((command) => command.aliases().includes("capability"));

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -3,19 +3,36 @@ import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { defaultRuntime } from "../runtime.js";
-import { registerAudioCapabilityCommands } from "./capability-cli/audio.js";
-import { registerEmbeddingCapabilityCommands } from "./capability-cli/embedding.js";
-import { registerImageCapabilityCommands } from "./capability-cli/image.js";
+import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import { CAPABILITY_METADATA, findCapabilityMetadata } from "./capability-cli/metadata.js";
-import { registerModelCapabilityCommands } from "./capability-cli/model.js";
 import { emitJsonOrText, providerSummaryText } from "./capability-cli/shared.js";
-import { registerTtsCapabilityCommands } from "./capability-cli/tts.js";
-import { registerVideoCapabilityCommands } from "./capability-cli/video.js";
-import { registerWebCapabilityCommands } from "./capability-cli/web.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 import { removeCommandByName } from "./program/command-tree.js";
 
-export { CAPABILITY_METADATA } from "./capability-cli/metadata.js";
+const capabilityCommandGroups = [
+  [
+    "model",
+    async () => (await import("./capability-cli/model.js")).registerModelCapabilityCommands,
+  ],
+  [
+    "image",
+    async () => (await import("./capability-cli/image.js")).registerImageCapabilityCommands,
+  ],
+  [
+    "audio",
+    async () => (await import("./capability-cli/audio.js")).registerAudioCapabilityCommands,
+  ],
+  ["tts", async () => (await import("./capability-cli/tts.js")).registerTtsCapabilityCommands],
+  [
+    "video",
+    async () => (await import("./capability-cli/video.js")).registerVideoCapabilityCommands,
+  ],
+  ["web", async () => (await import("./capability-cli/web.js")).registerWebCapabilityCommands],
+  [
+    "embedding",
+    async () => (await import("./capability-cli/embedding.js")).registerEmbeddingCapabilityCommands,
+  ],
+] as const;
 
 function registerCapabilityListAndInspect(capability: Command): void {
   capability
@@ -51,7 +68,34 @@ function registerCapabilityListAndInspect(capability: Command): void {
     });
 }
 
-export function registerCapabilityCli(program: Command): void {
+async function registerCapabilityDomainCommands(
+  capability: Command,
+  argv: string[],
+): Promise<void> {
+  const invocation = resolveCliArgvInvocation(argv);
+  if (!invocation.hasHelpOrVersion) {
+    const selectedName = invocation.commandPath[1];
+    if (selectedName === "list" || selectedName === "inspect") {
+      return;
+    }
+    const selected = capabilityCommandGroups.find(([name]) => name === selectedName);
+    if (selected) {
+      const register = await selected[1]();
+      register(capability);
+      return;
+    }
+  }
+
+  const registrars = await Promise.all(capabilityCommandGroups.map(([, load]) => load()));
+  for (const register of registrars) {
+    register(capability);
+  }
+}
+
+export async function registerCapabilityCli(
+  program: Command,
+  argv: string[] = process.argv,
+): Promise<void> {
   removeCommandByName(program, "infer");
   removeCommandByName(program, "capability");
 
@@ -66,11 +110,5 @@ export function registerCapabilityCli(program: Command): void {
     );
 
   registerCapabilityListAndInspect(capability);
-  registerModelCapabilityCommands(capability);
-  registerImageCapabilityCommands(capability);
-  registerAudioCapabilityCommands(capability);
-  registerTtsCapabilityCommands(capability);
-  registerVideoCapabilityCommands(capability);
-  registerWebCapabilityCommands(capability);
-  registerEmbeddingCapabilityCommands(capability);
+  await registerCapabilityDomainCommands(capability, argv);
 }

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -120,11 +120,15 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       loadModule: () => import("../promos-cli.js"),
       exportName: "registerPromosCli",
     },
-    {
-      commandNames: ["infer", "capability"],
-      loadModule: () => import("../capability-cli.js"),
-      exportName: "registerCapabilityCli",
+  ]),
+  {
+    commandNames: ["infer", "capability"],
+    register: async (program, argv) => {
+      const mod = await import("../capability-cli.js");
+      await mod.registerCapabilityCli(program, argv);
     },
+  },
+  ...defineImportedProgramCommandGroupSpecs([
     {
       // exec-approvals is a commander alias on the approvals command; the lazy
       // router only routes names listed here, so the alias must be owned too.

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -32,7 +32,7 @@ const { loadPrivateQaCliModule } = vi.hoisted(() => ({
 
 const { inferAction, registerCapabilityCli } = vi.hoisted(() => {
   const action = vi.fn();
-  const register = vi.fn((program: Command) => {
+  const register = vi.fn((program: Command, _argv: string[]) => {
     program.command("infer").alias("capability").action(action);
   });
   return { inferAction: action, registerCapabilityCli: register };
@@ -213,6 +213,11 @@ describe("registerSubCliCommands", () => {
     await program.parseAsync(["infer"], { from: "user" });
 
     expect(registerCapabilityCli).toHaveBeenCalledTimes(1);
+    expect(registerCapabilityCli).toHaveBeenCalledWith(expect.any(Command), [
+      "node",
+      "openclaw",
+      "infer",
+    ]);
     expect(inferAction).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw infer list --json`, `infer inspect`, and single-domain infer commands loaded every capability domain implementation before dispatch. Metadata-only startup therefore evaluated unrelated model, image, audio, TTS, video, web, and embedding code.

## Why This Change Was Made

Capability metadata remains registered synchronously, while an ordered, bundler-visible loader table imports no runtime domain for `list`/`inspect`, one domain for a recognized domain command, and all domains for help or fallback command-tree rendering. The lazy sub-CLI owner now passes the actual normalized `runCli(argv)` input into the registrar instead of rediscovering it from global process state.

The historical registration order and complete help/unknown-command tree are preserved. No command, option, output, provider behavior, config, or persisted state changes.

Production delta is +42 lines: the growth is the seven explicit dynamic-import edges plus the argv ownership handoff. In exchange, the built capability facade drops 80,145 bytes and the prior static domain-import path is removed. The touched dead facade re-export was also removed; its test imports metadata from the owning module directly.

## User Impact

Metadata-only and single-domain `infer` commands start with less JavaScript parsing and module evaluation. On the measured metadata path, median end-to-end process time fell 18.18%, with behavior unchanged.

AI-assisted: yes. The implementation and evidence were independently inspected and validated.

## Evidence

- Deterministic pre-fix regression: `src/cli/capability-cli.lazy.test.ts` failed on the exact base because `infer list --json` imported all seven runtime domains; the candidate imports none, while an image command imports only `image`.
- Built facade: 91,249 → 11,104 bytes (−87.83%); gzip 19,784 → 2,575 bytes; static imports 67 → 7.
- Exact base/candidate semantic differential: 24 metadata, alias, valid/invalid inspect, root/domain help, no-child, unknown-child, and per-domain dispatch cases produced identical status/stdout/stderr after normalizing only the expected build-commit banner. Canonical output: 21,859 bytes, SHA-256 `566dce74ed726b4f1c1d414103f5aa103d10e558d9d67a9e1165d3ea9c692175`.
- Node 24.15.0 built-CLI benchmark, alternating fresh processes, two warmups and 11 measured samples per variant, `openclaw.mjs infer list --json`: median 4,926.397 → 4,030.577 ms (−18.18%, 1.2223×).
- Focused and sibling coverage: 264 tests passed across capability registration, lazy sub-CLI argv ownership, argv resolution, help, and run-main behavior. Latest rebased head rerun: 21/21 owner-boundary tests passed.
- `node scripts/check-changed.mjs -- <five changed paths>` passed all core/core-test formatting, dead-export, typecheck, lint, database/media/runtime, and import-cycle gates.
- `pnpm build` passed on the exact reviewed candidate snapshot; later rebases contained no touched-path overlap. Exact-head CI is required before landing.
- Codex Sol/high autoreview reported no accepted/actionable P0/P1 findings on the identical stable patch; TruffleHog was clean.
- Live open PR/issue searches found no overlapping infer/capability lazy-loading work.
