### PR TITLE
fix(matrix): deliver explicit reasoning notices

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -110,6 +110,10 @@ during a send in the next throttle window. Explicit `flush()` still bypasses
 the delay for attention and finalization. Cancel pending updates and await
 in-flight work before closing or rotating a stream.
 
+For mode-dependent durable reasoning, provide `onReasoningLevelResolved`. Core calls it
+synchronously after inline and stored mode resolution and before the agent run; return `true` only
+when durable reasoning should enter block and final accounting. Stream callbacks stay separate.
+
 ### Commentary delivery ownership
 
 Set `commentaryPayloadsEnabled: true` when the channel supports durable commentary messages.

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
@@ -1,0 +1,103 @@
+// Matrix reply dispatcher tests cover channel-owned reasoning stream delivery.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MatrixClient } from "../sdk.js";
+import { createMatrixReplyDispatcher } from "./handler-reply-dispatcher.js";
+
+const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn(async () => ({ visibleReplySent: true })));
+
+vi.mock("./replies.js", async () => {
+  const actual = await vi.importActual<typeof import("./replies.js")>("./replies.js");
+  return {
+    ...actual,
+    deliverMatrixReplies: deliverMatrixRepliesMock,
+  };
+});
+
+function createDispatcher() {
+  return createMatrixReplyDispatcher({
+    cfg: {},
+    prefixOptions: { responsePrefixContextProvider: () => ({ identityName: undefined }) },
+    humanDelay: { mode: "off" },
+    typingCallbacks: {
+      onReplyStart: vi.fn(() => Promise.resolve()),
+      onIdle: vi.fn(() => undefined),
+    },
+    streaming: "off",
+    draftStream: undefined,
+    draftController: {
+      beginDraftGeneration: vi.fn(),
+      advanceDraftBlockBoundary: vi.fn(),
+      reset: vi.fn(),
+      resetReplyToIdForNextBlock: vi.fn(),
+      updateDraftFromLatestFullText: vi.fn(),
+      cancelProgressDraft: vi.fn(),
+      currentReplyToId: vi.fn(() => undefined),
+      draftDisposition: vi.fn(() => "inactive"),
+      buildPreviewToolProgressReplyOptions: vi.fn(() => ({})),
+    } as never,
+    client: {} as MatrixClient,
+    roomId: "!room:example.org",
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    textLimit: 4000,
+    replyToMode: "off",
+    accountId: "default",
+    mediaLocalRoots: [],
+    tableMode: "code",
+    logVerboseMessage: vi.fn(),
+  });
+}
+
+describe("createMatrixReplyDispatcher", () => {
+  beforeEach(() => {
+    deliverMatrixRepliesMock.mockClear();
+  });
+
+  it("delivers stream-mode reasoning when the reasoning block ends", async () => {
+    const dispatcher = createDispatcher();
+
+    expect(dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "Checking tools" })).toBe(
+      false,
+    );
+    expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
+
+    await expect(dispatcher.turnDispatcherOptions.onReasoningEnd?.()).resolves.toBe(true);
+
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roomId: "!room:example.org",
+        replies: [{ text: "Checking tools", isReasoning: true }],
+      }),
+    );
+  });
+
+  it("drains stream-mode reasoning notices before final replies", async () => {
+    let resolveReasoning!: (value: { visibleReplySent: boolean }) => void;
+    const reasoningDelivery = new Promise<{ visibleReplySent: boolean }>((resolve) => {
+      resolveReasoning = resolve;
+    });
+    deliverMatrixRepliesMock
+      .mockImplementationOnce(async () => await reasoningDelivery)
+      .mockResolvedValueOnce({ visibleReplySent: true });
+    const dispatcher = createDispatcher();
+
+    dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "Check @room first" });
+    const reasoningEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();
+    const finalDelivery = dispatcher.deliverReply({ text: "Final answer" }, { kind: "final" });
+    await Promise.resolve();
+
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+
+    resolveReasoning({ visibleReplySent: true });
+    await expect(reasoningEnd).resolves.toBe(true);
+    await expect(finalDelivery).resolves.toEqual({ visibleReplySent: true });
+
+    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ replies: [{ text: "Check @room first", isReasoning: true }] }),
+    );
+    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ replies: [{ text: "Final answer" }] }),
+    );
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
@@ -13,7 +13,7 @@ vi.mock("./replies.js", async () => {
   };
 });
 
-function createDispatcher() {
+function createDispatcher(config: { replyToMode?: "off" | "first"; replyToEventId?: string } = {}) {
   return createMatrixReplyDispatcher({
     cfg: {},
     prefixOptions: { responsePrefixContextProvider: () => ({ identityName: undefined }) },
@@ -38,7 +38,8 @@ function createDispatcher() {
     client: {} as MatrixClient,
     roomId: "!room:example.org",
     runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    replyToMode: "off",
+    replyToMode: config.replyToMode ?? "off",
+    replyToEventId: config.replyToEventId,
     accountId: "default",
     mediaLocalRoots: [],
     logVerboseMessage: vi.fn(),
@@ -88,41 +89,64 @@ describe("createMatrixReplyDispatcher", () => {
     );
   });
 
-  it("drains every reasoning window before the final reply", async () => {
-    let resolveFirst!: (value: { visibleReplySent: boolean }) => void;
-    const firstDelivery = new Promise<{ visibleReplySent: boolean }>((resolve) => {
-      resolveFirst = resolve;
-    });
-    deliverMatrixRepliesMock
-      .mockImplementationOnce(async () => await firstDelivery)
-      .mockResolvedValue({ visibleReplySent: true });
-    const dispatcher = createDispatcher();
-    dispatcher.setReasoningLevel("stream");
+  it("preserves the final reply target after suppressing off-mode reasoning", async () => {
+    const dispatcher = createDispatcher({ replyToMode: "first", replyToEventId: "$incoming" });
+    expect(dispatcher.setReasoningLevel("off")).toBe(false);
 
-    dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "First window" });
-    const firstEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();
-    dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "Second window" });
-    const secondEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();
-    const finalDelivery = dispatcher.deliverReply({ text: "Final answer" }, { kind: "final" });
-    await Promise.resolve();
+    await expect(
+      dispatcher.deliverReply({ text: "Hidden thought", isReasoning: true }, { kind: "final" }),
+    ).resolves.toMatchObject({ visibleReplySent: false });
+    await dispatcher.deliverReply({ text: "Visible final" }, { kind: "final" });
 
-    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
-    resolveFirst({ visibleReplySent: true });
-    await expect(firstEnd).resolves.toBe(true);
-    await expect(secondEnd).resolves.toBe(true);
-    await expect(finalDelivery).resolves.toEqual({ visibleReplySent: true });
-
-    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ replies: [{ text: "First window", isReasoning: true }] }),
-    );
-    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ replies: [{ text: "Second window", isReasoning: true }] }),
-    );
-    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({ replies: [{ text: "Final answer" }] }),
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledOnce();
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasRepliedRef: { value: false },
+        replies: [{ text: "Visible final" }],
+        replyToId: "$incoming",
+        replyToMode: "first",
+      }),
     );
   });
+
+  it.each(["block", "final"] as const)(
+    "drains every reasoning window before the %s reply",
+    async (kind) => {
+      let resolveFirst!: (value: { visibleReplySent: boolean }) => void;
+      const firstDelivery = new Promise<{ visibleReplySent: boolean }>((resolve) => {
+        resolveFirst = resolve;
+      });
+      deliverMatrixRepliesMock
+        .mockImplementationOnce(async () => await firstDelivery)
+        .mockResolvedValue({ visibleReplySent: true });
+      const dispatcher = createDispatcher();
+      dispatcher.setReasoningLevel("stream");
+
+      dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "First window" });
+      const firstEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();
+      dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "Second window" });
+      const secondEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();
+      const finalDelivery = dispatcher.deliverReply({ text: "Final answer" }, { kind });
+      await Promise.resolve();
+
+      expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+      resolveFirst({ visibleReplySent: true });
+      await expect(firstEnd).resolves.toBe(true);
+      await expect(secondEnd).resolves.toBe(true);
+      await expect(finalDelivery).resolves.toEqual({ visibleReplySent: true });
+
+      expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ replies: [{ text: "First window", isReasoning: true }] }),
+      );
+      expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ replies: [{ text: "Second window", isReasoning: true }] }),
+      );
+      expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ replies: [{ text: "Final answer" }] }),
+      );
+    },
+  );
 });

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
@@ -149,35 +149,4 @@ describe("createMatrixReplyDispatcher", () => {
       expect.objectContaining({ replies: [{ text: "Final answer" }] }),
     );
   });
-
-  it("drains stream-mode reasoning notices before final replies", async () => {
-    let resolveReasoning!: (value: { visibleReplySent: boolean }) => void;
-    const reasoningDelivery = new Promise<{ visibleReplySent: boolean }>((resolve) => {
-      resolveReasoning = resolve;
-    });
-    deliverMatrixRepliesMock
-      .mockImplementationOnce(async () => await reasoningDelivery)
-      .mockResolvedValueOnce({ visibleReplySent: true });
-    const dispatcher = createDispatcher();
-
-    dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "Check @room first" });
-    const reasoningEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();
-    const finalDelivery = dispatcher.deliverReply({ text: "Final answer" }, { kind: "final" });
-    await Promise.resolve();
-
-    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
-
-    resolveReasoning({ visibleReplySent: true });
-    await expect(reasoningEnd).resolves.toBe(true);
-    await expect(finalDelivery).resolves.toEqual({ visibleReplySent: true });
-
-    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ replies: [{ text: "Check @room first", isReasoning: true }] }),
-    );
-    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ replies: [{ text: "Final answer" }] }),
-    );
-  });
 });

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
@@ -4,14 +4,6 @@ import type { MatrixClient } from "../sdk.js";
 import { createMatrixReplyDispatcher } from "./handler-reply-dispatcher.js";
 
 const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn(async () => ({ visibleReplySent: true })));
