### PR TITLE
fix(ci): validate complete plugin binding proof logs

### DIFF
--- a/scripts/e2e/plugin-binding-command-escape-docker.sh
+++ b/scripts/e2e/plugin-binding-command-escape-docker.sh
@@ -62,9 +62,12 @@ const { StringDecoder } = require("node:string_decoder");
 const logPath = process.argv[2];
 const scanBytes = 65536;
 const maxLineChars = 4096;
+const stat = fs.statSync(logPath);
+const length = Math.min(stat.size, scanBytes);
 const buffer = Buffer.alloc(scanBytes);
 const fd = fs.openSync(logPath, "r");
 const decoder = new StringDecoder("utf8");
+let diagnosticTail = "";
 let carry = "";
 let discardingLongLine = false;
 let invalidSummary = false;
@@ -115,6 +118,10 @@ function scanText(text) {
   appendLineSegment(text.slice(start), false);
 }
 
+function isInvalidProof() {
+  return invalidSummary || summaryCount < 1 || summaryCount > 2 || totalPassed !== 3;
+}
+
 try {
   while (true) {
     const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, offset);
@@ -126,14 +133,20 @@ try {
   }
   scanText(decoder.end());
   appendLineSegment("", true);
+  if (isInvalidProof() && length > 0) {
+    const bytesRead = fs.readSync(fd, buffer, 0, length, stat.size - length);
+    diagnosticTail = buffer.subarray(0, bytesRead).toString("utf8");
+  }
 } finally {
   fs.closeSync(fd);
 }
 
