### PR TITLE
fix(release): retain native prebuilds in git fixtures

### DIFF
--- a/scripts/e2e/lib/doctor-install-switch/scenario.sh
+++ b/scripts/e2e/lib/doctor-install-switch/scenario.sh
@@ -25,7 +25,11 @@ tar -xzf "$package_tgz" -C "$git_root" --strip-components=1
 node scripts/e2e/lib/package-git-fixture.mjs prepare "$git_root"
 (
   cd "$git_root"
-  openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install --omit=optional --no-fund --no-audit >/tmp/openclaw-git-install.log 2>&1
+  # Git-style fixtures still need optional native prebuilds; omit only development dependencies.
+  if ! openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install --omit=dev --no-fund --no-audit >/tmp/openclaw-git-install.log 2>&1; then
+    openclaw_e2e_print_log /tmp/openclaw-git-install.log >&2
+    exit 1
+  fi
   git init -q
   git config user.email "docker-e2e@openclaw.local"
   git config user.name "OpenClaw Docker E2E"

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -61,7 +61,8 @@ node scripts/e2e/lib/package-git-fixture.mjs prepare "$git_root"
 node scripts/e2e/lib/update-channel-switch/assertions.mjs prepare-git-fixture "$git_root"
 (
   cd "$git_root"
-  if ! openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install --omit=optional --no-fund --no-audit >/tmp/openclaw-git-install.log 2>&1; then
+  # Git-style fixtures still need optional native prebuilds; omit only development dependencies.
+  if ! openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install --omit=dev --no-fund --no-audit >/tmp/openclaw-git-install.log 2>&1; then
     openclaw_e2e_print_log /tmp/openclaw-git-install.log >&2
     exit 1
   fi

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2436,7 +2436,7 @@ docker_e2e_docker_run_cmd run demo
       'openclaw_e2e_install_package "$ARTIFACTS/install-a.log" "OpenClaw package under node-A prefix" "$NPM_PREFIX_A"',
     );
     expectTextToIncludeAll(updateChannel, [
-      'openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install --omit=optional --no-fund --no-audit',
+      'openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install --omit=dev --no-fund --no-audit',
       'openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install -g --prefix /tmp/npm-prefix --omit=optional "$pkg_tgz_path"',
       "openclaw_e2e_print_log /tmp/openclaw-git-install.log",
       'openclaw_e2e_print_log "$package_install_log"',
@@ -2444,12 +2444,11 @@ docker_e2e_docker_run_cmd run demo
 
     expect(updateChannel).not.toContain("cat /tmp/openclaw-git-install.log");
     expect(updateChannel).not.toContain('cat "$package_install_log"');
-    expect(doctorSwitch).toContain(
-      'openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install --omit=optional --no-fund --no-audit',
-    );
-    expect(doctorSwitch).toContain(
+    expectTextToIncludeAll(doctorSwitch, [
+      'openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install --omit=dev --no-fund --no-audit',
       'openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install -g --prefix /tmp/npm-prefix --omit=optional "$package_tgz"',
-    );
+      "openclaw_e2e_print_log /tmp/openclaw-git-install.log",
+    ]);
     for (const script of [releaseUpgrade, upgradeSurvivor, pluginCorrupt]) {
       expect(script).toContain(
         'openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm install -g',


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release validation's package-derived git fixtures failed before doctor or update behavior could run when the fixture omitted optional native dependencies.

## Why This Change Was Made

The synthetic git fixtures now omit development dependencies while retaining optional platform prebuilds. This prevents Koffi from falling back to a CMake source build in the minimal Docker image. The doctor fixture also prints its bounded npm-install log on failure, matching the update fixture. AI-assisted.

## User Impact

No runtime behavior changes. Release validation can exercise package-to-git doctor and update switching against the actual package artifact instead of failing during fixture setup.

## Evidence

- Exact beta package artifact reproduced on Linux/amd64 with Node 24.16.0 and npm 11.13.0.
- Before: `npm install --omit=optional` removed the platform Koffi prebuild and failed because CMake was unavailable.
- After: `npm install --omit=dev` retained the prebuild; `require("koffi")` and the packaged CLI version check succeeded.
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts` — 199 passed.
- `bash -n scripts/e2e/lib/doctor-install-switch/scenario.sh scripts/e2e/update-channel-switch-docker.sh`
- Autoreview: clean.
