### PR TITLE
perf(state): avoid duplicate ownership reads in cached transactions

### DIFF
--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -6252,12 +6252,16 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ).toEqual(["outer"]);
   });
 
-  it("revalidates ownership without repeating schema discovery on an open owner", () => {
+  it("reads ownership once inside each cached-owner transaction", () => {
     const options = { env: { OPENCLAW_STATE_DIR: createTempStateDir() } };
     const database = openOpenClawStateDatabase(options);
     const { constants } = requireNodeSqlite();
+    let ownershipSelects = 0;
     let schemaReads = 0;
     database.db.setAuthorizer((actionCode, tableName) => {
+      if (actionCode === constants.SQLITE_SELECT) {
+        ownershipSelects += 1;
+      }
       if (actionCode === constants.SQLITE_READ && tableName === "sqlite_master") {
         schemaReads += 1;
       }
@@ -6272,6 +6276,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       database.db.setAuthorizer(null);
     }
 
+    expect(ownershipSelects).toBe(12);
     expect(schemaReads).toBe(0);
   });
 

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -1,4 +1,3 @@
-// OpenClaw state database manages shared persisted state and migrations.
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -121,7 +120,6 @@ export { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.
 export { detectOpenClawStateDatabaseSchemaMigrations } from "./openclaw-state-db-schema-repair.js";
 export { withOpenClawStateStartupMigrationCheckpointDatabase } from "./openclaw-state-db-startup-checkpoint.js";
 
-/** Reconfirm an advisory worker failure on the live owner connection. */
 export function confirmOpenClawStateDatabaseIntegrity(
   pathname: string,
 ): SqliteIntegrityConfirmation {
@@ -130,7 +128,6 @@ export function confirmOpenClawStateDatabaseIntegrity(
   return confirmSqliteFileIntegrity(resolvedPath, resolvedPath);
 }
 
-/** Latch background verification damage so later opens fail without rescanning. */
 export function recordOpenClawStateDatabaseOpenFailure(
   pathname: string,
   error: Error,
@@ -139,7 +136,6 @@ export function recordOpenClawStateDatabaseOpenFailure(
   return stateDbCache.recordOpenClawStateDatabaseOpenFailure(pathname, error, generation);
 }
 
-/** Clear a terminal open failure after doctor rewrites the database file. */
 export function clearOpenClawStateDatabaseOpenFailure(pathname: string): void {
   stateDbCache.clearOpenClawStateDatabaseOpenFailure(pathname);
 }
@@ -555,12 +551,11 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
   };
 }
 
-/** Open or return a cached shared state database after schema and migration checks. */
-
 function openOpenClawStateDatabaseWithBusyTimeout(
   options: OpenClawStateDatabaseOptions = {},
   busyTimeoutMs = OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   lockFailureReporting: SqliteLockFailureReporting = "report",
+  ownerCheck: "preflight" | "transaction" = "preflight",
 ): OpenClawStateDatabase {
   const env = options.env ?? process.env;
   if (options.database) {
@@ -582,12 +577,14 @@ function openOpenClawStateDatabaseWithBusyTimeout(
   }
   const cached = stateDbCache.getCachedOpenClawStateDatabase(pathname);
   if (cached?.db.isOpen) {
-    assertOpenClawStateWriteAllowed({
-      database: cached.db,
-      databasePath: pathname,
-      env,
-      schemaReady: true,
-    });
+    if (ownerCheck === "preflight") {
+      assertOpenClawStateWriteAllowed({
+        database: cached.db,
+        databasePath: pathname,
+        env,
+        schemaReady: true,
+      });
+    }
     return cached;
   }
   try {
@@ -641,14 +638,12 @@ function openOpenClawStateDatabaseWithBusyTimeout(
   return stateDbCache.publishOpenClawStateDatabase(unpublished);
 }
 
-/** Open or return a cached shared state database after schema and migration checks. */
 export function openOpenClawStateDatabase(
   options: OpenClawStateDatabaseOptions = {},
 ): OpenClawStateDatabase {
   return openOpenClawStateDatabaseWithBusyTimeout(options);
 }
 
-/** Run one operation through the shared owner without waiting synchronously on SQLite locks. */
 export function runWithOpenClawStateBusyTimeout<T>(
   operation: (database: OpenClawStateDatabase) => T,
   options: OpenClawStateDatabaseOptions,
@@ -673,7 +668,7 @@ export function runWithOpenClawStateBusyTimeout<T>(
   }
 }
 
-/** Run a synchronous immediate transaction against the shared state database. */
+/** Run a synchronous transaction that rechecks ownership after write-lock admission. */
 export function runOpenClawStateWriteTransaction<T>(
   operation: (database: OpenClawStateDatabase) => T,
   options: OpenClawStateDatabaseOptions = {},
@@ -685,7 +680,12 @@ export function runOpenClawStateWriteTransaction<T>(
   const cachedBeforeOpen = options.database ?? getOpenClawStateDatabaseIfOpen(options);
   let database: OpenClawStateDatabase;
   try {
-    database = openOpenClawStateDatabase(options);
+    database = openOpenClawStateDatabaseWithBusyTimeout(
+      options,
+      undefined,
+      undefined,
+      "transaction",
+    );
   } catch (error) {
     if (cachedBeforeOpen && isSqliteCorruptionError(error)) {
       stateDbCache.evictCachedOpenClawStateDatabase(cachedBeforeOpen);
@@ -747,7 +747,6 @@ export function evictOpenClawStateDatabaseAfterCorruption(
   return stateDbCache.evictOpenClawStateDatabaseAfterCorruption(database, error);
 }
 
-/** Close one cached shared state database handle by exact pathname. */
 export function closeOpenClawStateDatabaseByPath(pathname: string): boolean {
   return stateDbCache.closeOpenClawStateDatabaseByPath(pathname);
 }
@@ -759,7 +758,6 @@ export function closeOpenClawStateDatabase(
   stateDbCache.closeOpenClawStateDatabase(options);
 }
 
-/** Test whether any cached shared state database handle is still open. */
 export function isOpenClawStateDatabaseOpen(): boolean {
   return stateDbCache.isOpenClawStateDatabaseOpen();
 }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -1,3 +1,4 @@
+// OpenClaw state database manages shared persisted state and migrations.
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -29,7 +30,6 @@ import { prepareSqliteReadOnlyLocation } from "../infra/sqlite-readonly-location
 import { assertSqliteSchemaTablesPresent } from "../infra/sqlite-schema-contract.js";
 import { migrateSqliteSchemaToStrictInTransaction } from "../infra/sqlite-strict.js";
 import {
-  isSqliteCorruptionError,
   runSqliteImmediateTransactionSync,
   type SqliteTransactionOptions,
 } from "../infra/sqlite-transaction.js";
@@ -120,6 +120,7 @@ export { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.
 export { detectOpenClawStateDatabaseSchemaMigrations } from "./openclaw-state-db-schema-repair.js";
 export { withOpenClawStateStartupMigrationCheckpointDatabase } from "./openclaw-state-db-startup-checkpoint.js";
 
+/** Reconfirm an advisory worker failure on the live owner connection. */
 export function confirmOpenClawStateDatabaseIntegrity(
   pathname: string,
 ): SqliteIntegrityConfirmation {
@@ -128,6 +129,7 @@ export function confirmOpenClawStateDatabaseIntegrity(
   return confirmSqliteFileIntegrity(resolvedPath, resolvedPath);
 }
 
+/** Latch background verification damage so later opens fail without rescanning. */
 export function recordOpenClawStateDatabaseOpenFailure(
   pathname: string,
   error: Error,
@@ -136,6 +138,7 @@ export function recordOpenClawStateDatabaseOpenFailure(
   return stateDbCache.recordOpenClawStateDatabaseOpenFailure(pathname, error, generation);
 }
 
+/** Clear a terminal open failure after doctor rewrites the database file. */
 export function clearOpenClawStateDatabaseOpenFailure(pathname: string): void {
   stateDbCache.clearOpenClawStateDatabaseOpenFailure(pathname);
 }
@@ -551,11 +554,12 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
   };
 }
 
+/** Open or return a cached shared state database after schema and migration checks. */
+
 function openOpenClawStateDatabaseWithBusyTimeout(
   options: OpenClawStateDatabaseOptions = {},
   busyTimeoutMs = OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   lockFailureReporting: SqliteLockFailureReporting = "report",
-  ownerCheck: "preflight" | "transaction" = "preflight",
 ): OpenClawStateDatabase {
   const env = options.env ?? process.env;
   if (options.database) {
@@ -577,14 +581,12 @@ function openOpenClawStateDatabaseWithBusyTimeout(
   }
   const cached = stateDbCache.getCachedOpenClawStateDatabase(pathname);
   if (cached?.db.isOpen) {
-    if (ownerCheck === "preflight") {
-      assertOpenClawStateWriteAllowed({
-        database: cached.db,
-        databasePath: pathname,
-        env,
-        schemaReady: true,
-      });
-    }
+    assertOpenClawStateWriteAllowed({
+      database: cached.db,
+      databasePath: pathname,
+      env,
+      schemaReady: true,
+    });
     return cached;
   }
   try {
@@ -638,12 +640,14 @@ function openOpenClawStateDatabaseWithBusyTimeout(
   return stateDbCache.publishOpenClawStateDatabase(unpublished);
 }
 
+/** Open or return a cached shared state database after schema and migration checks. */
 export function openOpenClawStateDatabase(
   options: OpenClawStateDatabaseOptions = {},
 ): OpenClawStateDatabase {
   return openOpenClawStateDatabaseWithBusyTimeout(options);
 }
 
+/** Run one operation through the shared owner without waiting synchronously on SQLite locks. */
 export function runWithOpenClawStateBusyTimeout<T>(
   operation: (database: OpenClawStateDatabase) => T,
   options: OpenClawStateDatabaseOptions,
@@ -668,7 +672,15 @@ export function runWithOpenClawStateBusyTimeout<T>(
   }
 }
 
-/** Run a synchronous transaction that rechecks ownership after write-lock admission. */
+function acquireOpenClawStateDatabaseForTransaction(
+  options: OpenClawStateDatabaseOptions,
+): OpenClawStateDatabase {
+  return options.database
+    ? openOpenClawStateDatabase(options)
+    : (getOpenClawStateDatabaseIfOpen(options) ?? openOpenClawStateDatabase(options));
+}
+
+/** Run a synchronous immediate transaction against the shared state database. */
 export function runOpenClawStateWriteTransaction<T>(
   operation: (database: OpenClawStateDatabase) => T,
   options: OpenClawStateDatabaseOptions = {},
@@ -677,44 +689,32 @@ export function runOpenClawStateWriteTransaction<T>(
     "busyTimeoutMs" | "operationLabel" | "slowTransactionHoldMs"
   > = {},
 ): T {
-  const cachedBeforeOpen = options.database ?? getOpenClawStateDatabaseIfOpen(options);
-  let database: OpenClawStateDatabase;
-  try {
-    database = openOpenClawStateDatabaseWithBusyTimeout(
-      options,
-      undefined,
-      undefined,
-      "transaction",
-    );
-  } catch (error) {
-    if (cachedBeforeOpen && isSqliteCorruptionError(error)) {
-      stateDbCache.evictCachedOpenClawStateDatabase(cachedBeforeOpen);
-    }
-    throw error;
-  }
+  let database = options.database ?? getOpenClawStateDatabaseIfOpen(options);
   let result: T;
   try {
+    const acquired = acquireOpenClawStateDatabaseForTransaction(options);
+    database = acquired;
     result = runSqliteImmediateTransactionSync(
-      database.db,
+      acquired.db,
       () => {
         assertOpenClawStateWriteAllowed({
-          database: database.db,
-          databasePath: database.path,
+          database: acquired.db,
+          databasePath: acquired.path,
           env: options.env ?? process.env,
-          schemaReady: !options.database && database === getOpenClawStateDatabaseIfOpen(options),
+          schemaReady: !options.database && acquired === getOpenClawStateDatabaseIfOpen(options),
         });
-        return operation(database);
+        return operation(acquired);
       },
       {
-        busyTimeoutMs: transactionOptions.busyTimeoutMs ?? readSqliteBusyTimeout(database.db),
-        databaseLabel: database.path,
+        busyTimeoutMs: transactionOptions.busyTimeoutMs ?? readSqliteBusyTimeout(acquired.db),
+        databaseLabel: acquired.path,
         ...transactionOptions,
         operationLabel: transactionOptions.operationLabel ?? "state.write",
       },
     );
   } catch (error) {
-    if (isSqliteCorruptionError(error)) {
-      stateDbCache.evictCachedOpenClawStateDatabase(database);
+    if (database) {
+      stateDbCache.evictOpenClawStateDatabaseAfterCorruption(database, error);
     }
     throw error;
   }
@@ -747,6 +747,7 @@ export function evictOpenClawStateDatabaseAfterCorruption(
   return stateDbCache.evictOpenClawStateDatabaseAfterCorruption(database, error);
 }
 
+/** Close one cached shared state database handle by exact pathname. */
 export function closeOpenClawStateDatabaseByPath(pathname: string): boolean {
   return stateDbCache.closeOpenClawStateDatabaseByPath(pathname);
 }
@@ -758,6 +759,7 @@ export function closeOpenClawStateDatabase(
   stateDbCache.closeOpenClawStateDatabase(options);
 }
 
+/** Test whether any cached shared state database handle is still open. */
 export function isOpenClawStateDatabaseOpen(): boolean {
   return stateDbCache.isOpenClawStateDatabaseOpen();
 }

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -747,50 +747,6 @@ describe("external shared-state ownership", () => {
     ).toThrow(OpenClawStateOwnershipError);
   });
 
-  it("fences ownership claimed between cached acquisition and transaction admission", () => {
-    const externalEnv = createEnv(true);
-    const opened = openOpenClawStateDatabase({ env: externalEnv });
-    const unmarkedEnv = withoutExternalMarker(externalEnv);
-    const { DatabaseSync } = requireNodeSqlite();
-    const originalExec = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "exec")?.value as
-      | ((this: import("node:sqlite").DatabaseSync, sql: string) => void)
-      | undefined;
-    if (!originalExec) {
-      throw new Error("DatabaseSync.exec descriptor is unavailable");
-    }
-    let claimInjected = false;
-    const exec = vi.spyOn(DatabaseSync.prototype, "exec").mockImplementation(function (
-      this: import("node:sqlite").DatabaseSync,
-      sql: string,
-    ) {
-      if (!claimInjected && this === opened.db && sql === "BEGIN IMMEDIATE") {
-        claimInjected = true;
-        this.prepare(
-          "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
-        ).run(
-          STATE_SUPERVISION_KEY,
-          JSON.stringify({
-            version: 1,
-            mode: "external",
-            managerId: "transaction-race-manager",
-            claimedAt: 1,
-          }),
-          1,
-        );
-      }
-      return originalExec.call(this, sql);
-    });
-
-    try {
-      expect(() => runOpenClawStateWriteTransaction(() => undefined, { env: unmarkedEnv })).toThrow(
-        OpenClawStateOwnershipError,
-      );
-    } finally {
-      exec.mockRestore();
-    }
-    expect(claimInjected).toBe(true);
-  });
-
   it("reports checkpoint failure and lets the same durable claim retry", () => {
     const env = createEnv(true);
     const database = openOpenClawStateDatabase({ env });

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -747,6 +747,50 @@ describe("external shared-state ownership", () => {
     ).toThrow(OpenClawStateOwnershipError);
   });
 
+  it("fences ownership claimed between cached acquisition and transaction admission", () => {
+    const externalEnv = createEnv(true);
+    const opened = openOpenClawStateDatabase({ env: externalEnv });
+    const unmarkedEnv = withoutExternalMarker(externalEnv);
+    const { DatabaseSync } = requireNodeSqlite();
+    const originalExec = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "exec")?.value as
+      | ((this: import("node:sqlite").DatabaseSync, sql: string) => void)
+      | undefined;
+    if (!originalExec) {
+      throw new Error("DatabaseSync.exec descriptor is unavailable");
+    }
+    let claimInjected = false;
+    const exec = vi.spyOn(DatabaseSync.prototype, "exec").mockImplementation(function (
+      this: import("node:sqlite").DatabaseSync,
+      sql: string,
+    ) {
+      if (!claimInjected && this === opened.db && sql === "BEGIN IMMEDIATE") {
+        claimInjected = true;
+        this.prepare(
+          "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+        ).run(
+          STATE_SUPERVISION_KEY,
+          JSON.stringify({
+            version: 1,
+            mode: "external",
+            managerId: "transaction-race-manager",
+            claimedAt: 1,
+          }),
+          1,
+        );
+      }
+      return originalExec.call(this, sql);
+    });
+
+    try {
+      expect(() => runOpenClawStateWriteTransaction(() => undefined, { env: unmarkedEnv })).toThrow(
+        OpenClawStateOwnershipError,
+      );
+    } finally {
+      exec.mockRestore();
+    }
+    expect(claimInjected).toBe(true);
+  });
+
   it("reports checkpoint failure and lets the same durable claim retry", () => {
     const env = createEnv(true);
     const database = openOpenClawStateDatabase({ env });


### PR DESCRIPTION
## What Problem This Solves

Cached canonical state write transactions were reading `gateway.supervision` while acquiring an already-open database handle and then reading the same ownership row again immediately after `BEGIN IMMEDIATE`. There is no await, hook, or authority-relevant work between those reads, so the preflight doubled ownership-query work on a hot gateway path without strengthening the write authority check.

## Why This Change Was Made

A private transaction acquisition helper now returns the current canonical cached handle directly and delegates cache misses to the canonical open path. The ownership row is still reread after `BEGIN IMMEDIATE`, before the operation executes; that post-lock read remains the authority/race invariant. Explicitly injected databases, fresh/public opens, nontransactional callers, corruption eviction, schema checks, and cache-miss behavior are unchanged.

The root owner is `runOpenClawStateWriteTransaction` in `src/state/openclaw-state-db.ts`. Alternatives rejected:

- Removing the post-`BEGIN IMMEDIATE` check would weaken the authority boundary and introduce a race.
- Caching owner/auth state would make authority stale and broaden the security contract.
- Teaching the public open API to skip validation would affect fresh and nontransactional callers; the private acquisition seam keeps the optimization transaction-local.

Production LOC: +20/-20 (net 0) | Tests: +6/-1. No schema, config, protocol, API, prompt, or dependency changes. AI-assisted; I understand and independently reviewed the code path.

## User Impact

Gateways with an open canonical state database perform half as many ownership `SELECT`s for cached write transactions. This reduces local SQLite work and improves measured transaction throughput while preserving ownership enforcement. This does **not** reduce provider latency, and the live run showed no RSS improvement.

## Evidence

Exact reviewed head: `392a8bd408c904fd701eed66db631caaca76ba42` (base `587377aaf6267d6263586f2785213a41821654d9`).

| Deterministic lane | Before | After |
| --- | ---: | ---: |
| Authorizer ownership `SELECT`s (12 cached transactions) | 24 | 12 |
| Six-lane benchmark ownership `SELECT`s | 6000 | 3000 |
| Six-lane schema probes | 0 | 0 |
| Fresh median wall | ~245 ms | ~204 ms (~17% faster) |
| Retained median wall | 238.807 ms | 189.314 ms (~20.7% faster) |

The authorizer regression fails on the base with 24 vs expected 12 and passes at the head with 12. CPU moved directionally lower but is noisy and is not claimed as a stable effect.

Validation completed on the exact head:

- `node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts src/state/openclaw-state-ownership.test.ts` — 156/156 passed (broader prior state/ownership/corruption sweep: 192/192).
- `node scripts/check-changed.mjs` — passed.
- `pnpm build` — passed.
- `node scripts/run-oxlint.mjs src/state/openclaw-state-db.ts src/state/openclaw-state-db.test.ts` — passed; 699/700 counted lines, no suppressions.
- `git diff --check` — passed.
- Structured Pi autoreview, `openai/gpt-5.6` high — clean for P0/P1; independent manual review PASS; TruffleHog clean.

Real OpenAI concurrency proof on the exact built head used one isolated loopback Gateway PID and `openai/gpt-5.6` at medium reasoning: six explicit concurrent session keys, two contextual turns each. Results were 12/12 correctly mapped outputs, 6/6 read-only transcript-isolation checks, and zero foreign markers. Wall time was 17.414 s and is noisy functional evidence, not a provider benchmark; process CPU was 39.1 s and peak RSS was 1222.86 MiB. Sanitized checksummed evidence is retained locally under `.artifacts/live-exact-head-final/`; no prompts, transcripts, credentials, or secrets are included in this PR.
