### PR TITLE
fix(doctor): suppress skipped memory warnings for all agents

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -1077,6 +1077,22 @@ describe("noteMemorySearchHealth", () => {
       'Agent "secondary": Remember across conversations is effectively enabled for agent "secondary", but memory search is disabled. Enable memory search or set memory.search.rememberAcrossConversations to false.',
     );
   });
+
+  it("does not warn for secondary key-optional providers when readiness was skipped", async () => {
+    const multiAgentCfg = {
+      agents: { list: [{ id: "agent-default" }, { id: "secondary" }] },
+    } as OpenClawConfig;
+    resolveAgentDir.mockImplementation((_cfg, agentId) => `/tmp/${agentId}`);
+    resolveAgentWorkspaceDir.mockImplementation((_cfg, agentId) => `/tmp/${agentId}/workspace`);
+    resolveMemorySearchConfig.mockReturnValue({ provider: "ollama", local: {}, remote: {} });
+
+    await noteMemorySearchHealth(multiAgentCfg, {
+      ...skippedGatewayOptions,
+      includeWorkspaceMemoryHealth: false,
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
 });
 
 describe("memory recall doctor integration", () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -582,7 +582,10 @@ export async function noteMemorySearchHealth(
       ...opts,
       noteFn,
       includeWorkspaceMemoryHealth: false,
-      gatewayMemoryProbe: scope.agentId === defaultAgentId ? opts?.gatewayMemoryProbe : undefined,
+      gatewayMemoryProbe:
+        scope.agentId === defaultAgentId || opts?.gatewayMemoryProbe?.skipped
+          ? opts?.gatewayMemoryProbe
+          : undefined,
     });
   }
 }


### PR DESCRIPTION
Fixes openclaw/openclaw#127857

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --lint --all` with a multi-agent, key-optional embedding provider such as Ollama would receive false readiness warnings for every non-default agent even though Doctor intentionally skipped the Gateway readiness probe.

## Why This Change Was Made

The existing renderer correctly suppresses warnings for an intentionally skipped probe, but the multi-agent loop only forwarded that probe state to the default agent. This change preserves the state-only `skipped` result across all agent scopes while continuing to restrict real checked Gateway readiness facts to the default agent.

## User Impact

Healthy multi-agent installations no longer appear broken solely because the all-check collector deliberately did not probe embeddings. Real probe failures and timeouts still produce warnings.

## Evidence

- Added a regression test with default and secondary agents using Ollama.
- Confirmed the new test fails on pre-fix `main` with the secondary-agent false warning.
- `pnpm vitest run src/commands/doctor-memory-search.test.ts` — 70 passed.
- `pnpm vitest run src/flows/doctor-health-contributions.test.ts` — 115 passed.
- `./node_modules/.bin/oxfmt --check src/commands/doctor-memory-search.ts src/commands/doctor-memory-search.test.ts` — passed.
- `git diff --check` — passed.
- `pnpm check` reached an unrelated current-main assertion-safety ratchet mismatch: `extensions/discord/src/internal/gateway.ts: 8 < 9`; the touched files were not involved.

### Real multi-agent behavior proof

Executed the PR head (`cebac379013108ebbe709f09848f0c215d5be060`) against a real, valid OpenClaw configuration with 9 agents, including a secondary agent using the key-optional Ollama provider. The command was read-only and the transcript below is reduced to non-sensitive counts and relevant findings.

```text
$ openclaw config validate
Config valid

$ openclaw config get agents.entries | [redacted structural summary]
agentCount=9
secondaryKeyOptionalProvider=ollama

$ pnpm openclaw doctor --lint --all | [redacted relevant-finding summary]
checksRun=60
checksSkipped=0
totalFindings=11
memoryOrEmbeddingReadinessFindings=[]
```

The remaining 11 findings were unrelated operational checks; no memory-search or embedding readiness warning was emitted for the secondary Ollama agent.

AI-assisted: yes. I reviewed the issue, comments, linked historical fix, current source, and the resulting code/test behavior.



### Maintainer exact-head refresh

- Rebased conflict-free onto current `main` at `bbdf7abcff42835c07be4158b7e09226276200a9`; stable patch ID unchanged.
- Controlled regression: the new secondary-agent test fails against current-main production code with the exact false Ollama warning.
- Exact head `3d6da3f342502775f644fb3c8acfa1752e23d825`: 185 focused tests passed; targeted format/lint and `git diff --check` passed.
- Direct nine-agent Doctor collector proof: 9 agents, 0 memory-search readiness findings.
- Max-P1 autoreview: no actionable findings, confidence 0.97.

Punchcard-Session: golden-brook-river-jy
