### PR TITLE
fix(discord): restore question receipts after rejected acknowledgements

### DIFF
--- a/extensions/discord/src/monitor/questions.test.ts
+++ b/extensions/discord/src/monitor/questions.test.ts
@@ -1,6 +1,15 @@
 // Discord question component feedback tests.
+import { InteractionResponseType, MessageFlags } from "discord-api-types/v10";
 import { describe, expect, it, vi } from "vitest";
-import type { ButtonInteraction } from "../internal/discord.js";
+import {
+  createInteraction as createDiscordInteraction,
+  type ButtonInteraction,
+} from "../internal/discord.js";
+import {
+  attachRestMock,
+  createInternalComponentInteractionPayload,
+  createInternalTestClient,
+} from "../internal/test-builders.test-support.js";
 import { createDiscordQuestionButton } from "./questions.js";
 
 type InteractionHarness = {
@@ -90,5 +99,100 @@ describe("Discord question button", () => {
       content: "Answer submitted.",
       ephemeral: true,
     });
+  });
+
+  it.each(
+    [
+      {
+        name: "submitted answer",
+        result: {
+          status: "answered" as const,
+          questionId: "target",
+          optionValue: "Production",
+        },
+        expectedText: "Answer submitted.",
+      },
+      {
+        name: "already answered question",
+        result: { status: "already-terminal" as const, reason: "already-terminal" as const },
+        expectedText: "This question was already answered.",
+      },
+      {
+        name: "question resolution failure",
+        error: new Error("question service unavailable"),
+        expectedText: "Could not submit this answer.",
+      },
+    ].flatMap((outcome) => [
+      { ...outcome, acknowledged: false },
+      { ...outcome, acknowledged: true },
+    ]),
+  )("delivers $name feedback when acknowledgement is $acknowledged", async (testCase) => {
+    const client = createInternalTestClient();
+    const post = vi.fn(async () => undefined);
+    if (!testCase.acknowledged) {
+      post.mockRejectedValueOnce(new Error("temporary connection reset"));
+    }
+    attachRestMock(client, { post });
+    const interaction = createDiscordInteraction(
+      client,
+      createInternalComponentInteractionPayload({
+        id: "interaction-1",
+        token: "interaction-token",
+        user: {
+          id: "user-1",
+          username: "Alice",
+          discriminator: "0",
+          avatar: null,
+          global_name: null,
+        },
+      }),
+    ) as ButtonInteraction;
+    const resolveQuestion = vi.fn(async () => {
+      if (testCase.error) {
+        throw testCase.error;
+      }
+      return testCase.result;
+    });
+    const button = createDiscordQuestionButton({
+      cfg: {} as never,
+      accountId: "default",
+      authorizeQuestion: vi.fn(async () => true),
+      resolveQuestion: resolveQuestion as never,
+    });
+
+    await button.run(interaction, {
+      id: "ask_0123456789abcdef0123456789abcdef",
+      i: "1",
+    });
+
+    expect(resolveQuestion).toHaveBeenCalledOnce();
+    expect(post).toHaveBeenNthCalledWith(
+      1,
+      "/interactions/interaction-1/interaction-token/callback",
+      {
+        body: { type: InteractionResponseType.DeferredMessageUpdate },
+      },
+    );
+    if (testCase.acknowledged) {
+      expect(post).toHaveBeenNthCalledWith(
+        2,
+        "/webhooks/app1/interaction-token",
+        { body: { content: testCase.expectedText, flags: MessageFlags.Ephemeral } },
+        undefined,
+      );
+      expect(interaction.responseState).toBe("deferred-update");
+    } else {
+      expect(post).toHaveBeenNthCalledWith(
+        2,
+        "/interactions/interaction-1/interaction-token/callback",
+        {
+          body: {
+            type: InteractionResponseType.ChannelMessageWithSource,
+            data: { content: testCase.expectedText, flags: MessageFlags.Ephemeral },
+          },
+        },
+      );
+      expect(interaction.responseState).toBe("replied");
+    }
   });
 });

