### PR TITLE
fix(release): tighten beta blocker proof boundaries

### DIFF
--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "9710975f83bb3f66f49e662ea5aea1b7ce2ac119e4e684d4475c760040d73eb1",
-  "generatedAt": "2026-08-23T11:30:05Z",
+  "bindingSha256": "3139f5e3e10dbc93452c120e3029fc6d4a7615cd2fac72b733d9b2c3239d2424",
+  "generatedAt": "2026-08-23T12:15:37Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "1f1d198d12037d74baa8ea0e28fd4b4f4b006f1877443903ede5220f9b0d235a"
+    "candidateDiffSha256": "49f9e17d5685b0ba6fdfb9ec67258325f24c88632c2a096d3b3f27337ac38f8e"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -364,13 +364,17 @@ describe("auth.test boot call", () => {
     let dispatchedContext: Record<string, unknown> | undefined;
     useSlackChannelInboundDispatchOnce(async (params) => {
       dispatchedContext = params.ctxPayload;
+      const deliver = params.delivery?.deliver;
+      if (!deliver) {
+        throw new Error("expected Slack reply delivery callback");
+      }
       const reply = await params.replyResolver?.(
         params.ctxPayload,
         params.replyOptions,
         params.cfg,
       );
       for (const payload of Array.isArray(reply) ? reply : reply ? [reply] : []) {
-        await params.delivery.deliver(payload, { kind: "final" });
+        await deliver(payload, { kind: "final" });
       }
       return {
         admission: { kind: "dispatch" },

--- a/src/agents/auth-profiles/legacy-source-files.ts
+++ b/src/agents/auth-profiles/legacy-source-files.ts
@@ -15,9 +15,9 @@ export type LegacyAuthProfileSource = {
   path: string;
 };
 
-export type LegacyAuthProfileSourceEntryState = "missing" | "present" | "dangling-link";
+type LegacyAuthProfileSourceEntryState = "missing" | "present" | "dangling-link";
 
-export class LegacyAuthProfileSourceInspectionError extends Error {
+class LegacyAuthProfileSourceInspectionError extends Error {
   readonly code = "AUTH_PROFILE_MIGRATION_REQUIRED" as const;
   readonly action = "openclaw doctor --fix" as const;
   readonly sourcePath: string;


### PR DESCRIPTION
## Summary

- keep two auth inspection implementation details private so the production dead-code gate sees the intended surface
- require and narrow the Slack test delivery callback before invoking it
- rebind the Codex 0.149 approval receipt to the exact repaired candidate bytes

## Problem

The frozen beta candidate exposed two internal auth inspection declarations, and the Slack enterprise auth regression called a possibly absent test delivery callback without an explicit assertion. These are static proof blockers, not product behavior changes.

## Scope

Base is frozen candidate `554baf9b33287b212ab3b26303c37080cfeddbf4`. No `main` commits, runtime behavior changes, release mutations, or unrelated cleanup are included.

## Validation

- `git diff --check`
- `pnpm exec oxfmt --check src/agents/auth-profiles/legacy-source-files.ts extensions/slack/src/monitor/provider.auth-test-token.test.ts`
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/provider.auth-test-token.test.ts` — 26/26 passed
- `OPENCLAW_CODEX_REPO=/Users/runner/work/codex-rust-v0.149.0 node scripts/run-vitest.mjs extensions/codex/src/app-server/approval-policy-v0.149.proof.test.ts` — 2/2 passed against clean exact Codex commit `758ef40f50c1a458425c7cfbf1eb12cbc07af0b0`
- Blacksmith Testbox run `32638943408`: `deadcode:full` passed; `tsgo:extensions:test` then exposed the frozen base's pre-existing `extensions/acpx/src/runtime.ts:1658` missing-`promptStarted` fixture error. This PR does not touch the ACP surface.

## Codex Source Contract

Personally verified clean `rust-v0.149.0` commit `758ef40f50c1a458425c7cfbf1eb12cbc07af0b0`:

- `codex-rs/core/src/exec_policy_tests.rs:1010-1053`
- `codex-rs/core/src/exec_policy_tests.rs:1331-1350`
- `codex-rs/core/src/exec_policy_tests.rs:2090-2108`

## Checklist

- [x] exact frozen base
- [x] signed commits
- [x] private-data scrub
- [x] focused and hosted proof complete
- [ ] exact-head reviews and ClawSweeper clean
