### PR TITLE
fix(auth): preserve shared profile ownership on fresh installs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3371,7 +3371,7 @@ src/infra/state-migrations.meeting-transcripts.ts	2
 src/infra/state-migrations.node-host.ts	2
 src/infra/state-migrations.runtime-state.ts	7
 src/infra/state-migrations.session-store.ts	12
-src/infra/state-migrations.shared-auth-store.ts	2
+src/infra/state-migrations.shared-auth-store.ts	1
 src/infra/state-migrations.source-snapshot.ts	1
 src/infra/state-migrations.state-dir.ts	1
 src/infra/state-migrations.storage.ts	21

--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "38d7602a22d5858b20354d524ce6457d8264044ed8de65928cd458512cbe0444",
-  "generatedAt": "2026-08-23T11:13:09Z",
+  "bindingSha256": "72d338d7ade7888435c3640a9cd26168d62236f505345586558e8bd423f574ba",
+  "generatedAt": "2026-08-23T11:22:15Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "7c0cb1e3fd16d3a5b547e64cdcdd51b68bdcffadd82805a7972c15c83107e01f"
+    "candidateDiffSha256": "2404d331d2a3b8baadbb2454e19cfe2ade892ebe90310268d8f2513df4c45da1"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "2f4c43234d9e4da1bb317c7f2ca2524fd244fd4e56e31ea1766eba6b0eab18fc",
-  "generatedAt": "2026-08-23T11:05:14Z",
+  "bindingSha256": "3babee04e8fb329d959d8d2ec5e33080a26c96c50bd71365a4eb34aeae40fb42",
+  "generatedAt": "2026-08-23T11:09:44Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "3c58aec16afd512e0c511b1cb63d37705dca75247c9ee82d1a446d3aee780aef"
+    "candidateDiffSha256": "b1fda0a6e537a41cd9256b8288e3df534001deec54c44e64c91fd38d340e14be"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "3babee04e8fb329d959d8d2ec5e33080a26c96c50bd71365a4eb34aeae40fb42",
-  "generatedAt": "2026-08-23T11:09:44Z",
+  "bindingSha256": "38d7602a22d5858b20354d524ce6457d8264044ed8de65928cd458512cbe0444",
+  "generatedAt": "2026-08-23T11:13:09Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "b1fda0a6e537a41cd9256b8288e3df534001deec54c44e64c91fd38d340e14be"
+    "candidateDiffSha256": "7c0cb1e3fd16d3a5b547e64cdcdd51b68bdcffadd82805a7972c15c83107e01f"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "8e8d2a5135d82d6f5c00590ad5240c4b9736867199592ef91a1eabce0d1aaffa",
-  "generatedAt": "2026-08-23T10:48:39Z",
+  "bindingSha256": "2d780161606d6b80157e52237a902b896325c5330be9c6a5de659d11563ac2d3",
+  "generatedAt": "2026-08-23T10:56:55Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "2a60b0ef57671c4e1ac4568919035b20b2cb934c1fc7ac4db82533af76acc7d2"
+    "candidateDiffSha256": "a70d1c479bd9ca077781e48db89a7203414fb814590e862a277d3c19862dc450"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "72d338d7ade7888435c3640a9cd26168d62236f505345586558e8bd423f574ba",
-  "generatedAt": "2026-08-23T11:22:15Z",
+  "bindingSha256": "9710975f83bb3f66f49e662ea5aea1b7ce2ac119e4e684d4475c760040d73eb1",
+  "generatedAt": "2026-08-23T11:30:05Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "2404d331d2a3b8baadbb2454e19cfe2ade892ebe90310268d8f2513df4c45da1"
+    "candidateDiffSha256": "1f1d198d12037d74baa8ea0e28fd4b4f4b006f1877443903ede5220f9b0d235a"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "1bd053dbc6d97b92eaae6ed3203b6afc6d1b92f70da75a53db54e2eca4f85027",
-  "generatedAt": "2026-08-21T22:43:24Z",
+  "bindingSha256": "8e8d2a5135d82d6f5c00590ad5240c4b9736867199592ef91a1eabce0d1aaffa",
+  "generatedAt": "2026-08-23T10:48:39Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "d2fbcb727407445f86bccbaabb27639413e047eaca146640e31eb57860be7721"
+    "candidateDiffSha256": "2a60b0ef57671c4e1ac4568919035b20b2cb934c1fc7ac4db82533af76acc7d2"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "2d780161606d6b80157e52237a902b896325c5330be9c6a5de659d11563ac2d3",
-  "generatedAt": "2026-08-23T10:56:55Z",
+  "bindingSha256": "2f4c43234d9e4da1bb317c7f2ca2524fd244fd4e56e31ea1766eba6b0eab18fc",
+  "generatedAt": "2026-08-23T11:05:14Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "a70d1c479bd9ca077781e48db89a7203414fb814590e862a277d3c19862dc450"
+    "candidateDiffSha256": "3c58aec16afd512e0c511b1cb63d37705dca75247c9ee82d1a446d3aee780aef"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -25,6 +25,8 @@ type SlackProviderMonitor = (params: {
   setStatus?: (next: Record<string, unknown>) => void;
 }) => Promise<unknown>;
 type SlackStartupAuthClientFactory = typeof import("./client.js").createSlackStartupAuthClient;
+type SlackChannelInboundDispatch =
+  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
 
 const SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY = "openclawIngressLifecycle";
 
@@ -77,6 +79,7 @@ type SlackTestState = {
   >;
   socketModeLogger?: { error: (...args: unknown[]) => void };
   createSlackStartupAuthClientMock: Mock<SlackStartupAuthClientFactory>;
+  channelInboundDispatchOnce?: SlackChannelInboundDispatch;
 };
 
 // globalThis-backed singleton: with isolate=false, a vi.resetModules() in any
@@ -103,6 +106,7 @@ const slackTestState: SlackTestState = vi.hoisted(() => {
     resolveSlackUserAllowlistMock: vi.fn(),
     socketModeLogger: undefined,
     createSlackStartupAuthClientMock: vi.fn(),
+    channelInboundDispatchOnce: undefined,
   } as SlackTestState;
   return globalState["__slackTestState"];
 });
@@ -111,6 +115,10 @@ export const getSlackTestState = (): SlackTestState => slackTestState;
 
 export function useSlackStartupAuthClientOnce(factory: SlackStartupAuthClientFactory): void {
   slackTestState.createSlackStartupAuthClientMock.mockImplementationOnce(factory);
+}
+
+export function useSlackChannelInboundDispatchOnce(dispatch: SlackChannelInboundDispatch): void {
+  slackTestState.channelInboundDispatchOnce = dispatch;
 }
 
 type SlackClient = {
@@ -340,6 +348,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   slackTestState.config = config;
   slackTestState.appConstructorArgs = undefined;
   slackTestState.socketModeLogger = undefined;
+  slackTestState.channelInboundDispatchOnce = undefined;
   slackTestState.appStartMock.mockReset().mockResolvedValue(undefined);
   slackTestState.appStopMock.mockReset().mockResolvedValue(undefined);
   slackTestState.interactionRegistrations.length = 0;
@@ -404,8 +413,15 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     slackTestState.replyMock(...args) as ReturnType<ReplyResolver>;
   return {
     ...actual,
-    dispatchChannelInboundTurn: (params: DispatchParams) =>
-      actual.dispatchChannelInboundTurn({ ...params, replyResolver }),
+    dispatchChannelInboundTurn: (params: DispatchParams) => {
+      const enrichedParams = { ...params, replyResolver };
+      const dispatchOnce = slackTestState.channelInboundDispatchOnce;
+      if (dispatchOnce) {
+        slackTestState.channelInboundDispatchOnce = undefined;
+        return dispatchOnce(enrichedParams);
+      }
+      return actual.dispatchChannelInboundTurn(enrichedParams);
+    },
   };
 });
 

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -18,6 +18,7 @@ import {
   resetSlackTestState,
   startSlackMonitor as startSlackMonitorUntracked,
   stopSlackMonitor,
+  useSlackChannelInboundDispatchOnce,
   useSlackStartupAuthClientOnce,
 } from "../monitor.test-helpers.js";
 import { getSlackRuntime } from "../runtime.js";
