### PR TITLE
fix(ui): keep expanded panel tabs clear of shell controls

### DIFF
--- a/src/agents/compaction.abort-http.test.ts
+++ b/src/agents/compaction.abort-http.test.ts
@@ -9,7 +9,6 @@ describe("compaction retry backoff over real HTTP", () => {
   it("aborts after one provider response without changing the source history", async () => {
     const controller = new AbortController();
     const requests: Array<{ method: string; path: string }> = [];
-    let responseCompletedAt: number | undefined;
     let abortedAt: number | undefined;
     let abortTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -32,7 +31,6 @@ describe("compaction retry backoff over real HTTP", () => {
           // Start cancellation only after the real provider response can put
           // production compaction into its minimum 500 ms retry backoff.
           if (requests.length === 1) {
-            responseCompletedAt = performance.now();
             abortTimer = setTimeout(() => {
               abortedAt = performance.now();
               controller.abort();
@@ -89,11 +87,10 @@ describe("compaction retry backoff over real HTTP", () => {
       });
 
       await expect(summary).rejects.toThrow(/abort/i);
-      if (responseCompletedAt === undefined || abortedAt === undefined) {
+      if (abortedAt === undefined) {
         throw new Error("Compaction did not abort after the real loopback response");
       }
       expect(performance.now() - abortedAt).toBeLessThan(400);
-      expect(performance.now() - responseCompletedAt).toBeLessThan(400);
       expect(requests).toEqual([{ method: "POST", path: "/v1/chat/completions" }]);
       expect(Buffer.from(JSON.stringify(messages)).equals(originalHistory)).toBe(true);
     } finally {

--- a/ui/src/e2e/chat-side-panel-clearance.e2e.test.ts
+++ b/ui/src/e2e/chat-side-panel-clearance.e2e.test.ts
@@ -1,0 +1,388 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Locator, Page } from "playwright";
+import { expect, it } from "vitest";
+import {
+  controlUiBundledSettingsStorageKey,
+  installMockGateway,
+  type ControlUiMockGatewayScenario,
+} from "../test-helpers/control-ui-e2e.ts";
+import {
+  activateChatHeaderPanelAction,
+  failNextDeviceIdentityMint,
+} from "./chat-side-panel.test-support.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "chat side-panel shell clearance",
+  startServerBeforeBrowser: true,
+});
+
+const sessionKey = "agent:main:side-panel-clearance";
+const proofDir = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+const limitedScopes = ["operator.read", "operator.write"];
+const historyMessages = [
+  {
+    id: "side-panel-clearance-user",
+    role: "user",
+    content: [{ type: "text", text: "Keep the panel header controls reachable." }],
+    timestamp: Date.now() - 60_000,
+  },
+  {
+    id: "side-panel-clearance-assistant",
+    role: "assistant",
+    content: [{ type: "text", text: "The panel header now clears every shell control." }],
+    timestamp: Date.now(),
+  },
+];
+
+function scenario(
+  options: {
+    custodian?: boolean;
+    operatorScopes?: string[];
+    updateAvailable?: ControlUiMockGatewayScenario["updateAvailable"];
+  } = {},
+): ControlUiMockGatewayScenario {
+  return {
+    featureMethods: [
+      "device.scopes.requestUpgrade",
+      "device.scopes.waitUpgrade",
+      ...(options.custodian ? ["openclaw.chat"] : []),
+    ],
+    historyMessages,
+    methodResponses: {
+      "sessions.files.list": {
+        browser: {
+          path: "ui/src/pages/chat",
+          entries: [
+            {
+              kind: "file",
+              name: "chat-pane-render.ts",
+              path: "ui/src/pages/chat/chat-pane-render.ts",
+            },
+            { kind: "file", name: "sidebar.css", path: "ui/src/styles/chat/sidebar.css" },
+          ],
+        },
+        files: [
+          {
+            kind: "modified",
+            missing: false,
+            name: "chat-pane-render.ts",
+            path: "/workspace/openclaw/ui/src/pages/chat/chat-pane-render.ts",
+            size: 18_432,
+          },
+          {
+            kind: "read",
+            missing: false,
+            name: "sidebar.css",
+            path: "/workspace/openclaw/ui/src/styles/chat/sidebar.css",
+            size: 24_820,
+          },
+        ],
+        root: "/workspace/openclaw",
+        sessionKey,
+      },
+    },
+    ...(options.operatorScopes ? { operatorScopes: options.operatorScopes } : {}),
+    ...(options.updateAvailable ? { updateAvailable: options.updateAvailable } : {}),
+    sessionKey,
+    workspace: "/workspace/openclaw",
+    workspaceGit: true,
+  };
+}
+
+async function seedSettings(page: Page, themeMode: "light" | "dark") {
+  const settingsKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+  await page.addInitScript(
+    ({ key, seededSessionKey, seededThemeMode }) => {
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          theme: "claw",
+          themeMode: seededThemeMode,
+          sidebarSessionLayouts: {
+            [seededSessionKey]: { columns: [], open: false, expanded: false },
+          },
+        }),
+      );
+    },
+    { key: settingsKey, seededSessionKey: sessionKey, seededThemeMode: themeMode },
+  );
+}
+
+function sidePanel(page: Page): Locator {
+  return page.locator(".sidebar-region__right-runtime .side-panel");
+}
+
+async function openExpandedFilesPanel(page: Page, beforeExpandProof?: string): Promise<void> {
+  await page.goto(`${suite.server.baseUrl}chat?session=${encodeURIComponent(sessionKey)}`);
+  await page.locator(".chat-group").first().waitFor();
+  await activateChatHeaderPanelAction(page, "Show session files");
+  if (beforeExpandProof) {
+    await capturePanel(page, beforeExpandProof);
+  }
+  await sidePanel(page).getByRole("button", { name: "Expand side panel" }).click();
+  await sidePanel(page).getByRole("button", { name: "Restore side panel" }).waitFor();
+}
+
+async function waitForShellLayout(page: Page): Promise<void> {
+  await page.locator(".shell").evaluate(async (shell) => {
+    const finiteAnimations = shell
+      .getAnimations({ subtree: true })
+      .filter((animation) => Number.isFinite(animation.effect?.getComputedTiming().endTime));
+    await Promise.allSettled(finiteAnimations.map((animation) => animation.finished));
+  });
+}
+
+async function expectPanelHeaderControlsClearShellChrome(page: Page): Promise<void> {
+  const panelControls = sidePanel(page).locator(
+    ":scope > .side-panel__header :is(button, wa-tab):visible",
+  );
+  const panelCount = await panelControls.count();
+  expect(panelCount).toBeGreaterThan(0);
+
+  const geometry = await page.evaluate(() => {
+    const rect = (element: Element) => {
+      const box = element.getBoundingClientRect();
+      return { bottom: box.bottom, left: box.left, right: box.right, top: box.top };
+    };
+    const header = document.querySelector(
+      ".sidebar-region__right-runtime .side-panel > .side-panel__header",
+    );
+    if (!header) {
+      throw new Error("Expanded side panel has no header");
+    }
+    const headerRect = rect(header);
+    const headerStyle = getComputedStyle(header);
+    const panels = [
+      ...document.querySelectorAll(
+        ".sidebar-region__right-runtime .side-panel > .side-panel__header :is(button, wa-tab):not([hidden])",
+      ),
+    ].map(rect);
+    const shells = [
+      ...document.querySelectorAll(
+        ":is(.shell-chrome-controls, .macos-titlebar-controls, .sidebar-attention--floating) button:not([hidden]), .scope-upgrade-shell-status:not([hidden])",
+      ),
+    ]
+      .map(rect)
+      .filter((shell) => shell.bottom > headerRect.top && shell.top < headerRect.bottom);
+    return {
+      contentLeft: headerRect.left + Number.parseFloat(headerStyle.paddingLeft),
+      contentRight: headerRect.right - Number.parseFloat(headerStyle.paddingRight),
+      direction: headerStyle.direction,
+      panels,
+      shells,
+    };
+  });
+
+  expect(geometry.shells.length).toBeGreaterThan(0);
+  const shellRight = Math.max(...geometry.shells.map((box) => box.right));
+  const panelLeft = Math.min(...geometry.panels.map((box) => box.left));
+  expect(geometry.contentLeft - shellRight).toBeGreaterThanOrEqual(4);
+  expect(geometry.contentLeft - shellRight).toBeLessThanOrEqual(16);
+  expect(panelLeft - shellRight).toBeGreaterThanOrEqual(8);
+  if (geometry.direction !== "rtl") {
+    expect(panelLeft - shellRight).toBeLessThanOrEqual(16);
+  }
+  expect(
+    geometry.panels.every(
+      (box) => box.left >= geometry.contentLeft - 0.5 && box.right <= geometry.contentRight + 0.5,
+    ),
+  ).toBe(true);
+  for (let index = 0; index < panelCount; index += 1) {
+    await panelControls.nth(index).click({ trial: true });
+  }
+}
+
+async function capturePanel(page: Page, name: string): Promise<void> {
+  if (!proofDir) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.screenshot({ fullPage: true, path: path.join(proofDir, `${name}.png`) });
+}
+
+suite.define(() => {
+  it.each([
+    {
+      beforeExpandProof: "right-docked",
+      custodian: false,
+      deviceLess: false,
+      direction: "ltr",
+      expectedControl: ".shell-chrome-controls__search",
+      expectedUpdate: false,
+      name: "expanded navigation",
+      navCollapsed: false,
+      operatorScopes: undefined,
+      proof: "expanded-nav",
+      themeMode: "dark" as const,
+      updateAvailable: undefined,
+    },
+    {
+      beforeExpandProof: undefined,
+      custodian: false,
+      deviceLess: false,
+      direction: "ltr",
+      expectedControl: ".shell-chrome-controls__search",
+      expectedUpdate: false,
+      name: "collapsed navigation",
+      navCollapsed: true,
+      operatorScopes: undefined,
+      proof: "collapsed-nav",
+      themeMode: "dark" as const,
+      updateAvailable: undefined,
+    },
+    {
+      beforeExpandProof: undefined,
+      custodian: true,
+      deviceLess: false,
+      direction: "ltr",
+      expectedControl: ".shell-chrome-controls__custodian",
+      expectedUpdate: true,
+      name: "collapsed navigation with custodian and attention",
+      navCollapsed: true,
+      operatorScopes: undefined,
+      proof: "collapsed-nav-custodian-attention",
+      themeMode: "dark" as const,
+      updateAvailable: {
+        channel: "stable",
+        currentVersion: "2026.8.1",
+        latestVersion: "2026.8.2",
+      },
+    },
+    {
+      beforeExpandProof: undefined,
+      custodian: false,
+      deviceLess: true,
+      direction: "ltr",
+      expectedControl: ".scope-upgrade-shell-status",
+      expectedUpdate: false,
+      name: "limited-access status",
+      navCollapsed: false,
+      operatorScopes: limitedScopes,
+      proof: "limited-access",
+      themeMode: "light" as const,
+      updateAvailable: undefined,
+    },
+    {
+      beforeExpandProof: undefined,
+      custodian: false,
+      deviceLess: true,
+      direction: "rtl",
+      expectedControl: ".scope-upgrade-shell-status",
+      expectedUpdate: false,
+      name: "collapsed RTL limited-access status and attention",
+      navCollapsed: true,
+      operatorScopes: limitedScopes,
+      proof: "collapsed-rtl-limited-attention",
+      themeMode: "dark" as const,
+      updateAvailable: undefined,
+    },
+  ])("keeps expanded panel controls in a compact safe gap for $name", async (testCase) => {
+    await suite.withPage(
+      {
+        colorScheme: testCase.themeMode,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1600 },
+      },
+      async ({ page }) => {
+        if (testCase.deviceLess) {
+          await failNextDeviceIdentityMint(page);
+        }
+        await seedSettings(page, testCase.themeMode);
+        await installMockGateway(
+          page,
+          scenario({
+            custodian: testCase.custodian,
+            operatorScopes: testCase.operatorScopes,
+            updateAvailable: testCase.updateAvailable,
+          }),
+        );
+        await openExpandedFilesPanel(page, testCase.beforeExpandProof);
+        await page.evaluate((direction) => {
+          document.documentElement.dir = direction;
+        }, testCase.direction);
+        if (testCase.navCollapsed) {
+          await page.getByRole("button", { name: "Collapse sidebar", exact: true }).click();
+          await expect
+            .poll(() => page.locator(".shell").getAttribute("class"))
+            .toContain("shell--nav-collapsed");
+          await page.locator(".sidebar-attention--floating .sidebar-issues-button").waitFor();
+        }
+        await page.locator(testCase.expectedControl).waitFor();
+        if (testCase.expectedUpdate) {
+          const updateSlot = page.locator(
+            ".sidebar-attention--floating .sidebar-footer-update-slot",
+          );
+          await updateSlot.waitFor();
+          await updateSlot.hover();
+          await waitForShellLayout(page);
+          await expectPanelHeaderControlsClearShellChrome(page);
+          await page.mouse.move(800, 700);
+          await updateSlot.locator(".sidebar-footer-update").focus();
+          await waitForShellLayout(page);
+          await expectPanelHeaderControlsClearShellChrome(page);
+        }
+        await waitForShellLayout(page);
+        await expectPanelHeaderControlsClearShellChrome(page);
+        await capturePanel(page, testCase.proof);
+      },
+    );
+  });
+
+  it("keeps the mobile limited-access header below the topbar without a desktop gutter", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "light",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 844, width: 390 },
+      },
+      async ({ page }) => {
+        await failNextDeviceIdentityMint(page);
+        await seedSettings(page, "light");
+        await installMockGateway(page, scenario({ operatorScopes: limitedScopes }));
+        await openExpandedFilesPanel(page);
+        const status = page.locator(".scope-upgrade-shell-status");
+        await status.waitFor();
+        const geometry = await page.evaluate(() => {
+          const header = document
+            .querySelector(".sidebar-region__right-runtime .side-panel > .side-panel__header")
+            ?.getBoundingClientRect();
+          const firstControl = document
+            .querySelector(
+              ".sidebar-region__right-runtime .side-panel > .side-panel__header :is(button, wa-tab)",
+            )
+            ?.getBoundingClientRect();
+          const panelControls = [
+            ...document.querySelectorAll(
+              ".sidebar-region__right-runtime .side-panel > .side-panel__header :is(button, wa-tab)",
+            ),
+          ].map((element) => element.getBoundingClientRect());
+          const scopeStatus = document
+            .querySelector(".scope-upgrade-shell-status")
+            ?.getBoundingClientRect();
+          if (!header || !firstControl || !scopeStatus) {
+            throw new Error("Mobile limited-access geometry is incomplete");
+          }
+          return {
+            controlInset: firstControl.left - header.left,
+            overlaps: panelControls.some((control) => {
+              const overlapX =
+                Math.min(control.right, scopeStatus.right) -
+                Math.max(control.left, scopeStatus.left);
+              const overlapY =
+                Math.min(control.bottom, scopeStatus.bottom) -
+                Math.max(control.top, scopeStatus.top);
+              return overlapX > 0.5 && overlapY > 0.5;
+            }),
+          };
+        });
+        expect(geometry.overlaps).toBe(false);
+        expect(geometry.controlInset).toBeLessThanOrEqual(16);
+        await capturePanel(page, "mobile-limited-access");
+      },
+    );
+  });
+});

