### PR TITLE
feat(android): unify agent and session pickers

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -237,17 +237,6 @@
       ]
     },
     {
-      "id": "native.android.df03ebb12a9184ac",
-      "source": "$emoji $name",
-      "surface": "android",
-      "sites": [
-        {
-          "kind": "ui-call",
-          "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt"
-        }
-      ]
-    },
-    {
       "id": "native.android.c8d4706f1ebe8e51",
       "source": "$held held",
       "surface": "android",
@@ -9030,17 +9019,6 @@
         {
           "kind": "ui-call",
           "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt"
-        }
-      ]
-    },
-    {
-      "id": "native.android.895a25d9e1e76ae9",
-      "source": "More Agents",
-      "surface": "android",
-      "sites": [
-        {
-          "kind": "ui-call",
-          "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt"
         }
       ]
     },

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/AgentPicker.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/AgentPicker.kt
@@ -43,11 +43,12 @@ internal data class AgentPickerState(
 internal fun agentPickerState(
   agents: List<GatewayAgentSummary>,
   selectedAgentId: String?,
+  fallbackToFirst: Boolean = true,
 ): AgentPickerState {
   val selectable = agents.selectableAgents().distinctBy(GatewayAgentSummary::id)
   val selected =
     selectable.firstOrNull { it.id == selectedAgentId?.trim() }
-      ?: selectable.firstOrNull()
+      ?: if (fallbackToFirst) selectable.firstOrNull() else null
   return AgentPickerState(agents = selectable, selected = selected)
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/AgentPicker.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/AgentPicker.kt
@@ -1,0 +1,142 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.GatewayAgentSummary
+import ai.openclaw.app.selectableAgents
+import ai.openclaw.app.ui.design.ClawAgentAvatar
+import ai.openclaw.app.ui.design.ClawTheme
+import ai.openclaw.app.ui.design.agentAvatarSource
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+internal data class AgentPickerState(
+  val agents: List<GatewayAgentSummary>,
+  val selected: GatewayAgentSummary?,
+)
+
+internal fun agentPickerState(
+  agents: List<GatewayAgentSummary>,
+  selectedAgentId: String?,
+): AgentPickerState {
+  val selectable = agents.selectableAgents().distinctBy(GatewayAgentSummary::id)
+  val selected =
+    selectable.firstOrNull { it.id == selectedAgentId?.trim() }
+      ?: selectable.firstOrNull()
+  return AgentPickerState(agents = selectable, selected = selected)
+}
+
+internal fun agentPickerName(agent: GatewayAgentSummary): String = agent.name?.trim()?.takeIf(String::isNotEmpty) ?: agent.id
+
+@Composable
+internal fun AgentPicker(
+  state: AgentPickerState,
+  onSelectAgent: (String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val selected = state.selected ?: return
+  var expanded by remember { mutableStateOf(false) }
+
+  Box(modifier = modifier) {
+    Surface(
+      onClick = { expanded = true },
+      modifier = Modifier.fillMaxWidth().heightIn(min = ClawTheme.spacing.touchTarget),
+      shape = RoundedCornerShape(ClawTheme.radii.pill),
+      color = ClawTheme.colors.surfaceRaised.copy(alpha = 0.72f),
+      contentColor = ClawTheme.colors.text,
+      border = BorderStroke(1.dp, ClawTheme.colors.border.copy(alpha = 0.7f)),
+    ) {
+      Row(
+        modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+      ) {
+        AgentPickerAvatar(agent = selected, size = 24)
+        Text(
+          text = agentPickerName(selected),
+          style = ClawTheme.type.caption,
+          maxLines = 1,
+          modifier = Modifier.weight(1f),
+          overflow = TextOverflow.Ellipsis,
+        )
+        Icon(
+          imageVector = Icons.Default.KeyboardArrowDown,
+          contentDescription = null,
+          modifier = Modifier.size(18.dp),
+        )
+      }
+    }
+
+    DropdownMenu(
+      expanded = expanded,
+      onDismissRequest = { expanded = false },
+      containerColor = ClawTheme.colors.surfaceRaised,
+    ) {
+      state.agents.forEach { agent ->
+        DropdownMenuItem(
+          text = {
+            Text(
+              text = agentPickerName(agent),
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+            )
+          },
+          leadingIcon = { AgentPickerAvatar(agent = agent, size = 24) },
+          trailingIcon = {
+            if (agent.id == selected.id) {
+              Icon(imageVector = Icons.Default.Check, contentDescription = null)
+            }
+          },
+          onClick = {
+            expanded = false
+            onSelectAgent(agent.id)
+          },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun AgentPickerAvatar(
+  agent: GatewayAgentSummary,
+  size: Int,
+) {
+  val avatarSize = size.dp
+  ClawAgentAvatar(source = agentAvatarSource(agent), size = avatarSize) {
+    Box(
+      modifier = Modifier.size(avatarSize).clip(CircleShape).background(ClawTheme.colors.surfacePressed),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text(
+        text = agent.emoji?.trim()?.takeIf(String::isNotEmpty) ?: agentPickerName(agent).take(1).uppercase(),
+        style = ClawTheme.type.caption,
+      )
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/AgentPicker.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/AgentPicker.kt
@@ -37,8 +37,11 @@ import androidx.compose.ui.unit.dp
 
 internal data class AgentPickerState(
   val agents: List<GatewayAgentSummary>,
-  val selected: GatewayAgentSummary?,
-)
+  val selectedAgentId: String?,
+) {
+  val selected: GatewayAgentSummary?
+    get() = agents.firstOrNull { it.id == selectedAgentId }
+}
 
 internal fun agentPickerState(
   agents: List<GatewayAgentSummary>,
@@ -46,13 +49,21 @@ internal fun agentPickerState(
   fallbackToFirst: Boolean = true,
 ): AgentPickerState {
   val selectable = agents.selectableAgents().distinctBy(GatewayAgentSummary::id)
-  val selected =
-    selectable.firstOrNull { it.id == selectedAgentId?.trim() }
-      ?: if (fallbackToFirst) selectable.firstOrNull() else null
-  return AgentPickerState(agents = selectable, selected = selected)
+  val requestedAgentId = selectedAgentId?.trim()?.takeIf(String::isNotEmpty)
+  val effectiveAgentId =
+    selectable
+      .firstOrNull { it.id == requestedAgentId }
+      ?.id
+      ?: if (fallbackToFirst) selectable.firstOrNull()?.id else requestedAgentId
+  return AgentPickerState(
+    agents = selectable,
+    selectedAgentId = effectiveAgentId,
+  )
 }
 
 internal fun agentPickerName(agent: GatewayAgentSummary): String = agent.name?.trim()?.takeIf(String::isNotEmpty) ?: agent.id
+
+internal fun agentPickerLabel(state: AgentPickerState): String? = state.selected?.let(::agentPickerName) ?: state.selectedAgentId
 
 @Composable
 internal fun AgentPicker(
@@ -60,7 +71,8 @@ internal fun AgentPicker(
   onSelectAgent: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  val selected = state.selected ?: return
+  val selectedAgentId = state.selectedAgentId ?: return
+  val label = agentPickerLabel(state) ?: return
   var expanded by remember { mutableStateOf(false) }
 
   Box(modifier = modifier) {
@@ -77,9 +89,9 @@ internal fun AgentPicker(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(7.dp),
       ) {
-        AgentPickerAvatar(agent = selected, size = 24)
+        state.selected?.let { selected -> AgentPickerAvatar(agent = selected, size = 24) }
         Text(
-          text = agentPickerName(selected),
+          text = label,
           style = ClawTheme.type.caption,
           maxLines = 1,
           modifier = Modifier.weight(1f),
@@ -109,7 +121,7 @@ internal fun AgentPicker(
           },
           leadingIcon = { AgentPickerAvatar(agent = agent, size = 24) },
           trailingIcon = {
-            if (agent.id == selected.id) {
+            if (agent.id == selectedAgentId) {
               Icon(imageVector = Icons.Default.Check, contentDescription = null)
             }
           },

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
@@ -5,7 +5,6 @@ import ai.openclaw.app.GatewayConnectionDisplay
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.i18n.nativeString
-import ai.openclaw.app.selectableAgents
 import ai.openclaw.app.ui.design.ClawTheme
 import ai.openclaw.app.ui.design.OpenClawMascot
 import androidx.compose.foundation.background
@@ -34,8 +33,6 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.Dashboard
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -44,7 +41,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -57,7 +53,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -91,25 +86,6 @@ internal val SidebarDestination.compactLabelSource: String
     }
 
 internal fun SidebarDestination.compactLocalizedLabel(): String = nativeString(compactLabelSource)
-
-internal data class SidebarAgentRoster(
-  val selected: GatewayAgentSummary?,
-  val others: List<GatewayAgentSummary>,
-)
-
-internal fun sidebarAgentRoster(
-  agents: List<GatewayAgentSummary>,
-  selectedAgentId: String?,
-): SidebarAgentRoster {
-  val selectable = agents.selectableAgents().distinctBy(GatewayAgentSummary::id)
-  val selected =
-    selectable.firstOrNull { it.id == selectedAgentId?.trim() }
-      ?: selectable.firstOrNull()
-  return SidebarAgentRoster(
-    selected = selected,
-    others = selectable.filterNot { it.id == selected?.id },
-  )
-}
 
 private const val SIDEBAR_SESSION_LIMIT = 8
 
@@ -213,10 +189,9 @@ internal fun OpenClawSidebar(
   onSelectDestination: (SidebarDestination) -> Unit,
 ) {
   val palette = sidebarPalette()
-  val roster = sidebarAgentRoster(agents, selectedAgentId)
+  val agentPicker = agentPickerState(agents, selectedAgentId)
   val storedGroups by viewModel.sessionCustomGroups.collectAsState()
   var query by rememberSaveable { mutableStateOf("") }
-  var agentsExpanded by remember { mutableStateOf(false) }
   var sessionsExpanded by rememberSaveable { mutableStateOf(false) }
   val recentPresentation =
     sidebarSessionPresentation(
@@ -330,46 +305,13 @@ internal fun OpenClawSidebar(
             }
         }
       } else {
-        SidebarSectionTitle(nativeString("Agents"), palette)
-        roster.selected?.let { selected ->
-          SidebarAgentRow(
-            agent = selected,
-            selected = true,
-            palette = palette,
-            onClick = { onSelectAgent(selected.id) },
+        if (agentPicker.selected != null) {
+          SidebarSectionTitle(nativeString("Agents"), palette)
+          AgentPicker(
+            state = agentPicker,
+            onSelectAgent = onSelectAgent,
+            modifier = Modifier.fillMaxWidth(),
           )
-        }
-        if (roster.others.isNotEmpty()) {
-          Box {
-            SidebarActionRow(
-              label = nativeString("More Agents"),
-              icon = Icons.Default.KeyboardArrowDown,
-              palette = palette,
-              onClick = { agentsExpanded = true },
-            )
-            DropdownMenu(
-              expanded = agentsExpanded,
-              onDismissRequest = { agentsExpanded = false },
-              containerColor = palette.elevated,
-            ) {
-              roster.others.forEach { agent ->
-                DropdownMenuItem(
-                  text = {
-                    Text(
-                      text = sidebarAgentName(agent),
-                      color = palette.text,
-                      maxLines = 1,
-                      overflow = TextOverflow.Ellipsis,
-                    )
-                  },
-                  onClick = {
-                    agentsExpanded = false
-                    onSelectAgent(agent.id)
-                  },
-                )
-              }
-            }
-          }
         }
 
         SidebarSectionTitle(nativeString("Pages"), palette, modifier = Modifier.padding(top = 12.dp))

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SidebarContent.kt
@@ -137,7 +137,7 @@ private fun ChatSessionEntry.isDashboardSession(): Boolean {
 
 internal fun sidebarSessionTitle(session: ChatSessionEntry): String = sessionPresentationTitle(session) { session.key }
 
-internal fun sidebarAgentName(agent: GatewayAgentSummary): String = agent.name?.trim()?.takeIf(String::isNotEmpty) ?: agent.id
+internal fun sidebarAgentName(agent: GatewayAgentSummary): String = agentPickerName(agent)
 
 internal data class SidebarPalette(
   val background: Color,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -45,10 +45,9 @@ import ai.openclaw.app.i18n.nativeText
 import ai.openclaw.app.i18n.resolveNativeTextResource
 import ai.openclaw.app.i18n.verbatimText
 import ai.openclaw.app.resolveAgentIdFromMainSessionKey
-import ai.openclaw.app.selectableAgents
+import ai.openclaw.app.ui.AgentPicker
+import ai.openclaw.app.ui.agentPickerState
 import ai.openclaw.app.ui.copyGatewayDiagnosticsReport
-import ai.openclaw.app.ui.design.AgentAvatarSource
-import ai.openclaw.app.ui.design.ClawAgentAvatar
 import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawLoadingState
 import ai.openclaw.app.ui.design.ClawPanel
@@ -59,7 +58,6 @@ import ai.openclaw.app.ui.design.ClawStatus
 import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTheme
 import ai.openclaw.app.ui.design.OpenClawMascot
-import ai.openclaw.app.ui.design.agentAvatarSource
 import ai.openclaw.app.ui.gatewayDiagnosticsEndpoint
 import ai.openclaw.app.ui.gatewayStatusForDisplay
 import ai.openclaw.app.ui.localizedUppercase
@@ -689,22 +687,30 @@ fun ChatScreen(
       },
     )
 
-    ChatAgentSelector(
-      activeAgentId = activeAgentId,
-      agents = gatewayAgents,
-      onSelectAgent = viewModel::selectChatAgent,
-    )
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      ChatAgentSelector(
+        activeAgentId = activeAgentId,
+        agents = gatewayAgents,
+        onSelectAgent = viewModel::selectChatAgent,
+        modifier = Modifier.weight(1f),
+      )
 
-    ChatSessionSwitcher(
-      sessionKey = sessionKey,
-      sessions = sessions,
-      mainSessionKey = mainSessionKey,
-      onSelectSession = { entry ->
-        viewModel.switchChatSession(entry.key, entry.ownerAgentId)
-        viewModel.refreshChatSessions(limit = 100)
-      },
-      onOpenSessions = onOpenSessions,
-    )
+      ChatSessionSwitcher(
+        sessionKey = sessionKey,
+        sessions = sessions,
+        mainSessionKey = mainSessionKey,
+        onSelectSession = { entry ->
+          viewModel.switchChatSession(entry.key, entry.ownerAgentId)
+          viewModel.refreshChatSessions(limit = 100)
+        },
+        onOpenSessions = onOpenSessions,
+        modifier = Modifier.weight(1f),
+      )
+    }
 
     errorText?.takeIf { it.isNotBlank() }?.let { error ->
       ChatNotice(
@@ -978,24 +984,43 @@ private fun ChatAgentSelector(
   activeAgentId: String,
   agents: List<GatewayAgentSummary>,
   onSelectAgent: (String) -> Unit,
+  modifier: Modifier = Modifier,
 ) {
-  val selectableAgents = agents.selectableAgents()
-  if (selectableAgents.size <= 1) return
+  val state = agentPickerState(agents, activeAgentId)
+  if (state.agents.size <= 1) return
+  AgentPicker(state = state, onSelectAgent = onSelectAgent, modifier = modifier)
+}
 
-  Row(
-    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(6.dp),
-  ) {
-    selectableAgents.forEach { agent ->
-      ChatSessionChip(
-        text = chatAgentChipText(agent),
-        avatarSource = agentAvatarSource(agent),
-        active = agent.id == activeAgentId,
-        onClick = { onSelectAgent(agent.id) },
-      )
-    }
-  }
+internal data class ChatSessionPickerState(
+  val choices: List<ChatSessionEntry>,
+  val selected: ChatSessionEntry?,
+  val hasMore: Boolean,
+)
+
+internal fun chatSessionPickerState(
+  sessionKey: String,
+  sessions: List<ChatSessionEntry>,
+  mainSessionKey: String,
+  nowMs: Long = System.currentTimeMillis(),
+): ChatSessionPickerState {
+  val allChoices =
+    resolveSessionChoices(
+      currentSessionKey = sessionKey,
+      sessions = sessions,
+      mainSessionKey = mainSessionKey,
+      nowMs = nowMs,
+    )
+  val choices =
+    compactSessionChoices(
+      choices = allChoices,
+      currentSessionKey = sessionKey,
+      mainSessionKey = mainSessionKey,
+    )
+  return ChatSessionPickerState(
+    choices = choices,
+    selected = choices.firstOrNull { isActiveSessionChoice(it.key, sessionKey, mainSessionKey) } ?: choices.firstOrNull(),
+    hasMore = hasAdditionalSessionChoices(sessions, choices, mainSessionKey),
+  )
 }
 
 @Composable
@@ -1005,100 +1030,78 @@ private fun ChatSessionSwitcher(
   mainSessionKey: String,
   onSelectSession: (ChatSessionEntry) -> Unit,
   onOpenSessions: () -> Unit,
+  modifier: Modifier = Modifier,
 ) {
-  val allChoices =
-    remember(sessionKey, sessions, mainSessionKey) {
-      resolveSessionChoices(
-        currentSessionKey = sessionKey,
-        sessions = sessions,
-        mainSessionKey = mainSessionKey,
-      )
-    }
-  val choices =
-    remember(sessionKey, allChoices, mainSessionKey) {
-      compactSessionChoices(
-        choices = allChoices,
-        currentSessionKey = sessionKey,
-        mainSessionKey = mainSessionKey,
-      )
-    }
-  val hasMoreSessions =
-    remember(sessions, choices, mainSessionKey) {
-      hasAdditionalSessionChoices(
-        sessions = sessions,
-        displayedChoices = choices,
-        mainSessionKey = mainSessionKey,
-      )
-    }
-  if (choices.size <= 1 && !hasMoreSessions) return
+  val state = remember(sessionKey, sessions, mainSessionKey) { chatSessionPickerState(sessionKey, sessions, mainSessionKey) }
+  val selected = state.selected ?: return
+  if (state.choices.size <= 1 && !state.hasMore) return
+  var expanded by remember { mutableStateOf(false) }
 
-  Row(
-    modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(6.dp),
-  ) {
-    choices.forEach { entry ->
-      ChatSessionChip(
-        text = chatSessionChipText(entry = entry, mainSessionKey = mainSessionKey),
-        active = isActiveSessionChoice(entry.key, sessionKey, mainSessionKey),
-        onClick = { onSelectSession(entry) },
-      )
-    }
-    if (hasMoreSessions) {
-      Surface(
-        onClick = onOpenSessions,
-        modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
-        shape = RoundedCornerShape(ClawTheme.radii.pill),
-        color = ClawTheme.colors.surfaceRaised.copy(alpha = 0.72f),
-        contentColor = ClawTheme.colors.textMuted,
-        border = BorderStroke(1.dp, ClawTheme.colors.border.copy(alpha = 0.7f)),
-      ) {
-        Row(
-          modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
-          verticalAlignment = Alignment.CenterVertically,
-          horizontalArrangement = Arrangement.spacedBy(5.dp),
-        ) {
-          Icon(imageVector = Icons.Default.MoreHoriz, contentDescription = null, modifier = Modifier.size(16.dp))
-          Text(text = nativeString("All"), style = ClawTheme.type.caption, maxLines = 1)
-        }
-      }
-    }
-  }
-}
-
-@Composable
-private fun ChatSessionChip(
-  text: String,
-  avatarSource: AgentAvatarSource? = null,
-  active: Boolean,
-  onClick: () -> Unit,
-) {
-  Surface(
-    onClick = onClick,
-    modifier = Modifier.heightIn(min = ClawTheme.spacing.touchTarget),
-    shape = RoundedCornerShape(ClawTheme.radii.pill),
-    color = if (active) ClawTheme.colors.surfacePressed.copy(alpha = 0.9f) else ClawTheme.colors.surfaceRaised.copy(alpha = 0.72f),
-    contentColor = ClawTheme.colors.text,
-    border = BorderStroke(1.dp, if (active) ClawTheme.colors.borderStrong else ClawTheme.colors.border.copy(alpha = 0.7f)),
-  ) {
-    Row(
-      modifier =
-        Modifier.padding(
-          horizontal = if (avatarSource == null) 11.dp else 8.dp,
-          vertical = if (avatarSource == null) 7.dp else 5.dp,
-        ),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(6.dp),
+  Box(modifier = modifier) {
+    Surface(
+      onClick = { expanded = true },
+      modifier = Modifier.fillMaxWidth().heightIn(min = ClawTheme.spacing.touchTarget),
+      shape = RoundedCornerShape(ClawTheme.radii.pill),
+      color = ClawTheme.colors.surfaceRaised.copy(alpha = 0.72f),
+      contentColor = ClawTheme.colors.text,
+      border = BorderStroke(1.dp, ClawTheme.colors.border.copy(alpha = 0.7f)),
     ) {
-      if (avatarSource != null) {
-        ClawAgentAvatar(source = avatarSource, size = 20.dp) {}
+      Row(
+        modifier = Modifier.padding(horizontal = 10.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+      ) {
+        Text(
+          text = chatSessionChipText(entry = selected, mainSessionKey = mainSessionKey),
+          modifier = Modifier.weight(1f),
+          style = ClawTheme.type.caption,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+        Icon(
+          imageVector = Icons.Default.KeyboardArrowDown,
+          contentDescription = null,
+          modifier = Modifier.size(18.dp),
+        )
       }
-      Text(
-        text = text,
-        style = ClawTheme.type.caption,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-      )
+    }
+
+    DropdownMenu(
+      expanded = expanded,
+      onDismissRequest = { expanded = false },
+      containerColor = ClawTheme.colors.surfaceRaised,
+    ) {
+      state.choices.forEach { entry ->
+        val active = isActiveSessionChoice(entry.key, sessionKey, mainSessionKey)
+        DropdownMenuItem(
+          text = {
+            Text(
+              text = chatSessionChipText(entry = entry, mainSessionKey = mainSessionKey),
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+            )
+          },
+          trailingIcon = {
+            if (active) {
+              Icon(imageVector = Icons.Default.Check, contentDescription = null)
+            }
+          },
+          onClick = {
+            expanded = false
+            onSelectSession(entry)
+          },
+        )
+      }
+      if (state.hasMore) {
+        DropdownMenuItem(
+          text = { Text(text = nativeString("All"), maxLines = 1) },
+          leadingIcon = { Icon(imageVector = Icons.Default.MoreHoriz, contentDescription = null) },
+          onClick = {
+            expanded = false
+            onOpenSessions()
+          },
+        )
+      }
     }
   }
 }
@@ -3057,12 +3060,6 @@ internal fun chatSessionChipText(
       entry.key.takeIf { entry.updatedAtMs != null } ?: nativeString("Current")
     }
   return friendlySessionName(name)
-}
-
-internal fun chatAgentChipText(agent: GatewayAgentSummary): String {
-  val name = agent.name?.trim()?.takeIf { it.isNotEmpty() } ?: agent.id
-  val emoji = agent.emoji?.trim()?.takeIf { it.isNotEmpty() } ?: return name
-  return nativeString("\$emoji \$name", emoji, name)
 }
 
 internal fun selectedChatAgentId(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -46,6 +46,7 @@ import ai.openclaw.app.i18n.resolveNativeTextResource
 import ai.openclaw.app.i18n.verbatimText
 import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import ai.openclaw.app.ui.AgentPicker
+import ai.openclaw.app.ui.AgentPickerState
 import ai.openclaw.app.ui.agentPickerState
 import ai.openclaw.app.ui.copyGatewayDiagnosticsReport
 import ai.openclaw.app.ui.design.ClawListItem
@@ -987,7 +988,7 @@ private fun ChatAgentSelector(
   modifier: Modifier = Modifier,
 ) {
   val state = chatAgentPickerState(activeAgentId = activeAgentId, agents = agents)
-  if (state.agents.size <= 1) return
+  if (!shouldShowChatAgentPicker(state)) return
   AgentPicker(state = state, onSelectAgent = onSelectAgent, modifier = modifier)
 }
 
@@ -995,6 +996,8 @@ internal fun chatAgentPickerState(
   activeAgentId: String,
   agents: List<GatewayAgentSummary>,
 ) = agentPickerState(agents = agents, selectedAgentId = activeAgentId, fallbackToFirst = false)
+
+internal fun shouldShowChatAgentPicker(state: AgentPickerState): Boolean = state.agents.isNotEmpty() && (state.agents.size > 1 || state.selected == null)
 
 internal data class ChatSessionPickerState(
   val choices: List<ChatSessionEntry>,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -986,10 +986,15 @@ private fun ChatAgentSelector(
   onSelectAgent: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  val state = agentPickerState(agents, activeAgentId)
+  val state = chatAgentPickerState(activeAgentId = activeAgentId, agents = agents)
   if (state.agents.size <= 1) return
   AgentPicker(state = state, onSelectAgent = onSelectAgent, modifier = modifier)
 }
+
+internal fun chatAgentPickerState(
+  activeAgentId: String,
+  agents: List<GatewayAgentSummary>,
+) = agentPickerState(agents = agents, selectedAgentId = activeAgentId, fallbackToFirst = false)
 
 internal data class ChatSessionPickerState(
   val choices: List<ChatSessionEntry>,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/AgentPickerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/AgentPickerTest.kt
@@ -1,0 +1,41 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.GatewayAgentSummary
+import ai.openclaw.app.ui.design.ClawDesignTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AgentPickerTest {
+  @get:Rule
+  val composeRule = createComposeRule()
+
+  @Test
+  fun unknownSelectionRemainsVisibleAndCanSwitchToAnAvailableAgent() {
+    var selectedAgentId: String? = null
+    composeRule.setContent {
+      ClawDesignTheme {
+        AgentPicker(
+          state =
+            AgentPickerState(
+              agents = listOf(GatewayAgentSummary(id = "main", name = "Main", emoji = null, kind = null)),
+              selectedAgentId = "missing",
+            ),
+          onSelectAgent = { selectedAgentId = it },
+        )
+      }
+    }
+
+    composeRule.onNodeWithText("missing").assertIsDisplayed().performClick()
+    composeRule.onNodeWithText("Main").assertIsDisplayed().performClick()
+
+    assertEquals("main", selectedAgentId)
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SidebarShellLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SidebarShellLogicTest.kt
@@ -97,6 +97,7 @@ class SidebarShellLogicTest {
 
     assertEquals(listOf("main", "ops"), state.agents.map(GatewayAgentSummary::id))
     assertEquals("ops", state.selected?.id)
+    assertEquals("ops", state.selectedAgentId)
   }
 
   @Test
@@ -104,6 +105,7 @@ class SidebarShellLogicTest {
     val state = agentPickerState(listOf(agent("main"), agent("ops")), selectedAgentId = "missing")
 
     assertEquals("main", state.selected?.id)
+    assertEquals("main", state.selectedAgentId)
   }
 
   @Test
@@ -111,6 +113,7 @@ class SidebarShellLogicTest {
     val state = agentPickerState(listOf(agent("system", kind = "system")), selectedAgentId = "main")
 
     assertNull(state.selected)
+    assertNull(state.selectedAgentId)
     assertEquals(emptyList<String>(), state.agents.map(GatewayAgentSummary::id))
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SidebarShellLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SidebarShellLogicTest.kt
@@ -82,9 +82,9 @@ class SidebarShellLogicTest {
   }
 
   @Test
-  fun agentRosterExcludesSystemAgentsAndKeepsTheSelectedAgentFirst() {
-    val roster =
-      sidebarAgentRoster(
+  fun agentPickerExcludesSystemAgentsDeduplicatesAndKeepsTheSelection() {
+    val state =
+      agentPickerState(
         agents =
           listOf(
             agent("main"),
@@ -95,16 +95,23 @@ class SidebarShellLogicTest {
         selectedAgentId = "ops",
       )
 
-    assertEquals("ops", roster.selected?.id)
-    assertEquals(listOf("main"), roster.others.map(GatewayAgentSummary::id))
+    assertEquals(listOf("main", "ops"), state.agents.map(GatewayAgentSummary::id))
+    assertEquals("ops", state.selected?.id)
   }
 
   @Test
-  fun emptySelectableAgentRosterHasNoSyntheticSelection() {
-    val roster = sidebarAgentRoster(listOf(agent("system", kind = "system")), selectedAgentId = "main")
+  fun agentPickerFallsBackToTheFirstSelectableAgent() {
+    val state = agentPickerState(listOf(agent("main"), agent("ops")), selectedAgentId = "missing")
 
-    assertNull(roster.selected)
-    assertEquals(emptyList<String>(), roster.others.map(GatewayAgentSummary::id))
+    assertEquals("main", state.selected?.id)
+  }
+
+  @Test
+  fun emptyAgentPickerHasNoSyntheticSelection() {
+    val state = agentPickerState(listOf(agent("system", kind = "system")), selectedAgentId = "main")
+
+    assertNull(state.selected)
+    assertEquals(emptyList<String>(), state.agents.map(GatewayAgentSummary::id))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
@@ -6,6 +6,7 @@ import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.SessionBranch
+import ai.openclaw.app.ui.agentPickerLabel
 import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -164,10 +165,25 @@ class ChatScreenTest {
       )
 
     assertNull(state.selected)
+    assertEquals("missing", state.selectedAgentId)
+    assertEquals("missing", agentPickerLabel(state))
+    assertTrue(shouldShowChatAgentPicker(state))
     assertEquals(
       listOf("main", "ops"),
       state.agents.map(GatewayAgentSummary::id),
     )
+  }
+
+  @Test
+  fun agentSelectorKeepsUnknownSelectionSwitchableWithOneAvailableAgent() {
+    val state =
+      chatAgentPickerState(
+        activeAgentId = "missing",
+        agents = listOf(GatewayAgentSummary(id = "main", name = "main", emoji = null, kind = null)),
+      )
+
+    assertTrue(shouldShowChatAgentPicker(state))
+    assertEquals("missing", agentPickerLabel(state))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
@@ -1,6 +1,5 @@
 package ai.openclaw.app.ui.chat
 
-import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.PendingAssistantAutoSend
 import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.ChatMessageContent
@@ -94,19 +93,7 @@ class ChatScreenTest {
   }
 
   @Test
-  fun agentChipUsesEmojiAndFallsBackToId() {
-    assertEquals(
-      "🦾 Scout",
-      chatAgentChipText(GatewayAgentSummary(id = "scout", name = "Scout", emoji = " 🦾 ")),
-    )
-    assertEquals(
-      "ops",
-      chatAgentChipText(GatewayAgentSummary(id = "ops", name = " ", emoji = null)),
-    )
-  }
-
-  @Test
-  fun sessionChipUsesTheSharedDashboardTitlePrecedence() {
+  fun sessionPickerUsesTheSharedDashboardTitlePrecedence() {
     val dashboardKey = "agent:main:dashboard:fresh"
 
     assertEquals(
@@ -129,6 +116,32 @@ class ChatScreenTest {
         mainSessionKey = "agent:main:node-phone",
       ),
     )
+  }
+
+  @Test
+  fun sessionPickerKeepsTheActiveSessionAndSignalsAdditionalChoices() {
+    val now = 1_700_000_000_000L
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "main", updatedAtMs = now),
+        ChatSessionEntry(key = "active", updatedAtMs = now - 1),
+        ChatSessionEntry(key = "recent-1", updatedAtMs = now - 2),
+        ChatSessionEntry(key = "recent-2", updatedAtMs = now - 3),
+        ChatSessionEntry(key = "recent-3", updatedAtMs = now - 4),
+        ChatSessionEntry(key = "recent-4", updatedAtMs = now - 5),
+      )
+
+    val state =
+      chatSessionPickerState(
+        sessionKey = "active",
+        sessions = sessions,
+        mainSessionKey = "main",
+        nowMs = now,
+      )
+
+    assertEquals("active", state.selected?.key)
+    assertEquals(listOf("main", "active", "recent-1", "recent-2", "recent-3"), state.choices.map { it.key })
+    assertTrue(state.hasMore)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.PendingAssistantAutoSend
 import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.ChatMessageContent
@@ -148,6 +149,25 @@ class ChatScreenTest {
   fun agentSelectorUsesCanonicalMainSession() {
     assertEquals("scout", selectedChatAgentId("agent:scout:node-phone", "main"))
     assertEquals("main", selectedChatAgentId("main", "main"))
+  }
+
+  @Test
+  fun agentSelectorDoesNotReplaceMissingActiveAgentWithRosterFallback() {
+    val state =
+      chatAgentPickerState(
+        activeAgentId = "missing",
+        agents =
+          listOf(
+            GatewayAgentSummary(id = "main", name = "main", emoji = null, kind = null),
+            GatewayAgentSummary(id = "ops", name = "ops", emoji = null, kind = null),
+          ),
+      )
+
+    assertNull(state.selected)
+    assertEquals(
+      listOf("main", "ops"),
+      state.agents.map(GatewayAgentSummary::id),
+    )
   }
 
   @Test


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Closes #125060.

Android exposed agent selection through a sidebar roster and chat-header chips. Session switching used another chip row. With several agents or sessions, these controls consumed vertical space and used inconsistent interaction patterns.

## What Changed

- One shared native Agent picker is used in the sidebar and chat.
- Chat places a compact Session picker beside the Agent picker.
- Existing agent and session selection callbacks remain the owners of state changes.
- If the active chat agent is absent from the current roster, the picker remains visible as an unknown selection and still allows choosing an available agent.
- The sidebar retains its existing first-selectable-agent fallback.

Gateway, transport, pairing, persistence, and recent-session behavior are unchanged.

## Product Scope

Issue #125060 explicitly requests the shared compact Agent picker. The adjacent compact Session picker applies the same space-saving interaction to the existing recent-session chip row; maintainers can accept or reject that additional Android UX choice independently.

## Evidence

### Current head

- **Head:** `86175ec6c51ee201f568dd7f5b126b56a82da137`
- **CI:** all required checks pass, including Android Play build, Android unit tests, Android ktlint, and `openclaw/ci-gate`.
- **Unknown-agent regression coverage:** the Compose interaction test renders the picker with an absent active agent, opens its menu, selects an available agent, and verifies the callback.

```bash
cd apps/android
./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.AgentPickerTest --console=plain
```

- **Result:** `BUILD SUCCESSFUL`

```bash
cd apps/android
./gradlew :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck --console=plain
```

- **Result:** `BUILD SUCCESSFUL`

```bash
pnpm native:i18n:verify
```

- **Result:** `native-app-i18n: entries=4235 changed=false`

### Physical-device picker proof

The existing Pixel recording and screenshots were captured at `3562e52201b426756fedfc4f7956e05a14b46b31`. They demonstrate the shared Agent and Session picker presentation and normal selection flow. They predate the current head's unknown-active-agent usability fix and are not presented as proof of that later edge case.

#### Before

https://github.com/user-attachments/assets/a10a8af4-46cd-4175-bb98-fa01d96157ca

<table>
  <tr>
    <td align="center"><img width="260" alt="openclaw-android-agent-session-picker-before" src="https://github.com/user-attachments/assets/9ba3c714-1b5e-4f39-8621-2ebba9b16e93" /></td>
    <td align="center"><img width="260" alt="openclaw-android-agent-session-picker-before1" src="https://github.com/user-attachments/assets/d30ef275-c284-4a39-ba64-bc5ca0784a34" /></td>
  </tr>
</table>

#### After

https://github.com/user-attachments/assets/c8c0f096-a024-46ac-a59b-e5a188717c5d

<table>
  <tr>
    <td align="center"><img width="260" alt="openclaw-android-agent-session-picker-after" src="https://github.com/user-attachments/assets/9dc7120d-440b-4531-a29a-c5939ac45355" /></td>
    <td align="center"><img width="260" alt="openclaw-android-agent-session-picker-after1" src="https://github.com/user-attachments/assets/d0097bac-515f-441b-a033-e52e01cc9722" /></td>
  </tr>
</table>

### Final-head hardware-emulator proof

<!-- pr-agent-proof-gate-v2 profile=android-hardware-emulator tests=pass direct=pass real_behavior=pass -->
<!-- pr-agent-direct-proof-v1 kind=hardware-emulator-media head=86175ec6c51ee201f568dd7f5b126b56a82da137 -->

- **PR head:** `86175ec6c51ee201f568dd7f5b126b56a82da137`
- **Runtime:** Android API 35 x86_64 emulator on an AWS `mac1.metal` host with macOS Hypervisor Framework acceleration (`kern.hv_support=1`).
- **Production code:** `AgentPicker` compiled from the exact PR head.
- **Harness boundary:** a proof-only instrumentation APK supplied the deterministic missing active ID and the available `Main` / `Support` roster; it was not committed or pushed.
- **Interaction:** the production picker displayed `missing-agent`, opened its available-agent menu, selected `Main`, and updated its visible selection.
- **Result:** `AgentPickerProofTest.unknownSelectionOpensAndSelectsAvailableAgent` passed twice, including the recorded run: `OK (1 test)`.
- **Video SHA-256:** `4e05be098adb8533ce5bfbc4e13c98e28ee380b90aa51ed444cb734dc533e31b`.
- **Proof bundle:** [provenance and downloadable files](https://gist.github.com/roboclaw-bot/bdbe9487cd61451fdaa458ae58e4e78f).
- **Recorded interaction:** [MP4](https://gist.githubusercontent.com/roboclaw-bot/bdbe9487cd61451fdaa458ae58e4e78f/raw/beac925e0f635676a0958dd54521261db99e9c41/pr128309-unknown-agent-proof.mp4).

<table>
  <tr>
    <th>Unknown active agent</th>
    <th>Picker remains usable</th>
    <th>Available agent selected</th>
  </tr>
  <tr>
    <td><img width="240" alt="unknown active agent remains visible" src="https://gist.githubusercontent.com/roboclaw-bot/bdbe9487cd61451fdaa458ae58e4e78f/raw/ba1092cfa029415743d2136c2616e42acc8b62ab/01-unknown-agent.png" /></td>
    <td><img width="240" alt="unknown agent picker menu open" src="https://gist.githubusercontent.com/roboclaw-bot/bdbe9487cd61451fdaa458ae58e4e78f/raw/91bbc006930bfd8bd0b02f7b66195d7b5ec07d6b/02-menu-open.png" /></td>
    <td><img width="240" alt="main agent selected" src="https://gist.githubusercontent.com/roboclaw-bot/bdbe9487cd61451fdaa458ae58e4e78f/raw/120c1a0756b61d2991485bddb3eed7bd6119faf4/03-main-selected.png" /></td>
  </tr>
</table>

This proof establishes the changed unknown-agent interaction on the final head. It is hardware-accelerated emulator evidence, not a claim of physical-device coverage.
