### PR TITLE
fix(agents): stop cancelled compactions before model requests

### DIFF
--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -2,10 +2,16 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { serializeConversation } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { runCompactionPlanningWorker } from "./compaction-planning-worker-runtime.js";
+import * as compactionPlanningWorkerRuntime from "./compaction-planning-worker-runtime.js";
+import {
+  CompactionPlanningWorkerError,
+  runCompactionPlanningWorker,
+} from "./compaction-planning-worker-runtime.js";
 import {
   buildOversizedFallbackPlanWithWorker,
+  buildStageSplitPlanWithWorker,
   buildSummaryChunksWithWorker,
+  computeAdaptiveChunkRatioWithWorker,
 } from "./compaction-planning-worker.js";
 import { estimateMessagesTokens } from "./compaction-planning.js";
 import { runCompactionPlanningWorkerInput } from "./compaction-planning.worker.js";
@@ -25,6 +31,29 @@ function createSyntheticWorkerUrl(source: string): URL {
   // without relying on a bundled build artifact.
   return new URL(`data:text/javascript,${encodeURIComponent(source)}`);
 }
+
+const cancellablePlanningOperations = [
+  {
+    operation: "summary chunks",
+    run: (messages: AgentMessage[], signal: AbortSignal) =>
+      buildSummaryChunksWithWorker({ messages, maxChunkTokens: 1_200, signal }),
+  },
+  {
+    operation: "oversized fallback",
+    run: (messages: AgentMessage[], signal: AbortSignal) =>
+      buildOversizedFallbackPlanWithWorker({ messages, contextWindow: 1_200, signal }),
+  },
+  {
+    operation: "stage splitting",
+    run: (messages: AgentMessage[], signal: AbortSignal) =>
+      buildStageSplitPlanWithWorker({ messages, maxChunkTokens: 1_200, signal }),
+  },
+  {
+    operation: "adaptive chunk sizing",
+    run: (messages: AgentMessage[], signal: AbortSignal) =>
+      computeAdaptiveChunkRatioWithWorker({ messages, contextWindow: 1_200, signal }),
+  },
+];
 
 describe("compaction planning worker", () => {
   let packagedSummaryChunks: Awaited<ReturnType<typeof runCompactionPlanningWorker>>;
@@ -56,6 +85,69 @@ describe("compaction planning worker", () => {
         status: "failed",
         error: "invalid compaction planning worker input",
       });
+    }
+  });
+
+  it.each(
+    cancellablePlanningOperations.flatMap(({ operation, run }) =>
+      [63, 64].map((messageCount) => ({ operation, run, messageCount })),
+    ),
+  )(
+    "honors cancellation for $operation with $messageCount messages",
+    async ({ run, messageCount }) => {
+      const reason = new Error("operator cancelled compaction");
+      const signal = AbortSignal.abort(reason);
+      const messages = Array.from({ length: messageCount }, (_, index) =>
+        makeMessage(index + 1, "active user request"),
+      );
+
+      await expect(run(messages, signal)).rejects.toBe(reason);
+    },
+  );
+
+  it("does not resume cancelled compaction when its worker becomes unavailable", async () => {
+    const controller = new AbortController();
+    const reason = new Error("operator cancelled compaction");
+    const worker = vi
+      .spyOn(compactionPlanningWorkerRuntime, "runCompactionPlanningWorker")
+      .mockImplementationOnce(async () => {
+        controller.abort(reason);
+        throw new CompactionPlanningWorkerError("worker disappeared", "unavailable");
+      });
+
+    try {
+      await expect(
+        buildSummaryChunksWithWorker({
+          messages: Array.from({ length: 64 }, (_, index) => makeMessage(index + 1, "request")),
+          maxChunkTokens: 1_200,
+          signal: controller.signal,
+        }),
+      ).rejects.toBe(reason);
+    } finally {
+      worker.mockRestore();
+    }
+  });
+
+  it("does not restore a worker plan after its compaction has been cancelled", async () => {
+    const controller = new AbortController();
+    const reason = new Error("operator cancelled compaction");
+    const worker = vi
+      .spyOn(compactionPlanningWorkerRuntime, "runCompactionPlanningWorker")
+      .mockImplementationOnce(async () => {
+        controller.abort(reason);
+        return { kind: "summaryChunks", chunkIndexes: [[0]] };
+      });
+
+    try {
+      await expect(
+        buildSummaryChunksWithWorker({
+          messages: Array.from({ length: 64 }, (_, index) => makeMessage(index + 1, "request")),
+          maxChunkTokens: 1_200,
+          signal: controller.signal,
+        }),
+      ).rejects.toBe(reason);
+    } finally {
+      worker.mockRestore();
     }
   });
 

