### PR TITLE
fix(ai): clamp OpenAI Responses max_output_tokens to model capacity

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.test.ts
+++ b/packages/ai/src/providers/azure-openai-responses.test.ts
@@ -164,6 +164,26 @@ describe("azure-openai-responses", () => {
     }
   });
 
+  it("clamps oversized output limits to the model capacity", async () => {
+    let sentParams: { max_output_tokens?: unknown } | undefined;
+    const hostFetch: typeof fetch = async (input, init) => {
+      sentParams = (await new Request(input, init).json()) as typeof sentParams;
+      return Response.json({ error: { message: "captured" } }, { status: 400 });
+    };
+
+    configureAiTransportHost({ buildModelFetch: () => hostFetch });
+    try {
+      await streamSimpleAzureOpenAIResponses(azureResponsesModel, context, {
+        apiKey: "test-api-key",
+        maxTokens: 200_000,
+      }).result();
+
+      expect(sentParams?.max_output_tokens).toBe(8192);
+    } finally {
+      configureAiTransportHost({});
+    }
+  });
+
   it("fences compaction replay by the resolved Azure endpoint", async () => {
     const routeA = "https://route-a.openai.azure.com/openai/v1";
     const routeB = "https://route-b.openai.azure.com/openai/v1";

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -321,6 +321,21 @@ describe("Responses output token limits", () => {
 
     expect(params.max_output_tokens).toBe(expected);
   });
+
+  it("clamps oversized maxTokens to the model catalog capacity while keeping the floor", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    applyCommonResponsesParams(params, nativeOpenAIModel, { messages: [] }, { maxTokens: 200_000 });
+
+    expect(nativeOpenAIModel.maxTokens).toBe(8192);
+    expect(params.max_output_tokens).toBe(8192);
+  });
+
+  it("keeps a below-cap request unchanged above the floor", () => {
+    const params = {} as ResponseCreateParamsStreaming;
+    applyCommonResponsesParams(params, nativeOpenAIModel, { messages: [] }, { maxTokens: 8_192 });
+
+    expect(params.max_output_tokens).toBe(8_192);
+  });
 });
 
 describe("Responses reasoning effort", () => {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -194,7 +194,8 @@ export function applyCommonResponsesParams<TApi extends Api>(
   config?: { setDefaultReasoningOff?: boolean },
 ): void {
   if (options?.maxTokens) {
-    params.max_output_tokens = Math.max(options.maxTokens, 16);
+    // The established 16-token minimum stays; the model catalog owns the cap.
+    params.max_output_tokens = Math.min(Math.max(options.maxTokens, 16), model.maxTokens);
   }
 
   if (options?.temperature !== undefined && supportsOpenAITemperature(model)) {

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -17,6 +17,7 @@ import {
   type OpenAIToolProjection,
 } from "../providers/openai-tool-projection.js";
 import { normalizeOpenAIStrictToolParameters } from "../providers/openai-tool-schema.js";
+import { clampMaxTokensToModel } from "../providers/simple-options.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { resolveOpenAIStrictToolSetting } from "./host-policy.js";
 import type { OpenAIResponsesReplayMode } from "./openai-responses-compaction-replay.js";
@@ -290,7 +291,9 @@ export function buildOpenAIResponsesParams(
       : {}),
     ...(metadata ? { metadata } : {}),
   };
-  const effectiveMaxTokens = options?.maxTokens || model.maxTokens;
+  // The model catalog owns output capacity; an authored request cap above it
+  // would make strict endpoints deterministically reject the whole turn.
+  const effectiveMaxTokens = clampMaxTokensToModel(model, options?.maxTokens || model.maxTokens);
   if (effectiveMaxTokens) {
     params.max_output_tokens = effectiveMaxTokens;
   }

--- a/packages/ai/src/transports/openai-responses-params-max-tokens.test.ts
+++ b/packages/ai/src/transports/openai-responses-params-max-tokens.test.ts
@@ -1,0 +1,73 @@
+import type { Context, Model } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import {
+  buildOpenAIResponsesParams,
+  sanitizeOpenAICodexResponsesParams,
+} from "./openai-responses-params-internal.js";
+
+const context = {
+  messages: [{ role: "user", content: "hello", timestamp: 0 }],
+} satisfies Context;
+
+function responsesModel(overrides: Partial<Model<"openai-responses">> = {}) {
+  return {
+    id: "gpt-5.6-luna",
+    name: "GPT-5.6 Luna",
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 4_096,
+    ...overrides,
+  } satisfies Model<"openai-responses">;
+}
+
+describe("buildOpenAIResponsesParams max_output_tokens capacity clamp", () => {
+  it("preserves a request below the model cap", () => {
+    const params = buildOpenAIResponsesParams(responsesModel(), context, { maxTokens: 2_048 });
+    expect(params.max_output_tokens).toBe(2_048);
+  });
+
+  it("clamps an oversized request to the model cap", () => {
+    const params = buildOpenAIResponsesParams(responsesModel(), context, {
+      maxTokens: 200_000,
+    });
+    expect(params.max_output_tokens).toBe(4_096);
+  });
+
+  it("keeps undefined and zero fallback semantics on the model cap", () => {
+    expect(buildOpenAIResponsesParams(responsesModel(), context, {}).max_output_tokens).toBe(4_096);
+    expect(
+      buildOpenAIResponsesParams(responsesModel(), context, { maxTokens: 0 }).max_output_tokens,
+    ).toBe(4_096);
+  });
+
+  it("clamps the same oversized request for Azure Responses models", () => {
+    const azureModel = responsesModel({
+      id: "gpt-5.6-luna",
+      provider: "azure-openai-responses",
+      baseUrl: "https://account.openai.azure.com/openai/v1",
+    });
+    const params = buildOpenAIResponsesParams(azureModel, context, { maxTokens: 100_000 });
+    expect(params.max_output_tokens).toBe(4_096);
+  });
+
+  it("keeps Codex Responses stripping unsupported fields after clamping", () => {
+    const codexModel = responsesModel({
+      id: "gpt-5.6-codex",
+      api: "openai-chatgpt-responses",
+      provider: "openai",
+      baseUrl: "https://chatgpt.com/backend-api/codex",
+    });
+    const built = buildOpenAIResponsesParams(codexModel, context, { maxTokens: 200_000 });
+    const params = sanitizeOpenAICodexResponsesParams(
+      codexModel,
+      built as unknown as Record<string, unknown>,
+    );
+    expect(params.max_output_tokens).toBeUndefined();
+    expect(Object.hasOwn(params, "max_output_tokens")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #127560

**AI-assisted:** yes — built with Claude; prompts/session logs available on request.

## What Problem This Solves

An authored `maxTokens` above the selected Responses model's declared output capacity was sent unchanged as `max_output_tokens`. A valid `agents.defaults.params.maxTokens`, per-model, per-agent, or run override could make strict endpoints reject every affected normal turn and direct/local compaction with a deterministic 400, and a global override could poison fallback candidates independently (#127560).

## Why This Change Was Made

`buildOpenAIResponsesParams` resolved `options?.maxTokens || model.maxTokens` and published it raw — the builder held both the request cap and the model capacity but performed no upper clamp. Sibling transports already enforce this boundary: Anthropic uses `clampMaxTokensToModel`, and OpenAI Completions clamps with regression coverage.

This clamps at that canonical last boundary using the existing helper, preserving current fallback semantics exactly (`undefined` and `0` still fall back to the model cap via the existing `||` shape). The model catalog's `maxTokens` remains the capacity owner for operators needing more real headroom. No caller sites were patched.

- Covers both OpenAI Responses and Azure OpenAI Responses, which share this builder.
- Codex Responses is unaffected: `sanitizeOpenAICodexResponsesParams` continues stripping the field downstream (composed-flow regression included).

## User Impact

Oversized token overrides no longer deterministically break turns on strict endpoints; they clamp to the model's declared capacity like every other transport.

## Evidence

Local, base = current `upstream/main`:

- New focused suite `openai-responses-params-max-tokens.test.ts` covers the issue's full matrix: below-cap preserved, oversized clamped (OpenAI + Azure), undefined/zero fallback preserved, Codex strip composed after clamping.
- Pre-fix failure proof: with the fix stashed, exactly the two oversized-clamp cases fail (`expected 200_000-capped value to be 4_096`) while preserve/fallback/Codex cases pass both ways; restored fix → 5/5 green.
- Adjacent transport suites unaffected: client.compact + continuation 20/20 green.
- oxlint (262 rules) and oxfmt clean; net production delta +3 LOC (clamp + invariant comment).

Known proof gap: repo-wide typecheck/test lanes not completable locally (host CPU saturation); CI covers them.


## After-fix strict-endpoint wire evidence

Rebased onto current `main` (head `938ed621`); focused suite re-run green on the new base.

The shipped transport stream function (`createOpenAIResponsesTransportStreamFn` → `buildOpenAIResponsesParams`) was driven at a real TCP socket against a local strict-contract Responses endpoint that mirrors real strict behavior: requests with `max_output_tokens` above its 4,096 model cap receive OpenAI-shaped `400 invalid_request_error` (`max_output_tokens_exceeded`); conforming requests receive a normal SSE completion.

Authored override in both runs: `maxTokens: 200000` against a model whose catalog capacity is `4_096`.

| Tree | Request captured on the wire | Endpoint response | Stream result |
|---|---|---|---|
| unfixed `main` | `"max_output_tokens":200000` | `400 invalid_request_error` (`max_output_tokens_exceeded`) | `stopReason: "error"` |
| this PR head | `"max_output_tokens":4096` | `200`, SSE `response.completed` | `stopReason: "stop"` |

That is the exact failure mode from the issue (deterministic strict-endpoint rejection of every affected turn) eliminated by the clamp, observed at the request boundary rather than in unit assertions.

**Scope note:** this trace uses a local strict-contract endpoint because no OpenAI API key is available in this environment. The clamp itself is provider-agnostic request shaping verified at the wire level here and by the focused builder suite; if a maintainer wants an api.openai.com trace attached before merge, say so and one will be added.


## Simple-path clamp (addresses the ClawSweeper P2 finding)

`applyCommonResponsesParams` — the shared simple Responses parameter owner reachable from plugin LLM completion without a managed transport requirement — now bounds authored `maxTokens` by the model catalog capacity while **retaining the established 16-token minimum**:

```ts
params.max_output_tokens = Math.min(Math.max(options.maxTokens, 16), model.maxTokens);
```

Both routes are now covered at their respective owners:

- Managed transport builder (`buildOpenAIResponsesParams`): clamped via `clampMaxTokensToModel` with wire-level evidence above.
- Simple owner (`applyCommonResponsesParams`): floor-preserving capacity clamp; OpenAI and Azure simple completions share this single owner.

New coverage:

- `openai-responses-shared.test.ts`: oversized request clamps to catalog capacity (`200000 → 8192`); below-cap request unchanged; the pre-existing floor table (`1→16, 15→16, 16→16, 32→32`) passes unchanged, proving minimum behavior retained.
- `azure-openai-responses.test.ts`: end-to-end fetch-capture asserts an oversized simple Azure completion sends `max_output_tokens: 8192` on the wire.

All four affected suites green post-change (106/106), including exact-head validation of the managed-path suite. Head is now `524a728c`.
