### PR TITLE
test(memory-core): release cached databases before removing fixture state dirs

### DIFF
--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Command } from "commander";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { resolveSessionTranscriptsDirForAgent as resolveTestSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
@@ -161,6 +162,10 @@ afterAll(async () => {
   if (!fixtureRoot) {
     return;
   }
+  // The agent close releases its leases through shared state and reopens it, so the
+  // shared handle is released second; otherwise Windows fails the removal with EBUSY.
+  closeOpenClawAgentDatabasesForTest();
+  resetPluginStateStoreForTests();
   await fs.rm(fixtureRoot, { recursive: true, force: true });
   resetMemoryCoreDreamingStateForTests();
 });

--- a/extensions/memory-core/src/dreaming-startup-cleanup.test.ts
+++ b/extensions/memory-core/src/dreaming-startup-cleanup.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { getSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   appendSqliteSessionTranscriptEventForTest,
@@ -30,6 +31,7 @@ afterEach(async () => {
   vi.useRealTimers();
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
+  resetPluginStateStoreForTests();
   await fs.rm(stateDir, { recursive: true, force: true });
 });
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -19,6 +19,7 @@ import {
   type MemorySyncParams,
   type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -413,6 +414,10 @@ describe("session startup catch-up", () => {
     }
     startupHarnessDatabases.clear();
     closeOpenClawAgentDatabasesForTest();
+    // Closing the agent databases releases their leases through shared state, which
+    // reopens it, so the shared handle has to be released after that and before the
+    // removal or Windows fails the unlink with EBUSY.
+    resetPluginStateStoreForTests();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -4,7 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
@@ -107,6 +109,10 @@ describe("memory manager FTS-only reindex", () => {
 
   afterAll(async () => {
     await closeAllMemorySearchManagers();
+    // The agent close releases its leases through shared state and reopens it, so the
+    // shared handle is released second; otherwise Windows fails the removal with EBUSY.
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
     if (fixtureRoot) {
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -4,7 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
 import { acquireMemoryReindexLock } from "./manager-reindex-lock.js";
@@ -52,6 +54,10 @@ describe("memory manager reindex recovery", () => {
     }
     const { closeAllMemorySearchManagers } = await import("./index.js");
     await closeAllMemorySearchManagers();
+    // The agent close releases its leases through shared state and reopens it, so the
+    // shared handle is released second; otherwise Windows fails the removal with EBUSY.
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
     await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -3,7 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
 import type { MemoryIndexManager } from "./manager.js";
@@ -78,6 +80,10 @@ describe("memory manager self-heal missing identity with FTS-only chunks", () =>
 
   afterAll(async () => {
     await closeAllMemorySearchManagers();
+    // The agent close releases its leases through shared state and reopens it, so the
+    // shared handle is released second; otherwise Windows fails the removal with EBUSY.
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
     if (fixtureRoot) {
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -7,6 +7,8 @@ import type {
   MemorySearchConfig,
   OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type WatchIgnoredFn = (watchPath: string, stats?: { isDirectory?: () => boolean }) => boolean;
@@ -208,6 +210,10 @@ describe("memory watcher config", () => {
     await closeAllMemorySearchManagers();
     clearRegistry();
     restoreWatcherStateDir();
+    // The agent close releases its leases through shared state and reopens it, so the
+    // shared handle is released second; otherwise Windows fails the removal with EBUSY.
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
     if (workspaceDir) {
       await fs.rm(workspaceDir, { recursive: true, force: true });
       workspaceDir = "";

--- a/extensions/memory-core/src/test-helpers.ts
+++ b/extensions/memory-core/src/test-helpers.ts
@@ -2,7 +2,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterAll, beforeAll } from "vitest";
@@ -210,6 +214,10 @@ export function createMemoryCoreTestHarness() {
     if (!fixtureRoot) {
       return;
     }
+    // The agent close releases its leases through shared state and reopens it, so the
+    // shared handle is released second; otherwise Windows fails the removal with EBUSY.
+    closeOpenClawAgentDatabasesForTest();
+    resetPluginStateStoreForTests();
     await fs.rm(fixtureRoot, { recursive: true, force: true });
     resetMemoryCoreDreamingStateForTests();
   });


### PR DESCRIPTION
Related: #119796

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where contributors on Windows cannot get a green local run of `extensions/memory-core`:
eleven suites in the `extension-memory` shard fail in teardown with `EBUSY: resource busy or locked`,
never in an assertion. Each fixture removes its temporary state directory while a SQLite handle
opened underneath it is still cached, so the removal fails and the suite is reported as failed even
though every assertion in it passed. On Linux, unlinking an open file succeeds, so CI never sees it.

```
Error: EBUSY: resource busy or locked, unlink
  'C:\...\Temp\openclaw-session-startup-XXXXXX\state\openclaw.sqlite'
Error: EBUSY: resource busy or locked, unlink
  'C:\...\Temp\openclaw\memory-core-test-fixtures-XXXXXX\openclaw-dreaming-state-32\agents\main\agent\openclaw-agent.sqlite'
```

The file named varies between the shared state database, the per-agent database and their
`-wal` / `-shm` companions, because the removal walks the directory.

## Why This Change Was Made

Each fixture now releases the databases it actually leaves open, immediately before the removal,
in the ordering merged for this class in #127201: close the cached per-agent databases first, then
the shared state store.

The order is load-bearing, not decoration. The agent close releases its leases *through* shared
state, which reopens it, so releasing shared state first only moves the lock from
`openclaw-agent.sqlite` to `state\openclaw.sqlite-wal`.

- `src/test-helpers.ts` is the shared harness: its `afterAll` removed the fixture root without
  releasing anything, which is why four suites that never touch a state path of their own
  (`dreaming-narrative`, `dreaming-phases`, `redaction-product-boundaries`, `session-backfill`)
  failed at suite level. One teardown covers all four.
- `manager-sync-ops.startup-catchup.test.ts` and `dreaming-startup-cleanup.test.ts` already closed
  the agent databases and never released the shared store, so only the store release was added.
- `manager.reindex-recovery.test.ts`, `manager.fts-only-reindex.test.ts`,
  `manager.self-heal-missing-identity.test.ts`, `manager.watcher-config.test.ts` and `cli.test.ts`
  released neither at the removal point, so both calls were added in that order.

Tests only; no production file is touched.

## User Impact

Contributors on Windows can run the `extensions/memory-core` suites to completion instead of reading
teardown failures that have nothing to do with the code under test. Behavior on Linux and macOS is
unchanged.

## Evidence

Windows 11, Node 24.18.1. Base arm measured twice on `main`, at `8e04df0205c` (this branch's base)
and again at `bca206d794b`, with identical results; the branch arm is that same tree with only these
eight files patched.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts \
  --configLoader runner extensions/memory-core
```

| whole `extensions/memory-core` | `main` | with this branch |
|---|---|---|
| test files | 13 failed / 77 passed (90) | **4 failed / 86 passed (90)** |
| tests | 47 failed / 1111 passed / 3 skipped | **4 failed / 1154 passed / 3 skipped** |
| `EBUSY` occurrences | **50** | **0** |
| duration | 174s | 178s |

The four remaining failures are pre-existing on `main` and are **not** `EBUSY`: a stale-sqlite-lock
case in `short-term-promotion`, a watcher glob case in `manager.watcher-config`, a status-output case
in `cli`, and a timezone case in `index`. They are separate Windows defects and this branch does not
touch them.

Both calls are load-bearing. Measured on the five suites that go through the shared harness and the
CLI fixture, same command and same tree, only the teardown mutated:

| arm | result |
|---|---|
| `main` (`bca206d794b`) | 5 files failed, **5** `EBUSY` |
| this branch | **1 failed / 212 passed**, 0 `EBUSY` (the one failure is the pre-existing `cli` case) |
| drop `closeOpenClawAgentDatabasesForTest()` | 5 files failed, 5 `EBUSY` on `openclaw-agent.sqlite` |
| drop `resetPluginStateStoreForTests()` | 4 files failed, 4 `EBUSY` on `openclaw.sqlite` |

The same mutation pair on the four `src/memory/` fixtures that received both calls: dropping the
agent close leaves 6 failed / 7 `EBUSY` on `openclaw-agent.sqlite`; dropping the store release leaves
9 failed / 10 `EBUSY` on `openclaw.sqlite`.

- `./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.extensions.test.json --noEmit` -> byte-identical
  output to `main` (the same six pre-existing `extensions/acpx` errors, none in these files)
- `./node_modules/.bin/oxlint <the eight files>` -> exit 0
- `./node_modules/.bin/oxfmt --check <the eight files>` -> exit 0

One local note that is not a code issue: once the teardown failures stop, the shard goes quiet for
longer than `scripts/run-vitest.mjs`'s 120s no-output watchdog allows, so the branch arm was run with
`OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=600000`. The run itself finishes in the same wall-clock time as
the base arm.

## Relationship to the other repairs in this class

Disjoint from every open or merged repair of the same Windows teardown class, so they can land in any
order:

```
#119809 (merged)  lifecycle fixtures
#126352 (merged)  eight extensions/ files, including extensions/memory-core/doctor-contract-api.test.ts
#127201 (merged)  src/gateway/github-publication.test-support.ts
#127236 (merged)  two extensions/nostr suites
#119964 (open)    three extensions/zalouser/ files
this PR           eight extensions/memory-core files
```

`extensions/memory-core` was swept after #127236 landed. `doctor-contract-api.test.ts` in the same
directory was repaired by #126352, is green on `main`, and is untouched here; the failures that
remained are the ones whose fixtures release nothing, or release only the agent databases, at the
point where they remove their directory.
