### PR TITLE
refactor: consolidate loader test fixtures

### DIFF
--- a/src/plugins/loader.activation.test-utils.ts
+++ b/src/plugins/loader.activation.test-utils.ts
@@ -32,6 +32,11 @@ import {
   expectCacheMissThenHit,
   globalAfterEach0,
   globalAfterAll1,
+  channelPluginSource,
+  updatePluginManifest,
+  writeFixtureJson,
+  writeFixtureText,
+  pluginManifest,
 } from "./loader.test-harness.js";
 import {
   listMemoryPromptPreparations,
@@ -1226,19 +1231,7 @@ describe("loadOpenClawPlugins", () => {
       filename: "unrelated-plugin.cjs",
       body: `module.exports = { id: "unrelated-plugin", register() { throw new Error("unrelated plugin should not load"); } };`,
     });
-    fs.writeFileSync(
-      path.join(unrelated.dir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "unrelated-plugin",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["target-plugin"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    updatePluginManifest(unrelated, { channels: ["target-plugin"] });
 
     const registry = loadOpenClawPlugins({
       cache: false,
@@ -1265,43 +1258,15 @@ describe("loadOpenClawPlugins", () => {
       id: "lazy-channel-plugin",
       filename: "lazy-channel.cjs",
       body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
-  module.exports = {
-    id: "lazy-channel-plugin",
-    register(api) {
-      api.registerChannel({
-        plugin: {
-          id: "lazy-channel",
-          meta: {
-            id: "lazy-channel",
-            label: "Lazy Channel",
-            selectionLabel: "Lazy Channel",
-            docsPath: "/channels/lazy-channel",
-            blurb: "lazy test channel",
-          },
-          capabilities: { chatTypes: ["direct"] },
-          config: {
-            listAccountIds: () => [],
-            resolveAccount: () => ({ accountId: "default" }),
-          },
-          outbound: { deliveryMode: "direct" },
-        },
-      });
-    },
-  };`,
+${channelPluginSource({
+  pluginId: "lazy-channel-plugin",
+  channelId: "lazy-channel",
+  label: "Lazy Channel",
+  docsPath: "/channels/lazy-channel",
+  blurb: "lazy test channel",
+})}`,
     });
-    fs.writeFileSync(
-      path.join(plugin.dir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "lazy-channel-plugin",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["lazy-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    updatePluginManifest(plugin, { channels: ["lazy-channel"] });
     const config = {
       plugins: {
         load: { paths: [plugin.file] },
@@ -1357,43 +1322,15 @@ describe("loadOpenClawPlugins", () => {
     const { workspaceDir, workspacePluginDir } = writeWorkspacePlugin({
       id: "workspace-shadow",
       body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
-  module.exports = {
-    id: "workspace-shadow",
-    register(api) {
-      api.registerChannel({
-        plugin: {
-          id: "workspace-shadow",
-          meta: {
-            id: "workspace-shadow",
-            label: "Workspace Shadow",
-            selectionLabel: "Workspace Shadow",
-            docsPath: "/channels/workspace-shadow",
-            blurb: "workspace shadow",
-          },
-          capabilities: { chatTypes: ["direct"] },
-          config: {
-            listAccountIds: () => [],
-            resolveAccount: () => undefined,
-          },
-          outbound: { deliveryMode: "direct" },
-        },
-      });
-    },
-  };`,
+${channelPluginSource({
+  pluginId: "workspace-shadow",
+  label: "Workspace Shadow",
+  docsPath: "/channels/workspace-shadow",
+  blurb: "workspace shadow",
+  resolveAccount: false,
+})}`,
     });
-    fs.writeFileSync(
-      path.join(workspacePluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "workspace-shadow",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["workspace-shadow"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    updatePluginManifest({ dir: workspacePluginDir }, { channels: ["workspace-shadow"] });
 
     const registry = loadOpenClawPlugins({
       cache: false,
@@ -1423,43 +1360,15 @@ describe("loadOpenClawPlugins", () => {
     const { workspaceDir, workspacePluginDir } = writeWorkspacePlugin({
       id: "trusted-workspace-shadow",
       body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
-  module.exports = {
-    id: "trusted-workspace-shadow",
-    register(api) {
-      api.registerChannel({
-        plugin: {
-          id: "telegram",
-          meta: {
-            id: "telegram",
-            label: "Trusted Workspace Telegram",
-            selectionLabel: "Trusted Workspace Telegram",
-            docsPath: "/channels/telegram",
-            blurb: "trusted workspace telegram",
-          },
-          capabilities: { chatTypes: ["direct"] },
-          config: {
-            listAccountIds: () => [],
-            resolveAccount: () => ({ accountId: "default" }),
-          },
-          outbound: { deliveryMode: "direct" },
-        },
-      });
-    },
-  };`,
+${channelPluginSource({
+  pluginId: "trusted-workspace-shadow",
+  channelId: "telegram",
+  label: "Trusted Workspace Telegram",
+  docsPath: "/channels/telegram",
+  blurb: "trusted workspace telegram",
+})}`,
     });
-    fs.writeFileSync(
-      path.join(workspacePluginDir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "trusted-workspace-shadow",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["telegram"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    updatePluginManifest({ dir: workspacePluginDir }, { channels: ["telegram"] });
 
     const registry = loadOpenClawPlugins({
       cache: false,
@@ -1492,43 +1401,14 @@ describe("loadOpenClawPlugins", () => {
       id: "untrusted-load-path-channel",
       filename: "untrusted-load-path-channel.cjs",
       body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
-  module.exports = {
-    id: "untrusted-load-path-channel",
-    register(api) {
-      api.registerChannel({
-        plugin: {
-          id: "untrusted-load-path-channel",
-          meta: {
-            id: "untrusted-load-path-channel",
-            label: "Untrusted Load Path Channel",
-            selectionLabel: "Untrusted Load Path Channel",
-            docsPath: "/channels/untrusted-load-path-channel",
-            blurb: "untrusted load-path setup gate",
-          },
-          capabilities: { chatTypes: ["direct"] },
-          config: {
-            listAccountIds: () => [],
-            resolveAccount: () => ({ accountId: "default" }),
-          },
-          outbound: { deliveryMode: "direct" },
-        },
-      });
-    },
-  };`,
+${channelPluginSource({
+  pluginId: "untrusted-load-path-channel",
+  label: "Untrusted Load Path Channel",
+  docsPath: "/channels/untrusted-load-path-channel",
+  blurb: "untrusted load-path setup gate",
+})}`,
     });
-    fs.writeFileSync(
-      path.join(plugin.dir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "untrusted-load-path-channel",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["untrusted-load-path-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    updatePluginManifest(plugin, { channels: ["untrusted-load-path-channel"] });
 
     const scopedSetupRegistry = loadOpenClawPlugins({
       cache: false,
@@ -1560,43 +1440,14 @@ describe("loadOpenClawPlugins", () => {
       id: "denylisted-load-path-channel",
       filename: "denylisted-load-path-channel.cjs",
       body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
-  module.exports = {
-    id: "denylisted-load-path-channel",
-    register(api) {
-      api.registerChannel({
-        plugin: {
-          id: "denylisted-load-path-channel",
-          meta: {
-            id: "denylisted-load-path-channel",
-            label: "Denylisted Load Path Channel",
-            selectionLabel: "Denylisted Load Path Channel",
-            docsPath: "/channels/denylisted-load-path-channel",
-            blurb: "denylisted load-path setup gate",
-          },
-          capabilities: { chatTypes: ["direct"] },
-          config: {
-            listAccountIds: () => [],
-            resolveAccount: () => ({ accountId: "default" }),
-          },
-          outbound: { deliveryMode: "direct" },
-        },
-      });
-    },
-  };`,
+${channelPluginSource({
+  pluginId: "denylisted-load-path-channel",
+  label: "Denylisted Load Path Channel",
+  docsPath: "/channels/denylisted-load-path-channel",
+  blurb: "denylisted load-path setup gate",
+})}`,
     });
-    fs.writeFileSync(
-      path.join(plugin.dir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "denylisted-load-path-channel",
-          configSchema: EMPTY_PLUGIN_SCHEMA,
-          channels: ["denylisted-load-path-channel"],
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    updatePluginManifest(plugin, { channels: ["denylisted-load-path-channel"] });
 
     const scopedSetupRegistry = loadOpenClawPlugins({
       cache: false,
@@ -1626,63 +1477,28 @@ describe("loadOpenClawPlugins", () => {
     withStateDir((stateDir) => {
       const globalDir = path.join(stateDir, "extensions", "untrusted-global-channel");
       mkdirSafe(globalDir);
-      fs.writeFileSync(
-        path.join(globalDir, "index.cjs"),
+      writeFixtureText(
+        globalDir,
+        "index.cjs",
         `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
-  module.exports = {
-    id: "untrusted-global-channel",
-    register(api) {
-      api.registerChannel({
-        plugin: {
-          id: "untrusted-global-channel",
-          meta: {
-            id: "untrusted-global-channel",
-            label: "Untrusted Global Channel",
-            selectionLabel: "Untrusted Global Channel",
-            docsPath: "/channels/untrusted-global-channel",
-            blurb: "untrusted global setup gate",
-          },
-          capabilities: { chatTypes: ["direct"] },
-          config: {
-            listAccountIds: () => [],
-            resolveAccount: () => ({ accountId: "default" }),
-          },
-          outbound: { deliveryMode: "direct" },
-        },
+${channelPluginSource({
+  pluginId: "untrusted-global-channel",
+  label: "Untrusted Global Channel",
+  docsPath: "/channels/untrusted-global-channel",
+  blurb: "untrusted global setup gate",
+})}`,
+      );
+      writeFixtureJson(
+        globalDir,
+        "openclaw.plugin.json",
+        pluginManifest("untrusted-global-channel", ["untrusted-global-channel"]),
+      );
+      writeFixtureJson(globalDir, "package.json", {
+        name: "@openclaw/untrusted-global-channel",
+        version: "0.0.0-test",
+        main: "./index.cjs",
+        openclaw: { extensions: ["./index.cjs"] },
       });
-    },
-  };`,
-        "utf-8",
-      );
-      fs.writeFileSync(
-        path.join(globalDir, "openclaw.plugin.json"),
-        JSON.stringify(
-          {
-            id: "untrusted-global-channel",
-            configSchema: EMPTY_PLUGIN_SCHEMA,
-            channels: ["untrusted-global-channel"],
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
-      fs.writeFileSync(
-        path.join(globalDir, "package.json"),
-        JSON.stringify(
-          {
-            name: "@openclaw/untrusted-global-channel",
-            version: "0.0.0-test",
-            main: "./index.cjs",
-            openclaw: {
-              extensions: ["./index.cjs"],
-            },
-          },
-          null,
-          2,
-        ),
-        "utf-8",
-      );
 
       const scopedSetupRegistry = loadOpenClawPlugins({
         cache: false,

--- a/src/plugins/loader.base.test-utils.ts
+++ b/src/plugins/loader.base.test-utils.ts
@@ -971,15 +971,9 @@ describe("loadOpenClawPlugins", () => {
   };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          workspaceDir: plugin.dir,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["allowed-config-path"],
-            },
-          },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          pluginConfig: { allow: ["allowed-config-path"] },
         });
 
         const loaded = registry.plugins.find((entry) => entry.id === "allowed-config-path");
@@ -1008,15 +1002,9 @@ describe("loadOpenClawPlugins", () => {
   };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          workspaceDir: plugin.dir,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["returned-gateway-method"],
-            },
-          },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          pluginConfig: { allow: ["returned-gateway-method"] },
         });
 
         const responses: unknown[] = [];
@@ -1049,15 +1037,9 @@ describe("loadOpenClawPlugins", () => {
   };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          workspaceDir: plugin.dir,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["explicit-gateway-method"],
-            },
-          },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          pluginConfig: { allow: ["explicit-gateway-method"] },
         });
 
         const responses: unknown[] = [];
@@ -1096,15 +1078,9 @@ describe("loadOpenClawPlugins", () => {
   };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          workspaceDir: plugin.dir,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["profile-independent-gateway-method"],
-            },
-          },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          pluginConfig: { allow: ["profile-independent-gateway-method"] },
         });
         const descriptors = new Map(
           registry.gatewayMethodDescriptors.map((descriptor) => [descriptor.name, descriptor]),
@@ -1137,15 +1113,9 @@ describe("loadOpenClawPlugins", () => {
   };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          workspaceDir: plugin.dir,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["reserved-gateway-scope"],
-            },
-          },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          pluginConfig: { allow: ["reserved-gateway-scope"] },
         });
 
         expect(Object.keys(registry.gatewayHandlers)).toContain(RESERVED_ADMIN_PLUGIN_METHOD);
@@ -1171,16 +1141,10 @@ describe("loadOpenClawPlugins", () => {
   };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          workspaceDir: plugin.dir,
-          coreGatewayMethodNames: ["config.openFile"],
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["hidden-core-collision"],
-            },
-          },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          pluginConfig: { allow: ["hidden-core-collision"] },
+          options: { coreGatewayMethodNames: ["config.openFile"] },
         });
 
         expect(Object.keys(registry.gatewayHandlers)).not.toContain("config.openFile");
@@ -1208,14 +1172,10 @@ describe("loadOpenClawPlugins", () => {
   };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["async-register"],
-            },
-          },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          includeWorkspaceDir: false,
+          pluginConfig: { allow: ["async-register"] },
         });
 
         const loaded = registry.plugins.find((entry) => entry.id === "async-register");
@@ -1269,19 +1229,14 @@ describe("loadOpenClawPlugins", () => {
   module.exports = { id: "manifest-only-plugin", register() { throw new Error("manifest-only snapshot should not register"); } };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          activate: false,
-          loadModules: false,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["manifest-only-plugin"],
-              entries: {
-                "manifest-only-plugin": { enabled: true },
-              },
-            },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          includeWorkspaceDir: false,
+          pluginConfig: {
+            allow: ["manifest-only-plugin"],
+            entries: { "manifest-only-plugin": { enabled: true } },
           },
+          options: { activate: false, loadModules: false },
         });
 
         expect(fs.existsSync(importedMarker)).toBe(false);
@@ -1303,37 +1258,22 @@ describe("loadOpenClawPlugins", () => {
           body: `require("node:fs").writeFileSync(${JSON.stringify(importedMarker)}, "loaded", "utf-8");
   module.exports = { id: "manifest-surfaces-plugin", register() { throw new Error("manifest-only snapshot should not register"); } };`,
         });
-        fs.writeFileSync(
-          path.join(plugin.dir, "openclaw.plugin.json"),
-          JSON.stringify(
-            {
-              id: "manifest-surfaces-plugin",
-              configSchema: EMPTY_PLUGIN_SCHEMA,
-              channels: ["manifest-surfaces-channel"],
-              providers: ["manifest-surfaces-provider"],
-              cliBackends: ["manifest-surfaces-cli"],
-              setup: { cliBackends: ["manifest-surfaces-setup-cli"] },
-              commandAliases: [{ name: "manifest-surfaces-command" }],
-            },
-            null,
-            2,
-          ),
-          "utf-8",
-        );
+        updatePluginManifest(plugin, {
+          channels: ["manifest-surfaces-channel"],
+          providers: ["manifest-surfaces-provider"],
+          cliBackends: ["manifest-surfaces-cli"],
+          setup: { cliBackends: ["manifest-surfaces-setup-cli"] },
+          commandAliases: [{ name: "manifest-surfaces-command" }],
+        });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          activate: false,
-          loadModules: false,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["manifest-surfaces-plugin"],
-              entries: {
-                "manifest-surfaces-plugin": { enabled: true },
-              },
-            },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          includeWorkspaceDir: false,
+          pluginConfig: {
+            allow: ["manifest-surfaces-plugin"],
+            entries: { "manifest-surfaces-plugin": { enabled: true } },
           },
+          options: { activate: false, loadModules: false },
         });
 
         const record = registry.plugins.find((entry) => entry.id === "manifest-surfaces-plugin");
@@ -1360,34 +1300,17 @@ describe("loadOpenClawPlugins", () => {
     register() {},
   };`,
         });
-        fs.writeFileSync(
-          path.join(memoryPlugin.dir, "openclaw.plugin.json"),
-          JSON.stringify(
-            {
-              id: "memory-demo",
-              kind: "memory",
-              configSchema: EMPTY_PLUGIN_SCHEMA,
-            },
-            null,
-            2,
-          ),
-          "utf-8",
-        );
+        updatePluginManifest(memoryPlugin, { kind: "memory" });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          activate: false,
-          loadModules: false,
-          config: {
-            plugins: {
-              load: { paths: [memoryPlugin.file] },
-              allow: ["memory-demo"],
-              slots: { memory: "memory-demo" },
-              entries: {
-                "memory-demo": { enabled: true },
-              },
-            },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin: memoryPlugin,
+          includeWorkspaceDir: false,
+          pluginConfig: {
+            allow: ["memory-demo"],
+            slots: { memory: "memory-demo" },
+            entries: { "memory-demo": { enabled: true } },
           },
+          options: { activate: false, loadModules: false },
         });
 
         expectNoDiagnosticContaining({
@@ -1413,15 +1336,11 @@ describe("loadOpenClawPlugins", () => {
   module.exports = { id: "throws-after-import", register() {} };`,
         });
 
-        const registry = loadOpenClawPlugins({
-          cache: false,
-          activate: false,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["throws-after-import"],
-            },
-          },
+        const registry = loadRegistryFromSinglePlugin({
+          plugin,
+          includeWorkspaceDir: false,
+          pluginConfig: { allow: ["throws-after-import"] },
+          options: { activate: false },
         });
 
         try {
@@ -1619,17 +1538,10 @@ describe("loadOpenClawPlugins", () => {
         setActivePluginRegistry(previousRegistry, "existing-registry");
         resetGlobalHookRunner();
 
-        const scoped = loadOpenClawPlugins({
-          cache: false,
-          activate: false,
-          workspaceDir: plugin.dir,
-          config: {
-            plugins: {
-              load: { paths: [plugin.file] },
-              allow: ["allowed-nonactivating-scope"],
-            },
-          },
-          onlyPluginIds: ["allowed-nonactivating-scope"],
+        const scoped = loadRegistryFromSinglePlugin({
+          plugin,
+          pluginConfig: { allow: ["allowed-nonactivating-scope"] },
+          options: { activate: false, onlyPluginIds: ["allowed-nonactivating-scope"] },
         });
 
         expect(scoped.plugins.map((entry) => entry.id)).toEqual(["allowed-nonactivating-scope"]);
@@ -1683,16 +1595,11 @@ describe("loadOpenClawPlugins", () => {
     const discoverySpy = vi.spyOn(discovery, "discoverOpenClawPlugins");
     const manifestSpy = vi.spyOn(manifestRegistry, "loadPluginManifestRegistryCore");
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      config: {
-        plugins: {
-          load: { paths: [allowed.file] },
-          allow: ["allowed-empty-scope"],
-        },
-      },
-      onlyPluginIds: [],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin: allowed,
+      includeWorkspaceDir: false,
+      pluginConfig: { allow: ["allowed-empty-scope"] },
+      options: { activate: false, onlyPluginIds: [] },
     });
 
     expect(registry.plugins).toStrictEqual([]);
@@ -1728,17 +1635,10 @@ describe("loadOpenClawPlugins", () => {
     clearPluginCommands();
     clearPluginInteractiveHandlers();
 
-    const scoped = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["command-plugin"],
-        },
-      },
-      onlyPluginIds: ["command-plugin"],
+    const scoped = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["command-plugin"] },
+      options: { activate: false, onlyPluginIds: ["command-plugin"] },
     });
 
     expect(scoped.plugins.find((entry) => entry.id === "command-plugin")?.status).toBe("loaded");
@@ -1753,16 +1653,10 @@ describe("loadOpenClawPlugins", () => {
     expect(getPluginCommandSpecs("telegram")).toStrictEqual([]);
     expect(resolvePluginInteractiveNamespaceMatch("telegram", "pair:device")).toBeNull();
 
-    const active = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["command-plugin"],
-        },
-      },
-      onlyPluginIds: ["command-plugin"],
+    const active = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["command-plugin"] },
+      options: { onlyPluginIds: ["command-plugin"] },
     });
 
     expect(active.plugins.find((entry) => entry.id === "command-plugin")?.status).toBe("loaded");
@@ -1803,16 +1697,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["codex-harness"],
-        },
-      },
-      onlyPluginIds: ["codex-harness"],
+    loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["codex-harness"] },
+      options: { onlyPluginIds: ["codex-harness"] },
     });
     expect(listRegisteredAgentHarnessIdsForTest()).toEqual(["codex"]);
 
@@ -1954,16 +1842,10 @@ describe("loadOpenClawPlugins", () => {
       };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["failing-gateway-method"],
-        },
-      },
-      onlyPluginIds: ["failing-gateway-method"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["failing-gateway-method"] },
+      options: { onlyPluginIds: ["failing-gateway-method"] },
     });
 
     expect(registry.plugins[0]?.status).toBe("error");
@@ -2043,16 +1925,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["bad-harness"],
-        },
-      },
-      onlyPluginIds: ["bad-harness"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["bad-harness"] },
+      options: { onlyPluginIds: ["bad-harness"] },
     });
 
     expect(listRegisteredAgentHarnessIdsForTest()).toStrictEqual([]);
@@ -2081,17 +1957,10 @@ describe("loadOpenClawPlugins", () => {
     });
 
     clearInternalHooks();
-    const scoped = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["internal-hook-snapshot"],
-        },
-      },
-      onlyPluginIds: ["internal-hook-snapshot"],
+    const scoped = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["internal-hook-snapshot"] },
+      options: { activate: false, onlyPluginIds: ["internal-hook-snapshot"] },
     });
 
     expect(scoped.plugins.find((entry) => entry.id === "internal-hook-snapshot")?.status).toBe(
@@ -2168,15 +2037,9 @@ describe("loadOpenClawPlugins", () => {
       });
 
       clearInternalHooks();
-      loadOpenClawPlugins({
-        cache: false,
-        workspaceDir: plugin.dir,
-        config: {
-          plugins: {
-            load: { paths: [plugin.file] },
-            allow: ["internal-hook-lifecycle"],
-          },
-        },
+      loadRegistryFromSinglePlugin({
+        plugin,
+        pluginConfig: { allow: ["internal-hook-lifecycle"] },
       });
 
       const activeEvent = createInternalHookEvent("gateway", "startup", "gateway:startup");
@@ -2230,38 +2093,17 @@ describe("loadOpenClawPlugins", () => {
           },
         };`,
     });
-    fs.writeFileSync(
-      path.join(plugin.dir, "openclaw.plugin.json"),
-      JSON.stringify(
-        {
-          id: "hook-config-context",
-          configSchema: { type: "object" },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
+    updatePluginManifest(plugin, { configSchema: { type: "object" } });
 
     clearInternalHooks();
 
-    loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["hook-config-context"],
-          entries: {
-            "hook-config-context": {
-              config: {
-                marker: "plugin-config-visible",
-              },
-            },
-          },
-        },
+    loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["hook-config-context"],
+        entries: { "hook-config-context": { config: { marker: "plugin-config-visible" } } },
       },
-      onlyPluginIds: ["hook-config-context"],
+      options: { onlyPluginIds: ["hook-config-context"] },
     });
 
     const event = createInternalHookEvent("gateway", "startup", "gateway:startup");

--- a/src/plugins/loader.discovery-and-security.test-utils.ts
+++ b/src/plugins/loader.discovery-and-security.test-utils.ts
@@ -209,32 +209,8 @@ describe("loadOpenClawPlugins", () => {
             filename: "index.cjs",
             body: memoryPluginBody("memory-b"),
           });
-          fs.writeFileSync(
-            path.join(memoryADir, "openclaw.plugin.json"),
-            JSON.stringify(
-              {
-                id: "memory-a",
-                kind: "memory",
-                configSchema: EMPTY_PLUGIN_SCHEMA,
-              },
-              null,
-              2,
-            ),
-            "utf-8",
-          );
-          fs.writeFileSync(
-            path.join(memoryBDir, "openclaw.plugin.json"),
-            JSON.stringify(
-              {
-                id: "memory-b",
-                kind: "memory",
-                configSchema: EMPTY_PLUGIN_SCHEMA,
-              },
-              null,
-              2,
-            ),
-            "utf-8",
-          );
+          updatePluginManifest({ dir: memoryADir }, { kind: "memory" });
+          updatePluginManifest({ dir: memoryBDir }, { kind: "memory" });
           process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
 
           return loadOpenClawPlugins({
@@ -408,43 +384,7 @@ describe("loadOpenClawPlugins", () => {
         label:
           "loads dreaming engine alongside a different memory slot plugin when dreaming is enabled",
         loadRegistry: () => {
-          const bundledDir = makePluginLoaderTempDir();
-          const memoryCoreDir = path.join(bundledDir, "memory-core");
-          const memoryLanceDir = path.join(bundledDir, "memory-lancedb");
-          mkdirSafe(memoryCoreDir);
-          mkdirSafe(memoryLanceDir);
-          writePlugin({
-            id: "memory-core",
-            dir: memoryCoreDir,
-            filename: "index.cjs",
-            body: memoryPluginBody("memory-core"),
-          });
-          writePlugin({
-            id: "memory-lancedb",
-            dir: memoryLanceDir,
-            filename: "index.cjs",
-            body: memoryPluginBody("memory-lancedb"),
-          });
-          const openSchema = { type: "object", additionalProperties: true };
-          fs.writeFileSync(
-            path.join(memoryCoreDir, "openclaw.plugin.json"),
-            JSON.stringify(
-              { id: "memory-core", kind: "memory", configSchema: EMPTY_PLUGIN_SCHEMA },
-              null,
-              2,
-            ),
-            "utf-8",
-          );
-          fs.writeFileSync(
-            path.join(memoryLanceDir, "openclaw.plugin.json"),
-            JSON.stringify(
-              { id: "memory-lancedb", kind: "memory", configSchema: openSchema },
-              null,
-              2,
-            ),
-            "utf-8",
-          );
-          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+          setupBundledDreamingMemoryPlugins();
 
           return loadOpenClawPlugins({
             cache: false,
@@ -472,46 +412,9 @@ describe("loadOpenClawPlugins", () => {
       {
         label: "excludes dreaming engine when dreaming is disabled and it is not the slot",
         loadRegistry: () => {
-          const bundledDir = makePluginLoaderTempDir();
-          const memoryCoreDir = path.join(bundledDir, "memory-core");
-          const memoryLanceDir = path.join(bundledDir, "memory-lancedb");
-          mkdirSafe(memoryCoreDir);
-          mkdirSafe(memoryLanceDir);
-          writePlugin({
-            id: "memory-core",
-            dir: memoryCoreDir,
-            filename: "index.cjs",
-            body: `throw new Error("memory-core should not load when dreaming is disabled");`,
+          setupBundledDreamingMemoryPlugins({
+            coreBody: `throw new Error("memory-core should not load when dreaming is disabled");`,
           });
-          writePlugin({
-            id: "memory-lancedb",
-            dir: memoryLanceDir,
-            filename: "index.cjs",
-            body: memoryPluginBody("memory-lancedb"),
-          });
-          fs.writeFileSync(
-            path.join(memoryCoreDir, "openclaw.plugin.json"),
-            JSON.stringify(
-              { id: "memory-core", kind: "memory", configSchema: EMPTY_PLUGIN_SCHEMA },
-              null,
-              2,
-            ),
-            "utf-8",
-          );
-          fs.writeFileSync(
-            path.join(memoryLanceDir, "openclaw.plugin.json"),
-            JSON.stringify(
-              {
-                id: "memory-lancedb",
-                kind: "memory",
-                configSchema: { type: "object", additionalProperties: true },
-              },
-              null,
-              2,
-            ),
-            "utf-8",
-          );
-          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
 
           return loadOpenClawPlugins({
             cache: false,
@@ -549,15 +452,7 @@ describe("loadOpenClawPlugins", () => {
             filename: "index.cjs",
             body: `throw new Error("memory-core should not load when memory slot is none");`,
           });
-          fs.writeFileSync(
-            path.join(memoryCoreDir, "openclaw.plugin.json"),
-            JSON.stringify(
-              { id: "memory-core", kind: "memory", configSchema: EMPTY_PLUGIN_SCHEMA },
-              null,
-              2,
-            ),
-            "utf-8",
-          );
+          updatePluginManifest({ dir: memoryCoreDir }, { kind: "memory" });
           process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
 
           return loadOpenClawPlugins({

--- a/src/plugins/loader.hooks-and-runtime.test-utils.ts
+++ b/src/plugins/loader.hooks-and-runtime.test-utils.ts
@@ -20,59 +20,15 @@ import {
   globalAfterEach0,
   globalAfterAll1,
   updatePluginManifest,
+  writeFixtureText,
+  writeFixtureJson,
+  pluginManifest,
+  channelPluginSource,
 } from "./loader.test-harness.js";
 import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
 
 afterEach(globalAfterEach0);
 afterAll(globalAfterAll1);
-
-function writeFixtureText(rootDir: string, relativePath: string, body: string) {
-  const filePath = path.join(rootDir, relativePath);
-  mkdirSafe(path.dirname(filePath));
-  fs.writeFileSync(filePath, body, "utf-8");
-}
-
-function writeFixtureJson(rootDir: string, relativePath: string, value: unknown) {
-  writeFixtureText(rootDir, relativePath, JSON.stringify(value, null, 2));
-}
-
-function pluginManifest(id: string, channels?: string[]) {
-  return {
-    id,
-    configSchema: EMPTY_PLUGIN_SCHEMA,
-    ...(channels ? { channels } : {}),
-  };
-}
-
-function channelPluginSource(params: {
-  pluginId: string;
-  channelId?: string;
-  label: string;
-  docsPath: string;
-  blurb: string;
-}) {
-  const channelId = params.channelId ?? params.pluginId;
-  return `module.exports = { id: ${JSON.stringify(params.pluginId)}, register(api) {
-    api.registerChannel({
-      plugin: {
-        id: ${JSON.stringify(channelId)},
-        meta: {
-          id: ${JSON.stringify(channelId)},
-          label: ${JSON.stringify(params.label)},
-          selectionLabel: ${JSON.stringify(params.label)},
-          docsPath: ${JSON.stringify(params.docsPath)},
-          blurb: ${JSON.stringify(params.blurb)},
-        },
-        capabilities: { chatTypes: ["direct"] },
-        config: {
-          listAccountIds: () => [],
-          resolveAccount: () => ({ accountId: "default" }),
-        },
-        outbound: { deliveryMode: "direct" },
-      },
-    });
-  } };`;
-}
 
 function createSetupFailureFixture(params: {
   id: string;

--- a/src/plugins/loader.registration.test-utils.ts
+++ b/src/plugins/loader.registration.test-utils.ts
@@ -43,6 +43,7 @@ import {
   listEmbeddingProviders,
   expectGlobalHookRunner,
   createDetachedTaskRuntimeStub,
+  loadRegistryFromSinglePlugin,
   updatePluginManifest,
   expectDiagnosticContaining,
   expectCachePartitionByPluginSource,
@@ -90,16 +91,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["duplicate-legacy-hook"],
-        },
-      },
-      onlyPluginIds: ["duplicate-legacy-hook"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["duplicate-legacy-hook"] },
+      options: { onlyPluginIds: ["duplicate-legacy-hook"] },
     });
 
     expect(
@@ -128,16 +123,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["typed-name-legacy-register"],
-        },
-      },
-      onlyPluginIds: ["typed-name-legacy-register"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["typed-name-legacy-register"] },
+      options: { onlyPluginIds: ["typed-name-legacy-register"] },
     });
 
     expect(registry.legacyInternalHooks.map((entry) => entry.event)).toEqual([
@@ -173,16 +162,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["legacy-type-action-register"],
-        },
-      },
-      onlyPluginIds: ["legacy-type-action-register"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["legacy-type-action-register"] },
+      options: { onlyPluginIds: ["legacy-type-action-register"] },
     });
 
     expect(registry.legacyInternalHooks.map((entry) => entry.event)).toEqual([
@@ -350,16 +333,10 @@ describe("loadOpenClawPlugins", () => {
     clearPluginCommands();
     clearPluginInteractiveHandlers();
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["failing-side-effects"],
-        },
-      },
-      onlyPluginIds: ["failing-side-effects"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["failing-side-effects"] },
+      options: { onlyPluginIds: ["failing-side-effects"] },
     });
 
     const failedRecord = registry.plugins.find((entry) => entry.id === "failing-side-effects");
@@ -408,16 +385,10 @@ describe("loadOpenClawPlugins", () => {
           },
         };`,
     });
-    const priorRegistry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: prior.dir,
-      config: {
-        plugins: {
-          load: { paths: [prior.file] },
-          allow: ["activation-prior"],
-        },
-      },
-      onlyPluginIds: ["activation-prior"],
+    const priorRegistry = loadRegistryFromSinglePlugin({
+      plugin: prior,
+      pluginConfig: { allow: ["activation-prior"] },
+      options: { onlyPluginIds: ["activation-prior"] },
     });
     const priorKey = getActivePluginRegistryKey();
     const priorMode = getActivePluginRuntimeSubagentMode();
@@ -487,16 +458,10 @@ describe("loadOpenClawPlugins", () => {
 
     clearInternalHooks();
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["nameless-hook"],
-        },
-      },
-      onlyPluginIds: ["nameless-hook"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["nameless-hook"] },
+      options: { onlyPluginIds: ["nameless-hook"] },
     });
 
     const record = registry.plugins.find((entry) => entry.id === "nameless-hook");
@@ -530,16 +495,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["invalid-memory-capability"],
-        },
-      },
-      onlyPluginIds: ["invalid-memory-capability"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["invalid-memory-capability"] },
+      options: { onlyPluginIds: ["invalid-memory-capability"] },
     });
 
     const record = registry.plugins.find((entry) => entry.id === "invalid-memory-capability");
@@ -721,16 +680,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          allow: ["private-worker-controls"],
-          load: { paths: [plugin.file] },
-        },
-      },
-      onlyPluginIds: ["private-worker-controls"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["private-worker-controls"] },
+      options: { onlyPluginIds: ["private-worker-controls"] },
     });
 
     expect(registry.nodeHostCommands).toEqual([]);
@@ -800,18 +753,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const scoped = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["snapshot-memory"],
-          slots: { memory: "snapshot-memory" },
-        },
-      },
-      onlyPluginIds: ["snapshot-memory"],
+    const scoped = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["snapshot-memory"], slots: { memory: "snapshot-memory" } },
+      options: { activate: false, onlyPluginIds: ["snapshot-memory"] },
     });
 
     expect(scoped.plugins.find((entry) => entry.id === "snapshot-memory")?.status).toBe("loaded");
@@ -848,17 +793,10 @@ describe("loadOpenClawPlugins", () => {
       contracts: { embeddingProviders: ["snapshot"] },
     });
 
-    const scoped = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["snapshot-embedding"],
-        },
-      },
-      onlyPluginIds: ["snapshot-embedding"],
+    const scoped = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["snapshot-embedding"] },
+      options: { activate: false, onlyPluginIds: ["snapshot-embedding"] },
     });
 
     expect(scoped.plugins.find((entry) => entry.id === "snapshot-embedding")?.status).toBe(
@@ -895,17 +833,10 @@ describe("loadOpenClawPlugins", () => {
       contracts: { embeddingProviders: ["shared"] },
     });
 
-    const scoped = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["snapshot-shared-embedding"],
-        },
-      },
-      onlyPluginIds: ["snapshot-shared-embedding"],
+    const scoped = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["snapshot-shared-embedding"] },
+      options: { activate: false, onlyPluginIds: ["snapshot-shared-embedding"] },
     });
 
     expect(scoped.plugins.find((entry) => entry.id === "snapshot-shared-embedding")?.status).toBe(
@@ -939,16 +870,10 @@ describe("loadOpenClawPlugins", () => {
       contracts: { embeddingProviders: ["failed"] },
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["failing-embedding"],
-        },
-      },
-      onlyPluginIds: ["failing-embedding"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["failing-embedding"] },
+      options: { onlyPluginIds: ["failing-embedding"] },
     });
 
     expect(registry.plugins.find((entry) => entry.id === "failing-embedding")?.status).toBe(
@@ -998,17 +923,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["failing-memory"],
-          slots: { memory: "failing-memory" },
-        },
-      },
-      onlyPluginIds: ["failing-memory"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["failing-memory"], slots: { memory: "failing-memory" } },
+      options: { onlyPluginIds: ["failing-memory"] },
     });
 
     expect(registry.plugins.find((entry) => entry.id === "failing-memory")?.status).toBe("error");
@@ -1045,17 +963,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const scoped = loadOpenClawPlugins({
-      cache: false,
-      activate: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["snapshot-detached-runtime"],
-        },
-      },
-      onlyPluginIds: ["snapshot-detached-runtime"],
+    const scoped = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["snapshot-detached-runtime"] },
+      options: { activate: false, onlyPluginIds: ["snapshot-detached-runtime"] },
     });
 
     expect(scoped.plugins.find((entry) => entry.id === "snapshot-detached-runtime")?.status).toBe(
@@ -1080,16 +991,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["detached-runtime-refresh"],
-        },
-      },
-      onlyPluginIds: ["detached-runtime-refresh"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["detached-runtime-refresh"] },
+      options: { onlyPluginIds: ["detached-runtime-refresh"] },
     });
 
     expect(registry.detachedTaskRuntimes).toHaveLength(1);
@@ -1122,16 +1027,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["failing-detached-runtime"],
-        },
-      },
-      onlyPluginIds: ["failing-detached-runtime"],
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["failing-detached-runtime"] },
+      options: { onlyPluginIds: ["failing-detached-runtime"] },
     });
 
     expect(registry.plugins.find((entry) => entry.id === "failing-detached-runtime")?.status).toBe(
@@ -1543,16 +1442,10 @@ describe("loadOpenClawPlugins", () => {
       contracts: { tools: ["attested_tool", "unknown_policy_tool"] },
     });
 
-    const registry = loadOpenClawPlugins({
-      activate: false,
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["conversation-read-provenance-test"],
-        },
-      },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["conversation-read-provenance-test"] },
+      options: { activate: false },
     });
 
     expect(registry.tools).toHaveLength(2);
@@ -1586,16 +1479,10 @@ describe("loadOpenClawPlugins", () => {
         };`,
     });
 
-    const registry = loadOpenClawPlugins({
-      activate: false,
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["undeclared-tool-owner"],
-        },
-      },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["undeclared-tool-owner"] },
+      options: { activate: false },
     });
 
     expect(registry.tools).toStrictEqual([]);
@@ -1627,16 +1514,10 @@ describe("loadOpenClawPlugins", () => {
     });
     updatePluginManifest(plugin, { contracts: { tools: ["manifest_tool"] } });
 
-    const registry = loadOpenClawPlugins({
-      activate: false,
-      cache: false,
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          load: { paths: [plugin.file] },
-          allow: ["wrong-tool-owner"],
-        },
-      },
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: { allow: ["wrong-tool-owner"] },
+      options: { activate: false },
     });
 
     expect(registry.tools).toStrictEqual([]);

--- a/src/plugins/loader.test-harness.ts
+++ b/src/plugins/loader.test-harness.ts
@@ -86,29 +86,64 @@ export function createDetachedTaskRuntimeStub(id: string): DetachedTaskLifecycle
   };
 }
 
-const BUNDLED_TELEGRAM_PLUGIN_BODY = `module.exports = {
-  id: "telegram",
-  register(api) {
+export function writeFixtureText(rootDir: string, relativePath: string, body: string) {
+  const filePath = path.join(rootDir, relativePath);
+  mkdirSafe(path.dirname(filePath));
+  fs.writeFileSync(filePath, body, "utf-8");
+}
+
+export function writeFixtureJson(rootDir: string, relativePath: string, value: unknown) {
+  writeFixtureText(rootDir, relativePath, JSON.stringify(value, null, 2));
+}
+
+export function pluginManifest(id: string, channels?: string[]) {
+  return { id, configSchema: EMPTY_PLUGIN_SCHEMA, ...(channels ? { channels } : {}) };
+}
+
+export function channelPluginSource(params: {
+  pluginId: string;
+  channelId?: string;
+  label: string;
+  docsPath: string;
+  blurb: string;
+  configured?: boolean;
+  resolveAccount?: false;
+}) {
+  const channelId = params.channelId ?? params.pluginId;
+  const resolveAccount =
+    params.resolveAccount === false
+      ? "undefined"
+      : params.configured
+        ? '({ accountId: "default", token: "configured" })'
+        : '({ accountId: "default" })';
+  return `module.exports = { id: ${JSON.stringify(params.pluginId)}, register(api) {
     api.registerChannel({
       plugin: {
-        id: "telegram",
+        id: ${JSON.stringify(channelId)},
         meta: {
-          id: "telegram",
-          label: "Telegram",
-          selectionLabel: "Telegram",
-          docsPath: "/channels/telegram",
-          blurb: "telegram channel",
+          id: ${JSON.stringify(channelId)},
+          label: ${JSON.stringify(params.label)},
+          selectionLabel: ${JSON.stringify(params.label)},
+          docsPath: ${JSON.stringify(params.docsPath)},
+          blurb: ${JSON.stringify(params.blurb)},
         },
         capabilities: { chatTypes: ["direct"] },
         config: {
-          listAccountIds: () => [],
-          resolveAccount: () => ({ accountId: "default" }),
+          listAccountIds: () => ${params.configured ? '["default"]' : "[]"},
+          resolveAccount: () => ${resolveAccount},
         },
         outbound: { deliveryMode: "direct" },
       },
     });
-  },
-};`;
+  } };`;
+}
+
+const BUNDLED_TELEGRAM_PLUGIN_BODY = channelPluginSource({
+  pluginId: "telegram",
+  label: "Telegram",
+  docsPath: "/channels/telegram",
+  blurb: "telegram channel",
+});
 
 export function simplePluginBody(id: string) {
   return `module.exports = { id: ${JSON.stringify(id)}, register() {} };`;
@@ -154,27 +189,10 @@ export function setupBundledDreamingMemoryPlugins(params?: {
         : memoryPluginBody(selectedId),
   });
   const openSchema = { type: "object", additionalProperties: true };
-  fs.writeFileSync(
-    path.join(memoryCoreDir, "openclaw.plugin.json"),
-    JSON.stringify(
-      { id: "memory-core", kind: "memory", configSchema: EMPTY_PLUGIN_SCHEMA },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
-  fs.writeFileSync(
-    path.join(selectedMemoryDir, "openclaw.plugin.json"),
-    JSON.stringify(
-      {
-        id: selectedId,
-        kind: params?.selectedKind ?? "memory",
-        configSchema: openSchema,
-      },
-      null,
-      2,
-    ),
-    "utf-8",
+  updatePluginManifest({ dir: memoryCoreDir }, { kind: "memory" });
+  updatePluginManifest(
+    { dir: selectedMemoryDir },
+    { kind: params?.selectedKind ?? "memory", configSchema: openSchema },
   );
   process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
   return { bundledDir, selectedId };
@@ -684,34 +702,11 @@ export function createSetupEntryChannelPluginFixture(params: {
     ? '({ accountId: "default", token: "configured" })'
     : '({ accountId: "default" })';
 
-  fs.writeFileSync(
-    path.join(pluginDir, "package.json"),
-    JSON.stringify(
-      {
-        name: params.packageName,
-        openclaw: {
-          extensions: ["./index.cjs"],
-          setupEntry: "./setup-entry.cjs",
-        },
-      },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
-  fs.writeFileSync(
-    path.join(pluginDir, "openclaw.plugin.json"),
-    JSON.stringify(
-      {
-        id: params.id,
-        configSchema: EMPTY_PLUGIN_SCHEMA,
-        channels: [params.id],
-      },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
+  writeFixtureJson(pluginDir, "package.json", {
+    name: params.packageName,
+    openclaw: { extensions: ["./index.cjs"], setupEntry: "./setup-entry.cjs" },
+  });
+  writeFixtureJson(pluginDir, "openclaw.plugin.json", pluginManifest(params.id, [params.id]));
   fs.writeFileSync(
     path.join(pluginDir, "index.cjs"),
     params.useBundledFullEntryContract
@@ -756,29 +751,13 @@ module.exports = {
   register() {},
 };`
       : `require("node:fs").writeFileSync(${JSON.stringify(fullMarker)}, "loaded", "utf-8");
-module.exports = {
-  id: ${JSON.stringify(params.id)},
-  register(api) {
-    api.registerChannel({
-      plugin: {
-        id: ${JSON.stringify(params.id)},
-        meta: {
-          id: ${JSON.stringify(params.id)},
-          label: ${JSON.stringify(params.label)},
-          selectionLabel: ${JSON.stringify(params.label)},
-          docsPath: ${JSON.stringify(`/channels/${params.id}`)},
-          blurb: ${JSON.stringify(params.fullBlurb)},
-        },
-        capabilities: { chatTypes: ["direct"] },
-        config: {
-          listAccountIds: () => ${listAccountIds},
-          resolveAccount: () => ${resolveAccount},
-        },
-        outbound: { deliveryMode: "direct" },
-      },
-    });
-  },
-};`,
+${channelPluginSource({
+  pluginId: params.id,
+  label: params.label,
+  docsPath: `/channels/${params.id}`,
+  blurb: params.fullBlurb,
+  configured: params.configured,
+})}`,
     "utf-8",
   );
   fs.writeFileSync(


### PR DESCRIPTION
## What Problem This Solves

The loader regression suite repeated large fixture and expectation setup blocks across its test-support modules. That duplication made security, discovery, activation, registration, and runtime test maintenance harder to review consistently.

## Why This Change Was Made

This maintainer-requested cleanup consolidates the repeated loader fixtures behind the existing test harness while preserving every loader behavior and assertion. It changes test support only; production loader code and public contracts are untouched.

AI-assisted maintainer cleanup. I reviewed the final code, proof, and exact landing diff.

## User Impact

No runtime behavior changes. Contributors get a smaller, more coherent loader test fixture surface with the same regression coverage.

## Evidence

- Production LOC: `+0/-0`; test support: `+316/-947` (net `-631`).
- Current-main base: `889d93ac6dee99e89c44c1dcc053f12a08e2e3b2`; exact head: `0854a1b812e7aa5e0478bb5f813c8979cccbb9aa`.
- Exact plain and binary diff SHA-256: `b16ef14ee864a1329b4832407bd02c32417604558a563ae6e0f0a62fca28f6c4`.
- `node scripts/run-vitest.mjs src/plugins/loader.test.ts --configLoader runner --no-cache --maxWorkers 1`: 183/183 passed on the current-main staging base.
- Independent equivalence audit: all 564 loader assertion expressions preserved; all five importing suites and helper semantics unchanged.
- Focused typed lint, formatting, and `git diff --check`: passed.
- Mandatory exact-source autoreview: secret scan clean; isolated Codex review reported no actionable findings (0.99 patch-correctness confidence).
