### PR TITLE
fix(cli): return JSON for channel capability failures

### DIFF
--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -3,6 +3,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getChannelPlugin, listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import { ExpectedCliError } from "../../cli/failure-output.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 import { channelsCapabilitiesCommand } from "./capabilities.js";
 
@@ -189,6 +190,77 @@ describe("channelsCapabilitiesCommand", () => {
 
     expect(errors).toStrictEqual([]);
     expect(logs).toStrictEqual([JSON.stringify({ channels: [] }, null, 2)]);
+  });
+
+  it.each([
+    {
+      name: "account without a channel",
+      options: { account: "ghost", json: true },
+      message: "--account requires a specific --channel. Run openclaw channels list to choose one.",
+      discoversChannels: false,
+    },
+    {
+      name: "account with all channels",
+      options: { channel: "all", account: "ghost" },
+      message: "--account requires a specific --channel. Run openclaw channels list to choose one.",
+      discoversChannels: false,
+    },
+    {
+      name: "target without a channel",
+      options: { target: "channel:1", json: true },
+      message: "--target requires a specific --channel. Run openclaw channels list to choose one.",
+      discoversChannels: false,
+    },
+    {
+      name: "target with all channels",
+      options: { channel: "all", target: "channel:1" },
+      message: "--target requires a specific --channel. Run openclaw channels list to choose one.",
+      discoversChannels: false,
+    },
+    {
+      name: "account before target when both lack a channel",
+      options: { account: "ghost", target: "channel:1" },
+      message: "--account requires a specific --channel. Run openclaw channels list to choose one.",
+      discoversChannels: false,
+    },
+    {
+      name: "unknown channel after installable plugin lookup",
+      options: { channel: "definitely-not-a-channel", json: true },
+      message:
+        'Unknown channel "definitely-not-a-channel". Run `openclaw channels list --all` to see configured and installable channels.',
+      discoversChannels: true,
+    },
+  ])("rejects $name before resolving or probing an account", async (testCase) => {
+    const plugin = buildPlugin({ id: "slack" });
+    const listAccountIds = vi.fn(() => ["default"]);
+    const resolveAccount = vi.fn(() => ({ accountId: "default" }));
+    const probeAccount = vi.fn(async () => ({ ok: true }));
+    plugin.config.listAccountIds = listAccountIds;
+    plugin.config.resolveAccount = resolveAccount;
+    plugin.status = { probeAccount };
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([plugin]);
+
+    const failure = channelsCapabilitiesCommand(testCase.options, runtime);
+
+    await expect(failure).rejects.toBeInstanceOf(ExpectedCliError);
+    await expect(failure).rejects.toMatchObject({
+      message: testCase.message,
+      humanOutput: testCase.message,
+      machineOutput: testCase.message,
+    });
+    expect(logs).toStrictEqual([]);
+    expect(errors).toStrictEqual([]);
+    expect(mocks.listReadOnlyChannelPluginsForConfig).toHaveBeenCalledTimes(
+      testCase.discoversChannels ? 1 : 0,
+    );
+    expect(mocks.resolveInstallableChannelPlugin).toHaveBeenCalledTimes(
+      testCase.discoversChannels ? 1 : 0,
+    );
+    expect(listAccountIds).not.toHaveBeenCalled();
+    expect(resolveAccount).not.toHaveBeenCalled();
+    expect(probeAccount).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(mocks.refreshPluginRegistryAfterConfigMutation).not.toHaveBeenCalled();
   });
 
   it("rejects malformed timeouts before capability probes", async () => {

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -18,6 +18,7 @@ import type {
 } from "../../channels/plugins/types.public.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { formatUnknownChannelMessage } from "../../cli/error-format.js";
+import { ExpectedCliError } from "../../cli/failure-output.js";
 import { parseTimeoutMsWithFallback } from "../../cli/parse-timeout.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -314,23 +315,10 @@ export async function channelsCapabilitiesCommand(
   const rawChannel = normalizeLowercaseStringOrEmpty(opts.channel);
   const rawTarget = normalizeOptionalString(opts.target) ?? "";
 
-  if (opts.account && (!rawChannel || rawChannel === "all")) {
-    runtime.error(
-      danger(
-        `--account requires a specific --channel. Run ${formatCliCommand("openclaw channels list")} to choose one.`,
-      ),
-    );
-    runtime.exit(1);
-    return;
-  }
-  if (rawTarget && (!rawChannel || rawChannel === "all")) {
-    runtime.error(
-      danger(
-        `--target requires a specific --channel. Run ${formatCliCommand("openclaw channels list")} to choose one.`,
-      ),
-    );
-    runtime.exit(1);
-    return;
+  if ((!rawChannel || rawChannel === "all") && (opts.account || rawTarget)) {
+    const option = opts.account ? "--account" : "--target";
+    const message = `${option} requires a specific --channel. Run ${formatCliCommand("openclaw channels list")} to choose one.`;
+    throw new ExpectedCliError({ message, humanOutput: danger(message), machineOutput: message });
   }
 
   const plugins = listReadOnlyChannelPluginsForConfig(cfg, {
@@ -371,9 +359,8 @@ export async function channelsCapabilitiesCommand(
       );
       return;
     }
-    runtime.error(danger(formatUnknownChannelMessage({ channel: rawChannel })));
-    runtime.exit(1);
-    return;
+    const message = formatUnknownChannelMessage({ channel: rawChannel });
+    throw new ExpectedCliError({ message, humanOutput: danger(message), machineOutput: message });
   }
 
   const reports: ChannelCapabilitiesReport[] = [];

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -331,6 +331,84 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it.each([
+    {
+      name: "account validation in human mode",
+      args: ["channels", "capabilities", "--account", "ghost"],
+      message: "--account requires a specific --channel. Run openclaw channels list to choose one.",
+      human: true,
+    },
+    {
+      name: "account validation with JSON before its option",
+      args: ["channels", "capabilities", "--json", "--account", "ghost"],
+      message: "--account requires a specific --channel. Run openclaw channels list to choose one.",
+    },
+    {
+      name: "target validation with JSON after its option and explicit Commander routing",
+      args: ["channels", "capabilities", "--target", "channel:1", "--json"],
+      message: "--target requires a specific --channel. Run openclaw channels list to choose one.",
+      commander: true,
+    },
+    {
+      name: "unknown channel validation with JSON before its option",
+      args: ["channels", "capabilities", "--json", "--channel", "definitely-not-a-channel"],
+      message:
+        'Unknown channel "definitely-not-a-channel". Run `openclaw channels list --all` to see configured and installable channels.',
+    },
+    {
+      name: "account validation through dual-TTY finalization",
+      args: ["channels", "capabilities", "--account", "ghost", "--json"],
+      message: "--account requires a specific --channel. Run openclaw channels list to choose one.",
+      tty: true,
+    },
+  ])(
+    "renders channels capabilities $name through the canonical failure owner",
+    async (testCase) => {
+      await withTempHome(
+        async (tempHome) => {
+          const preload = Buffer.from(
+            [
+              'import net from "node:net";',
+              'net.Socket.prototype.connect = function () { throw new Error("AUTOQA_NETWORK_FORBIDDEN"); };',
+              'globalThis.fetch = async () => { throw new Error("AUTOQA_NETWORK_FORBIDDEN"); };',
+              ...("tty" in testCase
+                ? [
+                    'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });',
+                    'Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
+                  ]
+                : []),
+            ].join("\n"),
+          ).toString("base64");
+          const result = runBuiltCli(tempHome, testCase.args, {
+            NODE_OPTIONS: `--import=data:text/javascript;base64,${preload}`,
+            OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+            OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+            OPENCLAW_GATEWAY_PORT: "29871",
+            ...("commander" in testCase ? { OPENCLAW_DISABLE_ROUTE_FIRST: "1" } : {}),
+            ...("tty" in testCase ? { FORCE_COLOR: "1" } : {}),
+          });
+
+          expect(result.status, result.stderr).toBe(1);
+          if ("human" in testCase) {
+            expect(result.stdout).toBe("");
+          } else {
+            expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
+            expect(JSON.parse(result.stdout)).toEqual({
+              ok: false,
+              error: { type: "cli_error", message: testCase.message },
+            });
+          }
+          expect(result.stderr).toContain(testCase.message);
+          expect(result.stderr).not.toContain("AUTOQA_NETWORK_FORBIDDEN");
+          if ("tty" in testCase) {
+            expect(result.stderr).toContain("\u001B[?25h");
+          }
+        },
+        { prefix: "openclaw-channels-capabilities-failure-e2e-" },
+      );
+    },
+  );
+
   it("returns one canonical document for a command that previously failed on stderr only", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw channels capabilities --json` returned exit code 1 with empty stdout for semantic validation failures: `--account` or `--target` without a specific channel, and unknown explicit channels. Automation then encountered an unrelated JSON parse error instead of the actionable channel validation message.

## Why This Change Was Made

The shared capabilities command owner now throws canonical expected CLI errors instead of writing stderr and exiting directly. Account and target validation share one guard, while unknown-channel validation remains after installed and installable plugin discovery. Human output keeps terminal styling; machine output remains plain and parseable.

Production delta: +7/-20, net -13 lines. Tests: +150 lines.

AI-assisted: yes. The owner boundary, validation precedence, plugin-discovery ordering, human and machine output split, and tests were reviewed and understood.

## User Impact

Channel-capability JSON consumers now receive one canonical `cli_error` document for these validation failures. Human diagnostics, successful capability output, timeout behavior, account resolution, probing, and channel discovery remain unchanged.

## Evidence

- Pre-fix exact-main reproduction: account, target, and unknown-channel cases exited 1 with empty stdout.
- Owner/sibling proof: 130 tests passed across capability, channel CLI, status, resolve, logs, one-shot exit, and canonical failure-renderer suites.
- Latest-head owner sanity: 15/15 passed after the final rebase.
- Built-process proof: 5/5 passed on `2e04f762ea5647dbbf2193f71af96cdf0fd7b2ea`, covering human mode, JSON flag placement, forced Commander, unknown channel, network prohibition, ANSI-free stdout, and dual-TTY finalization. The subsequent main range did not touch any changed file.
- Complete changed-file gate passed, including formatting, three typecheck lanes, lint, dead-export, plugin-boundary, and import-cycle checks.
- Exact-head CI run 32628418444 on `d2535026f7a4e408f191f70fb2e674b8bba9268b`: green.
- Fresh P1 autoreview: no accepted/actionable findings.
- ClawSweeper: no findings; its only remaining step was normal exact-head CI, now complete. Its live source-tree invocation was infeasible because the read-only checkout had no built `dist`, while the exact-head built-process CI above covers the changed path.
- `git diff --check`: passed.
