### PR TITLE
chore(test): shrink Discord assertion baseline

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -364,7 +364,7 @@ extensions/discord/src/internal/entity-cache.ts	3
 extensions/discord/src/internal/gateway-dispatch.ts	7
 extensions/discord/src/internal/gateway-payload.ts	1
 extensions/discord/src/internal/gateway-voice-state-cache.ts	4
-extensions/discord/src/internal/gateway.ts	9
+extensions/discord/src/internal/gateway.ts	8
 extensions/discord/src/internal/interaction-dispatch.ts	12
 extensions/discord/src/internal/interaction-options.ts	2
 extensions/discord/src/internal/interaction-response.ts	2


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the fast baseline-ratchet CI job fails on current `main` after Discord gateway assertion usage dropped from 9 to 8.

## Why This Change Was Made

Updates the assertion-safety ledger to the lower count already enforced by the Discord source. No production behavior changes.

## User Impact

No user-visible behavior change. Required CI can correctly accept the stricter assertion count instead of reporting a stale-baseline failure.

## Evidence

- Current-main CI failure: https://github.com/openclaw/openclaw/actions/runs/32637333635
- `pnpm check:assertion-safety`
- `node scripts/check-changed.mjs -- config/assertion-safety-baseline.txt`
- `git diff --check`