--- a/src/agents/compaction-planning-worker.ts
+++ b/src/agents/compaction-planning-worker.ts
@@ -48,6 +48,7 @@ async function runCompactionPlan<TInput extends CompactionPlanningWorkerInput, T
     messages: AgentMessage[],
   ) => TResult;
 }): Promise<TResult> {
+  params.signal?.throwIfAborted();
   const messages = sanitizeCompactionMessages(params.input.messages);
   if (messages.length < COMPACTION_PLANNING_WORKER_MIN_MESSAGES) {
     return params.fallback(params.input.messages);
@@ -61,6 +62,7 @@ async function runCompactionPlan<TInput extends CompactionPlanningWorkerInput, T
       },
       signal: params.signal,
     });
+    params.signal?.throwIfAborted();
     if (value.kind !== params.input.kind) {
       throw new CompactionPlanningWorkerError(
         "unexpected compaction planning worker result",
@@ -73,6 +75,7 @@ async function runCompactionPlan<TInput extends CompactionPlanningWorkerInput, T
     );
   } catch (error) {
     if (error instanceof CompactionPlanningWorkerError && error.code === "unavailable") {
+      params.signal?.throwIfAborted();
       return params.fallback(messages);
     }
     throw error;

--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -137,14 +137,9 @@ describe("summarizeWithFallback", () => {
     expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(2);
   });
 
-  it("does not retry and propagates AbortError immediately when caller signal is already aborted", async () => {
+  it("does not contact the provider when the caller signal is already aborted", async () => {
     const controller = new AbortController();
     controller.abort();
-
-    const providerAbortErr = Object.assign(new Error("This operation was aborted"), {
-      name: "AbortError",
-    });
-    agentSessionMocks.generateSummary.mockRejectedValueOnce(providerAbortErr);
 
     await expect(
       summarizeWithFallback({
@@ -164,8 +159,7 @@ describe("summarizeWithFallback", () => {
       }),
     ).rejects.toMatchObject({ name: "AbortError" });
 
-    // Caller abort is terminal — no retry, no fallback to placeholder.
-    expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(1);
+    expect(agentSessionMocks.generateSummary).not.toHaveBeenCalled();
   });
 
   it("stops retry backoff promptly when the caller aborts mid-sleep", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users cancelling a conversation compaction would still trigger summarization planning and, for ordinary short histories, contact the model provider after cancellation. Cancellation could also be lost while a planning worker completed or became unavailable.

## Why This Change Was Made

Compaction has one shared planning owner for summary chunks, oversized-message fallback, stage splitting, and adaptive chunk sizing. The worker-backed path already respected cancellation, but the synchronous path used for fewer than 64 messages bypassed that lifecycle check. Validate the original abort signal before planning, after awaited worker completion, and before unavailable-worker fallback so all four operations preserve the exact cancellation reason without changing configuration, storage, provider contracts, or public APIs.

## User Impact

Cancelled compactions stop before making an unnecessary model-provider request. The same cancellation behavior now applies to both short and long histories and to worker completion or failure races.

## Evidence

- Authentic pre-fix regression: six failures across all four 63-message planning operations, the unavailable-worker race, and the completed-worker race; all four existing 64-message cancellation paths already passed.
- Final exact head: `252df2d790beb2907cf95aac81e3b79cd849c9a7`.
- Six focused suites, 83 passing tests across two Vitest shards, including real loopback HTTP abort, partial-summary recovery, identifier preservation, and an existing provider-boundary regression strengthened to require zero model calls after cancellation:

```text
node scripts/run-vitest.mjs src/agents/compaction-planning-worker.test.ts src/agents/compaction.test.ts src/agents/compaction.summarize-fallback.test.ts src/agents/compaction.abort-http.test.ts src/agents/compaction-partial-summary.test.ts src/agents/compaction.identifier-preservation.test.ts
```

- Core production typechecking, owning source-test typechecking, focused typed lint, formatting, max-lines ratchet, and assertion-safety ratchet pass. The combined all-project test-type command also includes an unrelated pre-existing local dependency-install gap for UI-only `@panzoom/panzoom` and `@types/pako`; the owning `src` test-type shard is clean.
- Fresh full committed-branch Codex autoreview: clean. Separate independent reviewer reran the same 83 tests and confirmed the corrected zero-provider-call boundary.
- Production delta: +3 lines, protecting three required lifecycle boundaries; no public API, configuration, persistent-state, protocol, or authentication changes.
- AI-assisted.
