### PR TITLE
fix(ui): show browser inspection failures without attaching stale elements

### DIFF
--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -1,3 +1,4 @@
+import { nothing, render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import {
@@ -15,6 +16,7 @@ import {
   type BrowserRequestEnvelope,
 } from "./browser-panel-controller-test-support.ts";
 import { BrowserPanelController } from "./browser-panel-controller.ts";
+import { renderBrowserPanelChrome } from "./browser-panel-render.ts";
 
 setupBrowserPanelTestCleanup();
 
@@ -548,6 +550,86 @@ describe("BrowserPanelController capture and input ownership", () => {
     expect(controller.view?.dataUrl).toContain(btoa("fresh screenshot"));
     expect(screenshotCount).toBe(2);
     expect(controller.loading).toBe(false);
+  });
+
+  it("clears stale inspected elements and owned errors across a failed inspection retry", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    let inspections = 0;
+    const initialNode = createInspectedNode("initial");
+    const recoveredNode = createInspectedNode("recovered");
+    const { client } = createBrowserClient(async () => {
+      inspections += 1;
+      if (inspections === 2) {
+        throw new Error("Browser connection temporarily unavailable");
+      }
+      return { result: inspections === 1 ? initialNode : recoveredNode };
+    });
+    const controller = createBrowserPanelTestController(client, "tab-a");
+    controller.setMode("inspect");
+
+    controller.handleOverlayPointerMove(createPointer(10, 20));
+    await flushBrowserResponses();
+    expect(controller.inspected).toEqual(initialNode);
+
+    await vi.advanceTimersByTimeAsync(120);
+    controller.handleOverlayPointerMove(createPointer(30, 40));
+    expect(controller.inspected).toBeNull();
+    await flushBrowserResponses();
+
+    expect(controller.errorText).toBe(
+      "Browser request failed: Browser connection temporarily unavailable",
+    );
+    expect(controller.mode).toBe("inspect");
+    expect(controller.evaluateUnavailable).toBe(false);
+    expect(controller.inspected).toBeNull();
+    const renderedPanel = document.createElement("div");
+    const renderPanel = () =>
+      render(
+        renderBrowserPanelChrome(
+          controller,
+          "right",
+          400,
+          400,
+          () => {},
+          () => {},
+          nothing,
+        ),
+        renderedPanel,
+      );
+    renderPanel();
+    expect(renderedPanel.querySelector('[role="alert"]')?.textContent).toBe(
+      "Browser request failed: Browser connection temporarily unavailable",
+    );
+
+    await vi.advanceTimersByTimeAsync(120);
+    controller.handleOverlayPointerMove(createPointer(70, 80));
+    await flushBrowserResponses();
+
+    expect(controller.inspected).toEqual(recoveredNode);
+    expect(controller.errorText).toBeNull();
+    expect(controller.inspectPointer).toEqual({ x: 0.7, y: 0.8 });
+    renderPanel();
+    expect(renderedPanel.querySelector('[role="alert"]')).toBeNull();
+    expect(
+      renderedPanel.querySelector<HTMLButtonElement>('button[aria-label="Inspect element"]')
+        ?.disabled,
+    ).toBe(false);
+  });
+
+  it("preserves the localized disabled-evaluation inspection outcome", async () => {
+    const { client } = createBrowserClient(async () => {
+      throw new Error("browser evaluateEnabled=false");
+    });
+    const controller = createBrowserPanelTestController(client, "tab-a");
+    controller.setMode("inspect");
+
+    controller.handleOverlayPointerMove(createPointer(10, 20));
+    await flushBrowserResponses();
+
+    expect(controller.evaluateUnavailable).toBe(true);
+    expect(controller.mode).toBe("interact");
+    expect(controller.errorText).toBeTruthy();
+    expect(controller.errorText).not.toContain("Browser request failed");
   });
 
   it("keeps the newest inspected element when pointer responses finish out of order", async () => {

--- a/ui/src/components/browser/browser-panel-controller-input.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.ts
@@ -65,6 +65,7 @@ interface BrowserPanelInputHost extends BrowserPanelInputState {
 export class BrowserPanelInputController {
   private drawingStroke: AnnotationStroke | null = null;
   private suppressStageClick = false;
+  private inspectionError: string | null = null;
 
   constructor(private readonly host: BrowserPanelInputHost) {}
 
@@ -214,21 +215,33 @@ export class BrowserPanelInputController {
         this.host.view?.targetId === targetId &&
         this.host.mode === "inspect",
     );
+    this.host.setState("inspected", null);
     this.host.setState("inspectPointer", stagePoint);
+    this.paintOverlay();
     this.host.pendingInput.queueInspection(INSPECT_THROTTLE_MS, current, () => {
       void inspectBrowserElementAt(client, { targetId, x: point.x, y: point.y })
         .then((node) => {
           if (current()) {
+            if (this.inspectionError !== null && this.host.errorText === this.inspectionError) {
+              this.host.setState("errorText", null);
+            }
+            this.inspectionError = null;
             this.host.setState("inspected", node);
             this.paintOverlay();
           }
         })
         .catch((error: unknown) => {
-          if (current() && isBrowserEvaluateDisabledError(error)) {
+          if (!current()) {
+            return;
+          }
+          if (isBrowserEvaluateDisabledError(error)) {
             this.host.setState("evaluateUnavailable", true);
             this.host.setState("errorText", t("browser.inspectUnavailable"));
             this.host.setState("mode", "interact");
+            return;
           }
+          this.host.reportError(error);
+          this.inspectionError = this.host.errorText;
         });
     });
   }

--- a/ui/src/components/browser/browser-panel-controller.test.ts
+++ b/ui/src/components/browser/browser-panel-controller.test.ts
@@ -860,32 +860,35 @@ describe("BrowserPanelController tab and lifecycle ownership", () => {
     expect(screenshots[0]?.[1]).toMatchObject({ body: { targetId: "tab-b" } });
   });
 
-  it("does not disable a replacement gateway after an old inspection rejects", async () => {
-    vi.useFakeTimers({ now: 1_000 });
-    const previousInspection = createDeferred<unknown>();
-    const previous = createBrowserClient(async () => await previousInspection.promise);
-    const replacement = createBrowserClient(async () => ({ running: true, tabs: [] }));
-    const host = new TestBrowserPanelHost(previous.client);
-    const controller = new BrowserPanelController(host);
-    controller.activeTargetId = "tab-a";
-    controller.view = createView("tab-a");
-    controller.setMode("inspect");
-    controller.handleOverlayPointerMove(createPointer(10, 20));
+  it.each(["browser evaluateEnabled=false", "Browser connection temporarily unavailable"])(
+    "ignores a stale inspection rejection after gateway replacement: %s",
+    async (failure) => {
+      vi.useFakeTimers({ now: 1_000 });
+      const previousInspection = createDeferred<unknown>();
+      const previous = createBrowserClient(async () => await previousInspection.promise);
+      const replacement = createBrowserClient(async () => ({ running: true, tabs: [] }));
+      const host = new TestBrowserPanelHost(previous.client);
+      const controller = new BrowserPanelController(host);
+      controller.activeTargetId = "tab-a";
+      controller.view = createView("tab-a");
+      controller.setMode("inspect");
+      controller.handleOverlayPointerMove(createPointer(10, 20));
 
-    host.open = false;
-    host.client = replacement.client;
-    controller.synchronizeHostProperties(new Map([["client", previous.client]]));
-    host.open = true;
-    controller.activeTargetId = "tab-b";
-    controller.view = createView("tab-b");
-    controller.setMode("inspect");
-    previousInspection.reject(new Error("browser evaluateEnabled=false"));
-    await flushBrowserResponses();
+      host.open = false;
+      host.client = replacement.client;
+      controller.synchronizeHostProperties(new Map([["client", previous.client]]));
+      host.open = true;
+      controller.activeTargetId = "tab-b";
+      controller.view = createView("tab-b");
+      controller.setMode("inspect");
+      previousInspection.reject(new Error(failure));
+      await flushBrowserResponses();
 
-    expect(controller.evaluateUnavailable).toBe(false);
-    expect(controller.mode).toBe("inspect");
-    expect(controller.errorText).toBeNull();
-  });
+      expect(controller.evaluateUnavailable).toBe(false);
+      expect(controller.mode).toBe("inspect");
+      expect(controller.errorText).toBeNull();
+    },
+  );
   it("preserves normal coalesced wheel actions on their original tab", async () => {
     vi.useFakeTimers();
     const { client, request } = createBrowserClient(async (envelope) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting an element in the Control UI Browser panel would receive no visible outcome when the Gateway rejected the inspection. A failed inspection after a successful one could also leave the previous element selected and attach the wrong element to a later annotation.

## Why This Change Was Made

The Browser panel now owns inspection failure and selection together: a new pointer invalidates the previous element immediately, live failures use the existing redacted request-error banner, stale Gateway/client responses remain fenced, and a successful retry clears only the error created by inspection. The existing evaluate-disabled behavior and retryable inspection mode are preserved.

## User Impact

Browser inspection problems are visible, an outdated element cannot be accidentally attached to an annotation, and a successful retry removes the previous inspection error without disabling the browser.

## Evidence

- Before the fix, the real BrowserPanelController Gateway rejection regression returned `errorText=null`; after a previous successful selection, the next pointer still retained the previous inspected element.
- The regression now exercises a real Lit-rendered Browser panel through successful inspection A, rejected inspection B, and successful inspection C. It proves the actual `[role="alert"]` contains the existing formatted error, the stale element is cleared before B resolves, the alert disappears after C, and the Inspect button remains enabled.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-autoqa-browser-inspect-committed-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/components/browser ui/src/lib/format-error.test.ts`: **10 suites / 92 tests passed** on candidate head `c8b4a32dfb4a88bfb1d8af1fc21c7bfb817165b5`.
- Separate independent browser-owner review executed the same full browser/redaction surface: **10 suites / 92 tests passed**, no actionable findings.
- Fresh authenticated full committed-branch review: clean. Formatting, targeted lint, UI i18n, max-lines, assertion-safety, and `git diff --check` all passed.
- Full local UI typecheck and Chromium screenshots are unavailable because the existing shared install is missing current-main dependencies `@panzoom/panzoom` and `@types/pako`; the actual rendered DOM integration above is executed and passing. Hosted CI remains authoritative for complete UI dependency/type coverage.
- Production delta: **+13 lines**, needed for live inspection ownership, stale-target invalidation, and inspection-owned error recovery. No public API, configuration, security, protocol, persistence, or product-policy changes.
