### PR TITLE
fix(ci): await Slack provider reply delivery

### DIFF
--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 // Slack helper module supports monitor helpers behavior.
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
@@ -25,6 +26,8 @@ type SlackProviderMonitor = (params: {
   setStatus?: (next: Record<string, unknown>) => void;
 }) => Promise<unknown>;
 type SlackStartupAuthClientFactory = typeof import("./client.js").createSlackStartupAuthClient;
+type SlackChannelInboundDispatch =
+  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
 
 const SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY = "openclawIngressLifecycle";
 
@@ -77,6 +80,7 @@ type SlackTestState = {
   >;
   socketModeLogger?: { error: (...args: unknown[]) => void };
   createSlackStartupAuthClientMock: Mock<SlackStartupAuthClientFactory>;
+  channelInboundDispatchOnce?: SlackChannelInboundDispatch;
 };
 
 // globalThis-backed singleton: with isolate=false, a vi.resetModules() in any
@@ -103,6 +107,7 @@ const slackTestState: SlackTestState = vi.hoisted(() => {
     resolveSlackUserAllowlistMock: vi.fn(),
     socketModeLogger: undefined,
     createSlackStartupAuthClientMock: vi.fn(),
+    channelInboundDispatchOnce: undefined,
   } as SlackTestState;
   return globalState["__slackTestState"];
 });
@@ -111,6 +116,47 @@ export const getSlackTestState = (): SlackTestState => slackTestState;
 
 export function useSlackStartupAuthClientOnce(factory: SlackStartupAuthClientFactory): void {
   slackTestState.createSlackStartupAuthClientMock.mockImplementationOnce(factory);
+}
+
+export function useSlackReplyDeliveryOnce(
+  onContext?: (ctxPayload: Record<string, unknown>) => void,
+): Promise<void> {
+  if (slackTestState.channelInboundDispatchOnce) {
+    throw new Error("Slack reply delivery is already armed");
+  }
+  const settled = createDeferred<void>();
+  slackTestState.channelInboundDispatchOnce = async (params) => {
+    try {
+      onContext?.(params.ctxPayload);
+      const deliver = params.delivery?.deliver;
+      if (!deliver) {
+        throw new Error("expected Slack reply delivery callback");
+      }
+      const reply = await params.replyResolver?.(
+        params.ctxPayload,
+        params.replyOptions,
+        params.cfg,
+      );
+      for (const payload of Array.isArray(reply) ? reply : reply ? [reply] : []) {
+        await deliver(payload, { kind: "final" });
+      }
+      settled.resolve();
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: params.ctxPayload,
+        routeSessionKey: params.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: Boolean(reply),
+          counts: { tool: 0, block: 0, final: reply ? 1 : 0 },
+        },
+      };
+    } catch (error) {
+      settled.reject(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
+  };
+  return settled.promise;
 }
 
 type SlackClient = {
@@ -340,6 +386,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   slackTestState.config = config;
   slackTestState.appConstructorArgs = undefined;
   slackTestState.socketModeLogger = undefined;
+  slackTestState.channelInboundDispatchOnce = undefined;
   slackTestState.appStartMock.mockReset().mockResolvedValue(undefined);
   slackTestState.appStopMock.mockReset().mockResolvedValue(undefined);
   slackTestState.interactionRegistrations.length = 0;
@@ -404,8 +451,15 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     slackTestState.replyMock(...args) as ReturnType<ReplyResolver>;
   return {
     ...actual,
-    dispatchChannelInboundTurn: (params: DispatchParams) =>
-      actual.dispatchChannelInboundTurn({ ...params, replyResolver }),
+    dispatchChannelInboundTurn: (params: DispatchParams) => {
+      const enrichedParams = { ...params, replyResolver };
+      const dispatchOnce = slackTestState.channelInboundDispatchOnce;
+      if (dispatchOnce) {
+        slackTestState.channelInboundDispatchOnce = undefined;
+        return dispatchOnce(enrichedParams);
+      }
+      return actual.dispatchChannelInboundTurn(enrichedParams);
+    },
   };
 });
 

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 // Slack helper module supports monitor helpers behavior.
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
-import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
@@ -26,8 +25,6 @@ type SlackProviderMonitor = (params: {
   setStatus?: (next: Record<string, unknown>) => void;
 }) => Promise<unknown>;
 type SlackStartupAuthClientFactory = typeof import("./client.js").createSlackStartupAuthClient;
