### PR TITLE
fix(macos): attach the onboarding CLI install prompt to the window

### DIFF
--- a/apps/macos/Sources/OpenClaw/CLIInstallPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstallPrompter.swift
@@ -60,14 +60,17 @@ final class CLIInstallPrompter {
         guard lastPrompt != version else { return }
         AppDefaults.standard.set(version, forKey: cliInstallPromptedVersionKey)
 
-        if let target = self.installTargetForCurrentBuild(confirmStable: true) {
+        if let target = await self.installTargetForCurrentBuild(confirmStable: true, presentingSheetOn: nil) {
             Task { _ = await self.installCLI(target: target) }
         }
 
         self.logger.debug("cli install prompt handled reason=\(reason, privacy: .public)")
     }
 
-    func installTargetForCurrentBuild(confirmStable: Bool = false) -> CLIInstaller.InstallTarget? {
+    func installTargetForCurrentBuild(
+        confirmStable: Bool = false,
+        presentingSheetOn window: NSWindow?) async -> CLIInstaller.InstallTarget?
+    {
         let appVersion = Self.appVersion()
         if let target = CLIInstaller.automaticInstallTarget(
             appVersion: appVersion,
@@ -80,7 +83,7 @@ final class CLIInstallPrompter {
             alert.addButton(withTitle: "Install CLI")
             alert.addButton(withTitle: "Not Now")
             alert.addButton(withTitle: "Open Settings")
-            switch alert.runModal() {
+            switch await self.present(alert, presentingSheetOn: window) {
             case .alertFirstButtonReturn:
                 return target
             case .alertThirdButtonReturn:
@@ -91,14 +94,18 @@ final class CLIInstallPrompter {
             }
         }
 
-        return self.chooseChannel(
+        return await self.chooseChannel(
             suggested: CLIInstaller.suggestedChannel(
                 appVersion: appVersion,
-                isDebug: CLIInstallBuild.isDebug))
+                isDebug: CLIInstallBuild.isDebug),
+            presentingSheetOn: window)
             .map(CLIInstaller.InstallTarget.channel)
     }
 
-    private func chooseChannel(suggested: CLIInstaller.Channel) -> CLIInstaller.Channel? {
+    private func chooseChannel(
+        suggested: CLIInstaller.Channel,
+        presentingSheetOn window: NSWindow?) async -> CLIInstaller.Channel?
+    {
         let channels = [suggested] + CLIInstaller.Channel.allCases.filter { $0 != suggested }
         let alert = NSAlert()
         alert.messageText = "Choose OpenClaw CLI channel"
@@ -111,10 +118,16 @@ final class CLIInstallPrompter {
             alert.addButton(withTitle: channel.label)
         }
         alert.addButton(withTitle: "Not Now")
-        let response = alert.runModal()
+        let response = await self.present(alert, presentingSheetOn: window)
         let index = response.rawValue - NSApplication.ModalResponse.alertFirstButtonReturn.rawValue
         guard channels.indices.contains(index) else { return nil }
         return channels[index]
+    }
+
+    private func present(_ alert: NSAlert, presentingSheetOn window: NSWindow?) async -> NSApplication.ModalResponse {
+        // Attaching onboarding alerts preserves their AX visibility and window-relative z-order.
+        guard let window else { return alert.runModal() }
+        return await alert.beginSheetModal(for: window)
     }
 
     private func installCLI(

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -539,7 +539,10 @@ final class OnboardingController: NSObject, NSWindowDelegate {
     static let shared = OnboardingController()
     static let windowStyleMask: NSWindow.StyleMask = [.titled, .closable, .resizable, .fullSizeContentView]
     private var window: NSWindow?
-    var sheetPresentationWindow: NSWindow? { self.window }
+    var sheetPresentationWindow: NSWindow? {
+        self.window
+    }
+
     /// Human description of work in flight ("Installing the Gateway…").
     /// While set, closing the window asks for confirmation instead of quitting
     /// setup mid-operation.

--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -539,6 +539,7 @@ final class OnboardingController: NSObject, NSWindowDelegate {
     static let shared = OnboardingController()
     static let windowStyleMask: NSWindow.StyleMask = [.titled, .closable, .resizable, .fullSizeContentView]
     private var window: NSWindow?
+    var sheetPresentationWindow: NSWindow? { self.window }
     /// Human description of work in flight ("Installing the Gateway…").
     /// While set, closing the window asks for confirmation instead of quitting
     /// setup mid-operation.
@@ -638,6 +639,7 @@ final class OnboardingController: NSObject, NSWindowDelegate {
 struct OnboardingView: View {
     enum CLIInstallPhase {
         case idle
+        case choosingTarget
         case installing
         case startingService
     }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -146,9 +146,6 @@ extension OnboardingView {
     func startCLIInstall() {
         guard self.onboardingVisible, !installingCLI else { return }
         installingCLI = true
-        OnboardingController.shared.setWindowCloseEnabled(false)
-        // Cmd-W bypasses the disabled close button; the delegate asks first.
-        OnboardingController.shared.busyReason = "OpenClaw is installing the Gateway service."
         Task { @MainActor in await self.runCLIInstall() }
     }
 
@@ -159,17 +156,24 @@ extension OnboardingView {
     }
 
     func runCLIInstall() async {
-        self.cliInstallPhase = .installing
+        self.cliInstallPhase = .choosingTarget
         defer {
             self.installingCLI = false
             self.cliInstallPhase = .idle
             OnboardingController.shared.setWindowCloseEnabled(true)
             OnboardingController.shared.busyReason = nil
         }
-        guard let target = CLIInstallPrompter.shared.installTargetForCurrentBuild() else {
+        // Choosing a target is not installation: keep its spinner and close/busy guards inactive.
+        guard let target = await CLIInstallPrompter.shared.installTargetForCurrentBuild(
+            presentingSheetOn: OnboardingController.shared.sheetPresentationWindow)
+        else {
             cliStatus = "CLI installation cancelled."
             return
         }
+        self.cliInstallPhase = .installing
+        OnboardingController.shared.setWindowCloseEnabled(false)
+        // Cmd-W bypasses the disabled close button; the delegate asks first.
+        OnboardingController.shared.busyReason = "OpenClaw is installing the Gateway service."
         let installed = await CLIInstaller.install(target: target) { message in
             self.cliStatus = message
         }

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -879,6 +879,7 @@ extension OnboardingView {
     private var installStepStateForInstall: InstallStepState {
         if self.cliInstalled { return .done }
         if self.installingCLI {
+            if self.cliInstallPhase == .choosingTarget { return .pending }
             return self.cliInstallPhase == .startingService ? .done : .running
         }
         if self.installFailed { return .failed }


### PR DESCRIPTION
## What Problem This Solves

On an unreleased (debug) macOS build, the onboarding "Getting things ready" page resolves its CLI install target through `CLIInstallPrompter` → `NSAlert.runModal()` — a detached app-modal panel. Reproduced live on a real Mac during a full onboarding pass:

- The alert is a separate panel, not attached to the onboarding window. It does not appear in the app's accessibility window list, and system permission dialogs stack directly on top of it — in the observed run, a screen-recording TCC prompt and the app's own local-network TCC prompt covered it completely.
- Before the user has chosen anything, `startCLIInstall()` had already set `installingCLI`, switched the "Install OpenClaw" row to a running spinner, disabled the window close button, and set `busyReason = "OpenClaw is installing the Gateway service."`.
- Net result observed: the main thread sat parked in `runModal` for 30+ minutes while the page displayed an active install spinner and the window refused to close. The user-visible story was "install in progress"; the truth was "a question you cannot see is waiting for you".

Severity-wise this is the worst class in the doctrine: an action that produces nothing, with UI actively claiming otherwise.

## Why This Change Was Made

Two coupled fixes, both scoped to the prompt seam:

1. **Sheet attachment.** `installTargetForCurrentBuild` and `chooseChannel` are now async and take `presentingSheetOn window:`. During onboarding they present via `beginSheetModal(for:)` on the onboarding window (`OnboardingController.sheetPresentationWindow`), so the prompt is z-bound to the window, dims the page it blocks, and is visible in the window's capture/AX tree. The non-onboarding caller (`checkAndPromptIfNeededAsync`, which has no onboarding window) passes nil and keeps `runModal()` exactly as before. Sheet and modal responses share the `.alertFirstButtonReturn`-relative constants, so the channel index math is unchanged.
2. **Honest busy state.** A new `CLIInstallPhase.choosingTarget` covers the wait for the user's decision: the install row renders `.pending` (not a spinner), the close button stays enabled, and `busyReason` stays nil. `installingCLI`/close-disable/busy engage only after a target is chosen, in `runCLIInstall` right before real work starts. Closing the window while the sheet is up resolves the sheet with a cancel response, which flows through the existing "CLI installation cancelled." path.

No alert text, button titles, or button order changed. The localization baseline is byte-identical (`native-app-i18n: entries=4212 changed=false`).

## User Impact

Debug/unreleased builds only (release builds resolve an automatic install target on this path and never reach the chooser). For those builds: the channel prompt is now visibly attached to the onboarding window, the checklist no longer claims an install is running while waiting for input, and the window can be closed during the prompt.

## Evidence

Live before/after on the packaged app (`BUNDLE_ID=ai.openclaw.mac.onboardtest`, isolated `OPENCLAW_PROFILE`, fresh profile per run):

- **Before**: window-scoped captures show the CLI page with an active "Install OpenClaw" spinner and no dialog anywhere; the app's AX window list contains only the onboarding window; `sample` of the process shows the main thread parked under `chooseChannel` → `runModal`; two system TCC prompts sat above the invisible alert.
- **After**: the same flow shows the "Choose OpenClaw CLI channel" sheet attached to the onboarding window (captured in the window screenshot), install rows rendered as pending circles behind the dimmed page, and "Not Now" resolving to the cancelled status.

Build: `swift build` in `apps/macos` — `Build complete!`. Onboarding-filtered `swift test` run locally after restaging Sparkle.framework (results in PR checks either way; the touched logic is exercised by CI's mac lane).

Autoreview (codex/gpt-5.6-sol, xhigh): clean, no accepted or actionable findings.

Production LOC +33/−12 across four files; no test-line changes (the prompt seam is AppKit presentation; the statically testable helpers are untouched).

## Follow-up (not in this PR)

The live session also exposed a pre-existing race on the same page, independent of presentation style: the CLI-status probe can find an already-valid CLI (debug project-root `node_modules/.bin` path) and auto-activate the gateway to onboarding completion while the install prompt is still open, leaving a stale prompt over a finished flow. That race existed with `runModal` too (where the stale prompt was invisible); it deserves its own issue rather than a rider here.
