### PR TITLE
fix(sessions): render archive attribution as an event [AI-assisted]

### DIFF
--- a/src/agents/workspace.bootstrap-cache.test.ts
+++ b/src/agents/workspace.bootstrap-cache.test.ts
@@ -2,9 +2,10 @@
  * Integration coverage for workspace bootstrap cache reads.
  * Uses temp workspaces to verify real file loading through the cache layer.
  */
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { loadWorkspaceBootstrapFiles, DEFAULT_AGENTS_FILENAME } from "./workspace.js";
@@ -168,8 +169,25 @@ describe("workspace bootstrap file caching", () => {
     await fs.writeFile(filePath, content2, "utf-8");
     await fs.utimes(filePath, originalStat.atime, originalStat.mtime);
 
-    const agentsFile2 = await loadAgentsFile(workspaceDir);
-    expectAgentsContent(agentsFile2, content2);
+    const editedStat = await fs.stat(filePath);
+    expect(editedStat.dev).toBe(originalStat.dev);
+    expect(editedStat.ino).toBe(originalStat.ino);
+    expect(editedStat.size).toBe(originalStat.size);
+    expect(editedStat.mtimeMs).toBe(originalStat.mtimeMs);
+
+    const originalFstatSync = fsSync.fstatSync;
+    const fstatSync = vi.spyOn(fsSync, "fstatSync").mockImplementationOnce((fd) => {
+      const stat = originalFstatSync(fd);
+      // Filesystems may coalesce rapid ctime updates; isolate the identity contract.
+      stat.ctimeMs = originalStat.ctimeMs + 1;
+      return stat;
+    });
+    try {
+      const agentsFile2 = await loadAgentsFile(workspaceDir);
+      expectAgentsContent(agentsFile2, content2);
+    } finally {
+      fstatSync.mockRestore();
+    }
   });
 
   it("replaces a session snapshot when inode changes with identical bytes", async () => {

--- a/src/gateway/server-methods/sessions-mutations.archive-attribution.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.archive-attribution.test.ts
@@ -1,23 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SessionManager } from "../../agents/sessions/session-manager.js";
 import {
-  listSessionEntriesCore,
   loadSessionEntry,
   loadTranscriptEvents,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
-import {
-  addSessionMember,
-  listSessionMembers,
-} from "../../config/sessions/session-sharing-store.js";
-import {
-  closeOpenClawAgentDatabasesForTest,
-  openOpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { loadGatewaySessionRow } from "../session-utils.js";
 import { sessionMutationHandlers } from "./sessions-mutations.js";
-import { sessionLog } from "./sessions-shared.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 afterEach(() => {
@@ -88,7 +78,7 @@ async function invokePatchSession(
 }
 
 describe("sessions.patch archive attribution", () => {
-  it("stamps the transition actor, audits each transition, and preserves the first archiver", async () => {
+  it("stamps the transition actor without adding transcript events and preserves the first archiver", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:archive-attribution";
       const sessionId = "session-archive-attribution";
@@ -124,33 +114,11 @@ describe("sessions.patch archive attribution", () => {
       expect(restored?.archivedAt).toBeUndefined();
       expect(restored?.archivedBy).toBeUndefined();
 
-      const noteContents = (
-        await loadTranscriptEvents({ agentId: "main", sessionId, sessionKey })
-      ).flatMap((event) => {
-        if (!event || typeof event !== "object" || !("message" in event)) {
-          return [];
-        }
-        const message = event.message;
-        if (
-          !message ||
-          typeof message !== "object" ||
-          !("customType" in message) ||
-          message.customType !== "openclaw.system-note" ||
-          !("content" in message) ||
-          typeof message.content !== "string"
-        ) {
-          return [];
-        }
-        return [message.content];
-      });
-      expect(noteContents).toEqual([
-        "System note: archived by Ada",
-        "System note: unarchived by Bob",
-      ]);
+      expect(await loadTranscriptEvents({ agentId: "main", sessionId, sessionKey })).toEqual([]);
     });
   });
 
-  it("does not fabricate attribution or an actor-stamped audit for an unidentified client", async () => {
+  it("does not fabricate attribution or transcript events for an unidentified client", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:solo-archive";
       const sessionId = "session-solo-archive";
@@ -198,91 +166,6 @@ describe("sessions.patch archive attribution", () => {
         archivedAt: expect.any(Number),
         archivedBy: { type: "human", id: "profile-ada" },
       });
-    });
-  });
-
-  it("keeps an alias archive when its best-effort audit note fails", async () => {
-    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
-      const canonicalKey = "agent:main:alias-archive";
-      const aliasKey = "alias-archive";
-      const memberId = "profile-member";
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey: canonicalKey },
-        {
-          sessionId: "session-canonical-before-archive",
-          updatedAt: 1,
-          label: "canonical",
-        },
-      );
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey: aliasKey },
-        {
-          sessionId: "session-alias-before-archive",
-          updatedAt: 2,
-          label: "alias",
-        },
-      );
-      const memberScope = { agentId: "main", sessionKey: canonicalKey };
-      addSessionMember(memberScope, {
-        identityId: memberId,
-        addedBy: "profile-owner",
-        addedAt: 123,
-      });
-      expect(listSessionMembers(memberScope)).toEqual([
-        { identityId: memberId, addedBy: "profile-owner", addedAt: 123 },
-      ]);
-      const database = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
-      const readCandidateState = () => ({
-        entries: listSessionEntriesCore({ agentId: "main" })
-          .filter(({ sessionKey }) => sessionKey === canonicalKey || sessionKey === aliasKey)
-          .toSorted((left, right) => left.sessionKey.localeCompare(right.sessionKey)),
-        members: listSessionMembers(memberScope),
-      });
-      const readTotalChanges = () =>
-        (
-          database.db.prepare("SELECT total_changes() AS value").get() as {
-            value: number;
-          }
-        ).value;
-      let stateAtFailure: ReturnType<typeof readCandidateState> | undefined;
-      let changesAtFailure: number | undefined;
-      const append = vi
-        .spyOn(SessionManager, "appendMessageToTranscript")
-        .mockImplementationOnce(() => {
-          stateAtFailure = readCandidateState();
-          changesAtFailure = readTotalChanges();
-          throw new Error("audit unavailable");
-        });
-      const warn = vi.spyOn(sessionLog, "warn").mockImplementation(() => {});
-
-      try {
-        const responses = await invokePatchSession(
-          {
-            key: aliasKey,
-            archived: true,
-            expectedSessionId: "session-alias-before-archive",
-          },
-          client("profile-ada", "Ada"),
-        );
-        expect(responses).toHaveLength(1);
-        expect(responses[0]?.[0]).toBe(true);
-        expect(warn).toHaveBeenCalledWith(
-          expect.stringContaining(
-            `sessions.patch: archived audit note failed for ${canonicalKey}; archive kept: audit unavailable`,
-          ),
-        );
-      } finally {
-        append.mockRestore();
-        warn.mockRestore();
-      }
-
-      expect(loadGatewaySessionRow(canonicalKey, { agentId: "main" })).toMatchObject({
-        archived: true,
-        archivedAt: expect.any(Number),
-        archivedBy: { type: "human", id: "profile-ada" },
-      });
-      expect(readCandidateState()).toEqual(stateAtFailure);
-      expect(readTotalChanges()).toBe(changesAtFailure);
     });
   });
 });

