### PR TITLE
perf(status): batch text report output

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -381,7 +381,5 @@ export async function statusCommand(
       updateRestartValue,
     }),
   );
-  for (const line of lines) {
-    runtime.log(line);
-  }
+  runtime.log(lines.join("\n"));
 }


### PR DESCRIPTION
## What Problem This Solves

Plain-text `openclaw status` assembled its complete ordered report, then sent each line through a separate runtime logging boundary. A representative report crossed console/progress-cleanup and write handling 45 times despite already being fully materialized.

## Why This Change Was Made

Emit the owner-built report once by joining its existing lines with newlines. Pre-report config, secret, verbose, and failure diagnostics remain in their original positions; JSON and `status --all` are unchanged.

## User Impact

Operators receive the same status report bytes and line order with less final-output overhead. There is no config, protocol, persistence, privacy, or security behavior change.

## Evidence

- Exact current-main parent: `bfad1bf454138d57b51106376b5d7cffd9b948f0`.
- Deterministic owner proof: 45 report entries and 947 bytes; final emission changes from 45 writes to one. Baseline and candidate streams are byte-identical, retain the final newline, and share SHA-256 `2bbb1dab7923484bf8cf3507a89e21d5807d3c4602905a0d75e8cdfe8268ecc5`.
- Fresh Node 24 owner microbenchmark, 20,000 reports × 7 alternating samples: 509.682 ms median linewise versus 11.022 ms batched, 46.24× / 97.84% lower for final dispatch only (not an end-to-end status-runtime claim).
- The same six status owner/sibling files passed before and after the repair: 6 files / 29 tests.
- `node scripts/check-changed.mjs -- src/commands/status.command.ts`: passed all core/core-test typechecks, lint, format, dead-code, import-cycle, and repository guards.
- `pnpm build`: passed all build phases and the Control UI startup budget.
- `git diff --check`: passed.
- Diff-scoped deslop found no cleanup issue. No call-count unit test was retained because it would couple tests to this implementation detail; existing behavior tests plus exact byte-stream proof cover the public contract.
- Exact-head Codex Sol/high autoreview passed with no actionable findings and rated the patch correct at 0.96.
