### PR TITLE
fix(ios): device status leaves battery monitoring enabled

### DIFF
--- a/apps/ios/Sources/Device/DeviceStatusService.swift
+++ b/apps/ios/Sources/Device/DeviceStatusService.swift
@@ -42,7 +42,9 @@ final class DeviceStatusService: DeviceStatusServicing {
 
     private func batteryStatus() -> OpenClawBatteryStatusPayload {
         let device = UIDevice.current
+        let wasMonitoring = device.isBatteryMonitoringEnabled
         device.isBatteryMonitoringEnabled = true
+        defer { device.isBatteryMonitoringEnabled = wasMonitoring }
         let level = device.batteryLevel >= 0 ? Double(device.batteryLevel) : nil
         let state: OpenClawBatteryState = switch device.batteryState {
         case .charging: .charging

--- a/apps/ios/Sources/Device/DeviceStatusService.swift
+++ b/apps/ios/Sources/Device/DeviceStatusService.swift
@@ -11,7 +11,7 @@ final class DeviceStatusService: DeviceStatusServicing {
     }
 
     func status() async throws -> OpenClawDeviceStatusPayload {
-        let battery = self.batteryStatus()
+        let battery = Self.batteryStatus(device: UIDevice.current)
         let thermal = self.thermalStatus()
         let storage = self.storageStatus()
         let network = await self.networkStatus.currentStatus()
@@ -40,8 +40,7 @@ final class DeviceStatusService: DeviceStatusServicing {
             locale: locale)
     }
 
-    private func batteryStatus() -> OpenClawBatteryStatusPayload {
-        let device = UIDevice.current
+    static func batteryStatus(device: UIDevice) -> OpenClawBatteryStatusPayload {
         let wasMonitoring = device.isBatteryMonitoringEnabled
         device.isBatteryMonitoringEnabled = true
         defer { device.isBatteryMonitoringEnabled = wasMonitoring }

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -974,22 +974,43 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
     }
 }
 
+@MainActor
+private final class BatteryMonitoringDevice: UIDevice {
+    private var monitoringEnabled: Bool
+    private(set) var monitoringStatesDuringBatteryReads: [Bool] = []
+
+    init(monitoringEnabled: Bool) {
+        self.monitoringEnabled = monitoringEnabled
+        super.init()
+    }
+
+    override var isBatteryMonitoringEnabled: Bool {
+        get { self.monitoringEnabled }
+        set { self.monitoringEnabled = newValue }
+    }
+
+    override var batteryLevel: Float {
+        self.monitoringStatesDuringBatteryReads.append(self.monitoringEnabled)
+        return 0.5
+    }
+
+    override var batteryState: UIDevice.BatteryState {
+        self.monitoringStatesDuringBatteryReads.append(self.monitoringEnabled)
+        return .charging
+    }
+}
+
 @Suite(.serialized) struct NodeAppModelInvokeTests {
-    @Test @MainActor func `device status preserves battery monitoring ownership`() async {
-        let device = UIDevice.current
-        let original = device.isBatteryMonitoringEnabled
-        defer { device.isBatteryMonitoringEnabled = original }
-        let appModel = NodeAppModel()
+    @Test @MainActor func `device status battery snapshot preserves monitoring ownership`() {
+        for initial in [false, true] {
+            let device = BatteryMonitoringDevice(monitoringEnabled: initial)
 
-        for requestedInitial in [false, true] {
-            device.isBatteryMonitoringEnabled = requestedInitial
-            // Simulator battery support varies, so preserve the state UIKit actually accepted.
-            let initial = device.isBatteryMonitoringEnabled
-            let response = await appModel.handleInvoke(BridgeInvokeRequest(
-                id: "device-status-\(requestedInitial)",
-                command: OpenClawDeviceCommand.status.rawValue))
+            let payload = DeviceStatusService.batteryStatus(device: device)
 
-            #expect(response.ok)
+            #expect(payload.level == 0.5)
+            #expect(payload.state == .charging)
+            #expect(!device.monitoringStatesDuringBatteryReads.isEmpty)
+            #expect(device.monitoringStatesDuringBatteryReads.allSatisfy(\.self))
             #expect(device.isBatteryMonitoringEnabled == initial)
         }
     }
@@ -7561,5 +7582,4 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
             try await appModel.sendVoiceTranscript(text: "hello", sessionKey: "main")
         }
     }
-
 }

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -1010,7 +1010,7 @@ private final class BatteryMonitoringDevice: UIDevice {
             #expect(payload.level == 0.5)
             #expect(payload.state == .charging)
             #expect(!device.monitoringStatesDuringBatteryReads.isEmpty)
-            #expect(device.monitoringStatesDuringBatteryReads.allSatisfy(\.self))
+            #expect(device.monitoringStatesDuringBatteryReads.allSatisfy { $0 })
             #expect(device.isBatteryMonitoringEnabled == initial)
         }
     }

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -975,6 +975,23 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 }
 
 @Suite(.serialized) struct NodeAppModelInvokeTests {
+    @Test @MainActor func `device status preserves battery monitoring ownership`() async {
+        let device = UIDevice.current
+        let original = device.isBatteryMonitoringEnabled
+        defer { device.isBatteryMonitoringEnabled = original }
+        let appModel = NodeAppModel()
+
+        for initial in [false, true] {
+            device.isBatteryMonitoringEnabled = initial
+            let response = await appModel.handleInvoke(BridgeInvokeRequest(
+                id: "device-status-\(initial)",
+                command: OpenClawDeviceCommand.status.rawValue))
+
+            #expect(response.ok)
+            #expect(device.isBatteryMonitoringEnabled == initial)
+        }
+    }
+
     @Test @MainActor func `health summary routes a fixed period to the health service`() async throws {
         let service = MockHealthSummaryService()
         let appModel = NodeAppModel(healthSummaryService: service)

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -981,10 +981,12 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         defer { device.isBatteryMonitoringEnabled = original }
         let appModel = NodeAppModel()
 
-        for initial in [false, true] {
-            device.isBatteryMonitoringEnabled = initial
+        for requestedInitial in [false, true] {
+            device.isBatteryMonitoringEnabled = requestedInitial
+            // Simulator battery support varies, so preserve the state UIKit actually accepted.
+            let initial = device.isBatteryMonitoringEnabled
             let response = await appModel.handleInvoke(BridgeInvokeRequest(
-                id: "device-status-\(initial)",
+                id: "device-status-\(requestedInitial)",
                 command: OpenClawDeviceCommand.status.rawValue))
 
             #expect(response.ok)

--- a/apps/ios/WatchApp/Sources/WatchDirectNode.swift
+++ b/apps/ios/WatchApp/Sources/WatchDirectNode.swift
@@ -688,7 +688,9 @@ final class WatchDirectNode {
 
     private func deviceStatus() -> OpenClawDeviceStatusPayload {
         let device = WKInterfaceDevice.current()
+        let wasMonitoring = device.isBatteryMonitoringEnabled
         device.isBatteryMonitoringEnabled = true
+        defer { device.isBatteryMonitoringEnabled = wasMonitoring }
         let batteryState: OpenClawBatteryState = switch device.batteryState {
         case .charging: .charging
         case .full: .full


### PR DESCRIPTION
Closes #127483

## What Problem This Solves

Fixes an issue where users requesting iPhone `device.status` would leave battery monitoring enabled for the rest of the app process, even when no other feature had enabled it. The analogous direct-node request on Apple Watch had the same ownership leak.

## Why This Change Was Made

Both native status owners now save the battery-monitoring state accepted by their platform, enable monitoring only for the synchronous snapshot, and restore the saved state with `defer`.

The iPhone regression now calls the production battery-snapshot owner with a deterministic `UIDevice` subclass. This keeps the check on the real production path while proving both initially disabled and initially enabled ownership states even when iOS Simulator itself rejects battery monitoring.

## User Impact

An iPhone or Apple Watch device-status request no longer leaves unnecessary battery notifications and monitoring work enabled. Features that already own battery monitoring keep it enabled after the request.

## Evidence

- Pre-fix UIKit runtime reproduction using the production iPhone service: `initial=false final=true`.
- Deterministic Mac Catalyst/UIKit proof compiled the production snapshot owner: every battery read observed monitoring enabled, then `initial=false final=false` and `initial=true final=true`.
- Mutation proof removed the restoration from that same production owner and failed as intended with `initial=false final=true`; the regression therefore detects the lifecycle bug on Simulator-capable CI.
- The Watch lifecycle fragment type-checks against the watchOS 26.5 SDK, and the modified production `WatchDirectNode.swift` parses for the watchOS target.
- `node scripts/check-changed.mjs -- apps/ios/Sources/Device/DeviceStatusService.swift apps/ios/Tests/NodeAppModelInvokeTests.swift apps/ios/WatchApp/Sources/WatchDirectNode.swift` — passed, including Swift lint (0 violations), formatting, dependency guards, and native-state checks.
- Focused SwiftFormat lint — 0 of 3 changed files require formatting; the iPhone regression source also parses against the iOS 26.5 Simulator SDK.
- This host exposes the iOS and watchOS SDK files but does not have their platform destinations installed, so local Xcode cannot select the full app or Watch targets. The PR `ios-build` lane remains the exact-target compile and test verification.
