### PR TITLE
fix: keep manually stopped idle channel accounts stopped

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1016,6 +1016,19 @@ describe("server-channels auto restart", () => {
     expect(stopAccount).not.toHaveBeenCalled();
   });
 
+  it("records explicit manual stop intent for an idle account without a stop hook", async () => {
+    const startAccount = vi.fn(async () => undefined);
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.stopChannel("discord", "automatic", { manual: false });
+    await manager.stopChannel("discord", "operator");
+
+    expect(manager.isManuallyStopped("discord", "automatic")).toBe(false);
+    expect(manager.isManuallyStopped("discord", "operator")).toBe(true);
+    expect(startAccount).not.toHaveBeenCalled();
+  });
+
   it("does not auto-restart after manual stop during backoff", async () => {
     const startAccount = vi.fn(async () => {});
     installTestRegistry(

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -1108,22 +1108,17 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       ...store.stops.keys(),
       ...store.tasks.keys(),
     ]);
+    // Preserve no-enumeration channel-wide idle stops. An explicit account stop
+    // must still commit manual intent before health monitoring can restart it.
     if (!accountId && lifecycleIds.size === 0) {
       return;
     }
-    // Fast path: nothing running and no explicit plugin shutdown hook to run.
-    if (!plugin?.gateway?.stopAccount && lifecycleIds.size === 0) {
-      return;
-    }
     const cfg = getRuntimeConfig();
-    const knownIds = new Set<string>([
-      ...lifecycleIds,
-      ...(plugin ? plugin.config.listAccountIds(cfg) : []),
-    ]);
-    if (accountId) {
-      knownIds.clear();
-      knownIds.add(accountId);
-    }
+    const knownIds = new Set<string>(
+      accountId
+        ? [accountId]
+        : [...lifecycleIds, ...(plugin ? plugin.config.listAccountIds(cfg) : [])],
+    );
 
     // Gate replacement starts before teardown begins. Failures still reject only
     // after every sibling account has finished its independent lifecycle cleanup.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where explicitly stopping an already-idle channel account could appear successful without recording the operator's stop intent. The channel health monitor could then restart that account on its next recovery pass.

## Why This Change Was Made

The channel manager now preserves its channel-wide no-enumeration fast path but lets exact-account stops reach the existing manual-intent owner even when no provider task or stop hook is active. Explicit account targeting no longer enumerates unrelated configured accounts, and nonmanual reload/health stops retain their existing behavior.

## User Impact

Operators can reliably keep a previously failed or idle channel account stopped. A later health check will honor the explicit stop instead of unexpectedly restarting the account.

## Evidence

- The focused regression failed before the production change in both Gateway test projects because the explicit idle account remained `isManuallyStopped(...) === false`.
- `node scripts/run-vitest.mjs src/gateway/server-channels.test.ts src/gateway/channel-health-monitor.test.ts` — 312/312 tests passed on the rebased head.
- `node scripts/check-changed.mjs -- src/gateway/server-channels.ts src/gateway/server-channels.test.ts` — full changed-file gate passed, including formatting, lint, core/test typechecks, import cycles, and repository guards.
- Fresh final branch autoreview: no actionable findings; patch correct with 0.99 confidence.
- Exact-head CI run [`32645440460`](https://github.com/openclaw/openclaw/actions/runs/32645440460) completed successfully with no pending or failed checks.
- Production LOC: +7/-12 (net -5). Tests: +13/-0.

This is a deterministic Gateway-manager lifecycle fix; no external provider or live channel operation is required for the owner-boundary proof.

## ClawSweeper Review

ClawSweeper's latest review of exact head `d50ca81b3db8b0eb9832ae0b932ba97304dd4669` found no code or security issue and agreed this is the best owner-boundary repair. Its live-proof wrapper marked the combined focused command partial because an expected terminal headline was not observed within 30 seconds; the captured output showed the executed suites passing, while the same exact combined command independently completed 312/312 and exact-head CI run `32645440460` is green. The requested P1/P2 mitigation is exact merge-head validation plus ordinary maintainer review: repository-native review artifacts validate `READY FOR /prepare-pr` with zero findings, and `prepare-run` will validate the current-main merge candidate before landing. No external-provider proof is required because no provider contract changed.