--- a/extensions/discord/src/monitor/questions.ts
+++ b/extensions/discord/src/monitor/questions.ts
@@ -41,31 +41,28 @@ class QuestionButton extends Button {
     try {
       await interaction.acknowledge();
     } catch {}
-    let result: Awaited<ReturnType<QuestionResolver>>;
+    let content: string;
     try {
-      result = await this.ctx.resolveQuestion({
+      const result = await this.ctx.resolveQuestion({
         cfg: this.ctx.cfg,
         questionId: callback.questionId,
         optionIndex: callback.optionIndex,
         senderId: interaction.userId,
         clientDisplayName: `Discord question (${this.ctx.accountId})`,
       });
+      content =
+        result.status === "answered" ? "Answer submitted." : "This question was already answered.";
     } catch {
-      try {
-        await interaction.followUp({ content: "Could not submit this answer.", ephemeral: true });
-      } catch {}
-      return;
+      content = "Could not submit this answer.";
     }
     try {
-      await interaction.followUp({
-        content:
-          result.status === "answered"
-            ? "Answer submitted."
-            : "This question was already answered.",
-        ephemeral: true,
-      });
+      const feedback = { content, ephemeral: true };
+      // A rejected acknowledgement leaves the initial callback available, not the webhook.
+      await (interaction.responseState === "unacknowledged"
+        ? interaction.reply(feedback)
+        : interaction.followUp(feedback));
     } catch {
-      // Gateway state already committed; receipt delivery is best-effort.
+      // Gateway state may already be committed; receipt delivery is best-effort.
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users answering a Discord question would receive no visible confirmation or failure explanation when Discord rejected the initial component acknowledgement, even though the answer could already have been accepted by OpenClaw.

## Why This Change Was Made

Discord only accepts an interaction follow-up after its initial callback succeeds. The private question-feedback owner now reads the authoritative interaction response state and uses an ephemeral initial reply when acknowledgement failed, while retaining the existing ephemeral follow-up after an accepted acknowledgement. Successful answers, already-answered questions, and question-resolution failures share one canonical feedback path; authorization, answer ownership, public APIs, and provider configuration are unchanged.

Security-sensitive execution-approval and plugin-binding approval interaction owners share related acknowledgement lifecycle patterns and require separate owner/security review. They are intentionally out of scope and were not modified.

## User Impact

Discord users reliably see whether their answer was submitted, already handled, or could not be submitted after a transient acknowledgement failure. Existing private response visibility and one-time answer resolution stay unchanged.

## Evidence

- Exact reviewed head: `7ed5bf34ee15a16a5da1aa192759b277a2d29e02`.
- Authentic owner-boundary RED before the fix: all three resolution outcomes attempted `/webhooks/...` after the initial acknowledgement was rejected instead of using the still-available interaction callback.
- Actual Discord interaction/REST lifecycle GREEN after the fix: six table cases cover submitted, already-answered, and failed-resolution outcomes crossed with accepted and rejected acknowledgements, verifying callback types 6/4, exact callback versus webhook routes, ephemeral flags, final response state, and exactly one resolution.
- 86 Discord owner, native interaction, component, provider-registration, question-envelope, and activity tests passed; seven Slack and Telegram sibling question-feedback tests passed separately.
- Independent reviewer reran five owner/sibling suites: 64 tests passed; final full-diff review CLEAN. Fresh authenticated complete committed-branch review CLEAN.
- Targeted typed lint, formatting, whitespace, plugin boundaries, dependency pins, export scans, and changed-file guards passed. Repository-wide extension production/test typechecks encounter only pre-existing unchanged ACPX `promptStarted`/`elicitationModes` diagnostics; no changed Discord file emits a diagnostic.
- Production delta: 11 additions, 14 deletions (net -3); regression tests are counted separately. Authenticated live Discord delivery was not run; exact provider-request behavior was exercised through the real interaction owner and REST request boundary.
