### PR TITLE
fix(ui): warning callouts render without warning styles

### DIFF
--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -412,6 +412,11 @@ describe("agents tools panel (browser)", () => {
                 severity: "info",
                 message: "MCP servers are configured but not connected yet.",
               },
+              {
+                id: "tool-schema-quarantined",
+                severity: "warning",
+                message: "A tool with an unsupported schema was quarantined.",
+              },
             ],
           },
         }),
@@ -420,9 +425,21 @@ describe("agents tools panel (browser)", () => {
     );
     await Promise.resolve();
 
-    expect(container.querySelector(".agent-tools-notices .callout.info")?.textContent?.trim()).toBe(
-      "MCP servers are configured but not connected yet.",
-    );
+    expect(
+      Array.from(container.querySelectorAll(".agent-tools-notices .callout")).map((notice) => ({
+        className: notice.className,
+        text: notice.textContent?.trim(),
+      })),
+    ).toEqual([
+      {
+        className: "callout info",
+        text: "MCP servers are configured but not connected yet.",
+      },
+      {
+        className: "callout warn",
+        text: "A tool with an unsupported schema was quarantined.",
+      },
+    ]);
   });
 
   it("closes expanded tool rows when the parent group collapses", async () => {

--- a/ui/src/pages/agents/panels-tools-skills.ts
+++ b/ui/src/pages/agents/panels-tools-skills.ts
@@ -193,7 +193,7 @@ function renderEffectiveToolNotices(result: ToolsEffectiveResult | null) {
       ${notices.map(
         (notice) => html`
           <div
-            class="callout ${notice.severity === "warning" ? "warning" : "info"}"
+            class="callout ${notice.severity === "warning" ? "warn" : "info"}"
             style="margin-top: 12px"
           >
             ${formatUiExternalText(notice.message)}

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -540,17 +540,15 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     const body = renderSettingsPage(
       html`
         ${!this.hasManageAccess()
-          ? html`<div class="callout warning" role="note">
-              ${t("cloudWorkersPage.adminRequired")}
-            </div>`
+          ? html`<div class="callout warn" role="note">${t("cloudWorkersPage.adminRequired")}</div>`
           : nothing}
         ${this.catalogError
-          ? html`<div class="callout warning" role="status">
+          ? html`<div class="callout warn" role="status">
               ${t("cloudWorkersPage.catalogFailed", { error: this.catalogError })}
             </div>`
           : nothing}
         ${this.notice
-          ? html`<div class="callout warning" role="status">${this.notice}</div>`
+          ? html`<div class="callout warn" role="status">${this.notice}</div>`
           : nothing}
         ${renderSettingsSection(
           {

--- a/ui/src/pages/config/updates.ts
+++ b/ui/src/pages/config/updates.ts
@@ -409,7 +409,7 @@ export function renderUpdates(props: UpdatesViewProps): TemplateResult {
       ${renderSettingsPage(
         [
           !props.canAdmin
-            ? html`<div class="callout warning" role="note">${t("updates.adminRequired")}</div>`
+            ? html`<div class="callout warn" role="note">${t("updates.adminRequired")}</div>`
             : nothing,
           renderBuildFacts(props),
           renderRecordedAttempt(props),

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -184,7 +184,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
       </div>
       ${props.message
         ? html`<div
-            class="callout ${props.message.kind}"
+            class="callout ${props.message.kind === "error" ? "danger" : "success"}"
             role=${props.message.kind === "error" ? "alert" : "status"}
           >
             ${props.message.text}

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -66,7 +66,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
   const body = html`
     <div class="settings-row settings-row--stacked model-providers__defaults">
       ${props.models.length === 0
-        ? html`<div class="callout warning">${t("modelProviders.defaults.noModels")}</div>`
+        ? html`<div class="callout warn">${t("modelProviders.defaults.noModels")}</div>`
         : nothing}
       <div class="model-providers__default-grid">
         <label class="field">
@@ -191,7 +191,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
           </div>`
         : nothing}
       ${props.message?.warning
-        ? html`<div class="callout warning" role="status">${props.message.warning}</div>`
+        ? html`<div class="callout warn" role="status">${props.message.warning}</div>`
         : nothing}
     </div>
   `;

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -444,7 +444,7 @@ describe("renderModelProviders", () => {
       "Config refresh failed after the secret was committed.",
     ]);
     expect(messages[0]?.classList.contains("success")).toBe(true);
-    expect(messages[1]?.classList.contains("warning")).toBe(true);
+    expect(messages[1]?.classList.contains("warn")).toBe(true);
   });
 
   it("keeps committed default-model success visible beside its refresh warning", () => {
@@ -467,7 +467,7 @@ describe("renderModelProviders", () => {
       "Config refresh failed after the model defaults were committed.",
     ]);
     expect(messages[0]?.classList.contains("success")).toBe(true);
-    expect(messages[1]?.classList.contains("warning")).toBe(true);
+    expect(messages[1]?.classList.contains("warn")).toBe(true);
   });
 
   it("announces provider and default-model mutation failures as accessible alerts", () => {

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -480,12 +480,13 @@ describe("renderModelProviders", () => {
       }),
     );
 
-    expect(text(container.querySelector('[data-provider-id="openai"] [role="alert"]'))).toBe(
-      "Provider credential could not be saved.",
-    );
-    expect(text(container.querySelector('.model-providers__defaults [role="alert"]'))).toBe(
-      "Default models could not be saved.",
-    );
+    const providerAlert = container.querySelector('[data-provider-id="openai"] [role="alert"]');
+    const defaultsAlert = container.querySelector('.model-providers__defaults [role="alert"]');
+
+    expect(text(providerAlert)).toBe("Provider credential could not be saved.");
+    expect(text(defaultsAlert)).toBe("Default models could not be saved.");
+    expect(providerAlert?.classList.contains("danger")).toBe(true);
+    expect(defaultsAlert?.classList.contains("danger")).toBe(true);
   });
 
   it("keeps model behavior available while provider data loads", () => {

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -116,7 +116,10 @@ function renderMutationMessage(message: ModelProviderRowMessage | undefined) {
     return nothing;
   }
   return html`
-    <div class="callout ${message.kind}" role=${message.kind === "error" ? "alert" : "status"}>
+    <div
+      class="callout ${message.kind === "error" ? "danger" : "success"}"
+      role=${message.kind === "error" ? "alert" : "status"}
+    >
       ${message.text}
     </div>
     ${message.warning

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -120,7 +120,7 @@ function renderMutationMessage(message: ModelProviderRowMessage | undefined) {
       ${message.text}
     </div>
     ${message.warning
-      ? html`<div class="callout warning" role="status">${message.warning}</div>`
+      ? html`<div class="callout warn" role="status">${message.warning}</div>`
       : nothing}
   `;
 }
@@ -651,7 +651,7 @@ export function renderModelProviders(props: ModelProvidersViewProps) {
     )}
     ${props.quickAddSupported ? renderAddProvider(props) : nothing}
     ${props.mutationBlockedReason
-      ? html`<div class="callout warning">${props.mutationBlockedReason}</div>`
+      ? html`<div class="callout warn">${props.mutationBlockedReason}</div>`
       : nothing}
   `);
 }

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -568,11 +568,11 @@ function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectR
     : nothing;
   if (!props.canAdmin) {
     return html`${current}
-      <div class="callout warning" role="note">${t("modelSetup.access.adminRequired")}</div>`;
+      <div class="callout warn" role="note">${t("modelSetup.access.adminRequired")}</div>`;
   }
   if (props.gatewayTooOld) {
     return html`${current}
-      <div class="callout warning" role="note">${t("modelSetup.access.gatewayTooOld")}</div>`;
+      <div class="callout warn" role="note">${t("modelSetup.access.gatewayTooOld")}</div>`;
   }
   return html`
     ${current} ${renderEmptyState(props, result)} ${renderCandidateRows(props, result)}
@@ -586,11 +586,11 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
   if (props.page.phase === "ready") {
     body = renderReady(props, props.page.result);
   } else if (!props.canAdmin) {
-    body = html`<div class="callout warning" role="note">
+    body = html`<div class="callout warn" role="note">
       ${t("modelSetup.access.adminRequired")}
     </div>`;
   } else if (props.gatewayTooOld) {
-    body = html`<div class="callout warning" role="note">
+    body = html`<div class="callout warn" role="note">
       ${t("modelSetup.access.gatewayTooOld")}
     </div>`;
   } else if (props.page.phase === "loading") {
@@ -624,7 +624,7 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
           : nothing}
       </div>
       ${props.refreshWarning
-        ? html`<div class="callout warning" role="alert">${props.refreshWarning}</div>`
+        ? html`<div class="callout warn" role="alert">${props.refreshWarning}</div>`
         : nothing}
       ${body}
     </div>

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -48,7 +48,7 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
         </div>
         <div class="model-setup-wizard__body">
           ${props.refreshWarning
-            ? html`<div class="callout warning" role="alert">${props.refreshWarning}</div>`
+            ? html`<div class="callout warn" role="alert">${props.refreshWarning}</div>`
             : nothing}
           ${props.state.phase === "starting"
             ? html`<div role="status">

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -156,7 +156,7 @@ function renderProviderUsage(providers: ProviderUsageSnapshot[], unavailable: bo
     html`
       ${unavailable
         ? html`
-            <div class="callout warning usage-callout">${t("usage.providerUsage.unavailable")}</div>
+            <div class="callout warn usage-callout">${t("usage.providerUsage.unavailable")}</div>
           `
         : nothing}
       <div class="usage-panel provider-usage-section">
@@ -776,7 +776,7 @@ export function renderUsage(props: UsageProps) {
                 : nothing}
               ${queryWarnings.length > 0
                 ? html`
-                    <div class="callout warning usage-callout usage-callout--tight">
+                    <div class="callout warn usage-callout usage-callout--tight">
                       ${queryWarnings.join(" · ")}
                     </div>
                   `
@@ -788,16 +788,14 @@ export function renderUsage(props: UsageProps) {
               : nothing}
             ${cacheStatusTitle
               ? html`
-                  <div class="callout warning usage-callout usage-cache-warning">
+                  <div class="callout warn usage-callout usage-cache-warning">
                     ${t("usage.cacheStatus.warning")} ${cacheStatusTitle}
                   </div>
                 `
               : nothing}
             ${data.sessionsLimitReached
               ? html`
-                  <div class="callout warning usage-callout">
-                    ${t("usage.sessions.limitReached")}
-                  </div>
+                  <div class="callout warn usage-callout">${t("usage.sessions.limitReached")}</div>
                 `
               : nothing}
           </div>

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -627,13 +627,7 @@
   margin-top: 0;
 }
 
-.callout.warning {
-  border-color: color-mix(in srgb, var(--warn) 22%, var(--border));
-  background: var(--warn-subtle);
-  color: var(--text);
-}
-
-.callout.warning.usage-cache-warning {
+.callout.warn.usage-cache-warning {
   border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
   background: var(--warn-subtle);
   color: var(--accent);


### PR DESCRIPTION
Closes #128251

## What Problem This Solves

Fixes an issue where users viewing warning states in Model Setup, Models, Cloud workers, Updates, and Usage would see neutral or page-specific styling instead of the shared warning treatment.

## Why This Change Was Made

All 18 warning callouts now use the existing canonical `warn` modifier. The page-local `warning` base style in Usage was removed, leaving one warning callout name and one shared visual implementation; the distinct Usage cache emphasis remains scoped to that page.

## User Impact

Gateway-version, admin-access, catalog, cache, and model warnings now consistently use amber warning color, border, and background in dark and light themes across five pages.

## Evidence

- Control UI mock on `127.0.0.1:5334` with `operator.read,operator.write` reproduced the affected admin warning on Model Setup, Models, Cloud workers, and Updates.
- Before: Model Setup, Cloud workers, and Updates computed `background-image: none` with neutral text/border in both themes. Models inherited a separate Usage-only style.
- After: all four pages compute the canonical `callout.warn` gradient, warning text, and warning border in both themes.
- Model-provider credential and default-model mutation failures now use the styled `callout.danger` variant while retaining accessible alert semantics.
- Dark and light before/after screenshots are attached below.
- `node scripts/run-vitest.mjs ui/src/pages/model-providers/view.test.ts ui/src/pages/agents/panels-tools-skills.browser.test.ts` (51 tests passed; the mutation-error regression failed before the fix and passed after it)
- `pnpm check:changed`
- `pnpm ui:build`
- Production LOC: +25/-32 (net -7). Tests: +29/-11 (net +18). Focused coverage protects info and warning runtime notices, the canonical `warn` modifier, and styled `danger` callouts for both model mutation error renderers.

### Dark theme

![Dark theme before and after](https://github.com/user-attachments/assets/d9bffeca-2d3f-4917-861b-9cad0fd0de67)

### Light theme

![Light theme before and after](https://github.com/user-attachments/assets/6792d36d-8381-486c-9b9a-6b2cd0a7d280)



