### PR TITLE
fix(agents): preserve image attachment ownership in queued follow-ups

### DIFF
--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -418,11 +418,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
    * Internal: Queue a follow-up message (already expanded, no extension command check).
    */
   private async queueFollowUp(text: string, images?: ImageContent[]): Promise<void> {
-    const message = {
-      role: "user",
-      content: this.createUserContent(text, images),
-      timestamp: Date.now(),
-    } satisfies AgentMessage;
+    const message = this.createUserMessage(text, images);
     this.trackQueuedUserMessage(message, "followUp", text);
     this.agent.followUp(message);
   }

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -480,9 +480,10 @@ describe("AgentSession queued user turns", () => {
     });
   });
 
-  it("carries prompt facts non-enumerably on the exact steered message", async () => {
+  it("preserves prompt image ownership across steered and follow-up messages", async () => {
     const session = await createSessionFromManager(SessionManager.inMemory());
     const steer = vi.spyOn(session.agent, "steer").mockImplementation(() => undefined);
+    const followUp = vi.spyOn(session.agent, "followUp").mockImplementation(() => undefined);
     const media = [{ path: "/tmp/a.png", contentType: "image/png" }];
     const imageOrder = ["inline"] as const;
     const image: ImageContent = { type: "image", data: "aW1hZ2U=", mimeType: "image/png" };
@@ -509,6 +510,10 @@ describe("AgentSession queued user turns", () => {
       mediaImageBlockFactIndexes: [0],
     });
     expect(JSON.stringify(runtimeMessage)).not.toContain("runtimePromptMediaFacts");
+    await session.followUp("inspect queued attachment", images);
+    expect(followUp.mock.calls[0]?.[0]).toMatchObject({
+      __openclaw: { mediaImageBlockFactIndexes: [0] },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- preserve the structured image-fact ownership of queued agent follow-up messages
- route initial prompts, steering, and follow-ups through the existing canonical user-message constructor
- remove the duplicate follow-up message builder (production delta: +1/-5, net -4 lines)

## Root cause

Queued follow-ups independently built user messages from image content and never attached the existing `mediaImageBlockFactIndexes` metadata. Initial prompts and steering already use the canonical constructor, so their image ownership survived replay while queued follow-up attachments lost their provenance.

## Verification

- Confirmed the queued-follow-up regression fails on untouched main because the emitted message lacks `__openclaw.mediaImageBlockFactIndexes`.
- Extended the existing steering regression to prove both steering and queued follow-ups preserve the same structured image ownership without duplicating fixtures.
- `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts` — 31 tests passed.
- Targeted formatting, lint, and `git diff --check` passed.
- Independent structured Codex review: no actionable findings.

## Risk

Low: reuses the existing private user-message constructor, changes no storage schema, public API, configuration, provider behavior, or Gateway protocol, and removes the divergent production path.
