### PR TITLE
fix(outbound): prevent empty chunkers from silently dropping replies

### DIFF
--- a/src/infra/outbound/message-plan.test.ts
+++ b/src/infra/outbound/message-plan.test.ts
@@ -33,6 +33,39 @@ describe("outbound message planning", () => {
     expect(units.map((unit) => unit.overrides.deliveryPartCount)).toEqual([2, 2]);
   });
 
+  it.each([
+    { label: "default", chunkMode: undefined },
+    { label: "length", chunkMode: "length" as const },
+    { label: "newline", chunkMode: "newline" as const },
+  ])("preserves nonempty text when a $label chunker returns nothing", ({ chunkMode }) => {
+    const policy = createReplyToDeliveryPolicy({ replyToId: "reply-1", replyToMode: "first" });
+    const reply = policy.resolveCurrentReplyTo({});
+    const units = planOutboundTextMessageUnits({
+      text: "visible reply",
+      textLimit: 64,
+      chunkMode,
+      chunker: () => [],
+      overrides: { replyToId: reply.replyToId, replyToIdSource: reply.source },
+      consumeReplyTo: (overrides) =>
+        policy.applyReplyToConsumption(overrides, {
+          consumeImplicitReply: overrides.replyToIdSource === "implicit",
+        }),
+    });
+
+    expect(units).toEqual([
+      {
+        kind: "text",
+        text: "visible reply",
+        overrides: {
+          replyToId: "reply-1",
+          replyToIdSource: "implicit",
+          deliveryPartIndex: 0,
+          deliveryPartCount: 1,
+        },
+      },
+    ]);
+  });
+
   it("keeps explicit text replies from consuming the implicit slot", () => {
     const policy = createReplyToDeliveryPolicy({
       replyToId: "implicit-reply",

--- a/src/infra/outbound/message-plan.ts
+++ b/src/infra/outbound/message-plan.ts
@@ -89,9 +89,10 @@ function chunkTextForPlan(params: {
   chunker: OutboundMessageChunker;
   formatting?: OutboundDeliveryFormattingOptions;
 }): string[] {
-  return params.formatting
+  const chunks = params.formatting
     ? params.chunker(params.text, params.limit, { formatting: params.formatting })
     : params.chunker(params.text, params.limit);
+  return chunks.length === 0 && params.text ? [params.text] : chunks;
 }
 
 /**
@@ -158,9 +159,6 @@ export function planOutboundTextMessageUnits(params: {
         chunker: params.chunker,
         formatting: params.formatting,
       });
-      if (!chunks.length && blockChunk) {
-        chunks.push(blockChunk);
-      }
       for (const chunk of chunks) {
         units.push(planTextUnit(chunk, units.length, params.chunkedTextFormatting));
       }


### PR DESCRIPTION
## What Problem This Solves

Prevents normal outbound replies from disappearing completely when a channel-specific text chunker unexpectedly returns no parts for a nonempty message.

## Why This Change Was Made

The newline chunking branch already preserved nonempty text after an empty adapter chunk result, but default and length-based chunking silently produced zero platform sends. Move that existing invariant into the single shared chunk-planning owner and delete the duplicate newline-only recovery branch.

## User Impact

Visible replies are delivered across every chunking mode instead of being silently lost or misreported as lacking a platform receipt. Existing reply-to consumption, delivery-part numbering, and formatting behavior are preserved.

## Evidence

- Added one table-driven owner regression covering default, length, and newline chunking with implicit reply ownership and exact send-part topology.
- On untouched main, default and length cases failed with zero planned sends; newline already passed, proving the intended sibling behavior.
- `node scripts/run-vitest.mjs src/infra/outbound/message-plan.test.ts src/infra/outbound/reply-policy.test.ts` — 11 tests passed.
- Targeted formatting, lint, and `git diff --check` passed.
- Independent structured Codex review found no actionable issues.
- Production delta: +2/-4 lines (net -2); no public configuration, protocol, persistence, or plugin contract changes.

## ClawSweeper Rank-Up Review

- Exact-head required CI is green. Skipped the suggested refresh-only rebase because the PR remains mergeable and repository landing policy avoids rebasing solely because `main` advanced.
