### PR TITLE
fix(gateway): live sessions stall or reorder across agent identities

### DIFF
--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -650,14 +650,30 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
     expect(broadcastToConnIds.mock.calls[0]?.[1]).toMatchObject({ messageSeq: 7 });
   });
 
-  it("does not stall one session's broadcasts behind another session's pending seq read", async () => {
+  it.each([
+    {
+      name: "distinct session keys",
+      slowAgentId: "main",
+      slowSessionKey: "agent:main:slow",
+      fastAgentId: "main",
+      fastSessionKey: "agent:main:main",
+    },
+    {
+      name: "global sessions owned by different agents",
+      slowAgentId: "main",
+      slowSessionKey: "global",
+      fastAgentId: "research",
+      fastSessionKey: "global",
+    },
+  ])("does not stall $name behind another transcript's pending seq read", async (scenario) => {
     let releaseSlowCount: (value: number | undefined) => void = () => undefined;
-    readSessionMessageCountAsyncMock.mockImplementation((params: { sessionKey?: string }) =>
-      params.sessionKey === "agent:main:slow"
-        ? new Promise<number | undefined>((resolve) => {
-            releaseSlowCount = resolve;
-          })
-        : Promise.resolve(3),
+    readSessionMessageCountAsyncMock.mockImplementation(
+      (params: { agentId?: string; sessionKey?: string }) =>
+        params.agentId === scenario.slowAgentId && params.sessionKey === scenario.slowSessionKey
+          ? new Promise<number | undefined>((resolve) => {
+              releaseSlowCount = resolve;
+            })
+          : Promise.resolve(3),
     );
     loadAccessorSessionEntryReadOnlyMock.mockReturnValue({ sessionId: "sess-main" });
     const { broadcastToConnIds, handler } = createHandler(false);
@@ -667,32 +683,74 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       message: { role: "assistant", content: [{ type: "text", text: "slow" }] },
       messageId: "slow-1",
       target: {
-        agentId: "main",
+        agentId: scenario.slowAgentId,
         sessionId: "sess-slow",
-        sessionKey: "agent:main:slow",
+        sessionKey: scenario.slowSessionKey,
         storePath: "/tmp/slow-sessions.json",
       },
     });
+    await vi.waitFor(() => expect(readSessionMessageCountAsyncMock).toHaveBeenCalledOnce());
 
-    await handler({
+    const fastTask = handler({
       sessionFile: "/tmp/sess-main.jsonl",
-      sessionKey: "agent:main:main",
+      agentId: scenario.fastAgentId,
+      sessionKey: scenario.fastSessionKey,
       message: { role: "assistant", content: [{ type: "text", text: "fast" }] },
       messageId: "fast-1",
       messageSeq: 1,
     });
 
-    // The independent lane broadcast completed while the slow lane is parked.
-    expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
-    expect(broadcastToConnIds.mock.calls[0]?.[1]).toMatchObject({ messageId: "fast-1" });
+    try {
+      // The independent lane must publish while the other transcript remains parked.
+      await vi.waitFor(() => expect(broadcastToConnIds).toHaveBeenCalledOnce(), {
+        timeout: 100,
+        interval: 5,
+      });
+      expect(broadcastToConnIds.mock.calls[0]?.[1]).toMatchObject({ messageId: "fast-1" });
+    } finally {
+      releaseSlowCount(5);
+      await Promise.allSettled([slowTask, fastTask]);
+    }
 
-    releaseSlowCount(5);
-    await slowTask;
     expect(broadcastToConnIds).toHaveBeenCalledTimes(2);
     expect(broadcastToConnIds.mock.calls[1]?.[1]).toMatchObject({ messageId: "slow-1" });
   });
 
-  it("preserves message order within one session lane", async () => {
+  it.each([
+    {
+      name: "an agent-qualified session",
+      firstSessionKey: "agent:main:main",
+      secondSessionKey: "agent:main:main",
+      agentId: "main",
+    },
+    {
+      name: "an ownerless legacy global update",
+      firstSessionKey: "global",
+      secondSessionKey: "global",
+      agentId: "main",
+    },
+    {
+      name: "a global session and its agent-qualified alias",
+      firstSessionKey: "global",
+      secondSessionKey: "agent:main:global",
+      agentId: "main",
+    },
+    {
+      name: "an ownerless global update in its configured fixed store",
+      firstSessionKey: "global",
+      secondSessionKey: "global",
+      agentId: "ops",
+      config: {
+        session: { store: "/tmp/owned-shared.sqlite" },
+        agents: {
+          ownership: "explicit",
+          defaults: { sessionStore: { agentId: "ops" } },
+          entries: { ops: {}, research: {} },
+        },
+      },
+    },
+  ])("preserves message order for $name", async (scenario) => {
+    runtimeConfigState.value = scenario.config ?? {};
     let releaseFirstCount: (value: number | undefined) => void = () => undefined;
     readSessionMessageCountAsyncMock.mockImplementationOnce(
       () =>
@@ -707,25 +765,29 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       message: { role: "assistant", content: [{ type: "text", text: "first" }] },
       messageId: "ordered-1",
       target: {
-        agentId: "main",
+        agentId: scenario.agentId,
         sessionId: "sess-main",
-        sessionKey: "agent:main:main",
+        sessionKey: scenario.firstSessionKey,
         storePath: "/tmp/explicit-sessions.json",
       },
     });
+    await vi.waitFor(() => expect(readSessionMessageCountAsyncMock).toHaveBeenCalledOnce());
     const secondTask = handler({
       sessionFile: "/tmp/sess-main.jsonl",
-      sessionKey: "agent:main:main",
+      sessionKey: scenario.secondSessionKey,
       message: { role: "assistant", content: [{ type: "text", text: "second" }] },
       messageId: "ordered-2",
       messageSeq: 2,
     });
 
     await Promise.resolve();
-    expect(broadcastToConnIds).not.toHaveBeenCalled();
-
-    releaseFirstCount(1);
-    await Promise.all([firstTask, secondTask]);
+    await Promise.resolve();
+    try {
+      expect(broadcastToConnIds).not.toHaveBeenCalled();
+    } finally {
+      releaseFirstCount(1);
+      await Promise.allSettled([firstTask, secondTask]);
+    }
     expect(broadcastToConnIds.mock.calls.map((call) => call[1]?.messageId)).toEqual([
       "ordered-1",
       "ordered-2",

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -16,9 +16,11 @@ const sessionRow = vi.hoisted(() => ({
 const resolveEmbeddedAgentRunProgressStateMock = vi.hoisted(() => vi.fn());
 const loadGatewaySessionRowMock = vi.hoisted(() => vi.fn());
 const projectChatDisplayMessageMock = vi.hoisted(() => vi.fn((message: unknown) => message));
+const listAccessorSessionEntriesReadOnlyMock = vi.hoisted(() => vi.fn());
 const loadAccessorSessionEntryReadOnlyMock = vi.hoisted(() => vi.fn());
 const loadGatewaySessionEntryReadOnlyMock = vi.hoisted(() => vi.fn());
 const readSessionMessageCountAsyncMock = vi.hoisted(() => vi.fn());
+const resolveTranscriptSessionKeyBySessionIdMock = vi.hoisted(() => vi.fn());
 const runtimeConfigState = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
 
 vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => runtimeConfigState.value }));
@@ -26,7 +28,9 @@ vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/sessions/session-accessor.js")>();
   return {
     ...actual,
+    listSessionEntriesReadOnly: listAccessorSessionEntriesReadOnlyMock,
     loadSessionEntryReadOnly: loadAccessorSessionEntryReadOnlyMock,
+    resolveTranscriptSessionKeyBySessionId: resolveTranscriptSessionKeyBySessionIdMock,
   };
 });
 vi.mock("./chat-display-projection.js", () => ({
@@ -110,10 +114,12 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resolveEmbeddedAgentRunProgressStateMock.mockReturnValue(undefined);
+    listAccessorSessionEntriesReadOnlyMock.mockReturnValue([]);
     loadAccessorSessionEntryReadOnlyMock.mockReturnValue(undefined);
     loadGatewaySessionEntryReadOnlyMock.mockReturnValue({ entry: undefined, storePath: "" });
     loadGatewaySessionRowMock.mockReturnValue(sessionRow);
     readSessionMessageCountAsyncMock.mockResolvedValue(undefined);
+    resolveTranscriptSessionKeyBySessionIdMock.mockReturnValue(undefined);
     loadGatewaySessionRowMock.mockReturnValue(sessionRow);
     runtimeConfigState.value = {};
     sessionRow.key = "agent:main:main";
@@ -736,6 +742,13 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       agentId: "main",
     },
     {
+      name: "a marker-only update and its canonical transcript key",
+      firstSessionKey: "agent:main:main",
+      secondSessionKey: "agent:main:main",
+      agentId: "main",
+      markerOnly: true,
+    },
+    {
       name: "an ownerless global update in its configured fixed store",
       firstSessionKey: "global",
       secondSessionKey: "global",
@@ -759,17 +772,27 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
         }),
     );
     loadAccessorSessionEntryReadOnlyMock.mockReturnValue({ sessionId: "sess-main" });
+    if (scenario.markerOnly) {
+      listAccessorSessionEntriesReadOnlyMock.mockReturnValue([
+        { key: scenario.firstSessionKey, entry: { sessionId: "sess-main" } },
+      ]);
+      resolveTranscriptSessionKeyBySessionIdMock.mockReturnValue(scenario.firstSessionKey);
+    }
     const { broadcastToConnIds, handler } = createHandler(false);
 
     const firstTask = handler({
       message: { role: "assistant", content: [{ type: "text", text: "first" }] },
       messageId: "ordered-1",
-      target: {
-        agentId: scenario.agentId,
-        sessionId: "sess-main",
-        sessionKey: scenario.firstSessionKey,
-        storePath: "/tmp/explicit-sessions.json",
-      },
+      ...(scenario.markerOnly
+        ? { sessionFile: `sqlite:${scenario.agentId}:sess-main:/tmp/explicit-sessions.json` }
+        : {
+            target: {
+              agentId: scenario.agentId,
+              sessionId: "sess-main",
+              sessionKey: scenario.firstSessionKey,
+              storePath: "/tmp/explicit-sessions.json",
+            },
+          }),
     });
     await vi.waitFor(() => expect(readSessionMessageCountAsyncMock).toHaveBeenCalledOnce());
     const secondTask = handler({

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -152,13 +152,15 @@ export function createTranscriptUpdateBroadcastHandler(params: {
         ? readTranscriptUpdateLifecycleOwner(update)?.lifecycleRevision
         : undefined);
     const queuedUpdate = lifecycleRevision ? { ...update, lifecycleRevision } : update;
+    const legacyMarker = parseSqliteSessionFileMarker(update.sessionFile);
     const sessionKey =
       normalizeOptionalString(update.target?.sessionKey) ??
-      normalizeOptionalString(update.sessionKey);
+      normalizeOptionalString(update.sessionKey) ??
+      (legacyMarker ? resolveTranscriptSessionKeyBySessionId(legacyMarker) : undefined);
     let agentId =
       normalizeOptionalString(update.target?.agentId) ??
       normalizeOptionalString(update.agentId) ??
-      parseSqliteSessionFileMarker(update.sessionFile)?.agentId;
+      legacyMarker?.agentId;
     if (!agentId && sessionKey?.toLowerCase() === "global") {
       const config = getRuntimeConfig();
       const persistedOwner = resolvePersistedSessionStoreOwnerForKey(config, sessionKey);

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -29,7 +29,10 @@ import {
   buildGatewaySessionEventRow,
   projectSessionEventActiveRunIds,
 } from "./session-event-payload.js";
-import { resolveSessionSubscriptionKeys } from "./session-subscription-keys.js";
+import {
+  resolveSessionSubscriptionKey,
+  resolveSessionSubscriptionKeys,
+} from "./session-subscription-keys.js";
 import { projectSessionMessagePayload } from "./session-transcript-message.js";
 import { readSessionMessageCountAsync } from "./session-transcript-readers.js";
 import {
@@ -149,11 +152,26 @@ export function createTranscriptUpdateBroadcastHandler(params: {
         ? readTranscriptUpdateLifecycleOwner(update)?.lifecycleRevision
         : undefined);
     const queuedUpdate = lifecycleRevision ? { ...update, lifecycleRevision } : update;
-    const laneKey =
+    const sessionKey =
       normalizeOptionalString(update.target?.sessionKey) ??
-      normalizeOptionalString(update.sessionKey) ??
-      normalizeOptionalString(update.sessionFile) ??
-      "";
+      normalizeOptionalString(update.sessionKey);
+    let agentId =
+      normalizeOptionalString(update.target?.agentId) ??
+      normalizeOptionalString(update.agentId) ??
+      parseSqliteSessionFileMarker(update.sessionFile)?.agentId;
+    if (!agentId && sessionKey?.toLowerCase() === "global") {
+      const config = getRuntimeConfig();
+      const persistedOwner = resolvePersistedSessionStoreOwnerForKey(config, sessionKey);
+      agentId =
+        persistedOwner.kind === "configured"
+          ? persistedOwner.agentId
+          : tryResolveLegacyCompatibilityAgentId(config);
+    }
+    // Raw global is per-agent storage identity; its qualified aliases must share a lane.
+    const laneKey =
+      sessionKey && agentId
+        ? resolveSessionSubscriptionKey(sessionKey, agentId)
+        : (sessionKey ?? normalizeOptionalString(update.sessionFile) ?? "");
     // Preserve transcript update order within the lane even when counting
     // messages requires an async read from the session file.
     const tail = broadcastQueues.get(laneKey) ?? Promise.resolve();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators viewing multiple agents could see one agent's live `global` session stop updating while another agent waited for transcript projection. The same session could also display messages out of order when successive updates used its bare `global` key and its agent-qualified alias, or when a marker-only SQLite transcript update was followed by its canonical session key.

## Why This Change Was Made

Gateway transcript broadcasting already promises one ordered lane per transcript, but it keyed lanes by the raw session string instead of the transcript's agent-qualified identity. Reuse the existing canonical session subscription key and resolve ownership at the transcript producer boundary, preserving explicit agent ownership, legacy SQLite markers, configured fixed-store owners, compatibility defaults, unresolved legacy events, and existing same-session ordering. Resolve marker-only updates to their authoritative persisted session key before assigning the queue so they share the canonical transcript's lane.

## User Impact

Different agents' live session updates no longer block one another, while messages for the same session remain correctly ordered across legacy and agent-qualified names. No public API, protocol, configuration, authentication, security, or storage contract changes.

## Evidence

- Exact reviewed head: `936b3d15b2b3c278b95f534244e3c1d0d32686af`.
- Before: three genuine owner-boundary regressions failed in both Gateway test projects: cross-agent global delivery stalled, a same-agent qualified alias delivered the second message first, and a later canonical update overtook an in-flight marker-only SQLite transcript update.
- After: `node scripts/run-vitest.mjs src/gateway/server-session-events.test.ts src/gateway/server-runtime-subscriptions.test.ts src/gateway/server-node-subscriptions.test.ts src/gateway/server.node-chat-subscriptions.test.ts src/gateway/server-chat.agent-events.test.ts --configLoader runner --experimental.fsModuleCachePath /private/tmp/openclaw-autoqa-gateway-agent-vitest-correction-cache` passed **428 tests**, including real isolated localhost WebSocket delivery.
- `node scripts/run-vitest.mjs src/sessions/transcript-events.test.ts --configLoader runner --experimental.fsModuleCachePath /private/tmp/openclaw-autoqa-gateway-agent-vitest-unit-cache` passed **21 producer tests**.
- Real SQLite-backed Gateway integration passed **2 marker-delivery tests**; renewed independent review separately passed **89 owner, producer, and live marker-integration tests** and reported no actionable findings. Fresh authenticated correction review also reported no actionable findings.
- The ClawSweeper marker-only queue-lane finding and both rank-up moves are addressed at the existing authoritative transcript producer boundary and covered by an authentic failing-before/passing-after regression.
- Core production and Gateway test typechecks, scoped lint, formatting, and `git diff --check` passed.
- Production delta: **+20 lines**, required to preserve canonical explicit, marker-only, fixed-store, and compatibility owner identities without changing the public protocol; test delta: **+85 lines**.
