### PR TITLE
fix(agents): status-only replies silently suppress fallback and task completion

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1827,7 +1827,7 @@ src/agents/embedded-agent-runner/openrouter-model-capabilities.ts	2
 src/agents/embedded-agent-runner/prepared-compaction-runtime.ts	1
 src/agents/embedded-agent-runner/prompt-cache-observability.ts	2
 src/agents/embedded-agent-runner/replay-history.ts	60
-src/agents/embedded-agent-runner/result-fallback-classifier.ts	3
+src/agents/embedded-agent-runner/result-fallback-classifier.ts	2
 src/agents/embedded-agent-runner/run-entry.ts	3
 src/agents/embedded-agent-runner/run-orchestrator.ts	1
 src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts	5

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -4,6 +4,11 @@ import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../failover/user-copy.js";
 import { runWithModelFallback } from "../model-fallback-runner.js";
 import { classifyEmbeddedAgentRunResultForModelFallback } from "./result-fallback-classifier.js";
 
+const supplementalSpeechPayload = {
+  mediaUrl: "file:///tmp/answer.mp3",
+  ttsSupplement: { spokenText: "answer", visibleTextAlreadyDelivered: true },
+};
+
 describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
   it("does not fallback when sessions_spawn accepted a child session", () => {
     // Accepted child sessions mean the turn made progress even if the parent did
@@ -128,7 +133,23 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     });
   });
 
