### PR TITLE
feat(ui): unify operator notice presentation

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -258,6 +258,7 @@ function buildUpdateFixture(fixture: CliOptions["fixture"], nowMs: number): Upda
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const uiRoot = path.join(repoRoot, "ui");
 const boardFixturePath = "/__fixtures/board/";
+const noticesFixturePath = "/__fixtures/notices/";
 const boardFixtureHtml = `<!doctype html>
 <html lang="en">
   <head>
@@ -298,6 +299,34 @@ const boardFixtureHtml = `<!doctype html>
   <body>
     <div id="app"></div>
     <script type="module" src="/src/test-helpers/board-fixture.ts"></script>
+  </body>
+</html>`;
+const noticesFixtureHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <title>OpenClaw Notice Inventory</title>
+    <script>
+      const requestedTheme = new URLSearchParams(location.search).get("theme");
+      const mediaQuery = matchMedia("(prefers-color-scheme: light)");
+      const applyTheme = () => {
+        const mode = requestedTheme || (mediaQuery.matches ? "light" : "dark");
+        document.documentElement.dataset.theme = mode;
+        document.documentElement.dataset.themeMode = mode;
+        document.documentElement.className = "wa-" + mode;
+        document.documentElement.style.colorScheme = mode;
+      };
+      applyTheme();
+      mediaQuery.addEventListener("change", applyTheme);
+    </script>
+    <link rel="stylesheet" href="/src/styles.css" />
+    <style>body { margin: 0; min-width: 320px; min-height: 100vh; background: var(--bg); }</style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-helpers/notices-fixture.ts"></script>
   </body>
 </html>`;
 
@@ -3205,6 +3234,24 @@ function createBoardFixturePlugin(): Plugin {
   };
 }
 
+function createNoticesFixturePlugin(): Plugin {
+  return {
+    name: "openclaw-control-ui-notices-fixture",
+    configureServer(server) {
+      server.middlewares.use(noticesFixturePath, (_req, res, next) => {
+        void server
+          .transformIndexHtml(noticesFixturePath, noticesFixtureHtml)
+          .then((html) => {
+            res.statusCode = 200;
+            res.setHeader("content-type", "text/html; charset=utf-8");
+            res.end(html);
+          })
+          .catch((error: unknown) => next(error as Error));
+      });
+    },
+  };
+}
+
 function hostForUrl(boundAddress: string, requestedHost: string): string {
   const host = boundAddress === "0.0.0.0" || boundAddress === "::" ? requestedHost : boundAddress;
   const reachableHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
@@ -3259,7 +3306,11 @@ const server = await createServer({
       : {}),
     include: ["lit/directives/repeat.js"],
   },
-  plugins: [createMockGatewayPlugin(scenario), createBoardFixturePlugin()],
+  plugins: [
+    createMockGatewayPlugin(scenario),
+    createBoardFixturePlugin(),
+    createNoticesFixturePlugin(),
+  ],
   publicDir: path.join(uiRoot, "public"),
   resolve: {
     alias: [
@@ -3281,6 +3332,9 @@ await server.listen();
 console.log(`[control-ui-mock] ${resolveServerUrl(server, options.host)}`);
 console.log(
   `[control-ui-mock] board fixture: ${resolveServerUrl(server, options.host, boardFixturePath)}`,
+);
+console.log(
+  `[control-ui-mock] notices fixture: ${resolveServerUrl(server, options.host, noticesFixturePath)}`,
 );
 await waitForShutdown();
 await server.close();

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -577,7 +577,7 @@ class OpenClawShell
     }
     void import("../lib/chat/composer-draft-retirement.runtime.ts").then(
       ({ retireDeletedComposerDrafts }) => retireDeletedComposerDrafts(context, deletedSessions),
-      () => showToast({ message: t("sessionsView.draftCleanupFailed") }),
+      () => showToast({ message: t("sessionsView.draftCleanupFailed"), variant: "warning" }),
     );
   }
 

--- a/ui/src/app/update-success-notice.test.ts
+++ b/ui/src/app/update-success-notice.test.ts
@@ -33,6 +33,7 @@ describe("update success notice", () => {
 
     expect(showToastMock).toHaveBeenCalledWith({
       message: "Gateway updated · now on abcdef1.",
+      variant: "success",
     });
   });
 });

--- a/ui/src/app/update-success-notice.ts
+++ b/ui/src/app/update-success-notice.ts
@@ -42,7 +42,7 @@ export function announceVerifiedUpdateInstall(identity: UpdateInstallIdentity): 
   }
   if (!reloadControlUiIfStale(identity)) {
     takeRecordedUpdateSuccess();
-    showToast({ message: formatUpdateSuccess(identity) });
+    showToast({ message: formatUpdateSuccess(identity), variant: "success" });
   }
 }
 
@@ -62,5 +62,5 @@ export function announceRecordedUpdateSuccess(): void {
   } catch {
     return;
   }
