### PR TITLE
fix(feishu): prevent blank duplicate replies when card receipts are absent

### DIFF
--- a/extensions/feishu/src/delivery-trace.test.ts
+++ b/extensions/feishu/src/delivery-trace.test.ts
@@ -14,7 +14,7 @@ import {
   type WireRecorder,
 } from "openclaw/plugin-sdk/channel-contract-testing";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
-import { afterAll, afterEach, beforeAll, describe, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { FeishuConfigSchema } from "./config-schema.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -33,6 +33,7 @@ type FeishuTraceState = {
   reactionCount: number;
   cardCount: number;
   setupCount: number;
+  omitNextMessageReceipt: boolean;
   wireFaults: Array<{ fault: "rate-limit"; retryAfterMs: number }>;
 };
 
@@ -46,6 +47,7 @@ const traceState = vi.hoisted(
     reactionCount: 0,
     cardCount: 0,
     setupCount: 0,
+    omitNextMessageReceipt: false,
     wireFaults: [],
   }),
 );
@@ -147,6 +149,7 @@ afterEach(() => {
   traceState.account = null;
   traceState.larkClient = null;
   traceState.cardKitFetch = null;
+  traceState.omitNextMessageReceipt = false;
   traceState.wireFaults = [];
   streamingStartBackoffUntilByAccount.clear();
 });
