### PR TITLE
fix(feishu): report delivered replies when message receipts are missing

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1638,7 +1638,14 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         .deliver({ text }, { kind: "final" })
         .catch((caught: unknown) => caught);
 
-      expect(isChannelPartialDeliveryError(error)).toBe(true);
+      expect(error).toMatchObject({
+        code: "CHANNEL_PARTIAL_DELIVERY",
+        deliveryResult: {
+          content: text,
+          messageIds: [],
+          visibleReplySent: true,
+        },
+      });
       expect(provider).toHaveBeenCalledOnce();
       await Promise.resolve(options.onError?.(error, { kind: "final" }));
       expect(result.getVisibleReplyState().visibleReplySent).toBe(true);
@@ -1647,6 +1654,50 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       if (provider !== sendMessageFeishuMock) {
         expect(sendMessageFeishuMock).not.toHaveBeenCalled();
       }
+    },
+  );
+
+  it.each([
+    { kind: "text", provider: sendMessageFeishuMock, acceptedBeforeReceiptLoss: 0 },
+    { kind: "text", provider: sendMessageFeishuMock, acceptedBeforeReceiptLoss: 1 },
+    { kind: "card", provider: sendStructuredCardFeishuMock, acceptedBeforeReceiptLoss: 0 },
+    { kind: "card", provider: sendStructuredCardFeishuMock, acceptedBeforeReceiptLoss: 1 },
+  ])(
+    "retains accepted $kind chunk content after receipt loss with $acceptedBeforeReceiptLoss prior receipts",
+    async ({ kind, provider, acceptedBeforeReceiptLoss }) => {
+      useNonStreamingAutoAccount();
+      const runtime = getFeishuRuntimeMock();
+      runtime.channel.text.resolveTextChunkLimit.mockReturnValue(6);
+      runtime.channel.text.chunkMarkdownTextWithMode.mockReturnValue(["first", "second", "third"]);
+
+      if (acceptedBeforeReceiptLoss > 0) {
+        provider.mockResolvedValueOnce({ messageId: "om-first" });
+      }
+      provider.mockRejectedValueOnce(
+        createChannelPartialDeliveryError(
+          new Error("Feishu reply failed: no message_id returned"),
+          {
+            messageIds: [],
+            visibleReplySent: true,
+          },
+        ),
+      );
+      const { options } = createDispatcherHarness();
+      const text = kind === "card" ? "| first | second |\n| - | - |" : "firstsecondthird";
+
+      const error = await options
+        .deliver({ text }, { kind: "final" })
+        .catch((caught: unknown) => caught);
+
+      expect(error).toMatchObject({
+        code: "CHANNEL_PARTIAL_DELIVERY",
+        deliveryResult: {
+          content: acceptedBeforeReceiptLoss > 0 ? "firstsecond" : "first",
+          messageIds: acceptedBeforeReceiptLoss > 0 ? ["om-first"] : [],
+          visibleReplySent: true,
+        },
+      });
+      expect(provider).toHaveBeenCalledTimes(acceptedBeforeReceiptLoss + 1);
     },
   );
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -763,18 +763,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         acceptedChunks.push(chunk);
         markVisibleReplySent();
       } catch (error: unknown) {
-        if (isChannelPartialDeliveryError(error)) {
+        const acceptedChunk = isChannelPartialDeliveryError(error)
+          ? error.deliveryResult
+          : undefined;
+        if (acceptedChunk) {
+          acceptedChunks.push(acceptedChunk.content ?? chunk);
           markVisibleReplySent();
         }
-        throw createFeishuPartialReplyDeliveryError(
-          error,
-          createFeishuReplyDeliveryResult({
+        throw createFeishuPartialReplyDeliveryError(error, {
+          ...acceptedChunk,
+          ...createFeishuReplyDeliveryResult({
             results,
-            visibleReplySent: results.length > 0,
+            visibleReplySent: results.length > 0 || acceptedChunk !== undefined,
             content: acceptedChunks.join(""),
             kind: paramsLocal.useCard ? "card" : "text",
           }),
-        );
+        });
       }
     }
     if (paramsLocal.infoKind === "final") {


### PR DESCRIPTION
Related: #128130

## What Problem This Solves

Fixes an issue where users receiving Feishu text replies or interactive cards would see an accepted message while delivery hooks reported the wrong reply content when Feishu acknowledged a chunk without returning its message identifier. On the first chunk, observers could incorrectly report the entire unsent reply; after an earlier successful chunk, observers could omit the newly accepted text.

## Why This Change Was Made

Feishu's own SDK types declare the successful message response and its `message_id` optional. The existing provider-result owner correctly marks a missing identifier as accepted partial delivery, but the private chunked-reply owner discarded the current accepted chunk because it counted only previous receipts. Record the accepted chunk and its actual content at that existing ownership boundary while retaining prior message identifiers, visibility, and the no-duplicate-send invariant across plain text, interactive cards, static streaming fallback, and voice fallback. This preserves the separately landed voice-fallback aggregation in #128130 and changes no public SDK, configuration, security, authentication, protocol, or storage surface. Production delta: +4 lines.

## User Impact

Feishu reply observers now report exactly the content users actually received, even if the first or a later accepted text/card chunk has no provider receipt. Existing accepted message identifiers remain available, and an already-visible reply is never sent again.

## Evidence

- Captured six authentic failing dispatcher-boundary regressions before the repair: ordinary text and cards, plus text/card fanout losing the first or second accepted chunk receipt.
- The same six cases pass after the canonical owner fix, including preserved prior identifiers and suppression of duplicate fallback sends.
- Fresh exact-head owner, sender, streaming, error-release, actual Lark SDK localhost loopback, and core delivery-lifecycle proof: **188 tests passing across seven files and two shards**.
- Direct installed Lark SDK contract inspection independently confirms that a successful create response may omit its delivery identifier:

  ```ts
  create: (...) => Promise<{
    code?: number;
    data?: {
      message_id?: string;
    };
  }>;
  ```

  Source: `@larksuiteoapi/node-sdk/types/index.d.ts`, Feishu IM message `create` declaration. The real SDK localhost loopback also passes in the exact-head Feishu proof above.
- Broader owner/sibling proof before the mechanically identical rebase: **472 passing test executions**; an independent read-only reviewer additionally passed **183 tests** across six Feishu suites.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main` passes after incorporating the already-landed Discord baseline correction; max-lines ratchet, exact-file lint, formatting, and `git diff --check` also pass.
- Authenticated full committed-branch review and a separate independent owner-boundary review both report no actionable findings.
- ClawSweeper independently ran the four focused accepted-chunk regressions successfully (`4 passed | 126 skipped`); its reported observer failure is only a 30-second output-expectation timeout on a run that completed successfully after 32.61 seconds.
- Local whole-workspace extension typechecking encounters existing unrelated ACPX installed-dependency/type mismatches; it reports no Feishu diagnostic. Exact-head hosted CI remains required before landing.
- Reviewed head: `d17923ddb22d68fe4387d2c0f0da4e743807455b`.