-const getSessionEntryMock = vi.hoisted(() => vi.fn());
-const resolveStorePathMock = vi.hoisted(() => vi.fn(() => "/tmp/matrix-proof.sqlite"));
-
-vi.mock("openclaw/plugin-sdk/session-store-runtime", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("openclaw/plugin-sdk/session-store-runtime")>()),
-  getSessionEntry: getSessionEntryMock,
-  resolveStorePath: resolveStorePathMock,
-}));
 
 vi.mock("./replies.js", async () => {
   const actual = await vi.importActual<typeof import("./replies.js")>("./replies.js");
@@ -21,13 +13,9 @@ vi.mock("./replies.js", async () => {
   };
 });
 
-function createDispatcher(
-  reasoningDefault: "off" | "on" | "stream" = "stream",
-  sessionKey?: string,
-) {
+function createDispatcher() {
   return createMatrixReplyDispatcher({
-    cfg: { agents: { defaults: { reasoningDefault } } },
-    ...(sessionKey ? { sessionKey } : {}),
+    cfg: {},
     prefixOptions: { responsePrefixContextProvider: () => ({ identityName: undefined }) },
     humanDelay: { mode: "off" },
     typingCallbacks: {
@@ -60,41 +48,30 @@ function createDispatcher(
 describe("createMatrixReplyDispatcher", () => {
   beforeEach(() => {
     deliverMatrixRepliesMock.mockReset().mockResolvedValue({ visibleReplySent: true });
-    getSessionEntryMock.mockReset().mockReturnValue(undefined);
-    resolveStorePathMock.mockReset().mockReturnValue("/tmp/matrix-proof.sqlite");
   });
 
-  it("disables both reasoning lanes when visibility is off", () => {
-    const dispatcher = createDispatcher("off");
+  it.each([
+    { level: "off" as const, delivered: false },
+    { level: "stream" as const, delivered: false },
+    { level: "on" as const, delivered: true },
+  ])(
+    "delivers durable reasoning only when the resolved mode is $level",
+    async ({ level, delivered }) => {
+      const dispatcher = createDispatcher();
+      dispatcher.setReasoningLevel(level);
 
-    expect(dispatcher.reasoningPayloadsEnabled).toBe(false);
-    expect(dispatcher.turnDispatcherOptions.onReasoningStream).toBeUndefined();
-    expect(dispatcher.turnDispatcherOptions.onReasoningEnd).toBeUndefined();
-  });
+      await dispatcher.deliverReply(
+        { text: "Resolved thought", isReasoning: true },
+        { kind: "final" },
+      );
 
-  it("fails closed when the session reasoning preference cannot be read", () => {
-    getSessionEntryMock.mockImplementation(() => {
-      throw new Error("session store unavailable");
-    });
-
-    const dispatcher = createDispatcher("on", "agent:main:main");
-
-    expect(dispatcher.reasoningPayloadsEnabled).toBe(false);
-    expect(dispatcher.turnDispatcherOptions.onReasoningStream).toBeUndefined();
-    expect(dispatcher.turnDispatcherOptions.onReasoningEnd).toBeUndefined();
-  });
-  it("enables only durable reasoning when visibility is on", () => {
-    const dispatcher = createDispatcher("on");
-
-    expect(dispatcher.reasoningPayloadsEnabled).toBe(true);
-    expect(dispatcher.turnDispatcherOptions.onReasoningStream).toBeUndefined();
-    expect(dispatcher.turnDispatcherOptions.onReasoningEnd).toBeUndefined();
-  });
+      expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(delivered ? 1 : 0);
+    },
+  );
 
   it("delivers stream-mode reasoning when the reasoning block ends", async () => {
     const dispatcher = createDispatcher();
-
-    expect(dispatcher.reasoningPayloadsEnabled).toBe(false);
+    dispatcher.setReasoningLevel("stream");
 
     expect(dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "Checking tools" })).toBe(
       false,
@@ -120,6 +97,7 @@ describe("createMatrixReplyDispatcher", () => {
       .mockImplementationOnce(async () => await firstDelivery)
       .mockResolvedValue({ visibleReplySent: true });
     const dispatcher = createDispatcher();
+    dispatcher.setReasoningLevel("stream");
 
     dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "First window" });
     const firstEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
@@ -50,11 +50,9 @@ function createDispatcher(
     client: {} as MatrixClient,
     roomId: "!room:example.org",
     runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    textLimit: 4000,
     replyToMode: "off",
     accountId: "default",
     mediaLocalRoots: [],
-    tableMode: "code",
     logVerboseMessage: vi.fn(),
   });
 }

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
@@ -4,6 +4,14 @@ import type { MatrixClient } from "../sdk.js";
 import { createMatrixReplyDispatcher } from "./handler-reply-dispatcher.js";
 
 const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn(async () => ({ visibleReplySent: true })));
+const getSessionEntryMock = vi.hoisted(() => vi.fn());
+const resolveStorePathMock = vi.hoisted(() => vi.fn(() => "/tmp/matrix-proof.sqlite"));
+
+vi.mock("openclaw/plugin-sdk/session-store-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/session-store-runtime")>()),
+  getSessionEntry: getSessionEntryMock,
+  resolveStorePath: resolveStorePathMock,
+}));
 
 vi.mock("./replies.js", async () => {
   const actual = await vi.importActual<typeof import("./replies.js")>("./replies.js");
@@ -13,9 +21,13 @@ vi.mock("./replies.js", async () => {
   };
 });
 
-function createDispatcher(reasoningDefault: "off" | "on" | "stream" = "stream") {
+function createDispatcher(
+  reasoningDefault: "off" | "on" | "stream" = "stream",
+  sessionKey?: string,
+) {
   return createMatrixReplyDispatcher({
     cfg: { agents: { defaults: { reasoningDefault } } },
+    ...(sessionKey ? { sessionKey } : {}),
     prefixOptions: { responsePrefixContextProvider: () => ({ identityName: undefined }) },
     humanDelay: { mode: "off" },
     typingCallbacks: {
@@ -49,7 +61,9 @@ function createDispatcher(reasoningDefault: "off" | "on" | "stream" = "stream") 
 
 describe("createMatrixReplyDispatcher", () => {
   beforeEach(() => {
-    deliverMatrixRepliesMock.mockClear();
+    deliverMatrixRepliesMock.mockReset().mockResolvedValue({ visibleReplySent: true });
+    getSessionEntryMock.mockReset().mockReturnValue(undefined);
+    resolveStorePathMock.mockReset().mockReturnValue("/tmp/matrix-proof.sqlite");
   });
 
   it("disables both reasoning lanes when visibility is off", () => {
@@ -60,6 +74,17 @@ describe("createMatrixReplyDispatcher", () => {
     expect(dispatcher.turnDispatcherOptions.onReasoningEnd).toBeUndefined();
   });
 
+  it("fails closed when the session reasoning preference cannot be read", () => {
+    getSessionEntryMock.mockImplementation(() => {
+      throw new Error("session store unavailable");
+    });
+
+    const dispatcher = createDispatcher("on", "agent:main:main");
+
+    expect(dispatcher.reasoningPayloadsEnabled).toBe(false);
+    expect(dispatcher.turnDispatcherOptions.onReasoningStream).toBeUndefined();
+    expect(dispatcher.turnDispatcherOptions.onReasoningEnd).toBeUndefined();
+  });
   it("enables only durable reasoning when visibility is on", () => {
     const dispatcher = createDispatcher("on");
 
@@ -85,6 +110,43 @@ describe("createMatrixReplyDispatcher", () => {
         roomId: "!room:example.org",
         replies: [{ text: "Checking tools", isReasoning: true }],
       }),
+    );
+  });
+
+  it("drains every reasoning window before the final reply", async () => {
+    let resolveFirst!: (value: { visibleReplySent: boolean }) => void;
+    const firstDelivery = new Promise<{ visibleReplySent: boolean }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    deliverMatrixRepliesMock
+      .mockImplementationOnce(async () => await firstDelivery)
+      .mockResolvedValue({ visibleReplySent: true });
+    const dispatcher = createDispatcher();
+
+    dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "First window" });
+    const firstEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();
+    dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "Second window" });
+    const secondEnd = dispatcher.turnDispatcherOptions.onReasoningEnd?.();
+    const finalDelivery = dispatcher.deliverReply({ text: "Final answer" }, { kind: "final" });
+    await Promise.resolve();
+
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+    resolveFirst({ visibleReplySent: true });
+    await expect(firstEnd).resolves.toBe(true);
+    await expect(secondEnd).resolves.toBe(true);
+    await expect(finalDelivery).resolves.toEqual({ visibleReplySent: true });
+
+    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ replies: [{ text: "First window", isReasoning: true }] }),
+    );
+    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ replies: [{ text: "Second window", isReasoning: true }] }),
+    );
+    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ replies: [{ text: "Final answer" }] }),
     );
   });
 

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts
@@ -13,9 +13,9 @@ vi.mock("./replies.js", async () => {
   };
 });
 
