### PR TITLE
fix(gateway): prevent requests stalling after reconnect callbacks

### DIFF
--- a/packages/gateway-client/src/protocol-client.socket-factory.test.ts
+++ b/packages/gateway-client/src/protocol-client.socket-factory.test.ts
@@ -16,6 +16,7 @@ type SocketFactoryHarness = {
 
 function createSocketFactoryHarness(options?: {
   initialFailures?: number;
+  onClose?: () => void;
   onConnectError?: (error: Error) => void;
   retryFactoryError?: (error: Error) => boolean;
   rethrowFactoryError?: (error: Error) => boolean;
@@ -41,6 +42,7 @@ function createSocketFactoryHarness(options?: {
     buildConnectPlan: () => ({}),
     buildConnectParams: (plan) => plan,
     resolveClose: () => ({ retry: true, notify: true }),
+    onClose: options?.onClose,
     onConnectError,
     handshake: { mode: "require-challenge", timeoutMs: 100 },
     reconnect: { initialMs: 10, multiplier: 2, maxMs: 100 },
@@ -162,6 +164,43 @@ describe("GatewayProtocolClient socket factory recovery", () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(createSocket).toHaveBeenCalledTimes(2);
     expect(client.connected).toBe(true);
+
+    client.stop();
+  });
+
+  it("does not schedule a retry over a socket restarted by a close callback", async () => {
+    vi.useFakeTimers();
+    let recoveredRequest: Promise<{ healthy: boolean }> | undefined;
+    const { client, createSocket } = createSocketFactoryHarness({
+      onClose: () => {
+        client.start();
+        recoveredRequest = client.request("sessions.list", {}, { timeoutMs: null });
+      },
+    });
+
+    client.start();
+    createSocket.mock.calls[0]?.[0].close(1012, "service restart");
+
+    expect(createSocket).toHaveBeenCalledTimes(2);
+    expect(client.connected).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(createSocket).toHaveBeenCalledTimes(2);
+
+    const replacementSocket = createSocket.mock.results[1]?.value as GatewayProtocolSocket;
+    const requestFrame = vi.mocked(replacementSocket.send).mock.calls[0]?.[0];
+    expect(requestFrame).toBeDefined();
+    createSocket.mock.calls[1]?.[0].message(
+      JSON.stringify({
+        type: "res",
+        id: JSON.parse(requestFrame ?? "{}").id,
+        ok: true,
+        payload: { healthy: true },
+      }),
+    );
+    await expect(recoveredRequest).resolves.toEqual({ healthy: true });
+    expect(client.hasPendingRequests).toBe(false);
 
     client.stop();
   });

--- a/packages/gateway-client/src/protocol-client.ts
+++ b/packages/gateway-client/src/protocol-client.ts
@@ -467,7 +467,8 @@ export class GatewayProtocolClient<TPlan> {
         new Error(`gateway closed (${code}): ${reason}`),
     );
     this.invoke("close", () => this.opts.onClose?.(context, decision));
-    if (decision.retry && !this.stopped) {
+    // A close callback can reconnect synchronously and already own the next socket or retry.
+    if (decision.retry && !this.stopped && !this.socket && !this.reconnectSignal) {
       this.scheduleReconnect(decision.reconnectDelayMs ?? context.connectFailure?.reconnectDelayMs);
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway clients and the Control UI could reconnect after a disconnect but silently leave requests pending forever when a close callback immediately started the replacement connection.

## Why This Change Was Made

The shared browser-safe Gateway client invoked its close callback before scheduling the old connection's retry, but did not revalidate whether that callback had already opened a replacement socket. The old retry then created a third socket, leaked the still-open replacement, and fenced responses belonging to its pending requests. Preserve the existing single-owner lifecycle invariant by applying the same replacement-socket and pending-retry checks already used by the socket-factory error callback path. This does not change the Gateway wire protocol, authentication, persistent state, or public configuration.

## User Impact

Clients that reconnect from a close callback keep their replacement socket, deliver its responses normally, and do not leak an extra connection or leave requests silently stuck.

## Evidence

- Base: `fd4404d0b618297708302a6939421753533537f5`.
- Real current-source lifecycle reproduction before the fix returned `actualSockets: 3`, `replacementResponseObserved: "pending"`, and `sharedPendingRequestStillPresent: true`.
- The identical runtime reproduction after the fix returns `actualSockets: 2`, `replacementResponseObserved: "resolved"`, and `sharedPendingRequestStillPresent: false`.
- The new owner-boundary regression was run against the original source first and failed on the unexpected scheduled retry (`expected 1 to be +0`); after the repair, the focused Gateway socket-factory suite passes all 19 tests.
- The five adjacent lifecycle, handshake, request, response, and event-sequence suites pass all 40 tests.
- Existing factory-error callback recovery, normal reconnect backoff, stop/cancel behavior, TLS policy, and Node client transport cases remain covered.
- Changed-file formatting and linting, `git diff --check`, and a TruffleHog scan all pass.
- Production delta: +2/-1 (net +1; the additional line documents the non-obvious synchronous callback lifecycle invariant). Tests: +39/-0.
