### PR TITLE
fix(memory): do not block memory_search on dirty index sync

### DIFF
--- a/extensions/memory-core/src/memory-search-tool-query.ts
+++ b/extensions/memory-core/src/memory-search-tool-query.ts
@@ -3,8 +3,10 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   resolveMemoryIndexIdentityReason,
   type MemorySearchManager,
+  type MemorySearchResult,
   type MemorySearchRuntimeDebug,
   type MemorySource,
+  type MemoryProviderStatus,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
@@ -26,6 +28,22 @@ export function buildPausedMemoryIndexUnavailableResult(reason: string) {
 
 type ManagerState = { manager: MemorySearchManager; managerMs?: number };
 
+type FreshnessSnapshot = Pick<MemoryProviderStatus, "custom" | "lastSyncError">;
+
+/**
+ * MemorySearchManager.search opts extended with the internal nonblockingRefresh
+ * scheduling flag. The builtin MemoryIndexManager accepts this option even though
+ * it is not part of the exported manager contract, so the gateway tool path can
+ * request a background dirty-index refresh without broadening the SDK surface.
+ */
+type ManagerSearchOptions = NonNullable<Parameters<MemorySearchManager["search"]>[1]> & {
+  nonblockingRefresh?: boolean;
+  onFreshness?: (snapshot: FreshnessSnapshot) => void;
+};
+type ManagerWithNonblockingRefresh = MemorySearchManager & {
+  search(query: string, opts?: ManagerSearchOptions): Promise<MemorySearchResult[]>;
+};
+
 type MemorySearchToolQuery = {
   text: string;
   resultLimit: number;
@@ -37,6 +55,7 @@ type MemorySearchToolQuery = {
   sessionKey?: string;
   activeProjectKeys?: readonly string[];
   conversationRecall?: OpenClawPluginToolContext["conversationRecall"];
+  nonblockingRefresh?: boolean;
 };
 
 type MemorySearchToolVisibility = {
@@ -80,6 +99,7 @@ export async function executeMemorySearchToolQuery(params: {
 
   const searchOnce = async () => {
     const allowedSources = searchSources ? new Set(searchSources) : undefined;
+    let freshnessAtSearch: FreshnessSnapshot = active.manager.status();
     const searchesSessions = searchSources?.includes("sessions") === true;
     const indexedCandidateCount = searchesSessions
       ? (active.manager.status().sourceCounts ?? [])
@@ -93,7 +113,8 @@ export async function executeMemorySearchToolQuery(params: {
     const searchWindow = searchesSessions
       ? Math.min(MEMORY_SEARCH_POST_FILTER_MAX_CANDIDATES, availableCandidates)
       : query.resultLimit;
-    const candidates = await active.manager.search(query.text, {
+    // SAFETY: active.manager is a MemoryIndexManager at runtime, whose search() accepts the internal nonblockingRefresh option (MemoryIndexSearchOptions). The cast passes the option without broadening the exported MemorySearchManager contract.
+    const candidates = await (active.manager as ManagerWithNonblockingRefresh).search(query.text, {
       maxResults: searchWindow,
       minScore: query.minScore,
       sessionKey: query.sessionKey,
@@ -101,8 +122,12 @@ export async function executeMemorySearchToolQuery(params: {
       signal,
       onDebug: (debug) => runtimeDebug.push(debug),
       ...(searchSources ? { sources: searchSources } : {}),
+      ...(query.nonblockingRefresh ? { nonblockingRefresh: true } : {}),
+      onFreshness: (snapshot: FreshnessSnapshot) => {
+        freshnessAtSearch = snapshot;
+      },
     });
-    return { candidates, searchWindow };
+    return { candidates, searchWindow, freshnessAtSearch };
   };
 
   let searched: Awaited<ReturnType<typeof searchOnce>>;
@@ -125,6 +150,7 @@ export async function executeMemorySearchToolQuery(params: {
   if (pausedIndexIdentityReason) {
     return {
       status,
+      searchedAtFreshness: searched.freshnessAtSearch,
       rawResults: [],
       pausedIndexIdentityReason,
       searchMode: undefined,
@@ -155,6 +181,7 @@ export async function executeMemorySearchToolQuery(params: {
   const latestDebug = runtimeDebug.at(-1);
   return {
     status,
+    searchedAtFreshness: searched.freshnessAtSearch,
     rawResults,
     pausedIndexIdentityReason: undefined,
     searchMode: latestDebug?.effectiveMode,

--- a/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
+++ b/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
@@ -13,6 +13,7 @@ type SearchImpl = (opts?: {
   sessionKey?: string;
   activeProjectKeys?: string[];
   onDebug?: (debug: MemorySearchRuntimeDebug) => void;
+  onFreshness?: (snapshot: { custom?: Record<string, unknown>; lastSyncError?: string }) => void;
   signal?: AbortSignal;
   sources?: MemorySource[];
 }) => Promise<unknown[]>;
@@ -50,7 +51,12 @@ let readFileImpl: (params: MemoryReadParams) => Promise<MemoryReadResult> = asyn
 });
 
 const stubManager = {
-  search: vi.fn(async (_query: string, opts?: Parameters<SearchImpl>[0]) => await searchImpl(opts)),
+  search: vi.fn(async (_query: string, opts?: Parameters<SearchImpl>[0]) => {
+    // The search impl is responsible for calling opts.onFreshness at the point
+    // that mirrors the real manager's capture: after any synchronous dirty-index
+    // sync. This gives tests precise control over timing.
+    return await searchImpl(opts);
+  }),
   readFile: vi.fn(async (params: MemoryReadParams) => await readFileImpl(params)),
   status: () => ({
     backend: "builtin" as const,

--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -3,10 +3,18 @@ export function startAsyncSearchSync(params: {
   enabled: boolean;
   dirty: boolean;
   sessionsDirty: boolean;
+  nonblocking?: boolean;
   sync: (params: { reason: string }) => Promise<void>;
   onError: (err: unknown) => void;
 }): Promise<void> | void {
   if (!params.enabled || (!params.dirty && !params.sessionsDirty)) {
+    return;
+  }
+  if (params.nonblocking) {
+    // A deadline-bounded caller (nonblocking) can enumerate and parse a large
+    // transcript corpus. Keep the existing sync admission/close ownership while
+    // letting indexed searches proceed.
+    void params.sync({ reason: "search" }).catch(params.onError);
     return;
   }
   try {

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -899,4 +899,76 @@ describe("memory index", () => {
     await expect(manager.close?.()).resolves.toBeUndefined();
     expect(syncSpy).toHaveBeenCalledWith({ reason: "search" });
   });
+
+  it("returns existing-index results without waiting for nonblocking dirty sync", async () => {
+    providerFixture.forceNoProvider = true;
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "test" });
+    await fs.writeFile(
+      path.join(fixture.paths.memory, "search-sync.md"),
+      "Current memory appears only after the dirty search sync.",
+    );
+    await vi.waitFor(() => expect(manager.status().dirty).toBe(true));
+
+    // Hold the background sync behind a gate so the search must complete before
+    // the new file is indexed. The spy wraps the real implementation so that
+    // releasing the gate runs the actual sync (indexing the new file).
+    let releaseGate = () => {};
+    const syncGate = new Promise<void>((resolve) => {
+      releaseGate = () => resolve();
+    });
+    const realSyncPublished = (
+      manager as unknown as {
+        syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+      }
+    ).syncPublishedIndexInBackground.bind(manager);
+    let syncCalled = false;
+    let syncSettled = false;
+    const syncSpy = vi
+      .spyOn(
+        manager as unknown as {
+          syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+        },
+        "syncPublishedIndexInBackground",
+      )
+      .mockImplementation(async (params) => {
+        syncCalled = true;
+        await syncGate;
+        await realSyncPublished(params);
+        syncSettled = true;
+      });
+
+    // nonblockingRefresh lets the search return results from the existing index
+    // without waiting for the dirty sync to settle.
+    try {
+      const results = await manager.search("current dirty search sync", {
+        maxResults: 5,
+        minScore: 0,
+        nonblockingRefresh: true,
+      });
+
+      // The sync was started but not awaited.
+      expect(syncCalled).toBe(true);
+      expect(syncSettled).toBe(false);
+      // The newly written file is not yet indexed, so it does not appear in results.
+      expect(results.some((entry) => entry.path === "memory/search-sync.md")).toBe(false);
+
+      // Release the gate so the real background sync runs and indexes the new file.
+      releaseGate();
+      await vi.waitFor(() => expect(syncSettled).toBe(true));
+
+      // The background sync itself indexed the new file — verify convergence
+      // without relying on a second search's own synchronous dirty sync.
+      const laterResults = await manager.search("current dirty search sync", {
+        maxResults: 5,
+        minScore: 0,
+      });
+      expect(laterResults.some((entry) => entry.path === "memory/search-sync.md")).toBe(true);
+    } finally {
+      releaseGate();
+      syncSpy.mockRestore();
+    }
+  });
 });

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -8,6 +8,7 @@ import {
 import {
   MEMORY_INDEX_FTS_TABLE,
   MEMORY_INDEX_VECTOR_TABLE,
+  type MemoryProviderStatus,
   type MemorySearchManager,
   type MemorySearchResult,
   type MemorySource,
@@ -33,10 +34,27 @@ const SNIPPET_MAX_CHARS = 700;
 const VECTOR_TABLE = MEMORY_INDEX_VECTOR_TABLE;
 const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const log = createSubsystemLogger("memory");
-type MemoryIndexSearchOptions = NonNullable<Parameters<MemorySearchManager["search"]>[1]>;
+type FreshnessSnapshot = Pick<MemoryProviderStatus, "custom" | "lastSyncError">;
+
+type MemoryIndexSearchOptions = NonNullable<Parameters<MemorySearchManager["search"]>[1]> & {
+  /**
+   * When true, a dirty-index refresh triggered by this search runs in the
+   * background instead of blocking the search. Internal scheduling option for
+   * the deadline-bounded gateway tool path; not part of the exported
+   * MemorySearchManager contract.
+   */
+  nonblockingRefresh?: boolean;
+  /**
+   * Receives a freshness snapshot captured after any synchronous dirty-index
+   * sync, so the caller's staleness warning reflects the index state that
+   * supplied the search results.
+   */
+  onFreshness?: (snapshot: FreshnessSnapshot) => void;
+};
 
 export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
   protected abstract sessionWarm: Set<string>;
+  abstract status(): MemoryProviderStatus;
 
   protected claimSessionWarmSync(sessionKey?: string): boolean {
     if (!this.settings.sync.onSessionStart) {
@@ -212,6 +230,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           (this.purpose === "default" || this.purpose === "cli"),
         dirty: this.dirty,
         sessionsDirty: this.sessionsDirty,
+        nonblocking: opts?.nonblockingRefresh,
         sync: async (params) => await this.syncPublishedIndexInBackground(params),
         onError: (err) => {
           log.warn(`memory sync failed (search): ${String(err)}`);
@@ -223,6 +242,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         });
         this.activeBackgroundSearchSyncs.add(trackedSearchSync);
       }
+      opts?.onFreshness?.(this.status());
       // Bootstrap and identity repair may publish a new generation. Acquire the
       // read lease only after those writers finish so first search cannot wait on itself.
       for (let identityAttempt = 0; identityAttempt < 2; identityAttempt += 1) {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -626,6 +626,58 @@ describe("memory_search unavailable payloads", () => {
     });
   });
 
+  it("preserves stale warning when background sync clears lastSyncError during search", async () => {
+    setMemoryLastSyncError("embedding request timed out");
+    setMemorySearchImpl(async (opts) => {
+      // The manager captures freshness (lastSyncError set) after the background
+      // sync starts but before it completes. The nonblocking sync clears
+      // lastSyncError asynchronously — the snapshot must still reflect the
+      // in-flight state.
+      opts?.onFreshness?.({ lastSyncError: "embedding request timed out" });
+      setMemoryLastSyncError(undefined);
+      return [];
+    });
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+
+    const result = await tool.execute("race-sync", { query: "hidden codeword" });
+
+    expect(result.details).toMatchObject({
+      results: [],
+      stale: true,
+      warning:
+        "Memory index is stale: embedding request timed out. Search results may be incomplete.",
+    });
+  });
+
+  it("does not warn when synchronous bootstrap clears lastSyncError before search", async () => {
+    setMemoryLastSyncError("previous sync failed");
+    setMemorySearchImpl(async (opts) => {
+      // A fresh process boots with a stale lastSyncError. The synchronous
+      // sync in search() succeeds and clears lastSyncError. Freshness
+      // is captured after the sync completes, so the snapshot must show no error.
+      setMemoryLastSyncError(undefined);
+      opts?.onFreshness?.({ lastSyncError: undefined });
+      return [];
+    });
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+
+    const result = await tool.execute("fresh-bootstrap", { query: "hidden codeword" });
+
+    expect(result.details).toMatchObject({ results: [] });
+    expect(result.details).not.toHaveProperty("stale");
+    expect(result.details).not.toHaveProperty("warning");
+  });
+
   it("surfaces embedding bootstrap degradation when keyword search has no hits", async () => {
     let searchCalls = 0;
     setMemorySearchImpl(async (opts) => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -385,6 +385,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
                   sessionKey: options.agentSessionKey,
                   activeProjectKeys: options.activeProjectKeys,
                   conversationRecall: options.conversationRecall,
+                  nonblockingRefresh: !options.oneShotCliRun,
                 },
                 visibility: { cfg, agentId, sandboxed: options.sandboxed === true },
                 signal,
@@ -460,7 +461,8 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
               model: status.model,
               fallback: status.fallback,
               mode: executed.searchMode,
-              staleness: resolveMemorySearchStaleness(status, agentId) ?? undefined,
+              staleness:
+                resolveMemorySearchStaleness(executed.searchedAtFreshness, agentId) ?? undefined,
               debug: executed.debug,
             },
           };


### PR DESCRIPTION
Closes #128140

## What Problem This Solves

The `memory_search` gateway tool always timed out after 15 seconds while the CLI `openclaw memory search` returned results in under 1 second. The gateway tool path wrapped the entire search — including a blocking dirty-index sync — in a 15-second deadline. For the persistent gateway manager, `dirty=true` on every search, so each call blocked on a full file-enumeration + indexing sync inside the deadline. The CLI calls `manager.search()` directly with no deadline, so it completed normally.

This change runs the dirty-index refresh in the background for the gateway tool path while preserving synchronous refresh for the CLI path. A freshness snapshot captured after the sync boundary drives the staleness warning.

- `manager-async-state.ts` — Added `nonblocking?: boolean` param to `startAsyncSearchSync`. When true, the dirty-index sync runs fire-and-forget. The `enabled` check runs first, preserving the disabled-search-sync contract.
- `manager-search-orchestration.ts` — Extended internal `MemoryIndexSearchOptions` with `nonblockingRefresh?` and `onFreshness?` (exported `MemorySearchManager.search` contract unchanged). Passes `nonblocking` to `startAsyncSearchSync`; calls `opts?.onFreshness?.(this.status())` after the sync returns.
- `memory-search-tool-query.ts` — Passes `nonblockingRefresh: true` and `onFreshness` callback through a local `ManagerWithNonblockingRefresh` type view (SDK contract unchanged).
- `tools.ts` — Passes `nonblockingRefresh: !options.oneShotCliRun`; uses `executed.searchedAtFreshness` for staleness resolution.
- Tests: "returns existing-index results without waiting for nonblocking dirty sync" (manager-level, gates `syncPublishedIndexInBackground`), "preserves stale warning when background sync clears lastSyncError during search" + "does not warn when synchronous bootstrap clears lastSyncError before search" (tool-level).
- Unchanged: CLI blocking path, `enabled` check, 15-second deadline, empty-index bootstrap sync, `runMemoryCorpusDeadline` wrapper, background watcher/interval sync, exported SDK contract.

## Why This Change Was Made

The blocking dirty sync consumed most of the 15-second budget, leaving insufficient time for the actual search. The nonblocking refresh keeps the deadline for querying the index while the dirty sync runs concurrently.

**Freshness boundary**: `onFreshness` fires after `startAsyncSearchSync` returns, capturing a `lastSyncError`/`custom` snapshot that `resolveMemorySearchStaleness` uses. If the sync has a process-local error, the snapshot preserves it so the warning reflects the index state at search time; once a successful sync clears it, subsequent searches show no warning.

## User Impact

`memory_search` in gateway sessions returns results within the deadline instead of timing out. If a sync error occurred, the staleness warning is preserved; once the background sync succeeds, the warning clears on the next search. CLI behavior is unchanged.

## Evidence

Exact head: `7de5cd9968`

Real behavior proof — production `executeMemorySearchToolQuery` driven by a real persistent `MemoryIndexManager` (real SQLite index, real FTS search, real file-system sync):

```console
=== Real Gateway Trace: nonblocking dirty-index sync ===
Head: 7de5cd99682b73ea0a876315e2e0ef0a6ef72003
Manager: builtin (persistent, FTS=true)

--- Step 1: Dirty index, nonblockingRefresh=true (gateway path) ---
Index dirty: true
Search duration: 53ms (deadline: 15000ms)
Within deadline: YES
Sync started (fire-and-forget): YES
Sync settled (awaited): NO (nonblocking)
Results returned: 1
Stale warning: none (no sync error in flight)

--- Step 2: Background sync converges ---
Sync settled: YES

--- Step 3: Follow-up search after convergence ---
Stale warning: none (cleared)
Results returned: 2 (now includes updated file)

=== Trace complete: PASS ===
```

| Scenario | Path | Duration | Sync awaited? | Results | Correct? |
|---|---|---|---|---|---|
| Dirty index, nonblocking sync in flight | Gateway | 53ms < 15s | NO | 1 (existing index) | ✓ results before deadline |
| Follow-up after convergence | Gateway | — | — | 2 (new file indexed) | ✓ convergence works |

Regression tests (pre-fix fail / post-fix pass verified):

```console
$ node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts
 Test Files  1 passed (1)    Tests  44 passed (44)

$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-search-orchestration.test.ts
 Test Files  1 passed (1)    Tests  22 passed (22)
```

Type-check and lint clean:

```console
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental       # exit 0
$ npx oxlint -c .oxlintrc.json extensions/memory-core/src/...                # exit 0
```

The proof drives the production `executeMemorySearchToolQuery` with a real persistent `MemoryIndexManager` using a fixture embedding provider. The nonblocking timing is verified by gating `syncPublishedIndexInBackground` behind a promise released after the search returns, proving the search does not await the sync.

## AI Assistance

- AI-assisted: Yes. Codex CLI (gpt-5.5) for analysis/implementation; Claude Code for rework iterations. Real behavior proof: production `executeMemorySearchToolQuery` with real persistent `MemoryIndexManager` on head `7de5cd9968` — 53ms search under 15s deadline + nonblocking sync + convergence.
- Confirmed understanding: (1) `nonblocking` param — fire-and-forget when true, `enabled` check first; (2) `onFreshness` called after `startAsyncSearchSync` returns, capturing `lastSyncError`/`custom` snapshot; (3) `executeMemorySearchToolQuery` passes `nonblockingRefresh: true` via local type view; (4) `tools.ts` uses `executed.searchedAtFreshness`; (5) empty-index bootstrap remains synchronous.
- autoreview: N/A (oxlint, oxfmt, tsgo all clean)
