### PR TITLE
fix(media): stop silently skipping attachments with opaque download URLs

### DIFF
--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -116,6 +116,15 @@ describe("resolveCurrentTurnImages", () => {
       imageBytes: PNG_IMAGE_BYTES,
       expectedMime: "image/png",
     },
+    {
+      name: "an opaque image identified by separate filename metadata",
+      fileName: "opaque",
+      originalFileName: "photo.png",
+      contentType: "application/octet-stream",
+      kind: undefined,
+      imageBytes: PNG_IMAGE_BYTES,
+      expectedMime: "image/png",
+    },
   ])("hydrates $name using the verified byte MIME", async (testCase) => {
     await withTestDir({ prefix: "openclaw-current-turn-canonical-kind-" }, async (base) => {
       const imagePath = path.join(base, testCase.fileName);
@@ -127,6 +136,7 @@ describe("resolveCurrentTurnImages", () => {
           media: [
             {
               path: imagePath,
+              ...("originalFileName" in testCase ? { fileName: testCase.originalFileName } : {}),
               contentType: testCase.contentType,
               kind: testCase.kind,
               workspaceDir: base,

--- a/src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts
+++ b/src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts
@@ -25,6 +25,20 @@ describe("persisted media image layout", () => {
     },
     { name: "filename-only TIFF", media: { path: "/tmp/scan.tiff" }, image: true },
     {
+      name: "separate image filename with opaque source",
+      media: {
+        url: "https://cdn.example.test/download/opaque",
+        fileName: "photo.png",
+        contentType: "application/octet-stream",
+      },
+      image: true,
+    },
+    {
+      name: "separate SVG filename with opaque source",
+      media: { url: "https://cdn.example.test/download/opaque", fileName: "diagram.svg" },
+      image: false,
+    },
+    {
       name: "generic-binary TIFF",
       media: { path: "/tmp/scan.tif", contentType: "application/octet-stream" },
       image: true,

--- a/src/auto-reply/reply/inbound-media.test.ts
+++ b/src/auto-reply/reply/inbound-media.test.ts
@@ -50,6 +50,17 @@ describe("hasInboundAudio", () => {
 
   it("does not rederive audio from a media filename", () => {
     expect(hasInboundAudio({ media: [{ path: "/tmp/voice.ogg" }] })).toBe(false);
+    expect(
+      hasInboundAudio({
+        media: [
+          {
+            url: "https://cdn.example.test/download/opaque",
+            fileName: "voice.ogg",
+            contentType: "application/octet-stream",
+          },
+        ],
+      }),
+    ).toBe(false);
   });
 
   it("does not treat non-audio media as audio", () => {

--- a/src/media-understanding/attachments.normalize.test.ts
+++ b/src/media-understanding/attachments.normalize.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeAttachments,
   resolveAttachmentKind,
 } from "./attachments.normalize.js";
+import { selectAttachments } from "./attachments.select.js";
 
 describe("normalizeAttachmentPath", () => {
   it("allows localhost file URLs", () => {
@@ -146,6 +147,66 @@ describe("normalizeAttachments", () => {
       index: 0,
       alreadyTranscribed: false,
     });
+  });
+
+  it.each([
+    { fileName: "photo.png", capability: "image", contentType: "application/octet-stream" },
+    { fileName: "voice.ogg", capability: "audio", contentType: undefined },
+    { fileName: "clip.mp4", capability: "video", contentType: "application/octet-stream" },
+    { fileName: "scan.TIFF", capability: "image", contentType: "binary/octet-stream" },
+  ] as const)(
+    "selects opaque-source $fileName for its $capability provider",
+    ({ fileName, capability, contentType }) => {
+      const attachments = normalizeAttachments({
+        media: [
+          {
+            url: "https://cdn.example.test/download/opaque",
+            fileName,
+            contentType,
+          },
+        ],
+      });
+
+      expect(attachments.map(resolveAttachmentKind)).toEqual([capability]);
+      expect(selectAttachments({ capability, attachments }).selected).toEqual(attachments);
+    },
+  );
+
+  it.each([
+    {
+      name: "filename-only SVG",
+      fact: { fileName: "diagram.svg", contentType: "application/octet-stream" },
+    },
+    {
+      name: "authoritative document kind",
+      fact: { fileName: "photo.png", kind: "document" as const },
+    },
+    {
+      name: "authoritative document MIME",
+      fact: { fileName: "photo.png", contentType: "application/pdf" },
+    },
+  ])("does not select $name for image understanding", ({ fact }) => {
+    const attachments = normalizeAttachments({
+      media: [{ url: "https://cdn.example.test/download/opaque", ...fact }],
+    });
+
+    expect(selectAttachments({ capability: "image", attachments }).selected).toEqual([]);
+  });
+
+  it("prefers the source extension over a conflicting display filename", () => {
+    const attachments = normalizeAttachments({
+      media: [
+        {
+          path: "/tmp/opaque",
+          url: "https://cdn.example.test/download/voice.ogg",
+          fileName: "photo.png",
+          contentType: "application/octet-stream",
+        },
+      ],
+    });
+
+    expect(selectAttachments({ capability: "audio", attachments }).selected).toEqual(attachments);
+    expect(selectAttachments({ capability: "image", attachments }).selected).toEqual([]);
   });
 });
 

--- a/src/media-understanding/attachments.normalize.ts
+++ b/src/media-understanding/attachments.normalize.ts
@@ -9,6 +9,7 @@ import {
   isGenericBinaryMediaContentType,
   isImageMediaFact,
   normalizeMediaFacts,
+  resolveMediaFactKind,
 } from "../media/media-facts.js";
 import type { MediaAttachment } from "./types.js";
 
@@ -44,8 +45,9 @@ export function normalizeAttachments(ctx: MsgContext): MediaAttachment[] {
         index,
         alreadyTranscribed: fact.transcribed === true,
       };
-      if (fact.kind) {
-        attachment.kind = fact.kind;
+      const kind = fact.fileName ? (resolveMediaFactKind(fact) ?? fact.kind) : fact.kind;
+      if (kind) {
+        attachment.kind = kind;
       }
       if (fact.workspaceDir) {
         attachment.workspaceDir = fact.workspaceDir;

--- a/src/media-understanding/audio-preflight.test.ts
+++ b/src/media-understanding/audio-preflight.test.ts
@@ -65,6 +65,27 @@ describe("transcribeFirstAudio", () => {
     },
   );
 
+  it("transcribes an opaque audio source identified by separate filename metadata", async () => {
+    runAudioTranscriptionMock.mockResolvedValueOnce({
+      transcript: "voice note transcript",
+      attachments: [],
+    });
+    const ctx: MsgContext = {
+      Body: "<media:audio>",
+      media: [
+        {
+          url: "https://cdn.example.test/download/opaque",
+          fileName: "voice.ogg",
+          contentType: "application/octet-stream",
+        },
+      ],
+    };
+
+    await expect(transcribeFirstAudio({ ctx, cfg: {} })).resolves.toBe("voice note transcript");
+    expect(runAudioTranscriptionMock).toHaveBeenCalledOnce();
+    expect(ctx.media?.[0]?.transcribed).toBe(true);
+  });
+
   it("skips audio preflight when audio config is explicitly disabled", async () => {
     const transcript = await transcribeFirstAudio({
       ctx: {

--- a/src/media/media-facts.persisted.test.ts
+++ b/src/media/media-facts.persisted.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   canonicalizePersistedUserMessageMedia,
   isImageMediaFact,
+  isVideoMediaFact,
   normalizeMediaFacts,
   PERSISTED_LEGACY_MEDIA_KEYS,
   readPersistedMediaFacts,
@@ -221,6 +222,75 @@ describe("canonical image media facts", () => {
   it.each([
     { name: "filename-only SVG", fact: { path: "/tmp/diagram.svg" }, expected: false },
     {
+      name: "separate image filename with opaque source",
+      fact: {
+        url: "https://cdn.example.test/download/opaque",
+        fileName: "photo.png",
+        contentType: "application/octet-stream",
+      },
+      expected: true,
+    },
+    {
+      name: "separate TIFF filename with opaque source",
+      fact: {
+        url: "https://cdn.example.test/download/opaque",
+        fileName: "scan.TIFF",
+        contentType: "binary/octet-stream",
+      },
+      expected: true,
+    },
+    {
+      name: "separate SVG filename with opaque source",
+      fact: {
+        url: "https://cdn.example.test/download/opaque",
+        fileName: "diagram.svg",
+      },
+      expected: false,
+    },
+    {
+      name: "authoritative document with separate image filename",
+      fact: {
+        url: "https://cdn.example.test/download/opaque",
+        fileName: "photo.png",
+        contentType: "application/octet-stream",
+        kind: "document" as const,
+      },
+      expected: false,
+    },
+    {
+      name: "concrete document MIME with separate image filename",
+      fact: {
+        url: "https://cdn.example.test/download/opaque",
+        fileName: "photo.png",
+        contentType: "application/pdf",
+      },
+      expected: false,
+    },
+    {
+      name: "classified source before conflicting separate image filename",
+      fact: {
+        url: "https://cdn.example.test/download/voice.ogg",
+        fileName: "photo.png",
+        contentType: "application/octet-stream",
+      },
+      expected: false,
+    },
+    {
+      name: "classified URL before conflicting separate filename and opaque path",
+      fact: {
+        path: "/tmp/opaque",
+        url: "https://cdn.example.test/download/voice.ogg",
+        fileName: "photo.png",
+        contentType: "application/octet-stream",
+      },
+      expected: false,
+    },
+    {
+      name: "separate filename without an actual media source",
+      fact: { fileName: "photo.png", contentType: "application/octet-stream" },
+      expected: false,
+    },
+    {
       name: "unknown-kind SVG with generic MIME",
       fact: {
         path: "/tmp/diagram.svg",
@@ -277,6 +347,16 @@ describe("canonical image media facts", () => {
     },
   ])("classifies $name at the shared image-fact owner", ({ fact, expected }) => {
     expect(isImageMediaFact(fact)).toBe(expected);
+  });
+
+  it("classifies video from separate filename metadata when its source is opaque", () => {
+    expect(
+      isVideoMediaFact({
+        url: "https://cdn.example.test/download/opaque",
+        fileName: "clip.mp4",
+        contentType: "application/octet-stream",
+      }),
+    ).toBe(true);
   });
 
   it("preserves generic binary provenance without inventing authoritative documents", () => {

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -290,7 +290,8 @@ export function isGenericBinaryMediaContentType(contentType?: string | null): bo
   );
 }
 
-function classifyMediaFact(fact: MediaFactInput): MediaKind | undefined {
+/** Resolves attachment kind from authoritative facts before source or filename hints. */
+export function resolveMediaFactKind(fact: MediaFactInput): MediaKind | undefined {
   if (fact.kind && fact.kind !== "unknown") {
     return fact.kind;
   }
@@ -305,7 +306,19 @@ function classifyMediaFact(fact: MediaFactInput): MediaKind | undefined {
       ? (normalizedContentType as MediaKind)
       : undefined;
   }
-  const pathValue = normalizeOptionalString(fact.path) ?? normalizeOptionalString(fact.url);
+  const source = normalizeOptionalString(fact.path) ?? normalizeOptionalString(fact.url);
+  if (!source) {
+    return undefined;
+  }
+  const pathValue =
+    [fact.path, fact.url, fact.fileName].find((candidate) => {
+      const extension = getFileExtension(candidate);
+      return (
+        mimeTypeFromFilePath(candidate) !== undefined ||
+        extension === ".tif" ||
+        extension === ".tiff"
+      );
+    }) ?? source;
   const inferredMime = mimeTypeFromFilePath(pathValue);
   if (inferredMime === "image/svg+xml") {
     return undefined;
@@ -320,13 +333,13 @@ function classifyMediaFact(fact: MediaFactInput): MediaKind | undefined {
 
 /** Returns whether a fact can produce native image input. */
 export function isImageMediaFact(fact: MediaFactInput): boolean {
-  const kind = classifyMediaFact(fact);
+  const kind = resolveMediaFactKind(fact);
   return kind === "image" || kind === "sticker";
 }
 
 /** Returns whether a fact can produce native video input. */
 export function isVideoMediaFact(fact: MediaFactInput): boolean {
-  return classifyMediaFact(fact) === "video";
+  return resolveMediaFactKind(fact) === "video";
 }
 
 type MediaFactDefaults<TInput extends MediaFactInput = MediaFactInput> = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending images, voice notes, videos, or TIFF scans would have their attachments silently ignored when a channel supplied an opaque download URL or generic MIME type and stored the recognizable filename separately.

## Why This Change Was Made

The shared media-fact owner now derives an attachment's kind from its existing filename metadata only after honoring its explicit kind, concrete MIME type, and recognizable source path or URL. The media-understanding projection carries that derived fact into existing provider selection without expanding public attachment types or changing inbound-audio detection.

## User Impact

Photos, audio messages, videos, and TIFF scans with extensionless download URLs are understood and delivered to the correct existing provider instead of disappearing silently. Explicit documents, conflicting authoritative metadata, and filename-inferred SVGs retain their existing behavior.

## Evidence

- Before the fix, seven focused owner/provider assertions failed: opaque photo, TIFF, and video classification plus real image, audio, video, and TIFF attachment selection.
- After the fix and cached-main refresh, all eight affected owner/sibling suites pass: **162 tests across three Vitest shards**.
- Real existing boundaries cover native PNG prompt hydration, persisted image layout, image/audio/video provider selection, audio transcription preflight, TIFF support, SVG exclusion, explicit document/MIME/source precedence, and unchanged filename-only inbound-audio detection.
- Independent review separately reran the affected production matrix and **162 targeted assertions**, including embedded persisted PNG/SVG/TIFF replay.
- Core production typecheck, targeted oxlint, formatting, media-download guard, and assertion-safety ratchet all pass on the exact committed head.
- Full core-test typechecking encounters only pre-existing unrelated shared dependency gaps for `@panzoom/panzoom` and `pako` declarations; there are no diagnostics in changed files.
- Production delta: **+21/-6 (net +15)** for the shared internal classification owner and private projection; regression tests: **+197/-0**. No public type, configuration, storage, security, or provider API changes.
