### PR TITLE
perf(cron): batch list output

### DIFF
--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -305,8 +305,9 @@ describe("cron CLI with the real Gateway pagination contract", () => {
 
     await runCron(["list"]);
 
-    expect(mocks.runtime.log.mock.calls.some(([line]) => line.includes("Job 200"))).toBe(true);
-    expect(mocks.runtime.log).toHaveBeenCalledTimes(202);
+    const output = mocks.runtime.log.mock.calls.map(([line]) => String(line)).join("\n");
+    expect(output).toContain("Job 200");
+    expect(output.split("\n")).toHaveLength(202);
   });
 
   it("fails closed when every cron inventory snapshot changes", async () => {

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -28,7 +28,7 @@ vi.mock("../../channels/plugins/index.js", () => ({
 function createRuntimeLogCapture(): { logs: string[]; runtime: RuntimeEnv } {
   const logs: string[] = [];
   const runtime = {
-    log: (msg: string) => logs.push(msg),
+    log: (msg: string) => logs.push(...msg.split("\n")),
     error: () => {},
     exit: () => {},
   } as RuntimeEnv;

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -480,7 +480,7 @@ export function printCronList(
     formatCell("Model", CRON_MODEL_PAD),
   ].join(" ");
 
-  runtime.log(rich ? theme.heading(header) : header);
+  const lines = [rich ? theme.heading(header) : header];
   const now = Date.now();
 
   for (const job of jobs) {
@@ -555,8 +555,10 @@ export function printCronList(
         : colorize(rich, theme.muted, modelLabel),
     ].join(" ");
 
-    runtime.log(line.trimEnd());
+    lines.push(line.trimEnd());
   }
+
+  runtime.log(lines.join("\n"));
 }
 
 export function printCronShow(


### PR DESCRIPTION
## Summary

- emit the already-rendered plain `cron list` table through one `RuntimeEnv.log` boundary instead of one call per row
- preserve line-oriented behavioral assertions without retaining a call-cardinality implementation test

## Root cause and owner

`listCronJobsFromGateway` already returns one bounded inventory (200 rows/page × at most 50 pages), and `printCronList` fully rendered each ordered row before output. The final owner nevertheless crossed `defaultRuntime.log` / `console.log` once for the header and once per job. The sole production caller injects `defaultRuntime`; JSON, show, empty-list, routing, errors, and Gateway pagination are separate paths and remain unchanged.

The repair accumulates those already-rendered strings and emits `lines.join("\n")` once, matching the existing plain status/list batching idiom. Production diff: +4/-2 in one owner file. Existing tests retain line-oriented output coverage; no test-only production seam was added.

## Exact behavior proof

Current-base `9dbc72a544a89412adc3c63d0be14a1369a89513` and exact head `ab93c1a4650d4965343b0e24fecd521036575f37` were exercised with the maximum 10,000-job bounded inventory under `NO_COLOR=1 CI=1`:

- writes: 10,001 → 1
- output: 2,750,294 bytes / 10,001 lines on both
- trailing newline: present on both
- SHA-256 on both: `277ad2715ad92b7c3347230953667bda1ee71d621bbd665d5b0cf8895a4f84d3`
- byte-for-byte `cmp`: identical

The single joined string is about 2.75 MB at the existing hard pagination bound; no unbounded producer was introduced.

## Benchmark

Actual `printCronList` → default `RuntimeEnv.log`/console owner path, stdout redirected to `/dev/null`, 10,000 jobs, 3 warmups + 9 GC-separated rounds on Node 24.15.0:

- base median: 220.857 ms
- head median: 193.011 ms
- improvement: 12.61% (1.144×)

This is the bounded final rendering/output stage only, not a Gateway or scheduler throughput claim.

## Validation

- Exact current-base and exact-head focused suites: 2 files / 102 tests passed on each side.
- Exact-head full `src/cli/cron-cli` suite: 10 files / 256 tests passed.
- `node scripts/check-changed.mjs -- src/cli/cron-cli/shared.ts src/cli/cron-cli/shared.test.ts src/cli/cron-cli/cron-pagination.gateway.test.ts`: all core/core-test typechecks, format, lint, dead-code, boundary, storage/media/runtime, and import-cycle gates passed.
- `pnpm build`: passed all phases; Control UI startup gzip 345,318 B versus 345,049 B baseline + 512 B tolerance.
- `git show --check`: passed; worktree clean.
- Exact-head bundled Codex `gpt-5.6-sol`/high autoreview: no P0/P1 findings, patch correct at 0.99; TruffleHog preflight clean.
- Diff-scoped deslop: no finding.

## Test audit

The prior 202-call expectation was replaced with the independently meaningful 202 rendered-line contract. A new “called once” assertion was intentionally not retained because it would couple the suite to this optimization. Existing output, pagination, formatting, JSON, and error tests remain the behavioral guard.

## Overlap and risk

Live open-PR inspection found three same-file overlaps: #113107 changes JSON readback, #116652 changes stream/show status, and #63112 adds shell-command warning parsing. Their hunks and behavior owners are disjoint from `printCronList` final emission; current merge-tree is conflict-free. No open PR found for cron-list output batching.

Residual risk is limited to the bounded joined-string allocation. Exact maximum-size output, focused/full owner suites, build, and review are green.

Changelog: not required for this internal behavior-neutral performance repair.
