### PR TITLE
feat: add zero-config free web search fallback skill

### DIFF
--- a/src/skills/websearch.ts
+++ b/src/skills/websearch.ts
@@ -1,0 +1,61 @@
+export interface SearchResult {
+  title: string;
+  snippet: string;
+  link: string;
+}
+
+/**
+ * OpenClaw Skill: Free Web Search Fallback
+ * Built with native Node.js fetch and ESM syntax.
+ */
+export async function freeWebSearch(query: string): Promise<SearchResult[]> {
+  try {
+    const searchUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+    
+    const response = await fetch(searchUrl, {
+      method: 'GET',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const html = await response.text();
+    const results: SearchResult[] = [];
+
+    // Parse HTML snippets using regex without extra DOM parsing libraries
+    const resultBlockRegex = /<a class="result__snippet"[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = resultBlockRegex.exec(html)) !== null && results.length < 5) {
+      const link = match[1]?.trim() || '';
+      const rawSnippet = match[2] || '';
+      
+      // Clean HTML tags and entities
+      const cleanSnippet = rawSnippet
+        .replace(/<[^>]+>/g, '')
+        .replace(/&quot;/g, '"')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .trim();
+
+      if (cleanSnippet) {
+        results.push({
+          title: `Search result for: ${query}`,
+          snippet: cleanSnippet,
+          link: link,
+        });
+      }
+    }
+
+    return results;
+  } catch (error) {
+    console.error('[OpenClaw Skill Error] Free Web Search failed:', error);
+    return [];
+  }
+}


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
