### PR TITLE
fix(gateway): unhealthy channels appear ready after clock rollback

### DIFF
--- a/src/gateway/channel-health-monitor.clock-rollback.test.ts
+++ b/src/gateway/channel-health-monitor.clock-rollback.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
+import { startChannelHealthMonitor } from "./channel-health-monitor.js";
+import type { ChannelManager } from "./server-channels.js";
+
+const STARTED_AT = 1_000_000;
+const CHECK_INTERVAL_MS = 1_000;
+
+function createChannelManager(running: boolean) {
+  const account: ChannelAccountSnapshot = {
+    accountId: "default",
+    running,
+    connected: running,
+    enabled: true,
+    configured: true,
+  };
+  const snapshot = {
+    channels: { discord: account },
+    channelAccounts: { discord: { default: account } },
+  };
+  const manager: ChannelManager = {
+    getRuntimeSnapshot: vi.fn(() => snapshot),
+    getPluginCommandCatalogAccounts: vi.fn(() => new Map()),
+    startChannels: vi.fn(async () => {}),
+    startChannel: vi.fn(async () => {}),
+    stopChannel: vi.fn(async () => {}),
+    setAutostartSuppression: vi.fn(),
+    getAutostartSuppression: vi.fn(() => null),
+    recoverAutostartSuppression: vi.fn(async () => false),
+    setAmbientAutostartSuppressedChannelIds: vi.fn(),
+    isAmbientAutostartSuppressed: vi.fn(() => false),
+    markChannelLoggedOut: vi.fn(),
+    isHealthMonitorEnabled: vi.fn(() => true),
+    isManuallyStopped: vi.fn(() => false),
+    isAutoRestartScheduled: vi.fn(() => false),
+    resetRestartAttempts: vi.fn(),
+  };
+  return { account, manager };
+}
+
+describe("channel-health-monitor clock rollback", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(STARTED_AT);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not trap an existing monitor in startup grace after clock rollback", async () => {
+    const { manager } = createChannelManager(false);
+    const monitor = startChannelHealthMonitor({
+      channelManager: manager,
+      checkIntervalMs: CHECK_INTERVAL_MS,
+      timing: { monitorStartupGraceMs: CHECK_INTERVAL_MS },
+    });
+
+    vi.setSystemTime(STARTED_AT - 60_000);
+    await vi.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
+
+    expect(manager.startChannel).toHaveBeenCalledWith("discord", "default");
+    monitor.stop();
+  });
+
+  it.each([
+    { name: "restart cooldown", maxRestartsPerHour: 10 },
+    { name: "hourly restart budget", maxRestartsPerHour: 1 },
+  ])("discards future $name from an existing monitor", async ({ maxRestartsPerHour }) => {
+    const { account, manager } = createChannelManager(true);
+    const monitor = startChannelHealthMonitor({
+      channelManager: manager,
+      checkIntervalMs: CHECK_INTERVAL_MS,
+      cooldownCycles: 0,
+      maxRestartsPerHour,
+      timing: { monitorStartupGraceMs: 0 },
+    });
+
+    await vi.advanceTimersByTimeAsync(5 * CHECK_INTERVAL_MS);
+    account.running = false;
+    account.connected = false;
+    await vi.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(STARTED_AT + 3 * CHECK_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(CHECK_INTERVAL_MS);
+
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+    monitor.stop();
+  });
+});

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -521,13 +521,14 @@ describe("channel-health-monitor", () => {
     await expectNoRestart(manager);
   });
 
