### PR TITLE
test(control-ui): guard chat streaming runtime budgets

### DIFF
--- a/test/vitest/vitest.ui-e2e.sequencer.ts
+++ b/test/vitest/vitest.ui-e2e.sequencer.ts
@@ -24,6 +24,7 @@ const UI_E2E_FILE_SECONDS_HINTS = new Map<string, number>([
   ["chat-flow.models-reasoning.e2e.test.ts", 18],
   ["chat-flow.navigation-presentation.e2e.test.ts", 15],
   ["chat-flow.streaming.e2e.test.ts", 22],
+  ["chat-stream-runtime-budgets.e2e.test.ts", 34],
   ["chat-rail-columns.e2e.test.ts", 25],
   ["chat-retained-pane-hydration.e2e.test.ts", 15],
   ["chat-sidebar-panel-contract.e2e.test.ts", 27],

--- a/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
+++ b/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
@@ -1,0 +1,509 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  createChatFlowE2eSuite,
+  installMockGateway,
+  requireRecord,
+  requireString,
+} from "./chat-flow.test-support.ts";
+
+// Durable runtime budgets for the chat streaming surface. Byte budgets
+// (scripts/check-control-ui-performance.mts) cannot see rendering work, so
+// these tests protect the landed streaming optimizations at the DOM boundary:
+// the animation-frame render queue (ui/src/pages/chat/chat-state-render.ts),
+// the bounded live tool stream (ui/src/pages/chat/tool-stream.ts), and the
+// transcript/heap cost of long sessions. Structural counts are exact and
+// machine-speed independent; wall-clock/heap ceilings carry several-fold
+// headroom so shared runners stay green while algorithmic regressions
+// (per-event renders, quadratic transcript work, retained stream buffers)
+// still violate them by an order of magnitude.
+const suite = createChatFlowE2eSuite();
+
+type ChatFlowSuite = ReturnType<typeof createChatFlowE2eSuite>;
+type ChatFlowPage = Parameters<Parameters<ChatFlowSuite["withPage"]>[1]>[0]["page"];
+
+// Burst size for the render-scheduling gate. Each delta lands in its own
+// macrotask, so every event forces an invalidation; the animation-frame queue
+// is what keeps those invalidations executing inside frame callbacks instead
+// of on message/timer tasks.
+const BURST_DELTA_COUNT = 240;
+// Sanity floor: the burst must invalidate the chat page host at least twice,
+// proving the probe observed the streaming path at all.
+const MIN_BURST_HOST_UPDATES = 2;
+// Minimum share of host invalidations that must execute inside an animation
+// frame callback. The queue guarantees this for every stream-driven update;
+// only rare timer-driven strays (poll controllers) fall outside frames.
+const FRAME_SCHEDULED_MIN_RATIO = 0.9;
+
+// Shipped live-tool ceiling: ui/src/pages/chat/tool-stream.ts TOOL_STREAM_LIMIT.
+const TOOL_STREAM_LIMIT_CONTRACT = 50;
+// Realistic agent cadence: narration deltas separate tool calls, so each pair
+// (assistant delta, tool result) lands on its own timer tick. Pairs stay above
+// the shipped limit to prove eviction under sustained load.
+const TOOL_FLOOD_PAIR_COUNT = 60;
+const TOOL_FLOOD_PAIR_INTERVAL_MS = 60;
+// Gateway activity fencing drops any event whose seq is at or below the
+// newest seq already accepted, so flood events seed above every sequence the
+// mocked startup handshake has already delivered.
+const TOOL_FLOOD_SEQ_SEED = 1_000_000;
+
+const LONG_TRANSCRIPT_MESSAGE_COUNT = 400;
+// Wall ceiling with multi-x headroom over the measured baseline
+// (.artifacts/control-ui-e2e/stream-runtime-budgets/metrics.jsonl); sized to
+// tolerate loaded shared runners while still failing quadratic transcript work.
+const LONG_TRANSCRIPT_LOAD_CEILING_MS = 30_000;
+const RICH_TURN_CHUNK_COUNT = 150;
+// Post-GC resident JS heap after loading the long transcript and streaming the
+// rich turn. Headroom over the measured baseline retains transient parser and
+// renderer allocations; a leak that keeps streamed deltas alive breaks it.
+const STREAM_SESSION_HEAP_CEILING_BYTES = 96 * 1024 * 1024;
+
+const IDLE_WINDOW_MS = 4_000;
+const IDLE_LONGTASK_TOTAL_CEILING_MS = 600;
+
+type StreamPerfProbe = {
+  mutationBatches: number;
+  rafCount: number;
+  hostUpdates: number;
+  hostUpdatesInsideFrame: number;
+};
+
+type ScopedWindow = Window & {
+  __ocStreamPerf?: StreamPerfProbe;
+  __ocIdleProbe?: { longTasks: number; longTaskMs: number; rafCount: number };
+  __ocBurstDone?: boolean;
+  openclawControlUiE2eGateway?: {
+    emit: (event: string, payload?: unknown) => void;
+  };
+};
+
+const metricsArtifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "stream-runtime-budgets",
+);
+
+async function recordBudgetMetrics(
+  testName: string,
+  metrics: Record<string, number>,
+): Promise<void> {
+  await mkdir(metricsArtifactDir, { recursive: true });
+  await appendFile(
+    path.join(metricsArtifactDir, "metrics.jsonl"),
+    `${JSON.stringify({ testName, metrics, recordedAt: new Date().toISOString() })}\n`,
+  );
+}
+
+// Rendered transcripts strip markdown markers, so visibility polls match the
+// plain-text projection of the burst chunk emitted in-page
+// (`delta N with **boldN** and \`codeN\` tail`).
+function renderedChunkText(index: number): string {
+  return `delta ${index} with bold${index}`;
+}
+
+async function installRenderProbe(page: ChatFlowPage) {
+  await page.evaluate(() => {
+    const scope = window as ScopedWindow;
+    const chatPage = document.querySelector("openclaw-chat-page");
+    if (!chatPage) {
+      throw new Error("openclaw-chat-page is not mounted");
+    }
+    scope.__ocStreamPerf = {
+      mutationBatches: 0,
+      rafCount: 0,
+      hostUpdates: 0,
+      hostUpdatesInsideFrame: 0,
+    };
+    new MutationObserver((records) => {
+      if (records.length > 0) {
+        scope.__ocStreamPerf!.mutationBatches += 1;
+      }
+    }).observe(document.body, { childList: true, subtree: true, characterData: true });
+    let insideFrame = false;
+    const originalRequestAnimationFrame = window.requestAnimationFrame.bind(window);
+    window.requestAnimationFrame = (callback: FrameRequestCallback): number =>
+      originalRequestAnimationFrame((time) => {
+        scope.__ocStreamPerf!.rafCount += 1;
+        const previous = insideFrame;
+        insideFrame = true;
+        try {
+          callback(time);
+        } finally {
+          insideFrame = previous;
+        }
+      });
+    // Walk to the Lit base that owns requestUpdate and shadow it there so
+    // every host invalidation (any element) is attributed to whether it ran
+    // inside an animation frame callback. Stream-driven updates dominate the
+    // window, so the frame-scheduled share stays representative.
+    let owner: object | null = Object.getPrototypeOf(chatPage);
+    while (owner && !Object.hasOwn(owner, "requestUpdate")) {
+      owner = Object.getPrototypeOf(owner);
+    }
+    if (!owner || typeof (owner as { requestUpdate?: unknown }).requestUpdate !== "function") {
+      throw new Error("requestUpdate owner not found on chat page prototype chain");
+    }
+    const ownerPrototype = owner as { requestUpdate: (...args: unknown[]) => unknown };
+    const originalRequestUpdate = ownerPrototype.requestUpdate;
+    ownerPrototype.requestUpdate = function patchedRequestUpdate(this: object, ...args: unknown[]) {
+      const probe = scope.__ocStreamPerf!;
+      const tag = (this as HTMLElement).localName;
+      if (tag === "openclaw-chat-page" || tag === "openclaw-chat-pane") {
+        probe.hostUpdates += 1;
+        if (insideFrame) {
+          probe.hostUpdatesInsideFrame += 1;
+        }
+      }
+      return originalRequestUpdate.apply(this, args);
+    };
+  });
+}
+
+async function resetRenderProbe(page: ChatFlowPage) {
+  await page.evaluate(() => {
+    const scope = window as ScopedWindow;
+    scope.__ocStreamPerf = {
+      mutationBatches: 0,
+      rafCount: 0,
+      hostUpdates: 0,
+      hostUpdatesInsideFrame: 0,
+    };
+  });
+}
+
+async function readRenderProbe(page: ChatFlowPage): Promise<StreamPerfProbe> {
+  return page.evaluate(() => (window as ScopedWindow).__ocStreamPerf!);
+}
+
+// Emits each delta from its own macrotask so render work cannot hide inside
+// one task's microtask batching: the queue under test schedules commits per
+// animation frame, not per task.
+async function emitDeltaBurstInPage(
+  page: ChatFlowPage,
+  runId: string,
+  count: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ runId, count }) => {
+      const gateway = (window as ScopedWindow).openclawControlUiE2eGateway;
+      if (!gateway) {
+        throw new Error("mock gateway handle missing");
+      }
+      const scope = window as ScopedWindow;
+      scope.__ocBurstDone = false;
+      let emitted = 0;
+      const emitNext = () => {
+        emitted += 1;
+        const chunk = ` delta ${emitted} with **bold${emitted}** and \`code${emitted}\` tail`;
+        gateway.emit("chat", {
+          deltaText: chunk,
+          message: {
+            content: [{ text: chunk, type: "text" }],
+            role: "assistant",
+            timestamp: Date.now(),
+          },
+          runId,
+          sessionKey: "main",
+          state: "delta",
+        });
+        if (emitted < count) {
+          setTimeout(emitNext, 0);
+        } else {
+          scope.__ocBurstDone = true;
+        }
+      };
+      setTimeout(emitNext, 0);
+    },
+    { runId, count },
+  );
+  await page.waitForFunction(() => (window as ScopedWindow).__ocBurstDone === true, undefined, {
+    timeout: 30_000,
+    polling: 50,
+  });
+}
+
+async function openStreamingTurn(
+  page: ChatFlowPage,
+  gateway: Awaited<ReturnType<typeof installMockGateway>>,
+  prompt: string,
+): Promise<string> {
+  await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+  await page.getByRole("button", { name: "Send message" }).click();
+  const sendRequest = await gateway.waitForRequest("chat.send");
+  const params = requireRecord(sendRequest.params);
+  const runId = requireString(params.idempotencyKey, "chat send idempotency key");
+  // One visible warm-up delta puts the transcript into the live streaming
+  // state the burst and flood events attach to; it lands before any probe
+  // counters reset, so measured windows stay clean.
+  await gateway.emitGatewayEvent("chat", {
+    deltaText: " warmup",
+    message: {
+      content: [{ text: " warmup", type: "text" }],
+      role: "assistant",
+      timestamp: Date.now(),
+    },
+    runId,
+    sessionKey: "main",
+    state: "delta",
+  });
+  await page.locator(".chat-bubble.streaming").getByText("warmup").waitFor();
+  return runId;
+}
+
+async function emitToolResultFlood(
+  page: ChatFlowPage,
+  runId: string,
+  pairCount: number,
+): Promise<void> {
+  // Real agent turns alternate narration deltas and tool results, and Gateway
+  // frames arrive as separate socket messages; deliver each pair on its own
+  // timer tick so the live stream sees production-shaped input.
+  await page.evaluate(
+    ({ runId, pairCount, intervalMs, seqSeed }) => {
+      const scope = window as ScopedWindow;
+      const gateway = scope.openclawControlUiE2eGateway;
+      if (!gateway) {
+        throw new Error("mock gateway handle missing");
+      }
+      scope.__ocBurstDone = false;
+      let emitted = 0;
+      const emitPair = () => {
+        emitted += 1;
+        const chunk = ` working on step ${emitted}`;
+        gateway.emit("chat", {
+          deltaText: chunk,
+          message: {
+            content: [{ text: chunk, type: "text" }],
+            role: "assistant",
+            timestamp: Date.now(),
+          },
+          runId,
+          sessionKey: "main",
+          state: "delta",
+        });
+        gateway.emit("agent", {
+          data: {
+            name: "exec",
+            phase: "result",
+            result: `tool output ${emitted}`,
+            toolCallId: `call-${emitted}`,
+          },
+          runId,
+          seq: seqSeed + emitted,
+          sessionKey: "main",
+          stream: "tool",
+          ts: Date.now(),
+        });
+        if (emitted < pairCount) {
+          setTimeout(emitPair, intervalMs);
+        } else {
+          scope.__ocBurstDone = true;
+        }
+      };
+      setTimeout(emitPair, 0);
+    },
+    { runId, pairCount, intervalMs: TOOL_FLOOD_PAIR_INTERVAL_MS, seqSeed: TOOL_FLOOD_SEQ_SEED },
+  );
+  await page.waitForFunction(() => (window as ScopedWindow).__ocBurstDone === true, undefined, {
+    timeout: 60_000,
+    polling: 200,
+  });
+}
+
+function buildLongTranscriptFixture(messageCount: number): Array<Record<string, unknown>> {
+  return Array.from({ length: messageCount }, (_, index) => {
+    const role = index % 2 === 0 ? "user" : "assistant";
+    const sentinel = index === messageCount - 1 ? " LONG-TAIL-SENTINEL" : "";
+    const text =
+      role === "user"
+        ? `history question ${index}: ${"detail ".repeat(12)}`
+        : `history answer ${index}: ${"context ".repeat(16)}${sentinel}`;
+    return {
+      role,
+      content: [{ type: "text", text }],
+      timestamp: Date.now() - (messageCount - index) * 1_000,
+    };
+  });
+}
+
+suite.define(() => {
+  it("commits a streamed delta burst in frame-bound transcript batches", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page);
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const runId = await openStreamingTurn(page, gateway, "burst coalescing probe");
+
+        await installRenderProbe(page);
+        await resetRenderProbe(page);
+
+        await emitDeltaBurstInPage(page, runId, BURST_DELTA_COUNT);
+        await expect
+          .poll(() =>
+            page.evaluate(
+              (finalChunk) =>
+                (document.querySelector(".chat-thread-inner")?.textContent ?? "").includes(
+                  finalChunk,
+                ),
+              renderedChunkText(BURST_DELTA_COUNT),
+            ),
+          )
+          .toBe(true);
+        // Sample after the trailing animation frame drained so the batch count
+        // reflects the whole burst, not a mid-render snapshot.
+        await expect
+          .poll(async () => {
+            const before = await readRenderProbe(page);
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            const after = await readRenderProbe(page);
+            return before.mutationBatches === after.mutationBatches ? after : null;
+          })
+          .not.toBeNull();
+
+        const probe = await readRenderProbe(page);
+        await recordBudgetMetrics("delta-burst-commits", {
+          mutationBatches: probe.mutationBatches,
+          rafCount: probe.rafCount,
+          hostUpdates: probe.hostUpdates,
+          hostUpdatesInsideFrame: probe.hostUpdatesInsideFrame,
+        });
+
+        expect(probe.hostUpdates).toBeGreaterThanOrEqual(MIN_BURST_HOST_UPDATES);
+        expect(probe.hostUpdatesInsideFrame / probe.hostUpdates).toBeGreaterThanOrEqual(
+          FRAME_SCHEDULED_MIN_RATIO,
+        );
+      },
+    );
+  });
+
+  it("keeps the live tool stream bounded under a tool result flood", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page);
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const runId = await openStreamingTurn(page, gateway, "tool flood probe");
+
+        await emitToolResultFlood(page, runId, TOOL_FLOOD_PAIR_COUNT);
+        const floodCards = page.locator('[data-message-id^="tool:assistant:call-"]');
+        // Eviction drops the oldest entries and keeps the freshest ones.
+        await expect
+          .poll(() => floodCards.count(), { timeout: 15_000 })
+          .toBe(TOOL_STREAM_LIMIT_CONTRACT);
+        expect(await page.locator('[data-message-id^="tool:assistant:call-0"]').count()).toBe(0);
+        expect(
+          await page
+            .locator(`[data-message-id^="tool:assistant:call-${TOOL_FLOOD_PAIR_COUNT}"]`)
+            .count(),
+        ).toBe(1);
+      },
+    );
+  });
+
+  it("loads a long transcript and streams a rich turn inside budget ceilings", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page, context }) => {
+        const gateway = await installMockGateway(page, {
+          historyMessages: buildLongTranscriptFixture(LONG_TRANSCRIPT_MESSAGE_COUNT),
+        });
+
+        const loadStartedAt = Date.now();
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        await page
+          .locator(".chat-thread-inner")
+          .getByText("LONG-TAIL-SENTINEL")
+          .waitFor({ timeout: LONG_TRANSCRIPT_LOAD_CEILING_MS });
+        const loadMs = Date.now() - loadStartedAt;
+        expect(loadMs).toBeLessThanOrEqual(LONG_TRANSCRIPT_LOAD_CEILING_MS);
+
+        const runId = await openStreamingTurn(page, gateway, "rich streaming turn");
+        await emitDeltaBurstInPage(page, runId, RICH_TURN_CHUNK_COUNT);
+        await gateway.emitChatFinal({ runId, text: "rich turn finalized" });
+        await page.locator(".chat-thread-inner").getByText("rich turn finalized").waitFor();
+
+        const cdpSession = await context.newCDPSession(page);
+        // Metric collection requires the domain to be enabled first.
+        await cdpSession.send("Performance.enable");
+        await cdpSession.send("HeapProfiler.collectGarbage");
+        await cdpSession.send("HeapProfiler.collectGarbage");
+        const { metrics } = await cdpSession.send("Performance.getMetrics");
+        const heapUsedBytes = metrics.find((metric) => metric.name === "JSHeapUsedSize")!.value;
+        expect(heapUsedBytes).toBeLessThanOrEqual(STREAM_SESSION_HEAP_CEILING_BYTES);
+
+        await recordBudgetMetrics("long-transcript-rich-turn", {
+          loadMs,
+          heapUsedBytes: Math.round(heapUsedBytes),
+        });
+      },
+    );
+  });
+
+  it("stays quiet while idle after a settled stream", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page);
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+
+        const runId = await openStreamingTurn(page, gateway, "idle quiescence probe");
+        await gateway.emitChatFinal({ runId, text: "short finalized turn" });
+        await page.locator(".chat-thread-inner").getByText("short finalized turn").waitFor();
+
+        await page.evaluate(() => {
+          const scope = window as ScopedWindow;
+          scope.__ocIdleProbe = { longTasks: 0, longTaskMs: 0, rafCount: 0 };
+          new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+              scope.__ocIdleProbe!.longTasks += 1;
+              scope.__ocIdleProbe!.longTaskMs += entry.duration;
+            }
+          }).observe({ entryTypes: ["longtask"] });
+          const originalRequestAnimationFrame = window.requestAnimationFrame.bind(window);
+          window.requestAnimationFrame = (callback: FrameRequestCallback): number =>
+            originalRequestAnimationFrame((time) => {
+              scope.__ocIdleProbe!.rafCount += 1;
+              callback(time);
+            });
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, IDLE_WINDOW_MS));
+
+        const idle = await page.evaluate(() => (window as ScopedWindow).__ocIdleProbe!);
+        await recordBudgetMetrics("idle-quiescence", {
+          longTasks: idle.longTasks,
+          longTaskMs: Math.round(idle.longTaskMs),
+          rafCount: idle.rafCount,
+        });
+
+        expect(idle.longTaskMs).toBeLessThanOrEqual(IDLE_LONGTASK_TOTAL_CEILING_MS);
+        // rAF stays recorded but unasserted: the idle shell animates a
+        // continuous low-cost loop (~20 requests/s measured), so only long-task
+        // time discriminates runaway work from that baseline.
+      },
+    );
+  });
+});

