### PR TITLE
fix(ui): align Inbox popover tabs with hub tabs and theme the mascot icon

### DIFF
--- a/ui/src/components/hub-tabs.test.ts
+++ b/ui/src/components/hub-tabs.test.ts
@@ -28,6 +28,35 @@ describe("renderHubTabs", () => {
     expect(container.querySelector("#example-tab-memory .hub-tab__badge")?.textContent).toBe("New");
   });
 
+  it("forwards the aria-label to the shadow tablist", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    try {
+      render(
+        renderHubTabs({
+          id: "example",
+          active: "files",
+          tabs: [{ value: "files", label: "Files" }],
+          ariaLabel: "Example sections",
+          panelId: "example-panel",
+          onSelect: () => undefined,
+        }),
+        container,
+      );
+      const group = container.querySelector<HTMLElement & { updateComplete: Promise<unknown> }>(
+        "wa-tab-group",
+      );
+      await group?.updateComplete;
+      // syncTabGroupLabel resolves on the same updateComplete chain; yield once more.
+      await group?.updateComplete;
+      expect(group?.shadowRoot?.querySelector('[role="tablist"]')?.getAttribute("aria-label")).toBe(
+        "Example sections",
+      );
+    } finally {
+      container.remove();
+    }
+  });
+
   it("selects only enabled tabs from direct user activation", () => {
     const onSelect = vi.fn();
     const container = document.createElement("div");

--- a/ui/src/components/hub-tabs.ts
+++ b/ui/src/components/hub-tabs.ts
@@ -1,7 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import "../styles/hub-tabs.css";
-import "./web-awesome-tabs.ts";
+import { syncTabGroupLabel } from "./web-awesome-tabs.ts";
 
 export type HubTabOption<T extends string> = {
   value: T;
@@ -73,6 +73,7 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
       .active=${props.active ?? NO_ACTIVE_TAB}
       activation="manual"
       without-scroll-controls
+      ${ref((element) => syncTabGroupLabel(element, props.ariaLabel))}
     >
       ${props.tabs.map((tab) => {
         const selected = props.active === tab.value;

--- a/ui/src/components/icons-tools.ts
+++ b/ui/src/components/icons-tools.ts
@@ -197,9 +197,13 @@ export const toolIcons = {
   lobster: html`
     <svg viewBox="0 0 120 120" fill="none">
       <defs>
+        <!-- Gradient stops read theme tokens (base.css --lobster-icon-*): the
+             shipped hex pair sank into dark backgrounds, so dark mode brightens
+             both stops while light mode keeps the original artwork. var() is
+             only valid in style="", not presentation attributes. -->
         <linearGradient id="lob-g" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stop-color="#ff4d4d" />
-          <stop offset="100%" stop-color="#991b1b" />
+          <stop offset="0%" style="stop-color: var(--lobster-icon-body, #ff4d4d)" />
+          <stop offset="100%" style="stop-color: var(--lobster-icon-shade, #991b1b)" />
         </linearGradient>
       </defs>
       <path
@@ -211,10 +215,20 @@ export const toolIcons = {
         d="M100 45C115 40 120 50 115 60C110 70 100 65 95 55C92 48 95 45 100 45Z"
         fill="url(#lob-g)"
       />
-      <path d="M45 15Q35 5 30 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round" />
-      <path d="M75 15Q85 5 90 8" stroke="#ff4d4d" stroke-width="3" stroke-linecap="round" />
-      <circle cx="45" cy="35" r="6" fill="#050810" />
-      <circle cx="75" cy="35" r="6" fill="#050810" />
+      <path
+        d="M45 15Q35 5 30 8"
+        style="stroke: var(--lobster-icon-body, #ff4d4d)"
+        stroke-width="3"
+        stroke-linecap="round"
+      />
+      <path
+        d="M75 15Q85 5 90 8"
+        style="stroke: var(--lobster-icon-body, #ff4d4d)"
+        stroke-width="3"
+        stroke-linecap="round"
+      />
+      <circle cx="45" cy="35" r="6" style="fill: var(--lobster-icon-eye, #050810)" />
+      <circle cx="75" cy="35" r="6" style="fill: var(--lobster-icon-eye, #050810)" />
       <circle cx="46" cy="34" r="2.5" fill="#00e5cc" />
       <circle cx="76" cy="34" r="2.5" fill="#00e5cc" />
     </svg>

--- a/ui/src/components/sidebar-attention-layout.browser.test.ts
+++ b/ui/src/components/sidebar-attention-layout.browser.test.ts
@@ -1,27 +1,28 @@
 import { afterEach, describe, expect, it } from "vitest";
 import "../test-helpers/load-styles.ts";
+import "../styles/hub-tabs.css";
 import "../styles/sidebar-issues.css";
 import "./web-awesome-tabs.ts";
 
 afterEach(() => document.body.replaceChildren());
 
 describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
-  it("keeps tabs compact and item rails flush with the scrollport", async () => {
+  it("keeps hub tabs compact and item rails flush with the scrollport", async () => {
     const fixture = document.createElement("section");
     fixture.className = "sidebar-issues-panel";
     fixture.style.position = "static";
     fixture.style.width = "390px";
     fixture.style.height = "220px";
     fixture.innerHTML = `
-      <wa-tab-group class="sidebar-issues-panel__tabs" without-scroll-controls>
+      <wa-tab-group class="hub-tabs hub-tabs--sub sidebar-issues-panel__tabs" without-scroll-controls>
         ${["All", "Approvals", "Automations", "System"]
           .map(
             (label, index) => `<wa-tab
               slot="nav"
-              class="sidebar-issues-panel__tab"
+              class="hub-tab"
               panel="tab-${index}"
               ${index === 0 ? "active" : ""}
-            ><span>${label}</span><span class="sidebar-issues-panel__tab-count">${index}</span></wa-tab>`,
+            >${label}${index > 0 ? `<span class="hub-tab__badge hub-tab__badge--count">${index}</span>` : ""}</wa-tab>`,
           )
           .join("")}
       </wa-tab-group>
@@ -45,20 +46,19 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     const header = document.createElement("header");
     header.className = "sidebar-issues-panel__header";
     fixture.prepend(header);
-    const tab = fixture.querySelector<HTMLElement & { updateComplete: Promise<unknown> }>(
-      ".sidebar-issues-panel__tab",
-    );
+    const badgeTab = fixture.querySelectorAll<HTMLElement & { updateComplete: Promise<unknown> }>(
+      ".hub-tab",
+    )[1];
     expect(group).not.toBeNull();
-    expect(tab).not.toBeNull();
+    expect(badgeTab).not.toBeNull();
     await group?.updateComplete;
-    await tab?.updateComplete;
+    await badgeTab?.updateComplete;
 
-    const base = tab?.shadowRoot?.querySelector<HTMLElement>("[part='base']");
-    const label = tab?.querySelector<HTMLElement>("span:first-child");
-    const count = tab?.querySelector<HTMLElement>(".sidebar-issues-panel__tab-count");
+    const badge = badgeTab!.querySelector<HTMLElement>(".hub-tab__badge");
     const list = fixture.querySelector<HTMLElement>(".sidebar-issues-panel__list");
     const item = fixture.querySelector<HTMLElement>("[data-attention-kind]");
     const summary = fixture.querySelector<HTMLElement>(".sidebar-issues-panel__summary");
+    const track = group!.shadowRoot?.querySelector<HTMLElement>(".tabs");
 
     expect(group?.scrollWidth).toBe(group?.clientWidth);
     expect(getComputedStyle(group!).overflowX).toBe("hidden");
@@ -66,11 +66,16 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     expect(getComputedStyle(group!).backgroundColor).not.toBe(
       getComputedStyle(list!).backgroundColor,
     );
-    expect(getComputedStyle(group!).borderBottomWidth).toBe("1px");
-    expect(getComputedStyle(base!).padding).toBe("4px 8px");
-    expect(
-      count!.getBoundingClientRect().left - label!.getBoundingClientRect().right,
-    ).toBeGreaterThan(4);
+    // The track hairline is the header/list separator; it must span the panel.
+    expect(track).not.toBeNull();
+    expect(Number.parseFloat(getComputedStyle(track!).borderBottomWidth)).toBeGreaterThan(0);
+    expect(track!.getBoundingClientRect().width).toBeCloseTo(
+      group!.getBoundingClientRect().width,
+      1,
+    );
+    // Count badges render as pills separated from the tab label.
+    expect(badge).not.toBeNull();
+    expect(getComputedStyle(badge!).borderRadius).not.toBe("0px");
     expect(getComputedStyle(summary!).paddingBlock).toBe("8px");
     expect(item!.getBoundingClientRect().right).toBeCloseTo(list!.getBoundingClientRect().right, 1);
   });

--- a/ui/src/components/sidebar-attention-panel.runtime.ts
+++ b/ui/src/components/sidebar-attention-panel.runtime.ts
@@ -1,11 +1,11 @@
 import { html, nothing, type TemplateResult } from "lit";
-import { ref } from "lit/directives/ref.js";
 import type { NavigationRouteId } from "../app-navigation.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import type { ExecApprovalDecision, ExecApprovalRequest } from "../app/exec-approval.ts";
 import type { UpdateProgress } from "../app/update-confirmation.ts";
 import { t } from "../i18n/index.ts";
 import "../styles/sidebar-issues.css";
+import { renderHubTabs } from "./hub-tabs.ts";
 import { icons } from "./icons.ts";
 import type { SidebarAttentionItem } from "./sidebar-attention-items.ts";
 import {
@@ -15,7 +15,6 @@ import {
   renderSidebarUpdateSurface,
 } from "./sidebar-issue-item.ts";
 import { ISSUE_TABS, issueTabLabel, type IssueTab } from "./sidebar-issues-tabs.ts";
-import { syncTabGroupLabel } from "./web-awesome-tabs.ts";
 import "./menu-surface.ts";
 
 type SidebarAttentionPanelParams = {
@@ -38,28 +37,6 @@ type SidebarAttentionPanelParams = {
   updateSurface: boolean;
   watchUpdateProgress?: (listener: (progress: UpdateProgress) => void) => () => void;
 };
-
-function isIssueTab(value: string): value is IssueTab {
-  return ISSUE_TABS.some((tab) => tab === value);
-}
-
-function renderTab(tab: IssueTab, count: number, selected: boolean) {
-  const countLabel = t(count === 1 ? "attention.issueCount" : "attention.issueCountPlural", {
-    count: String(count),
-  });
-  return html`<wa-tab
-    slot="nav"
-    id=${`sidebar-issues-tab-${tab}`}
-    class="sidebar-issues-panel__tab"
-    panel=${tab}
-    aria-label=${`${issueTabLabel(tab)}, ${countLabel}`}
-    aria-controls="sidebar-issues-tabpanel"
-    ?active=${selected}
-  >
-    <span>${issueTabLabel(tab)}</span>
-    <span class="sidebar-issues-panel__tab-count" aria-hidden="true">${count}</span>
-  </wa-tab>`;
-}
 
 export function renderSidebarAttentionPanel(params: SidebarAttentionPanelParams): TemplateResult {
   const automationItems = params.items.filter(
@@ -154,21 +131,22 @@ export function renderSidebarAttentionPanel(params: SidebarAttentionPanelParams)
             ${icons.x}
           </button>
         </header>
-        <wa-tab-group
-          class="sidebar-issues-panel__tabs"
-          aria-label=${t("attention.tabs.label")}
-          .active=${params.selectedTab}
-          activation="auto"
-          without-scroll-controls
-          ${ref((element) => syncTabGroupLabel(element, t("attention.tabs.label")))}
-          @wa-tab-show=${(event: CustomEvent<{ name: string }>) => {
-            if (isIssueTab(event.detail.name)) {
-              params.onSelectTab(event.detail.name);
-            }
-          }}
-        >
-          ${ISSUE_TABS.map((tab) => renderTab(tab, tabCounts[tab], tab === params.selectedTab))}
-        </wa-tab-group>
+        ${renderHubTabs<IssueTab>({
+          id: "sidebar-issues",
+          active: params.selectedTab,
+          tabs: ISSUE_TABS.map((tab) => ({
+            value: tab,
+            label: issueTabLabel(tab),
+            // A zero count is the tab's resting state, not information — show
+            // the badge only when the tab actually holds items.
+            count: tabCounts[tab] > 0 ? tabCounts[tab] : null,
+          })),
+          ariaLabel: t("attention.tabs.label"),
+          panelId: "sidebar-issues-tabpanel",
+          className: "sidebar-issues-panel__tabs",
+          variant: "sub",
+          onSelect: params.onSelectTab,
+        })}
         <div class="sidebar-issues-panel__list-wrap">
           <div
             id="sidebar-issues-tabpanel"

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -466,7 +466,7 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
     }
   };
 
-  private selectTab(tab: IssueTab, focusTab = false) {
+  private selectTab(tab: IssueTab) {
     this.selectedTab = tab;
     void this.updateComplete.then(() => {
       if (!this.panelOpen || this.selectedTab !== tab) {
@@ -477,9 +477,6 @@ class SidebarAttention extends OpenClawLightDomContentsElement {
         list.scrollTop = 0;
       }
       this.syncOverflowCue();
-      if (focusTab) {
-        this.querySelector<HTMLElement>(`#sidebar-issues-tab-${tab}`)?.focus();
-      }
     });
   }
 

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -137,7 +137,7 @@ suite.define(() => {
     await inboxPanel.locator('[data-approval-id="approval-inline"]').waitFor();
     await inboxPanel.locator('[data-approval-id="approval-other"]').waitFor();
     await expect.poll(() => inboxPanel.locator("[data-approval-id]").count()).toBe(2);
-    await inboxPanel.getByRole("tab", { name: "Approvals, 2 inbox items" }).waitFor();
+    await inboxPanel.getByRole("tab", { name: "Approvals 2" }).waitFor();
     if (captureUiProof) {
       await currentPage.screenshot({ path: path.join(proofDir, "02-open-queue.png") });
     }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -89,6 +89,13 @@
   --inbox-attention-hover: color-mix(in srgb, var(--inbox-attention) 88%, black);
   --inbox-attention-foreground: #ffffff;
 
+  /* Lobster mascot icon (icons-tools.ts). Dark surfaces swallowed the shipped
+     #ff4d4d→#991b1b gradient, so dark mode lifts both stops; light mode
+     restores the original artwork below. */
+  --lobster-icon-body: #ff6d5a;
+  --lobster-icon-shade: #c2372b;
+  --lobster-icon-eye: #050810;
+
   /* Link text keeps the accent hue but cannot be --accent: chat paints user
      bubbles from that same token, so a link there fights its own background.
      Derived, not per-theme — --accent-hover is every palette's audited lifted
@@ -543,6 +550,11 @@
   --accent-glow: rgba(189, 69, 49, 0.12);
   --primary: #bd4531;
   --primary-foreground: #ffffff;
+
+  /* Original lobster artwork reads well on light surfaces. */
+  --lobster-icon-body: #ff4d4d;
+  --lobster-icon-shade: #991b1b;
+  --lobster-icon-eye: #050810;
 
   --secondary: #f4f1ec;
   --secondary-foreground: #403c35;

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -147,67 +147,26 @@
   scroll-padding-block-end: 58px;
 }
 
+/* Hub-tab strip (shared hub-tabs.css owns the tab look); this block only
+   places it in the popover: the track hairline doubles as the header/list
+   separator, so it must span the full panel width. */
 .sidebar-issues-panel__tabs {
   display: block;
   flex: none;
   overflow: hidden;
-  border-block-end: 1px solid var(--border);
   background: var(--secondary);
-  --indicator-color: transparent;
-  --track-color: transparent;
-  --track-width: 0;
 }
 
 .sidebar-issues-panel__tabs::part(tabs) {
   box-sizing: border-box;
   width: 100%;
-  gap: 2px;
-  padding: 0 6px 8px;
+  padding-inline: 8px;
 }
 
-.sidebar-issues-panel__tab {
-  display: block;
-  min-width: 0;
-  flex: 1 1 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: var(--muted);
-  cursor: var(--cursor-action);
-  font: inherit;
-  font-size: var(--control-ui-text-xs);
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.sidebar-issues-panel__tab::part(base) {
-  box-sizing: border-box;
-  width: 100%;
-  min-height: 32px;
-  justify-content: center;
-  gap: 5px;
-  padding: 4px 8px;
-  border-radius: var(--radius-md);
-}
-
-.sidebar-issues-panel__tab:hover::part(base) {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-.sidebar-issues-panel__tab:is([active], [aria-selected="true"])::part(base) {
-  background: color-mix(in srgb, var(--bg-hover) 92%, var(--text) 8%);
-  color: var(--text-strong);
-}
-
-.sidebar-issues-panel__tab:focus-visible::part(base) {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-.sidebar-issues-panel__tab-count {
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
+.sidebar-issues-panel__tabs wa-tab.hub-tab::part(base) {
+  /* Popover tabs are tap targets (mobile sheet); keep a taller hit area than
+     the page-hub sub tabs. */
+  padding-block: 6px 9px;
 }
 
 .sidebar-issues-panel__list-wrap {


### PR DESCRIPTION
## What Problem This Solves

The sidebar Inbox popover's tab strip didn't fit the rest of the Control UI:

- The active-tab pill highlight floated above an unrelated full-width hairline, so the "indicator" and the line never related to each other.
- Counts were rendered as bare text glued next to the label (`Approvals0`).
- Zero counts were always shown, adding noise for empty tabs.
- Keyboard focus drew two rings at once: Web Awesome's stock host outline plus the panel's own `::part(base)` ring.
- The Ask OpenClaw lobster icon hardcoded a light-surface red gradient (`#ff4d4d → #991b1b`) that sank into dark backgrounds.

## Why This Change Was Made

The system already has a canonical tab design — `renderHubTabs` (`ui/src/components/hub-tabs.ts` + `ui/src/styles/hub-tabs.css`): quiet text tabs, hairline track, accent underline indicator, pill count badges that tint when active, and correct single-focus-ring handling. The popover's hand-rolled strip predated it. This PR deletes the bespoke tab implementation and reuses the shared one, scoped so the track hairline doubles as the header/list separator (the "line" now is the indicator's track, not a stray border).

- Zero counts hide their badge (`count: n > 0 ? n : null`).
- The lobster icon's colors now flow through `--lobster-icon-*` tokens: brighter stops on dark (`:root` default), original artwork restored under `[data-theme-mode="light"]`. SVG presentation attributes can't carry `var()`, so the stops use inline `style`.
- Dead `focusTab` branch removed from `selectTab`.

Production LOC delta: ≈ −40 (panel runtime −22, sidebar-issues.css −41, attention −3, vs. +12 token block and +14 SVG style verbosity).

## User Impact

The Inbox popover reads like the rest of the app: underline-indicator tabs with pill badges, no zero-count noise, one focus ring, and a mascot icon that stays legible in dark mode. No behavior change to tab filtering, approvals, or dismissal flows; tab ids (`sidebar-issues-tab-*`) and the tabpanel wiring are unchanged.

## Evidence

Before / after (dark, `--fixture approval` mocked dev server):

| Before | After |
| --- | --- |
| ![before dark](https://github.com/user-attachments/assets/2090a268-351a-45f5-aa7e-2700117230a0) | ![after dark](https://github.com/user-attachments/assets/d0dca004-9140-400e-abbb-32e2f1e929fd) |

Focus state — doubled ring before, single soft accent ring after:

| Before | After |
| --- | --- |
| ![before focus](https://github.com/user-attachments/assets/3e68bce5-c539-4e52-9cbd-686b898ee15b) | ![after focus](https://github.com/user-attachments/assets/7d07aef7-65c2-4fe0-9beb-3f29196ed569) |

After, light theme: ![after light](https://github.com/user-attachments/assets/a9c34cdb-cc65-4a4b-8e7f-81511723a2ea)

Tab strip close-up (3x) — underline indicator + badges: ![tabs zoom](https://github.com/user-attachments/assets/d4f6f245-38e1-4eb0-b747-b88e5ef2282e)

Zero counts hidden (default fixture, Approvals has 0): ![tabs zero](https://github.com/user-attachments/assets/277debc9-8b38-4852-bc20-721d05a57874)

Brightened dark-mode lobster: ![header dark](https://github.com/user-attachments/assets/7b697df4-ea02-4a38-a009-e5fc0d55dc3e)

Validation:

- `node scripts/check-changed.mjs` green (format, oxlint, stylelint, tsgo core+UI, i18n verify, dead-export scan).
- `node scripts/run-vitest.mjs ui/src/components/sidebar-attention` — 14 passed.
- `vitest run --config ui/vitest.config.ts src/components/sidebar-attention-layout.browser.test.ts` (real Chromium) — updated to assert the hub-tab structure: full-width track hairline, pill badge geometry, no horizontal scroll, rails flush.
- Codex autoreview (`--mode uncommitted`): clean, no findings.
