### PR TITLE
fix(telegram): route commentary through one frozen progress owner

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -265,6 +265,13 @@ export async function runTelegramDispatchTurn(turn: Turn) {
               turn.streamMode === "progress" ? turn.commentaryProgressEnabled : undefined,
             progressPreambleEnabled: turn.progressPreambleEnabled,
             commentaryPayloadsEnabled: turn.progressPreambleEnabled,
+            // One commentary owner per turn (Slack/Discord parity, #121009):
+            // core freezes this getter at turn start, so an enabled commentary
+            // draft and the durable path can never both show the same preamble.
+            shouldDeliverCommentaryPayloads:
+              turn.streamMode === "progress" && turn.commentaryProgressEnabled
+                ? () => turn.verboseProgressActive()
+                : undefined,
             reasoningPayloadsEnabled: turn.durableReasoningPayloadsEnabled,
             onToolStart: (payload) => handleToolStart(turn, payload),
             onItemEvent: (payload) => handleItemEvent(turn, payload),

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -265,9 +265,8 @@ export async function runTelegramDispatchTurn(turn: Turn) {
               turn.streamMode === "progress" ? turn.commentaryProgressEnabled : undefined,
             progressPreambleEnabled: turn.progressPreambleEnabled,
             commentaryPayloadsEnabled: turn.progressPreambleEnabled,
-            // One commentary owner per turn (Slack/Discord parity, #121009):
-            // core freezes this getter at turn start, so an enabled commentary
-            // draft and the durable path can never both show the same preamble.
+            // Read the current getter after core freezes visibility so draft
+            // and durable commentary cannot both own the same preamble.
             shouldDeliverCommentaryPayloads:
               turn.streamMode === "progress" && turn.commentaryProgressEnabled
                 ? () => turn.verboseProgressActive()

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -720,6 +720,71 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     expect(lastPreview?.text).toContain("Checking recent context");
   });
 
+  it.each([
+    ["active", true],
+    ["inactive", false],
+  ])(
+    "freezes the durable commentary owner to verbose visibility %s",
+    async (_label, verboseActive) => {
+      const draftStream = createSequencedDraftStream(2001);
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+        await replyOptions?.onReplyStart?.();
+        expect(replyOptions?.commentaryPayloadsEnabled).toBe(true);
+        expect(replyOptions?.shouldDeliverCommentaryPayloads?.()).toBe(false);
+        replyOptions?.onVerboseProgressVisibility?.(() => verboseActive);
+        expect(replyOptions?.shouldDeliverCommentaryPayloads?.()).toBe(verboseActive);
+        await replyOptions?.onItemEvent?.({
+          kind: "preamble",
+          itemId: "preamble-1",
+          progressText: "Checking recent context",
+        });
+        return { queuedFinal: false };
+      });
+
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "progress",
+        telegramCfg: {
+          streaming: {
+            mode: "progress",
+            progress: { label: "Shelling", commentary: true },
+          },
+        },
+      });
+
+      const updates = draftStream.updatePreview.mock.calls
+        .map(([preview]) => preview.text)
+        .join("\n");
+      if (verboseActive) {
+        // The durable lane owns commentary: the draft must not repeat it.
+        expect(updates).not.toContain("Checking recent context");
+      } else {
+        // The draft owns commentary: exactly one visible copy per preamble.
+        expect(updates.split("Checking recent context")).toHaveLength(2);
+      }
+    },
+  );
+
+  it("omits the durable commentary owner when Telegram commentary progress is disabled", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      expect(replyOptions?.commentaryPayloadsEnabled).toBe(true);
+      expect(replyOptions?.shouldDeliverCommentaryPayloads).toBeUndefined();
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress: { label: "Shelling" },
+        },
+      },
+    });
+  });
+
   it("renders the Telegram preamble headline when commentary is disabled", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -766,20 +766,39 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     },
   );
 
