### PR TITLE
fix(codex): prevent steered answers from disappearing or crossing threads

### DIFF
--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -411,6 +411,7 @@ export class CodexAssistantProjection {
       !completedItemIds.has(itemId) ||
       itemIndex < this.persistableAssistantBarrier ||
       !text ||
+      isSilentReplyPayloadText(text) ||
       this.isToolProgressEchoText(itemId, text)
     ) {
       return undefined;

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -47,6 +47,9 @@ export class CodexAssistantProjection {
   // invalidation has to be recorded from the first item notification for each
   // native or dynamic handoff, or a later coda would revive every pre-tool final.
   private persistableAssistantBarrier = 0;
+  // A completed answer mirrored before a steer is already durable. Do not
+  // replay it as the enclosing turn's terminal answer if Codex emits no coda.
+  private persistedAssistantBoundary = false;
   private readonly persistableAssistantBarrierItemIds = new Set<string>();
 
   constructor(
@@ -345,6 +348,9 @@ export class CodexAssistantProjection {
     if (afterHandoff.length > 0) {
       return afterHandoff.slice(-1);
     }
+    if (this.persistedAssistantBoundary) {
+      return [];
+    }
     const recoveredAudible = this.collectPersistableAssistantTexts(0).filter(
       (text) => !isSilentReplyPayloadText(text),
     );
@@ -391,6 +397,40 @@ export class CodexAssistantProjection {
         },
       ];
     });
+  }
+
+  createCompletedAssistantBoundaryMessage(
+    completedItemIds: ReadonlySet<string>,
+    options: AssistantMessageOptions,
+  ): { itemId: string; message: AssistantMessage } | undefined {
+    const itemId = this.latestCompletedTerminalAssistantItemId;
+    const text = itemId ? this.assistantTextByItem.get(itemId)?.trim() : undefined;
+    const itemIndex = itemId ? this.assistantItemOrder.indexOf(itemId) : -1;
+    if (
+      !itemId ||
+      !completedItemIds.has(itemId) ||
+      itemIndex < this.persistableAssistantBarrier ||
+      !text ||
+      this.isToolProgressEchoText(itemId, text)
+    ) {
+      return undefined;
+    }
+    const message = this.createAssistantMessage(text, options);
+    return {
+      itemId,
+      message: {
+        ...message,
+        timestamp: this.assistantTimestampByItem.get(itemId) ?? message.timestamp,
+      },
+    };
+  }
+
+  markAssistantBoundaryPersisted(itemId: string): void {
+    const index = this.assistantItemOrder.indexOf(itemId);
+    if (index >= 0) {
+      this.persistableAssistantBarrier = Math.max(this.persistableAssistantBarrier, index + 1);
+      this.persistedAssistantBoundary = true;
+    }
   }
 
   finalizeAnswerCandidate(turn: { status?: string; items?: CodexThreadItem[] }): void {

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -42,6 +42,7 @@ export function buildCodexMessagesSnapshot(params: {
   commentaryMessages: ReadonlyArray<{ itemId: string; message: AssistantMessage }>;
   toolMessages: readonly AgentMessage[];
   lastAssistant: AssistantMessage | undefined;
+  lastAssistantIdentity?: string;
   createAssistantMirrorMessage: (title: string, text: string) => AssistantMessage;
 }): AgentMessage[] {
   const messages = promptSnapshot(params.runParams, params.turnId, params.upstreamUserText);
@@ -80,7 +81,12 @@ export function buildCodexMessagesSnapshot(params: {
   );
   messages.push(...visibleWorkMessages);
   if (params.lastAssistant) {
-    messages.push(attachCodexMirrorIdentity(params.lastAssistant, `${params.turnId}:assistant`));
+    messages.push(
+      attachCodexMirrorIdentity(
+        params.lastAssistant,
+        params.lastAssistantIdentity ?? `${params.turnId}:assistant`,
+      ),
+    );
   }
   return applyStickyTurnTaint(messages).map((message) =>
     projectAgentHarnessTranscriptMessageForDisplay({

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -6,6 +6,7 @@ import { projectAgentHarnessTranscriptMessageForDisplay } from "openclaw/plugin-
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CodexAssistantProjection } from "./event-projector-assistant.js";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
 import { promptSnapshot } from "./user-prompt-message.js";
 
@@ -94,4 +95,44 @@ export function buildCodexMessagesSnapshot(params: {
       message,
     }),
   );
+}
+
+export function buildCodexSteeringMessagesSnapshot(params: {
+  runParams: EmbeddedRunAttemptParams;
+  turnId: string;
+  upstreamUserText: string | undefined;
+  completedItemIds: ReadonlySet<string>;
+  assistantProjection: CodexAssistantProjection;
+  toolMessages: readonly AgentMessage[];
+}): { messages: AgentMessage[]; assistantBoundaryItemId?: string } {
+  const asyncMessages = params.assistantProjection
+    .collectAsyncMessages()
+    .filter(({ itemId }) => params.completedItemIds.has(itemId));
+  const commentaryMessages = params.assistantProjection
+    .collectCommentaryMessages()
+    .filter(({ itemId }) => params.completedItemIds.has(itemId));
+  const assistantBoundary = params.assistantProjection.createCompletedAssistantBoundaryMessage(
+    params.completedItemIds,
+    { tokenUsage: undefined, aborted: false, promptError: undefined },
+  );
+  const messages = buildCodexMessagesSnapshot({
+    runParams: params.runParams,
+    turnId: params.turnId,
+    upstreamUserText: params.upstreamUserText,
+    reasoningText: undefined,
+    planText: undefined,
+    asyncMessages,
+    commentaryMessages,
+    toolMessages: params.toolMessages,
+    lastAssistant: assistantBoundary?.message,
+    ...(assistantBoundary
+      ? { lastAssistantIdentity: `${params.turnId}:assistant:${assistantBoundary.itemId}` }
+      : {}),
+    createAssistantMirrorMessage: (title, text) =>
+      params.assistantProjection.createAssistantMirrorMessage(title, text),
+  }).filter((message) => message.role !== "user");
+  return {
+    messages,
+    ...(assistantBoundary ? { assistantBoundaryItemId: assistantBoundary.itemId } : {}),
+  };
 }

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -384,6 +384,23 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("NO_REPLY");
   });
 
+  it("omits a silent completed answer from the steering transcript boundary", async () => {
+    const projector = await createProjector(await createParams());
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "silent-before-steer",
+          phase: "final_answer",
+          text: "NO_REPLY",
+        },
+      }),
+    );
+
+    expect(projector.buildSteeringTranscriptPrefix()).toEqual([]);
+  });
+
   it("drops a pre-sleep final after a later sleep handoff", async () => {
     const projector = await createProjector(await createParams());
     const sleepItem = { type: "sleep", id: "sleep-1", durationMs: 250 };

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -27,7 +27,7 @@ import {
   buildCodexAttemptResult,
   type CodexAppServerToolTelemetry,
 } from "./event-projector-result.js";
-import { buildCodexMessagesSnapshot } from "./event-projector-snapshot.js";
+import { buildCodexSteeringMessagesSnapshot } from "./event-projector-snapshot.js";
 import { CodexToolProgressProjection } from "./event-projector-tool-progress.js";
 import { CodexToolTranscriptProjection } from "./event-projector-tool-transcript.js";
 import {
@@ -168,38 +168,16 @@ export class CodexAppServerEventProjector {
   }
 
   buildSteeringTranscriptPrefix(): AgentMessage[] {
-    const asyncMessages = this.assistantProjection
-      .collectAsyncMessages()
-      .filter(({ itemId }) => this.completedItemIds.has(itemId));
-    const assistantMessageOptions = {
-      tokenUsage: undefined,
-      aborted: false,
-      promptError: undefined,
-    };
-    const commentaryMessages = this.assistantProjection
-      .collectCommentaryMessages()
-      .filter(({ itemId }) => this.completedItemIds.has(itemId));
-    const assistantBoundary = this.assistantProjection.createCompletedAssistantBoundaryMessage(
-      this.completedItemIds,
-      assistantMessageOptions,
-    );
-    this.pendingSteeringAssistantBoundaryItemId = assistantBoundary?.itemId;
-    return buildCodexMessagesSnapshot({
+    const snapshot = buildCodexSteeringMessagesSnapshot({
       runParams: this.params,
       turnId: this.turnId,
       upstreamUserText: this.options.upstreamUserText,
-      reasoningText: undefined,
-      planText: undefined,
-      asyncMessages,
-      commentaryMessages,
+      completedItemIds: this.completedItemIds,
+      assistantProjection: this.assistantProjection,
       toolMessages: this.toolTranscriptProjection.transcriptMessages,
-      lastAssistant: assistantBoundary?.message,
-      ...(assistantBoundary
-        ? { lastAssistantIdentity: `${this.turnId}:assistant:${assistantBoundary.itemId}` }
-        : {}),
-      createAssistantMirrorMessage: (title, text) =>
-        this.assistantProjection.createAssistantMirrorMessage(title, text),
-    }).filter((message) => message.role !== "user");
+    });
+    this.pendingSteeringAssistantBoundaryItemId = snapshot.assistantBoundaryItemId;
+    return snapshot.messages;
   }
 
   markSteeringTranscriptPersisted(): void {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -91,6 +91,7 @@ export class CodexAppServerEventProjector {
   private readonly responseCompletions = new CodexResponseCompletionProjection();
   private completedCompactionCount = 0;
   private lastTranscriptTimestamp = 0;
+  private pendingSteeringAssistantBoundaryItemId: string | undefined;
 
   constructor(
     private readonly params: EmbeddedRunAttemptParams,
@@ -170,9 +171,19 @@ export class CodexAppServerEventProjector {
     const asyncMessages = this.assistantProjection
       .collectAsyncMessages()
       .filter(({ itemId }) => this.completedItemIds.has(itemId));
+    const assistantMessageOptions = {
+      tokenUsage: undefined,
+      aborted: false,
+      promptError: undefined,
+    };
     const commentaryMessages = this.assistantProjection
       .collectCommentaryMessages()
       .filter(({ itemId }) => this.completedItemIds.has(itemId));
+    const assistantBoundary = this.assistantProjection.createCompletedAssistantBoundaryMessage(
+      this.completedItemIds,
+      assistantMessageOptions,
+    );
+    this.pendingSteeringAssistantBoundaryItemId = assistantBoundary?.itemId;
     return buildCodexMessagesSnapshot({
       runParams: this.params,
       turnId: this.turnId,
@@ -182,10 +193,21 @@ export class CodexAppServerEventProjector {
       asyncMessages,
       commentaryMessages,
       toolMessages: this.toolTranscriptProjection.transcriptMessages,
-      lastAssistant: undefined,
+      lastAssistant: assistantBoundary?.message,
+      ...(assistantBoundary
+        ? { lastAssistantIdentity: `${this.turnId}:assistant:${assistantBoundary.itemId}` }
+        : {}),
       createAssistantMirrorMessage: (title, text) =>
         this.assistantProjection.createAssistantMirrorMessage(title, text),
     }).filter((message) => message.role !== "user");
+  }
+
+  markSteeringTranscriptPersisted(): void {
+    const itemId = this.pendingSteeringAssistantBoundaryItemId;
+    if (itemId) {
+      this.assistantProjection.markAssistantBoundaryPersisted(itemId);
+      this.pendingSteeringAssistantBoundaryItemId = undefined;
+    }
   }
 
   hasCompletedTerminalAssistantText(): boolean {

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -265,6 +265,7 @@ export async function activateCodexAttemptTurn(
           runMirrorIdentityPrefix: `${activeTurnId}:`,
           config: params.config,
         });
+        activeProjector.markSteeringTranscriptPersisted();
       }
       for (const item of inboundItems) {
         const recorder = item.userTurnTranscriptRecorder;

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -236,6 +236,19 @@ describe("runCodexAppServerAttempt steering", () => {
         },
       },
     });
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "agentMessage",
+          id: "pre-steer-answer",
+          phase: "final_answer",
+          text: "PRE-STEER-ANSWER",
+        },
+      },
+    });
 
     await vi.waitFor(() => {
       expect(
@@ -302,7 +315,7 @@ describe("runCodexAppServerAttempt steering", () => {
       const message = (event as { message?: { role?: string } }).message;
       return message?.role ? [message.role] : [];
     });
-    expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
+    expect(roles).toEqual(["user", "assistant", "assistant", "user", "assistant"]);
   });
 
   it("forwards queued text and images to the active app-server turn", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -11,7 +11,10 @@ import { writePackageDistInventory } from "../../scripts/lib/package-dist-invent
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
+import {
+  GATEWAY_SERVICE_RUNTIME_PID_ENV,
+  GATEWAY_SERVICE_SELECTOR_ENV_KEYS,
+} from "../daemon/constants.js";
 import type { ClawHubRiskAcknowledgementRequest } from "../infra/clawhub-install-trust.js";
 import { isBetaTag } from "../infra/update-channels.js";
 import { applyDevUpdateTargetEnv } from "../infra/update-dev-target.js";
@@ -109,6 +112,7 @@ const serviceEnvSnapshot = captureEnv([
   "OPENCLAW_SERVICE_MARKER",
   "OPENCLAW_SERVICE_KIND",
   GATEWAY_SERVICE_RUNTIME_PID_ENV,
+  ...GATEWAY_SERVICE_SELECTOR_ENV_KEYS,
 ]);
 
 vi.mock("@clack/prompts", () => ({
@@ -644,9 +648,13 @@ describe("update-cli", () => {
     programArguments: Array<string | undefined>,
     environment?: NodeJS.ProcessEnv,
   ): void => {
-    serviceReadCommand.mockResolvedValue({
+    const managedDefinition = {
       programArguments,
       ...(environment === undefined ? {} : { environment }),
+    };
+    serviceReadCommand.mockResolvedValue({
+      ...managedDefinition,
+      managedDefinition,
     });
   };
 
@@ -1505,6 +1513,9 @@ describe("update-cli", () => {
     delete process.env.OPENCLAW_SERVICE_MARKER;
     delete process.env.OPENCLAW_SERVICE_KIND;
     delete process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV];
+    for (const key of GATEWAY_SERVICE_SELECTOR_ENV_KEYS) {
+      delete process.env[key];
+    }
     restartHealthTestControl.snapshot = undefined;
     vi.clearAllMocks();
     serviceEnabled.mockResolvedValue(true);
@@ -1847,17 +1858,14 @@ describe("update-cli", () => {
     const managedRecords = {
       telegram: { source: "npm", spec: "@openclaw/telegram@beta" },
     } satisfies Record<string, PluginInstallRecord>;
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
-      environment: {
-        OPENCLAW_PROFILE: "work",
-        OPENCLAW_STATE_DIR: managedState,
-        OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
-        OPENCLAW_GATEWAY_PORT: "19222",
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        OPENCLAW_SERVICE_KIND: "gateway",
-        [GATEWAY_SERVICE_RUNTIME_PID_ENV]: "7777",
-      },
+    primeServiceCommand(["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"], {
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: managedState,
+      OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
+      OPENCLAW_GATEWAY_PORT: "19222",
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
+      [GATEWAY_SERVICE_RUNTIME_PID_ENV]: "7777",
     });
     serviceLoaded.mockResolvedValue(true);
     serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
@@ -1969,14 +1977,11 @@ describe("update-cli", () => {
       }),
     );
     const managedState = path.join(fixtureRoot, "fallback-managed");
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
-      environment: {
-        OPENCLAW_PROFILE: "work",
-        OPENCLAW_STATE_DIR: managedState,
-        OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
-        OPENCLAW_GATEWAY_PORT: "19222",
-      },
+    primeServiceCommand(["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"], {
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: managedState,
+      OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
+      OPENCLAW_GATEWAY_PORT: "19222",
     });
     serviceLoaded.mockResolvedValue(true);
     serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });
@@ -2027,14 +2032,11 @@ describe("update-cli", () => {
         candidate === path.join(process.cwd(), "openclaw.mjs"),
     );
     const managedState = path.join(fixtureRoot, "restart-doctor-managed");
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"],
-      environment: {
-        OPENCLAW_PROFILE: "work",
-        OPENCLAW_STATE_DIR: managedState,
-        OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
-        OPENCLAW_GATEWAY_PORT: "19222",
-      },
+    primeServiceCommand(["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"], {
+      OPENCLAW_PROFILE: "work",
+      OPENCLAW_STATE_DIR: managedState,
+      OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
+      OPENCLAW_GATEWAY_PORT: "19222",
     });
     serviceLoaded.mockResolvedValue(true);
     serviceReadRuntime.mockResolvedValue({ status: "running", pid: 4242, state: "running" });

--- a/ui/src/e2e/chat-agent-run-transcript.e2e.test.ts
+++ b/ui/src/e2e/chat-agent-run-transcript.e2e.test.ts
@@ -355,4 +355,75 @@ suite.define(() => {
 
     await context.close();
   });
+
+  it("keeps same-run events from another session out of the selected transcript", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1200 } });
+    const page = await context.newPage();
+    const runId = "run-shared-across-session-events";
+    const selectedText = "Selected session stream stays in its own row.";
+    const wrongSessionText = "Wrong session content must never enter this transcript. ".repeat(12);
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        transcriptMessage("user", "Earlier prompt", "run-earlier:user", "user-earlier", 1),
+        transcriptMessage("assistant", "Earlier answer", "run-earlier", "assistant-earlier", 2),
+      ],
+      inFlightRun: { runId, text: selectedText },
+      sessionInfo: {
+        activeRunIds: [runId],
+        hasActiveRun: true,
+        key: "main",
+      },
+    });
+
+    await page.goto(`${suite.server.baseUrl}chat`);
+    await page.getByText(selectedText, { exact: true }).waitFor();
+    const inactiveSessionKey = "agent:main:inactive-session";
+    await gateway.emitGatewayEvent("chat", {
+      deltaText: wrongSessionText,
+      message: { role: "assistant", content: [{ type: "text", text: wrongSessionText }] },
+      runId,
+      sessionKey: inactiveSessionKey,
+      state: "delta",
+    });
+    await gateway.emitGatewayEvent("chat", {
+      message: { role: "assistant", content: [{ type: "text", text: wrongSessionText }] },
+      runId,
+      sessionKey: inactiveSessionKey,
+      state: "final",
+    });
+
+    await expect.poll(() => page.getByText(wrongSessionText, { exact: true }).count()).toBe(0);
+    await expect.poll(() => page.getByText(selectedText, { exact: true }).count()).toBe(1);
+    const overlappingRows = await page.locator(".chat-virtual-row").evaluateAll((rows) => {
+      const bounds = rows
+        .map((row) => {
+          const rect = row.getBoundingClientRect();
+          return {
+            bottom: rect.bottom,
+            key: row.getAttribute("data-virtual-row-key"),
+            top: rect.top,
+          };
+        })
+        .filter((rect) => rect.bottom > rect.top)
+        .toSorted((left, right) => left.top - right.top);
+      return bounds.slice(1).flatMap((current, index) => {
+        const previous = bounds[index];
+        return previous && current.top < previous.bottom - 0.5
+          ? [{ current: current.key, previous: previous.key }]
+          : [];
+      });
+    });
+    expect(overlappingRows).toEqual([]);
+
+    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    if (artifactDir) {
+      await fs.mkdir(artifactDir, { recursive: true });
+      await page.screenshot({
+        path: path.join(artifactDir, "cross-session-run-isolation.png"),
+        fullPage: true,
+      });
+    }
+
+    await context.close();
+  });
 });

--- a/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
@@ -216,7 +216,7 @@ suite.define(() => {
       const inlineEditor = page.locator(".chat-queue__edit-input");
       await inlineEditor.waitFor({ timeout: 10_000 });
       await inlineEditor.fill("edited before send");
-      await page.locator(".chat-queue__edit-submit").click();
+      await inlineEditor.press("Control+Enter");
       await page.locator(".chat-queue__item", { hasText: "edited before send" }).waitFor();
 
       const lastGrip = page

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -513,6 +513,46 @@ describe("handleChatGatewayEvent", () => {
     expect(state.lastLocalTerminalReconcile).toBeUndefined();
   });
 
+  it("does not let a stale run id override session ownership", () => {
+    const visibleMessage = createTextChatMessage("assistant", "selected session stays visible");
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "shared-run-id",
+      chatMessages: [visibleMessage],
+      chatMessagesBySession: new Map(),
+      chatStream: "selected session stream",
+    });
+    const inactiveSessionKey = "agent:main:inactive-session";
+    seedChatSnapshot(state, { sessionKey: inactiveSessionKey });
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "shared-run-id",
+        sessionKey: inactiveSessionKey,
+        state: "delta",
+        deltaText: "wrong-session stream",
+      }),
+    ).toBe(null);
+    const inactiveFinal = createTextChatMessage("assistant", "wrong-session final");
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "shared-run-id",
+        sessionKey: inactiveSessionKey,
+        state: "final",
+        message: inactiveFinal,
+      }),
+    ).toBe(null);
+
+    expect(state.chatMessages).toEqual([visibleMessage]);
+    expect(state.chatStream).toBe("selected session stream");
+    expect(state.chatRunId).toBe("shared-run-id");
+    expect(
+      readChatMessagesFromCache(state.chatMessagesBySession ?? new Map(), state, {
+        sessionKey: inactiveSessionKey,
+      }),
+    ).toEqual([inactiveFinal]);
+  });
+
   it("ignores selected-agent global events for another agent", () => {
     const state = createState({
       sessionKey: "global",

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -215,9 +215,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     typeof payload.runId === "string" &&
     payload.runId === state.chatRunId;
   const authoritativeTerminalMatches = Boolean(
-    payload.runId &&
-    authoritativeHistoryAppliedForRun(state, payload.runId) &&
-    chatEventSessionMatches(state, payload),
+    payload.runId && authoritativeHistoryAppliedForRun(state, payload.runId) && sessionMatches,
   );
   if (!sessionMatches) {
     if (payload.state === "final") {

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -219,7 +219,7 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     authoritativeHistoryAppliedForRun(state, payload.runId) &&
     chatEventSessionMatches(state, payload),
   );
-  if (!sessionMatches && !activeRunMatches) {
+  if (!sessionMatches) {
     if (payload.state === "final") {
       const finalMessage = normalizedFinalMessage;
       if (finalMessage && !shouldHideAssistantChatMessage(finalMessage)) {

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -396,8 +396,9 @@ export function removeQueuedMessage(host: ChatQueueScopedSessionHost, id: string
 export function removeDeliveredQueuedChatSendForRun(
   host: ChatQueueScopedSessionHost,
   runId: string | undefined,
+  scope: StoredChatOutboxScope,
 ): ChatQueueItem | null {
-  const match = readDeliveredQueuedChatSendForRun(host, runId);
+  const match = readDeliveredQueuedChatSendForRun(host, runId, scope);
   if (!match) {
     return null;
   }
@@ -417,11 +418,13 @@ export function removeDeliveredQueuedChatSendForRun(
 export function readDeliveredQueuedChatSendForRun(
   host: ChatQueueScopedSessionHost,
   runId: string | undefined,
+  scope: StoredChatOutboxScope,
 ): { item: ChatQueueItem; outbox: StoredChatOutbox } | null {
   if (!runId) {
     return null;
   }
   const match = listStoredChatOutboxes(host)
+    .filter((outbox) => outbox.sessionKey === scope.sessionKey && outbox.agentId === scope.agentId)
     .flatMap((outbox) => outbox.queue.map((item) => ({ item, outbox })))
     .find(({ item }) => item.sendRunId === runId);
   return match ?? null;

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -14,6 +14,7 @@ import {
   listStoredChatOutboxes,
   removeStoredChatComposerQueueItem,
   resolveStoredChatOutboxScope,
+  storedChatOutboxScopeKey,
   updateStoredChatComposerQueueItem,
   updateStoredChatComposerQueueItems,
   type StoredChatQueueReplacement,
@@ -423,11 +424,12 @@ export function readDeliveredQueuedChatSendForRun(
   if (!runId) {
     return null;
   }
-  const match = listStoredChatOutboxes(host)
-    .filter((outbox) => outbox.sessionKey === scope.sessionKey && outbox.agentId === scope.agentId)
-    .flatMap((outbox) => outbox.queue.map((item) => ({ item, outbox })))
-    .find(({ item }) => item.sendRunId === runId);
-  return match ?? null;
+  const scopeKey = storedChatOutboxScopeKey(scope);
+  const outbox = listStoredChatOutboxes(host).find(
+    (candidate) => storedChatOutboxScopeKey(candidate) === scopeKey,
+  );
+  const item = outbox?.queue.find((candidate) => candidate.sendRunId === runId);
+  return item && outbox ? { item, outbox } : null;
 }
 
 export function clearPendingQueueItemsForRun(

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -5187,9 +5187,13 @@ describe("handleSendChat", () => {
     const host = makeChatHost({ chatQueue: [item] });
     expect(admitQueuedMessageForSession(host, host.sessionKey, item)).toBe(true);
 
-    expect(removeDeliveredQueuedChatSendForRun(host, item.sendRunId)).toMatchObject({
-      id: item.id,
-    });
+    expect(
+      removeDeliveredQueuedChatSendForRun(
+        host,
+        item.sendRunId,
+        resolveStoredChatOutboxScope(host, item.sessionKey),
+      ),
+    ).toMatchObject({ id: item.id });
 
     expect(host.chatQueue).toStrictEqual([]);
     expect(listStoredChatOutboxes(host)).toStrictEqual([]);
@@ -5209,12 +5213,126 @@ describe("handleSendChat", () => {
     const replacement = makeChatHost({ chatQueue: [], sessionKey: "agent:main:replacement" });
     expect(admitQueuedMessageForSession(sender, item.sessionKey, item)).toBe(true);
 
-    expect(removeDeliveredQueuedChatSendForRun(replacement, item.sendRunId)).toMatchObject({
-      id: item.id,
-    });
+    expect(
+      removeDeliveredQueuedChatSendForRun(
+        replacement,
+        item.sendRunId,
+        resolveStoredChatOutboxScope(replacement, item.sessionKey),
+      ),
+    ).toMatchObject({ id: item.id });
 
     expect(replacement.chatQueue).toStrictEqual([]);
     expect(listStoredChatOutboxes(replacement)).toStrictEqual([]);
+  });
+
+  it("keeps a selected queued send when a foreign terminal reuses its run id", () => {
+    const selected = {
+      id: "selected-terminal-collision",
+      text: "keep this selected-session prompt",
+      createdAt: 1,
+      sendAttempts: 1,
+      sendRunId: "shared-terminal-run",
+      sendState: "sending" as const,
+      sessionKey: "agent:main:selected",
+    };
+    const foreign = {
+      ...selected,
+      id: "foreign-terminal-collision",
+      text: "retire this foreign-session prompt",
+      sessionKey: "agent:main:foreign",
+    };
+    const host = makeChatHost({
+      chatQueue: [selected],
+      chatRunId: selected.sendRunId,
+      sessionKey: selected.sessionKey,
+    });
+    Object.assign(host, {
+      chatMessagesBySession: new Map(),
+      connectionEpoch: 1,
+      pendingSessionMessageReloadSessionKey: null,
+      requestUpdate: vi.fn(),
+    });
+    expect(admitQueuedMessageForSession(host, selected.sessionKey, selected)).toBe(true);
+    expect(admitQueuedMessageForSession(host, foreign.sessionKey, foreign)).toBe(true);
+
+    handlePageGatewayEvent(asChatPageHost(host), {
+      event: "chat",
+      payload: {
+        state: "final",
+        runId: foreign.sendRunId,
+        sessionKey: foreign.sessionKey,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "foreign reply" }],
+        },
+      },
+    } as Parameters<typeof handlePageGatewayEvent>[1]);
+
+    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatQueue).toEqual([expect.objectContaining({ id: selected.id })]);
+    expect(listStoredChatOutboxes(host)).toEqual([
+      expect.objectContaining({
+        sessionKey: selected.sessionKey,
+        queue: [expect.objectContaining({ id: selected.id })],
+      }),
+    ]);
+  });
+
+  it("routes an unscoped global terminal to the default agent outbox", () => {
+    const runId = "shared-global-terminal-run";
+    const selected = {
+      id: "selected-global-terminal",
+      text: "keep the selected agent prompt",
+      createdAt: 1,
+      sendAttempts: 1,
+      sendRunId: runId,
+      sendState: "sending" as const,
+      sessionKey: "global",
+      agentId: "work",
+    };
+    const defaultAgent = {
+      ...selected,
+      id: "default-global-terminal",
+      text: "retire the default agent prompt",
+      agentId: "main",
+    };
+    const host = makeChatHost({
+      assistantAgentId: selected.agentId,
+      chatMessagesBySession: new Map(),
+      chatQueue: [selected],
+      chatRunId: runId,
+      sessionKey: "global",
+    });
+    Object.assign(host, {
+      connectionEpoch: 1,
+      pendingSessionMessageReloadSessionKey: null,
+      requestUpdate: vi.fn(),
+    });
+    expect(admitQueuedMessageForSession(host, selected.sessionKey, selected)).toBe(true);
+    expect(admitQueuedMessageForSession(host, defaultAgent.sessionKey, defaultAgent)).toBe(true);
+
+    handlePageGatewayEvent(asChatPageHost(host), {
+      event: "chat",
+      payload: {
+        state: "final",
+        runId,
+        sessionKey: "global",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "default agent reply" }],
+        },
+      },
+    } as Parameters<typeof handlePageGatewayEvent>[1]);
+
+    expect(host.chatMessages).toStrictEqual([]);
+    expect(host.chatQueue).toEqual([expect.objectContaining({ id: selected.id })]);
+    expect(listStoredChatOutboxes(host)).toEqual([
+      expect.objectContaining({
+        agentId: selected.agentId,
+        queue: [expect.objectContaining({ id: selected.id })],
+        sessionKey: selected.sessionKey,
+      }),
+    ]);
   });
 
   it("preserves terminal user-turn ordering when an inactive split pane handles the event first", () => {
@@ -6117,7 +6235,13 @@ describe("handleSendChat", () => {
       await send;
       expect(latePeer.chatQueue[0]?.sendState).toBe("sending");
 
-      expect(removeDeliveredQueuedChatSendForRun(host, runId)).toMatchObject({ id: item.id });
+      expect(
+        removeDeliveredQueuedChatSendForRun(
+          host,
+          runId,
+          resolveStoredChatOutboxScope(host, item.sessionKey),
+        ),
+      ).toMatchObject({ id: item.id });
       expect(latePeer.chatQueue).toStrictEqual([]);
     } finally {
       stopLatePeer();

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -44,6 +44,11 @@ import {
   refreshSessionWorkspace,
   retireSessionWorkspaceCheckout,
 } from "./components/chat-session-workspace.ts";
+import {
+  resolveStoredChatOutboxScope,
+  storedChatOutboxScopeKey,
+  type StoredChatOutboxScope,
+} from "./composer-persistence.ts";
 import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
 import {
   reconcileChatRunFromCurrentSessionRow,
@@ -66,6 +71,19 @@ function sessionMessageMatchesChat(
 
 function selectedGlobalEventAgentId(state: ChatPageHost, agentId: string | null): string {
   return agentId ? normalizeAgentId(agentId) : resolveUiDefaultAgentId(state);
+}
+
+function chatEventOutboxScope(
+  state: ChatPageHost,
+  payload: ChatEventPayload | undefined,
+): StoredChatOutboxScope | undefined {
+  if (!payload?.sessionKey) {
+    return undefined;
+  }
+  const agentId = isUiGlobalSessionKey(payload.sessionKey)
+    ? selectedGlobalEventAgentId(state, payload.agentId ?? null)
+    : payload.agentId;
+  return resolveStoredChatOutboxScope(state, payload.sessionKey, agentId);
 }
 
 function globalSessionEventMatchesChat(
@@ -425,10 +443,13 @@ export function handlePageGatewayEvent(
 ) {
   if (event.event === "chat") {
     const payload = event.payload as ChatEventPayload | undefined;
+    const sessionMatches = Boolean(
+      payload && chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId),
+    );
     if (
       payload?.state === "delta" &&
       typeof payload.runId === "string" &&
-      chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId) &&
+      sessionMatches &&
       // Same-session background streams cannot clear the foreground run's status.
       (!state.chatRunId || state.chatRunId === payload.runId) &&
       state.observerDigest &&
@@ -436,26 +457,26 @@ export function handlePageGatewayEvent(
     ) {
       state.observerDigest = null;
     }
-    if (
-      payload?.state === "delta" &&
-      typeof payload.deltaText === "string" &&
-      chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId)
-    ) {
+    if (payload?.state === "delta" && typeof payload.deltaText === "string" && sessionMatches) {
       refreshPullRequestsForStreamedLinks(state, payload, payload.deltaText);
     }
-    const shouldCelebrateFirstReply = hasVisibleFinalAssistantReply(state, payload);
+    const shouldCelebrateFirstReply =
+      sessionMatches && hasVisibleFinalAssistantReply(state, payload);
     const shouldRefreshPullRequests =
       shouldCelebrateFirstReply && finalAssistantReplyHasPullRequestLink(state, payload);
     const terminal =
       payload?.state === "final" || payload?.state === "aborted" || payload?.state === "error";
-    const delivered = terminal ? rememberDeliveredQueuedUserTurn(state, payload?.runId) : null;
+    const outboxScope = terminal ? chatEventOutboxScope(state, payload) : undefined;
+    const delivered = outboxScope
+      ? rememberDeliveredQueuedUserTurn(state, payload?.runId, outboxScope)
+      : null;
     if (delivered) {
       // The queued projection is the only local copy until history catches up.
       // Materialize it before the terminal assistant to preserve transcript order.
       preserveQueuedUserTurn(state, delivered);
     }
     const result = handleChatGatewayEvent(state, payload);
-    if (terminal) {
+    if (terminal && sessionMatches) {
       clearPendingQueueItemsForRun(state, payload?.runId);
     }
     if (shouldCelebrateFirstReply && result === "final") {
@@ -466,9 +487,11 @@ export function handlePageGatewayEvent(
     }
     replayPendingSessionMessageReload(state, payload, isPresented);
     if (terminal) {
-      removeDeliveredQueuedChatSendForRun(state, payload?.runId);
+      if (outboxScope) {
+        removeDeliveredQueuedChatSendForRun(state, payload?.runId, outboxScope);
+      }
       void resumeStoredChatOutboxes(state);
-      if (chatScopedEventSessionMatches(state, payload?.sessionKey, payload?.agentId)) {
+      if (sessionMatches) {
         if (isPresented()) {
           refreshSessionWorkspace(state);
         } else {
@@ -537,6 +560,7 @@ const deliveredQueueTurnsByClient = new WeakMap<object, Map<string, ChatQueueIte
 function rememberDeliveredQueuedUserTurn(
   state: ChatPageHost,
   runId: string | undefined,
+  scope: StoredChatOutboxScope,
 ): ChatQueueItem | null {
   if (!runId) {
     return null;
@@ -550,10 +574,11 @@ function rememberDeliveredQueuedUserTurn(
     turns = new Map();
     deliveredQueueTurnsByClient.set(owner, turns);
   }
-  const stored = readDeliveredQueuedChatSendForRun(state, runId)?.item;
+  const deliveryKey = `${storedChatOutboxScopeKey(scope)}|${runId}`;
+  const stored = readDeliveredQueuedChatSendForRun(state, runId, scope)?.item;
   if (stored) {
-    turns.delete(runId);
-    turns.set(runId, stored);
+    turns.delete(deliveryKey);
+    turns.set(deliveryKey, stored);
     while (turns.size > MAX_REMEMBERED_DELIVERED_QUEUE_TURNS) {
       const oldestRunId = turns.keys().next().value;
       if (typeof oldestRunId !== "string") {
@@ -562,5 +587,5 @@ function rememberDeliveredQueuedUserTurn(
       turns.delete(oldestRunId);
     }
   }
-  return stored ?? turns.get(runId) ?? null;
+  return stored ?? turns.get(deliveryKey) ?? null;
 }

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -77,6 +77,8 @@ function chatEventOutboxScope(
   state: ChatPageHost,
   payload: ChatEventPayload | undefined,
 ): StoredChatOutboxScope | undefined {
+  // Gateway chat events always carry session ownership. Missing ownership must
+  // not fall back to correlation-only run IDs, which can collide across sessions.
   if (!payload?.sessionKey) {
     return undefined;
   }

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -447,22 +447,24 @@ export function handlePageGatewayEvent(
     const shouldCelebrateFirstReply = hasVisibleFinalAssistantReply(state, payload);
     const shouldRefreshPullRequests =
       shouldCelebrateFirstReply && finalAssistantReplyHasPullRequestLink(state, payload);
-    const terminal =
-      payload?.state === "final" || payload?.state === "aborted" || payload?.state === "error";
+    const terminalPayload =
+      payload &&
+      (payload.state === "final" || payload.state === "aborted" || payload.state === "error")
+        ? payload
+        : undefined;
     // Missing ownership must not fall back to correlation-only run IDs, which
     // can collide across sessions.
     const outboxScope =
-      terminal &&
-      payload?.sessionKey &&
+      terminalPayload &&
       resolveStoredChatOutboxScope(
         state,
-        payload.sessionKey,
-        isUiGlobalSessionKey(payload.sessionKey)
-          ? selectedGlobalEventAgentId(state, payload.agentId ?? null)
-          : payload.agentId,
+        terminalPayload.sessionKey,
+        isUiGlobalSessionKey(terminalPayload.sessionKey)
+          ? selectedGlobalEventAgentId(state, terminalPayload.agentId ?? null)
+          : terminalPayload.agentId,
       );
     const delivered = outboxScope
-      ? rememberDeliveredQueuedUserTurn(state, payload?.runId, outboxScope)
+      ? rememberDeliveredQueuedUserTurn(state, terminalPayload.runId, outboxScope)
       : null;
     if (delivered) {
       // The queued projection is the only local copy until history catches up.
@@ -470,8 +472,8 @@ export function handlePageGatewayEvent(
       preserveQueuedUserTurn(state, delivered);
     }
     const result = handleChatGatewayEvent(state, payload);
-    if (terminal && sessionMatches) {
-      clearPendingQueueItemsForRun(state, payload?.runId);
+    if (terminalPayload && sessionMatches) {
+      clearPendingQueueItemsForRun(state, terminalPayload.runId);
     }
     if (shouldCelebrateFirstReply && result === "final") {
       fireFirstReplyConfetti();
@@ -480,9 +482,9 @@ export function handlePageGatewayEvent(
       void state.refreshSessionPullRequests?.({ refresh: true });
     }
     replayPendingSessionMessageReload(state, payload, isPresented);
-    if (terminal) {
+    if (terminalPayload) {
       if (outboxScope) {
-        removeDeliveredQueuedChatSendForRun(state, payload?.runId, outboxScope);
+        removeDeliveredQueuedChatSendForRun(state, terminalPayload.runId, outboxScope);
       }
       void resumeStoredChatOutboxes(state);
       if (sessionMatches) {

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -73,21 +73,6 @@ function selectedGlobalEventAgentId(state: ChatPageHost, agentId: string | null)
   return agentId ? normalizeAgentId(agentId) : resolveUiDefaultAgentId(state);
 }
 
-function chatEventOutboxScope(
-  state: ChatPageHost,
-  payload: ChatEventPayload | undefined,
-): StoredChatOutboxScope | undefined {
-  // Gateway chat events always carry session ownership. Missing ownership must
-  // not fall back to correlation-only run IDs, which can collide across sessions.
-  if (!payload?.sessionKey) {
-    return undefined;
-  }
-  const agentId = isUiGlobalSessionKey(payload.sessionKey)
-    ? selectedGlobalEventAgentId(state, payload.agentId ?? null)
-    : payload.agentId;
-  return resolveStoredChatOutboxScope(state, payload.sessionKey, agentId);
-}
-
 function globalSessionEventMatchesChat(
   state: ChatPageHost,
   event: NonNullable<ReturnType<typeof readSessionChangedEvent>>,
@@ -395,13 +380,10 @@ function hasVisibleFinalAssistantReply(
   state: ChatPageHost,
   payload: ChatEventPayload | undefined,
 ): boolean {
-  if (payload?.state !== "final") {
-    return false;
-  }
-  const ownsReply =
-    chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId) ||
-    (typeof payload.runId === "string" && payload.runId === state.chatRunId);
-  if (!ownsReply) {
+  if (
+    payload?.state !== "final" ||
+    !chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId)
+  ) {
     return false;
   }
   const finalText = extractText(payload.message);
@@ -462,13 +444,23 @@ export function handlePageGatewayEvent(
     if (payload?.state === "delta" && typeof payload.deltaText === "string" && sessionMatches) {
       refreshPullRequestsForStreamedLinks(state, payload, payload.deltaText);
     }
-    const shouldCelebrateFirstReply =
-      sessionMatches && hasVisibleFinalAssistantReply(state, payload);
+    const shouldCelebrateFirstReply = hasVisibleFinalAssistantReply(state, payload);
     const shouldRefreshPullRequests =
       shouldCelebrateFirstReply && finalAssistantReplyHasPullRequestLink(state, payload);
     const terminal =
       payload?.state === "final" || payload?.state === "aborted" || payload?.state === "error";
-    const outboxScope = terminal ? chatEventOutboxScope(state, payload) : undefined;
+    // Missing ownership must not fall back to correlation-only run IDs, which
+    // can collide across sessions.
+    const outboxScope =
+      terminal &&
+      payload?.sessionKey &&
+      resolveStoredChatOutboxScope(
+        state,
+        payload.sessionKey,
+        isUiGlobalSessionKey(payload.sessionKey)
+          ? selectedGlobalEventAgentId(state, payload.agentId ?? null)
+          : payload.agentId,
+      );
     const delivered = outboxScope
       ? rememberDeliveredQueuedUserTurn(state, payload?.runId, outboxScope)
       : null;

--- a/ui/src/pages/lobsterdex/lobsterdex-page.e2e.test.ts
+++ b/ui/src/pages/lobsterdex/lobsterdex-page.e2e.test.ts
@@ -76,6 +76,10 @@ suite.define(() => {
         const blue = copyButtons.nth(1);
         const crimsonUrl = `${new URL(suite.server.baseUrl).origin}/settings/lobsterdex#lobsterdex-crimson`;
         const blueUrl = `${new URL(suite.server.baseUrl).origin}/settings/lobsterdex#lobsterdex-blue`;
+        await Promise.all([
+          gateway.waitForRequest("cron.list"),
+          gateway.waitForRequest("models.authStatus"),
+        ]);
         const requestsBeforeCopy = (await gateway.getRequests()).length;
 
         await crimson.focus();


### PR DESCRIPTION
## What Problem This Solves

Fixes a coupled transcript failure where a Codex answer shown immediately before a steer could disappear from durable history, while a stale shared run ID could let another session's live response replace the selected Control UI transcript or consume its queued send.

## Why This Change Was Made

Completed Codex assistant items are journaled at their authoritative item-complete boundary and committed before a steer is accepted, without replaying them at terminal finalization. The Control UI now treats session ownership as authoritative before run IDs and scopes terminal queue handoff/removal by `(sessionKey, agentId, runId)`.

The page-ingress repair preserves the intentional split-pane handoff: inactive panes may cache and retire the event owner's durable queue row, but a foreign terminal cannot mutate the selected pane's queue. Literal unscoped `global` events route to the default agent, matching chat-event semantics. Silent control payloads such as `NO_REPLY` are excluded from the new persistence boundary.

Production LOC: +164/-51 (net +113) | Tests: +309/-38 (net +271)

The production growth records two explicit ownership boundaries: Codex item completion versus enclosing turn finalization, and UI event scope versus correlation-only run IDs. Steering snapshot assembly lives in the existing snapshot owner so the projector remains below the repository line limit without a suppression.

## User Impact

Users can steer an active Codex turn without losing an answer that was already displayed. Switching between threads, agents, or split panes no longer allows a same-run event from another session to contaminate the selected transcript or retire its queued prompt.

## Evidence

### Before / after video

The deterministic mock-Gateway scenario uses the same `runId` for two sessions, emits a large delta/final from the inactive session, and reconciles the selected virtualized transcript while rows resize.

**Before fix — inactive-session content replaces the selected thread:**

https://github.com/user-attachments/assets/d5ad48f7-8e77-47a5-b3f1-e79086f9bea9

**After fix — the selected thread remains isolated and rows do not overlap:**

https://github.com/user-attachments/assets/732465ad-497c-42a8-becf-002348a2222a

Both WebM recordings were inspected at early, middle, and final frames before upload.

### Regression and focused verification

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.assistant.test.ts extensions/codex/src/app-server/run-attempt.steering.test.ts` — 32/32 passed
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/chat-gateway.test.ts` — 446/446 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-agent-run-transcript.e2e.test.ts` — 4/4 passed
- Lobsterdex clipboard E2E — 5 consecutive CI-mode runs passed after awaiting existing bootstrap RPCs before asserting zero clipboard-triggered Gateway requests
- Updater CLI — 247/247 passed under CI mode after isolating native service selectors and updating owned-service fixtures to the managed-definition contract
- Targeted update-cli changed gate — repository guards, core-test typecheck, and lint passed
- Queue-edit reconnect E2E — 5 consecutive CI-mode runs passed via the supported Control+Enter submit path; targeted repository gate passed
- Control UI startup bundle — 340,832 B gzip with fixed build identity (68 B below the 340,900 B baseline+tolerance limit)
- `node scripts/check-changed.mjs` — passed all selected UI, extension, typecheck, lint, boundary, dead-code, database-first, and cycle gates
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P1` — clean, no accepted/actionable findings (0.88 confidence)

Regression proof: restoring selected-pane/run-ID targeting makes both page-ingress ownership cases fail for the intended reason; restoring event-owned scope makes those cases and inactive-pane-first ordering pass. Restoring the pre-fix steering boundary makes the silent-payload regression persist a visible `NO_REPLY` row; restoring the predicate leaves the boundary empty.

### Codex dependency contract

Direct sibling Codex source inspection confirms the contract this patch relies on:

- `codex-rs/app-server-protocol/src/protocol/v2/turn.rs` requires `turn/steer` to name the active turn.
- `codex-rs/app-server/src/request_processors/turn_processor.rs` submits steer input through `steer_turn`.
- `codex-rs/app-server/src/bespoke_event_handling.rs` emits `item/completed` independently from the later enclosing `turn/completed` notification.

Therefore a completed answer before a same-turn steer is an authoritative boundary OpenClaw must persist.