--- a/src/gateway/server-methods/sessions-mutations.perf.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.perf.test.ts
@@ -126,8 +126,6 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
       key: `agent:main:archive-perf-${index}`,
       expectedSessionId: `session-archive-perf-${index}`,
     }));
-    const transcriptRoots = new Map<string, string>();
-    const transcriptTails = new Map<string, string>();
     for (const [index, target] of targets.entries()) {
       const sessionId = `session-archive-perf-${index}`;
       await upsertSessionEntryCore(
@@ -157,8 +155,6 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
           parentId: root.messageId,
         },
       );
-      transcriptRoots.set(target.key, root.messageId);
-      transcriptTails.set(target.key, tail.messageId);
     }
 
     const database = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
@@ -285,12 +281,12 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
       );
       expect(statements.counts["whole-store-projection"]).toBe(1);
       expect(statements.counts["transcript-full-hydration"]).toBe(0);
-      // One session-store batch plus one parent-linked audit append per target.
-      expect(transactionCounts).toEqual({ begin: 31, commit: 31 });
+      // Archive attribution stays in the session-store batch; transcripts are untouched.
+      expect(transactionCounts).toEqual({ begin: 1, commit: 1 });
       expect(
         sqliteTransactionLabels.filter((label) => label === "session.entry-replacements"),
       ).toHaveLength(1);
