### PR TITLE
fix(test): isolate provider failover mocks

### DIFF
--- a/test/vitest/vitest.agents-paths.mjs
+++ b/test/vitest/vitest.agents-paths.mjs
@@ -5,6 +5,9 @@ const embeddedRoot = `${agentsRoot}/embedded-agent-runner`;
 // These suites mock shared runtime, network, or plugin modules and cannot
 // share the non-isolated core worker without leaking module state.
 const coreIsolatedFiles = [
+  "src/agents/failover/classify.legacy-provider-predicates.test.ts",
+  "src/agents/failover/failover-classification.corpus.test.ts",
+  "src/agents/failover/provider-structured-signals.test.ts",
   "src/agents/media-generation-task-status-shared.test.ts",
   "src/agents/media-generation-task-status.test.ts",
   "src/agents/mcp-http-fetch.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the provider structured-failover suite could lose its module mock and fail nine assertions when CI packed it after other agents-support tests in a shared non-isolated worker.

## Why This Change Was Made

Routes all three failover suites that mock the shared lazy provider-runtime loader through the existing isolated agents test owner. This gives each suite a fresh module graph while keeping production code and test behavior unchanged.

## User Impact

No product behavior changes. Exact-head CI no longer depends on incidental shared-worker import order for provider failover coverage.

## Evidence

- Pre-fix CI failure: https://github.com/openclaw/openclaw/actions/runs/32637159391/job/97188600588
  - `provider-structured-signals.test.ts`: 9 failed / 13 passed while 100 sibling files passed.
  - Provider hook mock calls were 0 and classifications fell through to the unmocked results.
- Exact pre-fix compact `agentic-agents-support-hosted-1` shard reproduced its 101-file routing locally (2,126 tests); one local sample passed, confirming the failure is ordering-sensitive rather than deterministic per-file behavior.
- `node scripts/run-vitest.mjs src/agents/failover/classify.legacy-provider-predicates.test.ts src/agents/failover/failover-classification.corpus.test.ts src/agents/failover/provider-structured-signals.test.ts` — 3 files / 671 tests passed under `agents-core-isolated`.
- `node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts test/scripts/test-projects.test.ts test/vitest-scoped-config.test.ts` — 3 files / 399 tests passed.
- `node scripts/check-changed.mjs -- test/vitest/vitest.agents-paths.mjs`
- Mandatory Codex Sol/high autoreview: clean, no accepted/actionable findings; patch correct 0.99.
- `git diff --check`