-type SlackChannelInboundDispatch =
-  typeof import("openclaw/plugin-sdk/channel-inbound").dispatchChannelInboundTurn;
 
 const SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY = "openclawIngressLifecycle";
 
@@ -80,7 +77,6 @@ type SlackTestState = {
   >;
   socketModeLogger?: { error: (...args: unknown[]) => void };
   createSlackStartupAuthClientMock: Mock<SlackStartupAuthClientFactory>;
-  channelInboundDispatchOnce?: SlackChannelInboundDispatch;
 };
 
 // globalThis-backed singleton: with isolate=false, a vi.resetModules() in any
@@ -107,7 +103,6 @@ const slackTestState: SlackTestState = vi.hoisted(() => {
     resolveSlackUserAllowlistMock: vi.fn(),
     socketModeLogger: undefined,
     createSlackStartupAuthClientMock: vi.fn(),
-    channelInboundDispatchOnce: undefined,
   } as SlackTestState;
   return globalState["__slackTestState"];
 });
@@ -118,45 +113,11 @@ export function useSlackStartupAuthClientOnce(factory: SlackStartupAuthClientFac
   slackTestState.createSlackStartupAuthClientMock.mockImplementationOnce(factory);
 }
 
-export function useSlackReplyDeliveryOnce(
-  onContext?: (ctxPayload: Record<string, unknown>) => void,
+export async function runSlackHandlerWithDispatch(
+  handler: SlackHandler,
+  args: unknown,
 ): Promise<void> {
-  if (slackTestState.channelInboundDispatchOnce) {
-    throw new Error("Slack reply delivery is already armed");
-  }
-  const settled = createDeferred<void>();
-  slackTestState.channelInboundDispatchOnce = async (params) => {
-    try {
-      onContext?.(params.ctxPayload);
-      const deliver = params.delivery?.deliver;
-      if (!deliver) {
-        throw new Error("expected Slack reply delivery callback");
-      }
-      const reply = await params.replyResolver?.(
-        params.ctxPayload,
-        params.replyOptions,
-        params.cfg,
-      );
-      for (const payload of Array.isArray(reply) ? reply : reply ? [reply] : []) {
-        await deliver(payload, { kind: "final" });
-      }
-      settled.resolve();
-      return {
-        admission: { kind: "dispatch" },
-        dispatched: true,
-        ctxPayload: params.ctxPayload,
-        routeSessionKey: params.route.sessionKey,
-        dispatchResult: {
-          queuedFinal: Boolean(reply),
-          counts: { tool: 0, block: 0, final: reply ? 1 : 0 },
-        },
-      };
-    } catch (error) {
-      settled.reject(error instanceof Error ? error : new Error(String(error)));
-      throw error;
-    }
-  };
-  return settled.promise;
+  await handler(withSlackDispatchLifecycle(args));
 }
 
 type SlackClient = {
@@ -317,9 +278,12 @@ async function runSlackEventOnce(
   const handler = await getSlackHandlerOrThrow(name);
   // Normal Bolt handlers return after queue admission. Terminal-state tests use the
   // durable-ingress lifecycle so this helper can await the actual dispatch boundary.
-  const handlerArgs = opts?.awaitDispatch ? withSlackDispatchLifecycle(args) : args;
   try {
-    await handler(handlerArgs);
+    if (opts?.awaitDispatch) {
+      await runSlackHandlerWithDispatch(handler, args);
+    } else {
+      await handler(args);
+    }
   } finally {
     await stopSlackMonitor({ controller, run });
   }
@@ -386,7 +350,6 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   slackTestState.config = config;
   slackTestState.appConstructorArgs = undefined;
   slackTestState.socketModeLogger = undefined;
-  slackTestState.channelInboundDispatchOnce = undefined;
   slackTestState.appStartMock.mockReset().mockResolvedValue(undefined);
   slackTestState.appStopMock.mockReset().mockResolvedValue(undefined);
   slackTestState.interactionRegistrations.length = 0;
@@ -451,15 +414,8 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     slackTestState.replyMock(...args) as ReturnType<ReplyResolver>;
   return {
     ...actual,
-    dispatchChannelInboundTurn: (params: DispatchParams) => {
-      const enrichedParams = { ...params, replyResolver };
-      const dispatchOnce = slackTestState.channelInboundDispatchOnce;
-      if (dispatchOnce) {
-        slackTestState.channelInboundDispatchOnce = undefined;
-        return dispatchOnce(enrichedParams);
-      }
-      return actual.dispatchChannelInboundTurn(enrichedParams);
-    },
+    dispatchChannelInboundTurn: (params: DispatchParams) =>
+      actual.dispatchChannelInboundTurn({ ...params, replyResolver }),
   };
 });
 

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -18,6 +18,7 @@ import {
   resetSlackTestState,
   startSlackMonitor as startSlackMonitorUntracked,
   stopSlackMonitor,
+  useSlackReplyDeliveryOnce,
   useSlackStartupAuthClientOnce,
 } from "../monitor.test-helpers.js";
 import { getSlackRuntime } from "../runtime.js";
@@ -360,6 +361,10 @@ describe("auth.test boot call", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "identity preserved" });
+    let dispatchedContext: Record<string, unknown> | undefined;
+    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
+      dispatchedContext = ctxPayload;
+    });
 
     const monitor = startSlackMonitor(monitorSlackProvider, {
       appToken: "xapp-1-A1-opaque",
@@ -394,7 +399,17 @@ describe("auth.test boot call", () => {
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
-    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    await deliverySettled;
+    expect(dispatchedContext).toMatchObject({
+      Body: expect.stringMatching(/<@UENTERPRISE>.*status/u),
+      ChatType: "channel",
+      WasMentioned: true,
+    });
+    expect(sendMock).toHaveBeenCalledWith(
+      "channel:C12345678",
+      "identity preserved",
+      expect.any(Object),
+    );
     await expect(stopSlackMonitor(monitor)).resolves.toBeUndefined();
     expect(getSlackInstallationKind("default")).toBeUndefined();
   });
@@ -477,7 +492,12 @@ describe("presence polling transport", () => {
         ...options,
         env: options.env ?? process.env,
       });
-    getSlackTestState().replyMock.mockResolvedValue({ text: "ok" });
+    const { replyMock, sendMock } = getSlackTestState();
+    replyMock.mockResolvedValue({ text: "ok" });
+    let dispatchedContext: Record<string, unknown> | undefined;
+    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
+      dispatchedContext = ctxPayload;
+    });
 
     const nativeSetInterval = globalThis.setInterval;
     let triggerPresencePoll: (() => void) | undefined;
