### PR TITLE
refactor(plugins): unify plugin entry ordering

### DIFF
--- a/src/plugins/document-extractors.runtime.ts
+++ b/src/plugins/document-extractors.runtime.ts
@@ -7,19 +7,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveEnabledBundledManifestContractPlugins } from "./bundled-manifest-contract-plugins.js";
 import { loadBundledDocumentExtractorEntriesFromDir } from "./document-extractor-public-artifacts.js";
 import type { PluginDocumentExtractorEntry } from "./document-extractor-types.js";
+import { sortPluginEntriesForAutoDetect } from "./plugin-entry-order.js";
 import { createPluginIdScopeSet } from "./plugin-scope.js";
-
-function compareExtractors(
-  left: PluginDocumentExtractorEntry,
-  right: PluginDocumentExtractorEntry,
-): number {
-  const leftOrder = left.autoDetectOrder ?? Number.MAX_SAFE_INTEGER;
-  const rightOrder = right.autoDetectOrder ?? Number.MAX_SAFE_INTEGER;
-  if (leftOrder !== rightOrder) {
-    return leftOrder - rightOrder;
-  }
-  return left.id.localeCompare(right.id) || left.pluginId.localeCompare(right.pluginId);
-}
 
 function resolveExplicitAllowedDocumentExtractorPluginIds(params: {
   config?: OpenClawConfig;
@@ -82,5 +71,5 @@ export function resolvePluginDocumentExtractors(params?: {
       cause: loadErrors.length === 1 ? loadErrors[0] : new AggregateError(loadErrors),
     });
   }
-  return extractors.toSorted(compareExtractors);
+  return sortPluginEntriesForAutoDetect(extractors);
 }

--- a/src/plugins/plugin-entry-order.test.ts
+++ b/src/plugins/plugin-entry-order.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { sortPluginEntriesById, sortPluginEntriesForAutoDetect } from "./plugin-entry-order.js";
+
+type TestEntry = {
+  id: string;
+  pluginId: string;
+  autoDetectOrder?: number;
+};
+
+function toKeys(entries: readonly TestEntry[]): string[] {
+  return entries.map((entry) => `${entry.id}:${entry.pluginId}`);
+}
+
+describe("plugin entry order", () => {
+  it("sorts identities without mutating the input", () => {
+    const entries = [
+      { id: "beta", pluginId: "plugin-b" },
+      { id: "alpha", pluginId: "plugin-z" },
+      { id: "alpha", pluginId: "plugin-a" },
+    ] satisfies TestEntry[];
+
+    expect(toKeys(sortPluginEntriesById(entries))).toEqual([
+      "alpha:plugin-a",
+      "alpha:plugin-z",
+      "beta:plugin-b",
+    ]);
+    expect(toKeys(entries)).toEqual(["beta:plugin-b", "alpha:plugin-z", "alpha:plugin-a"]);
+  });
+
+  it("sorts auto-detect priorities before deterministic identity ties", () => {
+    const entries = [
+      { id: "unordered", pluginId: "plugin-u" },
+      { id: "beta", pluginId: "plugin-b", autoDetectOrder: 10 },
+      { id: "alpha", pluginId: "plugin-z", autoDetectOrder: 10 },
+      { id: "alpha", pluginId: "plugin-a", autoDetectOrder: 10 },
+      { id: "first", pluginId: "plugin-f", autoDetectOrder: 1 },
+    ] satisfies TestEntry[];
+
+    expect(toKeys(sortPluginEntriesForAutoDetect(entries))).toEqual([
+      "first:plugin-f",
+      "alpha:plugin-a",
+      "alpha:plugin-z",
+      "beta:plugin-b",
+      "unordered:plugin-u",
+    ]);
+    expect(toKeys(entries)).toEqual([
+      "unordered:plugin-u",
+      "beta:plugin-b",
+      "alpha:plugin-z",
+      "alpha:plugin-a",
+      "first:plugin-f",
+    ]);
+  });
+});

--- a/src/plugins/plugin-entry-order.ts
+++ b/src/plugins/plugin-entry-order.ts
@@ -1,0 +1,30 @@
+type PluginEntryIdentity = {
+  id: string;
+  pluginId: string;
+};
+
+type PluginAutoDetectEntry = PluginEntryIdentity & {
+  autoDetectOrder?: number;
+};
+
+function comparePluginEntryIdentity(left: PluginEntryIdentity, right: PluginEntryIdentity): number {
+  return left.id.localeCompare(right.id) || left.pluginId.localeCompare(right.pluginId);
+}
+
+export function sortPluginEntriesById<T extends PluginEntryIdentity>(entries: readonly T[]): T[] {
+  return entries.toSorted(comparePluginEntryIdentity);
+}
+
+/** Sorts auto-detect candidates by priority, then stable plugin identity. */
+export function sortPluginEntriesForAutoDetect<T extends PluginAutoDetectEntry>(
+  entries: readonly T[],
+): T[] {
+  return entries.toSorted((left, right) => {
+    const leftOrder = left.autoDetectOrder ?? Number.MAX_SAFE_INTEGER;
+    const rightOrder = right.autoDetectOrder ?? Number.MAX_SAFE_INTEGER;
+    if (leftOrder !== rightOrder) {
+      return leftOrder - rightOrder;
+    }
+    return comparePluginEntryIdentity(left, right);
+  });
+}

