### PR TITLE
fix(gateway): Responses API returns blank or truncated assistant output

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -391,12 +391,17 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
-  it.each([false, true])(
-    "accepts the official OpenAI SDK plain-text response format (stream: %s)",
-    async (stream) => {
+  it.each([
+    { stream: false, text: "SDK plain-text response", expected: "SDK plain-text response" },
+    { stream: true, text: "SDK plain-text response", expected: "SDK plain-text response" },
+    { stream: false, text: "", expected: "No response from OpenClaw." },
+    { stream: true, text: "", expected: "No response from OpenClaw." },
+  ])(
+    "returns visible official SDK response text (stream: $stream, text: $text)",
+    async ({ stream, text, expected }) => {
       agentCommandMock.mockClear();
       agentCommandMock.mockResolvedValueOnce({
-        payloads: [{ text: "SDK plain-text response" }],
+        payloads: [{ text }],
       } as never);
 
       const client = new OpenAI({
@@ -421,17 +426,51 @@ describe("OpenResponses HTTP API (e2e)", () => {
             textDeltas.push(event.delta);
           }
         }
-        expect(textDeltas.join("")).toBe("SDK plain-text response");
+        expect(textDeltas.join("")).toBe(expected);
         expect(eventTypes).toContain("response.completed");
       } else {
         const response = await client.responses.create({ ...request, stream: false });
         expect(response.status).toBe("completed");
-        expect(response.output_text).toBe("SDK plain-text response");
+        expect(response.output_text).toBe(expected);
       }
 
       expect(agentCommandMock).toHaveBeenCalledTimes(1);
     },
   );
+
+  it("preserves buffered leading text in official SDK streaming snapshots", async () => {
+    const expected = "<tag>ok</tag>";
+    agentCommandMock.mockClear();
+    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId;
+      if (!runId) {
+        throw new Error("expected a streaming response run ID");
+      }
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: expected, delta: "tag>ok</tag>" },
+      });
+      return { payloads: [{ text: expected }] };
+    }) as never);
+
+    const client = new OpenAI({
+      apiKey: "test",
+      baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+      defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+      maxRetries: 0,
+    });
+    const stream = client.responses.stream({
+      model: "openclaw",
+      input: "Preserve the complete assistant snapshot.",
+    });
+    const deltas: string[] = [];
+    stream.on("response.output_text.delta", (event) => deltas.push(event.delta));
+
+    const response = await stream.finalResponse();
+    expect(deltas.join("")).toBe(expected);
+    expect(response.output_text).toBe(expected);
+  });
 
   it.each([
     { name: "rewritten", replacementText: "final answer" },

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -251,6 +251,17 @@ function writeSseEvent(res: ServerResponse, event: StreamingEvent) {
   res.write(`data: ${JSON.stringify(event)}\n\n`);
 }
 
+function resolveResponsePayloadText(result: unknown): string {
+  const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
+  return Array.isArray(payloads)
+    ? payloads
+        .flatMap((payload) =>
+          typeof payload.text === "string" && payload.text ? [payload.text] : [],
+        )
+        .join("\n\n")
+    : "";
+}
+
 type ResolvedResponsesLimits = {
   maxBodyBytes: number;
   maxUrlParts: number;
@@ -736,7 +747,7 @@ export async function handleOpenResponsesHttpRequest(
       if (isFailedOpenAiAgentRun(result)) {
         throw new Error("agent run failed");
       }
-      const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
+      const assistantText = resolveResponsePayloadText(result);
       const usage = extractUsageFromResult(result);
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
@@ -769,14 +780,6 @@ export async function handleOpenResponsesHttpRequest(
       // pending call was emitted, so multi-tool turns lost every call but
       // the leading one.
       if (stopReason === "tool_calls" && pendingToolCalls && pendingToolCalls.length > 0) {
-        const assistantText =
-          Array.isArray(payloads) && payloads.length > 0
-            ? payloads
-                .map((p) => (typeof p.text === "string" ? p.text : ""))
-                .filter(Boolean)
-                .join("\n\n")
-            : "";
-
         const output: OutputItem[] = [];
         if (assistantText) {
           output.push(
@@ -811,14 +814,6 @@ export async function handleOpenResponsesHttpRequest(
         return true;
       }
 
-      const content =
-        Array.isArray(payloads) && payloads.length > 0
-          ? payloads
-              .map((p) => (typeof p.text === "string" ? p.text : ""))
-              .filter(Boolean)
-              .join("\n\n")
-          : "No response from OpenClaw.";
-
       const response = createResponseResource({
         id: responseId,
         model,
@@ -826,7 +821,7 @@ export async function handleOpenResponsesHttpRequest(
         output: [
           createAssistantOutputItem({
             id: outputItemId,
-            text: content,
+            text: assistantText || "No response from OpenClaw.",
             phase: "final_answer",
             status: "completed",
           }),
@@ -1115,10 +1110,14 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
-      const content = resolveAssistantStreamDeltaText(evt);
+      const content =
+        typeof text === "string" && text.startsWith(streamedAssistantText)
+          ? text.slice(streamedAssistantText.length)
+          : resolveAssistantStreamDeltaText(evt);
       if (!content) {
         return;
       }
+      streamedAssistantText += content;
 
       // Hold assistant prose until the tool-choice contract is confirmed. A
       // `required`/pinned request must reject text-only turns, so streaming
@@ -1132,7 +1131,6 @@ export async function handleOpenResponsesHttpRequest(
 
       sawAssistantDelta = true;
       accumulatedText += content;
-      streamedAssistantText += content;
 
       writeSseEvent(res, {
         type: "response.output_text.delta",
@@ -1224,13 +1222,8 @@ export async function handleOpenResponsesHttpRequest(
 
       // Check for pending client tool calls BEFORE maybeFinalize() because the
       // lifecycle:end event may already have requested finalization.
-      const resultAny = result as { payloads?: Array<{ text?: string }>; meta?: unknown };
-      const resultPayloadText = Array.isArray(resultAny.payloads)
-        ? resultAny.payloads
-            .map((p) => (typeof p.text === "string" ? p.text : ""))
-            .filter(Boolean)
-            .join("\n\n")
-        : "";
+      const resultAny = result as { meta?: unknown };
+      const resultPayloadText = resolveResponsePayloadText(result);
       const meta = resultAny.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 


### PR DESCRIPTION
## What Problem This Solves

Fixes two issues where users of the Gateway `/v1/responses` endpoint would receive a completed but completely blank answer, or receive corrupted streamed text missing an initial buffered character such as `<`. The sibling chat-completions endpoint already handled both output cases correctly.

## Why This Change Was Made

Consolidate assistant-payload text extraction across Responses final answers, tool-call commentary, and streaming completion, applying the existing no-response diagnostic after normalization. For streamed assistant events, derive append-only deltas from the authoritative cumulative snapshot when available, matching the established chat-completions behavior and keeping tool-choice buffering aligned.

## User Impact

An empty model result now returns the existing visible “No response from OpenClaw.” diagnostic instead of an apparently successful blank answer. Responses API streaming preserves the complete assistant text—including buffered leading XML/HTML-like characters—in emitted deltas, terminal events, and the official SDK’s final response.

## Evidence

- Pre-fix red: both official SDK regressions fail against a real local Gateway HTTP server in both normal and isolated Gateway projects: empty nonstream output is `""`, and streamed `<tag>ok</tag>` incorrectly becomes `tag>ok</tag>`.
- Post-fix green: all 260 real Responses and sibling chat-completions HTTP/official-SDK cases pass across both Gateway projects, covering normal and empty text, replacement snapshots, append-only stream safety, tool-choice buffering, lifecycle completion, and terminal SDK output.
- Direct dependency contract inspection: installed SDK `ResponseAccumulator.ts` appends each `response.output_text.delta`, and `ResponseStream.ts` exposes cumulative snapshots plus `finalResponse()`.
- Core and Gateway-test TypeScript projects, focused lint/format, max-lines/assertion-safety ratchets, and runtime import-cycle checks pass.
- Production delta +20/-27, net -7 lines through removal of three duplicated payload-extraction paths.
- Fresh independent in-session source-aware review covers the complete final diff, sibling endpoint, official SDK contract, streamed replacements, tool choice, errors, and output invariants; the external review CLI was unavailable under the session approval boundary.
