### PR TITLE
fix(release): repair beta onboarding proof

### DIFF
--- a/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
+++ b/extensions/codex/src/app-server/fixtures/approval-policy-v0.149.proof.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 3,
-  "bindingSha256": "3139f5e3e10dbc93452c120e3029fc6d4a7615cd2fac72b733d9b2c3239d2424",
-  "generatedAt": "2026-08-23T12:15:37Z",
+  "bindingSha256": "06ea069a9218464720e8891948105b14485054cf437b9252c64f8bd12b3e6c05",
+  "generatedAt": "2026-08-23T13:20:46Z",
   "openclaw": {
     "frozenParent": "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
     "adapterSources": [
@@ -34,7 +34,7 @@
         "sha256": "e175ee6d2b6742ede87b2e84aec1a121d58e1c26edb6007e1618674b097fb760"
       }
     ],
-    "candidateDiffSha256": "49f9e17d5685b0ba6fdfb9ec67258325f24c88632c2a096d3b3f27337ac38f8e"
+    "candidateDiffSha256": "9a4cf85f39cf801b591d838ee77963936fcf4890714f4084c470e05af453e4fb"
   },
   "codex": {
     "version": "0.149.0",

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -52,6 +52,44 @@ async function runTrackedSlackMessageOnce(
   }
 }
 
+function useSlackReplyDeliveryOnce(
+  onContext?: (ctxPayload: Record<string, unknown>) => void,
+): Promise<void> {
+  const settled = createDeferred<void>();
+  useSlackChannelInboundDispatchOnce(async (params) => {
+    try {
+      onContext?.(params.ctxPayload);
+      const deliver = params.delivery?.deliver;
+      if (!deliver) {
+        throw new Error("expected Slack reply delivery callback");
+      }
+      const reply = await params.replyResolver?.(
+        params.ctxPayload,
+        params.replyOptions,
+        params.cfg,
+      );
+      for (const payload of Array.isArray(reply) ? reply : reply ? [reply] : []) {
+        await deliver(payload, { kind: "final" });
+      }
+      settled.resolve();
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: params.ctxPayload,
+        routeSessionKey: params.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: Boolean(reply),
+          counts: { tool: 0, block: 0, final: reply ? 1 : 0 },
+        },
+      };
+    } catch (error) {
+      settled.reject(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
+  });
+  return settled.promise;
+}
+
 const PROXY_ENV_KEYS = [
   "ALL_PROXY",
   "HTTPS_PROXY",
@@ -509,7 +547,12 @@ describe("presence polling transport", () => {
         ...options,
         env: options.env ?? process.env,
       });
-    getSlackTestState().replyMock.mockResolvedValue({ text: "ok" });
+    const { replyMock, sendMock } = getSlackTestState();
+    replyMock.mockResolvedValue({ text: "ok" });
+    let dispatchedContext: Record<string, unknown> | undefined;
+    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
+      dispatchedContext = ctxPayload;
+    });
 
     const nativeSetInterval = globalThis.setInterval;
     let triggerPresencePoll: (() => void) | undefined;
@@ -540,6 +583,15 @@ describe("presence polling transport", () => {
         context: { botUserId: "bot-user" },
         body: {},
       });
+      await deliverySettled;
+      expect(dispatchedContext).toMatchObject({
+        Body: expect.stringMatching(
+          /Ada: hello\n\[slack message id: 100\.000 channel: D_STALLED\]$/u,
+        ),
+        ChatType: "direct",
+        WasMentioned: false,
+      });
+      expect(sendMock).toHaveBeenCalledWith("channel:D_STALLED", "ok", expect.any(Object));
       expect(triggerPresencePoll).toBeTypeOf("function");
       triggerPresencePoll?.();
       await vi.waitFor(() => expect(server.requestCount).toBe(1), { timeout: 1_000 });
@@ -650,6 +702,10 @@ describe("user identity provider transport", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "acknowledged" });
+    let dispatchedContext: Record<string, unknown> | undefined;
+    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
+      dispatchedContext = ctxPayload;
+    });
     const monitor = await startWithoutBotToken(config);
     const handler = await getSlackHandlerOrThrow("message");
 