@@ -508,6 +528,15 @@ describe("presence polling transport", () => {
         context: { botUserId: "bot-user" },
         body: {},
       });
+      await deliverySettled;
+      expect(dispatchedContext).toMatchObject({
+        Body: expect.stringMatching(
+          /Ada: hello\n\[slack message id: 100\.000 channel: D_STALLED\]$/u,
+        ),
+        ChatType: "direct",
+        WasMentioned: false,
+      });
+      expect(sendMock).toHaveBeenCalledWith("channel:D_STALLED", "ok", expect.any(Object));
       expect(triggerPresencePoll).toBeTypeOf("function");
       triggerPresencePoll?.();
       await vi.waitFor(() => expect(server.requestCount).toBe(1), { timeout: 1_000 });
@@ -618,6 +647,10 @@ describe("user identity provider transport", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "acknowledged" });
+    let dispatchedContext: Record<string, unknown> | undefined;
+    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
+      dispatchedContext = ctxPayload;
+    });
     const monitor = await startWithoutBotToken(config);
     const handler = await getSlackHandlerOrThrow("message");
 
@@ -634,7 +667,13 @@ describe("user identity provider transport", () => {
       body: {},
     });
 
-    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    await deliverySettled;
+    expect(dispatchedContext).toMatchObject({
+      Body: expect.stringMatching(/<@U_SELF>.*status/u),
+      ChatType: "channel",
+      WasMentioned: true,
+    });
+    expect(sendMock).toHaveBeenCalledWith("channel:C1", "acknowledged", expect.any(Object));
     await stopSlackMonitor(monitor);
   });
 
