### PR TITLE
fix(plugins): prevent duplicate background services and discovery advertisers

### DIFF
--- a/src/plugins/registry-registrars-operations.ts
+++ b/src/plugins/registry-registrars-operations.ts
@@ -371,7 +371,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
     if (!id) {
       return;
     }
-    const existing = registry.services.find((entry) => entry.service.id === id);
+    const existing = registry.services.find((entry) => entry.service.id.trim() === id);
     if (existing) {
       // Snapshot and activating loads can both register the same owner; keep the first.
       if (existing.pluginId === record.id) {
@@ -405,7 +405,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
     if (!id) {
       return;
     }
-    const existing = registry.gatewayDiscoveryServices.find((entry) => entry.service.id === id);
+    const existing = registry.gatewayDiscoveryServices.find((row) => row.service.id.trim() === id);
     if (existing) {
       if (existing.pluginId === record.id) {
         return;

--- a/src/plugins/registry.service-registration.test.ts
+++ b/src/plugins/registry.service-registration.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { createPluginRecord } from "./loader-records.js";
+import { createPluginRegistry } from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
+import { startPluginServices } from "./services.js";
+
+class ClassBackedLifecycleService {
+  starts = 0;
+  advertisements = 0;
+
+  constructor(readonly id: string) {}
+
+  start() {
+    this.starts += 1;
+  }
+
+  advertise() {
+    this.advertisements += 1;
+  }
+}
+
+function createRegistrationFixture() {
+  const builder = createPluginRegistry({
+    logger: {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    runtime: {} as PluginRuntime,
+    activateGlobalSideEffects: false,
+  });
+  const createRecord = (id: string) =>
+    createPluginRecord({
+      id,
+      source: `/plugins/${id}/index.ts`,
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+  return { builder, createRecord };
+}
+
+describe("plugin service registration identity", () => {
+  it.each([
+    { surface: "service", sameOwner: false, paddedFirst: true },
+    { surface: "service", sameOwner: false, paddedFirst: false },
+    { surface: "service", sameOwner: true, paddedFirst: true },
+    { surface: "service", sameOwner: true, paddedFirst: false },
+    { surface: "discovery", sameOwner: false, paddedFirst: true },
+    { surface: "discovery", sameOwner: false, paddedFirst: false },
+    { surface: "discovery", sameOwner: true, paddedFirst: true },
+    { surface: "discovery", sameOwner: true, paddedFirst: false },
+  ] as const)(
+    "deduplicates $surface registrations (same owner: $sameOwner, padded first: $paddedFirst)",
+    async ({ surface, sameOwner, paddedFirst }) => {
+      const { builder, createRecord } = createRegistrationFixture();
+      const firstRecord = createRecord("first-owner");
+      const secondRecord = sameOwner ? firstRecord : createRecord("second-owner");
+      const firstApi = builder.createApi(firstRecord, { config: {} });
+      const secondApi = builder.createApi(secondRecord, { config: {} });
+      const firstService = new ClassBackedLifecycleService(
+        paddedFirst ? " shared-service " : "shared-service",
+      );
+      const secondService = new ClassBackedLifecycleService(
+        paddedFirst ? "shared-service" : " shared-service ",
+      );
+
+      if (surface === "service") {
+        firstApi.registerService(firstService);
+        secondApi.registerService(secondService);
+      } else {
+        firstApi.registerGatewayDiscoveryService(firstService);
+        secondApi.registerGatewayDiscoveryService(secondService);
+      }
+
+      const registrations =
+        surface === "service"
+          ? builder.registry.services
+          : builder.registry.gatewayDiscoveryServices;
+      expect(registrations).toHaveLength(1);
+      expect(registrations[0]?.service).toBe(firstService);
+      expect(registrations[0]?.service).toBeInstanceOf(ClassBackedLifecycleService);
+
+      const recordIds =
+        surface === "service" ? firstRecord.services : firstRecord.gatewayDiscoveryServiceIds;
+      expect(recordIds).toEqual(["shared-service"]);
+
+      if (sameOwner) {
+        expect(builder.registry.diagnostics).toEqual([]);
+      } else {
+        expect(builder.registry.diagnostics).toEqual([
+          expect.objectContaining({
+            pluginId: "second-owner",
+            message:
+              surface === "service"
+                ? "service already registered: shared-service (first-owner)"
+                : "gateway discovery service already registered: shared-service (first-owner)",
+          }),
+        ]);
+        expect(
+          surface === "service" ? secondRecord.services : secondRecord.gatewayDiscoveryServiceIds,
+        ).toEqual([]);
+      }
+
+      if (surface === "service") {
+        const handle = await startPluginServices({ registry: builder.registry, config: {} });
+        expect(firstService.starts).toBe(1);
+        expect(secondService.starts).toBe(0);
+        await handle.stop();
+      } else {
+        await builder.registry.gatewayDiscoveryServices[0]?.service.advertise({} as never);
+        expect(firstService.advertisements).toBe(1);
+        expect(secondService.advertisements).toBe(0);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin users would run the same background service or Gateway discovery advertiser more than once, without a duplicate-registration diagnostic, when the first registered identifier contains leading or trailing whitespace. This affected both duplicate registrations from one plugin and conflicting registrations from different plugins.

## Why This Change Was Made

Both service registrars already normalize incoming identifiers and published metadata, but previously compared those identifiers against the unnormalized identifier retained on the original service object. Compare both sides in their canonical form while preserving the exact original service descriptor, including class-backed object identity, prototypes, methods, and established same-owner/cross-owner behavior.

Production delta: 2 additions, 2 deletions (net zero). No public API, configuration, authentication, persistence, protocol, or dependency changes.

## User Impact

Plugin background services and Gateway discovery advertisers now start only once per canonical service identifier. Conflicting plugins receive the existing actionable duplicate diagnostic, repeated registration by the same owner remains idempotent, and class-backed plugin services keep their original instance and lifecycle methods.

## Evidence

- Before the fix, the focused real-registration matrix produced four failing regressions: padded-first normal services and discovery advertisers, each for same-owner and cross-owner registration. The four canonical-first control cases already passed.
- After the fix, all eight cases pass, covering both registration orders, both owner relationships, both service surfaces, canonical metadata, duplicate diagnostics, exact object identity, class prototypes, and once-only lifecycle calls.
- The existing loader, class-backed graceful-initialization, service-lifecycle, and strict replacement suites also pass: **226 tests across five files and three Vitest projects**.
- A real `startPluginServices` plus `startGatewayDiscovery` execution started and advertised the retained class-backed instance once, never invoked the duplicate, stopped the advertiser once, and produced both existing cross-owner diagnostics.
- Production core typechecking, the focused plugin-platform test typecheck, targeted core lint, format, conflict/max-lines/assertion-safety ratchets, dependency/ownership/dead-export checks, database-first/native-state guards, import-cycle checks, and remaining relevant boundary guards pass.
- The broad local core-test typecheck reaches two unrelated pre-existing omissions in the shared dependency install: `@panzoom/panzoom` and `@types/pako`; the UI, dependency manifests, and lockfile are unchanged. The plugin-platform test typecheck and production typecheck both pass independently.
- Independent first-class review and fresh authenticated Codex review of the complete committed branch both reported no actionable findings.
- Base: `0a70356c558ccd6a7582a14c9c720e92eb552201`; reviewed head: `f6dc58ac8c3b3e2b3e6bc899bf196841eb9a625d`.

Focused verification:

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-autoqa-plugin-service-id-vitest-cache-20260823 \
  node scripts/run-vitest.mjs \
  src/plugins/registry.service-registration.test.ts \
  src/plugins/loader.test.ts \
  src/plugins/plugin-graceful-init-failure.test.ts \
  src/plugins/services.test.ts \
  src/plugins/services.replacement.test.ts \
  --configLoader runner

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental \
  --tsBuildInfoFile .artifacts/tsgo-cache/plugin-service-lifecycle-core.tsbuildinfo
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.plugins-platform.json --builders 1
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  src/plugins/registry-registrars-operations.ts src/plugins/registry.service-registration.test.ts
```
