### PR TITLE
fix(macos): prevent invalid Gateway ports from crashing remote connections

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -122,12 +122,12 @@ enum GatewayEnvironment {
     {
         if let raw = environment["OPENCLAW_GATEWAY_PORT"] {
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let parsed = Int(trimmed), parsed > 0 { return parsed }
+            if let parsed = Int(trimmed), (1...65535).contains(parsed) { return parsed }
         }
-        if let configPort, configPort > 0 {
+        if let configPort, (1...65535).contains(configPort) {
             return configPort
         }
-        return storedPort > 0 ? storedPort : profile.defaultGatewayPort
+        return (1...65535).contains(storedPort) ? storedPort : profile.defaultGatewayPort
     }
 
     static func expectedGatewayVersion() -> Semver? {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -124,6 +124,21 @@ struct GatewayEnvironmentTests {
             configPort: nil,
             storedPort: 23001,
             profile: work) == 23001)
+        #expect(GatewayEnvironment.resolvedGatewayPort(
+            environment: ["OPENCLAW_GATEWAY_PORT": "65536"],
+            configPort: 22001,
+            storedPort: 23001,
+            profile: work) == 22001)
+        #expect(GatewayEnvironment.resolvedGatewayPort(
+            environment: [:],
+            configPort: 65536,
+            storedPort: 23001,
+            profile: work) == 23001)
+        #expect(GatewayEnvironment.resolvedGatewayPort(
+            environment: [:],
+            configPort: nil,
+            storedPort: 65536,
+            profile: work) == work.defaultGatewayPort)
         #expect(AppProfile(environment: [:]).defaultGatewayPort == 18789)
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS app could crash while establishing a remote Gateway tunnel when its environment, configuration, or saved preferences contained a TCP port above 65535.

## Why This Change Was Made

The macOS Gateway port-selection owner accepted every positive integer, although TCP ports and the existing Gateway configuration schema are limited to 1 through 65535. Enforce the same canonical bound at every existing precedence level so invalid inputs fall through to the next valid configured or profile-default port before tunnel consumers convert the result to `UInt16`.

## User Impact

Remote Gateway connections no longer terminate the macOS app when a malformed environment override, configuration value, or saved preference supplies an invalid port. Valid overrides, configured ports, stored ports, and named-profile defaults retain their existing priority and behavior.

## Evidence

- Extended the existing Gateway environment precedence regression with invalid environment, configuration, and stored-preference ports; all three cases failed on current `main`, each returning `65536`.
- After the owner-boundary repair, 69 tests across `GatewayEnvironmentTests`, `GatewayLaunchAgentManagerTests`, `GatewayProcessManagerTests`, and `GatewayAutostartPolicyTests` pass.
- Existing Gateway configuration schema and launch-agent parsing already enforce the same valid TCP range.
- Production change: +3/-3 lines; regression coverage: +15 lines; no new option, compatibility branch, dependency, or test-only production seam.
- Independent Codex review reported no actionable findings.

## ClawSweeper Rank-Up Review

- The suggested exact-head native macOS proof is complete: all 69 relevant Swift tests passed on this PR head; the independent exact-head CI gate is also green. The bot's attempted Swift command ran on a Linux worker and timed out, so it is not applicable evidence for the macOS package.
- Skipped the suggested refresh-only rebase because this PR is mergeable, current exact-head checks are green, and repository landing policy explicitly avoids rebasing solely because `main` advanced.
