### PR TITLE
fix(agents): keep delivery status independent

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -40,7 +40,6 @@ import {
   markPendingFinalDelivery,
   maskLifecycleIdentifier,
   recordAnnounceDeliveryResult,
-  safeMarkRequiredCompletionDeliveryBlocked,
   safeSetSubagentTaskDeliveryStatus,
 } from "./subagent-registry-lifecycle-delivery.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -93,10 +92,6 @@ export const finalizeResumedAnnounceGiveUp = async (
     entry,
     deliveryStatus: "failed",
     deliveryError,
-  });
-  safeMarkRequiredCompletionDeliveryBlocked(params, {
-    entry,
-    reason: deliveryError,
   });
   entry.wakeOnDescendantSettle = undefined;
   const completion = ensureCompletionState(entry);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-cleanup.ts
@@ -35,7 +35,6 @@ import {
   buildSafeLifecycleErrorMeta,
   markPendingFinalDelivery,
   maskLifecycleIdentifier,
-  safeMarkRequiredCompletionDeliveryBlocked,
   safeSetSubagentTaskDeliveryStatus,
 } from "./subagent-registry-lifecycle-delivery.js";
 import {
@@ -187,10 +186,6 @@ export function suspendPendingFinalDelivery(
     entry: args.entry,
     deliveryStatus: "failed",
     deliveryError: getDeliveryLastError(args.entry) ?? args.reason,
-  });
-  safeMarkRequiredCompletionDeliveryBlocked(params, {
-    entry: args.entry,
-    reason: getDeliveryLastError(args.entry) ?? args.reason,
   });
   logAnnounceGiveUp(args.entry, args.reason);
   markRequesterSettleWakePending(args.entry);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -15,7 +15,6 @@ import {
   failTaskRunByRunId,
   setDetachedTaskDeliveryStatusByRunId,
 } from "../../../tasks/detached-task-runtime.js";
-import { resolveRequiredCompletionDeliveryFailureTerminalResult } from "../../../tasks/task-completion-contract.js";
 import type { TaskDeliveryStatus } from "../../../tasks/task-registry.types.js";
 import {
   buildAnnounceIdFromChildRun,
@@ -24,7 +23,6 @@ import {
 import { isSilentAgentReplyText } from "../../embedded-agent-runner/message-visibility.js";
 import type { SubagentAnnounceDeliveryResult } from "../announce/subagent-announce-dispatch.js";
 import type { SubagentRunOutcome } from "../announce/subagent-announce-output.js";
-import { resolveSubagentCompletionResultText } from "../completion/subagent-completion-result.js";
 import {
   clearDeliveryState,
   ensureCompletionState,
@@ -209,6 +207,10 @@ const resolveSubagentTaskTarget = (
   };
 };
 
+/**
+ * Records delivery independently from the finalized execution/artifact state.
+ * A failed announcement must not rewrite a successful task or mirrored flow.
+ */
 export const safeSetSubagentTaskDeliveryStatus = (
   params: SubagentLifecycleOptions,
   args: {
@@ -279,42 +281,6 @@ export const safeFinalizeSubagentTaskRun = (
       outcomeStatus: args.outcome.status,
     });
     return [];
-  }
-};
-
-export const safeMarkRequiredCompletionDeliveryBlocked = (
-  params: SubagentLifecycleOptions,
-  args: {
-    entry: SubagentRunRecord;
-    reason?: string;
-  },
-) => {
-  if (
-    args.entry.expectsCompletionMessage !== true ||
-    args.entry.execution.outcome?.status !== "ok"
-  ) {
-    return;
-  }
-  const endedAt = args.entry.execution.endedAt ?? Date.now();
-  const terminalResult = resolveRequiredCompletionDeliveryFailureTerminalResult(args.reason);
-  const target = resolveSubagentTaskTarget(params, args.entry);
-  try {
-    completeTaskRunByRunId({
-      runId: target.runId,
-      runtime: "subagent",
-      sessionKey: target.sessionKey,
-      endedAt,
-      lastEventAt: Date.now(),
-      progressSummary: resolveSubagentCompletionResultText(args.entry),
-      terminalSummary: terminalResult.terminalSummary,
-      terminalOutcome: terminalResult.terminalOutcome,
-    });
-  } catch (err) {
-    params.warn("failed to mark subagent completion delivery blocked", {
-      error: buildSafeLifecycleErrorMeta(err),
-      runId: maskLifecycleIdentifier(args.entry.runId, "run"),
-      childSessionKey: maskLifecycleIdentifier(args.entry.childSessionKey, "session"),
-    });
   }
 };
 

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -18,7 +18,6 @@ import type {
 import {
   buildSafeLifecycleErrorMeta,
   maskLifecycleIdentifier,
-  safeMarkRequiredCompletionDeliveryBlocked,
   safeSetSubagentTaskDeliveryStatus,
 } from "./subagent-registry-lifecycle-delivery.js";
 import type { RequesterSettleWakeState, SubagentRunRecord } from "./subagent-registry.types.js";
@@ -146,7 +145,6 @@ const completeRequesterSettleWakeBatch = (
         deliveryStatus: "failed",
         deliveryError: error,
       });
-      safeMarkRequiredCompletionDeliveryBlocked(params, { entry, reason: error });
     }
   }
   for (const [runId, entry] of entries) {

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -3588,15 +3588,7 @@ describe("subagent registry lifecycle hardening", () => {
       deliveryStatus: "failed",
       error: "gateway request timeout for agent",
     });
-    expectFields(firstCallArg(taskExecutorMocks.completeTaskRunByRunId), {
-      runId: entry.runId,
-      runtime: "subagent",
-      sessionKey: entry.childSessionKey,
-      progressSummary: "final answer",
-      terminalOutcome: "blocked",
-      terminalSummary:
-        "Required completion delivery failed before reaching the requester: gateway request timeout for agent.",
-    });
+    expect(taskExecutorMocks.completeTaskRunByRunId).not.toHaveBeenCalled();
     expect(persistOrThrow).toHaveBeenCalled();
   });
 