--- a/ui/src/e2e/chat-side-panel.test-support.ts
+++ b/ui/src/e2e/chat-side-panel.test-support.ts
@@ -1,5 +1,27 @@
 import type { Page } from "playwright";
 
+export async function failNextDeviceIdentityMint(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const getRandomValues = globalThis.crypto.getRandomValues.bind(globalThis.crypto);
+    let identityMintFailed = false;
+    Object.defineProperty(globalThis.crypto, "getRandomValues", {
+      configurable: true,
+      value(array: Uint8Array<ArrayBuffer>) {
+        if (!identityMintFailed) {
+          identityMintFailed = true;
+          throw new Error("device identity unavailable");
+        }
+        Object.defineProperty(globalThis.crypto, "getRandomValues", {
+          configurable: true,
+          value: getRandomValues,
+        });
+        getRandomValues(array);
+        return array;
+      },
+    });
+  });
+}
+
 export async function openChatSidePanelType(page: Page, label: string): Promise<void> {
   const panel = page.locator(".sidebar-region__right-runtime .side-panel");
   if ((await panel.count()) === 0) {

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -1,6 +1,7 @@
 // Shipped apps stamp `openclaw-native-nav`; current apps advertise web chrome
 // at document start and stamp `openclaw-native-web-chrome` at document end.
 // Plain browsers keep their normal in-page controls.
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext } from "playwright";
 import { afterEach, expect, it } from "vitest";
@@ -9,6 +10,10 @@ import {
   type ControlUiMockGatewayScenario,
 } from "../test-helpers/control-ui-e2e.ts";
 import { chatSessionListResponse } from "./chat-flow.test-support.ts";
+import {
+  failNextDeviceIdentityMint,
+  openChatSidePanelType,
+} from "./chat-side-panel.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -17,6 +22,8 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 const TOAST_PROOF_DIR = path.resolve(".artifacts/control-ui-e2e/toast-layering");
+const railProofDir = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+const limitedScopes = ["operator.read", "operator.write"];
 const TOAST_SCENARIO: ControlUiMockGatewayScenario = {
   featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
   methodResponses: {
@@ -61,6 +68,7 @@ suite.define(() => {
 
   async function openPage(options: {
     colorScheme?: "dark" | "light";
+    deviceLess?: boolean;
     hasTouch?: boolean;
     height?: number;
     nativeNav?: boolean;
@@ -76,6 +84,9 @@ suite.define(() => {
       viewport: { height: options.height ?? 900, width: options.width ?? 1280 },
     });
     const page = await context.newPage();
+    if (options.deviceLess) {
+      await failNextDeviceIdentityMint(page);
+    }
     if (options.nativeNav) {
       // Mirrors the WKUserScript in DashboardWindowController.installNativeChromeScript,
       // which runs at document end. Playwright init scripts fire before
@@ -298,6 +309,92 @@ suite.define(() => {
     await expect
       .poll(() => page.locator(".shell").getAttribute("class"))
       .not.toContain("shell--nav-collapsed");
+  });
+
+  it.each([
+    {
+      deviceLess: false,
+      label: "ordinary collapsed-navigation",
+      navCollapsed: true,
+      operatorScopes: undefined,
+      width: 1280,
+    },
+    {
+      deviceLess: true,
+      label: "limited-access collapsed-navigation",
+      navCollapsed: true,
+      operatorScopes: limitedScopes,
+      width: 1280,
+    },
+    {
+      deviceLess: true,
+      label: "limited-access expanded-navigation",
+      navCollapsed: false,
+      operatorScopes: limitedScopes,
+      width: 620,
+    },
+  ])("keeps expanded side-panel tabs clear of $label web titlebar chrome", async (testCase) => {
+    const page = await openPage({
+      deviceLess: testCase.deviceLess,
+      scenario: testCase.operatorScopes
+        ? {
+            featureMethods: [
+              "chat.metadata",
+              "chat.startup",
+              "device.scopes.requestUpgrade",
+              "device.scopes.waitUpgrade",
+              "sessions.create",
+            ],
+            methodResponses: { "sessions.list": chatSessionListResponse() },
+            operatorScopes: testCase.operatorScopes,
+          }
+        : undefined,
+      webChrome: true,
+      width: testCase.width,
+    });
+    const toolbar = page.locator(".macos-titlebar-controls");
+    if (testCase.navCollapsed) {
+      await toolbar.getByRole("button", { name: "Collapse sidebar" }).click();
+    }
+    await openChatSidePanelType(page, "Side chat");
+    const panel = page.getByRole("region", { name: "Side panel" });
+    await panel.getByRole("button", { name: "Expand side panel" }).click();
+    await panel.getByRole("button", { name: "Restore side panel" }).waitFor();
+
+    const shellControls = page.locator(
+      ".macos-titlebar-controls button:visible, .scope-upgrade-shell-status:visible",
+    );
+    const panelControls = panel.locator(":scope > .side-panel__header :is(button, wa-tab):visible");
+    const shellBoxes = await Promise.all(
+      Array.from({ length: await shellControls.count() }, (_, index) =>
+        shellControls.nth(index).boundingBox(),
+      ),
+    );
+    const panelBoxes = await Promise.all(
+      Array.from({ length: await panelControls.count() }, (_, index) =>
+        panelControls.nth(index).boundingBox(),
+      ),
+    );
+    const shellRight = Math.max(...shellBoxes.flatMap((box) => (box ? [box.x + box.width] : [])));
+    const panelLeft = Math.min(...panelBoxes.flatMap((box) => (box ? [box.x] : [])));
+    expect(panelLeft - shellRight).toBeGreaterThanOrEqual(4);
+    expect(panelLeft - shellRight).toBeLessThanOrEqual(16);
+    if (testCase.deviceLess) {
+      await page.locator(".scope-upgrade-shell-status").waitFor();
+    }
+    for (let index = 0; index < (await panelControls.count()); index += 1) {
+      await panelControls.nth(index).click({ trial: true });
+    }
+    if (railProofDir) {
+      await mkdir(railProofDir, { recursive: true });
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(
+          railProofDir,
+          `native-web-${testCase.deviceLess ? "limited" : "ordinary"}-${testCase.navCollapsed ? "collapsed" : "expanded"}.png`,
+        ),
+      });
+    }
   });
 
   it("keeps only history controls in the Settings titlebar", async () => {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -840,40 +840,58 @@ openclaw-chat-pane {
   white-space: normal;
 }
 
-/* Plain web shell chrome overlays the first pane header. Expanded navigation
-   shows toggle + search; collapsed navigation adds new-thread between them. */
-html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-web-chrome)
-  .shell:not(.shell--nav-collapsed):not(.shell--mobile-nav)
-  .chat-split-view__column:first-child
-  > .chat-split-view__cell:first-child
-  :is(.chat-main__conversation-column, .chat-pane-primary-column)
-  > .chat-pane__header {
-  padding-left: 88px;
+/* Shell layout owns the dynamic physical-left safe edge. Native hosts replace
+   the web-control calculation with their actual window chrome. */
+.shell {
+  --shell-attention-width: 0px;
+  --shell-titlebar-inset: calc(var(--shell-chrome-safe-area-left) + var(--shell-attention-width));
 }
 
-html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-web-chrome)
-  .shell--nav-collapsed:not(.shell--mobile-nav)
-  .chat-split-view__column:first-child
-  > .chat-split-view__cell:first-child
-  :is(.chat-main__conversation-column, .chat-pane-primary-column)
-  > .chat-pane__header {
-  padding-left: 124px;
+html.openclaw-native-macos .shell:not(.shell--mobile-nav) {
+  --shell-titlebar-inset: 12px;
 }
 
-/* The floating attention cluster widens the overlay strip; clear its resting
-   width (inbox 32 + gap 4 + update 32 + 12 breathing) so the session title is
-   not covered. The update pill's hover expansion may transiently overlap.
-   Native-nav/web-chrome hosts pin the cluster at the far left, inside the
-   larger insets below. */
-html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-web-chrome)
-  .shell--nav-collapsed:not(.shell--mobile-nav):has(.sidebar-attention--floating)
-  .chat-split-view__column:first-child
-  > .chat-split-view__cell:first-child
-  :is(.chat-main__conversation-column, .chat-pane-primary-column)
-  > .chat-pane__header {
-  padding-left: calc(
-    var(--shell-chrome-controls-inset) + var(--shell-chrome-controls-collapsed-width) + 88px
-  );
+html.openclaw-native-macos .shell--nav-collapsed:not(.shell--mobile-nav) {
+  --shell-titlebar-inset: 90px;
+}
+
+html.openclaw-native-nav .shell--nav-collapsed:not(.shell--mobile-nav) {
+  --shell-titlebar-inset: 204px;
+}
+
+html.openclaw-native-web-chrome .shell--nav-collapsed:not(.shell--mobile-nav) {
+  --shell-titlebar-inset: calc(246px + var(--shell-access-width));
+}
+
+/* At the native 601/620px expanded-rail width, limited access remains in the
+   hosted titlebar just beyond the 258px rail edge. Clear its 28px control. */
+html.openclaw-native-web-chrome
+  .shell:not(.shell--mobile-nav, .shell--nav-collapsed):has(.scope-upgrade-shell-status) {
+  --shell-titlebar-inset: 24px;
+}
+
+/* Apply the safe edge to whichever header occupies the first content row;
+   mobile has a separate topbar row. */
+.shell:not(.shell--mobile-nav)
+  :is(
+    .chat-split-view__column:first-child
+      > .chat-split-view__cell:first-child
+      :is(.chat-main__conversation-column, .chat-pane-primary-column)
+      > .chat-pane__header,
+    .sidebar-region--expanded .side-panel__header
+  ) {
+  padding-left: var(--shell-titlebar-inset);
+}
+
+.shell--mobile-nav:has(.scope-upgrade-shell-status)
+  :is(
+    .chat-split-view__column:first-child
+      > .chat-split-view__cell:first-child
+      :is(.chat-main__conversation-column, .chat-pane-primary-column)
+      > .chat-pane__header,
+    .sidebar-region--expanded .side-panel__header
+  ) {
+  padding-right: calc(max(58px, env(safe-area-inset-right)) + 48px);
 }
 
 /* Native macOS desktop shells: the pane header is the window's top surface,
@@ -883,7 +901,9 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
    center the session title/actions 2px above the traffic-light/hosted-button
    centerline. Drawer layouts instead fold titlebar clearance into their 58px
    topbar row (layout.mobile.css). */
-html.openclaw-native-macos .shell:not(.shell--mobile-nav) .chat-pane__header {
+html.openclaw-native-macos
+  .shell:not(.shell--mobile-nav)
+  :is(.chat-pane__header, .sidebar-region--expanded .side-panel__header) {
   min-height: var(--openclaw-native-titlebar-height, 50px);
 }
 
@@ -903,43 +923,17 @@ html.openclaw-native-macos
   min-width: 398px;
 }
 
-html.openclaw-native-macos
-  .shell--nav-collapsed:not(.shell--mobile-nav)
-  .chat-split-view__column:first-child
-  > .chat-split-view__cell:first-child
-  :is(.chat-main__conversation-column, .chat-pane-primary-column)
-  > .chat-pane__header {
-  padding-left: 90px;
-}
-
 html.openclaw-native-nav
   .shell--nav-collapsed:not(.shell--mobile-nav)
   .chat-split-view__column:first-child {
   min-width: 512px;
 }
 
-html.openclaw-native-nav
-  .shell--nav-collapsed:not(.shell--mobile-nav)
-  .chat-split-view__column:first-child
-  > .chat-split-view__cell:first-child
-  :is(.chat-main__conversation-column, .chat-pane-primary-column)
-  > .chat-pane__header {
-  padding-left: 204px;
-}
-
 /* 246px = 78px traffic lights + (5 * 28px buttons + 4 * 4px gaps) + 12px.
-     The 554px minimum adds the 234px inset delta to the 320px base column. */
+   The base minimum adds the 234px inset delta to the 320px column floor;
+   limited-access chrome contributes one more control. */
 html.openclaw-native-web-chrome
   .shell--nav-collapsed:not(.shell--mobile-nav)
   .chat-split-view__column:first-child {
-  min-width: 554px;
-}
-
-html.openclaw-native-web-chrome
-  .shell--nav-collapsed:not(.shell--mobile-nav)
-  .chat-split-view__column:first-child
-  > .chat-split-view__cell:first-child
-  :is(.chat-main__conversation-column, .chat-pane-primary-column)
-  > .chat-pane__header {
-  padding-left: 246px;
+  min-width: calc(554px + var(--shell-access-width));
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -10,19 +10,11 @@
   --shell-chrome-controls-inset: 10px;
   --shell-chrome-control-size: 32px;
   --shell-chrome-controls-gap: 4px;
-  --shell-chrome-controls-access-width: 0px;
-  /* Four controls: the admin-gated Ask OpenClaw fallback joins the strip only
-     while the nav is collapsed, which is exactly when this width applies. */
-  --shell-chrome-controls-collapsed-width: calc(
-    var(--shell-chrome-control-size) + var(--shell-chrome-control-size) +
-      var(--shell-chrome-control-size) + var(--shell-chrome-control-size) +
-      var(--shell-chrome-controls-gap) + var(--shell-chrome-controls-gap) +
-      var(--shell-chrome-controls-gap) + var(--shell-chrome-controls-access-width)
-  );
-  --shell-chrome-safe-area-left: calc(
-    var(--shell-chrome-controls-inset) + var(--shell-chrome-controls-collapsed-width) -
-      var(--shell-chrome-control-size) - var(--shell-chrome-controls-gap) + 8px
-  );
+  --shell-access-width: 0px;
+  /* Collapsed navigation adds new-thread to the two persistent controls.
+     Optional controls contribute only while they are actually mounted. */
+  --shell-controls-width: calc(104px + var(--shell-access-width));
+  --shell-chrome-safe-area-left: calc(var(--shell-controls-width) - 18px);
   /* Desktop has no topbar row — the sidebar owns navigation. Narrow viewports
      (layout.mobile.css) and the chat split toolbar restore the row height. */
   --shell-topbar-height: 0px;
@@ -100,9 +92,9 @@
 .shell--nav-collapsed {
   grid-template-columns: 0 minmax(0, 1fr);
   --shell-nav-width: 0px;
-  --shell-chrome-safe-area-left: calc(
-    var(--shell-chrome-controls-inset) + var(--shell-chrome-controls-collapsed-width) + 8px
-  );
+  /* The collapsed strip shows all three base controls, so unlike the expanded
+     safe edge this keeps the complete collapsed width. */
+  --shell-chrome-safe-area-left: calc(var(--shell-controls-width) + 18px);
 }
 
 /* Drawer shells keep the nav mounted offscreen; desktop collapse removes it. */
@@ -181,9 +173,11 @@
 }
 
 .shell:has(.scope-upgrade-shell-status) {
-  --shell-chrome-controls-access-width: calc(
-    var(--shell-chrome-control-size) + var(--shell-chrome-controls-gap)
-  );
+  --shell-access-width: 36px;
+}
+
+.shell:has(.shell-chrome-controls__custodian) {
+  --shell-controls-width: calc(140px + var(--shell-access-width));
 }
 
 .scope-upgrade-shell-status {

--- a/ui/src/styles/sidebar-footer-update.css
+++ b/ui/src/styles/sidebar-footer-update.css
@@ -1,12 +1,21 @@
-/* Floating footer controls must clear the collapsed chrome and scope indicator. */
+/* Floating footer controls must clear the collapsed chrome and scope indicator.
+   Feed their actual resting width back into the first-row safe edge. */
+.shell--nav-collapsed:has(openclaw-sidebar-attention.sidebar-attention--floating) {
+  --shell-attention-width: 40px;
+}
+
+.shell--nav-collapsed:has(
+  openclaw-sidebar-attention.sidebar-attention--floating .sidebar-footer-update-slot
+) {
+  --shell-attention-width: 72px;
+}
+
 openclaw-sidebar-attention.sidebar-attention--floating {
   --sidebar-bg: var(--bg-content, var(--bg));
 
   position: fixed;
   top: 10px;
-  left: calc(
-    var(--shell-chrome-controls-inset) + var(--shell-chrome-controls-collapsed-width) + 8px
-  );
+  left: calc(var(--shell-chrome-controls-inset) + var(--shell-controls-width) + 8px);
   z-index: 45;
   display: flex;
   align-items: center;
@@ -15,7 +24,7 @@ openclaw-sidebar-attention.sidebar-attention--floating {
 
 /* Native navigation hides web controls but leaves its scope indicator in-page. */
 html.openclaw-native-nav openclaw-sidebar-attention.sidebar-attention--floating {
-  left: calc(var(--shell-chrome-controls-inset) + var(--shell-chrome-controls-access-width) + 6px);
+  left: calc(var(--shell-chrome-controls-inset) + var(--shell-access-width) + 6px);
 }
 
 html.openclaw-native-web-chrome openclaw-sidebar-attention.sidebar-attention--floating {


### PR DESCRIPTION
Closes #128261

AI-assisted: yes. The original attachment was re-opened at full resolution, the initial adaptive-drawer approach was removed, and every final screenshot below was generated from and inspected on the final UI tree. Head `6cc8c5d1e40` differs from the screenshot head only by the test-only CI-flake cleanup described below.

## What Problem This Solves

When a chat side panel expands into the first content row, its tab strip can render beneath fixed shell controls. The sidebar toggle and search buttons covered the active tab, close action, and new-tab control. Optional shell controls—limited-access status, Custodian, Inbox, and update attention—made fixed padding values incomplete.

## Why This Change Was Made

Shell layout now owns one physical safe edge for the first content row. Mounted optional controls contribute their width there, and whichever surface owns that row consumes the same value:

- ordinary desktop shell controls
- collapsed navigation and its new-session control
- limited-access and Custodian controls
- floating Inbox/update attention
- native macOS and hosted web-titlebar chrome
- the mobile limited-access action on the opposite edge

The expanded panel and the normal chat header therefore share one geometry contract instead of duplicating host-specific selectors. The regression suite asserts a compact 8–16px interactive gap, checks every control remains clickable, and covers dark/light, expanded/collapsed navigation, hover/focus, limited access, RTL, mobile, and native 620px titlebar states.

Production LOC: +85/-88 (net **−3**). The shared dynamic ownership boundary replaces the duplicated fixed-offset matrix while covering supported host/mobile variants. Tests: +508/-4.

## User Impact

Expanded side-panel tabs and actions remain readable and clickable. Dark theme is the primary visual proof. Navigation stays available, and the panel still occupies the full content region without a large fixed blank gutter.

## Evidence

### Before

The original report shows shell controls covering the side-panel tab strip:

![Before: shell controls overlap the side-panel tab](https://github.com/user-attachments/assets/5cb05443-4a60-4b09-82fd-8e0cfee4bb9e)

### After — dark theme

**Normal right-docked panel**

![Dark theme, right-docked side panel](https://github.com/user-attachments/assets/13e60d87-ff19-4723-b95e-b8a0efda3b66)

**Fully expanded panel with navigation visible**

![Dark theme, fully expanded panel with navigation visible](https://github.com/user-attachments/assets/0a50c7bb-ee51-47c3-b765-06796dcf364e)

**Fully expanded panel with navigation collapsed**

![Dark theme, fully expanded panel with navigation collapsed](https://github.com/user-attachments/assets/c363833e-4616-4550-a83c-a10eb2a536a5)

**Collapsed navigation with Custodian, Inbox, and update attention**

![Dark theme, optional shell controls remain clear of the panel](https://github.com/user-attachments/assets/62a11338-c228-4c25-9dbd-b433f3c29767)

### Edge states

**Limited-access light theme**

![Light theme limited-access state](https://github.com/user-attachments/assets/5ec195e5-c3b8-4d12-9ccd-39438dc45e75)

**Mobile limited-access state**

![Mobile limited-access state](https://github.com/user-attachments/assets/dd2fae83-c036-4481-b063-636016c8f9b3)

All after captures use the real Control UI shell and side-panel DOM/styles against the mocked Gateway fixture. No runtime CSS overrides were used.

### Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-side-panel-clearance.e2e.test.ts ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts` — 22/22 passed on head `7d0f08182d1`; the same run generated the screenshots above.
- `node scripts/run-vitest.mjs --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts ui/src/e2e/device-scope-upgrade.e2e.test.ts ui/src/e2e/update-confirmation.e2e.test.ts ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts --reporter=verbose` — 42/42 passed.
- `node ../scripts/run-vitest.mjs --config vitest.config.ts src/components/sidebar-attention-layout.browser.test.ts --reporter=verbose` from `ui/` — 2/2 passed.
- `pnpm ui:build` — passed; startup CSS is 44.8 KiB gzip against the 45.0 KiB budget.
- `pnpm build` — passed after reconciling the rebased worktree dependencies with `pnpm install`.
- `node scripts/check-changed.mjs` — passed formatting, guards, dead-export scan, i18n, core/UI typechecks, and lint.
- `node scripts/run-vitest.mjs src/agents/compaction.abort-http.test.ts --reporter=verbose` — 5/5 bounded loopback runs passed after removing the redundant response-start deadline that failed under shared-runner scheduling; post-abort latency, one-request, and history-integrity assertions remain.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` and `--max-priority P1` — clean; no accepted/actionable P0/P1 findings.

Follow-up noted: the native 620px fixture also exposes a pre-existing sidebar-brand/titlebar collision outside this panel-header invariant; its full-window capture is intentionally not presented as proof for this repair.
