### PR TITLE
fix(telegram): preserve inbound link destinations and labels

### DIFF
--- a/extensions/telegram/src/bot/body-helpers.inbound.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.inbound.test.ts
@@ -1,4 +1,5 @@
 import type { Message, MessageEntity } from "grammy/types";
+import { markdownToIR } from "openclaw/plugin-sdk/text-chunking";
 import { describe, expect, it } from "vitest";
 import { getTelegramTextParts, joinTelegramTextParts } from "./body-helpers.js";
 import { renderTelegramTextEntities } from "./inbound-text-entities.js";
@@ -50,6 +51,31 @@ describe("getTelegramTextParts", () => {
       entities: [],
     });
   });
+
+  it("preserves native poll links with Markdown-sensitive labels and destinations", () => {
+    const label = "docs]more";
+    const url = "https://example.com/report)final";
+    const result = getTelegramTextParts(
+      asTelegramMessage({
+        poll: {
+          id: "poll-links",
+          question: "Review the report?",
+          options: [{ text: "Yes", voter_count: 1 }],
+          total_voter_count: 1,
+          is_closed: false,
+          is_anonymous: true,
+          type: "regular",
+          allows_multiple_answers: false,
+          description: `Read ${label}`,
+          description_entities: [{ type: "text_link", offset: 5, length: label.length, url }],
+        },
+      }),
+    );
+
+    const parsed = markdownToIR(result.text);
+    expect(parsed.text).toContain(`Read ${label}`);
+    expect(parsed.links.map((link) => link.href)).toEqual([url]);
+  });
 });
 
 describe("joinTelegramTextParts", () => {
@@ -96,6 +122,35 @@ describe("joinTelegramTextParts", () => {
       text: "bold",
       entities: [{ type: "bold", offset: 0, length: 4 }],
     });
+  });
+
+  it("preserves links from joined messages and captions through the real Markdown parser", () => {
+    const messageLabel = "😀 report]";
+    const captionLabel = "[caption";
+    const messageUrl = "https://example.com/message)final";
+    const captionUrl = "https://example.com/caption(a)b)";
+    const result = joinTelegramTextParts(
+      [
+        asTelegramMessage({
+          text: `Read ${messageLabel}`,
+          entities: [
+            { type: "text_link", offset: 5, length: messageLabel.length, url: messageUrl },
+          ],
+        }),
+        asTelegramMessage({
+          caption: `Open ${captionLabel}`,
+          caption_entities: [
+            { type: "text_link", offset: 5, length: captionLabel.length, url: captionUrl },
+          ],
+        }),
+      ],
+      "\n",
+    );
+
+    const parsed = markdownToIR(renderTelegramTextEntities(result.text, result.entities));
+
+    expect(parsed.text).toBe(result.text);
+    expect(parsed.links.map((link) => link.href)).toEqual([messageUrl, captionUrl]);
   });
 });
 

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover helpers plugin behavior.
 import type { MessageEntity } from "grammy/types";
+import { markdownToIR } from "openclaw/plugin-sdk/text-chunking";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   describeReplyTarget,
@@ -956,4 +957,83 @@ describe("renderTelegramTextEntities", () => {
 
     expect(renderTelegramTextEntities(text, entities)).toBe("Hi 😀 **bold**");
   });
+
+  it.each([
+    {
+      description: "an unmatched closing parenthesis",
+      label: "docs",
+      url: "https://example.com/report)final",
+      expectedHref: "https://example.com/report)final",
+    },
+    {
+      description: "nested and trailing parentheses",
+      label: "docs",
+      url: "https://example.com/quarter(a)b)",
+      expectedHref: "https://example.com/quarter(a)b)",
+    },
+    {
+      description: "a literal destination backslash",
+      label: "docs",
+      url: String.raw`https://example.com/a\b)`,
+      expectedHref: "https://example.com/a%5Cb)",
+    },
+    {
+      description: "angle brackets and whitespace",
+      label: "docs",
+      url: "https://example.com/<report final>",
+      expectedHref: "https://example.com/%3Creport%20final%3E",
+    },
+    {
+      description: "a closing bracket in the linked label",
+      label: "docs]more",
+      url: "https://example.com/report)final",
+      expectedHref: "https://example.com/report)final",
+    },
+    {
+      description: "a literal backslash before a bracket in the linked label",
+      label: String.raw`docs\]more`,
+      url: "https://example.com/report)final",
+      expectedHref: "https://example.com/report)final",
+    },
+    {
+      description: "an opening bracket and UTF-16 emoji in the linked label",
+      label: "😀 [docs",
+      url: "https://example.com/report)final",
+      expectedHref: "https://example.com/report)final",
+    },
+    {
+      description: "a newline in a provider link destination",
+      label: "docs",
+      url: "https://example.com/report\nfinal",
+      expectedHref: "https://example.com/report%0Afinal",
+    },
+    {
+      description: "an already percent-encoded parenthesis",
+      label: "docs",
+      url: "https://example.com/report%29final",
+      expectedHref: "https://example.com/report%29final",
+    },
+  ])(
+    "preserves $description through the actual Markdown parser",
+    ({ label, url, expectedHref }) => {
+      const text = `Read ${label} now`;
+      const offset = "Read ".length;
+      const entities = [
+        { type: "bold", offset, length: label.length },
+        { type: "text_link", offset, length: label.length, url },
+      ] satisfies MessageEntity[];
+
+      const parsed = markdownToIR(renderTelegramTextEntities(text, entities));
+
+      expect(parsed.text).toBe(text);
+      expect(parsed.links).toEqual([
+        { start: offset, end: offset + label.length, href: expectedHref },
+      ]);
+      expect(parsed.styles).toContainEqual({
+        start: offset,
+        end: offset + label.length,
+        style: "bold",
+      });
+    },
+  );
 });

