### PR TITLE
test(audit): event-loop probes fail on shared-runner jitter instead of real blocking [AI-assisted]

### DIFF
--- a/src/audit/audit-event-writer.test.ts
+++ b/src/audit/audit-event-writer.test.ts
@@ -7,6 +7,7 @@ import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
+  registerOpenClawStateDatabaseLifecycleListener,
 } from "../state/openclaw-state-db.js";
 import { listAuditEvents, recordAuditEvent } from "./audit-event-store.js";
 import type { AuditEventInput } from "./audit-event-types.js";
@@ -25,6 +26,26 @@ import {
   processExecutionIdentityAdmissionWork,
 } from "./execution-identity-context.js";
 import type { TrustedMessageAuditEvent } from "./message-audit-events.js";
+
+function observeNonblockingSqliteTransactions(
+  database: DatabaseSync,
+  observed: number[],
+): () => void {
+  const originalExec = database.exec;
+  database.exec = (sql: string) => {
+    if (sql === "BEGIN IMMEDIATE") {
+      const busyTimeout = readSqliteBusyTimeout(database);
+      observed.push(busyTimeout);
+      if (busyTimeout !== 0) {
+        throw new Error(`audit writer attempted a blocking SQLite transaction (${busyTimeout} ms)`);
+      }
+    }
+    return originalExec.call(database, sql);
+  };
+  return () => {
+    database.exec = originalExec;
+  };
+}
 
 function defineObjectPrototypeProperties(descriptors: PropertyDescriptorMap): void {
   // oxlint-disable-next-line no-extend-native -- Exercise hostile prototype pollution across the real clone boundary.
@@ -262,20 +283,38 @@ describe("audit event writer", () => {
     const contender = new DatabaseSync(path);
     contender.exec("PRAGMA busy_timeout = 0; BEGIN IMMEDIATE");
     const errors: string[] = [];
-    const probeStartedAt = performance.now();
+    const observedBusyTimeouts: number[] = [];
+    let openedBusyTimeout: number | undefined;
+    let restoreExec: (() => void) | undefined;
+    const clearDatabaseListener = registerOpenClawStateDatabaseLifecycleListener((event) => {
+      if (event.kind !== "opened" || event.database.path !== path) {
+        return;
+      }
+      openedBusyTimeout = readSqliteBusyTimeout(event.database.db);
+      restoreExec = observeNonblockingSqliteTransactions(event.database.db, observedBusyTimeouts);
+    });
     const writer = createAuditEventWriter({ stateDir, onError: (error) => errors.push(error) });
 
     try {
-      const eventLoopDelay = await new Promise<number>((resolve) => {
-        setTimeout(() => resolve(performance.now() - probeStartedAt), 25);
-      });
-      expect(eventLoopDelay).toBeLessThan(250);
       await writer.ready;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(contender.isTransaction).toBe(true);
+      expect(openedBusyTimeout).toBe(0);
+      expect(observedBusyTimeouts).not.toHaveLength(0);
+      expect(observedBusyTimeouts.every((busyTimeout) => busyTimeout === 0)).toBe(true);
       expect(writer.record({ ...input(), sourceId: "cold-owner", runId: "cold-owner" })).toBe(true);
     } finally {
-      contender.exec("ROLLBACK");
-      contender.close();
-      await writer.stop();
+      try {
+        contender.exec("ROLLBACK");
+        contender.close();
+      } finally {
+        try {
+          await writer.stop();
+        } finally {
+          restoreExec?.();
+          clearDatabaseListener();
+        }
+      }
     }
 
     expect(errors).toEqual([]);
@@ -342,6 +381,8 @@ describe("audit event writer", () => {
     db.exec("DELETE FROM audit_identity_keys;");
     const contender = new DatabaseSync(path);
     contender.exec("PRAGMA busy_timeout = 0; BEGIN IMMEDIATE");
+    const observedBusyTimeouts: number[] = [];
+    const restoreExec = observeNonblockingSqliteTransactions(db, observedBusyTimeouts);
     const clearSink = configureExecutionIdentityAdmissionSink(writer.recordExecutionIdentity);
     const admittedAt = Date.now();
 
@@ -380,11 +421,10 @@ describe("audit event writer", () => {
         accepted: true,
       });
       expect(performance.now() - startedAt).toBeLessThan(250);
-      const eventLoopProbeStartedAt = performance.now();
-      const eventLoopDelay = await new Promise<number>((resolve) => {
-        setTimeout(() => resolve(performance.now() - eventLoopProbeStartedAt), 25);
-      });
-      expect(eventLoopDelay).toBeLessThan(250);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(contender.isTransaction).toBe(true);
+      expect(observedBusyTimeouts).not.toHaveLength(0);
+      expect(observedBusyTimeouts.every((busyTimeout) => busyTimeout === 0)).toBe(true);
       expect(readSqliteBusyTimeout(db)).toBe(5_000);
       expect(
         writer.recordExecutionIdentity({
@@ -411,7 +451,11 @@ describe("audit event writer", () => {
         contender.close();
       } finally {
         clearSink();
-        await writer.stop();
+        try {
+          await writer.stop();
+        } finally {
+          restoreExec();
+        }
       }
     }
 

--- a/src/audit/audit-event-writer.test.ts
+++ b/src/audit/audit-event-writer.test.ts
@@ -31,7 +31,8 @@ function observeNonblockingSqliteTransactions(
   database: DatabaseSync,
   observed: number[],
 ): () => void {
-  const originalExec = database.exec;
+  const originalExecDescriptor = Object.getOwnPropertyDescriptor(database, "exec");
+  const originalExec = database.exec.bind(database);
   database.exec = (sql: string) => {
     if (sql === "BEGIN IMMEDIATE") {
       const busyTimeout = readSqliteBusyTimeout(database);
@@ -40,10 +41,15 @@ function observeNonblockingSqliteTransactions(
         throw new Error(`audit writer attempted a blocking SQLite transaction (${busyTimeout} ms)`);
       }
     }
-    return originalExec.call(database, sql);
+    return originalExec(sql);
   };
   return () => {
-    database.exec = originalExec;
+    if (originalExecDescriptor) {
+      Object.defineProperty(database, "exec", originalExecDescriptor);
+      return;
+    }
+    const ownDatabaseMethod: { exec?: DatabaseSync["exec"] } = database;
+    delete ownDatabaseMethod.exec;
   };
 }
 
@@ -297,7 +303,9 @@ describe("audit event writer", () => {
 
     try {
       await writer.ready;
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(contender.isTransaction).toBe(true);
       expect(openedBusyTimeout).toBe(0);
       expect(observedBusyTimeouts).not.toHaveLength(0);
@@ -421,7 +429,9 @@ describe("audit event writer", () => {
         accepted: true,
       });
       expect(performance.now() - startedAt).toBeLessThan(250);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(contender.isTransaction).toBe(true);
       expect(observedBusyTimeouts).not.toHaveLength(0);
       expect(observedBusyTimeouts.every((busyTimeout) => busyTimeout === 0)).toBe(true);


### PR DESCRIPTION
Related: #128223

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

> **Body updated 2026-08-24** to describe the shipped approach. @steipete took the branch over and replaced the original commit with a stronger fix: instead of widening the timing bound, the probes now assert the non-blocking invariant directly. The sections below describe that shipped solution, not the original proposal.

## What Problem This Solves

Resolves a problem where PR CI fails on an unrelated shard when a shared runner is under load. `src/audit/audit-event-writer.test.ts` proved the audit writer stays non-blocking under a held SQLite write lock by scheduling a 25 ms timer and asserting it fired within 250 ms. That is a proxy for the real invariant, and it fails whenever runner scheduling jitter delays the timer — with no product regression involved.

Observed twice on #128223, both in `checks-node-compact-large-6`:

- run [32640741873](https://github.com/openclaw/openclaw/actions/runs/32640741873/job/97197390796) — `expected 275.14786399999866 to be less than 250`
- run [32643396362](https://github.com/openclaw/openclaw/actions/runs/32643396362) — `expected 278.6432880000066 to be less than 250`, same test, same line

Two of three runs of that shard tripped the probe.

## Why This Change Was Made

The probes now assert the invariant they actually exist to protect rather than a timing proxy. `observeNonblockingSqliteTransactions` wraps the state database's `exec`, and every `BEGIN IMMEDIATE` the audit writer issues is checked to run with `busy_timeout = 0`, throwing if it is ever non-zero. A new state-database lifecycle listener captures the busy timeout at open time, and the tests additionally assert the contender still holds its transaction (`contender.isTransaction`) and that at least one observed transaction was recorded — so the assertions cannot pass vacuously.

The regression this guards is a synchronous SQLite open/insert that waits out `OPENCLAW_SQLITE_BUSY_TIMEOUT_MS` (5 s, `src/state/openclaw-state-db-contract.ts`). Asserting `busy_timeout === 0` at each transaction detects that failure mode directly and deterministically, with no dependence on wall-clock timing, so the test no longer has a jitter surface at all. The wrapper restores the original `exec` own-property descriptor (or deletes the own property when the method came from the prototype) so the observation cannot leak into sibling tests. No production code changes.

## User Impact

No user-visible change. Contributor and maintainer PR CI stops going red on runner scheduling jitter in this audit test, and the test now fails for the real reason — a blocking audit write — instead of for a slow runner.

## Evidence

AI-assisted (Claude Code); reviewed and understood.

- `pnpm test src/audit/audit-event-writer.test.ts` on head `f098cf242a7` → `Test Files 1 passed (1)`, `Tests 11 passed (11)`.
- `node scripts/run-oxlint.mjs src/audit/audit-event-writer.test.ts` → exit 0.
- `pnpm check:changed` → exit 0; `git diff --check` clean.
- Both CI failure traces above establish the fault this replaces; the new assertions exercise the same production SQLite boundary under a genuinely held write lock.
- Not a current `main` failure at the time of filing (recent `main` reds were `checks-fast-baseline-ratchets`); no other open issue or PR tracks this probe.
