### PR TITLE
fix(update): use prepared Gateway install identity

### DIFF
--- a/src/gateway/server-methods/update-run-campaign.test.ts
+++ b/src/gateway/server-methods/update-run-campaign.test.ts
@@ -35,10 +35,10 @@ const runGatewayUpdateMock =
   vi.fn<typeof import("../../infra/update-runner.js").runGatewayUpdate>();
 const runGatewayUpdatePreflightMock =
   vi.fn<typeof import("../../infra/update-runner.js").runGatewayUpdatePreflight>();
-type UpdateInstallSurface = Awaited<
-  ReturnType<typeof import("../../infra/update-runner.js").resolveUpdateInstallSurface>
->;
-const resolveUpdateInstallSurfaceMock = vi.fn<() => Promise<UpdateInstallSurface>>();
+const resolveUpdateInstallSurfaceMock =
+  vi.fn<typeof import("../../infra/update-runner.js").resolveUpdateInstallSurface>();
+const initializeGatewayUpdateStatusMock =
+  vi.fn<typeof import("../../infra/update-startup.js").initializeGatewayUpdateStatus>();
 const detectRespawnSupervisorMock = vi.fn<() => RespawnSupervisor | null>();
 const startManagedServiceUpdateHandoffMock = vi.fn<
   typeof import("../../infra/update-managed-service-handoff.js").startManagedServiceUpdateHandoff
