### PR TITLE
fix(qa): fail onboarding when required assertions are missing

### DIFF
--- a/scripts/e2e/qa-cli-onboarding.mjs
+++ b/scripts/e2e/qa-cli-onboarding.mjs
@@ -138,4 +138,4 @@ if (signal) {
   process.kill(process.pid, signal);
 }
 const missingBoundary = results.some((result) => result.status !== "pass");
-process.exit(code === 0 && !missingBoundary ? 0 : (code ?? 1));
+process.exit(code === 0 && missingBoundary ? 1 : (code ?? 1));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where onboarding QA could report success even though its evidence recorded a failed guided-onboarding, Gateway-auth, remote-onboarding, or targeted-reconfiguration boundary.

## Why This Change Was Made

The onboarding QA owner correctly detected missing executable assertion markers but returned the Docker child's successful exit code instead of failing the overall process. Make a missing required boundary override child exit code zero while preserving successful complete runs and every original nonzero child exit code. This matches the existing plugin-install QA sibling's failure semantics without changing onboarding behavior or public contracts.

## User Impact

Onboarding QA and exit-code-based CI callers now fail loudly when any required onboarding assertion is absent, instead of silently accepting incomplete coverage.

## Evidence

- Base: `bf91e00d36cc94db57d23fd15a6a3c2aaa10f7ab`.
- Executed the complete actual onboarding QA entrypoint against an isolated synthetic shell fixture that emitted five required markers but omitted guided onboarding. Before the fix, the process exited 0 while `qa-evidence.json` recorded `cli-guided-onboarding: fail`; after the fix, the identical full entrypoint exits 1 and preserves the explicit failed evidence.
- Executed the complete entrypoint with every required marker: exit 0 and all four evidence boundaries pass.
- Executed the complete entrypoint with every marker and a child exit code of 7: the owner preserves exit code 7.
- Changed-file formatting and linting plus `git diff --check` pass.
- Tooling production delta: +1/-1, net zero.