@@ -649,6 +688,10 @@ describe("user identity provider transport", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "hello back" });
+    let dispatchedContext: Record<string, unknown> | undefined;
+    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
+      dispatchedContext = ctxPayload;
+    });
     const monitor = await startWithoutBotToken(config);
     const handler = await getSlackHandlerOrThrow("message");
     const baseEvent = {
@@ -663,7 +706,13 @@ describe("user identity provider transport", () => {
       context: { botUserId: "U_SELF" },
       body: {},
     });
-    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    await deliverySettled;
+    expect(dispatchedContext).toMatchObject({
+      Body: expect.stringMatching(/Ada: hello\n\[slack message id: 100\.000 channel: D1\]$/u),
+      ChatType: "direct",
+      WasMentioned: false,
+    });
+    expect(sendMock).toHaveBeenCalledWith("channel:D1", "hello back", expect.any(Object));
 
     await handler({
       event: { ...baseEvent, user: "U_SELF", ts: "101.000" },

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -16,9 +16,9 @@ import {
   getSlackHandlers,
   getSlackTestState,
   resetSlackTestState,
+  runSlackHandlerWithDispatch,
   startSlackMonitor as startSlackMonitorUntracked,
   stopSlackMonitor,
-  useSlackReplyDeliveryOnce,
   useSlackStartupAuthClientOnce,
 } from "../monitor.test-helpers.js";
 import { getSlackRuntime } from "../runtime.js";
@@ -361,10 +361,6 @@ describe("auth.test boot call", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "identity preserved" });
-    let dispatchedContext: Record<string, unknown> | undefined;
-    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
-      dispatchedContext = ctxPayload;
-    });
 
     const monitor = startSlackMonitor(monitorSlackProvider, {
       appToken: "xapp-1-A1-opaque",
@@ -380,7 +376,7 @@ describe("auth.test boot call", () => {
     expect(getSlackInstallationKind("default")).toBe("enterprise");
 
     const handler = await getSlackHandlerOrThrow("message");
-    await handler({
+    await runSlackHandlerWithDispatch(handler, {
       event: {
         type: "message",
         user: "UOTHER123",
@@ -399,7 +395,7 @@ describe("auth.test boot call", () => {
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
-    await deliverySettled;
+    const dispatchedContext = replyMock.mock.calls[0]?.[0];
     expect(dispatchedContext).toMatchObject({
       Body: expect.stringMatching(/<@UENTERPRISE>.*status/u),
       ChatType: "channel",
@@ -494,10 +490,6 @@ describe("presence polling transport", () => {
       });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "ok" });
-    let dispatchedContext: Record<string, unknown> | undefined;
-    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
-      dispatchedContext = ctxPayload;
-    });
 
     const nativeSetInterval = globalThis.setInterval;
     let triggerPresencePoll: (() => void) | undefined;
@@ -516,7 +508,7 @@ describe("presence polling transport", () => {
     const monitor = startSlackMonitor(monitorSlackProvider);
     try {
       const handler = await getSlackHandlerOrThrow("message");
-      await handler({
+      await runSlackHandlerWithDispatch(handler, {
         event: {
           type: "message",
           user: "U_STALLED",
@@ -528,7 +520,7 @@ describe("presence polling transport", () => {
         context: { botUserId: "bot-user" },
         body: {},
       });
-      await deliverySettled;
+      const dispatchedContext = replyMock.mock.calls[0]?.[0];
       expect(dispatchedContext).toMatchObject({
         Body: expect.stringMatching(
           /Ada: hello\n\[slack message id: 100\.000 channel: D_STALLED\]$/u,
@@ -647,14 +639,10 @@ describe("user identity provider transport", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "acknowledged" });
-    let dispatchedContext: Record<string, unknown> | undefined;
-    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
-      dispatchedContext = ctxPayload;
-    });
     const monitor = await startWithoutBotToken(config);
     const handler = await getSlackHandlerOrThrow("message");
 
-    await handler({
+    await runSlackHandlerWithDispatch(handler, {
       event: {
         type: "message",
         user: "U_OTHER",
@@ -667,7 +655,7 @@ describe("user identity provider transport", () => {
       body: {},
     });
 
-    await deliverySettled;
+    const dispatchedContext = replyMock.mock.calls[0]?.[0];
     expect(dispatchedContext).toMatchObject({
       Body: expect.stringMatching(/<@U_SELF>.*status/u),
       ChatType: "channel",
@@ -688,10 +676,6 @@ describe("user identity provider transport", () => {
     });
     const { replyMock, sendMock } = getSlackTestState();
     replyMock.mockResolvedValue({ text: "hello back" });
-    let dispatchedContext: Record<string, unknown> | undefined;
-    const deliverySettled = useSlackReplyDeliveryOnce((ctxPayload) => {
-      dispatchedContext = ctxPayload;
-    });
     const monitor = await startWithoutBotToken(config);
     const handler = await getSlackHandlerOrThrow("message");
     const baseEvent = {
@@ -701,12 +685,12 @@ describe("user identity provider transport", () => {
       text: "hello",
     };
 
-    await handler({
+    await runSlackHandlerWithDispatch(handler, {
       event: { ...baseEvent, user: "U_OTHER", ts: "100.000" },
       context: { botUserId: "U_SELF" },
       body: {},
     });
-    await deliverySettled;
+    const dispatchedContext = replyMock.mock.calls[0]?.[0];
     expect(dispatchedContext).toMatchObject({
       Body: expect.stringMatching(/Ada: hello\n\[slack message id: 100\.000 channel: D1\]$/u),
       ChatType: "direct",

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -981,7 +981,7 @@ describe("connected identity health", () => {
     });
     expect(getSlackHandlers().has("reaction_added")).toBe(true);
 
-    await handler({
+    await runSlackHandlerWithDispatch(handler, {
       event: {
         type: "message",
         user: "UOTHER123",
@@ -1003,7 +1003,12 @@ describe("connected identity health", () => {
       expect.objectContaining({ channel: "C12345678" }),
     );
     expect(replyMock).toHaveBeenCalledTimes(1);
-    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    const dispatchedContext = replyMock.mock.calls[0]?.[0];
+    expect(dispatchedContext).toMatchObject({
+      Body: expect.stringMatching(/<@UENTERPRISE>.*status/u),
+      ChatType: "channel",
+      WasMentioned: true,
+    });
     expect(sendMock).toHaveBeenCalledWith(
       "channel:C12345678",
       "identity restored",


### PR DESCRIPTION
Related: #128192
Related: #128226

## What Problem This Solves

Fixes an issue where five Slack provider-auth tests could finish their Bolt handler before asynchronous reply delivery completed, then poll `sendMock` as an indirect completion signal. Beta release validation exposed this as nondeterministic harness evidence.

## Why This Change Was Made

Adds one shared Slack test seam that attaches the existing durable-ingress lifecycle to a Bolt handler invocation. The affected Enterprise Grid startup, stalled-presence, user-mention, user-DM, and recovered Enterprise identity cases now await the real dispatcher and delivery boundary, then assert the dispatched context and final send.

No dispatcher behavior is replaced or reproduced. There are no runtime, auth, product, release, or publication code changes.

## User Impact

No user-visible behavior changes. Slack provider CI now records deterministic reply-delivery completion instead of relying on mock polling timing.

## Evidence

- `node scripts/run-vitest.mjs extensions/slack/src/monitor/provider.auth-test-token.test.ts`
  - 1 file passed, 26 tests passed
- Three fresh-process repetitions of the five affected cases
  - each run: 5 passed, 21 skipped
- `pnpm format extensions/slack/src/monitor.test-helpers.ts extensions/slack/src/monitor/provider.auth-test-token.test.ts`
- `git diff --check`
- `node scripts/check-changed.mjs -- extensions/slack/src/monitor.test-helpers.ts extensions/slack/src/monitor/provider.auth-test-token.test.ts`
  - all pre-typecheck checks passed
  - extension test typecheck remains blocked by unrelated current-main dependency drift in ACPX, CUA Computer, and terminal-core
  - no Slack errors were reported

Production LOC: +0/-0
Tests: +60/-12

Provenance: beta repair PRs #128192 and #128226 exposed and mitigated the race while qualifying the frozen release candidate. This PR carries only the reusable test-harness repair onto current `main`.

Review follow-up: the first exact-head ClawSweeper review correctly rejected a synthetic dispatcher override. The replacement waits through the existing durable-ingress lifecycle instead. Exact review then identified the remaining recovered-identity polling sibling; this head migrates that fifth case to the same seam.

AI-assisted: yes.
