### PR TITLE
fix(tui): recover assistant responses after reconnecting to replacement runs

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -3754,6 +3754,38 @@ describe("tui-event-handlers: streaming watchdog", () => {
     handlers.dispose?.();
   });
 
+  it.each([
+    { description: "replaces the previous run", previousRunId: "run-before-reconnect" },
+    { description: "appears after an idle disconnect", previousRunId: null },
+  ])("rearms reconnect recovery when authoritative history $description", ({ previousRunId }) => {
+    const { state, setActivityStatus, loadHistory, handlers } = createHarness({
+      streamingWatchdogMs: 5_000,
+    });
+
+    if (previousRunId) {
+      handlers.handleChatEvent({
+        runId: previousRunId,
+        message: { content: "previous reply" },
+      });
+    }
+    handlers.pauseStreamingWatchdog();
+    handlers.reconnectStreamingWatchdog();
+
+    state.activeChatRunId = "run-after-reconnect";
+    handlers.reconnectStreamingWatchdog({
+      state: "active",
+      runId: "run-after-reconnect",
+    });
+
+    vi.advanceTimersByTime(5_001);
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+
+    handlers.dispose?.();
+  });
+
   it("reloads history only once when reconnect recovery and deferred history refresh overlap", () => {
     const { loadHistory, noteLocalRunId, handlers } = createHarness({
       streamingWatchdogMs: 5_000,

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -248,9 +248,9 @@ describe.sequential("TUI PTY harness", () => {
   );
 
   it(
-    "reconciles active and terminal runs after reconnect history",
-    () => exerciseTuiReconnectOutcomes(STARTUP_TIMEOUT_MS),
-    STARTUP_TEST_TIMEOUT_MS,
+    "reconciles active, replacement, and terminal runs after reconnect history",
+    () => exerciseTuiReconnectOutcomes(35_000),
+    45_000,
   );
 
   it.each([{ failures: 1 }, { failures: 2 }, { failures: 3 }, { failures: 4 }])(

--- a/src/tui/tui-pty-reconnect-fixture-test-support.ts
+++ b/src/tui/tui-pty-reconnect-fixture-test-support.ts
@@ -3,11 +3,13 @@ export const TUI_PTY_RECONNECT_FIXTURE = {
   variables: `
       const disconnectReason = process.env.OPENCLAW_TUI_PTY_DISCONNECT_REASON;
       const reconnectOutcome = process.env.OPENCLAW_TUI_PTY_RECONNECT_OUTCOME;
+      const replacementReconnect = reconnectOutcome === "replacement" || reconnectOutcome === "appeared";
       let disconnectPending = disconnectReason === undefined
         ? 0
         : Number(process.env.OPENCLAW_TUI_PTY_DISCONNECT_COUNT ?? 1);
       let reconnectHistoryReady = false;
       let reconnectRunId = "run-reconnect-fixture";
+      let replacementReconnectHistoryLoads = 0;
   `,
   disconnect: `
         emitDisconnect() {
@@ -47,6 +49,18 @@ export const TUI_PTY_RECONNECT_FIXTURE = {
   `,
   loadHistory: `
           if (reconnectHistoryReady && reconnectOutcome) {
+            if (replacementReconnect) {
+              replacementReconnectHistoryLoads += 1;
+              record("replacementReconnectHistory", {
+                attempt: replacementReconnectHistoryLoads,
+              });
+              if (replacementReconnectHistoryLoads > 1) {
+                return {
+                  sessionInfo: { ...sessionEntry(sessionKey), status: "done" },
+                  messages: [{ role: "assistant", content: "PTY_RECONNECT_RECOVERED" }],
+                };
+              }
+            }
             const sessionInfo = {
               ...sessionEntry(sessionKey),
               ...(reconnectOutcome === "interrupted"
@@ -60,8 +74,15 @@ export const TUI_PTY_RECONNECT_FIXTURE = {
               messages: reconnectOutcome === "completed"
                 ? [{ role: "assistant", content: "PTY_RECONNECT_COMPLETED" }]
                 : [],
-              ...(reconnectOutcome === "active"
-                ? { inFlightRun: { runId: reconnectRunId, text: "PTY_RECONNECT_PARTIAL" } }
+              ...(reconnectOutcome === "active" || replacementReconnect
+                ? {
+                    inFlightRun: {
+                      runId: replacementReconnect ? "run-reconnect-replacement" : reconnectRunId,
+                      text: replacementReconnect
+                        ? "PTY_RECONNECT_REPLACEMENT"
+                        : "PTY_RECONNECT_PARTIAL",
+                    },
+                  }
                 : {}),
             };
           }

--- a/src/tui/tui-pty-reconnect-test-support.ts
+++ b/src/tui/tui-pty-reconnect-test-support.ts
@@ -13,8 +13,8 @@ const RECONNECT_CASES = [
 ] as const;
 
 export async function exerciseTuiReconnectOutcomes(timeoutMs: number): Promise<void> {
-  await Promise.all(
-    RECONNECT_CASES.map(async ({ outcome, marker, activity }) => {
+  await Promise.all([
+    ...RECONNECT_CASES.map(async ({ outcome, marker, activity }) => {
       const fixture = await startTuiFixture({
         env: {
           OPENCLAW_TUI_PTY_DISCONNECT_REASON: "fixture transport loss",
@@ -42,6 +42,40 @@ export async function exerciseTuiReconnectOutcomes(timeoutMs: number): Promise<v
         );
         expect(frame.join("\n")).not.toContain("PTY_LATE_RECONNECT_FINAL");
         expect(frame.join("\n").includes("run aborted")).toBe(outcome === "interrupted");
+      } finally {
+        await fixture.cleanup();
+      }
+    }),
+    exerciseTuiReplacementReconnectRecovery(timeoutMs),
+  ]);
+}
+
+async function exerciseTuiReplacementReconnectRecovery(timeoutMs: number): Promise<void> {
+  await Promise.all(
+    ["replacement", "appeared"].map(async (outcome) => {
+      const fixture = await startTuiFixture({
+        env: {
+          OPENCLAW_TUI_PTY_DISCONNECT_REASON: "fixture transport loss",
+          OPENCLAW_TUI_PTY_RECONNECT_OUTCOME: outcome,
+        },
+      });
+      try {
+        await fixture.run.waitForOutput("local ready", timeoutMs);
+        if (outcome === "replacement") {
+          await fixture.run.write("reconnect terminal proof\r", { delay: false });
+          await fixture.run.waitForOutput("PTY_RECONNECT_PARTIAL", timeoutMs);
+        }
+        await fixture.run.write("/gateway-status\r", { delay: false });
+        await fixture.run.waitForOutput("gateway reconnected after transport loss", timeoutMs);
+        await fixture.run.waitForOutput("PTY_RECONNECT_REPLACEMENT", timeoutMs);
+        await fixture.run.waitForOutput("PTY_RECONNECT_RECOVERED", timeoutMs);
+
+        const frame = await waitForSynchronizedFrameRows(
+          fixture.run,
+          (rows) => rows.some((row) => row.includes("PTY_RECONNECT_RECOVERED")),
+          timeoutMs,
+        );
+        expect(frame.join("\n")).not.toContain("PTY_RECONNECT_REPLACEMENT");
       } finally {
         await fixture.cleanup();
       }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1446,7 +1446,11 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     const activeRunAtStart = state.activeChatRunId;
     const result = await loadHistorySnapshot();
     if (result.loaded) {
-      if (reconcileReconnect && activeRunAtStart && activeRunAtStart === state.activeChatRunId) {
+      // History can adopt a newer run before returning; terminal outcomes
+      // still belong only to the unchanged run captured before the request.
+      const recoveredRunId =
+        result.runOutcome.state === "active" ? result.runOutcome.runId : activeRunAtStart;
+      if (reconcileReconnect && recoveredRunId && recoveredRunId === state.activeChatRunId) {
         reconcileReconnectRun(result.runOutcome);
       }
       restoreConnectionNotices();


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users reconnecting the terminal interface would see a replacement or newly started assistant run remain stuck at `streaming` indefinitely when that run appeared while the Gateway connection was interrupted.

## Why This Change Was Made

Reconnect history is the authoritative owner of the current in-flight run, but the reconnect coordinator only reconciled runs whose identifier still matched the run captured before loading that history. When history adopted a replacement run, or discovered a run after an idle disconnect, the old watchdog stayed attached to the obsolete run and silently exited without recovering the visible conversation.

The reconnect owner now reconciles the active run reported by authoritative history while retaining the original owner check for terminal outcomes. Existing session/connection-generation guards, failed or unloaded history handling, and unchanged-run behavior remain intact; no protocol, auth, configuration, storage, timeout, or public API contracts change. Production growth is two executable lines plus two required invariant-comment lines.

## User Impact

After reconnecting, terminal users recover the current assistant response even when the Gateway replaced the previous run or started one while the terminal was disconnected. Existing completed, interrupted, and failed-run outcomes continue to render normally.

## Evidence

- Genuine real-terminal PTY regression before the fix: replacement run remains at `streaming` and times out after approximately 37 seconds waiting for `PTY_RECONNECT_RECOVERED`.
- The identical real-terminal flow passes after the fix in approximately 33 seconds using the unmodified production 30-second watchdog. One focused PTY scenario concurrently covers unchanged active, replacement active, newly appeared active, interrupted, failed, and completed reconnect outcomes.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-tui-reconnect-vitest-cache-20260823 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts --configLoader runner src/tui/tui-event-handlers.test.ts src/tui/tui-session-actions.test.ts src/tui/tui-session-run-coordinator.test.ts src/tui/tui.test.ts` — 342 tests across four owner-boundary suites pass.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-tui-reconnect-vitest-cache-20260823 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner src/tui/tui-pty-harness.e2e.test.ts -t 'reconciles active, replacement, and terminal runs after reconnect history'` — real PTY reconnect flow passes.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile /private/tmp/openclaw-tui-reconnect-core-20260823.tsbuildinfo` — production types pass.
- `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.plugins-platform.json --builders 1` — the actual TUI test-type shard passes.
- Focused formatting, lint, mandatory assertion-safety ratchet, independent code review, and authenticated committed-diff review all pass.
