### PR TITLE
fix(crabbox): preserve Machine0 provisioning budget

### DIFF
--- a/docs/plugins/reference/crabbox.md
+++ b/docs/plugins/reference/crabbox.md
@@ -24,4 +24,15 @@ contracts: `workerProviders`
 
 See [Cloud worker environments](/gateway/configuration-reference#crabbox-profile) for the profile schema and lifecycle notes.
 
+Forward Gateway environment variables to an operator-provided setup script by listing their names in the Crabbox profile settings:
+
+```json5 validate=false
+{
+  setup: 'install-worker "$OPENCLAW_WORKER_ARTIFACT_TOKEN"',
+  setupEnv: ["OPENCLAW_WORKER_ARTIFACT_TOKEN"],
+}
+```
+
+`setupEnv` explicitly forwards up to 16 unique environment variable names to the setup command only. Values are read from the Gateway process environment and are never stored in the profile configuration. Missing variables fail before a machine is allocated.
+
 <!-- openclaw-plugin-reference:manual-end -->

--- a/extensions/crabbox/src/crabbox-worker-command-error.ts
+++ b/extensions/crabbox/src/crabbox-worker-command-error.ts
@@ -1,23 +1,33 @@
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { WorkerProviderError } from "openclaw/plugin-sdk/plugin-entry";
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
-import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const MAX_COMMAND_DETAIL_CHARS = 512;
 
 function crabboxCommandDetail(result: SpawnResult): string {
-  const raw = (result.stderr || result.stdout).trim();
+  const raw = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
   if (!raw) {
     return "";
   }
   const compressed = redactSensitiveText(raw).replace(/\s+/gu, " ");
-  const redacted = sliceUtf16Safe(compressed, -MAX_COMMAND_DETAIL_CHARS);
+  const omitted = " ... ";
+  const remaining = MAX_COMMAND_DETAIL_CHARS - omitted.length;
+  const redacted =
+    compressed.length <= MAX_COMMAND_DETAIL_CHARS
+      ? compressed
+      : `${truncateUtf16Safe(compressed, Math.ceil(remaining / 2))}${omitted}${sliceUtf16Safe(
+          compressed,
+          -Math.floor(remaining / 2),
+        )}`;
   return redacted ? `: ${redacted}` : "";
 }
 
 export function crabboxCommandError(action: string, result: SpawnResult): Error {
   if (result.termination !== "exit") {
-    return new Error(`Crabbox ${action} did not exit normally (${result.termination})`);
+    return new Error(
+      `Crabbox ${action} did not exit normally (${result.termination})${crabboxCommandDetail(result)}`,
+    );
   }
   const exitCode = result.code === null ? "unknown" : String(result.code);
   return new Error(

--- a/extensions/crabbox/src/crabbox-worker-profile.ts
+++ b/extensions/crabbox/src/crabbox-worker-profile.ts
@@ -160,6 +160,9 @@ export function parseCrabboxProfile(profile: WorkerProfile): CrabboxProfile {
           "Crabbox profile setupEnv must contain only valid POSIX environment variable names",
         );
       }
+      if (name === "CRABBOX_ENV_ALLOW") {
+        throw new WorkerProviderError(`Crabbox profile setupEnv name ${name} is reserved`);
+      }
       return name;
     });
     if (new Set(setupEnv).size !== setupEnv.length) {

--- a/extensions/crabbox/src/crabbox-worker-profile.ts
+++ b/extensions/crabbox/src/crabbox-worker-profile.ts
@@ -18,6 +18,7 @@ const PROFILE_KEYS = new Set([
   "idleTimeout",
   "provider",
   "setup",
+  "setupEnv",
   "ttl",
 ]);
 const GO_DURATION_PATTERN = /^\+?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|μs|ms|s|m|h))+$/u;
@@ -45,6 +46,7 @@ type CrabboxProfile = {
   provider: string;
   ttl: string;
   setup?: string;
+  setupEnv?: string[];
 };
 
 const CRABBOX_FALLBACK_MACHINE_CLASSES = ["standard", "fast", "large", "beast"] as const;