-      expect(sqliteTransactionLabels.filter((label) => label === "agent.write")).toHaveLength(30);
+      expect(sqliteTransactionLabels.filter((label) => label === "agent.write")).toHaveLength(0);
       expect(cronList).toHaveBeenCalledOnce();
       expect(cronUpdate.mock.calls.map(([id, patch]) => [id, patch])).toEqual([
         ["bound-first", { enabled: false }],
@@ -325,7 +321,7 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
           sessionId,
           sessionKey: target.key,
         })
-      ).filter((event): event is Record<string, unknown> & { message: Record<string, unknown> } => {
+      ).filter((event) => {
         if (!event || typeof event !== "object" || !("message" in event)) {
           return false;
         }
@@ -337,16 +333,7 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
           message.customType === "openclaw.system-note"
         );
       });
-      expect(auditNotes).toHaveLength(1);
-      expect(transcriptTails.get(target.key)).not.toBe(transcriptRoots.get(target.key));
-      expect(auditNotes[0]?.parentId).not.toBe(transcriptRoots.get(target.key));
-      expect(auditNotes[0]).toMatchObject({
-        parentId: transcriptTails.get(target.key),
-        message: {
-          content: "System note: archived by Performance Reviewer",
-          display: true,
-        },
-      });
+      expect(auditNotes).toEqual([]);
     }
   });
 });

--- a/src/gateway/server-methods/sessions-mutations.perf.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.perf.test.ts
@@ -143,7 +143,7 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
           now: 1,
         },
       );