-  showToast({ message: formatUpdateSuccess(identity) });
+  showToast({ message: formatUpdateSuccess(identity), variant: "success" });
 }

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -441,6 +441,8 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
           }}
           >${t("chat.sidebar.sectionHiddenRecovery")}</a
         >`,
+      variant: "info",
+      key: `sidebar-section-hidden:${catalogId}`,
       actionLabel: t("common.undo"),
       onAction: () => setStoredSessionCatalogHidden(catalogId, false),
       durationMs: 12_000,

--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -775,9 +775,7 @@ describe("openclaw-board-view", () => {
     await vi.waitFor(() => expect(allow?.disabled).toBe(false));
   });
 
-  it("toasts failed rejection while keeping controls and leaves successful decisions quiet", async () => {
-    const toastHost = document.createElement("openclaw-toast-host");
-    document.body.append(toastHost);
+  it("keeps failed decisions inline and leaves successful decisions quiet", async () => {
     const grant = vi.fn(async (_name: string, decision: "granted" | "rejected") => {
       if (decision === "rejected") {
         throw new Error("approval service unavailable");
@@ -790,16 +788,11 @@ describe("openclaw-board-view", () => {
     allow?.click();
     await vi.waitFor(() => expect(grant).toHaveBeenCalledWith("alpha", "granted"));
     await vi.waitFor(() => expect(reject?.disabled).toBe(false));
-    expect(toastHost.querySelector(".app-toast")).toBeNull();
-
     reject?.click();
     await vi.waitFor(() => {
       expect(
         view.querySelector('[data-test-id="board-widget-action-error"]')?.textContent,
       ).toContain("approval service unavailable");
-      expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
-        "Could not reject widget access. Try again.",
-      );
     });
     expect(allow?.disabled).toBe(false);
     expect(reject?.disabled).toBe(false);

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -20,7 +20,6 @@ import {
   type PluginBoardWidgetRenderer,
 } from "../../lib/board/widgets/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { showToast } from "../../lib/toast.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { renderBoardMcpAppContent } from "./board-mcp-app-content.ts";
 import { BoardMcpAppLifecycle } from "./board-mcp-app-lifecycle.ts";
@@ -154,7 +153,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     super.disconnectedCallback();
   }
 
-  private async runAction(action: () => Promise<void>, failureMessage?: string): Promise<void> {
+  private async runAction(action: () => Promise<void>): Promise<void> {
     if (this.actionPending || this.busy) {
       return;
     }
@@ -165,9 +164,6 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
       await action();
     } catch (error) {
       this.actionError = formatUiError(error);
-      if (failureMessage) {
-        showToast({ message: failureMessage });
-      }
     } finally {
       this.actionPending = false;
     }
@@ -178,10 +174,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     callbacks: BoardWidgetCellCallbacks,
     decision: BoardGrantDecision,
   ): void {
-    const failureMessage = t(
-      decision === "granted" ? "board.widget.allowFailed" : "board.widget.rejectFailed",
-    );
-    void this.runAction(() => callbacks.grant(widget.name, decision), failureMessage);
+    void this.runAction(() => callbacks.grant(widget.name, decision));
   }
 
   private handleMenuSelect(

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -116,7 +116,7 @@ describe("openclaw-modal-dialog", () => {
       const { modal } = await renderModal();
       const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
 
-      showToast({ message: "Saved" });
+      showToast({ message: "Saved", variant: "success" });
       modal.hide();
       await modal.updateComplete;
       await appHost.updateComplete;

--- a/ui/src/components/session-organizer-batch-mutations.test.ts
+++ b/ui/src/components/session-organizer-batch-mutations.test.ts
@@ -491,7 +491,6 @@ describe("session organizer destructive confirmations", () => {
         },
       ],
     });
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => undefined);
 
     const pending = deleteSessionsBatch(harness.host, rows, harness.scope);
     const actions = await waitForConfirmDialogActions();
@@ -517,10 +516,10 @@ describe("session organizer destructive confirmations", () => {
     ]);
     expect(harness.publishSessionMutationError).toHaveBeenCalledWith(harness.scope, retryError);
     expect(retryError).not.toContain("GatewayRequestError");
-    expect(alertSpy).toHaveBeenCalledWith(
-      "Managed Worktrees:\nopenclaw/busy — live run or cleanup active",
-    );
-    alertSpy.mockRestore();
+    expect(showToast).toHaveBeenCalledWith({
+      message: "Managed Worktrees:\nopenclaw/busy — live run or cleanup active",
+      variant: "warning",
+    });
   });
 
   it.each(destructiveOperations)("sends no $name request when cancelled", async (operation) => {
@@ -553,7 +552,10 @@ describe("session organizer destructive confirmations", () => {
       // The abort resolves the dialog to `false`, same as a user cancel, so the
       // operator needs a distinct, visible outcome or their lost intent reads
       // as a click that simply did nothing.
-      expect(showToast).toHaveBeenCalledWith({ message: operation.staleMessage });
+      expect(showToast).toHaveBeenCalledWith({
+        message: operation.staleMessage,
+        variant: "warning",
+      });
 
       // A fresh confirmation (the reconnect's own retry) must be able to open
       // immediately; a stale dialog holding the shared lock would block it.
@@ -596,6 +598,7 @@ describe("session organizer destructive confirmations", () => {
     // the no-access branch, so the operator learns where it went.
     expect(showToast).toHaveBeenCalledWith({
       message: "Managed Worktrees:\nfeature — cleanup failed",
+      variant: "warning",
     });
   });
 

--- a/ui/src/components/session-organizer-catalog.ts
+++ b/ui/src/components/session-organizer-catalog.ts
@@ -106,7 +106,7 @@ export async function deleteSessionGroup(
   // too, so without this order the operator's lost intent would look like an
   // ordinary cancel instead of the reconnect that actually dropped it.
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
-    showToast({ message: t("sessionsView.deleteGroupStale", { group }) });
+    showToast({ message: t("sessionsView.deleteGroupStale", { group }), variant: "warning" });
     return false;
   }
   if (!confirmed) {

--- a/ui/src/components/session-organizer-operations.runtime.ts
+++ b/ui/src/components/session-organizer-operations.runtime.ts
@@ -170,6 +170,8 @@ export async function archiveSessionWithUndo(
   }
   showToast({
     message: t("sessionsView.sessionArchived"),
+    variant: "success",
+    key: `session-archived:${session.key}`,
     actionLabel: t("common.undo"),
     onAction: () =>
       void restoreArchivedSessions(host, [{ session, pinned: session.pinned }], scope),
@@ -196,6 +198,8 @@ async function archiveSessionsWithUndo(
       archived.length === 1
         ? t("sessionsView.sessionArchived")
         : t("sessionsView.sessionsArchived", { count: String(archived.length) }),
+    variant: "success",
+    key: `sessions-archived:${archived.map(({ session }) => session.key).join(",")}`,
     actionLabel: t("common.undo"),
     onAction: () => void restoreArchivedSessions(host, archived, scope),
   });
@@ -290,7 +294,10 @@ export async function deleteSessionsBatch(
   // too, so without this order the operator's lost intent would look like an
   // ordinary cancel instead of the reconnect that actually dropped it.
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
-    showToast({ message: t("sessionsView.deleteSessionsStale", { count: String(rows.length) }) });
+    showToast({
+      message: t("sessionsView.deleteSessionsStale", { count: String(rows.length) }),
+      variant: "warning",
+    });
     return;
   }
   if (!confirmed) {
@@ -320,7 +327,10 @@ export async function deleteSessionsBatch(
       }
     }
     if (result.preservedWorktrees.length > 0) {
-      window.alert(formatPreservedWorktreesNotice(result.preservedWorktrees));
+      showToast({
+        message: formatPreservedWorktreesNotice(result.preservedWorktrees),
+        variant: "warning",
+      });
       if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
         return;
       }
@@ -448,7 +458,7 @@ export async function createSessionGroup(
     // Closing on that would leave the skipped rows unaccounted for, so the
     // partial outcome is named here; it is terminal, as the group already exists.
     if (moved === "completed" && targets.length < sessions.length) {
-      showToast({ message: t("sessionsView.newGroupMovePartial") });
+      showToast({ message: t("sessionsView.newGroupMovePartial"), variant: "warning" });
     }
     return moved;
   }
@@ -461,7 +471,7 @@ export async function createSessionGroup(
   // not proof the sessions are gone — say so rather than closing on a silent
   // non-outcome the operator cannot account for.
   if (sessions.length > 0) {
-    showToast({ message: t("sessionsView.newGroupMoveSkipped") });
+    showToast({ message: t("sessionsView.newGroupMoveSkipped"), variant: "warning" });
   }
   // Re-render so the new section shows up.
   host.requestUpdate();
@@ -546,7 +556,10 @@ export async function stopCloudWorker(
   // too, so without this order the operator's lost intent would look like an
   // ordinary cancel instead of the reconnect that actually dropped it.
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
-    showToast({ message: t("sessionsView.stopCloudWorkerStale", { session: session.label }) });
+    showToast({
+      message: t("sessionsView.stopCloudWorkerStale", { session: session.label }),
+      variant: "warning",
+    });
     return;
   }
   if (!confirmed) {
@@ -589,7 +602,10 @@ export async function deleteSession(
   // too, so without this order the operator's lost intent would look like an
   // ordinary cancel instead of the reconnect that actually dropped it.
   if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
-    showToast({ message: t("sessionsView.deleteSessionStale", { session: session.label }) });
+    showToast({
+      message: t("sessionsView.deleteSessionStale", { session: session.label }),
+      variant: "warning",
+    });
     return;
   }
   if (!confirmed) {
@@ -628,7 +644,7 @@ export async function deleteSession(
         requiredScope: "operator.admin",
       });
       if (!removeAccess.allowed) {
-        window.alert(formatPreservedWorktreesNotice([preserved]));
+        showToast({ message: formatPreservedWorktreesNotice([preserved]), variant: "warning" });
         if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
           return;
         }
@@ -646,6 +662,7 @@ export async function deleteSession(
         if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
           showToast({
             message: formatPreservedWorktreesNotice([preserved]),
+            variant: "warning",
           });
           return;
         }

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -283,7 +283,10 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
               break;
             case "copy-session-id":
               void copyToClipboard(session.sessionId ?? "").then((copied) => {
-                showToast({ message: t(copied ? "common.copied" : "common.copyFailed") });
+                showToast({
+                  message: t(copied ? "common.copied" : "common.copyFailed"),
+                  variant: copied ? "success" : "danger",
+                });
               });
               break;
             case "toggle-pin":

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -231,6 +231,26 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
     }
   });
 
+  it("renders the complete notice inventory by zone", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(new URL("/__fixtures/notices/", fixtureServer.url).toString(), {
+        waitUntil: "networkidle",
+      });
+
+      await page.getByRole("heading", { name: "Operator notices by zone" }).waitFor();
+      expect(await page.locator(".notice-fixture__zone").count()).toBe(7);
+      expect(await page.locator(".notice-fixture__toast-gallery .app-toast").count()).toBe(4);
+      expect(
+        await page.locator(".notice-fixture__session-chips .notice-fixture__chip").count(),
+      ).toBe(4);
+      expect(await page.locator(".notice-fixture .callout").count()).toBe(6);
+      expect(await page.locator("openclaw-toast-host .app-toast").count()).toBe(3);
+    } finally {
+      await page.close();
+    }
+  });
+
   it("opens a visible catalog session with its transcript in chronological order", async () => {
     const page = await browser.newPage();
     try {

--- a/ui/src/lib/chat/composer-draft-retirement.runtime.ts
+++ b/ui/src/lib/chat/composer-draft-retirement.runtime.ts
@@ -20,7 +20,7 @@ export async function retireDeletedComposerDrafts(
   const reportFailure = () => {
     if (!failureReported) {
       failureReported = true;
-      showToast({ message: t("sessionsView.draftCleanupFailed") });
+      showToast({ message: t("sessionsView.draftCleanupFailed"), variant: "warning" });
     }
   };
   void deleteStoredChatSessionSnapshots(

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -5,7 +5,6 @@ import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
 import { copyToClipboard } from "../clipboard.ts";
 import { serializeConfigForm } from "../config-form-utils.ts";
 import { formatUiError, formatUiExternalText } from "../format-error.ts";
-import { showToast } from "../toast.ts";
 import {
   adoptConfigSetAck,
   applyConfigSnapshot,
@@ -652,7 +651,6 @@ export async function openConfigFile(state: RuntimeConfigState): Promise<void> {
     }
     if (isCurrent()) {
       state.lastError = formatUiExternalText(message);
-      showToast({ message: state.lastError });
     }
   };
   try {

--- a/ui/src/lib/toast.test.ts
+++ b/ui/src/lib/toast.test.ts
@@ -18,132 +18,121 @@ afterEach(() => {
 });
 
 describe("shared toast", () => {
-  it("reports when no host can present the toast", () => {
-    expect(showToast({ message: "Unavailable" })).toBe(false);
-  });
-
-  it("shows and replaces the active toast", async () => {
+  it("keeps three independent outcomes and evicts the oldest on saturation", async () => {
     const host = await mountHost();
+    const dismissed = vi.fn();
 
-    showToast({ message: "First" });
+    showToast({ message: "First", variant: "info", onDismiss: dismissed });
+    showToast({ message: "Second", variant: "success" });
+    showToast({ message: "Third", variant: "warning" });
+    showToast({ message: "Fourth", variant: "danger" });
     await host.updateComplete;
-    expect(host.querySelector(".app-toast__message")?.textContent).toBe("First");
 
-    showToast({ message: "Second" });
-    await host.updateComplete;
-    expect(host.querySelectorAll(".app-toast")).toHaveLength(1);
-    expect(host.querySelector(".app-toast__message")?.textContent).toBe("Second");
+    expect(
+      [...host.querySelectorAll(".app-toast__message")].map((node) => node.textContent),
+    ).toEqual(["Second", "Third", "Fourth"]);
+    expect(dismissed).toHaveBeenCalledWith("replaced");
   });
 
-  it("uses the active modal's toast layer before the app layer", async () => {
-    const appHost = await mountHost();
+  it("updates a keyed outcome without consuming another stack slot", async () => {
+    const host = await mountHost();
+    const dismissed = vi.fn();
+
+    showToast({ key: "sync", message: "Syncing", variant: "info", onDismiss: dismissed });
+    showToast({ key: "sync", message: "Synced", variant: "success" });
+    await host.updateComplete;
+
+    expect(host.querySelectorAll(".app-toast")).toHaveLength(1);
+    expect(host.textContent).toContain("Synced");
+    expect(dismissed).toHaveBeenCalledWith("replaced");
+  });
+
+  it.each([
+    ["info", "status", "polite"],
+    ["success", "status", "polite"],
+    ["warning", "alert", "assertive"],
+    ["danger", "alert", "assertive"],
+  ] as const)(
+    "presents %s with the matching live-region semantics",
+    async (variant, role, live) => {
+      const host = await mountHost();
+
+      showToast({ message: variant, variant });
+      await host.updateComplete;
+
+      const toast = host.querySelector(".app-toast");
+      expect(toast?.getAttribute("role")).toBe(role);
+      expect(toast?.getAttribute("aria-live")).toBe(live);
+      expect(toast?.classList.contains(`app-toast--${variant}`)).toBe(true);
+    },
+  );
+
+  it("anchors a scoped outcome to the visible owning session pane", async () => {
+    const host = await mountHost();
+    const pane = document.createElement("openclaw-chat-pane") as HTMLElement & {
+      sessionKey?: string;
+    };
+    pane.className = "chat-pane-cache__pane--visible";
+    pane.sessionKey = "agent:main:active";
+    vi.spyOn(pane, "getBoundingClientRect").mockReturnValue(new DOMRect(20, 40, 600, 700));
+    document.body.append(pane);
+
+    showToast({
+      message: "Session outcome",
+      variant: "success",
+      scope: { kind: "session", sessionKey: pane.sessionKey },
+    });
+    await host.updateComplete;
+
+    expect(host.querySelector(".app-toast--session")).not.toBeNull();
+  });
+
+  it("uses the active modal toast layer", async () => {
+    const host = await mountHost();
     const modal = document.createElement("openclaw-modal-dialog");
     modal.open = true;
     document.body.append(modal);
     await modal.updateComplete;
     const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
 
-    showToast({ message: "Above overlay" });
-    await appHost.updateComplete;
+    showToast({ message: "Above overlay", variant: "warning" });
+    await host.updateComplete;
 
-    expect(moveBefore).toHaveBeenCalledWith(appHost, null);
+    expect(moveBefore).toHaveBeenCalledWith(host, null);
     expect(moveBefore.mock.contexts).toContain(modal);
-    expect(appHost.textContent).toContain("Above overlay");
   });
 
-  it("routes through an active modal inside a shadow root", async () => {
-    const appHost = await mountHost();
-    const shadowOwner = document.createElement("div");
-    const shadowRoot = shadowOwner.attachShadow({ mode: "open" });
-    const modal = document.createElement("openclaw-modal-dialog");
-    modal.open = true;
-    shadowRoot.append(modal);
-    document.body.append(shadowOwner);
-    await modal.updateComplete;
-    const moveBefore = vi.spyOn(Element.prototype, "moveBefore");
-
-    showToast({ message: "Critical session notice" });
-    await appHost.updateComplete;
-
-    expect(moveBefore).toHaveBeenCalledWith(appHost, null);
-    expect(moveBefore.mock.contexts).toContain(modal);
-    expect(appHost.textContent).toContain("Critical session notice");
-  });
-
-  it("auto-dismisses after the configured duration", async () => {
-    vi.useFakeTimers();
-    const host = await mountHost();
-    const anchor = document.createElement("div");
-    document.body.append(anchor);
-    vi.spyOn(anchor, "getBoundingClientRect").mockReturnValue(new DOMRect(0, 0, 100, 100));
-
-    showToast({ anchor, message: "Temporary", durationMs: 50 });
-    await host.updateComplete;
-    await vi.advanceTimersByTimeAsync(50);
-    await host.updateComplete;
-
-    expect(host.querySelector('.app-toast[data-active="false"]')).not.toBeNull();
-
-    await vi.runAllTimersAsync();
-    await host.updateComplete;
-
-    expect(host.querySelector(".app-toast")).toBeNull();
-  });
-
-  it("runs its action once and dismisses", async () => {
+  it("dismisses only the acted-on outcome", async () => {
     const host = await mountHost();
     const onAction = vi.fn();
-    showToast({ message: "Archived", actionLabel: "Undo", onAction });
+    showToast({ message: "Archived", variant: "success", actionLabel: "Undo", onAction });
+    showToast({ message: "Still visible", variant: "info" });
     await host.updateComplete;
 
     host.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
     await host.updateComplete;
 
     expect(onAction).toHaveBeenCalledOnce();
-    expect(host.querySelector(".app-toast")).toBeNull();
+    expect(host.querySelectorAll(".app-toast")).toHaveLength(1);
+    expect(host.textContent).toContain("Still visible");
   });
 
-  it("preserves the dismissal reason when an exiting toast is replaced", async () => {
+  it("uses each variant's default lifetime", async () => {
     vi.useFakeTimers();
     const host = await mountHost();
-    const anchor = document.createElement("div");
-    document.body.append(anchor);
-    vi.spyOn(anchor, "getBoundingClientRect").mockReturnValue(new DOMRect(0, 0, 100, 100));
-    const reasons: string[] = [];
+    const lifetimes = [
+      ["success", 5_000],
+      ["info", 6_000],
+      ["warning", 8_000],
+      ["danger", 12_000],
+    ] as const;
 
-    showToast({ anchor, message: "First", onDismiss: (reason) => reasons.push(reason) });
-    await host.updateComplete;
-    host.querySelector<HTMLButtonElement>(".app-toast__dismiss")?.click();
-    await host.updateComplete;
-    showToast({ message: "Second" });
-
-    expect(reasons).toEqual(["dismiss"]);
-  });
-
-  it("reports why a toast is replaced, dismissed, acted on, or disconnected", async () => {
-    const host = await mountHost();
-    const reasons: string[] = [];
-
-    showToast({ message: "First", onDismiss: (reason) => reasons.push(reason) });
-    showToast({
-      message: "Second",
-      actionLabel: "Undo",
-      onAction: () => reasons.push("ran-action"),
-      onDismiss: (reason) => reasons.push(reason),
-    });
-    await host.updateComplete;
-    host.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
-    await host.updateComplete;
-
-    showToast({ message: "Third", onDismiss: (reason) => reasons.push(reason) });
-    await host.updateComplete;
-    host.querySelector<HTMLButtonElement>(".app-toast__dismiss")?.click();
-    await host.updateComplete;
-    expect(host.querySelector(".app-toast")).toBeNull();
-
-    showToast({ message: "Fourth", onDismiss: (reason) => reasons.push(reason) });
-    host.remove();
-
-    expect(reasons).toEqual(["replaced", "action", "ran-action", "dismiss", "disconnected"]);
+    for (const [variant, duration] of lifetimes) {
+      showToast({ key: "lifetime", message: variant, variant });
+      await host.updateComplete;
+      await vi.advanceTimersByTimeAsync(duration + 150);
+      await host.updateComplete;
+      expect(host.querySelector(".app-toast")).toBeNull();
+    }
   });
 });

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -6,24 +6,35 @@ import { t } from "../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { formatUiExternalText } from "./format-error.ts";
 
+type ToastVariant = "info" | "success" | "warning" | "danger";
 type ToastDismissReason = "action" | "dismiss" | "disconnected" | "replaced" | "timeout";
 
 export type ToastOptions = {
-  /** A template lets a message name a destination the operator can actually open,
-   * instead of spelling out a settings path the toast then makes them find. */
   message: string | TemplateResult;
-  /** Positions a compact toast at the top center of the owning surface. */
-  anchor?: Element;
-  anchorTopOffset?: number;
-  icon?: TemplateResult;
+  variant: ToastVariant;
+  key?: string;
+  scope?: { kind: "session"; sessionKey: string };
   actionLabel?: string;
   onAction?: () => void;
   onDismiss?: (reason: ToastDismissReason) => void;
   durationMs?: number;
 };
 
-const DEFAULT_TOAST_DURATION_MS = 6_000;
-const TOAST_EXIT_FALLBACK_MS = 450;
+type ToastEntry = ToastOptions & {
+  id: number;
+  active: boolean;
+  timer: ReturnType<typeof globalThis.setTimeout> | null;
+};
+
+const MAX_VISIBLE_TOASTS = 3;
+const DEFAULT_DURATIONS: Record<ToastVariant, number> = {
+  info: 6_000,
+  success: 5_000,
+  warning: 8_000,
+  danger: 12_000,
+};
+const TOAST_EXIT_MS = 150;
+let nextToastId = 0;
 
 function activeModalToastLayer() {
   return [...(document.openClawModalToastLayers ?? [])].findLast(
@@ -31,24 +42,26 @@ function activeModalToastLayer() {
   );
 }
 
-// Outcomes reported during startup (a restored post-update result, for example)
-// race the shell that owns the host element. Hold the latest one instead of
-// dropping it, so no caller's message disappears because it arrived too early.
-let queuedToast: ToastOptions | null = null;
+function sessionToastAnchor(sessionKey: string): Element | null {
+  const panes = document.querySelectorAll<HTMLElement & { sessionKey?: string }>(
+    "openclaw-chat-pane.chat-pane-cache__pane--visible",
+  );
+  return [...panes].find((pane) => pane.sessionKey === sessionKey) ?? null;
+}
+
+// Startup outcomes can precede the shell. Preserve the same bounded admission
+// policy used by a mounted host so early bursts do not collapse to one event.
+let queuedToasts: ToastOptions[] = [];
 
 class OpenClawToastHost extends OpenClawLightDomContentsElement {
-  @state() private toast: ToastOptions | null = null;
-  @state() private active = false;
-  private dismissTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
-  private exitTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
-  private exitReason: ToastDismissReason | null = null;
+  @state() private entries: ToastEntry[] = [];
 
   override connectedCallback() {
     super.connectedCallback();
-    const pending = queuedToast;
-    queuedToast = null;
-    if (pending) {
-      this.show(pending);
+    const pending = queuedToasts;
+    queuedToasts = [];
+    for (const toast of pending) {
+      this.show(toast);
     }
   }
 
@@ -57,138 +70,147 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
     if (!this.isConnected && this.parentElement?.localName === "openclaw-modal-dialog" && target) {
       target.append(this);
     } else {
-      this.dismiss("disconnected");
+      for (const entry of this.entries) {
+        this.finishDismiss(entry, "disconnected");
+      }
     }
     super.disconnectedCallback();
   }
 
-  /** Keep the active outcome intact while moveBefore() crosses top-layer owners. */
+  /** Keep active outcomes intact while moveBefore() crosses top-layer owners. */
   connectedMoveCallback() {}
 
   show(options: ToastOptions) {
-    this.finishDismiss(this.exitReason ?? "replaced");
-    this.toast = options;
-    this.active = true;
-    this.exitReason = null;
-    this.dismissTimer = globalThis.setTimeout(
-      () => this.dismiss("timeout"),
-      options.durationMs ?? DEFAULT_TOAST_DURATION_MS,
+    const matching = options.key
+      ? this.entries.find((entry) => entry.key === options.key)
+      : undefined;
+    if (matching) {
+      matching.onDismiss?.("replaced");
+      this.clearTimer(matching);
+      Object.assign(matching, options, { active: true });
+      this.startTimer(matching);
+      this.entries = [...this.entries];
+      return;
+    }
+
+    if (this.entries.length === MAX_VISIBLE_TOASTS) {
+      this.finishDismiss(this.entries[0]!, "replaced");
+    }
+    const entry: ToastEntry = {
+      ...options,
+      id: ++nextToastId,
+      active: true,
+      timer: null,
+    };
+    this.entries = [...this.entries, entry];
+    this.startTimer(entry);
+  }
+
+  private startTimer(entry: ToastEntry) {
+    entry.timer = globalThis.setTimeout(
+      () => this.dismiss(entry, "timeout"),
+      entry.durationMs ?? DEFAULT_DURATIONS[entry.variant],
     );
   }
 
-  private clearDismissTimer() {
-    if (this.dismissTimer !== null) {
-      globalThis.clearTimeout(this.dismissTimer);
-      this.dismissTimer = null;
-    }
-    if (this.exitTimer !== null) {
-      globalThis.clearTimeout(this.exitTimer);
-      this.exitTimer = null;
+  private clearTimer(entry: ToastEntry) {
+    if (entry.timer !== null) {
+      globalThis.clearTimeout(entry.timer);
+      entry.timer = null;
     }
   }
 
-  private finishDismiss(reason: ToastDismissReason) {
-    const toast = this.toast;
-    this.clearDismissTimer();
-    this.active = false;
-    this.exitReason = null;
-    this.toast = null;
-    toast?.onDismiss?.(reason);
-  }
-
-  private dismiss(reason: ToastDismissReason) {
-    const toast = this.toast;
-    if (!toast) {
+  private finishDismiss(entry: ToastEntry, reason: ToastDismissReason) {
+    if (!this.entries.includes(entry)) {
       return;
     }
-    this.clearDismissTimer();
-    const reducedMotion = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-    const anchorRect = toast.anchor?.isConnected ? toast.anchor.getBoundingClientRect() : null;
-    const anchored = anchorRect !== null && anchorRect.width > 0;
+    this.clearTimer(entry);
+    this.entries = this.entries.filter((candidate) => candidate !== entry);
+    entry.onDismiss?.(reason);
+  }
+
+  private dismiss(entry: ToastEntry, reason: ToastDismissReason) {
+    this.clearTimer(entry);
     if (
-      (reason !== "dismiss" && reason !== "timeout") ||
-      reducedMotion ||
-      !this.isConnected ||
-      !anchored
+      reason === "action" ||
+      reason === "disconnected" ||
+      reason === "replaced" ||
+      globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches
     ) {
-      this.finishDismiss(reason);
+      this.finishDismiss(entry, reason);
       return;
     }
-    this.active = false;
-    this.exitReason = reason;
-    this.exitTimer = globalThis.setTimeout(() => {
-      if (this.toast === toast) {
-        this.finishDismiss(reason);
-      }
-    }, TOAST_EXIT_FALLBACK_MS);
+    entry.active = false;
+    this.entries = [...this.entries];
+    globalThis.setTimeout(() => this.finishDismiss(entry, reason), TOAST_EXIT_MS);
   }
 
   override render() {
-    const toast = this.toast;
-    if (!toast) {
-      return nothing;
-    }
-    const anchorRect = toast.anchor?.isConnected ? toast.anchor.getBoundingClientRect() : null;
-    const anchored = anchorRect !== null && anchorRect.width > 0;
+    return html`${this.entries.map((entry, index) => this.renderEntry(entry, index))}`;
+  }
+
+  private renderEntry(entry: ToastEntry, index: number) {
+    const anchor = entry.scope ? sessionToastAnchor(entry.scope.sessionKey) : null;
+    const rect = anchor?.getBoundingClientRect();
+    const anchored = rect !== undefined && rect.width > 0;
+    const assertive = entry.variant === "warning" || entry.variant === "danger";
+    const icon =
+      entry.variant === "success"
+        ? icons.check
+        : entry.variant === "info"
+          ? icons.radio
+          : icons.alertTriangle;
     return html`
       <div