-if (invalidSummary || summaryCount < 1 || summaryCount > 2 || totalPassed !== 3) {
+if (isInvalidProof()) {
+  console.error("expected focused Vitest summary for exactly 3 passed tests");
   console.error(
-    `expected one aggregate or two split Vitest summaries for exactly 3 passed tests; saw ${summaryCount} summaries totaling ${totalPassed}`,
+    `saw ${summaryCount} summaries totaling ${totalPassed}; expected one aggregate or two split summaries`,
   );
+  console.error(diagnosticTail);
   process.exit(1);
 }
 NODE

--- a/scripts/e2e/plugin-binding-command-escape-docker.sh
+++ b/scripts/e2e/plugin-binding-command-escape-docker.sh
@@ -33,7 +33,19 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run --rm 
   -e "FOCUSED_TEST_REGEX=$FOCUSED_TEST_REGEX" \
   -e OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-cache \
   "$IMAGE_NAME" \
-  bash -lc 'set -euo pipefail; corepack enable; node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts --reporter=verbose -t "$FOCUSED_TEST_REGEX"' \
+  bash -lc '
+    set -euo pipefail
+    # Main has one aggregate entry; frozen candidates may split binding cases into a second file.
+    test_files=(src/auto-reply/reply/dispatch-from-config.test.ts)
+    if [[ -f src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test.ts ]]; then
+      test_files=(
+        src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test.ts
+        src/auto-reply/reply/dispatch-from-config.test.ts
+      )
+    fi
+    corepack enable
+    node scripts/run-vitest.mjs "${test_files[@]}" --reporter=verbose -t "$FOCUSED_TEST_REGEX"
+  ' \
   >"$RUN_LOG" 2>&1
 status=$?
 set -e
@@ -46,22 +58,82 @@ fi
 
 if ! node - "$RUN_LOG" <<'NODE'
 const fs = require("node:fs");
+const { StringDecoder } = require("node:string_decoder");
 const logPath = process.argv[2];
 const scanBytes = 65536;
-const stat = fs.statSync(logPath);
-const length = Math.min(stat.size, scanBytes);
-const buffer = Buffer.alloc(length);
+const maxLineChars = 4096;
+const buffer = Buffer.alloc(scanBytes);
 const fd = fs.openSync(logPath, "r");
+const decoder = new StringDecoder("utf8");
+let carry = "";
+let discardingLongLine = false;
+let invalidSummary = false;
+let summaryCount = 0;
+let totalPassed = 0;
+let offset = 0;
+
+function scanLine(line) {
+  const normalized = line.replace(/\x1B\[[0-?]*[ -/]*[@-~]/gu, "");
+  const match = normalized.match(/^\s*Tests\s+(\d+) passed\b/u);
+  if (!match) {
+    return;
+  }
+  const count = Number.parseInt(match[1], 10);
+  summaryCount += 1;
+  if (!Number.isSafeInteger(count) || count <= 0 || summaryCount > 2) {
+    invalidSummary = true;
+    return;
+  }
+  totalPassed += count;
+}
+
+function appendLineSegment(segment, ended) {
+  if (!discardingLongLine) {
+    if (carry.length + segment.length <= maxLineChars) {
+      carry += segment;
+    } else {
+      carry = "";
+      discardingLongLine = true;
+    }
+  }
+  if (!ended) {
+    return;
+  }
+  if (!discardingLongLine) {
+    scanLine(carry.endsWith("\r") ? carry.slice(0, -1) : carry);
+  }
+  carry = "";
+  discardingLongLine = false;
+}
+
+function scanText(text) {
+  let start = 0;
+  for (let newline = text.indexOf("\n"); newline !== -1; newline = text.indexOf("\n", start)) {
+    appendLineSegment(text.slice(start, newline), true);
+    start = newline + 1;
+  }
+  appendLineSegment(text.slice(start), false);
+}
+
 try {
-  fs.readSync(fd, buffer, 0, length, stat.size - length);
+  while (true) {
+    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, offset);
+    if (bytesRead === 0) {
+      break;
+    }
+    offset += bytesRead;
+    scanText(decoder.write(buffer.subarray(0, bytesRead)));
+  }
+  scanText(decoder.end());
+  appendLineSegment("", true);
 } finally {
   fs.closeSync(fd);
 }
-const text = buffer.toString("utf8").replace(/\x1B\[[0-?]*[ -/]*[@-~]/gu, "");
 
-if (!/(?:^|\n)\s*Tests\s+3 passed\b/u.test(text)) {
-  console.error("expected focused Vitest summary for exactly 3 passed tests");
-  console.error(text.slice(-4000));
+if (invalidSummary || summaryCount < 1 || summaryCount > 2 || totalPassed !== 3) {
+  console.error(
+    `expected one aggregate or two split Vitest summaries for exactly 3 passed tests; saw ${summaryCount} summaries totaling ${totalPassed}`,
+  );
   process.exit(1);
 }
 NODE

--- a/test/scripts/plugin-binding-command-escape-docker.test.ts
+++ b/test/scripts/plugin-binding-command-escape-docker.test.ts
@@ -1,0 +1,134 @@
+import { Buffer } from "node:buffer";
+import { readFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as stringDecoder from "node:string_decoder";
+import vm from "node:vm";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = "scripts/e2e/plugin-binding-command-escape-docker.sh";
+const script = readFileSync(SCRIPT_PATH, "utf8");
+const parserMatch = script.match(
+  /if ! node - "\$RUN_LOG" <<'NODE'\n(?<parser>[\s\S]*?)\nNODE\nthen/u,
+);
+
+if (!parserMatch?.groups?.parser) {
+  throw new Error(`failed to extract embedded log parser from ${SCRIPT_PATH}`);
+}
+
+const parser = parserMatch.groups.parser;
+
+class ParserExit extends Error {
+  constructor(readonly code: number) {
+    super(`parser exited ${code}`);
+  }
+}
+
+function runParser(log: string, options: { maxReadBytes?: number } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-plugin-binding-log-proof-"));
+  const logPath = join(root, "vitest.log");
+  const errors: string[] = [];
+  const readSizes: number[] = [];
+  writeFileSync(logPath, log);
+
+  const fsProxy = new Proxy(fs, {
+    get(target, property, receiver) {
+      if (property !== "readSync") {
+        return Reflect.get(target, property, receiver);
+      }
+      return (
+        fd: number,
+        buffer: NodeJS.ArrayBufferView,
+        offset: number,
+        length: number,
+        position: number | null,
+      ) => {
+        const boundedLength = Math.min(length, options.maxReadBytes ?? length);
+        const bytesRead = fs.readSync(fd, buffer, offset, boundedLength, position);
+        readSizes.push(bytesRead);
+        return bytesRead;
+      };
+    },
+  });
+
+  try {
+    vm.runInNewContext(parser, {
+      Buffer,
+      console: {
+        error: (...args: unknown[]) => errors.push(args.map(String).join(" ")),
+      },
+      process: {
+        argv: ["node", "-", logPath],
+        exit: (code = 0) => {
+          throw new ParserExit(code);
+        },
+      },
+      require: (specifier: string) => {
+        if (specifier === "node:fs") {
+          return fsProxy;
+        }
+        if (specifier === "node:string_decoder") {
+          return stringDecoder;
+        }
+        throw new Error(`unexpected parser dependency: ${specifier}`);
+      },
+    });
+    return { errors, readSizes, status: 0 };
+  } catch (error) {
+    if (error instanceof ParserExit) {
+      return { errors, readSizes, status: error.code };
+    }
+    throw error;
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+describe("plugin binding Docker log proof", () => {
+  it("runs the aggregate main suite and both files after the suite split", () => {
+    expect(script).toContain(
+      "if [[ -f src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test.ts ]]",
+    );
+    expect(script).toContain(
+      "src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test.ts",
+    );
+    expect(script).toContain("src/auto-reply/reply/dispatch-from-config.test.ts");
+    expect(script).toContain('node scripts/run-vitest.mjs "${test_files[@]}"');
+  });
+
+  it("aggregates split summaries across the complete log with bounded partial reads", () => {
+    const noise = "not a summary\n".repeat(6000);
+    const log = [
+      "\u001B[32m Tests  2 passed\u001B[39m\n",
+      `${noise}\u{1F98A}${noise}`,
+      "\u001B[32m Tests  1 passed\u001B[39m\n",
+    ].join("");
+
+    const result = runParser(log, { maxReadBytes: 3 });
+
+    expect(Buffer.byteLength(noise)).toBeGreaterThan(65536);
+    expect(result.status).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(result.readSizes.length).toBeGreaterThan(2);
+    expect(result.readSizes.every((size) => size <= 3)).toBe(true);
+  });
+
+  it("accepts one aggregate summary", () => {
+    expect(runParser(" Tests  3 passed | 4 skipped (7)\n").status).toBe(0);
+  });
+
+  it("rejects split summaries with the wrong total", () => {
+    const result = runParser(" Tests  1 passed\n Tests  1 passed\n");
+
+    expect(result.status).toBe(1);
+    expect(result.errors.join("\n")).toContain("2 summaries totaling 2");
+  });
+
+  it("rejects extra summaries even when their total is three", () => {
+    const result = runParser(" Tests  1 passed\n Tests  1 passed\n Tests  1 passed\n");
+
+    expect(result.status).toBe(1);
+    expect(result.errors.join("\n")).toContain("3 summaries");
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1320,6 +1320,7 @@ describe("scripts/test-projects changed-target routing", () => {
       "test/scripts/codex-media-path-client.test.ts",
       "test/scripts/package-acceptance-workflow.test.ts",
       "test/scripts/live-plugin-tool-assertions.test.ts",
+      "test/scripts/plugin-binding-command-escape-docker.test.ts",
     ]);
   });
 


### PR DESCRIPTION
Related: #128192

## What Problem This Solves

Fixes an issue where the plugin-binding Docker release proof could inspect only the final 64 KiB of Vitest output and miss an earlier summary after the focused suite was split across files.

## Why This Change Was Made

The harness now reads the complete log in bounded chunks with UTF-8-safe decoding, accepts either the current aggregate suite summary or two split summaries totaling exactly three passed tests, and rejects extra or inconsistent summaries. It also runs the split lifecycle entry when that file exists without backporting the beta-only test refactor to main.

Provenance: discovered while stabilizing the frozen beta candidate in #128192; this PR carries only the reusable release-harness repair to current main.

## User Impact

No product behavior changes. Release maintainers get deterministic plugin-binding evidence even when verbose output exceeds 64 KiB or the focused tests are split across Vitest entry files.

Production LOC: +0/-0 | Release harness: +91/-6 | Tests: +134/-0

## Evidence

- exact relevant contract proof: 2 existing Docker-helper assertions passed plus 5 parser tests passed
- `bash -n scripts/e2e/plugin-binding-command-escape-docker.sh` - passed
- focused `oxlint` and `oxfmt --check` - passed
- `git diff --check origin/main...HEAD` - passed
- Blacksmith Testbox `tbx_01m0qf22fcx5x60wge6my7xmgz` on pre-review head `33668c7f407a` - Docker smoke passed with `OK (3 focused tests)`; command 1m57s; one-shot lease stopped. The follow-up head change only restores bounded failure diagnostics and the existing helper contract.
- Testbox Actions run: https://github.com/openclaw/openclaw/actions/runs/32644373391
- full `test/scripts/docker-build-helper.test.ts` attempt: 198 passed; one unrelated existing survivor-phase case timed out at 120s (`records an interrupted upgrade survivor phase as failed`)
- scoped `node scripts/check-changed.mjs -- ...` passed all guards through test-root typecheck; typecheck then hit an unrelated shared-install error in `ui/vite.config.ts` because the existing `pako` package lacks declarations

Best-fix verdict: best. The verifier owns the release evidence contract, so it reads and validates the authoritative complete log instead of increasing tail size or weakening the expected test count.
