### PR TITLE
fix(node-host): prevent MCP reconnect storms after outages

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -364,7 +364,7 @@ extensions/discord/src/internal/entity-cache.ts	3
 extensions/discord/src/internal/gateway-dispatch.ts	7
 extensions/discord/src/internal/gateway-payload.ts	1
 extensions/discord/src/internal/gateway-voice-state-cache.ts	4
-extensions/discord/src/internal/gateway.ts	9
+extensions/discord/src/internal/gateway.ts	8
 extensions/discord/src/internal/interaction-dispatch.ts	12
 extensions/discord/src/internal/interaction-options.ts	2
 extensions/discord/src/internal/interaction-response.ts	2

--- a/src/node-host/mcp.recovery.test.ts
+++ b/src/node-host/mcp.recovery.test.ts
@@ -600,6 +600,55 @@ describe("node host MCP live lifecycle", () => {
     expect(attempts).toBe(attemptsAtClose);
   });
 
+  it("bounds reconnect fan-out and retires admission-queued attempts on close", async () => {
+    vi.useFakeTimers();
+    let active = 0;
+    let maxActive = 0;
+    const attemptsByServer = new Map<string, number>();
+    const retryReleases: Array<() => void> = [];
+    const servers = Object.fromEntries(
+      Array.from({ length: 7 }, (_, index) => [`server-${index}`, { command: "server" }]),
+    );
+    const createClientMock = vi.fn((serverName: string) =>
+      createClient({
+        connect: async () => {
+          const attempts = (attemptsByServer.get(serverName) ?? 0) + 1;
+          attemptsByServer.set(serverName, attempts);
+          if (attempts === 1) {
+            throw new Error("offline");
+          }
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise<void>((resolve) => {
+            retryReleases.push(() => {
+              active -= 1;
+              resolve();
+            });
+          });
+        },
+      }),
+    );
+    const manager = await startNodeHostMcpManager(servers, {
+      createClient: createClientMock,
+      resolveTransport: () => stdioTransport,
+      warn: vi.fn(),
+    });
+    expect(createClientMock).toHaveBeenCalledTimes(7);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(active).toBe(6);
+    expect(maxActive).toBe(6);
+    expect(createClientMock).toHaveBeenCalledTimes(13);
+
+    await manager.close();
+    expect(createClientMock).toHaveBeenCalledTimes(13);
+    for (const release of retryReleases.splice(0)) {
+      release();
+    }
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(createClientMock).toHaveBeenCalledTimes(13);
+  });
+
   it("keeps global ordering and descriptor caps after refresh", async () => {
     let listed = [tool("initial")];
     let notifyToolsChanged: (() => void) | undefined;

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -12,6 +12,7 @@ import {
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import pLimit from "p-limit";
 import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/src/schema/nodes.js";
 import {
   connectMcpClient,
@@ -35,7 +36,6 @@ import {
   NODE_MCP_TOOL_CALL_TIMEOUT_MS,
   NODE_MCP_TOOLS_CALL_COMMAND,
 } from "../infra/node-commands.js";
-import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { VERSION } from "../version.js";
 
 const NODE_MCP_PLUGIN_ID = "node-mcp";
@@ -288,6 +288,7 @@ export async function startNodeHostMcpManager(
       ) as NodeHostMcpClient);
   const resolveTransport = deps.resolveTransport ?? resolveMcpTransport;
   const descriptors: NodePluginToolDescriptor[] = [];
+  const connectionAdmission = pLimit(NODE_MCP_CONNECT_CONCURRENCY);
   const lifecycleAbortController = new AbortController();
   const lifecycleSignal = deps.signal
     ? AbortSignal.any([deps.signal, lifecycleAbortController.signal])
@@ -377,89 +378,95 @@ export async function startNodeHostMcpManager(
     state.retryTimer.unref?.();
   };
 
-  const connectAndList = async (
-    state: NodeHostMcpServerState,
-    signal: AbortSignal,
-  ): Promise<void> => {
-    let resolved: NodeHostMcpTransport | null | undefined;
-    let session: NodeHostMcpSession | undefined;
-    try {
-      resolved = resolveTransport(state.serverName, state.config);
-      if (!resolved) {
-        states.delete(state.serverName);
-        throw new Error("invalid or unsupported transport");
-      }
-      let onToolsChanged = () => {};
-      const client = createClient(state.serverName, {
-        onToolsChanged: () => onToolsChanged(),
-      });
-      const createdSession: NodeHostMcpSession = {
-        ...resolved,
-        client,
-        connected: false,
-        toolCallTimeoutMs: resolveMcpRequestTimeoutMs(state.config, NODE_MCP_TOOL_CALL_TIMEOUT_MS),
-        abortController: new AbortController(),
-      };
-      onToolsChanged = () => {
-        if (state.current === createdSession) {
-          requestRefresh(state, createdSession);
-        }
-      };
-      session = createdSession;
-      state.current = createdSession;
-      // MCP Client exposes callback properties rather than an EventTarget surface.
-      // oxlint-disable-next-line unicorn/prefer-add-event-listener
-      client.onclose = () => {
-        if (createdSession.connected && invalidateCurrent(state, createdSession)) {
-          enqueueWork(state, async () => {
-            await disposeNodeHostMcpSession(createdSession);
-            scheduleRetry(state);
-          });
-        }
-      };
-      await connectMcpClient({
-        client,
-        transport: resolved.transport,
-        timeoutMs: resolved.connectionTimeoutMs,
-        signal,
-      });
-      if (closed || signal.aborted || state.current !== session) {
+  const connectAndList = (state: NodeHostMcpServerState, signal: AbortSignal): Promise<void> =>
+    connectionAdmission(async () => {
+      // Admission rechecks lifecycle so close can drain queued work without
+      // creating a late client or transport.
+      if (closed || signal.aborted) {
         return;
       }
-      session.connected = true;
-      const listSignal = AbortSignal.any([signal, session.abortController.signal]);
-      await enqueueCatalogWork(state, async () => {
-        const next = await listAllTools(
+      let resolved: NodeHostMcpTransport | null | undefined;
+      let session: NodeHostMcpSession | undefined;
+      try {
+        resolved = resolveTransport(state.serverName, state.config);
+        if (!resolved) {
+          states.delete(state.serverName);
+          throw new Error("invalid or unsupported transport");
+        }
+        let onToolsChanged = () => {};
+        const client = createClient(state.serverName, {
+          onToolsChanged: () => onToolsChanged(),
+        });
+        const createdSession: NodeHostMcpSession = {
+          ...resolved,
           client,
-          createdSession.requestTimeoutMs,
-          (toolName) => isMcpToolAllowed(state.config.toolFilter, toolName),
-          listSignal,
-        );
-        if (closed || state.current !== createdSession) {
+          connected: false,
+          toolCallTimeoutMs: resolveMcpRequestTimeoutMs(
+            state.config,
+            NODE_MCP_TOOL_CALL_TIMEOUT_MS,
+          ),
+          abortController: new AbortController(),
+        };
+        onToolsChanged = () => {
+          if (state.current === createdSession) {
+            requestRefresh(state, createdSession);
+          }
+        };
+        session = createdSession;
+        state.current = createdSession;
+        // MCP Client exposes callback properties rather than an EventTarget surface.
+        // oxlint-disable-next-line unicorn/prefer-add-event-listener
+        client.onclose = () => {
+          if (createdSession.connected && invalidateCurrent(state, createdSession)) {
+            enqueueWork(state, async () => {
+              await disposeNodeHostMcpSession(createdSession);
+              scheduleRetry(state);
+            });
+          }
+        };
+        await connectMcpClient({
+          client,
+          transport: resolved.transport,
+          timeoutMs: resolved.connectionTimeoutMs,
+          signal,
+        });
+        if (closed || signal.aborted || state.current !== session) {
           return;
         }
-        createdSession.toolMetadata = next.metadata;
-        state.listedTools = next.tools;
-        state.retryDelayMs = NODE_MCP_RETRY_INITIAL_MS;
-        rebuildDescriptors();
-      });
-      // A notification received during startup queues behind the initial list.
-      // Wait for that refresh so the manager never publishes the older snapshot.
-      await state.catalogWork;
-    } catch (error) {
-      const lostOwnership = session !== undefined && state.current !== session;
-      if (session && state.current === session) {
-        invalidateCurrent(state, session);
-        await disposeNodeHostMcpSession(session);
-      } else if (!session) {
-        resolved?.detachStderr?.();
+        session.connected = true;
+        const listSignal = AbortSignal.any([signal, session.abortController.signal]);
+        await enqueueCatalogWork(state, async () => {
+          const next = await listAllTools(
+            client,
+            createdSession.requestTimeoutMs,
+            (toolName) => isMcpToolAllowed(state.config.toolFilter, toolName),
+            listSignal,
+          );
+          if (closed || state.current !== createdSession) {
+            return;
+          }
+          createdSession.toolMetadata = next.metadata;
+          state.listedTools = next.tools;
+          state.retryDelayMs = NODE_MCP_RETRY_INITIAL_MS;
+          rebuildDescriptors();
+        });
+        // A notification received during startup queues behind the initial list.
+        // Wait for that refresh so the manager never publishes the older snapshot.
+        await state.catalogWork;
+      } catch (error) {
+        const lostOwnership = session !== undefined && state.current !== session;
+        if (session && state.current === session) {
+          invalidateCurrent(state, session);
+          await disposeNodeHostMcpSession(session);
+        } else if (!session) {
+          resolved?.detachStderr?.();
+        }
+        if (closed || signal.aborted || lostOwnership) {
+          return;
+        }
+        throw error;
       }
-      if (closed || signal.aborted || lostOwnership) {
-        return;
-      }
-      throw error;
-    }
-  };
+    });
 
   async function reconnect(state: NodeHostMcpServerState): Promise<void> {
     if (closed || state.current) {
@@ -538,11 +545,7 @@ export async function startNodeHostMcpManager(
       }
     }
   });
-  await runTasksWithConcurrency({
-    tasks,
-    limit: NODE_MCP_CONNECT_CONCURRENCY,
-    errorMode: "continue",
-  });
+  await Promise.all(tasks.map((task) => task()));
   startupComplete = true;
   for (const state of states.values()) {
     if (!state.current) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where node hosts configured with more than six MCP servers could reconnect every failed server at once after an outage, even though initial startup limits connection work to six concurrent servers.

## Why This Change Was Made

The node-host MCP manager now owns one process-lifetime six-slot admission limiter shared by startup and every reconnect. Work that waits in the limiter rechecks shutdown and cancellation before creating a transport or client, so closing the manager also retires queued reconnects.

This branch also includes the required shrink-only assertion-safety baseline maintenance for newly merged #121468. That merge removed one unsafe assertion from the Discord Gateway but left its baseline at 9, causing current `main` and PR merge-tree CI to fail with `gateway.ts: 8 < 9`; the baseline now records the actual count of 8.

## User Impact

Operators get bounded MCP recovery pressure after shared outages instead of a reconnect storm that can spike process, socket, and server load. Startup behavior and per-server backoff remain unchanged. The assertion-baseline correction has no runtime behavior change; it restores the intended shrink-only CI gate.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/node-host/mcp.recovery.test.ts -t 'bounds reconnect fan-out'` failed because all seven retries became active (`expected 6, received 7`).
- Focused owner proof after the final rebase: `src/node-host/mcp.recovery.test.ts` + `src/node-host/mcp.test.ts`, 34/34 tests passed.
- Full changed-file gate passed on final local head `140f8602c77669b4233b7ccceacaa3d6ab9eeee0`, including both core typecheck lanes, core/script lint, format, assertion/max-lines ratchets, dead-code, database-first, sidecar-loader, import-cycle, webhook, and pairing guards.
- The exact previously failing command now passes: `pnpm check:assertion-safety --base origin/main` reports 4,281 files and 13,497 grandfathered assertions.
- Current-main CI runs `32635976067`, `32636100451`, `32636331753`, and `32637083845` independently reproduce the unrelated baseline failure introduced after the last green main run `32635732826`.
- Direct dependency contract inspection of pinned `p-limit` 7.3.1 source and types confirmed the limiter starts at most the configured concurrency, queues later work, and releases a slot only after the admitted promise settles. This PR adds no dependency or lockfile change.
- Final structured autoreview against rebased `origin/main`: clean, no accepted/actionable findings (0.97 confidence).
- ClawSweeper found no actionable patch defect. Its unavailable-pnpm live-proof gap is covered by the 34/34 local owner suite above; its dependency-inspection gap is covered by the direct `p-limit` source/type inspection above; exact-head hosted CI is the remaining gate.
- Production LOC: +86/-83 (net +3) | Tests: +49/-0 | CI baseline: +1/-1. The production delta establishes the manager-lifetime admission owner and close-time queue fence.
- Provenance: the reconnect path was introduced in #125092 on 2026-08-17 (code author and merger @steipete); the startup-only limiter did not cover later retry timers.
- Targeted live GitHub issue/PR searches for node-host MCP reconnect concurrency and retry fanout found no duplicate repair.

AI-assisted: yes.
