### PR TITLE
fix(cli): resolve alias targets from the write snapshot

### DIFF
--- a/src/commands/models/aliases.test.ts
+++ b/src/commands/models/aliases.test.ts
@@ -379,6 +379,77 @@ describe("modelsAliasesAddCommand", () => {
     const written = replaceParams?.nextConfig as OpenClawConfig;
     expect(written.agents?.defaults?.models?.["openai/gpt-5.4-mini"]?.alias).toBe("fast");
   });
+
+  it("attaches the alias to the target named by the CAS-fenced snapshot, not a pre-command read", async () => {
+    // The config loaded at command start maps `target` to one model; by the time
+    // the write snapshot is taken another writer has remapped it. The write is
+    // fenced by the snapshot hash, so the alias must follow the snapshot's target.
+    const staleCfg = {
+      agents: { defaults: { models: { "openai/gpt-5.6-sol": { alias: "target" } } } },
+    } as unknown as OpenClawConfig;
+    const currentCfg = {
+      agents: { defaults: { models: { "anthropic/claude-opus-5": { alias: "target" } } } },
+    } as unknown as OpenClawConfig;
+    mocks.loadModelsConfig.mockResolvedValue(staleCfg);
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      ...snapshot(currentCfg),
+      hash: "current-hash",
+    });
+    mocks.replaceConfigFile.mockResolvedValue(undefined);
+    const runtime = makeRuntime();
+
+    await modelsAliasesAddCommand("new-name", "target", runtime);
+
+    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
+    expect(replaceParams?.baseHash).toBe("current-hash");
+    expect(replaceParams?.nextConfig.agents?.defaults?.models).toEqual({
+      "anthropic/claude-opus-5": { alias: "new-name" },
+    });
+    expect(runtime.logs).toContain("Alias new-name -> anthropic/claude-opus-5");
+  });
+
+  it.each([
+    {
+      label: "resolves a runtime-only alias while writing only source config",
+      sourceConfig: {
+        agents: { defaults: { models: { "anthropic/claude-sonnet-4-6": {} } } },
+      },
+      runtimeConfig: {
+        agents: { defaults: { models: { "anthropic/claude-sonnet-4-6": { alias: "sonnet" } } } },
+      },
+      expectedModels: { "anthropic/claude-sonnet-4-6": { alias: "fast" } },
+    },
+    {
+      label: "keeps authored aliases ahead of runtime-only aliases",
+      sourceConfig: {
+        agents: { defaults: { models: { "openai/gpt-5.5": { alias: "sonnet" } } } },
+      },
+      runtimeConfig: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": { alias: "sonnet" },
+              "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+            },
+          },
+        },
+      },
+      expectedModels: { "openai/gpt-5.5": { alias: "fast" } },
+    },
+  ])("$label (parity with models set)", async ({ sourceConfig, runtimeConfig, expectedModels }) => {
+    mocks.loadModelsConfig.mockResolvedValue(runtimeConfig);
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      ...snapshot(sourceConfig as unknown as OpenClawConfig),
+      runtimeConfig,
+    });
+    mocks.replaceConfigFile.mockResolvedValue(undefined);
+
+    await modelsAliasesAddCommand("fast", "sonnet", makeRuntime());
+
+    const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
+    expect(replaceParams?.nextConfig.agents?.defaults?.models).toEqual(expectedModels);
+  });
 });
 
 describe("modelsAliasesListCommand <-> modelsAliasesRemoveCommand agreement", () => {

--- a/src/commands/models/aliases.test.ts
+++ b/src/commands/models/aliases.test.ts
@@ -380,15 +380,19 @@ describe("modelsAliasesAddCommand", () => {
     expect(written.agents?.defaults?.models?.["openai/gpt-5.4-mini"]?.alias).toBe("fast");
   });
 
-  it("attaches the alias to the target named by the CAS-fenced snapshot, not a pre-command read", async () => {
-    // The config loaded at command start maps `target` to one model; by the time
-    // the write snapshot is taken another writer has remapped it. The write is
-    // fenced by the snapshot hash, so the alias must follow the snapshot's target.
+  it("resolves alias targets from the CAS-fenced snapshot", async () => {
     const staleCfg = {
-      agents: { defaults: { models: { "openai/gpt-5.6-sol": { alias: "target" } } } },
+      agents: { defaults: { models: { "openai/gpt-5.6-sol": { alias: "old-alias" } } } },
     } as unknown as OpenClawConfig;
     const currentCfg = {
-      agents: { defaults: { models: { "anthropic/claude-opus-5": { alias: "target" } } } },
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.6-sol": { params: { temperature: 0.2 } },
+            "anthropic/claude-opus-5": { alias: "old-alias" },
+          },
+        },
+      },
     } as unknown as OpenClawConfig;
     mocks.loadModelsConfig.mockResolvedValue(staleCfg);
     mocks.readConfigFileSnapshot.mockResolvedValue({
@@ -398,47 +402,24 @@ describe("modelsAliasesAddCommand", () => {
     mocks.replaceConfigFile.mockResolvedValue(undefined);
     const runtime = makeRuntime();
 
-    await modelsAliasesAddCommand("new-name", "target", runtime);
+    await modelsAliasesAddCommand("new-alias", "old-alias", runtime);
 
-    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
     const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
     expect(replaceParams?.baseHash).toBe("current-hash");
     expect(replaceParams?.nextConfig.agents?.defaults?.models).toEqual({
-      "anthropic/claude-opus-5": { alias: "new-name" },
+      "openai/gpt-5.6-sol": { params: { temperature: 0.2 } },
+      "anthropic/claude-opus-5": { alias: "new-alias" },
     });
-    expect(runtime.logs).toContain("Alias new-name -> anthropic/claude-opus-5");
+    expect(runtime.logs).toContain("Alias new-alias -> anthropic/claude-opus-5");
   });
 
-  it.each([
-    {
-      label: "resolves a runtime-only alias while writing only source config",
-      sourceConfig: {
-        agents: { defaults: { models: { "anthropic/claude-sonnet-4-6": {} } } },
-      },
-      runtimeConfig: {
-        agents: { defaults: { models: { "anthropic/claude-sonnet-4-6": { alias: "sonnet" } } } },
-      },
-      expectedModels: { "anthropic/claude-sonnet-4-6": { alias: "fast" } },
-    },
-    {
-      label: "keeps authored aliases ahead of runtime-only aliases",
-      sourceConfig: {
-        agents: { defaults: { models: { "openai/gpt-5.5": { alias: "sonnet" } } } },
-      },
-      runtimeConfig: {
-        agents: {
-          defaults: {
-            models: {
-              "openai/gpt-5.5": { alias: "sonnet" },
-              "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
-            },
-          },
-        },
-      },
-      expectedModels: { "openai/gpt-5.5": { alias: "fast" } },
-    },
-  ])("$label (parity with models set)", async ({ sourceConfig, runtimeConfig, expectedModels }) => {
-    mocks.loadModelsConfig.mockResolvedValue(runtimeConfig);
+  it("resolves a runtime-only alias while persisting only source config", async () => {
+    const sourceConfig = {
+      agents: { defaults: { models: { "anthropic/claude-sonnet-4-6": {} } } },
+    };
+    const runtimeConfig = {
+      agents: { defaults: { models: { "anthropic/claude-sonnet-4-6": { alias: "sonnet" } } } },
+    };
     mocks.readConfigFileSnapshot.mockResolvedValue({
       ...snapshot(sourceConfig as unknown as OpenClawConfig),
       runtimeConfig,
@@ -448,7 +429,9 @@ describe("modelsAliasesAddCommand", () => {
     await modelsAliasesAddCommand("fast", "sonnet", makeRuntime());
 
     const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
-    expect(replaceParams?.nextConfig.agents?.defaults?.models).toEqual(expectedModels);
+    expect(replaceParams?.nextConfig.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": { alias: "fast" },
+    });
   });
 });
 

--- a/src/commands/models/aliases.ts
+++ b/src/commands/models/aliases.ts
@@ -6,7 +6,7 @@ import { normalizeAgentModelMapForConfig } from "../../config/model-input.js";
 import { type RuntimeEnv, writeRuntimeJson, writeRuntimeStdout } from "../../runtime.js";
 import { normalizeAlias } from "./alias-name.js";
 import { loadModelsConfig } from "./load-config.js";
-import { ensureFlagCompatibility, resolveModelTarget, updateConfig } from "./shared.js";
+import { ensureFlagCompatibility, resolveModelTargetForWrite, updateConfig } from "./shared.js";
 
 /** Lists configured model aliases as JSON, plain pairs, or human-readable rows. */
 export async function modelsAliasesListCommand(
@@ -55,11 +55,18 @@ export async function modelsAliasesAddCommand(
 ) {
   const alias = normalizeAlias(aliasRaw);
   const normalizedAlias = alias.toLowerCase();
-  const cfg = await loadModelsConfig({ commandName: "models aliases add", runtime });
-  const resolved = resolveModelTarget({ raw: modelRaw, cfg });
-  await updateConfig((cfgLocal) => {
+  let target: string | undefined;
+  await updateConfig((cfg, context) => {
+    // `modelRaw` may itself be an alias; resolve it from the fenced snapshot so a
+    // concurrent remap cannot attach the alias to a stale target under a green CAS.
+    const resolved = resolveModelTargetForWrite({
+      cfg,
+      resolveCfg: context.runtimeConfig,
+      modelRaw,
+    });
     const modelKey = `${resolved.provider}/${resolved.model}`;
-    const nextModels = { ...cfgLocal.agents?.defaults?.models };
+    target = modelKey;
+    const nextModels = { ...cfg.agents?.defaults?.models };
     // Model selection folds alias case, so case variants must not collide.
     for (const [key, entry] of Object.entries(nextModels)) {
       const existing = entry?.alias?.trim();
@@ -70,11 +77,11 @@ export async function modelsAliasesAddCommand(
     const existing = nextModels[modelKey] ?? {};
     nextModels[modelKey] = { ...existing, alias };
     return {
-      ...cfgLocal,
+      ...cfg,
       agents: {
-        ...cfgLocal.agents,
+        ...cfg.agents,
         defaults: {
-          ...cfgLocal.agents?.defaults,
+          ...cfg.agents?.defaults,
           models: nextModels,
         },
       },
@@ -82,7 +89,7 @@ export async function modelsAliasesAddCommand(
   });
 
   logConfigUpdated(runtime);
-  runtime.log(`Alias ${alias} -> ${resolved.provider}/${resolved.model}`);
+  runtime.log(`Alias ${alias} -> ${target}`);
 }
 
 /** Removes a configured alias by name. */

--- a/src/commands/models/aliases.ts
+++ b/src/commands/models/aliases.ts
@@ -6,7 +6,7 @@ import { normalizeAgentModelMapForConfig } from "../../config/model-input.js";
 import { type RuntimeEnv, writeRuntimeJson, writeRuntimeStdout } from "../../runtime.js";
 import { normalizeAlias } from "./alias-name.js";
 import { loadModelsConfig } from "./load-config.js";
-import { ensureFlagCompatibility, resolveModelTargetForWrite, updateConfig } from "./shared.js";
+import { ensureFlagCompatibility, resolveModelTarget, updateConfig } from "./shared.js";
 
 /** Lists configured model aliases as JSON, plain pairs, or human-readable rows. */
 export async function modelsAliasesListCommand(
@@ -55,18 +55,13 @@ export async function modelsAliasesAddCommand(
 ) {
   const alias = normalizeAlias(aliasRaw);
   const normalizedAlias = alias.toLowerCase();
-  let target: string | undefined;
-  await updateConfig((cfg, context) => {
-    // `modelRaw` may itself be an alias; resolve it from the fenced snapshot so a
-    // concurrent remap cannot attach the alias to a stale target under a green CAS.
-    const resolved = resolveModelTargetForWrite({
-      cfg,
-      resolveCfg: context.runtimeConfig,
-      modelRaw,
-    });
+  let target = modelRaw;
+  await updateConfig((cfgLocal, context) => {
+    // Alias resolution must share the snapshot whose hash fences this write.
+    const resolved = resolveModelTarget({ raw: modelRaw, cfg: context.runtimeConfig });
     const modelKey = `${resolved.provider}/${resolved.model}`;
     target = modelKey;
-    const nextModels = { ...cfg.agents?.defaults?.models };
+    const nextModels = { ...cfgLocal.agents?.defaults?.models };
     // Model selection folds alias case, so case variants must not collide.
     for (const [key, entry] of Object.entries(nextModels)) {
       const existing = entry?.alias?.trim();
@@ -77,11 +72,11 @@ export async function modelsAliasesAddCommand(
     const existing = nextModels[modelKey] ?? {};
     nextModels[modelKey] = { ...existing, alias };
     return {
-      ...cfg,
+      ...cfgLocal,
       agents: {
-        ...cfg.agents,
+        ...cfgLocal.agents,
         defaults: {
-          ...cfg.agents?.defaults,
+          ...cfgLocal.agents?.defaults,
           models: nextModels,
         },
       },

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -247,7 +247,7 @@ export function applyDefaultModelPrimaryUpdate(params: {
   field: "model" | "imageModel";
   resolvedTarget?: { provider: string; model: string };
 }): OpenClawConfig {
-  const resolved = params.resolvedTarget ?? resolveDefaultModelPrimaryTarget(params);
+  const resolved = params.resolvedTarget ?? resolveModelTargetForWrite(params);
   const nextModels = {
     ...params.cfg.agents?.defaults?.models,
   } as Record<string, AgentModelEntryConfig>;
@@ -271,7 +271,13 @@ export function applyDefaultModelPrimaryUpdate(params: {
   };
 }
 
-function resolveDefaultModelPrimaryTarget(params: {
+/**
+ * Resolves a CLI model ref for a config write. Authored aliases in the source
+ * config win; otherwise the runtime config resolves built-in aliases that only
+ * exist after defaults are applied. Call from inside `updateConfig` so the
+ * target comes from the same snapshot whose hash fences the write.
+ */
+export function resolveModelTargetForWrite(params: {
   cfg: OpenClawConfig;
   resolveCfg?: OpenClawConfig;
   modelRaw: string;
@@ -289,7 +295,7 @@ export async function updateDefaultModelPrimaryConfig(params: {
 }): Promise<{ updated: OpenClawConfig; warning?: string }> {
   let warning: string | undefined;
   const updated = await updateConfig((cfg, context) => {
-    const resolvedTarget = resolveDefaultModelPrimaryTarget({
+    const resolvedTarget = resolveModelTargetForWrite({
       cfg,
       resolveCfg: context.runtimeConfig,
       modelRaw: params.modelRaw,

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -247,7 +247,7 @@ export function applyDefaultModelPrimaryUpdate(params: {
   field: "model" | "imageModel";
   resolvedTarget?: { provider: string; model: string };
 }): OpenClawConfig {
-  const resolved = params.resolvedTarget ?? resolveModelTargetForWrite(params);
+  const resolved = params.resolvedTarget ?? resolveDefaultModelPrimaryTarget(params);
   const nextModels = {
     ...params.cfg.agents?.defaults?.models,
   } as Record<string, AgentModelEntryConfig>;
@@ -271,13 +271,7 @@ export function applyDefaultModelPrimaryUpdate(params: {
   };
 }
 
-/**
- * Resolves a CLI model ref for a config write. Authored aliases in the source
- * config win; otherwise the runtime config resolves built-in aliases that only
- * exist after defaults are applied. Call from inside `updateConfig` so the
- * target comes from the same snapshot whose hash fences the write.
- */
-export function resolveModelTargetForWrite(params: {
+function resolveDefaultModelPrimaryTarget(params: {
   cfg: OpenClawConfig;
   resolveCfg?: OpenClawConfig;
   modelRaw: string;
@@ -295,7 +289,7 @@ export async function updateDefaultModelPrimaryConfig(params: {
 }): Promise<{ updated: OpenClawConfig; warning?: string }> {
   let warning: string | undefined;
   const updated = await updateConfig((cfg, context) => {
-    const resolvedTarget = resolveModelTargetForWrite({
+    const resolvedTarget = resolveDefaultModelPrimaryTarget({
       cfg,
       resolveCfg: context.runtimeConfig,
       modelRaw: params.modelRaw,


### PR DESCRIPTION
Closes #127618

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

`openclaw models aliases add <alias> <model-or-alias>` resolved the target before
`updateConfig` obtained the snapshot and hash that fence the write. If another
config writer remapped the input alias between those reads, the command
successfully attached the new alias to the stale model and logged that stale
target.

## Why This Change Was Made

`modelsAliasesAddCommand` now resolves `modelRaw` inside the `updateConfig`
mutator from `context.runtimeConfig`. Resolution and the compare-and-swap write
therefore share one authoritative snapshot. The canonical model key is persisted
to the source config and retained for the post-commit success line.

No shared resolver, config shape, CLI flag, migration, fallback, or docs change
is included.

## User Impact

- `models aliases add` follows the alias mapping current at the fenced write.
- The printed `Alias <alias> -> <target>` line matches the persisted target.
- Runtime-only built-in aliases still resolve while only source-form config is
  written.

## Evidence

AI-assisted (Claude Code and Codex); I have read and understand the change.

**Red-before on current main**

`node scripts/run-vitest.mjs src/commands/models/aliases.test.ts`

The reconstructed two-snapshot regression failed as intended: the stale
pre-snapshot mapped `old-alias` to `openai/gpt-5.6-sol`, the CAS snapshot mapped
it to `anthropic/claude-opus-5`, and pre-fix code wrote `new-alias` to the stale
OpenAI target. Result: 1 failed, 17 passed.

**Focused owner and sibling tests**

```text
scripts/pr review-tests 128223 \
  src/commands/models/aliases.test.ts \
  src/commands/models/set.test.ts \
  src/commands/models/shared.test.ts \
  src/commands/models/fallbacks-shared.test.ts \
  src/commands/promos/claim.test.ts \
  src/commands/promos/list.test.ts
```

All requested files passed and were observed in the native review output.
`pnpm check:changed` and `git diff --check` also passed.

**Autoreview**

Fresh branch autoreview with Codex `gpt-5.6-sol` at high reasoning reported no
accepted or actionable findings; overall correctness confidence was 0.99.

**Real CLI/config-I/O proof**

Blacksmith Testbox lease `tbx_01m118jw10zrx3x400tr2ten3b`, Actions run
`33058459463`, executed the exact reviewed tree with an isolated config. An
external atomic writer moved `old-alias` from the OpenAI model to the Anthropic
model before the real CLI write:

```text
SETUP dependency install and build passed
INITIAL old-alias -> openai/gpt-5.6-sol
WRITER old-alias -> anthropic/claude-opus-5
COMMAND models aliases add new-alias old-alias
Updated config: <PROOF_DIR>/openclaw.json
Alias new-alias -> anthropic/claude-opus-5
PERSISTED {"openai/gpt-5.6-sol":{"params":{"temperature":0.2}},"anthropic/claude-opus-5":{"alias":"new-alias"}}
```

The remote command and assertions exited 0.

**Gate note**

Local `prepare-gates` build and check passed. The full test encountered unrelated
tooling noise: `telegram-user-crabbox-proof.test.ts` reproduced the same failure
on current main, `test-live.test.ts` passed on current-main retry, and the
`test-perf-budget.test.ts` / `test-projects.test.ts` shard reproduced a no-output
hang on current main. An initial Blacksmith Testbox full-gate lease failed before
tests because its hydrated checkout lacked `node_modules` and could not import
`tsx`.

Exact-head CI run `33057073509` completed successfully with no failed jobs.
`OPENCLAW_TESTBOX=1 scripts/pr prepare-run 128223` accepted that hosted proof and
completed with `gates_mode=hosted_exact_or_recent_parent`.

## Repair Closeout

- Root cause: `aliases add` resolved `modelRaw` before the CAS-owned config
  snapshot existed.
- Owner: `src/commands/models/aliases.ts`.
- Canonical fix: resolve inside `updateConfig` using `context.runtimeConfig`.
- Sibling coverage: aliases, set, fallbacks-shared, shared, and promo command
  tests passed.
- Production LOC: +6/-4, net +2.
- Tests: +54/-0.
- Effective diff: two files; `src/commands/models/shared.ts` is unchanged.