@@ -71,10 +71,6 @@ vi.mock("../../config/sessions.js", () => ({
 vi.mock("../../infra/gateway-supervision.js", () => ({
   EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON: "external-supervisor-update-required",
   isGatewayExternallySupervised: () => false,
-}));
-
-vi.mock("../../infra/openclaw-root.js", () => ({
-  resolveOpenClawPackageRoot: async () => "/tmp/openclaw",
 }));
 
 vi.mock("../../infra/package-json.js", () => ({
@@ -138,6 +134,7 @@ vi.mock("../../infra/update-runner.js", () => ({
 vi.mock("../../infra/update-startup.js", () => ({
   getUpdateAvailable: () => null,
   getUpdateSchedule: () => updateSchedule,
+  initializeGatewayUpdateStatus: initializeGatewayUpdateStatusMock,
 }));
 
 vi.mock("../../version.js", () => ({
@@ -191,6 +188,12 @@ beforeEach(() => {
     root: "/tmp/openclaw",
     packageRoot: "/tmp/openclaw",
   });
+  initializeGatewayUpdateStatusMock.mockReset();
+  initializeGatewayUpdateStatusMock.mockResolvedValue({
+    root: "/tmp/openclaw",
+    status: { root: "/tmp/openclaw", installKind: "git", packageManager: "pnpm" },
+    installReceipt: null,
+  });
   detectRespawnSupervisorMock.mockReset();
   detectRespawnSupervisorMock.mockReturnValue(null);
   startManagedServiceUpdateHandoffMock.mockClear();
@@ -229,6 +232,20 @@ function setDevCampaignSchedule(upstreamSha = "frozen-upstream-sha"): void {
   };
 }
 
+function mockPackageInstallSurface(kind: "global" | "package-root"): void {
+  const root = "/tmp/openclaw";
+  initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
+    root,
+    status: { root, installKind: "package", packageManager: "npm" },
+    installReceipt: null,
+  });
+  resolveUpdateInstallSurfaceMock.mockResolvedValueOnce(
+    kind === "global"
+      ? { kind, mode: "npm", root, packageRoot: root }
+      : { kind, mode: "unknown", root, packageRoot: root },
+  );
+}
+
 async function invokeUpdateRun(): Promise<void> {
   const { updateHandlers } = await import("./update.js");
   await expectDefined(
@@ -252,12 +269,7 @@ async function invokeUpdateRun(): Promise<void> {
 describe("update.run campaign ownership", () => {
   it("pins a directly applied package campaign to its announced version", async () => {
     updateChannel = "beta";
-    resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
-      kind: "package-root",
-      mode: "unknown",
-      root: "/tmp/openclaw",
-      packageRoot: "/tmp/openclaw",
-    });
+    mockPackageInstallSurface("package-root");
 
     await invokeUpdateRun();
 
@@ -273,12 +285,7 @@ describe("update.run campaign ownership", () => {
   it("pins a managed package campaign handoff to its announced version", async () => {
     updateChannel = "beta";
     detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
-    resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
-      kind: "global",
-      mode: "npm",
-      root: "/tmp/openclaw",
-      packageRoot: "/tmp/openclaw",
-    });
+    mockPackageInstallSurface("global");
 
     await withEnvAsync({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, invokeUpdateRun);
 
@@ -290,12 +297,7 @@ describe("update.run campaign ownership", () => {
   it("keeps a configless extended-stable package install on that channel", async () => {
     versionMock.value = "2026.6.33";
     detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
-    resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
-      kind: "global",
-      mode: "npm",
-      root: "/tmp/openclaw",
-      packageRoot: "/tmp/openclaw",
-    });
+    mockPackageInstallSurface("global");
 
     await withEnvAsync({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, invokeUpdateRun);
 
@@ -307,12 +309,7 @@ describe("update.run campaign ownership", () => {
   it("keeps a plain package update on the moving configured channel", async () => {
     updateChannel = "beta";
     adoptCampaignMock.mockReturnValueOnce(undefined);
-    resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
-      kind: "package-root",
-      mode: "unknown",
-      root: "/tmp/openclaw",
-      packageRoot: "/tmp/openclaw",
-    });
+    mockPackageInstallSurface("package-root");
 
     await invokeUpdateRun();
 
@@ -320,6 +317,57 @@ describe("update.run campaign ownership", () => {
     expect(runGatewayUpdateMock).toHaveBeenCalledWith(
       expect.not.objectContaining({ tag: expect.anything() }),
     );
+  });
+
+  it("uses the prepared Git checkout instead of process artifacts", async () => {
+    adoptCampaignMock.mockReturnValueOnce(undefined);
+    initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
+      root: "/tmp/openclaw-source",
+      status: {
+        root: "/tmp/openclaw-source",
+        installKind: "git",
+        packageManager: "pnpm",
+      },
+      installReceipt: null,
+    });
+    resolveUpdateInstallSurfaceMock.mockImplementationOnce(async ({ root, installKind }) =>
+      root === "/tmp/openclaw-source" && installKind === "git"
+        ? { kind: "git", mode: "git", root, packageRoot: root }
+        : {
+            kind: "global",
+            mode: "npm",
+            root: "/tmp/openclaw-launcher-package",
+            packageRoot: "/tmp/openclaw-launcher-package",
+          },
+    );
+    runGatewayUpdateMock.mockResolvedValueOnce({
+      status: "ok",
+      mode: "git",
+      root: "/tmp/openclaw-source",
+      steps: [],
+      durationMs: 100,
+    });
+
+    await invokeUpdateRun();
+
+    expect(runGatewayUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/tmp/openclaw-source" }),
+    );
+    expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing prepared root without scanning the process working directory", async () => {
+    adoptCampaignMock.mockReturnValueOnce(undefined);
+    initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
+      root: null,
+      status: { root: null, installKind: "unknown", packageManager: "unknown" },
+      installReceipt: null,
+    });
+    resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({ kind: "missing", mode: "unknown" });
+
+    await invokeUpdateRun();
+
+    expect(runGatewayUpdateMock).not.toHaveBeenCalled();
   });
 
   it("pins a directly applied dev campaign to its announced commit", async () => {
@@ -439,12 +487,7 @@ describe("update.run campaign ownership", () => {
 
   it("keeps the adopted campaign after a managed-service handoff starts", async () => {
     detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
-    resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
-      kind: "global",
-      mode: "npm",
-      root: "/tmp/openclaw",
-      packageRoot: "/tmp/openclaw",
-    });
+    mockPackageInstallSurface("global");
 
     await withEnvAsync({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, invokeUpdateRun);
 

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -18,15 +18,10 @@ const runGatewayUpdateMock =
   vi.fn<typeof import("../../infra/update-runner.js").runGatewayUpdate>();
 const runGatewayUpdatePreflightMock =
   vi.fn<typeof import("../../infra/update-runner.js").runGatewayUpdatePreflight>();
-type UpdateInstallSurface = Awaited<
-  ReturnType<typeof import("../../infra/update-runner.js").resolveUpdateInstallSurface>
->;
-const resolveUpdateInstallSurfaceMock = vi.fn<() => Promise<UpdateInstallSurface>>(async () => ({
-  kind: "git",
-  mode: "git",
-  root: "/tmp/openclaw",
-  packageRoot: "/tmp/openclaw",
-}));
+const resolveUpdateInstallSurfaceMock =
+  vi.fn<typeof import("../../infra/update-runner.js").resolveUpdateInstallSurface>();
+const initializeGatewayUpdateStatusMock =
+  vi.fn<typeof import("../../infra/update-startup.js").initializeGatewayUpdateStatus>();
 const getLatestUpdateRestartSentinelMock = vi.fn<() => RestartSentinelPayload | null>(() => null);
 const refreshLatestUpdateRestartSentinelMock = vi.fn<() => Promise<RestartSentinelPayload | null>>(
   async () => null,
@@ -34,7 +29,6 @@ const refreshLatestUpdateRestartSentinelMock = vi.fn<() => Promise<RestartSentin
 const recordLatestUpdateRestartSentinelMock = vi.fn();
 const isRestartEnabledMock = vi.fn(() => true);
 const readPackageVersionMock = vi.fn(async () => "1.0.0");
-const checkUpdateStatusMock = vi.fn();
 const versionMock = vi.hoisted(() => ({ value: "1.0.0" }));
 const detectRespawnSupervisorMock = vi.fn<() => RespawnSupervisor | null>(() => null);
 const normalizeUpdateChannelMock = vi.fn((): UpdateChannel | null => null);
@@ -117,16 +111,6 @@ vi.mock("../../config/sessions.js", () => ({
   },
 }));
 
-vi.mock("../../infra/openclaw-root.js", async () => {
-  const actual = await vi.importActual<typeof import("../../infra/openclaw-root.js")>(
-    "../../infra/openclaw-root.js",
-  );
-  return {
-    ...actual,
-    resolveOpenClawPackageRoot: async () => "/tmp/openclaw",
-  };
-});
-
 vi.mock("../../infra/restart-sentinel.js", async () => {
   const actual = await vi.importActual("../../infra/restart-sentinel.js");
   return {
@@ -154,10 +138,6 @@ vi.mock("../../infra/package-json.js", () => ({
   readPackageVersion: readPackageVersionMock,
 }));
 
-vi.mock("../../infra/update-check.js", () => ({
-  checkUpdateStatus: checkUpdateStatusMock,
-}));
-
 vi.mock("../../version.js", () => ({
   get VERSION() {
     return versionMock.value;
@@ -178,6 +158,7 @@ vi.mock("../../infra/update-channels.js", async () => {
 vi.mock("../../infra/update-startup.js", () => ({
   getUpdateAvailable: getUpdateAvailableMock,
   getUpdateSchedule: getUpdateScheduleMock,
+  initializeGatewayUpdateStatus: initializeGatewayUpdateStatusMock,
   refreshGatewayUpdateStatus: refreshGatewayUpdateStatusMock,
 }));
 
@@ -290,12 +271,19 @@ beforeEach(() => {
   });
   runGatewayUpdatePreflightMock.mockReset();
   runGatewayUpdatePreflightMock.mockResolvedValue(undefined);
-  resolveUpdateInstallSurfaceMock.mockClear();
-  resolveUpdateInstallSurfaceMock.mockResolvedValue({
-    kind: "git",
-    mode: "git",
+  resolveUpdateInstallSurfaceMock.mockReset();
+  resolveUpdateInstallSurfaceMock.mockImplementation(async ({ root, installKind }) =>
+    root && installKind === "git"
+      ? { kind: "git", mode: "git", root, packageRoot: root }
+      : root && installKind === "package"
+        ? { kind: "package-root", mode: "unknown", root, packageRoot: root }
+        : { kind: "missing", mode: "unknown" },
+  );
+  initializeGatewayUpdateStatusMock.mockReset();
+  initializeGatewayUpdateStatusMock.mockResolvedValue({
     root: "/tmp/openclaw",
-    packageRoot: "/tmp/openclaw",
+    status: { root: "/tmp/openclaw", installKind: "git", packageManager: "pnpm" },
+    installReceipt: null,
   });
   getLatestUpdateRestartSentinelMock.mockClear();
   refreshLatestUpdateRestartSentinelMock.mockClear();
@@ -378,6 +366,11 @@ async function withProcessEnv<T>(
 }
 
 function mockGlobalInstallSurface() {
+  initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
+    root: "/tmp/openclaw-global",
+    status: { root: "/tmp/openclaw-global", installKind: "package", packageManager: "npm" },
+    installReceipt: null,
+  });
   resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
     kind: "global",
     mode: "npm",
@@ -387,11 +380,10 @@ function mockGlobalInstallSurface() {
 }
 
 function mockGitInstallSurface(root: string) {
-  resolveUpdateInstallSurfaceMock.mockResolvedValueOnce({
-    kind: "git",
-    mode: "git",
+  initializeGatewayUpdateStatusMock.mockResolvedValueOnce({
     root,
-    packageRoot: root,
+    status: { root, installKind: "git", packageManager: "pnpm" },
+    installReceipt: null,
   });
 }
 

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -1,7 +1,6 @@
 // Update gateway methods run self-update flows, report status, write restart
 // sentinels, and hand off managed-service restarts when needed.
 import { randomUUID } from "node:crypto";
-import os from "node:os";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   validateUpdateHoldParams,
@@ -19,7 +18,6 @@ import {
   EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON,
   isGatewayExternallySupervised,
 } from "../../infra/gateway-supervision.js";
-import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageVersion } from "../../infra/package-json.js";
 import { type RestartSentinelPayload, writeRestartSentinel } from "../../infra/restart-sentinel.js";
 import {
@@ -59,6 +57,7 @@ import {
   getUpdateAvailable,
   getUpdateEffectiveChannel,
   getUpdateSchedule,
+  initializeGatewayUpdateStatus,
   refreshGatewayUpdateStatus,
 } from "../../infra/update-startup.js";
 import { VERSION } from "../../version.js";
@@ -80,14 +79,6 @@ function formatUpdateRunErrorMessage(err: unknown): string {
     return err.message || err.name;
   }
   return String(err);
-}
-
-function tryResolveProcessCwd(): string | undefined {
-  try {
-    return process.cwd();
-  } catch {
-    return undefined;
-  }
 }
 
 // Explicit callers share only active checkout work for the exact config snapshot.
@@ -308,30 +299,18 @@ export const updateHandlers: GatewayRequestHandlers = {
     try {
       const config = context.getRuntimeConfig();
       const configChannel = normalizeUpdateChannel(config.update?.channel);
-      const invocationCwd = tryResolveProcessCwd();
-      const root =
-        (await resolveOpenClawPackageRoot({
-          moduleUrl: import.meta.url,
-          argv1: process.argv[1],
-          ...(invocationCwd ? { cwd: invocationCwd } : {}),
-        })) ??
-        invocationCwd ??
-        os.homedir();
+      const { root, status } = await initializeGatewayUpdateStatus();
       const installSurface = await resolveUpdateInstallSurface({
+        root,
+        installKind: status.installKind,
         timeoutMs,
-        cwd: root,
-        argv1: process.argv[1],
       });
       const installRoot = installSurface.root;
       const effectiveChannel = resolveEffectiveUpdateChannel({
         configChannel,
         currentVersion: VERSION,
-        installKind:
-          installSurface.kind === "git"
-            ? "git"
-            : installSurface.kind === "global" || installSurface.kind === "package-root"
-              ? "package"
-              : "unknown",
+        installKind: status.installKind,
+        git: status.git,
       }).channel;
       const supervisor = detectRespawnSupervisor(process.env, process.platform);
       const hasHandoffContext = supervisor
@@ -346,14 +325,20 @@ export const updateHandlers: GatewayRequestHandlers = {
         !isGatewayExternallySupervised()
           ? await runGatewayUpdatePreflight(installRoot, timeoutMs, adoptedDevTarget)
           : undefined;
-      if (isGatewayExternallySupervised()) {
-        const beforeVersion = installSurface.root
-          ? await readPackageVersion(installSurface.root)
-          : null;
+      if (installSurface.kind === "missing") {
+        result = {
+          status: "error",
+          mode: "unknown",
+          reason: "not-openclaw-root",
+          steps: [],
+          durationMs: 0,
+        };
+      } else if (isGatewayExternallySupervised()) {
+        const beforeVersion = await readPackageVersion(installSurface.root);
         result = {
           status: "skipped",
           mode: installSurface.mode,
-          ...(installSurface.root ? { root: installSurface.root } : {}),
+          root: installSurface.root,
           reason: EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON,
           ...(beforeVersion ? { before: { version: beforeVersion } } : {}),
           steps: [],
@@ -525,8 +510,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         // RPC server before the response and restart sentinel become durable.
         result = await runGatewayUpdate({
           timeoutMs,
-          cwd: root,
-          argv1: process.argv[1],
+          cwd: installSurface.root,
           channel:
             installSurface.kind === "git"
               ? (configChannel ?? undefined)

--- a/src/infra/update-runner-install-surface.ts
+++ b/src/infra/update-runner-install-surface.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { detectGlobalInstallManagerForRoot } from "./update-global.js";
-import { resolveUpdateInstallRoot, updateInstallRootsMatch } from "./update-install-root.js";
+import { updateInstallRootsMatch } from "./update-install-root.js";
 import { buildUpdateCommandRunner, UPDATE_RUNNER_TIMEOUT_MS } from "./update-runner-command.js";
 import type {
   CommandRunner,
@@ -112,33 +112,27 @@ export async function looksLikeGitCheckout(root: string): Promise<boolean> {
   }
 }
 
-export async function resolveUpdateInstallSurface(
-  opts: Pick<UpdateRunnerOptions, "cwd" | "argv1" | "timeoutMs" | "runCommand"> = {},
-): Promise<UpdateInstallSurface> {
-  const { runCommand } = await buildUpdateCommandRunner(opts.runCommand);
-  const timeoutMs = opts.timeoutMs ?? UPDATE_RUNNER_TIMEOUT_MS;
-  const candidates = buildStartDirs(opts);
-  const packageRoot = await findPackageRoot(candidates);
-
-  const gitRoot = await resolveGitRoot(runCommand, candidates, timeoutMs, packageRoot);
-  if (gitRoot && !packageRoot) {
-    return { kind: "missing", mode: "unknown", root: resolveUpdateInstallRoot(gitRoot) };
-  }
-  if (gitRoot && packageRoot) {
-    return { kind: "git", mode: "git", root: gitRoot, packageRoot };
-  }
-  if (!packageRoot) {
+export async function resolveUpdateInstallSurface(opts: {
+  root: string | null;
+  installKind: "git" | "package" | "unknown";
+  timeoutMs?: number;
+  runCommand?: CommandRunner;
+}): Promise<UpdateInstallSurface> {
+  const root = opts.root;
+  if (!root || opts.installKind === "unknown") {
     return { kind: "missing", mode: "unknown" };
   }
-
-  const globalManager = await detectGlobalInstallManagerForRoot(runCommand, packageRoot, timeoutMs);
-  if (globalManager) {
-    return {
-      kind: "global",
-      mode: globalManager,
-      root: packageRoot,
-      packageRoot,
-    };
+  if (opts.installKind === "git") {
+    return { kind: "git", mode: "git", root, packageRoot: root };
   }
-  return { kind: "package-root", mode: "unknown", root: packageRoot, packageRoot };
+  const { runCommand } = await buildUpdateCommandRunner(opts.runCommand);
+  const globalManager = await detectGlobalInstallManagerForRoot(
+    runCommand,
+    root,
+    opts.timeoutMs ?? UPDATE_RUNNER_TIMEOUT_MS,
+  );
+  if (globalManager) {
+    return { kind: "global", mode: globalManager, root, packageRoot: root };
+  }
+  return { kind: "package-root", mode: "unknown", root, packageRoot: root };
 }

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -13,6 +13,7 @@ import { pathExists } from "../utils.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import type { UpdateChannel } from "./update-channels.js";
 import type { DevUpdateTarget } from "./update-dev-target.js";
+import { buildUpdateCommandRunner } from "./update-runner-command.js";
 import {
   resolveUpdateDoctorExecutionPolicy,
   resolveUpdateInstallSurface,
@@ -202,12 +203,13 @@ describe("runGatewayUpdate", () => {
     async () => {
       await setupGitCheckout();
       const fakeBinDir = path.join(tempDir, "fake-bin");
-      const fakeGitPath = path.join(fakeBinDir, "git");
+      const fakeCommandName = "openclaw-update-timeout-fixture.cjs";
+      const fakeCommandPath = path.join(fakeBinDir, fakeCommandName);
       const childPidPath = path.join(tempDir, "nested-child.pid");
       await fs.mkdir(fakeBinDir, { recursive: true });
       await fs.writeFile(
-        fakeGitPath,
-        `#!${process.execPath}\n` +
+        fakeCommandPath,
+        "#!/usr/bin/env node\n" +
           `const { spawn } = require("node:child_process");\n` +
           `const fs = require("node:fs");\n` +
           `const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });\n` +
@@ -215,28 +217,25 @@ describe("runGatewayUpdate", () => {
           `setInterval(() => {}, 1000);\n`,
         "utf-8",
       );
-      await fs.chmod(fakeGitPath, 0o755);
-
-      // Keep install-surface candidates on the fixture root so this test exercises
-      // one timed-out process tree instead of repeating the timeout for Vitest's cwd.
-      const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tempDir);
+      await fs.chmod(fakeCommandPath, 0o755);
       let childPid: number | null = null;
       let childExited = false;
       try {
-        await withEnvAsync(
-          {
+        const { runCommand } = await buildUpdateCommandRunner();
+        const result = await runCommand([process.execPath, fakeCommandPath], {
+          timeoutMs: 500,
+          env: {
+            ...process.env,
+            NODE_OPTIONS: "",
             OPENCLAW_UPDATE_TEST_CHILD_PID_PATH: childPidPath,
-            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
           },
-          async () => {
-            await resolveUpdateInstallSurface({ cwd: tempDir, timeoutMs: 500 });
-          },
-        );
+        });
+        expect(result.termination).toBe("timeout");
+        expect(await pathExists(childPidPath)).toBe(true);
         childPid = Number.parseInt(await fs.readFile(childPidPath, "utf-8"), 10);
         expect(Number.isInteger(childPid) && childPid > 0).toBe(true);
         childExited = await waitForProcessExit(childPid);
       } finally {
-        cwdSpy.mockRestore();
         if (childPid && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
         }
@@ -247,7 +246,7 @@ describe("runGatewayUpdate", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "prefers the invoking pnpm 11 project over its shared-store cwd",
+    "classifies a prepared pnpm 11 project by its canonical package root",
     async () => {
       const globalRoot = path.join(tempDir, "pnpm-home", "global", "v11");
       const installDir = path.join(globalRoot, "install-a");
@@ -288,8 +287,8 @@ describe("runGatewayUpdate", () => {
 
       await expect(
         resolveUpdateInstallSurface({
-          cwd: storeRoot,
-          argv1: path.join(packageRoot, "openclaw.mjs"),
+          root: packageRoot,
+          installKind: "package",
           timeoutMs: 1000,
           runCommand,
         }),
@@ -302,29 +301,14 @@ describe("runGatewayUpdate", () => {
     },
   );
 
-  it("skips an unrelated enclosing git root before the OpenClaw checkout", async () => {
-    const versionManagerRoot = path.join(tempDir, "version-manager");
-    const binDir = path.join(versionManagerRoot, "bin");
+  it("uses a prepared Git checkout without probing process artifacts again", async () => {
     const sourceRoot = path.join(tempDir, "source");
-    await Promise.all([
-      fs.mkdir(binDir, { recursive: true }),
-      fs.mkdir(sourceRoot, { recursive: true }),
-    ]);
-    await fs.writeFile(
-      path.join(sourceRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "1.0.0" }),
-      "utf8",
-    );
-
-    const { runner, calls } = createRunner({
-      [`git -C ${binDir} rev-parse --show-toplevel`]: { stdout: versionManagerRoot },
-      [`git -C ${sourceRoot} rev-parse --show-toplevel`]: { stdout: sourceRoot },
-    });
+    const { runner, calls } = createRunner({});
 
     await expect(
       resolveUpdateInstallSurface({
-        argv1: path.join(binDir, "openclaw"),
-        cwd: sourceRoot,
+        root: sourceRoot,
+        installKind: "git",
         timeoutMs: 1000,
         runCommand: runner,
       }),
@@ -334,7 +318,20 @@ describe("runGatewayUpdate", () => {
       root: sourceRoot,
       packageRoot: sourceRoot,
     });
-    expect(calls).toContain(`git -C ${sourceRoot} rev-parse --show-toplevel`);
+    expect(calls).toEqual([]);
+  });
+
+  it("preserves non-global package roots without probing Git or the process cwd", async () => {
+    const root = path.join(tempDir, "standalone-package");
+    const { runner, calls } = createRunner({
+      "npm root -g": { stdout: path.join(tempDir, "npm-global") },
+      "pnpm root -g": { stdout: path.join(tempDir, "pnpm-global") },
+    });
+
+    await expect(
+      resolveUpdateInstallSurface({ root, installKind: "package", runCommand: runner }),
+    ).resolves.toEqual({ kind: "package-root", mode: "unknown", root, packageRoot: root });
+    expect(calls).toEqual(["npm root -g", "pnpm root -g"]);
   });
 
   async function setupUiIndex() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway-triggered updates could classify a canonical Git checkout as a package install when the running launcher or process working directory resembled a global package. That mismatch prevented the Gateway update path from using the same Git root and install kind already reported by startup status and the CLI.

## Why This Change Was Made

`update.run` now consumes the lifecycle-owned install root and kind prepared by Gateway update startup instead of scanning module, argv, and cwd artifacts again. Git checkouts use that canonical root directly; package installs retain the existing global-package ownership check, and a missing prepared root fails explicitly without a cwd fallback.

AI-assisted; the rebased patch is byte-identical to the independently reviewed implementation.

## User Impact

Git-based Gateway deployments can trigger the intended Git update flow consistently even when launched through a packaged wrapper. Package/global update behavior and public configuration remain unchanged.

## Evidence

- Regression before the fix: both Gateway test projects failed because `runGatewayUpdate` did not receive the prepared Git checkout when process artifacts resembled a global package.
- Focused post-rebase suites: 100 Gateway and 152 infrastructure tests passed.
- Sibling update status, hold, and role-allowlist suites: 44 tests passed.
- Targeted oxfmt and oxlint passed for all five changed files.
- `git diff --check` passed.
- Branch autoreview against current `origin/main` reported no accepted/actionable findings.
- Production delta: +38/-60, net -22 lines. Tests: +142/-110, net +32 lines.
