### PR TITLE
fix(macos): make OpenClaw settings pane responsive

### DIFF
--- a/apps/macos/Sources/OpenClaw/SystemAgentSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SystemAgentSettings.swift
@@ -17,24 +17,30 @@ struct SystemAgentSettings: View {
         sessionPrefix: "mac-settings-openclaw")
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            SettingsPageHeader(
-                title: "OpenClaw",
-                subtitle: """
-                Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.
-                """)
+        GeometryReader { geometry in
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: 20) {
+                    SettingsPageHeader(
+                        title: "OpenClaw",
+                        subtitle: """
+                        Your AI-powered setup helper. It can check status, fix config, \
+                        switch models, and connect channels.
+                        """)
 
-            SettingsCardGroup("Chat") {
-                SystemAgentOnboardingChatView(model: self.chat)
-                    .frame(maxWidth: .infinity, minHeight: 320, maxHeight: .infinity)
+                    SettingsCardGroup("Chat") {
+                        SystemAgentOnboardingChatView(model: self.chat)
+                            .frame(maxWidth: .infinity, minHeight: 320, maxHeight: .infinity)
+                    }
+                    .frame(maxHeight: .infinity)
+
+                    Text("Tip: try “status”, “doctor”, “set default model …”, or “connect telegram”.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .settingsDetailContent()
+                .frame(minHeight: geometry.size.height, alignment: .top)
             }
-            .frame(maxHeight: .infinity)
-
-            Text("Tip: try “status”, “doctor”, “set default model …”, or “connect telegram”.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
         }
-        .settingsDetailContent()
         .task(id: self.isActive) {
             guard self.isActive else { return }
             Self.configureChatCallbacks(

--- a/apps/macos/Tests/OpenClawIPCTests/SystemAgentSettingsLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SystemAgentSettingsLayoutTests.swift
@@ -1,0 +1,100 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import OpenClaw
+
+@MainActor
+final class SystemAgentSettingsLayoutTests: XCTestCase {
+    private static var retainedWindows: [NSWindow] = []
+
+    func testPaneOwnsScrollableDetailContainer() async throws {
+        let hosting = NSHostingView(rootView: SystemAgentSettings(
+            isActive: false,
+            onReplyReceived: {}))
+        hosting.frame = NSRect(x: 0, y: 0, width: 800, height: 260)
+        let window = Self.retainWindow(hosting)
+
+        try await Self.waitForLayout(hosting, stage: "system agent detail scroll") {
+            Self.detailScrollView(in: hosting) != nil
+        }
+        let scroll = try XCTUnwrap(Self.detailScrollView(in: hosting))
+        let maximumOffset = scroll.documentView.map {
+            max(0, $0.bounds.height - scroll.contentView.bounds.height)
+        } ?? 0
+        XCTAssertGreaterThan(maximumOffset, 0)
+
+        window.orderOut(nil)
+    }
+
+    func testChatUsesAvailableDetailHeight() async throws {
+        let hosting = NSHostingView(rootView: SystemAgentSettings(
+            isActive: false,
+            onReplyReceived: {}))
+        hosting.frame = NSRect(x: 0, y: 0, width: 800, height: 700)
+        let window = Self.retainWindow(hosting)
+
+        try await Self.waitForLayout(hosting, stage: "system agent chat fills detail height") {
+            Self.chatScrollView(in: hosting)?.frame.height ?? 0 > hosting.frame.height / 2
+        }
+
+        window.orderOut(nil)
+    }
+
+    private static func retainWindow(_ hosting: NSView) -> NSWindow {
+        let window = NSWindow(
+            contentRect: hosting.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.isReleasedWhenClosed = false
+        window.contentView = hosting
+        self.retainedWindows.append(window)
+        return window
+    }
+
+    private static func detailScrollView(in view: NSView) -> NSScrollView? {
+        self.descendants(of: NSScrollView.self, in: view).first { scrollView in
+            guard let documentView = scrollView.documentView else { return false }
+            let containsChatScroll = !self.descendants(of: NSScrollView.self, in: documentView).isEmpty
+            return containsChatScroll && documentView.bounds.height > scrollView.contentView.bounds.height + 1
+        }
+    }
+
+    private static func chatScrollView(in view: NSView) -> NSScrollView? {
+        self.descendants(of: NSScrollView.self, in: view).first { scrollView in
+            scrollView.frame.width > 500 && self.descendants(of: NSScrollView.self, in: scrollView).count == 1
+        }
+    }
+
+    private static func descendants<T: NSView>(of type: T.Type, in view: NSView) -> [T] {
+        var matches: [T] = []
+        if let match = view as? T { matches.append(match) }
+        for child in view.subviews {
+            matches.append(contentsOf: self.descendants(of: type, in: child))
+        }
+        return matches
+    }
+
+    private static func waitForLayout(
+        _ hosting: NSView,
+        stage: String,
+        timeout: Duration = .seconds(3),
+        until condition: @MainActor () -> Bool) async throws
+    {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            hosting.layoutSubtreeIfNeeded()
+            if condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        throw SettingsLayoutTimeout(stage: stage)
+    }
+
+    private struct SettingsLayoutTimeout: Error, CustomStringConvertible {
+        let stage: String
+        var description: String {
+            "Settings layout timed out during \(self.stage)"
+        }
+    }
+}


### PR DESCRIPTION
Closes #128173

## What Problem This Solves

The native macOS OpenClaw Settings pane leaves most of the detail area unused at normal window sizes and provides no reliable vertical scroll path when the window is short.

## Why This Change Was Made

- Give the OpenClaw chat a minimum height derived from the available detail viewport.
- Place the pane in a vertical `ScrollView` so constrained content remains reachable.
- Preserve the existing chat and quick-action behavior.

## User Impact

The OpenClaw chat uses the available Settings window instead of staying as a compact card, and the pane scrolls when vertically constrained.

## Evidence

- `swift test --package-path apps/macos --filter SystemAgentSettingsLayoutTests` — 2/2 passed.
- SwiftFormat with `config/swiftformat` — 0/2 files require formatting.
- SwiftLint with `config/swiftlint.yml` — 0 violations.
- `git diff --check` — passed.
- OpenClaw autoreview — clean; confidence 0.90.
- Before/after runtime screenshots will be attached in a PR comment.

AI assistance was used to investigate, implement, test, and review this change. The final diff and proof were inspected against current `main`.