@@ -3767,19 +3759,8 @@ describe("subagent registry lifecycle hardening", () => {
     expect(entry.delivery?.suspendedAt).toBeTypeOf("number");
     expect(entry.delivery?.suspendedReason).toBe("expiry");
     expect(entry.cleanupCompletedAt).toBeUndefined();
-    expectFields(
-      findCallArg(
-        taskExecutorMocks.completeTaskRunByRunId,
-        (arg) => arg.terminalOutcome === "blocked",
-      ),
-      {
-        runId: entry.runId,
-        runtime: "subagent",
-        sessionKey: entry.childSessionKey,
-        terminalOutcome: "blocked",
-        terminalSummary:
-          "Required completion delivery failed before reaching the requester: UNAVAILABLE: requester wake failed; direct-primary: UNAVAILABLE: requester wake failed.",
-      },
+    expect(taskExecutorMocks.completeTaskRunByRunId).not.toHaveBeenCalledWith(
+      expect.objectContaining({ terminalOutcome: "blocked" }),
     );
     expect(persist).toHaveBeenCalled();
   });


### PR DESCRIPTION
Fixes #128245

## What Problem This Solves

A successful detached subagent execution can be re-finalized as blocked solely because its requester announcement fails or expires. The task then has status succeeded, deliveryStatus failed, and terminalOutcome blocked; mirrored TaskFlow state follows the blocked outcome instead of the verified execution/artifact result.

This change keeps execution and delivery independent. Delivery failures remain auditable and retryable in the dedicated delivery state without overwriting an already finalized successful task or flow.

## Summary
- stop re-finalizing successful detached subagent runs as blocked when completion announcement delivery fails
- keep delivery failures in the dedicated deliveryStatus/error state
- preserve the original execution terminal outcome and mirrored TaskFlow result
- retain the existing blocked behavior for genuinely missing or progress-only required deliverables

## Evidence
- Focused lifecycle suite passed: 298 tests across agents-core and agents-support.
- Focused oxlint passed on all five changed files.
- Focused oxfmt passed on all five changed files.
- Full repository guards passed.
- Production, scripts, extensions, UI, and test-root typecheck stages passed.
- Repo-wide local lint reached oxlint core but was interrupted after making no progress for more than five minutes; GitHub CI remains authoritative.
- Regression assertions now prove failed/suspended delivery updates deliveryStatus without any second completeTaskRunByRunId call that sets terminalOutcome to blocked.

## Behavior

A successful run with a failed/suspended announcement now remains successful. Its delivery state remains failed and auditable/retryable without rewriting execution or artifact truth.