### PR TITLE
fix(feishu): preserve accepted document-comment delivery identity

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -2280,6 +2280,7 @@ describe("feishuOutbound comment-thread routing", () => {
   });
 
   it("preserves comment-thread routing when deliverCommentThreadText falls back to add_comment", async () => {
+    const onDeliveryResult = vi.fn();
     deliverCommentThreadTextMock.mockResolvedValueOnce({
       delivery_mode: "add_comment",
       comment_id: "comment_msg",
@@ -2291,13 +2292,15 @@ describe("feishuOutbound comment-thread routing", () => {
       to: "comment:docx:doxcn123:7623358762119646411",
       text: "whole-comment follow-up",
       accountId: "main",
+      onDeliveryResult,
     });
 
     expect(commentThreadParams()?.file_token).toBe("doxcn123");
     expect(commentThreadParams()?.file_type).toBe("docx");
     expect(commentThreadParams()?.comment_id).toBe("7623358762119646411");
     expect(commentThreadParams()?.content).toBe("whole-comment follow-up");
-    expectFeishuResult(result, "reply_from_add_comment");
+    expectFeishuResult(result, "comment_msg");
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.messageId).toBe("comment_msg");
   });
 
   it("does not wait for ambient comment typing cleanup before sending comment-thread replies", async () => {

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -377,9 +377,7 @@ async function sendCommentThreadReply(params: {
     });
     return {
       messageId:
-        (typeof result.reply_id === "string" && result.reply_id) ||
-        (typeof result.comment_id === "string" && result.comment_id) ||
-        "",
+        (result.delivery_mode === "reply_comment" ? result.reply_id : result.comment_id) ?? "",
       chatId: target.commentId,
       result,
     };


### PR DESCRIPTION
## What Problem This Solves

Fixes incorrect Feishu document-comment delivery receipts when a reply is delivered by creating a new document comment instead.

## Why This Change Was Made

The Feishu document delivery owner explicitly reports whether it replied to a comment or created a new comment. The regular comment dispatcher already selects the accepted platform message ID from that delivery mode, but the outbound adapter independently preferred any reply ID even when a new comment was actually accepted. Preserve the real accepted comment identity at the outbound producer and in its delivery-progress callback.

## User Impact

Feishu document comments now keep the correct message identity for delivery tracking, deduplication, retries, and follow-up actions when document restrictions require creating a new comment.

## Evidence

- Extended the existing real outbound comment fixture; before the production fix it deterministically failed with expected `comment_msg` but actual `reply_from_add_comment`.
- Verified both the returned message ID and the delivery progress callback use the actual accepted comment ID.
- `node scripts/run-vitest.mjs extensions/feishu/src/outbound.test.ts extensions/feishu/src/comment-dispatcher.test.ts` — 125 tests passed across both owner and sibling paths.
- Targeted formatting, extension lint, and `git diff --check` passed.
- Independent structured Codex review found no actionable issues.
- Production delta: +1/-3 lines (net -2); no provider API, configuration, plugin SDK, Gateway protocol, or persistence-schema change.
