### PR TITLE
perf(discord): avoid duplicate inbound binding lookup

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -928,6 +928,44 @@ describe("preflightDiscordMessage", () => {
     expect(expectPreflightResult(result).boundSessionKey).toBe(threadBinding.targetSessionKey);
   });
 
+  it("looks up thread bindings once for an accepted ordinary guild message", async () => {
+    const channelId = "channel-binding-lookup-once";
+    const manager = createThreadBindingManager({
+      cfg: DEFAULT_PREFLIGHT_CFG,
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+    });
+    onTestFinished(() => manager.stop());
+    const getByThreadId = vi.spyOn(manager, "getByThreadId");
+    const message = createDiscordMessage({
+      id: "m-binding-lookup-once",
+      channelId,
+      content: "ordinary human message <@openclaw-bot>",
+      author: { id: "user-1", bot: false, username: "alice" },
+      mentionedUsers: [{ id: "openclaw-bot" }],
+    });
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: DEFAULT_PREFLIGHT_CFG,
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId: "guild-1",
+          author: message.author,
+          message,
+        }),
+        client: createGuildTextClient(channelId),
+      }),
+      threadBindings: manager,
+    });
+
+    expect(expectPreflightResult(result).message.id).toBe(message.id);
+    expect(getByThreadId).toHaveBeenCalledTimes(1);
+    expect(getByThreadId).toHaveBeenCalledWith(channelId);
+  });
+
   it("drops hydrated bound-thread webhook copies after fetching an empty payload", async () => {
     const threadBinding = createThreadBinding({
       targetKind: "session",

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -278,8 +278,10 @@ export async function preflightDiscordMessage(
   const messageText = resolveDiscordMessageText(message, {
     includeForwarded: true,
   });
+  // Only bot/webhook traffic can be rejected before canonical routing; ordinary
+  // messages should reach the single authoritative binding lookup below.
   const injectedBoundThreadBinding =
-    !isDirectMessage && !isGroupDm
+    !isDirectMessage && !isGroupDm && (webhookId || author.bot)
       ? resolveInjectedBoundThreadLookupRecord({
           threadBindings: params.threadBindings,
           threadId: messageChannelId,


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable work on every accepted ordinary Discord guild message. Human guild traffic looked up the same thread binding before route resolution and again in the canonical conversation-binding route, even though only bot and webhook traffic can use the early result for self-loop rejection.

## Why This Change Was Made

The Discord preflight owner now performs the pre-routing binding lookup only for bot or webhook traffic. Ordinary human messages reach the single authoritative conversation-binding route lookup. This adds no cache and does not change DMs, group DMs, thread routing, bound webhook/bot filtering, PluralKit handling, authentication, privacy, ordering, media, mentions, or durable admission.

## User Impact

Ordinary Discord guild messages avoid one redundant thread-binding lookup while retaining identical routing and delivery behavior.

## Evidence

- Frozen base: `cd86b59a35a5ed1eafa4a9a9155b608cc201d23b`; exact candidate: `646aea9a1d5e057d0ca1584bdc605373314f4cc4`.
- Current-base regression proof failed for the intended reason: an accepted human guild message called the real manager's `getByThreadId` twice instead of once. The candidate passes with one canonical lookup.
- Full owner preflight suite: 63/63 tests passed.
- Transport/context/media/mention/room-event siblings: 126/126 tests passed across seven files.
- Complete Discord extension: 227 files / 2,868 tests passed.
- `node scripts/check-changed.mjs -- extensions/discord/src/monitor/message-handler.preflight.ts extensions/discord/src/monitor/message-handler.preflight.test.ts`
- `pnpm build`
- `git diff --check`
- Authenticated Codex `gpt-5.6-sol`/high autoreview: clean, patch correct (0.95), no accepted/actionable P0/P1 findings; TruffleHog preflight clean.
- Latest `origin/main` advanced to `20cdebb23dacb7f9ae21f28dd07a9ef8d837fe88` without touching either changed file; the patch applies cleanly there, so the proven commit was not rebased solely for drift.
- Provenance: the duplicate early lookup was introduced by commit `95079949c3a2dab3380efe7593b34f02a416153f` on 2026-04-05, authored and committed by Gustavo Madeira Santana. No associated PR is traceable from GitHub, so no PR attribution is inferred.
