### PR TITLE
chore(mock): keep Control UI mock tabs identifiable

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1,5 +1,6 @@
 // Control Ui Mock Dev script supports OpenClaw repository automation.
 import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import qrcode from "qrcode";
@@ -54,6 +55,8 @@ type CliOptions = {
   host: string;
   operatorScopes?: string[];
   port: number;
+  title?: string;
+  titleFile?: string;
 };
 
 type SessionListOptions = {
@@ -90,6 +93,9 @@ const OBSERVER_DEMO_RUN_ID = "mock-session-observer-run";
 const PLAN_DEMO_RUN_ID = "mock-plan-run";
 const CUSTODIAN_CHAT_REPLY_DELAY_MS = 600;
 const CHAT_SEND_REPLY_DELAY_MS = 200;
+const MOCK_TITLE_PATH = "/__mock/title";
+const MOCK_TITLE_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_MOCK_TITLE = "OpenClaw Control";
 
 type UpdateFixture = {
   available: UpdateAvailable;
@@ -336,9 +342,21 @@ function parseArgs(args: string[]): CliOptions {
       options.operatorScopes = parseOperatorScopes(args[++i]);
     } else if (arg.startsWith("--operator-scopes=")) {
       options.operatorScopes = parseOperatorScopes(arg.slice("--operator-scopes=".length));
+    } else if (arg === "--title") {
+      options.title = parseTitle(args[++i]);
+    } else if (arg.startsWith("--title=")) {
+      options.title = parseTitle(arg.slice("--title=".length));
+    } else if (arg === "--title-file") {
+      options.titleFile = args[++i]?.trim() || undefined;
+    } else if (arg.startsWith("--title-file=")) {
+      options.titleFile = arg.slice("--title-file=".length).trim() || undefined;
     }
   }
   return options;
+}
+
+function parseTitle(value: string | undefined): string | undefined {
+  return value?.trim() || undefined;
 }
 
 function parseFixture(value: string | undefined): CliOptions["fixture"] {
@@ -3144,16 +3162,76 @@ function createStatefulMockInitScript(): string {
   return `(() => { const __name = (target) => target; (${installControlUiStatefulMocks.toString()})(${CUSTODIAN_CHAT_REPLY_DELAY_MS}, ${CHAT_SEND_REPLY_DELAY_MS}); })();`;
 }
 
-function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin {
+function installMockTitlePolling(endpoint: string, intervalMs: number): void {
+  const updateTitle = async (): Promise<void> => {
+    try {
+      const response = await fetch(endpoint, { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+      const title = await response.text();
+      if (title && document.title !== title) {
+        document.title = title;
+      }
+    } catch {
+      // Keep the mock usable while its title source is temporarily unavailable.
+    }
+  };
+  void updateTitle();
+  window.setInterval(() => void updateTitle(), intervalMs);
+}
+
+function createMockTitleInitScript(): string {
+  return `(() => { const __name = (target) => target; (${installMockTitlePolling.toString()})(${JSON.stringify(MOCK_TITLE_PATH)}, ${MOCK_TITLE_POLL_INTERVAL_MS}); })();`;
+}
+
+function readHtmlTitle(html: string): string | undefined {
+  return parseTitle(html.match(/<title>([^<]*)<\/title>/i)?.[1]);
+}
+
+async function readMockTitle(options: CliOptions, currentTitle: string): Promise<string> {
+  if (options.titleFile) {
+    try {
+      const fileTitle = parseTitle(await readFile(options.titleFile, "utf8"));
+      if (fileTitle) {
+        return fileTitle;
+      }
+    } catch {
+      // A missing or transiently replaced file falls through to the stable title.
+    }
+  }
+  return options.title ?? currentTitle;
+}
+
+function createMockGatewayPlugin(
+  scenario: ControlUiMockGatewayScenario,
+  options: CliOptions,
+): Plugin {
   const initScript = escapeScriptContent(createControlUiMockGatewayInitScript(scenario));
   const statefulInitScript = escapeScriptContent(createStatefulMockInitScript());
+  const titleInitScript = escapeScriptContent(createMockTitleInitScript());
   const bootstrapBody = JSON.stringify(createControlUiMockBootstrapConfig(scenario));
+  let currentTitle = DEFAULT_MOCK_TITLE;
   return {
     configureServer(server) {
       server.middlewares.use(CONTROL_UI_BOOTSTRAP_CONFIG_PATH, (_req, res) => {
         res.statusCode = 200;
         res.setHeader("content-type", "application/json");
         res.end(bootstrapBody);
+      });
+      server.middlewares.use(MOCK_TITLE_PATH, (req, res, next) => {
+        if (req.method !== "GET") {
+          next();
+          return;
+        }
+        void readMockTitle(options, currentTitle)
+          .then((title) => {
+            res.statusCode = 200;
+            res.setHeader("cache-control", "no-store");
+            res.setHeader("content-type", "text/plain; charset=utf-8");
+            res.end(title);
+          })
+          .catch(next);
       });
     },
     // ui/vite.config.ts registers a placeholder bootstrap-config middleware and
@@ -3162,9 +3240,10 @@ function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin
     enforce: "pre",
     name: "openclaw-control-ui-mock-gateway",
     transformIndexHtml(html) {
+      currentTitle = readHtmlTitle(html) ?? currentTitle;
       return html.replace(
         "</head>",
-        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${statefulInitScript}\n    </script>\n  </head>`,
+        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${statefulInitScript}\n${titleInitScript}\n    </script>\n  </head>`,
       );
     },
   };
@@ -3244,7 +3323,7 @@ const server = await createServer({
       : {}),
     include: ["lit/directives/repeat.js"],
   },
-  plugins: [createMockGatewayPlugin(scenario), createBoardFixturePlugin()],
+  plugins: [createMockGatewayPlugin(scenario, options), createBoardFixturePlugin()],
   publicDir: path.join(uiRoot, "public"),
   resolve: {
     alias: [

--- a/test/scripts/control-ui-mock-dev.test.ts
+++ b/test/scripts/control-ui-mock-dev.test.ts
@@ -1,0 +1,115 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const children = new Set<ChildProcess>();
+const temporaryDirectories = new Set<string>();
+
+async function reservePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to reserve a Control UI mock test port");
+  }
+  return address.port;
+}
+
+async function startMockServer(port: number, titleFile: string): Promise<string> {
+  const child = spawn(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      "scripts/control-ui-mock-dev.ts",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--title-file",
+      titleFile,
+    ],
+    { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] },
+  );
+  children.add(child);
+
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  return await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out starting Control UI mock server: ${stderr}`));
+    }, 20_000);
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      const match = chunk.match(/\[control-ui-mock\] (http:\/\/\S+)/);
+      if (match?.[1]) {
+        clearTimeout(timeout);
+        resolve(match[1]);
+      }
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      reject(new Error(`Control UI mock server exited (${code ?? signal}): ${stderr}`));
+    });
+  });
+}
+
+afterEach(async () => {
+  const exits = Array.from(children, async (child) => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        child.once("exit", () => {
+          resolve();
+        });
+      });
+    }
+  });
+  await Promise.all(exits);
+  children.clear();
+  await Promise.all(
+    Array.from(temporaryDirectories, (directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+  temporaryDirectories.clear();
+});
+
+describe("Control UI mock title endpoint", () => {
+  it("reads the title file again for every request", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "openclaw-mock-title-"));
+    temporaryDirectories.add(directory);
+    const titleFile = path.join(directory, "title.txt");
+    await writeFile(titleFile, "First mock title\n", "utf8");
+    const serverUrl = await startMockServer(await reservePort(), titleFile);
+    const endpoint = new URL("/__mock/title", serverUrl);
+
+    const first = await fetch(endpoint);
+    expect(first.headers.get("cache-control")).toBe("no-store");
+    await expect(first.text()).resolves.toBe("First mock title");
+
+    await writeFile(titleFile, "Second mock title\n", "utf8");
+    const second = await fetch(endpoint);
+    expect(second.headers.get("cache-control")).toBe("no-store");
+    await expect(second.text()).resolves.toBe("Second mock title");
+  }, 30_000);
+});


### PR DESCRIPTION
## What Problem This Solves

Developers running multiple Control UI mock instances cannot distinguish their browser tabs because every instance uses the same application-owned title.

## Why This Change Was Made

In this PR, the mock dev server accepts `--title` and `--title-file`, exposes the resolved value through a no-store `GET /__mock/title` endpoint, and injects mock-only polling that updates the tab every two seconds. The title file is read on every request so external tooling can update a running mock without restarting it.

## User Impact

Control UI mock tabs can show a stable, instance-specific status title that changes while the server is running. This affects development tooling only; the production Control UI bundle is unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/control-ui-mock-dev.test.ts` — 1 test passed; verifies that changing the file changes the next endpoint response.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/control-ui-mock-dev.ts test/scripts/control-ui-mock-dev.test.ts` — passed.
- `node --disable-warning=ExperimentalWarning scripts/check-script-erasability.mjs` — 520 script files checked.
- Manual command: `node --import tsx scripts/control-ui-mock-dev.ts --host 127.0.0.1 --port 5333 --title-file /tmp/herdr/mock-titles/5333.txt`.
- In the same browser tab, the title changed from `💬 Teste · :5333` to `✅ Teste · :5333` without a reload.

Initial title (`💬 Teste · :5333`):

![Control UI mock with the initial dynamic tab title](https://github.com/user-attachments/assets/2506d288-7205-4028-88b8-157829357663)

Updated title (`✅ Teste · :5333`):

![Control UI mock after the title file changed](https://github.com/user-attachments/assets/214ca306-643d-4779-8597-c0466c6a8b7a)