-        class="app-toast ${anchored ? "app-toast--anchored" : ""}"
-        data-active=${this.active ? "true" : "false"}
+        class="app-toast app-toast--${entry.variant} ${anchored ? "app-toast--session" : ""}"
+        data-active=${entry.active ? "true" : "false"}
         style=${styleMap(
           anchored
             ? {
-                "--app-toast-anchor-center": `${anchorRect.left + anchorRect.width / 2}px`,
-                "--app-toast-anchor-top": `${anchorRect.top + (toast.anchorTopOffset ?? 0)}px`,
-                "--app-toast-anchor-width": `${anchorRect.width}px`,
+                "--app-toast-anchor-center": `${rect.left + rect.width / 2}px`,
+                "--app-toast-anchor-top": `${rect.top + 56 + index * 44}px`,
+                "--app-toast-anchor-width": `${rect.width}px`,
               }
-            : {},
+            : { "--app-toast-index": String(this.globalIndex(entry)) },
         )}
-        role="status"
-        aria-live="polite"
+        role=${assertive ? "alert" : "status"}
+        aria-live=${assertive ? "assertive" : "polite"}
         aria-atomic="true"
-        @transitionend=${(event: TransitionEvent) => {
-          if (
-            event.target === event.currentTarget &&
-            event.propertyName === "opacity" &&
-            !this.active &&
-            this.exitReason
-          ) {
-            this.finishDismiss(this.exitReason);
-          }
-        }}
       >