--- a/extensions/telegram/src/bot/inbound-text-entities.ts
+++ b/extensions/telegram/src/bot/inbound-text-entities.ts
@@ -101,7 +101,12 @@ function markdownAffixesForTelegramEntity(
     case "pre":
       return markdownPreAffixes(entity, content);
     case "text_link":
-      return ["[", `](${entity.url})`];
+      return [
+        "[",
+        `](${entity.url.replace(/[\\()<>\s]/gu, (character) =>
+          character === "(" || character === ")" ? `\\${character}` : encodeURIComponent(character),
+        )})`,
+      ];
     default:
       return null;
   }
@@ -191,6 +196,7 @@ export function renderTelegramTextEntities(
 
   const sortedQuoteEdges = [...quoteEdges].toSorted((left, right) => left - right);
   const boundaries = new Map<number, TelegramMarkdownBoundary[]>();
+  const escapedLinkLabelOffsets = new Set<number>();
   const addBoundary = (offset: number, boundary: TelegramMarkdownBoundary) => {
     const entries = boundaries.get(offset);
     if (entries) {
@@ -205,6 +211,11 @@ export function renderTelegramTextEntities(
     }
     for (const segment of splitTelegramFormattingAtQuoteEdges(text, entity, sortedQuoteEdges)) {
       const content = text.slice(segment.offset, segment.offset + segment.length);
+      if (segment.type === "text_link") {
+        for (const match of content.matchAll(/[\\[\]]/gu)) {
+          escapedLinkLabelOffsets.add(segment.offset + match.index);
+        }
+      }
       const affixes = markdownAffixesForTelegramEntity(segment, content);
       if (!affixes) {
         continue;
@@ -252,7 +263,7 @@ export function renderTelegramTextEntities(
         });
     }
     if (offset < text.length) {
-      result += text[offset];
+      result += escapedLinkLabelOffsets.has(offset) ? `\\${text[offset]}` : text[offset];
     }
   }
   return result;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users sending clickable text links would give the agent a truncated destination or lose the link entirely when its URL contained unmatched parentheses, backslashes, angle brackets, or whitespace, or when its visible label contained Markdown brackets. The same corruption affected ordinary messages, captions, buffered message history, and native poll descriptions.

## Why This Change Was Made

Telegram provides clickable labels and their destinations as structured message entities, but the private inbound renderer interpolated both directly into Markdown without honoring Markdown's separate destination and label grammars. Repair the canonical Telegram-owned entity renderer: preserve existing output for ordinary links, escape destination parentheses, encode characters that cannot safely appear in a destination, and escape bracket/backslash characters at their original UTF-16 label offsets. Existing overlapping formatting, emoji offsets, and rejected unsafe URL schemes remain intact.

Production delta: **+11 lines**. Both the destination grammar and original-offset label escaping are necessary to preserve the already-shipped user-visible link contract across every caller without adding a helper, public API, configuration, fallback, or cross-plugin dependency.

## User Impact

Agents receive the complete link label and intended URL from Telegram messages, media captions, buffered conversation history, and native polls. Legitimate nested or unmatched parentheses, pre-encoded URLs, Unicode labels, overlapping bold formatting, and literal label brackets no longer silently alter the text or point the agent at the wrong destination.

## Evidence

- Before the fix, **8 genuine owner-boundary regressions failed** while 72 existing cases passed. The real production Markdown parser truncated a URL such as `https://example.com/report)final` to `https://example.com/report` and leaked `final)` into visible text; bracketed labels could remove the link entirely.
- After the fix, **235 tests passed across 11 Telegram owner, message-context, buffered-history, native-quote, formatting, chunking, and outbound suites**.
- A separate independent reviewer passed the **82 owner/sibling tests** and **2,340 combinations through the actual production renderer and Markdown parser**, including labels, URLs, nested formatting, UTF-16 emoji offsets, unchanged safe output, and rejected unsafe schemes.
- Exact focused command: `node scripts/run-vitest.mjs extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/bot/body-helpers.inbound.test.ts extensions/telegram/src/bot/native-quote.test.ts extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/bot-message-context.group-body.test.ts extensions/telegram/src/bot-message-context.forwarded-batch.test.ts extensions/telegram/src/bot-message-context.reply-batch.test.ts extensions/telegram/src/bot-message-context.prompt-context.test.ts extensions/telegram/src/format.test.ts extensions/telegram/src/send.chunks.test.ts extensions/telegram/src/telegram-outbound.test.ts`.
- Scoped typed lint, formatting, assertion-safety ratchet, max-lines ratchet, and `git diff --check` passed. Full extension production/test type lanes reported only the existing unrelated `extensions/acpx` `promptStarted`/`elicitationModes` dependency mismatch; no touched Telegram type diagnostics occurred.
- Both the independent code review and the fresh authenticated review of the complete committed branch reported no actionable findings.
- Verified head: `7fce6c49b759d2bef7e9b081c79af56c7d9f22a7`. Hosted exact-head CI will run when the draft becomes ready.
