### PR TITLE
fix(cron): scheduled job results disappear after temporary network failures

### DIFF
--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -1,5 +1,9 @@
 // Strict cron announcement transport tests cover scheduler-authorized alert delivery.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OutboundDeliveryError,
+  PlatformMessageNotDispatchedError,
+} from "../infra/outbound/deliver-types.js";
 
 const mocks = vi.hoisted(() => ({
   resolveDeliveryTarget: vi.fn(),
@@ -107,6 +111,62 @@ describe("sendCronAnnouncePayloadStrict", () => {
     await expect(delivery).rejects.toThrow("delivery deadline exceeded");
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
   });
+
+  it.each(["raw-partial", "wrapped-partial", "failed-after-send"] as const)(
+    "preserves recipient-reached evidence across a %s failure",
+    async (failureKind) => {
+      const rejectedChunk = new PlatformMessageNotDispatchedError(
+        "second chunk was never dispatched",
+        {
+          cause: Object.assign(new Error("connect ECONNREFUSED"), {
+            code: "ECONNREFUSED",
+            syscall: "connect",
+          }),
+        },
+      );
+      const firstChunk = { channel: "telegram" as const, messageId: "already-delivered" };
+      const deliveryError =
+        failureKind === "wrapped-partial"
+          ? new OutboundDeliveryError("delivery failed after the first chunk", {
+              cause: rejectedChunk,
+              results: [firstChunk],
+              stage: "platform_send",
+            })
+          : rejectedChunk;
+      mocks.deliverOutboundPayloads.mockImplementationOnce(
+        async (params: { onPayloadDeliveryOutcome?: (outcome: unknown) => void }) => {
+          if (failureKind === "wrapped-partial") {
+            throw deliveryError;
+          }
+          params.onPayloadDeliveryOutcome?.({
+            index: 0,
+            status: "failed",
+            error: deliveryError,
+            sentBeforeError: true,
+            stage: "platform_send",
+          });
+          return failureKind === "raw-partial" ? [firstChunk] : [];
+        },
+      );
+      const onDeliveryAttempt = vi.fn();
+
+      await expect(
+        sendCronAnnouncePayloadStrict({
+          deps: {} as never,
+          cfg: {} as never,
+          agentId: "main",
+          jobId: "job-1",
+          target: { channel: "telegram", to: "123" },
+          payload: { text: "Automation failed" },
+          abortSignal: new AbortController().signal,
+          onDeliveryAttempt,
+        }),
+      ).rejects.toThrow(deliveryError.message);
+
+      expect(onDeliveryAttempt).toHaveBeenCalledExactlyOnceWith(true);
+      expect(mocks.deliverOutboundPayloads).toHaveBeenCalledOnce();
+    },
+  );
 
   it.each([
     {

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -1,7 +1,10 @@
 /** Sends cron announce payloads and best-effort failure notifications. */
 
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
-import { sendDurableMessageBatchCore } from "../channels/message/runtime.js";
+import {
+  durableMessageBatchMayHaveReachedRecipient,
+  sendDurableMessageBatchCore,
+} from "../channels/message/runtime.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -92,6 +95,7 @@ async function deliverCronAnnouncePayload(params: {
   };
   payload: ReplyPayload;
   abortSignal: AbortSignal;
+  onDeliveryAttempt?: (reachedRecipient: boolean) => void;
 }): Promise<void> {
   // Cron delivery is durable and non-best-effort for primary announces; partial
   // channel failure must surface as a cron run failure.
@@ -108,6 +112,7 @@ async function deliverCronAnnouncePayload(params: {
     deps: createOutboundSendDeps(params.deps),
     signal: params.abortSignal,
   });
+  params.onDeliveryAttempt?.(durableMessageBatchMayHaveReachedRecipient(send));
   if (send.status === "failed" || send.status === "partial_failed") {
     throw send.error;
   }
@@ -122,6 +127,7 @@ export async function sendCronAnnouncePayloadStrict(params: {
   target: CronAnnounceTarget;
   payload: ReplyPayload;
   abortSignal: AbortSignal;
+  onDeliveryAttempt?: (reachedRecipient: boolean) => void;
 }): Promise<void> {
   const delivery = await resolveCronAnnounceDelivery(params);
   if (!delivery.ok) {
@@ -136,5 +142,6 @@ export async function sendCronAnnouncePayloadStrict(params: {
     delivery,
     payload: params.payload,
     abortSignal: params.abortSignal,
+    onDeliveryAttempt: params.onDeliveryAttempt,
   });
 }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -11,6 +11,10 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveHeartbeatSession } from "../infra/heartbeat-runner-session.js";
+import {
+  OutboundDeliveryError,
+  PlatformMessageNotDispatchedError,
+} from "../infra/outbound/deliver-types.js";
 import { resolveSystemEventOptionsOwnerAgentId } from "../infra/system-event-ownership.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -215,6 +219,7 @@ vi.mock("../cron/trigger-script.js", () => ({
 
 import { getInProcessGatewayToolContext } from "../agents/tools/in-process-gateway.js";
 import {
+  abortActiveCronTaskRuns,
   registerActiveCronTaskRun,
   trackActiveCronTaskRunSettlement,
 } from "../cron/service/active-run-cancellation.js";
@@ -1677,6 +1682,256 @@ describe("buildGatewayCronService", () => {
       expect(state.cron.getJob(job.id)?.state.lastDeliveryError).toBeUndefined();
     } finally {
       state.cron.stop();
+    }
+  });
+
+  it.each(["command", "script"] as const)(
+    "retries proven pre-dispatch failure before delivering one-shot %s cron output",
+    async (payloadKind) => {
+      vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+      const cfg = createCronConfig(`server-cron-${payloadKind}-announce-retry`);
+      cfg.cron = { ...cfg.cron, triggers: { enabled: true } };
+      loadConfigMock.mockReturnValue(cfg);
+      cronScriptExecutorMock.mockResolvedValueOnce({
+        kind: "completed",
+        notify: "scheduled result",
+        stateChanged: false,
+      });
+      sendCronAnnouncePayloadStrictMock.mockRejectedValueOnce(
+        new PlatformMessageNotDispatchedError("platform unavailable before dispatch", {
+          cause: Object.assign(new Error("connect ECONNREFUSED"), {
+            code: "ECONNREFUSED",
+            syscall: "connect",
+          }),
+        }),
+      );
+
+      const state = buildGatewayCronService({
+        cfg,
+        deps: {} as CliDeps,
+        broadcast: () => {},
+      });
+      try {
+        const job = await state.cron.add({
+          name: `${payloadKind} announce retry`,
+          enabled: true,
+          deleteAfterRun: true,
+          schedule: { kind: "at", at: new Date(1).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload:
+            payloadKind === "command"
+              ? {
+                  kind: "command" as const,
+                  argv: [process.execPath, "-e", "process.stdout.write('scheduled result')"],
+                }
+              : { kind: "script" as const, script: "return { notify: 'scheduled result' }" },
+          delivery: { mode: "announce", channel: "telegram", to: "123" },
+        });
+
+        await state.cron.run(job.id, "force");
+
+        expect(sendCronAnnouncePayloadStrictMock).toHaveBeenCalledTimes(2);
+        const firstAttempt = requireRecord(
+          callArg(sendCronAnnouncePayloadStrictMock, 0, 0, "first cron announce attempt"),
+          "first cron announce attempt",
+        );
+        const secondAttempt = requireRecord(
+          callArg(sendCronAnnouncePayloadStrictMock, 1, 0, "second cron announce attempt"),
+          "second cron announce attempt",
+        );
+        expect(secondAttempt.abortSignal).toBe(firstAttempt.abortSignal);
+        expect(state.cron.getJob(job.id)).toBeUndefined();
+        const finished = runCronChangedMock.mock.calls
+          .map(([event]) => requireRecord(event, "cron_changed event"))
+          .find((event) => event.action === "finished" && event.jobId === job.id);
+        expect(finished).toMatchObject({
+          status: "ok",
+          completionStatus: "succeeded",
+          deliveryStatus: "delivered",
+        });
+      } finally {
+        state.cron.stop();
+        vi.unstubAllEnvs();
+      }
+    },
+  );
+
+  it.each([
+    { payloadKind: "command", errorKind: "raw" },
+    { payloadKind: "command", errorKind: "wrapped" },
+    { payloadKind: "script", errorKind: "raw" },
+    { payloadKind: "script", errorKind: "wrapped" },
+  ] as const)(
+    "never resends accepted $payloadKind output after a $errorKind partial-delivery failure",
+    async ({ payloadKind, errorKind }) => {
+      vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+      const cfg = createCronConfig(`server-cron-${payloadKind}-${errorKind}-partial`);
+      cfg.cron = { ...cfg.cron, triggers: { enabled: true } };
+      loadConfigMock.mockReturnValue(cfg);
+      cronScriptExecutorMock.mockResolvedValueOnce({
+        kind: "completed",
+        notify: "scheduled result",
+        stateChanged: false,
+      });
+      const rejectedChunk = new PlatformMessageNotDispatchedError(
+        "second chunk was never dispatched",
+        {
+          cause: Object.assign(new Error("connect ECONNREFUSED"), {
+            code: "ECONNREFUSED",
+            syscall: "connect",
+          }),
+        },
+      );
+      const deliveryError =
+        errorKind === "raw"
+          ? rejectedChunk
+          : new OutboundDeliveryError("delivery failed after the first chunk", {
+              cause: rejectedChunk,
+              results: [{ channel: "telegram", messageId: "already-delivered" }],
+              stage: "platform_send",
+            });
+      sendCronAnnouncePayloadStrictMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const attempt = requireRecord(args[0], "partial cron announcement");
+        if (typeof attempt.onDeliveryAttempt === "function") {
+          attempt.onDeliveryAttempt(true);
+        }
+        throw deliveryError;
+      });
+
+      const state = buildGatewayCronService({
+        cfg,
+        deps: {} as CliDeps,
+        broadcast: () => {},
+      });
+      try {
+        const job = await state.cron.add({
+          name: `${payloadKind} partial announcement`,
+          enabled: true,
+          deleteAfterRun: false,
+          schedule: { kind: "at", at: new Date(1).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload:
+            payloadKind === "command"
+              ? {
+                  kind: "command" as const,
+                  argv: [process.execPath, "-e", "process.stdout.write('scheduled result')"],
+                }
+              : { kind: "script" as const, script: "return { notify: 'scheduled result' }" },
+          delivery: { mode: "announce", channel: "telegram", to: "123" },
+        });
+
+        await state.cron.run(job.id, "force");
+
+        expect(sendCronAnnouncePayloadStrictMock).toHaveBeenCalledOnce();
+        expect(state.cron.getJob(job.id)?.state.lastDeliveryStatus).toBe("not-delivered");
+      } finally {
+        state.cron.stop();
+        vi.unstubAllEnvs();
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "permanent typed rejection",
+      error: new PlatformMessageNotDispatchedError("platform rejected this message", {
+        cause: new Error("invalid payload"),
+        retryable: false,
+      }),
+    },
+    {
+      name: "ambiguous transport failure",
+      error: Object.assign(new Error("read ECONNRESET after sending"), {
+        code: "ECONNRESET",
+      }),
+    },
+  ])("does not duplicate a command announcement after $name", async ({ error }) => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    const cfg = createCronConfig("server-cron-command-no-unsafe-retry");
+    loadConfigMock.mockReturnValue(cfg);
+    sendCronAnnouncePayloadStrictMock.mockRejectedValueOnce(error);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "command no unsafe retry",
+        enabled: true,
+        deleteAfterRun: false,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [process.execPath, "-e", "process.stdout.write('scheduled result')"],
+        },
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(sendCronAnnouncePayloadStrictMock).toHaveBeenCalledOnce();
+      expect(state.cron.getJob(job.id)?.state).toMatchObject({
+        lastRunStatus: "ok",
+        lastDeliveryStatus: "not-delivered",
+        lastDeliveryError: expect.stringContaining(error.message),
+      });
+    } finally {
+      state.cron.stop();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("does not retry a command announcement after its cron run is cancelled", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    const cfg = createCronConfig("server-cron-command-cancelled-retry");
+    loadConfigMock.mockReturnValue(cfg);
+    let deliverySignal: AbortSignal | undefined;
+    sendCronAnnouncePayloadStrictMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const request = requireRecord(args[0], "cancelled cron announce attempt");
+      deliverySignal = request.abortSignal as AbortSignal;
+      expect(abortActiveCronTaskRuns("Cancelled by operator.")).toBe(1);
+      throw new PlatformMessageNotDispatchedError("platform unavailable before dispatch", {
+        cause: Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+          syscall: "connect",
+        }),
+      });
+    });
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "cancelled command announcement",
+        enabled: true,
+        deleteAfterRun: false,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [process.execPath, "-e", "process.stdout.write('scheduled result')"],
+        },
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(sendCronAnnouncePayloadStrictMock).toHaveBeenCalledOnce();
+      expect(deliverySignal?.aborted).toBe(true);
+      expect(state.cron.getJob(job.id)?.state.lastRunStatus).toBe("error");
+    } finally {
+      state.cron.stop();
+      vi.unstubAllEnvs();
     }
   });
 

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -37,6 +37,7 @@ import { runCronCommandJob } from "../cron/command-runner.js";
 import { resolveCronStoredDeliveryContext } from "../cron/delivery-context.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