@@ -360,6 +361,28 @@ describe("auth.test boot call", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "identity preserved" });
+    let dispatchedContext: Record<string, unknown> | undefined;
+    useSlackChannelInboundDispatchOnce(async (params) => {
+      dispatchedContext = params.ctxPayload;
+      const reply = await params.replyResolver?.(
+        params.ctxPayload,
+        params.replyOptions,
+        params.cfg,
+      );
+      for (const payload of Array.isArray(reply) ? reply : reply ? [reply] : []) {
+        await params.delivery.deliver(payload, { kind: "final" });
+      }
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: params.ctxPayload,
+        routeSessionKey: params.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: Boolean(reply),
+          counts: { tool: 0, block: 0, final: reply ? 1 : 0 },
+        },
+      };
+    });
 
     const monitor = startSlackMonitor(monitorSlackProvider, {
       appToken: "xapp-1-A1-opaque",
@@ -394,6 +417,11 @@ describe("auth.test boot call", () => {
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(dispatchedContext).toMatchObject({
+      Body: expect.stringMatching(/<@UENTERPRISE>.*status/u),
+      ChatType: "channel",
+      WasMentioned: true,
+    });
     await vi.waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
     await expect(stopSlackMonitor(monitor)).resolves.toBeUndefined();
     expect(getSlackInstallationKind("default")).toBeUndefined();

--- a/scripts/e2e/plugin-binding-command-escape-docker.sh
+++ b/scripts/e2e/plugin-binding-command-escape-docker.sh
@@ -46,27 +46,48 @@ fi
 
 if ! node - "$RUN_LOG" <<'NODE'
 const fs = require("node:fs");
+const { StringDecoder } = require("node:string_decoder");
 const logPath = process.argv[2];
 const scanBytes = 65536;
 const stat = fs.statSync(logPath);
-const length = Math.min(stat.size, scanBytes);
-const buffer = Buffer.alloc(length);
+const buffer = Buffer.alloc(Math.min(stat.size, scanBytes));
 const fd = fs.openSync(logPath, "r");
+const decoder = new StringDecoder("utf8");
+const passCounts = [];
+let carry = "";
+let offset = 0;
+
+function scanText(text) {
+  const lines = `${carry}${text}`.split(/\r?\n/u);
+  carry = lines.pop() ?? "";
+  for (const line of lines) {
+    const normalized = line.replace(/\x1B\[[0-?]*[ -/]*[@-~]/gu, "");
+    const match = normalized.match(/^\s*Tests\s+(\d+) passed\b/u);
+    if (match) {
+      passCounts.push(Number.parseInt(match[1], 10));
+    }
+  }
+}
+
 try {
-  fs.readSync(fd, buffer, 0, length, stat.size - length);
+  while (offset < stat.size) {
+    const length = Math.min(buffer.length, stat.size - offset);
+    const bytesRead = fs.readSync(fd, buffer, 0, length, offset);
+    if (bytesRead === 0) {
+      break;
+    }
+    offset += bytesRead;
+    scanText(decoder.write(buffer.subarray(0, bytesRead)));
+  }
+  scanText(decoder.end());
+  scanText("\n");
 } finally {
   fs.closeSync(fd);
 }
-const text = buffer.toString("utf8").replace(/\x1B\[[0-?]*[ -/]*[@-~]/gu, "");
-const passCounts = Array.from(
-  text.matchAll(/(?:^|\n)\s*Tests\s+(\d+) passed\b/gu),
-  (match) => Number.parseInt(match[1], 10),
-);
 const totalPassed = passCounts.reduce((sum, count) => sum + count, 0);
 
 if (passCounts.length !== 2 || totalPassed !== 3) {
   console.error("expected focused Vitest summary for exactly 3 passed tests");
-  console.error(text.slice(-4000));
   process.exit(1);
 }
 NODE

--- a/scripts/e2e/plugin-binding-command-escape-docker.sh
+++ b/scripts/e2e/plugin-binding-command-escape-docker.sh
@@ -58,8 +58,13 @@ try {
   fs.closeSync(fd);
 }
 const text = buffer.toString("utf8").replace(/\x1B\[[0-?]*[ -/]*[@-~]/gu, "");
+const passCounts = Array.from(
+  text.matchAll(/(?:^|\n)\s*Tests\s+(\d+) passed\b/gu),
+  (match) => Number.parseInt(match[1], 10),
+);
+const totalPassed = passCounts.reduce((sum, count) => sum + count, 0);
 
-if (!/(?:^|\n)\s*Tests\s+3 passed\b/u.test(text)) {
+if (passCounts.length !== 2 || totalPassed !== 3) {
   console.error("expected focused Vitest summary for exactly 3 passed tests");
   console.error(text.slice(-4000));
   process.exit(1);

--- a/scripts/e2e/plugin-binding-command-escape-docker.sh
+++ b/scripts/e2e/plugin-binding-command-escape-docker.sh
@@ -33,7 +33,7 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run --rm 
   -e "FOCUSED_TEST_REGEX=$FOCUSED_TEST_REGEX" \
   -e OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-cache \
   "$IMAGE_NAME" \
-  bash -lc 'set -euo pipefail; corepack enable; node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts --reporter=verbose -t "$FOCUSED_TEST_REGEX"' \
+  bash -lc 'set -euo pipefail; corepack enable; node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test.ts src/auto-reply/reply/dispatch-from-config.test.ts --reporter=verbose -t "$FOCUSED_TEST_REGEX"' \
   >"$RUN_LOG" 2>&1
 status=$?
 set -e

--- a/src/agents/auth-profiles.sqlite-store.test.ts
+++ b/src/agents/auth-profiles.sqlite-store.test.ts
@@ -11,6 +11,10 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as kyselySync from "../infra/kysely-sync.js";
 import * as nodeSqlite from "../infra/node-sqlite.js";
+import {
+  detectSharedAuthStoreMigration,
+  migrateSharedAuthStore,
+} from "../infra/state-migrations.shared-auth-store.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -30,13 +34,17 @@ import {
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
   resolveAuthProfileDatabasePath,
+  writePersistedAuthProfileStateRaw,
+  writePersistedAuthProfileStoreRaw,
 } from "./auth-profiles/sqlite.js";
 import {
   ensureAuthProfileStore,
   getRuntimeAuthProfileStoreSnapshotRevision,
   saveAuthProfileStore,
+  updateAuthProfileStoreWithLock,
 } from "./auth-profiles/store.js";
-import type { AuthProfileStore, OAuthCredential } from "./auth-profiles/types.js";
+import type { ApiKeyCredential, AuthProfileStore, OAuthCredential } from "./auth-profiles/types.js";
+import { upsertAuthProfileWithLockOrThrow } from "./auth-profiles/upsert-with-lock.js";
 
 type RuntimeOnlyOverlay = {
   profileId: string;
@@ -58,20 +66,23 @@ vi.mock("../plugins/provider-runtime.js", () => ({
   resolveExternalAuthProfilesWithPlugins: () => [],
 }));
 
+function apiKeyCredential(key: string): ApiKeyCredential {
+  return { type: "api_key", provider: "openai", key };
+}
+
 function apiKeyStore(key: string): AuthProfileStore {
   return {
     version: 1,
     profiles: {
-      "openai:default": {
-        type: "api_key",
-        provider: "openai",
-        key,
-      },
+      "openai:default": apiKeyCredential(key),
     },
   };
 }
 
-async function withAgentDirEnv(prefix: string, run: (agentDir: string) => void | Promise<void>) {
+async function withAgentDirEnv(
+  prefix: string,
+  run: (agentDir: string, stateDir: string) => void | Promise<void>,
+) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   const agentDir = path.join(root, "agents", "main", "agent");
   try {
@@ -81,7 +92,7 @@ async function withAgentDirEnv(prefix: string, run: (agentDir: string) => void |
         OPENCLAW_STATE_DIR: root,
         OPENCLAW_AGENT_DIR: agentDir,
       },
-      async () => await run(agentDir),
+      async () => await run(agentDir, root),
     );
   } finally {
     clearRuntimeAuthProfileStoreSnapshots();
@@ -126,13 +137,24 @@ describe("auth profile sqlite store", () => {
     });
   });
 
-  it("persists the relocated shared store through the shared-state adapter", async () => {
-    await withAgentDirEnv("openclaw-auth-shared-state-", () => {
-      writeConfigMachineState("auth.sharedStore", { location: "state-db" });
-      saveAuthProfileStore({
-        ...apiKeyStore("sk-shared"),
-        order: { openai: ["openai:default"] },
+  it.each([
+    { label: "pre-recorded ownership", recordOwnership: true },
+    { label: "fresh ownership", recordOwnership: false },
+  ])("persists the shared store through the shared-state adapter with $label", async (testCase) => {
+    await withAgentDirEnv("openclaw-auth-shared-state-", async (agentDir) => {
+      if (testCase.recordOwnership) {
+        writeConfigMachineState("auth.sharedStore", { location: "state-db" });
+      }
+      const updated = await updateAuthProfileStoreWithLock({
+        agentDir,
+        sharedStoreWrite: true,
+        updater: (store) => {
+          store.profiles["openai:default"] = apiKeyCredential("sk-shared");
+          store.order = { openai: ["openai:default"] };
+          return true;
+        },
       });
+      expect(updated).not.toBeNull();
 
       expect(ensureAuthProfileStore(undefined, { syncExternalCli: false })).toMatchObject({
         profiles: { "openai:default": { key: "sk-shared" } },
@@ -149,7 +171,218 @@ describe("auth profile sqlite store", () => {
           .prepare("SELECT store_key FROM auth_profile_state WHERE store_key = 'shared'")
           .get(),
       ).toEqual({ store_key: "shared" });
+      expect(
+        database
+          .prepare(
+            "SELECT value_json FROM config_machine_state WHERE state_key = 'auth.sharedStore'",
+          )
+          .get(),
+      ).toEqual({ value_json: JSON.stringify({ location: "state-db" }) });
       database.close();
+      expect(fs.existsSync(resolveAuthProfileDatabasePath(agentDir))).toBe(false);
+    });
+  });
+
+  it.each([
+    {
+      label: "credential row",
+      seed: (agentDir: string) =>
+        writePersistedAuthProfileStoreRaw(apiKeyStore("sk-legacy"), agentDir),
+    },
+    {
+      label: "runtime-state row",
+      seed: (agentDir: string) =>
+        writePersistedAuthProfileStateRaw(
+          { version: 1, order: { openai: ["openai:legacy"] } },
+          agentDir,
+        ),
+    },
+  ])("keeps legacy ownership when the main agent has a $label", async (testCase) => {
+    await withAgentDirEnv("openclaw-auth-shared-legacy-", async (agentDir) => {
+      testCase.seed(agentDir);
+
+      await upsertAuthProfileWithLockOrThrow({
+        agentDir,
+        profileId: "openai:default",
+        credential: apiKeyCredential("sk-updated"),
+      });
+
+      const sharedDatabase = new DatabaseSync(resolveOpenClawStateSqlitePath());
+      expect(
+        sharedDatabase
+          .prepare(
+            "SELECT value_json FROM config_machine_state WHERE state_key = 'auth.sharedStore'",
+          )
+          .get(),
+      ).toBeUndefined();
+      expect(
+        sharedDatabase
+          .prepare("SELECT store_key FROM auth_profile_stores WHERE store_key = 'shared'")
+          .get(),
+      ).toBeUndefined();
+      sharedDatabase.close();
+      expect(inspectPersistedAuthProfileStoreRaw(agentDir).status).toBe("readable");
+    });
+  });
+
+  it("memoizes legacy inspection and follows Doctor's ownership flip", async () => {
+    await withAgentDirEnv("openclaw-auth-shared-memo-", async (agentDir, stateDir) => {
+      const sourcePath = resolveAuthProfileDatabasePath(agentDir);
+      writePersistedAuthProfileStoreRaw(apiKeyStore("sk-legacy"), agentDir);
+      const realLstat = fs.lstatSync;
+      let sourceInspections = 0;
+      const lstatSpy = vi.spyOn(fs, "lstatSync").mockImplementation((pathname, options) => {
+        if (path.resolve(String(pathname)) === path.resolve(sourcePath)) {
+          sourceInspections += 1;
+        }
+        return realLstat(pathname, options as never);
+      });
+
+      try {
+        for (const key of ["sk-first", "sk-second"]) {
+          await upsertAuthProfileWithLockOrThrow({
+            agentDir,
+            profileId: "openai:default",
+            credential: apiKeyCredential(key),
+          });
+        }
+        expect(sourceInspections).toBe(1);
+
+        const detected = detectSharedAuthStoreMigration({
+          stateDir,
+          doctorOnlyStateMigrations: true,
+        });
+        await migrateSharedAuthStore({ detected, stateDir });
+        const inspectionsAfterDoctor = sourceInspections;
+
+        await upsertAuthProfileWithLockOrThrow({
+          agentDir,
+          profileId: "openai:default",
+          credential: apiKeyCredential("sk-after-doctor"),
+        });
+
+        expect(sourceInspections).toBe(inspectionsAfterDoctor);
+        expect(ensureAuthProfileStore(undefined, { syncExternalCli: false })).toMatchObject({
+          profiles: { "openai:default": { key: "sk-after-doctor" } },
+        });
+        expect(inspectPersistedAuthProfileStoreRaw(agentDir).status).toBe("missing");
+      } finally {
+        lstatSpy.mockRestore();
+      }
+    });
+  });
+
+  it("keeps legacy ownership while shared-auth cleanup is pending", async () => {
+    await withAgentDirEnv("openclaw-auth-shared-pending-", async (agentDir) => {
+      const sourcePath = resolveAuthProfileDatabasePath(agentDir);
+      writeConfigMachineState("test.seed", true);
+      const sharedDatabase = new DatabaseSync(resolveOpenClawStateSqlitePath());
+      sharedDatabase
+        .prepare(
+          `INSERT INTO migration_runs (id, started_at, finished_at, status, report_json)
+           VALUES ('shared-auth-pending', 1, NULL, 'copied', '{}')`,
+        )
+        .run();
+      sharedDatabase
+        .prepare(
+          `INSERT INTO migration_sources
+             (source_key, migration_kind, source_path, target_table, source_sha256,
+              source_size_bytes, source_record_count, last_run_id, status, imported_at,
+              removed_source, report_json)
+           VALUES ('shared-auth-pending:store', 'shared-auth-store-state-db', ?,
+                   'auth_profile_stores', NULL, NULL, NULL, 'shared-auth-pending',
+                   'copied', 1, 0, '{}')`,
+        )
+        .run(sourcePath);
+      sharedDatabase.close();
+
+      await upsertAuthProfileWithLockOrThrow({
+        agentDir,
+        profileId: "openai:default",
+        credential: apiKeyCredential("sk-after-crash"),
+      });
+
+      const after = new DatabaseSync(resolveOpenClawStateSqlitePath());
+      expect(
+        after
+          .prepare(
+            "SELECT value_json FROM config_machine_state WHERE state_key = 'auth.sharedStore'",
+          )
+          .get(),
+      ).toBeUndefined();
+      expect(
+        after.prepare("SELECT store_key FROM auth_profile_stores WHERE store_key = 'shared'").get(),
+      ).toBeUndefined();
+      after.close();
+      expect(inspectPersistedAuthProfileStoreRaw(agentDir).status).toBe("readable");
+    });
+  });
+
+  it("keeps legacy ownership when the main-agent source is unreadable", async () => {
+    await withAgentDirEnv("openclaw-auth-shared-unreadable-", async (agentDir) => {
+      const sourcePath = resolveAuthProfileDatabasePath(agentDir);
+      const realLstat = fs.lstatSync;
+      const lstatSpy = vi.spyOn(fs, "lstatSync").mockImplementation((pathname, options) => {
+        if (path.resolve(String(pathname)) === path.resolve(sourcePath)) {
+          throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+        }
+        return realLstat(pathname, options as never);
+      });
+
+      try {
+        await upsertAuthProfileWithLockOrThrow({
+          agentDir,
+          profileId: "openai:default",
+          credential: apiKeyCredential("sk-unreadable"),
+        });
+      } finally {
+        lstatSpy.mockRestore();
+      }
+
+      const sharedDatabase = new DatabaseSync(resolveOpenClawStateSqlitePath());
+      expect(
+        sharedDatabase
+          .prepare(
+            "SELECT value_json FROM config_machine_state WHERE state_key = 'auth.sharedStore'",
+          )
+          .get(),
+      ).toBeUndefined();
+      sharedDatabase.close();
+      expect(inspectPersistedAuthProfileStoreRaw(agentDir).status).toBe("readable");
+    });
+  });
+
+  it("keeps legacy ownership when a retired-file probe fails", async () => {
+    await withAgentDirEnv("openclaw-auth-shared-file-probe-error-", async (agentDir) => {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const realExistsSync = fs.existsSync.bind(fs);
+      let authPathProbes = 0;
+      const existsSpy = vi.spyOn(fs, "existsSync").mockImplementation((pathname) => {
+        if (path.resolve(String(pathname)) === path.resolve(authPath)) {
+          authPathProbes += 1;
+          throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+        }
+        return realExistsSync(pathname);
+      });
+
+      try {
+        writePersistedAuthProfileStoreRaw(apiKeyStore("sk-first"));
+        writePersistedAuthProfileStoreRaw(apiKeyStore("sk-second"));
+        expect(authPathProbes).toBe(1);
+      } finally {
+        existsSpy.mockRestore();
+      }
+
+      const sharedDatabase = new DatabaseSync(resolveOpenClawStateSqlitePath());
+      expect(
+        sharedDatabase
+          .prepare(
+            "SELECT value_json FROM config_machine_state WHERE state_key = 'auth.sharedStore'",
+          )
+          .get(),
+      ).toBeUndefined();
+      sharedDatabase.close();
+      expect(inspectPersistedAuthProfileStoreRaw(agentDir).status).toBe("readable");
     });
   });
 

--- a/src/agents/auth-profiles.sqlite-store.test.ts
+++ b/src/agents/auth-profiles.sqlite-store.test.ts
@@ -355,14 +355,14 @@ describe("auth profile sqlite store", () => {
   it("keeps legacy ownership when a retired-file probe fails", async () => {
     await withAgentDirEnv("openclaw-auth-shared-file-probe-error-", async (agentDir) => {
       const authPath = path.join(agentDir, "auth-profiles.json");
-      const realExistsSync = fs.existsSync.bind(fs);
+      const realLstatSync = fs.lstatSync.bind(fs);
       let authPathProbes = 0;
-      const existsSpy = vi.spyOn(fs, "existsSync").mockImplementation((pathname) => {
+      const lstatSpy = vi.spyOn(fs, "lstatSync").mockImplementation((pathname, options) => {
         if (path.resolve(String(pathname)) === path.resolve(authPath)) {
           authPathProbes += 1;
           throw Object.assign(new Error("permission denied"), { code: "EACCES" });
         }
-        return realExistsSync(pathname);
+        return realLstatSync(pathname, options as never);
       });
 
       try {
@@ -370,7 +370,7 @@ describe("auth profile sqlite store", () => {
         writePersistedAuthProfileStoreRaw(apiKeyStore("sk-second"));
         expect(authPathProbes).toBe(1);
       } finally {
-        existsSpy.mockRestore();
+        lstatSpy.mockRestore();
       }
 
       const sharedDatabase = new DatabaseSync(resolveOpenClawStateSqlitePath());
@@ -404,25 +404,25 @@ describe("auth profile sqlite store", () => {
     await withAgentDirEnv("openclaw-auth-sqlite-late-legacy-", (agentDir) => {
       saveAuthProfileStore(apiKeyStore("not-a-real"), agentDir);
       const legacyPath = path.join(agentDir, "auth.json");
-      const existsSync = fs.existsSync.bind(fs);
+      const lstatSync = fs.lstatSync.bind(fs);
       let legacyChecks = 0;
-      const existsSpy = vi.spyOn(fs, "existsSync").mockImplementation((pathname) => {
+      const lstatSpy = vi.spyOn(fs, "lstatSync").mockImplementation((pathname, options) => {
         if (path.resolve(String(pathname)) === path.resolve(legacyPath)) {
           legacyChecks += 1;
           if (legacyChecks === 2) {
             fs.writeFileSync(legacyPath, '{"openai":{"key":"not-a-real"}}\n', "utf8");
-            return true;
+            return lstatSync(pathname, options as never);
           }
-          return false;
+          throw Object.assign(new Error("missing"), { code: "ENOENT" });
         }
-        return existsSync(pathname);
+        return lstatSync(pathname, options as never);
       });
       try {
         expect(() => ensureAuthProfileStore(agentDir, { syncExternalCli: false })).toThrow(
           "requires legacy credential migration",
         );
       } finally {
-        existsSpy.mockRestore();
+        lstatSpy.mockRestore();
       }
       expect(fs.existsSync(legacyPath)).toBe(true);
     });

--- a/src/agents/auth-profiles/legacy-source-diagnostic.test.ts
+++ b/src/agents/auth-profiles/legacy-source-diagnostic.test.ts
@@ -36,4 +36,26 @@ describe("listAuthProfileStoresRequiringMigration", () => {
       expect(() => assertAuthProfileMigrationReady(credentialAgentDir)).not.toThrow();
     });
   });
+
+  it.skipIf(process.platform === "win32")(
+    "keeps a broken auth-profiles symlink on the Doctor-owned migration path",
+    async () => {
+      await withTestDir({ prefix: "openclaw-auth-migration-broken-link-" }, async (root) => {
+        const agentDir = path.join(root, "agent");
+        const env = { OPENCLAW_STATE_DIR: path.join(root, "state") };
+        await fs.mkdir(agentDir, { recursive: true });
+        await fs.symlink("missing-auth-profiles.json", path.join(agentDir, "auth-profiles.json"));
+
+        expect(listAuthProfileStoresRequiringMigration({ agentDirs: [agentDir], env })).toEqual([
+          resolveAuthProfileDatabasePath(agentDir),
+        ]);
+        expect(() => assertAuthProfileMigrationReady(agentDir)).toThrow(
+          expect.objectContaining({
+            action: "openclaw doctor --fix",
+            code: "AUTH_PROFILE_MIGRATION_REQUIRED",
+          }),
+        );
+      });
+    },
+  );
 });

--- a/src/agents/auth-profiles/legacy-source-diagnostic.ts
+++ b/src/agents/auth-profiles/legacy-source-diagnostic.ts
@@ -1,95 +1,30 @@
-import fs from "node:fs";
-import path from "node:path";
-import { resolveOAuthDir } from "../../config/paths.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { shortenHomePath } from "../../utils.js";
+import {
+  listLegacyAuthProfileSources,
+  type LegacyAuthProfileSource,
+  type LegacyAuthProfileSourceKind,
+} from "./legacy-source-files.js";
 import { resolveSharedAuthStorePath } from "./path-resolve.js";
 import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
+
+export {
+  listLegacyAuthProfileArchives,
+  listLegacyAuthProfileSources,
+  resolveLegacyOAuthPath,
+} from "./legacy-source-files.js";
 
 const AUTH_PROFILE_MIGRATION_REQUIRED_CODE = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
 export const AUTH_PROFILE_MIGRATION_COMMAND = "openclaw doctor --fix" as const;
 const log = createSubsystemLogger("auth-profiles/persistence");
 
-type LegacyAuthProfileSourceKind = "auth-profiles" | "auth-state" | "legacy-auth" | "legacy-oauth";
-
-type LegacyAuthProfileSource = {
-  kind: LegacyAuthProfileSourceKind;
-  path: string;
-};
-
 function isCredentialSource(source: LegacyAuthProfileSource): boolean {
   return source.kind !== "auth-state";
 }
 
-export function resolveLegacyOAuthPath(env: NodeJS.ProcessEnv = process.env): string {
-  return path.join(resolveOAuthDir(env), "oauth.json");
-}
-
 function resolveAuthProfileOwnerPath(agentDir?: string): string {
   return agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath();
-}
-
-function resolveLegacySourceAgentDir(
-  agentDir: string | undefined,
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  return agentDir
-    ? path.dirname(resolveAuthProfileOwnerPath(agentDir))
-    : resolveSharedMainAuthAgentDir(env);
-}
-
-/** Detects retired auth files by name only; runtime code must never read their contents. */
-export function listLegacyAuthProfileSources(params: {
-  agentDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): LegacyAuthProfileSource[] {
-  const agentDir = resolveLegacySourceAgentDir(params.agentDir, params.env);
-  const candidates: LegacyAuthProfileSource[] = [
-    { kind: "auth-profiles", path: path.join(agentDir, "auth-profiles.json") },
-    { kind: "auth-state", path: path.join(agentDir, "auth-state.json") },
-    { kind: "legacy-auth", path: path.join(agentDir, "auth.json") },
-  ];
-  const sharedMainDir = resolveSharedMainAuthAgentDir(params.env);
-  if (path.resolve(agentDir) === path.resolve(sharedMainDir)) {
-    candidates.push({ kind: "legacy-oauth", path: resolveLegacyOAuthPath(params.env) });
-  }
-  return candidates.filter((candidate) => fs.existsSync(candidate.path));
-}
-
-export function listLegacyAuthProfileArchives(params: {
-  agentDirs: readonly string[];
-  env?: NodeJS.ProcessEnv;
-}): LegacyAuthProfileSource[] {
-  const candidates = new Map<string, LegacyAuthProfileSourceKind>();
-  for (const agentDir of params.agentDirs) {
-    candidates.set(path.join(agentDir, "auth-profiles.json"), "auth-profiles");
-    candidates.set(path.join(agentDir, "auth-state.json"), "auth-state");
-    candidates.set(path.join(agentDir, "auth.json"), "legacy-auth");
-  }
-  candidates.set(resolveLegacyOAuthPath(params.env), "legacy-oauth");
-  const archives: LegacyAuthProfileSource[] = [];
-  for (const [sourcePath, kind] of candidates) {
-    const directory = path.dirname(sourcePath);
-    const baseName = path.basename(sourcePath);
-    const migratedPrefix = `${baseName}.migrated-`;
-    const priorImportPrefix = `${baseName}.sqlite-import.`;
-    let entries: string[];
-    try {
-      entries = fs.readdirSync(directory);
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (
-        entry.startsWith(migratedPrefix) ||
-        (entry.startsWith(priorImportPrefix) && entry.endsWith(".bak"))
-      ) {
-        archives.push({ kind, path: path.join(directory, entry) });
-      }
-    }
-  }
-  return archives;
 }
 
 export function hasLegacyAuthProfileCredentialSource(agentDir?: string): boolean {

--- a/src/agents/auth-profiles/legacy-source-files.ts
+++ b/src/agents/auth-profiles/legacy-source-files.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveOAuthDir } from "../../config/paths.js";
+import { resolveUserPath } from "../../utils.js";
+import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
+
+export type LegacyAuthProfileSourceKind =
+  | "auth-profiles"
+  | "auth-state"
+  | "legacy-auth"
+  | "legacy-oauth";
+
+export type LegacyAuthProfileSource = {
+  kind: LegacyAuthProfileSourceKind;
+  path: string;
+};
+
+export function resolveLegacyOAuthPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveOAuthDir(env), "oauth.json");
+}
+
+function resolveLegacySourceAgentDir(
+  agentDir: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return agentDir ? resolveUserPath(agentDir) : resolveSharedMainAuthAgentDir(env);
+}
+
+/** Detects retired auth files by name only; runtime code must never read their contents. */
+export function listLegacyAuthProfileSources(params: {
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): LegacyAuthProfileSource[] {
+  const agentDir = resolveLegacySourceAgentDir(params.agentDir, params.env);
+  const candidates: LegacyAuthProfileSource[] = [
+    { kind: "auth-profiles", path: path.join(agentDir, "auth-profiles.json") },
+    { kind: "auth-state", path: path.join(agentDir, "auth-state.json") },
+    { kind: "legacy-auth", path: path.join(agentDir, "auth.json") },
+  ];
+  const sharedMainDir = resolveSharedMainAuthAgentDir(params.env);
+  if (path.resolve(agentDir) === path.resolve(sharedMainDir)) {
+    candidates.push({ kind: "legacy-oauth", path: resolveLegacyOAuthPath(params.env) });
+  }
+  return candidates.filter((candidate) => fs.existsSync(candidate.path));
+}
+
+export function listLegacyAuthProfileArchives(params: {
+  agentDirs: readonly string[];
+  env?: NodeJS.ProcessEnv;
+}): LegacyAuthProfileSource[] {
+  const candidates = new Map<string, LegacyAuthProfileSourceKind>();
+  for (const agentDir of params.agentDirs) {
+    candidates.set(path.join(agentDir, "auth-profiles.json"), "auth-profiles");
+    candidates.set(path.join(agentDir, "auth-state.json"), "auth-state");
+    candidates.set(path.join(agentDir, "auth.json"), "legacy-auth");
+  }
+  candidates.set(resolveLegacyOAuthPath(params.env), "legacy-oauth");
+  const archives: LegacyAuthProfileSource[] = [];
+  for (const [sourcePath, kind] of candidates) {
+    const directory = path.dirname(sourcePath);
+    const baseName = path.basename(sourcePath);
+    const migratedPrefix = `${baseName}.migrated-`;
+    const priorImportPrefix = `${baseName}.sqlite-import.`;
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(directory);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (
+        entry.startsWith(migratedPrefix) ||
+        (entry.startsWith(priorImportPrefix) && entry.endsWith(".bak"))
+      ) {
+        archives.push({ kind, path: path.join(directory, entry) });
+      }
+    }
+  }
+  return archives;
+}

--- a/src/agents/auth-profiles/legacy-source-files.ts
+++ b/src/agents/auth-profiles/legacy-source-files.ts
@@ -15,6 +15,8 @@ export type LegacyAuthProfileSource = {
   path: string;
 };
 
+export type LegacyAuthProfileSourceEntryState = "missing" | "present" | "dangling-link";
+
 export class LegacyAuthProfileSourceInspectionError extends Error {
   readonly code = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
   readonly action = "openclaw doctor --fix" as const;
@@ -41,18 +43,32 @@ function resolveLegacySourceAgentDir(
   return agentDir ? resolveUserPath(agentDir) : resolveSharedMainAuthAgentDir(env);
 }
 
-function hasLegacySourceEntry(sourcePath: string): boolean {
+export function inspectLegacyAuthProfileSourceEntry(
+  sourcePath: string,
+): LegacyAuthProfileSourceEntryState {
   let entry: fs.Stats;
   try {
     entry = fs.lstatSync(sourcePath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
+      return "missing";
     }
     throw new LegacyAuthProfileSourceInspectionError(sourcePath, error);
   }
-  if (entry.isFile() || entry.isSymbolicLink()) {
-    return true;
+  if (entry.isFile()) {
+    return "present";
+  }
+  if (entry.isSymbolicLink()) {
+    try {
+      fs.statSync(sourcePath);
+      return "present";
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ELOOP") {
+        return "dangling-link";
+      }
+      throw new LegacyAuthProfileSourceInspectionError(sourcePath, error);
+    }
   }
   throw new LegacyAuthProfileSourceInspectionError(
     sourcePath,
@@ -75,7 +91,9 @@ export function listLegacyAuthProfileSources(params: {
   if (path.resolve(agentDir) === path.resolve(sharedMainDir)) {
     candidates.push({ kind: "legacy-oauth", path: resolveLegacyOAuthPath(params.env) });
   }
-  return candidates.filter((candidate) => hasLegacySourceEntry(candidate.path));
+  return candidates.filter(
+    (candidate) => inspectLegacyAuthProfileSourceEntry(candidate.path) !== "missing",
+  );
 }
 
 export function listLegacyAuthProfileArchives(params: {

--- a/src/agents/auth-profiles/legacy-source-files.ts
+++ b/src/agents/auth-profiles/legacy-source-files.ts
@@ -15,6 +15,21 @@ export type LegacyAuthProfileSource = {
   path: string;
 };
 
+export class LegacyAuthProfileSourceInspectionError extends Error {
+  readonly code = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
+  readonly action = "openclaw doctor --fix" as const;
+  readonly sourcePath: string;
+
+  constructor(sourcePath: string, cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`Cannot inspect legacy auth source ${sourcePath}; run openclaw doctor --fix: ${detail}`, {
+      cause,
+    });
+    this.name = "LegacyAuthProfileSourceInspectionError";
+    this.sourcePath = sourcePath;
+  }
+}
+
 export function resolveLegacyOAuthPath(env: NodeJS.ProcessEnv = process.env): string {
   return path.join(resolveOAuthDir(env), "oauth.json");
 }
@@ -24,6 +39,25 @@ function resolveLegacySourceAgentDir(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   return agentDir ? resolveUserPath(agentDir) : resolveSharedMainAuthAgentDir(env);
+}
+
+function hasLegacySourceEntry(sourcePath: string): boolean {
+  let entry: fs.Stats;
+  try {
+    entry = fs.lstatSync(sourcePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw new LegacyAuthProfileSourceInspectionError(sourcePath, error);
+  }
+  if (entry.isFile() || entry.isSymbolicLink()) {
+    return true;
+  }
+  throw new LegacyAuthProfileSourceInspectionError(
+    sourcePath,
+    new Error("entry is not a regular file or symbolic link"),
+  );
 }
 
 /** Detects retired auth files by name only; runtime code must never read their contents. */
@@ -41,7 +75,7 @@ export function listLegacyAuthProfileSources(params: {
   if (path.resolve(agentDir) === path.resolve(sharedMainDir)) {
     candidates.push({ kind: "legacy-oauth", path: resolveLegacyOAuthPath(params.env) });
   }
-  return candidates.filter((candidate) => fs.existsSync(candidate.path));
+  return candidates.filter((candidate) => hasLegacySourceEntry(candidate.path));
 }
 
 export function listLegacyAuthProfileArchives(params: {

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -963,7 +963,8 @@ describe("promoteAuthProfileInOrder", () => {
   it("normalizes copied secrets when using the locked upsert path", async () => {
     await withAuthProfileTestState(
       "openclaw-auth-profile-upsert-",
-      async ({ agentDir }) => {
+      async ({ agentDirFor }) => {
+        const agentDir = agentDirFor("work");
         fs.mkdirSync(agentDir, { recursive: true });
 
         await upsertAuthProfileWithLock({

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -197,6 +197,7 @@ export function upsertAuthProfile(params: {
   store.profiles[params.profileId] = credential;
   saveAuthProfileStore(store, params.agentDir, {
     filterExternalAuthProfiles: false,
+    sharedStoreWrite: true,
     syncExternalCli: false,
   });
 }

--- a/src/agents/auth-profiles/shared-store-bootstrap.ts
+++ b/src/agents/auth-profiles/shared-store-bootstrap.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { hasErrnoCode } from "../../infra/errno.js";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import { writeConfigMachineState } from "../../state/config-machine-state.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../../state/openclaw-state-db-readonly.js";
+import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import { resolveUserPath } from "../../utils.js";
+import { listLegacyAuthProfileSources } from "./legacy-source-files.js";
+import {
+  noteCommittedSharedAuthStoreOwnership,
+  resolveSharedAuthStoreOwnership,
+  SHARED_AUTH_STORE_STATE_KEY,
+  type SharedAuthStoreOwnership,
+} from "./path-resolve.js";
+import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
+
+const PRIMARY_ROW_KEY = "primary";
+const SHARED_AUTH_STORE_MIGRATION_KIND = "shared-auth-store-state-db";
+
+// Ownership objects are process-stable per state root. Doctor replaces the cached object
+// after relocation, so legacy inspection is memoized only for that ownership generation.
+const inspectedLegacySharedAuthOwnerships = new WeakSet<SharedAuthStoreOwnership>();
+
+type SourceAuthDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "auth_profile_store" | "auth_profile_state"
+>;
+type SharedAuthMigrationDatabase = Pick<OpenClawStateKyselyDatabase, "migration_sources">;
+
+export type SharedAuthLegacyStoreRow = { store_json: string; updated_at: number };
+export type SharedAuthLegacyStateRow = { state_json: string; updated_at: number };
+export type SharedAuthLegacyRows = {
+  store: SharedAuthLegacyStoreRow | null;
+  state: SharedAuthLegacyStateRow | null;
+};
+
+export class SharedAuthStoreSourceInspectionError extends Error {
+  readonly code = "SHARED_AUTH_STORE_SOURCE_UNREADABLE" as const;
+  readonly action = "openclaw doctor --fix" as const;
+  readonly sourcePath: string;
+
+  constructor(sourcePath: string, operation: string, cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`Cannot ${operation} legacy shared auth database ${sourcePath}: ${detail}`, { cause });
+    this.name = "SharedAuthStoreSourceInspectionError";
+    this.sourcePath = sourcePath;
+  }
+}
+
+export function inspectSharedAuthLegacySourceFile(
+  sourcePath: string,
+): { status: "missing" } | { status: "present"; size: number } {
+  let entry: fs.Stats;
+  try {
+    entry = fs.lstatSync(sourcePath);
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return { status: "missing" };
+    }
+    throw new SharedAuthStoreSourceInspectionError(sourcePath, "inspect", error);
+  }
+  let target = entry;
+  if (entry.isSymbolicLink()) {
+    try {
+      target = fs.statSync(sourcePath);
+    } catch (error) {
+      throw new SharedAuthStoreSourceInspectionError(sourcePath, "resolve", error);
+    }
+  }
+  if (!target.isFile()) {
+    throw new SharedAuthStoreSourceInspectionError(
+      sourcePath,
+      "open",
+      new Error("path is not a regular file"),
+    );
+  }
+  return { status: "present", size: target.size };
+}
+
+export function readSharedAuthLegacyRowsFromDatabase(database: DatabaseSync): SharedAuthLegacyRows {
+  const db = getNodeSqliteKysely<SourceAuthDatabase>(database);
+  const store = tableExists(database, "auth_profile_store")
+    ? (executeSqliteQueryTakeFirstSync(
+        database,
+        db
+          .selectFrom("auth_profile_store")
+          .select(["store_json", "updated_at"])
+          .where("store_key", "=", PRIMARY_ROW_KEY),
+      ) ?? null)
+    : null;
+  const state = tableExists(database, "auth_profile_state")
+    ? (executeSqliteQueryTakeFirstSync(
+        database,
+        db
+          .selectFrom("auth_profile_state")
+          .select(["state_json", "updated_at"])
+          .where("state_key", "=", PRIMARY_ROW_KEY),
+      ) ?? null)
+    : null;
+  return { store, state };
+}
+
+export function inspectSharedAuthLegacyRowsReadOnly(sourcePath: string): SharedAuthLegacyRows {
+  if (inspectSharedAuthLegacySourceFile(sourcePath).status === "missing") {
+    return { store: null, state: null };
+  }
+  let database: DatabaseSync;
+  try {
+    database = openNodeSqliteDatabase(sourcePath, { readOnly: true });
+  } catch (error) {
+    throw new SharedAuthStoreSourceInspectionError(sourcePath, "open", error);
+  }
+  try {
+    return readSharedAuthLegacyRowsFromDatabase(database);
+  } catch (error) {
+    throw new SharedAuthStoreSourceInspectionError(sourcePath, "read", error);
+  } finally {
+    database.close();
+  }
+}
+
+export function hasPendingSharedAuthCleanup(env: NodeJS.ProcessEnv, sourcePath: string): boolean {
+  return (
+    withExistingOpenClawStateDatabaseReadOnly(
+      ({ db: database }) => {
+        const db = getNodeSqliteKysely<SharedAuthMigrationDatabase>(database);
+        const row = executeSqliteQueryTakeFirstSync(
+          database,
+          db
+            .selectFrom("migration_sources")
+            .select("source_key")
+            .where("migration_kind", "=", SHARED_AUTH_STORE_MIGRATION_KIND)
+            .where("source_path", "=", sourcePath)
+            .where("removed_source", "=", 0)
+            .limit(1),
+        );
+        return Boolean(row);
+      },
+      { env },
+    ) ?? false
+  );
+}
+
+function initializeFreshSharedAuthStore(env: NodeJS.ProcessEnv): void {
+  const ownership = resolveSharedAuthStoreOwnership(env);
+  if (ownership.location === "state-db" || inspectedLegacySharedAuthOwnerships.has(ownership)) {
+    return;
+  }
+  const sourcePath = path.join(resolveSharedMainAuthAgentDir(env), "openclaw-agent.sqlite");
+  try {
+    if (listLegacyAuthProfileSources({ env }).length > 0) {
+      inspectedLegacySharedAuthOwnerships.add(ownership);
+      return;
+    }
+    const rows = inspectSharedAuthLegacyRowsReadOnly(sourcePath);
+    if (rows.store || rows.state || hasPendingSharedAuthCleanup(env, sourcePath)) {
+      inspectedLegacySharedAuthOwnerships.add(ownership);
+      return;
+    }
+  } catch {
+    // Doctor owns unreadable or partially migrated legacy state; never infer past it.
+    inspectedLegacySharedAuthOwnerships.add(ownership);
+    return;
+  }
+  writeConfigMachineState(SHARED_AUTH_STORE_STATE_KEY, { location: "state-db" }, { env });
+  noteCommittedSharedAuthStoreOwnership({ location: "state-db" }, env);
+}
+
+export function prepareFreshSharedAuthStoreWrite(params: {
+  agentDir: string | undefined;
+  allowExplicitMain: boolean;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  // A main-agent credential is shared; explicit main writes must follow the shared target.
+  // On legacy roots both routes already resolve to the same file, so redirecting is a no-op.
+  const isSharedWrite =
+    params.agentDir === undefined ||
+    (params.allowExplicitMain &&
+      path.resolve(resolveUserPath(params.agentDir, params.env)) ===
+        path.resolve(resolveSharedMainAuthAgentDir(params.env)));
+  if (isSharedWrite) {
+    initializeFreshSharedAuthStore(params.env);
+  }
+  return isSharedWrite;
+}

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -38,6 +38,7 @@ import {
 import { resolveUserPath } from "../../utils.js";
 import { resolveRegisteredAgentIdForDir } from "../agent-dir-registry.js";
 import { resolveSharedAuthStoreOwnership, resolveSharedAuthStorePath } from "./path-resolve.js";
+import { prepareFreshSharedAuthStoreWrite } from "./shared-store-bootstrap.js";
 
 type AgentAuthProfileDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -166,11 +167,13 @@ function resolveAuthProfileDatabaseKind(
   agentDir: string | undefined,
   database?: Pick<AuthProfileDatabase, "db">,
 ): AuthProfileDatabaseTarget["kind"] {
-  return agentDir !== undefined
-    ? "agent"
-    : database && !("agentId" in database)
-      ? "shared-state"
-      : resolveAuthProfileDatabaseOptions(agentDir).kind;
+  if (database && "agentId" in database) {
+    return "agent";
+  }
+  if (database && "path" in database) {
+    return "shared-state";
+  }
+  return resolveAuthProfileDatabaseOptions(agentDir).kind;
 }
 
 function inspectAuthProfileTable(
@@ -658,12 +661,24 @@ export function writePersistedAuthProfileStateRaw(
 export function runAuthProfileWriteTransaction<T>(
   agentDir: string | undefined,
   operation: (database: AuthProfileDatabase) => T,
-  options: { env?: NodeJS.ProcessEnv; stateDir?: string } = {},
+  options: {
+    env?: NodeJS.ProcessEnv;
+    sharedStoreWrite?: boolean;
+    stateDir?: string;
+  } = {},
 ): T {
   const env =
     options.env ??
     (options.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: options.stateDir } : process.env);
-  const databaseTarget = resolveAuthProfileDatabaseOptions(agentDir, env);
+  const sharedStoreWrite = prepareFreshSharedAuthStoreWrite({
+    agentDir,
+    allowExplicitMain: options.sharedStoreWrite === true,
+    env,
+  });
+  const databaseTarget = resolveAuthProfileDatabaseOptions(
+    sharedStoreWrite ? undefined : agentDir,
+    env,
+  );
   if (databaseTarget.kind === "agent") {
     return runOpenClawAgentWriteTransaction(operation, databaseTarget);
   }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -91,6 +91,7 @@ type SaveAuthProfileStoreOptions = {
   preserveOrderProfileIds?: Iterable<string>;
   preserveStateProfileIds?: Iterable<string>;
   pruneOrderProfileIds?: Iterable<string>;
+  sharedStoreWrite?: boolean;
   syncExternalCli?: boolean;
 };
 
@@ -864,6 +865,7 @@ function mergeRuntimeExternalProfileState(params: {
 /** Apply an auth store update inside the SQLite write lock. */
 export async function updateAuthProfileStoreWithLock(params: {
   agentDir?: string;
+  sharedStoreWrite?: boolean;
   stateDir?: string;
   saveOptions?: SaveAuthProfileStoreOptions;
   updater: (store: AuthProfileStore) => boolean;
@@ -891,7 +893,7 @@ export async function updateAuthProfileStoreWithLock(params: {
         }
         return loadedStore;
       },
-      { stateDir: params.stateDir },
+      { sharedStoreWrite: params.sharedStoreWrite, stateDir: params.stateDir },
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -1312,25 +1314,30 @@ function saveAuthProfileStoreInTransaction(
   database: AuthProfileDatabase,
   publishFromSuppliedStore = false,
 ): () => void {
-  const savedAuthPath = agentDir ? resolveAgentAuthPath(agentDir) : database.path;
-  const mainAuthPath = agentDir ? resolveSharedAuthPath() : database.path;
+  // Shared-state rows are global: never scope their persistence or runtime snapshots to an
+  // agent, or shared credentials are published and cached as agent-local state.
+  const persistenceAgentDir = "agentId" in database ? agentDir : undefined;
+  const savedAuthPath = persistenceAgentDir
+    ? resolveAgentAuthPath(persistenceAgentDir)
+    : database.path;
+  const mainAuthPath = persistenceAgentDir ? resolveSharedAuthPath() : database.path;
   const savesMainStore = savedAuthPath === mainAuthPath;
-  const loadedPersistedStores = loadPersistedAuthProfileStores(agentDir, database);
+  const loadedPersistedStores = loadPersistedAuthProfileStores(persistenceAgentDir, database);
   const persistedStores: PersistedAuthProfileStores = {
     ...loadedPersistedStores,
     localStore: loadedPersistedStores.localStore ?? {
       version: AUTH_STORE_VERSION,
       profiles: {},
-      ...loadPersistedAuthProfileState(agentDir, database),
+      ...loadPersistedAuthProfileState(persistenceAgentDir, database),
     },
   };
   const localStore = buildLocalAuthProfileStoreForSave({
     store,
-    agentDir,
+    agentDir: persistenceAgentDir,
     options,
     persistedStores,
   });
-  const existingRaw = readPersistedAuthProfileStoreRaw(agentDir, database);
+  const existingRaw = readPersistedAuthProfileStoreRaw(persistenceAgentDir, database);
   const payload = preserveLegacyOAuthRefsOnSave({
     payload: buildPersistedAuthProfileSecretsStore(localStore),
     existingRaw,
@@ -1349,20 +1356,25 @@ function saveAuthProfileStoreInTransaction(
   const credentialsChanged = !isDeepStrictEqual(existingRaw, payload);
   const statePayload = buildPersistedAuthProfileState(localStore);
   const stateChanged = !isDeepStrictEqual(
-    readPersistedAuthProfileStateRaw(agentDir, database),
+    readPersistedAuthProfileStateRaw(persistenceAgentDir, database),
     statePayload,
   );
   const suppliedRuntimeStore = publishFromSuppliedStore
     ? markRuntimePersistedProfiles(
-        buildRuntimeAuthProfileStoreForSave({ store, agentDir, options, persistedStores }),
+        buildRuntimeAuthProfileStoreForSave({
+          store,
+          agentDir: persistenceAgentDir,
+          options,
+          persistedStores,
+        }),
         localStore,
       )
     : undefined;
   if (credentialsChanged) {
-    writePersistedAuthProfileStoreRaw(payload, agentDir, database);
+    writePersistedAuthProfileStoreRaw(payload, persistenceAgentDir, database);
   }
   if (stateChanged) {
-    writePersistedAuthProfileStateRaw(statePayload, agentDir, database);
+    writePersistedAuthProfileStateRaw(statePayload, persistenceAgentDir, database);
   }
   const publishRuntimeSnapshots = () => {
     // Main-store publication invalidates derived stores. Capture the latest
@@ -1373,7 +1385,7 @@ function saveAuthProfileStoreInTransaction(
         )
       : [];
     if (credentialsChanged || stateChanged) {
-      noteRuntimeAuthProfileStorePersistedMutation(agentDir, {
+      noteRuntimeAuthProfileStorePersistedMutation(persistenceAgentDir, {
         credentialsChanged,
         profileSetChanged,
         stateChanged,
@@ -1381,7 +1393,7 @@ function saveAuthProfileStoreInTransaction(
       });
     }
     if (suppliedRuntimeStore) {
-      const existing = getRuntimeAuthProfileStoreSnapshot(agentDir);
+      const existing = getRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
       if (existing) {
         const materialized = preserveResolvedSecretBackedCredentials({
           next: suppliedRuntimeStore,
@@ -1389,7 +1401,7 @@ function saveAuthProfileStoreInTransaction(
         });
         setRuntimeAuthProfileStoreSnapshot(
           mergeRuntimeExternalProfileReferences({ next: materialized, existing }),
-          agentDir,
+          persistenceAgentDir,
         );
       }
       if (savesMainStore && (credentialsChanged || stateChanged)) {
@@ -1408,7 +1420,7 @@ function saveAuthProfileStoreInTransaction(
       }
       return;
     }
-    refreshRuntimeAuthProfileStoreSnapshot(agentDir);
+    refreshRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
     for (const derived of derivedSnapshots) {
       const refreshed = loadAuthProfileStoreWithoutExternalProfiles(derived.agentDir);
       const materialized = preserveResolvedSecretBackedCredentials({
@@ -1451,14 +1463,18 @@ export function saveAuthProfileStore(
     return;
   }
   let publishRuntimeSnapshots: (() => void) | undefined;
-  runAuthProfileWriteTransaction(effectiveAgentDir, (transactionDatabase) => {
-    publishRuntimeSnapshots = saveAuthProfileStoreInTransaction(
-      store,
-      effectiveAgentDir,
-      options,
-      transactionDatabase,
-    );
-  });
+  runAuthProfileWriteTransaction(
+    effectiveAgentDir,
+    (transactionDatabase) => {
+      publishRuntimeSnapshots = saveAuthProfileStoreInTransaction(
+        store,
+        effectiveAgentDir,
+        options,
+        transactionDatabase,
+      );
+    },
+    { sharedStoreWrite: options?.sharedStoreWrite },
+  );
   publishRuntimeSnapshotsAfterCommit(publishRuntimeSnapshots);
 }
 

--- a/src/agents/auth-profiles/upsert-with-lock.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.ts
@@ -17,6 +17,7 @@ export async function upsertAuthProfileWithLock(params: {
   const credential = normalizeAuthProfileCredential(params.credential);
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
+    sharedStoreWrite: true,
     stateDir: params.stateDir,
     saveOptions: {
       filterExternalAuthProfiles: false,

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -185,6 +185,80 @@ afterEach(async () => {
 });
 
 describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
+  it("keeps JSON-era ownership through shared writes until Doctor imports the credential", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:json-era": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-json-era",
+        },
+      },
+    });
+    const legacyDatabasePath = path.join(state.agentDir(), "openclaw-agent.sqlite");
+    expect(fs.existsSync(legacyDatabasePath)).toBe(false);
+
+    const realExistsSync = fs.existsSync.bind(fs);
+    let legacyJsonProbes = 0;
+    const existsSpy = vi.spyOn(fs, "existsSync").mockImplementation((pathname) => {
+      if (path.resolve(String(pathname)) === path.resolve(authPath)) {
+        legacyJsonProbes += 1;
+      }
+      return realExistsSync(pathname);
+    });
+    try {
+      for (const key of ["sk-first-write", "sk-second-write"]) {
+        writePersistedAuthProfileStoreRaw({
+          version: 1,
+          profiles: {
+            "anthropic:written": {
+              type: "api_key",
+              provider: "anthropic",
+              key,
+            },
+          },
+        });
+      }
+      expect(legacyJsonProbes).toBe(1);
+    } finally {
+      existsSpy.mockRestore();
+    }
+
+    const beforeDoctor = openOpenClawStateDatabase({ env: state.env });
+    expect(
+      beforeDoctor.db
+        .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
+        .get("auth.sharedStore"),
+    ).toBeUndefined();
+    expect(fs.existsSync(legacyDatabasePath)).toBe(true);
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      env: state.env,
+      now: () => 123,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toEqual([expect.stringContaining("Migrated auth profile JSON")]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles).toMatchObject({
+      "openai:json-era": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-json-era",
+      },
+      "anthropic:written": {
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-second-write",
+      },
+    });
+    expect(fs.existsSync(authPath)).toBe(false);
+    expectMigratedArchive(authPath);
+  });
+
   it("migrates the inherited auth owner after it leaves the explicit roster", async () => {
     const state = await makeTestState();
     const authPath = await writeLegacyAuthProfilesJson(

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -222,6 +222,29 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     },
   );
 
+  it.skipIf(process.platform === "win32")(
+    "removes a dangling shared OAuth link without reporting a stale migration failure",
+    async () => {
+      const state = await makeTestState();
+      const oauthPath = state.statePath("credentials/oauth.json");
+      fs.mkdirSync(path.dirname(oauthPath), { recursive: true });
+      fs.symlinkSync("missing-oauth.json", oauthPath);
+
+      const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+        cfg: {},
+        prompter: makePrompter(true),
+        env: state.env,
+      });
+
+      expect(result.detected).toContain(oauthPath);
+      expect(result.changes).toEqual([
+        expect.stringContaining("Removed dangling legacy auth source link"),
+      ]);
+      expect(result.warnings).toEqual([]);
+      expect(() => fs.lstatSync(oauthPath)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+    },
+  );
+
   it("keeps JSON-era ownership through shared writes until Doctor imports the credential", async () => {
     const state = await makeTestState();
     const authPath = await writeLegacyAuthProfilesJson(state, {

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -200,13 +200,13 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     const legacyDatabasePath = path.join(state.agentDir(), "openclaw-agent.sqlite");
     expect(fs.existsSync(legacyDatabasePath)).toBe(false);
 
-    const realExistsSync = fs.existsSync.bind(fs);
+    const realLstatSync = fs.lstatSync.bind(fs);
     let legacyJsonProbes = 0;
-    const existsSpy = vi.spyOn(fs, "existsSync").mockImplementation((pathname) => {
+    const lstatSpy = vi.spyOn(fs, "lstatSync").mockImplementation((pathname, options) => {
       if (path.resolve(String(pathname)) === path.resolve(authPath)) {
         legacyJsonProbes += 1;
       }
-      return realExistsSync(pathname);
+      return realLstatSync(pathname, options as never);
     });
     try {
       for (const key of ["sk-first-write", "sk-second-write"]) {
@@ -223,7 +223,7 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       }
       expect(legacyJsonProbes).toBe(1);
     } finally {
-      existsSpy.mockRestore();
+      lstatSpy.mockRestore();
     }
 
     const beforeDoctor = openOpenClawStateDatabase({ env: state.env });

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -245,6 +245,51 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     },
   );
 
+  it("leaves shared OAuth that appears after confirmation for a fresh Doctor run", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: {
+        "openai:confirmed": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-confirmed",
+        },
+      },
+    });
+    const oauthPath = state.statePath("credentials/oauth.json");
+    const prompter = makePrompter(true);
+    prompter.confirmAutoFix = vi.fn(async () => {
+      fs.mkdirSync(path.dirname(oauthPath), { recursive: true });
+      fs.writeFileSync(
+        oauthPath,
+        `${JSON.stringify({
+          openai: {
+            access: "appeared-after-confirmation",
+            refresh: "appeared-after-confirmation",
+            expires: 1_900_000_000_000,
+          },
+        })}\n`,
+        "utf8",
+      );
+      return true;
+    });
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter,
+      env: state.env,
+    });
+
+    expect(result.changes).toEqual([expect.stringContaining("Migrated auth profile JSON")]);
+    expect(result.warnings).toEqual([
+      "Legacy auth source set changed during migration; retry Doctor.",
+    ]);
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(fs.existsSync(oauthPath)).toBe(true);
+    expectNoMigratedArchive(oauthPath);
+  });
+
   it("keeps JSON-era ownership through shared writes until Doctor imports the credential", async () => {
     const state = await makeTestState();
     const authPath = await writeLegacyAuthProfilesJson(state, {

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -185,6 +185,43 @@ afterEach(async () => {
 });
 
 describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
+  it.skipIf(process.platform === "win32")(
+    "removes a dangling legacy auth profile link so startup can proceed",
+    async () => {
+      const state = await makeTestState();
+      const authPath = path.join(state.agentDir(), "auth-profiles.json");
+      fs.mkdirSync(path.dirname(authPath), { recursive: true });
+      fs.symlinkSync("missing-auth-profiles.json", authPath);
+
+      expect(fs.lstatSync(authPath).isSymbolicLink()).toBe(true);
+      expect(
+        listAuthProfileStoresRequiringMigration({
+          agentDirs: [state.agentDir()],
+          env: state.env,
+        }),
+      ).toHaveLength(1);
+
+      const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+        cfg: {},
+        prompter: makePrompter(true),
+        env: state.env,
+      });
+
+      expect(result.detected).toContain(authPath);
+      expect(result.changes).toEqual([
+        expect.stringContaining("Removed dangling legacy auth source link"),
+      ]);
+      expect(result.warnings).toEqual([]);
+      expect(() => fs.lstatSync(authPath)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+      expect(
+        listAuthProfileStoresRequiringMigration({
+          agentDirs: [state.agentDir()],
+          env: state.env,
+        }),
+      ).toEqual([]);
+    },
+  );
+
   it("keeps JSON-era ownership through shared writes until Doctor imports the credential", async () => {
     const state = await makeTestState();
     const authPath = await writeLegacyAuthProfilesJson(state, {

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -989,6 +989,13 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       const sharedStateTarget =
         candidate.agentDir === undefined &&
         resolveSharedAuthStoreOwnership(env).location === "state-db";
+      // A shared candidate on a legacy root names the main agent dir explicitly: it resolves to the
+      // same database, but an undefined agent dir would enter the shared-write bootstrap and could
+      // record state-db ownership midway through this import. Doctor stays the only owner of that flip.
+      const transactionAgentDir =
+        sharedStateTarget || candidate.agentDir !== undefined
+          ? candidate.agentDir
+          : resolveSharedMainAuthAgentDir(env);
       let sourceReceipts = candidateSourcePaths.filter(fs.existsSync).map((pathname) =>
         prepareAuthProfileSourceReceipt({
           pathname,
@@ -1160,7 +1167,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         try {
           assertAuthProfileMigrationSourcesUnchanged(candidate, sourceReceipts);
           verifiedStore = runAuthProfileWriteTransaction(
-            candidate.agentDir,
+            transactionAgentDir,
             (database) => {
               const authoritative = loadAuthProfileMigrationTargetStore(
                 candidate.agentDir,

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -13,6 +13,7 @@ import {
   listLegacyAuthProfileArchives,
   resolveLegacyOAuthPath,
 } from "../agents/auth-profiles/legacy-source-diagnostic.js";
+import { inspectLegacyAuthProfileSourceEntry } from "../agents/auth-profiles/legacy-source-files.js";
 import {
   areOAuthCredentialsEquivalent,
   hasMatchingOAuthIdentity,
@@ -605,11 +606,24 @@ function hasImportableAuthProfileStore(store: AuthProfileStore | null): store is
   return Boolean(store && (Object.keys(store.profiles).length > 0 || hasAuthProfileState(store)));
 }
 
+function removeDanglingLegacyAuthSourceLinks(
+  sourcePaths: readonly string[],
+  result: LegacyFlatAuthProfileRepairResult,
+): void {
+  for (const pathname of sourcePaths) {
+    if (inspectLegacyAuthProfileSourceEntry(pathname) !== "dangling-link") {
+      continue;
+    }
+    fs.unlinkSync(pathname);
+    result.changes.push(
+      `Removed dangling legacy auth source link ${shortenHomePath(pathname)}; its target was unavailable.`,
+    );
+  }
+}
+
 function hasLegacyAuthProfileSource(candidate: AuthProfileSqliteMigrationCandidate): boolean {
-  return (
-    fs.existsSync(candidate.authPath) ||
-    fs.existsSync(candidate.statePath) ||
-    fs.existsSync(candidate.legacyPath)
+  return [candidate.authPath, candidate.statePath, candidate.legacyPath].some(
+    (pathname) => inspectLegacyAuthProfileSourceEntry(pathname) !== "missing",
   );
 }
 
@@ -656,7 +670,7 @@ function assertAuthProfileMigrationSourcesUnchanged(
   const receiptByPath = new Map(receipts.map((receipt) => [receipt.sourcePath, receipt]));
   for (const pathname of [candidate.authPath, candidate.statePath, candidate.legacyPath]) {
     const receipt = receiptByPath.get(path.resolve(pathname));
-    if (fs.existsSync(pathname) !== Boolean(receipt)) {
+    if ((inspectLegacyAuthProfileSourceEntry(pathname) !== "missing") !== Boolean(receipt)) {
       throw new Error("legacy auth source set changed during migration; retry Doctor");
     }
     if (!receipt) {
@@ -912,7 +926,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   const candidates = listAuthProfileSqliteMigrationCandidates(params.cfg, env);
   const configStore = coerceLegacyConfigAuthProfileStore(params.cfg);
   const oauthPath = resolveLegacyOAuthPath(env);
-  const hasLegacyOAuth = fs.existsSync(oauthPath);
+  const hasLegacyOAuth = inspectLegacyAuthProfileSourceEntry(oauthPath) !== "missing";
   const detected = candidates.filter(
     (candidate) =>
       hasLegacyAuthProfileSource(candidate) ||
@@ -932,7 +946,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
           .filter((pathname, index, entries) => entries.indexOf(pathname) === index)
           .filter(
             (pathname) =>
-              fs.existsSync(pathname) ||
+              inspectLegacyAuthProfileSourceEntry(pathname) !== "missing" ||
               (configStore &&
                 isDefaultAgentCandidate(candidate, params.cfg, env) &&
                 pathname === candidate.authPath),
@@ -985,6 +999,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         fs.mkdirSync(path.dirname(pathname), { recursive: true });
       }
       releaseSources = acquireAuthProfileMigrationSourceLocks(candidateSourcePaths);
+      removeDanglingLegacyAuthSourceLinks(candidateSourcePaths, result);
       const targetDatabasePath = resolveMigrationTargetDatabasePath(candidate.agentDir, env);
       const sharedStateTarget =
         candidate.agentDir === undefined &&
@@ -996,21 +1011,23 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         sharedStateTarget || candidate.agentDir !== undefined
           ? candidate.agentDir
           : resolveSharedMainAuthAgentDir(env);
-      let sourceReceipts = candidateSourcePaths.filter(fs.existsSync).map((pathname) =>
-        prepareAuthProfileSourceReceipt({
-          pathname,
-          targetDatabasePath,
-          targetTable:
-            pathname === candidate.statePath
-              ? "auth_profile_state"
-              : sharedStateTarget
-                ? "auth_profile_stores"
-                : "auth_profile_store",
-          targetStoreKey: sharedStateTarget ? "shared" : "primary",
-          now,
-          env,
-        }),
-      );
+      let sourceReceipts = candidateSourcePaths
+        .filter((pathname) => inspectLegacyAuthProfileSourceEntry(pathname) === "present")
+        .map((pathname) =>
+          prepareAuthProfileSourceReceipt({
+            pathname,
+            targetDatabasePath,
+            targetTable:
+              pathname === candidate.statePath
+                ? "auth_profile_state"
+                : sharedStateTarget
+                  ? "auth_profile_stores"
+                  : "auth_profile_store",
+            targetStoreKey: sharedStateTarget ? "shared" : "primary",
+            now,
+            env,
+          }),
+        );
       sourceReceipts = sourceReceipts.filter(
         (receipt) => !archivePreviouslyMigratedAuthProfileSource(receipt, result),
       );
@@ -1321,7 +1338,15 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   const sharedMainCredentialSourceRemains = [
     resolveAuthStorePath(sharedMainAgentDir),
     resolveLegacyAuthStorePath(sharedMainAgentDir),
-  ].some((pathname) => fs.existsSync(pathname));
+  ].some((pathname) => inspectLegacyAuthProfileSourceEntry(pathname) !== "missing");
+  if (hasLegacyOAuth && inspectLegacyAuthProfileSourceEntry(oauthPath) === "dangling-link") {
+    const releaseSource = acquireAuthProfileMigrationSourceLocks([oauthPath]);
+    try {
+      removeDanglingLegacyAuthSourceLinks([oauthPath], result);
+    } finally {
+      releaseSource();
+    }
+  }
   if (hasLegacyOAuth && sharedMainCredentialSourceRemains) {
     result.warnings.push(
       `Deferred shared legacy OAuth migration until higher-priority shared-main credential sources are resolved by ${formatCliCommand("openclaw doctor --fix")}.`,

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1348,7 +1348,9 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
     }
   }
   const hasLegacyOAuthAfterCleanup = inspectLegacyAuthProfileSourceEntry(oauthPath) !== "missing";
-  if (hasLegacyOAuthAfterCleanup && sharedMainCredentialSourceRemains) {
+  if (!hasLegacyOAuth && hasLegacyOAuthAfterCleanup) {
+    result.warnings.push("Legacy auth source set changed during migration; retry Doctor.");
+  } else if (hasLegacyOAuthAfterCleanup && sharedMainCredentialSourceRemains) {
     result.warnings.push(
       `Deferred shared legacy OAuth migration until higher-priority shared-main credential sources are resolved by ${formatCliCommand("openclaw doctor --fix")}.`,
     );

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1347,11 +1347,12 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       releaseSource();
     }
   }
-  if (hasLegacyOAuth && sharedMainCredentialSourceRemains) {
+  const hasLegacyOAuthAfterCleanup = inspectLegacyAuthProfileSourceEntry(oauthPath) !== "missing";
+  if (hasLegacyOAuthAfterCleanup && sharedMainCredentialSourceRemains) {
     result.warnings.push(
       `Deferred shared legacy OAuth migration until higher-priority shared-main credential sources are resolved by ${formatCliCommand("openclaw doctor --fix")}.`,
     );
-  } else if (hasLegacyOAuth) {
+  } else if (hasLegacyOAuthAfterCleanup) {
     try {
       migrateLegacyOAuthFile({ oauthPath, env, now, result });
     } catch (err) {

--- a/src/commands/doctor-model-catalog-credentials.test.ts
+++ b/src/commands/doctor-model-catalog-credentials.test.ts
@@ -108,7 +108,22 @@ describe("doctor model catalog credential migration", () => {
     expect(first.migrated).toBe(3);
     expect(first.warnings).toEqual([]);
     expect(cfg.models?.providers?.configured?.apiKey).toBe("configured-secret");
-    expect(loadPersistedAuthProfileStore(agentDir)?.profiles).toMatchObject({
+    // A fresh root records state-db shared ownership, so the migrated credentials persist in the
+    // shared store rather than the agent file. Read through the owner for this state root instead of
+    // pinning the storage layout.
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = state.stateDir;
+    let migratedProfiles: Record<string, unknown>;
+    try {
+      migratedProfiles = loadPersistedAuthProfileStore(undefined)?.profiles ?? {};
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+    expect(migratedProfiles).toMatchObject({
       "configured:default": {
         type: "api_key",
         provider: "configured",

--- a/src/infra/state-migrations.shared-auth-store.ts
+++ b/src/infra/state-migrations.shared-auth-store.ts
@@ -10,6 +10,16 @@ import {
 } from "../agents/auth-profiles/path-resolve.js";
 import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import {
+  hasPendingSharedAuthCleanup,
+  inspectSharedAuthLegacyRowsReadOnly,
+  inspectSharedAuthLegacySourceFile,
+  readSharedAuthLegacyRowsFromDatabase,
+  SharedAuthStoreSourceInspectionError,
+  type SharedAuthLegacyRows as AuthRows,
+  type SharedAuthLegacyStateRow as StateRow,
+  type SharedAuthLegacyStoreRow as StoreRow,
+} from "../agents/auth-profiles/shared-store-bootstrap.js";
+import {
   closeAuthProfileReadPool,
   resolveAuthProfileDatabaseOwnerId,
 } from "../agents/auth-profiles/sqlite.js";
@@ -18,8 +28,6 @@ import {
   closeOpenClawAgentDatabaseByPath,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import { tableExists as sqliteTableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import {
@@ -27,7 +35,6 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
-import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import type { SharedAuthStoreMigrationDetection } from "./state-migrations.shared-auth-store.types.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
@@ -50,23 +57,7 @@ type SharedAuthMigrationDatabase = Pick<
   | "migration_sources"
 >;
 
-type StoreRow = { store_json: string; updated_at: number };
-type StateRow = { state_json: string; updated_at: number };
-type AuthRows = { store: StoreRow | null; state: StateRow | null };
 type MigrationStage = "copied" | "ownership-flipped" | "completed";
-
-class SharedAuthStoreSourceInspectionError extends Error {
-  readonly code = "SHARED_AUTH_STORE_SOURCE_UNREADABLE" as const;
-  readonly action = "openclaw doctor --fix" as const;
-  readonly sourcePath: string;
-
-  constructor(sourcePath: string, operation: string, cause: unknown) {
-    const detail = cause instanceof Error ? cause.message : String(cause);
-    super(`Cannot ${operation} legacy shared auth database ${sourcePath}: ${detail}`, { cause });
-    this.name = "SharedAuthStoreSourceInspectionError";
-    this.sourcePath = sourcePath;
-  }
-}
 
 function sourceMigrationKey(sourcePath: string, sourceTable: string): string {
   return `shared-auth-store:${createHash("sha256")
@@ -76,90 +67,17 @@ function sourceMigrationKey(sourcePath: string, sourceTable: string): string {
     .digest("hex")}`;
 }
 
-function inspectSourceFile(
-  sourcePath: string,
-): { status: "missing" } | { status: "present"; size: number } {
-  let entry: fs.Stats;
-  try {
-    entry = fs.lstatSync(sourcePath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { status: "missing" };
-    }
-    throw new SharedAuthStoreSourceInspectionError(sourcePath, "inspect", error);
-  }
-  let target = entry;
-  if (entry.isSymbolicLink()) {
-    try {
-      target = fs.statSync(sourcePath);
-    } catch (error) {
-      throw new SharedAuthStoreSourceInspectionError(sourcePath, "resolve", error);
-    }
-  }
-  if (!target.isFile()) {
-    throw new SharedAuthStoreSourceInspectionError(
-      sourcePath,
-      "open",
-      new Error("path is not a regular file"),
-    );
-  }
-  return { status: "present", size: target.size };
-}
-
-function readSourceRowsFromDatabase(database: DatabaseSync): AuthRows {
-  const db = getNodeSqliteKysely<SourceAuthDatabase>(database);
-  const store = sqliteTableExists(database, "auth_profile_store")
-    ? (executeSqliteQueryTakeFirstSync(
-        database,
-        db
-          .selectFrom("auth_profile_store")
-          .select(["store_json", "updated_at"])
-          .where("store_key", "=", SOURCE_STORE_KEY),
-      ) ?? null)
-    : null;
-  const state = sqliteTableExists(database, "auth_profile_state")
-    ? (executeSqliteQueryTakeFirstSync(
-        database,
-        db
-          .selectFrom("auth_profile_state")
-          .select(["state_json", "updated_at"])
-          .where("state_key", "=", SOURCE_STORE_KEY),
-      ) ?? null)
-    : null;
-  return { store, state };
-}
-
-function inspectSourceRowsReadOnly(sourcePath: string): AuthRows {
-  const source = inspectSourceFile(sourcePath);
-  if (source.status === "missing") {
-    return { store: null, state: null };
-  }
-  let database: DatabaseSync;
-  try {
-    database = openNodeSqliteDatabase(sourcePath, { readOnly: true });
-  } catch (error) {
-    throw new SharedAuthStoreSourceInspectionError(sourcePath, "open", error);
-  }
-  try {
-    return readSourceRowsFromDatabase(database);
-  } catch (error) {
-    throw new SharedAuthStoreSourceInspectionError(sourcePath, "read", error);
-  } finally {
-    database.close();
-  }
-}
-
 function readSourceSnapshot(params: { env: NodeJS.ProcessEnv; sourcePath: string }): {
   rows: AuthRows;
   size: number | null;
 } {
-  const source = inspectSourceFile(params.sourcePath);
+  const source = inspectSharedAuthLegacySourceFile(params.sourcePath);
   if (source.status === "missing") {
     return { rows: { store: null, state: null }, size: null };
   }
   try {
     const rows = runOpenClawAgentWriteTransaction(
-      ({ db }) => readSourceRowsFromDatabase(db),
+      ({ db }) => readSharedAuthLegacyRowsFromDatabase(db),
       {
         agentId: resolveAuthProfileDatabaseOwnerId(path.dirname(params.sourcePath)),
         path: params.sourcePath,
@@ -467,14 +385,14 @@ function flipOwnership(params: {
 }
 
 function cleanupSourceRows(params: { env: NodeJS.ProcessEnv; sourcePath: string }): boolean {
-  if (inspectSourceFile(params.sourcePath).status === "missing") {
+  if (inspectSharedAuthLegacySourceFile(params.sourcePath).status === "missing") {
     return false;
   }
   try {
     const removed = runOpenClawAgentWriteTransaction(
       ({ db: database }) => {
         const db = getNodeSqliteKysely<SourceAuthDatabase>(database);
-        const before = readSourceRowsFromDatabase(database);
+        const before = readSharedAuthLegacyRowsFromDatabase(database);
         executeSqliteQuerySync(
           database,
           db.deleteFrom("auth_profile_store").where("store_key", "=", SOURCE_STORE_KEY),
@@ -483,7 +401,7 @@ function cleanupSourceRows(params: { env: NodeJS.ProcessEnv; sourcePath: string 
           database,
           db.deleteFrom("auth_profile_state").where("state_key", "=", SOURCE_STORE_KEY),
         );
-        const after = readSourceRowsFromDatabase(database);
+        const after = readSharedAuthLegacyRowsFromDatabase(database);
         if (after.store || after.state) {
           throw new Error("legacy shared auth rows remain after cleanup");
         }
@@ -521,28 +439,6 @@ function finalizeMigration(params: {
   );
 }
 
-function hasPendingCleanup(env: NodeJS.ProcessEnv, sourcePath: string): boolean {
-  return (
-    withExistingOpenClawStateDatabaseReadOnly(
-      ({ db: database }) => {
-        const db = getNodeSqliteKysely<SharedAuthMigrationDatabase>(database);
-        const row = executeSqliteQueryTakeFirstSync(
-          database,
-          db
-            .selectFrom("migration_sources")
-            .select("source_key")
-            .where("migration_kind", "=", MIGRATION_KIND)
-            .where("source_path", "=", sourcePath)
-            .where("removed_source", "=", 0)
-            .limit(1),
-        );
-        return Boolean(row);
-      },
-      { env },
-    ) ?? false
-  );
-}
-
 /** Detect relocation or unfinished cleanup only in the explicit Doctor repair path. */
 export function detectSharedAuthStoreMigration(params: {
   stateDir: string;
@@ -554,14 +450,14 @@ export function detectSharedAuthStoreMigration(params: {
     return { sourcePath, hasLegacy: false };
   }
   const ownership = resolveSharedAuthStoreOwnership(env);
-  const sourceRows = inspectSourceRowsReadOnly(sourcePath);
+  const sourceRows = inspectSharedAuthLegacyRowsReadOnly(sourcePath);
   return {
     sourcePath,
     hasLegacy:
       ownership.location === "legacy-main" ||
       sourceRows.store !== null ||
       sourceRows.state !== null ||
-      hasPendingCleanup(env, sourcePath),
+      hasPendingSharedAuthCleanup(env, sourcePath),
   };
 }
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5128,6 +5128,8 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
       'docker_e2e_docker_cmd rm -f "$CONTAINER_NAME"',
       "lets authorized gateway-style plugin commands escape plugin-owned bindings",
       "keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin",
+      "text.matchAll",
+      "passCounts.length !== 2 || totalPassed !== 3",
       "expected focused Vitest summary for exactly 3 passed tests",
     ]);
     expect(runner).not.toContain("-- --reporter=verbose");

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3984,7 +3984,8 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     const pluginBinding = readFileSync(PLUGIN_BINDING_COMMAND_ESCAPE_DOCKER_E2E_PATH, "utf8");
     expect(pluginBinding).toContain("const scanBytes = 65536");
     expect(pluginBinding).toContain("fs.statSync(logPath)");
-    expect(pluginBinding).toContain("fs.readSync(fd, buffer, 0, length, stat.size - length)");
+    expect(pluginBinding).toContain("while (offset < stat.size)");
+    expect(pluginBinding).toContain("fs.readSync(fd, buffer, 0, length, offset)");
     expect(pluginBinding).not.toContain("process.env.OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES");
     expect(pluginBinding).not.toContain('readFileSync(logPath, "utf8")');
   });
@@ -5128,7 +5129,7 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
       'docker_e2e_docker_cmd rm -f "$CONTAINER_NAME"',
       "lets authorized gateway-style plugin commands escape plugin-owned bindings",
       "keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin",
-      "text.matchAll",
+      "scanText(decoder.write",
       "passCounts.length !== 2 || totalPassed !== 3",
       "expected focused Vitest summary for exactly 3 passed tests",
     ]);

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5121,6 +5121,8 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
 
     expectTextToIncludeAll(runner, [
       "--reporter=verbose -t",
+      "src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test.ts",
+      "src/auto-reply/reply/dispatch-from-config.test.ts",
       'DOCKER_RUN_TIMEOUT="${OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_DOCKER_RUN_TIMEOUT:-900s}"',
       'DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run --rm',
       'docker_e2e_docker_cmd rm -f "$CONTAINER_NAME"',


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a fresh or partially migrated installation could claim the shared authentication profile store before legacy JSON, SQLite, or pending migration evidence had been resolved. It also repairs two release-only test boundaries that could stall or omit the exact beta validation cases.

## Why This Change Was Made

The authentication store now establishes ownership once at the shared-store boundary, fails closed to Doctor when legacy or unreadable evidence remains, and keeps shared writes on that owner without a schema bump. Doctor owns cleanup and migration, including dangling legacy links and source-set changes after confirmation. The Slack enterprise startup test uses a one-shot dispatch seam while retaining the real prepared identity and delivery path. The plugin-binding Docker smoke targets both current Vitest entrypoints and aggregates their two focused summaries.

The final Codex 0.149 approval receipt binds those bytes to the frozen candidate ancestry. This PR is rooted at frozen candidate `9a83cbf29d8f637cbe566d809811cb6a13c93664`; it does not adopt later `main` changes.

## User Impact

Fresh installs retain the canonical shared authentication store. Upgrades with legacy, dangling, unreadable, or incomplete migration state receive the Doctor-owned repair path instead of an unsafe ownership guess. A legacy OAuth source that appears after confirmation is left untouched and requires a fresh Doctor run.

## Evidence

- Exact head: `2423773af6d3e50e22a62f64bd63c4d5a18d58e5`.
- Auth/Doctor exact-head focused suites: 55 + 23 + 2 passed locally and on Blacksmith Testbox.
- Slack provider `auth.test` suite: 26/26 passed on Blacksmith Testbox through the real prepared identity and delivery adapter.
- Codex app-server protocol sync/check passed on Blacksmith Testbox with `OPENCLAW_CODEX_REPO` pinned to clean `rust-v0.149.0` commit `758ef40f50c1a458425c7cfbf1eb12cbc07af0b0`.
- Codex 0.149 candidate-bound approval proof: 2/2 passed on exact head.
- Hosted run `32635966167` proved the split command-escape cases pass as `2 + 1`; its old single-summary validator then rejected the valid split. Narrow rerun `32636598043` proved the first summary could fall outside the tail-only scan. Exact head `2423773af6d` streams the complete log in bounded 64 KiB chunks and still requires two summaries totaling exactly three. Narrow Blacksmith Testbox run `32636795756` passed with `OK (3 focused tests)`.
- Exact Codex source inspected at `rust-v0.149.0` / `758ef40f50c1a458425c7cfbf1eb12cbc07af0b0`: `codex-rs/core/src/exec_policy_tests.rs:1010-1053`, `codex-rs/core/src/exec_policy_tests.rs:1331-1350`, and `codex-rs/core/src/exec_policy_tests.rs:2090-2108`.

## Scope And Risk

- No SQLite schema bump.
- Production growth establishes the shared-store ownership security invariant, fail-closed legacy evidence handling, deterministic Doctor migration/cleanup, and confirmation race safety.
- Slack and command-escape changes are test/harness only.