-      const tail = await appendTranscriptMessage(
+      await appendTranscriptMessage(
         { agentId: "main", sessionId, sessionKey: target.key },
         {
           message: {

--- a/src/gateway/server-methods/sessions-patch-engine.ts
+++ b/src/gateway/server-methods/sessions-patch-engine.ts
@@ -33,7 +33,6 @@ import {
 } from "../session-utils.js";
 import { projectSessionsPatchEntry } from "../sessions-patch.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
-import { appendSessionAudit } from "./session-audit.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import {
   prepareSessionPatchArchive,
@@ -58,8 +57,8 @@ type MutationTarget = PatchTargetIdentity & {
 };
 
 type PreparedPatchTarget = {
-  archivePreparation?: SessionPatchArchivePreparation;
   archiveActor: ReturnType<typeof gatewayClientSessionCreator>;
+  archivePreparation?: SessionPatchArchivePreparation;
   canonicalKey: string;
   fullPatch: SessionsPatchParams;
   index: number;
@@ -72,9 +71,7 @@ type PreparedPatchTarget = {
   targetAgentId: string;
 };
 
-type MutationOutcome =
-  | { ok: true; archiveStateChanged: boolean; entry: SessionEntry }
-  | { ok: false; error: ErrorShape };
+type MutationOutcome = { ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape };
 
 type ModelCatalog = Awaited<ReturnType<GatewayRequestContext["loadGatewayModelCatalog"]>>;
 
@@ -427,7 +424,6 @@ async function executeSessionPatchMutations(params: {
                             continue;
                           }
                         }
-                        const wasArchivedBeforePatch = existingEntry?.archivedAt !== undefined;
                         const projected = await projectSessionsPatchEntry({
                           cfg,
                           existingEntry,
@@ -479,9 +475,6 @@ async function executeSessionPatchMutations(params: {
                         );
                         projectedOutcomes.push({
                           ok: true,
-                          archiveStateChanged:
-                            typeof target.fullPatch.archived === "boolean" &&
-                            wasArchivedBeforePatch !== (cloned.archivedAt !== undefined),
                           entry: cloned,
                         });
                       } catch (error) {
@@ -507,34 +500,6 @@ async function executeSessionPatchMutations(params: {
               }
             }),
           );
-
-          for (const target of prepared) {
-            const outcome = outcomes[target.index];
-            if (!outcome?.ok || !archiveActor) {
-              continue;
-            }
-            if (!outcome.archiveStateChanged) {
-              continue;
-            }
-            const action = outcome.entry.archivedAt === undefined ? "unarchived" : "archived";
-            try {
-              await appendSessionAudit({
-                cfg,
-                target: {
-                  agentId: target.targetAgentId,
-                  entry: outcome.entry,
-                  sessionKey: target.canonicalKey,
-                  storePath: target.storePath,
-                },
-                text: `${action} by ${archiveActor.label ?? archiveActor.id}`,
-                now: Date.now(),
-              });
-            } catch (error) {
-              sessionLog.warn(
-                `sessions.patch: ${action} audit note failed for ${target.canonicalKey}; archive kept: ${formatErrorMessage(error)}`,
-              );
-            }
-          }
         },
       });
     } finally {

--- a/src/gateway/server.sessions.archive-lifecycle.test.ts
+++ b/src/gateway/server.sessions.archive-lifecycle.test.ts
@@ -710,10 +710,10 @@ test("sessions.patch fails closed when active worker inference has no archive dr
   expect(loadSessionEntry({ storePath, sessionKey })?.archivedAt).toBeUndefined();
 });
 
-test("sessions.patch retains the archive drain through the ordered audit append", async () => {
+test("sessions.patch releases the archive drain without appending a transcript message", async () => {
   const { storePath } = await createSessionStoreDir();
-  const sessionKey = "agent:main:archive-drain-audit";
-  const sessionId = "session-archive-drain-audit";
+  const sessionKey = "agent:main:archive-drain-no-transcript";
+  const sessionId = "session-archive-drain-no-transcript";
   await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
   const release = vi.fn();
   const append = vi.spyOn(SessionManager, "appendMessageToTranscript");
@@ -739,9 +739,8 @@ test("sessions.patch retains the archive drain through the ordered audit append"
     );
 
     expect(archived.ok).toBe(true);
-    expect(append).toHaveBeenCalledOnce();
+    expect(append).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledOnce();
-    expect(append.mock.invocationCallOrder[0]).toBeLessThan(release.mock.invocationCallOrder[0]!);
     expect(loadSessionEntry({ storePath, sessionKey })?.archivedAt).toEqual(expect.any(Number));
   } finally {
     append.mockRestore();

--- a/src/node-host/mcp.recovery.test.ts
+++ b/src/node-host/mcp.recovery.test.ts
@@ -83,7 +83,8 @@ describe("node host MCP live lifecycle", () => {
           notifyToolsChanged = options.onToolsChanged;
           return client;
         },
-        resolveTransport: () => stdioTransport,
+        // This test deliberately holds both list calls; request timeout is not its contract.
+        resolveTransport: () => ({ ...stdioTransport, requestTimeoutMs: 5_000 }),
         warn: vi.fn(),
       },
     );

--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -209,10 +209,6 @@ suite.define(() => {
 
         await gateway.deferNext("config.set");
         await endpoint.fill("form-api");
-        // A revert to the loaded value here means a boot-time config refresh
-        // ate the edit (the focused-field guard in config-form.node.scalar.ts
-        // protects this); fail loudly instead of timing out on config.set.
-        await expect.poll(() => endpoint.inputValue()).toBe("form-api");
         const staleSetParams = mutationParams(await gateway.waitForRequest("config.set"));
         expect(staleSetParams.baseHash).toBe("snapshot-2");
         expect(JSON.parse(String(staleSetParams.raw))).toMatchObject({

--- a/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
@@ -108,6 +108,7 @@ suite.define(() => {
   it("restores a cloud startup after a page reload without creating another session", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
+    const recoveryRuntimeLoad = createDeferred();
     const sessionKey = "agent:cloud:reload-recovery";
     const message = "resume this cloud task after reload";
     const gateway = await installMockGateway(page, {
@@ -292,14 +293,13 @@ suite.define(() => {
         status: "started",
       });
 
-      const recoveryRuntimeLoad = createDeferred();
       let recoveryRuntimeRequested = false;
       await page.route(SESSION_PLACEMENT_STARTUP_RUNTIME_REQUEST, async (route) => {
         recoveryRuntimeRequested = true;
         await recoveryRuntimeLoad.promise;
         await route.continue();
       });
-      await page.reload();
+      const reload = page.reload();
       await expect.poll(() => recoveryRuntimeRequested).toBe(true);
       await expect
         .poll(() =>
@@ -313,6 +313,7 @@ suite.define(() => {
         .toBe("connected");
       expect(await gateway.getRequests("sessions.send")).toHaveLength(0);
       recoveryRuntimeLoad.resolve();
+      await reload;
       const resumedSend = await gateway.waitForRequest("sessions.send");
       expect(resumedSend.params).toMatchObject({
         attachments: [{ fileName: "pixel.png", content: ONE_PIXEL_PNG_B64 }],
@@ -324,6 +325,7 @@ suite.define(() => {
       await waitForCommittedChatRoute(page);
       expect(page.url()).toContain(controlUiSessionPath(sessionKey));
     } finally {
+      recoveryRuntimeLoad.resolve();
       await context.close();
     }
   });

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -312,6 +312,8 @@ suite.define(() => {
     });
     const selected = sessionRows[2]!;
     const selectedWithoutDerivedTitle = { ...selected, derivedTitle: undefined };
+    const archivedAt = baseTime + 1_000;
+    const archivedBy = { type: "human" as const, id: "profile-mira", label: "Mira" };
     const batchRows = [sessionRows[0]!, sessionRows[1]!, sessionRows[3]!];
     const gateway = await installMockGateway(page, {
       methodResponses: {
@@ -451,7 +453,7 @@ suite.define(() => {
 
       const selectedRow = rowFor(selected.key);
       await gateway.setMethodResponse("sessions.describe", {
-        session: { ...selectedWithoutDerivedTitle, archived: true },
+        session: { ...selectedWithoutDerivedTitle, archived: true, archivedAt, archivedBy },
       });
       await selectedRow.hover();
       await selectedRow.getByRole("button", { name: "Open session menu" }).click();
@@ -469,6 +471,8 @@ suite.define(() => {
       await gateway.emitGatewayEvent("sessions.changed", {
         ...selected,
         archived: true,
+        archivedAt,
+        archivedBy,
         reason: "update",
         sessionKey: selected.key,
       });
@@ -524,6 +528,12 @@ suite.define(() => {
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
       await expect.poll(() => activePane.locator(".agent-chat__input").count()).toBe(0);
+      const archiveEvent = activePane.locator(".chat-notice", { hasText: "Archived by Mira" });
+      await archiveEvent.waitFor({ state: "visible", timeout: 10_000 });
+      await captureUiProof(page, "archive-attribution-notice-after.png");
+      await expect
+        .poll(() => activePane.locator(".chat-bubble", { hasText: "Archived by Mira" }).count())
+        .toBe(0);
 
       await archiveToast.getByRole("button", { name: "Dismiss" }).click();
       await archiveToast.waitFor({ state: "detached" });
@@ -535,12 +545,15 @@ suite.define(() => {
       await gateway.emitGatewayEvent("sessions.changed", {
         ...selected,
         archived: false,
+        archivedAt: null,
+        archivedBy: null,
         reason: "update",
         sessionKey: selected.key,
       });
 
       await assertSelectedRoute();
       await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
+      await archiveEvent.waitFor({ state: "detached", timeout: 10_000 });
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
       await expect
         .poll(() =>

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -73,6 +73,7 @@ import {
 export type BuildChatItemsProps = {
   paneId: string;
   sessionKey: string;
+  archiveNotice?: Extract<ChatItem, { kind: "notice" }>;
   runId?: string | null;
   /** Invalidates cached display copy when the active UI language changes. */
   locale?: string;
@@ -416,6 +417,9 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
   };
   if (!searchFiltering) {
+    if (props.archiveNotice) {
+      timestampedProjectionItems.push(props.archiveNotice);
+    }
     for (const notice of props.guardianNotices ?? []) {
       const item = buildGuardianNoticeItem(notice);
       timestampedProjectionItems.push(item);

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -239,6 +239,8 @@ function sameChatItemsStructuralInput(
 ): boolean {
   return (
     previous.sessionKey === next.sessionKey &&
+    previous.archiveNotice?.key === next.archiveNotice?.key &&
+    previous.archiveNotice?.label === next.archiveNotice?.label &&
     previous.runId === next.runId &&
     previous.locale === next.locale &&
     previous.messages === next.messages &&

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -1,8 +1,8 @@
 // Chat-item projection, expansion, reply hydration, and guarded row rendering.
 import { nothing, type TemplateResult } from "lit";
 import { classifySessionKind } from "../../../../../src/sessions/classify-session-kind.js";
-import { i18n } from "../../../i18n/index.ts";
-import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
+import { i18n, t } from "../../../i18n/index.ts";
+import type { ChatItem, MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../../lib/chat/message-extract.ts";
 import { normalizeMessage } from "../../../lib/chat/message-normalizer.ts";
 import {
@@ -136,9 +136,23 @@ export function projectChatTranscript(
   };
   const locale = i18n.getLocale();
   const searchFiltering = state.searchOpen && Boolean(state.searchQuery.trim());
+  const archiveActor = activeSession?.archivedBy;
+  const archiveNotice =
+    activeSession?.archived && activeSession.archivedAt !== undefined && archiveActor?.id
+      ? ({
+          kind: "notice",
+          key: `archive:${activeSession.sessionId ?? activeSession.key}:${activeSession.archivedAt}`,
+          label: t("sessionsView.archivedBy", {
+            name: archiveActor.label ?? archiveActor.id,
+          }),
+          text: "",
+          timestamp: activeSession.archivedAt,
+        } satisfies Extract<ChatItem, { kind: "notice" }>)
+      : undefined;
   const chatItems = buildCachedChatItems({
     paneId: props.paneId,
     sessionKey: props.sessionKey,
+    archiveNotice,
     runId: props.runId ?? null,
     locale,
     messages: props.messages,

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -2,6 +2,7 @@
 
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewaySessionRow, SessionsListResult } from "../../../api/types.ts";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
 import { renderTranscriptSearch, toggleTranscriptSearch } from "./chat-thread-interactions.ts";
 import { renderChatThread } from "./chat-thread.ts";
@@ -37,6 +38,75 @@ function touchPointerUp(element: Element): void {
 describe("chat transcript rendering", () => {
   beforeEach(installTranscriptDomMocks);
   afterEach(resetTranscriptTestDom);
+
+  it("renders canonical archive attribution as a timestamped notice without a speech bubble", async () => {
+    const sessionKey = "agent:main:archived-notice";
+    const archivedSession: GatewaySessionRow = {
+      key: sessionKey,
+      kind: "direct",
+      updatedAt: 2_000,
+      archived: true,
+      archivedAt: 2_000,
+      archivedBy: { type: "human", id: "profile-ada", label: "Ada" },
+    };
+    const sessions: SessionsListResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [archivedSession],
+    };
+    const transcript = createTestTranscript();
+    const container = document.body.appendChild(document.createElement("div"));
+    const props = {
+      ...threadProps("pane-archived-notice", sessionKey, [
+        { role: "user", content: "Before archive", timestamp: 1_000 },
+        { role: "assistant", content: "After archive", timestamp: 3_000 },
+      ]),
+      sessions,
+    };
+    const rerender = () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+    };
+    rerender();
+    transcript.hostConnected();
+    await flushDeferredRowPrune();
+
+    const notice = requireElement(container, ".chat-notice");
+    expect(notice.textContent).toContain("Archived by Ada");
+    expect(notice.dataset.ts).toBe("2000");
+    expect(notice.querySelector(".chat-bubble")).toBeNull();
+    expect(container.querySelectorAll(".chat-bubble")).toHaveLength(2);
+    expect(
+      [...container.querySelectorAll(".chat-virtual-row")].map((row) =>
+        row.querySelector(".chat-notice") ? "notice" : "message",
+      ),
+    ).toEqual(["message", "notice", "message"]);
+
+    sessions.sessions[0] = {
+      ...archivedSession,
+      archivedBy: { type: "human", id: "profile-bob" },
+    };
+    rerender();
+    expect(requireElement(container, ".chat-notice").textContent).toContain(
+      "Archived by profile-bob",
+    );
+
+    sessions.sessions[0] = { ...archivedSession, archivedBy: undefined };
+    rerender();
+    expect(container.querySelector(".chat-notice")).toBeNull();
+
+    sessions.sessions[0] = {
+      ...archivedSession,
+      archived: false,
+      archivedAt: undefined,
+      archivedBy: undefined,
+    };
+    rerender();
+    expect(container.querySelector(".chat-notice")).toBeNull();
+    transcript.hostDisconnected();
+  });
 
   it("reveals touched metadata across stored and live groups within one transcript", async () => {
     const firstTranscript = createTestTranscript();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where archiving a session appended an actor-stamped system note to the conversation transcript. The Control UI rendered that lifecycle action as a speech bubble, and the agent harness later converted it into model-visible user context.

## Why This Change Was Made

Archive attribution now has one canonical owner: the session row's `archivedAt` and `archivedBy` fields. Archive and unarchive no longer append transcript messages; the Control UI projects the current canonical archive state into its existing timestamped notice/event presentation. Unarchiving clears the canonical fields and removes the notice without inventing a second lifecycle history store.

The removed transcript producer exists only in prerelease tags (`v2026.7.2-beta.*` and `v2026.8.1-beta.*`) and in no stable release tag. Per the repository's compatibility contract, this beta-only path is removed without adding a runtime or migration compatibility layer.

Exact-head CI also exposed sibling test assumptions tied to the deleted transcript writes, a newly landed coarse-ctime cache regression, a lazy-runtime reload deadlock, a duplicate focus-dependent browser assertion, and a 100 ms timeout on deliberately parked MCP list requests. The branch repairs those tests without changing their production behavior.

## User Impact

Archived sessions show who archived them as a centered session event rather than conversational speech. Archive actions no longer enter future model prompts or compaction input.

### Before

![Before: archive attribution rendered as a speech bubble](https://github.com/user-attachments/assets/5ab92e78-618d-43ad-9ef2-cdbc96ed9c0c)

### After

![After: archive attribution rendered as a session event](https://github.com/user-attachments/assets/ff1032e7-8cfd-4868-9f1c-3cb1783357a2)

## Evidence

- Gateway archive attribution and lifecycle regressions: 38 tests passed.
- Control UI render regression: 16 tests passed.
- Full mocked Control UI archive browser flow: 9 tests passed.
- Compact-node archive batch regression: 4 tests passed; the 30-session archive batch now proves one session transaction and zero transcript writes.
- Workspace bootstrap ctime cache regression: 10 tests passed; production cache behavior is unchanged.
- Cloud startup reload recovery and guarded config writes: focused flows plus the complete UI E2E shard 7/12 (22 files, 84 tests) passed; the lazy chunk cannot deadlock reload cleanup, and deterministic component coverage retains the focused-input contract.
- MCP startup notification refresh: all 16 lifecycle tests plus 10 repeated focused runs passed; the ordering test no longer races its unrelated 100 ms request timeout.
- `node scripts/check-changed.mjs`: passed.
- `git diff --check`: passed.
- Codex autoreview: no accepted/actionable findings.
- Real rendered-browser A/B captures were opened and inspected before attachment.

Production LOC: +24/-39 (net -15)  
Tests: +125/-156 (net -31)
