### PR TITLE
fix(macos): resolve the onboarding install prompt when the gateway is already running

### DIFF
--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -605,8 +605,15 @@ final class OnboardingController: NSObject, NSWindowDelegate {
 
     func close() {
         self.busyReason = nil
+        // AppKit ignores close while its modal sheet is still attached.
+        self.dismissAttachedSheet()
         self.window?.close()
         self.window = nil
+    }
+
+    func dismissAttachedSheet() {
+        guard let window, let sheet = window.attachedSheet else { return }
+        window.endSheet(sheet)
     }
 
     func setWindowCloseEnabled(_ enabled: Bool) {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -94,8 +94,24 @@ extension OnboardingView {
         }
     }
 
+    static func shouldResolveInstallPromptForRunningGateway(
+        gatewayStatus: GatewayProcessManager.Status,
+        isLocal: Bool,
+        phase: CLIInstallPhase) -> Bool
+    {
+        guard isLocal, phase == .choosingTarget else { return false }
+        return switch gatewayStatus {
+        case .running, .attachedExisting: true
+        case .stopped, .starting, .failed: false
+        }
+    }
+
     func reviseCLIActivationFailureIfGatewayReady(_ status: GatewayProcessManager.Status) {
-        guard Self.shouldReviseCLIActivationFailure(
+        let resolvesInstallPrompt = Self.shouldResolveInstallPromptForRunningGateway(
+            gatewayStatus: status,
+            isLocal: state.connectionMode == .local,
+            phase: cliInstallPhase)
+        guard resolvesInstallPrompt || Self.shouldReviseCLIActivationFailure(
             gatewayStatus: status,
             isLocal: state.connectionMode == .local,
             executableReady: cliExecutableReady,
@@ -104,6 +120,10 @@ extension OnboardingView {
         cliInstalled = true
         cliStatusKnown = true
         cliStatus = nil
+        if resolvesInstallPrompt {
+            // A running local gateway already fulfills the pending install prompt.
+            OnboardingController.shared.dismissAttachedSheet()
+        }
     }
 
     /// LocalGatewayActivation.failed carries the reason bound to that specific activation
@@ -167,6 +187,8 @@ extension OnboardingView {
         guard let target = await CLIInstallPrompter.shared.installTargetForCurrentBuild(
             presentingSheetOn: OnboardingController.shared.sheetPresentationWindow)
         else {
+            // Gateway readiness can resolve onboarding while this sheet is open.
+            guard !cliInstalled else { return }
             cliStatus = "CLI installation cancelled."
             return
         }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -255,6 +255,33 @@ struct OnboardingViewSmokeTests {
             installed: false))
     }
 
+    @Test func `running local gateway resolves only its pending CLI install prompt`() {
+        for status in [GatewayProcessManager.Status.running(details: nil), .attachedExisting(details: "pid 4242")] {
+            #expect(OnboardingView.shouldResolveInstallPromptForRunningGateway(
+                gatewayStatus: status,
+                isLocal: true,
+                phase: .choosingTarget))
+        }
+        for status in [GatewayProcessManager.Status.starting, .stopped, .failed("unavailable")] {
+            #expect(!OnboardingView.shouldResolveInstallPromptForRunningGateway(
+                gatewayStatus: status,
+                isLocal: true,
+                phase: .choosingTarget))
+        }
+        for mode in [AppState.ConnectionMode.remote, .unconfigured] {
+            #expect(!OnboardingView.shouldResolveInstallPromptForRunningGateway(
+                gatewayStatus: .running(details: nil),
+                isLocal: mode == .local,
+                phase: .choosingTarget))
+        }
+        for phase in [OnboardingView.CLIInstallPhase.idle, .installing, .startingService] {
+            #expect(!OnboardingView.shouldResolveInstallPromptForRunningGateway(
+                gatewayStatus: .running(details: nil),
+                isLocal: true,
+                phase: phase))
+        }
+    }
+
     @Test func `gateway start failure message retains the concrete reason`() {
         #expect(
             OnboardingView.gatewayStartFailureMessage(


### PR DESCRIPTION
## What Problem This Solves

Fixes #128194.

Local-mode onboarding has two rightful actors on the "Getting things ready" page. The page's own install flow may open an install-target prompt (unreleased builds). Independently, committing the connection mode to "On this Mac" starts the gateway through `ConnectionModeCoordinator.applyLocalMode` — by design, so the default path yields a working bot as fast as possible. When the gateway comes up on its own (dev-root checkouts where it launches from the repo dist, or an externally attached gateway), AI setup auto-connects and `finish()` runs.

Instrumented live run (os_log timeline, hands-off after reaching the CLI page):

```
08:55:17.546  startCLIInstall → runCLIInstall BEGIN (prompting)      ← sheet opens
08:55:17.876  GatewayProcessManager.setActive(true)                  ← mode-commit autostart
08:55:36.821  gateway status .running                                ← revise path fires, but its
                                                                       executableReady guard skips
08:57:18.705  aiSetup.onConnected → finish()
08:57:18.706  OnboardingController.close()  window=true sheet=true   ← close() silently no-ops
```

`NSWindow.close()` is ineffective while a sheet is attached. End state: onboarding **completed** (dashboard open, `onboardingSeen=1`, gateway service running) plus a zombie onboarding window showing a dead CLI page with a stale "Choose OpenClaw CLI channel" sheet. Answering that sheet wrote "CLI installation cancelled." into a finished flow. Before #128183 the same race existed with the detached `runModal` panel — invisible instead of stale.

## Why This Change Was Made

Two coupled fixes at the owning seams:

1. **`OnboardingController.close()` always tears the window down.** A new `dismissAttachedSheet()` ends any attached sheet before `window.close()`. The `beginSheetModal` continuation resumes with a non-button response and flows through the existing cancel path of a view that is going away.
2. **A running local gateway resolves a pending install prompt.** The prompt asks "which channel should I install to get you a gateway?" — moot once a local gateway is running. A new tested static, `shouldResolveInstallPromptForRunningGateway(gatewayStatus:isLocal:phase:)`, extends the existing gateway-status revise path (`reviseCLIActivationFailureIfGatewayReady`, already wired to every status change) to the `.choosingTarget` phase: the step is marked installed, status text cleared, and the moot sheet dismissed. `runCLIInstall`'s nil-target branch returns quietly when the step already resolved, so a dismissal never overwrites the resolved state with a cancellation message; genuine user declines keep the "CLI installation cancelled." status. The existing failure-state helper and its deliberate `executableReady` guard are untouched.

The auto-completion behavior itself is preserved on purpose — a user who picks the default and waits gets a working bot with zero extra clicks; this change only removes the orphaned UI it used to leave behind.

## User Impact

Anyone whose gateway starts independently of the CLI page's install flow — primarily dev-root/unreleased builds and attached-gateway setups. Onboarding that completes on its own now ends with the onboarding window actually closed and no stale dialog; a prompt that becomes moot mid-decision disappears instead of dangling.

## Evidence

- Root cause proven with os_log instrumentation on a live packaged app (timeline above; `close() window=true sheet=true` with the window observably surviving in three separate runs).
- Fix verified live on a fresh isolated profile: the same hands-off flow now ends with **only the dashboard window** — no "Welcome to OpenClaw" window, no sheet — while `onboardingSeen=1` and the gateway service runs.
- `swift build` — Build complete. `swiftformat --lint` — 0/337 files require formatting. `pnpm native:i18n:baseline` — entries=4237, changed=false.
- New table test covers the static: running/attachedExisting + local + choosingTarget → true; starting/stopped/failed, remote/unconfigured, and idle/installing/startingService phases → false.
- Autoreview (codex/gpt-5.6-sol, xhigh): clean, no accepted or actionable findings.
- Production +30/−1, tests +27/−0.
