### PR TITLE
refactor(workboard): consolidate gateway and schema helpers

### DIFF
--- a/extensions/workboard/src/gateway-helpers.ts
+++ b/extensions/workboard/src/gateway-helpers.ts
@@ -19,12 +19,37 @@ export type GatewayMethodContext = Parameters<
   Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]
 >[0];
 type GatewayRespond = GatewayMethodContext["respond"];
+type WorkboardGatewayResultHandler = (context: GatewayMethodContext) => unknown;
+type WorkboardGatewayScope = NonNullable<
+  NonNullable<Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2]>["scope"]
+>;
 
 export function respondError(respond: GatewayRespond, error: unknown) {
   respond(false, undefined, {
     code: "workboard_error",
     message: formatErrorMessage(error),
   });
+}
+
+export function registerWorkboardResultMethods(
+  api: OpenClawPluginApi,
+  methods: ReadonlyArray<
+    readonly [method: string, scope: WorkboardGatewayScope, handler: WorkboardGatewayResultHandler]
+  >,
+): void {
+  for (const [method, scope, handler] of methods) {
+    api.registerGatewayMethod(
+      method,
+      async (context) => {
+        try {
+          context.respond(true, await handler(context));
+        } catch (error) {
+          respondError(context.respond, error);
+        }
+      },
+      { scope },
+    );
+  }
 }
 
 export function readId(params: Record<string, unknown>): string {

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -1,4 +1,5 @@
 // Workboard plugin module implements gateway behavior.
+import type { WorkboardCard } from "@openclaw/workboard-contract";
 import type { OpenClawPluginApi } from "../api.js";
 import { redactClaimToken } from "./card-redaction.js";
 import {
@@ -6,7 +7,7 @@ import {
   createWorkboardDispatchHandler,
   listWorkboardCards,
   readId,
-  respondError,
+  registerWorkboardResultMethods,
 } from "./gateway-helpers.js";
 import {
   registerWorkboardWorkspaceBoardMethod,
@@ -29,6 +30,10 @@ function redactDiagnosticsRows(result: Awaited<ReturnType<WorkboardStore["diagno
   };
 }
 
+async function redactCardResult(card: Promise<WorkboardCard>) {
+  return { card: redactClaimToken(await card) };
+}
+
 export function registerWorkboardGatewayMethods(params: {
   api: OpenClawPluginApi;
   store?: WorkboardStore;
@@ -41,17 +46,14 @@ export function registerWorkboardGatewayMethods(params: {
     redactCard: redactClaimToken,
   });
 
-  api.registerGatewayMethod(
-    "workboard.cards.list",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, await listWorkboardCards(store, requestParams.boardId, redactClaimToken));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
+  registerWorkboardResultMethods(api, [
+    [
+      "workboard.cards.list",
+      READ_SCOPE,
+      async ({ params: requestParams }) =>
+        await listWorkboardCards(store, requestParams.boardId, redactClaimToken),
+    ],
+  ]);
 
   registerWorkboardWorkspaceCardMethods({ api, store, redactCard: redactClaimToken });
 
@@ -61,259 +63,127 @@ export function registerWorkboardGatewayMethods(params: {
     { scope: WRITE_SCOPE },
   );
 
-  api.registerGatewayMethod(
-    "workboard.cards.move",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(
-            await store.move(readId(requestParams), requestParams.status, requestParams.position),
-          ),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.delete",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, await store.delete(readId(requestParams)));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.comment",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.addComment(readId(requestParams), requestParams)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.link",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.addLink(readId(requestParams), requestParams)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.linkDependency",
-    async ({ params: requestParams, respond }) => {
-      try {
+  registerWorkboardResultMethods(api, [
+    [
+      "workboard.cards.move",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(
+          store.move(readId(requestParams), requestParams.status, requestParams.position),
+        ),
+    ],
+    [
+      "workboard.cards.delete",
+      WRITE_SCOPE,
+      ({ params: requestParams }) => store.delete(readId(requestParams)),
+    ],
+    [
+      "workboard.cards.comment",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.addComment(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.link",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.addLink(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.linkDependency",
+      WRITE_SCOPE,
+      ({ params: requestParams }) => {
         const parentId = requestParams.parentId;
         const childId = requestParams.childId;
         if (typeof parentId !== "string" || typeof childId !== "string") {
           throw new Error("parentId and childId are required.");
         }
-        respond(true, {
-          card: redactClaimToken(await store.linkCards(parentId, childId)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.proof",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.addProof(readId(requestParams), requestParams)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.artifact",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.addArtifact(readId(requestParams), requestParams)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.claim",
-    async ({ params: requestParams, respond }) => {
-      try {
+        return redactCardResult(store.linkCards(parentId, childId));
+      },
+    ],
+    [
+      "workboard.cards.proof",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.addProof(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.artifact",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.addArtifact(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.claim",
+      WRITE_SCOPE,
+      async ({ params: requestParams }) => {
         const claimed = await store.claim(readId(requestParams), requestParams);
-        respond(true, { ...claimed, card: redactClaimToken(claimed.card) });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.heartbeat",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.heartbeat(readId(requestParams), requestParams)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.release",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.releaseClaim(readId(requestParams), requestParams)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.promote",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.promote(readId(requestParams), requestParams, null)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.reassign",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.reassign(readId(requestParams), requestParams, null)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.reclaim",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.reclaim(readId(requestParams), requestParams, null)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.complete",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.complete(readId(requestParams), requestParams, null)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.block",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.block(readId(requestParams), requestParams, null)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.unblock",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.unblock(readId(requestParams))),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
+        return { ...claimed, card: redactClaimToken(claimed.card) };
+      },
+    ],
+    [
+      "workboard.cards.heartbeat",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.heartbeat(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.release",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.releaseClaim(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.promote",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.promote(readId(requestParams), requestParams, null)),
+    ],
+    [
+      "workboard.cards.reassign",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.reassign(readId(requestParams), requestParams, null)),
+    ],
+    [
+      "workboard.cards.reclaim",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.reclaim(readId(requestParams), requestParams, null)),
+    ],
+    [
+      "workboard.cards.complete",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.complete(readId(requestParams), requestParams, null)),
+    ],
+    [
+      "workboard.cards.block",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.block(readId(requestParams), requestParams, null)),
+    ],
+    [
+      "workboard.cards.unblock",
+      WRITE_SCOPE,
+      ({ params: requestParams }) => redactCardResult(store.unblock(readId(requestParams))),
+    ],
+  ]);
 
   registerWorkboardWorkspaceBulkMethod({ api, store, redactCard: redactClaimToken });
 
-  api.registerGatewayMethod(
-    "workboard.cards.diagnostics",
-    async ({ respond }) => {
-      try {
-        respond(true, redactDiagnosticsRows(await store.diagnostics()));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.diagnostics.refresh",
-    async ({ respond }) => {
-      try {
-        respond(true, redactDiagnosticsRows(await store.refreshDiagnostics()));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
+  registerWorkboardResultMethods(api, [
+    [
+      "workboard.cards.diagnostics",
+      READ_SCOPE,
+      async () => redactDiagnosticsRows(await store.diagnostics()),
+    ],
+    [
+      "workboard.cards.diagnostics.refresh",
+      WRITE_SCOPE,
+      async () => redactDiagnosticsRows(await store.refreshDiagnostics()),
+    ],
+  ]);
 
   api.registerGatewayMethod(
     "workboard.cards.dispatch",
@@ -327,253 +197,134 @@ export function registerWorkboardGatewayMethods(params: {
     { scope: WRITE_SCOPE },
   );
 
-  api.registerGatewayMethod(
-    "workboard.boards.list",
-    async ({ respond }) => {
-      try {
-        respond(true, await store.listBoards());
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
+  registerWorkboardResultMethods(api, [
+    ["workboard.boards.list", READ_SCOPE, () => store.listBoards()],
+  ]);
 
   registerWorkboardWorkspaceBoardMethod({ api, store, redactCard: redactClaimToken });
 
-  api.registerGatewayMethod(
-    "workboard.boards.archive",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          board: await store.archiveBoard(requestParams.id, requestParams.archived),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.boards.delete",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, await store.deleteBoard(requestParams.id));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.stats",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, await store.stats({ boardId: requestParams.boardId }));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.runs",
-    async ({ params: requestParams, respond }) => {
-      try {
+  registerWorkboardResultMethods(api, [
+    [
+      "workboard.boards.archive",
+      WRITE_SCOPE,
+      async ({ params: requestParams }) => ({
+        board: await store.archiveBoard(requestParams.id, requestParams.archived),
+      }),
+    ],
+    [
+      "workboard.boards.delete",
+      WRITE_SCOPE,
+      ({ params: requestParams }) => store.deleteBoard(requestParams.id),
+    ],
+    [
+      "workboard.cards.stats",
+      READ_SCOPE,
+      ({ params: requestParams }) => store.stats({ boardId: requestParams.boardId }),
+    ],
+    [
+      "workboard.cards.runs",
+      READ_SCOPE,
+      async ({ params: requestParams }) => {
         const result = await store.runs(readId(requestParams));
-        respond(true, { ...result, card: redactClaimToken(result.card) });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
+        return { ...result, card: redactClaimToken(result.card) };
+      },
+    ],
+  ]);
 
   registerWorkboardWorkspaceWorkflowMethods({ api, store, redactCard: redactClaimToken });
 
-  api.registerGatewayMethod(
-    "workboard.notifications.subscribe",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, { subscription: await store.subscribeNotifications(requestParams) });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.notifications.list",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, await store.listNotificationSubscriptions(requestParams));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.notifications.delete",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, await store.deleteNotificationSubscription(readId(requestParams)));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.notifications.events",
-    async ({ params: requestParams, respond }) => {
-      try {
+  registerWorkboardResultMethods(api, [
+    [
+      "workboard.notifications.subscribe",
+      WRITE_SCOPE,
+      async ({ params: requestParams }) => ({
+        subscription: await store.subscribeNotifications(requestParams),
+      }),
+    ],
+    [
+      "workboard.notifications.list",
+      READ_SCOPE,
+      ({ params: requestParams }) => store.listNotificationSubscriptions(requestParams),
+    ],
+    [
+      "workboard.notifications.delete",
+      WRITE_SCOPE,
+      ({ params: requestParams }) => store.deleteNotificationSubscription(readId(requestParams)),
+    ],
+    [
+      "workboard.notifications.events",
+      READ_SCOPE,
+      ({ params: requestParams }) => {
         assertNoCursorAdvance(requestParams);
-        respond(true, await store.notificationEvents(requestParams));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.notifications.advance",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, await store.advanceNotificationEvents(requestParams));
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.attachments.list",
-    async ({ params: requestParams, respond }) => {
-      try {
+        return store.notificationEvents(requestParams);
+      },
+    ],
+    [
+      "workboard.notifications.advance",
+      WRITE_SCOPE,
+      ({ params: requestParams }) => store.advanceNotificationEvents(requestParams),
+    ],
+    [
+      "workboard.cards.attachments.list",
+      READ_SCOPE,
+      async ({ params: requestParams }) => {
         const result = await store.listAttachments(readId(requestParams));
-        respond(true, { ...result, card: redactClaimToken(result.card) });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.attachments.get",
-    async ({ params: requestParams, respond }) => {
-      try {
+        return { ...result, card: redactClaimToken(result.card) };
+      },
+    ],
+    [
+      "workboard.cards.attachments.get",
+      READ_SCOPE,
+      async ({ params: requestParams }) => {
         const attachment = await store.getAttachment(readId(requestParams));
         if (!attachment) {
           throw new Error(`attachment not found: ${readId(requestParams)}`);
         }
-        respond(true, attachment);
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.attachments.add",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.addAttachment(readId(requestParams), requestParams)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.attachments.delete",
-    async ({ params: requestParams, respond }) => {
-      try {
+        return attachment;
+      },
+    ],
+    [
+      "workboard.cards.attachments.add",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.addAttachment(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.attachments.delete",
+      WRITE_SCOPE,
+      ({ params: requestParams }) => {
         const attachmentId = requestParams.attachmentId;
         if (typeof attachmentId !== "string" || !attachmentId.trim()) {
           throw new Error("attachmentId is required.");
         }
-        respond(true, {
-          card: redactClaimToken(
-            await store.deleteAttachment(readId(requestParams), attachmentId.trim()),
-          ),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.workerLog",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(await store.addWorkerLog(readId(requestParams), requestParams)),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.protocolViolation",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(
-            await store.recordProtocolViolation(readId(requestParams), requestParams),
-          ),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.archive",
-    async ({ params: requestParams, respond }) => {
-      try {
-        respond(true, {
-          card: redactClaimToken(
-            await store.archive(readId(requestParams), requestParams.archived),
-          ),
-        });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: WRITE_SCOPE },
-  );
-
-  api.registerGatewayMethod(
-    "workboard.cards.export",
-    async ({ respond }) => {
-      try {
+        return redactCardResult(store.deleteAttachment(readId(requestParams), attachmentId.trim()));
+      },
+    ],
+    [
+      "workboard.cards.workerLog",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.addWorkerLog(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.protocolViolation",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.recordProtocolViolation(readId(requestParams), requestParams)),
+    ],
+    [
+      "workboard.cards.archive",
+      WRITE_SCOPE,
+      ({ params: requestParams }) =>
+        redactCardResult(store.archive(readId(requestParams), requestParams.archived)),
+    ],
+    [
+      "workboard.cards.export",
+      READ_SCOPE,
+      async () => {
         const exported = await store.exportCards();
-        respond(true, { ...exported, cards: exported.cards.map(redactClaimToken) });
-      } catch (error) {
-        respondError(respond, error);
-      }
-    },
-    { scope: READ_SCOPE },
-  );
+        return { ...exported, cards: exported.cards.map(redactClaimToken) };
+      },
+    ],
+  ]);
 }

--- a/extensions/workboard/src/tools-card-mutations.ts
+++ b/extensions/workboard/src/tools-card-mutations.ts
@@ -1,7 +1,7 @@
 import { WORKBOARD_STATUSES, type WorkboardCard } from "@openclaw/workboard-contract";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import type { AgentToolResult } from "openclaw/plugin-sdk/tool-results";
-import { Type } from "typebox";
+import { Type, type TProperties } from "typebox";
 import type { WorkboardMutationScope } from "./store-inputs.js";
 import type { WorkboardStore } from "./store.js";
 
@@ -21,6 +21,10 @@ export function claimTokenField(description = "Claim token returned by workboard
   return Type.Optional(Type.String({ description }));
 }
 
+export function strictObject<const Properties extends TProperties>(properties: Properties) {
+  return Type.Object(properties, { additionalProperties: false });
+}
+
 export function createWorkboardMoveTool(params: {
   store: WorkboardStore;
   readScopedCardToolParams: (rawParams: unknown) => Promise<ScopedMoveParams>;
@@ -31,17 +35,14 @@ export function createWorkboardMoveTool(params: {
     label: "Workboard Move",
     description:
       "Move a Workboard card to another status. Claimed cards require matching claim scope.",
-    parameters: Type.Object(
-      {
-        id: cardIdField(),
-        status: Type.Union(
-          WORKBOARD_STATUSES.map((status) => Type.Literal(status)),
-          { description: "Target Workboard status." },
-        ),
-        [ClaimTokenFieldName]: claimTokenField("Claim token for claimed cards."),
-      },
-      { additionalProperties: false },
-    ),
+    parameters: strictObject({
+      id: cardIdField(),
+      status: Type.Union(
+        WORKBOARD_STATUSES.map((status) => Type.Literal(status)),
+        { description: "Target Workboard status." },
+      ),
+      [ClaimTokenFieldName]: claimTokenField("Claim token for claimed cards."),
+    }),
     execute: async (_toolCallId, rawParams) => {
       const { record, id, scope } = await params.readScopedCardToolParams(rawParams);
       return params.redactedCardResult(

--- a/extensions/workboard/src/tools-orchestration.ts
+++ b/extensions/workboard/src/tools-orchestration.ts
@@ -6,7 +6,7 @@ import type { AgentToolResult } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
 import { redactClaimToken } from "./card-redaction.js";
 import type { WorkboardStore } from "./store.js";
-import { cardIdField, claimTokenField } from "./tools-card-mutations.js";
+import { cardIdField, claimTokenField, strictObject } from "./tools-card-mutations.js";
 
 type ScopedCardParams = {
   record: Record<string, unknown>;
@@ -20,13 +20,10 @@ type WorkboardCardMutation = (
   scope: ScopedCardParams["scope"],
 ) => Promise<WorkboardCard>;
 
-const CardIdSchema = Type.Object(
-  {
-    id: cardIdField(),
-    token: claimTokenField(),
-  },
-  { additionalProperties: false },
-);
+const CardIdSchema = strictObject({
+  id: cardIdField(),
+  token: claimTokenField(),
+});
 const ScopedClaimTokenField = claimTokenField("Claim token for claimed cards.");
 const OptionalNextStatusField = Type.Optional(
   Type.String({ description: "Optional next status." }),
@@ -66,57 +63,48 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_boards",
       label: "Workboard Boards",
       description: "List Workboard board namespaces with active, archived, and status counts.",
-      parameters: Type.Object({}, { additionalProperties: false }),
+      parameters: strictObject({}),
       execute: async () => jsonResult(await store.listBoards()),
     },
     {
       name: "workboard_board_create",
       label: "Workboard Board Create",
       description: "Create or update a Workboard board namespace with persisted SQLite metadata.",
-      parameters: Type.Object(
-        {
-          id: Type.String({ description: "Board id." }),
-          name: Type.Optional(Type.String({ description: "Display name." })),
-          description: Type.Optional(Type.String({ description: "Board description." })),
-          icon: Type.Optional(Type.String({ description: "Short icon or label." })),
-          color: Type.Optional(Type.String({ description: "Display color token." })),
-          automationJobId: Type.Optional(
-            Type.String({
-              description: "Owning automation job id.",
-              minLength: 1,
-              maxLength: 128,
-            }),
-          ),
-          defaultWorkspace: Type.Optional(
-            Type.Object(
-              {
-                kind: Type.String({ description: "scratch, dir, or worktree." }),
-                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
-                branch: Type.Optional(Type.String({ description: "Suggested branch." })),
-              },
-              { additionalProperties: false },
+      parameters: strictObject({
+        id: Type.String({ description: "Board id." }),
+        name: Type.Optional(Type.String({ description: "Display name." })),
+        description: Type.Optional(Type.String({ description: "Board description." })),
+        icon: Type.Optional(Type.String({ description: "Short icon or label." })),
+        color: Type.Optional(Type.String({ description: "Display color token." })),
+        automationJobId: Type.Optional(
+          Type.String({
+            description: "Owning automation job id.",
+            minLength: 1,
+            maxLength: 128,
+          }),
+        ),
+        defaultWorkspace: Type.Optional(
+          strictObject({
+            kind: Type.String({ description: "scratch, dir, or worktree." }),
+            path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+            branch: Type.Optional(Type.String({ description: "Suggested branch." })),
+          }),
+        ),
+        orchestration: Type.Optional(
+          strictObject({
+            autoDecompose: Type.Optional(
+              Type.Boolean({ description: "Mark ready triage cards for decomposition." }),
             ),
-          ),
-          orchestration: Type.Optional(
-            Type.Object(
-              {
-                autoDecompose: Type.Optional(
-                  Type.Boolean({ description: "Mark ready triage cards for decomposition." }),
-                ),
-                autoDecomposePerDispatch: Type.Optional(
-                  Type.Number({ description: "Maximum orchestration candidates per dispatch." }),
-                ),
-                defaultAssignee: Type.Optional(Type.String({ description: "Default assignee." })),
-                orchestratorProfile: Type.Optional(
-                  Type.String({ description: "Orchestrator profile id." }),
-                ),
-              },
-              { additionalProperties: false },
+            autoDecomposePerDispatch: Type.Optional(
+              Type.Number({ description: "Maximum orchestration candidates per dispatch." }),
             ),
-          ),
-        },
-        { additionalProperties: false },
-      ),
+            defaultAssignee: Type.Optional(Type.String({ description: "Default assignee." })),
+            orchestratorProfile: Type.Optional(
+              Type.String({ description: "Orchestrator profile id." }),
+            ),
+          }),
+        ),
+      }),
       execute: async (_toolCallId, rawParams) =>
         jsonResult({ board: await store.upsertBoard(asNonArrayRecord(rawParams)) }),
     },
@@ -124,13 +112,10 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_board_archive",
       label: "Workboard Board Archive",
       description: "Archive or restore persisted Workboard board metadata.",
-      parameters: Type.Object(
-        {
-          id: Type.String({ description: "Board id." }),
-          archived: Type.Optional(Type.Boolean({ description: "Archive when true." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: Type.String({ description: "Board id." }),
+        archived: Type.Optional(Type.Boolean({ description: "Archive when true." })),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = asNonArrayRecord(rawParams);
         return jsonResult({ board: await store.archiveBoard(record.id, record.archived) });
@@ -140,10 +125,7 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_board_delete",
       label: "Workboard Board Delete",
       description: "Delete an empty non-default Workboard board metadata record.",
-      parameters: Type.Object(
-        { id: Type.String({ description: "Board id." }) },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({ id: Type.String({ description: "Board id." }) }),
       execute: async (_toolCallId, rawParams) =>
         jsonResult(await store.deleteBoard(asNonArrayRecord(rawParams).id)),
     },
@@ -151,12 +133,9 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_stats",
       label: "Workboard Stats",
       description: "Summarize Workboard counts by status and assignee for one board or all boards.",
-      parameters: Type.Object(
-        {
-          boardId: Type.Optional(Type.String({ description: "Optional board id filter." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        boardId: Type.Optional(Type.String({ description: "Optional board id filter." })),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = asNonArrayRecord(rawParams);
         return jsonResult(await store.stats({ boardId: record.boardId }));
@@ -178,36 +157,30 @@ export function createWorkboardOrchestrationTools(params: {
       label: "Workboard Specify",
       description:
         "Turn a rough triage/backlog Workboard card into a specified todo card after reasoning through the requirements.",
-      parameters: Type.Object(
-        {
-          id: Type.String({ description: "Workboard card id." }),
-          title: Type.Optional(Type.String({ description: "Clarified title." })),
-          notes: Type.Optional(
-            Type.String({ description: "Clarified notes or acceptance criteria." }),
-          ),
-          agentId: Type.Optional(Type.String({ description: "Assigned agent id." })),
-          priority: Type.Optional(Type.String({ description: "low, normal, high, or urgent." })),
-          labels: Type.Optional(Type.Array(Type.String(), { description: "Card labels." })),
-          boardId: Type.Optional(Type.String({ description: "Board id." })),
-          tenant: Type.Optional(Type.String({ description: "Tenant or routing namespace." })),
-          skills: Type.Optional(Type.Array(Type.String(), { description: "Suggested skills." })),
-          workspace: Type.Optional(
-            Type.Object(
-              {
-                kind: Type.String({ description: "scratch, dir, or worktree." }),
-                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
-                branch: Type.Optional(Type.String({ description: "Suggested branch." })),
-              },
-              { additionalProperties: false },
-            ),
-          ),
-          maxRuntimeSeconds: Type.Optional(Type.Number({ description: "Runtime budget." })),
-          maxRetries: Type.Optional(Type.Number({ description: "Retry budget." })),
-          summary: Type.Optional(Type.String({ description: "Specification summary comment." })),
-          token: Type.Optional(Type.String({ description: "Claim token for claimed cards." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: Type.String({ description: "Workboard card id." }),
+        title: Type.Optional(Type.String({ description: "Clarified title." })),
+        notes: Type.Optional(
+          Type.String({ description: "Clarified notes or acceptance criteria." }),
+        ),
+        agentId: Type.Optional(Type.String({ description: "Assigned agent id." })),
+        priority: Type.Optional(Type.String({ description: "low, normal, high, or urgent." })),
+        labels: Type.Optional(Type.Array(Type.String(), { description: "Card labels." })),
+        boardId: Type.Optional(Type.String({ description: "Board id." })),
+        tenant: Type.Optional(Type.String({ description: "Tenant or routing namespace." })),
+        skills: Type.Optional(Type.Array(Type.String(), { description: "Suggested skills." })),
+        workspace: Type.Optional(
+          strictObject({
+            kind: Type.String({ description: "scratch, dir, or worktree." }),
+            path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+            branch: Type.Optional(Type.String({ description: "Suggested branch." })),
+          }),
+        ),
+        maxRuntimeSeconds: Type.Optional(Type.Number({ description: "Runtime budget." })),
+        maxRetries: Type.Optional(Type.Number({ description: "Retry budget." })),
+        summary: Type.Optional(Type.String({ description: "Specification summary comment." })),
+        token: Type.Optional(Type.String({ description: "Claim token for claimed cards." })),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = asNonArrayRecord(rawParams);
         const id = readStringParam(record, "id", { required: true });
@@ -223,51 +196,38 @@ export function createWorkboardOrchestrationTools(params: {
       label: "Workboard Decompose",
       description:
         "Fan out a Workboard card into linked child cards and optionally complete the parent orchestration card.",
-      parameters: Type.Object(
-        {
-          id: Type.String({ description: "Parent Workboard card id." }),
-          token: Type.Optional(Type.String({ description: "Claim token for claimed cards." })),
-          summary: Type.Optional(Type.String({ description: "Decomposition summary." })),
-          completeParent: Type.Optional(
-            Type.Boolean({
-              description: "Complete the parent after child creation. Default true.",
-            }),
-          ),
-          children: Type.Array(
-            Type.Object(
-              {
-                title: Type.String({ description: "Child title." }),
-                notes: Type.Optional(Type.String({ description: "Child notes." })),
-                agentId: Type.Optional(Type.String({ description: "Assigned agent id." })),
-                priority: Type.Optional(
-                  Type.String({ description: "low, normal, high, or urgent." }),
-                ),
-                labels: Type.Optional(Type.Array(Type.String())),
-                boardId: Type.Optional(Type.String()),
-                tenant: Type.Optional(Type.String()),
-                skills: Type.Optional(Type.Array(Type.String())),
-                workspace: Type.Optional(
-                  Type.Object(
-                    {
-                      kind: Type.String({ description: "scratch, dir, or worktree." }),
-                      path: Type.Optional(
-                        Type.String({ description: "Absolute dir/worktree path." }),
-                      ),
-                      branch: Type.Optional(Type.String({ description: "Suggested branch." })),
-                    },
-                    { additionalProperties: false },
-                  ),
-                ),
-                maxRuntimeSeconds: Type.Optional(Type.Number()),
-                maxRetries: Type.Optional(Type.Number()),
-                idempotencyKey: Type.Optional(Type.String()),
-              },
-              { additionalProperties: false },
+      parameters: strictObject({
+        id: Type.String({ description: "Parent Workboard card id." }),
+        token: Type.Optional(Type.String({ description: "Claim token for claimed cards." })),
+        summary: Type.Optional(Type.String({ description: "Decomposition summary." })),
+        completeParent: Type.Optional(
+          Type.Boolean({
+            description: "Complete the parent after child creation. Default true.",
+          }),
+        ),
+        children: Type.Array(
+          strictObject({
+            title: Type.String({ description: "Child title." }),
+            notes: Type.Optional(Type.String({ description: "Child notes." })),
+            agentId: Type.Optional(Type.String({ description: "Assigned agent id." })),
+            priority: Type.Optional(Type.String({ description: "low, normal, high, or urgent." })),
+            labels: Type.Optional(Type.Array(Type.String())),
+            boardId: Type.Optional(Type.String()),
+            tenant: Type.Optional(Type.String()),
+            skills: Type.Optional(Type.Array(Type.String())),
+            workspace: Type.Optional(
+              strictObject({
+                kind: Type.String({ description: "scratch, dir, or worktree." }),
+                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+                branch: Type.Optional(Type.String({ description: "Suggested branch." })),
+              }),
             ),
-          ),
-        },
-        { additionalProperties: false },
-      ),
+            maxRuntimeSeconds: Type.Optional(Type.Number()),
+            maxRetries: Type.Optional(Type.Number()),
+            idempotencyKey: Type.Optional(Type.String()),
+          }),
+        ),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = asNonArrayRecord(rawParams);
         const id = readStringParam(record, "id", { required: true });
@@ -284,19 +244,16 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_notify_subscribe",
       label: "Workboard Notify Subscribe",
       description: "Persist a Workboard notification subscription in the plugin SQLite store.",
-      parameters: Type.Object(
-        {
-          boardId: Type.Optional(Type.String({ description: "Board id. Default default." })),
-          cardId: Type.Optional(Type.String({ description: "Card id." })),
-          sessionKey: Type.Optional(Type.String({ description: "Session key." })),
-          runId: Type.Optional(Type.String({ description: "Run id." })),
-          target: Type.Optional(Type.String({ description: "Human-readable target." })),
-          eventKinds: Type.Optional(
-            Type.Array(Type.String(), { description: "completed, failed, stale." }),
-          ),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        boardId: Type.Optional(Type.String({ description: "Board id. Default default." })),
+        cardId: Type.Optional(Type.String({ description: "Card id." })),
+        sessionKey: Type.Optional(Type.String({ description: "Session key." })),
+        runId: Type.Optional(Type.String({ description: "Run id." })),
+        target: Type.Optional(Type.String({ description: "Human-readable target." })),
+        eventKinds: Type.Optional(
+          Type.Array(Type.String(), { description: "completed, failed, stale." }),
+        ),
+      }),
       execute: async (_toolCallId, rawParams) =>
         jsonResult({
           subscription: await store.subscribeNotifications(asNonArrayRecord(rawParams)),
@@ -306,13 +263,10 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_notify_list",
       label: "Workboard Notify List",
       description: "List persisted Workboard notification subscriptions.",
-      parameters: Type.Object(
-        {
-          boardId: Type.Optional(Type.String({ description: "Board id." })),
-          cardId: Type.Optional(Type.String({ description: "Card id." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        boardId: Type.Optional(Type.String({ description: "Board id." })),
+        cardId: Type.Optional(Type.String({ description: "Card id." })),
+      }),
       execute: async (_toolCallId, rawParams) =>
         jsonResult(await store.listNotificationSubscriptions(asNonArrayRecord(rawParams))),
     },
@@ -320,15 +274,12 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_notify_events",
       label: "Workboard Notify Events",
       description: "Read replay-safe Workboard notification events without advancing cursors.",
-      parameters: Type.Object(
-        {
-          subscriptionId: Type.Optional(Type.String({ description: "Subscription id." })),
-          boardId: Type.Optional(Type.String({ description: "Board id." })),
-          cardId: Type.Optional(Type.String({ description: "Card id." })),
-          limit: Type.Optional(Type.Number({ description: "Maximum events. Default 50." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        subscriptionId: Type.Optional(Type.String({ description: "Subscription id." })),
+        boardId: Type.Optional(Type.String({ description: "Board id." })),
+        cardId: Type.Optional(Type.String({ description: "Card id." })),
+        limit: Type.Optional(Type.Number({ description: "Maximum events. Default 50." })),
+      }),
       execute: async (_toolCallId, rawParams) =>
         jsonResult(await store.notificationEvents(asNonArrayRecord(rawParams))),
     },
@@ -336,13 +287,10 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_notify_advance",
       label: "Workboard Notify Advance",
       description: "Read Workboard notification events and advance the subscription cursor.",
-      parameters: Type.Object(
-        {
-          subscriptionId: Type.String({ description: "Subscription id." }),
-          limit: Type.Optional(Type.Number({ description: "Maximum events. Default 50." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        subscriptionId: Type.String({ description: "Subscription id." }),
+        limit: Type.Optional(Type.Number({ description: "Maximum events. Default 50." })),
+      }),
       execute: async (_toolCallId, rawParams) =>
         jsonResult(await store.advanceNotificationEvents(asNonArrayRecord(rawParams))),
     },
@@ -350,10 +298,7 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_notify_unsubscribe",
       label: "Workboard Notify Unsubscribe",
       description: "Delete a persisted Workboard notification subscription.",
-      parameters: Type.Object(
-        { id: Type.String({ description: "Subscription id." }) },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({ id: Type.String({ description: "Subscription id." }) }),
       execute: async (_toolCallId, rawParams) => {
         const id = readStringParam(asNonArrayRecord(rawParams), "id", { required: true });
         return jsonResult(await store.deleteNotificationSubscription(id));
@@ -364,17 +309,12 @@ export function createWorkboardOrchestrationTools(params: {
       label: "Workboard Promote",
       description:
         "Promote a dependency-ready card into ready, optionally forcing past holds for operator recovery.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          token: ScopedClaimTokenField,
-          force: Type.Optional(
-            Type.Boolean({ description: "Bypass dependency or schedule holds." }),
-          ),
-          reason: OptionalOperatorNoteField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        token: ScopedClaimTokenField,
+        force: Type.Optional(Type.Boolean({ description: "Bypass dependency or schedule holds." })),
+        reason: OptionalOperatorNoteField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         return runScopedCardMutation(rawParams, (id, record, scope) =>
           store.promote(id, record, scope),
@@ -385,17 +325,14 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_reassign",
       label: "Workboard Reassign",
       description: "Change a card assignee and optionally reset failure state during recovery.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          token: ScopedClaimTokenField,
-          agentId: Type.Optional(Type.String({ description: "New assignee id." })),
-          status: OptionalNextStatusField,
-          resetFailures: Type.Optional(Type.Boolean({ description: "Reset failure count." })),
-          reason: OptionalOperatorNoteField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        token: ScopedClaimTokenField,
+        agentId: Type.Optional(Type.String({ description: "New assignee id." })),
+        status: OptionalNextStatusField,
+        resetFailures: Type.Optional(Type.Boolean({ description: "Reset failure count." })),
+        reason: OptionalOperatorNoteField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         return runScopedCardMutation(rawParams, (id, record, scope) =>
           store.reassign(id, record, scope),
@@ -407,15 +344,12 @@ export function createWorkboardOrchestrationTools(params: {
       label: "Workboard Reclaim",
       description:
         "Release a stale claim and stop running attempts so another agent can pick it up.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          token: ScopedClaimTokenField,
-          status: OptionalNextStatusField,
-          reason: OptionalOperatorNoteField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        token: ScopedClaimTokenField,
+        status: OptionalNextStatusField,
+        reason: OptionalOperatorNoteField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         return runScopedCardMutation(rawParams, (id, record, scope) =>
           store.reclaim(id, record, scope),
@@ -427,12 +361,9 @@ export function createWorkboardOrchestrationTools(params: {
       label: "Workboard Dispatch",
       description:
         "Advance persisted board state without launching workers: promote unblocked cards, reclaim expired claims, and block timed-out runs.",
-      parameters: Type.Object(
-        {
-          boardId: Type.Optional(Type.String({ description: "Optional board id filter." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        boardId: Type.Optional(Type.String({ description: "Optional board id filter." })),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = asNonArrayRecord(rawParams);
         const result = await store.dispatch({ boardId: record.boardId });
@@ -449,17 +380,14 @@ export function createWorkboardOrchestrationTools(params: {
       name: "workboard_worker_log",
       label: "Workboard Worker Log",
       description: "Append a persisted worker log entry to a Workboard card.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          level: Type.Optional(Type.String({ description: "info, warning, or error." })),
-          message: Type.String({ description: "Worker log message." }),
-          sessionKey: Type.Optional(Type.String({ description: "Linked session key." })),
-          runId: Type.Optional(Type.String({ description: "Linked run id." })),
-          token: ScopedClaimTokenField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        level: Type.Optional(Type.String({ description: "info, warning, or error." })),
+        message: Type.String({ description: "Worker log message." }),
+        sessionKey: Type.Optional(Type.String({ description: "Linked session key." })),
+        runId: Type.Optional(Type.String({ description: "Linked run id." })),
+        token: ScopedClaimTokenField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         const { record, id, scope } = await readScopedCardToolParams(rawParams);
         return redactedCardResult(await store.addWorkerLog(id, record, scope));
@@ -470,16 +398,13 @@ export function createWorkboardOrchestrationTools(params: {
       label: "Workboard Protocol Violation",
       description:
         "Block a card and record a worker protocol violation when work stops without complete/block.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          detail: Type.Optional(Type.String({ description: "Violation detail." })),
-          sessionKey: Type.Optional(Type.String({ description: "Linked session key." })),
-          runId: Type.Optional(Type.String({ description: "Linked run id." })),
-          token: ScopedClaimTokenField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        detail: Type.Optional(Type.String({ description: "Violation detail." })),
+        sessionKey: Type.Optional(Type.String({ description: "Linked session key." })),
+        runId: Type.Optional(Type.String({ description: "Linked run id." })),
+        token: ScopedClaimTokenField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         const { record, id, scope } = await readClaimedCardToolParams(rawParams);
         return redactedCardResult(await store.recordProtocolViolation(id, record, scope));

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -10,7 +10,12 @@ import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { Type } from "typebox";
 import { redactClaimToken } from "./card-redaction.js";
 import { WorkboardStore } from "./store.js";
-import { cardIdField, claimTokenField, createWorkboardMoveTool } from "./tools-card-mutations.js";
+import {
+  cardIdField,
+  claimTokenField,
+  createWorkboardMoveTool,
+  strictObject,
+} from "./tools-card-mutations.js";
 import { createWorkboardOrchestrationTools } from "./tools-orchestration.js";
 
 function contextOwner(ctx: OpenClawPluginToolContext | undefined): string {
@@ -161,13 +166,10 @@ function redactedProofResult(card: WorkboardCard) {
   });
 }
 
-const CardIdSchema = Type.Object(
-  {
-    id: cardIdField(),
-    token: claimTokenField(),
-  },
-  { additionalProperties: false },
-);
+const CardIdSchema = strictObject({
+  id: cardIdField(),
+  token: claimTokenField(),
+});
 
 export function createWorkboardTools(params: {
   api: OpenClawPluginApi;
@@ -206,24 +208,19 @@ export function createWorkboardTools(params: {
       label: "Workboard List",
       description:
         "List Workboard cards with compact claim and diagnostic state. Use before choosing or routing board work.",
-      parameters: Type.Object(
-        {
-          status: Type.Optional(Type.String({ description: "Optional card status filter." })),
-          agentId: Type.Optional(Type.String({ description: "Optional agent id filter." })),
-          tenant: Type.Optional(Type.String({ description: "Optional tenant filter." })),
-          boardId: Type.Optional(Type.String({ description: "Optional board id filter." })),
-          limit: Type.Optional(
-            Type.Number({ description: "Maximum cards to return. Default 50." }),
-          ),
-          refreshDiagnostics: Type.Optional(
-            Type.Boolean({ description: "Refresh stored diagnostics before listing." }),
-          ),
-          includeArchived: Type.Optional(
-            Type.Boolean({ description: "Include archived cards. Default false." }),
-          ),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        status: Type.Optional(Type.String({ description: "Optional card status filter." })),
+        agentId: Type.Optional(Type.String({ description: "Optional agent id filter." })),
+        tenant: Type.Optional(Type.String({ description: "Optional tenant filter." })),
+        boardId: Type.Optional(Type.String({ description: "Optional board id filter." })),
+        limit: Type.Optional(Type.Number({ description: "Maximum cards to return. Default 50." })),
+        refreshDiagnostics: Type.Optional(
+          Type.Boolean({ description: "Refresh stored diagnostics before listing." }),
+        ),
+        includeArchived: Type.Optional(
+          Type.Boolean({ description: "Include archived cards. Default false." }),
+        ),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = rawParams as Record<string, unknown>;
         if (record.refreshDiagnostics === true) {
@@ -252,41 +249,33 @@ export function createWorkboardTools(params: {
       label: "Workboard Create",
       description:
         "Create a Workboard card, optionally with parent dependencies, tenant, skills, workspace, and idempotency key.",
-      parameters: Type.Object(
-        {
-          title: Type.String({ description: "Card title." }),
-          notes: Type.Optional(Type.String({ description: "Card notes or acceptance criteria." })),
-          status: Type.Optional(Type.String({ description: "Initial status." })),
-          priority: Type.Optional(Type.String({ description: "low, normal, high, or urgent." })),
-          labels: Type.Optional(Type.Array(Type.String(), { description: "Card labels." })),
-          agentId: Type.Optional(Type.String({ description: "Assigned agent id." })),
-          parents: Type.Optional(Type.Array(Type.String(), { description: "Parent card ids." })),
-          token: Type.Optional(
-            Type.String({ description: "Claim token for claimed parent cards." }),
-          ),
-          tenant: Type.Optional(Type.String({ description: "Soft tenant namespace." })),
-          boardId: Type.Optional(Type.String({ description: "Soft board namespace." })),
-          createdByCardId: Type.Optional(
-            Type.String({ description: "Parent card that created this card." }),
-          ),
-          idempotencyKey: Type.Optional(Type.String({ description: "Idempotent create key." })),
-          skills: Type.Optional(Type.Array(Type.String(), { description: "Suggested skills." })),
-          workspace: Type.Optional(
-            Type.Object(
-              {
-                kind: Type.String({ description: "scratch, dir, or worktree." }),
-                path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
-                branch: Type.Optional(Type.String({ description: "Suggested branch." })),
-              },
-              { additionalProperties: false },
-            ),
-          ),
-          maxRuntimeSeconds: Type.Optional(Type.Number({ description: "Run timeout seconds." })),
-          maxRetries: Type.Optional(Type.Number({ description: "Retry budget." })),
-          scheduledAt: Type.Optional(Type.Number({ description: "Unix epoch milliseconds." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        title: Type.String({ description: "Card title." }),
+        notes: Type.Optional(Type.String({ description: "Card notes or acceptance criteria." })),
+        status: Type.Optional(Type.String({ description: "Initial status." })),
+        priority: Type.Optional(Type.String({ description: "low, normal, high, or urgent." })),
+        labels: Type.Optional(Type.Array(Type.String(), { description: "Card labels." })),
+        agentId: Type.Optional(Type.String({ description: "Assigned agent id." })),
+        parents: Type.Optional(Type.Array(Type.String(), { description: "Parent card ids." })),
+        token: Type.Optional(Type.String({ description: "Claim token for claimed parent cards." })),
+        tenant: Type.Optional(Type.String({ description: "Soft tenant namespace." })),
+        boardId: Type.Optional(Type.String({ description: "Soft board namespace." })),
+        createdByCardId: Type.Optional(
+          Type.String({ description: "Parent card that created this card." }),
+        ),
+        idempotencyKey: Type.Optional(Type.String({ description: "Idempotent create key." })),
+        skills: Type.Optional(Type.Array(Type.String(), { description: "Suggested skills." })),
+        workspace: Type.Optional(
+          strictObject({
+            kind: Type.String({ description: "scratch, dir, or worktree." }),
+            path: Type.Optional(Type.String({ description: "Absolute dir/worktree path." })),
+            branch: Type.Optional(Type.String({ description: "Suggested branch." })),
+          }),
+        ),
+        maxRuntimeSeconds: Type.Optional(Type.Number({ description: "Run timeout seconds." })),
+        maxRetries: Type.Optional(Type.Number({ description: "Retry budget." })),
+        scheduledAt: Type.Optional(Type.Number({ description: "Unix epoch milliseconds." })),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = rawParams as Record<string, unknown>;
         readParentIds(record.parents);
@@ -302,16 +291,13 @@ export function createWorkboardTools(params: {
       label: "Workboard Link",
       description:
         "Link a parent card to a child card so the child becomes ready only after parents are done.",
-      parameters: Type.Object(
-        {
-          parentId: Type.String({ description: "Parent card id." }),
-          childId: Type.String({ description: "Child card id." }),
-          token: Type.Optional(
-            Type.String({ description: "Claim token for claimed parent or child cards." }),
-          ),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        parentId: Type.String({ description: "Parent card id." }),
+        childId: Type.String({ description: "Child card id." }),
+        token: Type.Optional(
+          Type.String({ description: "Claim token for claimed parent or child cards." }),
+        ),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = rawParams as Record<string, unknown>;
         const parentId = readStringParam(record, "parentId", { required: true });
@@ -346,13 +332,10 @@ export function createWorkboardTools(params: {
       label: "Workboard Claim",
       description:
         "Claim a Workboard card for this agent and move backlog/todo cards into running. Returns a claim token for heartbeats and release.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          ttlSeconds: Type.Optional(Type.Number({ description: "Claim TTL in seconds." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        ttlSeconds: Type.Optional(Type.Number({ description: "Claim TTL in seconds." })),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const record = rawParams as Record<string, unknown>;
         const id = readStringParam(record, "id", { required: true });
@@ -368,14 +351,11 @@ export function createWorkboardTools(params: {
       label: "Workboard Heartbeat",
       description:
         "Refresh this agent's Workboard claim heartbeat. Use during long-running card work so diagnostics do not mark it stale.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          token: claimTokenField(),
-          note: Type.Optional(Type.String({ description: "Optional compact progress note." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        token: claimTokenField(),
+        note: Type.Optional(Type.String({ description: "Optional compact progress note." })),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const { record, id, scope } = await readScopedCardToolParams(rawParams);
         return redactedRawCardResult(
@@ -391,16 +371,13 @@ export function createWorkboardTools(params: {
       label: "Workboard Release",
       description:
         "Release this agent's Workboard claim after finishing, pausing, or handing off card work.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          token: claimTokenField(),
-          status: Type.Optional(
-            Type.String({ description: "Optional next card status after release." }),
-          ),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        token: claimTokenField(),
+        status: Type.Optional(
+          Type.String({ description: "Optional next card status after release." }),
+        ),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const { record, id, scope } = await readScopedCardToolParams(rawParams);
         return redactedRawCardResult(
@@ -415,14 +392,11 @@ export function createWorkboardTools(params: {
       name: "workboard_comment",
       label: "Workboard Comment",
       description: "Append a compact comment to a Workboard card.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          body: Type.String({ description: "Comment body." }),
-          token: ScopedClaimTokenField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        body: Type.String({ description: "Comment body." }),
+        token: ScopedClaimTokenField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         const { record, id, scope } = await readScopedCardToolParams(rawParams);
         return redactedRawCardResult(await store.addComment(id, { body: record.body }, scope));
@@ -433,23 +407,16 @@ export function createWorkboardTools(params: {
       label: "Workboard Proof",
       description:
         "Attach proof or artifact metadata to a Workboard card after running tests, checks, or producing screenshots/logs. Returns proofId; pass it to workboard_complete when that call reports the terminal status for this proof.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          status: Type.Optional(
-            Type.String({ description: "passed, failed, skipped, or unknown." }),
-          ),
-          label: Type.Optional(Type.String({ description: "Proof label." })),
-          command: Type.Optional(Type.String({ description: "Command or exact step run." })),
-          url: Type.Optional(Type.String({ description: "Proof or artifact URL." })),
-          note: Type.Optional(Type.String({ description: "Short proof note." })),
-          artifactPath: Type.Optional(
-            Type.String({ description: "Optional local artifact path." }),
-          ),
-          token: ScopedClaimTokenField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        status: Type.Optional(Type.String({ description: "passed, failed, skipped, or unknown." })),
+        label: Type.Optional(Type.String({ description: "Proof label." })),
+        command: Type.Optional(Type.String({ description: "Command or exact step run." })),
+        url: Type.Optional(Type.String({ description: "Proof or artifact URL." })),
+        note: Type.Optional(Type.String({ description: "Short proof note." })),
+        artifactPath: Type.Optional(Type.String({ description: "Optional local artifact path." })),
+        token: ScopedClaimTokenField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         const { record, id, scope } = await readScopedCardToolParams(rawParams);
         const hasArtifact =
@@ -475,50 +442,40 @@ export function createWorkboardTools(params: {
       label: "Workboard Complete",
       description:
         "Complete a claimed Workboard card with a structured summary, proof, artifacts, and created-card manifest.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          token: claimTokenField(),
-          summary: Type.Optional(Type.String({ description: "Completion summary." })),
-          proofId: Type.Optional(
-            Type.String({
-              description:
-                "Proof id returned by workboard_proof when resolving that pending proof.",
+      parameters: strictObject({
+        id: cardIdField(),
+        token: claimTokenField(),
+        summary: Type.Optional(Type.String({ description: "Completion summary." })),
+        proofId: Type.Optional(
+          Type.String({
+            description: "Proof id returned by workboard_proof when resolving that pending proof.",
+          }),
+        ),
+        proof: Type.Optional(
+          strictObject({
+            status: Type.Optional(
+              Type.String({ description: "passed, failed, skipped, or unknown." }),
+            ),
+            label: Type.Optional(Type.String({ description: "Proof label." })),
+            command: Type.Optional(Type.String({ description: "Command or step run." })),
+            url: Type.Optional(Type.String({ description: "Proof URL." })),
+            note: Type.Optional(Type.String({ description: "Proof note." })),
+          }),
+        ),
+        artifacts: Type.Optional(
+          Type.Array(
+            strictObject({
+              label: Type.Optional(Type.String()),
+              url: Type.Optional(Type.String()),
+              path: Type.Optional(Type.String()),
+              mimeType: Type.Optional(Type.String()),
             }),
           ),
-          proof: Type.Optional(
-            Type.Object(
-              {
-                status: Type.Optional(
-                  Type.String({ description: "passed, failed, skipped, or unknown." }),
-                ),
-                label: Type.Optional(Type.String({ description: "Proof label." })),
-                command: Type.Optional(Type.String({ description: "Command or step run." })),
-                url: Type.Optional(Type.String({ description: "Proof URL." })),
-                note: Type.Optional(Type.String({ description: "Proof note." })),
-              },
-              { additionalProperties: false },
-            ),
-          ),
-          artifacts: Type.Optional(
-            Type.Array(
-              Type.Object(
-                {
-                  label: Type.Optional(Type.String()),
-                  url: Type.Optional(Type.String()),
-                  path: Type.Optional(Type.String()),
-                  mimeType: Type.Optional(Type.String()),
-                },
-                { additionalProperties: false },
-              ),
-            ),
-          ),
-          createdCardIds: Type.Optional(
-            Type.Array(Type.String(), { description: "Cards created during this run." }),
-          ),
-        },
-        { additionalProperties: false },
-      ),
+        ),
+        createdCardIds: Type.Optional(
+          Type.Array(Type.String(), { description: "Cards created during this run." }),
+        ),
+      }),
       execute: async (_toolCallId, rawParams) => {
         return runClaimedCardMutation(rawParams, (id, record, scope) =>
           store.complete(id, record, scope),
@@ -530,17 +487,14 @@ export function createWorkboardTools(params: {
       label: "Workboard Attachment Add",
       description:
         "Store a small Workboard attachment in plugin SQLite KV and link it to the card.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          fileName: Type.String({ description: "Attachment file name." }),
-          contentBase64: Type.String({ description: "Base64 attachment content." }),
-          mimeType: Type.Optional(Type.String({ description: "Attachment MIME type." })),
-          note: Type.Optional(Type.String({ description: "Optional attachment note." })),
-          token: ScopedClaimTokenField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        fileName: Type.String({ description: "Attachment file name." }),
+        contentBase64: Type.String({ description: "Base64 attachment content." }),
+        mimeType: Type.Optional(Type.String({ description: "Attachment MIME type." })),
+        note: Type.Optional(Type.String({ description: "Optional attachment note." })),
+        token: ScopedClaimTokenField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         const { record, id, scope } = await readScopedCardToolParams(rawParams);
         return redactedCardResult(await store.addAttachment(id, record, scope));
@@ -550,12 +504,9 @@ export function createWorkboardTools(params: {
       name: "workboard_attachment_read",
       label: "Workboard Attachment Read",
       description: "Read one Workboard attachment from plugin SQLite KV.",
-      parameters: Type.Object(
-        {
-          id: Type.String({ description: "Attachment id." }),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: Type.String({ description: "Attachment id." }),
+      }),
       execute: async (_toolCallId, rawParams) => {
         const id = readStringParam(rawParams as Record<string, unknown>, "id", {
           required: true,
@@ -571,14 +522,11 @@ export function createWorkboardTools(params: {
       name: "workboard_attachment_delete",
       label: "Workboard Attachment Delete",
       description: "Delete one Workboard attachment from plugin SQLite KV and the card index.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          attachmentId: Type.String({ description: "Attachment id." }),
-          token: ScopedClaimTokenField,
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        attachmentId: Type.String({ description: "Attachment id." }),
+        token: ScopedClaimTokenField,
+      }),
       execute: async (_toolCallId, rawParams) => {
         const { record, id, scope } = await readScopedCardToolParams(rawParams);
         const attachmentId = readStringParam(record, "attachmentId", { required: true });
@@ -589,14 +537,11 @@ export function createWorkboardTools(params: {
       name: "workboard_block",
       label: "Workboard Block",
       description: "Block a claimed Workboard card with a durable reason and release the claim.",
-      parameters: Type.Object(
-        {
-          id: cardIdField(),
-          token: claimTokenField(),
-          reason: Type.Optional(Type.String({ description: "Blocker summary." })),
-        },
-        { additionalProperties: false },
-      ),
+      parameters: strictObject({
+        id: cardIdField(),
+        token: claimTokenField(),
+        reason: Type.Optional(Type.String({ description: "Blocker summary." })),
+      }),
       execute: async (_toolCallId, rawParams) => {
         return runClaimedCardMutation(rawParams, (id, record, scope) =>
           store.block(id, record, scope),


### PR DESCRIPTION
## What Problem This Solves

Workboard's card tools and Gateway handlers repeated large schema and registration blocks. That duplication made the authorization scopes, strict input contracts, dispatch order, and response behavior harder to audit and keep synchronized.

## Why This Change Was Made

This maintainer-requested refactor consolidates the repeated schema and Gateway helper plumbing inside the Workboard plugin. It preserves every existing method, scope, strict schema identity, workspace boundary, redaction rule, and dispatch outcome.

AI-assisted maintainer cleanup. I reviewed the final code, proof, and exact landing diff.

## User Impact

No user-visible behavior changes. Contributors get a smaller, more coherent Workboard implementation with the same security and runtime contracts.

## Evidence

- Production LOC: `+582/-935` (net `-353`) across exactly five Workboard files.
- Current-main base: `b977ccb21e2b4b8bff05729548ea1b1558a74a33`; exact head: `cee5e7b0eaca8b572b52438bdec9235d3ff8243a`.
- Exact plain and binary diff SHA-256: `31e51dce4fc43356fabfab06f02223b1c3ded70174feda51e8afad0cb27f7fec`.
- Full Workboard suite: 337/337 passed; focused Gateway and tools suites: 18/18 passed.
- Schema equivalence: all 42 unique strict TypeBox identities preserved.
- Gateway equivalence: all 47 ordered handlers preserved with the same scopes (10 read, 37 write) and fingerprint `a4bee4b97adad54fc7e55db50c6ca0aae3cce46ee73154de49024692a445b43d`.
- Independent verification found no boundary, authority, workspace, redaction, or response-shape regression.
- Mandatory exact-source autoreview: secret scan clean; isolated Codex review reported no actionable findings (0.99 patch-correctness confidence).