@@ -144,6 +146,29 @@ export function parseCrabboxProfile(profile: WorkerProfile): CrabboxProfile {
   if (setupValue !== undefined && !setup) {
     throw new WorkerProviderError("Crabbox profile setup must be a non-empty command string");
   }
+  let setupEnv: string[] | undefined;
+  if (profile.setupEnv !== undefined) {
+    if (!Array.isArray(profile.setupEnv)) {
+      throw new WorkerProviderError("Crabbox profile setupEnv must be an array");
+    }
+    if (profile.setupEnv.length > 16) {
+      throw new WorkerProviderError("Crabbox profile setupEnv must contain at most 16 names");
+    }
+    setupEnv = profile.setupEnv.map((name) => {
+      if (typeof name !== "string" || !/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name)) {
+        throw new WorkerProviderError(
+          "Crabbox profile setupEnv must contain only valid POSIX environment variable names",
+        );
+      }
+      return name;
+    });
+    if (new Set(setupEnv).size !== setupEnv.length) {
+      throw new WorkerProviderError("Crabbox profile setupEnv must not contain duplicate names");
+    }
+    if (setupEnv.length > 0 && !setup) {
+      throw new WorkerProviderError("Crabbox profile setupEnv requires setup");
+    }
+  }
   const desktop = profile.desktop;
   if (desktop !== undefined && typeof desktop !== "boolean") {
     throw new WorkerProviderError("Crabbox profile desktop must be a boolean");
@@ -165,8 +190,44 @@ export function parseCrabboxProfile(profile: WorkerProfile): CrabboxProfile {
     idleTimeout,
     provider,
     setup,
+    setupEnv,
     ttl,
   };
+}
+
+function resolveCrabboxProfileSetupEnv(
+  setupEnv: readonly string[] | undefined,
+): Record<string, string> | undefined {
+  if (!setupEnv?.length) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    setupEnv.map((name) => {
+      const value = process.env[name];
+      if (!Object.hasOwn(process.env, name) || value === undefined) {
+        throw new WorkerProviderError(`Crabbox profile setupEnv variable is missing: ${name}`);
+      }
+      return [name, value];
+    }),
+  );
+}
+
+export function resolveCrabboxProvisionProfile(
+  profile: WorkerProfile,
+  requestedClassValue: unknown,
+): { profile: CrabboxProfile; forwardedEnv?: Record<string, string> } {
+  const configured = parseCrabboxProfile(profile);
+  const requestedClass = nonEmptyString(requestedClassValue);
+  if (
+    requestedClassValue !== undefined &&
+    (!requestedClass || requestedClass.length > MAX_CRABBOX_MACHINE_CLASS_LENGTH)
+  ) {
+    throw new WorkerProviderError(
+      "Crabbox machine class must be a non-empty string of at most 128 characters",
+    );
+  }
+  const resolved = requestedClass ? { ...configured, class: requestedClass } : configured;
+  return { profile: resolved, forwardedEnv: resolveCrabboxProfileSetupEnv(resolved.setupEnv) };
 }
 
 export function listCrabboxMachineOptions(

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -2720,56 +2720,67 @@ describe("Crabbox worker provider", () => {
     await expect(cliMissing.inspect(lease)).rejects.toThrow("inspect could not start");
   });
 
-  it("retains the redacted terminal provider failure after verbose provisioning progress", async () => {
-    const secret = ["sk", "abcdefghijklmnop"].join("-");
-    const terminalCause = "machine0 provider rejected authenticated provisioning";
-    const failurePrefix = "Crabbox warmup failed with exit code 5: ";
-    const provider = providerWithRunner(async () =>
-      commandResult({
-        code: 5,
-        stderr: [
-          "coordinator lease class=standard preferred_type=machine0",
-          "provisioning progress ".repeat(100),
-          `token=${secret}`,
-          terminalCause,
-        ].join("\n"),
-        stdout: "stdout must not replace stderr",
-      }),
-    );
-
-    const error = await provider
-      .provision({ ...PROFILE, provider: "machine0" }, OPERATION_ID)
-      .catch((cause: unknown) => cause);
-    expect(error).toBeInstanceOf(Error);
-    const message = error instanceof Error ? error.message : "";
-    expect(message).toContain(terminalCause);
-    expect(message).not.toContain(secret);
-    expect(message).not.toContain("stdout must not replace stderr");
-    expect(message).toHaveLength(failurePrefix.length + 512);
-    expect(message.startsWith(failurePrefix)).toBe(true);
-  });
-
-  it("preserves UTF-16 boundaries at the start of terminal provider failure details", async () => {
-    const suffix = "x".repeat(511);
-    const provider = providerWithRunner(async () =>
-      commandResult({ code: 2, stderr: `progress😀${suffix}` }),
-    );
-
-    const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
-    expect(error).toBeInstanceOf(Error);
-    const message = error instanceof Error ? error.message : "";
-    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}${suffix}`);
-    expect(hasLoneSurrogate(message)).toBe(false);
-  });
-
   it.each([
-    { name: "exactly at the bound", prefix: "" },
-    { name: "beyond the bound", prefix: "earlier progress " },
-  ])("keeps a complete stdout boundary pair $name", async ({ prefix }) => {
+    { action: "warmup", termination: "exit", code: 5 },
+    { action: "inspect", termination: "timeout", code: null },
+  ] as const)(
+    "preserves bounded, redacted terminal diagnostics for $action $termination failures",
+    async ({ action, termination, code }) => {
+      const secret = ["sk", "abcdefghijklmnop"].join("-");
+      const terminalStderr = "Machine0 terminal stderr: provider quota exhausted";
+      const terminalStdout = "Machine0 terminal stdout: quota window has not reset";
+      const provider = providerWithRunner(async () =>
+        commandResult({
+          code,
+          termination,
+          killed: termination !== "exit",
+          stderr: `provider warning ${secret} ${"provider progress ".repeat(90)}${terminalStderr}`,
+          stdout: terminalStdout,
+        }),
+      );
+      const operation =
+        action === "warmup"
+          ? provider.provision({ ...PROFILE, provider: "machine0" }, OPERATION_ID)
+          : provider.inspect(lifecycleLease());
+
+      const error = await operation.catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(Error);
+      const message = error instanceof Error ? error.message : "";
+      const failurePrefix =
+        action === "warmup"
+          ? "Crabbox warmup failed with exit code 5: "
+          : "Crabbox inspect did not exit normally (timeout): ";
+      expect(message).toContain("provider warning");
+      expect(message).toContain(terminalStderr);
+      expect(message).toContain(terminalStdout);
+      expect(message).not.toContain(secret);
+      expect(message.length).toBeLessThanOrEqual(failurePrefix.length + 512);
+      expect(hasLoneSurrogate(message)).toBe(false);
+    },
+  );
+
+  it.each(["stderr", "stdout"] as const)(
+    "preserves UTF-16 boundaries and terminal detail from %s",
+    async (stream) => {
+      const provider = providerWithRunner(async () =>
+        commandResult({
+          code: 2,
+          [stream]: `${"x".repeat(253)}😀${"y".repeat(300)}😀 terminal failure`,
+        }),
+      );
+
+      const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(Error);
+      const message = error instanceof Error ? error.message : "";
+      expect(message).toContain("😀 terminal failure");
+      expect(message.length).toBeLessThanOrEqual(INSPECT_FAILURE_PREFIX.length + 512);
+      expect(hasLoneSurrogate(message)).toBe(false);
+    },
+  );
+
+  it("keeps a complete stdout boundary pair exactly at the bound", async () => {
     const detail = `${"x".repeat(510)}😀`;
-    const provider = providerWithRunner(async () =>
-      commandResult({ code: 2, stdout: `${prefix}${detail}` }),
-    );
+    const provider = providerWithRunner(async () => commandResult({ code: 2, stdout: detail }));
 
     const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -1702,8 +1702,8 @@ describe("Crabbox worker provider", () => {
     {
       providerId: "machine0",
       warmupTimeoutMs: 50 * 60_000,
-      lifecycleTimeoutMs: 3 * 60_000,
-      provisionTimeoutMs: 71 * 60_000,
+      lifecycleTimeoutMs: 5 * 60_000,
+      provisionTimeoutMs: 75 * 60_000,
     },
   ])(
     "runs one fixed $providerId warmup, ignores its output, and inspects only the canonical id",
@@ -1809,6 +1809,36 @@ describe("Crabbox worker provider", () => {
     },
   );
 
+  it("preserves a full Machine0 inspection window after a near-max warmup", async () => {
+    const profile = { ...PROFILE, provider: "machine0" };
+    let elapsedMs = 0;
+    let initialInspectTimeoutMs = 0;
+    const now = vi.spyOn(Date, "now").mockImplementation(() => elapsedMs);
+    const provider = providerWithRunner(async (argv, options) => {
+      if (argv[1] === "warmup") {
+        elapsedMs = 50 * 60_000;
+        return commandResult();
+      }
+      if (argv[1] === "inspect") {
+        if (initialInspectTimeoutMs === 0) {
+          initialInspectTimeoutMs = options.timeoutMs;
+          elapsedMs += 4 * 60_000;
+        }
+        return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
+      }
+      return commandResult();
+    });
+
+    try {
+      await expect(provider.provision(profile, OPERATION_ID)).resolves.toMatchObject({
+        leaseId: LEASE_ID,
+      });
+      expect(initialInspectTimeoutMs).toBe(5 * 60_000);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it("reserves the full Machine0 cleanup budget after late node enrollment failure", async () => {
     const profile = { ...PROFILE, provider: "machine0" };
     let elapsedMs = 0;
@@ -1836,14 +1866,14 @@ describe("Crabbox worker provider", () => {
             packageSpecs: ["openclaw@2026.8.1"],
             displayName: "Bound worker",
             waitForDeviceId: async () => {
-              elapsedMs = 68 * 60_000;
+              elapsedMs = 70 * 60_000;
               throw new Error("node enrollment expired");
             },
           }),
         }),
       ).rejects.toMatchObject({ code: "cleanup_indeterminate", leaseId: LEASE_ID });
 
-      expect(cleanupTimeoutMs).toBe(3 * 60_000);
+      expect(cleanupTimeoutMs).toBe(5 * 60_000);
       expect(provider.resolveProvisionTimeoutMs?.(profile)).toBe(elapsedMs);
     } finally {
       now.mockRestore();

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -1703,7 +1703,7 @@ describe("Crabbox worker provider", () => {
       providerId: "machine0",
       warmupTimeoutMs: 50 * 60_000,
       lifecycleTimeoutMs: 3 * 60_000,
-      provisionTimeoutMs: 69 * 60_000,
+      provisionTimeoutMs: 71 * 60_000,
     },
   ])(
     "runs one fixed $providerId warmup, ignores its output, and inspects only the canonical id",
@@ -1744,6 +1744,10 @@ describe("Crabbox worker provider", () => {
       expect({
         warmupOptions: calls[0]?.options,
         provisionTimeoutMs: provider.resolveProvisionTimeoutMs?.(profile),
+        provisionTimeoutWithSetupMs: provider.resolveProvisionTimeoutMs?.({
+          ...profile,
+          setup: "install-node",
+        }),
       }).toEqual({
         warmupOptions: {
           timeoutMs: warmupTimeoutMs,
@@ -1751,6 +1755,7 @@ describe("Crabbox worker provider", () => {
           killProcessTree: true,
         },
         provisionTimeoutMs,
+        provisionTimeoutWithSetupMs: provisionTimeoutMs + 15 * 60_000,
       });
       expect(calls[1]?.argv).toEqual([
         SIBLING_BINARY,
@@ -1803,6 +1808,47 @@ describe("Crabbox worker provider", () => {
       ]);
     },
   );
+
+  it("reserves the full Machine0 cleanup budget after late node enrollment failure", async () => {
+    const profile = { ...PROFILE, provider: "machine0" };
+    let elapsedMs = 0;
+    let cleanupTimeoutMs = 0;
+    const now = vi.spyOn(Date, "now").mockImplementation(() => elapsedMs);
+    const provider = providerWithRunner(async (argv, options) => {
+      if (argv[1] === "inspect") {
+        return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
+      }
+      if (argv[1] === "stop") {
+        cleanupTimeoutMs = options.timeoutMs;
+        elapsedMs += options.timeoutMs;
+        return commandResult({ code: null, killed: true, termination: "timeout" });
+      }
+      return commandResult();
+    });
+
+    try {
+      await expect(
+        provider.provision(profile, OPERATION_ID, {
+          beginNodeEnrollment: async () => ({
+            mode: "resume" as const,
+            deviceId: "device-bound",
+            openclawVersion: "2026.8.1",
+            packageSpecs: ["openclaw@2026.8.1"],
+            displayName: "Bound worker",
+            waitForDeviceId: async () => {
+              elapsedMs = 68 * 60_000;
+              throw new Error("node enrollment expired");
+            },
+          }),
+        }),
+      ).rejects.toMatchObject({ code: "cleanup_indeterminate", leaseId: LEASE_ID });
+
+      expect(cleanupTimeoutMs).toBe(3 * 60_000);
+      expect(provider.resolveProvisionTimeoutMs?.(profile)).toBe(elapsedMs);
+    } finally {
+      now.mockRestore();
+    }
+  });
 
   it("overrides the configured class for one provision operation", async () => {
     const calls: string[][] = [];

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -839,7 +839,7 @@ describe("Crabbox worker provider", () => {
   it("preserves the allocated lease and both failures when setup cleanup times out", async () => {
     let releaseCommitted = false;
     const provider = providerWithRunner(async (argv) => {
-      if (argv[1] === "inspect") {
+      if (argv[1] === "inspect" || argv[1] === "status") {
         return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
       }
       if (argv[1] === "run") {
@@ -1399,7 +1399,7 @@ describe("Crabbox worker provider", () => {
       if (argv[1] === "config" && argv[2] === "show") {
         return commandResult({ stdout: JSON.stringify(config) });
       }
-      if (argv[1] === "inspect") {
+      if (argv[1] === "inspect" || argv[1] === "status") {
         return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
       }
       if (argv[1] === "run" && String(options.input).includes("openclaw-worker-browser")) {
@@ -1515,7 +1515,7 @@ describe("Crabbox worker provider", () => {
     const pairingSecret = "pairing-secret-value-0123456789";
     const provider = providerWithRunner(async (argv, options) => {
       calls.push({ argv, options });
-      if (argv[1] === "inspect") {
+      if (argv[1] === "inspect" || argv[1] === "status") {
         return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
       }
       if (argv[1] === "run" && String(options.input).includes("node.log tail:")) {
@@ -1588,7 +1588,7 @@ describe("Crabbox worker provider", () => {
     const calls: string[][] = [];
     const provider = providerWithRunner(async (argv, options) => {
       calls.push(argv);
-      if (argv[1] === "inspect") {
+      if (argv[1] === "inspect" || argv[1] === "status") {
         return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
       }
       if (argv[1] === "run" && String(options.input).includes("node.log tail:")) {
@@ -1623,7 +1623,7 @@ describe("Crabbox worker provider", () => {
     },
   ])("bounds enrollment evidence for $name", async ({ output, expected }) => {
     const provider = providerWithRunner(async (argv, options) => {
-      if (argv[1] === "inspect") {
+      if (argv[1] === "inspect" || argv[1] === "status") {
         return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
       }
       if (argv[1] === "run" && String(options.input).includes("node.log tail:")) {
@@ -1725,6 +1725,7 @@ describe("Crabbox worker provider", () => {
           : commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
       });
       const profile = { ...PROFILE, provider: providerId };
+      const readinessAction = providerId === "machine0" ? "status" : "inspect";
 
       await expect(provider.provision(profile, OPERATION_ID)).resolves.toMatchObject({
         leaseId: LEASE_ID,
@@ -1768,13 +1769,14 @@ describe("Crabbox worker provider", () => {
       });
       expect(calls[1]?.argv).toEqual([
         SIBLING_BINARY,
-        "inspect",
+        readinessAction,
         "--provider",
         providerId,
         "--network",
         "public",
         "--id",
         LEASE_ID,
+        ...(providerId === "machine0" ? ["--wait", "--wait-timeout", "4m"] : []),
         "--json",
       ]);
       expect(calls[1]?.options.timeoutMs).toBe(lifecycleTimeoutMs);
@@ -1805,7 +1807,7 @@ describe("Crabbox worker provider", () => {
         expect.arrayContaining(["--allow-env", "CRABBOX_WORKER_SETUP_CODE"]),
       );
       expect(calls[2]?.argv.join(" ")).not.toContain("setup-code");
-      expect(calls[3]?.argv[1]).toBe("inspect");
+      expect(calls[3]?.argv[1]).toBe(readinessAction);
       expect(calls[3]?.options.timeoutMs).toBe(lifecycleTimeoutMs);
 
       const lease = lifecycleLease(LEASE_ID, profile);
@@ -1829,7 +1831,7 @@ describe("Crabbox worker provider", () => {
       const delays: number[] = [];
       const provider = providerWithRunner(
         async (argv) => {
-          if (argv[1] === "inspect") {
+          if (argv[1] === "inspect" || argv[1] === "status") {
             inspections += 1;
             return commandResult({
               stdout: inspectJson({ ready: inspections > 1, sshHostKey: HOST_KEY }),
@@ -1860,7 +1862,7 @@ describe("Crabbox worker provider", () => {
         elapsedMs = 50 * 60_000;
         return commandResult();
       }
-      if (argv[1] === "inspect") {
+      if (argv[1] === "inspect" || argv[1] === "status") {
         inspectTimeouts.push(options.timeoutMs);
         if (inspectTimeouts.length <= 2) {
           elapsedMs += 4 * 60_000;
@@ -1888,7 +1890,7 @@ describe("Crabbox worker provider", () => {
     let cleanupTimeoutMs = 0;
     const now = vi.spyOn(Date, "now").mockImplementation(() => elapsedMs);
     const provider = providerWithRunner(async (argv, options) => {
-      if (argv[1] === "inspect") {
+      if (argv[1] === "inspect" || argv[1] === "status") {
         return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
       }
       if (argv[1] === "stop") {

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -79,13 +79,14 @@ function lifecycleLease(leaseId = LEASE_ID, profile: WorkerProfile = PROFILE) {
 function providerWithRawRunner(
   runCommand: CrabboxCommandRunner,
   warn?: (message: string) => void,
+  sleep: (milliseconds: number) => Promise<void> = async () => {},
 ): WorkerProvider {
   const provider = createCrabboxWorkerProvider({
     runCommand,
     openclawRoot: OPENCLAW_ROOT,
     pathEnv: "",
     isExecutable: (candidate) => candidate === SIBLING_BINARY,
-    sleep: async () => {},
+    sleep,
     wallpaperPath: WORKER_WALLPAPER_PATH,
     ...(warn ? { warn } : {}),
   });
@@ -109,13 +110,21 @@ function providerWithRawRunner(
   };
 }
 
-function providerWithRunner(runCommand: CrabboxCommandRunner, warn?: (message: string) => void) {
-  return providerWithRawRunner(async (argv, options) => {
-    if (argv[1] === "config" && argv[2] === "show") {
-      return commandResult({ stdout: JSON.stringify({ aws: { instanceProfile: "" } }) });
-    }
-    return runCommand(argv, options);
-  }, warn);
+function providerWithRunner(
+  runCommand: CrabboxCommandRunner,
+  warn?: (message: string) => void,
+  sleep?: (milliseconds: number) => Promise<void>,
+) {
+  return providerWithRawRunner(
+    async (argv, options) => {
+      if (argv[1] === "config" && argv[2] === "show") {
+        return commandResult({ stdout: JSON.stringify({ aws: { instanceProfile: "" } }) });
+      }
+      return runCommand(argv, options);
+    },
+    warn,
+    sleep,
+  );
 }
 
 function failedNodeEnrollment(
@@ -1806,6 +1815,38 @@ describe("Crabbox worker provider", () => {
         ["inspect", lifecycleTimeoutMs],
         ["stop", lifecycleTimeoutMs],
       ]);
+    },
+  );
+
+  it.each([
+    { providerId: "aws", expectedIntervalMs: 2_000 },
+    { providerId: "hetzner", expectedIntervalMs: 2_000 },
+    { providerId: "machine0", expectedIntervalMs: 60_000 },
+  ])(
+    "paces $providerId readiness re-inspection at $expectedIntervalMs ms",
+    async ({ providerId, expectedIntervalMs }) => {
+      let inspections = 0;
+      const delays: number[] = [];
+      const provider = providerWithRunner(
+        async (argv) => {
+          if (argv[1] === "inspect") {
+            inspections += 1;
+            return commandResult({
+              stdout: inspectJson({ ready: inspections > 1, sshHostKey: HOST_KEY }),
+            });
+          }
+          return commandResult();
+        },
+        undefined,
+        async (milliseconds) => {
+          delays.push(milliseconds);
+        },
+      );
+
+      await expect(
+        provider.provision({ ...PROFILE, provider: providerId }, OPERATION_ID),
+      ).resolves.toMatchObject({ leaseId: LEASE_ID });
+      expect(delays).toEqual([expectedIntervalMs]);
     },
   );
 

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -1703,7 +1703,7 @@ describe("Crabbox worker provider", () => {
       providerId: "machine0",
       warmupTimeoutMs: 50 * 60_000,
       lifecycleTimeoutMs: 5 * 60_000,
-      provisionTimeoutMs: 75 * 60_000,
+      provisionTimeoutMs: 80 * 60_000,
     },
   ])(
     "runs one fixed $providerId warmup, ignores its output, and inspects only the canonical id",
@@ -1809,10 +1809,10 @@ describe("Crabbox worker provider", () => {
     },
   );
 
-  it("preserves a full Machine0 inspection window after a near-max warmup", async () => {
+  it("reserves separate Machine0 inspection and readiness windows after a near-max warmup", async () => {
     const profile = { ...PROFILE, provider: "machine0" };
     let elapsedMs = 0;
-    let initialInspectTimeoutMs = 0;
+    const inspectTimeouts: number[] = [];
     const now = vi.spyOn(Date, "now").mockImplementation(() => elapsedMs);
     const provider = providerWithRunner(async (argv, options) => {
       if (argv[1] === "warmup") {
@@ -1820,11 +1820,13 @@ describe("Crabbox worker provider", () => {
         return commandResult();
       }
       if (argv[1] === "inspect") {
-        if (initialInspectTimeoutMs === 0) {
-          initialInspectTimeoutMs = options.timeoutMs;
+        inspectTimeouts.push(options.timeoutMs);
+        if (inspectTimeouts.length <= 2) {
           elapsedMs += 4 * 60_000;
         }
-        return commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
+        return commandResult({
+          stdout: inspectJson({ ready: inspectTimeouts.length > 1, sshHostKey: HOST_KEY }),
+        });
       }
       return commandResult();
     });
@@ -1833,7 +1835,7 @@ describe("Crabbox worker provider", () => {
       await expect(provider.provision(profile, OPERATION_ID)).resolves.toMatchObject({
         leaseId: LEASE_ID,
       });
-      expect(initialInspectTimeoutMs).toBe(5 * 60_000);
+      expect(inspectTimeouts.slice(0, 2)).toEqual([5 * 60_000, 5 * 60_000]);
     } finally {
       now.mockRestore();
     }
@@ -1866,7 +1868,7 @@ describe("Crabbox worker provider", () => {
             packageSpecs: ["openclaw@2026.8.1"],
             displayName: "Bound worker",
             waitForDeviceId: async () => {
-              elapsedMs = 70 * 60_000;
+              elapsedMs = 75 * 60_000;
               throw new Error("node enrollment expired");
             },
           }),

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -649,6 +649,8 @@ describe("Crabbox worker provider", () => {
   ])(
     "runs profile setup $name without widening node enrollment",
     async ({ setupEnv, forwardedEnv }) => {
+      vi.stubEnv("CRABBOX_ENV_ALLOW", "OPENCLAW_UNSELECTED_SECRET");
+      vi.stubEnv("OPENCLAW_UNSELECTED_SECRET", "unselected-secret");
       for (const [name, value] of Object.entries(forwardedEnv ?? {})) {
         vi.stubEnv(name, value);
       }
@@ -688,7 +690,10 @@ describe("Crabbox worker provider", () => {
         ...Object.keys(forwardedEnv ?? {}).flatMap((name) => ["--allow-env", name]),
         "--script-stdin",
       ]);
-      expect(setupCall?.options.env).toEqual(forwardedEnv);
+      expect(setupCall?.options.env).toEqual({
+        ...forwardedEnv,
+        CRABBOX_ENV_ALLOW: setupEnv?.join(",") || ",",
+      });
       expect(setupCall?.options.input).toBe(setup);
       expect(enrollmentCall?.options.env).toEqual({
         CRABBOX_WORKER_SETUP_CODE: "secret-setup-value",
@@ -2314,6 +2319,10 @@ describe("Crabbox worker provider", () => {
     { profile: { ...PROFILE, setup: "install-node", setupEnv: [""] }, message: "valid" },
     { profile: { ...PROFILE, setup: "install-node", setupEnv: ["1TOKEN"] }, message: "valid" },
     { profile: { ...PROFILE, setup: "install-node", setupEnv: ["BAD-NAME"] }, message: "valid" },
+    {
+      profile: { ...PROFILE, setup: "install-node", setupEnv: ["CRABBOX_ENV_ALLOW"] },
+      message: "CRABBOX_ENV_ALLOW is reserved",
+    },
     {
       profile: { ...PROFILE, setup: "install-node", setupEnv: ["TOKEN", "TOKEN"] },
       message: "duplicate",

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -14,6 +14,7 @@ import * as doctorRuntime from "./crabbox-worker-doctor-runtime.js";
 import {
   findCrabboxBinary,
   operationLeaseId,
+  parseCrabboxProfile,
   resolveCrabboxBinary,
 } from "./crabbox-worker-profile.js";
 import { createCrabboxWorkerProvider, resolveOpenClawRoot } from "./crabbox-worker-provider.js";
@@ -39,6 +40,7 @@ const PROFILE = {
   idleTimeout: "60m",
 };
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.unstubAllEnvs());
 
 type CrabboxWorkerProviderDependencies = NonNullable<
   Parameters<typeof createCrabboxWorkerProvider>[0]
@@ -634,42 +636,88 @@ describe("Crabbox worker provider", () => {
     expect(calls.flatMap((call) => call.argv)).not.toContain("rsync");
   });
 
-  it("runs the profile setup command on the ready lease and keeps it", async () => {
-    const calls: Array<{ argv: string[]; options: Parameters<CrabboxCommandRunner>[1] }> = [];
-    let warmed = false;
-    const provider = providerWithRunner(async (argv, options) => {
-      calls.push({ argv, options });
-      if (argv[1] === "warmup") {
-        warmed = true;
-        return commandResult({ stdout: `leased ${LEASE_ID} slug=test\n` });
+  it.each([
+    { name: "without forwarded environment", setupEnv: undefined, forwardedEnv: undefined },
+    {
+      name: "with only explicitly forwarded Gateway environment",
+      setupEnv: ["OPENCLAW_WORKER_ARTIFACT_TOKEN", "CRABBOX_EMPTY_VALUE"],
+      forwardedEnv: {
+        OPENCLAW_WORKER_ARTIFACT_TOKEN: "fixture-artifact-token",
+        CRABBOX_EMPTY_VALUE: "",
+      },
+    },
+  ])(
+    "runs profile setup $name without widening node enrollment",
+    async ({ setupEnv, forwardedEnv }) => {
+      for (const [name, value] of Object.entries(forwardedEnv ?? {})) {
+        vi.stubEnv(name, value);
       }
-      if (argv[1] === "run") {
-        return commandResult();
-      }
-      return warmed || argv.includes(LEASE_ID)
-        ? commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) })
-        : commandResult({ code: 4, stderr: `lease/server not found: ${argv.at(-2)}` });
-    });
+      const calls: Array<{ argv: string[]; options: Parameters<CrabboxCommandRunner>[1] }> = [];
+      let warmed = false;
+      const provider = providerWithRunner(async (argv, options) => {
+        calls.push({ argv, options });
+        if (argv[1] === "warmup") {
+          warmed = true;
+          return commandResult({ stdout: `leased ${LEASE_ID} slug=test\n` });
+        }
+        if (argv[1] === "run") {
+          return commandResult();
+        }
+        return warmed || argv.includes(LEASE_ID)
+          ? commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) })
+          : commandResult({ code: 4, stderr: `lease/server not found: ${argv.at(-2)}` });
+      });
 
-    const setup = "command -v node || install-node";
-    await expect(provider.provision({ ...PROFILE, setup }, OPERATION_ID)).resolves.toMatchObject({
-      leaseId: LEASE_ID,
+      const setup = "command -v node || install-node";
+      const profile = { ...PROFILE, setup, ...(setupEnv ? { setupEnv } : {}) };
+      await expect(provider.provision(profile, OPERATION_ID)).resolves.toMatchObject({
+        leaseId: LEASE_ID,
+      });
+      const [setupCall, enrollmentCall] = calls.filter((call) => call.argv[1] === "run");
+      expect(setupCall?.argv.slice(1)).toEqual([
+        "run",
+        "--provider",
+        "aws",
+        "--network",
+        "public",
+        "--tailscale=false",
+        "--id",
+        LEASE_ID,
+        "--keep=true",
+        "--no-sync",
+        ...Object.keys(forwardedEnv ?? {}).flatMap((name) => ["--allow-env", name]),
+        "--script-stdin",
+      ]);
+      expect(setupCall?.options.env).toEqual(forwardedEnv);
+      expect(setupCall?.options.input).toBe(setup);
+      expect(enrollmentCall?.options.env).toEqual({
+        CRABBOX_WORKER_SETUP_CODE: "secret-setup-value",
+      });
+      expect(
+        enrollmentCall?.argv.filter((argument, index, argv) => argv[index - 1] === "--allow-env"),
+      ).toEqual(["CRABBOX_WORKER_SETUP_CODE"]);
+      expect(
+        calls.filter((call) => call.argv[1] !== "run").every((call) => !call.options.env),
+      ).toBe(true);
+    },
+  );
+
+  it("rejects a missing profile setup environment variable before invoking Crabbox", async () => {
+    const missingName = "OPENCLAW_MISSING_WORKER_ARTIFACT_TOKEN";
+    vi.stubEnv(missingName, undefined);
+    const runCommand = vi.fn<CrabboxCommandRunner>();
+    const provider = providerWithRawRunner(runCommand);
+
+    await expect(
+      provider.provision(
+        { ...PROFILE, setup: "install-node", setupEnv: [missingName] },
+        OPERATION_ID,
+      ),
+    ).rejects.toMatchObject({
+      code: "invalid_profile",
+      message: expect.stringContaining(missingName),
     });
-    const runCall = calls.find((call) => call.argv[1] === "run");
-    expect(runCall?.argv.slice(1)).toEqual([
-      "run",
-      "--provider",
-      "aws",
-      "--network",
-      "public",
-      "--tailscale=false",
-      "--id",
-      LEASE_ID,
-      "--keep=true",
-      "--no-sync",
-      "--script-stdin",
-    ]);
-    expect(runCall?.options.input).toBe(setup);
+    expect(runCommand).not.toHaveBeenCalled();
   });
 
   it("waits for post-setup SSH readiness and returns the final endpoint", async () => {
@@ -1284,6 +1332,16 @@ describe("Crabbox worker provider", () => {
     await expect(provider.provision({ ...PROFILE, setup: "  " }, "provision:x")).rejects.toThrow(
       "Crabbox profile setup must be a non-empty command string",
     );
+  });
+
+  it.each([
+    ["OPENCLAW_WORKER_ARTIFACT_TOKEN"],
+    ["OPENCLAW_WORKER_ARTIFACT_TOKEN", "_SECOND_VALUE2"],
+  ])("accepts valid profile setup environment names %j", (...setupEnv) => {
+    expect(parseCrabboxProfile({ ...PROFILE, setup: "install-node", setupEnv })).toMatchObject({
+      setup: "install-node",
+      setupEnv,
+    });
   });
 
   it.each([
@@ -2250,6 +2308,25 @@ describe("Crabbox worker provider", () => {
     { profile: { ...PROFILE, idleTimeout: "0s" }, message: "positive Go duration" },
     { profile: { ...PROFILE, binary: " " }, message: "binary" },
     { profile: { ...PROFILE, binary: "crabbox" }, message: "absolute path" },
+    { profile: { ...PROFILE, setup: "install-node", setupEnv: "TOKEN" }, message: "array" },
+    { profile: { ...PROFILE, setup: "install-node", setupEnv: null }, message: "array" },
+    { profile: { ...PROFILE, setup: "install-node", setupEnv: [4] }, message: "valid" },
+    { profile: { ...PROFILE, setup: "install-node", setupEnv: [""] }, message: "valid" },
+    { profile: { ...PROFILE, setup: "install-node", setupEnv: ["1TOKEN"] }, message: "valid" },
+    { profile: { ...PROFILE, setup: "install-node", setupEnv: ["BAD-NAME"] }, message: "valid" },
+    {
+      profile: { ...PROFILE, setup: "install-node", setupEnv: ["TOKEN", "TOKEN"] },
+      message: "duplicate",
+    },
+    {
+      profile: {
+        ...PROFILE,
+        setup: "install-node",
+        setupEnv: Array.from({ length: 17 }, (_, index) => `TOKEN_${index}`),
+      },
+      message: "at most 16",
+    },
+    { profile: { ...PROFILE, setupEnv: ["TOKEN"] }, message: "requires setup" },
     { profile: { ...PROFILE, typo: true }, message: "unknown" },
   ])("rejects an invalid profile ($message)", async ({ profile, message }) => {
     let invoked = false;

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -1686,80 +1686,123 @@ describe("Crabbox worker provider", () => {
     },
   );
 
-  it("runs one fixed warmup, ignores its output, and inspects only the canonical id", async () => {
-    const calls: Array<{ argv: string[]; options: Parameters<CrabboxCommandRunner>[1] }> = [];
-    const provider = providerWithRunner(async (argv, options) => {
-      calls.push({ argv, options });
-      return argv[1] === "warmup"
-        ? commandResult({ stdout: "warmup completed without a lease token\n" })
-        : commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
-    });
+  it.each([
+    {
+      providerId: "aws",
+      warmupTimeoutMs: 50 * 60_000,
+      lifecycleTimeoutMs: 60_000,
+      provisionTimeoutMs: 67 * 60_000,
+    },
+    {
+      providerId: "hetzner",
+      warmupTimeoutMs: 50 * 60_000,
+      lifecycleTimeoutMs: 60_000,
+      provisionTimeoutMs: 67 * 60_000,
+    },
+    {
+      providerId: "machine0",
+      warmupTimeoutMs: 50 * 60_000,
+      lifecycleTimeoutMs: 3 * 60_000,
+      provisionTimeoutMs: 69 * 60_000,
+    },
+  ])(
+    "runs one fixed $providerId warmup, ignores its output, and inspects only the canonical id",
+    async ({ providerId, warmupTimeoutMs, lifecycleTimeoutMs, provisionTimeoutMs }) => {
+      const calls: Array<{ argv: string[]; options: Parameters<CrabboxCommandRunner>[1] }> = [];
+      const provider = providerWithRunner(async (argv, options) => {
+        calls.push({ argv, options });
+        return argv[1] === "warmup"
+          ? commandResult({ stdout: "warmup completed without a lease token\n" })
+          : commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) });
+      });
+      const profile = { ...PROFILE, provider: providerId };
 
-    await expect(provider.provision(PROFILE, OPERATION_ID)).resolves.toMatchObject({
-      leaseId: LEASE_ID,
-    });
-    expect(calls).toHaveLength(4);
-    expect(calls[0]?.argv).toEqual([
-      SIBLING_BINARY,
-      "warmup",
-      "--provider",
-      "aws",
-      "--network",
-      "public",
-      "--tailscale=false",
-      "--class",
-      "standard",
-      "--ttl",
-      "24h",
-      "--idle-timeout",
-      "60m",
-      "--lease-id",
-      LEASE_ID,
-      "--slug",
-      expect.stringMatching(/^openclaw-[a-f0-9]{32}$/u),
-      "--keep=true",
-    ]);
-    expect(calls[0]?.options).toEqual({
-      timeoutMs: 50 * 60_000,
-      maxOutputBytes: 65_536,
-      killProcessTree: true,
-    });
-    expect(calls[1]?.argv).toEqual([
-      SIBLING_BINARY,
-      "inspect",
-      "--provider",
-      "aws",
-      "--network",
-      "public",
-      "--id",
-      LEASE_ID,
-      "--json",
-    ]);
-    expect(calls[2]?.argv[1]).toBe("run");
-    expect(String(calls[2]?.options.input)).toContain("openclaw@2026.8.1");
-    expect(String(calls[2]?.options.input)).toContain("'OpenClaw 2026.8.1'|'OpenClaw 2026.8.1 '*");
-    expect(String(calls[2]?.options.input)).toContain(
-      'npx --yes --package "$package_spec" -- openclaw',
-    );
-    expect(String(calls[2]?.options.input)).toContain(
-      "OpenClaw worker bootstrap could not install Gateway version 2026.8.1",
-    );
-    expect(String(calls[2]?.options.input)).toContain(
-      'connect --target-file "$setup_code_file" --ephemeral',
-    );
-    expect(String(calls[2]?.options.input)).toContain("setsid -f sh -c");
-    expect(String(calls[2]?.options.input)).not.toContain("config set nodeHost.workerRuns.enabled");
-    expect(String(calls[2]?.options.input)).not.toContain("nohup");
-    expect(String(calls[2]?.options.input)).not.toContain("secret-setup-value");
-    expect(calls[2]?.options.env).toMatchObject({
-      CRABBOX_WORKER_SETUP_CODE: "secret-setup-value",
-    });
-    expect(calls[2]?.argv).toEqual(
-      expect.arrayContaining(["--allow-env", "CRABBOX_WORKER_SETUP_CODE"]),
-    );
-    expect(calls[2]?.argv.join(" ")).not.toContain("setup-code");
-    expect(calls[3]?.argv[1]).toBe("inspect");
-  });
+      await expect(provider.provision(profile, OPERATION_ID)).resolves.toMatchObject({
+        leaseId: LEASE_ID,
+      });
+      expect(calls).toHaveLength(4);
+      expect(calls[0]?.argv).toEqual([
+        SIBLING_BINARY,
+        "warmup",
+        "--provider",
+        providerId,
+        "--network",
+        "public",
+        "--tailscale=false",
+        "--class",
+        "standard",
+        "--ttl",
+        "24h",
+        "--idle-timeout",
+        "60m",
+        "--lease-id",
+        LEASE_ID,
+        "--slug",
+        expect.stringMatching(/^openclaw-[a-f0-9]{32}$/u),
+        "--keep=true",
+      ]);
+      expect({
+        warmupOptions: calls[0]?.options,
+        provisionTimeoutMs: provider.resolveProvisionTimeoutMs?.(profile),
+      }).toEqual({
+        warmupOptions: {
+          timeoutMs: warmupTimeoutMs,
+          maxOutputBytes: 65_536,
+          killProcessTree: true,
+        },
+        provisionTimeoutMs,
+      });
+      expect(calls[1]?.argv).toEqual([
+        SIBLING_BINARY,
+        "inspect",
+        "--provider",
+        providerId,
+        "--network",
+        "public",
+        "--id",
+        LEASE_ID,
+        "--json",
+      ]);
+      expect(calls[1]?.options.timeoutMs).toBe(lifecycleTimeoutMs);
+      expect(calls[2]?.argv[1]).toBe("run");
+      expect(String(calls[2]?.options.input)).toContain("openclaw@2026.8.1");
+      expect(String(calls[2]?.options.input)).toContain(
+        "'OpenClaw 2026.8.1'|'OpenClaw 2026.8.1 '*",
+      );
+      expect(String(calls[2]?.options.input)).toContain(
+        'npx --yes --package "$package_spec" -- openclaw',
+      );
+      expect(String(calls[2]?.options.input)).toContain(
+        "OpenClaw worker bootstrap could not install Gateway version 2026.8.1",
+      );
+      expect(String(calls[2]?.options.input)).toContain(
+        'connect --target-file "$setup_code_file" --ephemeral',
+      );
+      expect(String(calls[2]?.options.input)).toContain("setsid -f sh -c");
+      expect(String(calls[2]?.options.input)).not.toContain(
+        "config set nodeHost.workerRuns.enabled",
+      );
+      expect(String(calls[2]?.options.input)).not.toContain("nohup");
+      expect(String(calls[2]?.options.input)).not.toContain("secret-setup-value");
+      expect(calls[2]?.options.env).toMatchObject({
+        CRABBOX_WORKER_SETUP_CODE: "secret-setup-value",
+      });
+      expect(calls[2]?.argv).toEqual(
+        expect.arrayContaining(["--allow-env", "CRABBOX_WORKER_SETUP_CODE"]),
+      );
+      expect(calls[2]?.argv.join(" ")).not.toContain("setup-code");
+      expect(calls[3]?.argv[1]).toBe("inspect");
+      expect(calls[3]?.options.timeoutMs).toBe(lifecycleTimeoutMs);
+
+      const lease = lifecycleLease(LEASE_ID, profile);
+      await expect(provider.inspect(lease)).resolves.toEqual({ status: "active" });
+      await expect(provider.destroy(lease)).resolves.toBeUndefined();
+      expect(calls.slice(4).map(({ argv, options }) => [argv[1], options.timeoutMs])).toEqual([
+        ["inspect", lifecycleTimeoutMs],
+        ["stop", lifecycleTimeoutMs],
+      ]);
+    },
+  );
 
   it("overrides the configured class for one provision operation", async () => {
     const calls: string[][] = [];
@@ -2036,7 +2079,7 @@ describe("Crabbox worker provider", () => {
       pathEnv: "",
       isExecutable: (candidate) => candidate === SIBLING_BINARY,
       sleep: async () => {
-        nowMs += resolveCrabboxProvisionBaseTimeoutMs({}) + 1;
+        nowMs += resolveCrabboxProvisionBaseTimeoutMs(PROFILE) + 1;
       },
       wallpaperPath: WORKER_WALLPAPER_PATH,
     });

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -35,11 +35,11 @@ import {
 import {
   buildCrabboxWarmupArgs,
   CRABBOX_WORKER_PROVIDER_ID,
-  nonEmptyString,
   operationLeaseId,
   operationSlug,
   parseCrabboxProfile,
   resolveCrabboxBinary,
+  resolveCrabboxProvisionProfile,
 } from "./crabbox-worker-profile.js";
 import {
   countCrabboxProvisionSetupPhases,
@@ -515,14 +515,10 @@ export function createCrabboxWorkerProvider(
       ) {
         throw new WorkerProviderError("Crabbox execution mode is unsupported");
       }
-      const configured = parseCrabboxProfile(profile);
-      const requestedClass = nonEmptyString(options?.machineClass);
-      if (options?.machineClass !== undefined && (!requestedClass || requestedClass.length > 128)) {
-        throw new WorkerProviderError(
-          "Crabbox machine class must be a non-empty string of at most 128 characters",
-        );
-      }
-      const parsed = requestedClass ? { ...configured, class: requestedClass } : configured;
+      const { profile: parsed, forwardedEnv } = resolveCrabboxProvisionProfile(
+        profile,
+        options?.machineClass,
+      );
       const warmupTimeoutMs = parsed.desktop
         ? CRABBOX_DESKTOP_WARMUP_TIMEOUT_MS
         : CRABBOX_WARMUP_TIMEOUT_MS;
@@ -621,6 +617,7 @@ export function createCrabboxWorkerProvider(
         inspectedParams.inspect = await runProvisionSetupAndWaitReady({
           ...inspectedParams,
           setup: parsed.setup,
+          forwardedEnv,
           sleep,
         });
       }

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -51,12 +51,12 @@ import {
   resolveCrabboxLifecycleTimeoutMs,
   resolveCrabboxProvisionBaseTimeoutMs,
   resolveCrabboxProvisionCallTimeoutMs,
+  resolveCrabboxReadyPollIntervalMs,
 } from "./crabbox-worker-timeouts.js";
 import { loadCrabboxWorkerWallpaperBase64 } from "./crabbox-worker-wallpaper.js";
 
 export { resolveOpenClawRoot } from "./crabbox-worker-profile.js";
 
-const READY_POLL_INTERVAL_MS = 2_000;
 const MAX_ERROR_DETAIL_CHARS = 512;
 // Only states that prove the resource is gone or stopped map to `destroyed`. Crabbox also
 // treats `deleting` and `failed` as unable to become ready, but those can retain resources
@@ -271,7 +271,7 @@ async function waitForProvisionReady(
     assertProvisionSecurityPolicy({ inspect, provider: params.provider });
     while (inspect.ready !== true && !isUnusableProvisionState(inspect.state)) {
       const remaining = remainingProvisionTimeout(params.deadline, CRABBOX_LIFECYCLE_TIMEOUT_MS);
-      await params.sleep(Math.min(READY_POLL_INTERVAL_MS, remaining));
+      await params.sleep(Math.min(resolveCrabboxReadyPollIntervalMs(params.provider), remaining));
       inspect = await inspectAgain();
       assertProvisionSecurityPolicy({ inspect, provider: params.provider });
     }

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -305,6 +305,7 @@ async function runProvisionSetup(
     setup: string;
     timeoutMs?: number;
     forwardedEnv?: Record<string, string>;
+    env?: NodeJS.ProcessEnv;
   },
 ): Promise<void> {
   let result: SpawnResult;
@@ -313,7 +314,7 @@ async function runProvisionSetup(
       action: "setup",
       args: crabboxLeaseRunArgs({ ...params, id: params.inspect.id }, params.forwardedEnv),
       binary: params.binary,
-      env: params.forwardedEnv,
+      env: params.env ?? params.forwardedEnv,
       input: params.setup,
       runCommand: params.runCommand,
       timeoutMs: remainingProvisionTimeout(
@@ -332,10 +333,7 @@ async function runProvisionSetup(
 }
 
 async function runProvisionSetupAndWaitReady(
-  params: ProvisionInspectContext & {
-    setup: string;
-    timeoutMs?: number;
-    forwardedEnv?: Record<string, string>;
+  params: Parameters<typeof runProvisionSetup>[0] & {
     sleep: (milliseconds: number) => Promise<void>;
   },
 ): Promise<ParsedInspect> {
@@ -619,6 +617,7 @@ export function createCrabboxWorkerProvider(
           ...inspectedParams,
           setup: parsed.setup,
           forwardedEnv,
+          env: { ...forwardedEnv, CRABBOX_ENV_ALLOW: parsed.setupEnv?.join(",") || "," },
           sleep,
         });
       }

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -45,6 +45,7 @@ import {
   countCrabboxProvisionSetupPhases,
   CRABBOX_DESKTOP_WARMUP_TIMEOUT_MS,
   CRABBOX_LIFECYCLE_TIMEOUT_MS,
+  CRABBOX_MACHINE0_READY_WAIT_TIMEOUT,
   CRABBOX_NODE_ENROLLMENT_TIMEOUT_MS,
   CRABBOX_SETUP_TIMEOUT_MS,
   CRABBOX_WARMUP_TIMEOUT_MS,
@@ -156,17 +157,22 @@ async function inspectWithContext(params: {
   id: string;
   runCommand: CrabboxCommandRunner;
   timeoutMs?: number;
+  waitForReady?: boolean;
 }): Promise<InspectCommandResult> {
+  const action = params.waitForReady ? "status" : "inspect";
   const result = await runCrabboxCommand({
-    action: "inspect",
+    action,
     args: [
-      "inspect",
+      action,
       "--provider",
       params.context.provider,
       "--network",
       "public",
       "--id",
       params.id,
+      ...(params.waitForReady
+        ? ["--wait", "--wait-timeout", CRABBOX_MACHINE0_READY_WAIT_TIMEOUT]
+        : []),
       "--json",
     ],
     binary: params.context.binary,
@@ -192,7 +198,7 @@ async function inspectWithContext(params: {
   if (result.termination === "exit" && isAuthoritativeLeaseAbsence(result, params.id)) {
     return { status: "unknown" };
   }
-  throw crabboxCommandError("inspect", result);
+  throw crabboxCommandError(action, result);
 }
 
 function remainingProvisionTimeout(deadline: number, maximum: number): number {
@@ -259,6 +265,7 @@ async function waitForProvisionReady(
         params.deadline,
         resolveCrabboxLifecycleTimeoutMs(params.provider),
       ),
+      waitForReady: params.provider === "machine0",
     });
     if (replay.status === "unknown") {
       throw new Error("Crabbox operation lease disappeared while waiting for SSH readiness");
@@ -579,6 +586,7 @@ export function createCrabboxWorkerProvider(
             deadline,
             resolveCrabboxLifecycleTimeoutMs(parsed.provider),
           ),
+          waitForReady: parsed.provider === "machine0",
         });
       } catch (error) {
         // Transport failure after warmup is indeterminate; preserve the lease for durable replay.

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -35,6 +35,7 @@ import {
 import {
   buildCrabboxWarmupArgs,
   CRABBOX_WORKER_PROVIDER_ID,
+  nonEmptyString,
   operationLeaseId,
   operationSlug,
   parseCrabboxProfile,

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -48,6 +48,7 @@ import {
   CRABBOX_NODE_ENROLLMENT_TIMEOUT_MS,
   CRABBOX_SETUP_TIMEOUT_MS,
   CRABBOX_WARMUP_TIMEOUT_MS,
+  resolveCrabboxLifecycleTimeoutMs,
   resolveCrabboxProvisionBaseTimeoutMs,
   resolveCrabboxProvisionCallTimeoutMs,
 } from "./crabbox-worker-timeouts.js";
@@ -170,7 +171,7 @@ async function inspectWithContext(params: {
     ],
     binary: params.context.binary,
     runCommand: params.runCommand,
-    timeoutMs: params.timeoutMs ?? CRABBOX_LIFECYCLE_TIMEOUT_MS,
+    timeoutMs: params.timeoutMs ?? resolveCrabboxLifecycleTimeoutMs(params.context.provider),
   });
   if (result.termination === "exit" && result.code === 0) {
     // A successful but malformed response cannot attest the fixed lease. Command failures and
@@ -254,7 +255,10 @@ async function waitForProvisionReady(
       expectedLeaseId: inspect.id,
       id: inspect.id,
       runCommand: params.runCommand,
-      timeoutMs: remainingProvisionTimeout(params.deadline, CRABBOX_LIFECYCLE_TIMEOUT_MS),
+      timeoutMs: remainingProvisionTimeout(
+        params.deadline,
+        resolveCrabboxLifecycleTimeoutMs(params.provider),
+      ),
     });
     if (replay.status === "unknown") {
       throw new Error("Crabbox operation lease disappeared while waiting for SSH readiness");
@@ -345,7 +349,7 @@ async function stopProvisionId(params: {
     provider: params.provider,
     runCommand: params.runCommand,
     // Cleanup gets its own budget so an exhausted provision deadline cannot leak a lease.
-    timeoutMs: CRABBOX_LIFECYCLE_TIMEOUT_MS,
+    timeoutMs: resolveCrabboxLifecycleTimeoutMs(params.provider),
   });
 }
 
@@ -571,7 +575,10 @@ export function createCrabboxWorkerProvider(
           expectedLeaseId: leaseId,
           id: leaseId,
           runCommand,
-          timeoutMs: remainingProvisionTimeout(deadline, CRABBOX_LIFECYCLE_TIMEOUT_MS),
+          timeoutMs: remainingProvisionTimeout(
+            deadline,
+            resolveCrabboxLifecycleTimeoutMs(parsed.provider),
+          ),
         });
       } catch (error) {
         // Transport failure after warmup is indeterminate; preserve the lease for durable replay.
@@ -707,7 +714,11 @@ export function createCrabboxWorkerProvider(
       const context = resolveLeaseContext(lease);
       // Fence the provider keepalive before teardown so an in-flight touch cannot reschedule.
       heartbeats.stop(context.id);
-      await stopCrabboxLease({ ...context, runCommand });
+      await stopCrabboxLease({
+        ...context,
+        runCommand,
+        timeoutMs: resolveCrabboxLifecycleTimeoutMs(context.provider),
+      });
     },
   };
 }

--- a/extensions/crabbox/src/crabbox-worker-timeouts.ts
+++ b/extensions/crabbox/src/crabbox-worker-timeouts.ts
@@ -43,7 +43,9 @@ export function resolveCrabboxProvisionBaseTimeoutMs(
   const warmupTimeoutMs = profile.desktop
     ? CRABBOX_DESKTOP_WARMUP_TIMEOUT_MS
     : CRABBOX_WARMUP_TIMEOUT_MS;
-  return warmupTimeoutMs + resolveCrabboxLifecycleTimeoutMs(profile.provider);
+  const lifecycleTimeoutMs = resolveCrabboxLifecycleTimeoutMs(profile.provider);
+  // Machine0 needs separate windows for authoritative inspection and readiness retry.
+  return warmupTimeoutMs + lifecycleTimeoutMs * (profile.provider === "machine0" ? 2 : 1);
 }
 
 export function countCrabboxProvisionSetupPhases(profile: CrabboxProvisionTimeoutProfile): number {

--- a/extensions/crabbox/src/crabbox-worker-timeouts.ts
+++ b/extensions/crabbox/src/crabbox-worker-timeouts.ts
@@ -31,6 +31,11 @@ const CRABBOX_MACHINE0_LIFECYCLE_TIMEOUT_MS = 5 * 60_000;
 export const CRABBOX_SETUP_TIMEOUT_MS = 15 * 60_000;
 export const CRABBOX_NODE_ENROLLMENT_TIMEOUT_MS = 15 * 60_000;
 
+// Match Machine0's provider-read cadence; fast re-inspection can exhaust its hourly API budget.
+export function resolveCrabboxReadyPollIntervalMs(provider: string): number {
+  return provider === "machine0" ? 60_000 : 2_000;
+}
+
 export function resolveCrabboxLifecycleTimeoutMs(provider: string): number {
   return provider === "machine0"
     ? CRABBOX_MACHINE0_LIFECYCLE_TIMEOUT_MS

--- a/extensions/crabbox/src/crabbox-worker-timeouts.ts
+++ b/extensions/crabbox/src/crabbox-worker-timeouts.ts
@@ -1,4 +1,5 @@
 type CrabboxProvisionTimeoutProfile = {
+  provider: string;
   desktop?: boolean;
   setup?: string;
 };
@@ -23,10 +24,18 @@ export const CRABBOX_HEARTBEAT_TIMEOUT_MS = 150_000;
 // lifecycle budget — a hung binary must fall back to label-only choices
 // promptly instead of stalling the whole cloud picker.
 export const CRABBOX_MACHINE_CATALOG_TIMEOUT_MS = 5_000;
+// Exceed Machine0's one-minute read backoff while bounding inspect and stop recovery.
+const CRABBOX_MACHINE0_LIFECYCLE_TIMEOUT_MS = 3 * 60_000;
 // Setup gets its own budget on top of provision so a slow warmup cannot starve it.
 // Setup may install an exact candidate CLI and official plugins on a minimal cloud image.
 export const CRABBOX_SETUP_TIMEOUT_MS = 15 * 60_000;
 export const CRABBOX_NODE_ENROLLMENT_TIMEOUT_MS = 15 * 60_000;
+
+export function resolveCrabboxLifecycleTimeoutMs(provider: string): number {
+  return provider === "machine0"
+    ? CRABBOX_MACHINE0_LIFECYCLE_TIMEOUT_MS
+    : CRABBOX_LIFECYCLE_TIMEOUT_MS;
+}
 
 export function resolveCrabboxProvisionBaseTimeoutMs(
   profile: CrabboxProvisionTimeoutProfile,
@@ -34,7 +43,7 @@ export function resolveCrabboxProvisionBaseTimeoutMs(
   const warmupTimeoutMs = profile.desktop
     ? CRABBOX_DESKTOP_WARMUP_TIMEOUT_MS
     : CRABBOX_WARMUP_TIMEOUT_MS;
-  return warmupTimeoutMs + CRABBOX_LIFECYCLE_TIMEOUT_MS;
+  return warmupTimeoutMs + resolveCrabboxLifecycleTimeoutMs(profile.provider);
 }
 
 export function countCrabboxProvisionSetupPhases(profile: CrabboxProvisionTimeoutProfile): number {

--- a/extensions/crabbox/src/crabbox-worker-timeouts.ts
+++ b/extensions/crabbox/src/crabbox-worker-timeouts.ts
@@ -57,6 +57,6 @@ export function resolveCrabboxProvisionCallTimeoutMs(
     resolveCrabboxProvisionBaseTimeoutMs(profile) +
     countCrabboxProvisionSetupPhases(profile) * CRABBOX_SETUP_TIMEOUT_MS +
     CRABBOX_NODE_ENROLLMENT_TIMEOUT_MS +
-    CRABBOX_LIFECYCLE_TIMEOUT_MS
+    resolveCrabboxLifecycleTimeoutMs(profile.provider)
   );
 }

--- a/extensions/crabbox/src/crabbox-worker-timeouts.ts
+++ b/extensions/crabbox/src/crabbox-worker-timeouts.ts
@@ -31,6 +31,9 @@ const CRABBOX_MACHINE0_LIFECYCLE_TIMEOUT_MS = 5 * 60_000;
 export const CRABBOX_SETUP_TIMEOUT_MS = 15 * 60_000;
 export const CRABBOX_NODE_ENROLLMENT_TIMEOUT_MS = 15 * 60_000;
 
+// Leave one minute inside the lifecycle cap for process startup and cleanup handoff.
+export const CRABBOX_MACHINE0_READY_WAIT_TIMEOUT = "4m";
+
 // Match Machine0's provider-read cadence; fast re-inspection can exhaust its hourly API budget.
 export function resolveCrabboxReadyPollIntervalMs(provider: string): number {
   return provider === "machine0" ? 60_000 : 2_000;

--- a/extensions/crabbox/src/crabbox-worker-timeouts.ts
+++ b/extensions/crabbox/src/crabbox-worker-timeouts.ts
@@ -24,8 +24,8 @@ export const CRABBOX_HEARTBEAT_TIMEOUT_MS = 150_000;
 // lifecycle budget — a hung binary must fall back to label-only choices
 // promptly instead of stalling the whole cloud picker.
 export const CRABBOX_MACHINE_CATALOG_TIMEOUT_MS = 5_000;
-// Exceed Machine0's one-minute read backoff while bounding inspect and stop recovery.
-const CRABBOX_MACHINE0_LIFECYCLE_TIMEOUT_MS = 3 * 60_000;
+// Fixed-lease inspection can follow warmup's final read; allow four one-minute retries.
+const CRABBOX_MACHINE0_LIFECYCLE_TIMEOUT_MS = 5 * 60_000;
 // Setup gets its own budget on top of provision so a slow warmup cannot starve it.
 // Setup may install an exact candidate CLI and official plugins on a minimal cloud image.
 export const CRABBOX_SETUP_TIMEOUT_MS = 15 * 60_000;

--- a/src/gateway/worker-environments/provider-provisioning.replay.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.replay.test.ts
@@ -361,11 +361,9 @@ describe("worker environment service provision replay", () => {
     expect(destroy).not.toHaveBeenCalled();
   });
 
-  it("preserves an allocated lease after indeterminate provision cleanup across restart", async () => {
+  it.each([true, false])("recovers indeterminate cleanup (released: %s)", async (released) => {
     const leaseId = "lease:worker-provision-cleanup";
-    let releaseCommitted = false;
     const provision = vi.fn(async () => {
-      releaseCommitted = true;
       throw WorkerProviderError.cleanupIndeterminate(
         leaseId,
         new Error("worker enrollment failed"),
@@ -373,7 +371,7 @@ describe("worker environment service provision replay", () => {
       );
     });
     const inspect = vi.fn(async () => ({
-      status: releaseCommitted ? ("destroyed" as const) : ("active" as const),
+      status: released ? ("destroyed" as const) : ("active" as const),
     }));
     const destroy = vi.fn(async () => {});
     const provider = support.createProvider({ provision, inspect, destroy });
@@ -416,7 +414,10 @@ describe("worker environment service provision replay", () => {
 
     expect(provision).toHaveBeenCalledTimes(1);
     expect(inspect).toHaveBeenCalledWith({ leaseId, profile: { region: "test" } });
-    expect(destroy).not.toHaveBeenCalled();
+    expect(destroy).toHaveBeenCalledTimes(released ? 0 : 1);
+    if (!released) {
+      expect(destroy).toHaveBeenCalledWith({ leaseId, profile: { region: "test" } });
+    }
     expect(support.testState.store.get(pending.environmentId)).toMatchObject({
       state: "failed",
       leaseId: null,


### PR DESCRIPTION
Closes #128114

## What Problem This Solves

Machine0-backed Crabbox cloud workers could fail before their first agent turn because their real provisioning, readiness, and provider-read behavior exceeded the generic cloud-worker budgets. Live testing also exposed two owner-boundary gaps: Machine0 readiness needs the readiness-aware Crabbox status path rather than snapshot inspection, and operator setup needs a bounded way to receive an explicitly selected Gateway credential without widening node enrollment or inheriting Crabbox's ambient environment allowlist.

## Why This Change Was Made

The bundled Crabbox plugin now owns the Machine0-specific contract while OpenClaw core remains provider-generic:

- Machine0 warmup: 30 minutes.
- Machine0 lifecycle operations: 5 minutes.
- Provisioning base: 40 minutes, reserving one authoritative post-warmup inspection and one readiness re-attestation window.
- Outer provider call: 60 minutes without setup; 65 minutes with one setup phase, including 15-minute node enrollment and a full 5-minute cleanup allowance.
- Readiness: `status --wait --wait-timeout 4m`, paced at 60 seconds. AWS and Hetzner retain their existing 2-second cadence and generic budgets.
- Exact lease ownership survives indeterminate cleanup and replay; command failures retain bounded, redacted beginning-and-terminal diagnostics.

Profiles may name up to 16 setup-only environment variables through `setupEnv`. Values are resolved from the Gateway environment before allocation, never stored in profile configuration, and forwarded only to the operator setup command. `CRABBOX_ENV_ALLOW` is reserved and rejected. Every setup invocation overrides Crabbox's ambient/configured allowlist with exactly the selected names, or an explicit empty list when none are selected. Node enrollment remains isolated to its setup code.

## User Impact

A documented Machine0 profile can provision a real worker, survive provider pacing and SSH readiness, install an exact private worker artifact, enroll the node, run an authenticated model/tool turn, and reclaim the fixed lease without duplicate provisioning. Other Crabbox providers retain their existing timing and environment behavior.

## Evidence

- Focused provider regression suite: `node scripts/run-vitest.mjs extensions/crabbox/src/crabbox-worker-provider.test.ts` — **156 passed**.
- Changed-file validation: `node scripts/check-changed.mjs -- extensions/crabbox/src/crabbox-worker-profile.ts extensions/crabbox/src/crabbox-worker-provider.ts extensions/crabbox/src/crabbox-worker-provider.test.ts` — passed, including format, extension/test typechecks, lint, plugin boundaries, dead exports, doctor contracts, database-first, and import-cycle guards.
- Full build: `pnpm build` — passed in 5m21s.
- Mandatory Codex-backed autoreview — clean; no accepted/actionable findings.
- Exact-head CI: [run 32835010585](https://github.com/openclaw/openclaw/actions/runs/32835010585) — green for `6835eeef2cbda457c4e7f42051ca4fd13a9e6c70`.
- Dependency repair: [openclaw/crabbox#1513](https://github.com/openclaw/crabbox/pull/1513) merged as `489820efcac3c4309e5515c0cce60d2c28abf82c`; its merge tree is byte-identical to the exact `da61a8aa2526f2209a4157f202b1c5b8fd39310b` binary used below.

### Exact-head live Gateway proof

A session-owned isolated Gateway used OpenClaw head `6835eeef2cbda457c4e7f42051ca4fd13a9e6c70`, the merged Crabbox tree, and a private npm artifact whose authenticated read-back matched all 57,357,254 bytes and SHA-256 `bafda1bcc0baf52b2bfff73b8c9931304444b6cb07e161dc0d4f95da7d1ed07e`.

Before allocation, the temporary public ingress and loopback endpoint returned the same Gateway device identity. The Gateway process deliberately inherited `CRABBOX_ENV_ALLOW=OPENCLAW_UNSELECTED_SECRET` plus an unselected value. Remote setup asserted that both the reserved control variable and unselected value were absent, while the selected artifact token was required to download and verify the exact artifact. This proves the final `setupEnv` authority chain in both directions.

Observed flow:

- Requested portable class `tiny`; Machine0 selected native size `large`.
- Placement became active in 370 seconds.
- Lease, node identity, worker bundle hash, and remote workspace were all populated.
- `sessions.send` completed an authenticated worker model/tool turn.
- The model replied exactly `MACHINE0_GATEWAY_MODEL_OK`.
- The worker created `MACHINE0_GATEWAY_OK.txt` with the exact 33 bytes `machine0 exact-head gateway proof` and no trailing newline.
- Canonical `sessions.reclaim`, archive, and delete completed; the managed worktree disappeared.
- Final authoritative verification after provider convergence: zero owned Machine0 VMs, isolated Gateway inactive, temporary tunnel inactive, injected environment removed, pairing route restored, and the canonical Gateway active.

The proof unit exited nonzero only after the model/file proof because its immediate post-delete inventory assertion raced Machine0's eventual deletion visibility. Canonical reclaim and session deletion had already succeeded; the bounded 65-second follow-up produced the zero-resource result above.

### Change size

The final security-boundary follow-up is production **+7/-5 (net +2)** and tests **+10/-1 (net +9)**. The full branch includes the Machine0 timing/readiness owner repair, extracted cloud-config policy, exact setup allowlist, regression coverage, and no changelog edit.