-function createDispatcher() {
+function createDispatcher(reasoningDefault: "off" | "on" | "stream" = "stream") {
   return createMatrixReplyDispatcher({
-    cfg: {},
+    cfg: { agents: { defaults: { reasoningDefault } } },
     prefixOptions: { responsePrefixContextProvider: () => ({ identityName: undefined }) },
     humanDelay: { mode: "off" },
     typingCallbacks: {
@@ -52,8 +52,26 @@ describe("createMatrixReplyDispatcher", () => {
     deliverMatrixRepliesMock.mockClear();
   });
 
+  it("disables both reasoning lanes when visibility is off", () => {
+    const dispatcher = createDispatcher("off");
+
+    expect(dispatcher.reasoningPayloadsEnabled).toBe(false);
+    expect(dispatcher.turnDispatcherOptions.onReasoningStream).toBeUndefined();
+    expect(dispatcher.turnDispatcherOptions.onReasoningEnd).toBeUndefined();
+  });
+
+  it("enables only durable reasoning when visibility is on", () => {
+    const dispatcher = createDispatcher("on");
+
+    expect(dispatcher.reasoningPayloadsEnabled).toBe(true);
+    expect(dispatcher.turnDispatcherOptions.onReasoningStream).toBeUndefined();
+    expect(dispatcher.turnDispatcherOptions.onReasoningEnd).toBeUndefined();
+  });
+
   it("delivers stream-mode reasoning when the reasoning block ends", async () => {
     const dispatcher = createDispatcher();
+
+    expect(dispatcher.reasoningPayloadsEnabled).toBe(false);
 
     expect(dispatcher.turnDispatcherOptions.onReasoningStream?.({ text: "Checking tools" })).toBe(
       false,

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -79,6 +79,14 @@ export function createMatrixReplyDispatcher(config: {
   const hasRepliedRef = { value: false };
   let finalReplyDeliveryFailed = false;
   let nonFinalReplyDeliveryFailed = false;
+  let latestReasoningStreamText = "";
+  let pendingReasoningNoticeDelivery: Promise<boolean> | undefined;
+  const drainPendingReasoningNoticeDelivery = async () => {
+    const pending = pendingReasoningNoticeDelivery;
+    if (pending) {
+      await pending;
+    }
+  };
   const beginNextBlockDraft = () => {
     // Each block owns a new draft generation; prior retained/consumed state must not
     // suppress settlement or cleanup for the next provider-visible event.
@@ -93,6 +101,9 @@ export function createMatrixReplyDispatcher(config: {
     ...prefixOptions,
     humanDelay,
     deliver: async (payload: ReplyPayload, info: { kind: string }) => {
+      if (info.kind === "final") {
+        await drainPendingReasoningNoticeDelivery();
+      }
       const completeDelivery = async (
         result: MatrixReplyDeliveryResult,
       ): Promise<MatrixReplyDeliveryResult> => {
@@ -485,6 +496,45 @@ export function createMatrixReplyDispatcher(config: {
         beginNextBlockDraft();
       }
       runtime.error?.(`matrix ${info.kind} reply failed: ${String(err)}`);
+    },
+    onReasoningStream: (payload: { text?: string }) => {
+      latestReasoningStreamText = normalizeOptionalString(payload.text) ?? "";
+      return false;
+    },
+    onReasoningEnd: async () => {
+      const text = latestReasoningStreamText;
+      latestReasoningStreamText = "";
+      if (!text) {
+        return false;
+      }
+      const delivery = deliverMatrixReplies({
+        cfg,
+        replies: [{ text, isReasoning: true }],
+        roomId,
+        client,
+        runtime,
+        textLimit,
+        replyToMode,
+        hasRepliedRef,
+        threadId: threadTarget,
+        replyToId: threadTarget ?? replyToEventId ?? undefined,
+        accountId,
+        mediaLocalRoots,
+        tableMode,
+      })
+        .then((result) => result.visibleReplySent)
+        .catch((error: unknown) => {
+          nonFinalReplyDeliveryFailed = true;
+          runtime.error?.(`matrix reasoning reply failed: ${String(error)}`);
+          return false;
+        });
+      const trackedDelivery = delivery.finally(() => {
+        if (pendingReasoningNoticeDelivery === trackedDelivery) {
+          pendingReasoningNoticeDelivery = undefined;
+        }
+      });
+      pendingReasoningNoticeDelivery = trackedDelivery;
+      return await trackedDelivery;
     },
     onReplyStart: typingCallbacks.onReplyStart,
     onIdle: typingCallbacks.onIdle,

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -1,4 +1,3 @@
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import {
   createPreviewMessageReceipt,
   defineFinalizableLivePreviewAdapter,
@@ -10,7 +9,6 @@ import {
   getReplyPayloadTtsSupplement,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
-import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveMatrixExtraContent } from "../../outbound.js";
 import type { CoreConfig, MatrixStreamingMode, ReplyToMode } from "../../types.js";
@@ -39,34 +37,8 @@ import {
 type MatrixDraftController = Awaited<ReturnType<typeof createMatrixDraftController>>;
 type MatrixReasoningLevel = "on" | "stream" | "off";
 
-function resolveMatrixReasoningLevel(params: {
-  cfg: CoreConfig;
-  agentId?: string;
-  sessionKey?: string;
-}): MatrixReasoningLevel {
-  const agentDefault = resolveAgentConfig(params.cfg, params.agentId ?? "main")?.reasoningDefault;
-  const configuredDefault = agentDefault ?? params.cfg.agents?.defaults?.reasoningDefault;
-  const configDefault: MatrixReasoningLevel =
-    configuredDefault === "on" || configuredDefault === "stream" ? configuredDefault : "off";
-  if (!params.sessionKey) {
-    return configDefault;
-  }
-  try {
-    const level = getSessionEntry({
-      agentId: params.agentId,
-      sessionKey: params.sessionKey,
-      storePath: resolveStorePath(params.cfg.session?.store, { agentId: params.agentId }),
-    })?.reasoningLevel;
-    return level === "on" || level === "stream" || level === "off" ? level : configDefault;
-  } catch {
-    return "off";
-  }
-}
-
 export function createMatrixReplyDispatcher(config: {
   cfg: CoreConfig;
-  agentId?: string;
-  sessionKey?: string;
   prefixOptions: Omit<ReturnType<typeof createReplyPrefixOptions>, "onModelSelected">;
   humanDelay: ReturnType<
     typeof import("openclaw/plugin-sdk/agent-runtime").resolveHumanDelayConfig
@@ -87,8 +59,6 @@ export function createMatrixReplyDispatcher(config: {
 }) {
   const {
     cfg,
-    agentId,
-    sessionKey,
     prefixOptions,
     humanDelay,
     typingCallbacks,
@@ -105,9 +75,7 @@ export function createMatrixReplyDispatcher(config: {
     mediaLocalRoots,
     logVerboseMessage,
   } = config;
-  const reasoningLevel = resolveMatrixReasoningLevel({ cfg, agentId, sessionKey });
-  const reasoningDurableEnabled = reasoningLevel === "on";
-  const reasoningWindowEnabled = reasoningLevel === "stream";
+  let reasoningLevel: MatrixReasoningLevel = "off";
   const quietDraftStreaming = streaming === "quiet" || streaming === "progress";
   // Tool, block, and final payloads are delivered separately but share one first-reply slot.
   const hasRepliedRef = { value: false };
@@ -145,6 +113,9 @@ export function createMatrixReplyDispatcher(config: {
     deliver: async (payload: ReplyPayload, info: { kind: string }) => {
       if (info.kind === "final") {
         await reasoningNoticeDeliveryQueue;
+      }
+      if (payload.isReasoning === true && reasoningLevel !== "on") {
+        return mergeMatrixReplyDeliveryResults([]);
       }
       const completeDelivery = async (
         result: MatrixReplyDeliveryResult,
@@ -472,35 +443,31 @@ export function createMatrixReplyDispatcher(config: {
       }
       runtime.error?.(`matrix ${info.kind} reply failed: ${String(err)}`);
     },
-    onReasoningStream: reasoningWindowEnabled
-      ? (payload: { text?: string }) => {
-          latestReasoningStreamText = normalizeOptionalString(payload.text) ?? "";
+    onReasoningStream: (payload: { text?: string }) => {
+      if (reasoningLevel === "stream") {
+        latestReasoningStreamText = normalizeOptionalString(payload.text) ?? "";
+      }
+      return false;
+    },
+    onReasoningEnd: async () => {
+      const text = latestReasoningStreamText;
+      latestReasoningStreamText = "";
+      if (reasoningLevel !== "stream" || !text) {
+        return false;
+      }
+      const delivery = reasoningNoticeDeliveryQueue
+        .then(async () => (await deliverReplies([{ text, isReasoning: true }])).visibleReplySent)
+        .catch((error: unknown) => {
+          nonFinalReplyDeliveryFailed = true;
+          runtime.error?.(`matrix reasoning reply failed: ${String(error)}`);
           return false;
-        }
-      : undefined,
-    onReasoningEnd: reasoningWindowEnabled
-      ? async () => {
-          const text = latestReasoningStreamText;
-          latestReasoningStreamText = "";
-          if (!text) {
-            return false;
-          }
-          const delivery = reasoningNoticeDeliveryQueue
-            .then(
-              async () => (await deliverReplies([{ text, isReasoning: true }])).visibleReplySent,
-            )
-            .catch((error: unknown) => {
-              nonFinalReplyDeliveryFailed = true;
-              runtime.error?.(`matrix reasoning reply failed: ${String(error)}`);
-              return false;
-            });
-          reasoningNoticeDeliveryQueue = delivery.then(
-            () => undefined,
-            () => undefined,
-          );
-          return await delivery;
-        }
-      : undefined,
+        });
+      reasoningNoticeDeliveryQueue = delivery.then(
+        () => undefined,
+        () => undefined,
+      );
+      return await delivery;
+    },
     onReplyStart: typingCallbacks.onReplyStart,
     onIdle: typingCallbacks.onIdle,
   };
@@ -514,8 +481,13 @@ export function createMatrixReplyDispatcher(config: {
     deliverReply,
     onReplyError,
     turnDispatcherOptions,
+    setReasoningLevel: (level: MatrixReasoningLevel) => {
+      reasoningLevel = level;
+      if (level !== "stream") {
+        latestReasoningStreamText = "";
+      }
+    },
     finalReplyDeliveryFailed: () => finalReplyDeliveryFailed,
     nonFinalReplyDeliveryFailed: () => nonFinalReplyDeliveryFailed,
-    reasoningPayloadsEnabled: reasoningDurableEnabled,
   };
 }

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -111,7 +111,7 @@ export function createMatrixReplyDispatcher(config: {
     ...prefixOptions,
     humanDelay,
     deliver: async (payload: ReplyPayload, info: { kind: string }) => {
-      if (info.kind === "final") {
+      if (payload.isReasoning !== true) {
         await reasoningNoticeDeliveryQueue;
       }
       if (payload.isReasoning === true && reasoningLevel !== "on") {

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -45,11 +45,7 @@ function resolveMatrixReasoningLevel(params: {
   sessionKey?: string;
 }): MatrixReasoningLevel {
   const agentDefault = resolveAgentConfig(params.cfg, params.agentId ?? "main")?.reasoningDefault;
-  const configuredDefault =
-    agentDefault ??
-    // SAFETY: Matrix extension types narrow agents, but runtime config carries defaults here.
-    (params.cfg.agents as { defaults?: { reasoningDefault?: unknown } } | undefined)?.defaults
-      ?.reasoningDefault;
+  const configuredDefault = agentDefault ?? params.cfg.agents?.defaults?.reasoningDefault;
   const configDefault: MatrixReasoningLevel =
     configuredDefault === "on" || configuredDefault === "stream" ? configuredDefault : "off";
   if (!params.sessionKey) {
@@ -119,9 +115,20 @@ export function createMatrixReplyDispatcher(config: {
   let nonFinalReplyDeliveryFailed = false;
   let latestReasoningStreamText = "";
   let reasoningNoticeDeliveryQueue: Promise<void> = Promise.resolve();
-  const drainPendingReasoningNoticeDelivery = async () => {
-    await reasoningNoticeDeliveryQueue;
-  };
+  const deliverReplies = (replies: ReplyPayload[]) =>
+    deliverMatrixReplies({
+      cfg,
+      replies,
+      roomId,
+      client,
+      runtime,
+      replyToMode,
+      hasRepliedRef,
+      threadId: threadTarget,
+      replyToId: threadTarget ?? replyToEventId ?? undefined,
+      accountId,
+      mediaLocalRoots,
+    });
   const beginNextBlockDraft = () => {
     // Each block owns a new draft generation; prior retained/consumed state must not
     // suppress settlement or cleanup for the next provider-visible event.
@@ -137,7 +144,7 @@ export function createMatrixReplyDispatcher(config: {
     humanDelay,
     deliver: async (payload: ReplyPayload, info: { kind: string }) => {
       if (info.kind === "final") {
-        await drainPendingReasoningNoticeDelivery();
+        await reasoningNoticeDeliveryQueue;
       }
       const completeDelivery = async (
         result: MatrixReplyDeliveryResult,
@@ -208,21 +215,7 @@ export function createMatrixReplyDispatcher(config: {
 
         if (draftController.draftDisposition() !== "active") {
           await draftStream.discardPending();
-          return await completeDelivery(
-            await deliverMatrixReplies({
-              cfg,
-              replies: [fallbackPayload],
-              roomId,
-              client,
-              runtime,
-              replyToMode,
-              hasRepliedRef,
-              threadId: threadTarget,
-              replyToId: threadTarget ?? replyToEventId ?? undefined,
-              accountId,
-              mediaLocalRoots,
-            }),
-          );
+          return await completeDelivery(await deliverReplies([fallbackPayload]));
         }
 
         const payloadReplyMismatch =
@@ -337,20 +330,7 @@ export function createMatrixReplyDispatcher(config: {
               fallbackResult = await settleDraftReplacement({
                 draftEventId,
                 draftContent: draftStream.content() ?? preparedFinalPreviewContent,
-                deliver: async () =>
-                  await deliverMatrixReplies({
-                    cfg,
-                    replies: [fallbackPayload],
-                    roomId,
-                    client,
-                    runtime,
-                    replyToMode,
-                    hasRepliedRef,
-                    threadId: threadTarget,
-                    replyToId: threadTarget ?? replyToEventId ?? undefined,
-                    accountId,
-                    mediaLocalRoots,
-                  }),
+                deliver: () => deliverReplies([fallbackPayload]),
               });
               return fallbackResult.visibleReplySent;
             },
@@ -436,20 +416,7 @@ export function createMatrixReplyDispatcher(config: {
               : draftContent
                 ? createDraftDeliveryResult(draftEventId, draftContent)
                 : mergeMatrixReplyDeliveryResults([]);
-          const deliverMedia = async () =>
-            await deliverMatrixReplies({
-              cfg,
-              replies: [mediaPayload],
-              roomId,
-              client,
-              runtime,
-              replyToMode,
-              hasRepliedRef,
-              threadId: threadTarget,
-              replyToId: threadTarget ?? replyToEventId ?? undefined,
-              accountId,
-              mediaLocalRoots,
-            });
+          const deliverMedia = () => deliverReplies([mediaPayload]);
           if (reusesDraftAsFinalText) {
             draftController.markDraftConsumed();
             let mediaDelivery: MatrixReplyDeliveryResult;
@@ -479,20 +446,7 @@ export function createMatrixReplyDispatcher(config: {
             payloadReplyMismatch ||
             mustDeliverFinalNormally ||
             draftFinalTextNeedsNormalMentionDelivery);
-        const deliverFallback = async () =>
-          await deliverMatrixReplies({
-            cfg,
-            replies: [fallbackPayload],
-            roomId,
-            client,
-            runtime,
-            replyToMode,
-            hasRepliedRef,
-            threadId: threadTarget,
-            replyToId: threadTarget ?? replyToEventId ?? undefined,
-            accountId,
-            mediaLocalRoots,
-          });
+        const deliverFallback = () => deliverReplies([fallbackPayload]);
         const draftContent = draftStream.content();
         if (shouldRedactDraft && draftEventId && draftContent) {
           return await completeDelivery(
@@ -505,21 +459,7 @@ export function createMatrixReplyDispatcher(config: {
         }
         return await completeDelivery(await deliverFallback());
       }
-      return await completeDelivery(
-        await deliverMatrixReplies({
-          cfg,
-          replies: [payload],
-          roomId,
-          client,
-          runtime,
-          replyToMode,
-          hasRepliedRef,
-          threadId: threadTarget,
-          replyToId: threadTarget ?? replyToEventId ?? undefined,
-          accountId,
-          mediaLocalRoots,
-        }),
-      );
+      return await completeDelivery(await deliverReplies([payload]));
     },
     onError: (err: unknown, info: { kind: "tool" | "block" | "final" }) => {
       if (info.kind === "final") {
@@ -547,24 +487,7 @@ export function createMatrixReplyDispatcher(config: {
           }
           const delivery = reasoningNoticeDeliveryQueue
             .then(
-              async () =>
-                (
-                  await deliverMatrixReplies({
-                    cfg,
-                    replies: [{ text, isReasoning: true }],
-                    roomId,
-                    client,
-                    runtime,
-                    textLimit,
-                    replyToMode,
-                    hasRepliedRef,
-                    threadId: threadTarget,
-                    replyToId: threadTarget ?? replyToEventId ?? undefined,
-                    accountId,
-                    mediaLocalRoots,
-                    tableMode,
-                  })
-                ).visibleReplySent,
+              async () => (await deliverReplies([{ text, isReasoning: true }])).visibleReplySent,
             )
             .catch((error: unknown) => {
               nonFinalReplyDeliveryFailed = true;

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -117,6 +117,9 @@ export function createMatrixReplyDispatcher(config: {
       if (payload.isReasoning === true && reasoningLevel !== "on") {
         return mergeMatrixReplyDeliveryResults([]);
       }
+      if (payload.isReasoning === true) {
+        return await deliverReplies([payload]);
+      }
       const completeDelivery = async (
         result: MatrixReplyDeliveryResult,
       ): Promise<MatrixReplyDeliveryResult> => {

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -63,7 +63,7 @@ function resolveMatrixReasoningLevel(params: {
     })?.reasoningLevel;
     return level === "on" || level === "stream" || level === "off" ? level : configDefault;
   } catch {
-    return configDefault;
+    return "off";
   }
 }
 
@@ -118,12 +118,9 @@ export function createMatrixReplyDispatcher(config: {
   let finalReplyDeliveryFailed = false;
   let nonFinalReplyDeliveryFailed = false;
   let latestReasoningStreamText = "";
-  let pendingReasoningNoticeDelivery: Promise<boolean> | undefined;
+  let reasoningNoticeDeliveryQueue: Promise<void> = Promise.resolve();
   const drainPendingReasoningNoticeDelivery = async () => {
-    const pending = pendingReasoningNoticeDelivery;
-    if (pending) {
-      await pending;
-    }
+    await reasoningNoticeDeliveryQueue;
   };
   const beginNextBlockDraft = () => {
     // Each block owns a new draft generation; prior retained/consumed state must not
@@ -548,34 +545,37 @@ export function createMatrixReplyDispatcher(config: {
           if (!text) {
             return false;
           }
-          const delivery = deliverMatrixReplies({
-            cfg,
-            replies: [{ text, isReasoning: true }],
-            roomId,
-            client,
-            runtime,
-            textLimit,
-            replyToMode,
-            hasRepliedRef,
-            threadId: threadTarget,
-            replyToId: threadTarget ?? replyToEventId ?? undefined,
-            accountId,
-            mediaLocalRoots,
-            tableMode,
-          })
-            .then((result) => result.visibleReplySent)
+          const delivery = reasoningNoticeDeliveryQueue
+            .then(
+              async () =>
+                (
+                  await deliverMatrixReplies({
+                    cfg,
+                    replies: [{ text, isReasoning: true }],
+                    roomId,
+                    client,
+                    runtime,
+                    textLimit,
+                    replyToMode,
+                    hasRepliedRef,
+                    threadId: threadTarget,
+                    replyToId: threadTarget ?? replyToEventId ?? undefined,
+                    accountId,
+                    mediaLocalRoots,
+                    tableMode,
+                  })
+                ).visibleReplySent,
+            )
             .catch((error: unknown) => {
               nonFinalReplyDeliveryFailed = true;
               runtime.error?.(`matrix reasoning reply failed: ${String(error)}`);
               return false;
             });
-          const trackedDelivery = delivery.finally(() => {
-            if (pendingReasoningNoticeDelivery === trackedDelivery) {
-              pendingReasoningNoticeDelivery = undefined;
-            }
-          });
-          pendingReasoningNoticeDelivery = trackedDelivery;
-          return await trackedDelivery;
+          reasoningNoticeDeliveryQueue = delivery.then(
+            () => undefined,
+            () => undefined,
+          );
+          return await delivery;
         }
       : undefined,
     onReplyStart: typingCallbacks.onReplyStart,

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -489,6 +489,7 @@ export function createMatrixReplyDispatcher(config: {
       if (level !== "stream") {
         latestReasoningStreamText = "";
       }
+      return level === "on";
     },
     finalReplyDeliveryFailed: () => finalReplyDeliveryFailed,
     nonFinalReplyDeliveryFailed: () => nonFinalReplyDeliveryFailed,

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import {
   createPreviewMessageReceipt,
   defineFinalizableLivePreviewAdapter,
@@ -9,6 +10,7 @@ import {
   getReplyPayloadTtsSupplement,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveMatrixExtraContent } from "../../outbound.js";
 import type { CoreConfig, MatrixStreamingMode, ReplyToMode } from "../../types.js";
@@ -35,9 +37,40 @@ import {
 } from "./runtime-api.js";
 
 type MatrixDraftController = Awaited<ReturnType<typeof createMatrixDraftController>>;
+type MatrixReasoningLevel = "on" | "stream" | "off";
+
+function resolveMatrixReasoningLevel(params: {
+  cfg: CoreConfig;
+  agentId?: string;
+  sessionKey?: string;
+}): MatrixReasoningLevel {
+  const agentDefault = resolveAgentConfig(params.cfg, params.agentId ?? "main")?.reasoningDefault;
+  const configuredDefault =
+    agentDefault ??
+    // SAFETY: Matrix extension types narrow agents, but runtime config carries defaults here.
+    (params.cfg.agents as { defaults?: { reasoningDefault?: unknown } } | undefined)?.defaults
+      ?.reasoningDefault;
+  const configDefault: MatrixReasoningLevel =
+    configuredDefault === "on" || configuredDefault === "stream" ? configuredDefault : "off";
+  if (!params.sessionKey) {
+    return configDefault;
+  }
+  try {
+    const level = getSessionEntry({
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      storePath: resolveStorePath(params.cfg.session?.store, { agentId: params.agentId }),
+    })?.reasoningLevel;
+    return level === "on" || level === "stream" || level === "off" ? level : configDefault;
+  } catch {
+    return configDefault;
+  }
+}
 
 export function createMatrixReplyDispatcher(config: {
   cfg: CoreConfig;
+  agentId?: string;
+  sessionKey?: string;
   prefixOptions: Omit<ReturnType<typeof createReplyPrefixOptions>, "onModelSelected">;
   humanDelay: ReturnType<
     typeof import("openclaw/plugin-sdk/agent-runtime").resolveHumanDelayConfig
@@ -58,6 +91,8 @@ export function createMatrixReplyDispatcher(config: {
 }) {
   const {
     cfg,
+    agentId,
+    sessionKey,
     prefixOptions,
     humanDelay,
     typingCallbacks,
@@ -74,6 +109,9 @@ export function createMatrixReplyDispatcher(config: {
     mediaLocalRoots,
     logVerboseMessage,
   } = config;
+  const reasoningLevel = resolveMatrixReasoningLevel({ cfg, agentId, sessionKey });
+  const reasoningDurableEnabled = reasoningLevel === "on";
+  const reasoningWindowEnabled = reasoningLevel === "stream";
   const quietDraftStreaming = streaming === "quiet" || streaming === "progress";
   // Tool, block, and final payloads are delivered separately but share one first-reply slot.
   const hasRepliedRef = { value: false };
@@ -497,45 +535,49 @@ export function createMatrixReplyDispatcher(config: {
       }
       runtime.error?.(`matrix ${info.kind} reply failed: ${String(err)}`);
     },
-    onReasoningStream: (payload: { text?: string }) => {
-      latestReasoningStreamText = normalizeOptionalString(payload.text) ?? "";
-      return false;
-    },
-    onReasoningEnd: async () => {
-      const text = latestReasoningStreamText;
-      latestReasoningStreamText = "";
-      if (!text) {
-        return false;
-      }
-      const delivery = deliverMatrixReplies({
-        cfg,
-        replies: [{ text, isReasoning: true }],
-        roomId,
-        client,
-        runtime,
-        textLimit,
-        replyToMode,
-        hasRepliedRef,
-        threadId: threadTarget,
-        replyToId: threadTarget ?? replyToEventId ?? undefined,
-        accountId,
-        mediaLocalRoots,
-        tableMode,
-      })
-        .then((result) => result.visibleReplySent)
-        .catch((error: unknown) => {
-          nonFinalReplyDeliveryFailed = true;
-          runtime.error?.(`matrix reasoning reply failed: ${String(error)}`);
+    onReasoningStream: reasoningWindowEnabled
+      ? (payload: { text?: string }) => {
+          latestReasoningStreamText = normalizeOptionalString(payload.text) ?? "";
           return false;
-        });
-      const trackedDelivery = delivery.finally(() => {
-        if (pendingReasoningNoticeDelivery === trackedDelivery) {
-          pendingReasoningNoticeDelivery = undefined;
         }
-      });
-      pendingReasoningNoticeDelivery = trackedDelivery;
-      return await trackedDelivery;
-    },
+      : undefined,
+    onReasoningEnd: reasoningWindowEnabled
+      ? async () => {
+          const text = latestReasoningStreamText;
+          latestReasoningStreamText = "";
+          if (!text) {
+            return false;
+          }
+          const delivery = deliverMatrixReplies({
+            cfg,
+            replies: [{ text, isReasoning: true }],
+            roomId,
+            client,
+            runtime,
+            textLimit,
+            replyToMode,
+            hasRepliedRef,
+            threadId: threadTarget,
+            replyToId: threadTarget ?? replyToEventId ?? undefined,
+            accountId,
+            mediaLocalRoots,
+            tableMode,
+          })
+            .then((result) => result.visibleReplySent)
+            .catch((error: unknown) => {
+              nonFinalReplyDeliveryFailed = true;
+              runtime.error?.(`matrix reasoning reply failed: ${String(error)}`);
+              return false;
+            });
+          const trackedDelivery = delivery.finally(() => {
+            if (pendingReasoningNoticeDelivery === trackedDelivery) {
+              pendingReasoningNoticeDelivery = undefined;
+            }
+          });
+          pendingReasoningNoticeDelivery = trackedDelivery;
+          return await trackedDelivery;
+        }
+      : undefined,
     onReplyStart: typingCallbacks.onReplyStart,
     onIdle: typingCallbacks.onIdle,
   };
@@ -551,5 +593,6 @@ export function createMatrixReplyDispatcher(config: {
     turnDispatcherOptions,
     finalReplyDeliveryFailed: () => finalReplyDeliveryFailed,
     nonFinalReplyDeliveryFailed: () => nonFinalReplyDeliveryFailed,
+    reasoningPayloadsEnabled: reasoningDurableEnabled,
   };
 }

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3064,6 +3064,7 @@ describe("matrix monitor handler draft streaming", () => {
     info: { kind: string },
   ) => Promise<unknown>;
   type ReplyOpts = {
+    preserveProgressCallbackStartOrder?: boolean;
     onReplyStart?: () => Promise<void> | void;
     onPartialReply?: (payload: { text: string }) => void;
     onBlockReplyQueued?: (
@@ -3212,6 +3213,15 @@ describe("matrix monitor handler draft streaming", () => {
 
     return { dispatch, redactEventMock, logVerboseMessage };
   }
+
+  it("preserves progress callback start order for reasoning lifecycle", async () => {
+    const { dispatch } = createStreamingHarness();
+    const { opts, finish } = await dispatch();
+
+    expect(opts.preserveProgressCallbackStartOrder).toBe(true);
+
+    await finish();
+  });
 
   it("records a failed block typing restart without replaying the accepted delivery", async () => {
     const acceptedDelivery = createMockMatrixDeliveryResult("$accepted", "Already delivered block");

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3182,7 +3182,10 @@ describe("matrix monitor handler draft streaming", () => {
             markComplete: () => {},
             waitForIdle: async () => {},
           },
-          replyOptions: {},
+          replyOptions: {
+            onReasoningStream: params?.onReasoningStream,
+            onReasoningEnd: params?.onReasoningEnd,
+          },
           markDispatchIdle: () => {},
           markRunComplete: () => {},
         };

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3067,7 +3067,7 @@ describe("matrix monitor handler draft streaming", () => {
   type ReplyOpts = {
     preserveProgressCallbackStartOrder?: boolean;
     reasoningPayloadsEnabled?: boolean;
-    onReasoningLevelResolved?: (level: "off" | "on" | "stream") => void;
+    onReasoningLevelResolved?: (level: "off" | "on" | "stream") => boolean;
     onReasoningStream?: (payload: { text?: string }) => Promise<boolean> | boolean;
     onReasoningEnd?: () => Promise<boolean> | boolean;
     onReplyStart?: () => Promise<void> | void;

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3182,10 +3182,7 @@ describe("matrix monitor handler draft streaming", () => {
             markComplete: () => {},
             waitForIdle: async () => {},
           },
-          replyOptions: {
-            onReasoningStream: params?.onReasoningStream,
-            onReasoningEnd: params?.onReasoningEnd,
-          },
+          replyOptions: {},
           markDispatchIdle: () => {},
           markRunComplete: () => {},
         };
@@ -3232,18 +3229,24 @@ describe("matrix monitor handler draft streaming", () => {
   });
 
   it("applies the current-turn inline on mode before durable reasoning delivery", async () => {
-    const { dispatch } = createStreamingHarness({ streaming: "off" });
+    const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
     const { deliver, opts, finish } = await dispatch("/reasoning on explain this");
 
     expect(opts.reasoningPayloadsEnabled).toBe(true);
-    opts.onReasoningLevelResolved?.("on");
-    await deliver({ text: "Reasoning:\nInline on thought", isReasoning: true }, { kind: "final" });
+    expect(opts.onReasoningLevelResolved?.("on")).toBe(true);
+    opts.onPartialReply?.({ text: "Visible answer draft" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledOnce();
+    });
+    await deliver({ text: "Reasoning:\nInline on thought", isReasoning: true }, { kind: "block" });
 
     expect(deliverMatrixRepliesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [{ text: "Reasoning:\nInline on thought", isReasoning: true }],
       }),
     );
+    expect(editMessageMatrixMock).not.toHaveBeenCalled();
+    expect(redactEventMock).not.toHaveBeenCalled();
     await finish();
   });
 
@@ -3251,7 +3254,7 @@ describe("matrix monitor handler draft streaming", () => {
     const { dispatch } = createStreamingHarness({ streaming: "off" });
     const { deliver, opts, finish } = await dispatch("/reasoning stream explain this");
 
-    opts.onReasoningLevelResolved?.("stream");
+    expect(opts.onReasoningLevelResolved?.("stream")).toBe(false);
     await opts.onReasoningStream?.({ text: "Reasoning:\nInline stream thought" });
     await opts.onReasoningEnd?.();
     await deliver({ text: "Inline final" }, { kind: "final" });
@@ -3265,6 +3268,27 @@ describe("matrix monitor handler draft streaming", () => {
     expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ replies: [{ text: "Inline final" }] }),
+    );
+    await finish();
+  });
+
+  it("keeps off-mode reasoning invisible without spending final reply accounting", async () => {
+    const { dispatch } = createStreamingHarness({ replyToMode: "first", streaming: "off" });
+    const { deliver, opts, finish } = await dispatch("/reasoning off explain this");
+
+    expect(opts.onReasoningLevelResolved?.("off")).toBe(false);
+    await expect(
+      deliver({ text: "Hidden thought", isReasoning: true }, { kind: "final" }),
+    ).resolves.toMatchObject({ visibleReplySent: false });
+    await deliver({ text: "Visible final" }, { kind: "final" });
+
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledOnce();
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasRepliedRef: { value: false },
+        replies: [{ text: "Visible final" }],
+        replyToMode: "first",
+      }),
     );
     await finish();
   });

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3059,12 +3059,17 @@ describe("matrix monitor handler draft streaming", () => {
       ttsSupplement?: { spokenText: string; visibleTextAlreadyDelivered?: boolean };
       isCompactionNotice?: boolean;
       isError?: boolean;
+      isReasoning?: boolean;
       replyToId?: string;
     },
     info: { kind: string },
   ) => Promise<unknown>;
   type ReplyOpts = {
     preserveProgressCallbackStartOrder?: boolean;
+    reasoningPayloadsEnabled?: boolean;
+    onReasoningLevelResolved?: (level: "off" | "on" | "stream") => void;
+    onReasoningStream?: (payload: { text?: string }) => Promise<boolean> | boolean;
+    onReasoningEnd?: () => Promise<boolean> | boolean;
     onReplyStart?: () => Promise<void> | void;
     onPartialReply?: (payload: { text: string }) => void;
     onBlockReplyQueued?: (
@@ -3191,11 +3196,11 @@ describe("matrix monitor handler draft streaming", () => {
       }) as never,
     });
 
-    const dispatch = async () => {
+    const dispatch = async (body = "hello") => {
       // Start handler without awaiting — it blocks on runGate.
       const handlerDone = handler(
         "!room:example.org",
-        createMatrixTextMessageEvent({ eventId: "$msg1", body: "hello" }),
+        createMatrixTextMessageEvent({ eventId: "$msg1", body }),
       );
       await captured;
       return {
@@ -3220,6 +3225,44 @@ describe("matrix monitor handler draft streaming", () => {
 
     expect(opts.preserveProgressCallbackStartOrder).toBe(true);
 
+    await finish();
+  });
+
+  it("applies the current-turn inline on mode before durable reasoning delivery", async () => {
+    const { dispatch } = createStreamingHarness({ streaming: "off" });
+    const { deliver, opts, finish } = await dispatch("/reasoning on explain this");
+
+    expect(opts.reasoningPayloadsEnabled).toBe(true);
+    opts.onReasoningLevelResolved?.("on");
+    await deliver({ text: "Reasoning:\nInline on thought", isReasoning: true }, { kind: "final" });
+
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{ text: "Reasoning:\nInline on thought", isReasoning: true }],
+      }),
+    );
+    await finish();
+  });
+
+  it("applies the current-turn inline stream mode before reasoning callbacks", async () => {
+    const { dispatch } = createStreamingHarness({ streaming: "off" });
+    const { deliver, opts, finish } = await dispatch("/reasoning stream explain this");
+
+    opts.onReasoningLevelResolved?.("stream");
+    await opts.onReasoningStream?.({ text: "Reasoning:\nInline stream thought" });
+    await opts.onReasoningEnd?.();
+    await deliver({ text: "Inline final" }, { kind: "final" });
+
+    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        replies: [{ text: "Reasoning:\nInline stream thought", isReasoning: true }],
+      }),
+    );
+    expect(deliverMatrixRepliesMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ replies: [{ text: "Inline final" }] }),
+    );
     await finish();
   });
 

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3076,6 +3076,7 @@ describe("matrix monitor handler draft streaming", () => {
       payload: {
         text?: string;
         isCompactionNotice?: boolean;
+        isReasoning?: boolean;
       },
       context?: { assistantMessageIndex?: number },
     ) => Promise<void> | void;
@@ -4507,6 +4508,25 @@ describe("matrix monitor handler draft streaming", () => {
     expect(singleTextMessageBody(1)).toBe("Beta");
     expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
     expect(redactEventMock).not.toHaveBeenCalled();
+    await finish();
+  });
+
+  it("keeps reasoning outside answer draft boundaries", async () => {
+    const { dispatch } = createStreamingHarness({ blockStreamingEnabled: true });
+    const { opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Alpha" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledOnce();
+    });
+
+    await opts.onBlockReplyQueued?.({ text: "Thinking", isReasoning: true });
+    opts.onPartialReply?.({ text: "AlphaBeta" });
+
+    await waitForMatrixState(() => {
+      expectMatrixEdit("!room:example.org", "$draft1", "AlphaBeta");
+    });
+    expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledOnce();
     await finish();
   });
 

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -581,6 +581,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                 : undefined,
               onBlockReplyQueued: draftStream
                 ? (payload, context) => {
+                    if (payload.isReasoning === true) {
+                      return false;
+                    }
                     if (payload.isCompactionNotice === true) {
                       return false;
                     }

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -421,6 +421,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       draftControllerRef = draftController;
       const replyDispatcher = createMatrixReplyDispatcher({
         cfg,
+        agentId: _route.agentId,
+        sessionKey: _route.sessionKey,
         prefixOptions,
         humanDelay: resolveHumanDelayConfigImpl(cfg, _route.agentId),
         typingCallbacks,
@@ -437,7 +439,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         mediaLocalRoots,
         logVerboseMessage,
       });
-      const { deliverReply, onReplyError, turnDispatcherOptions } = replyDispatcher;
+      const { deliverReply, onReplyError, reasoningPayloadsEnabled, turnDispatcherOptions } =
+        replyDispatcher;
       const pinnedMainDmOwner = isDirectMessage
         ? await (async () => {
             const { liveCfg, liveDmAllowFrom } = await handlerState.resolveLiveAccountAllowlists();
@@ -566,7 +569,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             replyOptions: {
               preserveProgressCallbackStartOrder: true,
               skillFilter: roomConfig?.skills,
-              reasoningPayloadsEnabled: true,
+              reasoningPayloadsEnabled: reasoningPayloadsEnabled || undefined,
               // Preserve explicit block streaming with draft previews: drafts update the live
               // block, while block deliveries finalize completed blocks as separate events.
               disableBlockStreaming: !blockStreamingEnabled,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -421,8 +421,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       draftControllerRef = draftController;
       const replyDispatcher = createMatrixReplyDispatcher({
         cfg,
-        agentId: _route.agentId,
-        sessionKey: _route.sessionKey,
         prefixOptions,
         humanDelay: resolveHumanDelayConfigImpl(cfg, _route.agentId),
         typingCallbacks,
@@ -439,7 +437,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         mediaLocalRoots,
         logVerboseMessage,
       });
-      const { deliverReply, onReplyError, reasoningPayloadsEnabled, turnDispatcherOptions } =
+      const { deliverReply, onReplyError, setReasoningLevel, turnDispatcherOptions } =
         replyDispatcher;
       const pinnedMainDmOwner = isDirectMessage
         ? await (async () => {
@@ -569,7 +567,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             replyOptions: {
               preserveProgressCallbackStartOrder: true,
               skillFilter: roomConfig?.skills,
-              reasoningPayloadsEnabled: reasoningPayloadsEnabled || undefined,
+              // Core resolves inline and stored reasoning policy after Matrix creates its dispatcher.
+              // Admit typed payloads here, then let the resolved-turn callback select the Matrix lane.
+              reasoningPayloadsEnabled: true,
+              onReasoningLevelResolved: setReasoningLevel,
               // Preserve explicit block streaming with draft previews: drafts update the live
               // block, while block deliveries finalize completed blocks as separate events.
               disableBlockStreaming: !blockStreamingEnabled,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -565,6 +565,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             },
             replyOptions: {
               skillFilter: roomConfig?.skills,
+              reasoningPayloadsEnabled: true,
               // Preserve explicit block streaming with draft previews: drafts update the live
               // block, while block deliveries finalize completed blocks as separate events.
               disableBlockStreaming: !blockStreamingEnabled,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -571,6 +571,8 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               // Admit typed payloads here, then let the resolved-turn callback select the Matrix lane.
               reasoningPayloadsEnabled: true,
               onReasoningLevelResolved: setReasoningLevel,
+              onReasoningStream: turnDispatcherOptions.onReasoningStream,
+              onReasoningEnd: turnDispatcherOptions.onReasoningEnd,
               // Preserve explicit block streaming with draft previews: drafts update the live
               // block, while block deliveries finalize completed blocks as separate events.
               disableBlockStreaming: !blockStreamingEnabled,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -564,6 +564,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               onSettled: () => draftController.cancelProgressDraft(),
             },
             replyOptions: {
+              preserveProgressCallbackStartOrder: true,
               skillFilter: roomConfig?.skills,
               reasoningPayloadsEnabled: true,
               // Preserve explicit block streaming with draft previews: drafts update the live

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -387,6 +387,38 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).cfg).toBe(cfg);
   });
 
+  it("delivers explicit reasoning payloads as Matrix notices", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "Reasoning:\nCheck the tool result", isReasoning: true }],
+      roomId: "room:reasoning",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(0)[0]).toBe("room:reasoning");
+    expect(sendCall(0)[1]).toBe("Thinking\n\n_Check the tool result_");
+    expect(sendOptions(0).msgtype).toBe("m.notice");
+    expect(sendOptions(0).disableMentions).toBe(true);
+  });
+
+  it("disables Matrix mentions for explicit reasoning notices", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "Reasoning:\nCheck @room and @alice:example.org", isReasoning: true }],
+      roomId: "room:reasoning",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendOptions(0)).toMatchObject({ msgtype: "m.notice", disableMentions: true });
+  });
+
   it("delivers literal reasoning tags inside Markdown code", async () => {
     const text = "Use `<mm:think>example</mm:think>` literally.";
 

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -394,7 +394,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:reasoning",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -390,7 +390,7 @@ describe("deliverMatrixReplies", () => {
   it("delivers explicit reasoning payloads as Matrix notices", async () => {
     await deliverMatrixReplies({
       cfg,
-      replies: [{ text: "Reasoning:\nCheck the tool result", isReasoning: true }],
+      replies: [{ text: "Reasoning:\nCheck the tool result and @room", isReasoning: true }],
       roomId: "room:reasoning",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
@@ -400,23 +400,9 @@ describe("deliverMatrixReplies", () => {
 
     expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
     expect(sendCall(0)[0]).toBe("room:reasoning");
-    expect(sendCall(0)[1]).toBe("Thinking\n\n_Check the tool result_");
+    expect(sendCall(0)[1]).toBe("Thinking\n\n_Check the tool result and @room_");
     expect(sendOptions(0).msgtype).toBe("m.notice");
     expect(sendOptions(0).disableMentions).toBe(true);
-  });
-
-  it("disables Matrix mentions for explicit reasoning notices", async () => {
-    await deliverMatrixReplies({
-      cfg,
-      replies: [{ text: "Reasoning:\nCheck @room and @alice:example.org", isReasoning: true }],
-      roomId: "room:reasoning",
-      client: {} as MatrixClient,
-      runtime: runtimeEnv,
-      textLimit: 4000,
-      replyToMode: "off",
-    });
-
-    expect(sendOptions(0)).toMatchObject({ msgtype: "m.notice", disableMentions: true });
   });
 
   it("delivers literal reasoning tags inside Markdown code", async () => {

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -404,6 +404,29 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).disableMentions).toBe(true);
   });
 
+  it("suppresses mentions in reasoning media captions", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        {
+          text: "Reasoning:\nCheck @room and @alice:example.org",
+          mediaUrl: "file:///tmp/reasoning.png",
+          isReasoning: true,
+        },
+      ],
+      roomId: "room:reasoning-media",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledOnce();
+    expect(sendOptions(0)).toMatchObject({
+      mediaUrl: "file:///tmp/reasoning.png",
+      disableMentions: true,
+    });
+  });
+
   it("delivers literal reasoning tags inside Markdown code", async () => {
     const text = "Use `<mm:think>example</mm:think>` literally.";
 

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -209,6 +209,7 @@ export async function deliverMatrixReplies(params: {
           audioAsVoice: reply.audioAsVoice,
           accountId: params.accountId,
           extraContent: first ? extraContent : undefined,
+          disableMentions: isReasoningPayload ? true : undefined,
           onDeliveryResult,
         });
         first = false;

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -1,3 +1,4 @@
+import { formatReasoningMessage } from "openclaw/plugin-sdk/agent-runtime";
 // Matrix plugin module implements replies behavior.
 import {
   createChannelPartialDeliveryError,
@@ -15,6 +16,7 @@ import { resolveMatrixExtraContent } from "../../outbound.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
 import { sendMessageMatrix } from "../send.js";
+import { MsgType } from "../send/types.js";
 import type { MatrixSendResult } from "../send/types.js";
 import type { OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
@@ -94,6 +96,14 @@ function createMatrixReplyDeliveryResult(
   };
 }
 
+function resolveMatrixReasoningReplyText(text?: string): string | undefined {
+  const raw = typeof text === "string" ? text.trim() : "";
+  const reasoningPrefix = "Reasoning:\n";
+  const body = raw.startsWith(reasoningPrefix) ? raw.slice(reasoningPrefix.length).trim() : raw;
+  const formatted = formatReasoningMessage(body);
+  return formatted || undefined;
+}
+
 function resolveVisibleMatrixReplyText(text?: string): string | undefined {
   if (typeof text !== "string") {
     return undefined;
@@ -132,9 +142,12 @@ export async function deliverMatrixReplies(params: {
   const acceptedResults: MatrixSendResult[] = [];
   try {
     for (const reply of params.replies) {
-      const visibleText = resolveVisibleMatrixReplyText(reply.text);
+      const isReasoningPayload = reply.isReasoning === true;
+      const visibleText = isReasoningPayload
+        ? resolveMatrixReasoningReplyText(reply.text)
+        : resolveVisibleMatrixReplyText(reply.text);
       const { hasMedia, hasText, mediaUrls } = resolveSendableOutboundReplyParts(reply);
-      if (reply.isReasoning === true || (!hasMedia && reply.text && visibleText === undefined)) {
+      if (!isReasoningPayload && !hasMedia && reply.text && visibleText === undefined) {
         logVerbose("matrix reply suppressed as reasoning-only");
         continue;
       }
@@ -177,6 +190,7 @@ export async function deliverMatrixReplies(params: {
           threadId: params.threadId,
           accountId: params.accountId,
           extraContent,
+          ...(isReasoningPayload ? { msgtype: MsgType.Notice, disableMentions: true } : {}),
           onDeliveryResult,
         });
         continue;

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -1133,6 +1133,22 @@ describe("sendMessageMatrix mentions", () => {
     expect(sentContent(sendMessage)["m.mentions"]).toEqual({});
   });
 
+  it("suppresses mention metadata when requested", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix("room:!room:example", "@room hi @alice:example.org", {
+      client,
+      cfg: {} as never,
+      msgtype: "m.notice",
+      disableMentions: true,
+    });
+
+    const content = sentContent(sendMessage);
+    expect(content.msgtype).toBe("m.notice");
+    expect(content.body).toBe("@room hi @alice:example.org");
+    expect(content["m.mentions"]).toEqual({});
+  });
+
   it("marks room mentions via m.mentions.room", async () => {
     const { client, sendMessage } = makeClient();
 

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -1175,6 +1175,20 @@ describe("sendMessageMatrix mentions", () => {
     });
   });
 
+  it("suppresses mention metadata in media captions when requested", async () => {
+    const { client, sendMessage } = makeClient();
+
+    await sendMessageMatrix("room:!room:example", "caption @room @alice:example.org", {
+      client,
+      cfg: {} as never,
+      mediaUrl: "file:///tmp/photo.png",
+      disableMentions: true,
+    });
+
+    expect(sentContent(sendMessage)["m.mentions"]).toEqual({});
+    expect(sentContent(sendMessage).formatted_body).not.toContain("matrix.to");
+  });
+
   it("does not emit mentions from fallback filenames when there is no caption", async () => {
     const { client, sendMessage } = makeClient();
     loadWebMediaMock.mockResolvedValue({

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -1147,6 +1147,7 @@ describe("sendMessageMatrix mentions", () => {
     expect(content.msgtype).toBe("m.notice");
     expect(content.body).toBe("@room hi @alice:example.org");
     expect(content["m.mentions"]).toEqual({});
+    expect(content.formatted_body).not.toContain("matrix.to");
   });
 
   it("marks room mentions via m.mentions.room", async () => {

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -172,6 +172,10 @@ function withMatrixExtraContentFields<T extends Record<string, unknown>>(
   return { ...content, ...extraContent };
 }
 
+function suppressMatrixMentions<T extends Record<string, unknown>>(content: T): T {
+  return { ...content, "m.mentions": {} };
+}
+
 async function resolvePreviousEditMentions(params: {
   client: MatrixClient;
   content: Record<string, unknown> | undefined;
@@ -243,8 +247,11 @@ export async function sendMessageMatrix(
           content: MatrixOutboundContent,
           receiptKind: MessageReceiptPartKind,
         ) => {
+          const enrichedContent = withMatrixExtraContentFields(content, pendingExtraContent);
           events.push({
-            content: withMatrixExtraContentFields(content, pendingExtraContent),
+            content: opts.disableMentions
+              ? suppressMatrixMentions(enrichedContent)
+              : enrichedContent,
             receiptKind,
           });
           pendingExtraContent = undefined;
@@ -328,7 +335,7 @@ export async function sendMessageMatrix(
             if (!chunk.trim()) {
               continue;
             }
-            const content = buildTextContent(chunk, relation);
+            const content = buildTextContent(chunk, relation, { msgtype: opts.msgtype });
             await enrichMatrixFormattedContent({
               client,
               content,

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -307,6 +307,7 @@ export async function sendMessageMatrix(
             content,
             markdown: captionMarkdown,
             preparedBody: captionMarkdown === convertedText ? singleEventBody : undefined,
+            includeMentions: opts.disableMentions ? false : undefined,
             tableMode,
           });
           prepareContent(content, receiptKind);
@@ -322,6 +323,7 @@ export async function sendMessageMatrix(
               content: followup,
               markdown: chunk,
               preparedBody: chunk === convertedText ? singleEventBody : undefined,
+              includeMentions: opts.disableMentions ? false : undefined,
               tableMode,
             });
             prepareContent(followup, "text");
@@ -337,6 +339,7 @@ export async function sendMessageMatrix(
               content,
               markdown: chunk,
               preparedBody: chunk === convertedText ? singleEventBody : undefined,
+              includeMentions: opts.disableMentions ? false : undefined,
               tableMode,
             });
             prepareContent(content, "text");

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -172,10 +172,6 @@ function withMatrixExtraContentFields<T extends Record<string, unknown>>(
   return { ...content, ...extraContent };
 }
 
-function suppressMatrixMentions<T extends Record<string, unknown>>(content: T): T {
-  return { ...content, "m.mentions": {} };
-}
-
 async function resolvePreviousEditMentions(params: {
   client: MatrixClient;
   content: Record<string, unknown> | undefined;
@@ -250,7 +246,7 @@ export async function sendMessageMatrix(
           const enrichedContent = withMatrixExtraContentFields(content, pendingExtraContent);
           events.push({
             content: opts.disableMentions
-              ? suppressMatrixMentions(enrichedContent)
+              ? { ...enrichedContent, "m.mentions": {} }
               : enrichedContent,
             receiptKind,
           });

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -98,6 +98,8 @@ export type MatrixSendOpts = {
   replyToId?: string;
   threadId?: string | number | null;
   timeoutMs?: number;
+  /** Override text event type for non-media Matrix replies. */
+  msgtype?: MatrixTextMsgType;
   /** Opaque durable queue id used to derive Matrix transaction ids. */
   deliveryQueueId?: string;
   /** Stable provider-send index within one durable payload. */
@@ -108,6 +110,8 @@ export type MatrixSendOpts = {
   onPlatformSendDispatch?: () => Promise<void>;
   /** Additional Matrix event content fields to merge into the first sent event. */
   extraContent?: MatrixExtraContentFields;
+  /** Suppress Matrix mention metadata even when the rendered body contains mention-like text. */
+  disableMentions?: boolean;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
   /** Persist each concrete platform send before any later event can fail. */

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -230,6 +230,7 @@ export type MatrixConfig = {
 };
 
 export type CoreConfig = {
+  agents?: OpenClawConfig["agents"];
   channels?: {
     matrix?: MatrixConfig;
     defaults?: {

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -230,7 +230,6 @@ export type MatrixConfig = {
 };
 
 export type CoreConfig = {
-  agents?: OpenClawConfig["agents"];
   channels?: {
     matrix?: MatrixConfig;
     defaults?: {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -11,6 +11,7 @@ import type { UserTurnTranscriptRecorder } from "../sessions/user-turn-transcrip
 import type { ReplyPayload } from "./reply-payload.js";
 import type { TypingController } from "./reply/typing.js";
 import type { SourceReplyDeliveryMode } from "./source-reply-delivery-mode.types.js";
+import type { ReasoningLevel } from "./thinking.shared.js";
 
 export type { SourceReplyDeliveryMode } from "./source-reply-delivery-mode.types.js";
 
@@ -295,6 +296,8 @@ export type GetReplyOptions = {
   progressPreambleEnabled?: boolean;
   /** Deliver durable reasoning payloads to channels that own a separate reasoning lane. */
   reasoningPayloadsEnabled?: boolean;
+  /** Reports the canonical reasoning visibility resolved for this turn. */
+  onReasoningLevelResolved?: (level: ReasoningLevel) => void;
   /** Deliver durable commentary (💬) payloads to channels that own a separate commentary lane. */
   commentaryPayloadsEnabled?: boolean;
   /** Optional turn-frozen commentary owner; visibility is live by default.

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -296,8 +296,8 @@ export type GetReplyOptions = {
   progressPreambleEnabled?: boolean;
   /** Deliver durable reasoning payloads to channels that own a separate reasoning lane. */
   reasoningPayloadsEnabled?: boolean;
-  /** Reports the canonical reasoning visibility resolved for this turn. */
-  onReasoningLevelResolved?: (level: ReasoningLevel) => void;
+  /** Reports the canonical reasoning visibility and returns durable-payload eligibility. */
+  onReasoningLevelResolved?: (level: ReasoningLevel) => boolean;
   /** Deliver durable commentary (💬) payloads to channels that own a separate commentary lane. */
   commentaryPayloadsEnabled?: boolean;
   /** Optional turn-frozen commentary owner; visibility is live by default.

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -209,6 +209,7 @@ export async function runCliFallbackCandidate(
             );
           },
           onReasoningText: createCliReasoningStreamBridge(turn.opts?.onReasoningStream),
+          onReasoningEnd: turn.opts?.onReasoningEnd,
           onPlanUpdate: turn.opts?.onPlanUpdate,
           onReasoningProgress: async (payload) => {
             await turn.opts?.onReasoningProgress?.(payload);

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -258,7 +258,7 @@ describe("runCliAgentWithLifecycle", () => {
     });
     const closeStarted = createDeferred();
     const releaseClose = createDeferred();
-    const onAssistantText = vi.fn(async () => undefined);
+    const onAssistantText = vi.fn(async (_text: string) => undefined);
 
     const run = runCliAgentWithLifecycle({
       runId: "run-delayed-reasoning-close",

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -167,14 +167,27 @@ describe("runCliAgentWithLifecycle", () => {
       });
       return { payloads: [{ text: "Visible answer" }], meta: { durationMs: 1 } };
     });
+    const callbackOrder: string[] = [];
     const onReasoningText = vi.fn<(payload: ReasoningTextPayload) => Promise<void>>(
-      async () => undefined,
+      async ({ text }) => {
+        callbackOrder.push(`reasoning:${text}`);
+      },
     );
+    const onReasoningEnd = vi.fn(async () => {
+      callbackOrder.push("reasoning:end");
+      throw new Error("reasoning notice failed");
+    });
+    const onAssistantText = vi.fn(async () => {
+      callbackOrder.push("assistant");
+    });
 
     const result = await runCliAgentWithLifecycle({
       runId: "run-thinking-bridge",
       provider: "claude-cli",
+      onAssistantText,
+      onReasoningEnd,
       onReasoningText,
+      preserveProgressCallbackStartOrder: true,
       runParams: {
         sessionId: "session-1",
         sessionFile: "/tmp/session.jsonl",
@@ -192,6 +205,12 @@ describe("runCliAgentWithLifecycle", () => {
     expect(onReasoningText.mock.calls.map((call) => call[0])).toEqual([
       { text: "Thinking", isReasoningSnapshot: true },
       { text: "Thinking more", isReasoningSnapshot: true },
+    ]);
+    expect(callbackOrder).toEqual([
+      "reasoning:Thinking",
+      "reasoning:Thinking more",
+      "reasoning:end",
+      "assistant",
     ]);
     expect(result.payloads).toEqual([
       { text: "Thinking more", isReasoning: true },

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -163,6 +163,21 @@ describe("runCliAgentWithLifecycle", () => {
       emitAgentEvent({
         runId: params.runId,
         stream: "assistant",
+        data: { text: "First answer", delta: "First answer" },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "tool",
+        data: { phase: "start", name: "search", toolCallId: "tool-1", args: {} },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "thinking",
+        data: { text: "Second window", delta: "Second window", isReasoningSnapshot: true },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
         data: { text: "Visible answer", delta: "Visible answer" },
       });
       return { payloads: [{ text: "Visible answer" }], meta: { durationMs: 1 } };
@@ -177,8 +192,8 @@ describe("runCliAgentWithLifecycle", () => {
       callbackOrder.push("reasoning:end");
       throw new Error("reasoning notice failed");
     });
-    const onAssistantText = vi.fn(async () => {
-      callbackOrder.push("assistant");
+    const onAssistantText = vi.fn(async (text: string) => {
+      callbackOrder.push(`assistant:${text}`);
     });
 
     const result = await runCliAgentWithLifecycle({
@@ -201,19 +216,23 @@ describe("runCliAgentWithLifecycle", () => {
       },
     });
 
-    expect(onReasoningText).toHaveBeenCalledTimes(2);
+    expect(onReasoningText).toHaveBeenCalledTimes(3);
     expect(onReasoningText.mock.calls.map((call) => call[0])).toEqual([
       { text: "Thinking", isReasoningSnapshot: true },
       { text: "Thinking more", isReasoningSnapshot: true },
+      { text: "Second window", isReasoningSnapshot: true },
     ]);
     expect(callbackOrder).toEqual([
       "reasoning:Thinking",
       "reasoning:Thinking more",
       "reasoning:end",
-      "assistant",
+      "reasoning:Second window",
+      "assistant:First answer",
+      "reasoning:end",
+      "assistant:Visible answer",
     ]);
     expect(result.payloads).toEqual([
-      { text: "Thinking more", isReasoning: true },
+      { text: "Second window", isReasoning: true },
       { text: "Visible answer" },
     ]);
   });

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,6 +1,7 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { withTestAdmittedRunContext } from "../../agents/admitted-run-context.test-support.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
@@ -162,11 +163,6 @@ describe("runCliAgentWithLifecycle", () => {
       });
       emitAgentEvent({
         runId: params.runId,
-        stream: "assistant",
-        data: { text: "First answer", delta: "First answer" },
-      });
-      emitAgentEvent({
-        runId: params.runId,
         stream: "tool",
         data: { phase: "start", name: "search", toolCallId: "tool-1", args: {} },
       });
@@ -195,6 +191,9 @@ describe("runCliAgentWithLifecycle", () => {
     const onAssistantText = vi.fn(async (text: string) => {
       callbackOrder.push(`assistant:${text}`);
     });
+    const onToolEvent = vi.fn(async () => {
+      callbackOrder.push("tool");
+    });
 
     const result = await runCliAgentWithLifecycle({
       runId: "run-thinking-bridge",
@@ -202,6 +201,7 @@ describe("runCliAgentWithLifecycle", () => {
       onAssistantText,
       onReasoningEnd,
       onReasoningText,
+      onToolEvent,
       preserveProgressCallbackStartOrder: true,
       runParams: {
         sessionId: "session-1",
@@ -227,13 +227,71 @@ describe("runCliAgentWithLifecycle", () => {
       "reasoning:Thinking more",
       "reasoning:end",
       "reasoning:Second window",
-      "assistant:First answer",
+      "tool",
       "reasoning:end",
       "assistant:Visible answer",
     ]);
     expect(result.payloads).toEqual([
       { text: "Second window", isReasoning: true },
       { text: "Visible answer" },
+    ]);
+  });
+
+  it("holds every assistant delta behind an in-flight reasoning close", async () => {
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "thinking",
+        data: { text: "Thinking", delta: "Thinking", isReasoningSnapshot: true },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "First answer", delta: "First answer" },
+      });
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "Second answer", delta: "Second answer" },
+      });
+      return { payloads: [{ text: "Second answer" }], meta: { durationMs: 1 } };
+    });
+    const closeStarted = createDeferred();
+    const releaseClose = createDeferred();
+    const onAssistantText = vi.fn(async () => undefined);
+
+    const run = runCliAgentWithLifecycle({
+      runId: "run-delayed-reasoning-close",
+      provider: "claude-cli",
+      onAssistantText,
+      onReasoningEnd: async () => {
+        closeStarted.resolve();
+        await releaseClose.promise;
+      },
+      onReasoningText: async () => undefined,
+      preserveProgressCallbackStartOrder: true,
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-delayed-reasoning-close",
+      },
+    });
+
+    await closeStarted.promise;
+    await Promise.resolve();
+    expect(onAssistantText).not.toHaveBeenCalled();
+
+    releaseClose.resolve();
+    await run;
+    expect(onAssistantText.mock.calls.map((call) => call[0])).toEqual([
+      "First answer",
+      "Second answer",
     ]);
   });
 

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -441,6 +441,7 @@ type RunCliAgentWithLifecycleParams = {
   preserveProgressCallbackStartOrder?: boolean;
   onAssistantText?: (text: string) => Promise<boolean | void>;
   onReasoningText?: (payload: ReasoningTextPayload) => Promise<void>;
+  onReasoningEnd?: GetReplyOptions["onReasoningEnd"];
   onReasoningProgress?: (payload: ReasoningProgressPayload) => Promise<void>;
   onToolEvent?: (payload: CliToolEventPayload) => Promise<void>;
   onCommentaryText?: (payload: CommentaryTextPayload) => Promise<void>;
@@ -625,6 +626,9 @@ async function runCliAgentWithLifecycleInternal(
     }
     const result = params.transformResult?.(rawResult) ?? rawResult;
     await stopAgentEventBridges(bridges);
+    if (finalReasoningText) {
+      await params.onReasoningEnd?.();
+    }
 
     const cliText = normalizeOptionalString(result.payloads?.[0]?.text);
     const durableReasoningText = normalizeOptionalString(finalReasoningText);

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -589,6 +589,7 @@ async function runCliAgentWithLifecycleInternal(
     suppressed: params.suppressAssistantBridge,
     startOrder: progressStartOrder,
     deliver: async (payload: ReasoningTextPayload) => {
+      reasoningEnded = false;
       finalReasoningText = normalizeOptionalString(payload.text);
       await params.onReasoningText?.(payload);
     },

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -561,16 +561,22 @@ async function runCliAgentWithLifecycleInternal(
     : undefined;
   let finalReasoningText: string | undefined;
   let reasoningEnded = false;
-  const endReasoning = async () => {
+  // CLI stream bridges drain independently. Every boundary shares this tail so
+  // later tool or assistant callbacks cannot overtake an in-flight close.
+  let reasoningClose = Promise.resolve();
+  const endReasoning = () => {
     if (!finalReasoningText || reasoningEnded) {
-      return;
+      return reasoningClose;
     }
     reasoningEnded = true;
-    try {
-      await params.onReasoningEnd?.();
-    } catch {
-      // Channel progress callbacks cannot turn a valid CLI result into a run failure.
-    }
+    reasoningClose = reasoningClose.then(async () => {
+      try {
+        await params.onReasoningEnd?.();
+      } catch {
+        // Channel progress callbacks cannot turn a valid CLI result into a run failure.
+      }
+    });
+    return reasoningClose;
   };
   const onAssistantText = params.onAssistantText;
   const assistantBridge = createAssistantTextBridge({
@@ -603,7 +609,10 @@ async function runCliAgentWithLifecycleInternal(
   const toolBridge = createToolEventBridge({
     runId: params.runId,
     suppressed: params.suppressAssistantBridge,
-    deliver: params.onToolEvent,
+    deliver: async (payload) => {
+      await endReasoning();
+      await params.onToolEvent?.(payload);
+    },
     startOrder: progressStartOrder,
   });
   const commentaryBridge = createCommentaryEventBridge({

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -618,7 +618,12 @@ async function runCliAgentWithLifecycleInternal(
   const commentaryBridge = createCommentaryEventBridge({
     runId: params.runId,
     suppressed: params.suppressAssistantBridge,
-    deliver: params.onCommentaryText,
+    deliver: params.onCommentaryText
+      ? async (payload) => {
+          await endReasoning();
+          await params.onCommentaryText?.(payload);
+        }
+      : undefined,
     startOrder: progressStartOrder,
   });
   const planBridge = createPlanUpdateBridge({
@@ -693,6 +698,7 @@ async function runCliAgentWithLifecycleInternal(
     return resultWithReasoning;
   } catch (err) {
     await stopAgentEventBridges(bridges);
+    await endReasoning();
     await params.onErrorBeforeLifecycle?.(err);
     if (emitLifecycleTerminal) {
       emitAgentEvent({

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -559,13 +559,31 @@ async function runCliAgentWithLifecycleInternal(
   const progressStartOrder = params.preserveProgressCallbackStartOrder
     ? createAgentEventDeliveryStartOrder()
     : undefined;
+  let finalReasoningText: string | undefined;
+  let reasoningEnded = false;
+  const endReasoning = async () => {
+    if (!finalReasoningText || reasoningEnded) {
+      return;
+    }
+    reasoningEnded = true;
+    try {
+      await params.onReasoningEnd?.();
+    } catch {
+      // Channel progress callbacks cannot turn a valid CLI result into a run failure.
+    }
+  };
+  const onAssistantText = params.onAssistantText;
   const assistantBridge = createAssistantTextBridge({
     runId: params.runId,
     suppressed: params.suppressAssistantBridge,
-    deliver: params.onAssistantText,
+    deliver: onAssistantText
+      ? async (text) => {
+          await endReasoning();
+          return await onAssistantText(text);
+        }
+      : undefined,
     startOrder: progressStartOrder,
   });
-  let finalReasoningText: string | undefined;
   const reasoningBridge = createReasoningTextBridge({
     runId: params.runId,
     suppressed: params.suppressAssistantBridge,
@@ -626,9 +644,7 @@ async function runCliAgentWithLifecycleInternal(
     }
     const result = params.transformResult?.(rawResult) ?? rawResult;
     await stopAgentEventBridges(bridges);
-    if (finalReasoningText) {
-      await params.onReasoningEnd?.();
-    }
+    await endReasoning();
 
     const cliText = normalizeOptionalString(result.payloads?.[0]?.text);
     const durableReasoningText = normalizeOptionalString(finalReasoningText);

--- a/src/auto-reply/reply/agent-runner-cli-reasoning-boundaries.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-reasoning-boundaries.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTestAdmittedRunContext } from "../../agents/admitted-run-context.test-support.js";
+import { emitAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
+import { runCliAgentWithLifecycle as runCliAgentWithLifecycleProduction } from "./agent-runner-cli-dispatch.js";
+
+type ProductionLifecycleParams = Parameters<typeof runCliAgentWithLifecycleProduction>[0];
+type LifecycleParams = Omit<ProductionLifecycleParams, "runParams"> & {
+  runParams: Omit<ProductionLifecycleParams["runParams"], "admittedRunContext">;
+};
+
+const cliDispatchState = vi.hoisted(() => ({ runCliAgentMock: vi.fn() }));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (...args: unknown[]) => cliDispatchState.runCliAgentMock(...args),
+}));
+
+const runCliAgentWithLifecycle = (params: LifecycleParams) =>
+  runCliAgentWithLifecycleProduction({
+    ...params,
+    runParams: withTestAdmittedRunContext(params.runParams),
+  });
+
+function createRunParams(runId: string): LifecycleParams["runParams"] {
+  return {
+    sessionId: "session-1",
+    sessionFile: "/tmp/session.jsonl",
+    workspaceDir: "/tmp/workspace",
+    prompt: "hello",
+    provider: "claude-cli",
+    model: "claude",
+    thinkLevel: "high",
+    timeoutMs: 1_000,
+    runId,
+  };
+}
+
+afterEach(() => {
+  resetAgentEventsForTest();
+  cliDispatchState.runCliAgentMock.mockReset();
+});
+
+describe("runCliAgentWithLifecycle reasoning boundaries", () => {
+  it("closes reasoning before commentary delivery", async () => {
+    const runId = "run-reasoning-commentary-boundary";
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(async () => {
+      emitAgentEvent({
+        runId,
+        stream: "thinking",
+        data: { text: "Thinking", delta: "Thinking", isReasoningSnapshot: true },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "item",
+        data: { kind: "preamble", itemId: "commentary-1", progressText: "Checking files" },
+      });
+      return { payloads: [{ text: "Visible answer" }], meta: { durationMs: 1 } };
+    });
+    const callbackOrder: string[] = [];
+
+    await runCliAgentWithLifecycle({
+      runId,
+      provider: "claude-cli",
+      onReasoningText: async () => {
+        callbackOrder.push("reasoning");
+      },
+      onReasoningEnd: async () => {
+        callbackOrder.push("reasoning:end");
+      },
+      onCommentaryText: async () => {
+        callbackOrder.push("commentary");
+      },
+      preserveProgressCallbackStartOrder: true,
+      runParams: createRunParams(runId),
+    });
+
+    expect(callbackOrder).toEqual(["reasoning", "reasoning:end", "commentary"]);
+  });
+
+  it("closes reasoning before reporting a CLI error", async () => {
+    const runId = "run-reasoning-error-boundary";
+    const failure = new Error("CLI failed after reasoning");
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(async () => {
+      emitAgentEvent({
+        runId,
+        stream: "thinking",
+        data: { text: "Thinking", delta: "Thinking", isReasoningSnapshot: true },
+      });
+      throw failure;
+    });
+    const callbackOrder: string[] = [];
+
+    await expect(
+      runCliAgentWithLifecycle({
+        runId,
+        provider: "claude-cli",
+        onReasoningText: async () => {
+          callbackOrder.push("reasoning");
+        },
+        onReasoningEnd: async () => {
+          callbackOrder.push("reasoning:end");
+        },
+        onErrorBeforeLifecycle: async () => {
+          callbackOrder.push("error");
+        },
+        preserveProgressCallbackStartOrder: true,
+        runParams: createRunParams(runId),
+      }),
+    ).rejects.toBe(failure);
+
+    expect(callbackOrder).toEqual(["reasoning", "reasoning:end", "error"]);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
@@ -741,8 +741,13 @@ describe("executeAgentTurn: CLI progress bridging", () => {
       },
     ]);
     expect(onReasoningEnd).toHaveBeenCalledOnce();
-    expect(expectDefined(onReasoningStream.mock.invocationCallOrder.at(-1))).toBeLessThan(
-      expectDefined(onReasoningEnd.mock.invocationCallOrder[0]),
+    expect(
+      expectDefined(
+        onReasoningStream.mock.invocationCallOrder.at(-1),
+        "last reasoning stream callback order",
+      ),
+    ).toBeLessThan(
+      expectDefined(onReasoningEnd.mock.invocationCallOrder[0], "reasoning end callback order"),
     );
   });
 

--- a/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { createCliJsonlStreamingParser } from "../../agents/cli-output-stream.js";
@@ -698,6 +699,7 @@ describe("executeAgentTurn: CLI progress bridging", () => {
     const onReasoningStream = vi.fn<NonNullable<GetReplyOptions["onReasoningStream"]>>(
       async (_payload) => undefined,
     );
+    const onReasoningEnd = vi.fn<NonNullable<GetReplyOptions["onReasoningEnd"]>>(async () => false);
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     const followupRun = createFollowupRun();
     followupRun.run.provider = "claude-cli";
@@ -710,7 +712,7 @@ describe("executeAgentTurn: CLI progress bridging", () => {
         Provider: "telegram",
         MessageSid: "msg",
       } as unknown as TemplateContext,
-      opts: { onReasoningStream },
+      opts: { onReasoningEnd, onReasoningStream },
       typingSignals: createMockTypingSignaler(),
       blockReplyPipeline: null,
       blockStreamingEnabled: false,
@@ -738,6 +740,10 @@ describe("executeAgentTurn: CLI progress bridging", () => {
         requiresReasoningProgressOptIn: true,
       },
     ]);
+    expect(onReasoningEnd).toHaveBeenCalledOnce();
+    expect(expectDefined(onReasoningStream.mock.invocationCallOrder.at(-1))).toBeLessThan(
+      expectDefined(onReasoningEnd.mock.invocationCallOrder[0]),
+    );
   });
 
   it("bridges tagged Claude CLI reasoning separately from its visible answer", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
@@ -1775,6 +1775,41 @@ describe("dispatchReplyFromConfig", () => {
     }
   });
 
+  it.each([
+    { level: "on" as const, enabled: true },
+    { level: "off" as const, enabled: false },
+    { level: "stream" as const, enabled: false },
+  ])(
+    "applies resolved $level durable reasoning eligibility to core accounting",
+    async ({ level, enabled }) => {
+      setNoAbort();
+      const dispatcher = createDispatcher();
+      const reasoning = { text: "thinking...", isReasoning: true } satisfies ReplyPayload;
+      const answer = { text: "The answer is 42" } satisfies ReplyPayload;
+      const onReasoningLevelResolved = vi.fn(() => enabled);
+
+      await dispatchReplyFromConfig({
+        ctx: buildTestCtx({ Provider: "matrix", Surface: "matrix" }),
+        cfg: emptyConfig,
+        dispatcher,
+        replyOptions: { reasoningPayloadsEnabled: true, onReasoningLevelResolved },
+        replyResolver: async (_ctx, opts) => {
+          expect(opts?.onReasoningLevelResolved?.(level)).toBe(enabled);
+          await opts?.onBlockReply?.(reasoning);
+          return enabled ? answer : [reasoning, answer];
+        },
+      });
+
+      expect(onReasoningLevelResolved).toHaveBeenCalledExactlyOnceWith(level);
+      expect(
+        vi.mocked(dispatcher.sendBlockReply).mock.calls.map(([payload]) => payload.text),
+      ).toEqual(enabled ? [reasoning.text] : []);
+      expect(
+        vi.mocked(dispatcher.sendFinalReply).mock.calls.map(([payload]) => payload.text),
+      ).toEqual([answer.text]);
+    },
+  );
+
   it("does not redeliver a final that already settled as an identical block", async () => {
     setNoAbort();
     const delivered: Array<{ kind: string; text?: string }> = [];

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -53,7 +53,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     notifySessionMetadataChanges,
     onToolResultFromReplyOptions,
     params,
-    reasoningPayloadsEnabled,
+    recordAgentDispatchCompleted,
     replyConfig,
     replyRoute,
     resolveToolDeliveryPayload,
@@ -70,6 +70,8 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     waitForPendingDirectBlockReplyDelivery,
     wrapProgressCallback,
   } = state;
+  // Keep the block and final snapshots aligned so hidden modes spend no slot.
+  const onReasoningLevelResolved = params.replyOptions?.onReasoningLevelResolved;
   // Bind at invocation so every public resolver consumes the request generation without widening its Plugin SDK contract.
   const replyResolver = bindPreparedReplyDispatchRuntime(
     params.configOverride ? undefined : state.preparedReplyDispatchRuntime,
@@ -119,6 +121,12 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   onSessionPrepared: state.notePreparedSession,
                 } satisfies InternalReplyResolverOptions),
                 onObservedReplyDelivery: state.markObservedReplyDelivery,
+                onReasoningLevelResolved: onReasoningLevelResolved
+                  ? (level) => {
+                      state.reasoningPayloadsEnabled = onReasoningLevelResolved(level);
+                      return state.reasoningPayloadsEnabled;
+                    }
+                  : undefined,
                 suppressToolErrorWarnings: state.suppressToolErrorWarnings,
                 typingPolicy: typing.typingPolicy,
                 suppressTyping: typing.suppressTyping,
@@ -155,7 +163,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                   state.deliverStandaloneCommentaryProgress ||
                   state.canForwardSuppressedSourceItemEvents ||
                   params.replyOptions?.commentaryProgressEnabled,
-                reasoningPayloadsEnabled,
+                reasoningPayloadsEnabled: state.reasoningPayloadsEnabled,
                 commentaryPayloadsEnabled,
                 onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
                   forwardWhenSourceDeliverySuppressed: true,
@@ -420,13 +428,9 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     ) {
                       return;
                     }
-                    // Durable reasoning is a channel-owned lane; generic channels
-                    // keep the historical suppression unless they explicitly opt in.
-                    if (inputPayload.isReasoning === true && !reasoningPayloadsEnabled) {
+                    if (inputPayload.isReasoning === true && !state.reasoningPayloadsEnabled) {
                       return;
                     }
-                    // Durable commentary is a channel-owned lane; generic channels keep the
-                    // historical suppression unless they explicitly opt in.
                     if (inputPayload.isCommentary === true && !commentaryPayloadsEnabled) {
                       return;
                     }
@@ -440,10 +444,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     if (!payload) {
                       return;
                     }
-                    // Accumulate block text for TTS generation after streaming.
-                    // Exclude status notices — they are informational UI signals
-                    // and must not be synthesised into the spoken reply. Display
-                    // lanes stay out too: they are presentation, never final text.
+                    // Accumulate TTS text after streaming; status/display lanes are never spoken.
                     const isStatusNotice = isReplyPayloadStatusNotice(payload);
                     const contributesToFinalReply =
                       !isStatusNotice &&
@@ -496,9 +497,8 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                     if (!hasOutboundReplyContent(visiblePayload, { trimText: true })) {
                       return;
                     }
-                    // Channels that keep a live draft preview may need to rotate their
-                    // preview state at the logical block boundary before queued block
-                    // delivery drains asynchronously through the dispatcher.
+                    // Rotate live previews at the logical block boundary before queued
+                    // block delivery drains asynchronously through the dispatcher.
                     const payloadMetadata = getReplyPayloadMetadata(payload);
                     const queuedContext =
                       payloadMetadata?.assistantMessageIndex !== undefined
@@ -555,8 +555,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                         !state.suppressAutomaticSourceDelivery &&
                         params.replyOptions?.onBlockReplyQueued
                       ) {
-                        // Block callbacks are delivery facts, not queue-admission facts.
-                        // Resolve them after beforeDeliver hooks without stalling streaming.
+                        // Resolve delivery-fact callbacks after hooks without stalling streaming.
                         trackDispatchLifecycleWork(
                           wasReplyDeliveredAsBlock(normalizedPayload, context?.abortSignal).then(
                             async (delivered) => {

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -53,7 +53,6 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     notifySessionMetadataChanges,
     onToolResultFromReplyOptions,
     params,
-    recordAgentDispatchCompleted,
     replyConfig,
     replyRoute,
     resolveToolDeliveryPayload,

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -23,6 +23,7 @@ type CaptureSessionDiffBaseline =
   (typeof import("../../sessions/session-diff.js"))["captureSessionDiffBaseline"];
 const mocks = vi.hoisted(() => ({
   captureSessionDiffBaseline: vi.fn<CaptureSessionDiffBaseline>(),
+  handleInlineActions: vi.fn(),
   resolveReplyDirectives: vi.fn(),
   initSessionState: vi.fn(),
 }));
@@ -117,12 +118,21 @@ describe("getReplyFromConfig configOverride", () => {
     vi.stubEnv("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
     mocks.resolveReplyDirectives.mockReset();
     mocks.initSessionState.mockReset();
+    mocks.handleInlineActions.mockReset();
     mocks.captureSessionDiffBaseline.mockReset();
     vi.mocked(loadConfigMock).mockReset();
     vi.mocked(runPreparedReplyMock).mockReset();
 
     vi.mocked(loadConfigMock).mockReturnValue({});
     mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+    mocks.handleInlineActions.mockImplementation(async (params: unknown) => {
+      const result = params as { directives?: unknown; cleanedBody?: string };
+      return {
+        kind: "continue",
+        directives: result.directives ?? {},
+        cleanedBody: result.cleanedBody ?? "",
+      };
+    });
     const sessionKey = "agent:main:telegram:123";
     const storePath = path.join(tempDirs.make("openclaw-get-reply-session-"), "sessions.json");
     const entry: InternalSessionEntry = {
@@ -176,6 +186,32 @@ describe("getReplyFromConfig configOverride", () => {
 
     expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
   });
+
+  it.each(["on", "stream"] as const)(
+    "reports the current-turn inline reasoning mode %s before the agent run",
+    async (level) => {
+      const ctx = buildGetReplyCtx();
+      const onReasoningLevelResolved = vi.fn();
+      mocks.resolveReplyDirectives.mockResolvedValueOnce(
+        createGetReplyContinueDirectivesResult({
+          body: `/reasoning ${level} explain this`,
+          abortKey: ctx.SessionKey ?? "agent:main:telegram:123",
+          from: ctx.From ?? "telegram:user:42",
+          to: ctx.To ?? "telegram:123",
+          senderId: ctx.SenderId ?? "user:42",
+          commandSource: "message",
+          senderIsOwner: true,
+          resetHookTriggered: false,
+          resolvedReasoningLevel: level,
+        }),
+      );
+
+      await getReplyFromConfig(ctx, { onReasoningLevelResolved }, {});
+
+      expect(onReasoningLevelResolved).toHaveBeenCalledExactlyOnceWith(level);
+      expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
+    },
+  );
 
   it("settles a precreated baseline claim before reply execution", async () => {
     const sessionId = "precreated-get-reply";

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -187,11 +187,13 @@ describe("getReplyFromConfig configOverride", () => {
     expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
   });
 
-  it.each(["on", "stream"] as const)(
+  it.each(["on", "off", "stream"] as const)(
     "reports the current-turn inline reasoning mode %s before the agent run",
     async (level) => {
       const ctx = buildGetReplyCtx();
-      const onReasoningLevelResolved = vi.fn();
+      const onReasoningLevelResolved = vi.fn(
+        (resolvedLevel: typeof level) => resolvedLevel === "on",
+      );
       mocks.resolveReplyDirectives.mockResolvedValueOnce(
         createGetReplyContinueDirectivesResult({
           body: `/reasoning ${level} explain this`,
@@ -209,7 +211,11 @@ describe("getReplyFromConfig configOverride", () => {
       await getReplyFromConfig(ctx, { onReasoningLevelResolved }, {});
 
       expect(onReasoningLevelResolved).toHaveBeenCalledExactlyOnceWith(level);
-      expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
+      expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          opts: expect.objectContaining({ reasoningPayloadsEnabled: level === "on" }),
+        }),
+      );
     },
   );
 

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -293,6 +293,32 @@ describe("getReplyFromConfig message hooks", () => {
     expect(triggerCount).toBe(2);
   });
 
+  it.each(["on", "stream"] as const)(
+    "reports the current-turn inline reasoning mode %s before the agent run",
+    async (level) => {
+      const body = `/reasoning ${level} explain this`;
+      const onReasoningLevelResolved = vi.fn();
+      mocks.resolveReplyDirectives.mockResolvedValueOnce(
+        createGetReplyContinueDirectivesResult({
+          body,
+          abortKey: "agent:main:telegram:-100123",
+          from: "telegram:user",
+          to: "telegram:chat",
+          senderId: "user",
+          commandSource: "message",
+          senderIsOwner: true,
+          resetHookTriggered: false,
+          resolvedReasoningLevel: level,
+        }),
+      );
+
+      await getReplyFromConfig(buildCtx(), { onReasoningLevelResolved }, withFastReplyConfig({}));
+
+      expect(onReasoningLevelResolved).toHaveBeenCalledExactlyOnceWith(level);
+      expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
+    },
+  );
+
   it("prepares durable session state before media understanding", async () => {
     const order: string[] = [];
     mocks.resolveReplySessionPreprocessingState.mockImplementationOnce(() => {

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -293,32 +293,6 @@ describe("getReplyFromConfig message hooks", () => {
     expect(triggerCount).toBe(2);
   });
 
-  it.each(["on", "stream"] as const)(
-    "reports the current-turn inline reasoning mode %s before the agent run",
-    async (level) => {
-      const body = `/reasoning ${level} explain this`;
-      const onReasoningLevelResolved = vi.fn();
-      mocks.resolveReplyDirectives.mockResolvedValueOnce(
-        createGetReplyContinueDirectivesResult({
-          body,
-          abortKey: "agent:main:telegram:-100123",
-          from: "telegram:user",
-          to: "telegram:chat",
-          senderId: "user",
-          commandSource: "message",
-          senderIsOwner: true,
-          resetHookTriggered: false,
-          resolvedReasoningLevel: level,
-        }),
-      );
-
-      await getReplyFromConfig(buildCtx(), { onReasoningLevelResolved }, withFastReplyConfig({}));
-
-      expect(onReasoningLevelResolved).toHaveBeenCalledExactlyOnceWith(level);
-      expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
-    },
-  );
-
   it("prepares durable session state before media understanding", async () => {
     const order: string[] = [];
     mocks.resolveReplySessionPreprocessingState.mockImplementationOnce(() => {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -952,6 +952,7 @@ export async function getReplyFromConfig(
       enableLocalPathSelfServe([finalized, sessionCtx]);
     }
     logResolverTiming("milestone", "before_fast_directive_prepared_reply");
+    resolvedOpts?.onReasoningLevelResolved?.("off");
     const fastReplyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
       runPreparedReply({
         ctx,
@@ -1303,6 +1304,7 @@ export async function getReplyFromConfig(
   }
 
   logResolverTiming("milestone", "before_run_prepared_reply");
+  resolvedOpts?.onReasoningLevelResolved?.(resolvedReasoningLevel);
   const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
     runPreparedReply({
       ctx,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -50,7 +50,7 @@ import type { GetReplyOptions } from "../get-reply-options.types.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../heartbeat.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { RuntimeMsgContext as MsgContext } from "../templating.js";
-import { normalizeThinkLevel, normalizeVerboseLevel } from "../thinking.js";
+import { normalizeThinkLevel, normalizeVerboseLevel, type ReasoningLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { resolveDefaultModel } from "./directive-handling.defaults.js";
 import { resolveActiveExplicitSteerSessionKey } from "./explicit-steer-routing.js";
@@ -738,6 +738,12 @@ export async function getReplyFromConfig(
     opts: optsWithSessionSkillOverrides,
     disabled: sessionModelSelectionLocked,
   });
+  const resolveReasoningPayloadOptions = (level: ReasoningLevel) => {
+    const reasoningPayloadsEnabled = resolvedOpts?.onReasoningLevelResolved?.(level);
+    return reasoningPayloadsEnabled === undefined
+      ? resolvedOpts
+      : { ...resolvedOpts, reasoningPayloadsEnabled };
+  };
   const internalResolvedOpts = resolvedOpts as RuntimeInternalGetReplyOptions | undefined;
   let { abortedLastRun } = sessionState;
   resolverTimingSessionKey = sessionKey ?? resolverTimingSessionKey;
@@ -952,7 +958,6 @@ export async function getReplyFromConfig(
       enableLocalPathSelfServe([finalized, sessionCtx]);
     }
     logResolverTiming("milestone", "before_fast_directive_prepared_reply");
-    resolvedOpts?.onReasoningLevelResolved?.("off");
     const fastReplyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
       runPreparedReply({
         ctx,
@@ -991,7 +996,7 @@ export async function getReplyFromConfig(
         perMessageQueueMode: undefined,
         perMessageQueueOptions: undefined,
         typing,
-        opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
+        opts: withExtractedFileImages(resolveReasoningPayloadOptions("off"), extractedFileImages),
         defaultModel,
         timeoutMs,
         isNewSession,
@@ -1177,7 +1182,6 @@ export async function getReplyFromConfig(
   cleanedBody = inlineActionResult.cleanedBody;
   const explicitSkillSelections = inlineActionResult.explicitSkillSelections;
   const queueModeOverride = inlineActionResult.queueModeOverride;
-  const preparedReplyOpts = withExtractedFileImages(resolvedOpts, extractedFileImages);
   abortedLastRun = inlineActionResult.abortedLastRun ?? abortedLastRun;
   const runAutoFallbackPrimaryProbe = directives.hasModelDirective
     ? undefined
@@ -1304,7 +1308,10 @@ export async function getReplyFromConfig(
   }
 
   logResolverTiming("milestone", "before_run_prepared_reply");
-  resolvedOpts?.onReasoningLevelResolved?.(resolvedReasoningLevel);
+  const preparedReplyOpts = withExtractedFileImages(
+    resolveReasoningPayloadOptions(resolvedReasoningLevel),
+    extractedFileImages,
+  );
   const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
     runPreparedReply({
       ctx,

--- a/src/plugin-sdk/reply-runtime.contract.test.ts
+++ b/src/plugin-sdk/reply-runtime.contract.test.ts
@@ -20,6 +20,7 @@ type ProgressBoundaryCallback = GetReplyOptions[
   | "onBlockReplyQueued"
   | "onCompactionStart"
   | "onCompactionEnd"];
+type ResolvedReasoningCallback = Exclude<GetReplyOptions["onReasoningLevelResolved"], undefined>;
 
 describe("reply runtime public progress contracts", () => {
   it("exports acceptance-aware progress callback results", () => {
@@ -44,6 +45,13 @@ describe("reply runtime public progress contracts", () => {
     expectTypeOf<
       Exclude<GetReplyOptions["shouldDeliverCommentaryPayloads"], undefined>
     >().returns.toEqualTypeOf<boolean>();
+  });
+
+  it("exports the resolved reasoning delivery gate", () => {
+    expectTypeOf<Parameters<ResolvedReasoningCallback>>().toEqualTypeOf<
+      [level: "off" | "on" | "stream"]
+    >();
+    expectTypeOf<ReturnType<ResolvedReasoningCallback>>().toEqualTypeOf<boolean>();
   });
 });
 


### PR DESCRIPTION
Closes #81892

## What Problem This Solves

Fixes Matrix reasoning delivery so explicitly tagged reasoning is delivered as Matrix notices instead of being suppressed, while unflagged reasoning-looking text remains hidden.

## Why This Change Was Made

Matrix now opts into explicit reasoning payloads and delivers them through a separate notice path. Stream-mode reasoning buffers the latest reasoning text and sends it when the reasoning block ends, without overwriting the active answer draft.

Reasoning notice delivery is tracked by the Matrix reply dispatcher and drained before final reply delivery, so the reasoning notice cannot be overtaken by the final answer. Reasoning notices also suppress Matrix mention metadata, so `@room` or Matrix IDs inside model reasoning cannot notify room members.

## User Impact

Users who enable Matrix reasoning can see explicit reasoning output, including `/reasoning stream` summaries, while final answer delivery, draft delivery, and Matrix mention safety remain intact.

## Evidence

- `pnpm test extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts extensions/matrix/src/matrix/monitor/replies.test.ts extensions/matrix/src/matrix/send.test.ts`
- `pnpm check:changed -- extensions/matrix/src/matrix/send/types.ts extensions/matrix/src/matrix/send.ts extensions/matrix/src/matrix/send.test.ts extensions/matrix/src/matrix/monitor/replies.ts extensions/matrix/src/matrix/monitor/replies.test.ts extensions/matrix/src/matrix/monitor/handler.ts extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.test.ts`

Safety / ordering proof:

- explicit reasoning replies call `sendMessageMatrix(..., { msgtype: "m.notice", disableMentions: true })`
- Matrix send suppresses `m.mentions` when `disableMentions` is true
- regression test sends `@room` / `@alice:example.org` with `disableMentions: true` and asserts the event remains `m.notice` with `m.mentions: {}`
- dispatcher regression test starts a stream-mode reasoning notice delivery, starts final reply delivery before the notice resolves, and asserts final delivery waits until the reasoning notice resolves before sending the final answer

AI-assisted implementation; I reviewed Matrix reasoning delivery, active-draft behavior, mention handling, ordering, and validation output.



### Exact-head Matrix transport proof

On head `a90f2c26680913993eacf08d1827b7c1f4f4b42c`, a real repository `MatrixClient` sent events through an isolated loopback HTTP homeserver. The proof exercised `createMatrixReplyDispatcher` for all three configured reasoning modes and captured the homeserver PUT bodies.

| Mode | Observed Matrix events, in wire order |
|---|---|
| `off` | one `m.text` final; no reasoning event |
| `on` | one `m.notice` durable reasoning, then one `m.text` final |
| `stream` | one `m.notice` stream-end reasoning, then one `m.text` final |

Both reasoning notices contained `"m.mentions": {}` even though the input included `@room` and a Matrix user ID. The script asserted event counts and mention suppression and exited 0. The access token, loopback port, room ID, and user ID were disposable proof-only values.



Follow-up validation: session-store read errors now fail closed to `off`, and reasoning notices use one serialized delivery queue. A two-window regression proves both notices complete in source order before the final reply.