-        ${toast.icon
-          ? html`<span class="app-toast__icon" aria-hidden="true">${toast.icon}</span>`
-          : nothing}
+        <span class="app-toast__icon" aria-hidden="true">${icon}</span>
         <span class="app-toast__message"
-          >${typeof toast.message === "string"
-            ? formatUiExternalText(toast.message)
-            : toast.message}</span
+          >${typeof entry.message === "string"
+            ? formatUiExternalText(entry.message)
+            : entry.message}</span
         >
-        ${toast.actionLabel && toast.onAction
-          ? html`
-              <button
-                type="button"
-                class="app-toast__action"
-                @click=${() => {
-                  this.dismiss("action");
-                  toast.onAction?.();
-                }}
-              >
-                ${toast.actionLabel}
-              </button>
-            `
+        ${entry.actionLabel && entry.onAction
+          ? html`<button
+              type="button"
+              class="app-toast__action"
+              @click=${() => {
+                this.dismiss(entry, "action");
+                entry.onAction?.();
+              }}
+            >
+              ${entry.actionLabel}
+            </button>`
           : nothing}
         <button
           type="button"
           class="app-toast__dismiss"
           aria-label=${t("common.dismiss")}
-          @click=${() => this.dismiss("dismiss")}
+          @click=${() => this.dismiss(entry, "dismiss")}
         >
           ${icons.x}
         </button>
       </div>
     `;
+  }
+
+  private globalIndex(entry: ToastEntry): number {
+    return this.entries
+      .filter((candidate) => !candidate.scope || !sessionToastAnchor(candidate.scope.sessionKey))
+      .indexOf(entry);
   }
 }
 
@@ -198,7 +220,14 @@ export function showToast(options: ToastOptions): boolean {
   }
   const host = document.querySelector<OpenClawToastHost>("openclaw-toast-host");
   if (!host) {
-    queuedToast = options;
+    const matching = options.key
+      ? queuedToasts.findIndex((entry) => entry.key === options.key)
+      : -1;
+    if (matching >= 0) {
+      queuedToasts[matching] = options;
+    } else {
+      queuedToasts = [...queuedToasts.slice(-(MAX_VISIBLE_TOASTS - 1)), options];
+    }
     return false;
   }
   const modal = activeModalToastLayer();
@@ -219,7 +248,6 @@ export function showToast(options: ToastOptions): boolean {
   return true;
 }
 
-// Guarded so DOM-free (node) consumers of send-failure surfacing can load this module.
 if (typeof customElements !== "undefined" && !customElements.get("openclaw-toast-host")) {
   customElements.define("openclaw-toast-host", OpenClawToastHost);
 }

--- a/ui/src/pages/chat/browser-annotation-removal.ts
+++ b/ui/src/pages/chat/browser-annotation-removal.ts
@@ -53,6 +53,9 @@ export function removeBrowserAnnotationWithUndo(
   const presentToast = dependencies.presentToast ?? showToast;
   const presented = presentToast({
     message: labels.removed,
+    variant: "info",
+    key: `browser-annotation:${attachment.id}`,
+    scope: { kind: "session", sessionKey: sourceSessionKey },
     actionLabel: labels.undo,
     onAction: () => {
       if (settled) {
@@ -69,7 +72,11 @@ export function removeBrowserAnnotationWithUndo(
       }
       if (!canAdmitBrowserAnnotation(latest, modelContext)) {
         finalizeRemoval();
-        presentToast({ message: labels.undoUnavailable });
+        presentToast({
+          message: labels.undoUnavailable,
+          variant: "danger",
+          scope: { kind: "session", sessionKey: sourceSessionKey },
+        });
         return;
       }
       settled = true;

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -180,9 +180,14 @@ export class ChatPane extends ChatPaneLayoutRender {
       isGatewayMethodAdvertised(gatewaySnapshot, "progressCard.put") === true;
     const onDismissProgressCard = canDismissProgressCard
       ? (card: NonNullable<ChatProps["progressCard"]>) => {
-          void this.progressCard
-            .dismiss(card)
-            .catch(() => showToast({ message: t("sessionProgressCard.dismissFailed") }));
+          void this.progressCard.dismiss(card).catch(() =>
+            showToast({
+              message: t("sessionProgressCard.dismissFailed"),
+              variant: "danger",
+              key: `progress-dismiss:${state.sessionKey}`,
+              scope: { kind: "session", sessionKey: state.sessionKey },
+            }),
+          );
         }
       : undefined;
     const restartRecoveryTombstoned = selectedSession?.restartRecoveryStatus === "tombstoned";
@@ -281,7 +286,6 @@ export class ChatPane extends ChatPaneLayoutRender {
           effortAccess: mutationAccess.effort,
           permissionAccess: mutationAccess.permission,
           canSelectFull: hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null),
-          toastAnchor: this,
           onModelSetup: () => this.context.navigate("model-setup"),
         });
     const props: ChatProps = {

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -87,7 +87,6 @@ describe("chat pane composer controls", () => {
       chatStream: null,
     } as unknown as ChatPageHost;
     const onModelSetup = vi.fn();
-    const toastAnchor = document.createElement("div");
 
     const controls = renderChatPaneComposerControls({
       state,
@@ -97,7 +96,6 @@ describe("chat pane composer controls", () => {
       effortAccess: { allowed: true, requiredScope: "operator.write" },
       permissionAccess: { allowed: true, requiredScope: "operator.write" },
       canSelectFull: true,
-      toastAnchor,
       onModelSetup,
     });
     render(controls.composerControls, container);
@@ -147,7 +145,6 @@ describe("chat pane composer controls", () => {
       effortAccess: { allowed: true, requiredScope: "operator.write" },
       permissionAccess: { allowed: true, requiredScope: "operator.write" },
       canSelectFull: false,
-      toastAnchor: document.createElement("div"),
       onModelSetup: vi.fn(),
     });
     render(renderChatPermissionPicker(controls.permissionPicker), container);
@@ -195,7 +192,6 @@ describe("chat pane composer controls", () => {
   ] as const)("shows the next-run notice only for a $label session", async (sessionCase) => {
     showToastMock.mockClear();
     const patch = vi.fn(async () => ({}));
-    const toastAnchor = document.createElement("div");
     const state = {
       chatRunId: sessionCase.chatRunId,
       connected: true,
@@ -224,7 +220,6 @@ describe("chat pane composer controls", () => {
       effortAccess: { allowed: true, requiredScope: "operator.write" },
       permissionAccess: { allowed: true, requiredScope: "operator.write" },
       canSelectFull: true,
-      toastAnchor,
       onModelSetup: vi.fn(),
     });
 
@@ -234,9 +229,11 @@ describe("chat pane composer controls", () => {
     if (sessionCase.toastCount === 1) {
       expect(showToastMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          anchor: toastAnchor,
           durationMs: 5_000,
           message: "New permissions apply to the next run.",
+          variant: "info",
+          key: `permission-mode:${state.sessionKey}`,
+          scope: { kind: "session", sessionKey: state.sessionKey },
         }),
       );
     }
@@ -270,7 +267,6 @@ describe("chat pane composer controls", () => {
       effortAccess: { allowed: true, requiredScope: "operator.write" },
       permissionAccess: { allowed: true, requiredScope: "operator.write" },
       canSelectFull: true,
-      toastAnchor: document.createElement("div"),
       onModelSetup: vi.fn(),
     });
     render(controls.composerControls, container);

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -1,7 +1,6 @@
 import { html } from "lit";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
-import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import {
   readSessionMethodAccess,
@@ -87,7 +86,6 @@ export function renderChatPaneComposerControls(params: {
   effortAccess: SessionMethodAccess;
   permissionAccess: SessionMethodAccess;
   canSelectFull: boolean;
-  toastAnchor: Element;
   onModelSetup: () => void;
 }): {
   composerControls: NonNullable<ChatProps["composerControls"]>;
@@ -101,7 +99,6 @@ export function renderChatPaneComposerControls(params: {
     effortAccess,
     permissionAccess,
     canSelectFull,
-    toastAnchor,
     onModelSetup,
   } = params;
   const modelCatalogState = resolveChatModelCatalogState(state);
@@ -170,15 +167,12 @@ export function renderChatPaneComposerControls(params: {
             scopedAgentParamsForSession(state, state.sessionKey),
           );
           if (runWasActive) {
-            const topbarHeight = toastAnchor
-              .querySelector(".chat-pane__header")
-              ?.getBoundingClientRect().height;
             showToast({
-              anchor: toastAnchor,
-              anchorTopOffset: (topbarHeight ?? 0) + 12,
               durationMs: 5_000,
-              icon: icons.shieldCheck,
               message: t("chat.permissionControls.nextRun"),
+              variant: "info",
+              key: `permission-mode:${state.sessionKey}`,
+              scope: { kind: "session", sessionKey: state.sessionKey },
             });
           }
         } catch (error) {

--- a/ui/src/pages/chat/chat-send-support.ts
+++ b/ui/src/pages/chat/chat-send-support.ts
@@ -147,5 +147,8 @@ export function surfaceChatDeliveryFailure(
         !scopedAgentId ||
         (session.agentId !== undefined && normalizeAgentId(session.agentId) === scopedAgentId)),
   );
-  showToast({ message: `${resolveSessionDisplayName(sessionKey, row)}: ${message}` });
+  showToast({
+    message: `${resolveSessionDisplayName(sessionKey, row)}: ${message}`,
+    variant: "danger",
+  });
 }

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -537,7 +537,6 @@ describe("refreshChat", () => {
       effortAccess: { allowed: true, requiredScope: "operator.write" },
       permissionAccess: { allowed: true, requiredScope: "operator.write" },
       canSelectFull: true,
-      toastAnchor: document.createElement("div"),
       onModelSetup: vi.fn(),
     });
     render(controls.composerControls, container);

--- a/ui/src/pages/chat/components/chat-attachment-admission.ts
+++ b/ui/src/pages/chat/components/chat-attachment-admission.ts
@@ -20,6 +20,7 @@ function skippedFilesToast(messageKey: string, skipped: readonly File[]): void {
         .join(", "),
       more: skipped.length > 3 ? ` +${skipped.length - 3}` : "",
     }),
+    variant: "danger",
   });
 }
 

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -337,6 +337,7 @@ async function appendAttachmentFiles(
           names: failed.slice(0, 3).join(", "),
           more: failed.length > 3 ? ` +${failed.length - 3}` : "",
         }),
+        variant: "danger",
       });
     }
     if (additions.length === 0) {

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -267,6 +267,7 @@ export function renderGroupedMessage(
   const toolCards = (opts.showToolCalls ?? true) ? extractToolCardsCached(message, messageKey) : [];
   const hasToolCards = toolCards.length > 0;
   const imageRenderOptions = {
+    sessionKey: opts.sessionKey,
     localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
     resourceBasePath: opts.resourceBasePath,
     authToken: opts.assistantAttachmentAuthToken,

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -146,6 +146,12 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
   if (images.length === 0) {
     return nothing;
   }
+  const presentImageToast = (message: string, variant: "success" | "danger") =>
+    showToast({
+      message,
+      variant,
+      scope: opts?.sessionKey ? { kind: "session", sessionKey: opts.sessionKey } : undefined,
+    });
 
   const openImage = (img: RenderableImageBlock, previewUrl: string) => {
     const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
@@ -177,7 +183,7 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
             : null;
           if (!safeUrl) {
             pendingWindow?.close();
-            showToast({ message: t("chat.imageLightbox.loadFailed") });
+            presentImageToast(t("chat.imageLightbox.loadFailed"), "danger");
           } else if (pendingWindow) {
             pendingWindow.location.replace(safeUrl);
           } else {
@@ -186,20 +192,20 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
         })
         .catch(() => {
           pendingWindow?.close();
-          showToast({ message: t("chat.imageLightbox.loadFailed") });
+          presentImageToast(t("chat.imageLightbox.loadFailed"), "danger");
         });
       return;
     }
     void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts, img.artifactId, "full")
       .then((freshUrl) => {
         if (!freshUrl) {
-          showToast({ message: t("chat.imageLightbox.loadFailed") });
+          presentImageToast(t("chat.imageLightbox.loadFailed"), "danger");
           return;
         }
         const release = cacheKey ? retainManagedImageBlobUrl(cacheKey) : undefined;
         openResolvedImage(opts.onOpenImage, freshUrl, title, release, requestVersion);
       })
-      .catch(() => showToast({ message: t("chat.imageLightbox.loadFailed") }));
+      .catch(() => presentImageToast(t("chat.imageLightbox.loadFailed"), "danger"));
   };
 
   const renderImageElement = (img: RenderableImageBlock, previewUrl: string) => {
@@ -505,7 +511,11 @@ function renderManagedImageActions(
       const blob = await readManagedOutgoingImageBlob(image.displayUrl, opts, image.artifactId);
       downloadImageBlob(blob, imageDownloadFileName(title, blob.type));
     } catch {
-      showToast({ message: t("chat.imageLightbox.downloadFailed") });
+      showToast({
+        message: t("chat.imageLightbox.downloadFailed"),
+        variant: "danger",
+        scope: opts?.sessionKey ? { kind: "session", sessionKey: opts.sessionKey } : undefined,
+      });
     }
   };
   const copy = async () => {
@@ -518,9 +528,17 @@ function renderManagedImageActions(
       );
       void png.catch(() => {});
       await navigator.clipboard.write([new ClipboardItem({ "image/png": png })]);
-      showToast({ message: t("common.copied") });
+      showToast({
+        message: t("common.copied"),
+        variant: "success",
+        scope: opts?.sessionKey ? { kind: "session", sessionKey: opts.sessionKey } : undefined,
+      });
     } catch {
-      showToast({ message: t("chat.imageLightbox.copyFailed") });
+      showToast({
+        message: t("chat.imageLightbox.copyFailed"),
+        variant: "danger",
+        scope: opts?.sessionKey ? { kind: "session", sessionKey: opts.sessionKey } : undefined,
+      });
     }
   };
   return html`

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -28,6 +28,7 @@ export type ArtifactDownloadResolver = (params: {
 }) => Promise<{ url: string; expiresAt?: string } | null>;
 
 export type ImageRenderOptions = {
+  sessionKey?: string;
   localMediaPreviewRoots?: readonly string[];
   resourceBasePath?: string;
   authToken?: string | null;

--- a/ui/src/pages/chat/components/chat-voice-activity.ts
+++ b/ui/src/pages/chat/components/chat-voice-activity.ts
@@ -124,7 +124,7 @@ export function renderChatVoiceError(props: ChatVoiceErrorProps): TemplateResult
     return nothing;
   }
   return html`
-    <div class="agent-chat__stt-interim agent-chat__talk-status" role="alert">
+    <div class="agent-chat__stt-interim agent-chat__talk-status" role="status">
       <span class="agent-chat__talk-status-text">${props.detail}</span>
       ${props.onDismissError
         ? html`

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -59,7 +59,7 @@ async function pinWidget(event: Event, pin: () => Promise<void>): Promise<void> 
     button.ariaLabel = t("chat.toolCards.pinToDashboard");
     const failureLabel = t("chat.toolCards.pinToDashboardFailed");
     button.title = failureLabel;
-    showToast({ message: failureLabel });
+    showToast({ message: failureLabel, variant: "danger" });
   }
 }
 
