### PR TITLE
fix(cli): installed hook packs cannot update by npm package name

### DIFF
--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -426,7 +426,10 @@ describe("plugins cli update", () => {
     expect(configWriteMock).not.toHaveBeenCalled();
   });
 
-  it("updates tracked hook packs through plugins update", async () => {
+  it.each([
+    ["demo-hooks", undefined],
+    ["@acme/demo-hooks", "@acme/demo-hooks"],
+  ])("updates tracked hook packs through plugins update (%s)", async (target, specOverride) => {
     const cfg = {} as OpenClawConfig;
     const nextConfig = cfg;
 
@@ -452,16 +455,14 @@ describe("plugins cli update", () => {
       ],
     });
 
-    await runPluginsCommand([
-      "plugins",
-      "update",
-      "demo-hooks",
-      "--dangerously-force-unsafe-install",
-    ]);
+    await runPluginsCommand(["plugins", "update", target, "--dangerously-force-unsafe-install"]);
 
     const hookUpdateParams = expectSingleCallParams(updateNpmInstalledHookPacksMock);
     expect(hookUpdateParams.config).toEqual({ ...cfg, plugins: { installs: {} } });
     expect(hookUpdateParams.hookIds).toEqual(["demo-hooks"]);
+    expect(hookUpdateParams.specOverrides).toEqual(
+      specOverride ? { "demo-hooks": specOverride } : undefined,
+    );
     expect(hookUpdateParams.dangerouslyForceUnsafeInstall).toBe(true);
     expect(updateNpmInstalledPluginsMock).not.toHaveBeenCalled();
     expect(configWriteMock).toHaveBeenCalledWith(nextConfig);

--- a/src/cli/plugins-update-selection.test.ts
+++ b/src/cli/plugins-update-selection.test.ts
@@ -227,6 +227,54 @@ describe("resolvePluginUpdateSelection", () => {
 });
 
 describe("resolveHookPackUpdateSelection", () => {
+  it.each([
+    { packageName: "@acme/demo-hooks", requestedSpec: "@acme/demo-hooks" },
+    { packageName: "openclaw-demo-hooks", requestedSpec: "openclaw-demo-hooks" },
+    { packageName: "@acme/demo-hooks", requestedSpec: "@acme/demo-hooks@beta" },
+    { packageName: "@acme/demo-hooks", requestedSpec: "@acme/demo-hooks@1.2.3" },
+  ])(
+    "maps npm package spec $requestedSpec to its tracked hook pack",
+    ({ packageName, requestedSpec }) => {
+      expect(
+        resolveHookPackUpdateSelection({
+          installs: {
+            "demo-hooks": createNpmHookInstall({
+              spec: `${packageName}@1.0.0`,
+              resolvedName: packageName,
+            }),
+          },
+          rawId: requestedSpec,
+        }),
+      ).toEqual({
+        hookIds: ["demo-hooks"],
+        specOverrides: { "demo-hooks": requestedSpec },
+      });
+    },
+  );
+
+  it("preserves the tracked npm spec when updating by exact hook-pack id", () => {
+    expect(
+      resolveHookPackUpdateSelection({
+        installs: {
+          "demo-hooks": createNpmHookInstall({ spec: "@acme/demo-hooks@beta" }),
+        },
+        rawId: "demo-hooks",
+      }),
+    ).toEqual({ hookIds: ["demo-hooks"] });
+  });
+
+  it("does not guess an owner when an npm package maps to multiple tracked hook packs", () => {
+    expect(
+      resolveHookPackUpdateSelection({
+        installs: {
+          alpha: createNpmHookInstall({ spec: "@acme/shared" }),
+          beta: createNpmHookInstall({ spec: "@acme/shared" }),
+        },
+        rawId: "@acme/shared",
+      }),
+    ).toEqual({ hookIds: [] });
+  });
+
   it("does not treat inherited prototype keys as installed hook ids", () => {
     expect(
       resolveHookPackUpdateSelection({

--- a/src/cli/plugins-update-selection.ts
+++ b/src/cli/plugins-update-selection.ts
@@ -88,7 +88,7 @@ export function resolveHookPackUpdateSelection(params: {
   }
 
   const parsedSpec = parseRegistryNpmSpec(params.rawId);
-  if (!parsedSpec || parsedSpec.selectorKind === "none") {
+  if (!parsedSpec) {
     return { hookIds: [] };
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw plugins update @scope/hook-package` would see “No tracked plugin or hook pack found” even though that npm hook pack was installed. Ordinary plugins already accepted bare package names, but hook packs incorrectly required a version or dist-tag whenever the npm package name differed from the recorded hook ID.

## Why This Change Was Made

Remove the hook selector's extra rejection of valid selector-free registry package names so plugins and hook packs share the same existing exact-ID, npm-name, ownership, and explicit-spec behavior. No new fallback, option, storage path, or install policy is added.

## User Impact

Operators can update installed hook packs by their scoped or unscoped npm package name, including moving a pinned install back to the registry default release line. Exact hook IDs still preserve their tracked spec, version/tag overrides still work, and ambiguous package ownership remains rejected.

## Evidence

- Pre-fix red: scoped and unscoped hook-package selector regressions fail; the actual Commander `plugins update @acme/demo-hooks --dangerously-force-unsafe-install` exits 1.
- Post-fix green: all 22 package-selector tests and all 52 actual plugins-update CLI tests pass, including exact ID precedence, ambiguous ownership, dist-tags, exact versions, preserved install policy, and correct npm override forwarding.
- Core and CLI-test TypeScript projects, focused oxlint/oxfmt, and both assertion-safety/max-lines ratchets pass.
- Production change is a deletion from an existing condition with zero net added lines; no configuration, persistence, protocol, or SDK contract changes.
- Fresh independent in-session source-aware review covers selector parsing, caller and updater ownership, npm safety, existing plugin parity, and the complete final diff; the external review CLI was unavailable under the session approval boundary.