@@ -171,11 +174,11 @@ function nextMessageId(): string {
 }
 
 function createRecordingLarkClient() {
-  const messageSendResult = (messageId: string) => ({
-    code: 0,
-    msg: "ok",
-    data: { message_id: messageId },
-  });
+  const messageSendResult = (messageId: string) => {
+    const data = traceState.omitNextMessageReceipt ? {} : { message_id: messageId };
+    traceState.omitNextMessageReceipt = false;
+    return { code: 0, msg: "ok", data };
+  };
   return {
     im: {
       message: {
@@ -184,6 +187,7 @@ function createRecordingLarkClient() {
           data: { receive_id: string; msg_type: string; content: string; root_id?: string };
         }) => {
           const messageId = nextMessageId();
+          const response = messageSendResult(messageId);
           traceState.recordWireCall({
             method: "im.message.create",
             target: args.data.receive_id,
@@ -193,15 +197,16 @@ function createRecordingLarkClient() {
               content: parseJsonRecord(args.data.content),
               ...(args.data.root_id ? { root_id: args.data.root_id } : {}),
             },
-            result: { message_id: messageId },
+            result: response.data,
           });
-          return Promise.resolve(messageSendResult(messageId));
+          return Promise.resolve(response);
         },
         reply: (args: {
           path: { message_id: string };
           data: { msg_type: string; content: string; reply_in_thread?: boolean };
         }) => {
           const messageId = nextMessageId();
+          const response = messageSendResult(messageId);
           traceState.recordWireCall({
             method: "im.message.reply",
             target: args.path.message_id,
@@ -210,9 +215,9 @@ function createRecordingLarkClient() {
               content: parseJsonRecord(args.data.content),
               ...(args.data.reply_in_thread ? { reply_in_thread: true } : {}),
             },
-            result: { message_id: messageId },
+            result: response.data,
           });
-          return Promise.resolve(messageSendResult(messageId));
+          return Promise.resolve(response);
         },
         delete: (args: { path: { message_id: string } }) => {
           traceState.recordWireCall({
@@ -407,6 +412,32 @@ const FEISHU_TRACE_SCENARIOS: readonly DeliveryTraceScenarioName[] = [
 ];
 
 describe("feishu delivery trace goldens", () => {
+  it("updates the accepted card without a duplicate send when its message receipt is absent", async () => {
+    const events = await runDeliveryTraceScenario({
+      scenario: deliveryTraceScenarios["final-only"],
+      setup: (recorder) => {
+        const dispatch = setupFeishuTrace(recorder, "final-only");
+        traceState.omitNextMessageReceipt = true;
+        return dispatch;
+      },
+    });
+    const messages = events.filter(
+      (event) => event.kind === "im.message.reply" || event.kind === "im.message.create",
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ data: { result: {} } });
+    expect(
+      events.some((event) =>
+        event.kind.startsWith("PUT /cardkit/v1/cards/card-1/elements/content/content"),
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.kind === "PATCH /cardkit/v1/cards/card-1/settings")).toBe(
+      true,
+    );
+    expect(streamingStartBackoffUntilByAccount.has("main")).toBe(false);
+  });
+
   for (const scenarioName of FEISHU_TRACE_SCENARIOS) {
     it(`records ${scenarioName}`, async () => {
       const events = await runDeliveryTraceScenario({

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -286,6 +286,167 @@ describe("FeishuStreamingSession", () => {
     return { authTokens, client, deps };
   }
 
+  function mockAcceptedStreamingCard(params: {
+    accountId: string;
+    response?: { code: number; msg: string; data?: { message_id?: string } };
+    rejectClose?: boolean;
+  }) {
+    const requests: Array<{ path: string; body: Record<string, unknown> }> = [];
+    const deps = createMemoryFetch((url, body) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (url.pathname.endsWith("/cardkit/v1/cards")) {
+        return jsonResponse({ code: 0, msg: "ok", data: { card_id: "card_accepted" } });
+      }
+      requests.push({ path: url.pathname, body: JSON.parse(body) as Record<string, unknown> });
+      return jsonResponse(
+        params.rejectClose && url.pathname.endsWith("/settings")
+          ? { code: 91400, msg: "close rejected" }
+          : { code: 0, msg: "ok" },
+      );
+    });
+    const response = params.response ?? { code: 0, msg: "ok", data: {} };
+    const create = vi.fn(async () => response);
+    const reply = vi.fn(async () => response);
+    const remove = vi.fn(async () => ({ code: 0, msg: "ok" }));
+    const client = {
+      im: { message: { create, reply, delete: remove } },
+    } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
+    const session = new FeishuStreamingSession(
+      client,
+      { appId: params.accountId, appSecret: "test-secret" },
+      undefined,
+      deps,
+    );
+    return { session, requests, create, reply, remove };
+  }
+
+  it.each([
+    { mode: "create", options: undefined, method: "create" },
+    { mode: "root_create", options: { rootId: "root_1" }, method: "create" },
+    {
+      mode: "reply",
+      options: { replyToMessageId: "inbound_1", replyInThread: true },
+      method: "reply",
+    },
+  ] as const)(
+    "updates and closes an accepted $mode card when its optional message receipt is absent",
+    async ({ mode, options, method }) => {
+      const { session, requests, create, reply } = mockAcceptedStreamingCard({
+        accountId: `accepted-without-receipt-${mode}`,
+      });
+
+      await session.start("chat_1", "chat_id", options);
+      await session.update("The accepted answer");
+
+      await expect(session.closeWithResult("The accepted answer")).resolves.toEqual({
+        visibleReplySent: true,
+        content: "The accepted answer",
+      });
+      expect(method === "reply" ? reply : create).toHaveBeenCalledOnce();
+      expect(method === "reply" ? create : reply).not.toHaveBeenCalled();
+      if (mode === "root_create") {
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({ root_id: "root_1" }),
+          }),
+        );
+      } else if (mode === "create") {
+        expect(create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.not.objectContaining({ root_id: expect.anything() }),
+          }),
+        );
+      } else {
+        expect(reply).toHaveBeenCalledWith(
+          expect.objectContaining({
+            path: { message_id: "inbound_1" },
+            data: expect.objectContaining({ reply_in_thread: true }),
+          }),
+        );
+      }
+      expect(requests.map(({ path }) => path)).toEqual([
+        "/open-apis/cardkit/v1/cards/card_accepted/elements/content/content",
+        "/open-apis/cardkit/v1/cards/card_accepted/settings",
+      ]);
+      expect(session.isActive()).toBe(false);
+    },
+  );
+
+  it("clears an accepted preview without requesting deletion with an absent message receipt", async () => {
+    const { session, requests, remove } = mockAcceptedStreamingCard({
+      accountId: "discard-without-receipt",
+    });
+
+    await session.start("chat_1");
+    await session.update("Transient preview");
+    await session.discard();
+
+    expect(remove).not.toHaveBeenCalled();
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/open-apis/cardkit/v1/cards/card_accepted/elements/content/content",
+      "/open-apis/cardkit/v1/cards/card_accepted/elements/content",
+      "/open-apis/cardkit/v1/cards/card_accepted/settings",
+    ]);
+    expect(JSON.parse(String(requests[1]?.body.element))).toEqual({
+      tag: "markdown",
+      content: "",
+      element_id: "content",
+    });
+    expect(session.isActive()).toBe(false);
+  });
+
+  it("deletes an accepted preview normally when its message receipt is present", async () => {
+    const { session, requests, remove } = mockAcceptedStreamingCard({
+      accountId: "discard-with-receipt",
+      response: { code: 0, msg: "ok", data: { message_id: "om_accepted" } },
+    });
+
+    await session.start("chat_1");
+    await session.update("Transient preview");
+    await session.discard();
+
+    expect(remove).toHaveBeenCalledExactlyOnceWith({ path: { message_id: "om_accepted" } });
+    expect(requests.map(({ path }) => path)).toEqual([
+      "/open-apis/cardkit/v1/cards/card_accepted/elements/content/content",
+    ]);
+    expect(session.isActive()).toBe(false);
+  });
+
+  it("preserves accepted visible card content when receipt-free finalization fails", async () => {
+    const { session } = mockAcceptedStreamingCard({
+      accountId: "failed-close-without-receipt",
+      rejectClose: true,
+    });
+
+    await session.start("chat_1");
+    await session.update("Already visible answer");
+
+    await expect(session.closeWithResult("Already visible answer")).rejects.toMatchObject({
+      name: "FeishuStreamingFinalizationError",
+      result: {
+        visibleReplySent: true,
+        content: "Already visible answer",
+      },
+    });
+  });
+
+  it("still rejects provider-declined streaming card messages", async () => {
+    const { session } = mockAcceptedStreamingCard({
+      accountId: "declined-streaming-card",
+      response: { code: 230099, msg: "message rejected" },
+    });
+
+    await expect(session.start("chat_1")).rejects.toThrow("Send card failed: message rejected");
+    expect(session.isActive()).toBe(false);
+  });
+
   it("rejects oversized streaming tenant-token JSON before buffering the full body", async () => {
     let streamState:
       | {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -26,7 +26,7 @@ type Credentials = {
 };
 type CardState = {
   cardId: string;
-  messageId: string;
+  messageId?: string;
   sequence: number;
   currentText: string;
   sentText: string;
@@ -372,19 +372,6 @@ export class FeishuStreamingSession {
           }),
         "Send card failed",
       );
-    } else if (sendMode === "root_create") {
-      // root_id is undeclared in the SDK types but accepted at runtime
-      sendRes = await requestFeishuApi(
-        () =>
-          this.client.im.message.create({
-            params: { receive_id_type: receiveIdType },
-            data: Object.assign(
-              { receive_id: receiveId, msg_type: "interactive", content: cardContent },
-              { root_id: sendOptions.rootId },
-            ),
-          }),
-        "Send card failed",
-      );
     } else {
       sendRes = await requestFeishuApi(
         () =>
@@ -394,24 +381,27 @@ export class FeishuStreamingSession {
               receive_id: receiveId,
               msg_type: "interactive",
               content: cardContent,
+              // The SDK omits root_id from its types, but Feishu accepts it at runtime.
+              ...(sendMode === "root_create" ? { root_id: sendOptions.rootId } : {}),
             },
           }),
         "Send card failed",
       );
     }
-    if (sendRes.code !== 0 || !sendRes.data?.message_id) {
+    if (sendRes.code !== 0) {
       throw new Error(`Send card failed: ${sendRes.msg}`);
     }
 
+    const messageId = sendRes.data?.message_id?.trim();
     this.state = {
       cardId,
-      messageId: sendRes.data.message_id,
+      ...(messageId ? { messageId } : {}),
       sequence: 1,
       currentText: "",
       sentText: "",
       hasNote: Boolean(options?.note),
     };
-    this.log?.(`Started streaming: cardId=${cardId}, messageId=${sendRes.data.message_id}`);
+    this.log?.(`Started streaming: cardId=${cardId}${messageId ? `, messageId=${messageId}` : ""}`);
   }
 
   private async updateCardContent(
@@ -723,7 +713,7 @@ export class FeishuStreamingSession {
     const result: FeishuStreamingCloseResult = {
       visibleReplySent: visibleContentSent,
       ...(visibleContentSent ? { content: finalState.sentText } : {}),
-      messageId: finalState.messageId,
+      ...(finalState.messageId ? { messageId: finalState.messageId } : {}),
     };
     if (finalWriteError !== undefined || closeError !== undefined) {
       const cause =
@@ -753,21 +743,26 @@ export class FeishuStreamingSession {
     if (!this.state || this.closed) {
       return;
     }
+    const { cardId, messageId } = this.state;
+    if (!messageId) {
+      // Accepted cards without a message receipt can still be cleared by card id.
+      await this.close("");
+      return;
+    }
     this.closed = true;
     this.clearFlushTimer();
     await this.queue;
 
-    const currentState = this.state;
     try {
       const response = await this.client.im.message.delete({
-        path: { message_id: currentState.messageId },
+        path: { message_id: messageId },
       });
       if (response.code !== undefined && response.code !== 0) {
         throw new Error(`Delete streaming card message failed: ${response.msg ?? response.code}`);
       }
       this.state = null;
       this.pendingText = null;
-      this.log?.(`Discarded streaming card: cardId=${currentState.cardId}`);
+      this.log?.(`Discarded streaming card: cardId=${cardId}`);
     } catch (error) {
       this.log?.(`Discard failed: ${String(error)}`);
       this.closed = false;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu/Lark users would see an abandoned empty streaming card followed by a duplicate static reply when the provider successfully accepted an interactive message but omitted its optional message ID. The same successful response incorrectly disabled streaming for the account for 60 seconds.

Related: #128130, #128213.

## Why This Change Was Made

CardKit updates and finalization are owned by the card ID, while the message ID is optional in both upstream SDK send contracts and is needed only for an optional receipt or native message deletion. Keep an accepted card alive using its card ID, omit unavailable receipts truthfully, clear receipt-free previews through the existing CardKit lifecycle, and consolidate both create modes behind one canonical provider send while preserving thread routing.

Treating an already accepted card as an ordinary send failure or recovering with a second static card was rejected because both approaches abandon visible provider state and duplicate delivery. No public API, configuration, persistence, security policy, or SDK contract changes.

## User Impact

Feishu and Lark replies continue streaming and complete as one visible message even when the provider does not return a message receipt. Existing threaded replies, normal message receipts, native preview deletion, provider rejection handling, and finalization failure reporting remain unchanged.

## Evidence

- Exact reviewed head: `0f32aab012d32d0693968923e6de769c66324248`.
- Authentic pre-fix owner and real-dispatcher boundary reproduction: six failing regressions across direct create, threaded root create, reply, receipt-free preview cleanup, finalization, and duplicate platform delivery; the unchanged rejected-provider control passed.
- Exact committed head: **227 passing tests across eight Feishu owner, wire-trace, dispatcher, delivery, and sibling send suites** using `node scripts/run-vitest.mjs extensions/feishu/src/streaming-card.test.ts extensions/feishu/src/streaming-card.error-release.test.ts extensions/feishu/src/delivery-trace.test.ts extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/send-result.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/outbound-delivery.test.ts extensions/feishu/src/send.reply-fallback.test.ts`.
- Independent reviewer reran both changed boundary suites: **39 passing tests**, including exact root-thread and reply-thread request payloads; independent and authenticated Codex reviews reported no actionable findings.
- Full production and test type lanes report **zero diagnostics in touched Feishu files**; the existing local shared dependency installation independently reproduces unrelated ACPX type diagnostics unchanged on a clean current-main-compatible checkout.
- Targeted formatter, extension lint, conflict markers, assertion-safety ratchet, max-lines ratchet, and `git diff --check` all pass without baseline changes.
- Production: **+16/-21 lines (net -5)**. The real dispatcher/provider-boundary trace verifies exactly one accepted interactive send, continued CardKit updates and closeout, no static fallback, and no erroneous backoff. No live authenticated Feishu account was available; the existing real-dispatcher wire harness supplies channel-visible behavior proof.

AI-assisted: Codex.