@@ -666,7 +722,13 @@ describe("user identity provider transport", () => {
       body: {},
     });
 
-    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    await deliverySettled;
+    expect(dispatchedContext).toMatchObject({
+      Body: expect.stringMatching(/<@U_SELF>.*status/u),
+      ChatType: "channel",
+      WasMentioned: true,
+    });
+    expect(sendMock).toHaveBeenCalledWith("channel:C1", "acknowledged", expect.any(Object));
     await stopSlackMonitor(monitor);
   });
 
@@ -681,6 +743,10 @@ describe("user identity provider transport", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "hello back" });
+    let dispatchedContext: Record<string, unknown> | undefined;
+    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
+      dispatchedContext = ctxPayload;
+    });
     const monitor = await startWithoutBotToken(config);
     const handler = await getSlackHandlerOrThrow("message");
     const baseEvent = {
@@ -695,7 +761,13 @@ describe("user identity provider transport", () => {
       context: { botUserId: "U_SELF" },
       body: {},
     });
-    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    await deliverySettled;
+    expect(dispatchedContext).toMatchObject({
+      Body: expect.stringMatching(/Ada: hello\n\[slack message id: 100\.000 channel: D1\]$/u),
+      ChatType: "direct",
+      WasMentioned: false,
+    });
+    expect(sendMock).toHaveBeenCalledWith("channel:D1", "hello back", expect.any(Object));
 
     await handler({
       event: { ...baseEvent, user: "U_SELF", ts: "101.000" },

--- a/scripts/e2e/lib/auth-profile-store-assertions.d.mts
+++ b/scripts/e2e/lib/auth-profile-store-assertions.d.mts
@@ -1,0 +1,15 @@
+export type AuthProfileStoreAssertionOptions = {
+  missingMessage?: string;
+  envRefMessage?: string;
+  rawKeyMessage?: string;
+  rawKeyNeedle?: string;
+};
+
+export declare function readSharedAuthProfileStoreText(stateDir: string): string;
+
+export declare function assertNoLegacyPrimaryAuthRows(stateDir: string): void;
+
+export declare function assertOpenAiEnvAuthProfileStore(
+  storeJson: string,
+  options?: AuthProfileStoreAssertionOptions,
+): void;

--- a/scripts/e2e/lib/auth-profile-store-assertions.mjs
+++ b/scripts/e2e/lib/auth-profile-store-assertions.mjs
@@ -1,5 +1,72 @@
 // Shared auth profile store assertions for install/onboard E2E proof.
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { isRecord } from "../../lib/record-shared.mjs";
+
+export function readSharedAuthProfileStoreText(stateDir) {
+  const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
+  if (!fs.existsSync(dbPath)) {
+    return "";
+  }
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const row = db
+      .prepare("SELECT store_json FROM auth_profile_stores WHERE store_key = ?")
+      .get("shared");
+    return typeof row?.store_json === "string" ? row.store_json : "";
+  } catch {
+    return "";
+  } finally {
+    db?.close();
+  }
+}
+
+export function assertNoLegacyPrimaryAuthRows(stateDir) {
+  const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  if (!fs.existsSync(dbPath)) {
+    return;
+  }
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const legacyRows = [
+      {
+        table: "auth_profile_store",
+        query: "SELECT 1 AS present FROM auth_profile_store WHERE store_key = ? LIMIT 1",
+      },
+      {
+        table: "auth_profile_state",
+        query: "SELECT 1 AS present FROM auth_profile_state WHERE state_key = ? LIMIT 1",
+      },
+    ];
+    for (const entry of legacyRows) {
+      const schema = db
+        .prepare("SELECT type FROM sqlite_schema WHERE name = ? LIMIT 1")
+        .get(entry.table);
+      if (!schema) {
+        continue;
+      }
+      if (schema.type !== "table") {
+        throw new Error(`${entry.table} is ${String(schema.type)}, not a table`);
+      }
+      if (db.prepare(entry.query).get("primary")) {
+        throw new Error(`onboard preserved a retired primary row in ${entry.table}`);
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("onboard preserved a retired")) {
+      throw error;
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`could not validate the main-agent auth database: ${detail}`, {
+      cause: error,
+    });
+  } finally {
+    db?.close();
+  }
+}
 
 function hasExpectedOpenAiEnvRef(profile) {
   if (!isRecord(profile)) {

--- a/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
+++ b/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
@@ -1,12 +1,15 @@
 // Assertions for npm onboard channel-agent E2E scenarios.
 import fs from "node:fs";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import {
   assertAgentReplyContainsMarker,
   assertOpenAiRequestLogUsed,
 } from "../agent-turn-output.mjs";
-import { assertOpenAiEnvAuthProfileStore } from "../auth-profile-store-assertions.mjs";
+import {
+  assertNoLegacyPrimaryAuthRows,
+  assertOpenAiEnvAuthProfileStore,
+  readSharedAuthProfileStoreText,
+} from "../auth-profile-store-assertions.mjs";
 import { readPositiveIntEnv } from "../env-limits.mjs";
 import {
   applyMockOpenAiModelConfig,
@@ -77,38 +80,16 @@ function extractStatusSection(text, title) {
   return stripAnsi(section.join("\n"));
 }
 
-function readAuthProfileStoreText(agentDir) {
-  const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
-  if (!fs.existsSync(dbPath)) {
-    return "";
-  }
-  let db;
-  try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
-    const row = db
-      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
-      .get("primary");
-    return typeof row?.store_json === "string" ? row.store_json : "";
-  } catch {
-    return "";
-  } finally {
-    db?.close();
-  }
-}
-
 function assertOnboardState() {
   const home = process.argv[3];
   const stateDir = path.join(home, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
-  const agentDir = path.join(stateDir, "agents", "main", "agent");
 
   if (!fs.existsSync(configPath)) {
     throw new Error("onboard did not write openclaw.json");
   }
-  if (!fs.existsSync(agentDir)) {
-    throw new Error("onboard did not create main agent dir");
-  }
-  const authStoreText = readAuthProfileStoreText(agentDir);
+  assertNoLegacyPrimaryAuthRows(stateDir);
+  const authStoreText = readSharedAuthProfileStoreText(stateDir);
   if (!authStoreText) {
     throw new Error("onboard did not persist auth profile store");
   }

--- a/scripts/e2e/lib/release-scenarios/assertions.mjs
+++ b/scripts/e2e/lib/release-scenarios/assertions.mjs
@@ -1,12 +1,15 @@
 // Assertions for release scenario E2E packages and plugin state.
 import fs from "node:fs";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import {
   assertAgentReplyContainsMarker,
   assertOpenAiRequestLogUsed,
 } from "../agent-turn-output.mjs";
-import { assertOpenAiEnvAuthProfileStore } from "../auth-profile-store-assertions.mjs";
+import {
+  assertNoLegacyPrimaryAuthRows,
+  assertOpenAiEnvAuthProfileStore,
+  readSharedAuthProfileStoreText,
+} from "../auth-profile-store-assertions.mjs";
 import {
   applyMockOpenAiModelConfig,
   parseMockOpenAiPort,
@@ -49,39 +52,16 @@ function authProfilesPath() {
   );
 }
 
-function authProfilesDatabasePath() {
-  return path.join(
-    process.env.HOME ?? "",
-    ".openclaw",
-    "agents",
-    "main",
-    "agent",
-    "openclaw-agent.sqlite",
-  );
-}
-
-function readAuthProfileStoreSqliteText() {
-  const dbPath = authProfilesDatabasePath();
-  if (!fs.existsSync(dbPath)) {
-    return "";
-  }
-  let db;
-  try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
-    const row = db
-      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
-      .get("primary");
-    return typeof row?.store_json === "string" ? row.store_json : "";
-  } catch {
-    return "";
-  } finally {
-    db?.close();
-  }
+function stateDir() {
+  return process.env.OPENCLAW_STATE_DIR ?? path.dirname(configPath());
 }
 
 function readStateText() {
   const paths = [configPath(), authProfilesPath()].filter((file) => fs.existsSync(file));
-  return [...paths.map((file) => fs.readFileSync(file, "utf8")), readAuthProfileStoreSqliteText()]
+  return [
+    ...paths.map((file) => fs.readFileSync(file, "utf8")),
+    readSharedAuthProfileStoreText(stateDir()),
+  ]
     .filter(Boolean)
     .join("\n");
 }
@@ -96,7 +76,8 @@ function configureMockOpenAi() {
 function assertOpenAiEnvRef() {
   const rawKey = process.argv[3];
   assert(fs.existsSync(configPath()), "openclaw.json missing");
-  assertOpenAiEnvAuthProfileStore(readAuthProfileStoreSqliteText(), {
+  assertNoLegacyPrimaryAuthRows(stateDir());
+  assertOpenAiEnvAuthProfileStore(readSharedAuthProfileStoreText(stateDir()), {
     missingMessage: "OpenAI env ref was not persisted",
     envRefMessage: "OpenAI env ref was not persisted",
     rawKeyMessage: "raw OpenAI key was persisted",

--- a/test/scripts/npm-onboard-channel-agent-assertions.test.ts
+++ b/test/scripts/npm-onboard-channel-agent-assertions.test.ts
@@ -37,12 +37,13 @@ function writeOnboardConfig(home: string): void {
   );
 }
 
-function writeAuthProfileStoreSqlite(agentDir: string, store: unknown): void {
-  fs.mkdirSync(agentDir, { recursive: true });
-  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+function writeSharedAuthProfileStoreSqlite(home: string, store: unknown): void {
+  const stateDir = path.join(home, ".openclaw", "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const db = new DatabaseSync(path.join(stateDir, "openclaw.sqlite"));
   try {
     db.exec(`
-      CREATE TABLE IF NOT EXISTS auth_profile_store (
+      CREATE TABLE IF NOT EXISTS auth_profile_stores (
         store_key TEXT NOT NULL PRIMARY KEY,
         store_json TEXT NOT NULL,
         updated_at INTEGER NOT NULL
@@ -50,13 +51,49 @@ function writeAuthProfileStoreSqlite(agentDir: string, store: unknown): void {
     `);
     db.prepare(
       `
-        INSERT INTO auth_profile_store (store_key, store_json, updated_at)
+        INSERT INTO auth_profile_stores (store_key, store_json, updated_at)
         VALUES (?, ?, ?)
       `,
-    ).run("primary", JSON.stringify(store), Date.now());
+    ).run("shared", JSON.stringify(store), Date.now());
   } finally {
     db.close();
   }
+}
+
+function writeAgentAuthDatabase(
+  home: string,
+  rows: {
+    stateKeys?: string[];
+    storeKeys?: string[];
+  } = {},
+): string {
+  const agentDir = path.join(home, ".openclaw", "agents", "main", "agent");
+  fs.mkdirSync(agentDir, { recursive: true });
+  const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE auth_profile_store (
+        store_key TEXT NOT NULL PRIMARY KEY,
+        store_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      ) STRICT;
+      CREATE TABLE auth_profile_state (
+        state_key TEXT NOT NULL PRIMARY KEY,
+        state_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      ) STRICT;
+    `);
+    for (const key of rows.storeKeys ?? []) {
+      db.prepare("INSERT INTO auth_profile_store VALUES (?, '{}', ?)").run(key, Date.now());
+    }
+    for (const key of rows.stateKeys ?? []) {
+      db.prepare("INSERT INTO auth_profile_state VALUES (?, '{}', ?)").run(key, Date.now());
+    }
+  } finally {
+    db.close();
+  }
+  return dbPath;
 }
 
 function runAssert(home: string, channel: string, ...tokens: string[]) {
@@ -217,13 +254,13 @@ describe("npm onboard channel agent assertions", () => {
     }
   });
 
-  it("validates OpenAI env refs from the SQLite auth profile store", () => {
+  it("validates OpenAI env refs from the shared SQLite auth profile store", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
     const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
 
     try {
       writeOnboardConfig(tempDir);
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeSharedAuthProfileStoreSqlite(tempDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -238,6 +275,7 @@ describe("npm onboard channel agent assertions", () => {
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe("");
+      expect(fs.existsSync(agentDir)).toBe(false);
       expect(fs.existsSync(path.join(agentDir, "auth-profiles.json"))).toBe(false);
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
@@ -257,11 +295,10 @@ describe("npm onboard channel agent assertions", () => {
 
     for (const store of cases) {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
-      const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
 
       try {
         writeOnboardConfig(tempDir);
-        writeAuthProfileStoreSqlite(agentDir, store);
+        writeSharedAuthProfileStoreSqlite(tempDir, store);
 
         const result = runOnboardAssert(tempDir);
 
@@ -275,11 +312,10 @@ describe("npm onboard channel agent assertions", () => {
 
   it("rejects inline OpenAI keys in the SQLite auth profile store", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
-    const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
 
     try {
       writeOnboardConfig(tempDir);
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeSharedAuthProfileStoreSqlite(tempDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -294,6 +330,137 @@ describe("npm onboard channel agent assertions", () => {
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("auth profile persisted the raw OpenAI test key");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts a main-agent database without retired primary auth rows", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+    try {
+      writeOnboardConfig(tempDir);
+      writeSharedAuthProfileStoreSqlite(tempDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      writeAgentAuthDatabase(tempDir, {
+        stateKeys: ["last-good"],
+        storeKeys: ["workspace"],
+      });
+
+      const result = runOnboardAssert(tempDir);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  for (const legacyRow of [
+    { key: "primary", table: "auth_profile_store" },
+    { key: "primary", table: "auth_profile_state" },
+  ] as const) {
+    it(`rejects a retired primary row in ${legacyRow.table}`, () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+      try {
+        writeOnboardConfig(tempDir);
+        writeSharedAuthProfileStoreSqlite(tempDir, {
+          version: 1,
+          profiles: {
+            "openai:api-key": {
+              type: "api_key",
+              provider: "openai",
+              keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+            },
+          },
+        });
+        writeAgentAuthDatabase(tempDir, {
+          stateKeys: legacyRow.table === "auth_profile_state" ? [legacyRow.key] : [],
+          storeKeys: legacyRow.table === "auth_profile_store" ? [legacyRow.key] : [],
+        });
+
+        const result = runOnboardAssert(tempDir);
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          `onboard preserved a retired primary row in ${legacyRow.table}`,
+        );
+      } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+      }
+    });
+  }
+
+  it("fails closed when the main-agent database is unreadable", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+    try {
+      writeOnboardConfig(tempDir);
+      writeSharedAuthProfileStoreSqlite(tempDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
+      fs.mkdirSync(agentDir, { recursive: true });
+      fs.writeFileSync(path.join(agentDir, "openclaw-agent.sqlite"), "not sqlite");
+
+      const result = runOnboardAssert(tempDir);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("could not validate the main-agent auth database");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("fails closed when a retired auth table is replaced by a view", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+
+    try {
+      writeOnboardConfig(tempDir);
+      writeSharedAuthProfileStoreSqlite(tempDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      const dbPath = writeAgentAuthDatabase(tempDir);
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.exec(`
+          DROP TABLE auth_profile_store;
+          CREATE VIEW auth_profile_store AS
+            SELECT 'primary' AS store_key, '{}' AS store_json, 1 AS updated_at;
+        `);
+      } finally {
+        db.close();
+      }
+
+      const result = runOnboardAssert(tempDir);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "could not validate the main-agent auth database: auth_profile_store is view, not a table",
+      );
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
     }

--- a/test/scripts/release-scenarios-assertions.test.ts
+++ b/test/scripts/release-scenarios-assertions.test.ts
@@ -1,6 +1,6 @@
 // Release Scenarios Assertions tests cover release scenarios assertions script behavior.
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -32,12 +32,13 @@ function runAssertion(args: string[], env?: NodeJS.ProcessEnv) {
   });
 }
 
-function writeAuthProfileStoreSqlite(agentDir: string, store: unknown) {
-  mkdirSync(agentDir, { recursive: true });
-  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+function writeAuthProfileStoreSqlite(stateDir: string, store: unknown) {
+  const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+  mkdirSync(path.dirname(databasePath), { recursive: true });
+  const db = new DatabaseSync(databasePath);
   try {
     db.exec(`
-      CREATE TABLE IF NOT EXISTS auth_profile_store (
+      CREATE TABLE IF NOT EXISTS auth_profile_stores (
         store_key TEXT NOT NULL PRIMARY KEY,
         store_json TEXT NOT NULL,
         updated_at INTEGER NOT NULL
@@ -45,13 +46,49 @@ function writeAuthProfileStoreSqlite(agentDir: string, store: unknown) {
     `);
     db.prepare(
       `
-        INSERT INTO auth_profile_store (store_key, store_json, updated_at)
+        INSERT INTO auth_profile_stores (store_key, store_json, updated_at)
         VALUES (?, ?, ?)
       `,
-    ).run("primary", JSON.stringify(store), Date.now());
+    ).run("shared", JSON.stringify(store), Date.now());
   } finally {
     db.close();
   }
+}
+
+function writeAgentAuthDatabase(
+  stateDir: string,
+  rows: {
+    stateKeys?: string[];
+    storeKeys?: string[];
+  } = {},
+): string {
+  const agentDir = path.join(stateDir, "agents", "main", "agent");
+  mkdirSync(agentDir, { recursive: true });
+  const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE auth_profile_store (
+        store_key TEXT NOT NULL PRIMARY KEY,
+        store_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      ) STRICT;
+      CREATE TABLE auth_profile_state (
+        state_key TEXT NOT NULL PRIMARY KEY,
+        state_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      ) STRICT;
+    `);
+    for (const key of rows.storeKeys ?? []) {
+      db.prepare("INSERT INTO auth_profile_store VALUES (?, '{}', ?)").run(key, Date.now());
+    }
+    for (const key of rows.stateKeys ?? []) {
+      db.prepare("INSERT INTO auth_profile_state VALUES (?, '{}', ?)").run(key, Date.now());
+    }
+  } finally {
+    db.close();
+  }
+  return dbPath;
 }
 
 describe("release scenario assertions", () => {
@@ -196,7 +233,6 @@ describe("release scenario assertions", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const home = path.join(root, "home");
     const stateDir = path.join(home, ".openclaw");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
     const configPath = path.join(stateDir, "openclaw.json");
 
     try {
@@ -207,7 +243,7 @@ describe("release scenario assertions", () => {
           },
         },
       });
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeAuthProfileStoreSqlite(stateDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -221,10 +257,14 @@ describe("release scenario assertions", () => {
       const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
         HOME: home,
         OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
       });
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe("");
+      expect(
+        existsSync(path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite")),
+      ).toBe(false);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -234,7 +274,6 @@ describe("release scenario assertions", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const home = path.join(root, "home");
     const stateDir = path.join(home, ".openclaw");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
     const configPath = path.join(stateDir, "openclaw.json");
 
     try {
@@ -245,7 +284,7 @@ describe("release scenario assertions", () => {
           },
         },
       });
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeAuthProfileStoreSqlite(stateDir, {
         version: 1,
         profiles: {
           "openai:api-key": { note: "OPENAI_API_KEY" },
@@ -255,6 +294,7 @@ describe("release scenario assertions", () => {
       const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
         HOME: home,
         OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
       });
 
       expect(result.status).not.toBe(0);
@@ -268,7 +308,6 @@ describe("release scenario assertions", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const home = path.join(root, "home");
     const stateDir = path.join(home, ".openclaw");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
     const configPath = path.join(stateDir, "openclaw.json");
 
     try {
@@ -279,7 +318,7 @@ describe("release scenario assertions", () => {
           },
         },
       });
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeAuthProfileStoreSqlite(stateDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -293,6 +332,7 @@ describe("release scenario assertions", () => {
       const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
         HOME: home,
         OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
       });
 
       expect(result.status).not.toBe(0);
@@ -306,7 +346,6 @@ describe("release scenario assertions", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const home = path.join(root, "home");
     const stateDir = path.join(home, ".openclaw");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
     const configPath = path.join(stateDir, "openclaw.json");
 
     try {
@@ -322,7 +361,7 @@ describe("release scenario assertions", () => {
           },
         },
       });
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeAuthProfileStoreSqlite(stateDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -336,10 +375,194 @@ describe("release scenario assertions", () => {
       const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
         HOME: home,
         OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
       });
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("raw OpenAI key was persisted");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts a main-agent database without retired primary auth rows", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
+    const home = path.join(root, "home");
+    const stateDir = path.join(home, ".openclaw");
+    const configPath = path.join(stateDir, "openclaw.json");
+
+    try {
+      writeJson(configPath, {
+        auth: {
+          profiles: {
+            "openai:api-key": { provider: "openai", mode: "api_key" },
+          },
+        },
+      });
+      writeAuthProfileStoreSqlite(stateDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      writeAgentAuthDatabase(stateDir, {
+        stateKeys: ["last-good"],
+        storeKeys: ["workspace"],
+      });
+
+      const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
+        HOME: home,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  for (const legacyRow of [
+    { key: "primary", table: "auth_profile_store" },
+    { key: "primary", table: "auth_profile_state" },
+  ] as const) {
+    it(`rejects a retired primary row in ${legacyRow.table}`, () => {
+      const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
+      const home = path.join(root, "home");
+      const stateDir = path.join(home, ".openclaw");
+      const configPath = path.join(stateDir, "openclaw.json");
+
+      try {
+        writeJson(configPath, {
+          auth: {
+            profiles: {
+              "openai:api-key": { provider: "openai", mode: "api_key" },
+            },
+          },
+        });
+        writeAuthProfileStoreSqlite(stateDir, {
+          version: 1,
+          profiles: {
+            "openai:api-key": {
+              type: "api_key",
+              provider: "openai",
+              keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+            },
+          },
+        });
+        writeAgentAuthDatabase(stateDir, {
+          stateKeys: legacyRow.table === "auth_profile_state" ? [legacyRow.key] : [],
+          storeKeys: legacyRow.table === "auth_profile_store" ? [legacyRow.key] : [],
+        });
+
+        const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
+          HOME: home,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_STATE_DIR: stateDir,
+        });
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain(
+          `onboard preserved a retired primary row in ${legacyRow.table}`,
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+  }
+
+  it("fails closed when the main-agent auth database is unreadable", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
+    const home = path.join(root, "home");
+    const stateDir = path.join(home, ".openclaw");
+    const configPath = path.join(stateDir, "openclaw.json");
+
+    try {
+      writeJson(configPath, {
+        auth: {
+          profiles: {
+            "openai:api-key": { provider: "openai", mode: "api_key" },
+          },
+        },
+      });
+      writeAuthProfileStoreSqlite(stateDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      const agentDir = path.join(stateDir, "agents", "main", "agent");
+      mkdirSync(agentDir, { recursive: true });
+      writeFileSync(path.join(agentDir, "openclaw-agent.sqlite"), "not sqlite");
+
+      const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
+        HOME: home,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("could not validate the main-agent auth database");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("fails closed when a retired auth table is replaced by a view", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
+    const home = path.join(root, "home");
+    const stateDir = path.join(home, ".openclaw");
+    const configPath = path.join(stateDir, "openclaw.json");
+
+    try {
+      writeJson(configPath, {
+        auth: {
+          profiles: {
+            "openai:api-key": { provider: "openai", mode: "api_key" },
+          },
+        },
+      });
+      writeAuthProfileStoreSqlite(stateDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      const dbPath = writeAgentAuthDatabase(stateDir);
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.exec(`
+          DROP TABLE auth_profile_store;
+          CREATE VIEW auth_profile_store AS
+            SELECT 'primary' AS store_key, '{}' AS store_json, 1 AS updated_at;
+        `);
+      } finally {
+        db.close();
+      }
+
+      const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
+        HOME: home,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        "could not validate the main-agent auth database: auth_profile_store is view, not a table",
+      );
     } finally {
       rmSync(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves beta validation failures where fresh onboarding correctly persisted auth in the shared SQLite store, but release assertions still required a main-agent database and retired `primary` rows. It also removes three Slack test lifecycle races that could outlive their assertions.

## Why This Change Was Made

The release assertions now read the canonical shared `auth_profile_stores` row, permit an absent main-agent database, and fail closed when a real retired `primary` row or invalid legacy database surface exists. The Slack cases await their actual reply delivery before asserting or tearing down. No product/runtime behavior or workflow routing changes.

The candidate remains exact lineage from `daf78e48e1ffc4354dbf7bf01b8adb9963ea77da`; the Codex 0.149 proof receipt was refreshed after all candidate edits against clean upstream commit `758ef40f50c1a458425c7cfbf1eb12cbc07af0b0`.

## User Impact

No user-visible behavior change. This repairs release proof for the already-reviewed shared-auth storage behavior and makes the affected Slack validation deterministic.

## Evidence

- Frozen FRV blocker evidence:
  - npm onboarding shared-auth assertion: https://github.com/openclaw/openclaw/actions/runs/32640585900/job/97197589760
  - release typed-onboarding shared-auth assertion: https://github.com/openclaw/openclaw/actions/runs/32640587445/job/97197916981
  - Slack reply lifecycle race (`sendMock` observed 0 or 2 calls): https://github.com/openclaw/openclaw/actions/runs/32640585900/job/97197105009
- `test/scripts/npm-onboard-channel-agent-assertions.test.ts`: 17/17 passed
- `test/scripts/release-scenarios-assertions.test.ts`: 17/17 passed
- Classified Slack lifecycle slice: 3/3 passed across three consecutive runs
- `extensions/codex/src/app-server/approval-policy-v0.149.proof.test.ts`: 2/2 passed with `OPENCLAW_CODEX_REPO` pinned to clean `rust-v0.149.0` commit `758ef40f50c1a458425c7cfbf1eb12cbc07af0b0`
- `pnpm check:script-erasability`: passed
- Focused script oxlint: passed
- Focused formatting and `git diff --check`: passed

Direct upstream Codex source verified:

- `codex-rs/core/src/exec_policy_tests.rs:1010-1053`
- `codex-rs/core/src/exec_policy_tests.rs:1331-1350`
- `codex-rs/core/src/exec_policy_tests.rs:2090-2108`
- `codex-rs/core/src/exec_policy.rs:730-780`
- `codex-rs/core/src/config/mod.rs:3564-3582`

Hosted exact-head Package Acceptance passed:

- Run: https://github.com/openclaw/openclaw/actions/runs/32642173075
- source + harness SHA: `0639b520dd2a480d816530f780c10e6c2e6e89a6`
- `npm-onboard-channel-agent`: https://github.com/openclaw/openclaw/actions/runs/32642173075/job/97202875664
- `release-typed-onboarding`: https://github.com/openclaw/openclaw/actions/runs/32642173075/job/97202875737
- package integrity, selected-ref validation, Docker image binding, and final acceptance gate: passed

ClawSweeper exact-head review passed with no findings and security cleared:

- Run: https://github.com/openclaw/clawsweeper/actions/runs/32642488334
- Artifact: `9494052181` (`exact-review-32642488334-1`)

Rank-up disposition:

- exact-head Package Acceptance: satisfied by run `32642173075`
- direct Codex source: satisfied against clean `rust-v0.149.0` commit `758ef40f50c1a458425c7cfbf1eb12cbc07af0b0`
- current-main refresh: intentionally skipped because this release candidate is frozen to `daf78e48e1ffc4354dbf7bf01b8adb9963ea77da`; adopting main would violate the authorized release lineage

The separate Enterprise identity test exposed by the local full-file run passed its bounded one-test classification rerun (1/1); no additional scope was added.

- [x] AI-assisted
