### PR TITLE
fix(logging): preserve UUID token fragments

### DIFF
--- a/src/logging/redact-patterns.ts
+++ b/src/logging/redact-patterns.ts
@@ -189,7 +189,7 @@ export const DEFAULT_REDACT_PATTERNS: readonly string[] = [
   String.raw`(eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})`,
   String.raw`(pplx-[A-Za-z0-9_-]{10,})`,
   String.raw`(fal_[A-Za-z0-9_-]{10,})`,
-  String.raw`(fc-[A-Za-z0-9]{10,})`,
+  String.raw`${IDENTIFIER_SAFE_TOKEN_BOUNDARY}(fc-[A-Za-z0-9]{10,})`,
   String.raw`(bb_live_[A-Za-z0-9_-]{10,})`,
   String.raw`${BASE64_SAFE_TOKEN_BOUNDARY}(gAAAA[A-Za-z0-9_=-]{20,})`,
   String.raw`(sk_live_[A-Za-z0-9]{10,})`,

--- a/src/logging/redact-token-ordering.test.ts
+++ b/src/logging/redact-token-ordering.test.ts
@@ -64,6 +64,16 @@ describe("redactSensitiveText token ordering", () => {
     expect(redactSensitiveText(`id ${identifier}`, { mode: "tools" })).toBe(`id ${identifier}`);
   });
 
+  it("preserves UUIDs containing Firecrawl-shaped fragments without exposing Firecrawl tokens", () => {
+    const artifactId = "artifact_managed_image_3ac53ce7-a6d6-4229-b1fc-0123456789ab";
+    expect(redactSensitiveText(artifactId, { mode: "tools" })).toBe(artifactId);
+
+    const token = "fc-0123456789abcdef";
+    for (const prefix of ["", " ", "/", "="]) {
+      expect(redactSensitiveText(`${prefix}${token}`, { mode: "tools" })).not.toContain(token);
+    }
+  });
+
   it("masks full provider tokens before generic AWS-shaped chunks", () => {
     const token = fakeFlyTokenWithAwsShapedBody();
     const output = redactSensitiveText(`provider ${token}`, { mode: "tools" });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a UUID fragment could accidentally match the Firecrawl token redaction pattern. When a managed image artifact ID contained a group ending in `fc-` followed by its final 12 hexadecimal characters, transcript redaction corrupted the ID and later media resolution returned no artifact.

## Why This Change Was Made

The Firecrawl token pattern now uses the existing identifier-safe leading boundary. Real Firecrawl tokens remain redacted, while token-shaped substrings inside UUIDs and other identifiers remain intact.

AI-assisted; the patch was independently reviewed and repeatedly stress-tested.

## User Impact

Managed images and other UUID-keyed artifacts no longer disappear nondeterministically because redaction altered their identifiers. Secret redaction behavior for actual Firecrawl credentials remains unchanged.

## Evidence

- Deterministic pre-fix regression transformed a UUID ending in a Firecrawl-shaped fragment into a truncated redacted ID.
- Pre-fix managed-image integration stress reproduced on iteration 13 of 24.
- Post-fix focused suites: 171 tests passed.
- Exact agents-tools CI project/order: 90 files passed, 1 skipped; 2,055 tests passed, 1 skipped.
- Post-fix stress: 24/24 iterations passed.
- Core production and relevant logging test typechecks passed.
- Targeted oxfmt, oxlint, and `git diff --check` passed.
- Branch autoreview reported no accepted/actionable findings.
- Production delta: +1/-1, net zero. Tests: +10/-0.
