### PR TITLE
fix(release): install Bun smoke from candidate payload

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -1350,98 +1350,106 @@ jobs:
           exit "$failed"
 
   bun_global_install_smoke:
-    needs: [preflight, root_dockerfile_image, root_dockerfile_image_ready]
+    needs: [preflight, installer_smoke_candidate_payload]
     if: needs.preflight.outputs.run_full_install_smoke == 'true' && needs.preflight.outputs.run_bun_global_install_smoke == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    env:
-      OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1"
     steps:
       - *trusted_workflow_subdir_checkout_step
       - *trusted_workflow_subdir_identity_step
 
-      - name: Validate root Dockerfile image artifact binding
+      - name: Validate candidate payload artifact binding
         env:
-          ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
-          ARTIFACT_DIGEST: ${{ needs.root_dockerfile_image.outputs.artifact_digest }}
-          ARTIFACT_ID: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
-          ARTIFACT_NAME: ${{ needs.root_dockerfile_image.outputs.artifact_name }}
-          ARTIFACT_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
-          ARTIFACT_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          ARTIFACT_DIGEST: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_digest }}
+          ARTIFACT_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}
+          ARTIFACT_NAME: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_name }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}
+          ARTIFACT_RUN_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
+          ARTIFACT_HARNESS_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.harness_repository }}
+          ARTIFACT_HARNESS_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.harness_sha }}
+          ARTIFACT_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
+          ARTIFACT_TARGET_SHA: ${{ needs.installer_smoke_candidate_payload.outputs.target_sha }}
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
         run: |
           set -euo pipefail
           [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact ID is missing or invalid." >&2
+            echo "Candidate payload artifact ID is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_DIGEST" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Root image artifact digest is missing or invalid." >&2
-            exit 1
-          }
-          [[ "$ARCHIVE_SHA256" =~ ^[a-f0-9]{64}$ ]] || {
-            echo "Root image archive SHA-256 is missing or invalid." >&2
+            echo "Candidate payload artifact digest is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact run ID is missing or invalid." >&2
+            echo "Candidate payload artifact run ID is missing or invalid." >&2
             exit 1
           }
           [[ "$ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || {
-            echo "Root image artifact run attempt is missing or invalid." >&2
+            echo "Candidate payload artifact run attempt is missing or invalid." >&2
             exit 1
           }
-          expected_artifact_name="install-smoke-root-image-${TARGET_SHA:0:12}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
+          [[ "$ARTIFACT_REPOSITORY" == "$GITHUB_REPOSITORY" ]]
+          [[ "$ARTIFACT_TARGET_SHA" == "$TARGET_SHA" ]]
+          [[ "$ARTIFACT_HARNESS_REPOSITORY" == "$HARNESS_REPOSITORY" ]]
+          [[ "$ARTIFACT_HARNESS_SHA" == "$HARNESS_SHA" ]]
+          expected_artifact_name="install-smoke-candidate-payload-${TARGET_SHA}-${ARTIFACT_RUN_ID}-${ARTIFACT_RUN_ATTEMPT}"
           [[ "$ARTIFACT_NAME" == "$expected_artifact_name" ]] || {
-            echo "Root image artifact name does not match the target and producer run attempt." >&2
+            echo "Candidate payload artifact name does not match the producer tuple." >&2
             exit 1
           }
           bash .release-harness/scripts/docker/shared-image-artifact.sh \
-            verify-upload "Root image" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            verify-upload "Candidate payload" "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
-      - name: Download root Dockerfile image artifact
+      - name: Download candidate payload artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          artifact-ids: ${{ needs.root_dockerfile_image.outputs.artifact_id }}
-          path: ${{ runner.temp }}/install-smoke-root-image
-          run-id: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
+          artifact-ids: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}
+          path: ${{ runner.temp }}/install-smoke-candidate-payload
+          run-id: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
           github-token: ${{ github.token }}
-
-      - name: Verify and load root Dockerfile image artifact
-        env:
-          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
-          OPENCLAW_SHARED_IMAGE_ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
-          OPENCLAW_SHARED_IMAGE_RUN_ATTEMPT: ${{ needs.root_dockerfile_image.outputs.artifact_run_attempt }}
-          OPENCLAW_SHARED_IMAGE_RUN_ID: ${{ needs.root_dockerfile_image.outputs.artifact_run_id }}
-          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
-          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
-        run: |
-          set -euo pipefail
-          bash .release-harness/scripts/docker/shared-image-artifact.sh \
-            load "${RUNNER_TEMP}/install-smoke-root-image" install-smoke-root \
-            "$TARGET_SHA" "$WORKFLOW_SHA" "$IMAGE_REF"
-
-      - name: Require local root Dockerfile image
-        env:
-          IMAGE_REF: ${{ needs.root_dockerfile_image.outputs.image_ref }}
-        run: docker image inspect "$IMAGE_REF" >/dev/null
 
       - name: Setup trusted release harness for Bun smoke
         uses: ./.release-harness/.github/actions/setup-release-harness
         with:
           node-version: "24.x"
 