-  it("advances to the configured fallback after a generic external runner failure", async () => {
+  it.each([
+    {
+      name: "a generic external runner failure",
+      payload: { text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT },
+      code: "generic_external_run_failure",
+    },
+    {
+      name: "a transient status notice without a final reply",
+      payload: { text: "Still working", isStatusNotice: true },
+      code: "empty_result",
+    },
+    {
+      name: "supplemental speech without a final reply",
+      payload: supplementalSpeechPayload,
+      code: "empty_result",
+    },
+  ])("advances to the configured fallback after $name", async ({ payload, code }) => {
     const runs: Array<{ provider: string; model: string }> = [];
     const result = await runWithModelFallback({
       cfg: undefined,
@@ -140,7 +161,7 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
         runs.push({ provider, model });
         return runs.length === 1
           ? {
-              payloads: [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }],
+              payloads: [payload],
               meta: { durationMs: 1 },
             }
           : { payloads: [{ text: "fallback ok" }], meta: { durationMs: 1 } };
@@ -162,9 +183,11 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
       provider: "external",
       model: "primary",
       reason: "format",
-      code: "generic_external_run_failure",
-      error: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      code,
     });
+    if (code === "generic_external_run_failure") {
+      expect(result.attempts[0]?.error).toBe(GENERIC_EXTERNAL_RUN_FAILURE_TEXT);
+    }
   });
 
   it("classifies Codex subscription usage-limit payloads as rate-limit fallback", () => {
@@ -443,6 +466,30 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     {
       name: "commentary-only",
       payloads: [{ isCommentary: true, text: "progress only" }],
+      code: "empty_result",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "compaction-notice-only",
+      payloads: [{ isCompactionNotice: true, text: "Compacting context" }],
+      code: "empty_result",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "fallback-notice-only",
+      payloads: [{ isFallbackNotice: true, text: "Switching providers" }],
+      code: "empty_result",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "status-notice-only",
+      payloads: [{ isStatusNotice: true, text: "Still working" }],
+      code: "empty_result",
+      suffix: "without a visible assistant reply",
+    },
+    {
+      name: "supplemental-speech-only",
+      payloads: [supplementalSpeechPayload],
       code: "empty_result",
       suffix: "without a visible assistant reply",
     },

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -87,23 +87,15 @@ function hasDeliverableAssistantPayload(result: {
   meta?: { finalAssistantVisibleText?: unknown };
 }): boolean {
   const finalVisibleText = result.meta?.finalAssistantVisibleText;
-  const payloads = Array.isArray(result.payloads)
-    ? result.payloads.filter((payload) => {
-        if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-          return true;
-        }
-        const record = payload as { isCommentary?: unknown; visible?: unknown };
-        return record.isCommentary !== true && record.visible !== false;
-      })
-    : [];
   return (
     (typeof finalVisibleText === "string" &&
       finalVisibleText.trim().length > 0 &&
       !isSilentReplyPayloadText(finalVisibleText)) ||
-    hasVisibleAgentPayload(
-      { payloads },
-      { includeErrorPayloads: false, includeReasoningPayloads: false },
-    )
+    hasVisibleAgentPayload(result, {
+      includeErrorPayloads: false,
+      includeReasoningPayloads: false,
+      requireTerminalContent: true,
+    })
   );
 }
 

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -2063,6 +2063,36 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: false,
     },
     {
+      name: "only pre-tool commentary",
+      payloads: [{ text: "Waiting for the delegated task.", isCommentary: true }],
+      delivered: false,
+    },
+    {
+      name: "only a compaction notice",
+      payloads: [{ text: "Compacting the session.", isCompactionNotice: true }],
+      delivered: false,
+    },
+    {
+      name: "only a provider-fallback notice",
+      payloads: [{ text: "Switching providers.", isFallbackNotice: true }],
+      delivered: false,
+    },
+    {
+      name: "only a transient status notice",
+      payloads: [{ text: "Still working.", isStatusNotice: true }],
+      delivered: false,
+    },
+    {
+      name: "only supplemental TTS audio",
+      payloads: [
+        {
+          mediaUrl: "file:///tmp/answer.mp3",
+          ttsSupplement: { spokenText: "answer", visibleTextAlreadyDelivered: true },
+        },
+      ],
+      delivered: false,
+    },
+    {
       name: "a failed-tool warning and a successful visible reply",
       payloads: [
         { text: "Yield failed before completion.", isError: true },
@@ -2074,6 +2104,14 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       name: "hidden reasoning and a successful visible reply",
       payloads: [
         { text: "Waiting for the delegated task.", isReasoning: true },
+        { text: "The delegated task completed." },
+      ],
+      delivered: true,
+    },
+    {
+      name: "a status notice and a successful visible reply",
+      payloads: [
+        { text: "Still working.", isStatusNotice: true },
         { text: "The delegated task completed." },
       ],
       delivered: true,

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -435,6 +435,7 @@ export async function sendSubagentAnnounceDirectly(params: {
     const completionPayloadVisibility = {
       includeErrorPayloads: false,
       includeReasoningPayloads: false,
+      requireTerminalContent: true,
     };
     const hasVisibleGatewayPayload = Boolean(
       directAnnounceResult &&
@@ -446,7 +447,6 @@ export async function sendSubagentAnnounceDirectly(params: {
       hasVisibleAgentPayload(directAnnounceResult, {
         ...completionPayloadVisibility,
         includeSilentReplyPayloads: false,
-        requireTerminalContent: true,
       }),
     );
     const hasIntentionalSilentCompletionReply = Boolean(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting for an agent answer or delegated task completion would receive no reply when the only generated output was transient commentary, a compaction/provider/status notice, or supplemental speech audio. Model fallback incorrectly settled the unfinished turn, and grouped completion delivery incorrectly reported success even though no terminal assistant answer was produced.

## Why This Change Was Made

Both completion owners now use the existing canonical terminal-content classification instead of partially reimplementing visibility rules. This removes the divergent filtering path and its unsafe assertion, shares the same answer contract across fallback and delegated delivery, and preserves deliberate `NO_REPLY`, already-committed messaging-tool delivery, real attachments, and genuine assistant answers.

## User Impact

An unfinished turn now advances to the next configured model instead of going silent, and delegated completions containing only progress/status/speech supplements visibly fail instead of being falsely marked delivered. Mixed notices plus a real answer and intentional silent completions remain unchanged.

## Evidence

- Pre-fix red: six model-classification/fallback failures, including actual two-candidate fallback dispatch; five grouped completion failures through the real gateway/Slack-thread announcement boundary.
- Post-fix green: 63 canonical fallback/reply-payload/restart-recovery tests and 186 gateway-mediated delegated-completion tests.
- Core and agent-test TypeScript checks, targeted lint/format, assertion-safety and max-lines ratchets, and runtime import-cycle checks pass.
- Production delta: +6/-14 (net -8); tests: +89/-4. The assertion-safety baseline improves from three unchecked assertions to two.
- Fresh independent in-session source-aware review covers both ownership boundaries, sibling terminal-answer contracts, intentional silence, committed delivery, real media, and the complete final diff. The external review CLI was unavailable under the session's approval boundary.
