### PR TITLE
fix(release): accept frozen beta QA evidence

### DIFF
--- a/scripts/validate-qa-runtime-pair-summary.mts
+++ b/scripts/validate-qa-runtime-pair-summary.mts
@@ -62,17 +62,16 @@ const FROZEN_RUNTIME_PAIR_MANIFESTS = new Map([
   ["311047822ecdde24e824d839ab105ef08f17be00:core", FROZEN_CORE_RUNTIME_PAIR_MANIFEST],
   ["c37af96b18776fecc9e24268f27fc89b563481bf:core", FROZEN_CORE_RUNTIME_PAIR_MANIFEST],
 ]);
+const FROZEN_STATUSLESS_CORE_RUNTIME_PAIR_PROFILE = {
+  allowMissingRunStatus: true,
+  scenarioIds: FROZEN_CORE_RUNTIME_PAIR_MANIFEST.scenarioIds.filter(
+    (scenarioId) =>
+      scenarioId !== "codex-plugin-pinned-new" && scenarioId !== "codex-plugin-pinned-old",
+  ),
+};
 const FROZEN_RUNTIME_PAIR_COMPATIBILITY_PROFILES = new Map([
-  [
-    "ee5ead24b1b46a3560f28f8d57e0afcd911acacb:core",
-    {
-      allowMissingRunStatus: true,
-      scenarioIds: FROZEN_CORE_RUNTIME_PAIR_MANIFEST.scenarioIds.filter(
-        (scenarioId) =>
-          scenarioId !== "codex-plugin-pinned-new" && scenarioId !== "codex-plugin-pinned-old",
-      ),
-    },
-  ],
+  ["ee5ead24b1b46a3560f28f8d57e0afcd911acacb:core", FROZEN_STATUSLESS_CORE_RUNTIME_PAIR_PROFILE],
+  ["9a83cbf29d8f637cbe566d809811cb6a13c93664:core", FROZEN_STATUSLESS_CORE_RUNTIME_PAIR_PROFILE],
 ]);
 
 type RuntimePairValidationOptions = {

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -110,7 +110,10 @@ const frozenLegacyCoreScenarioIds = frozenCoreScenarioIds.filter(
   (scenarioId) =>
     scenarioId !== "codex-plugin-pinned-new" && scenarioId !== "codex-plugin-pinned-old",
 );
-const frozenLegacyTargetSha = "ee5ead24b1b46a3560f28f8d57e0afcd911acacb";
+const frozenLegacyTargetShas = [
+  "ee5ead24b1b46a3560f28f8d57e0afcd911acacb",
+  "9a83cbf29d8f637cbe566d809811cb6a13c93664",
+] as const;
 
 function frozenCoreSummary() {
   return summary(
@@ -246,146 +249,136 @@ describe("frozen QA runtime-pair summary validation", () => {
     });
   });
 
-  it("accepts the exact statusless frozen core profile after a successful suite", () => {
-    expect(
-      validateQaRuntimePairSummary(frozenLegacyStatuslessSummary(), {
-        candidateSuiteOutcome: "success",
-        targetSha: frozenLegacyTargetSha,
-        lane: "core",
-      }),
-    ).toEqual({
-      total: 25,
-      passed: 25,
-      failed: 0,
-      skipped: 0,
+  describe.each(frozenLegacyTargetShas)("statusless frozen core profile %s", (targetSha) => {
+    it("accepts the exact profile after a successful suite", () => {
+      expect(
+        validateQaRuntimePairSummary(frozenLegacyStatuslessSummary(), {
+          candidateSuiteOutcome: "success",
+          targetSha,
+          lane: "core",
+        }),
+      ).toEqual({
+        total: 25,
+        passed: 25,
+        failed: 0,
+        skipped: 0,
+      });
     });
-  });
 
-  it("rejects a nonterminal status even for the exact frozen profile", () => {
-    const fixture = frozenLegacyStatuslessSummary();
-    fixture.run.status = "running";
+    it("rejects a nonterminal status", () => {
+      const fixture = frozenLegacyStatuslessSummary();
+      fixture.run.status = "running";
 
-    expect(() =>
-      validateQaRuntimePairSummary(fixture, {
-        candidateSuiteOutcome: "success",
-        targetSha: frozenLegacyTargetSha,
-        lane: "core",
-      }),
-    ).toThrow("runtime-pair summary is not completed");
-  });
-
-  it.each([
-    ["missing suite outcome", { targetSha: frozenLegacyTargetSha, lane: "core" }],
-    [
-      "failed suite",
-      { candidateSuiteOutcome: "failure", targetSha: frozenLegacyTargetSha, lane: "core" },
-    ],
-    [
-      "skipped suite",
-      { candidateSuiteOutcome: "skipped", targetSha: frozenLegacyTargetSha, lane: "core" },
-    ],
-    [
-      "cancelled suite",
-      { candidateSuiteOutcome: "cancelled", targetSha: frozenLegacyTargetSha, lane: "core" },
-    ],
-    [
-      "unknown suite outcome",
-      { candidateSuiteOutcome: "unknown", targetSha: frozenLegacyTargetSha, lane: "core" },
-    ],
-    ["wrong target", { candidateSuiteOutcome: "success", targetSha: "0".repeat(40), lane: "core" }],
-    [
-      "wrong lane",
-      { candidateSuiteOutcome: "success", targetSha: frozenLegacyTargetSha, lane: "soak" },
-    ],
-  ])("rejects statusless frozen evidence with %s", (_label, options) => {
-    expect(() => validateQaRuntimePairSummary(frozenLegacyStatuslessSummary(), options)).toThrow(
-      "runtime-pair summary is not completed",
-    );
-  });
-
-  it.each([
-    ["missing startedAt", undefined, "2026-08-22T06:14:49.336Z"],
-    ["missing finishedAt", "2026-08-22T06:02:37.608Z", undefined],
-    ["invalid startedAt", "not-a-date", "2026-08-22T06:14:49.336Z"],
-    ["invalid finishedAt", "2026-08-22T06:02:37.608Z", "not-a-date"],
-    ["reversed timestamps", "2026-08-22T06:14:49.336Z", "2026-08-22T06:02:37.608Z"],
-  ])("rejects statusless frozen evidence with %s", (_label, startedAt, finishedAt) => {
-    const fixture = frozenLegacyStatuslessSummary();
-    if (startedAt === undefined) {
-      delete (fixture.run as { startedAt?: string }).startedAt;
-    } else {
-      fixture.run.startedAt = startedAt;
-    }
-    if (finishedAt === undefined) {
-      delete (fixture.run as { finishedAt?: string }).finishedAt;
-    } else {
-      fixture.run.finishedAt = finishedAt;
-    }
-
-    expect(() =>
-      validateQaRuntimePairSummary(fixture, {
-        candidateSuiteOutcome: "success",
-        targetSha: frozenLegacyTargetSha,
-        lane: "core",
-      }),
-    ).toThrow("runtime-pair summary is not completed");
-  });
-
-  it("rejects manifest drift before accepting a statusless frozen profile", () => {
-    const fixture = frozenLegacyStatuslessSummary();
-    fixture.run.scenarioIds.reverse();
-    fixture.scenarios.reverse();
-
-    expect(() =>
-      validateQaRuntimePairSummary(fixture, {
-        candidateSuiteOutcome: "success",
-        targetSha: frozenLegacyTargetSha,
-        lane: "core",
-      }),
-    ).toThrow("runtime-pair summary is not completed");
-  });
-
-  it("still rejects scenario and count failures after frozen profile admission", () => {
-    const options = {
-      candidateSuiteOutcome: "success",
-      targetSha: frozenLegacyTargetSha,
-      lane: "core",
-    };
-    const failedScenario = frozenLegacyStatuslessSummary();
-    failedScenario.scenarios[0]!.status = "fail";
-    failedScenario.counts.passed -= 1;
-    failedScenario.counts.failed += 1;
-    expect(() => validateQaRuntimePairSummary(failedScenario, options)).toThrow(
-      "runtime-pair failure or unsupported skip",
-    );
-
-    const countDrift = frozenLegacyStatuslessSummary();
-    countDrift.counts.passed -= 1;
-    expect(() => validateQaRuntimePairSummary(countDrift, options)).toThrow(
-      "counts do not match validated scenario evidence",
-    );
-  });
-
-  it("applies the trusted suite outcome gate to frozen report validation", () => {
-    const fixture = frozenLegacyStatuslessSummary();
-    const reportSummary = reportFor(fixture.scenarios);
-    const markdown = markdownFor(fixture.scenarios);
-    const options = {
-      candidateSuiteOutcome: "success",
-      targetSha: frozenLegacyTargetSha,
-      lane: "core",
-    };
-
-    expect(validateQaRuntimePairReport(fixture, reportSummary, markdown, options)).toMatchObject({
-      total: 25,
-      passed: 25,
+      expect(() =>
+        validateQaRuntimePairSummary(fixture, {
+          candidateSuiteOutcome: "success",
+          targetSha,
+          lane: "core",
+        }),
+      ).toThrow("runtime-pair summary is not completed");
     });
-    expect(() =>
-      validateQaRuntimePairReport(fixture, reportSummary, markdown, {
-        ...options,
-        candidateSuiteOutcome: "failure",
-      }),
-    ).toThrow("runtime-pair summary is not completed");
+
+    it.each([
+      ["missing suite outcome", { targetSha, lane: "core" }],
+      ["failed suite", { candidateSuiteOutcome: "failure", targetSha, lane: "core" }],
+      ["skipped suite", { candidateSuiteOutcome: "skipped", targetSha, lane: "core" }],
+      ["cancelled suite", { candidateSuiteOutcome: "cancelled", targetSha, lane: "core" }],
+      ["unknown suite outcome", { candidateSuiteOutcome: "unknown", targetSha, lane: "core" }],
+      [
+        "wrong target",
+        { candidateSuiteOutcome: "success", targetSha: "0".repeat(40), lane: "core" },
+      ],
+      ["wrong lane", { candidateSuiteOutcome: "success", targetSha, lane: "soak" }],
+    ])("rejects evidence with %s", (_label, options) => {
+      expect(() => validateQaRuntimePairSummary(frozenLegacyStatuslessSummary(), options)).toThrow(
+        "runtime-pair summary is not completed",
+      );
+    });
+
+    it.each([
+      ["missing startedAt", undefined, "2026-08-22T06:14:49.336Z"],
+      ["missing finishedAt", "2026-08-22T06:02:37.608Z", undefined],
+      ["invalid startedAt", "not-a-date", "2026-08-22T06:14:49.336Z"],
+      ["invalid finishedAt", "2026-08-22T06:02:37.608Z", "not-a-date"],
+      ["reversed timestamps", "2026-08-22T06:14:49.336Z", "2026-08-22T06:02:37.608Z"],
+    ])("rejects evidence with %s", (_label, startedAt, finishedAt) => {
+      const fixture = frozenLegacyStatuslessSummary();
+      if (startedAt === undefined) {
+        delete (fixture.run as { startedAt?: string }).startedAt;
+      } else {
+        fixture.run.startedAt = startedAt;
+      }
+      if (finishedAt === undefined) {
+        delete (fixture.run as { finishedAt?: string }).finishedAt;
+      } else {
+        fixture.run.finishedAt = finishedAt;
+      }
+
+      expect(() =>
+        validateQaRuntimePairSummary(fixture, {
+          candidateSuiteOutcome: "success",
+          targetSha,
+          lane: "core",
+        }),
+      ).toThrow("runtime-pair summary is not completed");
+    });
+
+    it("rejects manifest drift before profile admission", () => {
+      const fixture = frozenLegacyStatuslessSummary();
+      fixture.run.scenarioIds.reverse();
+      fixture.scenarios.reverse();
+
+      expect(() =>
+        validateQaRuntimePairSummary(fixture, {
+          candidateSuiteOutcome: "success",
+          targetSha,
+          lane: "core",
+        }),
+      ).toThrow("runtime-pair summary is not completed");
+    });
+
+    it("still rejects scenario and count failures after profile admission", () => {
+      const options = {
+        candidateSuiteOutcome: "success",
+        targetSha,
+        lane: "core",
+      };
+      const failedScenario = frozenLegacyStatuslessSummary();
+      failedScenario.scenarios[0]!.status = "fail";
+      failedScenario.counts.passed -= 1;
+      failedScenario.counts.failed += 1;
+      expect(() => validateQaRuntimePairSummary(failedScenario, options)).toThrow(
+        "runtime-pair failure or unsupported skip",
+      );
+
+      const countDrift = frozenLegacyStatuslessSummary();
+      countDrift.counts.passed -= 1;
+      expect(() => validateQaRuntimePairSummary(countDrift, options)).toThrow(
+        "counts do not match validated scenario evidence",
+      );
+    });
+
+    it("applies the trusted suite outcome gate to report validation", () => {
+      const fixture = frozenLegacyStatuslessSummary();
+      const reportSummary = reportFor(fixture.scenarios);
+      const markdown = markdownFor(fixture.scenarios);
+      const options = {
+        candidateSuiteOutcome: "success",
+        targetSha,
+        lane: "core",
+      };
+
+      expect(validateQaRuntimePairReport(fixture, reportSummary, markdown, options)).toMatchObject({
+        total: 25,
+        passed: 25,
+      });
+      expect(() =>
+        validateQaRuntimePairReport(fixture, reportSummary, markdown, {
+          ...options,
+          candidateSuiteOutcome: "failure",
+        }),
+      ).toThrow("runtime-pair summary is not completed");
+    });
   });
 
   it("requires skipped count when validated evidence contains skips", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the frozen beta candidate's successful QA runtime-pair evidence was rejected because its test-only candidate SHA was not listed in the exact statusless-summary compatibility profile.

## Why This Change Was Made

The candidate `9a83cbf29d8f637cbe566d809811cb6a13c93664` is a test-only child of the already-reviewed `ee5ead24b1b46a3560f28f8d57e0afcd911acacb` candidate and has identical QA producer/report bytes. This change reuses the existing fail-closed profile for those two exact `:core` keys only; it does not add ancestry matching or a generalized compatibility allowance.

The full admission and rejection matrix now runs against both exact SHAs, including suite outcome, timestamps, lane, target, manifest order, scenario failure, count drift, and report validation.

Release tooling LOC: +9/-10 (net -1) | Tests: +121/-128 (net -7)

## User Impact

Release validation can accept the already-produced 25/25 QA evidence for this exact frozen beta candidate while continuing to reject incomplete, failed, malformed, or unrelated evidence.

## Evidence

- Signed exact head: `7103acf120ad10a26702ddcfeacded01804234f2`
- Exact parent: `61f27aadfebdb490e5657765f18a8dd1832bb901`
- Hosted failing lane: https://github.com/openclaw/openclaw/actions/runs/32632164508/job/97176566346
- Hosted artifact `9491519584` replayed through both summary-only and summary+report validation:
  - 25 total, 25 passed, 0 failed, 0 skipped
  - candidate suite outcome `success`
  - target SHA `9a83cbf29d8f637cbe566d809811cb6a13c93664`
  - lane `core`
- `node scripts/run-vitest.mjs test/scripts/validate-qa-runtime-pair-summary.test.ts`: 52/52 passed
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/validate-qa-runtime-pair-summary.mts test/scripts/validate-qa-runtime-pair-summary.test.ts`: passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/validate-qa-runtime-pair-summary.mts`: passed
- `pnpm check:script-erasability`: passed
- `git diff --check`: passed

The broader shared-install TypeScript gate remains red on unrelated pre-existing errors in `packages/terminal-core/src/ansi.ts` and the missing `pako` declaration used by `ui/vite.config.ts`; neither file is touched here.

### Exact-head review closeout

- Copilot reviewed both changed files at `7103acf120ad10a26702ddcfeacded01804234f2` and produced no comments.
- ClawSweeper exact-head run https://github.com/openclaw/clawsweeper/actions/runs/32634091305 completed successfully:
  - overall correctness: patch is correct
  - security: cleared
  - full review comments: none
  - focused hosted proof: 52/52 passed
- ClawSweeper's requested frozen-artifact replay is satisfied by artifact `9491519584`; both summary-only and summary+report validation pass at 25/25 on this exact head.
- Hosted `check-lint` job https://github.com/openclaw/openclaw/actions/runs/32634021750/job/97181036453 fails only at inherited base file `scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs:136` (`preserve-caught-error`). The PR does not touch that file, and `61f27aadfebdb490e5657765f18a8dd1832bb901..7103acf120ad10a26702ddcfeacded01804234f2` has no diff there. This frozen-base failure is not widened into the exact QA compatibility repair.
