### PR TITLE
fix(ui): delay build chip hovercard until intent

### DIFF
--- a/ui/src/components/sidebar-build-chip.ts
+++ b/ui/src/components/sidebar-build-chip.ts
@@ -30,7 +30,12 @@ class SidebarBuildChip extends OpenClawLightDomContentsElement {
       return nothing;
     }
     return html`
-      <openclaw-tooltip class="sidebar-hover-tooltip" .delay=${600} .closeDelay=${300}>
+      <openclaw-tooltip
+        class="sidebar-hover-tooltip"
+        .delay=${600}
+        .closeDelay=${300}
+        .openOnClick=${true}
+      >
         <a
           class="sidebar-footer-build"
           href=${pathForRoute("about", this.basePath)}

--- a/ui/src/components/sidebar-build-chip.ts
+++ b/ui/src/components/sidebar-build-chip.ts
@@ -30,12 +30,7 @@ class SidebarBuildChip extends OpenClawLightDomContentsElement {
       return nothing;
     }
     return html`
-      <openclaw-tooltip
-        class="sidebar-hover-tooltip"
-        .delay=${600}
-        .closeDelay=${300}
-        .openOnClick=${true}
-      >
+      <openclaw-tooltip class="sidebar-hover-tooltip" .delay=${600} .closeDelay=${300}>
         <a
           class="sidebar-footer-build"
           href=${pathForRoute("about", this.basePath)}

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -303,12 +303,11 @@ describe("openclaw-tooltip", () => {
     expectOpenCount(1);
   });
 
