### PR TITLE
improve(ui): even out transcript turn and run block spacing

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -45,7 +45,6 @@ type CliOptions = {
   fixture?:
     | "approval"
     | "board"
-    | "chat-spacing"
     | "code-fences"
     | "swarm"
     | "update-available"
@@ -349,7 +348,6 @@ function parseFixture(value: string | undefined): CliOptions["fixture"] {
   if (
     value !== "approval" &&
     value !== "board" &&
-    value !== "chat-spacing" &&
     value !== "code-fences" &&
     value !== "swarm" &&
     value !== "update-available" &&
@@ -1299,27 +1297,18 @@ function buildScrollableChatHistory(baseTime: number): unknown[] {
   // Completed work turn: commentary + tool results ahead of the final reply
   // exercise the collapsed "Worked for X" rollup at the end of the thread.
   const workTurnBase = baseTime + 37 * 60_000;
-  const workRunId = "mock-work-run";
   messages.push(
+    chatHistoryMessage(
+      "user",
+      "Mock work request: refactor the render guard and rerun the suite.",
+      workTurnBase,
+    ),
+    chatHistoryMessage(
+      "assistant",
+      "Checking the guard implementation before editing.",
+      workTurnBase + 5_000,
+    ),
     {
-      ...chatHistoryMessage(
-        "user",
-        "Mock work request: refactor the render guard and rerun the suite.",
-        workTurnBase,
-      ),
-      __openclaw: { id: "mock-work-request", idempotencyKey: `${workRunId}:user` },
-    },
-    {
-      ...chatHistoryMessage(
-        "assistant",
-        "Checking the guard implementation before editing.",
-        workTurnBase + 5_000,
-      ),
-      __openclaw: { runId: workRunId },
-      phase: "commentary",
-    },
-    {
-      __openclaw: { runId: workRunId },
       role: "toolResult",
       toolCallId: "mock-work-read",
       toolName: "read",
@@ -1327,141 +1316,20 @@ function buildScrollableChatHistory(baseTime: number): unknown[] {
       timestamp: workTurnBase + 12_000,
     },
     {
-      __openclaw: { runId: workRunId },
       role: "toolResult",
       toolCallId: "mock-work-exec",
       toolName: "exec",
       content: [{ type: "text", text: "pnpm test chat-thread — 12 passed." }],
       timestamp: workTurnBase + 95_000,
     },
-    {
-      ...chatHistoryMessage(
-        "assistant",
-        "Refactored the render guard and reran the suite; all 12 tests pass.",
-        workTurnBase + 172_000,
-      ),
-      __openclaw: { runId: workRunId },
-      phase: "final_answer",
-    },
+    chatHistoryMessage(
+      "assistant",
+      "Refactored the render guard and reran the suite; all 12 tests pass.",
+      workTurnBase + 172_000,
+    ),
   );
 
   return messages;
-}
-
-const CHAT_SPACING_SESSION_KEY = "agent:main:dashboard:chat-spacing-review";
-const CHAT_SPACING_FIRST_RUN_ID = "mock-chat-spacing-initial-review";
-const CHAT_SPACING_REVIEW_RUN_ID = "mock-chat-spacing-maintainer-review";
-
-function chatSpacingToolResults(
-  runId: string,
-  startedAt: number,
-  counts: { commands: number; progressCards?: number; webSearches?: number },
-): unknown[] {
-  const names = [
-    ...Array.from({ length: counts.commands }, () => "exec"),
-    ...Array.from({ length: counts.progressCards ?? 0 }, () => "progress_card"),
-    ...Array.from({ length: counts.webSearches ?? 0 }, () => "web_search"),
-  ];
-  return names.map((toolName, index) => ({
-    __openclaw: { runId },
-    role: "toolResult",
-    toolCallId: `${runId}-${startedAt}-${index}`,
-    toolName,
-    content: [{ type: "text", text: `${toolName} mock result ${index + 1}` }],
-    timestamp: startedAt + index,
-  }));
-}
-
-function buildChatSpacingHistory(now: number): unknown[] {
-  const firstTurnAt = now - 3 * 60 * 60_000;
-  const userTurnAt = firstTurnAt + 10 * 60_000;
-  const forwarded =
-    "Full review-only OpenClaw maintainer review of #127841. Work from /home/openclaw/.openclaw/projects/05ecb4050064f070/openclaw. Use a clean exact-head worktree if feasible; if full materialization fails, use a sparse worktree or temporary bare repository plus only the touched/test paths. Do not mutate GitHub or source. Read root/scoped AGENTS.md and use openclaw-pr-maintainer plus testing/test-audit. Verify premise on current main and shipped behavior with exact line; architecture/owner/config/fallback/compat/protocol/schema/persistence/LOC; intent/history; provenance and reproducibility; complete evidence map; exact-head/current-main proof, CI and ClawSweeper; one verdict and single deciding reason; best-fix judgment and detailed file-level handoff. Do not stop for missing gh auth or a failed full checkout. Full access/high/fast/gateway execution configured. FINISH report; do not acknowledge only.";
-  const exactHead =
-    "Exact-head materialization succeeded: PR head `a0f2bb64…` is one commit ahead and 139 commits behind current `main` (`5c922502…`). Current main has since changed the same failure/retry surface and restored `send_attempt_started` for this case, so the deciding question is now semantic supersession—not merely rebase freshness. I’m tracing that later owner change and its linked bugs before judging.";
-  const plan = [
-    "Codex plan:",
-    "",
-    "- [completed] Read review/testing policy and recover isolated checkout",
-    "- [completed] Reconstruct PR metadata, exact diff, history, and evidence map",
-    "- [in_progress] Verify premise on exact head, current main, and shipped tags",
-    "- [pending] Audit tests, CI, ClawSweeper, compatibility, and LOC",
-    "- [pending] Deliver one verdict with deciding reason and file-level handoff",
-  ].join("\n");
-  const continuing =
-    "Continuing the review from the isolated exact-head checkout. I’m reconstructing the evidence gathered so far, then I’ll finish exact-head/current-main tests, CI and ClawSweeper checks, and return the single maintainer verdict with file-level handoff.";
-  const coherent =
-    "The exact-head patch is internally coherent, but the branch is now semantically stale: current `main` changed the same retry/queue-ownership neighborhood in #124310 and intentionally retains `send_attempt_started` for the adapter-rejection case. I’m now testing whether rebasing the PR would preserve the new caller-vs-queue retry contract or regress it; that is the deciding merge question.";
-
-  return [
-    {
-      ...chatHistoryMessage("assistant", forwarded, firstTurnAt),
-      senderLabel: "Forwarded from roboclaw",
-      provenance: { kind: "inter_session", sourceTool: "sessions_send" },
-      __openclaw: { id: "mock-chat-spacing-forwarded", runId: CHAT_SPACING_FIRST_RUN_ID },
-    },
-    {
-      ...chatHistoryMessage(
-        "assistant",
-        "Materializing the exact PR head and tracing the current-main retry owner.",
-        firstTurnAt + 15_000,
-      ),
-      __openclaw: { runId: CHAT_SPACING_FIRST_RUN_ID },
-      phase: "commentary",
-    },
-    ...chatSpacingToolResults(CHAT_SPACING_FIRST_RUN_ID, firstTurnAt + 30_000, {
-      commands: 3,
-    }),
-    {
-      ...chatHistoryMessage("assistant", exactHead, firstTurnAt + 145_000),
-      __openclaw: { runId: CHAT_SPACING_FIRST_RUN_ID },
-      phase: "final_answer",
-    },
-    ...chatSpacingToolResults(CHAT_SPACING_FIRST_RUN_ID, firstTurnAt + 146_000, {
-      commands: 35,
-      webSearches: 4,
-    }),
-    {
-      ...chatHistoryMessage(
-        "user",
-        "Begin and complete the full PR #127841 maintainer review now. The complete requirements are recorded in the preceding session message; perform them and return the final report, not an acknowledgment.",
-        userTurnAt,
-      ),
-      senderLabel: "Vyctor Brzezowski",
-      __openclaw: {
-        id: "mock-chat-spacing-user",
-        idempotencyKey: `${CHAT_SPACING_REVIEW_RUN_ID}:user`,
-        senderId: "profile-vyctor",
-        senderName: "Vyctor Brzezowski",
-      },
-    },
-    {
-      ...chatHistoryMessage("assistant", plan, userTurnAt + 12_000),
-      __openclaw: { runId: CHAT_SPACING_REVIEW_RUN_ID },
-      phase: "commentary",
-    },
-    {
-      ...chatHistoryMessage("assistant", continuing, userTurnAt + 20_000),
-      __openclaw: { runId: CHAT_SPACING_REVIEW_RUN_ID },
-      phase: "commentary",
-    },
-    ...chatSpacingToolResults(CHAT_SPACING_REVIEW_RUN_ID, userTurnAt + 35_000, {
-      commands: 24,
-      progressCards: 1,
-      // The aggregate label counts generic tool calls together, so one
-      // progress_card plus two searches renders the reference's “×3”.
-      webSearches: 2,
-    }),
-    {
-      ...chatHistoryMessage("assistant", coherent, userTurnAt + 89_000),
-      __openclaw: { runId: CHAT_SPACING_REVIEW_RUN_ID },
-      phase: "final_answer",
-    },
-    ...chatSpacingToolResults(CHAT_SPACING_REVIEW_RUN_ID, userTurnAt + 90_000, {
-      commands: 13,
-      progressCards: 1,
-    }),
-  ];
 }
 
 function buildCodeFenceChatHistory(baseTime: number): unknown[] {
@@ -1491,10 +1359,9 @@ async function createChatPickerScenario(
   fixture?: CliOptions["fixture"],
 ): Promise<ControlUiMockGatewayScenario> {
   const baseTime = Date.parse("2026-05-22T09:00:00.000Z");
-  const chatSpacingFixture = fixture === "chat-spacing";
   const selfProfile: UserProfile = {
-    id: chatSpacingFixture ? "profile-vyctor" : "presence-riley",
-    displayName: chatSpacingFixture ? "Vyctor Brzezowski" : "Riley",
+    id: "presence-riley",
+    displayName: "Riley",
     avatarMime: null,
     mergedInto: null,
     createdAt: baseTime,
@@ -1812,24 +1679,6 @@ async function createChatPickerScenario(
   const activitySessions = buildActivitySessionRows(Date.now());
   const sessions = [
     ...activitySessions,
-    ...(chatSpacingFixture
-      ? [
-          sessionRow(CHAT_SPACING_SESSION_KEY, "PR #127841 maintainer review", Date.now(), {
-            createdActor: {
-              type: "human",
-              id: "profile-vyctor",
-              label: "Vyctor Brzezowski",
-            },
-            owner: {
-              actor: {
-                type: "human",
-                id: "profile-vyctor",
-                label: "Vyctor Brzezowski",
-              },
-            },
-          }),
-        ]
-      : []),
     ...(fixture === "workboard"
       ? [
           sessionRow(workboardMocks.sessionKey, "Product operations dashboard", baseTime, {
@@ -2017,9 +1866,8 @@ async function createChatPickerScenario(
     swarmEnabled: fixture === "swarm",
     workboardEnabled: fixture === "workboard",
   });
-  const historyMessages = chatSpacingFixture
-    ? buildChatSpacingHistory(Date.now())
-    : fixture === "code-fences"
+  const historyMessages =
+    fixture === "code-fences"
       ? buildCodeFenceChatHistory(baseTime)
       : buildScrollableChatHistory(baseTime);
   const planSessionInfo = {
@@ -2046,16 +1894,6 @@ async function createChatPickerScenario(
     sessionId: "control-ui-e2e-session",
     sessionInfo: planSessionInfo,
     inFlightRun: planInFlightRun,
-    thinkingLevel: null,
-  };
-  const chatSpacingHistory = {
-    messages: historyMessages,
-    sessionId: "control-ui-chat-spacing-session",
-    sessionInfo: {
-      activeRunIds: [],
-      hasActiveRun: false,
-      key: CHAT_SPACING_SESSION_KEY,
-    },
     thinkingLevel: null,
   };
   const custodianHistory = {
@@ -2199,48 +2037,12 @@ async function createChatPickerScenario(
     ],
     methodResponses: {
       ...buildBackgroundTasksMock(baseTime),
-      ...(chatSpacingFixture ? { "tasks.list": { tasks: [] } } : {}),
       ...cronMocks,
       "chat.history": {
-        cases: [
-          ...(chatSpacingFixture
-            ? [
-                {
-                  match: { sessionKey: CHAT_SPACING_SESSION_KEY },
-                  response: chatSpacingHistory,
-                },
-              ]
-            : []),
-          { match: { sessionKey: "agent:main:main" }, response: planChatHistory },
-        ],
+        cases: [{ match: { sessionKey: "agent:main:main" }, response: planChatHistory }],
       },
       "chat.startup": {
         cases: [
-          ...(chatSpacingFixture
-            ? [
-                {
-                  match: { sessionKey: CHAT_SPACING_SESSION_KEY },
-                  response: {
-                    ...chatSpacingHistory,
-                    agentsList: {
-                      agents: [
-                        {
-                          id: "main",
-                          identity: { name: "Molty" },
-                          name: "Molty",
-                          workspace: "/Users/vyctor/Code/openclaw",
-                          workspaceGit: true,
-                        },
-                      ],
-                      defaultId: "main",
-                      mainKey: "main",
-                      scope: "agent",
-                    },
-                    metadata: { models: modelProviders.models },
-                  },
-                },
-              ]
-            : []),
           {
             match: { sessionKey: "agent:main:main" },
             response: {
@@ -2264,25 +2066,7 @@ async function createChatPickerScenario(
           },
         ],
       },
-      "progressCard.get": chatSpacingFixture
-        ? {
-            card: {
-              sessionKey: CHAT_SPACING_SESSION_KEY,
-              revision: 1,
-              updatedAt: Date.now(),
-              steps: [
-                { step: "Read review/testing policy", status: "completed" },
-                { step: "Reconstruct exact-head evidence", status: "completed" },
-                {
-                  step: "Verify premise on exact head, current main, and shipped tags",
-                  status: "in_progress",
-                },
-                { step: "Audit CI, ClawSweeper, compatibility, and LOC", status: "pending" },
-                { step: "Deliver the maintainer verdict", status: "pending" },
-              ],
-            },
-          }
-        : { card: null },
+      "progressCard.get": { card: null },
       "users.self": { profile: selfProfile },
       // Talk settings page pickers: realtime catalog with the model/voice
       // suggestion lists the gateway emits for provider entries.
@@ -3192,11 +2976,7 @@ async function createChatPickerScenario(
       ],
     },
     sessionArchiveFiltering: true,
-    sessionKey: chatSpacingFixture
-      ? CHAT_SPACING_SESSION_KEY
-      : fixture === "workboard"
-        ? workboardMocks.sessionKey
-        : "agent:main:main",
+    sessionKey: fixture === "workboard" ? workboardMocks.sessionKey : "agent:main:main",
     workspace: "/Users/peter/Projects/openclaw",
     workspaceGit: true,
   };
@@ -3364,28 +3144,9 @@ function createStatefulMockInitScript(): string {
   return `(() => { const __name = (target) => target; (${installControlUiStatefulMocks.toString()})(${CUSTODIAN_CHAT_REPLY_DELAY_MS}, ${CHAT_SEND_REPLY_DELAY_MS}); })();`;
 }
 
-function createMockDocumentTitleScript(title: string): string {
-  return `(() => {
-    const title = ${JSON.stringify(title)};
-    const syncTitle = () => {
-      if (document.title !== title) document.title = title;
-    };
-    syncTitle();
-    new MutationObserver(syncTitle).observe(document.head, {
-      childList: true,
-      characterData: true,
-      subtree: true,
-    });
-  })();`;
-}
-
-function createMockGatewayPlugin(
-  scenario: ControlUiMockGatewayScenario,
-  documentTitle: string,
-): Plugin {
+function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin {
   const initScript = escapeScriptContent(createControlUiMockGatewayInitScript(scenario));
   const statefulInitScript = escapeScriptContent(createStatefulMockInitScript());
-  const titleInitScript = escapeScriptContent(createMockDocumentTitleScript(documentTitle));
   const bootstrapBody = JSON.stringify(createControlUiMockBootstrapConfig(scenario));
   return {
     configureServer(server) {
@@ -3403,7 +3164,7 @@ function createMockGatewayPlugin(
     transformIndexHtml(html) {
       return html.replace(
         "</head>",
-        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${statefulInitScript}\n    </script>\n    <script data-openclaw-control-ui-mock-title>\n${titleInitScript}\n    </script>\n  </head>`,
+        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${statefulInitScript}\n    </script>\n  </head>`,
       );
     },
   };
@@ -3483,10 +3244,7 @@ const server = await createServer({
       : {}),
     include: ["lit/directives/repeat.js"],
   },
-  plugins: [
-    createMockGatewayPlugin(scenario, `💬 Chat spacing · :${options.port}`),
-    createBoardFixturePlugin(),
-  ],
+  plugins: [createMockGatewayPlugin(scenario), createBoardFixturePlugin()],
   publicDir: path.join(uiRoot, "public"),
   resolve: {
     alias: [

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -45,6 +45,7 @@ type CliOptions = {
   fixture?:
     | "approval"
     | "board"
+    | "chat-spacing"
     | "code-fences"
     | "swarm"
     | "update-available"
@@ -348,6 +349,7 @@ function parseFixture(value: string | undefined): CliOptions["fixture"] {
   if (
     value !== "approval" &&
     value !== "board" &&
+    value !== "chat-spacing" &&
     value !== "code-fences" &&
     value !== "swarm" &&
     value !== "update-available" &&
@@ -1297,18 +1299,27 @@ function buildScrollableChatHistory(baseTime: number): unknown[] {
   // Completed work turn: commentary + tool results ahead of the final reply
   // exercise the collapsed "Worked for X" rollup at the end of the thread.
   const workTurnBase = baseTime + 37 * 60_000;
+  const workRunId = "mock-work-run";
   messages.push(
-    chatHistoryMessage(
-      "user",
-      "Mock work request: refactor the render guard and rerun the suite.",
-      workTurnBase,
-    ),
-    chatHistoryMessage(
-      "assistant",
-      "Checking the guard implementation before editing.",
-      workTurnBase + 5_000,
-    ),
     {
+      ...chatHistoryMessage(
+        "user",
+        "Mock work request: refactor the render guard and rerun the suite.",
+        workTurnBase,
+      ),
+      __openclaw: { id: "mock-work-request", idempotencyKey: `${workRunId}:user` },
+    },
+    {
+      ...chatHistoryMessage(
+        "assistant",
+        "Checking the guard implementation before editing.",
+        workTurnBase + 5_000,
+      ),
+      __openclaw: { runId: workRunId },
+      phase: "commentary",
+    },
+    {
+      __openclaw: { runId: workRunId },
       role: "toolResult",
       toolCallId: "mock-work-read",
       toolName: "read",
@@ -1316,20 +1327,141 @@ function buildScrollableChatHistory(baseTime: number): unknown[] {
       timestamp: workTurnBase + 12_000,
     },
     {
+      __openclaw: { runId: workRunId },
       role: "toolResult",
       toolCallId: "mock-work-exec",
       toolName: "exec",
       content: [{ type: "text", text: "pnpm test chat-thread — 12 passed." }],
       timestamp: workTurnBase + 95_000,
     },
-    chatHistoryMessage(
-      "assistant",
-      "Refactored the render guard and reran the suite; all 12 tests pass.",
-      workTurnBase + 172_000,
-    ),
+    {
+      ...chatHistoryMessage(
+        "assistant",
+        "Refactored the render guard and reran the suite; all 12 tests pass.",
+        workTurnBase + 172_000,
+      ),
+      __openclaw: { runId: workRunId },
+      phase: "final_answer",
+    },
   );
 
   return messages;
+}
+
+const CHAT_SPACING_SESSION_KEY = "agent:main:dashboard:chat-spacing-review";
+const CHAT_SPACING_FIRST_RUN_ID = "mock-chat-spacing-initial-review";
+const CHAT_SPACING_REVIEW_RUN_ID = "mock-chat-spacing-maintainer-review";
+
+function chatSpacingToolResults(
+  runId: string,
+  startedAt: number,
+  counts: { commands: number; progressCards?: number; webSearches?: number },
+): unknown[] {
+  const names = [
+    ...Array.from({ length: counts.commands }, () => "exec"),
+    ...Array.from({ length: counts.progressCards ?? 0 }, () => "progress_card"),
+    ...Array.from({ length: counts.webSearches ?? 0 }, () => "web_search"),
+  ];
+  return names.map((toolName, index) => ({
+    __openclaw: { runId },
+    role: "toolResult",
+    toolCallId: `${runId}-${startedAt}-${index}`,
+    toolName,
+    content: [{ type: "text", text: `${toolName} mock result ${index + 1}` }],
+    timestamp: startedAt + index,
+  }));
+}
+
+function buildChatSpacingHistory(now: number): unknown[] {
+  const firstTurnAt = now - 3 * 60 * 60_000;
+  const userTurnAt = firstTurnAt + 10 * 60_000;
+  const forwarded =
+    "Full review-only OpenClaw maintainer review of #127841. Work from /home/openclaw/.openclaw/projects/05ecb4050064f070/openclaw. Use a clean exact-head worktree if feasible; if full materialization fails, use a sparse worktree or temporary bare repository plus only the touched/test paths. Do not mutate GitHub or source. Read root/scoped AGENTS.md and use openclaw-pr-maintainer plus testing/test-audit. Verify premise on current main and shipped behavior with exact line; architecture/owner/config/fallback/compat/protocol/schema/persistence/LOC; intent/history; provenance and reproducibility; complete evidence map; exact-head/current-main proof, CI and ClawSweeper; one verdict and single deciding reason; best-fix judgment and detailed file-level handoff. Do not stop for missing gh auth or a failed full checkout. Full access/high/fast/gateway execution configured. FINISH report; do not acknowledge only.";
+  const exactHead =
+    "Exact-head materialization succeeded: PR head `a0f2bb64…` is one commit ahead and 139 commits behind current `main` (`5c922502…`). Current main has since changed the same failure/retry surface and restored `send_attempt_started` for this case, so the deciding question is now semantic supersession—not merely rebase freshness. I’m tracing that later owner change and its linked bugs before judging.";
+  const plan = [
+    "Codex plan:",
+    "",
+    "- [completed] Read review/testing policy and recover isolated checkout",
+    "- [completed] Reconstruct PR metadata, exact diff, history, and evidence map",
+    "- [in_progress] Verify premise on exact head, current main, and shipped tags",
+    "- [pending] Audit tests, CI, ClawSweeper, compatibility, and LOC",
+    "- [pending] Deliver one verdict with deciding reason and file-level handoff",
+  ].join("\n");
+  const continuing =
+    "Continuing the review from the isolated exact-head checkout. I’m reconstructing the evidence gathered so far, then I’ll finish exact-head/current-main tests, CI and ClawSweeper checks, and return the single maintainer verdict with file-level handoff.";
+  const coherent =
+    "The exact-head patch is internally coherent, but the branch is now semantically stale: current `main` changed the same retry/queue-ownership neighborhood in #124310 and intentionally retains `send_attempt_started` for the adapter-rejection case. I’m now testing whether rebasing the PR would preserve the new caller-vs-queue retry contract or regress it; that is the deciding merge question.";
+
+  return [
+    {
+      ...chatHistoryMessage("assistant", forwarded, firstTurnAt),
+      senderLabel: "Forwarded from roboclaw",
+      provenance: { kind: "inter_session", sourceTool: "sessions_send" },
+      __openclaw: { id: "mock-chat-spacing-forwarded", runId: CHAT_SPACING_FIRST_RUN_ID },
+    },
+    {
+      ...chatHistoryMessage(
+        "assistant",
+        "Materializing the exact PR head and tracing the current-main retry owner.",
+        firstTurnAt + 15_000,
+      ),
+      __openclaw: { runId: CHAT_SPACING_FIRST_RUN_ID },
+      phase: "commentary",
+    },
+    ...chatSpacingToolResults(CHAT_SPACING_FIRST_RUN_ID, firstTurnAt + 30_000, {
+      commands: 3,
+    }),
+    {
+      ...chatHistoryMessage("assistant", exactHead, firstTurnAt + 145_000),
+      __openclaw: { runId: CHAT_SPACING_FIRST_RUN_ID },
+      phase: "final_answer",
+    },
+    ...chatSpacingToolResults(CHAT_SPACING_FIRST_RUN_ID, firstTurnAt + 146_000, {
+      commands: 35,
+      webSearches: 4,
+    }),
+    {
+      ...chatHistoryMessage(
+        "user",
+        "Begin and complete the full PR #127841 maintainer review now. The complete requirements are recorded in the preceding session message; perform them and return the final report, not an acknowledgment.",
+        userTurnAt,
+      ),
+      senderLabel: "Vyctor Brzezowski",
+      __openclaw: {
+        id: "mock-chat-spacing-user",
+        idempotencyKey: `${CHAT_SPACING_REVIEW_RUN_ID}:user`,
+        senderId: "profile-vyctor",
+        senderName: "Vyctor Brzezowski",
+      },
+    },
+    {
+      ...chatHistoryMessage("assistant", plan, userTurnAt + 12_000),
+      __openclaw: { runId: CHAT_SPACING_REVIEW_RUN_ID },
+      phase: "commentary",
+    },
+    {
+      ...chatHistoryMessage("assistant", continuing, userTurnAt + 20_000),
+      __openclaw: { runId: CHAT_SPACING_REVIEW_RUN_ID },
+      phase: "commentary",
+    },
+    ...chatSpacingToolResults(CHAT_SPACING_REVIEW_RUN_ID, userTurnAt + 35_000, {
+      commands: 24,
+      progressCards: 1,
+      // The aggregate label counts generic tool calls together, so one
+      // progress_card plus two searches renders the reference's “×3”.
+      webSearches: 2,
+    }),
+    {
+      ...chatHistoryMessage("assistant", coherent, userTurnAt + 89_000),
+      __openclaw: { runId: CHAT_SPACING_REVIEW_RUN_ID },
+      phase: "final_answer",
+    },
+    ...chatSpacingToolResults(CHAT_SPACING_REVIEW_RUN_ID, userTurnAt + 90_000, {
+      commands: 13,
+      progressCards: 1,
+    }),
+  ];
 }
 
 function buildCodeFenceChatHistory(baseTime: number): unknown[] {
@@ -1359,9 +1491,10 @@ async function createChatPickerScenario(
   fixture?: CliOptions["fixture"],
 ): Promise<ControlUiMockGatewayScenario> {
   const baseTime = Date.parse("2026-05-22T09:00:00.000Z");
+  const chatSpacingFixture = fixture === "chat-spacing";
   const selfProfile: UserProfile = {
-    id: "presence-riley",
-    displayName: "Riley",
+    id: chatSpacingFixture ? "profile-vyctor" : "presence-riley",
+    displayName: chatSpacingFixture ? "Vyctor Brzezowski" : "Riley",
     avatarMime: null,
     mergedInto: null,
     createdAt: baseTime,
@@ -1679,6 +1812,24 @@ async function createChatPickerScenario(
   const activitySessions = buildActivitySessionRows(Date.now());
   const sessions = [
     ...activitySessions,
+    ...(chatSpacingFixture
+      ? [
+          sessionRow(CHAT_SPACING_SESSION_KEY, "PR #127841 maintainer review", Date.now(), {
+            createdActor: {
+              type: "human",
+              id: "profile-vyctor",
+              label: "Vyctor Brzezowski",
+            },
+            owner: {
+              actor: {
+                type: "human",
+                id: "profile-vyctor",
+                label: "Vyctor Brzezowski",
+              },
+            },
+          }),
+        ]
+      : []),
     ...(fixture === "workboard"
       ? [
           sessionRow(workboardMocks.sessionKey, "Product operations dashboard", baseTime, {
@@ -1866,8 +2017,9 @@ async function createChatPickerScenario(
     swarmEnabled: fixture === "swarm",
     workboardEnabled: fixture === "workboard",
   });
-  const historyMessages =
-    fixture === "code-fences"
+  const historyMessages = chatSpacingFixture
+    ? buildChatSpacingHistory(Date.now())
+    : fixture === "code-fences"
       ? buildCodeFenceChatHistory(baseTime)
       : buildScrollableChatHistory(baseTime);
   const planSessionInfo = {
@@ -1894,6 +2046,16 @@ async function createChatPickerScenario(
     sessionId: "control-ui-e2e-session",
     sessionInfo: planSessionInfo,
     inFlightRun: planInFlightRun,
+    thinkingLevel: null,
+  };
+  const chatSpacingHistory = {
+    messages: historyMessages,
+    sessionId: "control-ui-chat-spacing-session",
+    sessionInfo: {
+      activeRunIds: [],
+      hasActiveRun: false,
+      key: CHAT_SPACING_SESSION_KEY,
+    },
     thinkingLevel: null,
   };
   const custodianHistory = {
@@ -2037,12 +2199,48 @@ async function createChatPickerScenario(
     ],
     methodResponses: {
       ...buildBackgroundTasksMock(baseTime),
+      ...(chatSpacingFixture ? { "tasks.list": { tasks: [] } } : {}),
       ...cronMocks,
       "chat.history": {
-        cases: [{ match: { sessionKey: "agent:main:main" }, response: planChatHistory }],
+        cases: [
+          ...(chatSpacingFixture
+            ? [
+                {
+                  match: { sessionKey: CHAT_SPACING_SESSION_KEY },
+                  response: chatSpacingHistory,
+                },
+              ]
+            : []),
+          { match: { sessionKey: "agent:main:main" }, response: planChatHistory },
+        ],
       },
       "chat.startup": {
         cases: [
+          ...(chatSpacingFixture
+            ? [
+                {
+                  match: { sessionKey: CHAT_SPACING_SESSION_KEY },
+                  response: {
+                    ...chatSpacingHistory,
+                    agentsList: {
+                      agents: [
+                        {
+                          id: "main",
+                          identity: { name: "Molty" },
+                          name: "Molty",
+                          workspace: "/Users/vyctor/Code/openclaw",
+                          workspaceGit: true,
+                        },
+                      ],
+                      defaultId: "main",
+                      mainKey: "main",
+                      scope: "agent",
+                    },
+                    metadata: { models: modelProviders.models },
+                  },
+                },
+              ]
+            : []),
           {
             match: { sessionKey: "agent:main:main" },
             response: {
@@ -2066,7 +2264,25 @@ async function createChatPickerScenario(
           },
         ],
       },
-      "progressCard.get": { card: null },
+      "progressCard.get": chatSpacingFixture
+        ? {
+            card: {
+              sessionKey: CHAT_SPACING_SESSION_KEY,
+              revision: 1,
+              updatedAt: Date.now(),
+              steps: [
+                { step: "Read review/testing policy", status: "completed" },
+                { step: "Reconstruct exact-head evidence", status: "completed" },
+                {
+                  step: "Verify premise on exact head, current main, and shipped tags",
+                  status: "in_progress",
+                },
+                { step: "Audit CI, ClawSweeper, compatibility, and LOC", status: "pending" },
+                { step: "Deliver the maintainer verdict", status: "pending" },
+              ],
+            },
+          }
+        : { card: null },
       "users.self": { profile: selfProfile },
       // Talk settings page pickers: realtime catalog with the model/voice
       // suggestion lists the gateway emits for provider entries.
@@ -2976,7 +3192,11 @@ async function createChatPickerScenario(
       ],
     },
     sessionArchiveFiltering: true,
-    sessionKey: fixture === "workboard" ? workboardMocks.sessionKey : "agent:main:main",
+    sessionKey: chatSpacingFixture
+      ? CHAT_SPACING_SESSION_KEY
+      : fixture === "workboard"
+        ? workboardMocks.sessionKey
+        : "agent:main:main",
     workspace: "/Users/peter/Projects/openclaw",
     workspaceGit: true,
   };
@@ -3144,9 +3364,28 @@ function createStatefulMockInitScript(): string {
   return `(() => { const __name = (target) => target; (${installControlUiStatefulMocks.toString()})(${CUSTODIAN_CHAT_REPLY_DELAY_MS}, ${CHAT_SEND_REPLY_DELAY_MS}); })();`;
 }
 
-function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin {
+function createMockDocumentTitleScript(title: string): string {
+  return `(() => {
+    const title = ${JSON.stringify(title)};
+    const syncTitle = () => {
+      if (document.title !== title) document.title = title;
+    };
+    syncTitle();
+    new MutationObserver(syncTitle).observe(document.head, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+  })();`;
+}
+
+function createMockGatewayPlugin(
+  scenario: ControlUiMockGatewayScenario,
+  documentTitle: string,
+): Plugin {
   const initScript = escapeScriptContent(createControlUiMockGatewayInitScript(scenario));
   const statefulInitScript = escapeScriptContent(createStatefulMockInitScript());
+  const titleInitScript = escapeScriptContent(createMockDocumentTitleScript(documentTitle));
   const bootstrapBody = JSON.stringify(createControlUiMockBootstrapConfig(scenario));
   return {
     configureServer(server) {
@@ -3164,7 +3403,7 @@ function createMockGatewayPlugin(scenario: ControlUiMockGatewayScenario): Plugin
     transformIndexHtml(html) {
       return html.replace(
         "</head>",
-        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${statefulInitScript}\n    </script>\n  </head>`,
+        `    <script data-openclaw-control-ui-mock-gateway>\n${initScript}\n${statefulInitScript}\n    </script>\n    <script data-openclaw-control-ui-mock-title>\n${titleInitScript}\n    </script>\n  </head>`,
       );
     },
   };
@@ -3244,7 +3483,10 @@ const server = await createServer({
       : {}),
     include: ["lit/directives/repeat.js"],
   },
-  plugins: [createMockGatewayPlugin(scenario), createBoardFixturePlugin()],
+  plugins: [
+    createMockGatewayPlugin(scenario, `💬 Chat spacing · :${options.port}`),
+    createBoardFixturePlugin(),
+  ],
   publicDir: path.join(uiRoot, "public"),
   resolve: {
     alias: [

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -311,18 +311,18 @@ function runBlockSpacingHtml() {
               <div class="chat-work-group__separator"></div>
             </div>
           </div>
-          <div class="chat-group-footer"><span class="chat-sender-name">Assistant</span></div>
+          <div class="chat-group-footer">
+            <span class="chat-sender-name">Assistant</span>
+            <div class="chat-group-footer-actions">
+              <button class="chat-copy-btn" type="button" aria-label="Copy">${iconSvg()}</button>
+            </div>
+          </div>
         </div>
         <div class="chat-group user chat-group--with-footer" data-next-turn>
           <div class="chat-group-messages">
             <div class="chat-bubble"><div class="chat-text">Next turn</div></div>
           </div>
-          <div class="chat-group-footer">
-            <span class="chat-sender-name">You</span>
-            <div class="chat-group-footer-actions">
-              <button class="chat-copy-btn" type="button" aria-label="Copy">${iconSvg()}</button>
-            </div>
-          </div>
+          <div class="chat-group-footer"><span class="chat-sender-name">You</span></div>
         </div>
       </div>
     </div>

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -289,6 +289,34 @@ function completedWorkSpacingHtml() {
   `;
 }
 
+function runBlockSpacingHtml() {
+  return `
+    <div class="chat-thread chat-thread--direct" role="log">
+      <div class="chat-thread-inner">
+        <div class="chat-group assistant chat-group--with-footer" data-run-turn>
+          <div class="chat-group-messages">
+            <div class="chat-bubble" data-run-block="text"><div class="chat-text">Opening text</div></div>
+            <div class="chat-bubble" data-run-block="detail"><div class="chat-text">Detail text</div></div>
+            <div class="chat-bubble chat-bubble--tool-shell" data-run-block="tool">Tool row</div>
+            <div class="chat-activity-group" data-run-block="list">Tool list</div>
+            <div class="chat-activity-group chat-work-group" data-run-block="work">
+              <button class="chat-inline-disclosure chat-activity-group__summary" type="button">Worked for 10s</button>
+              <div class="chat-work-group__separator"></div>
+            </div>
+          </div>
+          <div class="chat-group-footer"><span class="chat-sender-name">Assistant</span></div>
+        </div>
+        <div class="chat-group user chat-group--with-footer" data-next-turn>
+          <div class="chat-group-messages">
+            <div class="chat-bubble"><div class="chat-text">Next turn</div></div>
+          </div>
+          <div class="chat-group-footer"><span class="chat-sender-name">You</span></div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
 function chatFooterActionsHtml() {
   return `
     <div class="chat-group-footer-actions">
@@ -1302,6 +1330,46 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
       expect(gaps.before).toBeCloseTo(expectedGap, 0);
       expect(gaps.after).toBeCloseTo(expectedGap, 0);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it.each([
+    { label: "desktop", width: 1366, hasTouch: false },
+    { label: "mobile", width: 430, hasTouch: true },
+  ])("keeps transcript turn and run block spacing on $label", async ({ width, hasTouch }) => {
+    const page = await openBrowserPage(width, 900, { hasTouch, isolated: true });
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${runBlockSpacingHtml()}</body></html>`,
+      );
+
+      const gaps = await page.evaluate(() => {
+        const rect = (selector: string) =>
+          document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();
+        const gap = (before: string, after: string) => rect(after).top - rect(before).bottom;
+        return {
+          intraTurn: gap('[data-run-block="text"]', '[data-run-block="detail"]'),
+          textToTool: gap('[data-run-block="detail"]', '[data-run-block="tool"]'),
+          toolToList: gap('[data-run-block="tool"]', '[data-run-block="list"]'),
+          listToWork: gap('[data-run-block="list"]', '[data-run-block="work"]'),
+          workedForSeparator: gap(
+            '[data-run-block="work"] > button',
+            ".chat-work-group__separator",
+          ),
+          turn: gap('[data-run-block="work"]', "[data-next-turn] .chat-bubble"),
+        };
+      });
+
+      expect(gaps).toEqual({
+        intraTurn: 2,
+        textToTool: 4,
+        toolToList: 12,
+        listToWork: 12,
+        workedForSeparator: 0,
+        turn: 50,
+      });
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -324,6 +324,17 @@ function runBlockSpacingHtml() {
           </div>
           <div class="chat-group-footer"><span class="chat-sender-name">You</span></div>
         </div>
+        <div class="chat-group user chat-group--with-footer" data-persistent-turn>
+          <div class="chat-group-messages">
+            <div class="chat-bubble"><div class="chat-text">Persistent identity turn</div></div>
+          </div>
+          <div class="chat-group-footer chat-group-footer--persistent-identity">
+            <span class="chat-sender-name">You</span>
+            <div class="chat-group-footer-actions">
+              <button class="chat-copy-btn" type="button" aria-label="Copy">${iconSvg()}</button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   `;
@@ -1372,6 +1383,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             ".chat-work-group__separator",
           ),
           turn: gap('[data-run-block="work"]', "[data-next-turn] .chat-bubble"),
+          persistentTurn: gap(
+            "[data-next-turn] .chat-bubble",
+            "[data-persistent-turn] .chat-bubble",
+          ),
         };
       });
 
@@ -1383,6 +1398,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expandedTextToTool: 6,
         workedForSeparator: 0,
         turn: 50,
+        persistentTurn: 50,
       });
     } finally {
       await closeBrowserPage(page);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -298,7 +298,14 @@ function runBlockSpacingHtml() {
             <div class="chat-bubble" data-run-block="text"><div class="chat-text">Opening text</div></div>
             <div class="chat-bubble" data-run-block="detail"><div class="chat-text">Detail text</div></div>
             <div class="chat-bubble chat-bubble--tool-shell" data-run-block="tool">Tool row</div>
-            <div class="chat-activity-group" data-run-block="list">Tool list</div>
+            <div class="chat-activity-group" data-run-block="list">
+              <div class="chat-activity-group__body">
+                <div class="chat-group-messages">
+                  <div class="chat-bubble" data-expanded-row="text">Expanded detail</div>
+                  <div class="chat-bubble chat-bubble--tool-shell" data-expanded-row="tool">Expanded tool row</div>
+                </div>
+              </div>
+            </div>
             <div class="chat-activity-group chat-work-group" data-run-block="work">
               <button class="chat-inline-disclosure chat-activity-group__summary" type="button">Worked for 10s</button>
               <div class="chat-work-group__separator"></div>
@@ -1354,6 +1361,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           textToTool: gap('[data-run-block="detail"]', '[data-run-block="tool"]'),
           toolToList: gap('[data-run-block="tool"]', '[data-run-block="list"]'),
           listToWork: gap('[data-run-block="list"]', '[data-run-block="work"]'),
+          expandedTextToTool: gap('[data-expanded-row="text"]', '[data-expanded-row="tool"]'),
           workedForSeparator: gap(
             '[data-run-block="work"] > button',
             ".chat-work-group__separator",
@@ -1364,9 +1372,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
       expect(gaps).toEqual({
         intraTurn: 2,
-        textToTool: 4,
+        textToTool: 12,
         toolToList: 12,
         listToWork: 12,
+        expandedTextToTool: 6,
         workedForSeparator: 0,
         turn: 50,
       });

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -317,7 +317,12 @@ function runBlockSpacingHtml() {
           <div class="chat-group-messages">
             <div class="chat-bubble"><div class="chat-text">Next turn</div></div>
           </div>
-          <div class="chat-group-footer"><span class="chat-sender-name">You</span></div>
+          <div class="chat-group-footer">
+            <span class="chat-sender-name">You</span>
+            <div class="chat-group-footer-actions">
+              <button class="chat-copy-btn" type="button" aria-label="Copy">${iconSvg()}</button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -335,6 +335,29 @@ function runBlockSpacingHtml() {
             </div>
           </div>
         </div>
+        <div class="chat-group assistant chat-group--with-footer" data-after-persistent-turn>
+          <div class="chat-group-messages">
+            <div class="chat-bubble"><div class="chat-text">After persistent identity</div></div>
+          </div>
+          <div class="chat-group-footer"><span class="chat-sender-name">Assistant</span></div>
+        </div>
+        <div class="chat-group user chat-group--with-footer chat-group--meta-revealed" data-revealed-persistent-turn>
+          <div class="chat-group-messages">
+            <div class="chat-bubble"><div class="chat-text">Revealed persistent identity</div></div>
+          </div>
+          <div class="chat-group-footer chat-group-footer--persistent-identity">
+            <span class="chat-sender-name">You</span>
+            <div class="chat-group-footer-actions">
+              <button class="chat-copy-btn" type="button" aria-label="Copy">${iconSvg()}</button>
+            </div>
+          </div>
+        </div>
+        <div class="chat-group assistant chat-group--with-footer" data-after-revealed-turn>
+          <div class="chat-group-messages">
+            <div class="chat-bubble"><div class="chat-text">After revealed identity</div></div>
+          </div>
+          <div class="chat-group-footer"><span class="chat-sender-name">Assistant</span></div>
+        </div>
       </div>
     </div>
   `;
@@ -1384,6 +1407,14 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           ),
           turn: gap('[data-run-block="work"]', "[data-next-turn] .chat-bubble"),
           persistentTurn: gap(
+            "[data-persistent-turn] .chat-bubble",
+            "[data-after-persistent-turn] .chat-bubble",
+          ),
+          revealedPersistentTurn: gap(
+            "[data-revealed-persistent-turn] .chat-bubble",
+            "[data-after-revealed-turn] .chat-bubble",
+          ),
+          simpleToPersistentTurn: gap(
             "[data-next-turn] .chat-bubble",
             "[data-persistent-turn] .chat-bubble",
           ),
@@ -1399,6 +1430,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         workedForSeparator: 0,
         turn: 50,
         persistentTurn: 50,
+        revealedPersistentTurn: 50,
+        simpleToPersistentTurn: 50,
       });
     } finally {
       await closeBrowserPage(page);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -92,6 +92,7 @@
 }
 
 .chat-group-messages {
+  --chat-message-type-boundary-gap: var(--space-1);
   position: relative; /* anchors message-local popovers */
   display: flex;
   flex-direction: column;
@@ -104,6 +105,14 @@
 }
 
 .chat-group-messages
+  > :is(
+    .chat-bubble--tool-shell + .chat-bubble:not(.chat-bubble--tool-shell),
+    .chat-bubble:not(.chat-bubble--tool-shell) + .chat-bubble--tool-shell
+  ) {
+  margin-block-start: var(--chat-message-type-boundary-gap);
+}
+
+.chat-group > .chat-group-messages
   > :is(
     .chat-bubble--tool-shell + .chat-bubble:not(.chat-bubble--tool-shell),
     .chat-bubble:not(.chat-bubble--tool-shell) + .chat-bubble--tool-shell,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -773,6 +773,11 @@ img.chat-avatar.chat-avatar--logo {
     margin-bottom: var(--chat-touch-row-margin);
   }
 
+  .chat-group.chat-group--with-footer:has(.chat-group-footer-actions) {
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+
   .chat-group-footer {
     margin-top: 4px;
   }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -773,7 +773,9 @@ img.chat-avatar.chat-avatar--logo {
     margin-bottom: var(--chat-touch-row-margin);
   }
 
-  .chat-group.chat-group--with-footer:has(.chat-group-footer-actions) {
+  .chat-group.chat-group--with-footer:has(
+    .chat-group-footer:not(.chat-group-footer--persistent-identity) .chat-group-footer-actions
+  ) {
     padding-bottom: 0;
     margin-bottom: 0;
   }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -3,15 +3,17 @@
    ============================================= */
 
 /* Chat Group Layout - default (assistant/other on left). Groups without a
-   footer keep the shared 26px rhythm directly. Footer-bearing groups split
+   footer keep the shared turn gap directly. Footer-bearing groups split
    message content and footer into separate rows so each row keeps the avatar
    gutter while only the message row controls avatar alignment. */
 .chat-group {
   --chat-message-column-max: var(--chat-message-max-width, min(900px, 68%));
+  --chat-run-block-gap: 12px;
+  --chat-turn-gap: 50px;
   display: flex;
   gap: 10px;
   align-items: flex-start;
-  padding-bottom: 26px;
+  padding-bottom: var(--chat-turn-gap);
   margin-left: 4px;
   margin-right: 16px;
 }
@@ -55,7 +57,7 @@
   grid-template-rows: auto auto;
   gap: 2px 10px;
   justify-content: start;
-  padding-bottom: 0;
+  padding-bottom: calc(var(--chat-turn-gap) - 26px);
 }
 
 .chat-group.user.chat-group--with-footer {
@@ -90,7 +92,6 @@
 }
 
 .chat-group-messages {
-  --chat-message-type-boundary-gap: var(--space-1);
   position: relative; /* anchors message-local popovers */
   display: flex;
   flex-direction: column;
@@ -105,9 +106,15 @@
 .chat-group-messages
   > :is(
     .chat-bubble--tool-shell + .chat-bubble:not(.chat-bubble--tool-shell),
-    .chat-bubble:not(.chat-bubble--tool-shell) + .chat-bubble--tool-shell
+    .chat-bubble:not(.chat-bubble--tool-shell) + .chat-bubble--tool-shell,
+    .chat-bubble + .chat-activity-group,
+    .chat-activity-group + .chat-bubble,
+    .chat-work-group + .chat-bubble,
+    .chat-work-group + .chat-activity-group,
+    .chat-bubble + .chat-work-group,
+    .chat-activity-group + .chat-work-group
   ) {
-  margin-block-start: var(--chat-message-type-boundary-gap);
+  margin-block-start: calc(var(--chat-run-block-gap) - 2px);
 }
 
 /* User messages align content right */

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -775,6 +775,9 @@ img.chat-avatar.chat-avatar--logo {
 
   .chat-group.chat-group--with-footer:has(
     .chat-group-footer:not(.chat-group-footer--persistent-identity) .chat-group-footer-actions
+  ),
+  .chat-group.chat-group--with-footer:is(.chat-group--meta-revealed, :focus-within):has(
+    .chat-group-footer--persistent-identity .chat-group-footer-actions
   ) {
     padding-bottom: 0;
     margin-bottom: 0;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -114,7 +114,8 @@
   margin-block-start: var(--chat-message-type-boundary-gap);
 }
 
-.chat-group > .chat-group-messages
+.chat-group
+  > .chat-group-messages
   > :is(
     .chat-bubble--tool-shell + .chat-bubble:not(.chat-bubble--tool-shell),
     .chat-bubble:not(.chat-bubble--tool-shell) + .chat-bubble--tool-shell,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -7,8 +7,10 @@
    message content and footer into separate rows so each row keeps the avatar
    gutter while only the message row controls avatar alignment. */
 .chat-group {
+  --chat-footer-row-offset: 26px;
   --chat-message-column-max: var(--chat-message-max-width, min(900px, 68%));
   --chat-run-block-gap: 12px;
+  --chat-touch-row-margin: 14px;
   --chat-turn-gap: 50px;
   display: flex;
   gap: 10px;
@@ -57,7 +59,7 @@
   grid-template-rows: auto auto;
   gap: 2px 10px;
   justify-content: start;
-  padding-bottom: calc(var(--chat-turn-gap) - 26px);
+  padding-bottom: calc(var(--chat-turn-gap) - var(--chat-footer-row-offset));
 }
 
 .chat-group.user.chat-group--with-footer {
@@ -762,11 +764,12 @@ img.chat-avatar.chat-avatar--logo {
   /* Shared message renderers stay touch-readable by default. Transcript rows
      opt into one-at-a-time disclosure through their owning thread. */
   .chat-group {
+    --chat-footer-row-offset: 44px;
     --chat-footer-disclosure-opacity: 1;
     --chat-footer-disclosure-pointer-events: auto;
     --chat-footer-detail-position: static;
-    padding-bottom: 0;
-    margin-bottom: 14px;
+    padding-bottom: calc(var(--chat-turn-gap) - var(--chat-touch-row-margin));
+    margin-bottom: var(--chat-touch-row-margin);
   }
 
   .chat-group-footer {


### PR DESCRIPTION
## What Problem This Solves

Transcript turns and the semantic blocks within a single agent run used the same tight rhythm, making long runs with text, tool activity, lists, and the completed-work summary harder to scan.

## Why This Change Was Made

The chat transcript now uses one 50px turn-gap token and one 12px top-level run-block token. Ordinary 2px intra-turn spacing, expanded tool-row spacing, and the `Worked for` header plus separator remain unchanged; touch footer states keep controls in flow without stretching resting turn rhythm.

The visual-only mock fixture used for review and proof was removed before publication.

## User Impact

Long conversations have a clearer, consistent rhythm across desktop and mobile, dark and light themes. Agent runs read as one response while text, tool activity, lists, and completion summaries remain distinct.

## Evidence

### Measured behavior

- Consecutive turn gap: 26px before -> 50px after on desktop; 44px before -> 50px after on the representative mobile transition.
- Top-level run block gap: 2px before -> 12px after.
- Ordinary intra-turn gap: 2px before and after.
- Expanded text/tool spacing: unchanged at 6px rendered (2px flex gap + existing 4px boundary margin).
- `Worked for` header -> separator: 0px before and after.
- Touch footers: 50px for ordinary, 44px-action, hidden persistent, and revealed non-peer states; revealed peer actions may expand transiently to preserve in-flow controls and prevent overlap.

### Visual proof

The same long mock conversation is shown before and after in desktop/mobile and dark/light. It includes text, tool rollups, list activity, `Worked for` with its attached separator, and the progress card.

| | Dark | Light |
| --- | --- | --- |
| **Desktop before** | ![Desktop before, dark](https://github.com/user-attachments/assets/432ba76e-3b41-4328-bfa1-f3f6a6580f7a) | ![Desktop before, light](https://github.com/user-attachments/assets/7da14f1c-d8b6-442e-9d25-f501758bbcff) |
| **Desktop after** | ![Desktop after, dark](https://github.com/user-attachments/assets/1601507f-3c80-45ae-8d4c-78507072736e) | ![Desktop after, light](https://github.com/user-attachments/assets/6921cd1d-78ec-49bc-a370-bf991f0c36f1) |
| **Mobile before** | ![Mobile before, dark](https://github.com/user-attachments/assets/bc7fdcc2-9528-4d12-9cb4-37b1c8e21ea6) | ![Mobile before, light](https://github.com/user-attachments/assets/56c27588-a9a2-4afa-ac44-4bcb71f00cfa) |
| **Mobile after** | ![Mobile after, dark](https://github.com/user-attachments/assets/94fd9f76-bede-4980-9d43-9dba70a0646d) | ![Mobile after, light](https://github.com/user-attachments/assets/395655ce-00ac-40ab-bca8-c1faec74c2a0) |

### Validation

- `OPENCLAW_VITEST_MAX_WORKERS=2 node ../scripts/run-vitest.mjs --config vitest.config.ts src/pages/chat/chat-responsive.browser.test.ts --run -t "keeps transcript turn and run block spacing|balances completed-work spacing|keeps wrapped message footers inside measured virtual rows"` (6 passed)
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs`
- Full layout file: 90/91 pass; the sole composer-label overflow failure reproduces unchanged on `origin/main` (82px scroll width vs 80px client width) and is unrelated to transcript spacing.
- New tests: 2 viewport cases in one table-driven test; both fail on pre-fix CSS for the intended spacing mismatches.
- OpenCode review with `github-copilot/gpt-5.6-sol`, variant `high`: no actionable findings; approved.

Production LOC: +34/-4 (net +30) | Tests: +131/-0. Production growth defines the approved spacing tokens, top-level block boundary, and touch footer-state compensation; no mock fixture ships.
