### PR TITLE
fix(ui): keep mount recovery working when the service worker is broken

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -355,6 +355,22 @@
           scheduleRecovery();
         }
 
+        function unregisterServiceWorkers() {
+          if (!navigator.serviceWorker?.getRegistrations) return;
+          // Recovery must not depend on a possibly broken worker. Navigations bypass it,
+          // so a reload can self-heal after the registrations are removed.
+          void navigator.serviceWorker
+            .getRegistrations()
+            .then(function (registrations) {
+              return Promise.all(
+                registrations.map(function (registration) {
+                  return registration.unregister();
+                }),
+              );
+            })
+            .catch(function () {});
+        }
+
         function retryCurrentDocument() {
           if (
             appStarted ||
@@ -388,6 +404,7 @@
               if (!appStarted) window.location.replace(documentUrl.href);
             })
             .catch(function () {
+              unregisterServiceWorkers();
               finishRecoveryAttempt();
             })
             .finally(function () {
@@ -429,6 +446,7 @@
 
         if (retry) {
           retry.addEventListener("click", function () {
+            unregisterServiceWorkers();
             window.location.reload();
           });
         }

--- a/ui/src/app/mount-fallback.test.ts
+++ b/ui/src/app/mount-fallback.test.ts
@@ -216,13 +216,21 @@ describe("Control UI mount fallback", () => {
   it("bounds automatic recovery attempts while the gateway is unavailable", async () => {
     const frameWindow = createIsolatedWindow();
     const fetch = vi.fn().mockRejectedValue(new Error("gateway unavailable"));
+    const unregister = vi.fn().mockResolvedValue(true);
+    const getRegistrations = vi.fn().mockResolvedValue([{ unregister }]);
     Object.defineProperty(frameWindow, "fetch", { configurable: true, value: fetch });
+    Object.defineProperty(frameWindow.navigator, "serviceWorker", {
+      configurable: true,
+      value: { getRegistrations },
+    });
     installFallbackShell(frameWindow, await readIndexHtmlWithDelay(1));
 
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(6));
+    await vi.waitFor(() => expect(unregister).toHaveBeenCalled());
     await waitForWindowTimeout(frameWindow, 10);
 
     expect(fetch).toHaveBeenCalledTimes(6);
+    expect(getRegistrations).toHaveBeenCalled();
     expect(
       requireElementById(
         frameWindow,

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -29,7 +29,11 @@ if (isProd && "serviceWorker" in navigator) {
       window.location.reload();
     }
   });
-  void navigator.serviceWorker.register(swUrl, { updateViaCache: "none" });
+  void navigator.serviceWorker
+    .register(swUrl, { updateViaCache: "none" })
+    .catch((error: unknown) => {
+      console.warn("OpenClaw service worker registration failed.", error);
+    });
 } else if (!isProd && "serviceWorker" in navigator) {
   // Unregister any leftover dev SW to avoid stale cache issues.
   void navigator.serviceWorker.getRegistrations().then((registrations) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users loading the Control UI with a broken, stale, evicted, or browser-blocked service worker could see an unhandled registration rejection and become permanently stuck on the mount fallback. The fallback's subresource probe was intercepted by the broken worker, exhausted all retries, and incorrectly reported that the gateway was unavailable even though direct document and API requests still worked.

## Why This Change Was Made

Service-worker registration failures are now handled with one concise warning and no retry loop. Mount recovery best-effort unregisters service workers after a failed probe and before a manual retry, without awaiting cleanup or changing retry pacing, so the next worker-free navigation can load the app bundle and register a fresh worker.

AI-assisted: yes. The resulting code and proof were reviewed with the repository autoreview workflow.

## User Impact

The Control UI can self-heal instead of leaving the origin bricked when the service worker is the failed layer. Registration restrictions no longer produce an unhandled promise rejection on every page load.

## Evidence

- Live before-fix observation on `127.0.0.1:19789`: every service-worker-mediated fetch failed while `/` and `/api/*` worked; mount recovery exhausted six attempts and misreported "gateway unavailable". Manually unregistering the worker and reloading immediately healed the page.
- Pre-fix regression proof: `ui/src/app/mount-fallback.test.ts` failed because the rejected recovery probe never called `unregister()`.
- Focused test after the fix and after rebasing: `node scripts/run-vitest.mjs ui/src/app/mount-fallback.test.ts` — 1 file passed, 9 tests passed.
- Changed gate used the trusted-source local fallback: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — exit 0 for `coreTests, ui`, including formatting, Control UI i18n verification, core-test/UI typechecks, core lint, and UI style lint.
- Local fallback reason: Blacksmith Testbox targeted and full sync timed out, followed by Blacksmith API TLS handshake failures; affected lease `tbx_01m0pvkh7bfjazy570nn0dd4fd`. The lease was subsequently stopped successfully.
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings on the committed branch diff.
- No screenshot was captured: the behavior is a service-worker failure/recovery path rather than a visual layout change; the live observation and boundary regression above cover the operator-visible failure and recovery.