+      - name: Verify candidate payload contents
+        env:
+          HARNESS_REPOSITORY: ${{ steps.workflow.outputs.repository }}
+          HARNESS_SHA: ${{ steps.workflow.outputs.sha }}
+          MANIFEST_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}
+          PACKAGE_VERSION: ${{ needs.installer_smoke_candidate_payload.outputs.package_version }}
+          PRODUCER_RUN_ATTEMPT: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}
+          PRODUCER_RUN_ID: ${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}
+          SOURCE_ARCHIVE_SHA256: ${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}
+          TARGET_REPOSITORY: ${{ needs.installer_smoke_candidate_payload.outputs.repository }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          node .release-harness/scripts/install-smoke-candidate-payload.mts verify \
+            --payload-dir "${RUNNER_TEMP}/install-smoke-candidate-payload" \
+            --repository "$TARGET_REPOSITORY" \
+            --target-sha "$TARGET_SHA" \
+            --harness-repository "$HARNESS_REPOSITORY" \
+            --harness-sha "$HARNESS_SHA" \
+            --run-id "$PRODUCER_RUN_ID" \
+            --run-attempt "$PRODUCER_RUN_ATTEMPT" \
+            --package-version "$PACKAGE_VERSION" \
+            --manifest-sha256 "$MANIFEST_SHA256" \
+            --source-archive-sha256 "$SOURCE_ARCHIVE_SHA256"
+
       - name: Install Bun for global smoke
         run: npm install -g bun@1.3.14
 
-      - name: Run Bun global install image-provider smoke
+      - name: Run Bun global install candidate-payload smoke
         working-directory: .release-harness
         env:
-          OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
-          OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0"
+          OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ: ${{ runner.temp }}/install-smoke-candidate-payload/candidate.tgz
         run: bash scripts/e2e/bun-global-install-smoke.sh
 
   docker-e2e-fast:

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -305,7 +305,7 @@ describe("install smoke no-push root image transport", () => {
 
   it("verifies and loads the immutable artifact in every consumer", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
-    for (const jobName of ["root_dockerfile_smokes", "bun_global_install_smoke"]) {
+    for (const jobName of ["root_dockerfile_smokes"]) {
       const consumer = job(workflow, jobName);
       expect(consumer.needs, jobName).toContain("root_dockerfile_image_ready");
       expect(consumer.env?.OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE, jobName).toBe("1");
@@ -367,7 +367,7 @@ describe("install smoke no-push root image transport", () => {
     }
 
     const text = readFileSync(INSTALL_SMOKE_REUSABLE, "utf8");
-    expect(text.match(/verify-upload "Root image"/g)).toHaveLength(2);
+    expect(text.match(/verify-upload "Root image"/g)).toHaveLength(1);
     expect(text).not.toContain("gh api");
   });
 
@@ -507,15 +507,54 @@ describe("install smoke no-push root image transport", () => {
     }
 
     const bunConsumer = job(workflow, "bun_global_install_smoke");
+    expect(bunConsumer.needs).toEqual(["preflight", "installer_smoke_candidate_payload"]);
+    const bunBinding = step(bunConsumer, "Validate candidate payload artifact binding");
+    expect(bunBinding.env).toMatchObject({
+      ARTIFACT_DIGEST: "${{ needs.installer_smoke_candidate_payload.outputs.artifact_digest }}",
+      ARTIFACT_ID: "${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}",
+      ARTIFACT_RUN_ATTEMPT:
+        "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}",
+      ARTIFACT_RUN_ID: "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}",
+      ARTIFACT_HARNESS_SHA: "${{ needs.installer_smoke_candidate_payload.outputs.harness_sha }}",
+      ARTIFACT_TARGET_SHA: "${{ needs.installer_smoke_candidate_payload.outputs.target_sha }}",
+      HARNESS_SHA: "${{ steps.workflow.outputs.sha }}",
+      TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
+    });
+    expect(bunBinding.run).toContain('[[ "$ARTIFACT_HARNESS_SHA" == "$HARNESS_SHA" ]]');
+    expect(bunBinding.run).toContain("verify-upload");
+    expect(step(bunConsumer, "Download candidate payload artifact").with).toMatchObject({
+      "artifact-ids": "${{ needs.installer_smoke_candidate_payload.outputs.artifact_id }}",
+      "run-id": "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}",
+    });
     expect(step(bunConsumer, "Setup trusted release harness for Bun smoke")).toMatchObject({
       uses: "./.release-harness/.github/actions/setup-release-harness",
       with: { "node-version": "24.x" },
     });
+    const bunVerify = step(bunConsumer, "Verify candidate payload contents");
+    expect(bunVerify.env).toMatchObject({
+      MANIFEST_SHA256: "${{ needs.installer_smoke_candidate_payload.outputs.manifest_sha256 }}",
+      PACKAGE_VERSION: "${{ needs.installer_smoke_candidate_payload.outputs.package_version }}",
+      PRODUCER_RUN_ATTEMPT:
+        "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_attempt }}",
+      PRODUCER_RUN_ID: "${{ needs.installer_smoke_candidate_payload.outputs.artifact_run_id }}",
+      SOURCE_ARCHIVE_SHA256:
+        "${{ needs.installer_smoke_candidate_payload.outputs.source_archive_sha256 }}",
+    });
+    expect(bunVerify.run).toContain("install-smoke-candidate-payload.mts verify");
+    expect(bunVerify.run).toContain('--run-id "$PRODUCER_RUN_ID"');
+    expect(bunVerify.run).toContain('--run-attempt "$PRODUCER_RUN_ATTEMPT"');
     expect(step(bunConsumer, "Install Bun for global smoke").run).toBe("npm install -g bun@1.3.14");
-    expect(step(bunConsumer, "Run Bun global install image-provider smoke")).toMatchObject({
+    expect(step(bunConsumer, "Run Bun global install candidate-payload smoke")).toMatchObject({
       "working-directory": ".release-harness",
+      env: {
+        OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0",
+        OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ:
+          "${{ runner.temp }}/install-smoke-candidate-payload/candidate.tgz",
+      },
       run: "bash scripts/e2e/bun-global-install-smoke.sh",
     });
+    expect(JSON.stringify(bunConsumer)).not.toContain("root_dockerfile_image");
+    expect(JSON.stringify(bunConsumer)).not.toContain("OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE");
     expect(JSON.stringify(bunConsumer)).not.toContain(
       "./.release-harness/.github/actions/setup-node-env",
     );
@@ -658,7 +697,7 @@ describe("install smoke no-push root image transport", () => {
     });
   });
 
-  it("passes package changelog intent only to current-tree smoke scripts", () => {
+  it("passes package changelog intent only to the candidate packager", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
     expect(
       step(
@@ -668,12 +707,8 @@ describe("install smoke no-push root image transport", () => {
     ).toMatchObject({
       ALLOW_UNRELEASED_CHANGELOG: "${{ inputs.allow_unreleased_changelog }}",
     });
-    expect(
-      step(job(workflow, "bun_global_install_smoke"), "Run Bun global install image-provider smoke")
-        .env,
-    ).toMatchObject({
-      OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG:
-        "${{ inputs.allow_unreleased_changelog }}",
-    });
+    expect(JSON.stringify(job(workflow, "bun_global_install_smoke"))).not.toContain(
+      "OPENCLAW_BUN_GLOBAL_SMOKE_ALLOW_UNRELEASED_CHANGELOG",
+    );
   });
 });

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2173,13 +2173,14 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     expect(workflow).toContain("uses: ./.release-harness/.github/actions/setup-release-harness");
     expect(workflow).toContain("npm install -g bun@1.3.14");
     expect(workflow).toContain('install-bun: "false"');
-    expect(workflow).toContain("Run Bun global install image-provider smoke");
+    expect(workflow).toContain("Run Bun global install candidate-payload smoke");
     expect(workflow).toContain("working-directory: .release-harness");
     expect(workflow).toContain("bash scripts/e2e/bun-global-install-smoke.sh");
     expect(workflow).not.toContain("uses: ./.release-harness/.github/actions/setup-node-env");
     expect(workflow).toContain(
-      "OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}",
+      "OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ: ${{ runner.temp }}/install-smoke-candidate-payload/candidate.tgz",
     );
+    expect(workflow).not.toContain("OPENCLAW_BUN_GLOBAL_SMOKE_DIST_IMAGE");
     expect(workflow).toContain("group: ${{ github.workflow }}-workflow-call-${{ github.run_id }}");
     expect(workflow).toContain("cancel-in-progress: false");
     expect(workflow).not.toContain(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release validation's Bun global-install smoke repackaged a mixed candidate/tooling tree and rejected a valid prerelease Code SHA because the tooling checkout lacked the future release changelog section.

## Why This Change Was Made

The Bun smoke now consumes the same sealed, SHA-bound candidate tarball already produced for install smoke. It validates the artifact producer tuple, manifest, source archive, candidate SHA, tooling SHA, and version before installing it. This removes the second packaging path and keeps strict changelog enforcement at the candidate package producer. AI-assisted.

## User Impact

No runtime behavior changes. Release validation now tests Bun installation against the exact bytes selected for publication rather than a package reconstructed from mixed source and build identities.

## Evidence

- Reproduced the beta failure: candidate-built `dist` was combined with Tooling-SHA `package.json` and `CHANGELOG.md`.
- Existing focused proof: release-check run 32632164508, Bun job 97178728957, passed with the sealed candidate payload path.
- `node scripts/run-vitest.mjs test/scripts/install-smoke-no-push-workflow.test.ts test/scripts/install-smoke-candidate-payload.test.ts` — 17 passed.
- `pnpm check:workflows` — passed.
- Autoreview — clean.