--- a/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
+++ b/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
@@ -75,10 +75,18 @@ type StreamPerfProbe = {
   hostUpdatesInsideFrame: number;
 };
 
+type ToolProjectionProbe = {
+  beforeThrottleCardCount: number | null;
+  afterThrottleCardCount: number | null;
+  afterThrottleText: string | null;
+  ready: boolean;
+};
+
 type ScopedWindow = Window & {
   ocStreamPerf?: StreamPerfProbe;
   ocIdleProbe?: { longTasks: number; longTaskMs: number };
   ocBurstDone?: boolean;
+  ocToolProjectionProbe?: ToolProjectionProbe;
   openclawControlUiE2eGateway?: {
     emit: (event: string, payload?: unknown) => void;
   };
@@ -258,7 +266,106 @@ async function openStreamingTurn(
   return runId;
 }
 
-async function emitToolLifecycleFlood(
+async function probeDeferredToolProjection(page: ChatFlowPage, runId: string): Promise<void> {
+  await page.evaluate(
+    ({ runId: targetRunId, seqSeed }) => {
+      const scope = window as ScopedWindow;
+      const gateway = scope.openclawControlUiE2eGateway;
+      if (!gateway) {
+        throw new Error("mock gateway handle missing");
+      }
+      const probe: ToolProjectionProbe = {
+        beforeThrottleCardCount: null,
+        afterThrottleCardCount: null,
+        afterThrottleText: null,
+        ready: false,
+      };
+      scope.ocToolProjectionProbe = probe;
+      let seq = seqSeed;
+      const emitToolPhase = (phase: string, data: Record<string, unknown>) => {
+        gateway.emit("agent", {
+          data: { name: "edit", phase, toolCallId: "call-1", ...data },
+          runId: targetRunId,
+          seq: ++seq,
+          sessionKey: "main",
+          stream: "tool",
+          ts: Date.now(),
+        });
+      };
+      const cardSelector = '[data-message-id^="tool:assistant:call-1:"]';
+      gateway.emit("chat", {
+        deltaText: " working on step 1",
+        message: {
+          content: [{ text: " working on step 1", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId: targetRunId,
+        sessionKey: "main",
+        state: "delta",
+      });
+      emitToolPhase("start", { args: { path: "src/file-1.ts" } });
+      setTimeout(() => emitToolPhase("update", { partialResult: "partial output 1" }), 10);
+      setTimeout(() => emitToolPhase("input_delta", { diff: { added: 1, removed: 1 } }), 20);
+      // Sample before the 80ms owner timer. An eager non-terminal projection
+      // makes the card visible here and fails the absence contract.
+      setTimeout(() => {
+        probe.beforeThrottleCardCount = document.querySelectorAll(cardSelector).length;
+      }, 50);
+      // Leave result un-emitted. After the owner timer and two render frames,
+      // the running card must expose the latest update/input_delta projection.
+      setTimeout(() => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            const cards = document.querySelectorAll(cardSelector);
+            probe.afterThrottleCardCount = cards.length;
+            probe.afterThrottleText = cards[0]?.textContent ?? null;
+            probe.ready = true;
+          });
+        });
+      }, 120);
+    },
+    { runId, seqSeed: TOOL_FLOOD_SEQ_SEED },
+  );
+  await page.waitForFunction(
+    () => (window as ScopedWindow).ocToolProjectionProbe?.ready === true,
+    undefined,
+    { timeout: 10_000, polling: 20 },
+  );
+}
+
+async function completeFirstToolLifecycle(page: ChatFlowPage, runId: string): Promise<void> {
+  await page.evaluate(
+    ({ runId: targetRunId, seq }) => {
+      const gateway = (window as ScopedWindow).openclawControlUiE2eGateway;
+      if (!gateway) {
+        throw new Error("mock gateway handle missing");
+      }
+      gateway.emit("agent", {
+        data: {
+          name: "edit",
+          phase: "result",
+          result: "tool output 1",
+          toolCallId: "call-1",
+        },
+        runId: targetRunId,
+        seq,
+        sessionKey: "main",
+        stream: "tool",
+        ts: Date.now(),
+      });
+    },
+    { runId, seq: TOOL_FLOOD_SEQ_SEED + 4 },
+  );
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+}
+
+async function emitRemainingToolLifecycleFlood(
   page: ChatFlowPage,
   runId: string,
   pairCount: number,
@@ -274,8 +381,8 @@ async function emitToolLifecycleFlood(
         throw new Error("mock gateway handle missing");
       }
       scope.ocBurstDone = false;
-      let emitted = 0;
-      let seq = seqSeed;
+      let emitted = 1;
+      let seq = seqSeed + 4;
       const emitToolPhase = (phase: string, data: Record<string, unknown>) => {
         gateway.emit("agent", {
           data: {
@@ -321,7 +428,7 @@ async function emitToolLifecycleFlood(
           }, phaseIntervalMs);
         }, phaseIntervalMs);
       };
-      setTimeout(emitCall, 0);
+      setTimeout(emitCall, phaseIntervalMs);
     },
     {
       runId,
@@ -424,7 +531,22 @@ suite.define(() => {
         await gateway.waitForRequest("chat.startup");
         const runId = await openStreamingTurn(page, gateway, "tool flood probe");
 
-        await emitToolLifecycleFlood(page, runId, TOOL_FLOOD_PAIR_COUNT);
+        await probeDeferredToolProjection(page, runId);
+        const projection = await page.evaluate(
+          () => (window as ScopedWindow).ocToolProjectionProbe!,
+        );
+        expect(projection.beforeThrottleCardCount).toBe(0);
+        expect(projection.afterThrottleCardCount).toBe(1);
+        expect(projection.afterThrottleText).toContain("Editing");
+        expect(projection.afterThrottleText).toContain("+1");
+        expect(projection.afterThrottleText).toContain("-1");
+
+        await completeFirstToolLifecycle(page, runId);
+        const firstCard = page.locator('[data-message-id^="tool:assistant:call-1:"]');
+        expect(await firstCard.count()).toBe(1);
+        expect(await firstCard.textContent()).toContain("Edited");
+
+        await emitRemainingToolLifecycleFlood(page, runId, TOOL_FLOOD_PAIR_COUNT);
         const floodCards = page.locator('[data-message-id^="tool:assistant:call-"]');
         // Eviction drops the oldest entries and keeps the freshest ones.
         await expect

--- a/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
+++ b/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
@@ -31,6 +31,10 @@ const BURST_DELTA_COUNT = 240;
 // Sanity floor: the burst must invalidate the chat page host at least twice,
 // proving the probe observed the streaming path at all.
 const MIN_BURST_HOST_UPDATES = 2;
+// Valid frame-queued runs commit 115-144 host updates for this burst. A direct
+// update per delta produces 241, so this ceiling catches lost coalescing while
+// retaining headroom for runner cadence.
+const MAX_BURST_HOST_UPDATES = 180;
 // Minimum share of host invalidations that must execute inside an animation
 // frame callback. The queue guarantees this for every stream-driven update;
 // only rare timer-driven strays (poll controllers) fall outside frames.
@@ -38,11 +42,12 @@ const FRAME_SCHEDULED_MIN_RATIO = 0.9;
 
 // Shipped live-tool ceiling: ui/src/pages/chat/tool-stream.ts TOOL_STREAM_LIMIT.
 const TOOL_STREAM_LIMIT_CONTRACT = 50;
-// Realistic agent cadence: narration deltas separate tool calls, so each pair
-// (assistant delta, tool result) lands on its own timer tick. Pairs stay above
-// the shipped limit to prove eviction under sustained load.
+// Realistic agent cadence: narration deltas separate complete tool lifecycles.
+// Calls stay above the shipped limit to prove eviction under sustained load.
 const TOOL_FLOOD_PAIR_COUNT = 60;
-const TOOL_FLOOD_PAIR_INTERVAL_MS = 60;
+// The lifecycle spans the 80ms projection throttle so start/update/input_delta
+// exercise its deferred flush before result forces the final projection.
+const TOOL_FLOOD_PHASE_INTERVAL_MS = 30;
 // Gateway activity fencing drops any event whose seq is at or below the
 // newest seq already accepted, so flood events seed above every sequence the
 // mocked startup handshake has already delivered.
@@ -253,16 +258,16 @@ async function openStreamingTurn(
   return runId;
 }
 
-async function emitToolResultFlood(
+async function emitToolLifecycleFlood(
   page: ChatFlowPage,
   runId: string,
   pairCount: number,
 ): Promise<void> {
-  // Real agent turns alternate narration deltas and tool results, and Gateway
-  // frames arrive as separate socket messages; deliver each pair on its own
-  // timer tick so the live stream sees production-shaped input.
+  // Gateway frames arrive as separate socket messages. Space each lifecycle
+  // phase across timer ticks so the live stream exercises deferred projection,
+  // not only the result path's forced flush.
   await page.evaluate(
-    ({ runId: targetRunId, pairCount: targetPairCount, intervalMs, seqSeed }) => {
+    ({ runId: targetRunId, pairCount: targetPairCount, phaseIntervalMs, seqSeed }) => {
       const scope = window as ScopedWindow;
       const gateway = scope.openclawControlUiE2eGateway;
       if (!gateway) {
@@ -270,7 +275,23 @@ async function emitToolResultFlood(
       }
       scope.ocBurstDone = false;
       let emitted = 0;
-      const emitPair = () => {
+      let seq = seqSeed;
+      const emitToolPhase = (phase: string, data: Record<string, unknown>) => {
+        gateway.emit("agent", {
+          data: {
+            name: "edit",
+            phase,
+            toolCallId: `call-${emitted}`,
+            ...data,
+          },
+          runId: targetRunId,
+          seq: ++seq,
+          sessionKey: "main",
+          stream: "tool",
+          ts: Date.now(),
+        });
+      };
+      const emitCall = () => {
         emitted += 1;
         const chunk = ` working on step ${emitted}`;
         gateway.emit("chat", {
@@ -284,28 +305,30 @@ async function emitToolResultFlood(
           sessionKey: "main",
           state: "delta",
         });
-        gateway.emit("agent", {
-          data: {
-            name: "exec",
-            phase: "result",
-            result: `tool output ${emitted}`,
-            toolCallId: `call-${emitted}`,
-          },
-          runId: targetRunId,
-          seq: seqSeed + emitted,
-          sessionKey: "main",
-          stream: "tool",
-          ts: Date.now(),
-        });
-        if (emitted < targetPairCount) {
-          setTimeout(emitPair, intervalMs);
-        } else {
-          scope.ocBurstDone = true;
-        }
+        emitToolPhase("start", { args: { path: `src/file-${emitted}.ts` } });
+        setTimeout(() => {
+          emitToolPhase("update", { partialResult: `partial output ${emitted}` });
+          setTimeout(() => {
+            emitToolPhase("input_delta", { diff: { added: emitted, removed: 1 } });
+            setTimeout(() => {
+              emitToolPhase("result", { result: `tool output ${emitted}` });
+              if (emitted < targetPairCount) {
+                setTimeout(emitCall, phaseIntervalMs);
+              } else {
+                scope.ocBurstDone = true;
+              }
+            }, phaseIntervalMs);
+          }, phaseIntervalMs);
+        }, phaseIntervalMs);
       };
-      setTimeout(emitPair, 0);
+      setTimeout(emitCall, 0);
     },
-    { runId, pairCount, intervalMs: TOOL_FLOOD_PAIR_INTERVAL_MS, seqSeed: TOOL_FLOOD_SEQ_SEED },
+    {
+      runId,
+      pairCount,
+      phaseIntervalMs: TOOL_FLOOD_PHASE_INTERVAL_MS,
+      seqSeed: TOOL_FLOOD_SEQ_SEED,
+    },
   );
   await page.waitForFunction(() => (window as ScopedWindow).ocBurstDone === true, undefined, {
     timeout: 60_000,
@@ -380,6 +403,7 @@ suite.define(() => {
         });
 
         expect(probe.hostUpdates).toBeGreaterThanOrEqual(MIN_BURST_HOST_UPDATES);
+        expect(probe.hostUpdates).toBeLessThanOrEqual(MAX_BURST_HOST_UPDATES);
         expect(probe.hostUpdatesInsideFrame / probe.hostUpdates).toBeGreaterThanOrEqual(
           FRAME_SCHEDULED_MIN_RATIO,
         );
@@ -387,7 +411,7 @@ suite.define(() => {
     );
   });
 
-  it("keeps the live tool stream bounded under a tool result flood", async () => {
+  it("keeps the live tool stream bounded under complete tool lifecycles", async () => {
     await suite.withPage(
       {
         locale: "en-US",
@@ -400,7 +424,7 @@ suite.define(() => {
         await gateway.waitForRequest("chat.startup");
         const runId = await openStreamingTurn(page, gateway, "tool flood probe");
 
-        await emitToolResultFlood(page, runId, TOOL_FLOOD_PAIR_COUNT);
+        await emitToolLifecycleFlood(page, runId, TOOL_FLOOD_PAIR_COUNT);
         const floodCards = page.locator('[data-message-id^="tool:assistant:call-"]');
         // Eviction drops the oldest entries and keeps the freshest ones.
         await expect

--- a/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
+++ b/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
@@ -61,6 +61,7 @@ const STREAM_SESSION_HEAP_CEILING_BYTES = 96 * 1024 * 1024;
 
 const IDLE_WINDOW_MS = 4_000;
 const IDLE_LONGTASK_TOTAL_CEILING_MS = 600;
+const IDLE_TASK_DURATION_CEILING_MS = 600;
 
 type StreamPerfProbe = {
   mutationBatches: number;
@@ -70,9 +71,9 @@ type StreamPerfProbe = {
 };
 
 type ScopedWindow = Window & {
-  __ocStreamPerf?: StreamPerfProbe;
-  __ocIdleProbe?: { longTasks: number; longTaskMs: number; rafCount: number };
-  __ocBurstDone?: boolean;
+  ocStreamPerf?: StreamPerfProbe;
+  ocIdleProbe?: { longTasks: number; longTaskMs: number };
+  ocBurstDone?: boolean;
   openclawControlUiE2eGateway?: {
     emit: (event: string, payload?: unknown) => void;
   };
@@ -110,7 +111,7 @@ async function installRenderProbe(page: ChatFlowPage) {
     if (!chatPage) {
       throw new Error("openclaw-chat-page is not mounted");
     }
-    scope.__ocStreamPerf = {
+    scope.ocStreamPerf = {
       mutationBatches: 0,
       rafCount: 0,
       hostUpdates: 0,
@@ -118,14 +119,14 @@ async function installRenderProbe(page: ChatFlowPage) {
     };
     new MutationObserver((records) => {
       if (records.length > 0) {
-        scope.__ocStreamPerf!.mutationBatches += 1;
+        scope.ocStreamPerf!.mutationBatches += 1;
       }
     }).observe(document.body, { childList: true, subtree: true, characterData: true });
     let insideFrame = false;
     const originalRequestAnimationFrame = window.requestAnimationFrame.bind(window);
     window.requestAnimationFrame = (callback: FrameRequestCallback): number =>
       originalRequestAnimationFrame((time) => {
-        scope.__ocStreamPerf!.rafCount += 1;
+        scope.ocStreamPerf!.rafCount += 1;
         const previous = insideFrame;
         insideFrame = true;
         try {
@@ -148,7 +149,7 @@ async function installRenderProbe(page: ChatFlowPage) {
     const ownerPrototype = owner as { requestUpdate: (...args: unknown[]) => unknown };
     const originalRequestUpdate = ownerPrototype.requestUpdate;
     ownerPrototype.requestUpdate = function patchedRequestUpdate(this: object, ...args: unknown[]) {
-      const probe = scope.__ocStreamPerf!;
+      const probe = scope.ocStreamPerf!;
       const tag = (this as HTMLElement).localName;
       if (tag === "openclaw-chat-page" || tag === "openclaw-chat-pane") {
         probe.hostUpdates += 1;
@@ -164,7 +165,7 @@ async function installRenderProbe(page: ChatFlowPage) {
 async function resetRenderProbe(page: ChatFlowPage) {
   await page.evaluate(() => {
     const scope = window as ScopedWindow;
-    scope.__ocStreamPerf = {
+    scope.ocStreamPerf = {
       mutationBatches: 0,
       rafCount: 0,
       hostUpdates: 0,
@@ -174,7 +175,7 @@ async function resetRenderProbe(page: ChatFlowPage) {
 }
 
 async function readRenderProbe(page: ChatFlowPage): Promise<StreamPerfProbe> {
-  return page.evaluate(() => (window as ScopedWindow).__ocStreamPerf!);
+  return page.evaluate(() => (window as ScopedWindow).ocStreamPerf!);
 }
 
 // Emits each delta from its own macrotask so render work cannot hide inside
@@ -186,13 +187,13 @@ async function emitDeltaBurstInPage(
   count: number,
 ): Promise<void> {
   await page.evaluate(
-    ({ runId, count }) => {
+    ({ runId: targetRunId, count: targetCount }) => {
       const gateway = (window as ScopedWindow).openclawControlUiE2eGateway;
       if (!gateway) {
         throw new Error("mock gateway handle missing");
       }
       const scope = window as ScopedWindow;
-      scope.__ocBurstDone = false;
+      scope.ocBurstDone = false;
       let emitted = 0;
       const emitNext = () => {
         emitted += 1;
@@ -204,21 +205,21 @@ async function emitDeltaBurstInPage(
             role: "assistant",
             timestamp: Date.now(),
           },
-          runId,
+          runId: targetRunId,
           sessionKey: "main",
           state: "delta",
         });
-        if (emitted < count) {
+        if (emitted < targetCount) {
           setTimeout(emitNext, 0);
         } else {
-          scope.__ocBurstDone = true;
+          scope.ocBurstDone = true;
         }
       };
       setTimeout(emitNext, 0);
     },
     { runId, count },
   );
-  await page.waitForFunction(() => (window as ScopedWindow).__ocBurstDone === true, undefined, {
+  await page.waitForFunction(() => (window as ScopedWindow).ocBurstDone === true, undefined, {
     timeout: 30_000,
     polling: 50,
   });
@@ -261,13 +262,13 @@ async function emitToolResultFlood(
   // frames arrive as separate socket messages; deliver each pair on its own
   // timer tick so the live stream sees production-shaped input.
   await page.evaluate(
-    ({ runId, pairCount, intervalMs, seqSeed }) => {
+    ({ runId: targetRunId, pairCount: targetPairCount, intervalMs, seqSeed }) => {
       const scope = window as ScopedWindow;
       const gateway = scope.openclawControlUiE2eGateway;
       if (!gateway) {
         throw new Error("mock gateway handle missing");
       }
-      scope.__ocBurstDone = false;
+      scope.ocBurstDone = false;
       let emitted = 0;
       const emitPair = () => {
         emitted += 1;
@@ -279,7 +280,7 @@ async function emitToolResultFlood(
             role: "assistant",
             timestamp: Date.now(),
           },
-          runId,
+          runId: targetRunId,
           sessionKey: "main",
           state: "delta",
         });
@@ -290,23 +291,23 @@ async function emitToolResultFlood(
             result: `tool output ${emitted}`,
             toolCallId: `call-${emitted}`,
           },
-          runId,
+          runId: targetRunId,
           seq: seqSeed + emitted,
           sessionKey: "main",
           stream: "tool",
           ts: Date.now(),
         });
-        if (emitted < pairCount) {
+        if (emitted < targetPairCount) {
           setTimeout(emitPair, intervalMs);
         } else {
-          scope.__ocBurstDone = true;
+          scope.ocBurstDone = true;
         }
       };
       setTimeout(emitPair, 0);
     },
     { runId, pairCount, intervalMs: TOOL_FLOOD_PAIR_INTERVAL_MS, seqSeed: TOOL_FLOOD_SEQ_SEED },
   );
-  await page.waitForFunction(() => (window as ScopedWindow).__ocBurstDone === true, undefined, {
+  await page.waitForFunction(() => (window as ScopedWindow).ocBurstDone === true, undefined, {
     timeout: 60_000,
     polling: 200,
   });
@@ -362,7 +363,9 @@ suite.define(() => {
         await expect
           .poll(async () => {
             const before = await readRenderProbe(page);
-            await new Promise((resolve) => setTimeout(resolve, 200));
+            await new Promise((resolve) => {
+              setTimeout(resolve, 200);
+            });
             const after = await readRenderProbe(page);
             return before.mutationBatches === after.mutationBatches ? after : null;
           })
@@ -403,10 +406,16 @@ suite.define(() => {
         await expect
           .poll(() => floodCards.count(), { timeout: 15_000 })
           .toBe(TOOL_STREAM_LIMIT_CONTRACT);
-        expect(await page.locator('[data-message-id^="tool:assistant:call-0"]').count()).toBe(0);
+        const firstRetainedCall = TOOL_FLOOD_PAIR_COUNT - TOOL_STREAM_LIMIT_CONTRACT + 1;
+        expect(await page.locator('[data-message-id^="tool:assistant:call-1:"]').count()).toBe(0);
         expect(
           await page
-            .locator(`[data-message-id^="tool:assistant:call-${TOOL_FLOOD_PAIR_COUNT}"]`)
+            .locator(`[data-message-id^="tool:assistant:call-${firstRetainedCall}:"]`)
+            .count(),
+        ).toBe(1);
+        expect(
+          await page
+            .locator(`[data-message-id^="tool:assistant:call-${TOOL_FLOOD_PAIR_COUNT}:"]`)
             .count(),
         ).toBe(1);
       },
@@ -464,7 +473,7 @@ suite.define(() => {
         serviceWorkers: "block",
         viewport: { height: 900, width: 1280 },
       },
-      async ({ page }) => {
+      async ({ page, context }) => {
         const gateway = await installMockGateway(page);
         await page.goto(`${suite.server.baseUrl}chat`);
         await gateway.waitForRequest("chat.startup");
@@ -473,36 +482,41 @@ suite.define(() => {
         await gateway.emitChatFinal({ runId, text: "short finalized turn" });
         await page.locator(".chat-thread-inner").getByText("short finalized turn").waitFor();
 
+        const cdpSession = await context.newCDPSession(page);
+        await cdpSession.send("Performance.enable");
+        const beforeMetrics = await cdpSession.send("Performance.getMetrics");
+        const taskDurationBefore = beforeMetrics.metrics.find(
+          (metric) => metric.name === "TaskDuration",
+        )!.value;
         await page.evaluate(() => {
           const scope = window as ScopedWindow;
-          scope.__ocIdleProbe = { longTasks: 0, longTaskMs: 0, rafCount: 0 };
+          scope.ocIdleProbe = { longTasks: 0, longTaskMs: 0 };
           new PerformanceObserver((list) => {
             for (const entry of list.getEntries()) {
-              scope.__ocIdleProbe!.longTasks += 1;
-              scope.__ocIdleProbe!.longTaskMs += entry.duration;
+              scope.ocIdleProbe!.longTasks += 1;
+              scope.ocIdleProbe!.longTaskMs += entry.duration;
             }
           }).observe({ entryTypes: ["longtask"] });
-          const originalRequestAnimationFrame = window.requestAnimationFrame.bind(window);
-          window.requestAnimationFrame = (callback: FrameRequestCallback): number =>
-            originalRequestAnimationFrame((time) => {
-              scope.__ocIdleProbe!.rafCount += 1;
-              callback(time);
-            });
         });
 
-        await new Promise((resolve) => setTimeout(resolve, IDLE_WINDOW_MS));
+        await new Promise((resolve) => {
+          setTimeout(resolve, IDLE_WINDOW_MS);
+        });
 
-        const idle = await page.evaluate(() => (window as ScopedWindow).__ocIdleProbe!);
+        const afterMetrics = await cdpSession.send("Performance.getMetrics");
+        const taskDurationAfter = afterMetrics.metrics.find(
+          (metric) => metric.name === "TaskDuration",
+        )!.value;
+        const taskDurationMs = (taskDurationAfter - taskDurationBefore) * 1_000;
+        const idle = await page.evaluate(() => (window as ScopedWindow).ocIdleProbe!);
         await recordBudgetMetrics("idle-quiescence", {
           longTasks: idle.longTasks,
           longTaskMs: Math.round(idle.longTaskMs),
-          rafCount: idle.rafCount,
+          taskDurationMs: Math.round(taskDurationMs),
         });
 
         expect(idle.longTaskMs).toBeLessThanOrEqual(IDLE_LONGTASK_TOTAL_CEILING_MS);
-        // rAF stays recorded but unasserted: the idle shell animates a
-        // continuous low-cost loop (~20 requests/s measured), so only long-task
-        // time discriminates runaway work from that baseline.
+        expect(taskDurationMs).toBeLessThanOrEqual(IDLE_TASK_DURATION_CEILING_MS);
       },
     );
   });


### PR DESCRIPTION
## What Problem This Solves

The Control UI has bundle-size budgets and process-level performance scenarios, but no in-browser runtime guards for chat stream render coalescing, bounded live tool state, long-transcript cost, or idle main-thread work. A regression could render on every streamed delta, retain an unbounded tool stream, or leak long sessions while CI remained green.

## Why This Change Was Made

This adds browser-level budgets to the existing mocked-Gateway Control UI E2E lane:

- 240 streamed deltas must remain frame-scheduled and commit no more than 180 host updates.
- The first tool lifecycle is observed before `result`: absent before the 80ms throttle, partially projected after it, and completed immediately by `result`. The flood then continues through 60 calls and retains exactly the newest 50 cards.
- A 400-message transcript plus rich streamed turn stays within load-time and post-GC heap ceilings.
- A settled stream stays within aggregate and long-task idle budgets.
- The duration-weighted UI E2E sequencer accounts for this suite at 34 seconds.

No production code, config, dependency, or public contract changes.

## User Impact

Operators see no behavior change. Developers get a focused CI failure when chat streaming coalescing, tool-stream throttling or retention, long-session cost, or idle work regresses.

## Evidence

Environment: Linux, Playwright Chromium 1.62.1, `OPENCLAW_VITEST_MAX_WORKERS=2`.

Focused E2E command:

```text
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
```

Three consecutive green runs on `2b706a53aad`, 4/4 tests each:

| Run | Duration |
|---|---:|
| 1 | 36.45s |
| 2 | 30.73s |
| 3 | 32.74s |

Negative proof:

- Forcing every non-terminal phase to flush immediately made the pre-throttle sample find one card instead of zero.
- Removing `flushToolStreamSync(host)` from the 80ms timer left zero cards after the throttle instead of the required partial card.
- Removing the pending-frame dedupe and stale-callback fence from `requestChatPageUpdate` made the burst fail at `241 > 180` updates while `240/241` still ran inside rAF.

Production was restored after each mutation; the committed diff remains E2E/test support only.

Additional validation:

- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs test/vitest-ui-e2e-config.test.ts` (4/4)
- `node scripts/check-changed.mjs -- ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts test/vitest/vitest.ui-e2e.sequencer.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --max-priority P2` (clean; no actionable findings)
- Production LOC: +0/-0; tests/test support: +670/-0 from the PR base.
