### PR TITLE
fix(agents): stop recommending unavailable gateway tools

### DIFF
--- a/src/agents/agent-tools.deferred-followup.ts
+++ b/src/agents/agent-tools.deferred-followup.ts
@@ -10,7 +10,8 @@ function replaceDescription(tool: AnyAgentTool, description: string): AnyAgentTo
   return copyAgentToolMetadata(tool, updated);
 }
 
-const SESSION_TOOL_FOLLOWUPS = [
+const TOOL_FOLLOWUPS = [
+  ["gateway", "openclaw", " unavailable; ask human.", ": use openclaw tool."],
   [
     "sessions_search",
     "sessions_history",
@@ -32,13 +33,10 @@ const SESSION_TOOL_FOLLOWUPS = [
   ],
 ] as const;
 
-function describeAvailableSessionTool(
-  tool: AnyAgentTool,
-  availableTools: ReadonlySet<string>,
-): string {
+function describeAvailableTool(tool: AnyAgentTool, availableTools: ReadonlySet<string>): string {
   let description = tool.description;
   // Preserve byte-stable default prompt placement while gating every named sibling.
-  for (const [sourceTool, requiredTool, original, expanded] of SESSION_TOOL_FOLLOWUPS) {
+  for (const [sourceTool, requiredTool, original, expanded] of TOOL_FOLLOWUPS) {
     if (sourceTool === tool.name && availableTools.has(requiredTool)) {
       description = description.replace(original, expanded);
     }
@@ -95,7 +93,7 @@ export function applyToolAvailabilityDescriptions(
     if (tool.name === "agents_wait") {
       return replaceDescription(tool, describeAgentsWaitTool(hasSessionsSpawnTool));
     }
-    const description = describeAvailableSessionTool(tool, availableTools);
+    const description = describeAvailableTool(tool, availableTools);
     return description === tool.description ? tool : replaceDescription(tool, description);
   });
 }

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -18,6 +18,8 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
+import { finalizeAgentTools } from "./agent-tools.finalize.js";
+import { filterToolsByPolicy } from "./agent-tools.policy.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import { SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import {
@@ -46,6 +48,8 @@ import {
 } from "./tool-search.js";
 import { testing } from "./tool-search.test-support.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
+import { createGatewayTool } from "./tools/gateway-tool.js";
+import { createOpenClawDelegateToolsForRun } from "./tools/openclaw-delegate-tool.js";
 
 type TestCatalogContext = {
   sessionId?: string;
@@ -926,6 +930,75 @@ describe("Tool Search", () => {
 
     expect(catalogRef.current?.entries.map((entry) => entry.name)).toEqual(["fake_lookup"]);
   });
+
+  it.each([
+    {
+      scenario: "delegation was never provided",
+      agentId: "openclaw",
+      denyOpenClaw: false,
+      expected: "Read gateway config + schema. Writes/restart unavailable; ask human.",
+    },
+    {
+      scenario: "policy removed delegation",
+      agentId: "main",
+      denyOpenClaw: true,
+      expected: "Read gateway config + schema. Writes/restart unavailable; ask human.",
+    },
+    {
+      scenario: "delegation remains authorized",
+      agentId: "main",
+      denyOpenClaw: false,
+      expected: "Read gateway config + schema. Writes/restart: use openclaw tool.",
+    },
+  ])(
+    "keeps gateway guidance consistent across final and deferred surfaces when $scenario",
+    ({ agentId, denyOpenClaw, expected }) => {
+      const authorizedTools = filterToolsByPolicy(
+        [createGatewayTool(), ...createOpenClawDelegateToolsForRun({ sessionAgentId: agentId })],
+        denyOpenClaw ? { deny: ["openclaw"] } : undefined,
+      );
+      const finalizedTools = finalizeAgentTools({
+        tools: authorizedTools,
+        hookContext: {},
+        wrapBeforeToolCallHook: false,
+      });
+      const gateway = expectDefined(
+        finalizedTools.find((tool) => tool.name === "gateway"),
+        "finalized gateway tool",
+      );
+
+      expect(finalizedTools.some((tool) => tool.name === "openclaw")).toBe(
+        expected.includes("openclaw"),
+      );
+      expect(gateway.description).toBe(expected);
+
+      for (const mode of ["code", "tools", "directory"] as const) {
+        const catalogRef = createToolSearchCatalogRef();
+        const config = { tools: { toolSearch: { enabled: true, mode } } };
+        const tools = [...createToolSearchTools({ config, catalogRef }), ...finalizedTools];
+
+        if (mode === "directory") {
+          applyToolSchemaDirectoryCatalog({ tools, config, catalogRef });
+        } else {
+          applyToolSearchCatalog({ tools, config, catalogRef });
+        }
+
+        const entry = expectDefined(
+          catalogRef.current?.entries.find((candidate) => candidate.name === "gateway"),
+          `${mode} gateway catalog entry`,
+        );
+
+        expect(entry.description).toBe(expected);
+        expect(entry.tool.description).toBe(expected);
+        expect(buildToolSchemaDirectoryPrompt({ config, catalogRef })).toContain(
+          `- gateway (core): ${expected}`,
+        );
+        expect(resolveToolSearchCatalogTool({ config, catalogRef }, "gateway")?.description).toBe(
+          expected,
+        );
+      }
+    },
+  );
 
   it.each([
     {

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -23,7 +23,7 @@ describe("gateway tool", () => {
 
     expect(parameters.properties?.action?.enum).toEqual(["config.get", "config.schema.lookup"]);
     expect(tool.description).toBe(
-      "Read gateway config + schema. Writes/restart: use openclaw tool.",
+      "Read gateway config + schema. Writes/restart unavailable; ask human.",
     );
   });
 

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -109,7 +109,7 @@ export function createGatewayTool(): AnyAgentTool {
   return {
     label: "Gateway",
     name: "gateway",
-    description: "Read gateway config + schema. Writes/restart: use openclaw tool.",
+    description: "Read gateway config + schema. Writes/restart unavailable; ask human.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args, signal) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where regular agents with the read-only `gateway` tool were told to use the unavailable system-agent-only `openclaw` tool for writes and restarts. The system prompt correctly said that capability was unavailable, so the model received contradictory guidance and could attempt a tool it did not have.

## Why This Change Was Made

The gateway tool’s standalone description is now truthful by default. The existing final-authorized-tool projection restores the prior `use openclaw tool` guidance only when `openclaw` actually survives policy and schema projection. Direct tools, Tool Search catalogs, deferred schemas, and directory prompts therefore share one authoritative availability decision. The merged session/conversation guidance from #127648 remains unchanged.

Production delta: +6/-8, net -2 lines. Tests: +74/-1, net +73 lines.

AI-assisted: yes. The final-authorized-set ownership, policy-denied behavior, Tool Search propagation, prompt stability, and tests were reviewed and understood.

## User Impact

Agents no longer receive instructions to call an unavailable tool. Regular agents are told that gateway writes and restarts are unavailable and to ask the human; authorized system-agent surfaces retain the original actionable delegation guidance.

## Evidence

- Pre-fix final-surface reproduction: gateway-only and policy-denied tool sets still advertised `openclaw`.
- Latest-head proof: 174 focused tests passed across gateway, Tool Search, deferred-followup, and delegation surfaces.
- Direct, Tool Search code/tools modes, and directory-mode catalogs all cover unavailable, policy-denied, and authorized delegation.
- All seven canonical prompt snapshots remain byte-current.
- Complete changed-file gate passed, including production/test typechecking, targeted lint, dead-export, and architecture guards.
- Exact-head CI run 32634057647 on `8c1be3e4ccb198aca9946d823c21b2bbc88b9541`: green.
- Fresh P1 autoreview: no accepted/actionable findings.
- ClawSweeper: no findings. Its focused live command passed all three cases twice; the textual matcher missed the Vitest test title in terminal output. A duplicate review started afterward without a head change and does not block landing.
- `git diff --check`: passed.