-  it("omits the durable commentary owner when Telegram commentary progress is disabled", async () => {
+  it.each([
+    {
+      label: "progress commentary is disabled",
+      streamMode: "progress",
+      commentary: false,
+      commentaryPayloadsEnabled: true,
+    },
+    {
+      label: "partial streaming owns the answer preview",
+      streamMode: "partial",
+      commentary: true,
+      commentaryPayloadsEnabled: undefined,
+    },
+    {
+      label: "streaming is disabled",
+      streamMode: "off",
+      commentary: true,
+      commentaryPayloadsEnabled: undefined,
+    },
+  ] as const)("omits the durable commentary owner when $label", async (scenario) => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
-      expect(replyOptions?.commentaryPayloadsEnabled).toBe(true);
+      expect(replyOptions?.commentaryPayloadsEnabled).toBe(scenario.commentaryPayloadsEnabled);
       expect(replyOptions?.shouldDeliverCommentaryPayloads).toBeUndefined();
       return { queuedFinal: false };
     });
 
     await dispatchWithContext({
       context: createContext(),
-      streamMode: "progress",
+      streamMode: scenario.streamMode,
       telegramCfg: {
         streaming: {
-          mode: "progress",
-          progress: { label: "Shelling" },
+          mode: scenario.streamMode,
+          progress: { label: "Shelling", commentary: scenario.commentary },
         },
       },
     });


### PR DESCRIPTION
Closes #128038

**AI-assisted:** yes — built with Claude; prompts/session logs available on request.

## What Problem This Solves

With `richMessages` + `streaming.mode="progress"` + `streaming.progress.commentary=true`, every completed assistant commentary preamble appeared twice in the Telegram progress draft (#128038): once through the draft projection and again through the durable commentary path, because both stayed enabled for the same turn.

## Why This Change Was Made

Telegram never supplied the optional `shouldDeliverCommentaryPayloads` owner callback that #121009 added for Slack/Discord, so `resolveTurnCommentaryProgressOwner` defaulted durable commentary delivery to enabled while the Telegram draft also rendered each preamble as an interleaved 💬 line. Core's own verbose-visibility decision was frozen per run, but Telegram's draft-side visibility slot remained live, so the two projections could disagree within one turn.

This wires the missing callback in `extensions/telegram/src/bot-message-dispatch-turn.ts`, gated exactly on when the compositor can render interleaved commentary lines (`streamMode === "progress" && commentaryProgressEnabled`) and reading the same `verboseProgressActive` slot that core freezes at turn start and re-resolves per admitted follow-up. This mirrors Discord's wiring in `message-handler.process-progress.ts`.

- Commentary draft enabled → callback present; when frozen visibility is false, core suppresses durable delivery and the draft is the single owner; when true, `handleItemEvent` already yields early and the durable lane delivers.
- Commentary disabled (`commentaryProgressEnabled === false`) → callback stays `undefined`; today's durable-only CLI-commentary path is unchanged (`bot-message-dispatch.progress-lifecycle.test.ts` still asserts this).

## User Impact

One visible copy per completed commentary item during tool-heavy turns. Progress messages no longer grow by repeating status text, keeping long-running work readable in Telegram.

## Evidence

Local, current `main` base `67613e73`:

- New regression tests fail pre-fix: with the fix stashed, `bot-message-dispatch.progress-updates.test.ts` reports 1 failed (owner-callback assertion); restored fix → green.
- Post-fix targeted suites: `bot-message-dispatch.progress-updates.test.ts` 30/30, plus full dispatch surface 251/251 across 17 suites (`pnpm test extensions/telegram/src/bot-message-dispatch`), re-run green after rebase (41/41 across the two touched suites).
- Owner-contract coverage mirrors Discord's: frozen getter returns false initially, tracks `onVerboseProgressVisibility`, draft renders exactly one copy when it owns commentary and nothing when the durable lane owns it.
- `tsgo -p extensions/telegram/tsconfig.json --noEmit` clean; oxlint (262 rules) and oxfmt clean on both changed files.

Known proof gap: full `tsgo:extensions:test` / core lanes were not completable locally (host CPU saturation); CI covers those lanes.


## Mock-gateway harness verdict (authorized lane)

Ephemeral topology, all local, no private data in any payload:

- **Gateway:** real OpenClaw gateway process (dist-backed `gateway run --allow-unconfigured`), loopback :19091, isolated `OPENCLAW_STATE_DIR`, PR head `4a51b972`.
- **Channel:** Telegram channel pointed at a mock Bot API via the documented `channels.telegram.apiRoot`; every bot-visible call captured to JSONL.
- **Provider:** scenario-aware mock OpenAI Responses server; the inbound prompt triggers its built-in scripted turn — phase-tagged commentary message item + `exec` tool call, then the final answer after the tool result.
- **Session config:** `verboseDefault: "on"`, `richMessages: true`, `streaming.mode: "progress"`, `streaming.progress.commentary: true` — the exact repro configuration from #128038.

Complete outbound Bot API traffic for the turn:

```text
sendRichMessage {"chat_id":"777000","rich_message":{"blocks":[{"type":"paragraph","text":"💬 Checking the workspace before answering."}]}}
sendRichMessage {"chat_id":"777000","rich_message":{"blocks":[{"type":"paragraph","text":"🛠️ Exec"}]}}
sendRichMessage {"chat_id":"777000","rich_message":{"blocks":[{"type":"paragraph","text":"OPENCLAW_E2E_DRAFTPROOF"}]}}
```

**Verdict:** exactly **one visible copy** of the completed commentary preamble across all outbound traffic; zero duplicated payloads; 2 model requests (commentary+toolcall, then final); final answer delivered.

```json
{"scenario":"telegram-commentary-one-owner","head":"4a51b972","counts":{"commentarySentenceVisibleCopies":1,"duplicateCopiesOfAnyPayload":0,"modelRequests":2,"finalAnswerDelivered":true},"assertion":"PASS"}
```

Scope note: steady-state runs render a single copy on unfixed `main` too — the defect repaired here is the mid-turn visibility race where draft projection and durable delivery could each project the same preamble. The unit suites prove that frozen-owner contract differentially (regression tests fail pre-fix); this verdict proves the changed path end-to-end through a real gateway process, real channel transport, and real HTTP provider renders exactly one visible copy.
