### PR TITLE
feat(ui): scope chat feedback to panes

### DIFF
--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -776,7 +776,7 @@ describe("openclaw-board-view", () => {
     await vi.waitFor(() => expect(allow?.disabled).toBe(false));
   });
 
-  it("toasts failed rejection while keeping controls and leaves successful decisions quiet", async () => {
+  it("shows failed rejection inline while keeping controls and leaves successful decisions quiet", async () => {
     const toastHost = document.createElement("openclaw-toast-host");
     document.body.append(toastHost);
     const grant = vi.fn(async (_name: string, decision: "granted" | "rejected") => {
@@ -798,9 +798,10 @@ describe("openclaw-board-view", () => {
       expect(
         view.querySelector('[data-test-id="board-widget-action-error"]')?.textContent,
       ).toContain("approval service unavailable");
-      expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
-        "Could not reject widget access. Try again.",
-      );
+      expect(
+        view.querySelector('[data-test-id="board-widget-action-error"]')?.textContent,
+      ).toContain("Could not reject widget access. Try again.");
+      expect(toastHost.querySelector(".app-toast")).toBeNull();
     });
     expect(allow?.disabled).toBe(false);
     expect(reject?.disabled).toBe(false);

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -20,7 +20,6 @@ import {
   type PluginBoardWidgetRenderer,
 } from "../../lib/board/widgets/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { showToast } from "../../lib/toast.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { renderBoardMcpAppContent } from "./board-mcp-app-content.ts";
 import { BoardMcpAppLifecycle } from "./board-mcp-app-lifecycle.ts";
@@ -164,10 +163,8 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     try {
       await action();
     } catch (error) {
-      this.actionError = formatUiError(error);
-      if (failureMessage) {
-        showToast({ message: failureMessage });
-      }
+      const detail = formatUiError(error);
+      this.actionError = failureMessage ? `${failureMessage}\n${detail}` : detail;
     } finally {
       this.actionPending = false;
     }

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -484,7 +484,9 @@ suite.define(() => {
     await pin.click();
 
     await expect.poll(async () => (await gateway.getRequests("board.widget.put")).length).toBe(1);
-    const toast = page.locator("openclaw-toast-host .app-toast");
+    const toast = page.locator("openclaw-session-toast-host .app-toast", {
+      hasText: "Could not pin to dashboard. Try again.",
+    });
     await toast.waitFor();
     expect(await toast.textContent()).toContain("Could not pin to dashboard. Try again.");
     expect(await pin.isEnabled()).toBe(true);

--- a/ui/src/e2e/session-dashboard.grant-failure.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.grant-failure.e2e.test.ts
@@ -15,7 +15,7 @@ const sessionKey = "agent:main:dashboard-grant-failure";
 const proofDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-grant-failure");
 
 suite.define(() => {
-  it("keeps a network-capability decision retryable and toasts when Allow fails", async () => {
+  it("keeps a network-capability decision retryable and shows one inline failure", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
       await mkdir(proofDir, { recursive: true });
@@ -87,14 +87,21 @@ suite.define(() => {
         decision: "granted",
         revision: 1,
       });
-      const toast = page.locator("openclaw-toast-host .app-toast");
-      await toast.waitFor();
-      expect(await toast.textContent()).toContain("Could not allow widget access. Try again.");
-      expect(await toast.textContent()).not.toContain("internal capability service detail");
       await expect.poll(() => allow.isEnabled()).toBe(true);
       expect(await reject.isEnabled()).toBe(true);
       await pending.waitFor();
-      await page.locator('[data-test-id="board-widget-action-error"]').waitFor();
+      const inlineError = page.locator('[data-test-id="board-widget-action-error"]');
+      await inlineError.waitFor();
+      expect(await inlineError.textContent()).toContain(
+        "Could not allow widget access. Try again.",
+      );
+      const details = inlineError.locator("details");
+      expect(await details.getAttribute("open")).toBeNull();
+      expect(await details.textContent()).toContain("internal capability service detail");
+      expect(
+        await page.getByText("internal capability service detail", { exact: true }).isVisible(),
+      ).toBe(false);
+      expect(await page.locator("openclaw-toast-host .app-toast").count()).toBe(0);
       if (recordProof) {
         await page.screenshot({ path: path.join(proofDir, "grant-failed.png") });
       }

--- a/ui/src/lib/config/config-gateway-operations.ts
+++ b/ui/src/lib/config/config-gateway-operations.ts
@@ -5,7 +5,6 @@ import type { ConfigSchemaResponse, ConfigSnapshot } from "../../api/types.ts";
 import { copyToClipboard } from "../clipboard.ts";
 import { serializeConfigForm } from "../config-form-utils.ts";
 import { formatUiError, formatUiExternalText } from "../format-error.ts";
-import { showToast } from "../toast.ts";
 import {
   adoptConfigSetAck,
   applyConfigSnapshot,
@@ -652,7 +651,6 @@ export async function openConfigFile(state: RuntimeConfigState): Promise<void> {
     }
     if (isCurrent()) {
       state.lastError = formatUiExternalText(message);
-      showToast({ message: state.lastError });
     }
   };
   try {

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
+import { renderSessionToastHost } from "../../lib/toast.ts";
 import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
 import {
   availableSidebarSlots,
@@ -81,14 +82,22 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       workspaceGit,
       sidebarLayout,
     );
+    const sessionToasts = renderSessionToastHost({
+      sessionKey: state.sessionKey,
+      presented: this.presented,
+      active: this.active,
+    });
     const chat = renderChat({
       ...chatProps,
       header: board.face === "dashboard" ? nothing : header,
+      sessionToasts: board.face === "dashboard" ? nothing : sessionToasts,
     });
     // Keep this root stable across board face changes so the guarded board runtime
     // remains connected while Chat is active.
     const primary = html`<div class="chat-pane-primary-column">
-      ${board.face === "dashboard" ? header : nothing}${this.renderBoardPrimary(board, chat)}
+      ${board.face === "dashboard"
+        ? html`${header}${sessionToasts}`
+        : nothing}${this.renderBoardPrimary(board, chat)}
     </div>`;
     const discussion = this.buildSessionDiscussionPanel(state, state.sessionKey.trim());
     const desktopAvailable = isDesktopPanelAvailable(this.context.gateway.snapshot);

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -179,9 +179,14 @@ export class ChatPane extends ChatPaneLayoutRender {
       isGatewayMethodAdvertised(gatewaySnapshot, "progressCard.put") === true;
     const onDismissProgressCard = canDismissProgressCard
       ? (card: NonNullable<ChatProps["progressCard"]>) => {
-          void this.progressCard
-            .dismiss(card)
-            .catch(() => showToast({ message: t("sessionProgressCard.dismissFailed") }));
+          void this.progressCard.dismiss(card).catch(() =>
+            showToast({
+              key: `progress-card-dismiss:${state.sessionKey}`,
+              message: t("sessionProgressCard.dismissFailed"),
+              scope: { kind: "session", sessionKey: state.sessionKey },
+              variant: "danger",
+            }),
+          );
         }
       : undefined;
     const restartRecoveryTombstoned = selectedSession?.restartRecoveryStatus === "tombstoned";

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -112,7 +112,9 @@ describe("chat pane header state", () => {
       // operator needs a distinct, visible outcome or their lost intent reads
       // as a click that simply did nothing.
       expect(showToast).toHaveBeenCalledWith({
+        key: "delete-session-stale:agent:main:current",
         message: t("sessionsView.deleteSessionStale", { session: "Current session" }),
+        variant: "warning",
       });
     } finally {
       document.body.replaceChildren();

--- a/ui/src/pages/chat/chat-send-support.ts
+++ b/ui/src/pages/chat/chat-send-support.ts
@@ -147,5 +147,9 @@ export function surfaceChatDeliveryFailure(
         !scopedAgentId ||
         (session.agentId !== undefined && normalizeAgentId(session.agentId) === scopedAgentId)),
   );
-  showToast({ message: `${resolveSessionDisplayName(sessionKey, row)}: ${message}` });
+  showToast({
+    key: `chat-delivery:${sessionKey}`,
+    message: `${resolveSessionDisplayName(sessionKey, row)}: ${message}`,
+    variant: "danger",
+  });
 }

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -261,6 +261,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     onForkMessage?: (entryId: string) => Promise<void> | void;
     backgroundTasks?: BackgroundTasksProps;
     header?: TemplateResult | typeof nothing;
+    sessionToasts?: TemplateResult | typeof nothing;
     sessionSuggestions?: readonly SessionSuggestion[];
     sessionSuggestionRole?: SessionSharingRole;
     sessionSuggestionBusyIds?: ReadonlySet<string>;
@@ -556,7 +557,8 @@ export function renderChat(props: ChatProps) {
           <div class="chat-split-container">
             <div class="chat-main">
               <div class="chat-main__conversation-column">
-                ${props.header ?? nothing} ${renderChatViewNotices(props)}
+                ${props.header ?? nothing} ${props.sessionToasts ?? nothing}
+                ${renderChatViewNotices(props)}
                 ${renderTranscriptSearch(props.paneId, requestUpdate)}
                 <div class="chat-main__conversation">
                   ${thread} ${earlierHistoryButton} ${scrollToBottomButton}

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -267,6 +267,7 @@ export function renderGroupedMessage(
   const toolCards = (opts.showToolCalls ?? true) ? extractToolCardsCached(message, messageKey) : [];
   const hasToolCards = toolCards.length > 0;
   const imageRenderOptions = {
+    sessionKey: opts.sessionKey,
     localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
     resourceBasePath: opts.resourceBasePath,
     authToken: opts.assistantAttachmentAuthToken,

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -38,6 +38,22 @@ const MANAGED_OUTGOING_IMAGE_FETCH_TIMEOUT_MS = 30_000;
 const MANAGED_OUTGOING_IMAGE_RETRY_MS = 5_000;
 type ManagedImageVariant = "full" | "thumbnail";
 
+function showImageToast(
+  options: ImageRenderOptions | undefined,
+  key: string,
+  message: string,
+  variant: "danger" | "success",
+) {
+  showToast({
+    key,
+    message,
+    ...(options?.sessionKey
+      ? { scope: { kind: "session" as const, sessionKey: options.sessionKey } }
+      : {}),
+    variant,
+  });
+}
+
 class ManagedImageResourceDirective extends AsyncDirective {
   private cacheKey: string | undefined;
   private image: RenderableImageBlock | undefined;
@@ -177,7 +193,12 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
             : null;
           if (!safeUrl) {
             pendingWindow?.close();
-            showToast({ message: t("chat.imageLightbox.loadFailed") });
+            showImageToast(
+              opts,
+              `image-load:${img.artifactId ?? img.displayUrl}`,
+              t("chat.imageLightbox.loadFailed"),
+              "danger",
+            );
           } else if (pendingWindow) {
             pendingWindow.location.replace(safeUrl);
           } else {
@@ -186,20 +207,37 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
         })
         .catch(() => {
           pendingWindow?.close();
-          showToast({ message: t("chat.imageLightbox.loadFailed") });
+          showImageToast(
+            opts,
+            `image-load:${img.artifactId ?? img.displayUrl}`,
+            t("chat.imageLightbox.loadFailed"),
+            "danger",
+          );
         });
       return;
     }
     void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts, img.artifactId, "full")
       .then((freshUrl) => {
         if (!freshUrl) {
-          showToast({ message: t("chat.imageLightbox.loadFailed") });
+          showImageToast(
+            opts,
+            `image-load:${img.artifactId ?? img.displayUrl}`,
+            t("chat.imageLightbox.loadFailed"),
+            "danger",
+          );
           return;
         }
         const release = cacheKey ? retainManagedImageBlobUrl(cacheKey) : undefined;
         openResolvedImage(opts.onOpenImage, freshUrl, title, release, requestVersion);
       })
-      .catch(() => showToast({ message: t("chat.imageLightbox.loadFailed") }));
+      .catch(() =>
+        showImageToast(
+          opts,
+          `image-load:${img.artifactId ?? img.displayUrl}`,
+          t("chat.imageLightbox.loadFailed"),
+          "danger",
+        ),
+      );
   };
 
   const renderImageElement = (img: RenderableImageBlock, previewUrl: string) => {
@@ -505,7 +543,12 @@ function renderManagedImageActions(
       const blob = await readManagedOutgoingImageBlob(image.displayUrl, opts, image.artifactId);
       downloadImageBlob(blob, imageDownloadFileName(title, blob.type));
     } catch {
-      showToast({ message: t("chat.imageLightbox.downloadFailed") });
+      showImageToast(
+        opts,
+        `image-download:${image.artifactId ?? image.displayUrl}`,
+        t("chat.imageLightbox.downloadFailed"),
+        "danger",
+      );
     }
   };
   const copy = async () => {
@@ -518,9 +561,19 @@ function renderManagedImageActions(
       );
       void png.catch(() => {});
       await navigator.clipboard.write([new ClipboardItem({ "image/png": png })]);
-      showToast({ message: t("common.copied") });
+      showImageToast(
+        opts,
+        `image-copy:${image.artifactId ?? image.displayUrl}`,
+        t("common.copied"),
+        "success",
+      );
     } catch {
-      showToast({ message: t("chat.imageLightbox.copyFailed") });
+      showImageToast(
+        opts,
+        `image-copy:${image.artifactId ?? image.displayUrl}`,
+        t("chat.imageLightbox.copyFailed"),
+        "danger",
+      );
     }
   };
   return html`

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -28,6 +28,7 @@ export type ArtifactDownloadResolver = (params: {
 }) => Promise<{ url: string; expiresAt?: string } | null>;
 
 export type ImageRenderOptions = {
+  sessionKey?: string;
   localMediaPreviewRoots?: readonly string[];
   resourceBasePath?: string;
   authToken?: string | null;

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -41,7 +41,11 @@ type WidgetCardOptions = {
   boardProvider?: BoardProvider;
 };
 
-async function pinWidget(event: Event, pin: () => Promise<void>): Promise<void> {
+async function pinWidget(
+  event: Event,
+  pin: () => Promise<void>,
+  sessionKey: string | undefined,
+): Promise<void> {
   const button = event.currentTarget;
   if (!(button instanceof HTMLButtonElement)) {
     return;
@@ -59,7 +63,12 @@ async function pinWidget(event: Event, pin: () => Promise<void>): Promise<void> 
     button.ariaLabel = t("chat.toolCards.pinToDashboard");
     const failureLabel = t("chat.toolCards.pinToDashboardFailed");
     button.title = failureLabel;
-    showToast({ message: failureLabel });
+    showToast({
+      key: "widget-pin",
+      message: failureLabel,
+      ...(sessionKey ? { scope: { kind: "session", sessionKey } as const } : {}),
+      variant: "danger",
+    });
   }
 }
 
@@ -68,17 +77,21 @@ async function pinCanvasWidget(
   preview: ToolPreview,
   provider: BoardProvider,
   name: string,
+  sessionKey: string | undefined,
 ): Promise<void> {
   const docId = preview.viewId?.trim();
   if (!docId) {
     return;
   }
-  return pinWidget(event, () =>
-    provider.pinWidget({
-      docId,
-      name,
-      ...(preview.title?.trim() ? { title: preview.title.trim() } : {}),
-    }),
+  return pinWidget(
+    event,
+    () =>
+      provider.pinWidget({
+        docId,
+        name,
+        ...(preview.title?.trim() ? { title: preview.title.trim() } : {}),
+      }),
+    sessionKey,
   );
 }
 
@@ -88,13 +101,17 @@ async function pinMcpAppWidget(
   provider: BoardProvider,
   name: string,
   viewId: string,
+  sessionKey: string | undefined,
 ): Promise<void> {
-  return pinWidget(event, () =>
-    provider.pinMcpApp({
-      viewId,
-      name,
-      ...(preview.title?.trim() ? { title: preview.title.trim() } : {}),
-    }),
+  return pinWidget(
+    event,
+    () =>
+      provider.pinMcpApp({
+        viewId,
+        name,
+        ...(preview.title?.trim() ? { title: preview.title.trim() } : {}),
+      }),
+    sessionKey,
   );
 }
 
@@ -424,7 +441,15 @@ function renderWidgetContent(
 function handleWidgetExportAction(
   event: CustomEvent<{ item: { value?: string } }>,
   title: string | undefined,
+  sessionKey: string | undefined,
 ) {
+  const present = (key: string, message: string, variant: "danger" | "success" | "warning") =>
+    showToast({
+      key,
+      message,
+      ...(sessionKey ? { scope: { kind: "session", sessionKey } as const } : {}),
+      variant,
+    });
   const value = event.detail.item.value;
   if (value === "raw-details") {
     const dropdown = event.currentTarget;
@@ -456,25 +481,29 @@ function handleWidgetExportAction(
           ?.querySelector<HTMLIFrameElement>(".chat-tool-card__preview-frame")
       : null;
   if (!frame) {
-    showToast({ message: t("chat.toolCards.widgetExportFailed") });
+    present("widget-export", t("chat.toolCards.widgetExportFailed"), "danger");
     return;
   }
   void exportWidget(value, frame, title)
     .then((result) => {
       if (result === "rerender-required") {
-        showToast({ message: t("chat.toolCards.widgetExportRerender") });
+        present("widget-export", t("chat.toolCards.widgetExportRerender"), "warning");
       } else if (result === "html") {
-        showToast({ message: t("chat.toolCards.widgetExportHtmlFallback") });
+        present("widget-export", t("chat.toolCards.widgetExportHtmlFallback"), "warning");
       } else if (value === "copy") {
-        showToast({ message: t("common.copied") });
+        present("widget-export", t("common.copied"), "success");
       }
     })
     .catch(() => {
-      showToast({ message: t("chat.toolCards.widgetExportFailed") });
+      present("widget-export", t("chat.toolCards.widgetExportFailed"), "danger");
     });
 }
 
-function renderWidgetActions(preview: ToolPreview, hasRawDetails: boolean) {
+function renderWidgetActions(
+  preview: ToolPreview,
+  hasRawDetails: boolean,
+  sessionKey: string | undefined,
+) {
   const canExportImage = !preview.mcpApp && isInternalCanvasEntryUrl(preview.url);
   if (!canExportImage && !hasRawDetails) {
     return nothing;
@@ -485,7 +514,7 @@ function renderWidgetActions(preview: ToolPreview, hasRawDetails: boolean) {
       placement="bottom-end"
       aria-label=${t("chat.toolCards.widgetActions")}
       @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) =>
-        handleWidgetExportAction(event, preview.title)}
+        handleWidgetExportAction(event, preview.title, sessionKey)}
     >
       <button
         slot="trigger"
@@ -573,13 +602,24 @@ function renderWidgetCard(
           aria-label=${pinLabel}
           @click=${(event: Event) =>
             contentKind === "mcp-app" && mcpAppViewId
-              ? void pinMcpAppWidget(event, preview, provider, pinName, mcpAppViewId)
-              : void pinCanvasWidget(event, preview, provider, pinName)}
+              ? void pinMcpAppWidget(
+                  event,
+                  preview,
+                  provider,
+                  pinName,
+                  mcpAppViewId,
+                  options?.sessionKey,
+                )
+              : void pinCanvasWidget(event, preview, provider, pinName, options?.sessionKey)}
         >
           ${icons.pin}
         </button>`
       : nothing;
-  const widgetActions = renderWidgetActions(preview, Boolean(options?.rawText));
+  const widgetActions = renderWidgetActions(
+    preview,
+    Boolean(options?.rawText),
+    options?.sessionKey,
+  );
   const actions =
     pinAction === nothing && widgetActions === nothing
       ? nothing

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -104,7 +104,11 @@ async function emitObserverAndReadToast(
       await runtime;
       await host.updateComplete;
 
-      const toast = host.querySelector<HTMLElement>(".app-toast");
+      const toast = [...host.querySelectorAll<HTMLElement>(".app-toast")].find((candidate) =>
+        candidate.textContent?.includes(
+          String((params.payload as { headline?: unknown }).headline),
+        ),
+      );
       const isVisible = (target: HTMLElement | null): target is HTMLElement => {
         if (!target?.isConnected) {
           return false;
@@ -118,7 +122,7 @@ async function emitObserverAndReadToast(
           bounds.height > 0
         );
       };
-      const visible = isVisible(toast);
+      const visible = isVisible(toast ?? null);
       let actionable: boolean | null = null;
       const result = () => ({
         actionable,
@@ -219,7 +223,9 @@ suite.define(() => {
         await host.locator(".app-toast__action").click({ trial: true });
 
         await modal.evaluate((element) => (element as HTMLElement & { hide: () => void }).hide());
-        const appToast = page.locator(".shell > openclaw-toast-host .app-toast");
+        const appToast = page.locator(".shell > openclaw-toast-host .app-toast", {
+          hasText: headline,
+        });
         await expect.poll(() => appToast.textContent()).toContain(headline);
         await appToast.getByRole("button", { name: "Dismiss" }).click();
       },
@@ -257,7 +263,7 @@ suite.define(() => {
         await page.getByText("Selected session A is ready.").waitFor({ state: "visible" });
         expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(selectedSessionKey));
 
-        const toast = page.locator(".app-toast");
+        const toast = page.locator(".app-toast", { hasText: "Background session is healthy" });
         await gateway.emitGatewayEvent(
           "session.observer",
           observerDigest({
@@ -472,7 +478,7 @@ suite.define(() => {
           revision: 1,
         });
 
-        const toast = page.locator(".app-toast");
+        const toast = page.locator(".app-toast", { hasText: headline });
         if (testCase.visible) {
           const toastState = await emitObserverAndReadToast(page, digest);
           expect(toastState.visible).toBe(true);

--- a/ui/src/pages/chat/critical-observer-notice.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.test.ts
@@ -124,7 +124,7 @@ describe("critical session observer notice", () => {
 
     show("agent:main:other", "stuck", 3);
     await toastHost.updateComplete;
-    expect(toastHost.querySelector(".app-toast")).toBeNull();
+    expect(toastHost.querySelector('.app-toast[data-state="open"]')).toBeNull();
 
     // Broad-only recipients miss recovery digests. A revision gap distinguishes
     // the next critical transition from an exact subscriber's repeat update.

--- a/ui/src/pages/chat/critical-observer-notice.ts
+++ b/ui/src/pages/chat/critical-observer-notice.ts
@@ -100,9 +100,11 @@ export function showCriticalSessionObserverNotice(params: {
   );
   const label = resolveSessionDisplayName(sessionKey, row);
   showToast({
+    key: `critical-observer:${sessionKey}`,
     message: `${t("sessionsView.attentionRequired")}: ${label} — ${headline}`,
     actionLabel: t("sessionsView.openSession"),
     onAction: () =>
       digest.agentId ? params.onOpen(sessionKey, digest.agentId) : params.onOpen(sessionKey),
+    variant: "danger",
   });
 }


### PR DESCRIPTION
Related: #128241
Depends on #128253 and parent PR #128270.

## What Problem This Solves

Resolves a problem where session-owned feedback appeared in the global corner, away from the active pane, while board action failures were announced twice and config failures duplicated an existing page error.

## Why This Change Was Made

This stacked follow-up registers a compact session presenter directly below each visible pane topbar, routes image/widget/progress outcomes by semantic session identity, moves active chips to the global host if their retained pane becomes hidden, and consolidates board/config failures into their existing inline owner surfaces. Composer-adjacent notices remain unchanged.

## User Impact

Session feedback now appears as a small severity chip in the pane it belongs to, including dashboard and split layouts. Hidden sessions still produce named global outcomes, and duplicate board/config announcements are removed without losing diagnostic details.

## Evidence

- `node scripts/run-vitest.mjs ...` — affected unit/component suites passed; full focused run covered 942 tests plus isolated pane coverage.
- Seven affected Control UI E2E files passed across focused runs, including session chip placement and inline board failure behavior.
- `node scripts/check-changed.mjs` — changed guards, format, i18n, typechecks, lint, and stylelint passed after final fixes.
- `pnpm ui:build` — 950 sidecars verified; startup JS/CSS performance limits passed.
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
- 32 inspected screenshots cover desktop/mobile × dark/light × four variants × global/session. Session rows confirm compact centered chips below the pane topbar.
- 5.04 s recording confirms three global cards remain actionable while Undo removes only its owning card.