+import { retryTransientDirectCronDelivery } from "../cron/isolated-agent/delivery-dispatch-policy.js";
 import { resolveCronJobBoundSessionKeys } from "../cron/job-session-bindings.js";
 import { toPublicCronJob } from "../cron/public-job.js";
 import { resolveCronScheduledToolPolicy } from "../cron/scheduled-tool-policy.js";
@@ -256,21 +257,33 @@ async function finalizeCronCompletionAnnouncement(params: {
   }
 
   const { agentId, cfg } = params.resolveCronAgent(params.job.agentId);
+  const abortSignal = params.abortSignal ?? new AbortController().signal;
+  let deliveryMayHaveReachedRecipient = false;
   try {
-    await sendCronAnnouncePayloadStrict({
-      deps: params.deps,
-      cfg,
-      agentId,
+    await retryTransientDirectCronDelivery({
       jobId: params.job.id,
-      target: {
-        channel: plan.channel,
-        to: plan.to,
-        threadId: plan.threadId,
-        accountId: plan.accountId,
-        sessionKey: resolveCronDeliverySessionKey(params.job),
-      },
-      payload: { text: params.text },
-      abortSignal: params.abortSignal ?? new AbortController().signal,
+      label: params.label,
+      signal: abortSignal,
+      shouldRetryError: () => !deliveryMayHaveReachedRecipient,
+      run: () =>
+        sendCronAnnouncePayloadStrict({
+          deps: params.deps,
+          cfg,
+          agentId,
+          jobId: params.job.id,
+          target: {
+            channel: plan.channel,
+            to: plan.to,
+            threadId: plan.threadId,
+            accountId: plan.accountId,
+            sessionKey: resolveCronDeliverySessionKey(params.job),
+          },
+          payload: { text: params.text },
+          abortSignal,
+          onDeliveryAttempt: (reachedRecipient) => {
+            deliveryMayHaveReachedRecipient ||= reachedRecipient;
+          },
+        }),
     });
     return {
       deliveryAttempted: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running scheduled command or script jobs would permanently lose the completed job's announcement when its channel hit a retryable network failure before the message was dispatched. Successful one-shot jobs were then deleted, leaving no automatic way to recover the missing result.

## Why This Change Was Made

Route both command and script completion announcements through the existing bounded transient-delivery retry owner. The strict cron delivery owner now reports the actual durable-batch recipient-reached fact before propagating its original error, and the Gateway latches that fact to stop retries whenever any message might already have reached a recipient.

This owner-boundary fact is essential: a partial batch can expose a raw or wrapped typed not-dispatched error from a later chunk even though an earlier chunk was already accepted. Reclassifying the nested error alone would duplicate delivered messages. Permanent errors, ambiguous post-dispatch failures, cancellation, failure notifications, and public contracts retain their existing behavior. Production grows by 20 lines because authoritative recipient evidence must cross the existing strict-delivery/Gateway owner boundary without replacing or weakening the canonical retry policy.

## User Impact

Scheduled command and script results are delivered after safe, proven pre-dispatch transient failures, including default successful one-shot jobs. Messages that were already accepted are never retried or duplicated, and aborting an active scheduled run still cancels delivery.

## Evidence

- Authentic pre-fix Gateway reproductions for both command and script one-shot jobs failed with one delivery attempt instead of the required two; both pass after the repair and preserve successful completion, delivered status, one-shot deletion, and the same abort signal.
- Authentic partial-delivery regressions for both job kinds and both raw/wrapped nested not-dispatched errors originally attempted delivery twice; all four now prove exactly one send.
- Real strict-delivery-owner regressions exercise the actual durable batch implementation and preserve recipient-reached evidence for raw partial failures, wrapped partial failures, and failed batches carrying accepted-recipient evidence.
- Focused Gateway owner/sibling suites: 114 tests passed across scheduled command/script jobs, notifications, presentation, and webhook delivery.
- Focused cron owner/sibling suites: 198 tests passed across strict delivery, failure notifications, isolated-agent announcement dispatch, and persisted delivery status.
- Total focused proof: **312 tests passed**. Core production types, Gateway tests, service tests, formatting, lint, max-lines ratchet, assertion-safety ratchet, independent architectural review, and authenticated full committed-branch review all passed.
- Redacted focused terminal proof for the injected-failure and recipient-reached no-duplicate suites:

  ```text
  Gateway owner and notification/webhook sibling suites:
  Test Files  4 passed (4)
       Tests  114 passed (114)

  Cron strict-delivery, isolated-agent, and persisted-status suites:
  Test Files  4 passed (4)
       Tests  198 passed (198)
  ```

- Exact-head required CI passed: `openclaw/ci-gate` succeeded in run `32633533055` for commit `eca620080f7075365b99fce81d18f411a1a1eb29`.
- Live-channel delivery was not run because this defect requires deterministically injecting typed transport failures, partial accepted batches, and cancellation into real durable owner/Gateway job execution; the actual owner-boundary and Gateway execution suites provide the reproducible operator-visible proof without sending duplicate live messages.
