### PR TITLE
fix(ai): preserve tool-result boundary whitespace for Mistral and Ollama

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -802,6 +802,17 @@ describe("convertToOllamaMessages", () => {
     expect(result).toEqual([{ role: "tool", content: "file1.txt\nfile2.txt" }]);
   });
 
+  it("preserves significant boundary whitespace in tool results", () => {
+    const result = convertToOllamaMessages([
+      {
+        role: "toolResult",
+        toolCallId: "call_ws",
+        content: [{ type: "text", text: "  indented\n" }],
+      },
+    ]);
+    expect(result).toEqual([{ role: "tool", content: "  indented\n", tool_call_id: "call_ws" }]);
+  });
+
   it("converts SDK 'toolResult' role to Ollama 'tool' role", () => {
     const messages = [{ role: "toolResult", content: "command output here" }];
     const result = convertToOllamaMessages(messages);

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -802,6 +802,22 @@ describe("Mistral provider", () => {
     });
   });
 
+  it("preserves tool-result boundary whitespace in the request payload", async () => {
+    const testContext = makeMistralToolResultContext("read_file", [
+      { type: "text", text: "  indented\n" },
+    ]);
+
+    await runMistralFixture(testContext);
+
+    const payload = mistralMockState.payloads[0] as {
+      messages: Array<{ role: string; content: Array<{ type: string; text?: string }> }>;
+    };
+    const toolMessage = payload.messages.find((message) => message.role === "tool");
+    const toolContent = Array.isArray(toolMessage?.content) ? toolMessage.content : [];
+    const textBlock = toolContent.find((block) => block.type === "text");
+    expect(textBlock?.text).toBe("  indented\n");
+  });
+
   it("serializes structured non-image blocks in tool results as JSON text", async () => {
     // Prove the host redaction port is applied to structured tool-result text.
     configureAiTransportHost({

--- a/packages/ai/src/providers/tool-result-text.test.ts
+++ b/packages/ai/src/providers/tool-result-text.test.ts
@@ -3,9 +3,43 @@ import {
   describeToolResultMediaPlaceholder,
   describeUnsupportedToolResultMedia,
   extractToolResultText,
+  formatToolResultText,
   hasMediaPayload,
   isImageWithMediaPayload,
 } from "./tool-result-text.js";
+
+describe("formatToolResultText", () => {
+  it("preserves significant boundary whitespace in nonblank tool output", () => {
+    expect(formatToolResultText({ text: "  indented\n", isError: false })).toBe("  indented\n");
+    expect(formatToolResultText({ text: "row1   \nrow2\n", isError: false })).toBe(
+      "row1   \nrow2\n",
+    );
+  });
+
+  it("falls back to placeholders only for blank tool output", () => {
+    expect(formatToolResultText({ text: "   \n\t", isError: false })).toBe("(no tool output)");
+    expect(
+      formatToolResultText({ text: "", mediaPlaceholder: "(see attached image)", isError: false }),
+    ).toBe("(see attached image)");
+  });
+
+  it("keeps the error prefix on unmodified output", () => {
+    expect(formatToolResultText({ text: "  failed  ", isError: true })).toBe(
+      "[tool error]   failed  ",
+    );
+  });
+
+  it("appends the omitted-media suffix after unmodified output", () => {
+    const text = "line with trailing spaces   ";
+    expect(
+      formatToolResultText({
+        text,
+        omittedMediaPlaceholder: "[tool image omitted]",
+        isError: false,
+      }),
+    ).toBe(`${text}\n[tool image omitted]`);
+  });
+});
 
 describe("hasMediaPayload", () => {
   it("requires non-empty inline data instead of media metadata", () => {

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -223,8 +223,11 @@ export function formatToolResultText(params: {
   isError: boolean;
 }): string {
   const trimmed = params.text.trim();
+  // trim() is only an emptiness predicate here: tool output boundary
+  // whitespace (indentation, trailing newlines) is significant durable
+  // content, so the nonblank body must emit params.text unmodified.
   const body = trimmed
-    ? `${trimmed}${params.omittedMediaPlaceholder ? `\n${params.omittedMediaPlaceholder}` : ""}`
+    ? `${params.text}${params.omittedMediaPlaceholder ? `\n${params.omittedMediaPlaceholder}` : ""}`
     : (params.omittedMediaPlaceholder ?? params.mediaPlaceholder ?? "(no tool output)");
   return `${params.isError ? "[tool error] " : ""}${body}`;
 }


### PR DESCRIPTION
Closes #127587

**AI-assisted:** yes — built with Claude; prompts/session logs available on request.

## What Problem This Solves

Native Mistral and Ollama requests silently stripped leading indentation and trailing whitespace from durable tool output. Source snippets, diffs, fixed-width data, and shell/read output lost their exact boundaries, so the model-visible payload diverged from the canonical transcript (#127587).

## Why This Change Was Made

The shared `formatToolResultText` helper in `packages/ai/src/providers/tool-result-text.ts` computed `params.text.trim()` but emitted the trimmed value instead of using `trim()` purely as an emptiness predicate. Chat Completions already models the intended contract (`sanitizeToolResultText` in `openai-completions-messages.ts`: trim to detect blankness, emit the full sanitized text). This aligns the shared formatter with that sibling behavior:

- Nonblank text now emits `params.text` unmodified (both call sites pass pre-sanitized `extractToolResultText` output).
- Blank/whitespace-only text keeps the existing placeholder fallback chain.
- Error prefix and omitted-media suffix behavior are unchanged.

## User Impact

Tool results on Mistral and Ollama preserve indentation and trailing newlines exactly as produced, matching every other transport and the durable transcript.

## Evidence

Local, base = current `upstream/main`:

- Shared regression tests fail pre-fix: with the fix stashed, 3 of the 4 new `formatToolResultText` cases fail with exactly the issue's deterministic proof (`expected '[tool error] failed' to be '[tool error]   failed  '`); restored fix → 17/17 green.
- Request-boundary tests added per the issue's coverage list: native Mistral fixture asserts the exact `"  indented\n"` text block reaches the provider payload; Ollama message-conversion test asserts the same through `convertToOllamaMessages`. All green post-fix (Mistral 29/29, Ollama stream-runtime 157/157, shared 17/17).
- oxlint (262 rules) and oxfmt clean on all four files; `tsgo -p packages/ai/tsconfig.json --noEmit` reports zero errors under `packages/ai/**` and `extensions/**` (remaining reported errors are pre-existing on `main` in unrelated `src/agents/*` test files and `src/media/qr-runtime.ts`, untouched here).

Known proof gap: repo-wide typecheck/test lanes not completable locally (host CPU saturation); CI covers them.


## Live provider evidence (after fix)

Real Ollama 0.22.0 on `127.0.0.1:11434`; the shipped plugin stream function (`createOllamaStreamFn` → `convertToOllamaMessages` → native `/api/chat`) was driven against it through a byte-capturing loopback proxy, so the trace below is the exact request body our code put on the wire.

Tool result authored in the conversation: `"  indented line\nrow with trailing spaces   \n"` (two leading spaces; three trailing spaces + newline).

| Tree | `role:"tool"` content captured on the wire |
|---|---|
| unfixed `main` | `"indented line\nrow with trailing spaces"` — leading indent and trailing spaces/newline stripped |
| this PR head | `"  indented line\nrow with trailing spaces   \n"` — byte-exact preservation |

The model then streamed a normal completion over the preserved content (`stopReason: "stop"`), confirming strict endpoints accept the unchanged payload.

**Mistral live-trace infeasibility:** no Mistral API key is available in this environment, so a live Mistral request trace could not be produced locally; CI runs the Mistral request-boundary fixture added here (`mistral.test.ts` asserts the exact `"  indented\n"` text block reaches the provider payload). Mistral and Ollama share the same repaired formatter, and the Ollama half above exercises that shared path end-to-end against a real server.
