### PR TITLE
fix(telegram): prevent duplicate replies after attachment delivery failures

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -183,6 +183,7 @@ async function deliverTextReply(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
+  acceptedMessageIds?: string[];
   recordMessageId: (messageId: number) => void;
   quoteOnlyOnFirstChunk?: boolean;
   onPlatformSendDispatch?: () => Promise<void>;
@@ -233,6 +234,7 @@ async function deliverTextReply(params: {
           silent: params.silent,
           replyMarkup: first ? params.replyMarkup : undefined,
           onAcceptedMessage: async (messageId, plainText) => {
+            params.acceptedMessageIds?.push(String(messageId));
             messageIds.push(String(messageId));
             await tracker.recordAccepted(messageId, async () => {
               firstDeliveredMessageId ??= messageId;
@@ -288,6 +290,7 @@ async function deliverMediaReply(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
+  acceptedMessageIds: string[];
   recordMessageId: (messageId: number) => void;
   textMode?: "html";
   onPlatformSendDispatch?: () => Promise<void>;
@@ -295,7 +298,6 @@ async function deliverMediaReply(params: {
   let firstDeliveredMessageId: number | undefined;
   let visibleFallbackText: string | undefined;
   let firstDeliveredCaption: string | undefined;
-  const deliveredMediaMessageIds: string[] = [];
   let first = true;
   let pendingFollowUpText: string | undefined;
   const recordPromptContextMessage = async (message: Message, text?: string) => {
@@ -328,36 +330,25 @@ async function deliverMediaReply(params: {
         }),
     });
     const message = delivery.result;
+    // Acceptance precedes topic checks and bookkeeping; losing this id lets
+    // later failures trigger a duplicate reply for an already visible message.
+    params.acceptedMessageIds.push(String(message.message_id));
     if (params.thread?.id !== undefined) {
-      try {
-        await reportTelegramProviderDelivery({
-          message,
-          messageId: message.message_id,
-          fallbackChatId: params.chatId,
-          successfulSendThread: params.thread,
-        });
-      } catch (error) {
-        throw mergeTelegramPartialDeliveryError(error, {
-          messageIds: deliveredMediaMessageIds,
-          visibleReplySent: true,
-        });
-      }
+      await reportTelegramProviderDelivery({
+        message,
+        messageId: message.message_id,
+        fallbackChatId: params.chatId,
+        successfulSendThread: params.thread,
+      });
     }
     firstDeliveredMessageId ??= message.message_id;
     firstDeliveredCaption ??= delivery.deliveredCaption;
     if (delivery.captionRemoved) {
       visibleFallbackText = "";
     }
-    deliveredMediaMessageIds.push(String(message.message_id));
     params.recordMessageId(message.message_id);
     await recordPromptContextMessage(message, delivery.deliveredCaption);
     markDelivered(params.progress);
-  };
-  const throwMediaPartial = (error: unknown): never => {
-    throw mergeTelegramPartialDeliveryError(error, {
-      messageIds: deliveredMediaMessageIds,
-      visibleReplySent: true,
-    });
   };
   const createVoiceFallbackProgress = (): DeliveryProgress => ({
     hasReplied: false,
@@ -456,6 +447,7 @@ async function deliverMediaReply(params: {
           replyMarkup: params.replyMarkup,
           replyToMode: options.replyToMode ?? params.replyToMode,
           progress: createVoiceFallbackProgress(),
+          acceptedMessageIds: params.acceptedMessageIds,
           recordMessageId: params.recordMessageId,
           quoteOnlyOnFirstChunk: true,
           onPlatformSendDispatch: params.onPlatformSendDispatch,
@@ -553,6 +545,7 @@ async function deliverMediaReply(params: {
           replyToId: params.replyToId,
           replyToMode: params.replyToMode,
           progress: params.progress,
+          acceptedMessageIds: params.acceptedMessageIds,
           recordMessageId: params.recordMessageId,
           onPlatformSendDispatch: params.onPlatformSendDispatch,
         });
@@ -563,17 +556,13 @@ async function deliverMediaReply(params: {
         }
       } catch (error) {
         if (!isTelegramEmptyContentError(error)) {
-          throwMediaPartial(error);
+          throw error;
         }
         visibleFallbackText = firstDeliveredCaption ?? "";
         if (params.replyMarkup && firstDeliveredMessageId !== undefined) {
-          try {
-            await params.bot.api.editMessageReplyMarkup(params.chatId, firstDeliveredMessageId, {
-              reply_markup: params.replyMarkup,
-            });
-          } catch (keyboardError) {
-            throwMediaPartial(keyboardError);
-          }
+          await params.bot.api.editMessageReplyMarkup(params.chatId, firstDeliveredMessageId, {
+            reply_markup: params.replyMarkup,
+          });
         }
       }
       pendingFollowUpText = undefined;
@@ -874,6 +863,7 @@ export async function deliverReplies(params: {
 
     let contentForSentHook =
       reply.text || (reply.audioAsVoice === true ? resolveVoiceFallbackText(reply) : "") || "";
+    const acceptedMessageIds: string[] = [];
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
@@ -950,6 +940,7 @@ export async function deliverReplies(params: {
           replyToId,
           replyToMode: params.replyToMode,
           progress,
+          acceptedMessageIds,
           recordMessageId,
           onPlatformSendDispatch: params.onPlatformSendDispatch,
           ...(params.textMode ? { textMode: params.textMode } : {}),
@@ -996,7 +987,12 @@ export async function deliverReplies(params: {
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,
       });
-      throw error;
+      throw acceptedMessageIds.length === 0
+        ? error
+        : mergeTelegramPartialDeliveryError(error, {
+            messageIds: acceptedMessageIds,
+            visibleReplySent: true,
+          });
     }
   }
 

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1140,6 +1140,202 @@ describe("deliverReplies", () => {
     expect(recordSentMessage).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    {
+      kind: "photo",
+      method: "sendPhoto",
+      fileName: "photo.jpg",
+      contentType: "image/jpeg",
+      audioAsVoice: false,
+    },
+    {
+      kind: "document",
+      method: "sendDocument",
+      fileName: "report.pdf",
+      contentType: "application/pdf",
+      audioAsVoice: false,
+    },
+    {
+      kind: "voice",
+      method: "sendVoice",
+      fileName: "voice.ogg",
+      contentType: "audio/ogg",
+      audioAsVoice: true,
+    },
+  ])("preserves accepted $kind ids when a later media send fails", async (testCase) => {
+    const rejection = new Error(`${testCase.kind} send failed`);
+    const sendMedia = vi
+      .fn()
+      .mockResolvedValueOnce({ message_id: 71, chat: { id: "123" } })
+      .mockRejectedValueOnce(rejection);
+    mockMediaLoad(testCase.fileName, testCase.contentType, "first");
+    mockMediaLoad(testCase.fileName, testCase.contentType, "second");
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [
+          {
+            mediaUrls: ["https://example.com/first", "https://example.com/second"],
+            ...(testCase.audioAsVoice ? { audioAsVoice: true } : {}),
+          },
+        ],
+        runtime: createRuntime(),
+        bot: createBot({ [testCase.method]: sendMedia }),
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["71"]);
+    expect(sendMedia).toHaveBeenCalledTimes(2);
+    expect(recordSentMessage).toHaveBeenCalledOnce();
+  });
+
+  it("preserves accepted media ids when a later media download fails", async () => {
+    const downloadError = new Error("later media download failed");
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 72, chat: { id: "123" } });
+    mockMediaLoad("photo.jpg", "image/jpeg", "first");
+    loadWebMedia.mockRejectedValueOnce(downloadError);
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [{ mediaUrls: ["https://example.com/first", "https://example.com/second"] }],
+        runtime: createRuntime(),
+        bot: createBot({ sendPhoto }),
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["72"]);
+    expect(sendPhoto).toHaveBeenCalledOnce();
+  });
+
+  it("preserves accepted media ids when accepted-message bookkeeping fails", async () => {
+    const bookkeepingError = new Error("accepted media bookkeeping failed");
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 73, chat: { id: "123" } });
+    mockMediaLoad("photo.jpg", "image/jpeg", "first");
+    recordSentMessage.mockImplementationOnce(() => {
+      throw bookkeepingError;
+    });
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [{ mediaUrl: "https://example.com/photo.jpg" }],
+        runtime: createRuntime(),
+        bot: createBot({ sendPhoto }),
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["73"]);
+    expect(sendPhoto).toHaveBeenCalledOnce();
+  });
+
+  it.each(["send", "download"])(
+    "preserves accepted voice fallback text when a later media %s fails",
+    async (failureMode) => {
+      const laterFailure = new Error(`later voice ${failureMode} failed`);
+      const sendVoice = vi.fn().mockRejectedValueOnce(createVoiceMessagesForbiddenError());
+      const sendMessage = vi.fn().mockResolvedValueOnce({ message_id: 74, chat: { id: "123" } });
+      mockMediaLoad("voice.ogg", "audio/ogg", "first");
+      if (failureMode === "download") {
+        loadWebMedia.mockRejectedValueOnce(laterFailure);
+      } else {
+        mockMediaLoad("voice.ogg", "audio/ogg", "second");
+        sendVoice.mockRejectedValueOnce(laterFailure);
+      }
+
+      let observed: unknown;
+      try {
+        await deliverWith({
+          replies: [
+            {
+              text: "Voice fallback",
+              audioAsVoice: true,
+              mediaUrls: ["https://example.com/first", "https://example.com/second"],
+            },
+          ],
+          runtime: createRuntime(),
+          bot: createBot({ sendVoice, sendMessage }),
+        });
+      } catch (error) {
+        observed = error;
+      }
+
+      expect(isChannelPartialDeliveryError(observed)).toBe(true);
+      if (!isChannelPartialDeliveryError(observed)) {
+        throw observed;
+      }
+      expect(observed.deliveryResult.messageIds).toEqual(["74"]);
+      expect(sendMessage).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("preserves media and accepted caption-follow-up ids when later media fails", async () => {
+    const sendPhoto = vi
+      .fn()
+      .mockResolvedValueOnce({ message_id: 75, chat: { id: "123" } })
+      .mockRejectedValueOnce(new Error("later photo failed"));
+    const sendMessage = vi.fn().mockResolvedValueOnce({ message_id: 76, chat: { id: "123" } });
+    mockMediaLoad("photo.jpg", "image/jpeg", "first");
+    mockMediaLoad("photo.jpg", "image/jpeg", "second");
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [
+          {
+            text: "x".repeat(1025),
+            mediaUrls: ["https://example.com/first", "https://example.com/second"],
+          },
+        ],
+        runtime: createRuntime(),
+        bot: createBot({ sendPhoto, sendMessage }),
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["75", "76"]);
+  });
+
+  it("keeps an initial media send failure unwrapped when nothing was delivered", async () => {
+    const rejection = new Error("initial photo send failed");
+    const sendPhoto = vi.fn().mockRejectedValue(rejection);
+    mockMediaLoad("photo.jpg", "image/jpeg", "first");
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrl: "https://example.com/photo.jpg" }],
+        runtime: createRuntime(),
+        bot: createBot({ sendPhoto }),
+      }),
+    ).rejects.toBe(rejection);
+
+    expect(recordSentMessage).not.toHaveBeenCalled();
+  });
+
   it("does not mirror media follow-up text that Telegram rejects as empty", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
     const invisibleText = "\u200B".repeat(1025);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users receiving multiple attachments could see an incorrect duplicate fallback reply after one photo, document, voice note, or voice fallback had already arrived and a later attachment failed to load or send.

## Why This Change Was Made

Telegram's private delivery owner now records each accepted media message and each media-owned fallback or caption-follow-up text chunk immediately at its authoritative acceptance boundary, before fallible topic validation or bookkeeping. One outer owner boundary merges the complete accepted-message history into the existing partial-delivery contract; initial failures with no accepted message still propagate unchanged.

## User Impact

Already delivered Telegram messages remain visible to native commands and channel lifecycle handling even when a later album item fails. Operators no longer receive a misleading duplicate empty-response fallback, and accepted media, voice-fallback, and caption-follow-up message IDs remain available for recovery and diagnostics.

## Evidence

- Exact reviewed head: `e3308ba36908796dff91cf8099e15c939c3056a1`.
- Eight authentic before-fix failures now pass: photo, document, and voice second-item rejection; later media download failure; accepted-message bookkeeping failure; voice fallback followed by either later send or download failure; and caption-follow-up receipt preservation. The first-send/no-delivery control remains unwrapped.
- Full targeted validation: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-autoqa-telegram-partial-delivery-vitest-cache node scripts/run-vitest.mjs extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/bot-native-command-dispatch.delivery.test.ts extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts extensions/telegram/src/chunk-delivery.test.ts extensions/telegram/src/send.test.ts --configLoader runner` — **5 files, 406 tests passed**.
- Targeted extension lint, formatting, max-lines ratchet, assertion-safety ratchet, and `git diff --check` all pass.
- Full extension production/test typecheck currently reports only existing unrelated ACpx `promptStarted` / `elicitationModes` diagnostics; there are no errors in either changed Telegram file.
- Both independent owner-boundary review and authenticated full committed-branch review are clean.
- Production delta: **26 additions / 30 deletions (net −4)**; regression coverage: **196 test lines**.
- Live Telegram credentialed proof was not run because this isolated repair has no authorized live-channel credential access; all proof uses the real Telegram delivery owner, native-command consumer, durable-send sibling, and channel partial-delivery contract.
- No public Plugin SDK, configuration, authentication, storage, or protocol changes.