-  it("restarts a disconnected starting channel dated after the current clock", async () => {
+  it.each([false, true])("restarts stale future channels (connected: %s)", async (connected) => {
     const now = Date.now();
-    const manager = createSnapshotManager({
-      discord: {
-        default: disconnectedAccount(now + 60_000, { lifecycle: "starting" }),
-      },
+    const account = disconnectedAccount(now + 60_000, {
+      connected,
+      lifecycle: connected ? "ready" : "starting",
+      lastTransportActivityAt: connected ? now - 300_000 : undefined,
     });
+    const manager = createSnapshotManager({ discord: { default: account } });
 
     await expectRestartedChannel(manager, "discord");
   });

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -521,6 +521,17 @@ describe("channel-health-monitor", () => {
     await expectNoRestart(manager);
   });
 
+  it("restarts a disconnected starting channel dated after the current clock", async () => {
+    const now = Date.now();
+    const manager = createSnapshotManager({
+      discord: {
+        default: disconnectedAccount(now + 60_000, { lifecycle: "starting" }),
+      },
+    });
+
+    await expectRestartedChannel(manager, "discord");
+  });
+
   it("does not restart a long-running channel during fresh reconnect grace", async () => {
     const now = Date.now();
     const manager = createSlackSnapshotManager(

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -1,4 +1,7 @@
-import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  isFutureDateTimestampMs,
+  resolveTimerTimeoutMs,
+} from "@openclaw/normalization-core/number-coercion";
 // Gateway channel health monitor.
 // Periodically evaluates channel account health and restarts stale runtimes.
 import type { ChannelId } from "../channels/plugins/types.public.js";
@@ -90,13 +93,18 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
   const rKey = (channelId: string, accountId: string) => `${channelId}:${accountId}`;
 
   function pruneOldRestarts(record: RestartRecord, now: number) {
-    record.restartsThisHour = record.restartsThisHour.filter((r) => now - r.at < ONE_HOUR_MS);
+    record.restartsThisHour = record.restartsThisHour.filter(
+      (r) => !isFutureDateTimestampMs(r.at, { nowMs: now }) && now - r.at < ONE_HOUR_MS,
+    );
   }
 
   async function runCheckWork() {
     try {
       const now = Date.now();
-      if (now - startedAt < timing.monitorStartupGraceMs) {
+      if (
+        !isFutureDateTimestampMs(startedAt, { nowMs: now }) &&
+        now - startedAt < timing.monitorStartupGraceMs
+      ) {
         return;
       }
 
@@ -188,7 +196,11 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           const continuingPendingRestart =
             pendingRestartState && record.pendingContinuationUsed !== true;
 
-          if (!continuingPendingRestart && now - record.lastRestartAt <= cooldownMs) {
+          if (
+            !continuingPendingRestart &&
+            !isFutureDateTimestampMs(record.lastRestartAt, { nowMs: now }) &&
+            now - record.lastRestartAt <= cooldownMs
+          ) {
             continue;
           }
 

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -116,6 +116,52 @@ describe("evaluateChannelHealth", () => {
     });
   });
 
+  it.each([
+    {
+      name: "starting lifecycle",
+      account: runningAccount({ connected: false, lifecycle: "starting", lastStartAt: 101_000 }),
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "recovering lifecycle",
+      account: runningAccount({ connected: false, lifecycle: "recovering", lastStartAt: 101_000 }),
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "unrecorded lifecycle",
+      account: runningAccount({ connected: false, lastStartAt: 101_000 }),
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "disconnected active run",
+      account: activeRunAccount(101_000, { lastStartAt: 0, activeRunStartedAt: 101_000 }),
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "activity inherited before a future lifecycle",
+      account: runningAccount({
+        connected: false,
+        lifecycle: "starting",
+        lastStartAt: 101_000,
+        busy: true,
+        lastRunActivityAt: 99_000,
+      }),
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "disconnect inherited before a future lifecycle",
+      account: runningAccount({
+        connected: false,
+        lifecycle: "recovering",
+        lastStartAt: 101_000,
+        lastDisconnect: { at: 99_000, error: "socket closed" },
+      }),
+      expected: { healthy: false, reason: "disconnected" },
+    },
+  ])("does not trust future activity for $name", ({ account, expected }) => {
+    expect(evaluateHealth(account)).toEqual(expected);
+  });
+
   it("lets recorded ready bypass wall-clock startup grace", () => {
     expect(
       evaluateHealth(runningAccount({ connected: false, lifecycle: "ready", lastStartAt: 99_999 })),
@@ -151,6 +197,12 @@ describe("evaluateChannelHealth", () => {
       name: "ignores a disconnect from the previous lifecycle",
       lastStartAt: 80_000,
       lastDisconnect: { at: 79_000, error: "socket closed" },
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "ignores a disconnect dated after the current clock",
+      lastStartAt: 0,
+      lastDisconnect: { at: 101_000, error: "socket closed" },
       expected: { healthy: false, reason: "disconnected" },
     },
   ] as const)("$name", ({ lastStartAt, lastDisconnect, expected }) => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -158,6 +158,15 @@ describe("evaluateChannelHealth", () => {
       }),
       expected: { healthy: false, reason: "disconnected" },
     },
+    {
+      name: "stale transport inherited before a future lifecycle",
+      account: connectedAccount({
+        lifecycle: "ready",
+        lastStartAt: 101_000,
+        lastTransportActivityAt: 0,
+      }),
+      expected: { healthy: false, reason: "stale-socket" },
+    },
   ])("does not trust future activity for $name", ({ account, expected }) => {
     expect(evaluateHealth(account)).toEqual(expected);
   });

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -1,5 +1,6 @@
 // Gateway channel health policy.
 // Evaluates channel lifecycle snapshots for restart/readiness decisions.
+import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import type { ChannelAccountSnapshot, ChannelId } from "../channels/plugins/types.public.js";
 
 type ChannelHealthSnapshot = {
@@ -75,6 +76,14 @@ function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
   return snapshot.enabled !== false && snapshot.configured !== false && snapshot.linked !== false;
 }
 
+function resolveObservedChannelTimestamp(value: unknown, now: number): number | null {
+  return typeof value === "number" &&
+    Number.isFinite(value) &&
+    !isFutureDateTimestampMs(value, { nowMs: now })
+    ? value
+    : null;
+}
+
 const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;
 const CHANNEL_RECONNECT_GRACE_MS = 120_000;
 // Keep these shared between the background health monitor and on-demand readiness
@@ -108,11 +117,13 @@ export function evaluateChannelHealth(
     typeof snapshot.lastStartAt === "number" && Number.isFinite(snapshot.lastStartAt)
       ? snapshot.lastStartAt
       : null;
+  const currentLifecycleStarted =
+    lastStartAt !== null && !isFutureDateTimestampMs(lastStartAt, { nowMs: policy.now });
   // Trust recorded starting/recovering only inside connect grace. Without a timestamp or after
   // the window, no progress is indistinguishable from a hang, so inference keeps restart authority.
   if (
     (snapshot.lifecycle === "starting" || snapshot.lifecycle === "recovering") &&
-    lastStartAt != null &&
+    currentLifecycleStarted &&
     policy.now - lastStartAt < policy.channelConnectGraceMs
   ) {
     return { healthy: true, reason: "startup-connect-grace" };
@@ -128,19 +139,15 @@ export function evaluateChannelHealth(
       ? Math.max(0, Math.trunc(snapshot.activeRuns))
       : 0;
   const isBusy = snapshot.busy === true || activeRuns > 0;
-  const lastRunActivityAt =
-    typeof snapshot.lastRunActivityAt === "number" && Number.isFinite(snapshot.lastRunActivityAt)
-      ? snapshot.lastRunActivityAt
-      : null;
-  const activeRunStartedAt =
-    typeof snapshot.activeRunStartedAt === "number" && Number.isFinite(snapshot.activeRunStartedAt)
-      ? snapshot.activeRunStartedAt
-      : null;
-  const lastTransportActivityAt =
-    typeof snapshot.lastTransportActivityAt === "number" &&
-    Number.isFinite(snapshot.lastTransportActivityAt)
-      ? snapshot.lastTransportActivityAt
-      : null;
+  const lastRunActivityAt = resolveObservedChannelTimestamp(snapshot.lastRunActivityAt, policy.now);
+  const activeRunStartedAt = resolveObservedChannelTimestamp(
+    snapshot.activeRunStartedAt,
+    policy.now,
+  );
+  const lastTransportActivityAt = resolveObservedChannelTimestamp(
+    snapshot.lastTransportActivityAt,
+    policy.now,
+  );
   const busyStateInitializedForLifecycle =
     lastStartAt == null || (lastRunActivityAt != null && lastRunActivityAt >= lastStartAt);
 
@@ -166,7 +173,7 @@ export function evaluateChannelHealth(
       return { healthy: false, reason: "stuck" };
     }
   }
-  if (snapshot.lifecycle === undefined && lastStartAt != null) {
+  if (snapshot.lifecycle === undefined && currentLifecycleStarted) {
     const upDuration = policy.now - lastStartAt;
     if (upDuration < policy.channelConnectGraceMs) {
       return { healthy: true, reason: "startup-connect-grace" };
@@ -174,10 +181,8 @@ export function evaluateChannelHealth(
   }
   if (snapshot.connected === false) {
     const lastDisconnectAt =
-      snapshot.lastDisconnect &&
-      typeof snapshot.lastDisconnect !== "string" &&
-      Number.isFinite(snapshot.lastDisconnect.at)
-        ? snapshot.lastDisconnect.at
+      snapshot.lastDisconnect && typeof snapshot.lastDisconnect !== "string"
+        ? resolveObservedChannelTimestamp(snapshot.lastDisconnect.at, policy.now)
         : null;
     // A disconnect is current only when its producer recorded it inside this
     // account lifecycle; patch-merged timestamps from prior runs grant no grace.

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -201,8 +201,7 @@ export function evaluateChannelHealth(
   const shouldCheckStaleSocket = snapshot.connected === true && lastTransportActivityAt != null;
   if (shouldCheckStaleSocket) {
     if (lastStartAt != null && lastTransportActivityAt < lastStartAt) {
-      const lifecycleEventGap = Math.max(0, policy.now - lastStartAt);
-      if (lifecycleEventGap <= policy.staleEventThresholdMs) {
+      if (currentLifecycleStarted && policy.now - lastStartAt <= policy.staleEventThresholdMs) {
         return { healthy: true, reason: "healthy" };
       }
       return { healthy: false, reason: "stale-socket" };

--- a/src/gateway/server-http.probe.clock-rollback.test.ts
+++ b/src/gateway/server-http.probe.clock-rollback.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChannelManager } from "./server-channels.js";
+import {
+  AUTH_NONE,
+  createRequest,
+  createResponse,
+  dispatchRequest,
+  withGatewayServer,
+} from "./server-http.test-harness.js";
+import { createReadinessChecker } from "./server/readiness.js";
+
+describe("Gateway readiness probe clock rollback", () => {
+  it.each([
+    { name: "stopped", lifecycle: "stopped", running: false },
+    { name: "starting", lifecycle: "starting", running: true },
+    { name: "recovering", lifecycle: "recovering", running: true },
+    { name: "unrecorded", lifecycle: undefined, running: true },
+  ] as const)("returns 503 for a $name channel after the clock moves backward", async (state) => {
+    let now = Date.now();
+    const startedAt = now - 300_000;
+    const account = {
+      accountId: "default",
+      running: true,
+      connected: true,
+      enabled: true,
+      configured: true,
+      lifecycle: "ready" as "ready" | "stopped" | "starting" | "recovering" | undefined,
+      lastStartAt: startedAt,
+    };
+    const channelManager = {
+      getRuntimeSnapshot: vi.fn(() => ({
+        channels: { discord: account },
+        channelAccounts: { discord: { default: account } },
+      })),
+      getAutostartSuppression: () => null,
+      isAmbientAutostartSuppressed: () => false,
+    } as unknown as ChannelManager;
+    const getReadiness = createReadinessChecker({ channelManager, startedAt, cacheTtlMs: 1_000 });
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    try {
+      await withGatewayServer({
+        prefix: "probe-clock-rollback-stopped-channel",
+        resolvedAuth: AUTH_NONE,
+        overrides: { getReadiness },
+        run: async (server) => {
+          const healthy = createResponse();
+          await dispatchRequest(server, createRequest({ path: "/readyz" }), healthy.res);
+          expect(healthy.res.statusCode).toBe(200);
+
+          account.running = state.running;
+          account.connected = false;
+          account.lifecycle = state.lifecycle;
+          account.lastStartAt = now;
+          now -= 60_000;
+
+          const stopped = createResponse();
+          await dispatchRequest(server, createRequest({ path: "/readyz" }), stopped.res);
+          expect(stopped.res.statusCode).toBe(503);
+          expect(JSON.parse(stopped.getBody())).toMatchObject({
+            ready: false,
+            failing: ["discord"],
+          });
+          expect(channelManager.getRuntimeSnapshot).toHaveBeenCalledTimes(2);
+        },
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+});

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -1,5 +1,6 @@
 // Health gateway methods return cached or refreshed status summaries while
 // detecting stale channel runtime state against live gateway snapshots.
+import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import { getStatusSummary } from "../../status/summary.js";
@@ -24,7 +25,11 @@ function shouldScheduleRequestRefresh(
   now: number,
 ): boolean {
   const startedAt = requestRefreshStartedAt.get(refresh);
-  if (startedAt !== undefined && now - startedAt < HEALTH_REFRESH_INTERVAL_MS) {
+  if (
+    startedAt !== undefined &&
+    !isFutureDateTimestampMs(startedAt, { nowMs: now }) &&
+    now - startedAt < HEALTH_REFRESH_INTERVAL_MS
+  ) {
     return false;
   }
   // Scope the throttle to the Gateway refresh owner so independent servers do
@@ -147,6 +152,7 @@ export const healthHandlers: GatewayRequestHandlers = {
       !wantsProbe &&
       cached &&
       !cachedDiffersFromRuntime &&
+      !isFutureDateTimestampMs(cached.ts, { nowMs: now }) &&
       now - cached.ts < HEALTH_REFRESH_INTERVAL_MS
     ) {
       respond(

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4551,6 +4551,33 @@ describe("gateway healthHandlers.health cache freshness", () => {
     expect(refreshHealthSnapshot).toHaveBeenCalledTimes(2);
   });
 
+  it("refreshes a cached health snapshot dated after the current clock", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T12:00:00Z"));
+    const cached = createHealthSnapshot({ ts: Date.now() + HEALTH_REFRESH_INTERVAL_MS });
+    const fresh = createHealthSnapshot({ ts: Date.now() });
+
+    const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({ cached, fresh });
+
+    expect(refreshHealthSnapshot).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(true, fresh, undefined);
+  });
+
+  it("restarts request-driven health refreshes when the clock moves backward", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T12:00:00Z"));
+    const cached = createHealthSnapshot({});
+    const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
+
+    await requestHealthSnapshot({ cached, refreshHealthSnapshot });
+    expect(refreshHealthSnapshot).toHaveBeenCalledOnce();
+
+    vi.setSystemTime(Date.now() - HEALTH_REFRESH_INTERVAL_MS);
+    await requestHealthSnapshot({ cached: { ...cached, ts: Date.now() }, refreshHealthSnapshot });
+
+    expect(refreshHealthSnapshot).toHaveBeenCalledTimes(2);
+  });
+
   it("bypasses a fresh cache for explicit admin probes", async () => {
     const cached = createHealthSnapshot({});
     const fresh = createHealthSnapshot({ ts: cached.ts + 1 });

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -498,6 +498,24 @@ describe("createReadinessChecker", () => {
     });
   });
 
+  it("refreshes stopped channels when the clock moves behind cached readiness", () => {
+    withReadinessClock(() => {
+      const { manager, readiness } = createReadinessHarness({
+        accounts: { discord: managedAccount({ lifecycle: "ready" }) },
+        cacheTtlMs: 1_000,
+      });
+
+      expect(readiness()).toEqual(readySnapshot());
+      vi.mocked(manager.getRuntimeSnapshot).mockReturnValue(
+        snapshotWith({ discord: stoppedAccount({ connected: false, lifecycle: "stopped" }) }),
+      );
+      vi.setSystemTime(Date.now() - 60_000);
+
+      expect(readiness()).toEqual(failingSnapshot(["discord"], FIVE_MIN_MS - 60_000));
+      expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("adds event-loop health to detailed readiness without changing readiness state", () => {
     withReadinessClock(() => {
       const { readiness } = createReadinessHarness({

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -1,4 +1,5 @@
 // Gateway readiness checker for channel health and startup sidecar state.
+import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
@@ -116,7 +117,11 @@ export function createReadinessChecker(
     if (deps.shouldSkipChannelReadiness?.()) {
       return withEventLoopHealth({ ready: true, failing: [], uptimeMs }, deps.getEventLoopHealth);
     }
-    if (cachedState && now - cachedAt < cacheTtlMs) {
+    if (
+      cachedState &&
+      !isFutureDateTimestampMs(cachedAt, { nowMs: now }) &&
+      now - cachedAt < cacheTtlMs
+    ) {
       return withEventLoopHealth({ ...cachedState, uptimeMs }, deps.getEventLoopHealth);
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators monitoring Gateway readiness or channel health would continue to see a stopped or disconnected channel reported as healthy after the host clock moved backward. Readiness probes could incorrectly return HTTP 200, cached health snapshots and refresh throttles could remain stale, and the automatic channel-health monitor could skip a restart that should have recovered the channel.

## Why This Change Was Made

Gateway health now treats future-dated observations as incapable of proving current readiness, freshness, or an active grace window. Channel lifecycle starts retain their authoritative boundary even when they are future-dated, so heartbeat and disconnect evidence inherited from an earlier lifecycle cannot revive the newer lifecycle; the same existing timestamp predicate validates readiness caches, health snapshots, and request-refresh throttles. Normal startup, reconnect, busy-run, absent-telemetry, and cache/throttle behavior are preserved.

## User Impact

Readiness endpoints accurately return HTTP 503 for stopped, starting, recovering, or otherwise disconnected channels after a clock rollback; health requests refresh stale snapshots promptly; and the health monitor resumes restarting channels that can no longer receive messages. No public API, configuration, authentication, protocol, persistent storage, or dependency contract changes.

## Evidence

- Authentic before/after regressions: real Gateway HTTP request dispatch previously returned `/readyz` HTTP 200 for four disconnected lifecycle states and now returns HTTP 503; the channel monitor previously skipped restarting a disconnected channel and now performs the restart.
- Additional owner-boundary regressions prove future startup timestamps, future run activity, future disconnects, prior-lifecycle inherited activity/disconnects, future cached snapshots, and backward-clock refresh throttling all fail safely.
- Full channel-policy, monitor, readiness, and actual HTTP suites: **274 tests passed**.
- Complete Gateway RPC health-cache/refresh owner suite: **34 tests passed**.
- Independent reviewer separately reran **38 focused regressions** and verified 11 real owner-boundary lifecycle cases; authenticated full-commit Codex review reported no actionable findings.
- Gateway production typecheck, both Gateway test typecheck shards, exact changed-file lint and formatting, max-lines ratchet, assertion-safety ratchet, canonical coercion guard, runtime-sidecar guard, and dead-export scans all passed.
- The full repository core-test typecheck additionally encounters pre-existing unrelated local missing UI development dependencies (`@panzoom/panzoom` and `@types/pako`); both Gateway-owned test shards pass without errors.
- Production change: **+16 lines**, justified by preserving the absent versus future-invalid lifecycle distinction and sharing canonical observed-timestamp normalization across channel health, readiness caches, and refresh ownership.
- Exact reviewed head: `6507a8fc1e199d382a534d57096bb3ee31472d00`.

<details>
<summary>Focused verification commands</summary>

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-gateway-health-vitest-cache node scripts/run-vitest.mjs src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts src/gateway/server/readiness.test.ts src/gateway/server-http.probe.clock-rollback.test.ts --configLoader runner --reporter=dot

OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-gateway-health-vitest-cache node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts --configLoader runner --reporter=dot -t 'gateway healthHandlers.health cache freshness'

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.gateway-root.json --builders 1
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.gateway-other.json --builders 1
```

</details>