@@ -424,7 +424,14 @@ function renderWidgetContent(
 function handleWidgetExportAction(
   event: CustomEvent<{ item: { value?: string } }>,
   title: string | undefined,
+  sessionKey: string | undefined,
 ) {
+  const present = (message: string, variant: "info" | "success" | "danger") =>
+    showToast({
+      message,
+      variant,
+      scope: sessionKey ? { kind: "session", sessionKey } : undefined,
+    });
   const value = event.detail.item.value;
   if (value === "raw-details") {
     const dropdown = event.currentTarget;
@@ -456,25 +463,29 @@ function handleWidgetExportAction(
           ?.querySelector<HTMLIFrameElement>(".chat-tool-card__preview-frame")
       : null;
   if (!frame) {
-    showToast({ message: t("chat.toolCards.widgetExportFailed") });
+    present(t("chat.toolCards.widgetExportFailed"), "danger");
     return;
   }
   void exportWidget(value, frame, title)
     .then((result) => {
       if (result === "rerender-required") {
-        showToast({ message: t("chat.toolCards.widgetExportRerender") });
+        present(t("chat.toolCards.widgetExportRerender"), "info");
       } else if (result === "html") {
-        showToast({ message: t("chat.toolCards.widgetExportHtmlFallback") });
+        present(t("chat.toolCards.widgetExportHtmlFallback"), "info");
       } else if (value === "copy") {
-        showToast({ message: t("common.copied") });
+        present(t("common.copied"), "success");
       }
     })
     .catch(() => {
-      showToast({ message: t("chat.toolCards.widgetExportFailed") });
+      present(t("chat.toolCards.widgetExportFailed"), "danger");
     });
 }
 
-function renderWidgetActions(preview: ToolPreview, hasRawDetails: boolean) {
+function renderWidgetActions(
+  preview: ToolPreview,
+  hasRawDetails: boolean,
+  sessionKey: string | undefined,
+) {
   const canExportImage = !preview.mcpApp && isInternalCanvasEntryUrl(preview.url);
   if (!canExportImage && !hasRawDetails) {
     return nothing;
@@ -485,7 +496,7 @@ function renderWidgetActions(preview: ToolPreview, hasRawDetails: boolean) {
       placement="bottom-end"
       aria-label=${t("chat.toolCards.widgetActions")}
       @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) =>
-        handleWidgetExportAction(event, preview.title)}
+        handleWidgetExportAction(event, preview.title, sessionKey)}
     >
       <button
         slot="trigger"
@@ -579,7 +590,11 @@ function renderWidgetCard(
           ${icons.pin}
         </button>`
       : nothing;
-  const widgetActions = renderWidgetActions(preview, Boolean(options?.rawText));
+  const widgetActions = renderWidgetActions(
+    preview,
+    Boolean(options?.rawText),
+    options?.sessionKey,
+  );
   const actions =
     pinAction === nothing && widgetActions === nothing
       ? nothing

--- a/ui/src/pages/chat/critical-observer-notice.ts
+++ b/ui/src/pages/chat/critical-observer-notice.ts
@@ -101,6 +101,7 @@ export function showCriticalSessionObserverNotice(params: {
   const label = resolveSessionDisplayName(sessionKey, row);
   showToast({
     message: `${t("sessionsView.attentionRequired")}: ${label} — ${headline}`,
+    variant: digest.health === "failed" ? "danger" : "warning",
     actionLabel: t("sessionsView.openSession"),
     onAction: () =>
       digest.agentId ? params.onOpen(sessionKey, digest.agentId) : params.onOpen(sessionKey),

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -540,17 +540,15 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     const body = renderSettingsPage(
       html`
         ${!this.hasManageAccess()
-          ? html`<div class="callout warning" role="note">
-              ${t("cloudWorkersPage.adminRequired")}
-            </div>`
+          ? html`<div class="callout warn" role="note">${t("cloudWorkersPage.adminRequired")}</div>`
           : nothing}
         ${this.catalogError
-          ? html`<div class="callout warning" role="status">
+          ? html`<div class="callout warn" role="status">
               ${t("cloudWorkersPage.catalogFailed", { error: this.catalogError })}
             </div>`
           : nothing}
         ${this.notice
-          ? html`<div class="callout warning" role="status">${this.notice}</div>`
+          ? html`<div class="callout warn" role="status">${this.notice}</div>`
           : nothing}
         ${renderSettingsSection(
           {

--- a/ui/src/pages/config/updates.ts
+++ b/ui/src/pages/config/updates.ts
@@ -409,7 +409,7 @@ export function renderUpdates(props: UpdatesViewProps): TemplateResult {
       ${renderSettingsPage(
         [
           !props.canAdmin
-            ? html`<div class="callout warning" role="note">${t("updates.adminRequired")}</div>`
+            ? html`<div class="callout warn" role="note">${t("updates.adminRequired")}</div>`
             : nothing,
           renderBuildFacts(props),
           renderRecordedAttempt(props),

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -66,7 +66,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
   const body = html`
     <div class="settings-row settings-row--stacked model-providers__defaults">
       ${props.models.length === 0
-        ? html`<div class="callout warning">${t("modelProviders.defaults.noModels")}</div>`
+        ? html`<div class="callout warn">${t("modelProviders.defaults.noModels")}</div>`
         : nothing}
       <div class="model-providers__default-grid">
         <label class="field">
@@ -191,7 +191,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
           </div>`
         : nothing}
       ${props.message?.warning
-        ? html`<div class="callout warning" role="status">${props.message.warning}</div>`
+        ? html`<div class="callout warn" role="status">${props.message.warning}</div>`
         : nothing}
     </div>
   `;

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -120,7 +120,7 @@ function renderMutationMessage(message: ModelProviderRowMessage | undefined) {
       ${message.text}
     </div>
     ${message.warning
-      ? html`<div class="callout warning" role="status">${message.warning}</div>`
+      ? html`<div class="callout warn" role="status">${message.warning}</div>`
       : nothing}
   `;
 }
@@ -651,7 +651,7 @@ export function renderModelProviders(props: ModelProvidersViewProps) {
     )}
     ${props.quickAddSupported ? renderAddProvider(props) : nothing}
     ${props.mutationBlockedReason
-      ? html`<div class="callout warning">${props.mutationBlockedReason}</div>`
+      ? html`<div class="callout warn">${props.mutationBlockedReason}</div>`
       : nothing}
   `);
 }

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -569,11 +569,11 @@ function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectR
     : nothing;
   if (!props.canAdmin) {
     return html`${current}
-      <div class="callout warning" role="note">${t("modelSetup.access.adminRequired")}</div>`;
+      <div class="callout warn" role="note">${t("modelSetup.access.adminRequired")}</div>`;
   }
   if (props.gatewayTooOld) {
     return html`${current}
-      <div class="callout warning" role="note">${t("modelSetup.access.gatewayTooOld")}</div>`;
+      <div class="callout warn" role="note">${t("modelSetup.access.gatewayTooOld")}</div>`;
   }
   return html`
     ${current} ${renderEmptyState(props, result)} ${renderCandidateRows(props, result)}
@@ -655,11 +655,11 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
   if (props.page.phase === "ready") {
     body = renderReady(props, props.page.result);
   } else if (!props.canAdmin) {
-    body = html`<div class="callout warning" role="note">
+    body = html`<div class="callout warn" role="note">
       ${t("modelSetup.access.adminRequired")}
     </div>`;
   } else if (props.gatewayTooOld) {
-    body = html`<div class="callout warning" role="note">
+    body = html`<div class="callout warn" role="note">
       ${t("modelSetup.access.gatewayTooOld")}
     </div>`;
   } else if (props.page.phase === "loading") {
@@ -693,7 +693,7 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
           : nothing}
       </div>
       ${props.refreshWarning
-        ? html`<div class="callout warning" role="alert">${props.refreshWarning}</div>`
+        ? html`<div class="callout warn" role="alert">${props.refreshWarning}</div>`
         : nothing}
       ${body}
     </div>

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -48,7 +48,7 @@ export function renderModelSetupWizard(props: WizardViewProps): TemplateResult |
         </div>
         <div class="model-setup-wizard__body">
           ${props.refreshWarning
-            ? html`<div class="callout warning" role="alert">${props.refreshWarning}</div>`
+            ? html`<div class="callout warn" role="alert">${props.refreshWarning}</div>`
             : nothing}
           ${props.state.phase === "starting"
             ? html`<div role="status">

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -726,7 +726,10 @@ class SessionsPage extends OpenClawLightDomElement {
         return;
       }
       if (result.preservedWorktrees.length > 0) {
-        window.alert(formatPreservedWorktreesNotice(result.preservedWorktrees));
+        showToast({
+          message: formatPreservedWorktreesNotice(result.preservedWorktrees),
+          variant: "warning",
+        });
       }
       if (result.deleted.length > 0) {
         const deleted = new Set(result.deleted);
@@ -1135,6 +1138,8 @@ class SessionsPage extends OpenClawLightDomElement {
     const agentId = this.sessionAgentId(row.key, scope.context);
     showToast({
       message: t("sessionsView.sessionArchived"),
+      variant: "success",
+      key: `session-archived:${row.key}`,
       actionLabel: t("common.undo"),
       onAction: () => {
         void scope.sessions.patch(
@@ -1459,7 +1464,10 @@ class SessionsPage extends OpenClawLightDomElement {
               break;
             case "copy-session-id":
               void copyToClipboard(row.sessionId ?? "").then((copied) => {
-                showToast({ message: t(copied ? "common.copied" : "common.copyFailed") });
+                showToast({
+                  message: t(copied ? "common.copied" : "common.copyFailed"),
+                  variant: copied ? "success" : "danger",
+                });
               });
               break;
             case "toggle-pin":

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -156,7 +156,7 @@ function renderProviderUsage(providers: ProviderUsageSnapshot[], unavailable: bo
     html`
       ${unavailable
         ? html`
-            <div class="callout warning usage-callout">${t("usage.providerUsage.unavailable")}</div>
+            <div class="callout warn usage-callout">${t("usage.providerUsage.unavailable")}</div>
           `
         : nothing}
       <div class="usage-panel provider-usage-section">
@@ -776,7 +776,7 @@ export function renderUsage(props: UsageProps) {
                 : nothing}
               ${queryWarnings.length > 0
                 ? html`
-                    <div class="callout warning usage-callout usage-callout--tight">
+                    <div class="callout warn usage-callout usage-callout--tight">
                       ${queryWarnings.join(" · ")}
                     </div>
                   `
@@ -788,16 +788,14 @@ export function renderUsage(props: UsageProps) {
               : nothing}
             ${cacheStatusTitle
               ? html`
-                  <div class="callout warning usage-callout usage-cache-warning">
+                  <div class="callout warn usage-callout usage-cache-warning">
                     ${t("usage.cacheStatus.warning")} ${cacheStatusTitle}
                   </div>
                 `
               : nothing}
             ${data.sessionsLimitReached
               ? html`
-                  <div class="callout warning usage-callout">
-                    ${t("usage.sessions.limitReached")}
-                  </div>
+                  <div class="callout warn usage-callout">${t("usage.sessions.limitReached")}</div>
                 `
               : nothing}
           </div>

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -696,13 +696,10 @@ openclaw-session-owner-chip {
   line-height: 1;
 }
 
-/* Passive notifications stay in the trailing top corner, away from the chat
- * composer and other bottom-docked controls. The host shows one toast at a time
- * (`show()` replaces the active one), so there is no stack to offset against. */
 .app-toast {
   position: fixed;
   right: calc(20px + var(--safe-area-right));
-  top: calc(20px + var(--safe-area-top));
+  bottom: calc(20px + var(--safe-area-bottom) + var(--app-toast-index) * 76px);
   z-index: var(--z-toast);
   display: flex;
   align-items: center;
@@ -714,45 +711,59 @@ openclaw-session-owner-chip {
   background: var(--popover);
   color: var(--popover-foreground);
   box-shadow: var(--shadow-lg);
+  transition:
+    translate 200ms var(--ease-out),
+    opacity 150ms var(--ease-out);
 }
 
-.app-toast--anchored {
-  right: auto;
-  left: var(--app-toast-anchor-center);
-  top: var(--app-toast-anchor-top);
-  transform: translateX(-50%);
-  gap: var(--space-2);
-  max-width: min(520px, calc(var(--app-toast-anchor-width) - 24px));
-  padding: 8px 12px;
-  border-color: color-mix(in srgb, var(--info) 12%, transparent);
-  border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--info) 12%, var(--popover));
-  transition-property: translate, scale, opacity;
-}
-
-.app-toast--anchored[data-active="true"] {
-  translate: 0 0;
-  scale: 1;
-  opacity: 1;
-  transition-duration: 200ms;
-  transition-timing-function: cubic-bezier(0.23, 1, 0.32, 1);
+.app-toast[data-active="false"] {
+  translate: 24px 0;
+  opacity: 0;
+  pointer-events: none;
 }
 
 @starting-style {
-  .app-toast--anchored[data-active="true"] {
-    translate: 0 -100%;
-    scale: 0.95;
+  .app-toast[data-active="true"] {
+    translate: 24px 0;
     opacity: 0;
   }
 }
 
-.app-toast--anchored[data-active="false"] {
-  translate: 0 -100%;
-  scale: 0.95;
-  opacity: 0;
-  pointer-events: none;
-  transition-duration: 400ms;
-  transition-timing-function: cubic-bezier(0.7, 0, 0.84, 0);
+.app-toast--session {
+  right: auto;
+  left: var(--app-toast-anchor-center);
+  top: var(--app-toast-anchor-top);
+  bottom: auto;
+  transform: translateX(-50%);
+  gap: var(--space-2);
+  max-width: min(520px, calc(var(--app-toast-anchor-width) - 24px));
+  padding: 8px 12px;
+  border-radius: var(--radius-full);
+}
+
+.app-toast--info {
+  --app-toast-tone: var(--info);
+}
+
+.app-toast--success {
+  --app-toast-tone: var(--ok);
+}
+
+.app-toast--warning {
+  --app-toast-tone: var(--warn);
+}
+
+.app-toast--danger {
+  --app-toast-tone: var(--danger);
+}
+
+.app-toast--info,
+.app-toast--success,
+.app-toast--warning,
+.app-toast--danger {
+  border-color: color-mix(in srgb, var(--app-toast-tone) 34%, var(--border));
+  background: color-mix(in srgb, var(--app-toast-tone) 10%, var(--popover));
+  color: color-mix(in srgb, var(--app-toast-tone) 82%, var(--text-strong));
 }
 
 .app-toast__icon {
@@ -761,7 +772,7 @@ openclaw-session-owner-chip {
   width: 16px;
   height: 16px;
   place-items: center;
-  color: var(--info);
+  color: var(--app-toast-tone);
 }
 
 .app-toast__icon svg {
@@ -775,10 +786,12 @@ openclaw-session-owner-chip {
   .app-toast {
     left: max(12px, var(--safe-area-left));
     right: max(12px, var(--safe-area-right));
+    top: calc(20px + var(--safe-area-top) + var(--app-toast-index) * 64px);
+    bottom: auto;
     max-width: none;
   }
 
-  .app-toast--anchored {
+  .app-toast--session {
     left: var(--app-toast-anchor-center);
     right: auto;
     max-width: calc(var(--app-toast-anchor-width) - 24px);
@@ -801,13 +814,13 @@ openclaw-session-owner-chip {
   -webkit-box-orient: vertical;
 }
 
-.app-toast--anchored .app-toast__message {
+.app-toast--session .app-toast__message {
   display: block;
   white-space: nowrap;
   font-size: var(--control-ui-text-sm);
 }
 
-.app-toast--anchored .app-toast__dismiss {
+.app-toast--session .app-toast__dismiss {
   width: 24px;
   height: 24px;
   margin-left: 2px;
@@ -815,7 +828,7 @@ openclaw-session-owner-chip {
   color: var(--muted);
 }
 
-.app-toast--anchored .app-toast__dismiss svg {
+.app-toast--session .app-toast__dismiss svg {
   width: 16px;
   height: 16px;
 }

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -627,13 +627,7 @@
   margin-top: 0;
 }
 
-.callout.warning {
-  border-color: color-mix(in srgb, var(--warn) 22%, var(--border));
-  background: var(--warn-subtle);
-  color: var(--text);
-}
-
-.callout.warning.usage-cache-warning {
+.callout.warn.usage-cache-warning {
   border-color: color-mix(in srgb, var(--accent) 32%, var(--border));
   background: var(--warn-subtle);
   color: var(--accent);

--- a/ui/src/test-helpers/notices-fixture.ts
+++ b/ui/src/test-helpers/notices-fixture.ts
@@ -1,0 +1,278 @@
+import { html, render } from "lit";
+import "../lib/toast.ts";
+
+const variants = ["info", "success", "warning", "danger"] as const;
+
+function callouts() {
+  return variants.map(
+    (variant) => html`<div class="callout ${variant === "warning" ? "warn" : variant}">
+      <strong>${variant}</strong><br />Persistent inline context owned by this surface.
+    </div>`,
+  );
+}
+
+render(
+  html`<style>
+      .notice-fixture {
+        box-sizing: border-box;
+        max-width: 1320px;
+        margin: 0 auto;
+        padding: 40px;
+        color: var(--text);
+      }
+      .notice-fixture__header {
+        margin-bottom: 32px;
+      }
+      .notice-fixture__eyebrow,
+      .notice-fixture__zone-code {
+        color: var(--muted);
+        font: 11px var(--mono);
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+      .notice-fixture h1 {
+        margin: 8px 0;
+        color: var(--text-strong);
+        font-size: 30px;
+      }
+      .notice-fixture__intro {
+        max-width: 760px;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+      .notice-fixture__grid {
+        display: grid;
+        gap: 20px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .notice-fixture__zone {
+        min-width: 0;
+        padding: 20px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        background: var(--card);
+      }
+      .notice-fixture__zone h2 {
+        margin: 5px 0 16px;
+        color: var(--text-strong);
+        font-size: 17px;
+      }
+      .notice-fixture__stack {
+        display: grid;
+        gap: 10px;
+      }
+      .notice-fixture__pane {
+        position: relative;
+        min-height: 250px;
+        overflow: hidden;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--bg);
+      }
+      .notice-fixture__pane-topbar {
+        height: 44px;
+        border-bottom: 1px solid var(--border);
+        background: var(--bg-elevated);
+      }
+      .notice-fixture__session-chips {
+        display: grid;
+        gap: 8px;
+        justify-items: center;
+        padding: 12px;
+      }
+      .notice-fixture__chip {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        max-width: calc(100% - 24px);
+        padding: 7px 11px;
+        border: 1px solid color-mix(in srgb, var(--tone) 34%, var(--border));
+        border-radius: var(--radius-full);
+        background: color-mix(in srgb, var(--tone) 10%, var(--popover));
+        color: color-mix(in srgb, var(--tone) 82%, var(--text-strong));
+        font-size: 12px;
+      }
+      .notice-fixture__composer {
+        margin-top: 28px;
+        padding: 12px;
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-lg);
+        background: var(--bg-elevated);
+      }
+      .notice-fixture__composer-label {
+        margin-bottom: 8px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .notice-fixture__banner {
+        padding: 11px 14px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--secondary);
+      }
+      .notice-fixture__toast-gallery {
+        display: grid;
+        gap: 10px;
+      }
+      .notice-fixture__toast-gallery .app-toast {
+        position: relative;
+        inset: auto;
+        max-width: none;
+        translate: none;
+        opacity: 1;
+      }
+      .notice-fixture__modal {
+        display: grid;
+        place-items: center;
+        min-height: 170px;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--overlay) 75%, transparent);
+      }
+      .notice-fixture__modal-card {
+        width: min(420px, calc(100% - 32px));
+        padding: 18px;
+        border: 1px solid color-mix(in srgb, var(--warn) 34%, var(--border));
+        border-radius: var(--radius-lg);
+        background: var(--popover);
+        box-shadow: var(--shadow-lg);
+      }
+      .notice-fixture__footer-row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .notice-fixture__badge {
+        min-width: 28px;
+        height: 28px;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--secondary);
+      }
+      @media (max-width: 768px) {
+        .notice-fixture {
+          padding: 20px 14px 360px;
+        }
+        .notice-fixture__grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+    <main class="notice-fixture">
+      <header class="notice-fixture__header">
+        <div class="notice-fixture__eyebrow">UX inventory fixture</div>
+        <h1>Operator notices by zone</h1>
+        <p class="notice-fixture__intro">
+          All canonical toast, chip, banner, callout, modal and composer-owned notice shapes are
+          visible together. Toggle <code>?theme=light</code> or <code>?theme=dark</code>.
+        </p>
+      </header>
+      <div class="notice-fixture__grid">
+        <section class="notice-fixture__zone">
+          <div class="notice-fixture__zone-code">Zone A / M1</div>
+          <h2>Pane-scoped notices</h2>
+          <div class="notice-fixture__pane">
+            <div class="notice-fixture__pane-topbar"></div>
+            <div class="notice-fixture__session-chips">
+              ${variants.map(
+                (variant) =>
+                  html`<div
+                    class="notice-fixture__chip"
+                    style=${`--tone: var(--${variant === "success" ? "ok" : variant === "warning" ? "warn" : variant})`}
+                  >
+                    <span>●</span><span>${variant}: session outcome near its pane</span
+                    ><button class="btn btn--ghost btn--xs">×</button>
+                  </div>`,
+              )}
+            </div>
+          </div>
+        </section>
+        <section class="notice-fixture__zone">
+          <div class="notice-fixture__zone-code">Zone B</div>
+          <h2>Decision modal</h2>
+          <div class="notice-fixture__modal">
+            <div class="notice-fixture__modal-card">
+              <strong>Exec approval needed</strong>
+              <p class="muted">A persistent warning that requires an operator decision.</p>
+              <button class="btn primary">Allow once</button> <button class="btn">Deny</button>
+            </div>
+          </div>
+        </section>
+        <section class="notice-fixture__zone">
+          <div class="notice-fixture__zone-code">Zones C-D / M2-M3</div>
+          <h2>Transcript and fixed composer</h2>
+          <div class="notice-fixture__stack">
+            <div class="chat-error" role="alert">
+              <span class="chat-error__dot"></span
+              ><span class="chat-error__content">Run failed with a recoverable error.</span>
+            </div>
+            <div class="notice-fixture__composer">
+              <div class="notice-fixture__composer-label">Composer-owned, fixed in place</div>
+              <div class="callout warn">You're offline. Messages will queue.</div>
+            </div>
+          </div>
+        </section>
+        <section class="notice-fixture__zone">
+          <div class="notice-fixture__zone-code">Zone E / M1</div>
+          <h2>Global toast variants</h2>
+          <div class="notice-fixture__toast-gallery">
+            ${variants.map(
+              (variant) => html`<div
+                class="app-toast app-toast--${variant}"
+                data-active="true"
+                role=${variant === "warning" || variant === "danger" ? "alert" : "status"}
+              >
+                <span class="app-toast__icon">●</span>
+                <span class="app-toast__message">${variant}: global operator outcome</span>
+                <button class="app-toast__dismiss">×</button>
+              </div>`,
+            )}
+          </div>
+        </section>
+        <section class="notice-fixture__zone">
+          <div class="notice-fixture__zone-code">Zone F</div>
+          <h2>Global status banner</h2>
+          <div class="notice-fixture__stack">
+            <div class="notice-fixture__banner">
+              Actions are unavailable while the Gateway reconnects.
+            </div>
+            <div class="callout danger">This view failed to load. Retry the route.</div>
+          </div>
+        </section>
+        <section class="notice-fixture__zone">
+          <div class="notice-fixture__zone-code">Inline inventory</div>
+          <h2>Canonical callouts</h2>
+          <div class="notice-fixture__stack">${callouts()}</div>
+        </section>
+        <section class="notice-fixture__zone">
+          <div class="notice-fixture__zone-code">Zones G / M4</div>
+          <h2>Persistent centers</h2>
+          <div class="notice-fixture__stack">
+            <div class="notice-fixture__footer-row">
+              <span class="notice-fixture__badge">9</span
+              ><span>Inbox: approvals, automations and system attention</span>
+            </div>
+            <div class="notice-fixture__footer-row">
+              <span class="notice-fixture__badge">↻</span
+              ><span>Update available, persistent until action</span>
+            </div>
+            <div class="sw-action-toast">Skill action running</div>
+          </div>
+        </section>
+      </div>
+      <openclaw-toast-host></openclaw-toast-host>
+    </main>`,
+  document.querySelector("#app")!,
+);
+
+const host = document.querySelector("openclaw-toast-host") as HTMLElement & {
+  show: (options: {
+    message: string;
+    variant: (typeof variants)[number];
+    durationMs: number;
+  }) => void;
+};
+for (const variant of variants.slice(1)) {
+  host.show({ message: `${variant}: global operator outcome`, variant, durationMs: 86_400_000 });
+}


### PR DESCRIPTION
Relates to #124363
Closes #128241

## What Problem This Solves

Control UI outcomes used a neutral single-slot toast, so success and failure looked alike and independent events replaced each other. Warning callouts also used a route-local spelling/style, session-owned transcript feedback appeared in the global corner, and session deletion still used blocking browser alerts.

## Why This Change Was Made

The existing owner in `ui/src/lib/toast.ts` is now the one canonical transient-notice mechanism. It admits explicit `info`, `success`, `warning`, and `danger` variants, derives global versus visible-session placement from scope, keeps a bounded stack of three, and updates state-like outcomes by key. Existing modal top-layer handoff and recovery actions remain owned by the same host.

The mapped Control UI producers now declare severity. Image, widget, annotation, permission, and progress-card feedback uses compact pane-scoped presentation when its session is visible. Composer-owned notices remain exactly where they were. Blocking worktree alerts become warning toasts; config and board duplicates stay only at their inline owner. Callout warning spelling is canonicalized to `warn`, and interim speech uses polite status semantics.

A standalone mock route at `/__fixtures/notices/` renders the full inventory together by the UX study's zones, including all global toast variants, session chips, banners, callouts, modal decisions, persistent centers, and the fixed composer zone.

## User Impact

Operators can distinguish outcomes at a glance, retain up to three independent global events, and receive session feedback beside the pane that owns it. Desktop global cards stack bottom-right; mobile cards remain full-width at the top. Warning and danger outcomes use assertive live regions, while info and success remain polite.

The composer layout is unchanged.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/toast.test.ts ui/src/pages/chat/chat-pane-session-controls.test.ts ui/src/pages/chat/browser-annotation-removal.test.ts ui/src/components/board/board-view.test.ts ui/src/lib/config/config-draft-model.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/widget-card.test.ts ui/src/app/update-success-notice.test.ts ui/src/components/session-organizer-batch-mutations.test.ts` - 345 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-fixture.e2e.test.ts` - 7 browser tests passed, including the complete notice inventory route.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json` - passed.
- `node scripts/run-tsgo.mjs -p tsconfig.scripts.json` - passed.
- `node scripts/run-tsgo-core-test-shards.mjs ui` - passed.
- `node scripts/check-changed.mjs -- <changed paths>` - formatting, guards, dead exports, i18n, and preceding gates passed; the first bounded invocation timed out during i18n, then the resumed run reached and exposed test-type drift, which was fixed and rechecked directly.
- `pnpm ui:build` - passed; startup JS and CSS remain within committed budgets.
- Codex autoreview (`gpt-5.6-sol`, high) - clean, no accepted/actionable findings.

Visual proof will be added after the operator's design iteration on the fixture.
