### PR TITLE
fix(slack): keep failed message retries in their original thread

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -1,9 +1,12 @@
+import { WebClient } from "@slack/web-api";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Slack tests cover action runtime plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SlackActionContext } from "./action-runtime.js";
 import { handleSlackAction, slackActionRuntime } from "./action-runtime.js";
+import { sendSlackMessage as sendSlackMessageThroughPublicOwner } from "./actions.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import { registerSlackInstallationState } from "./installation-identity-state.js";
 import { buildSlackThreadingToolContext } from "./threading-tool-context.js";
@@ -1369,6 +1372,161 @@ describe("handleSlackAction", () => {
     expectLastSlackSend("First", cfg, "1111111111.111111");
     await sendSecondMessageAndExpectNoThread({ cfg, context });
   });
+
+  it.each([
+    { replyToMode: "first", action: "sendMessage" },
+    { replyToMode: "first", action: "uploadFile" },
+    { replyToMode: "batched", action: "sendMessage" },
+    { replyToMode: "batched", action: "uploadFile" },
+  ] as const)(
+    "keeps the $replyToMode reply thread available after a failed $action",
+    async ({ replyToMode, action }) => {
+      const cfg = slackConfig({ replyToMode });
+      const hasRepliedRef = { value: false };
+      const context = {
+        currentChannelId: "C123",
+        currentThreadTs: "1111111111.111111",
+        replyToMode,
+        hasRepliedRef,
+      };
+      const params =
+        action === "uploadFile"
+          ? {
+              action,
+              to: "channel:C123",
+              filePath: "/tmp/report.txt",
+              initialComment: "First",
+            }
+          : { action, to: "channel:C123", content: "First" };
+      sendSlackMessage.mockRejectedValueOnce(new Error("Slack transport failed"));
+
+      await expect(handleSlackAction(params, cfg, context)).rejects.toThrow(
+        "Slack transport failed",
+      );
+      expect(hasRepliedRef.value).toBe(false);
+
+      await handleSlackAction(params, cfg, context);
+
+      expectSlackSendCall(0, "channel:C123", "First", {
+        cfg,
+        threadTs: "1111111111.111111",
+      });
+      expectSlackSendCall(1, "channel:C123", "First", {
+        cfg,
+        threadTs: "1111111111.111111",
+      });
+      expect(hasRepliedRef.value).toBe(true);
+      await sendSecondMessageAndExpectNoThread({ cfg, context });
+    },
+  );
+
+  it.each(["first", "batched"] as const)(
+    "records the accepted %s reply when a later prepared message fails",
+    async (replyToMode) => {
+      const cfg = slackConfig({ replyToMode });
+      const hasRepliedRef = { value: false };
+      const context = {
+        currentChannelId: "C123",
+        currentThreadTs: "1111111111.111111",
+        replyToMode,
+        hasRepliedRef,
+        preparedMessages: [{ text: "First" }, { text: "Second" }],
+      };
+      sendSlackMessage.mockResolvedValueOnce({ channelId: "C123" });
+      sendSlackMessage.mockRejectedValueOnce(new Error("Second Slack delivery failed"));
+
+      await expect(
+        handleSlackAction(
+          { action: "sendMessage", to: "channel:C123", content: "First" },
+          cfg,
+          context,
+        ),
+      ).rejects.toThrow("Second Slack delivery failed");
+
+      expectSlackSendCall(0, "channel:C123", "First", {
+        cfg,
+        threadTs: "1111111111.111111",
+      });
+      expect(hasRepliedRef.value).toBe(true);
+    },
+  );
+
+  it.each(["first", "batched"] as const)(
+    "records an accepted %s Slack text chunk when the next platform post fails",
+    async (replyToMode) => {
+      const cfg = slackConfig({ replyToMode });
+      const hasRepliedRef = { value: false };
+      const context = {
+        currentChannelId: "C123",
+        currentThreadTs: "1111111111.111111",
+        replyToMode,
+        hasRepliedRef,
+      };
+      const client = new WebClient("xoxb-test", { retryConfig: { retries: 0 } });
+      vi.spyOn(client.chat, "postMessage")
+        .mockResolvedValueOnce({ ok: true, channel: "C123", ts: "1111111111.111112" })
+        .mockRejectedValueOnce(new Error("Second Slack text chunk failed"));
+      sendSlackMessage.mockImplementationOnce(async (...args) => {
+        const [target, content, options] = args;
+        if (typeof target !== "string" || typeof content !== "string") {
+          throw new Error("Expected a Slack target and text");
+        }
+        return await sendSlackMessageThroughPublicOwner(target, content, {
+          ...requireRecord(options, "Slack send options"),
+          cfg,
+          client,
+        });
+      });
+
+      await expect(
+        handleSlackAction(
+          { action: "sendMessage", to: "channel:C123", content: "a".repeat(8500) },
+          cfg,
+          context,
+        ),
+      ).rejects.toThrow("Second Slack text chunk failed");
+
+      expect(client.chat.postMessage).toHaveBeenCalledTimes(2);
+      expect(hasRepliedRef.value).toBe(true);
+    },
+  );
+
+  it.each(["first", "batched"] as const)(
+    "keeps concurrent %s replies in their thread until a delivery succeeds",
+    async (replyToMode) => {
+      const cfg = slackConfig({ replyToMode });
+      const hasRepliedRef = { value: false };
+      const context = {
+        currentChannelId: "C123",
+        currentThreadTs: "1111111111.111111",
+        replyToMode,
+        hasRepliedRef,
+      };
+      const firstDelivery = createDeferred<{ channelId: string }>();
+      sendSlackMessage.mockReturnValueOnce(firstDelivery.promise);
+      const firstAttempt = handleSlackAction(
+        { action: "sendMessage", to: "channel:C123", content: "Pending" },
+        cfg,
+        context,
+      );
+      await vi.waitFor(() => expect(sendSlackMessage).toHaveBeenCalledOnce());
+
+      await handleSlackAction(
+        { action: "sendMessage", to: "channel:C123", content: "Accepted" },
+        cfg,
+        context,
+      );
+      expectSlackSendCall(1, "channel:C123", "Accepted", {
+        cfg,
+        threadTs: "1111111111.111111",
+      });
+      expect(hasRepliedRef.value).toBe(true);
+
+      firstDelivery.reject(new Error("First Slack delivery failed"));
+      await expect(firstAttempt).rejects.toThrow("First Slack delivery failed");
+      expect(hasRepliedRef.value).toBe(true);
+    },
+  );
 
   it("replyToMode=first threads standalone message-tool sends without ReplyToId", async () => {
     const cfg = slackConfig({ replyToMode: "first" });

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -8,6 +8,10 @@ import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ResolvedSlackAccount } from "./accounts.js";
+import {
+  resolveSlackAutoThreadId,
+  SLACK_PRIVATE_ACTION_DELIVERY_RESULT,
+} from "./action-threading.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import type { SlackConversationInfo } from "./channel-type.js";
 import { assertSlackDetachedTargetAllowed } from "./detached-target-admission.js";
@@ -122,55 +126,24 @@ export type SlackActionContext = {
   preparedMessages?: readonly SlackReplyDeliveryMessage[];
 };
 
-/**
- * Resolve threadTs for a Slack message based on context and replyToMode.
- * - "all": always inject threadTs
- * - "first"/"batched": inject only for the first eligible message (updates hasRepliedRef)
- * - "off": never auto-inject
- */
 function resolveThreadTsFromContext(
   explicitThreadTs: string | undefined,
   targetChannel: string,
   context: SlackActionContext | undefined,
   opts?: { suppressImplicitThread?: boolean },
 ): string | undefined {
-  // Agent explicitly provided threadTs - use it
   if (explicitThreadTs) {
     return explicitThreadTs;
   }
   if (opts?.suppressImplicitThread) {
     return undefined;
   }
-  if (!context?.currentChannelId && !context?.currentMessagingTarget) {
+  const threadTs = resolveSlackAutoThreadId({ to: targetChannel, toolContext: context });
+  if (isSingleUseReplyToMode(context?.replyToMode ?? "off") && !context?.hasRepliedRef) {
     return undefined;
   }
-
-  // Different channel - don't inject
-  if (!slackContextTargetsMatch(targetChannel, context)) {
-    return undefined;
-  }
-  if (!context.currentThreadTs) {
-    if (context.sameChannelThreadRequired) {
-      throw new Error(
-        "Slack thread context is required for same-channel replies from a threaded Slack turn. Set topLevel=true or threadId=null to post at the channel root.",
-      );
-    }
-    return undefined;
-  }
-
-  // Check replyToMode
-  if (context.replyToMode === "all") {
-    return context.currentThreadTs;
-  }
-  if (
-    isSingleUseReplyToMode(context.replyToMode ?? "off") &&
-    context.hasRepliedRef &&
-    !context.hasRepliedRef.value
-  ) {
-    context.hasRepliedRef.value = true;
-    return context.currentThreadTs;
-  }
-  return undefined;
+  // Planning stays pure so failed sends cannot consume a thread before delivery.
+  return threadTs;
 }
 
 function readSlackBlocksParam(params: Record<string, unknown>) {
@@ -660,6 +633,31 @@ export async function handleSlackAction(
     if (!isActionEnabled("messages")) {
       throw new Error("Slack messages are disabled.");
     }
+    const sendSlackMessage = async (
+      target: string,
+      content: string,
+      options: Parameters<typeof slackActionRuntime.sendSlackMessage>[2],
+    ) => {
+      const replyReference =
+        context?.hasRepliedRef && slackContextTargetsMatch(target, context)
+          ? context.hasRepliedRef
+          : undefined;
+      const result = await slackActionRuntime.sendSlackMessage(target, content, {
+        ...options,
+        ...(replyReference
+          ? {
+              [SLACK_PRIVATE_ACTION_DELIVERY_RESULT]: () => {
+                replyReference.value = true;
+              },
+            }
+          : {}),
+      });
+      // Injected adapters may expose only their complete delivery result.
+      if (replyReference) {
+        replyReference.value = true;
+      }
+      return result;
+    };
     switch (action) {
       case "sendMessage": {
         const to = readStringParam(params, "to", { required: true });
@@ -730,13 +728,13 @@ export async function handleSlackAction(
             // Reuse the resolved thread for both sends. Invoking the action twice
             // could consume replyToMode=first and move the full text off-thread.
             const { replyBroadcast: _replyBroadcast, ...blockSendOpts } = sendOpts;
-            await slackActionRuntime.sendSlackMessage(destination, "", {
+            await sendSlackMessage(destination, "", {
               ...blockSendOpts,
               blocks,
             });
-            return await slackActionRuntime.sendSlackMessage(destination, content, sendOpts);
+            return await sendSlackMessage(destination, content, sendOpts);
           }
-          return await slackActionRuntime.sendSlackMessage(destination, content ?? "", {
+          return await sendSlackMessage(destination, content ?? "", {
             ...sendOpts,
             blocks,
           });
@@ -747,13 +745,13 @@ export async function handleSlackAction(
                 | Awaited<ReturnType<typeof slackActionRuntime.sendSlackMessage>>
                 | undefined;
               if (mediaUrl) {
-                lastResult = await slackActionRuntime.sendSlackMessage(destination, "", {
+                lastResult = await sendSlackMessage(destination, "", {
                   ...baseSendOpts,
                   mediaUrl,
                 });
               }
               for (const [index, message] of preparedMessages.entries()) {
-                lastResult = await slackActionRuntime.sendSlackMessage(destination, message.text, {
+                lastResult = await sendSlackMessage(destination, message.text, {
                   ...baseSendOpts,
                   ...(index === 0 && replyBroadcast ? { replyBroadcast: true } : {}),
                   ...(message.blocks ? { blocks: message.blocks } : {}),
@@ -774,25 +772,18 @@ export async function handleSlackAction(
           : blocks
             ? await (async () => {
                 if (mediaUrl) {
-                  await slackActionRuntime.sendSlackMessage(destination, "", {
+                  await sendSlackMessage(destination, "", {
                     ...sendOpts,
                     mediaUrl,
                   });
                 }
                 return await sendContentAndBlocks();
               })()
-            : await slackActionRuntime.sendSlackMessage(destination, content ?? "", {
+            : await sendSlackMessage(destination, content ?? "", {
                 ...sendOpts,
                 mediaUrl: mediaUrl ?? undefined,
                 blocks,
               });
-
-        // Keep "first" mode consistent even when the agent explicitly provided
-        // threadTs: once we send a message to the current channel, consider the
-        // first reply "used" so later tool calls don't auto-thread again.
-        if (context?.hasRepliedRef && slackContextTargetsMatch(destination, context)) {
-          context.hasRepliedRef.value = true;
-        }
 
         return jsonResult({ ok: true, result });
       }
@@ -824,25 +815,17 @@ export async function handleSlackAction(
             suppressImplicitThread: params.topLevel === true || params.threadTs === null,
           },
         );
-        const result = await slackActionRuntime.sendSlackMessage(
-          destination,
-          initialComment ?? "",
-          {
-            ...buildActionOpts("write"),
-            mediaUrl: filePath,
-            mediaAccess: context?.mediaAccess,
-            mediaLocalRoots: context?.mediaLocalRoots,
-            mediaReadFile: context?.mediaReadFile,
-            threadTs: threadTs ?? undefined,
-            ...(forceDocument ? { forceDocument: true } : {}),
-            ...(filename ? { uploadFileName: filename } : {}),
-            ...(title ? { uploadTitle: title } : {}),
-          },
-        );
-
-        if (context?.hasRepliedRef && slackContextTargetsMatch(destination, context)) {
-          context.hasRepliedRef.value = true;
-        }
+        const result = await sendSlackMessage(destination, initialComment ?? "", {
+          ...buildActionOpts("write"),
+          mediaUrl: filePath,
+          mediaAccess: context?.mediaAccess,
+          mediaLocalRoots: context?.mediaLocalRoots,
+          mediaReadFile: context?.mediaReadFile,
+          threadTs: threadTs ?? undefined,
+          ...(forceDocument ? { forceDocument: true } : {}),
+          ...(filename ? { uploadFileName: filename } : {}),
+          ...(title ? { uploadTitle: title } : {}),
+        });
 
         return jsonResult({ ok: true, result });
       }

--- a/extensions/slack/src/action-threading.ts
+++ b/extensions/slack/src/action-threading.ts
@@ -2,6 +2,8 @@
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { slackContextTargetsMatch } from "./targets.js";
 
+export const SLACK_PRIVATE_ACTION_DELIVERY_RESULT = Symbol("slack.action.delivery-result");
+
 export function resolveSlackAutoThreadId(params: {
   to: string;
   toolContext?: {

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -7,6 +7,7 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
 import { resolveSlackAccount } from "./accounts.js";
+import { SLACK_PRIVATE_ACTION_DELIVERY_RESULT } from "./action-threading.js";
 import type { SlackAuthoredTextPlacement } from "./authored-text.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
 import { validateSlackBlocksArray } from "./blocks-input.js";
@@ -353,6 +354,10 @@ export async function sendSlackMessage(
     textIsSlackPlainText?: boolean;
   },
 ) {
+  const onDeliveryResult = Object.getOwnPropertyDescriptor(
+    opts,
+    SLACK_PRIVATE_ACTION_DELIVERY_RESULT,
+  )?.value;
   return await sendMessageSlack(to, content, {
     accountId: opts.accountId,
     cfg: opts.cfg,
@@ -373,6 +378,7 @@ export async function sendSlackMessage(
       : {}),
     ...(opts.uploadFileName ? { uploadFileName: opts.uploadFileName } : {}),
     ...(opts.uploadTitle ? { uploadTitle: opts.uploadTitle } : {}),
+    ...(typeof onDeliveryResult === "function" ? { onDeliveryResult } : {}),
     blocks: opts.blocks,
   });
 }

--- a/extensions/slack/src/send.upload.test.ts
+++ b/extensions/slack/src/send.upload.test.ts
@@ -276,6 +276,45 @@ describe("sendMessageSlack file upload with user IDs", () => {
     vi.restoreAllMocks();
   });
 
+  it.each(["first", "batched"] as const)(
+    "records an accepted %s upload when its remaining caption post fails",
+    async (replyToMode) => {
+      const { handleSlackAction, slackActionRuntime } = await import("./action-runtime.js");
+      const { sendSlackMessage: sendSlackMessageThroughPublicOwner } = await import("./actions.js");
+      const originalSender = slackActionRuntime.sendSlackMessage;
+      const hasRepliedRef = { value: false };
+      client.chat.postMessage.mockRejectedValueOnce(new Error("Remaining Slack caption failed"));
+      slackActionRuntime.sendSlackMessage = async (target, content, options) =>
+        await sendSlackMessageThroughPublicOwner(target, content, { ...options, client });
+
+      try {
+        await expect(
+          handleSlackAction(
+            {
+              action: "uploadFile",
+              to: "channel:C123CHAN",
+              filePath: "/tmp/report.txt",
+              initialComment: "a".repeat(8500),
+            },
+            SLACK_TEST_CFG,
+            {
+              currentChannelId: "C123CHAN",
+              currentThreadTs: "1111111111.111111",
+              replyToMode,
+              hasRepliedRef,
+            },
+          ),
+        ).rejects.toThrow("Remaining Slack caption failed");
+
+        expect(client.files.completeUploadExternal).toHaveBeenCalledOnce();
+        expect(client.chat.postMessage).toHaveBeenCalledOnce();
+        expect(hasRepliedRef.value).toBe(true);
+      } finally {
+        slackActionRuntime.sendSlackMessage = originalSender;
+      }
+    },
+  );
+
   it("disables image optimization for forced-media uploads", async () => {
     await sendUpload(client, {
       mediaUrl: "/tmp/original.png",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack users replying from a thread could have a retried message or file unexpectedly appear in the parent channel after the first delivery failed. Single-use `first` and `batched` reply modes also lost track of a message that Slack had already accepted when a later text chunk or upload-caption continuation failed.

## Why This Change Was Made

Slack's action runtime duplicated the canonical thread-selection policy and marked a thread as used while only planning delivery. Reuse the existing pure thread planner, carry a private receipt callback through the existing public action sender without changing its signature, and commit reply state at the canonical accepted-platform-delivery boundary. Keep the existing final-result path for injected send adapters. This also removes duplicate thread-selection logic and reduces production code by nine lines.

## User Impact

Failed Slack messages and file uploads can be retried in their intended thread. Successfully accepted text chunks, uploaded files, and concurrent replies keep accurate threading state even when a later portion of the same message fails. Explicit thread selection, intentional top-level sends, missing-thread protection, and public plugin APIs remain unchanged.

## Evidence

- Frozen reviewed head: `e29aa6bfb4c50d763e558376672cc0e2f5a20ce9`.
- Before the fix, four real action-boundary regressions failed for `first`/`batched` message/file retries; four deeper regressions also failed after Slack accepted the first text chunk or upload and rejected a later platform post.
- After the fix, **360 tests pass across nine Slack owner and sibling suites**, including failure/retry, accepted multi-part delivery, completed uploads, later caption failures, concurrent sends, block rendering, threading, outbound delivery, and reply dispatch.
- A real loopback Slack HTTP server and the actual Slack WebClient verified both reply modes: the first `chat.postMessage` response failed, the retry succeeded, and both actual request bodies retained the same `thread_ts`.
- Focused extension lint, formatting, whitespace, max-lines ratchet, and assertion-safety ratchet all pass. Full local extension production/test type lanes report only the existing unrelated ACPX `promptStarted`/`elicitationModes` diagnostics from the shared local dependency installation; the affected ACPX files and configuration are byte-identical on current `main`, and there are no Slack diagnostics.
- Independent maintainer review and a fresh authenticated full-branch Codex review are clean.
- Production delta: **59 additions / 68 deletions (net -9)**. Regression coverage: **197 added test lines**. No public API, configuration, authentication, persistence, or protocol changes.
