### PR TITLE
fix(acp): preserve configured thinking across session reuse

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -379,10 +379,16 @@ policy. Thinking uses the agent's `thinkingDefault`, then per-model
 harness keeps its own defaults.
 
 Changing a configured model or thinking value updates the existing session
-before its next turn without replacing the conversation. Removing a default
+before its next turn without replacing the conversation. Each option is saved
+only after the harness accepts it; a rejected option returns an error and keeps
+that option's previous selection. Model and thinking changes are independent,
+not an atomic batch. Removing a default
 uses any remaining configured policy; if none remains, OpenClaw retains the
 session's last selection. Omission is not a backend reset. To change thinking
 explicitly, use `/acp set thinking <level>` with a level supported by the harness.
+For Codex ACP, `off` only omits a fresh session's startup override. Switching an
+existing session to `off` is unsupported and returns an error without clearing
+its current reasoning effort or conversation.
 
 ### Example
 

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -372,6 +372,18 @@ Use `agents.entries.*.runtime` to define ACP defaults once per agent:
 2. `agents.entries.*.runtime.acp.*`
 3. Global ACP defaults (e.g. `acp.backend`)
 
+Configured bindings also forward the owning agent's explicit model and thinking
+policy. Thinking uses the agent's `thinkingDefault`, then per-model
+`agents.defaults.models["provider/model"].params.thinking`, then
+`agents.defaults.thinkingDefault`. Without configured policy, the external
+harness keeps its own defaults.
+
+Changing a configured model or thinking value updates the existing session
+before its next turn without replacing the conversation. Removing a default
+uses any remaining configured policy; if none remains, OpenClaw retains the
+session's last selection. Omission is not a backend reset. To change thinking
+explicitly, use `/acp set thinking <level>` with a level supported by the harness.
+
 ### Example
 
 ```json5
@@ -575,7 +587,7 @@ config-the-default error).
   Explicit thinking/reasoning effort. For Codex ACP, `minimal` maps to low
   effort, `low`/`medium`/`high`/`xhigh` map directly, and `off` omits the
   reasoning-effort startup override. When omitted, ACP spawns use existing
-  subagent thinking defaults and per-model
+  subagent thinking defaults, the configured target agent's `thinkingDefault`, and per-model
   `agents.defaults.models["provider/model"].params.thinking` for the selected
   model.
 </ParamField>

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1744,7 +1744,14 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       key: "thinking",
       value: "superhigh",
     },
-  ])("$name", async ({ key, value, expected }) => {
+    ...["thinking", "thought_level", "reasoning_effort"].map((key) => ({
+      name: `rejects unsupported live Codex ACP ${key}=off`,
+      key,
+      value: "off",
+      expected: undefined,
+      errorCode: "ACP_BACKEND_UNSUPPORTED_CONTROL",
+    })),
+  ])("$name", async ({ key, value, expected, errorCode }) => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:codex:acp:test",
@@ -1767,7 +1774,9 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       value,
     });
     if (!expected) {
-      await expect(update).rejects.toMatchObject({ code: "ACP_INVALID_RUNTIME_OPTION" });
+      await expect(update).rejects.toMatchObject({
+        code: errorCode ?? "ACP_INVALID_RUNTIME_OPTION",
+      });
       expect(setConfigOption).not.toHaveBeenCalled();
       return;
     }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1751,7 +1751,8 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       expected: undefined,
       errorCode: "ACP_BACKEND_UNSUPPORTED_CONTROL",
     })),
-  ])("$name", async ({ key, value, expected, errorCode }) => {
+  ])("$name", async (testCase) => {
+    const { key, value, expected } = testCase;
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({
         acpxRecordId: "agent:codex:acp:test",
@@ -1775,7 +1776,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
     if (!expected) {
       await expect(update).rejects.toMatchObject({
-        code: errorCode ?? "ACP_INVALID_RUNTIME_OPTION",
+        code: "errorCode" in testCase ? testCase.errorCode : "ACP_INVALID_RUNTIME_OPTION",
       });
       expect(setConfigOption).not.toHaveBeenCalled();
       return;

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1809,7 +1809,11 @@ export class AcpxRuntime implements CompleteAcpRuntime {
         const reasoningEffort =
           classification.kind === "override" ? classification.override.reasoningEffort : undefined;
         if (!reasoningEffort) {
-          return;
+          // `off` omits the startup override; Codex has no live control to unset effort.
+          throw new AcpRuntimeError(
+            "ACP_BACKEND_UNSUPPORTED_CONTROL",
+            "Clearing Codex reasoning effort on an existing session is unsupported. Choose a supported explicit effort; the current effort is unchanged.",
+          );
         }
         await delegate.setConfigOption({
           ...input,

--- a/src/acp/control-plane/manager.configured-bindings.test.ts
+++ b/src/acp/control-plane/manager.configured-bindings.test.ts
@@ -1,0 +1,97 @@
+/** Tests configured binding controls against the real ACP manager lifecycle. */
+import { describe, expect, it, vi } from "vitest";
+import { buildConfiguredAcpSessionKey } from "../persistent-bindings.types.js";
+import {
+  AcpRuntimeError,
+  AcpSessionManager,
+  baseCfg,
+  createRuntime,
+  hoisted,
+  installAcpSessionManagerTestLifecycle,
+  type SessionAcpMeta,
+} from "./manager.test-helpers.js";
+
+describe("AcpSessionManager configured bindings", () => {
+  installAcpSessionManagerTestLifecycle();
+
+  it("keeps startup omission but rejects live binding changes before overwriting accepted thinking", async () => {
+    const managerModule = await import("./manager.js");
+    const { ensureConfiguredAcpBindingSession } =
+      await import("../persistent-bindings.lifecycle.js");
+    const runtimeState = createRuntime();
+    runtimeState.setConfigOption.mockImplementation(async ({ value }) => {
+      if (value === "off") {
+        throw new AcpRuntimeError("ACP_BACKEND_UNSUPPORTED_CONTROL", "Live off is unsupported");
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    const spec = {
+      channel: "discord" as const,
+      accountId: "default",
+      conversationId: "configured-thinking",
+      agentId: "codex",
+      mode: "persistent" as const,
+      thinking: "off",
+    };
+    const sessionKey = buildConfiguredAcpSessionKey(spec);
+    let currentMeta: SessionAcpMeta | undefined;
+    hoisted.readAcpSessionEntryMock.mockImplementation(() =>
+      currentMeta ? { sessionKey, storeSessionKey: sessionKey, acp: currentMeta } : null,
+    );
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(
+      ({
+        mutate,
+      }: {
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta },
+        ) => SessionAcpMeta | null | undefined;
+      }) => {
+        currentMeta = mutate(currentMeta, { acp: currentMeta }) ?? currentMeta;
+        return { sessionId: "configured-session", updatedAt: Date.now(), acp: currentMeta };
+      },
+    );
+    const manager = new AcpSessionManager();
+    const getManager = vi.spyOn(managerModule, "getAcpSessionManager").mockReturnValue(manager);
+    const ensure = (thinking?: string) =>
+      ensureConfiguredAcpBindingSession({ cfg: baseCfg, spec: { ...spec, thinking } });
+    const runTurn = (requestId: string) =>
+      manager.runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey,
+        text: requestId,
+        mode: "prompt",
+        requestId,
+      });
+    try {
+      expect(await ensure("off")).toEqual({ ok: true, sessionKey });
+      await runTurn("first");
+      await runTurn("second");
+      expect(currentMeta?.runtimeOptions?.thinking).toBe("off");
+
+      expect(await ensure("high")).toEqual({ ok: true, sessionKey });
+      await runTurn("third");
+      const acceptedMeta = currentMeta;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        expect(await ensure("off")).toEqual({
+          ok: false,
+          sessionKey,
+          error: "Live off is unsupported",
+        });
+        expect(currentMeta).toEqual(acceptedMeta);
+      }
+      expect(await ensure()).toEqual({ ok: true, sessionKey });
+      await runTurn("fourth");
+      expect(currentMeta?.runtimeOptions?.thinking).toBe("high");
+      expect(runtimeState.ensureSession).toHaveBeenCalledOnce();
+      expect(runtimeState.close).not.toHaveBeenCalled();
+      expect(runtimeState.runTurn).toHaveBeenCalledTimes(4);
+    } finally {
+      getManager.mockRestore();
+    }
+  });
+});

--- a/src/acp/control-plane/manager.runtime-config.test.ts
+++ b/src/acp/control-plane/manager.runtime-config.test.ts
@@ -1,5 +1,6 @@
 /** Tests ACP runtime mode/config option persistence and backend control calls. */
 import { describe, expect, it, vi } from "vitest";
+import { buildConfiguredAcpSessionKey } from "../persistent-bindings.types.js";
 import {
   type AcpRuntime,
   AcpRuntimeError,
@@ -20,6 +21,87 @@ import {
 
 describe("AcpSessionManager runtime config", () => {
   installAcpSessionManagerTestLifecycle();
+
+  it("keeps startup omission but rejects live binding changes before overwriting accepted thinking", async () => {
+    const managerModule = await import("./manager.js");
+    const { ensureConfiguredAcpBindingSession } =
+      await import("../persistent-bindings.lifecycle.js");
+    const runtimeState = createRuntime();
+    runtimeState.setConfigOption.mockImplementation(async ({ value }) => {
+      if (value === "off") {
+        throw new AcpRuntimeError("ACP_BACKEND_UNSUPPORTED_CONTROL", "Live off is unsupported");
+      }
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    const spec = {
+      channel: "discord" as const,
+      accountId: "default",
+      conversationId: "configured-thinking",
+      agentId: "codex",
+      mode: "persistent" as const,
+      thinking: "off",
+    };
+    const sessionKey = buildConfiguredAcpSessionKey(spec);
+    let currentMeta: SessionAcpMeta | undefined;
+    hoisted.readAcpSessionEntryMock.mockImplementation(() =>
+      currentMeta ? { sessionKey, storeSessionKey: sessionKey, acp: currentMeta } : null,
+    );
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(
+      ({
+        mutate,
+      }: {
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta },
+        ) => SessionAcpMeta | null | undefined;
+      }) => {
+        currentMeta = mutate(currentMeta, { acp: currentMeta }) ?? currentMeta;
+        return { sessionId: "configured-session", updatedAt: Date.now(), acp: currentMeta };
+      },
+    );
+    const manager = new AcpSessionManager();
+    const getManager = vi.spyOn(managerModule, "getAcpSessionManager").mockReturnValue(manager);
+    const ensure = (thinking?: string) =>
+      ensureConfiguredAcpBindingSession({ cfg: baseCfg, spec: { ...spec, thinking } });
+    const runTurn = (requestId: string) =>
+      manager.runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey,
+        text: requestId,
+        mode: "prompt",
+        requestId,
+      });
+    try {
+      expect(await ensure("off")).toEqual({ ok: true, sessionKey });
+      await runTurn("first");
+      await runTurn("second");
+      expect(currentMeta?.runtimeOptions?.thinking).toBe("off");
+
+      expect(await ensure("high")).toEqual({ ok: true, sessionKey });
+      await runTurn("third");
+      const acceptedMeta = currentMeta;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        expect(await ensure("off")).toEqual({
+          ok: false,
+          sessionKey,
+          error: "Live off is unsupported",
+        });
+        expect(currentMeta).toEqual(acceptedMeta);
+      }
+      expect(await ensure()).toEqual({ ok: true, sessionKey });
+      await runTurn("fourth");
+      expect(currentMeta?.runtimeOptions?.thinking).toBe("high");
+      expect(runtimeState.ensureSession).toHaveBeenCalledOnce();
+      expect(runtimeState.close).not.toHaveBeenCalled();
+      expect(runtimeState.runTurn).toHaveBeenCalledTimes(4);
+    } finally {
+      getManager.mockRestore();
+    }
+  });
 
   it("persists runtime mode changes through setSessionRuntimeMode", async () => {
     const runtimeState = createRuntime();

--- a/src/acp/control-plane/manager.runtime-config.test.ts
+++ b/src/acp/control-plane/manager.runtime-config.test.ts
@@ -1,6 +1,5 @@
 /** Tests ACP runtime mode/config option persistence and backend control calls. */
 import { describe, expect, it, vi } from "vitest";
-import { buildConfiguredAcpSessionKey } from "../persistent-bindings.types.js";
 import {
   type AcpRuntime,
   AcpRuntimeError,
@@ -21,87 +20,6 @@ import {
 
 describe("AcpSessionManager runtime config", () => {
   installAcpSessionManagerTestLifecycle();
-
-  it("keeps startup omission but rejects live binding changes before overwriting accepted thinking", async () => {
-    const managerModule = await import("./manager.js");
-    const { ensureConfiguredAcpBindingSession } =
-      await import("../persistent-bindings.lifecycle.js");
-    const runtimeState = createRuntime();
-    runtimeState.setConfigOption.mockImplementation(async ({ value }) => {
-      if (value === "off") {
-        throw new AcpRuntimeError("ACP_BACKEND_UNSUPPORTED_CONTROL", "Live off is unsupported");
-      }
-    });
-    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
-      id: "acpx",
-      runtime: runtimeState.runtime,
-    });
-    const spec = {
-      channel: "discord" as const,
-      accountId: "default",
-      conversationId: "configured-thinking",
-      agentId: "codex",
-      mode: "persistent" as const,
-      thinking: "off",
-    };
-    const sessionKey = buildConfiguredAcpSessionKey(spec);
-    let currentMeta: SessionAcpMeta | undefined;
-    hoisted.readAcpSessionEntryMock.mockImplementation(() =>
-      currentMeta ? { sessionKey, storeSessionKey: sessionKey, acp: currentMeta } : null,
-    );
-    hoisted.upsertAcpSessionMetaMock.mockImplementation(
-      ({
-        mutate,
-      }: {
-        mutate: (
-          current: SessionAcpMeta | undefined,
-          entry: { acp?: SessionAcpMeta },
-        ) => SessionAcpMeta | null | undefined;
-      }) => {
-        currentMeta = mutate(currentMeta, { acp: currentMeta }) ?? currentMeta;
-        return { sessionId: "configured-session", updatedAt: Date.now(), acp: currentMeta };
-      },
-    );
-    const manager = new AcpSessionManager();
-    const getManager = vi.spyOn(managerModule, "getAcpSessionManager").mockReturnValue(manager);
-    const ensure = (thinking?: string) =>
-      ensureConfiguredAcpBindingSession({ cfg: baseCfg, spec: { ...spec, thinking } });
-    const runTurn = (requestId: string) =>
-      manager.runTurn({
-        provenance: "system",
-        cfg: baseCfg,
-        sessionKey,
-        text: requestId,
-        mode: "prompt",
-        requestId,
-      });
-    try {
-      expect(await ensure("off")).toEqual({ ok: true, sessionKey });
-      await runTurn("first");
-      await runTurn("second");
-      expect(currentMeta?.runtimeOptions?.thinking).toBe("off");
-
-      expect(await ensure("high")).toEqual({ ok: true, sessionKey });
-      await runTurn("third");
-      const acceptedMeta = currentMeta;
-      for (let attempt = 0; attempt < 2; attempt++) {
-        expect(await ensure("off")).toEqual({
-          ok: false,
-          sessionKey,
-          error: "Live off is unsupported",
-        });
-        expect(currentMeta).toEqual(acceptedMeta);
-      }
-      expect(await ensure()).toEqual({ ok: true, sessionKey });
-      await runTurn("fourth");
-      expect(currentMeta?.runtimeOptions?.thinking).toBe("high");
-      expect(runtimeState.ensureSession).toHaveBeenCalledOnce();
-      expect(runtimeState.close).not.toHaveBeenCalled();
-      expect(runtimeState.runTurn).toHaveBeenCalledTimes(4);
-    } finally {
-      getManager.mockRestore();
-    }
-  });
 
   it("persists runtime mode changes through setSessionRuntimeMode", async () => {
     const runtimeState = createRuntime();

--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -10,7 +10,7 @@ const managerMocks = vi.hoisted(() => ({
   resolveSession: vi.fn(),
   closeSession: vi.fn(),
   initializeSession: vi.fn(),
-  updateSessionRuntimeOptions: vi.fn(),
+  setSessionConfigOption: vi.fn(),
 }));
 
 vi.mock("./control-plane/manager.js", () => ({
@@ -18,7 +18,7 @@ vi.mock("./control-plane/manager.js", () => ({
     resolveSession: managerMocks.resolveSession,
     closeSession: managerMocks.closeSession,
     initializeSession: managerMocks.initializeSession,
-    updateSessionRuntimeOptions: managerMocks.updateSessionRuntimeOptions,
+    setSessionConfigOption: managerMocks.setSessionConfigOption,
   }),
 }));
 
@@ -39,7 +39,7 @@ beforeEach(async () => {
     metaCleared: false,
   });
   managerMocks.initializeSession.mockReset().mockResolvedValue(undefined);
-  managerMocks.updateSessionRuntimeOptions.mockReset().mockResolvedValue(undefined);
+  managerMocks.setSessionConfigOption.mockReset().mockResolvedValue(undefined);
   ({ ensureConfiguredAcpBindingSession } = await import("./persistent-bindings.lifecycle.js"));
 });
 
@@ -119,7 +119,7 @@ describe("ensureConfiguredAcpBindingSession", () => {
     expect(ensured).toEqual({ ok: true, sessionKey });
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
-    expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
+    expect(managerMocks.setSessionConfigOption).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -141,11 +141,11 @@ describe("ensureConfiguredAcpBindingSession", () => {
     });
 
     expect(ensured).toEqual({ ok: true, sessionKey });
-    expect(managerMocks.updateSessionRuntimeOptions).toHaveBeenCalledWith({
-      cfg: baseCfg,
-      sessionKey,
-      patch: runtimeOptions,
-    });
+    expect(managerMocks.setSessionConfigOption.mock.calls).toEqual(
+      Object.entries(runtimeOptions).map(([key, value]) => [
+        { cfg: baseCfg, sessionKey, key, value },
+      ]),
+    );
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
@@ -158,7 +158,28 @@ describe("ensureConfiguredAcpBindingSession", () => {
       ok: true,
       sessionKey,
     });
-    expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
+    expect(managerMocks.setSessionConfigOption).not.toHaveBeenCalled();
+    expect(managerMocks.closeSession).not.toHaveBeenCalled();
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+  });
+
+  it("reports rejected live thinking without replacing or overwriting the existing session", async () => {
+    const spec = createPersistentSpec({ thinking: "off" });
+    const sessionKey = mockReadySession({
+      spec,
+      cwd: "/workspace/openclaw",
+      thinking: "high",
+    });
+    managerMocks.setSessionConfigOption.mockRejectedValue(new Error("Live off is unsupported"));
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      expect(await ensureConfiguredAcpBindingSession({ cfg: baseCfg, spec })).toEqual({
+        ok: false,
+        sessionKey,
+        error: "Live off is unsupported",
+      });
+    }
+    expect(managerMocks.setSessionConfigOption).toHaveBeenCalledTimes(2);
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
@@ -259,10 +280,11 @@ describe("ensureConfiguredAcpBindingSession", () => {
     });
 
     expect(ensured).toEqual({ ok: true, sessionKey });
-    expect(managerMocks.updateSessionRuntimeOptions).toHaveBeenCalledWith({
+    expect(managerMocks.setSessionConfigOption).toHaveBeenCalledWith({
       cfg: baseCfg,
       sessionKey,
-      patch: { thinking: "off" },
+      key: "thinking",
+      value: "off",
     });
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
@@ -283,7 +305,7 @@ describe("ensureConfiguredAcpBindingSession", () => {
     });
 
     expect(ensured).toEqual({ ok: true, sessionKey });
-    expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
+    expect(managerMocks.setSessionConfigOption).not.toHaveBeenCalled();
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });

--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -122,14 +122,17 @@ describe("ensureConfiguredAcpBindingSession", () => {
     expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
   });
 
-  it("updates a configured model in place for a structurally matching session", async () => {
-    const spec = createPersistentSpec({
-      model: "anthropic/claude-sonnet-4-6",
-    });
+  it.each([
+    { model: "anthropic/claude-sonnet-4-6" },
+    { thinking: "off" },
+    { model: "anthropic/claude-sonnet-4-6", thinking: "off" },
+  ])("updates configured runtime options %j in place", async (runtimeOptions) => {
+    const spec = createPersistentSpec(runtimeOptions);
     const sessionKey = mockReadySession({
       spec,
       cwd: "/workspace/openclaw",
       model: "anthropic/claude-haiku-4-5",
+      thinking: "high",
     });
 
     const ensured = await ensureConfiguredAcpBindingSession({
@@ -141,8 +144,21 @@ describe("ensureConfiguredAcpBindingSession", () => {
     expect(managerMocks.updateSessionRuntimeOptions).toHaveBeenCalledWith({
       cfg: baseCfg,
       sessionKey,
-      patch: { model: "anthropic/claude-sonnet-4-6" },
+      patch: runtimeOptions,
     });
+    expect(managerMocks.closeSession).not.toHaveBeenCalled();
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+  });
+
+  it("does not rewrite matching runtime options", async () => {
+    const spec = createPersistentSpec({ model: "selected/model", thinking: "off" });
+    const sessionKey = mockReadySession({ spec, cwd: "/workspace/openclaw", ...spec });
+
+    expect(await ensureConfiguredAcpBindingSession({ cfg: baseCfg, spec })).toEqual({
+      ok: true,
+      sessionKey,
+    });
+    expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
@@ -252,11 +268,12 @@ describe("ensureConfiguredAcpBindingSession", () => {
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
 
-  it("clears a previously pinned thinking value once the configured default is removed", async () => {
+  it("preserves the session selection once configured defaults are removed", async () => {
     const spec = createPersistentSpec();
     const sessionKey = mockReadySession({
       spec,
       cwd: "/workspace/openclaw",
+      model: "manual/selected-model",
       thinking: "off",
     });
 
@@ -266,11 +283,7 @@ describe("ensureConfiguredAcpBindingSession", () => {
     });
 
     expect(ensured).toEqual({ ok: true, sessionKey });
-    expect(managerMocks.updateSessionRuntimeOptions).toHaveBeenCalledWith({
-      cfg: baseCfg,
-      sessionKey,
-      patch: { thinking: undefined },
-    });
+    expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });

--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -207,4 +207,46 @@ describe("ensureConfiguredAcpBindingSession", () => {
     });
     expect(initializeArgs).not.toHaveProperty("modelExplicit");
   });
+
+  it("forwards the owner agent's configured thinking default on session init", async () => {
+    const spec = createPersistentSpec({
+      model: "ollama-cloud/glm-5.2:cloud",
+      thinking: "off",
+    });
+    managerMocks.resolveSession.mockReturnValue({ kind: "none" });
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg: baseCfg,
+      spec,
+    });
+
+    expect(ensured.ok).toBe(true);
+    const initializeArgs = expectInitializeArgs();
+    expect(initializeArgs.runtimeOptions).toEqual({
+      model: "ollama-cloud/glm-5.2:cloud",
+      thinking: "off",
+    });
+  });
+
+  it("patches thinking drift in place for a structurally matching session", async () => {
+    const spec = createPersistentSpec({ thinking: "off" });
+    const sessionKey = mockReadySession({
+      spec,
+      cwd: "/workspace/openclaw",
+    });
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg: baseCfg,
+      spec,
+    });
+
+    expect(ensured).toEqual({ ok: true, sessionKey });
+    expect(managerMocks.updateSessionRuntimeOptions).toHaveBeenCalledWith({
+      cfg: baseCfg,
+      sessionKey,
+      patch: { thinking: "off" },
+    });
+    expect(managerMocks.closeSession).not.toHaveBeenCalled();
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+  });
 });

--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -60,6 +60,7 @@ function mockReadySession(params: {
   spec: ConfiguredAcpBindingSpec;
   cwd: string;
   model?: string;
+  thinking?: string;
   state?: "idle" | "running" | "error";
 }) {
   const sessionKey = buildConfiguredAcpSessionKey(params.spec);
@@ -74,6 +75,7 @@ function mockReadySession(params: {
       runtimeOptions: {
         cwd: params.cwd,
         ...(params.model ? { model: params.model } : {}),
+        ...(params.thinking ? { thinking: params.thinking } : {}),
       },
       state: params.state ?? "idle",
       lastActivityAt: Date.now(),
@@ -245,6 +247,29 @@ describe("ensureConfiguredAcpBindingSession", () => {
       cfg: baseCfg,
       sessionKey,
       patch: { thinking: "off" },
+    });
+    expect(managerMocks.closeSession).not.toHaveBeenCalled();
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+  });
+
+  it("clears a previously pinned thinking value once the configured default is removed", async () => {
+    const spec = createPersistentSpec();
+    const sessionKey = mockReadySession({
+      spec,
+      cwd: "/workspace/openclaw",
+      thinking: "off",
+    });
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg: baseCfg,
+      spec,
+    });
+
+    expect(ensured).toEqual({ ok: true, sessionKey });
+    expect(managerMocks.updateSessionRuntimeOptions).toHaveBeenCalledWith({
+      cfg: baseCfg,
+      sessionKey,
+      patch: { thinking: undefined },
     });
     expect(managerMocks.closeSession).not.toHaveBeenCalled();
     expect(managerMocks.initializeSession).not.toHaveBeenCalled();

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -60,6 +60,10 @@ export async function ensureConfiguredAcpBindingSession(params: {
 }): Promise<{ ok: true; sessionKey: string } | { ok: false; sessionKey: string; error: string }> {
   const sessionKey = buildConfiguredAcpSessionKey(params.spec);
   const acpManager = getAcpSessionManager();
+  const runtimeOptions = {
+    ...(params.spec.model ? { model: params.spec.model } : {}),
+    ...(params.spec.thinking ? { thinking: params.spec.thinking } : {}),
+  };
   try {
     const resolution = acpManager.resolveSession({
       cfg: params.cfg,
@@ -73,22 +77,19 @@ export async function ensureConfiguredAcpBindingSession(params: {
         meta: resolution.meta,
       })
     ) {
-      // Model/thinking drift is live-configurable; preserve the bound conversation and patch in place.
-      // Thinking also reconciles the explicit-to-unset transition: an undefined desired value still
-      // patches (to undefined) when a prior explicit value is pinned, clearing the stale session state.
-      const currentThinking = normalizeText(resolution.meta.runtimeOptions?.thinking);
-      const runtimeOptionsPatch = {
-        ...(params.spec.model &&
-        normalizeText(resolution.meta.runtimeOptions?.model) !== params.spec.model
-          ? { model: params.spec.model }
-          : {}),
-        ...(currentThinking !== params.spec.thinking ? { thinking: params.spec.thinking } : {}),
-      };
-      if (Object.keys(runtimeOptionsPatch).length > 0) {
+      // Omitted options retain the current selection: ACP has no generic unset control,
+      // and recreating a bound conversation to restore defaults would discard its history.
+      if (
+        (["model", "thinking"] as const).some(
+          (key) =>
+            runtimeOptions[key] !== undefined &&
+            normalizeText(resolution.meta.runtimeOptions?.[key]) !== runtimeOptions[key],
+        )
+      ) {
         await acpManager.updateSessionRuntimeOptions({
           cfg: params.cfg,
           sessionKey,
-          patch: runtimeOptionsPatch,
+          patch: runtimeOptions,
         });
       }
       return {
@@ -113,13 +114,7 @@ export async function ensureConfiguredAcpBindingSession(params: {
       sessionKey,
       agent: params.spec.acpAgentId ?? params.spec.agentId,
       mode: params.spec.mode,
-      runtimeOptions:
-        params.spec.model || params.spec.thinking
-          ? {
-              ...(params.spec.model ? { model: params.spec.model } : {}),
-              ...(params.spec.thinking ? { thinking: params.spec.thinking } : {}),
-            }
-          : undefined,
+      runtimeOptions,
       cwd: params.spec.cwd,
       backendId: params.spec.backend,
     });

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -77,20 +77,13 @@ export async function ensureConfiguredAcpBindingSession(params: {
         meta: resolution.meta,
       })
     ) {
-      // Omitted options retain the current selection: ACP has no generic unset control,
-      // and recreating a bound conversation to restore defaults would discard its history.
-      if (
-        (["model", "thinking"] as const).some(
-          (key) =>
-            runtimeOptions[key] !== undefined &&
-            normalizeText(resolution.meta.runtimeOptions?.[key]) !== runtimeOptions[key],
-        )
-      ) {
-        await acpManager.updateSessionRuntimeOptions({
-          cfg: params.cfg,
-          sessionKey,
-          patch: runtimeOptions,
-        });
+      // Apply before persisting: rejected controls must not overwrite accepted options.
+      // Model precedes effort; omission retains the selection because ACP has no unset.
+      for (const key of ["model", "thinking"] as const) {
+        const value = runtimeOptions[key];
+        if (value !== undefined && normalizeText(resolution.meta.runtimeOptions?.[key]) !== value) {
+          await acpManager.setSessionConfigOption({ cfg: params.cfg, sessionKey, key, value });
+        }
       }
       return {
         ok: true,

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -74,15 +74,15 @@ export async function ensureConfiguredAcpBindingSession(params: {
       })
     ) {
       // Model/thinking drift is live-configurable; preserve the bound conversation and patch in place.
+      // Thinking also reconciles the explicit-to-unset transition: an undefined desired value still
+      // patches (to undefined) when a prior explicit value is pinned, clearing the stale session state.
+      const currentThinking = normalizeText(resolution.meta.runtimeOptions?.thinking);
       const runtimeOptionsPatch = {
         ...(params.spec.model &&
         normalizeText(resolution.meta.runtimeOptions?.model) !== params.spec.model
           ? { model: params.spec.model }
           : {}),
-        ...(params.spec.thinking &&
-        normalizeText(resolution.meta.runtimeOptions?.thinking) !== params.spec.thinking
-          ? { thinking: params.spec.thinking }
-          : {}),
+        ...(currentThinking !== params.spec.thinking ? { thinking: params.spec.thinking } : {}),
       };
       if (Object.keys(runtimeOptionsPatch).length > 0) {
         await acpManager.updateSessionRuntimeOptions({

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -73,15 +73,22 @@ export async function ensureConfiguredAcpBindingSession(params: {
         meta: resolution.meta,
       })
     ) {
-      // Model drift is live-configurable; preserve the bound conversation and patch it in place.
-      if (
-        params.spec.model &&
+      // Model/thinking drift is live-configurable; preserve the bound conversation and patch in place.
+      const runtimeOptionsPatch = {
+        ...(params.spec.model &&
         normalizeText(resolution.meta.runtimeOptions?.model) !== params.spec.model
-      ) {
+          ? { model: params.spec.model }
+          : {}),
+        ...(params.spec.thinking &&
+        normalizeText(resolution.meta.runtimeOptions?.thinking) !== params.spec.thinking
+          ? { thinking: params.spec.thinking }
+          : {}),
+      };
+      if (Object.keys(runtimeOptionsPatch).length > 0) {
         await acpManager.updateSessionRuntimeOptions({
           cfg: params.cfg,
           sessionKey,
-          patch: { model: params.spec.model },
+          patch: runtimeOptionsPatch,
         });
       }
       return {
@@ -106,7 +113,13 @@ export async function ensureConfiguredAcpBindingSession(params: {
       sessionKey,
       agent: params.spec.acpAgentId ?? params.spec.agentId,
       mode: params.spec.mode,
-      runtimeOptions: params.spec.model ? { model: params.spec.model } : undefined,
+      runtimeOptions:
+        params.spec.model || params.spec.thinking
+          ? {
+              ...(params.spec.model ? { model: params.spec.model } : {}),
+              ...(params.spec.thinking ? { thinking: params.spec.thinking } : {}),
+            }
+          : undefined,
       cwd: params.spec.cwd,
       backendId: params.spec.backend,
     });

--- a/src/acp/persistent-bindings.types.ts
+++ b/src/acp/persistent-bindings.types.ts
@@ -29,6 +29,8 @@ export type ConfiguredAcpBindingSpec = {
   acpAgentId?: string;
   mode: AcpRuntimeSessionMode;
   model?: string;
+  /** Owner agent's effective thinking default, forwarded as the ACP session's thinking runtime option. */
+  thinking?: string;
   cwd?: string;
   backend?: string;
   label?: string;
@@ -106,6 +108,7 @@ export function toConfiguredAcpBindingRecord(spec: ConfiguredAcpBindingSpec): Se
       ...(spec.acpAgentId ? { acpAgentId: spec.acpAgentId } : {}),
       label: spec.label,
       ...(spec.model ? { model: spec.model } : {}),
+      ...(spec.thinking ? { thinking: spec.thinking } : {}),
       ...(spec.backend ? { backend: spec.backend } : {}),
       ...(spec.cwd ? { cwd: spec.cwd } : {}),
     },
@@ -164,6 +167,7 @@ export function resolveConfiguredAcpBindingSpecFromRecord(
     acpAgentId: normalizeText(record.metadata?.acpAgentId),
     mode: normalizeMode(record.metadata?.mode),
     model: normalizeText(record.metadata?.model),
+    thinking: normalizeText(record.metadata?.thinking),
     cwd: normalizeText(record.metadata?.cwd),
     backend: normalizeText(record.metadata?.backend),
     label: normalizeText(record.metadata?.label),

--- a/src/agents/subagents/spawn/acp-spawn-runtime.ts
+++ b/src/agents/subagents/spawn/acp-spawn-runtime.ts
@@ -118,7 +118,7 @@ export function resolveAcpSpawnRuntimeOptions(params: {
     };
   }
 
-  let thinking = thinkingPlan.thinkingOverride;
+  let thinking = thinkingPlan.thinkingOverride ?? targetAgentConfig?.thinkingDefault;
   if (!thinking && model) {
     const { provider, model: modelId } = splitModelRef(model);
     if (provider && modelId) {

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -11,6 +11,7 @@ import {
   testing as acpRuntimeRegistryTesting,
 } from "../../../acp/runtime/registry.js";
 import { createExecutionIdentityAdmissionToken } from "../../../audit/execution-identity-admission.js";
+import type { ThinkLevel } from "../../../auto-reply/thinking.shared.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { readAgentRuntimeExecutionLineage } from "../../../gateway/agent-runtime-execution-lineage.js";
@@ -1300,49 +1301,116 @@ describe("spawnAcpDirect", () => {
     });
   });
 
-  it("uses configured runtime=acp agent primary model as an ACP startup model", async () => {
-    replaceSpawnConfig({
-      ...createDefaultSpawnConfig(),
-      agents: {
-        list: [
-          {
-            id: "codex-acp",
-            runtime: {
-              type: "acp",
-              acp: { agent: "codex" },
+  it.each<{
+    scenario: string;
+    model?: string;
+    ownerThinking?: ThinkLevel;
+    globalThinking?: ThinkLevel;
+    modelThinking?: ThinkLevel;
+    subagentThinking?: ThinkLevel;
+    globalSubagentThinking?: ThinkLevel;
+    thinking?: ThinkLevel;
+    expectedThinking?: ThinkLevel;
+  }>([
+    {
+      scenario: "configured primary model with global thinking default",
+      model: "anthropic/claude-sonnet-4-6",
+      globalThinking: "off",
+      expectedThinking: "off",
+    },
+    {
+      scenario: "owner default before model and global defaults",
+      model: "anthropic/claude-sonnet-4-6",
+      ownerThinking: "off",
+      modelThinking: "adaptive",
+      globalThinking: "high",
+      expectedThinking: "off",
+    },
+    {
+      scenario: "owner default without a model override",
+      ownerThinking: "off",
+      globalThinking: "high",
+      expectedThinking: "off",
+    },
+    {
+      scenario: "target subagent default before owner default",
+      ownerThinking: "off",
+      subagentThinking: "low",
+      expectedThinking: "low",
+    },
+    {
+      scenario: "global subagent default before owner default",
+      ownerThinking: "off",
+      globalSubagentThinking: "medium",
+      expectedThinking: "medium",
+    },
+    {
+      scenario: "explicit thinking before subagent and owner defaults",
+      ownerThinking: "off",
+      subagentThinking: "low",
+      thinking: "high",
+      expectedThinking: "high",
+    },
+    {
+      scenario: "harness defaults without an owner or model override",
+      globalThinking: "high",
+    },
+  ])(
+    "resolves configured ACP spawn model and thinking ($scenario)",
+    async ({
+      model,
+      ownerThinking,
+      globalThinking,
+      modelThinking,
+      subagentThinking,
+      globalSubagentThinking,
+      thinking,
+      expectedThinking,
+    }) => {
+      replaceSpawnConfig({
+        ...createDefaultSpawnConfig(),
+        agents: {
+          list: [
+            {
+              id: "codex-acp",
+              runtime: { type: "acp", acp: { agent: "codex" } },
+              model,
+              thinkingDefault: ownerThinking,
+              subagents: { thinking: subagentThinking },
             },
-            model: "anthropic/claude-sonnet-4-6",
-          },
-        ],
-        defaults: {
-          thinkingDefault: "off",
-          subagents: {
-            allowAgents: ["codex"],
-            maxSpawnDepth: 2,
+          ],
+          defaults: {
+            thinkingDefault: globalThinking,
+            ...(model && modelThinking
+              ? { models: { [model]: { params: { thinking: modelThinking } } } }
+              : {}),
+            subagents: {
+              allowAgents: ["codex"],
+              maxSpawnDepth: 2,
+              thinking: globalSubagentThinking,
+            },
           },
         },
-      },
-    });
+      });
 
-    const result = await spawnAcpDirect(
-      {
-        task: "Investigate flaky tests",
-        agentId: "codex-acp",
-      },
-      {
-        agentSessionKey: "agent:main:main",
-      },
-    );
+      const result = await spawnAcpDirect(
+        { task: "Investigate flaky tests", agentId: "codex-acp", thinking },
+        { agentSessionKey: "agent:main:main" },
+      );
 
-    expectAcceptedSpawn(result);
-    expectInitializeSessionFields({
-      agent: "codex",
-      runtimeOptions: {
-        model: "anthropic/claude-sonnet-4-6",
-        thinking: "off",
-      },
-    });
-  });
+      expectAcceptedSpawn(result);
+      expectInitializeSessionFields({
+        agent: "codex",
+        runtimeOptions:
+          model || expectedThinking
+            ? {
+                ...(model ? { model } : {}),
+                ...(expectedThinking ? { thinking: expectedThinking } : {}),
+              }
+            : undefined,
+      });
+    },
+  );
 
   it("applies ACP spawn run timeout to runtime options and dispatch", async () => {
     const result = await spawnAcpDirect(

--- a/src/channels/plugins/acp-configured-binding-consumer.test.ts
+++ b/src/channels/plugins/acp-configured-binding-consumer.test.ts
@@ -1,5 +1,6 @@
 /** Tests configured ACP binding thinking-default precedence. */
 import { describe, expect, it } from "vitest";
+import { resolveConfiguredAcpBindingSpecFromRecord } from "../../acp/persistent-bindings.types.js";
 import type { AgentAcpBinding } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { acpConfiguredBindingConsumer } from "./acp-configured-binding-consumer.js";
@@ -23,7 +24,10 @@ function materializeThinking(cfg: OpenClawConfig): string | undefined {
     accountId: "default",
     conversation: { conversationId: "convo-1" },
   });
-  return materialized?.record.metadata?.thinking as string | undefined;
+  if (!materialized) {
+    throw new Error("expected a configured ACP binding");
+  }
+  return resolveConfiguredAcpBindingSpecFromRecord(materialized.record)?.thinking;
 }
 
 const baseCfg = {
@@ -63,5 +67,35 @@ describe("acpConfiguredBindingConsumer thinking precedence", () => {
     } satisfies OpenClawConfig;
 
     expect(materializeThinking(cfg)).toBe("adaptive");
+  });
+
+  it.each([false, "disabled", "none"])("forwards per-model thinking %s as off", (thinking) => {
+    expect(
+      materializeThinking({
+        ...baseCfg,
+        agents: {
+          ...baseCfg.agents,
+          defaults: {
+            thinkingDefault: "high",
+            models: { "ollama-cloud/glm-5.2:cloud": { params: { thinking } } },
+          },
+        },
+      }),
+    ).toBe("off");
+  });
+
+  it.each([undefined, "anthropic/claude-sonnet-4-6"])(
+    "leaves unconfigured thinking to the harness with model %s",
+    (model) => {
+      expect(materializeThinking({ agents: { list: [{ id: "codex", model }] } })).toBeUndefined();
+    },
+  );
+
+  it("forwards global thinking without requiring a configured model", () => {
+    expect(
+      materializeThinking({
+        agents: { list: [{ id: "codex" }], defaults: { thinkingDefault: "off" } },
+      }),
+    ).toBe("off");
   });
 });

--- a/src/channels/plugins/acp-configured-binding-consumer.test.ts
+++ b/src/channels/plugins/acp-configured-binding-consumer.test.ts
@@ -1,0 +1,67 @@
+/** Tests configured ACP binding thinking-default precedence. */
+import { describe, expect, it } from "vitest";
+import type { AgentAcpBinding } from "../../config/types.agents.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { acpConfiguredBindingConsumer } from "./acp-configured-binding-consumer.js";
+
+const binding: AgentAcpBinding = {
+  type: "acp",
+  agentId: "codex",
+  match: { channel: "discord" },
+};
+
+function materializeThinking(cfg: OpenClawConfig): string | undefined {
+  const factory = acpConfiguredBindingConsumer.buildTargetFactory({
+    cfg,
+    binding,
+    channel: "discord",
+    agentId: "codex",
+    target: { conversationId: "convo-1" },
+    bindingConversationId: "convo-1",
+  });
+  const materialized = factory?.materialize({
+    accountId: "default",
+    conversation: { conversationId: "convo-1" },
+  });
+  return materialized?.record.metadata?.thinking as string | undefined;
+}
+
+const baseCfg = {
+  session: { mainKey: "main", scope: "per-sender" },
+  agents: {
+    list: [{ id: "codex", model: "ollama-cloud/glm-5.2:cloud" }],
+    defaults: {
+      thinkingDefault: "adaptive",
+      models: {
+        "ollama-cloud/glm-5.2:cloud": { params: { thinking: "off" } },
+      },
+    },
+  },
+} satisfies OpenClawConfig;
+
+describe("acpConfiguredBindingConsumer thinking precedence", () => {
+  it("honors per-model params.thinking over the global default", () => {
+    expect(materializeThinking(baseCfg)).toBe("off");
+  });
+
+  it("still lets an explicit per-agent thinkingDefault win over per-model policy", () => {
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        ...baseCfg.agents,
+        list: [{ id: "codex", model: "ollama-cloud/glm-5.2:cloud", thinkingDefault: "high" }],
+      },
+    } satisfies OpenClawConfig;
+
+    expect(materializeThinking(cfg)).toBe("high");
+  });
+
+  it("falls back to the global default when neither agent nor per-model policy is set", () => {
+    const cfg = {
+      ...baseCfg,
+      agents: { ...baseCfg.agents, defaults: { thinkingDefault: "adaptive" } },
+    } satisfies OpenClawConfig;
+
+    expect(materializeThinking(cfg)).toBe("adaptive");
+  });
+});

--- a/src/channels/plugins/acp-configured-binding-consumer.ts
+++ b/src/channels/plugins/acp-configured-binding-consumer.ts
@@ -18,14 +18,14 @@ import {
   resolveAgentExplicitModelPrimary,
   resolveAgentWorkspaceDir,
 } from "../../agents/agent-scope.js";
-import { resolveConfiguredThinkingDefaultCore } from "../../agents/model-thinking-default-core.js";
+import { parseModelRef } from "../../agents/model-selection-normalize.js";
+import { resolveConfiguredThinkingDefault } from "../../agents/model-thinking-default.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   ConfiguredBindingRuleConfig,
   ConfiguredBindingTargetFactory,
 } from "./binding-types.js";
 import type { ConfiguredBindingConsumer } from "./configured-binding-consumers.js";
-import type { ChannelConfiguredBindingConversationRef } from "./types.adapters.js";
 
 function resolveAgentRuntimeAcpDefaults(params: { cfg: OpenClawConfig; ownerAgentId: string }): {
   acpAgentId?: string;
@@ -65,61 +65,6 @@ function resolveConfiguredBindingWorkspaceCwd(params: {
   return undefined;
 }
 
-function buildConfiguredAcpSpec(params: {
-  channel: string;
-  accountId: string;
-  conversation: ChannelConfiguredBindingConversationRef;
-  agentId: string;
-  acpAgentId?: string;
-  mode: "persistent" | "oneshot";
-  model?: string;
-  thinking?: string;
-  cwd?: string;
-  backend?: string;
-  label?: string;
-}): ConfiguredAcpBindingSpec {
-  return {
-    channel: params.channel as ConfiguredAcpBindingSpec["channel"],
-    accountId: params.accountId,
-    conversationId: params.conversation.conversationId,
-    parentConversationId: params.conversation.parentConversationId,
-    agentId: params.agentId,
-    acpAgentId: params.acpAgentId,
-    mode: params.mode,
-    model: params.model,
-    thinking: params.thinking,
-    cwd: params.cwd,
-    backend: params.backend,
-    label: params.label,
-  };
-}
-
-/** Splits an already-resolved `provider/model` ref for per-model thinking-policy lookup. */
-function splitConfiguredBindingModelRef(model: string): { provider: string; model: string } {
-  const slash = model.indexOf("/");
-  return slash > 0
-    ? { provider: model.slice(0, slash), model: model.slice(slash + 1) }
-    : { provider: "", model };
-}
-
-function resolveConfiguredBindingThinking(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  model?: string;
-}): string | undefined {
-  // Same precedence as chat replies (docs/tools/thinking.md): an explicit per-agent
-  // thinkingDefault wins outright, otherwise reuse the canonical resolver so per-model
-  // policy (agents.defaults.models[key].params.thinking) still outranks the global default.
-  const agentThinkingDefault = normalizeText(
-    resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault,
-  );
-  if (agentThinkingDefault) {
-    return agentThinkingDefault;
-  }
-  const { provider, model } = splitConfiguredBindingModelRef(params.model ?? "");
-  return normalizeText(resolveConfiguredThinkingDefaultCore({ cfg: params.cfg, provider, model }));
-}
-
 function buildAcpTargetFactory(params: {
   cfg: OpenClawConfig;
   binding: ConfiguredBindingRuleConfig;
@@ -139,11 +84,13 @@ function buildAcpTargetFactory(params: {
   const mode = normalizeMode(bindingOverrides.mode ?? runtimeDefaults.mode);
   // Every ACP binding uses its owner's explicit model, regardless of the owner's runtime type.
   const model = resolveAgentExplicitModelPrimary(params.cfg, params.agentId);
-  const thinking = resolveConfiguredBindingThinking({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    model,
-  });
+  const modelRef = model ? parseModelRef(model, "") : null;
+  // Forward configured policy only; an external harness owns its unconfigured defaults.
+  const thinking =
+    resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault ??
+    (modelRef
+      ? resolveConfiguredThinkingDefault({ cfg: params.cfg, ...modelRef })
+      : params.cfg.agents?.defaults?.thinkingDefault);
   const cwd =
     bindingOverrides.cwd ??
     runtimeDefaults.cwd ??
@@ -160,10 +107,11 @@ function buildAcpTargetFactory(params: {
     materialize: ({ accountId, conversation }) => {
       // Materialization is account/conversation-specific because wildcard bindings resolve to
       // stable ACP session keys only after the matched conversation is known.
-      const spec = buildConfiguredAcpSpec({
-        channel: params.channel,
+      const spec: ConfiguredAcpBindingSpec = {
+        channel: params.channel as ConfiguredAcpBindingSpec["channel"],
         accountId,
-        conversation,
+        conversationId: conversation.conversationId,
+        parentConversationId: conversation.parentConversationId,
         agentId: params.agentId,
         acpAgentId,
         mode,
@@ -172,7 +120,7 @@ function buildAcpTargetFactory(params: {
         cwd,
         backend,
         label,
-      });
+      };
       const record = toConfiguredAcpBindingRecord(spec);
       return {
         record,

--- a/src/channels/plugins/acp-configured-binding-consumer.ts
+++ b/src/channels/plugins/acp-configured-binding-consumer.ts
@@ -72,6 +72,7 @@ function buildConfiguredAcpSpec(params: {
   acpAgentId?: string;
   mode: "persistent" | "oneshot";
   model?: string;
+  thinking?: string;
   cwd?: string;
   backend?: string;
   label?: string;
@@ -85,10 +86,23 @@ function buildConfiguredAcpSpec(params: {
     acpAgentId: params.acpAgentId,
     mode: params.mode,
     model: params.model,
+    thinking: params.thinking,
     cwd: params.cwd,
     backend: params.backend,
     label: params.label,
   };
+}
+
+function resolveConfiguredBindingThinking(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+}): string | undefined {
+  // Same precedence as chat replies (docs/tools/thinking.md): per-agent thinkingDefault first,
+  // then the global default, so a configured ACP binding never silently drops the owner's policy.
+  return normalizeText(
+    resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault ??
+      params.cfg.agents?.defaults?.thinkingDefault,
+  );
 }
 
 function buildAcpTargetFactory(params: {
@@ -110,6 +124,7 @@ function buildAcpTargetFactory(params: {
   const mode = normalizeMode(bindingOverrides.mode ?? runtimeDefaults.mode);
   // Every ACP binding uses its owner's explicit model, regardless of the owner's runtime type.
   const model = resolveAgentExplicitModelPrimary(params.cfg, params.agentId);
+  const thinking = resolveConfiguredBindingThinking({ cfg: params.cfg, agentId: params.agentId });
   const cwd =
     bindingOverrides.cwd ??
     runtimeDefaults.cwd ??
@@ -134,6 +149,7 @@ function buildAcpTargetFactory(params: {
         acpAgentId,
         mode,
         model,
+        thinking,
         cwd,
         backend,
         label,

--- a/src/channels/plugins/acp-configured-binding-consumer.ts
+++ b/src/channels/plugins/acp-configured-binding-consumer.ts
@@ -18,6 +18,7 @@ import {
   resolveAgentExplicitModelPrimary,
   resolveAgentWorkspaceDir,
 } from "../../agents/agent-scope.js";
+import { resolveConfiguredThinkingDefaultCore } from "../../agents/model-thinking-default-core.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   ConfiguredBindingRuleConfig,
@@ -93,16 +94,30 @@ function buildConfiguredAcpSpec(params: {
   };
 }
 
+/** Splits an already-resolved `provider/model` ref for per-model thinking-policy lookup. */
+function splitConfiguredBindingModelRef(model: string): { provider: string; model: string } {
+  const slash = model.indexOf("/");
+  return slash > 0
+    ? { provider: model.slice(0, slash), model: model.slice(slash + 1) }
+    : { provider: "", model };
+}
+
 function resolveConfiguredBindingThinking(params: {
   cfg: OpenClawConfig;
   agentId: string;
+  model?: string;
 }): string | undefined {
-  // Same precedence as chat replies (docs/tools/thinking.md): per-agent thinkingDefault first,
-  // then the global default, so a configured ACP binding never silently drops the owner's policy.
-  return normalizeText(
-    resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault ??
-      params.cfg.agents?.defaults?.thinkingDefault,
+  // Same precedence as chat replies (docs/tools/thinking.md): an explicit per-agent
+  // thinkingDefault wins outright, otherwise reuse the canonical resolver so per-model
+  // policy (agents.defaults.models[key].params.thinking) still outranks the global default.
+  const agentThinkingDefault = normalizeText(
+    resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault,
   );
+  if (agentThinkingDefault) {
+    return agentThinkingDefault;
+  }
+  const { provider, model } = splitConfiguredBindingModelRef(params.model ?? "");
+  return normalizeText(resolveConfiguredThinkingDefaultCore({ cfg: params.cfg, provider, model }));
 }
 
 function buildAcpTargetFactory(params: {
@@ -124,7 +139,11 @@ function buildAcpTargetFactory(params: {
   const mode = normalizeMode(bindingOverrides.mode ?? runtimeDefaults.mode);
   // Every ACP binding uses its owner's explicit model, regardless of the owner's runtime type.
   const model = resolveAgentExplicitModelPrimary(params.cfg, params.agentId);
-  const thinking = resolveConfiguredBindingThinking({ cfg: params.cfg, agentId: params.agentId });
+  const thinking = resolveConfiguredBindingThinking({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    model,
+  });
   const cwd =
     bindingOverrides.cwd ??
     runtimeDefaults.cwd ??


### PR DESCRIPTION
## Summary

Configured live controls now apply before saving their accepted values. Codex ACP rejects unsupported live `off` changes explicitly, retaining the conversation and previous effort; fresh-session `off` continues to omit the startup override. This behavior was explicitly approved by the maintainer and verified with paired real native Codex sessions. The final Ollama sibling trace, all 255 isolated ACPX tests, and exact-head CI also pass.

Configured ACP agents now carry their thinking policy alongside their model, both when creating a bound session and when updating an existing conversation. ACP spawning also honors a configured target agent's `thinkingDefault` after explicit/subagent overrides.

Fixes #128145. Consolidates the configured-binding work in #129260 into this PR; thanks @chelsealong and @ayeshafayyaz-pixel.

## What Problem This Solves

The configured-binding producer and record carried model, backend, and cwd but omitted thinking. The lifecycle consequently never applied a configured thinking value. ACP spawning had the adjacent mismatch: it inherited the configured agent's model but skipped that agent's thinking default.

The canonical flow now resolves configured thinking at the binding producer (agent, then per-model policy, then global), carries it through the binding record, and reuses one explicit model/thinking projection for initialization and in-place reconciliation. Unconfigured external-harness defaults remain external-harness owned. A redundant spec-copy helper and the custom model-ref parser are removed in favor of the typed materialization and existing parser/resolver.

Removing the last configured value preserves the current session selection in both metadata and the backend. This follows the existing configured-model contract from #120046; it does not introduce an unset operation or reset a conversation. If removing an agent default reveals a remaining per-model/global policy, that concrete replacement is applied normally.

Ready-session updates reuse the manager's existing checked config-option command instead of metadata-only updates. Each model/thinking value is persisted only after backend acceptance. Rejection returns a visible error without marking the session broken or triggering recreation on the next admission. Model is applied before thinking; these are independent operations, not an atomic batch.

## Review findings and scope

- Addressed the live-unset finding by removing the misleading `thinking: undefined` update, not by discarding conversation history. ACPX 0.13.1 exposes string-valued config writes, not generic unset; ordinary close also preserves its desired settings.
- Addressed the already-ready-session gap from #129260 through the shared in-place reconciliation path.
- No new config keys, environment variables, dependency changes, SQLite schema changes, or protocol changes. The added binding metadata field carries existing configuration through the existing record shape; this is not an embedding/vector storage change.
- Addressed the Codex live-`off` finding at the plugin-owned adapter boundary: unsupported clearing is an error, not an acknowledged no-op. The configured lifecycle now uses apply-before-persist semantics, while startup omission remains supported.
- Production LOC: +37/-45 (net -8). Tests: +429/-51. Docs: +19/-1.
- Provenance: #120046 (authored and merged by @steipete on 2026-08-06) carried forward the thinking omission while adding configured-model propagation. The ACP spawn model inheritance predates this PR in commit `9ead0ae9219e87ba2c223ada385f380fea9415cc`; its code author was Peter Steinberger. These identify the incomplete owner boundary, not an assertion that this PR introduced the original defect.

## Evidence

- Red-before proof: current-main configured-binding producer drops all three tested configured thinking policies; the incoming PR fails session-selection preservation; ACP spawn fails owner-off precedence and model-less owner-off propagation.
- Additional red-before proof against `ab915c0`: all three live Codex effort aliases acknowledge `off` instead of rejecting it, and the real lifecycle/manager boundary accepts a rejected configured value. After repair, 136 focused tests pass, including fresh `off`, accepted `high`, repeated rejected `off`, omission, unchanged accepted metadata, and conversation reuse.
- Focused suite: 103 tests passed across configured-binding resolution, lifecycle, and ACP spawning, including record round-trip, per-model aliases, absent policy, existing-session updates, omission, explicit/subagent precedence, and harness defaults.
- Post-refresh broader suite: 282 tests passed across 20 files and six Vitest shards, including the ACP control plane, persistent bindings, channel binding/driver surfaces, and ACP spawning.
- Independent Codex review: no findings at the configured reporting threshold on the original branch, the live-off repair, and the final test-only follow-up. Manual owner-boundary review and regression proof also addressed the prior P1 findings. Dependency inspection covered ACPX's successful-set persistence, ordinary-close preservation, and config-option contract, plus Codex sparse model/effort settings ownership.
- Original full changed checks passed at `ab915c0`, including core/plugin type checks, tests type checks, lint, import cycles, dependency/boundary guards, and state guards. The final full changed-check run also passed, including the storage, sidecar, webhook, and pairing guards. Its initial file plan preceded the test-only move; the new focused file separately passed the ACP-owning test type shard and lint, and final exact-head CI covers the full resulting tree.
- Final-head test-only cleanup: 124 focused manager/configured-binding/plugin tests passed; the ACP-owning test type shard and focused lint passed. The first CI attempt caught a test-file line limit and a table-union type error; both were repaired without production changes in `20eb662338b51c1c40d2c530953b82e559e4e439`. Final exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/33131393073) passed, including the required gate and build artifacts. The separate [OpenGrep scan](https://github.com/openclaw/openclaw/actions/runs/33131392502/attempts/2) passed on retry: its first attempt failed to fetch the base commit before any scan ran; the second fetched it and completed the scan and SARIF upload successfully, with no source change.
- The broader local sweep passed 527 of 530 tests; three unchanged Pi catalog tests timed out during cold module loading. A complete local ACPX rerun reproduced those same three timeouts (252/255 passed). These runs are not counted as green. The exact-final-source isolated Linux whole-plugin rerun passed **255 tests across 22 files** in 28.64 seconds; all three affected Pi tests completed in 16.7–17.6 seconds under their unchanged 120-second deadlines. Provider credentials were removed before this run. The environment comparison supports local contention as the cause; no timeout, assertion, or production workaround was added.
- Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/33032111997) passed at `ab915c0e30dd02f9ef9bde426ac8f2425964306e`, including `build-artifacts` and required `openclaw/ci-gate`. An earlier PR-context check rejected the heading names; the required problem/evidence headings are now present and the checks are green.
- Direct Codex contract inspection was completed by the acting maintainer agent at `d47e5cc0e2bbd35774dff15c83570519735d2ac4`: [sparse model/effort settings](https://github.com/openai/codex/blob/d47e5cc0e2bbd35774dff15c83570519735d2ac4/codex-rs/core/src/session/step_settings.rs#L214) and [queued-versus-applied settings](https://github.com/openai/codex/blob/d47e5cc0e2bbd35774dff15c83570519735d2ac4/codex-rs/app-server/src/request_processors/turn_processor.rs#L704). The automated review's missing sibling checkout is not a remaining inspection gap.

### Live configured-binding trace

Completed an isolated, authenticated real-provider comparison: managed Gateway with normal signed-device authentication and real `config.set` hot reloads; actual configured-binding consumer → serialized record → lifecycle admission; public `chat.send` → real ACPX stdio → OpenClaw ACP bridge → `ollama-cloud/glm-5.2:cloud`. No manager/backend/provider mocks. This is owner-boundary integration, not Slack transport E2E or live model-switch proof.

Both versions received the same three-step scenario: configure owner thinking `off`, change it to `high`, then remove it entirely. Each step made a real provider turn. Later prompts asked for a randomized fictional sentence from the first turn without resending it. The final paired runs both exited 0; the baseline verdict deliberately asserts the known regression, while the candidate asserts the repair.

```json
{
  "baseline": {
    "source": "801cbbd665ef73027f1fc0e7ac52be1dc8cfe280",
    "configuredThinking": ["off", "high", null],
    "bindingSpecThinking": [null, null, null],
    "innerSessionThinking": [null, null, null],
    "acpxCurrentThoughtLevel": ["adaptive", "adaptive", "adaptive"],
    "acpxDesiredThoughtLevel": [null, null, null],
    "completedProviderTurns": 3,
    "innerOuterAndBackendSessionIdsStable": true,
    "historyRecallPreserved": true,
    "expectedRegressionReproduced": true
  },
  "candidate": {
    "source": "ab915c0e30dd02f9ef9bde426ac8f2425964306e",
    "configuredThinking": ["off", "high", null],
    "bindingSpecThinking": ["off", "high", null],
    "innerSessionThinking": ["off", "high", "high"],
    "acpxCurrentThoughtLevel": ["off", "high", "high"],
    "acpxDesiredThoughtLevel": ["off", "high", "high"],
    "completedProviderTurns": 3,
    "innerOuterAndBackendSessionIdsStable": true,
    "historyRecallPreserved": true,
    "repairVerified": true
  }
}
```

Provenance: all eight candidate source files matched their exact `ab915c0` Git blobs after transport; patch SHA-256 `4ae7008ecb6e8f51595b41b746e33c65e5cd7c3ba75ac888b59776c366145bac`. The live process source-loaded the changed owners with the unchanged trusted-baseline built plugin/child runtime; candidate build coverage comes separately from exact-head CI. The identical final proof script had SHA-256 `29ae1ca452ddc021a2ee9c44ee3f0ae26d28469b4bcb793c49ee0ffde0208146` and was invoked with `node --import tsx gateway-proof.mjs` in each isolated source copy.

One earlier fixture attempt failed its expected-reply marker because the model mistook a UUID-shaped test phrase for a credential. Canonical transcript evidence showed a normal completed high-thinking reply in approximately ten seconds, not a provider timeout. Replaced only the synthetic recall content with an ordinary fictional sentence and made terminal marker failures immediate; reran both versions with unchanged settings/history assertions and unchanged deadlines.

This trace addresses the earlier ClawSweeper configured-binding next-turn/session-state proof request. The binding field is ordinary existing metadata, not vector/embedding storage or a schema migration. The final candidate additionally changes the checked live-control path; its Codex proof is recorded separately below.

### Codex explicit-off repair

The final candidate additionally repeated the supported-control Ollama scenario with its fully rebuilt ACPX plugin and canonical active Gateway config. All three real provider turns passed: inner session thinking, current backend option, and desired option were each `off → high → high`; outer, inner, and backend session IDs stayed stable, and later replies recalled the first turn's fictional sentence. Final script SHA-256 `948e0fe874242fcedc3165ab8e0cb72cc7a0e0a4820dabb4201d11c69ba1ed2c`. The fixture uses the documented `--token-file` with an isolated generated Gateway token; an earlier missing-token handshake failed before any provider turn and is not counted as proof. The inner model is explicitly configured as reasoning-capable; this does not verify or change published model-catalog reasoning metadata. Both Codex and Ollama final phases use candidate `5c8f87f`, whose production/docs are byte-identical to final test-only head `20eb662`.

The subsequent ClawSweeper review correctly identified an uncovered Codex transition: `extensions/acpx/src/runtime.ts` mapped `off` to no effort and returned before delegate I/O, so an existing `high` selection was not cleared. The Ollama trace above does not establish Codex live-clear behavior.

Direct source inspection confirms the constraint: pinned `@agentclientprotocol/codex-acp@1.6.0` accepts only advertised string-valued reasoning efforts, not null/default/off. Codex `turn/start` maps its optional effort to a supplied update; null/omission preserves the current setting, despite an internal nullable update type. The adapter's legacy bare-model operation can select the model default, but that is neither the original startup policy nor a generic clear exposed through the current ACPX delegate. Native `none` is valid only for models advertising it and is not equivalent to the shipped OpenClaw `off` contract.

Stable OpenClaw `v2026.7.1-2` already omits the Codex startup override for `off`. The approved repair preserves that startup contract and returns `ACP_BACKEND_UNSUPPORTED_CONTROL` for live clearing. It does not map `off` to native `none`, reset the conversation, or claim metadata-only success. A separately defined upstream reset contract remains out of scope.

### Paired native Codex final-effect proof

Both phases completed successfully on isolated Linux: baseline `ab915c0` and candidate `5c8f87f` (production/docs byte-identical to final head `20eb662`). Each source copy received a full build, including its actual ACPX plugin, and used real `codex-cli 0.149.1` with `@agentclientprotocol/codex-acp@1.6.0`, public model `openai/gpt-5.6-sol`, normal signed Gateway authentication, public `chat.send`, actual configured-binding admission, and real config reloads. A passive allowlisted native-protocol tap recorded actual `turn/start` efforts and matching completed turns, not just OpenClaw metadata. Native startup default was deliberately set to `medium` in the test harness; this is not a claim about the model's catalog default.

| Observation | Baseline | Candidate |
| --- | --- | --- |
| First real turn | `high` | `high` |
| Explicit live `off` reply | Acknowledged success; metadata becomes `off` | Visible `ACP_BACKEND_UNSUPPORTED_CONTROL`; metadata remains `high` |
| Next real turn | Still `high` despite the acknowledgment | `high`, matching the retained accepted state |
| Configured `off`, including repeated admission | Accepted | Both attempts visibly rejected; accepted metadata/backend effort remain `high` |
| Omit policy, then real history-recall turn | `medium` after actual config reload | `high` |
| Separate fresh configured `off` session | Usable; actual controlled default `medium` | Usable; actual controlled default `medium` |
| Completed native provider turns | 4 | 4 |
| Existing conversation IDs and recalled history | Preserved | Preserved |

The baseline's warm explicit control is the reproduced no-op. Its later genuine config reload can resume the same thread with the controlled startup default, so the proof does not claim that every reinitialization retains `high`. The candidate retains accepted `high` across both rejected controls and reloads. Both phases used identical final harness SHA-256 `711f287ac04629464927c3196bb9b5b8f572e7ca28e11536d68a222198b15e45` and passive tap SHA-256 `1a614ed7b8fb07319bab6f4b1590e98e8886c047250d1ea888cdb0839ab28226`; candidate behavior patch SHA-256 `93fe08a70f87f31bfee103445e383122cccd85b586a7816764c89791453de054`. The acting maintainer agent inspected the actual structured state, error replies, stable IDs, native requests/completions, and history replies.

Earlier fixture failures were corrected, not counted as proof: cold source initialization preceded the client connection to avoid an idle client watchdog; the model was changed to an advertised public model with actual effort controls; and observation was made passive using the canonical active config object. Passing a separate raw config object to a status call had inadvertently reinitialized the runtime and changed what was being measured. Both baseline and candidate were rerun with the identical corrected harness; no production timeout, assertion, or reset workaround was added.

The latest ClawSweeper rank-up moves are addressed: the maintainer selected the visible-error contract, the real manager/lifecycle regression covers acceptance and rejection, and this trace establishes final effects on an existing Codex session. Direct acting-agent dependency inspection also includes pinned Codex `rust-v0.149.1` (`ff29a44391deccde0aba0f8390337d7f3c319ea4`), `codex-rs/app-server/src/request_processors/turn_processor.rs:535-549`, plus the current sparse-setting boundary linked above. This remains owner-boundary/provider proof, not Slack transport E2E or cross-model normalization proof.

Live cleanup was verified before the clean-machine test sweep: all seven task-owned state directories removed, no owned Gateway/ACP/Codex children remaining, all seven Gateway ports closed, and no provider credentials forwarded to tests. After the suite passed, the owned isolated lease was verified released and the task secret window removed. No operator state was touched.

## Known separate follow-up

Named follow-up: **Hidden native models lack ACP effort controls.** Pinned Codex can run a configured public model omitted from its default `model/list`, while the ACP adapter synthesizes a model choice without corresponding effort controls. The initial `gpt-5.4` fixture completed a real high-effort turn but exposed no effort option; pinned catalog visibility and adapter model-list handling explain the mismatch. This is a separate catalog/control-availability boundary. Final proof uses the advertised public model above and does not claim to fix hidden-model control discovery.

Named follow-up: **Model changes need pairwise model/effort acceptance ownership.** Codex ACP can retain the old effort when supported by the new model or select the new model's default otherwise (`codex-acp@1.6.0`, `applyModelChange`). The existing generic model setter persists only the requested model and retains thinking metadata; automatic next-turn thinking rejection is optional. Thus an unchanged configured effort can disagree with the new model's effective effort. Merely rechecking thinking on the first model-change admission is insufficient: after that rejection, the accepted model is already stored, so a retry can skip both matching values. This also affects the existing manual model-control owner and needs a separately defined effective-settings/acceptance contract, not a metadata-only guard, a Codex-specific `off` exception in core, or an assertion of atomic batch behavior. This PR's paired live proof keeps the model fixed and does not claim to repair cross-model effort normalization.

`/acp reset-options` currently closes the runtime normally and deletes OpenClaw option metadata; ACPX ordinary close preserves its own desired settings. A generic non-destructive backend-default reset needs a separate explicit contract. This PR does not recommend that command as a proven backend reset and does not add destructive reset behavior.

The report's explicit runtime mode `auto` is a separate control from configured thinking. The OpenClaw ACP bridge maps it to adaptive thinking, which can legitimately be rejected by an incompatible model; forwarding an owner default does not make unsupported explicit modes valid.

The paired live runs separately exercised `/acp set-mode auto`: both returned a visible unsupported-adaptive error. The candidate retained its accepted `high` setting after that rejection. This is not claimed as repaired by configured-default forwarding.

Named follow-up: **ACP `chat.send` duplicates canonical transcript turns because `reply_dispatch` does not communicate transcript ownership.** Both baseline and candidate canonical transcripts showed two outer user/assistant copies but one inner copy for each of the three provider turns. Source inspection finds both producers already on the trusted baseline: ACP dispatch persists the pair, then Gateway's non-agent finalizer persists it again with different idempotency ownership. The correct follow-up is the dispatch/recorder ownership handoff, not text-based storage deduplication or pretending a native agent run started. This independent path is unchanged by this PR.
