### PR TITLE
docs(channels): document per-account channels.start/stop recovery and selfChatMode

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -123,7 +123,7 @@ A separate WhatsApp number is recommended (setup and metadata are optimized for 
   </Accordion>
 
   <Accordion title="Personal-number fallback">
-    Onboarding supports personal-number mode and writes a self-chat-friendly baseline: `dmPolicy: "allowlist"`, `allowFrom` including your own number, `selfChatMode: true`. Runtime self-chat protections key off the linked self number plus `allowFrom`.
+    Onboarding supports personal-number mode and writes a self-chat-friendly baseline: `dmPolicy: "allowlist"`, `allowFrom` including your own number, `selfChatMode: true`. See [Personal-number and self-chat behavior](/channels/whatsapp#personal-number-and-self-chat-behavior) for admission and safeguard rules.
   </Accordion>
 </AccordionGroup>
 
@@ -274,7 +274,7 @@ Scope the opt-in to one account under `channels.whatsapp.accounts.<id>.pluginHoo
 
     - pairings persist in the channel allow-store and merge with configured `allowFrom`
     - scheduled automation and heartbeat recipient fallback use explicit delivery targets or configured `allowFrom`; DM pairing approvals are not implicit cron/heartbeat recipients
-    - if no allowlist is configured, the linked self number is allowed by default
+    - same-number self-DMs are allowed unless `selfChatMode: false` or `dmPolicy: "disabled"`; see [Self-chat behavior](/channels/whatsapp#personal-number-and-self-chat-behavior)
     - OpenClaw never auto-pairs outbound `fromMe` DMs (messages you send yourself from the linked device)
 
   </Tab>
@@ -343,15 +343,16 @@ Direct chats match E.164 numbers; groups match WhatsApp group JIDs. Group allowl
 
 ## Personal-number and self-chat behavior
 
-`channels.whatsapp.selfChatMode` (boolean; channel or per-account under `channels.whatsapp.accounts.<id>.selfChatMode`) controls whether messages you send from the linked number to yourself are admitted as agent input.
+`channels.whatsapp.selfChatMode` controls same-number DM admission and self-chat safeguards. Set it at the channel level or override it per account with `channels.whatsapp.accounts.<id>.selfChatMode`.
 
-- **Allowed values:** `true`, `false`, or unset. Default is **unset**: OpenClaw infers self-chat from whether the linked self number is present in `allowFrom` (onboarding writes a self-chat-friendly baseline that includes your own number, so the inferred default is usually on for personal-number setups).
-- **When enabled (`true`, or unset with the self number in `allowFrom`):** a DM you send from the linked number to yourself is admitted as a normal direct-message user turn — the agent reads it as input and may reply. Self access is **direct-only**: the self number is added to the DM `allowFrom` list for admission, not to group allowlists.
-- **When disabled (`false`):** self-originated DMs are not admitted as agent input even if your number is in `allowFrom`; set `selfChatMode: false` to use a personal-number account purely as an outbound/observing channel without a self-chat loop.
+- **`true` or unset:** DMs from the linked number to itself are admitted as agent input, even when that number is absent from `allowFrom`. `dmPolicy: "disabled"` still blocks all DMs.
+- **`false`:** self-originated DMs are ignored, even when your number is in `allowFrom`. Other inbound DMs and group messages still follow their access policies; this setting does not make the account outbound-only.
 
-Independent of `selfChatMode`, the following self-chat safeguards activate whenever the linked self number is also present in `allowFrom`: skip read receipts for self-chat turns, ignore mention-JID auto-trigger behavior that would ping yourself, and default replies to `[{identity.name}]` (or `[openclaw]`) when the channel/account `responsePrefix` is unset. These guards prevent the agent from replying to itself in a tight loop; the default reply prefix also makes self-authored replies visually distinct from inbound user messages.
+The implicit self-number allowance applies only to DMs, not group allowlists.
 
-If you send a probe to your own number as a liveness check for a personal-number account, expect it to be treated as agent input unless you explicitly set `selfChatMode: false`. For a dedicated OpenClaw number used only to probe a personal number, keep `selfChatMode` unset on the OpenClaw account instead.
+Self-chat safeguards are enabled by `true` and disabled by `false`. When the setting is unset, OpenClaw enables them if the linked self number appears in the configured `allowFrom`. These safeguards skip read receipts, suppress native self-mention triggers, and supply an identity reply prefix when no response prefix is configured.
+
+A liveness probe sent to your own number can therefore become agent input with `selfChatMode` unset or `true`. Set `selfChatMode: false` if you want to exclude those self-originated DMs.
 
 ## Message normalization and context
 
@@ -396,7 +397,7 @@ If you send a probe to your own number as a liveness check for a personal-number
     { channels: { whatsapp: { sendReadReceipts: false } } }
     ```
 
-    Per-account override: `channels.whatsapp.accounts.<id>.sendReadReceipts`. Self-chat turns skip read receipts even when globally enabled.
+    Per-account override: `channels.whatsapp.accounts.<id>.sendReadReceipts`. Self-chat safeguards skip read receipts even when globally enabled (see [Self-chat behavior](/channels/whatsapp#personal-number-and-self-chat-behavior)).
 
   </Accordion>
 </AccordionGroup>

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -343,7 +343,15 @@ Direct chats match E.164 numbers; groups match WhatsApp group JIDs. Group allowl
 
 ## Personal-number and self-chat behavior
 
-When the linked self number is also present in `allowFrom`, self-chat safeguards activate: skip read receipts for self-chat turns, ignore mention-JID auto-trigger behavior that would ping yourself, and default replies to `[{identity.name}]` (or `[openclaw]`) when the channel/account `responsePrefix` is unset.
+`channels.whatsapp.selfChatMode` (boolean; channel or per-account under `channels.whatsapp.accounts.<id>.selfChatMode`) controls whether messages you send from the linked number to yourself are admitted as agent input.
+
+- **Allowed values:** `true`, `false`, or unset. Default is **unset**: OpenClaw infers self-chat from whether the linked self number is present in `allowFrom` (onboarding writes a self-chat-friendly baseline that includes your own number, so the inferred default is usually on for personal-number setups).
+- **When enabled (`true`, or unset with the self number in `allowFrom`):** a DM you send from the linked number to yourself is admitted as a normal direct-message user turn — the agent reads it as input and may reply. Self access is **direct-only**: the self number is added to the DM `allowFrom` list for admission, not to group allowlists.
+- **When disabled (`false`):** self-originated DMs are not admitted as agent input even if your number is in `allowFrom`; set `selfChatMode: false` to use a personal-number account purely as an outbound/observing channel without a self-chat loop.
+
+Independent of `selfChatMode`, the following self-chat safeguards activate whenever the linked self number is also present in `allowFrom`: skip read receipts for self-chat turns, ignore mention-JID auto-trigger behavior that would ping yourself, and default replies to `[{identity.name}]` (or `[openclaw]`) when the channel/account `responsePrefix` is unset. These guards prevent the agent from replying to itself in a tight loop; the default reply prefix also makes self-authored replies visually distinct from inbound user messages.
+
+If you send a probe to your own number as a liveness check for a personal-number account, expect it to be treated as agent input unless you explicitly set `selfChatMode: false`. For a dedicated OpenClaw number used only to probe a personal number, keep `selfChatMode` unset on the OpenClaw account instead.
 
 ## Message normalization and context
 

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -172,6 +172,25 @@ openclaw channels logout --channel whatsapp
 - After a successful login, the CLI asks a reachable local Gateway to start the account; in remote mode it saves auth locally and notes that the remote runtime was not restarted.
 - Run `channels login` from a terminal on the gateway host. Agent `exec` blocks this interactive login flow; channel-native agent login tools, such as `whatsapp_login`, should be used from chat when available.
 
+## Per-account recovery (non-destructive)
+
+When a single account needs to reconnect but should keep its pairing and credentials, use the per-account lifecycle Gateway RPCs instead of re-authenticating. `channels.start` and `channels.stop` are `operator.admin` methods that stop or start one resolved account without touching auth state; calling `channels.stop` then `channels.start` reproduces the force-close-and-re-register sequence the WhatsApp watchdog already runs internally. They are Gateway RPCs, not `openclaw channels` subcommands, so invoke them with `openclaw gateway call`:
+
+```bash
+# stop the listener for one WhatsApp account without clearing its pairing
+openclaw gateway call channels.stop --params '{"channel":"whatsapp","accountId":"<accountId>"}'
+# start it again on a fresh listener (omit accountId to resolve the default account)
+openclaw gateway call channels.start --params '{"channel":"whatsapp"}'
+```
+
+- `channels.stop` returns `{ channel, accountId, stopped }`; `channels.start` returns `{ channel, accountId, started }` where `started: false` means the runtime reports the account is still stopped after the call.
+- This is deliberately narrower than the two heavier alternatives: `openclaw channels logout` + `channels login` re-pairs via QR and clears credentials, and `openclaw gateway restart` cycles every account on the host.
+- An external monitor that probes a chat and confirms the probe arrives inbound can therefore recover a single zombie account without disturbing the rest of the host. See [Restart recovery](/gateway/restart-recovery) for the related crash-loop-breaker SOP, which also uses `channels.start` as the manual override when channel autostart is suppressed.
+
+<Note>
+The per-account `channels.start` / `channels.stop` RPCs ship on `main` but are not in a published stable release tag yet. Operators on `v2026.7.1-2` cannot call them until the next release ships; until then, the documented `channels logout` / `channels login` and `gateway restart` paths remain the only released recovery options.
+</Note>
+
 ## Troubleshooting
 
 - Run `openclaw status --deep` for a broad probe.

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -174,22 +174,21 @@ openclaw channels logout --channel whatsapp
 
 ## Per-account recovery (non-destructive)
 
-When a single account needs to reconnect but should keep its pairing and credentials, use the per-account lifecycle Gateway RPCs instead of re-authenticating. `channels.start` and `channels.stop` are `operator.admin` methods that stop or start one resolved account without touching auth state; calling `channels.stop` then `channels.start` reproduces the force-close-and-re-register sequence the WhatsApp watchdog already runs internally. They are Gateway RPCs, not `openclaw channels` subcommands, so invoke them with `openclaw gateway call`:
+When one account needs to reconnect while keeping its pairing and credentials, call the `channels.stop` and `channels.start` Gateway RPCs. Both require `operator.admin`. Invoke them through `openclaw gateway call`:
 
 ```bash
-# stop the listener for one WhatsApp account without clearing its pairing
+# Stop one WhatsApp account without clearing its pairing.
 openclaw gateway call channels.stop --params '{"channel":"whatsapp","accountId":"<accountId>"}'
-# start it again on a fresh listener (omit accountId to resolve the default account)
-openclaw gateway call channels.start --params '{"channel":"whatsapp"}'
+# Start the same account again.
+openclaw gateway call channels.start --params '{"channel":"whatsapp","accountId":"<accountId>"}'
+openclaw channels status --channel whatsapp --probe
 ```
 
-- `channels.stop` returns `{ channel, accountId, stopped }`; `channels.start` returns `{ channel, accountId, started }` where `started: false` means the runtime reports the account is still stopped after the call.
-- This is deliberately narrower than the two heavier alternatives: `openclaw channels logout` + `channels login` re-pairs via QR and clears credentials, and `openclaw gateway restart` cycles every account on the host.
-- An external monitor that probes a chat and confirms the probe arrives inbound can therefore recover a single zombie account without disturbing the rest of the host. See [Restart recovery](/gateway/restart-recovery) for the related crash-loop-breaker SOP, which also uses `channels.start` as the manual override when channel autostart is suppressed.
+Use the same `accountId` in both calls. Omit it from both to select the default account.
 
-<Note>
-The per-account `channels.start` / `channels.stop` RPCs ship on `main` but are not in a published stable release tag yet. Operators on `v2026.7.1-2` cannot call them until the next release ships; until then, the documented `channels logout` / `channels login` and `gateway restart` paths remain the only released recovery options.
-</Note>
+`channels.stop` returns `{ channel, accountId, stopped }`; `channels.start` returns `{ channel, accountId, started }`. These booleans reflect the account's runtime snapshot after the operation: `started` is true only when `running` is true, and `stopped` is true when `running` is not true. A `started: false` response does not by itself establish that the account is stopped, and `started: true` does not establish that the provider connection is healthy. Check channel status and logs after recovery.
+
+Unlike this recovery path, `openclaw channels logout` clears the account's credentials and requires login again; `openclaw gateway restart` restarts the whole Gateway. See [Restart recovery](/gateway/restart-recovery) for the crash-loop breaker and its manual `channels.start` override.
 
 ## Troubleshooting
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -555,8 +555,8 @@ methods. Treat this as feature discovery, not a full enumeration of
 
   <Accordion title="Channels and login helpers">
     - `channels.status` returns built-in + bundled channel/plugin status summaries.
-    - `channels.start` (`operator.admin`) starts one channel account runtime without re-authenticating. Params `{ channel, accountId? }`; resolves the default account when `accountId` is omitted. Responds `{ channel, accountId, started }` — `started: false` means the runtime reports it is still stopped after the call. Use it for non-destructive per-account recovery; see [Per-account recovery](/cli/channels#per-account-recovery-non-destructive).
-    - `channels.stop` (`operator.admin`) stops one channel account runtime without clearing auth state, so the next `channels.start` re-registers a fresh listener on the existing pairing. Params `{ channel, accountId? }`; responds `{ channel, accountId, stopped }`. This is the non-destructive counterpart of `channels.logout`, which clears authentication.
+    - `channels.start` (`operator.admin`) starts one channel account runtime without re-authenticating. Params `{ channel, accountId? }`; omitted `accountId` selects the default account. Responds `{ channel, accountId, started }`, with `started` true only when the resulting runtime snapshot reports `running: true`. This is not a provider-connectivity check; see [Per-account recovery](/cli/channels#per-account-recovery-non-destructive).
+    - `channels.stop` (`operator.admin`) stops one channel account runtime without clearing auth state. Params `{ channel, accountId? }`; omitted `accountId` selects the default account. Responds `{ channel, accountId, stopped }`, with `stopped` true when the resulting runtime snapshot does not report `running: true`. Unlike `channels.logout`, it retains the account's credentials.
     - `channels.logout` logs out a specific channel/account where the channel supports it.
     - `web.login.start` starts a QR/web login flow for the current QR-capable web channel provider.
     - `web.login.wait` waits for that flow to complete and starts the channel on success.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -555,6 +555,8 @@ methods. Treat this as feature discovery, not a full enumeration of
 
   <Accordion title="Channels and login helpers">
     - `channels.status` returns built-in + bundled channel/plugin status summaries.
+    - `channels.start` (`operator.admin`) starts one channel account runtime without re-authenticating. Params `{ channel, accountId? }`; resolves the default account when `accountId` is omitted. Responds `{ channel, accountId, started }` — `started: false` means the runtime reports it is still stopped after the call. Use it for non-destructive per-account recovery; see [Per-account recovery](/cli/channels#per-account-recovery-non-destructive).
+    - `channels.stop` (`operator.admin`) stops one channel account runtime without clearing auth state, so the next `channels.start` re-registers a fresh listener on the existing pairing. Params `{ channel, accountId? }`; responds `{ channel, accountId, stopped }`. This is the non-destructive counterpart of `channels.logout`, which clears authentication.
     - `channels.logout` logs out a specific channel/account where the channel supports it.
     - `web.login.start` starts a QR/web login flow for the current QR-capable web channel provider.
     - `web.login.wait` waits for that flow to complete and starts the channel on success.


### PR DESCRIPTION
Closes #127954.

## What Problem This Solves

Resolves a problem where operators could not find the existing way to restart one channel account while preserving its pairing. It also explains when a WhatsApp message sent to the linked number itself becomes agent input, so a liveness probe does not unexpectedly trigger a reply.

## Why This Change Was Made

Document the existing `channels.stop` and `channels.start` Gateway RPCs with the same account in both example calls, their `operator.admin` scope, and a status check after recovery. Describe their result flags as runtime snapshots rather than provider-connectivity guarantees.

Separate WhatsApp self-DM admission from self-chat safeguards: `true` and unset admit same-number DMs even when the number is absent from `allowFrom`, unless DMs are disabled; explicit `false` ignores self-originated DMs. Safeguards follow the explicit setting, or the configured-allowlist heuristic when unset. This addresses the ClawSweeper finding and rank-up move, and corrects the nearby deployment and read-receipt descriptions. Thanks @LiuwqGit for the documentation contribution.

## User Impact

Operators can recover a single account without clearing its credentials or restarting the whole Gateway. Personal-number users can explicitly exclude self-originated probe messages with `selfChatMode: false`; their other inbound DMs and group messages continue to follow the existing access policies.

This documents existing behavior and adds no runtime, configuration, or protocol changes. The RPCs are already present in stable `v2026.7.1-2`, so the inaccurate unreleased caveat is removed.

## Evidence

- Current-source audit at `596df18a50f520622301a687f0e1e4e44cab0ee4`: [WhatsApp admission and safeguard ownership](https://github.com/openclaw/openclaw/blob/596df18a50f520622301a687f0e1e4e44cab0ee4/extensions/whatsapp/src/inbound-policy.ts#L66), [self-originated DM filtering](https://github.com/openclaw/openclaw/blob/596df18a50f520622301a687f0e1e4e44cab0ee4/extensions/whatsapp/src/inbound/access-control.ts#L130), and [lifecycle response semantics](https://github.com/openclaw/openclaw/blob/596df18a50f520622301a687f0e1e4e44cab0ee4/src/gateway/server-methods/channels.ts#L284).
- Inspected existing regression coverage for [omitted/enabled self-chat admission and explicit opt-out](https://github.com/openclaw/openclaw/blob/596df18a50f520622301a687f0e1e4e44cab0ee4/extensions/whatsapp/src/inbound/access-control.test.ts#L417) and [per-account lifecycle behavior](https://github.com/openclaw/openclaw/blob/596df18a50f520622301a687f0e1e4e44cab0ee4/src/gateway/server-methods/channels.start.test.ts). These runtime tests were read, not rerun for this docs-only correction.
- Confirmed stable-tag availability in the [`v2026.7.1-2` handlers](https://github.com/openclaw/openclaw/blob/v2026.7.1-2/src/gateway/server-methods/channels.ts#L595) and [method descriptors](https://github.com/openclaw/openclaw/blob/v2026.7.1-2/src/gateway/methods/core-descriptors.ts#L34), with the [published stable release](https://github.com/openclaw/openclaw/releases/tag/v2026.7.1-2).
- Trusted-main MDX validation and the focused formatting check passed for all three corrected pages. The internal-link audit passed with `checked_internal_links=7022` and `broken_links=0` on frozen main with only the reviewed documentation changes applied. The fixup patch applies cleanly to the reviewed PR head, and the whitespace check passed.
- [CI run 33340805362](https://github.com/openclaw/openclaw/actions/runs/33340805362) passed for exact head `a0669b37770cc8b0a2de9a3f1b5fb8536208c3d4`, including `check-docs` and `openclaw/ci-gate`.
- Fresh Codex autoreview of the complete documentation change returned scoped-clean with no accepted findings at the requested default P0 priority. The final three-file fixup also passed the canonical private staged-content scan.
- The full pinned Mintlify anchor audit reports four existing failures in `gateway/permission-modes.md`, `maturity/taxonomy.md`, `plugins/architecture.md`, and `start/why-openclaw.md`. None overlaps the edited pages or new links. A bounded comparison confirms their source and target inputs are unchanged from the reviewed main SHA. The new self-chat and per-account recovery anchors pass. No config examples changed.

Production LOC delta: 0. Test LOC delta: 0. Documentation only; no live channel restart or probe was needed to change these descriptions.