-  it("honors per-tooltip hover intent while focus and click stay immediate", async () => {
+  it("honors per-tooltip hover intent while keyboard focus stays immediate", async () => {
     const provider = createProvider();
     const { tooltip, trigger } = createRichTooltip("Intentional hovercard");
     tooltip.delay = 600;
     tooltip.closeDelay = 300;
-    tooltip.openOnClick = true;
     provider.append(tooltip);
     document.body.append(provider);
     await tooltip.updateComplete;
@@ -338,9 +337,6 @@ describe("openclaw-tooltip", () => {
     vi.advanceTimersByTime(0);
     expectOpenCount(0);
     dispatchMousePointer(trigger, "pointerleave");
-
-    trigger.click();
-    expectOpenCount(1);
   });
 
   it("keeps the accessible description in the trigger document tree", async () => {

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -4,7 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installNativeTitleGuard } from "./tooltip.ts";
 
 type TooltipElement = HTMLElement & {
+  closeDelay: number;
   content: string;
+  delay: number;
   openOnClick: boolean;
   readonly updateComplete: Promise<boolean>;
 };
@@ -136,6 +138,8 @@ describe("openclaw-tooltip", () => {
     expect(styles).toContain("--wa-tooltip-arrow-size: var(--openclaw-tooltip-arrow-size, 0px)");
     expect(styles).toContain("var(--overlay-border, var(--border-strong))");
     expect(styles).toContain("var(--overlay-shadow, var(--shadow-md))");
+    expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(styles).toContain("animation: none");
   });
 
   it("projects rich content into the Web Awesome tooltip", async () => {
@@ -296,6 +300,46 @@ describe("openclaw-tooltip", () => {
     dispatchTouchPointer(reveal.trigger, "pointerdown");
     dispatchTouchPointer(reveal.trigger, "pointerup");
     reveal.trigger.click();
+    expectOpenCount(1);
+  });
+
+  it("honors per-tooltip hover intent while focus and click stay immediate", async () => {
+    const provider = createProvider();
+    const { tooltip, trigger } = createRichTooltip("Intentional hovercard");
+    tooltip.delay = 600;
+    tooltip.closeDelay = 300;
+    tooltip.openOnClick = true;
+    provider.append(tooltip);
+    document.body.append(provider);
+    await tooltip.updateComplete;
+
+    hoverTrigger(trigger);
+    vi.advanceTimersByTime(300);
+    dispatchMousePointer(trigger, "pointerleave");
+    expectOpenCount(0);
+
+    hoverTrigger(trigger);
+    vi.advanceTimersByTime(599);
+    expectOpenCount(0);
+    vi.advanceTimersByTime(1);
+    expectOpenCount(1);
+
+    dispatchMousePointer(trigger, "pointerleave");
+    vi.advanceTimersByTime(299);
+    expectOpenCount(1);
+    vi.advanceTimersByTime(1);
+    expectOpenCount(0);
+
+    focusTrigger(trigger);
+    expectOpenCount(1);
+
+    trigger.dispatchEvent(new FocusEvent("focusout", { bubbles: true, composed: true }));
+    hoverTrigger(trigger);
+    vi.advanceTimersByTime(0);
+    expectOpenCount(0);
+    dispatchMousePointer(trigger, "pointerleave");
+
+    trigger.click();
     expectOpenCount(1);
   });
 

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -231,6 +231,8 @@ class Tooltip extends OpenClawLitElement {
 
   @property({ type: Number }) closeDelay = RICH_CONTENT_CLOSE_DELAY;
 
+  @property({ type: Number }) delay?: number;
+
   @property({ type: Boolean }) describe = true;
 
   @property({ type: Boolean }) disabled = false;
@@ -290,6 +292,17 @@ class Tooltip extends OpenClawLitElement {
 
     wa-tooltip[open]::part(body) {
       animation: var(--openclaw-tooltip-open-animation, none);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      wa-tooltip {
+        --show-duration: 0ms;
+        --hide-duration: 0ms;
+      }
+
+      wa-tooltip[open]::part(body) {
+        animation: none;
+      }
     }
 
     @keyframes openclaw-tooltip-hover-card-in {
@@ -411,6 +424,7 @@ class Tooltip extends OpenClawLitElement {
   private readonly handlePointerLeave = (event: PointerEvent) => {
     if (event.pointerType !== "touch") {
       this.triggerHovered = false;
+      this.clearTimers(false);
       this.maybeClose();
     }
   };
@@ -474,7 +488,10 @@ class Tooltip extends OpenClawLitElement {
       return;
     }
     const provider = this.tooltipProvider;
-    const delay = provider?.delayed === false ? 0 : Math.max(0, provider?.delay ?? HOVER_DELAY);
+    const delay =
+      this.delay === undefined && provider?.delayed === false
+        ? 0
+        : Math.max(0, this.delay ?? provider?.delay ?? HOVER_DELAY);
     this.openTimer = window.setTimeout(() => {
       this.openTimer = null;
       this.show();

--- a/ui/src/e2e/sidebar-account-footer.e2e.test.ts
+++ b/ui/src/e2e/sidebar-account-footer.e2e.test.ts
@@ -69,6 +69,26 @@ async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feat
     )?.trim();
     const buildPrefix = branch === "main" ? "git@0123456" : "feat/sidebar-f…@0123456";
     expect(buildLabel?.startsWith(`${buildPrefix} · `)).toBe(true);
+    const buildLink = menu.getByRole("link", { name: "Control UI build details" });
+    const buildTooltip = sidebar.locator("openclaw-sidebar-build-chip openclaw-tooltip wa-tooltip");
+    const buildTooltipCard = sidebar.locator(".sidebar-build-hover-card");
+    await page.clock.install();
+    await buildLink.hover();
+    await page.clock.runFor(300);
+    await page.mouse.move(0, 0);
+    await page.clock.runFor(300);
+    expect(await buildTooltip.getAttribute("open")).toBeNull();
+    await buildLink.hover();
+    await page.clock.runFor(600);
+    await expect.poll(() => buildTooltip.getAttribute("open")).not.toBeNull();
+    await page.clock.resume();
+    await captureUnionProof(page, "build-chip-hover-intent", `${branch}-${theme}-intent-open.png`, [
+      footer,
+      menuSurface,
+      buildTooltipCard,
+    ]);
+    await page.mouse.move(0, 0);
+    await buildTooltipCard.waitFor({ state: "hidden" });
     await captureUnionProof(page, "sidebar-account-footer", `${branch}-${theme}-menu-default.png`, [
       footer,
       menuSurface,

--- a/ui/src/e2e/sidebar-account-footer.e2e.test.ts
+++ b/ui/src/e2e/sidebar-account-footer.e2e.test.ts
@@ -163,4 +163,36 @@ suite.define(() => {
       await suite.closeBrowserContext(opened.context);
     }
   });
+
+  it("navigates from the build link without opening its hovercard", async () => {
+    const opened = await openSidebarFooterProofPage(suite);
+    try {
+      const { page, sidebar } = opened;
+      await sidebar.locator(".sidebar-identity-card").click();
+      const buildLink = sidebar.getByRole("link", {
+        name: "Control UI build details",
+        exact: true,
+      });
+      const tooltip = sidebar.locator("openclaw-sidebar-build-chip openclaw-tooltip wa-tooltip");
+      await tooltip.evaluate((element) => {
+        document.documentElement.dataset.buildTooltipOpenedByClick = "false";
+        element.addEventListener(
+          "wa-show",
+          () => {
+            document.documentElement.dataset.buildTooltipOpenedByClick = "true";
+          },
+          { once: true },
+        );
+      });
+
+      await buildLink.click();
+
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/about");
+      expect(await page.locator("html").getAttribute("data-build-tooltip-opened-by-click")).toBe(
+        "false",
+      );
+    } finally {
+      await suite.closeBrowserContext(opened.context);
+    }
+  });
 });


### PR DESCRIPTION
Closes #128229

## What Problem This Solves

Fixes an issue where users moving through the account menu would have the build details hovercard open during a brief pointer crossing, covering actions such as Settings.

## Why This Change Was Made

Restores the shared tooltip's per-trigger hover-intent contract, cancels pending opens on pointer leave, and keeps the build chip's explicit 600 ms delay independent of the provider skip-delay window. Keyboard focus remains immediate, while click/touch keeps the build link's existing navigation to About. Rich hovercard motion honors reduced-motion preferences.

## User Impact

Briefly crossing the build row no longer interrupts account-menu navigation. Sustained hover opens the build details after 600 ms, keyboard focus opens it immediately, and clicking or tapping the link navigates directly to About without also opening the hovercard.

## Evidence

Before: #128229 includes the observed hovercard covering the account menu.

After video, inspected frame-by-frame: the first brief crossing stays closed; sustained hover opens the card; both light and dark menu states remain coherent.

https://github.com/user-attachments/assets/6f528af9-a4ff-453f-80e7-8bcf62059da4

Light mode after:

![Build chip hover intent in light mode](https://github.com/user-attachments/assets/699acddf-aaec-4a6a-8d8e-6904d87e1fa0)

Dark mode after:

![Build chip hover intent in dark mode](https://github.com/user-attachments/assets/7987cf45-d3e0-47b3-9d71-0a01093f4b6a)

Validation:

- Regression test failed before the fix on the brief pointer traversal and passes after it.
- E2E now proves a primary click navigates to `/settings/about` without emitting `wa-show` for the build tooltip.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/components/tooltip.test.ts ui/src/components/sidebar-build-chip.node.test.ts` (48 passed)
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-account-footer.e2e.test.ts` (2 passed)
- `node scripts/check-changed.mjs -- ui/src/components/sidebar-build-chip.ts ui/src/components/tooltip.test.ts ui/src/e2e/sidebar-account-footer.e2e.test.ts` (passed)
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --max-priority P2` (clean; no accepted/actionable findings)

Production LOC: +18/-2. Tests: +92/-0.