--- a/src/plugins/web-content-extractors.runtime.ts
+++ b/src/plugins/web-content-extractors.runtime.ts
@@ -1,20 +1,9 @@
 // Runtime bridge for web content extractors supplied by plugins.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveEnabledBundledManifestContractPlugins } from "./bundled-manifest-contract-plugins.js";
+import { sortPluginEntriesForAutoDetect } from "./plugin-entry-order.js";
 import { loadBundledWebContentExtractorEntriesFromDir } from "./web-content-extractor-public-artifacts.js";
 import type { PluginWebContentExtractorEntry } from "./web-content-extractor-types.js";
-
-function compareExtractors(
-  left: PluginWebContentExtractorEntry,
-  right: PluginWebContentExtractorEntry,
-): number {
-  const leftOrder = left.autoDetectOrder ?? Number.MAX_SAFE_INTEGER;
-  const rightOrder = right.autoDetectOrder ?? Number.MAX_SAFE_INTEGER;
-  if (leftOrder !== rightOrder) {
-    return leftOrder - rightOrder;
-  }
-  return left.id.localeCompare(right.id) || left.pluginId.localeCompare(right.pluginId);
-}
 
 export function resolvePluginWebContentExtractors(params?: {
   config?: OpenClawConfig;
@@ -38,5 +27,5 @@ export function resolvePluginWebContentExtractors(params?: {
       extractors.push(...loaded);
     }
   }
-  return extractors.toSorted(compareExtractors);
+  return sortPluginEntriesForAutoDetect(extractors);
 }

--- a/src/plugins/web-fetch-providers.shared.ts
+++ b/src/plugins/web-fetch-providers.shared.ts
@@ -1,23 +1,20 @@
 // Shares web fetch provider loading helpers across provider plugins.
 import type { PluginLoadOptions } from "./loader.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
+import { sortPluginEntriesById, sortPluginEntriesForAutoDetect } from "./plugin-entry-order.js";
 import type { PluginWebFetchProviderEntry } from "./types.js";
-import {
-  resolveBundledWebProviderResolutionConfig,
-  sortPluginProviders,
-  sortPluginProvidersForAutoDetect,
-} from "./web-provider-resolution-shared.js";
+import { resolveBundledWebProviderResolutionConfig } from "./web-provider-resolution-shared.js";
 
 export function sortWebFetchProviders(
   providers: PluginWebFetchProviderEntry[],
 ): PluginWebFetchProviderEntry[] {
-  return sortPluginProviders(providers);
+  return sortPluginEntriesById(providers);
 }
 
 export function sortWebFetchProvidersForAutoDetect(
   providers: PluginWebFetchProviderEntry[],
 ): PluginWebFetchProviderEntry[] {
-  return sortPluginProvidersForAutoDetect(providers);
+  return sortPluginEntriesForAutoDetect(providers);
 }
 
 export function resolveBundledWebFetchResolutionConfig(params: {

--- a/src/plugins/web-provider-resolution-shared.ts
+++ b/src/plugins/web-provider-resolution-shared.ts
@@ -15,39 +15,6 @@ type WebProviderCandidateResolution = {
   manifestRecords?: readonly PluginManifestRecord[];
 };
 
-type WebProviderSortEntry = {
-  id: string;
-  pluginId: string;
-  autoDetectOrder?: number;
-};
-
-function comparePluginProvidersAlphabetically(
-  left: Pick<WebProviderSortEntry, "id" | "pluginId">,
-  right: Pick<WebProviderSortEntry, "id" | "pluginId">,
-): number {
-  return left.id.localeCompare(right.id) || left.pluginId.localeCompare(right.pluginId);
-}
-
-export function sortPluginProviders<T extends Pick<WebProviderSortEntry, "id" | "pluginId">>(
-  providers: T[],
-): T[] {
-  return providers.toSorted(comparePluginProvidersAlphabetically);
-}
-
-/** Sorts provider candidates for auto-detect while keeping equal priorities deterministic. */
-export function sortPluginProvidersForAutoDetect<T extends WebProviderSortEntry>(
-  providers: T[],
-): T[] {
-  return providers.toSorted((left, right) => {
-    const leftOrder = left.autoDetectOrder ?? Number.MAX_SAFE_INTEGER;
-    const rightOrder = right.autoDetectOrder ?? Number.MAX_SAFE_INTEGER;
-    if (leftOrder !== rightOrder) {
-      return leftOrder - rightOrder;
-    }
-    return comparePluginProvidersAlphabetically(left, right);
-  });
-}
-
 function pluginManifestDeclaresProviderConfig(
   record: PluginManifestRecord,
   configKey: WebProviderConfigKey,

--- a/src/plugins/web-search-providers.shared.ts
+++ b/src/plugins/web-search-providers.shared.ts
@@ -1,23 +1,20 @@
 // Shares web-search provider loading helpers across runtime paths.
 import type { PluginLoadOptions } from "./loader.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
+import { sortPluginEntriesById, sortPluginEntriesForAutoDetect } from "./plugin-entry-order.js";
 import type { PluginWebSearchProviderEntry } from "./types.js";
-import {
-  resolveBundledWebProviderResolutionConfig,
-  sortPluginProviders,
-  sortPluginProvidersForAutoDetect,
-} from "./web-provider-resolution-shared.js";
+import { resolveBundledWebProviderResolutionConfig } from "./web-provider-resolution-shared.js";
 
 export function sortWebSearchProviders(
   providers: PluginWebSearchProviderEntry[],
 ): PluginWebSearchProviderEntry[] {
-  return sortPluginProviders(providers);
+  return sortPluginEntriesById(providers);
 }
 
 export function sortWebSearchProvidersForAutoDetect(
   providers: PluginWebSearchProviderEntry[],
 ): PluginWebSearchProviderEntry[] {
-  return sortPluginProvidersForAutoDetect(providers);
+  return sortPluginEntriesForAutoDetect(providers);
 }
 
 export function resolveBundledWebSearchResolutionConfig(params: {


### PR DESCRIPTION
## What Problem This Solves

Plugin entry ordering policy was split across web-provider resolution and two extractor runtimes. The duplicated comparators encoded the same deterministic identity and auto-detect priority rules in three ownership surfaces, making future ordering changes prone to drift.

## Why This Change Was Made

- Adds a dependency-free `plugin-entry-order` leaf as the canonical owner for plugin entry ordering.
- Moves identity ordering and auto-detect priority ordering out of web-provider resolution.
- Reuses the same owner from web search, web fetch, document extraction, and web-content extraction.
- Preserves non-mutating sorting, numeric priority, undefined-priority placement, and `id`/`pluginId` tie-breaking.
- Removes the local extractor comparators and the generic sorter policy from web-provider resolution.

Production delta: +42/-73 (net -31). Test delta: +54/-0.

## User Impact

No intended user-visible behavior change. Provider and extractor selection order remains deterministic while the shared policy now has one owner.

## Evidence

- Exact reviewed head: `570360471b69595ecae395d4e710963aed377aec` (signed), tree `b61500a9ca5ffe4c4c329d19592a7f066a13d898`, patch-id `724a174d898dca4b2d41dea5be5842aee9f8e23d`.
- Independent source review: no findings; best-fix verdict; randomized equivalence matched 1,000 cases including negative, zero, undefined, `Number.MAX_SAFE_INTEGER`, infinities, and `NaN`.
- Focused local proof: 77 tests passed before publication.
- Blacksmith Testbox `tbx_01m0pzzrrpx9ccyyh46t1zs1r4`: 86/86 focused tests and 28/28 exact changed checks passed. Run: https://github.com/openclaw/openclaw/actions/runs/32631738294
- Direct AWS Crabbox `cbx_59271e0f7705`: 86/86 focused tests and the exact `core, coreTests` changed gate passed. Run: https://crabbox.openclaw.ai/portal/runs/run_96442965decf
- Targeted formatting passed for all seven files.
- `git diff --check` passed locally, on Testbox, and on direct AWS.
- ClawSweeper's live transcript ran `plugin-entry-order.test.ts` twice and both runs passed; its reported partial failure was only the terminal `expect_output` watcher timing out after the successful test output.

## Current Main And Rank-Up Move

The exact-head review compared this PR with current `main` after the branch was created. All five existing target blobs remain byte-identical, both new paths remain absent, the live open-PR collision scan is clear, and the merge-tree succeeds.

The suggested rebase is intentionally skipped because `main` movement is unrelated to this owner boundary and does not create a conflict or material stale-base risk. Rebasing solely for unrelated movement would discard the signed, independently reviewed, Testbox-proven, and AWS-proven head without changing the patch. Native prepare/landing must still revalidate the merge against the then-current `main`.
