### PR TITLE
fix(cli): reject ClawHub-only flags for source skills

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -812,6 +812,19 @@ describe("skills cli commands", () => {
     expect(installSkillFromSourceMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { spec: "git:owner/tools", flag: "--force-install" },
+    { spec: "./local-skill", flag: "--force-install" },
+    { spec: "git:owner/tools", flag: "--acknowledge-clawhub-risk" },
+    { spec: "./local-skill", flag: "--acknowledge-clawhub-risk" },
+  ])("rejects ClawHub-only $flag for source install $spec", async ({ spec, flag }) => {
+    await expect(runCommand(["skills", "install", spec, flag])).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors).toContain(`${flag} is only supported for ClawHub skill installs.`);
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
+  });
+
   it("installs a skill into the cwd-inferred agent workspace", async () => {
     routeWorkspaceByAgent();
     resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -686,8 +686,16 @@ export function registerSkillsCli(program: Command) {
             return;
           }
           if (isSkillSourceInstallSpec(slug)) {
-            if (opts.version) {
-              defaultRuntime.error("--version is only supported for ClawHub skill installs.");
+            const clawHubOnlyOption = [
+              opts.version && "--version",
+              opts.forceInstall && "--force-install",
+              (opts.acknowledgeClawhubRisk === true || opts.acknowledgeClawHubRisk === true) &&
+                "--acknowledge-clawhub-risk",
+            ].find(Boolean);
+            if (clawHubOnlyOption) {
+              defaultRuntime.error(
+                `${clawHubOnlyOption} is only supported for ClawHub skill installs.`,
+              );
               defaultRuntime.exit(1);
               return;
             }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing a skill from Git or a local directory could pass `--force-install` or `--acknowledge-clawhub-risk`, see the install proceed, and reasonably assume those ClawHub scan/trust controls had taken effect even though the source installer ignored them.

## Why This Change Was Made

The mixed-source `skills install` command now classifies all three ClawHub-only options at the existing source-dispatch boundary and rejects them before either installer runs. This extends the command's existing `--version` guard rather than adding a second parser path; ClawHub forwarding and source-owned `--acknowledge-install-policy-warning` behavior remain unchanged.

Production LOC: +10/-2 (net +8) | Tests: +13/-0. The production growth is the explicit parser/trust-boundary capability: identify each ClawHub-only option, preserve Commander casing compatibility for the acknowledgement flag, and return the exact rejected flag before mutation dispatch.

**Best-fix verdict:** This is the bounded owner-layer fix. Rejecting the flags in the source installer would be too late and would couple that lifecycle to CLI-only options; removing the shared options from the parser would also remove them from valid ClawHub installs.

**Provenance:** The mixed Git/local and ClawHub command was introduced in #84793, authored and self-merged by @Patrick-Erichsen on 2026-05-21. `--force-install` was later added in #90478, authored and self-merged by @Patrick-Erichsen on 2026-06-05, without extending the source-option rejection. `--acknowledge-clawhub-risk` was added in #81364, authored and self-merged by @jesse-merhi on 2026-06-26, with the same omission. No automation merger or automerge trigger was involved in those three landings.

## User Impact

Git/local skill installs now fail fast with `<flag> is only supported for ClawHub skill installs.` when either ClawHub-only trust flag is supplied. Operators no longer receive a successful install after requesting a scan/risk control that did nothing. This intentionally rejects previously accepted-but-ineffective invocations so the command matches its documented trust boundary.

## Evidence

- **Pre-fix regression proof:** the new table failed for all four Git/local × flag cases while the existing suite remained green: `90 passed, 4 failed`.
- **Focused owner suites:** `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts src/cli/skills-cli.test.ts` → `123/123 passed`.
- **Changed-file gate:** `node scripts/check-changed.mjs -- src/cli/skills-cli.ts src/cli/skills-cli.commands.test.ts` passed production/test typechecks, lint, formatting, dead-code, import-cycle, database-first, and repository guards.
- **Build:** `pnpm build` passed on the final source.
- **Real CLI:** the source runner rejected a local install with `--force-install` at exit 1; the built CLI rejected a local install with `--acknowledge-clawhub-risk` at exit 1. Both emitted the expected flag-specific diagnostic, and neither published a skill under the isolated temporary workspace.
- **Commander contract:** pinned Commander 15.0.0 implements `Option.attributeName()` with kebab-to-camel conversion in `node_modules/commander/lib/option.js`; a direct parser probe produced `{"acknowledgeClawhubRisk":true,"forceInstall":true}` and reported the exact option keys `acknowledgeClawhubRisk` / `forceInstall`.
- **Independent review:** final branch autoreview completed cleanly at 0.99 confidence with no accepted/actionable findings. ClawSweeper independently reported no findings and passed a real CLI rejection run on the exact head.
- **Exact-head CI:** [run 32629618354](https://github.com/openclaw/openclaw/actions/runs/32629618354) completed green at `4bb438cc134b1645ed0a1046b2eb6c45206a3c60`, including `openclaw/ci-gate` and all selected core shards.
- `git diff --check` passed.

AI-assisted: yes. I understand and reviewed the command dispatch, installer boundaries, regression coverage, dependency option-key contract, and validation above. No agent transcript is attached.
