### PR TITLE
feat(sessions): delegate full access safely

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6405,6 +6405,7 @@ public struct SessionCompanionExchange: Codable, Sendable {
 public struct SessionRow: Codable, Sendable {
     public let key: String
     public let sessionid: String?
+    public let lifecyclerevision: String?
     public let incognito: Bool?
     public let kind: AnyCodable
     public let label: String?
@@ -6476,6 +6477,7 @@ public struct SessionRow: Codable, Sendable {
     public init(
         key: String,
         sessionid: String? = nil,
+        lifecyclerevision: String? = nil,
         incognito: Bool? = nil,
         kind: AnyCodable,
         label: String? = nil,
@@ -6546,6 +6548,7 @@ public struct SessionRow: Codable, Sendable {
     {
         self.key = key
         self.sessionid = sessionid
+        self.lifecyclerevision = lifecyclerevision
         self.incognito = incognito
         self.kind = kind
         self.label = label
@@ -6618,6 +6621,7 @@ public struct SessionRow: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case key
         case sessionid = "sessionId"
+        case lifecyclerevision = "lifecycleRevision"
         case incognito
         case kind
         case label
@@ -9640,6 +9644,7 @@ public struct SessionsPatchParams: Codable, Sendable {
     public let agentid: String?
     public let expectedsessionid: String?
     public let expectedlifecyclerevision: String?
+    public let activerunpolicy: AnyCodable?
     public let label: AnyCodable?
     public let icon: AnyCodable?
     public let category: AnyCodable?
@@ -9677,6 +9682,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         agentid: String? = nil,
         expectedsessionid: String? = nil,
         expectedlifecyclerevision: String? = nil,
+        activerunpolicy: AnyCodable? = nil,
         label: AnyCodable? = nil,
         icon: AnyCodable? = nil,
         category: AnyCodable? = nil,
@@ -9713,6 +9719,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.agentid = agentid
         self.expectedsessionid = expectedsessionid
         self.expectedlifecyclerevision = expectedlifecyclerevision
+        self.activerunpolicy = activerunpolicy
         self.label = label
         self.icon = icon
         self.category = category
@@ -9751,6 +9758,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         case agentid = "agentId"
         case expectedsessionid = "expectedSessionId"
         case expectedlifecyclerevision = "expectedLifecycleRevision"
+        case activerunpolicy = "activeRunPolicy"
         case label
         case icon
         case category

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2078,7 +2078,7 @@ src/agents/subagents/spawn/subagent-depth.ts	1
 src/agents/subagents/spawn/subagent-spawn-cleanup.ts	1
 src/agents/subagents/spawn/subagent-spawn-gateway.ts	3
 src/agents/subagents/spawn/subagent-spawn-session-patch.ts	1
-src/agents/subagents/spawn/subagent-spawn.ts	2
+src/agents/subagents/spawn/subagent-spawn.ts	1
 src/agents/subagents/swarm/swarm-output-schema.ts	1
 src/agents/subagents/swarm/swarm-scheduler.ts	1
 src/agents/system-prompt-report.ts	2

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -123,6 +123,8 @@ See [Session state awareness](/concepts/session-state) for the full model: event
 
 `sessions_spawn` creates an isolated session for a background task by default. It is always non-blocking; it returns immediately with a `runId` and `childSessionKey`. Native sub-agent runs receive the delegated task in the child session's first visible `[Subagent Task]` message, while the system prompt carries only sub-agent runtime rules and routing context.
 
+A direct user turn in a `full` parent session may explicitly pass `permissionMode: "full"` to a native sub-agent spawn. The exact parent lifecycle and live run authority stay bound through child creation and launch. Omission never inherits full access, and ACP spawns keep their independent permission contract.
+
 Key options:
 
 - `runtime: "subagent"` (default) or `"acp"` for external harness agents.

--- a/docs/gateway/permission-modes.md
+++ b/docs/gateway/permission-modes.md
@@ -18,6 +18,8 @@ Session permission modes set one session's filesystem boundary and exec escalati
 
 `full` requires `operator.admin`. The other modes require `operator.write`.
 
+A direct user turn in an existing `full` session may explicitly delegate that mode with `sessions_spawn({ permissionMode: "full" })`. The option is native-subagent only, is hidden on ineligible turns, and never applies by omission. The child records a visible system note when the delegation commits.
+
 ## Session root and defaults
 
 The Gateway records `sessionRoot` when it creates the session. An explicit working directory becomes the root after canonical path resolution. A session without an explicit working directory uses the selected agent's canonical workspace.
@@ -31,5 +33,7 @@ A new managed worktree session defaults to `workspace` when no mode is specified
 An explicit session mode takes precedence over the session's legacy `execSecurity` and `execAsk` overrides. When the mode is unset, those fields and the normal global or per-agent configuration continue to work as before.
 
 An explicit `full` mode is the admin-authorized exception to host approval-file floors: its OpenClaw exec policy remains `full` with approvals off. Approval-file floors continue to tighten config-driven exec policy, legacy session overrides, unset modes, and every non-full session mode. Sandbox restrictions and tool allow/deny policy remain independent, and a harness may clamp an unsupported mode to a compatible safer policy tuple. Codex also continues to honor externally enforced `requirements.toml` constraints.
+
+Changing permission, exec, elevated, or tool policy rotates the session lifecycle revision. If work is active, `sessions.patch` rejects the change by default. Callers that own the current `sessionId` and `lifecycleRevision` can choose `activeRunPolicy: "stop"` to stop and drain that work before commit, or `"stop-and-continue"` to start one trusted continuation after the new policy commits. The operation records a visible system note; queued turns prepared under the old policy are discarded rather than replayed.
 
 For the independent sandbox, tool-policy, and elevated-exec controls, see [Sandbox vs tool policy vs elevated](/gateway/sandbox-vs-tool-policy-vs-elevated).

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -245,6 +245,9 @@ In `prefer` mode, hidden sub-agents are for internal legwork that the user does 
 <ParamField path="sandbox" type='"inherit" | "require"' default="inherit">
   `require` rejects the spawn unless the target child runtime is sandboxed.
 </ParamField>
+<ParamField path="permissionMode" type='"full"'>
+  Explicitly delegates full access to a native child. This field appears only during a direct user turn in an exact parent session that is already `full`; `runtime: "acp"` does not support it. Omission never inherits full access. Parent reset, downgrade, archive, run termination, worker-claim loss, or Gateway restart before child commit or launch rejects the delegation.
+</ParamField>
 <ParamField path="context" type='"isolated" | "fork"' default="isolated">
   `fork` branches the requester's current transcript into the child session. Native sub-agents only. Thread-bound spawns default to `fork`; non-thread spawns default to `isolated`. A visible fork must target the same agent as the requester.
 </ParamField>

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -49,4 +49,8 @@ export {
   PROTOCOL_VERSION,
 } from "./version.js";
 export type * from "./schema-types.js";
-export type { SessionsPatchResult } from "./sessions-patch-result.js";
+export type {
+  SessionsPatchActiveRunOutcome,
+  SessionsPatchContinuationOutcome,
+  SessionsPatchResult,
+} from "./sessions-patch-result.js";

--- a/packages/gateway-protocol/src/schema/sessions-patch.ts
+++ b/packages/gateway-protocol/src/schema/sessions-patch.ts
@@ -69,6 +69,9 @@ export const SessionsPatchParamsSchema = closedObject({
   /** Reject the mutation if the session was reset or replaced before it commits. */
   expectedSessionId: Type.Optional(NonEmptyString),
   expectedLifecycleRevision: Type.Optional(NonEmptyString),
+  activeRunPolicy: Type.Optional(
+    Type.Union([Type.Literal("reject"), Type.Literal("stop"), Type.Literal("stop-and-continue")]),
+  ),
   ...SessionsPatchMutationProperties,
 });
 

--- a/packages/gateway-protocol/src/schema/sessions-row.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.ts
@@ -42,6 +42,7 @@ export const SessionRowSchema = Type.Object(
   {
     key: Type.String(),
     sessionId: Type.Optional(Type.String()),
+    lifecycleRevision: Type.Optional(Type.String()),
     incognito: Type.Optional(Type.Literal(true)),
     kind: Type.Union([
       Type.Literal("direct"),

--- a/packages/gateway-protocol/src/schema/worker-admission.ts
+++ b/packages/gateway-protocol/src/schema/worker-admission.ts
@@ -215,6 +215,7 @@ export const WorkerSessionsSpawnParamsSchema = closedObject({
   agentId: Type.Optional(WorkerIdentifierSchema),
   model: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
   runTimeoutSeconds: Type.Optional(Type.Integer({ minimum: 0, maximum: 86_400 })),
+  permissionMode: Type.Optional(Type.Literal("full")),
 });
 
 export const WorkerSessionsSendParamsSchema = closedObject({

--- a/packages/gateway-protocol/src/sessions-patch-active-run.test.ts
+++ b/packages/gateway-protocol/src/sessions-patch-active-run.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { validateSessionsPatchParams } from "./index.js";
+
+describe("sessions.patch active run policy", () => {
+  it("accepts the closed policy and rejects unknown values", () => {
+    expect(
+      validateSessionsPatchParams({
+        key: "agent:main:policy-patch",
+        permissionMode: "full",
+        expectedSessionId: "session-policy-patch",
+        expectedLifecycleRevision: "revision-policy-patch",
+        activeRunPolicy: "stop-and-continue",
+      }),
+    ).toBe(true);
+    expect(
+      validateSessionsPatchParams({
+        key: "agent:main:policy-patch",
+        activeRunPolicy: "continue",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/gateway-protocol/src/sessions-patch-result.ts
+++ b/packages/gateway-protocol/src/sessions-patch-result.ts
@@ -1,9 +1,23 @@
+import type { ErrorShape } from "./schema/frames.js";
+
+export type SessionsPatchContinuationOutcome =
+  | { status: "started"; runId: string }
+  | { status: "rejected"; error: ErrorShape };
+
+export type SessionsPatchActiveRunOutcome = {
+  policy: "reject" | "stop" | "stop-and-continue";
+  stopped: boolean;
+  auditNote: "appended" | "failed";
+  continuation?: SessionsPatchContinuationOutcome;
+};
+
 // Local structural result keeps this package independent of core session types.
 export type SessionsPatchResult = {
   ok: true;
   path: string;
   key: string;
   entry: Record<string, unknown>;
+  activeRun?: SessionsPatchActiveRunOutcome;
   resolved?: {
     modelProvider?: string;
     model?: string;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,5 +1,6 @@
 // OpenClaw SDK module implements client behavior.
 import { randomUUID } from "node:crypto";
+import type { SessionsPatchParams, SessionsPatchResult } from "@openclaw/gateway-protocol";
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { readNonEmptyStringPreservingWhitespace as readNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import { EventHub } from "./event-hub.js";
@@ -713,7 +714,7 @@ export class Session {
     });
   }
 
-  async patch(params: Record<string, unknown>): Promise<unknown> {
+  async patch(params: Omit<SessionsPatchParams, "key">): Promise<SessionsPatchResult> {
     return await this.client.request("sessions.patch", { ...params, key: this.key });
   }
 

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -185,6 +185,32 @@ describe("createOpenClawCodingTools", () => {
     expect(latestCreateOpenClawToolsOptions().webSearchEnabled).toBe(false);
   });
 
+  it("prepares full delegation only for a direct user turn on a full parent", () => {
+    vi.mocked(createOpenClawTools).mockClear();
+    createOpenClawCodingTools({
+      trigger: "user",
+      sessionId: "parent-session",
+      sessionLifecycleRevision: "parent-revision",
+      sessionPermissionPolicy: { mode: "full", root: "/workspace" },
+    });
+
+    expect(latestCreateOpenClawToolsOptions()).toMatchObject({
+      sessionId: "parent-session",
+      sessionLifecycleRevision: "parent-revision",
+      fullAccessDelegationAvailable: true,
+    });
+
+    vi.mocked(createOpenClawTools).mockClear();
+    createOpenClawCodingTools({
+      trigger: "user",
+      sessionId: "parent-session",
+      sessionLifecycleRevision: "parent-revision",
+      sessionPermissionPolicy: { mode: "full", root: "/workspace" },
+      inputProvenance: { kind: "inter_session" },
+    });
+    expect(latestCreateOpenClawToolsOptions().fullAccessDelegationAvailable).toBe(false);
+  });
+
   it.each([
     {
       name: "fitting node",

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -59,7 +59,10 @@ import {
 } from "./conversation-tool-policy-pipeline.js";
 import { createCoreCodingTools } from "./core-coding-tools.js";
 import type { OpenClawCodingToolConstructionPlan } from "./core-tool-factory-descriptors.js";
-import { bindActiveCronCreatorAuthorityResolver } from "./cron-creator-authority-context.js";
+import {
+  bindActiveCronCreatorAuthorityResolver,
+  bindActiveOperatorTurnAuthority,
+} from "./cron-creator-authority-context.js";
 import { applyDelegationCapability, type DelegationCapability } from "./delegation-capability.js";
 import { prepareGitHubToolEnvironment } from "./github-tool-identity.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
@@ -115,6 +118,7 @@ import {
 } from "./tools/cron-tool.js";
 import type { CronToolOptions } from "./tools/cron-tool.types.js";
 import { wrapToolWithGatewayCallerIdentity } from "./tools/gateway-caller-context.js";
+import { isFullAccessDelegationTurn } from "./tools/sessions-spawn-full-access.js";
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
 
@@ -196,6 +200,8 @@ type OpenClawCodingToolsOptions = {
   runSessionKey?: string;
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
+  /** Exact lifecycle revision prepared with sessionId for privileged spawn admission. */
+  sessionLifecycleRevision?: string;
   /**
    * Explicit one-shot local CLI runs should not keep plugin-owned process
    * resources alive after emitting their result.
@@ -646,6 +652,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     recordToolPrepStage: options?.recordToolPrepStage,
   });
   const cronCreatorAuthorityResolver = bindActiveCronCreatorAuthorityResolver(options?.runId);
+  const directUserTurnAuthority = bindActiveOperatorTurnAuthority(options?.runId);
   // A fresh exact-run capability authorizes only automation creation. Keep every
   // other owner-only control-plane tool denied for senderless operator turns.
   const ownerOnlyCoreToolDenylist =
@@ -848,6 +855,12 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             senderIsOwner: options?.senderIsOwner,
             authProfileStore: options?.authProfileStore,
             sessionId: options?.sessionId,
+            sessionLifecycleRevision: options?.sessionLifecycleRevision,
+            fullAccessDelegationAvailable:
+              isFullAccessDelegationTurn({
+                permissionMode: options?.sessionPermissionPolicy?.mode,
+                directUserTurnAuthority,
+              }) && Boolean(options?.sessionId && options.sessionLifecycleRevision),
             conversationRecall: options?.conversationRecall,
             oneShotCliRun: options?.oneShotCliRun,
             inheritedToolAllowlist,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1168,6 +1168,7 @@ export function runAgentAttempt(params: {
     cwd: params.cwd,
     permissionMode: params.sessionEntry?.permissionMode,
     sessionRoot: params.sessionEntry?.sessionRoot,
+    sessionLifecycleRevision: params.sessionEntry?.lifecycleRevision,
     config: params.cfg,
     ...(params.pluginGeneration ? { pluginGeneration: params.pluginGeneration } : {}),
     agentHarnessId: embeddedAgentHarnessOverride,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -260,6 +260,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
           },
           sandbox: params.sandbox,
           sessionPermissionPolicy: params.sessionPermissionPolicy,
+          sessionLifecycleRevision: attempt.sessionLifecycleRevision,
           messageProvider: resolveAttemptToolPolicyMessageProvider(attempt),
           agentAccountId: attempt.agentAccountId,
           messageTo: attempt.messageTo,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -222,6 +222,7 @@ export type RunEmbeddedAgentParams = {
   cwd?: string;
   permissionMode?: SessionEntry["permissionMode"];
   sessionRoot?: string;
+  sessionLifecycleRevision?: string;
   agentDir?: string;
   /**
    * Run config consumed by core paths (model selection, tools, plugin

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -540,6 +540,9 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
             workspaceDir: spawnWorkspaceDir,
             inheritedToolAllowlist: options?.inheritedToolAllowlist,
             inheritedToolDenylist: options?.inheritedToolDenylist,
+            expectedParentSessionId: options?.sessionId,
+            expectedParentLifecycleRevision: options?.sessionLifecycleRevision,
+            fullAccessDelegationAvailable: options?.fullAccessDelegationAvailable,
           }),
         ]
       : []),

--- a/src/agents/openclaw-tools.types.ts
+++ b/src/agents/openclaw-tools.types.ts
@@ -125,6 +125,10 @@ export type OpenClawToolsOptions = {
   requesterSenderId?: string | null;
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
+  /** Exact lifecycle revision prepared with sessionId for privileged spawn admission. */
+  sessionLifecycleRevision?: string;
+  /** Host-prepared direct-user fact; execution still validates the live parent and run. */
+  fullAccessDelegationAvailable?: boolean;
   /** Trusted runtime-only authorization for one bounded cross-conversation recall pass. */
   conversationRecall?: ConversationRecallContext;
   /** One-shot local CLI runs release plugin-owned resources after their result. */

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -33,7 +33,7 @@ import { createOperationalRunInstanceRef } from "../../admitted-run-context.js";
 import { reserveChildAdmissionSlot } from "../../child-admission.js";
 import { withGatewayToolCallerIdentity } from "../../tools/gateway-caller-context.js";
 import { withParentExecutionIdentity } from "./execution-identity-spawn-context.js";
-import { setSubagentSpawnDepsForTest } from "./subagent-spawn-deps.js";
+import { testing as subagentSpawnTesting } from "./subagent-spawn.test-support.js";
 
 type SessionBindingAdapterCapabilities = NonNullable<SessionBindingAdapter["capabilities"]>;
 
@@ -961,7 +961,7 @@ describe("spawnAcpDirect", () => {
     const operationalRunInstance = createOperationalRunInstanceRef("parent-run");
     const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
     let capturedIdentity: AgentRuntimeIdentity | undefined;
-    setSubagentSpawnDepsForTest({
+    subagentSpawnTesting.setDepsForTest({
       hasInProcessGatewayContext: () => true,
       dispatchGatewayMethodInProcess: async <T>(
         _method: string,
@@ -1001,7 +1001,7 @@ describe("spawnAcpDirect", () => {
       );
     } finally {
       releaseAgentRunDelegatedAuthority(authority);
-      setSubagentSpawnDepsForTest();
+      subagentSpawnTesting.setDepsForTest();
     }
   });
 

--- a/src/agents/subagents/spawn/subagent-spawn-contract.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-contract.ts
@@ -1,4 +1,5 @@
 import type { FastMode } from "../../../shared/fast-mode.js";
+import type { FullAccessDelegationAdmission } from "../../tools/sessions-spawn-full-access.js";
 import type {
   SpawnSubagentContextMode,
   SpawnSubagentMode,
@@ -29,6 +30,8 @@ export type SpawnSubagentParams = {
   context?: SpawnSubagentContextMode;
   lightContext?: boolean;
   expectsCompletionMessage?: boolean;
+  permissionMode?: "full";
+  fullAccessAdmission?: FullAccessDelegationAdmission;
   attachments?: Array<{
     name: string;
     content: string;

--- a/src/agents/subagents/spawn/subagent-spawn-deps.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-deps.ts
@@ -1,4 +1,5 @@
 import type { SubagentLifecycleHookRunner } from "../../../plugins/hooks.js";
+import { callInProcessGatewayToolWithCreation } from "../../tools/in-process-gateway.js";
 import {
   callGateway,
   dispatchGatewayMethodInProcess,
@@ -23,6 +24,7 @@ type SubagentSpawnDeps = {
   loadPreparedModelCatalog: typeof loadPreparedModelCatalog;
   resolveProviderRefOwnership: typeof resolveProviderRefOwnership;
   resolveContextEngine: typeof resolveContextEngine;
+  createGatewaySession: typeof callInProcessGatewayToolWithCreation;
 };
 
 const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
@@ -36,6 +38,7 @@ const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
   loadPreparedModelCatalog,
   resolveProviderRefOwnership,
   resolveContextEngine,
+  createGatewaySession: callInProcessGatewayToolWithCreation,
 };
 
 let subagentSpawnDeps = defaultSubagentSpawnDeps;
@@ -44,11 +47,17 @@ export function getSubagentSpawnDeps(): SubagentSpawnDeps {
   return subagentSpawnDeps;
 }
 
-export function setSubagentSpawnDepsForTest(overrides?: Partial<SubagentSpawnDeps>): void {
+function setSubagentSpawnDepsForTest(overrides?: Partial<SubagentSpawnDeps>): void {
   subagentSpawnDeps = overrides
     ? {
         ...defaultSubagentSpawnDeps,
         ...overrides,
       }
     : defaultSubagentSpawnDeps;
+}
+
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  // SAFETY: this test-only symbol is written and consumed with the same setter contract.
+  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.subagentSpawnTestDeps")] =
+    setSubagentSpawnDepsForTest;
 }

--- a/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-session-patch.ts
@@ -1,21 +1,18 @@
-import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { buildSessionCreationStamp } from "../../../config/sessions/session-entry-provenance.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { resolveIncognitoOpenClawAgentSqlitePath } from "../../../state/openclaw-agent-db.js";
 import {
   inheritedToolAllowPatch,
   inheritedToolDenyPatch,
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
 } from "../../inherited-tool-deny.js";
+import type { FullAccessDelegationAdmission } from "../../tools/sessions-spawn-full-access.js";
+import type { SpawnSubagentResult } from "./subagent-spawn-contract.js";
 import { getSubagentSpawnDeps } from "./subagent-spawn-deps.js";
 import { splitModelRef } from "./subagent-spawn-plan.js";
-import {
-  resolveGatewaySessionStoreTarget,
-  upsertSessionEntryCore,
-} from "./subagent-spawn.runtime.js";
 
 function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<SessionEntry> {
   const entry: Partial<SessionEntry> = {};
@@ -74,7 +71,7 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
     entry.swarmCollector = true;
   }
   if (patch.swarmOutputSchema && typeof patch.swarmOutputSchema === "object") {
-    entry.swarmOutputSchema = patch.swarmOutputSchema as Record<string, unknown>;
+    entry.swarmOutputSchema = asNullableRecord(patch.swarmOutputSchema) ?? undefined;
   }
   if (typeof patch.model === "string" && patch.model.trim()) {
     const { provider, model } = splitModelRef(patch.model.trim());
@@ -100,6 +97,17 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   return entry;
 }
 
+function projectCreatedSessionEntry(
+  value: Record<string, unknown> | null,
+): SessionEntry | undefined {
+  return typeof value?.sessionId === "string" &&
+    value.sessionId.length > 0 &&
+    typeof value.updatedAt === "number"
+    ? // SAFETY: sessions.create schema-validates the row; this boundary verifies required identity fields before projection.
+      (value as unknown as SessionEntry)
+    : undefined;
+}
+
 export function loadSubagentConfig() {
   return getSubagentSpawnDeps().getRuntimeConfig();
 }
@@ -121,6 +129,9 @@ export async function createInitialSubagentSession(params: {
   swarmGroupId?: string;
   collect: boolean;
   outputSchema?: Record<string, unknown>;
+  childDepth: number;
+  permissionMode?: "full";
+  fullAccessAdmission?: FullAccessDelegationAdmission;
 }): Promise<{ status: "ok"; entry?: SessionEntry } | { status: "error"; error: string }> {
   const initialChildSessionPatch: Record<string, unknown> = {
     spawnedBy: params.requesterInternalKey,
@@ -140,71 +151,63 @@ export async function createInitialSubagentSession(params: {
     ...(params.outputSchema ? { swarmOutputSchema: params.outputSchema } : {}),
     ...(params.incognito ? { incognito: true } : {}),
   };
-  // Spawn owns a fresh child lifecycle. Cleanup freezes both fields before
-  // launch so it cannot delete a reset successor that reuses the session id.
-  const childSessionIdentity = {
-    sessionId: randomUUID(),
-    lifecycleRevision: randomUUID(),
-  };
   try {
-    const target = params.incognito
-      ? {
-          agentId: params.targetAgentId,
-          canonicalKey: params.childSessionKey,
-          storeKeys: [params.childSessionKey],
-          storePath: resolveIncognitoOpenClawAgentSqlitePath({ agentId: params.targetAgentId }),
-        }
-      : resolveGatewaySessionStoreTarget({
-          cfg: params.cfg,
-          key: params.childSessionKey,
-        });
-    const entry = await upsertSessionEntryCore(
+    const initialSpawnEntry = buildDirectChildSessionPatch(initialChildSessionPatch);
+    params.fullAccessAdmission?.assertActive();
+    const response = await getSubagentSpawnDeps().createGatewaySession(
+      "sessions.create",
       {
-        storePath: target.storePath,
-        sessionKey: target.canonicalKey,
+        key: params.childSessionKey,
+        agentId: params.targetAgentId,
+        parentSessionKey: params.requesterInternalKey,
+        spawnDepth: params.childDepth,
+        ...(params.incognito ? { incognito: true } : {}),
+        ...(params.permissionMode ? { permissionMode: params.permissionMode } : {}),
       },
       {
-        ...buildDirectChildSessionPatch(initialChildSessionPatch),
-        ...childSessionIdentity,
-        ...buildSessionCreationStamp({
-          via: "spawn",
-          actor: { type: "agent", id: params.requesterAgentId },
-        }),
+        via: "spawn",
+        actor: { type: "agent", id: params.requesterAgentId },
+        requesterSessionKey: params.requesterInternalKey,
+        completionOwnerSessionKey: params.completionOwnerSessionKey,
+        inheritedToolPolicy: {
+          version: 1,
+          allow: params.inheritedToolAllowlist ?? [],
+          deny: params.inheritedToolDenylist ?? [],
+        },
+        initialSpawnEntry,
+        ...(params.fullAccessAdmission ? { fullAccessAdmission: params.fullAccessAdmission } : {}),
       },
     );
-    return { status: "ok", entry: entry ?? undefined };
+    const entry = asNullableRecord(asNullableRecord(response)?.entry);
+    const expected = Object.entries(initialSpawnEntry);
+    if (!entry || expected.some(([key, value]) => !isDeepStrictEqual(entry[key], value))) {
+      return { status: "error", error: "child session creation did not commit spawn state" };
+    }
+    const createdEntry = projectCreatedSessionEntry(entry);
+    return createdEntry
+      ? { status: "ok", entry: createdEntry }
+      : { status: "error", error: "child session creation returned no session identity" };
   } catch (err) {
     const message = err instanceof Error ? err.message : typeof err === "string" ? err : "error";
-    return { status: "error", error: `child session patch failed: ${message}` };
+    return { status: "error", error: `child session creation failed: ${message}` };
   }
 }
 
-export async function persistInitialChildSessionRuntimeModel(params: {
-  cfg: OpenClawConfig;
+export async function rejectClosedFullAccessSpawn(params: {
+  admission?: FullAccessDelegationAdmission;
   childSessionKey: string;
-  resolvedModel?: string;
-}): Promise<string | undefined> {
-  const { provider, model } = splitModelRef(params.resolvedModel);
-  if (!model) {
-    return undefined;
-  }
+  cleanup: (emitLifecycleHooks?: boolean) => Promise<unknown>;
+  emitLifecycleHooks?: boolean;
+}): Promise<SpawnSubagentResult | undefined> {
   try {
-    const target = resolveGatewaySessionStoreTarget({
-      cfg: params.cfg,
-      key: params.childSessionKey,
-    });
-    await upsertSessionEntryCore(
-      {
-        storePath: target.storePath,
-        sessionKey: target.canonicalKey,
-      },
-      {
-        model,
-        ...(provider ? { modelProvider: provider } : {}),
-      },
-    );
+    params.admission?.assertActive();
     return undefined;
-  } catch (err) {
-    return err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+  } catch (error) {
+    await params.cleanup(params.emitLifecycleHooks);
+    return {
+      status: "forbidden",
+      error: error instanceof Error ? error.message : "full-access delegation authority changed",
+      childSessionKey: params.childSessionKey,
+    };
   }
 }

--- a/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.model-session.test.ts
@@ -32,16 +32,7 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     updateSessionStoreMock.mockReset();
     setupAcceptedSubagentGatewayMock(callGatewayMock);
 
-    updateSessionStoreMock.mockImplementation(
-      async (
-        _storePath: string,
-        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
-      ) => {
-        const store: Record<string, Record<string, unknown>> = {};
-        await mutator(store);
-        return store;
-      },
-    );
+    installSessionStoreCaptureMock(updateSessionStoreMock);
   });
 
   it("persists runtime model fields on the child session before starting the run", async () => {
@@ -84,7 +75,7 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     expect(result.modelApplied).toBe(true);
     expect(result.resolvedModel).toBe("openai/gpt-5.4");
     expect(result.resolvedProvider).toBe("openai");
-    expect(updateSessionStoreMock).toHaveBeenCalledTimes(2);
+    expect(updateSessionStoreMock).toHaveBeenCalledTimes(1);
     expectPersistedRuntimeModel({
       persistedStore,
       sessionKey: /^agent:main:subagent:/,

--- a/src/agents/subagents/spawn/subagent-spawn.runtime.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.runtime.ts
@@ -4,10 +4,7 @@
  * entire gateway/channel stack.
  */
 export { getRuntimeConfig } from "../../../config/config.js";
-export {
-  loadSessionEntryReadOnly as loadSessionEntry,
-  upsertSessionEntryCore,
-} from "../../../config/sessions/session-accessor.js";
+export { loadSessionEntryReadOnly as loadSessionEntry } from "../../../config/sessions/session-accessor.js";
 export { forkSessionEntryFromParent } from "../../../auto-reply/reply/session-fork.js";
 export { ensureContextEnginesInitialized } from "../../../context-engine/init.js";
 export { resolveContextEngine } from "../../../context-engine/registry.js";

--- a/src/agents/subagents/spawn/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test-helpers.ts
@@ -3,8 +3,10 @@
 import os from "node:os";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { expect, vi } from "vitest";
+import { buildSessionCreationStamp } from "../../../config/sessions/session-entry-provenance.js";
 import { resolveLeastPrivilegeOperatorScopesForMethod } from "../../../gateway/method-scopes.js";
 import type { SubagentLifecycleHookRunner } from "../../../plugins/hooks.js";
+import { resolveIncognitoOpenClawAgentSqlitePath } from "../../../state/openclaw-agent-db.js";
 
 type MockFn = (...args: unknown[]) => unknown;
 type MockImplementationTarget = {
@@ -202,6 +204,7 @@ export async function loadSubagentSpawnModuleForTest(params: {
   }) => { to?: string; threadId?: string };
   workspaceDir?: string;
   sessionStorePath?: string;
+  createGatewaySessionMock?: MockFn;
   resetModules?: boolean;
 }): Promise<SubagentSpawnModuleForTest> {
   if (params.resetModules ?? true) {
@@ -214,6 +217,41 @@ export async function loadSubagentSpawnModuleForTest(params: {
 
   vi.doMock("../../provider-model-normalization.runtime.js", () => ({
     normalizeProviderModelIdWithRuntime: () => undefined,
+  }));
+
+  vi.doMock("../../tools/in-process-gateway.js", () => ({
+    callInProcessGatewayToolWithCreation:
+      params.createGatewaySessionMock ??
+      (async (
+        _method: string,
+        request: Record<string, unknown>,
+        creation: { initialSpawnEntry?: Record<string, unknown> },
+      ) => {
+        const key = String(request.key);
+        const entry = {
+          ...creation.initialSpawnEntry,
+          sessionId: `session-${key}`,
+          lifecycleRevision: `revision-${key}`,
+          updatedAt: Date.now(),
+          parentSessionKey: request.parentSessionKey,
+          permissionMode: request.permissionMode,
+          ...buildSessionCreationStamp({ via: "spawn", actor: { type: "agent", id: "main" } }),
+        };
+        const storePath = request.incognito
+          ? resolveIncognitoOpenClawAgentSqlitePath({ agentId: String(request.agentId) })
+          : (params.sessionStorePath ?? "/tmp/subagent-spawn-model-session.json");
+        await (
+          params.updateSessionStoreMock ??
+          (async (_path: string, mutator: SessionStoreMutator) => {
+            const store: SessionStore = {};
+            await mutator(store);
+            return store;
+          })
+        )(storePath, (store: SessionStore) => {
+          store[key] = entry;
+        });
+        return { ok: true, key, entry };
+      }),
   }));
 
   vi.doMock("./subagent-spawn.runtime.js", () => ({
@@ -321,9 +359,9 @@ export async function loadSubagentSpawnModuleForTest(params: {
     // Real scope resolver: spawn's admin-tier pinning depends on params-aware
     // sessions.patch policy, so a stub here would hide policy regressions.
     resolveLeastPrivilegeOperatorScopesForMethod,
-    upsertSessionEntryCore: async (
+    patchSessionEntryCore: async (
       scope: { storePath?: string; sessionKey: string },
-      patch: Record<string, unknown>,
+      update: (entry: Record<string, unknown>) => Record<string, unknown> | null,
     ) => {
       const updateSessionStore =
         params.updateSessionStoreMock ??
@@ -336,7 +374,15 @@ export async function loadSubagentSpawnModuleForTest(params: {
       const storePath =
         scope.storePath ?? params.sessionStorePath ?? "/tmp/subagent-spawn-model-session.json";
       await updateSessionStore(storePath, (store: SessionStore) => {
-        updated = Object.assign({}, store[scope.sessionKey], patch);
+        const current = store[scope.sessionKey];
+        if (!current) {
+          return;
+        }
+        const patch = update(current);
+        if (!patch) {
+          return;
+        }
+        updated = Object.assign({}, current, patch);
         store[scope.sessionKey] = updated;
       });
       return updated ?? null;

--- a/src/agents/subagents/spawn/subagent-spawn.test-support.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test-support.ts
@@ -23,12 +23,11 @@ type Testing = {
   setDepsForTest(overrides?: Partial<SpawnDeps>): void;
 };
 
-function getTesting(): Testing {
-  return (globalThis as Record<PropertyKey, unknown>)[
-    Symbol.for("openclaw.subagentSpawnTestApi")
-  ] as Testing;
-}
-
 export const testing: Testing = {
-  setDepsForTest: (overrides) => getTesting().setDepsForTest(overrides),
+  setDepsForTest: (overrides) => {
+    const setDeps = (globalThis as Record<PropertyKey, unknown>)[
+      Symbol.for("openclaw.subagentSpawnTestDeps")
+    ] as Testing["setDepsForTest"];
+    setDeps(overrides);
+  },
 };

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -221,16 +221,7 @@ describe("spawnSubagentDirect seam flow", () => {
     installAcceptedSubagentGatewayMock(hoisted.callGatewayMock);
     hoisted.loadSessionStoreMock.mockReturnValue({});
 
-    hoisted.updateSessionStoreMock.mockImplementation(
-      async (
-        _storePath: string,
-        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
-      ) => {
-        const store: Record<string, Record<string, unknown>> = {};
-        await mutator(store);
-        return store;
-      },
-    );
+    installSessionStoreCaptureMock(hoisted.updateSessionStoreMock);
   });
 
   afterEach(() => {
@@ -1403,7 +1394,7 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(result.childSessionKey).toMatch(/^agent:main:subagent:/);
 
     const childSessionKey = result.childSessionKey as string;
-    expect(hoisted.updateSessionStoreMock).toHaveBeenCalledTimes(2);
+    expect(hoisted.updateSessionStoreMock).toHaveBeenCalledTimes(1);
     expect(persistedStore?.[childSessionKey]).toMatchObject({
       sessionId: expect.any(String),
       lifecycleRevision: expect.any(String),
@@ -1458,6 +1449,48 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(agentParams.provider).toBe("openai");
     expect(agentParams.model).toBe("gpt-5.4");
     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
+  });
+
+  it("routes hidden child creation through the Gateway owner with atomic spawn state", async () => {
+    const createGatewaySessionMock = vi.fn(async (_method, request, creation) => ({
+      ok: true,
+      key: request.key,
+      entry: {
+        ...creation.initialSpawnEntry,
+        sessionId: "gateway-child-session",
+        lifecycleRevision: "gateway-child-revision",
+        updatedAt: Date.now(),
+      },
+    }));
+    const { spawnSubagentDirect: spawnWithGatewayOwner } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: hoisted.callGatewayMock,
+      createGatewaySessionMock,
+      getRuntimeConfig: () => createSubagentSpawnTestConfig(),
+    });
+    installAcceptedSubagentGatewayMock(hoisted.callGatewayMock);
+
+    const result = await spawnWithGatewayOwner(
+      { task: "create through owner" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(createGatewaySessionMock).toHaveBeenCalledWith(
+      "sessions.create",
+      expect.objectContaining({
+        key: result.childSessionKey,
+        parentSessionKey: "agent:main:main",
+        spawnDepth: 1,
+      }),
+      expect.objectContaining({
+        via: "spawn",
+        requesterSessionKey: "agent:main:main",
+        initialSpawnEntry: expect.objectContaining({
+          spawnedBy: "agent:main:main",
+          subagentControlScope: "none",
+        }),
+      }),
+    );
   });
 
   it("dispatches spawned agent runs in process when a gateway context is available", async () => {

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -55,7 +55,6 @@ import type {
   SpawnSubagentParams,
   SpawnSubagentResult,
 } from "./subagent-spawn-contract.js";
-import { setSubagentSpawnDepsForTest } from "./subagent-spawn-deps.js";
 import {
   buildSubagentExecutionSessionSpawnContext,
   withSubagentGatewayExecutionIdentity,
@@ -66,7 +65,7 @@ import { createSubagentSpawnLifecycleEmitter } from "./subagent-spawn-lifecycle.
 import { resolveSubagentSpawnRequest } from "./subagent-spawn-request.js";
 import {
   createInitialSubagentSession,
-  persistInitialChildSessionRuntimeModel,
+  rejectClosedFullAccessSpawn,
 } from "./subagent-spawn-session-patch.js";
 import {
   bindThreadForSubagentSpawn,
@@ -104,6 +103,7 @@ export async function spawnSubagentDirect(
   const sandboxMode = params.sandbox === "require" ? "require" : "inherit";
   const requesterSessionKey = ctx.agentSessionKey;
   const gatewayContextResolver = getGatewayToolCallerIdentity()?.gatewayContextResolver;
+  const assertFullAccessDelegation = () => params.fullAccessAdmission?.assertActive();
   let requestedAgentId = params.agentId?.trim();
   const requestResolution = resolveSubagentSpawnRequest(params, ctx, {
     initial: requestedAgentId,
@@ -143,7 +143,6 @@ export async function spawnSubagentDirect(
     },
     childIdem,
   } = requestResolution.resolved;
-  let modelApplied = false;
   let threadBindingReady = false;
   let hasBoundThreadDeliveryOrigin = false;
   let childRunId: string = childIdem;
@@ -159,6 +158,7 @@ export async function spawnSubagentDirect(
       sandboxMode,
       swarmEnabled: swarmConfig.enabled,
     });
+    assertFullAccessDelegation();
     if (!childPlan.ok) {
       return childPlan.result;
     }
@@ -195,6 +195,9 @@ export async function spawnSubagentDirect(
       swarmGroupId,
       collect: params.collect === true,
       outputSchema: params.outputSchema,
+      childDepth,
+      permissionMode: params.permissionMode,
+      fullAccessAdmission: params.fullAccessAdmission,
     });
     if (initialSession.status === "error") {
       return {
@@ -213,6 +216,17 @@ export async function spawnSubagentDirect(
         deleteTranscript: true,
         ...provisionalSessionIdentity,
       });
+    const checkFullAccessDelegation = (emitLifecycleHooks = false) =>
+      rejectClosedFullAccessSpawn({
+        admission: params.fullAccessAdmission,
+        childSessionKey,
+        cleanup: cleanupCreatedSession,
+        emitLifecycleHooks,
+      });
+    const initialDelegationFailure = await checkFullAccessDelegation();
+    if (initialDelegationFailure) {
+      return initialDelegationFailure;
+    }
     const preparedSpawnContext = await prepareSubagentSessionContext({
       cfg,
       contextMode,
@@ -221,6 +235,10 @@ export async function spawnSubagentDirect(
       requesterInternalKey,
       childSessionKey,
     });
+    const contextDelegationFailure = await checkFullAccessDelegation();
+    if (contextDelegationFailure) {
+      return contextDelegationFailure;
+    }
     if (preparedSpawnContext.status === "error") {
       await cleanupCreatedSession();
       return {
@@ -228,22 +246,6 @@ export async function spawnSubagentDirect(
         error: preparedSpawnContext.error,
         childSessionKey,
       };
-    }
-    if (resolvedModel) {
-      const runtimeModelPersistError = await persistInitialChildSessionRuntimeModel({
-        cfg,
-        childSessionKey,
-        resolvedModel,
-      });
-      if (runtimeModelPersistError) {
-        await cleanupCreatedSession();
-        return {
-          status: "error",
-          error: runtimeModelPersistError,
-          childSessionKey,
-        };
-      }
-      modelApplied = true;
     }
     if (requestThreadBinding) {
       const bindResult = await bindThreadForSubagentSpawn({
@@ -260,6 +262,10 @@ export async function spawnSubagentDirect(
           threadId: childSessionOrigin?.threadId,
         },
       });
+      const threadDelegationFailure = await checkFullAccessDelegation(true);
+      if (threadDelegationFailure) {
+        return threadDelegationFailure;
+      }
       if (bindResult.status === "error") {
         await cleanupCreatedSession();
         return {
@@ -314,6 +320,10 @@ export async function spawnSubagentDirect(
       attachments: params.attachments,
       mountPathHint,
     });
+    const attachmentDelegationFailure = await checkFullAccessDelegation(threadBindingReady);
+    if (attachmentDelegationFailure) {
+      return attachmentDelegationFailure;
+    }
     if (materializedAttachments && materializedAttachments.status !== "ok") {
       await cleanupCreatedSession(threadBindingReady);
       return {
@@ -374,32 +384,37 @@ export async function spawnSubagentDirect(
       agentId: targetAgentId,
     });
     const launchChildRun = async () =>
-      await callNativeSubagentGateway(
-        withSubagentGatewayExecutionIdentity(
-          {
-            method: "agent",
-            params: childLaunch.request,
-            timeoutMs: childLaunch.timeoutMs,
-          },
-          {
-            sessionSpawnContext: buildSubagentExecutionSessionSpawnContext({
-              enabled: isExecutionIdentityCollectionEnabled(cfg),
-              backend: "subagent",
-              parentAgentId: requesterAgentId,
-              requesterRef: requesterInternalKey,
-              controllerRef: ownership.controllerSessionKey,
-              depth: childDepth,
-              maxDepth: maxSpawnDepth,
-              targetAgentId,
-              sandbox: sandboxMode,
-              inheritedToolAllowlist: ctx.inheritedToolAllowlist,
-              inheritedToolDenylist: ctx.inheritedToolDenylist,
-            }),
-            parentExecutionIdentityToken: readParentExecutionIdentity(ctx),
-          },
-        ),
-        childLaunch.authorization,
-      );
+      await (async () => {
+        assertFullAccessDelegation();
+        const launched = await callNativeSubagentGateway(
+          withSubagentGatewayExecutionIdentity(
+            {
+              method: "agent",
+              params: childLaunch.request,
+              timeoutMs: childLaunch.timeoutMs,
+            },
+            {
+              sessionSpawnContext: buildSubagentExecutionSessionSpawnContext({
+                enabled: isExecutionIdentityCollectionEnabled(cfg),
+                backend: "subagent",
+                parentAgentId: requesterAgentId,
+                requesterRef: requesterInternalKey,
+                controllerRef: ownership.controllerSessionKey,
+                depth: childDepth,
+                maxDepth: maxSpawnDepth,
+                targetAgentId,
+                sandbox: sandboxMode,
+                inheritedToolAllowlist: ctx.inheritedToolAllowlist,
+                inheritedToolDenylist: ctx.inheritedToolDenylist,
+              }),
+              parentExecutionIdentityToken: readParentExecutionIdentity(ctx),
+            },
+          ),
+          childLaunch.authorization,
+        );
+        assertFullAccessDelegation();
+        return launched;
+      })();
 
     const emitSpawnLifecycleHooks = createSubagentSpawnLifecycleEmitter({
       hookRunner,
@@ -442,6 +457,7 @@ export async function spawnSubagentDirect(
         if (result.status === "error") {
           throw new Error(result.error);
         }
+        assertFullAccessDelegation();
         return { contextEnginePreparation: result.preparation };
       },
       async dispatchTurn() {
@@ -522,6 +538,7 @@ export async function spawnSubagentDirect(
       progressOrigin,
       progressSessionKey: requesterInternalKey,
       buildRegistration: (_state, runId) => {
+        assertFullAccessDelegation();
         if (params.collect) {
           const latestAdmission = resolveAdmission();
           if (!latestAdmission.ok) {
@@ -697,7 +714,7 @@ export async function spawnSubagentDirect(
         ? `${acceptedNote} ${preparedSpawnContext.forkFallbackNote}`
         : acceptedNote,
       ...resolvedModelMetadata,
-      modelApplied: resolvedModel ? modelApplied : undefined,
+      modelApplied: resolvedModel ? true : undefined,
       attachments: attachmentsReceipt,
     };
   } finally {
@@ -706,14 +723,4 @@ export async function spawnSubagentDirect(
       removeQueuedSwarmRun(childRunId);
     }
   }
-}
-
-const testing = {
-  setDepsForTest(overrides?: Parameters<typeof setSubagentSpawnDepsForTest>[0]) {
-    setSubagentSpawnDepsForTest(overrides);
-  },
-};
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.subagentSpawnTestApi")] =
-    testing;
 }

--- a/src/agents/tools/in-process-gateway.ts
+++ b/src/agents/tools/in-process-gateway.ts
@@ -153,6 +153,9 @@ export async function callInProcessGatewayToolWithCreation<T = Record<string, un
   }
   // The fallback is a real local Gateway request. Carry spawn policy only in
   // the signed agent-runtime identity token, never in model-authored params.
+  if (creation.fullAccessAdmission) {
+    throw new Error("native privileged session creation requires in-process Gateway dispatch");
+  }
   if (creation.via !== "spawn" || !creation.inheritedToolPolicy) {
     return await callGatewayTool<T>(method, {}, params, {
       scopes,
@@ -166,6 +169,7 @@ export async function callInProcessGatewayToolWithCreation<T = Record<string, un
         ? { completionOwnerSessionKey: creation.completionOwnerSessionKey }
         : {}),
       inheritedToolPolicy: creation.inheritedToolPolicy,
+      ...(creation.initialSpawnEntry ? { initialSpawnEntry: creation.initialSpawnEntry } : {}),
     },
     () =>
       callGatewayTool<T>(method, {}, params, {

--- a/src/agents/tools/sessions-spawn-full-access.ts
+++ b/src/agents/tools/sessions-spawn-full-access.ts
@@ -1,0 +1,82 @@
+import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getActiveAgentRunDelegatedAuthority } from "../../infra/agent-run-registry.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { getGatewayToolCallerIdentity } from "./gateway-caller-context.js";
+
+export type FullAccessDelegationAdmission = Readonly<{
+  parentSessionId: string;
+  parentLifecycleRevision?: string;
+  assertActive: () => void;
+}>;
+
+export function isFullAccessDelegationTurn(params: {
+  permissionMode?: string;
+  directUserTurnAuthority?: { assertActive: () => void };
+}): boolean {
+  if (params.permissionMode !== "full" || !params.directUserTurnAuthority) {
+    return false;
+  }
+  try {
+    params.directUserTurnAuthority.assertActive();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createFullAccessDelegationAdmission(params: {
+  cfg: OpenClawConfig;
+  parentSessionKey: string;
+  parentSessionId: string;
+  parentLifecycleRevision?: string;
+  signal?: AbortSignal;
+}): FullAccessDelegationAdmission | undefined {
+  const identity = getGatewayToolCallerIdentity();
+  const operationalRunInstance = identity?.operationalRunInstance;
+  const delegatedAuthority = operationalRunInstance
+    ? getActiveAgentRunDelegatedAuthority(operationalRunInstance)
+    : undefined;
+  if (
+    !identity ||
+    identity.sessionKey !== params.parentSessionKey ||
+    !operationalRunInstance ||
+    !delegatedAuthority
+  ) {
+    return undefined;
+  }
+  const assertActive = () => {
+    if (
+      params.signal?.aborted ||
+      getGatewayToolCallerIdentity() !== identity ||
+      getActiveAgentRunDelegatedAuthority(operationalRunInstance) !== delegatedAuthority ||
+      identity.receiptAuthority?.() === false
+    ) {
+      throw new Error("full-access delegation authority is no longer active");
+    }
+    const parentAgentId =
+      parseAgentSessionKey(params.parentSessionKey)?.agentId ?? identity.agentId;
+    const parentEntry = loadSessionEntryReadOnly({
+      agentId: parentAgentId,
+      sessionKey: params.parentSessionKey,
+      storePath: resolveSessionStorePathCore(params.cfg.session?.store, { agentId: parentAgentId }),
+    });
+    if (
+      parentEntry?.sessionId !== params.parentSessionId ||
+      parentEntry.lifecycleRevision !== params.parentLifecycleRevision ||
+      parentEntry.permissionMode !== "full" ||
+      parentEntry.archivedAt !== undefined
+    ) {
+      throw new Error("full-access parent session authority changed");
+    }
+  };
+  assertActive();
+  return Object.freeze({
+    parentSessionId: params.parentSessionId,
+    ...(params.parentLifecycleRevision
+      ? { parentLifecycleRevision: params.parentLifecycleRevision }
+      : {}),
+    assertActive,
+  });
+}

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -6,6 +6,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
+import {
+  claimAgentRunDelegatedAuthority,
+  releaseAgentRunDelegatedAuthority,
+} from "../../infra/agent-run-registry.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { createOperationalRunInstanceRef } from "../admitted-run-context.js";
 import { readParentExecutionIdentity } from "../subagents/spawn/execution-identity-spawn-context.js";
@@ -346,6 +350,91 @@ describe("sessions_spawn tool", () => {
     expect(schema.properties?.runTimeoutSeconds).toMatchObject({ type: "integer", minimum: 0 });
     expect(schema.properties?.runTimeoutSeconds?.description).toContain("configured subagent");
     expect(schema.properties?.timeoutSeconds).toBeUndefined();
+  });
+
+  it("exposes full delegation only for a prepared eligible turn", () => {
+    const ordinary = createSessionsSpawnTool();
+    const eligible = createSessionsSpawnTool({ fullAccessDelegationAvailable: true });
+    const ordinaryProperties = (ordinary.parameters as { properties?: Record<string, unknown> })
+      .properties;
+    const eligibleProperties = (eligible.parameters as { properties?: Record<string, unknown> })
+      .properties;
+
+    expect(ordinaryProperties?.permissionMode).toBeUndefined();
+    expect(eligibleProperties?.permissionMode).toMatchObject({ enum: ["full"] });
+  });
+
+  it("delegates full only from the exact live full-access parent run", async () => {
+    await withTestDir({ prefix: "openclaw-full-spawn-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const parentSessionKey = "agent:main:main";
+      const parentSessionId = "full-parent";
+      const lifecycleRevision = "full-parent-revision";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: parentSessionKey, storePath },
+        {
+          sessionId: parentSessionId,
+          lifecycleRevision,
+          permissionMode: "full",
+          updatedAt: 1,
+        },
+      );
+      const operationalRunInstance = createOperationalRunInstanceRef("full-parent-run");
+      const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: parentSessionKey,
+        expectedParentSessionId: parentSessionId,
+        expectedParentLifecycleRevision: lifecycleRevision,
+        fullAccessDelegationAvailable: true,
+        config: { session: { store: storePath }, agents: { list: [{ id: "main" }] } },
+      });
+
+      try {
+        await withGatewayToolCallerIdentity(
+          {
+            agentId: "main",
+            sessionKey: parentSessionKey,
+            operationalRunInstance,
+          },
+          () => tool.execute("full-child", { task: "work", permissionMode: "full" }),
+        );
+        expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            permissionMode: "full",
+            fullAccessAdmission: expect.objectContaining({
+              parentSessionId,
+              parentLifecycleRevision: lifecycleRevision,
+              assertActive: expect.any(Function),
+            }),
+          }),
+          expect.any(Object),
+        );
+
+        releaseAgentRunDelegatedAuthority(authority);
+        const admission = hoisted.spawnSubagentDirectMock.mock.calls[0]?.[0]
+          ?.fullAccessAdmission as { assertActive: () => void };
+        expect(() => admission.assertActive()).toThrow("no longer active");
+      } finally {
+        releaseAgentRunDelegatedAuthority(authority);
+      }
+    });
+  });
+
+  it("never accepts full delegation for ACP", async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({ fullAccessDelegationAvailable: true });
+    await expect(
+      tool.execute("full-acp", { task: "work", runtime: "acp", permissionMode: "full" }),
+    ).rejects.toThrow('supports runtime="subagent" only');
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("does not pass a permission mode when the field is omitted", async () => {
+    const tool = createSessionsSpawnTool({ fullAccessDelegationAvailable: true });
+    await tool.execute("ordinary-child", { task: "work" });
+    const spawn = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
+    expect(spawn.permissionMode).toBeUndefined();
+    expect(spawn.fullAccessAdmission).toBeUndefined();
   });
 
   it("hides and rejects swarm parameters while tools.swarm is disabled", async () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -55,6 +55,7 @@ import {
   resolveEffectiveSessionToolsVisibility,
   resolveSandboxedSessionToolContext,
 } from "./sessions-helpers.js";
+import { createFullAccessDelegationAdmission } from "./sessions-spawn-full-access.js";
 import {
   maybeSpawnVisibleSession,
   type VisibleSessionsSpawnDeps,
@@ -133,6 +134,7 @@ function createSessionsSpawnToolSchema(params: {
   acpAvailable: boolean;
   threadAvailable: boolean;
   swarmEnabled: boolean;
+  fullAccessDelegationAvailable: boolean;
 }) {
   const spawnModes = params.threadAvailable ? SUBAGENT_SPAWN_MODES : (["run"] as const);
   const schema = {
@@ -191,6 +193,14 @@ function createSessionsSpawnToolSchema(params: {
     sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES, {
       description: '"inherit" parent sandbox policy; "require" fails unless child is sandboxed.',
     }),
+    ...(params.fullAccessDelegationAvailable
+      ? {
+          permissionMode: optionalStringEnum(["full"] as const, {
+            description:
+              "Explicitly delegate the current full-access session to this native child. Omission never inherits full access.",
+          }),
+        }
+      : {}),
     context: optionalStringEnum(SUBAGENT_SPAWN_CONTEXT_MODES, {
       description:
         "Native: omit/isolated clean; fork only needing requester transcript; visible fork requires same agent.",
@@ -292,6 +302,8 @@ export function createSessionsSpawnTool(
     swarmCollector?: boolean;
     /** Backend-derived parent incarnation; never sourced from model arguments. */
     expectedParentSessionId?: string;
+    expectedParentLifecycleRevision?: string;
+    fullAccessDelegationAvailable?: boolean;
     signal?: AbortSignal;
   } & VisibleSessionsSpawnDeps &
     SpawnedToolContext,
@@ -333,6 +345,7 @@ export function createSessionsSpawnTool(
       acpAvailable,
       threadAvailable,
       swarmEnabled: swarmConfig.enabled,
+      fullAccessDelegationAvailable: opts?.fullAccessDelegationAvailable === true,
     }),
     execute: async (_toolCallId, args) => {
       const params = args as Record<PropertyKey, unknown>;
@@ -391,6 +404,20 @@ export function createSessionsSpawnTool(
       const taskName = taskNameResult.taskName;
       const label = readToolStringParam(params, "label") ?? "";
       const runtime = params.runtime === "acp" ? "acp" : "subagent";
+      const requestsFullAccess = params.permissionMode === "full";
+      if (Object.hasOwn(params, "permissionMode") && !requestsFullAccess) {
+        throw new ToolInputError('sessions_spawn permissionMode supports only "full".');
+      }
+      if (requestsFullAccess && runtime !== "subagent") {
+        throw new ToolInputError(
+          'sessions_spawn permissionMode="full" supports runtime="subagent" only.',
+        );
+      }
+      if (requestsFullAccess && opts?.fullAccessDelegationAvailable !== true) {
+        throw new ToolInputError(
+          'sessions_spawn permissionMode="full" is unavailable for this turn.',
+        );
+      }
       if (collect && runtime === "acp") {
         throw new ToolInputError('sessions_spawn collect=true supports runtime="subagent" only.');
       }
@@ -421,6 +448,22 @@ export function createSessionsSpawnTool(
       if (opts?.expectedParentSessionId && !expectedParentSessionKey) {
         throw new Error("Exact parent session access requires a session key");
       }
+      const fullAccessAdmission = requestsFullAccess
+        ? expectedParentSessionKey && opts?.expectedParentSessionId
+          ? createFullAccessDelegationAdmission({
+              cfg: visibilityCfg,
+              parentSessionKey: expectedParentSessionKey,
+              parentSessionId: opts.expectedParentSessionId,
+              parentLifecycleRevision: opts.expectedParentLifecycleRevision,
+              signal: opts.signal,
+            })
+          : undefined
+        : undefined;
+      if (requestsFullAccess && !fullAccessAdmission) {
+        throw new ToolInputError(
+          'sessions_spawn permissionMode="full" requires the exact active full-access parent turn.',
+        );
+      }
       const spawnVisible = async () =>
         await maybeSpawnVisibleSession({
           raw: params,
@@ -431,6 +474,8 @@ export function createSessionsSpawnTool(
           requestedAgentId,
           runTimeoutSeconds,
           sandbox,
+          permissionMode: requestsFullAccess ? "full" : undefined,
+          fullAccessAdmission,
           options: opts,
         });
       const visibleResult = opts?.expectedParentSessionId
@@ -586,6 +631,8 @@ export function createSessionsSpawnTool(
           context,
           lightContext,
           expectsCompletionMessage,
+          permissionMode: requestsFullAccess ? "full" : undefined,
+          fullAccessAdmission,
           attachments,
           attachMountPath:
             params.attachAs && typeof params.attachAs === "object"

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -36,6 +36,7 @@ import {
   callInProcessGatewayToolWithCreation,
   type InProcessGatewayCaller,
 } from "./in-process-gateway.js";
+import type { FullAccessDelegationAdmission } from "./sessions-spawn-full-access.js";
 
 export const VISIBLE_SESSIONS_SPAWN_SCHEMA = {
   visible: Type.Optional(
@@ -107,6 +108,8 @@ export async function maybeSpawnVisibleSession(params: {
   requestedAgentId?: string;
   runTimeoutSeconds?: number;
   sandbox: "inherit" | "require";
+  permissionMode?: "full";
+  fullAccessAdmission?: FullAccessDelegationAdmission;
   options?: VisibleSessionsSpawnOptions;
 }): Promise<Record<string, unknown> | undefined> {
   const worktree = params.raw.worktree === true;
@@ -311,6 +314,9 @@ export async function maybeSpawnVisibleSession(params: {
             allow: [...(params.options?.inheritedToolAllowlist ?? [])],
             deny: [...(params.options?.inheritedToolDenylist ?? [])],
           },
+          ...(params.fullAccessAdmission
+            ? { fullAccessAdmission: params.fullAccessAdmission }
+            : {}),
         }));
     let response: {
       key?: string;
@@ -319,6 +325,7 @@ export async function maybeSpawnVisibleSession(params: {
       runError?: unknown;
     };
     try {
+      params.fullAccessAdmission?.assertActive();
       response = await createGatewayCall("sessions.create", {
         agentId: targetAgentId,
         ...(params.label ? { label: params.label } : {}),
@@ -329,6 +336,7 @@ export async function maybeSpawnVisibleSession(params: {
         // Declared spawn lineage: without it the child persists as a depth-0 root
         // and could spawn past maxSpawnDepth.
         spawnDepth: callerDepth + 1,
+        ...(params.permissionMode ? { permissionMode: params.permissionMode } : {}),
         ...(params.raw.context === "fork" ? { fork: true } : {}),
         ...(spawnedCwd ? { cwd: spawnedCwd } : {}),
         ...(worktree ? { worktree: true } : {}),

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -95,6 +95,7 @@ export function buildEmbeddedRunBaseParams(params: {
     cwd: params.run.cwd,
     permissionMode: params.run.permissionMode,
     sessionRoot: params.run.sessionRoot,
+    sessionLifecycleRevision: params.run.sessionLifecycleRevision,
     agentDir: params.run.agentDir,
     config,
     toolOverrides: params.run.toolOverrides,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -429,6 +429,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
       cwd: normalizeOptionalString(state.sessionEntry?.spawnedCwd),
       permissionMode: preparedSessionState.sessionEntry?.permissionMode,
       sessionRoot: normalizeOptionalString(preparedSessionState.sessionEntry?.sessionRoot),
+      sessionLifecycleRevision: preparedSessionState.sessionEntry?.lifecycleRevision,
       config: cfg,
       toolOverrides: preparedSessionState.sessionEntry?.toolOverrides,
       skillsSnapshot,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -184,6 +184,7 @@ export type FollowupRun = {
     cwd?: string;
     permissionMode?: SessionEntry["permissionMode"];
     sessionRoot?: string;
+    sessionLifecycleRevision?: string;
     config: OpenClawConfig;
     toolOverrides?: SessionToolOverrides;
     skillsSnapshot?: SkillSnapshot;

--- a/src/gateway/agent-runtime-identity-token.ts
+++ b/src/gateway/agent-runtime-identity-token.ts
@@ -154,6 +154,31 @@ const sessionSpawnContextSchema = z
       allow: stringListSchema,
       deny: stringListSchema,
     }),
+    initialSpawnEntry: z
+      .object({
+        completionOwnerSessionKey: ignoredOptionalStringSchema,
+        fastMode: z.union([z.boolean(), z.literal("auto")]).optional(),
+        inheritedToolAllow: stringListSchema.optional(),
+        inheritedToolDeny: stringListSchema.optional(),
+        inheritedToolPolicyVersion: z.literal(1).optional(),
+        model: ignoredOptionalStringSchema,
+        modelOverride: ignoredOptionalStringSchema,
+        modelOverrideFallbackOriginModel: ignoredOptionalStringSchema,
+        modelOverrideFallbackOriginProvider: ignoredOptionalStringSchema,
+        modelOverrideRouteResolution: z.literal("resolved").optional(),
+        modelOverrideSource: z.enum(["user", "auto"]).optional(),
+        modelProvider: ignoredOptionalStringSchema,
+        providerOverride: ignoredOptionalStringSchema,
+        subagentControlScope: z.enum(["children", "none"]).optional(),
+        subagentRole: z.enum(["orchestrator", "leaf"]).optional(),
+        swarmCollector: z.literal(true).optional(),
+        swarmGroupId: ignoredOptionalStringSchema,
+        swarmOutputSchema: z.record(z.string(), z.unknown()).optional(),
+        thinkingLevel: ignoredOptionalStringSchema,
+        spawnedWorkspaceDir: ignoredOptionalStringSchema,
+        spawnedCwd: ignoredOptionalStringSchema,
+      })
+      .optional(),
   })
   .transform(
     (context): AgentRuntimeSessionSpawnContext => ({
@@ -161,6 +186,7 @@ const sessionSpawnContextSchema = z
         ? { completionOwnerSessionKey: context.completionOwnerSessionKey }
         : {}),
       inheritedToolPolicy: context.inheritedToolPolicy,
+      ...(context.initialSpawnEntry ? { initialSpawnEntry: context.initialSpawnEntry } : {}),
     }),
   );
 const cronCreatorAuthorityGrantSchema = z

--- a/src/gateway/agent-runtime-session-spawn-context.ts
+++ b/src/gateway/agent-runtime-session-spawn-context.ts
@@ -1,3 +1,5 @@
+import type { SessionEntry } from "../config/sessions.js";
+
 export type AgentRuntimeSessionSpawnContext = {
   completionOwnerSessionKey?: string;
   inheritedToolPolicy: {
@@ -5,4 +7,26 @@ export type AgentRuntimeSessionSpawnContext = {
     allow: string[];
     deny: string[];
   };
+  initialSpawnEntry?: Pick<
+    SessionEntry,
+    | "completionOwnerSessionKey"
+    | "fastMode"
+    | "inheritedToolAllow"
+    | "inheritedToolDeny"
+    | "inheritedToolPolicyVersion"
+    | "model"
+    | "modelOverride"
+    | "modelOverrideFallbackOriginModel"
+    | "modelOverrideFallbackOriginProvider"
+    | "modelOverrideRouteResolution"
+    | "modelOverrideSource"
+    | "modelProvider"
+    | "providerOverride"
+    | "subagentControlScope"
+    | "subagentRole"
+    | "swarmCollector"
+    | "swarmGroupId"
+    | "swarmOutputSchema"
+    | "thinkingLevel"
+  > & { spawnedWorkspaceDir?: string; spawnedCwd?: string };
 };

--- a/src/gateway/server-methods/session-creation-provenance.ts
+++ b/src/gateway/server-methods/session-creation-provenance.ts
@@ -1,8 +1,13 @@
+import type { SessionEntry } from "../../config/sessions.js";
 import type {
   SessionCreatedActor,
   SessionCreatedVia,
 } from "../../config/sessions/session-entry-provenance.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
+import { appendSessionAudit } from "./session-audit.js";
+import { sessionLog } from "./sessions-shared.js";
 
 export type TrustedSessionCreation = {
   via: SessionCreatedVia;
@@ -17,6 +22,35 @@ export type TrustedSessionCreation = {
     allow: string[];
     deny: string[];
   };
+  /** Closure-bound native-spawn grant; never serialized or model-authored. */
+  fullAccessAdmission?: Readonly<{
+    parentSessionId: string;
+    parentLifecycleRevision?: string;
+    assertActive: () => void;
+  }>;
+  /** Native child state committed by createGatewaySession, not public RPC input. */
+  initialSpawnEntry?: Pick<
+    SessionEntry,
+    | "completionOwnerSessionKey"
+    | "fastMode"
+    | "inheritedToolAllow"
+    | "inheritedToolDeny"
+    | "inheritedToolPolicyVersion"
+    | "model"
+    | "modelOverride"
+    | "modelOverrideFallbackOriginModel"
+    | "modelOverrideFallbackOriginProvider"
+    | "modelOverrideRouteResolution"
+    | "modelOverrideSource"
+    | "modelProvider"
+    | "providerOverride"
+    | "subagentControlScope"
+    | "subagentRole"
+    | "swarmCollector"
+    | "swarmGroupId"
+    | "swarmOutputSchema"
+    | "thinkingLevel"
+  > & { spawnedWorkspaceDir?: string; spawnedCwd?: string };
 };
 
 /**
@@ -52,6 +86,9 @@ export function resolveOperatorSessionCreation(
           }
         : {}),
       inheritedToolPolicy: agentRuntimeIdentity.sessionSpawnContext.inheritedToolPolicy,
+      ...(agentRuntimeIdentity.sessionSpawnContext.initialSpawnEntry
+        ? { initialSpawnEntry: agentRuntimeIdentity.sessionSpawnContext.initialSpawnEntry }
+        : {}),
     };
   }
   const profileId = client?.authenticatedUserProfile?.profileId;
@@ -68,4 +105,27 @@ export function resolveAgentRunSessionCreation(
 ): TrustedSessionCreation {
   const actor = resolveOperatorSessionCreation(client).actor;
   return { via: "run", ...(actor ? { actor } : {}) };
+}
+
+export async function appendFullAccessDelegationAudit(params: {
+  cfg: OpenClawConfig;
+  creation: TrustedSessionCreation;
+  target: { agentId: string; entry: SessionEntry; sessionKey: string; storePath: string };
+}): Promise<void> {
+  const admission = params.creation.fullAccessAdmission;
+  if (!admission) {
+    return;
+  }
+  admission.assertActive();
+  try {
+    await appendSessionAudit({
+      cfg: params.cfg,
+      target: params.target,
+      text: "Created with explicitly delegated full access from its parent session.",
+      now: Date.now(),
+    });
+  } catch (error) {
+    sessionLog.warn(`failed to append full-access delegation note: ${formatErrorMessage(error)}`);
+  }
+  admission.assertActive();
 }

--- a/src/gateway/server-methods/session-patch-continuation.ts
+++ b/src/gateway/server-methods/session-patch-continuation.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from "node:crypto";
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { formatSystemTurnPrompt } from "../../sessions/system-turn-prompt.js";
+import { handleTrustedInternalChatSend } from "./chat-send-handler.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const PATCH_CONTINUATION_TEXT =
+  "Continue the interrupted work under the session's updated execution policy.";
+
+export async function launchSessionPatchContinuation(params: {
+  agentId: string;
+  client: GatewayRequestHandlerOptions["client"];
+  context: GatewayRequestHandlerOptions["context"];
+  req: GatewayRequestHandlerOptions["req"];
+  sessionId: string;
+  sessionKey: string;
+  assertCurrent: () => void;
+}) {
+  let outcome:
+    | { status: "started"; runId: string }
+    | { status: "rejected"; error: ReturnType<typeof errorShape> }
+    | undefined;
+  try {
+    await handleTrustedInternalChatSend(
+      {
+        req: params.req,
+        params: {
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
+          sessionId: params.sessionId,
+          message: formatSystemTurnPrompt(PATCH_CONTINUATION_TEXT),
+          idempotencyKey: `sessions-patch-continuation:${params.sessionId}:${randomUUID()}`,
+          deliver: false,
+          suppressCommandInterpretation: true,
+          systemInputProvenance: {
+            kind: "internal_system",
+            sourceSessionKey: params.sessionKey,
+            sourceTool: "sessions.patch",
+          },
+        },
+        respond: (ok, payload, error) => {
+          const responseRunId =
+            typeof payload === "object" && payload !== null && "runId" in payload
+              ? payload.runId
+              : undefined;
+          const runId = ok && typeof responseRunId === "string" ? responseRunId.trim() : "";
+          outcome =
+            ok && runId
+              ? { status: "started", runId }
+              : {
+                  status: "rejected",
+                  error:
+                    error ?? errorShape(ErrorCodes.UNAVAILABLE, "Continuation was not started."),
+                };
+        },
+        context: params.context,
+        client: params.client,
+        isWebchatConnect: () => false,
+      },
+      async () => {
+        params.assertCurrent();
+        return true;
+      },
+    );
+  } catch (error) {
+    outcome = {
+      status: "rejected",
+      error: errorShape(
+        ErrorCodes.UNAVAILABLE,
+        error instanceof Error ? error.message : "Continuation launch failed.",
+      ),
+    };
+  }
+  return (
+    outcome ?? {
+      status: "rejected" as const,
+      error: errorShape(ErrorCodes.UNAVAILABLE, "Continuation returned no outcome."),
+    }
+  );
+}

--- a/src/gateway/server-methods/sessions-archive-lifecycle.ts
+++ b/src/gateway/server-methods/sessions-archive-lifecycle.ts
@@ -1,5 +1,5 @@
 import { resolveEmbeddedSessionLane } from "../../agents/embedded-agent-runner/lanes.js";
-// Archive-owned cancellation and authoritative lifecycle drains.
+// Session-owned cancellation and authoritative lifecycle drains.
 import {
   abortEmbeddedAgentRun,
   isEmbeddedAgentRunInProgress,
@@ -13,6 +13,7 @@ import {
   replyRunRegistry,
   waitForReplyRunEndBySessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { hasProjectedAgentRunForSession } from "../../infra/agent-run-registry.js";
 import { withTimeout } from "../../infra/fs-safe.js";
 import { getCommandLaneSnapshot } from "../../process/command-queue.js";
 import {
@@ -53,7 +54,7 @@ function asArchiveInferenceDrainService(value: unknown): ArchiveInferenceDrainSe
     : undefined;
 }
 
-type SessionArchiveLifecycleParams = {
+type SessionLifecycleDrainParams = {
   context: GatewayRequestContext;
   storePath: string;
   sessionKeys: string[];
@@ -64,13 +65,13 @@ type SessionArchiveLifecycleParams = {
   lifecycleIdentities: string[];
 };
 
-export type SessionArchiveLifecycleDrain = {
+export type SessionLifecycleDrain = {
   release(): void;
   hasAuthoritativeWork(): boolean;
 };
 
 function hasAuthoritativeSessionWork(
-  params: SessionArchiveLifecycleParams,
+  params: SessionLifecycleDrainParams,
   workerDrain: WorkerInferenceSessionDrain | undefined,
   terminalDrain: AgentTerminalSessionDrain | undefined,
   workIdentities: string[],
@@ -92,6 +93,12 @@ function hasAuthoritativeSessionWork(
       agentId: params.agentId,
       defaultAgentId: params.defaultAgentId,
     }) ||
+    hasProjectedAgentRunForSession({
+      sessionKeys: params.sessionKeys,
+      ...(sessionId ? { sessionId } : {}),
+      agentId: params.agentId,
+      defaultAgentId: params.defaultAgentId,
+    }) ||
     Boolean(
       sessionId &&
       params.context.workerSessionPlacementService?.getMany([sessionId]).get(sessionId)?.turnClaim,
@@ -102,11 +109,13 @@ function hasAuthoritativeSessionWork(
 }
 
 /** Fence is already active when this starts; retain the returned runtime fence through commit. */
-export async function prepareSessionArchiveLifecycle(
-  params: SessionArchiveLifecycleParams,
-): Promise<SessionArchiveLifecycleDrain> {
-  // Reject transient/live-failed placement before archive cancellation has side effects.
-  await prepareSessionWorkerPlacementForArchive({ ...params, reclaimActive: false });
+export async function prepareSessionLifecycleDrain(
+  params: SessionLifecycleDrainParams & { reclaimPlacement: boolean; stopReason: string },
+): Promise<SessionLifecycleDrain> {
+  if (params.reclaimPlacement) {
+    // Reject transient/live-failed placement before archive cancellation has side effects.
+    await prepareSessionWorkerPlacementForArchive({ ...params, reclaimActive: false });
+  }
   const timeoutMs = SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS;
   const workIdentities = Array.from(
     new Set([...params.sessionKeys, ...(params.sessionId ? [params.sessionId] : [])]),
@@ -142,7 +151,7 @@ export async function prepareSessionArchiveLifecycle(
       agentId: params.agentId,
       defaultAgentId: params.defaultAgentId,
       abortOrigin: "rpc",
-      stopReason: "archive",
+      stopReason: params.stopReason,
       requester: { isAdmin: true },
       includeProtectedRuns: true,
       onControllerTargets: (targets) => {
@@ -195,12 +204,12 @@ export async function prepareSessionArchiveLifecycle(
         : Promise.resolve(false)
       : Promise.resolve(true);
     const workerWork = workerDrain
-      ? withTimeout(workerDrain.drained, timeoutMs, "worker inference archive drain").then(
+      ? withTimeout(workerDrain.drained, timeoutMs, "worker inference session drain").then(
           () => true,
         )
       : Promise.resolve(true);
     const terminalWork = terminalDrain
-      ? withTimeout(terminalDrain.drained, timeoutMs, "agent terminal archive drain").then(
+      ? withTimeout(terminalDrain.drained, timeoutMs, "agent terminal session drain").then(
           () => true,
         )
       : Promise.resolve(true);
@@ -214,10 +223,32 @@ export async function prepareSessionArchiveLifecycle(
       terminalWork,
     ]);
     if (!drains.every(Boolean)) {
-      throw new Error("Session work did not fully drain before archive");
+      throw new Error("Session work did not fully drain before lifecycle mutation");
     }
-    // Fresh exact placement must be reclaimed before archivedAt can commit.
-    await prepareSessionWorkerPlacementForArchive({ ...params, reclaimActive: true });
+    if (
+      hasProjectedAgentRunForSession({
+        sessionKeys: params.sessionKeys,
+        ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+        agentId: params.agentId,
+        defaultAgentId: params.defaultAgentId,
+      }) &&
+      !hasGatewaySessionAbortOwner({
+        context: params.context,
+        sessionKeys: params.sessionKeys,
+        sessionId: params.sessionId,
+        agentId: params.agentId,
+        defaultAgentId: params.defaultAgentId,
+      }) &&
+      !params.sessionKeys.some((key) => replyRunRegistry.isActive(key)) &&
+      !(params.sessionId && isReplyRunActiveForSessionId(params.sessionId)) &&
+      !(params.sessionId && isEmbeddedAgentRunInProgress(params.sessionId))
+    ) {
+      throw new Error("Session has a live run without a cancellable owner");
+    }
+    if (params.reclaimPlacement) {
+      // Fresh exact placement must be reclaimed before archivedAt can commit.
+      await prepareSessionWorkerPlacementForArchive({ ...params, reclaimActive: true });
+    }
     return {
       release: () => {
         terminalDrain?.release();
@@ -231,4 +262,14 @@ export async function prepareSessionArchiveLifecycle(
     workerDrain?.release();
     throw error;
   }
+}
+
+export async function prepareSessionArchiveLifecycle(
+  params: SessionLifecycleDrainParams,
+): Promise<SessionLifecycleDrain> {
+  return await prepareSessionLifecycleDrain({
+    ...params,
+    reclaimPlacement: true,
+    stopReason: "archive",
+  });
 }

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -48,7 +48,10 @@ import {
   shouldAttachPendingMessageSeq,
 } from "./session-create-initial-turn.js";
 import { prepareSessionCreateFilesystemRoot } from "./session-create-root.js";
-import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
+import {
+  appendFullAccessDelegationAudit,
+  resolveOperatorSessionCreation,
+} from "./session-creation-provenance.js";
 import { sessionLog } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -498,6 +501,18 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    if (
+      p.permissionMode === "full" &&
+      sessionCreation.via === "spawn" &&
+      !sessionCreation.fullAccessAdmission
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "full-access delegation admission is required"),
+      );
+      return;
+    }
     const allowExistingModelSelection = authorizeOperatorScopesForRequiredScope(
       ADMIN_SCOPE,
       clientScopes,
@@ -534,6 +549,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       spawnedCwd: p.worktree === true ? undefined : sessionCwd,
       sessionRoot: p.worktree === true ? undefined : sessionRoot,
       permissionMode: p.permissionMode ?? (p.worktree === true ? "workspace" : undefined),
+      initialSpawnEntry: sessionCreation.initialSpawnEntry,
       prepareLifecycle,
       onLifecycleCleanupError: (error) => {
         sessionLog.warn(
@@ -556,15 +572,28 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       armSessionDiffBaselineCapture: true,
       loadGatewayModelCatalog: () =>
         context.loadGatewayModelCatalog({ agentId: modelCatalogAgentId }),
-      ...(commitGuard ? { commitGuard } : {}),
+      ...(commitGuard || sessionCreation.fullAccessAdmission
+        ? {
+            commitGuard: () => {
+              commitGuard?.();
+              sessionCreation.fullAccessAdmission?.assertActive();
+            },
+          }
+        : {}),
       afterCreate: async ({ key, agentId, entry, storePath }) => {
         if (!authority.hasActive()) {
           return;
         }
+        await appendFullAccessDelegationAudit({
+          cfg,
+          creation: sessionCreation,
+          target: { agentId, entry, sessionKey: key, storePath },
+        });
         if (await worktreeTitle?.persist(agentId, entry, key, storePath)) {
           emitSessionsChanged(context, { sessionKey: key, agentId, reason: "chat.title" });
         }
         if (hasInitialTurn) {
+          sessionCreation.fullAccessAdmission?.assertActive();
           if (!authority.hasActive()) {
             return;
           }

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -27,7 +27,7 @@ import { projectAssignableSessionOwner, projectSessionActor } from "../session-u
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
-import { executeSessionPatch, executeSessionPatchMany } from "./sessions-patch-engine.js";
+import { executeSessionPatch, executeSessionPatchMany } from "./sessions-patch-execute.js";
 import { loadSessionsRuntimeModule, requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -71,7 +71,14 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     }
     respond(true, { outcomes: executed.outcomes }, undefined);
   },
-  "sessions.patch": async ({ params, respond, context, client, sessionMutationAuthorization }) => {
+  "sessions.patch": async ({
+    req,
+    params,
+    respond,
+    context,
+    client,
+    sessionMutationAuthorization,
+  }) => {
     if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {
       return;
     }
@@ -92,6 +99,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       client,
       context,
       patch: { ...params, key },
+      req,
       sessionMutationAuthorization,
     });
     if (!executed.ok) {

--- a/src/gateway/server-methods/sessions-patch-active-run.ts
+++ b/src/gateway/server-methods/sessions-patch-active-run.ts
@@ -1,0 +1,235 @@
+import {
+  ErrorCodes,
+  errorShape,
+  type ErrorShape,
+  type SessionCreatedActor,
+  type SessionsPatchActiveRunOutcome,
+  type SessionsPatchParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { resolveEmbeddedSessionLane } from "../../agents/embedded-agent-runner/lanes.js";
+import { isEmbeddedAgentRunInProgress } from "../../agents/embedded-agent-runner/runs.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import { hasPendingFollowupQueueWork } from "../../auto-reply/reply/queue/state.js";
+import {
+  isReplyRunActiveForSessionId,
+  replyRunRegistry,
+} from "../../auto-reply/reply/reply-run-registry.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { hasProjectedAgentRunForSession } from "../../infra/agent-run-registry.js";
+import { getCommandLaneSnapshot } from "../../process/command-queue.js";
+import { isCompetingSessionWorkAdmissionActive } from "../../sessions/session-lifecycle-admission.js";
+import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
+import { isExecutionAuthorityPatch } from "../sessions-patch-authority.js";
+import { projectSessionsPatchEntry } from "../sessions-patch.js";
+import { asWorkerInferenceControl } from "../worker-environments/inference-control.js";
+import { hasGatewaySessionAbortOwner } from "./chat-abort-runtime.js";
+import {
+  prepareSessionLifecycleDrain,
+  type SessionLifecycleDrain,
+} from "./sessions-archive-lifecycle.js";
+import { resolveSessionWorkerPlacementPatchError } from "./sessions-shared.js";
+import type { GatewayRequestContext } from "./types.js";
+
+export type SessionPatchActiveRunPreparation = {
+  drain: SessionLifecycleDrain;
+  stopped: boolean;
+};
+
+function activeRunError(key: string): ErrorShape {
+  return errorShape(
+    ErrorCodes.INVALID_REQUEST,
+    `Session ${key} has active work. Retry with activeRunPolicy "stop" or "stop-and-continue".`,
+    { details: { reason: "session-active" } },
+  );
+}
+
+function missingAuthorityIdentityError(key: string): ErrorShape {
+  return errorShape(
+    ErrorCodes.INVALID_REQUEST,
+    `expectedSessionId and expectedLifecycleRevision are required for execution-authority patch: ${key}`,
+  );
+}
+
+export async function validateSessionPatchAuthorityProjection(params: {
+  archivedBy?: SessionCreatedActor;
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  currentEntry: SessionEntry;
+  freshStore: Record<string, SessionEntry>;
+  freshStoreKeys: string[];
+  fullPatch: SessionsPatchParams;
+  loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
+  primaryKey: string;
+  requestedAgentId?: string;
+  targetAgentId: string;
+}): Promise<ErrorShape | undefined> {
+  const candidateKeys = new Set(params.freshStoreKeys);
+  const preview = await projectSessionsPatchEntry({
+    cfg: params.cfg,
+    existingEntry: params.currentEntry,
+    isLabelInUse: (label) =>
+      Object.entries(params.freshStore).some(
+        ([sessionKey, entry]) => !candidateKeys.has(sessionKey) && entry.label === label,
+      ),
+    storeKey: params.primaryKey,
+    agentId: params.requestedAgentId,
+    patch: params.fullPatch,
+    archivedBy: params.archivedBy,
+    loadGatewayModelCatalog: params.loadGatewayModelCatalog,
+  });
+  if (!preview.ok) {
+    return preview.error;
+  }
+  const placementError = resolveSessionWorkerPlacementPatchError({
+    agentId: params.targetAgentId,
+    cfg: params.cfg,
+    context: params.context,
+    entry: preview.entry,
+    key: params.fullPatch.key,
+    patch: params.fullPatch,
+    sessionKey: params.primaryKey,
+    validateModelRuntime: true,
+  });
+  return placementError ? errorShape(ErrorCodes.INVALID_REQUEST, placementError) : undefined;
+}
+
+function hasActiveSessionWork(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  entry: SessionEntry;
+  lifecycleIdentities: string[];
+  sessionKeys: string[];
+  storePath: string;
+  agentId: string;
+}): boolean {
+  const workIdentities = [...params.sessionKeys, params.entry.sessionId];
+  return (
+    isCompetingSessionWorkAdmissionActive(params.storePath, params.lifecycleIdentities) ||
+    params.sessionKeys.some((key) => replyRunRegistry.isActive(key)) ||
+    isReplyRunActiveForSessionId(params.entry.sessionId) ||
+    isEmbeddedAgentRunInProgress(params.entry.sessionId) ||
+    hasPendingFollowupQueueWork(workIdentities) ||
+    workIdentities.some(
+      (key) => getCommandLaneSnapshot(resolveEmbeddedSessionLane(key)).queuedCount > 0,
+    ) ||
+    hasGatewaySessionAbortOwner({
+      context: params.context,
+      sessionKeys: params.sessionKeys,
+      sessionId: params.entry.sessionId,
+      agentId: params.agentId,
+      defaultAgentId: tryResolveSessionCompatibilityOwnerAgentId(
+        params.cfg,
+        params.sessionKeys[0]!,
+      ),
+    }) ||
+    hasProjectedAgentRunForSession({
+      sessionKeys: params.sessionKeys,
+      sessionId: params.entry.sessionId,
+      agentId: params.agentId,
+      defaultAgentId: tryResolveSessionCompatibilityOwnerAgentId(
+        params.cfg,
+        params.sessionKeys[0]!,
+      ),
+    }) ||
+    Boolean(
+      params.context.workerSessionPlacementService
+        ?.getMany([params.entry.sessionId])
+        .get(params.entry.sessionId)?.turnClaim,
+    ) ||
+    (asWorkerInferenceControl(params.context.workerEnvironmentService)?.hasInferenceForSession(
+      params.entry.sessionId,
+    ) ??
+      false) ||
+    (params.context.terminalSessions?.hasAgentSessionWork({
+      kind: "agent",
+      agentSessionKey: params.sessionKeys[0]!,
+      agentSessionId: params.entry.sessionId,
+      agentId: params.agentId,
+    }) ??
+      false)
+  );
+}
+
+export async function prepareSessionPatchActiveRun(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  entry: SessionEntry;
+  fullPatch: SessionsPatchParams;
+  lifecycleIdentities: string[];
+  sessionKeys: string[];
+  storePath: string;
+  agentId: string;
+}): Promise<
+  { ok: true; value?: SessionPatchActiveRunPreparation } | { ok: false; error: ErrorShape }
+> {
+  if (!isExecutionAuthorityPatch(params.fullPatch)) {
+    return { ok: true };
+  }
+  const policy = params.fullPatch.activeRunPolicy ?? "reject";
+  if (
+    policy === "stop-and-continue" &&
+    (params.fullPatch.expectedSessionId === undefined ||
+      params.fullPatch.expectedLifecycleRevision === undefined)
+  ) {
+    return { ok: false, error: missingAuthorityIdentityError(params.fullPatch.key) };
+  }
+  const active = hasActiveSessionWork(params);
+  if (!active) {
+    return { ok: true };
+  }
+  if (policy === "reject") {
+    return { ok: false, error: activeRunError(params.fullPatch.key) };
+  }
+  if (
+    params.fullPatch.expectedSessionId === undefined ||
+    params.fullPatch.expectedLifecycleRevision === undefined
+  ) {
+    return { ok: false, error: missingAuthorityIdentityError(params.fullPatch.key) };
+  }
+  try {
+    const drain = await prepareSessionLifecycleDrain({
+      context: params.context,
+      storePath: params.storePath,
+      sessionKeys: params.sessionKeys,
+      sessionId: params.entry.sessionId,
+      sessionKey: params.sessionKeys[0]!,
+      agentId: params.agentId,
+      defaultAgentId: tryResolveSessionCompatibilityOwnerAgentId(
+        params.cfg,
+        params.sessionKeys[0]!,
+      ),
+      lifecycleIdentities: params.lifecycleIdentities,
+      reclaimPlacement: false,
+      stopReason: "session-policy-change",
+    });
+    return { ok: true, value: { drain, stopped: true } };
+  } catch {
+    return {
+      ok: false,
+      error: errorShape(
+        ErrorCodes.UNAVAILABLE,
+        `Session ${params.fullPatch.key} did not finish stopping. Retry the patch.`,
+        { retryable: true },
+      ),
+    };
+  }
+}
+
+export function activeRunPatchResult(params: {
+  auditNote: "appended" | "failed";
+  fullPatch: SessionsPatchParams;
+  stopped: boolean;
+  continuation?: SessionsPatchActiveRunOutcome["continuation"];
+}): SessionsPatchActiveRunOutcome | undefined {
+  if (!isExecutionAuthorityPatch(params.fullPatch)) {
+    return undefined;
+  }
+  const requestedPolicy = params.fullPatch.activeRunPolicy ?? "reject";
+  return {
+    policy: requestedPolicy === "stop-and-continue" && !params.stopped ? "reject" : requestedPolicy,
+    stopped: params.stopped,
+    auditNote: params.auditNote,
+    ...(params.continuation ? { continuation: params.continuation } : {}),
+  };
+}

--- a/src/gateway/server-methods/sessions-patch-archive.ts
+++ b/src/gateway/server-methods/sessions-patch-archive.ts
@@ -21,7 +21,7 @@ import {
 import { projectSessionsPatchEntry } from "../sessions-patch.js";
 import {
   prepareSessionArchiveLifecycle,
-  type SessionArchiveLifecycleDrain,
+  type SessionLifecycleDrain,
 } from "./sessions-archive-lifecycle.js";
 import {
   isAgentMainSessionKey,
@@ -32,7 +32,7 @@ import type { GatewayRequestContext } from "./types.js";
 
 export type SessionPatchArchivePreparation = {
   canonicalKey: string;
-  drain: SessionArchiveLifecycleDrain;
+  drain: SessionLifecycleDrain;
   entry?: SessionEntry;
 };
 

--- a/src/gateway/server-methods/sessions-patch-effects.ts
+++ b/src/gateway/server-methods/sessions-patch-effects.ts
@@ -1,0 +1,133 @@
+import type { SessionsPatchParams } from "../../../packages/gateway-protocol/src/index.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { disableCronJobsBoundToSessions } from "../../cron/job-session-bindings.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { ensureSessionGroupRegistered } from "../session-groups.js";
+import { triggerSessionPatchHook } from "../session-patch-hooks.js";
+import { appendSessionAudit } from "./session-audit.js";
+import { emitSessionsChanged } from "./session-change-event.js";
+import { persistSessionPatchModelSelection } from "./sessions-patch-model-selection.js";
+import { sessionLog } from "./sessions-shared.js";
+import type { GatewayRequestContext } from "./types.js";
+
+export async function appendSessionPatchAudits(params: {
+  cfg: OpenClawConfig;
+  manageActiveRunPolicy: boolean;
+  targets: Array<{
+    activeRunPreparation?: { stopped: boolean };
+    canonicalKey: string;
+    executionAuthorityFields: string[];
+    executionAuthorityPatch: boolean;
+    fullPatch: SessionsPatchParams;
+    outcome?: { ok: boolean; entry?: SessionEntry };
+    setActiveRunAuditNote: (value: "appended" | "failed") => void;
+    storePath: string;
+    targetAgentId: string;
+  }>;
+}): Promise<void> {
+  for (const target of params.targets) {
+    const outcome = target.outcome;
+    if (!outcome?.ok || !outcome.entry) {
+      continue;
+    }
+    if (!params.manageActiveRunPolicy || !target.executionAuthorityPatch) {
+      continue;
+    }
+    const visibleFields = target.executionAuthorityFields.join(",");
+    try {
+      await appendSessionAudit({
+        cfg: params.cfg,
+        target: {
+          agentId: target.targetAgentId,
+          entry: outcome.entry,
+          sessionKey: target.canonicalKey,
+          storePath: target.storePath,
+        },
+        text: target.activeRunPreparation?.stopped
+          ? `execution policy updated (${visibleFields}) after active work was stopped`
+          : `execution policy updated (${visibleFields}) while the session was idle`,
+        now: Date.now(),
+      });
+      target.setActiveRunAuditNote("appended");
+    } catch (error) {
+      target.setActiveRunAuditNote("failed");
+      sessionLog.warn(
+        `sessions.patch: execution-policy audit note failed for ${target.canonicalKey}; patch kept: ${formatErrorMessage(error)}`,
+      );
+    }
+  }
+}
+
+export async function applySessionPatchEffects(params: {
+  callerCanManageCron: boolean;
+  callerScopes: string[];
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  targets: Array<{
+    canonicalKey: string;
+    fullPatch: SessionsPatchParams;
+    outcome?: { ok: boolean; entry?: SessionEntry };
+    requestedAgentId?: string;
+    targetAgentId: string;
+  }>;
+}): Promise<void> {
+  let patched = false;
+  const archivedSessionKeys = new Set<string>();
+  for (const target of params.targets) {
+    if (!target.outcome?.ok || !target.outcome.entry) {
+      continue;
+    }
+    triggerSessionPatchHook({
+      cfg: params.cfg,
+      sessionEntry: target.outcome.entry,
+      sessionKey: target.canonicalKey,
+      patch: target.fullPatch,
+    });
+    persistSessionPatchModelSelection({
+      cfg: params.cfg,
+      callerScopes: params.callerScopes,
+      entry: target.outcome.entry,
+      patch: target.fullPatch,
+      sessionKey: target.canonicalKey,
+      targetAgentId: target.targetAgentId,
+    });
+    emitSessionsChanged(params.context, {
+      sessionKey: target.canonicalKey,
+      ...(target.requestedAgentId ? { agentId: target.requestedAgentId } : {}),
+      reason: "patch",
+    });
+    patched = true;
+    if (target.fullPatch.archived === true) {
+      archivedSessionKeys.add(target.canonicalKey);
+    }
+  }
+
+  const category = params.targets[0]?.fullPatch.category;
+  if (patched && typeof category === "string" && category.trim()) {
+    if (ensureSessionGroupRegistered(category)) {
+      emitSessionsChanged(params.context, { reason: "groups" });
+    }
+  }
+  if (!params.callerCanManageCron || archivedSessionKeys.size === 0) {
+    return;
+  }
+  try {
+    const disabledBySession = await disableCronJobsBoundToSessions({
+      cron: params.context.cron,
+      cfg: params.cfg,
+      sessionKeys: [...archivedSessionKeys],
+    });
+    for (const [sessionKey, disabledJobIds] of disabledBySession) {
+      if (disabledJobIds.length > 0) {
+        sessionLog.info(
+          `sessions.patch: disabled cron jobs bound to archived session ${sessionKey}: ${disabledJobIds.join(", ")}`,
+        );
+      }
+    }
+  } catch (error) {
+    sessionLog.warn(
+      `sessions.patch: failed to disable cron jobs for archived sessions: ${formatErrorMessage(error)}`,
+    );
+  }
+}

--- a/src/gateway/server-methods/sessions-patch-engine.ts
+++ b/src/gateway/server-methods/sessions-patch-engine.ts
@@ -2,7 +2,6 @@ import {
   ErrorCodes,
   errorShape,
   type ErrorShape,
-  type SessionsPatchManyResult,
   type SessionsPatchManyTarget,
   type SessionsPatchParams,
 } from "../../../packages/gateway-protocol/src/index.js";
@@ -14,40 +13,40 @@ import {
   type SessionEntryCanonicalReplacement,
 } from "../../config/sessions/session-accessor.sqlite-replacement-projection.js";
 import { SessionLabelOwnerIndex } from "../../config/sessions/session-entry-selection.js";
-import { disableCronJobsBoundToSessions } from "../../cron/job-session-bindings.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveMissingAgentHarnessSessionError } from "../../sessions/agent-harness-session-key.js";
 import { runExclusiveSessionLifecycleMutation } from "../../sessions/session-lifecycle-admission.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
-import { ensureSessionGroupRegistered } from "../session-groups.js";
-import { triggerSessionPatchHook } from "../session-patch-hooks.js";
 import { resolvePluginSessionOwnershipError } from "../session-plugin-ownership.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
-import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
-import { projectSessionPatchResult } from "../session-utils-model.js";
 import {
   resolveCanonicalGatewaySessionStoreKey,
   resolveCanonicalSessionEntryFromStoreKeys,
   resolveGatewaySessionStoreTargetWithStore,
-  type SessionsPatchResult,
 } from "../session-utils.js";
+import {
+  executionAuthorityPatchFields,
+  isExecutionAuthorityPatch,
+  resolveExecutionAuthorityChange,
+  rotateExecutionAuthorityRevision,
+} from "../sessions-patch-authority.js";
 import { projectSessionsPatchEntry } from "../sessions-patch.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
-import { emitSessionsChanged } from "./session-change-event.js";
+import {
+  prepareSessionPatchActiveRun,
+  validateSessionPatchAuthorityProjection,
+  type SessionPatchActiveRunPreparation,
+} from "./sessions-patch-active-run.js";
 import {
   prepareSessionPatchArchive,
   type SessionPatchArchivePreparation,
   validateSessionPatchArchiveProjection,
 } from "./sessions-patch-archive.js";
-import { persistSessionPatchModelSelection } from "./sessions-patch-model-selection.js";
+import { appendSessionPatchAudits, applySessionPatchEffects } from "./sessions-patch-effects.js";
 import { resolveSessionWorkerPlacementPatchError, sessionLog } from "./sessions-shared.js";
-import type {
-  GatewayClient,
-  GatewayRequestContext,
-  SessionMutationAuthorization,
-} from "./types.js";
+import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
-type PatchTargetIdentity = Pick<
+export type PatchTargetIdentity = Pick<
   SessionsPatchManyTarget,
   "agentId" | "expectedLifecycleRevision" | "expectedSessionId" | "key"
 >;
@@ -57,6 +56,8 @@ type MutationTarget = PatchTargetIdentity & {
 };
 
 type PreparedPatchTarget = {
+  activeRunPreparation?: SessionPatchActiveRunPreparation;
+  activeRunAuditNote?: "appended" | "failed";
   archiveActor: ReturnType<typeof gatewayClientSessionCreator>;
   archivePreparation?: SessionPatchArchivePreparation;
   canonicalKey: string;
@@ -115,23 +116,11 @@ function pluginOwnershipError(params: {
   });
 }
 
-function createCommitGuard(key: string, assertCurrent: (() => void) | undefined) {
-  return (): ErrorShape | undefined => {
-    try {
-      assertCurrent?.();
-      return undefined;
-    } catch (error) {
-      return error instanceof SessionMutationAuthorizationChangedError
-        ? error.error
-        : unexpectedPatchError(key, error);
-    }
-  };
-}
-
-async function executeSessionPatchMutations(params: {
+export async function executeSessionPatchMutations(params: {
   client: GatewayClient | null;
   context: GatewayRequestContext;
   patch: Omit<SessionsPatchParams, keyof PatchTargetIdentity>;
+  manageActiveRunPolicy: boolean;
   targets: readonly MutationTarget[];
 }): Promise<MutationCoreResult> {
   const cfg = params.context.getRuntimeConfig();
@@ -288,21 +277,110 @@ async function executeSessionPatchMutations(params: {
         prepare: async () => {
           await Promise.all(
             prepared
-              .filter((target) => target.fullPatch.archived === true)
+              .filter(
+                (target) =>
+                  target.fullPatch.archived === true ||
+                  (params.manageActiveRunPolicy && isExecutionAuthorityPatch(target.fullPatch)),
+              )
               .map(async (target) => {
                 try {
-                  const result = await prepareSessionPatchArchive({
+                  if (target.fullPatch.archived === true) {
+                    const result = await prepareSessionPatchArchive({
+                      cfg,
+                      commitGuard: params.targets[target.index]!.commitGuard,
+                      context: params.context,
+                      loadGatewayModelCatalog: () => loadModelCatalog(target.targetAgentId),
+                      ...(pluginOwnerId ? { pluginOwnerId } : {}),
+                      target,
+                    });
+                    if (result.ok) {
+                      target.archivePreparation = result.value;
+                    } else {
+                      outcomes[target.index] = result;
+                    }
+                    return;
+                  }
+                  if (!target.initialEntry) {
+                    outcomes[target.index] = {
+                      ok: false,
+                      error: sessionChangedError(target.key),
+                    };
+                    return;
+                  }
+                  const freshResolved = resolveGatewaySessionStoreTargetWithStore({
                     cfg,
-                    commitGuard: params.targets[target.index]!.commitGuard,
-                    context: params.context,
-                    loadGatewayModelCatalog: () => loadModelCatalog(target.targetAgentId),
-                    ...(pluginOwnerId ? { pluginOwnerId } : {}),
-                    target,
+                    key: target.key,
+                    ...(target.requestedAgentId ? { agentId: target.requestedAgentId } : {}),
+                    exactRead: true,
                   });
-                  if (result.ok) {
-                    target.archivePreparation = result.value;
-                  } else {
-                    outcomes[target.index] = result;
+                  const fresh = resolveCanonicalGatewaySessionStoreKey({
+                    cfg,
+                    key: target.key,
+                    store: freshResolved.store,
+                    ...(target.requestedAgentId ? { agentId: target.requestedAgentId } : {}),
+                  });
+                  const currentEntry = fresh.entry;
+                  const authorizationFailure = params.targets[target.index]!.commitGuard();
+                  const ownershipError = pluginOwnershipError({
+                    client: params.client,
+                    entry: currentEntry,
+                    key: fresh.primaryKey,
+                  });
+                  if (
+                    authorizationFailure ||
+                    ownershipError ||
+                    freshResolved.storePath !== target.storePath ||
+                    fresh.primaryKey !== target.canonicalKey ||
+                    (target.fullPatch.expectedSessionId !== undefined &&
+                      currentEntry?.sessionId !== target.fullPatch.expectedSessionId) ||
+                    (target.fullPatch.expectedLifecycleRevision !== undefined &&
+                      currentEntry?.lifecycleRevision !==
+                        target.fullPatch.expectedLifecycleRevision) ||
+                    currentEntry?.sessionId !== target.initialEntry.sessionId ||
+                    currentEntry?.lifecycleRevision !== target.initialEntry.lifecycleRevision
+                  ) {
+                    outcomes[target.index] = {
+                      ok: false,
+                      error:
+                        authorizationFailure ?? ownershipError ?? sessionChangedError(target.key),
+                    };
+                    return;
+                  }
+                  const projectionError = await validateSessionPatchAuthorityProjection({
+                    cfg,
+                    context: params.context,
+                    currentEntry,
+                    freshStore: freshResolved.store,
+                    freshStoreKeys: fresh.target.storeKeys,
+                    fullPatch: target.fullPatch,
+                    primaryKey: fresh.primaryKey,
+                    requestedAgentId: target.requestedAgentId,
+                    targetAgentId: target.targetAgentId,
+                    archivedBy: archiveActor,
+                    loadGatewayModelCatalog: () => loadModelCatalog(target.targetAgentId),
+                  });
+                  if (projectionError) {
+                    outcomes[target.index] = { ok: false, error: projectionError };
+                    return;
+                  }
+                  const activeRun = await prepareSessionPatchActiveRun({
+                    cfg,
+                    context: params.context,
+                    entry: currentEntry,
+                    fullPatch: target.fullPatch,
+                    lifecycleIdentities: target.lifecycleIdentities.filter(
+                      (identity): identity is string => Boolean(identity),
+                    ),
+                    sessionKeys: Array.from(
+                      new Set([target.canonicalKey, target.key, ...target.initialStoreKeys]),
+                    ),
+                    storePath: target.storePath,
+                    agentId: target.targetAgentId,
+                  });
+                  if (!activeRun.ok) {
+                    outcomes[target.index] = activeRun;
+                  } else if (activeRun.value) {
+                    target.activeRunPreparation = activeRun.value;
                   }
                 } catch (error) {
                   outcomes[target.index] = {
@@ -317,6 +395,13 @@ async function executeSessionPatchMutations(params: {
           const groups = new Map<string, PreparedPatchTarget[]>();
           for (const target of prepared) {
             if (target.fullPatch.archived === true && !target.archivePreparation) {
+              continue;
+            }
+            if (
+              params.manageActiveRunPolicy &&
+              isExecutionAuthorityPatch(target.fullPatch) &&
+              outcomes[target.index]
+            ) {
               continue;
             }
             const groupKey = `${target.storePath}\0${target.targetAgentId}`;
@@ -438,6 +523,35 @@ async function executeSessionPatchMutations(params: {
                           projectedOutcomes.push(projected);
                           continue;
                         }
+                        if (
+                          target.activeRunPreparation?.stopped &&
+                          existingEntry &&
+                          !resolveExecutionAuthorityChange(
+                            existingEntry,
+                            projected.entry,
+                            target.fullPatch,
+                          )
+                        ) {
+                          projectedOutcomes.push({
+                            ok: false,
+                            error: errorShape(
+                              ErrorCodes.INVALID_REQUEST,
+                              `Session ${target.key} execution policy is unchanged.`,
+                            ),
+                          });
+                          continue;
+                        }
+                        if (target.activeRunPreparation?.drain.hasAuthoritativeWork()) {
+                          projectedOutcomes.push({
+                            ok: false,
+                            error: errorShape(
+                              ErrorCodes.UNAVAILABLE,
+                              `Session ${target.key} is still active; retry the patch.`,
+                              { retryable: true },
+                            ),
+                          });
+                          continue;
+                        }
                         const placementPatchError = resolveSessionWorkerPlacementPatchError({
                           agentId: target.targetAgentId,
                           cfg,
@@ -463,15 +577,22 @@ async function executeSessionPatchMutations(params: {
                         const previousSessionKeys = candidateKeys.filter(
                           (sessionKey) => sessionKey !== primaryKey && workingStore[sessionKey],
                         );
+                        const committedEntry = params.manageActiveRunPolicy
+                          ? rotateExecutionAuthorityRevision(
+                              projected.entry,
+                              existingEntry,
+                              target.fullPatch,
+                            )
+                          : projected.entry;
                         replacements.push({
-                          entry: projected.entry,
+                          entry: committedEntry,
                           previousSessionKeys,
                           sessionKey: primaryKey,
                         });
                         const cloned = labelOwners.replaceEntry(
                           candidateKeys,
                           primaryKey,
-                          projected.entry,
+                          committedEntry,
                         );
                         projectedOutcomes.push({
                           ok: true,
@@ -500,11 +621,25 @@ async function executeSessionPatchMutations(params: {
               }
             }),
           );
+          await appendSessionPatchAudits({
+            cfg,
+            manageActiveRunPolicy: params.manageActiveRunPolicy,
+            targets: prepared.map((target) => ({
+              ...target,
+              executionAuthorityPatch: isExecutionAuthorityPatch(target.fullPatch),
+              executionAuthorityFields: executionAuthorityPatchFields(target.fullPatch),
+              outcome: outcomes[target.index],
+              setActiveRunAuditNote: (value) => {
+                target.activeRunAuditNote = value;
+              },
+            })),
+          });
         },
       });
     } finally {
       for (const target of prepared) {
         try {
+          target.activeRunPreparation?.drain.release();
           target.archivePreparation?.drain.release();
         } catch (error) {
           sessionLog.warn(
@@ -515,66 +650,22 @@ async function executeSessionPatchMutations(params: {
     }
   }
 
-  let patched = false;
-  const archivedSessionKeys = new Set<string>();
-  for (const target of prepared) {
-    const outcome = outcomes[target.index];
-    if (!outcome?.ok) {
-      continue;
-    }
-    triggerSessionPatchHook({
-      cfg,
-      sessionEntry: outcome.entry,
-      sessionKey: target.canonicalKey,
-      patch: target.fullPatch,
-    });
-    persistSessionPatchModelSelection({
-      cfg,
-      callerScopes,
-      entry: outcome.entry,
-      patch: target.fullPatch,
-      sessionKey: target.canonicalKey,
-      targetAgentId: target.targetAgentId,
-    });
-    emitSessionsChanged(params.context, {
-      sessionKey: target.canonicalKey,
-      ...(target.requestedAgentId ? { agentId: target.requestedAgentId } : {}),
-      reason: "patch",
-    });
-    patched = true;
-    if (target.fullPatch.archived === true) {
-      archivedSessionKeys.add(target.canonicalKey);
-    }
-  }
-
-  const category = params.patch.category;
-  if (patched && typeof category === "string" && category.trim()) {
-    // A first-use category is a group-catalog mutation: clients reload the
-    // catalog only on reason "groups" (the sessions.groups.* siblings emit it).
-    if (ensureSessionGroupRegistered(category)) {
-      emitSessionsChanged(params.context, { reason: "groups" });
-    }
-  }
-  if (callerCanManageCron && archivedSessionKeys.size > 0) {
-    try {
-      const disabledBySession = await disableCronJobsBoundToSessions({
-        cron: params.context.cron,
-        cfg,
-        sessionKeys: [...archivedSessionKeys],
-      });
-      for (const [sessionKey, disabledJobIds] of disabledBySession) {
-        if (disabledJobIds.length > 0) {
-          sessionLog.info(
-            `sessions.patch: disabled cron jobs bound to archived session ${sessionKey}: ${disabledJobIds.join(", ")}`,
-          );
-        }
-      }
-    } catch (error) {
-      sessionLog.warn(
-        `sessions.patch: failed to disable cron jobs for archived sessions: ${formatErrorMessage(error)}`,
-      );
-    }
-  }
+  await applySessionPatchEffects({
+    callerCanManageCron,
+    callerScopes,
+    cfg,
+    context: params.context,
+    targets: prepared.map((target) => {
+      const outcome = outcomes[target.index];
+      return {
+        canonicalKey: target.canonicalKey,
+        fullPatch: target.fullPatch,
+        requestedAgentId: target.requestedAgentId,
+        targetAgentId: target.targetAgentId,
+        outcome: outcome?.ok ? { ok: true, entry: outcome.entry } : { ok: false },
+      };
+    }),
+  });
 
   return {
     ok: true,
@@ -582,102 +673,5 @@ async function executeSessionPatchMutations(params: {
     outcomes: outcomes as MutationOutcome[],
     preparedByIndex,
     modelCatalogByAgent,
-  };
-}
-
-export async function executeSessionPatchMany(params: {
-  client: GatewayClient | null;
-  context: GatewayRequestContext;
-  patch: Omit<SessionsPatchParams, keyof PatchTargetIdentity>;
-  sessionMutationAuthorization?: SessionMutationAuthorization;
-  targets: readonly PatchTargetIdentity[];
-}): Promise<
-  { ok: false; error: ErrorShape } | { ok: true; outcomes: SessionsPatchManyResult["outcomes"] }
-> {
-  const executed = await executeSessionPatchMutations({
-    client: params.client,
-    context: params.context,
-    patch: params.patch,
-    targets: params.targets.map((target) => ({
-      ...target,
-      commitGuard: createCommitGuard(target.key.trim(), () =>
-        params.sessionMutationAuthorization?.assertTargetCurrent({
-          sessionKey: target.key.trim(),
-          ...(target.agentId ? { agentId: target.agentId } : {}),
-        }),
-      ),
-    })),
-  });
-  if (!executed.ok) {
-    return executed;
-  }
-  const outcomes: SessionsPatchManyResult["outcomes"] = [];
-  for (const [index, outcome] of executed.outcomes.entries()) {
-    const target = params.targets[index]!;
-    if (outcome.ok) {
-      outcomes.push(
-        target.agentId
-          ? { ok: true, key: target.key, agentId: target.agentId }
-          : { ok: true, key: target.key },
-      );
-      continue;
-    }
-    outcomes.push(
-      target.agentId
-        ? { ok: false, key: target.key, agentId: target.agentId, error: outcome.error }
-        : { ok: false, key: target.key, error: outcome.error },
-    );
-  }
-  return { ok: true, outcomes };
-}
-
-export async function executeSessionPatch(params: {
-  client: GatewayClient | null;
-  context: GatewayRequestContext;
-  patch: SessionsPatchParams;
-  sessionMutationAuthorization?: SessionMutationAuthorization;
-}): Promise<{ ok: false; error: ErrorShape } | { ok: true; result: SessionsPatchResult }> {
-  const target = {
-    key: params.patch.key,
-    ...(params.patch.agentId ? { agentId: params.patch.agentId } : {}),
-    ...(params.patch.expectedSessionId !== undefined
-      ? { expectedSessionId: params.patch.expectedSessionId }
-      : {}),
-    ...(params.patch.expectedLifecycleRevision !== undefined
-      ? { expectedLifecycleRevision: params.patch.expectedLifecycleRevision }
-      : {}),
-  };
-  const executed = await executeSessionPatchMutations({
-    client: params.client,
-    context: params.context,
-    patch: params.patch,
-    targets: [
-      {
-        ...target,
-        commitGuard: createCommitGuard(
-          target.key,
-          params.sessionMutationAuthorization?.assertCurrent,
-        ),
-      },
-    ],
-  });
-  if (!executed.ok) {
-    return executed;
-  }
-  const outcome = executed.outcomes[0]!;
-  if (!outcome.ok) {
-    return outcome;
-  }
-  const prepared = executed.preparedByIndex[0]!;
-  return {
-    ok: true,
-    result: await projectSessionPatchResult({
-      canonicalKey: prepared.canonicalKey,
-      cfg: executed.cfg,
-      entry: outcome.entry,
-      modelCatalogByAgent: executed.modelCatalogByAgent,
-      storePath: prepared.storePath,
-      targetAgentId: prepared.targetAgentId,
-    }),
   };
 }

--- a/src/gateway/server-methods/sessions-patch-execute.ts
+++ b/src/gateway/server-methods/sessions-patch-execute.ts
@@ -1,0 +1,181 @@
+import type {
+  ErrorShape,
+  RequestFrame,
+  SessionsPatchActiveRunOutcome,
+  SessionsPatchManyResult,
+  SessionsPatchParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
+import { projectSessionPatchResult } from "../session-utils-model.js";
+import {
+  resolveGatewaySessionStoreTargetWithStore,
+  type SessionsPatchResult,
+} from "../session-utils.js";
+import { isExecutionAuthorityPatch } from "../sessions-patch-authority.js";
+import { launchSessionPatchContinuation } from "./session-patch-continuation.js";
+import { activeRunPatchResult } from "./sessions-patch-active-run.js";
+import { executeSessionPatchMutations, type PatchTargetIdentity } from "./sessions-patch-engine.js";
+import { sessionLog } from "./sessions-shared.js";
+import type {
+  GatewayClient,
+  GatewayRequestContext,
+  SessionMutationAuthorization,
+} from "./types.js";
+
+function unexpectedPatchError(key: string, error: unknown): ErrorShape {
+  sessionLog.warn(`sessions.patch: target failed for ${key}: ${formatErrorMessage(error)}`);
+  return errorShape(
+    ErrorCodes.UNAVAILABLE,
+    "Session patch failed unexpectedly. Retry the request.",
+    {
+      retryable: true,
+    },
+  );
+}
+
+function createCommitGuard(key: string, assertCurrent: (() => void) | undefined) {
+  return (): ErrorShape | undefined => {
+    try {
+      assertCurrent?.();
+      return undefined;
+    } catch (error) {
+      return error instanceof SessionMutationAuthorizationChangedError
+        ? error.error
+        : unexpectedPatchError(key, error);
+    }
+  };
+}
+
+export async function executeSessionPatchMany(params: {
+  client: GatewayClient | null;
+  context: GatewayRequestContext;
+  patch: Omit<SessionsPatchParams, keyof PatchTargetIdentity>;
+  sessionMutationAuthorization?: SessionMutationAuthorization;
+  targets: readonly PatchTargetIdentity[];
+}): Promise<
+  { ok: false; error: ErrorShape } | { ok: true; outcomes: SessionsPatchManyResult["outcomes"] }
+> {
+  const executed = await executeSessionPatchMutations({
+    client: params.client,
+    context: params.context,
+    patch: params.patch,
+    // Batch has no stop policy surface: execution-authority changes still use
+    // exact CAS, reject active work, and rotate the lifecycle when idle.
+    manageActiveRunPolicy: true,
+    targets: params.targets.map((target) => ({
+      ...target,
+      commitGuard: createCommitGuard(target.key.trim(), () =>
+        params.sessionMutationAuthorization?.assertTargetCurrent({
+          sessionKey: target.key.trim(),
+          ...(target.agentId ? { agentId: target.agentId } : {}),
+        }),
+      ),
+    })),
+  });
+  if (!executed.ok) {
+    return executed;
+  }
+  return {
+    ok: true,
+    outcomes: executed.outcomes.map((outcome, index) => {
+      const target = params.targets[index]!;
+      return outcome.ok
+        ? target.agentId
+          ? { ok: true, key: target.key, agentId: target.agentId }
+          : { ok: true, key: target.key }
+        : target.agentId
+          ? { ok: false, key: target.key, agentId: target.agentId, error: outcome.error }
+          : { ok: false, key: target.key, error: outcome.error };
+    }),
+  };
+}
+
+export async function executeSessionPatch(params: {
+  client: GatewayClient | null;
+  context: GatewayRequestContext;
+  patch: SessionsPatchParams;
+  req: RequestFrame;
+  sessionMutationAuthorization?: SessionMutationAuthorization;
+}): Promise<{ ok: false; error: ErrorShape } | { ok: true; result: SessionsPatchResult }> {
+  const target = {
+    key: params.patch.key,
+    ...(params.patch.agentId ? { agentId: params.patch.agentId } : {}),
+    ...(params.patch.expectedSessionId !== undefined
+      ? { expectedSessionId: params.patch.expectedSessionId }
+      : {}),
+    ...(params.patch.expectedLifecycleRevision !== undefined
+      ? { expectedLifecycleRevision: params.patch.expectedLifecycleRevision }
+      : {}),
+  };
+  const executed = await executeSessionPatchMutations({
+    client: params.client,
+    context: params.context,
+    patch: params.patch,
+    manageActiveRunPolicy: true,
+    targets: [
+      {
+        ...target,
+        commitGuard: createCommitGuard(
+          target.key,
+          params.sessionMutationAuthorization?.assertCurrent,
+        ),
+      },
+    ],
+  });
+  if (!executed.ok) {
+    return executed;
+  }
+  const outcome = executed.outcomes[0]!;
+  if (!outcome.ok) {
+    return outcome;
+  }
+  const prepared = executed.preparedByIndex[0]!;
+  const result = await projectSessionPatchResult({
+    canonicalKey: prepared.canonicalKey,
+    cfg: executed.cfg,
+    entry: outcome.entry,
+    modelCatalogByAgent: executed.modelCatalogByAgent,
+    storePath: prepared.storePath,
+    targetAgentId: prepared.targetAgentId,
+  });
+  let continuation: SessionsPatchActiveRunOutcome["continuation"];
+  if (
+    isExecutionAuthorityPatch(params.patch) &&
+    params.patch.activeRunPolicy === "stop-and-continue" &&
+    prepared.activeRunPreparation?.stopped === true
+  ) {
+    continuation = await launchSessionPatchContinuation({
+      agentId: prepared.targetAgentId,
+      client: params.client,
+      context: params.context,
+      req: params.req,
+      sessionId: outcome.entry.sessionId,
+      sessionKey: prepared.canonicalKey,
+      assertCurrent: () => {
+        const current = resolveGatewaySessionStoreTargetWithStore({
+          cfg: executed.cfg,
+          key: prepared.canonicalKey,
+          agentId: prepared.targetAgentId,
+          exactRead: true,
+        }).store[prepared.canonicalKey];
+        params.sessionMutationAuthorization?.assertCurrent();
+        if (
+          current?.sessionId !== outcome.entry.sessionId ||
+          current?.lifecycleRevision !== outcome.entry.lifecycleRevision
+        ) {
+          throw new Error("Session changed before continuation launch.");
+        }
+      },
+    });
+  }
+  const activeRun = activeRunPatchResult({
+    auditNote: prepared.activeRunAuditNote ?? "failed",
+    fullPatch: prepared.fullPatch,
+    stopped:
+      prepared.activeRunPreparation?.stopped === true || prepared.archivePreparation !== undefined,
+    ...(continuation ? { continuation } : {}),
+  });
+  return { ok: true, result: activeRun ? { ...result, activeRun } : result };
+}

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -841,6 +841,62 @@ test("createGatewaySession forwards its commit guard into main-session reset", a
   }
 });
 
+test("createGatewaySession commits native spawn state and full mode under the parent guard", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const { createGatewaySession } = await import("./session-create-service.js");
+  const parentSessionKey = "agent:main:main";
+  await writeSessionStore({
+    entries: {
+      [parentSessionKey]: sessionStoreEntry("full-parent", {
+        lifecycleRevision: "full-parent-revision",
+        permissionMode: "full",
+      }),
+    },
+  });
+  const commitGuard = vi.fn();
+
+  const created = await createGatewaySession({
+    cfg: getRuntimeConfig(),
+    key: "agent:main:subagent:full-child",
+    agentId: "main",
+    parentSessionKey,
+    spawnDepth: 1,
+    permissionMode: "full",
+    spawnToolPolicy: { version: 1, allow: ["read"], deny: ["exec"] },
+    initialSpawnEntry: {
+      completionOwnerSessionKey: parentSessionKey,
+      subagentRole: "leaf",
+      subagentControlScope: "none",
+    },
+    commandSource: "test",
+    commitGuard,
+  });
+
+  expect(created).toMatchObject({
+    ok: true,
+    entry: {
+      permissionMode: "full",
+      parentSessionKey,
+      parentSessionId: "full-parent",
+      lifecycleRevision: expect.any(String),
+      spawnedBy: parentSessionKey,
+      completionOwnerSessionKey: parentSessionKey,
+      subagentRole: "leaf",
+      subagentControlScope: "none",
+      inheritedToolAllow: ["read"],
+      inheritedToolDeny: ["exec"],
+    },
+  });
+  expect(commitGuard).toHaveBeenCalled();
+  expect(
+    loadSessionEntry({
+      agentId: "main",
+      sessionKey: "agent:main:subagent:full-child",
+      storePath,
+    }),
+  ).toMatchObject({ permissionMode: "full", parentSessionId: "full-parent" });
+});
+
 test("chat.send fences dashboard title persistence from concurrent session deletion", async () => {
   const { storePath } = await createSessionStoreDir();
   const { ws } = await openClient();

--- a/src/gateway/server.sessions.patch-expected-identity.test.ts
+++ b/src/gateway/server.sessions.patch-expected-identity.test.ts
@@ -4,6 +4,7 @@ import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import { applySessionEntryCanonicalReplacements } from "../config/sessions/session-accessor.sqlite-replacement-projection.js";
 import { createDeferredCore as createDeferred } from "../shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import * as patchContinuation from "./server-methods/session-patch-continuation.js";
 import { embeddedRunMock, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
@@ -312,4 +313,219 @@ test("sessions.patch archives the expected session under its lifecycle lock", as
     lifecycleRevision,
     archivedAt: expect.any(Number),
   });
+});
+
+test("sessions.patch rejects an execution-authority mutation while exact session work is active", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:active-authority-patch";
+  const sessionId = "session-active-authority-patch";
+  const lifecycleRevision = "revision-active-authority-patch";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(sessionId, { lifecycleRevision }),
+    },
+  });
+  embeddedRunMock.activeIds.add(sessionId);
+
+  const patched = await directSessionReq("sessions.patch", {
+    key: sessionKey,
+    permissionMode: "full",
+    expectedSessionId: sessionId,
+    expectedLifecycleRevision: lifecycleRevision,
+  });
+
+  expect(patched).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST" },
+  });
+  expect(embeddedRunMock.abortCalls).toEqual([]);
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    sessionId,
+    lifecycleRevision,
+  });
+  expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty("permissionMode");
+});
+
+test("sessions.patch stops exact active work, rotates authority, and reports the visible note", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:stop-authority-patch";
+  const sessionId = "session-stop-authority-patch";
+  const lifecycleRevision = "revision-stop-authority-patch";
+  await writeSessionStore({
+    entries: {
+      [sessionKey]: sessionStoreEntry(sessionId, { lifecycleRevision }),
+    },
+  });
+  embeddedRunMock.activeIds.add(sessionId);
+  embeddedRunMock.waitResults.set(sessionId, true);
+
+  const patched = await directSessionReq<{
+    activeRun: { auditNote: string; policy: string; stopped: boolean };
+    entry: { lifecycleRevision: string; permissionMode: string };
+  }>("sessions.patch", {
+    key: sessionKey,
+    permissionMode: "full",
+    activeRunPolicy: "stop",
+    expectedSessionId: sessionId,
+    expectedLifecycleRevision: lifecycleRevision,
+  });
+
+  expect(patched).toMatchObject({
+    ok: true,
+    payload: {
+      activeRun: { auditNote: "appended", policy: "stop", stopped: true },
+      entry: { permissionMode: "full" },
+    },
+  });
+  expect(embeddedRunMock.abortCalls).toEqual([sessionId]);
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    sessionId,
+    permissionMode: "full",
+    lifecycleRevision: expect.not.stringMatching(lifecycleRevision),
+  });
+});
+
+test("sessions.patch keeps idle execution-authority patches compatible without explicit CAS", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:authority-patch-cas";
+  const sessionId = "session-authority-patch-cas";
+  await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
+
+  const patched = await directSessionReq("sessions.patch", {
+    key: sessionKey,
+    elevatedLevel: "full",
+  });
+
+  expect(patched).toMatchObject({
+    ok: true,
+    payload: { entry: { elevatedLevel: "full" } },
+  });
+  expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+    elevatedLevel: "full",
+    sessionId,
+  });
+});
+
+test("sessions.patch requires both CAS fields before stopping active authority", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:active-authority-patch-cas";
+  const sessionId = "session-active-authority-patch-cas";
+  await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
+  embeddedRunMock.activeIds.add(sessionId);
+
+  const patched = await directSessionReq("sessions.patch", {
+    key: sessionKey,
+    elevatedLevel: "full",
+    activeRunPolicy: "stop",
+    expectedSessionId: sessionId,
+  });
+
+  expect(patched).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST" },
+  });
+  expect(embeddedRunMock.abortCalls).toEqual([]);
+  expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty("elevatedLevel");
+});
+
+test("sessions.patch requires both CAS fields for stop-and-continue while idle", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:idle-authority-continuation-cas";
+  const sessionId = "session-idle-authority-continuation-cas";
+  await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
+
+  const patched = await directSessionReq("sessions.patch", {
+    key: sessionKey,
+    elevatedLevel: "full",
+    activeRunPolicy: "stop-and-continue",
+  });
+
+  expect(patched).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+  expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty("elevatedLevel");
+});
+
+test("sessions.patchMany keeps execution-authority targets side-effect free while active", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:batch-active-authority-patch";
+  const sessionId = "session-batch-active-authority-patch";
+  const lifecycleRevision = "revision-batch-active-authority-patch";
+  await writeSessionStore({
+    entries: { [sessionKey]: sessionStoreEntry(sessionId, { lifecycleRevision }) },
+  });
+  embeddedRunMock.activeIds.add(sessionId);
+
+  const patched = await directSessionReq<{
+    outcomes: Array<{ error?: { code: string }; key: string; ok: boolean }>;
+  }>("sessions.patchMany", {
+    targets: [
+      {
+        key: sessionKey,
+        expectedSessionId: sessionId,
+        expectedLifecycleRevision: lifecycleRevision,
+      },
+    ],
+    patch: { permissionMode: "full" },
+  });
+
+  expect(patched).toMatchObject({
+    ok: true,
+    payload: { outcomes: [{ key: sessionKey, ok: false, error: { code: "INVALID_REQUEST" } }] },
+  });
+  expect(embeddedRunMock.abortCalls).toEqual([]);
+  expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty("permissionMode");
+});
+
+test("sessions.patch returns a continuation rejection without hiding the committed patch", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:authority-continuation-rejection";
+  const sessionId = "session-authority-continuation-rejection";
+  const lifecycleRevision = "revision-authority-continuation-rejection";
+  await writeSessionStore({
+    entries: { [sessionKey]: sessionStoreEntry(sessionId, { lifecycleRevision }) },
+  });
+  embeddedRunMock.activeIds.add(sessionId);
+  embeddedRunMock.waitResults.set(sessionId, true);
+  const launch = vi.spyOn(patchContinuation, "launchSessionPatchContinuation").mockResolvedValue({
+    status: "rejected",
+    error: { code: "UNAVAILABLE", message: "continuation unavailable" },
+  });
+
+  try {
+    const patched = await directSessionReq<{
+      activeRun: {
+        continuation: { error: { message: string }; status: string };
+        policy: string;
+        stopped: boolean;
+      };
+      entry: { lifecycleRevision: string; permissionMode: string };
+    }>("sessions.patch", {
+      key: sessionKey,
+      permissionMode: "full",
+      activeRunPolicy: "stop-and-continue",
+      expectedSessionId: sessionId,
+      expectedLifecycleRevision: lifecycleRevision,
+    });
+
+    expect(patched).toMatchObject({
+      ok: true,
+      payload: {
+        activeRun: {
+          continuation: {
+            error: { message: "continuation unavailable" },
+            status: "rejected",
+          },
+          policy: "stop-and-continue",
+          stopped: true,
+        },
+        entry: { permissionMode: "full" },
+      },
+    });
+    expect(launch).toHaveBeenCalledOnce();
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      permissionMode: "full",
+      lifecycleRevision: expect.not.stringMatching(lifecycleRevision),
+    });
+  } finally {
+    launch.mockRestore();
+  }
 });

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -263,6 +263,29 @@ type TrustedInitialSessionEntry = {
   pluginExtensions?: SessionEntry["pluginExtensions"];
 };
 
+type TrustedSpawnSessionEntry = Pick<
+  SessionEntry,
+  | "completionOwnerSessionKey"
+  | "fastMode"
+  | "inheritedToolAllow"
+  | "inheritedToolDeny"
+  | "inheritedToolPolicyVersion"
+  | "model"
+  | "modelOverride"
+  | "modelOverrideFallbackOriginModel"
+  | "modelOverrideFallbackOriginProvider"
+  | "modelOverrideRouteResolution"
+  | "modelOverrideSource"
+  | "modelProvider"
+  | "providerOverride"
+  | "subagentControlScope"
+  | "subagentRole"
+  | "swarmCollector"
+  | "swarmGroupId"
+  | "swarmOutputSchema"
+  | "thinkingLevel"
+> & { spawnedWorkspaceDir?: string; spawnedCwd?: string };
+
 type GatewaySessionCommitResult =
   | {
       ok: true;
@@ -335,6 +358,8 @@ export async function createGatewaySession(params: {
   loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
   /** Trusted in-process initializer; never populated from public Gateway params. */
   initialEntry?: TrustedInitialSessionEntry;
+  /** Trusted native-spawn fields committed with the fresh child row. */
+  initialSpawnEntry?: TrustedSpawnSessionEntry;
   /** Public callers need admin before reconfiguring an adopted keyed session. */
   allowExistingModelSelection?: boolean;
   /** Admitted operator scopes; omitted only by trusted in-process callers. */
@@ -529,6 +554,21 @@ export async function createGatewaySession(params: {
     return {
       ok: false,
       error: errorShape(ErrorCodes.INVALID_REQUEST, "spawn tool policy requires spawnDepth"),
+    };
+  }
+  if (
+    params.initialSpawnEntry &&
+    (!params.spawnToolPolicy || params.spawnDepth === undefined || !parentSessionKey)
+  ) {
+    return {
+      ok: false,
+      error: errorShape(ErrorCodes.INVALID_REQUEST, "native spawn state requires spawn ownership"),
+    };
+  }
+  if (params.initialSpawnEntry?.spawnedCwd && params.spawnedCwd) {
+    return {
+      ok: false,
+      error: errorShape(ErrorCodes.INVALID_REQUEST, "native spawn cwd must have one owner"),
     };
   }
   let canonicalParentSessionKey: string | undefined;
@@ -760,7 +800,8 @@ export async function createGatewaySession(params: {
       parentSessionTarget &&
       (params.emitCommandHooks === true ||
         params.fork === true ||
-        params.authorizedPluginId !== undefined)
+        params.authorizedPluginId !== undefined ||
+        params.spawnToolPolicy !== undefined)
     ) {
       const currentParent = loadGatewaySessionEntryReadOnly(
         canonicalParentSessionKey,
@@ -769,13 +810,23 @@ export async function createGatewaySession(params: {
       const currentParentEntry = currentParent.entry;
       if (
         !currentParentEntry?.sessionId ||
-        currentParentEntry.sessionId !== parentSessionEntry?.sessionId
+        currentParentEntry.sessionId !== parentSessionEntry?.sessionId ||
+        currentParentEntry.lifecycleRevision !== parentSessionEntry?.lifecycleRevision
       ) {
         return {
           ok: false,
           error: errorShape(
             ErrorCodes.INVALID_REQUEST,
             `Parent session ${parentSessionKey} changed before ${params.fork === true ? "fork" : "/new"}; retry.`,
+          ),
+        };
+      }
+      if (params.permissionMode === "full" && currentParentEntry.permissionMode !== "full") {
+        return {
+          ok: false,
+          error: errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "full-access parent session authority changed before child creation",
           ),
         };
       }
@@ -1139,6 +1190,9 @@ export async function createGatewaySession(params: {
           // and plugin sessions) persists as a depth-0 root. Reused entries keep
           // their stored depth.
           ...(existingEntry === undefined ? { spawnDepth: params.spawnDepth ?? 0 } : {}),
+          ...(existingEntry === undefined && params.spawnToolPolicy
+            ? { lifecycleRevision: randomUUID() }
+            : {}),
           ...(existingEntry === undefined && spawnToolPolicy
             ? {
                 spawnedBy: spawnToolPolicy.parentSessionKey,
@@ -1153,6 +1207,9 @@ export async function createGatewaySession(params: {
                   ? { inheritedToolDeny: spawnToolPolicy.deny }
                   : {}),
               }
+            : {}),
+          ...(existingEntry === undefined && params.initialSpawnEntry
+            ? params.initialSpawnEntry
             : {}),
           ...(existingEntry === undefined && incognito ? { incognito: true as const } : {}),
         };
@@ -1325,7 +1382,8 @@ export async function createGatewaySession(params: {
     parentSessionTarget &&
     (params.emitCommandHooks === true ||
       params.fork === true ||
-      params.authorizedPluginId !== undefined)
+      params.authorizedPluginId !== undefined ||
+      params.spawnToolPolicy !== undefined)
   ) {
     lifecycleTargets.push({
       scope: parentSessionTarget.storePath,

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -538,6 +538,7 @@ export function buildGatewaySessionRow(params: {
 
   return {
     key,
+    lifecycleRevision: entry?.lifecycleRevision,
     visibility: entry ? (entry.visibility ?? "shared") : undefined,
     incognito: entry?.incognito,
     spawnedBy: subagentOwner || entry?.spawnedBy,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -12,6 +12,7 @@ import type {
   SessionRunStatus,
   SessionSharingRole,
   SessionVisibility,
+  SessionsPatchActiveRunOutcome,
 } from "../../packages/gateway-protocol/src/index.js";
 import type { QueueMode } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
@@ -133,6 +134,7 @@ export type GatewaySessionRow = {
   lastInteractionAt?: number;
   lastActivityAt?: number;
   sessionId?: string;
+  lifecycleRevision?: string;
   placement?: SessionPlacement;
   placementMove?: SessionPlacementMove;
   systemSent?: boolean;
@@ -242,6 +244,7 @@ export type SessionListModelCatalog = ReadonlyMap<string, ModelCatalogEntry[] | 
 
 export type SessionsPatchResult = SessionsPatchResultBase<SessionEntry> & {
   entry: SessionEntry;
+  activeRun?: SessionsPatchActiveRunOutcome;
   resolved?: {
     modelProvider?: string;
     model?: string;

--- a/src/gateway/sessions-patch-authority.ts
+++ b/src/gateway/sessions-patch-authority.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "node:crypto";
+import type { SessionsPatchParams } from "../../packages/gateway-protocol/src/index.js";
+import type { SessionEntry } from "../config/sessions.js";
+
+const EXECUTION_AUTHORITY_PATCH_FIELDS = [
+  "permissionMode",
+  "elevatedLevel",
+  "execHost",
+  "execSecurity",
+  "execAsk",
+  "execNode",
+  "toolOverrides",
+  "inheritedToolPolicyVersion",
+  "inheritedToolAllow",
+  "inheritedToolDeny",
+] as const;
+
+type SessionExecutionAuthorityField = (typeof EXECUTION_AUTHORITY_PATCH_FIELDS)[number];
+
+export function executionAuthorityPatchFields(
+  patch: SessionsPatchParams,
+): SessionExecutionAuthorityField[] {
+  return EXECUTION_AUTHORITY_PATCH_FIELDS.filter((field) => Object.hasOwn(patch, field));
+}
+
+export function isExecutionAuthorityPatch(patch: SessionsPatchParams): boolean {
+  return EXECUTION_AUTHORITY_PATCH_FIELDS.some((field) => Object.hasOwn(patch, field));
+}
+
+export function resolveExecutionAuthorityChange(
+  entry: SessionEntry,
+  projected: SessionEntry,
+  patch: SessionsPatchParams,
+): boolean {
+  return EXECUTION_AUTHORITY_PATCH_FIELDS.some((field) => {
+    if (!Object.hasOwn(patch, field)) {
+      return false;
+    }
+    return JSON.stringify(entry[field]) !== JSON.stringify(projected[field]);
+  });
+}
+
+export function rotateExecutionAuthorityRevision(
+  entry: SessionEntry,
+  previous: SessionEntry | undefined,
+  patch: SessionsPatchParams,
+): SessionEntry {
+  return previous && resolveExecutionAuthorityChange(previous, entry, patch)
+    ? { ...entry, lifecycleRevision: randomUUID() }
+    : entry;
+}

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -461,12 +461,12 @@ export class TerminalSessionManager {
     return owned.length;
   }
 
-  /** Fences and closes one durable agent-session incarnation through archive commit. */
+  /** Fences and closes one durable agent-session incarnation through lifecycle commit. */
   beginAgentSessionDrain(owner: AgentTerminalOwner): AgentTerminalSessionDrain {
     const drain = this.agentSessionDrain.begin(owner, () => this.hasAgentSessionWork(owner));
     for (const [pending, pendingOwner] of this.pendingOpens) {
       if (agentTerminalOwnerMatches(pendingOwner, owner)) {
-        pending.abort("terminal closed because its session was archived");
+        pending.abort("terminal closed because its session lifecycle changed");
       }
     }
     for (const session of Array.from(this.sessions.values())) {
@@ -476,6 +476,18 @@ export class TerminalSessionManager {
     }
     this.resolveAgentSessionDrainIfIdle(owner);
     return drain;
+  }
+
+  hasAgentSessionWork(owner: AgentTerminalOwner): boolean {
+    return (
+      [...this.pendingOpens.values()].some((pendingOwner) =>
+        agentTerminalOwnerMatches(pendingOwner, owner),
+      ) ||
+      [...this.sessions.values()].some(
+        (session) => !session.closed && agentTerminalOwnerMatches(session.owner, owner),
+      ) ||
+      this.agentSessionDrain.hasExiting(owner)
+    );
   }
 
   /**
@@ -561,18 +573,6 @@ export class TerminalSessionManager {
       return;
     }
     this.connections.addPendingOpen(connId, pending);
-  }
-
-  private hasAgentSessionWork(owner: AgentTerminalOwner): boolean {
-    return (
-      [...this.pendingOpens.values()].some((pendingOwner) =>
-        agentTerminalOwnerMatches(pendingOwner, owner),
-      ) ||
-      [...this.sessions.values()].some(
-        (session) => !session.closed && agentTerminalOwnerMatches(session.owner, owner),
-      ) ||
-      this.agentSessionDrain.hasExiting(owner)
-    );
   }
 
   private resolveAgentSessionDrainIfIdle(owner: AgentTerminalOwner): void {

--- a/src/gateway/worker-environments/inference-control-internal.ts
+++ b/src/gateway/worker-environments/inference-control-internal.ts
@@ -6,7 +6,7 @@ export type WorkerInferenceSessionDrain = {
 
 type BeginWorkerInferenceSessionDrain = (sessionId: string) => WorkerInferenceSessionDrain;
 
-// Archive lifecycle needs a stronger control without widening the inferred public service shape.
+// Session lifecycle needs a stronger control without widening the inferred public service shape.
 // The weak registration follows the concrete service instance's lifetime.
 const sessionDrainByService = new WeakMap<object, BeginWorkerInferenceSessionDrain>();
 

--- a/src/gateway/worker-environments/worker-session-full-access.ts
+++ b/src/gateway/worker-environments/worker-session-full-access.ts
@@ -1,0 +1,46 @@
+import type { WorkerSessionsSpawnParams } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { WORKER_FULL_ACCESS_DELEGATION_CAPABILITY } from "../../worker/tool-authority.js";
+import type { WorkerConnectionIdentity } from "./connection-identity.js";
+import type { WorkerSessionPlacementStore } from "./placement-store.js";
+import {
+  resolveWorkerSessionToolSource,
+  type WorkerSessionToolSource,
+} from "./worker-session-tool-topology.js";
+
+export function resolveWorkerFullAccessDelegation(params: {
+  identity: WorkerConnectionIdentity;
+  placements: WorkerSessionPlacementStore;
+  request: WorkerSessionsSpawnParams;
+  source: WorkerSessionToolSource;
+}) {
+  const requested = params.request.permissionMode === "full";
+  const allowed = params.placements.isWorkerTurnToolAuthorized(
+    params.source.turnClaim,
+    WORKER_FULL_ACCESS_DELEGATION_CAPABILITY,
+  );
+  const assertActive = () => {
+    const current = resolveWorkerSessionToolSource({
+      identity: params.identity,
+      placements: params.placements,
+    });
+    if (current.entry.permissionMode !== "full") {
+      throw new Error("Worker full-access parent session authority changed");
+    }
+  };
+  if (requested) {
+    if (!allowed) {
+      throw new Error("Worker full-access delegation is unavailable for this turn");
+    }
+    assertActive();
+  }
+  return {
+    requested,
+    allowed,
+    assertActive,
+    admission: {
+      parentSessionId: params.source.sessionId,
+      parentLifecycleRevision: params.source.entry.lifecycleRevision,
+      assertActive,
+    },
+  };
+}

--- a/src/gateway/worker-environments/worker-session-tool-executor.test.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.test.ts
@@ -68,12 +68,13 @@ vi.mock("../../agents/tools/sessions-spawn-tool.js", async () => {
       agentSessionKey: string;
       callGateway: (method: string, params: Record<string, unknown>) => Promise<unknown>;
     }) => ({
-      execute: async (_toolCallId: string, args: { task: string }) => {
+      execute: async (_toolCallId: string, args: { task: string; permissionMode?: "full" }) => {
         spawnCallerIdentity(getGatewayToolCallerIdentity());
         spawnArgs(args);
         const details = await options.callGateway("sessions.create", {
           parentSessionKey: options.agentSessionKey,
           task: args.task,
+          ...(args.permissionMode ? { permissionMode: args.permissionMode } : {}),
         });
         return {
           content: [{ type: "text", text: "spawned" }],
@@ -171,6 +172,7 @@ describe("worker session tool topology", () => {
     placements.authorizeWorkerTurnTools(sourceClaim, [
       "sessions_send",
       "sessions_spawn",
+      "sessions_spawn_full_access",
       "github_publish",
     ]);
     delegatedAuthorities = [];
@@ -527,6 +529,34 @@ describe("worker session tool topology", () => {
       PARENT_EXECUTION_IDENTITY_TOKEN.executionId,
     );
     expect(JSON.stringify(runtimeIdentity?.sessionSpawnContext)).not.toContain(SOURCE.sessionKey);
+  });
+
+  it("forwards full access only while the exact worker parent remains full", async () => {
+    setEntry(SOURCE.sessionKey, SOURCE.sessionId);
+    sessionEntries.set(SOURCE.sessionKey, {
+      ...sessionEntries.get(SOURCE.sessionKey)!,
+      permissionMode: "full",
+    });
+
+    await execute({
+      identity,
+      toolName: "sessions_spawn",
+      request: {
+        toolCallId: "spawn-full-child",
+        task: "start the full child",
+        permissionMode: "full",
+      },
+    });
+
+    expect(spawnArgs).toHaveBeenCalledWith(expect.objectContaining({ permissionMode: "full" }));
+    expect(gatewayCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ permissionMode: "full" }),
+        creation: expect.objectContaining({
+          fullAccessAdmission: expect.objectContaining({ assertActive: expect.any(Function) }),
+        }),
+      }),
+    );
   });
 
   it("coalesces concurrent spawn retries into one cloud child", async () => {

--- a/src/gateway/worker-environments/worker-session-tool-executor.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.ts
@@ -22,7 +22,6 @@ import { createSessionsSpawnTool } from "../../agents/tools/sessions-spawn-tool.
 import { jsonResult } from "../../agents/tools/tool-results.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../../config/agent-limits.js";
 import { getRuntimeConfig } from "../../config/config.js";
-import { sha256Base64Url, sha256HexPrefixCore } from "../../infra/crypto-digest.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { WORKER_TOOL_NAMES } from "../../worker/tool-authority.js";
 import type { GitHubPublicationCoordinator } from "../github-publication.js";
@@ -35,6 +34,12 @@ import {
 } from "./placement-turn-claim-events.js";
 import type { WorkerPlacementDispatchContract } from "./service-contract.js";
 import type { WorkerEnvironmentService } from "./service.js";
+import { resolveWorkerFullAccessDelegation } from "./worker-session-full-access.js";
+import {
+  computeWorkerSessionToolRequestDigest,
+  workerChildSessionKey,
+  workerSessionToolOperationKey,
+} from "./worker-session-tool-operation-key.js";
 import {
   serializeWorkerSessionToolResult as serializeResult,
   workerSessionToolErrorResult as errorResult,
@@ -75,24 +80,8 @@ class WorkerSessionToolOutcomeUnknownError extends Error {
   }
 }
 
-function computeRequestDigest(value: unknown): string {
-  return sha256Base64Url(`openclaw.worker-session-tool-request.v1\0${JSON.stringify(value)}`);
-}
-
-function operationKey(operationSeed: string, purpose: string): string {
-  return sha256Base64Url(`openclaw.worker-session-tool-operation.v1\0${operationSeed}\0${purpose}`);
-}
-
 function throwIfAborted(signal: AbortSignal | undefined): void {
   signal?.throwIfAborted();
-}
-
-function childSessionKey(params: { operationSeed: string; targetAgentId: string }): string {
-  const suffix = sha256HexPrefixCore(
-    `openclaw.worker-session-tool-operation.v1\0${params.operationSeed}\0child-session`,
-    32,
-  );
-  return `agent:${params.targetAgentId}:dashboard:cloud-${suffix}`;
 }
 
 export function createWorkerSessionToolExecutor(params: {
@@ -123,6 +112,12 @@ export function createWorkerSessionToolExecutor(params: {
       throw new Error("Worker source environment changed before child spawn");
     }
     const targetAgentId = normalizeAgentId(operation.request.agentId ?? operation.source.agentId);
+    const fullAccess = resolveWorkerFullAccessDelegation({
+      identity: operation.identity,
+      placements: params.placements,
+      request: operation.request,
+      source: operation.source,
+    });
     const authorizedTools = WORKER_TOOL_NAMES.filter((name) =>
       params.placements.isWorkerTurnToolAuthorized(operation.source.turnClaim, name),
     );
@@ -142,6 +137,9 @@ export function createWorkerSessionToolExecutor(params: {
           ...(operation.signal ? { signal: operation.signal } : {}),
           timeoutMs: null,
         });
+      }
+      if (fullAccess.requested) {
+        fullAccess.assertActive();
       }
       throwIfAborted(operation.signal);
       exactSource({ identity: operation.identity, placements: params.placements });
@@ -171,6 +169,7 @@ export function createWorkerSessionToolExecutor(params: {
         const createParams: Record<string, unknown> = {
           ...requestParams,
           key: operation.childSessionKey,
+          ...(fullAccess.requested ? { permissionMode: "full" } : {}),
         };
         delete createParams.task;
         creationAttempted = true;
@@ -183,6 +182,7 @@ export function createWorkerSessionToolExecutor(params: {
               actor: { type: "agent", id: operation.source.agentId },
               requesterSessionKey: operation.source.sessionKey,
               inheritedToolPolicy: { version: 1, allow: authorizedTools, deny: [] },
+              ...(fullAccess.requested ? { fullAccessAdmission: fullAccess.admission } : {}),
             },
             {
               ...(operation.signal ? { signal: operation.signal } : {}),
@@ -279,7 +279,7 @@ export function createWorkerSessionToolExecutor(params: {
           sourceSessionId: operation.source.sessionId,
           targetAgentId,
         });
-        const childRunId = operationKey(operation.operationSeed, "initial-task");
+        const childRunId = workerSessionToolOperationKey(operation.operationSeed, "initial-task");
         const config = getRuntimeConfig();
         const gatewayCaller = getGatewayToolCallerIdentity();
         const sessionSpawnContext = lineageCapability
@@ -403,6 +403,8 @@ export function createWorkerSessionToolExecutor(params: {
       inheritedToolDenylist: [],
       callGateway: gatewayCall,
       expectedParentSessionId: operation.source.sessionId,
+      expectedParentLifecycleRevision: operation.source.entry.lifecycleRevision,
+      fullAccessDelegationAvailable: fullAccess.allowed,
       ...(operation.signal ? { signal: operation.signal } : {}),
     });
     const executeSpawn = () =>
@@ -414,6 +416,7 @@ export function createWorkerSessionToolExecutor(params: {
         ...(operation.request.runTimeoutSeconds === undefined
           ? {}
           : { runTimeoutSeconds: operation.request.runTimeoutSeconds }),
+        ...(fullAccess.requested ? { permissionMode: "full" } : {}),
         expectsCompletionMessage: false,
         visible: true,
         worktree: true,
@@ -540,7 +543,7 @@ export function createWorkerSessionToolExecutor(params: {
       assertPublicationAuthority();
       return { resultJson: serializeResult(jsonResult(publication)) };
     }
-    const requestDigest = computeRequestDigest(
+    const requestDigest = computeWorkerSessionToolRequestDigest(
       request.toolName === "sessions_spawn"
         ? {
             toolName: request.toolName,
@@ -617,7 +620,7 @@ export function createWorkerSessionToolExecutor(params: {
         let childKey = started.childSessionKey;
         if (request.toolName === "sessions_spawn" && !childKey) {
           const targetAgentId = normalizeAgentId(request.request.agentId ?? source.agentId);
-          childKey = childSessionKey({
+          childKey = workerChildSessionKey({
             operationSeed: started.operationSeed,
             targetAgentId,
           });
@@ -648,7 +651,7 @@ export function createWorkerSessionToolExecutor(params: {
                 identity: request.identity,
                 target: target!,
                 request: request.request,
-                idempotencyKey: `worker-session-send:${operationKey(
+                idempotencyKey: `worker-session-send:${workerSessionToolOperationKey(
                   started.operationSeed,
                   "target-send",
                 )}`,

--- a/src/gateway/worker-environments/worker-session-tool-operation-key.ts
+++ b/src/gateway/worker-environments/worker-session-tool-operation-key.ts
@@ -1,0 +1,20 @@
+import { sha256Base64Url, sha256HexPrefixCore } from "../../infra/crypto-digest.js";
+
+export function computeWorkerSessionToolRequestDigest(value: unknown): string {
+  return sha256Base64Url(`openclaw.worker-session-tool-request.v1\0${JSON.stringify(value)}`);
+}
+
+export function workerSessionToolOperationKey(operationSeed: string, purpose: string): string {
+  return sha256Base64Url(`openclaw.worker-session-tool-operation.v1\0${operationSeed}\0${purpose}`);
+}
+
+export function workerChildSessionKey(params: {
+  operationSeed: string;
+  targetAgentId: string;
+}): string {
+  const suffix = sha256HexPrefixCore(
+    `openclaw.worker-session-tool-operation.v1\0${params.operationSeed}\0child-session`,
+    32,
+  );
+  return `agent:${params.targetAgentId}:dashboard:cloud-${suffix}`;
+}

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -10,10 +10,12 @@ import {
 } from "../../agents/session-placement-admission.js";
 import { convertToLlm } from "../../agents/sessions/messages.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
+import { isFullAccessDelegationTurn } from "../../agents/tools/sessions-spawn-full-access.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { emitAgentRunStatusEvent } from "../../infra/agent-run-status-events.js";
 import { redactSensitiveText } from "../../logging/redact.js";
 import { parseWorkerLaunchPlan } from "../../worker/launch-descriptor.js";
+import { WORKER_FULL_ACCESS_DELEGATION_CAPABILITY } from "../../worker/tool-authority.js";
 import { WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE } from "../../worker/transcript-message.js";
 import { prepareGitHubPublicationAvailability } from "../github-publication-availability.js";
 import {
@@ -112,6 +114,19 @@ async function executeWorkerTurn(params: {
   publishAcceptedWorkspace?: (claim: WorkerSessionTurnClaim) => Promise<void>;
 }) {
   const { placement, turn } = params;
+  const directUserTurnAuthority = turn.cronCreatorAuthorityCapability
+    ? {
+        assertActive: () => {
+          turn.cronCreatorAuthorityCapability?.signal.throwIfAborted();
+          if (
+            turn.cronCreatorAuthorityCapability?.active !== true ||
+            turn.cronCreatorAuthorityCapability.runId !== turn.runId
+          ) {
+            throw new Error("direct user turn authority is no longer active");
+          }
+        },
+      }
+    : undefined;
   const modelRef = assertSupportedTurn(turn);
   const environment = params.environments.get(placement.environmentId);
   const bootstrapReceipt = environment?.bootstrapReceipt;
@@ -214,7 +229,15 @@ async function executeWorkerTurn(params: {
     turn,
     githubPublicationAvailable,
   });
-  params.placements.authorizeWorkerTurnTools(params.turnClaim, toolAuthority.allowedToolNames);
+  const fullAccessDelegationAllowed =
+    isFullAccessDelegationTurn({
+      permissionMode: turn.permissionMode,
+      directUserTurnAuthority,
+    }) && toolAuthority.allowedToolNames.includes("sessions_spawn");
+  params.placements.authorizeWorkerTurnTools(params.turnClaim, [
+    ...toolAuthority.allowedToolNames,
+    ...(fullAccessDelegationAllowed ? [WORKER_FULL_ACCESS_DELEGATION_CAPABILITY] : []),
+  ]);
   const { operationalRunInstance, runtimeIdentity } = await prepareWorkerAgentRuntimeIdentity({
     agentId: placement.agentId,
     runtimeInstanceId: placement.environmentId,
@@ -254,6 +277,7 @@ async function executeWorkerTurn(params: {
                 workerContainmentRoot: placement.remoteWorkspaceDir,
               }
             : {}),
+          ...(fullAccessDelegationAllowed ? { fullAccessDelegationAllowed: true as const } : {}),
           modelRef,
           inferenceOptions: reasoning ? { reasoning } : {},
           ...(turn.extraSystemPrompt === undefined ? {} : { systemPrompt: turn.extraSystemPrompt }),

--- a/src/shared/session-method-scopes-base.ts
+++ b/src/shared/session-method-scopes-base.ts
@@ -20,6 +20,7 @@ const SESSIONS_PATCH_WRITE_SCOPE_ENVELOPE_FIELDS: ReadonlySet<string> = new Set(
   "agentId",
   "expectedSessionId",
   "expectedLifecycleRevision",
+  "activeRunPolicy",
 ]);
 
 const SESSIONS_DELETE_WRITE_SCOPE_FIELDS: ReadonlySet<string> = new Set([

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -63,6 +63,7 @@ import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
   replaceOversizedChatHistoryMessages,
 } from "../gateway/server-methods/chat.js";
+import { appendSessionAudit } from "../gateway/server-methods/session-audit.js";
 import { loadGatewayModelCatalog } from "../gateway/server-model-catalog.js";
 import { createGatewaySession } from "../gateway/session-create-service.js";
 import { performGatewaySessionReset } from "../gateway/session-reset-service.js";
@@ -79,6 +80,10 @@ import {
   resolveGatewaySessionStoreTargetWithStore,
   resolveSessionModelRef,
 } from "../gateway/session-utils.js";
+import {
+  isExecutionAuthorityPatch,
+  rotateExecutionAuthorityRevision,
+} from "../gateway/sessions-patch-authority.js";
 import { projectSessionsPatchEntry } from "../gateway/sessions-patch.js";
 import { waitForAbortSignal } from "../infra/abort-signal.js";
 import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
@@ -757,6 +762,43 @@ export class EmbeddedTuiBackend implements TuiBackend {
       agentId: opts.agentId,
       exactRead: true,
     });
+    const executionAuthorityPatch = isExecutionAuthorityPatch(opts);
+    let stoppedActiveRun = false;
+    if (executionAuthorityPatch) {
+      const current = loadGatewaySessionEntryReadOnly(target.canonicalKey ?? opts.key, {
+        agentId: target.agentId,
+      }).entry;
+      const hasActiveRun = this.hasAbortableSessionRun({
+        sessionKey: target.canonicalKey ?? opts.key,
+        agentId: opts.agentId,
+      });
+      if (hasActiveRun && opts.activeRunPolicy === "stop-and-continue") {
+        throw new Error("stop-and-continue requires the Gateway backend; use stop in local mode");
+      }
+      if (hasActiveRun && (opts.activeRunPolicy ?? "reject") === "reject") {
+        throw new Error(
+          "session has active work; abort it before changing execution policy in local mode",
+        );
+      }
+      if (hasActiveRun) {
+        if (
+          opts.expectedSessionId === undefined ||
+          opts.expectedLifecycleRevision === undefined ||
+          current?.sessionId !== opts.expectedSessionId ||
+          current.lifecycleRevision !== opts.expectedLifecycleRevision
+        ) {
+          throw new Error("stopping an active session requires the current session identity");
+        }
+        const runScope = {
+          sessionKey: target.canonicalKey ?? opts.key,
+          agentId: opts.agentId,
+        };
+        this.clearSessionRunQueues(runScope);
+        this.abortSessionRuns(runScope);
+        await this.waitForSessionRuns(runScope);
+        stoppedActiveRun = true;
+      }
+    }
     const applied = await applySessionPatchProjection<{ ok: false; error: ErrorShape }>({
       ...(opts.label === undefined ? { sessionKeys: target.storeKeys } : {}),
       storePath: target.storePath,
@@ -769,8 +811,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
         });
         return { primaryKey, candidateKeys: migratedTarget.storeKeys };
       },
-      project: async ({ primaryKey, existingEntry, isLabelInUse }) =>
-        await projectSessionsPatchEntry({
+      project: async ({ primaryKey, existingEntry, isLabelInUse }) => {
+        const projected = await projectSessionsPatchEntry({
           cfg,
           existingEntry,
           isLabelInUse,
@@ -779,7 +821,14 @@ export class EmbeddedTuiBackend implements TuiBackend {
           patch: opts,
           loadGatewayModelCatalog: () =>
             this.withRuntimePluginRegistry(() => loadEmbeddedTuiModelCatalog(cfg)),
-        }),
+        });
+        return projected.ok && executionAuthorityPatch
+          ? {
+              ok: true as const,
+              entry: rotateExecutionAuthorityRevision(projected.entry, existingEntry, opts),
+            }
+          : projected;
+      },
     });
     if (!applied.ok) {
       throw new Error(applied.error.message);
@@ -791,11 +840,47 @@ export class EmbeddedTuiBackend implements TuiBackend {
       agentId: opts.agentId,
     });
     const resolved = resolveSessionModelRef(cfg, applied.entry, agentId);
+    let activeRun: SessionsPatchResult["activeRun"];
+    if (executionAuthorityPatch) {
+      try {
+        await appendSessionAudit({
+          cfg,
+          target: {
+            agentId,
+            entry: applied.entry,
+            sessionKey: target.canonicalKey ?? opts.key,
+            storePath: target.storePath,
+          },
+          text: stoppedActiveRun
+            ? "execution policy updated after active local work was stopped"
+            : "execution policy updated while the local session was idle",
+          now: Date.now(),
+        });
+        activeRun = {
+          policy:
+            opts.activeRunPolicy === "stop-and-continue" && !stoppedActiveRun
+              ? "reject"
+              : (opts.activeRunPolicy ?? "reject"),
+          stopped: stoppedActiveRun,
+          auditNote: "appended",
+        };
+      } catch {
+        activeRun = {
+          policy:
+            opts.activeRunPolicy === "stop-and-continue" && !stoppedActiveRun
+              ? "reject"
+              : (opts.activeRunPolicy ?? "reject"),
+          stopped: stoppedActiveRun,
+          auditNote: "failed",
+        };
+      }
+    }
     return {
       ok: true as const,
       path: target.storePath,
       key: target.canonicalKey ?? opts.key,
       entry: { ...applied.entry },
+      ...(activeRun ? { activeRun } : {}),
       resolved: {
         modelProvider: resolved.provider,
         model: resolved.model,
@@ -1102,6 +1187,24 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (this.isSameRunScope(run, params) && !run.isBtw && this.isAbortableRun(runId, run)) {
         run.controller.abort();
       }
+    }
+  }
+
+  private clearSessionRunQueues(params: { sessionKey: string; agentId?: string }) {
+    for (const run of this.runs.values()) {
+      if (this.isSameRunScope(run, params) && !run.isBtw) {
+        delete run.pendingQueue;
+      }
+    }
+  }
+
+  private async waitForSessionRuns(params: { sessionKey: string; agentId?: string }) {
+    const pending = [...this.runs]
+      .filter(([, run]) => this.isSameRunScope(run, params) && !run.isBtw)
+      .flatMap(([runId]) => this.runPromises.get(runId) ?? []);
+    await Promise.allSettled(pending);
+    if (this.hasAbortableSessionRun(params)) {
+      throw new Error("local session work did not finish stopping");
     }
   }
 

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -258,9 +258,26 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   ): Promise<SessionsPatchResult | null> => {
     const selection = captureSessionSelection();
     try {
+      const executionAuthorityPatch =
+        patch.elevatedLevel !== undefined ||
+        patch.execHost !== undefined ||
+        patch.execSecurity !== undefined ||
+        patch.execAsk !== undefined ||
+        patch.execNode !== undefined ||
+        patch.permissionMode !== undefined ||
+        patch.toolOverrides !== undefined ||
+        patch.inheritedToolPolicyVersion !== undefined ||
+        patch.inheritedToolAllow !== undefined ||
+        patch.inheritedToolDeny !== undefined;
       const result = await client.patchSession({
         key: selection.sessionKey,
         ...(!parseAgentSessionKey(selection.sessionKey) ? { agentId: selection.agentId } : {}),
+        ...(executionAuthorityPatch && state.currentSessionId && state.sessionInfo.lifecycleRevision
+          ? {
+              expectedSessionId: state.currentSessionId,
+              expectedLifecycleRevision: state.sessionInfo.lifecycleRevision,
+            }
+          : {}),
         ...patch,
       });
       return isCurrentSessionSelection(selection) ? result : null;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -248,6 +248,9 @@ export function createSessionActions(context: SessionActionContext) {
     }
 
     const next = { ...state.sessionInfo };
+    if (entry?.lifecycleRevision !== undefined) {
+      next.lifecycleRevision = entry.lifecycleRevision;
+    }
     if (entry?.thinkingLevel !== undefined) {
       next.thinkingLevel = entry.thinkingLevel;
     }

--- a/src/tui/tui-session-info.ts
+++ b/src/tui/tui-session-info.ts
@@ -17,6 +17,7 @@ export type SessionInfoEntry = SessionInfo & {
 /** Compare only session facts that change visible TUI behavior. */
 export function sessionInfoUiEquals(left: SessionInfo, right: SessionInfo): boolean {
   return (
+    left.lifecycleRevision === right.lifecycleRevision &&
     left.thinkingLevel === right.thinkingLevel &&
     (left.thinkingLevels === right.thinkingLevels ||
       JSON.stringify(left.thinkingLevels ?? null) ===

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -98,6 +98,7 @@ export type AgentEvent = {
 export type ResponseUsageMode = "on" | "off" | "tokens" | "full";
 
 export type SessionInfo = {
+  lifecycleRevision?: string;
   thinkingLevel?: string;
   thinkingLevels?: Array<{ id: string; label: string }>;
   fastMode?: FastMode;

--- a/src/worker/embedded-agent.runtime.ts
+++ b/src/worker/embedded-agent.runtime.ts
@@ -88,6 +88,7 @@ type RunWorkerEmbeddedTurnParams = {
   transcript: WorkerEmbeddedTranscriptClient;
   live: WorkerEmbeddedLiveClient;
   sessions?: Parameters<typeof createWorkerSessionTools>[0];
+  allowFullAccessDelegation?: boolean;
   initialMessages?: WorkerTranscriptMessage[];
   suppressPromptTranscript?: boolean;
   systemPrompt?: string;
@@ -257,9 +258,9 @@ export async function runWorkerEmbeddedTurn(params: RunWorkerEmbeddedTurnParams)
         throw new Error("Worker session tool client unavailable");
       }
       const sessionTools = params.sessions
-        ? createWorkerSessionTools(params.sessions).filter((tool) =>
-            allowedToolNameSet.has(tool.name),
-          )
+        ? createWorkerSessionTools(params.sessions, {
+            fullAccessDelegation: params.allowFullAccessDelegation === true,
+          }).filter((tool) => allowedToolNameSet.has(tool.name))
         : [];
 
       return await createAgentSession({

--- a/src/worker/launch-descriptor.ts
+++ b/src/worker/launch-descriptor.ts
@@ -72,6 +72,7 @@ type WorkerLaunchAssignment = WorkerLaunchPermissionContext & {
   };
   toolAuthority: WorkerToolAuthority;
   browser?: WorkerBrowserLaunchDescriptor;
+  fullAccessDelegationAllowed?: true;
 };
 
 type WorkerLaunchAdmission = Omit<WorkerConnectParams["admission"], "runId"> & {
@@ -188,7 +189,13 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
         "liveEvents",
         "toolAuthority",
       ],
-      ["systemPrompt", "browser", "permissionMode", "workerContainmentRoot"],
+      [
+        "systemPrompt",
+        "browser",
+        "permissionMode",
+        "workerContainmentRoot",
+        "fullAccessDelegationAllowed",
+      ],
     )
   ) {
     return undefined;
@@ -202,6 +209,12 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
         typeof value.workerContainmentRoot !== "string" ||
         !isIdentifier(value.workerContainmentRoot) ||
         !isAbsoluteHostPath(value.workerContainmentRoot)))
+  ) {
+    return undefined;
+  }
+  if (
+    value.fullAccessDelegationAllowed !== undefined &&
+    (value.fullAccessDelegationAllowed !== true || value.permissionMode !== "full")
   ) {
     return undefined;
   }

--- a/src/worker/tool-authority.ts
+++ b/src/worker/tool-authority.ts
@@ -21,6 +21,9 @@ export const WORKER_SESSION_TOOL_NAMES = [
   "github_publish",
 ] as const;
 
+/** Private turn capability; never projected as a model-facing or inherited tool name. */
+export const WORKER_FULL_ACCESS_DELEGATION_CAPABILITY = "sessions_spawn_full_access";
+
 export const WORKER_TOOL_NAMES = [
   ...WORKER_LOCAL_TOOL_NAMES,
   ...WORKER_SESSION_TOOL_NAMES,

--- a/src/worker/worker-session-tools.test.ts
+++ b/src/worker/worker-session-tools.test.ts
@@ -3,6 +3,23 @@ import { describe, expect, it, vi } from "vitest";
 import { createWorkerSessionTools } from "./worker-session-tools.js";
 
 describe("worker Gateway tools", () => {
+  it("exposes full delegation only on a full worker turn", () => {
+    const client = {
+      requestGitHubPublish: vi.fn(),
+      requestSessionsSend: vi.fn(),
+      requestSessionsSpawn: vi.fn(),
+    };
+    const ordinary = createWorkerSessionTools(client).find(
+      (candidate) => candidate.name === "sessions_spawn",
+    );
+    const full = createWorkerSessionTools(client, { fullAccessDelegation: true }).find(
+      (candidate) => candidate.name === "sessions_spawn",
+    );
+
+    expect(JSON.stringify(ordinary?.parameters)).not.toContain("permissionMode");
+    expect(JSON.stringify(full?.parameters)).toContain("permissionMode");
+  });
+
   it("requests publication without accepting repository or credential authority", async () => {
     const requestGitHubPublish = vi.fn(async () => ({
       type: "res" as const,

--- a/src/worker/worker-session-tools.ts
+++ b/src/worker/worker-session-tools.ts
@@ -50,7 +50,10 @@ function parseToolResult(
   return parsed as AgentToolResult<unknown>;
 }
 
-export function createWorkerSessionTools(client: WorkerSessionRpcClient): AnyAgentTool[] {
+export function createWorkerSessionTools(
+  client: WorkerSessionRpcClient,
+  options: { fullAccessDelegation?: boolean } = {},
+): AnyAgentTool[] {
   return [
     {
       label: "GitHub Publish",
@@ -81,6 +84,9 @@ export function createWorkerSessionTools(client: WorkerSessionRpcClient): AnyAge
         agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
         model: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
         runTimeoutSeconds: Type.Optional(Type.Integer({ minimum: 0, maximum: 86_400 })),
+        ...(options.fullAccessDelegation
+          ? { permissionMode: Type.Optional(Type.Literal("full")) }
+          : {}),
       }),
       execute: async (toolCallId, raw) => {
         const params = raw as Omit<WorkerSessionsSpawnParams, "toolCallId">;

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -188,6 +188,7 @@ export async function runWorkerDescriptor(
           },
         },
         sessions: connection,
+        allowFullAccessDelegation: descriptor.assignment.fullAccessDelegationAllowed === true,
         signal: abortController.signal,
       });
       if (options.signal?.aborted) {

--- a/ui/src/lib/sessions/patch.ts
+++ b/ui/src/lib/sessions/patch.ts
@@ -30,6 +30,8 @@ export type SessionPatchOptions = {
   agentId?: string;
   /** Durable identity observed with the row before an archive or restore action. */
   expectedSessionId?: string;
+  /** Lifecycle generation paired with expectedSessionId for stop-and-continue changes. */
+  expectedLifecycleRevision?: string;
   /** Let a caller with stricter lifecycle ownership publish the resolved model value. */
   deferModelOverride?: boolean;
   /** Keep optimistic model state bound to the UI owner that initiated the patch. */

--- a/ui/src/lib/sessions/session-requests.ts
+++ b/ui/src/lib/sessions/session-requests.ts
@@ -142,12 +142,18 @@ export function requestSessionPatch(
   client: SessionRequestClient,
   key: string,
   patch: SessionPatch,
-  options: { agentId?: string | null; expectedSessionId?: string | null } = {},
+  options: {
+    agentId?: string | null;
+    expectedSessionId?: string | null;
+    expectedLifecycleRevision?: string | null;
+  } = {},
 ): Promise<SessionsPatchResult> {
   const expectedSessionId = options.expectedSessionId?.trim();
+  const expectedLifecycleRevision = options.expectedLifecycleRevision?.trim();
   const params = {
     ...buildSessionRequestParams(key, options.agentId),
     ...(expectedSessionId ? { expectedSessionId } : {}),
+    ...(expectedLifecycleRevision ? { expectedLifecycleRevision } : {}),
     ...patch,
   };
   return patch.archived === true


### PR DESCRIPTION
Closes #128233

## What Problem This Solves

Resolves a problem where a trusted full-access session could not explicitly delegate full access to a native subagent, while changing session execution policy during active work updated durable settings without replacing the already-prepared runtime authority.

## Why This Change Was Made

`sessions_spawn` now exposes `permissionMode: "full"` only on an exact direct user turn whose live parent session is already full access. Hidden and visible children share the canonical session creation owner, and the closure-bound admission is revalidated across parent lifecycle, operational run, worker claim, Gateway generation, child commit, and launch. Omission never inherits full access; ACP remains outside this contract.

Execution-authority patches now rotate the session lifecycle revision. Active work is rejected by default, or can be stopped and drained with exact session/revision CAS before commit; `stop-and-continue` launches one trusted continuation after commit. Chat, embedded/reply, queue, worker, terminal, and admission owners are fenced, and policy changes append a visible system note. This adds no config, protocol-version, or SQLite schema-version change.

## User Impact

Operators can explicitly delegate a trusted full-access task to a native subagent without weakening sandbox, tool-policy, depth, target-agent, or child-count ceilings. Permission and exec changes no longer leave active or queued work running under stale authority, and stop/continuation outcomes are visible in the patch result and transcript.

## Evidence

- Focused spawn/tool/ACP suites: 260 tests passed.
- Gateway creation suite: 228 tests passed.
- Gateway patch/archive suites: 70 tests passed after rebase.
- Worker session-tool suites: 40 tests passed.
- TUI suites: 250 tests passed.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, and `pnpm tsgo:ui` passed.
- Changed gate passed formatting, deadcode, core/UI typechecks, core/UI/script lint, protocol guards, plugin boundaries, import architecture checks, and app tests until one unrelated host-dependent package test: `test/scripts/package-mac-app.test.ts` assumes `bash -lc` preserves its isolated `PATH`; this host login shell restores `/usr/bin`, so the real pnpm is found and the expected missing-pnpm stderr is absent. The focused test reproduces unchanged on `origin/main`; no affected file overlaps this change.
- `pnpm protocol:gen`, `pnpm protocol:gen:swift`, and `pnpm protocol:gen:kotlin` refreshed the additive schema clients; no protocol version bump.
- Fresh autoreview on the final pre-push diff: clean, no accepted/actionable findings.
- Post-rebase smoke: 152 focused tests plus core typecheck passed on `d855aea0bfc`.

Production growth implements the public capability and lifecycle authority boundary; tests and generated clients are classified separately. The patch engine owner was reduced by 33 lines, and hidden spawn now commits its complete model/session state in one canonical creation instead of a direct create plus a second model write.
