### PR TITLE
fix(sessions): preserve artifacts during canonical repair

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -378,6 +378,67 @@ function createLightDreamingHarness(workspaceDir: string) {
   return createHarness(LIGHT_DREAMING_TEST_CONFIG, workspaceDir);
 }
 
+function createDefaultStorageLightDreamingHarness(
+  workspaceDir: string,
+  options: {
+    includeMainAgent?: boolean;
+    limit?: number;
+    lookbackDays?: number;
+    memorySearchEnabled?: boolean;
+  } = {},
+) {
+  return createHarness(
+    {
+      ...(options.includeMainAgent
+        ? { agents: { list: [{ id: "main", workspace: workspaceDir }] } }
+        : {}),
+      ...(options.memorySearchEnabled === false ? { memory: { search: { enabled: false } } } : {}),
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+                phases: {
+                  light: {
+                    enabled: true,
+                    limit: options.limit ?? 20,
+                    lookbackDays: options.lookbackDays ?? 7,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    workspaceDir,
+  );
+}
+
+function createNarrativeDreamingSweepConfig(workspaceDir: string): OpenClawConfig {
+  return {
+    ...LIGHT_DREAMING_TEST_CONFIG,
+    agents: { defaults: { workspace: workspaceDir, userTimezone: "UTC" } },
+    plugins: {
+      entries: {
+        "memory-core": {
+          config: {
+            dreaming: {
+              enabled: true,
+              timezone: "UTC",
+              phases: {
+                light: { enabled: true, limit: 20, lookbackDays: 2 },
+                rem: { enabled: false, limit: 0, lookbackDays: 2 },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
 async function triggerLightDreaming(
   beforeAgentReply: NonNullable<ReturnType<typeof createHarness>["beforeAgentReply"]>,
   workspaceDir: string,
@@ -487,39 +548,7 @@ describe("memory-core dreaming phases", () => {
       "- Move backups to S3 Glacier.",
       "- Keep retention at 365 days.",
     ]);
-    const testConfig: OpenClawConfig = {
-      ...LIGHT_DREAMING_TEST_CONFIG,
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-          userTimezone: "UTC",
-        },
-      },
-      plugins: {
-        entries: {
-          "memory-core": {
-            config: {
-              dreaming: {
-                enabled: true,
-                timezone: "UTC",
-                phases: {
-                  light: {
-                    enabled: true,
-                    limit: 20,
-                    lookbackDays: 2,
-                  },
-                  rem: {
-                    enabled: false,
-                    limit: 0,
-                    lookbackDays: 2,
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    };
+    const testConfig = createNarrativeDreamingSweepConfig(workspaceDir);
     const subagent = createMockNarrativeSubagent("The archive hummed softly.");
     const logger = {
       info: vi.fn(),
@@ -553,39 +582,7 @@ describe("memory-core dreaming phases", () => {
       "- Move backups to S3 Glacier.",
       "- Keep retention at 365 days.",
     ]);
-    const testConfig: OpenClawConfig = {
-      ...LIGHT_DREAMING_TEST_CONFIG,
-      agents: {
-        defaults: {
-          workspace: workspaceDir,
-          userTimezone: "UTC",
-        },
-      },
-      plugins: {
-        entries: {
-          "memory-core": {
-            config: {
-              dreaming: {
-                enabled: true,
-                timezone: "UTC",
-                phases: {
-                  light: {
-                    enabled: true,
-                    limit: 20,
-                    lookbackDays: 2,
-                  },
-                  rem: {
-                    enabled: false,
-                    limit: 0,
-                    lookbackDays: 2,
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    };
+    const testConfig = createNarrativeDreamingSweepConfig(workspaceDir);
     const subagent = createMockNarrativeSubagent();
     subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
     subagent.deleteSession.mockImplementation(() => {
@@ -995,29 +992,9 @@ describe("memory-core dreaming phases", () => {
     });
     expect(before).toHaveLength(0);
 
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      lookbackDays: 2,
+    });
 
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
@@ -1061,29 +1038,9 @@ describe("memory-core dreaming phases", () => {
       "utf-8",
     );
 
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      lookbackDays: 2,
+    });
 
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
@@ -1124,29 +1081,10 @@ describe("memory-core dreaming phases", () => {
       );
     }
 
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 1,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      limit: 1,
+      lookbackDays: 2,
+    });
 
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
@@ -1245,23 +1183,7 @@ describe("memory-core dreaming phases", () => {
       "utf-8",
     );
 
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: { light: { enabled: true, limit: 20, lookbackDays: 7 } },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir);
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
     });
@@ -1317,35 +1239,9 @@ describe("memory-core dreaming phases", () => {
         },
       ],
     });
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-          list: [{ id: "main", workspace: workspaceDir }],
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      includeMainAgent: true,
+    });
 
     let firstSessionIngestion;
     try {
@@ -1413,35 +1309,9 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-          list: [{ id: "main", workspace: workspaceDir }],
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      includeMainAgent: true,
+    });
 
     try {
       await withDreamingTestClock(async () => {
@@ -1485,35 +1355,9 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-          list: [{ id: "main", workspace: workspaceDir }],
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      includeMainAgent: true,
+    });
 
     try {
       await beforeAgentReply(
@@ -1553,35 +1397,9 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-          list: [{ id: "main", workspace: workspaceDir }],
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      includeMainAgent: true,
+    });
 
     try {
       await beforeAgentReply(
@@ -1664,35 +1482,9 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-          list: [{ id: "main", workspace: workspaceDir }],
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      includeMainAgent: true,
+    });
 
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-16T19:00:00.000Z"));
@@ -1794,35 +1586,9 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-          list: [{ id: "main", workspace: workspaceDir }],
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      includeMainAgent: true,
+    });
 
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-16T19:00:00.000Z"));
@@ -1900,35 +1666,9 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-          list: [{ id: "main", workspace: workspaceDir }],
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      includeMainAgent: true,
+    });
 
     try {
       await beforeAgentReply(
@@ -1977,34 +1717,7 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir);
 
     try {
       await withDreamingTestClock(async () => {
@@ -2077,34 +1790,7 @@ describe("memory-core dreaming phases", () => {
     const mtime = new Date("2026-04-06T01:05:00.000Z");
     await fs.utimes(archivePath, mtime, mtime);
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir);
 
     try {
       await withDreamingTestClock(async () => {
@@ -2141,34 +1827,9 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      lookbackDays: 2,
+    });
 
     try {
       await withDreamingTestClock(async () => {
@@ -2200,34 +1861,7 @@ describe("memory-core dreaming phases", () => {
       })),
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir);
 
     try {
       await withDreamingTestClock(async () => {
@@ -2362,34 +1996,7 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir);
 
     try {
       await withDreamingTestClock(async () => {
@@ -2440,40 +2047,9 @@ describe("memory-core dreaming phases", () => {
       ],
     });
 
-    const { beforeAgentReply } = createHarness(
-      {
-        memory: {
-          search: {
-            enabled: false,
-          },
-        },
-
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-          },
-        },
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 7,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      memorySearchEnabled: false,
+    });
 
     try {
       await withDreamingTestClock(async () => {
@@ -2505,29 +2081,9 @@ describe("memory-core dreaming phases", () => {
       "utf-8",
     );
 
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      lookbackDays: 2,
+    });
 
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
@@ -2576,23 +2132,9 @@ describe("memory-core dreaming phases", () => {
         "utf-8",
       );
     }
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: { light: { enabled: true, limit: 20, lookbackDays: 2 } },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      lookbackDays: 2,
+    });
 
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
@@ -2646,23 +2188,7 @@ describe("memory-core dreaming phases", () => {
         "utf-8",
       );
     }
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: { light: { enabled: true, limit: 20, lookbackDays: 7 } },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir);
 
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
@@ -2742,29 +2268,9 @@ describe("memory-core dreaming phases", () => {
       "utf-8",
     );
 
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      lookbackDays: 2,
+    });
 
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
@@ -2810,29 +2316,9 @@ describe("memory-core dreaming phases", () => {
       "utf-8",
     );
 
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
+    const { beforeAgentReply } = createDefaultStorageLightDreamingHarness(workspaceDir, {
+      lookbackDays: 2,
+    });
 
     await withDreamingTestClock(async () => {
       await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -87,6 +87,17 @@ type RemDreamingConfig = DreamingPhaseStorageConfig & {
   limit: number;
   minPatternStrength: number;
 };
+type DreamingPhaseRunParams<TConfig extends LightDreamingConfig | RemDreamingConfig> = {
+  agentId?: string;
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+  primaryWorkspaceDir?: string;
+  config: TConfig;
+  logger: Logger;
+  subagent?: DreamNarrativeRequest["subagent"];
+  detachNarratives?: boolean;
+  nowMs?: number;
+};
 const DAILY_MEMORY_FILENAME_RE = /^(\d{4}-\d{2}-\d{2})(?:-[^/]+)?\.md$/i;
 const DAILY_INGESTION_SCORE = 0.62;
 const DAILY_INGESTION_MAX_SNIPPET_CHARS = 280;
@@ -1279,17 +1290,9 @@ export function previewRemDreaming(params: {
   };
 }
 
-async function runLightDreaming(params: {
-  agentId?: string;
-  workspaceDir: string;
-  cfg?: OpenClawConfig;
-  primaryWorkspaceDir?: string;
-  config: LightDreamingConfig;
-  logger: Logger;
-  subagent?: DreamNarrativeRequest["subagent"];
-  detachNarratives?: boolean;
-  nowMs?: number;
-}): Promise<DreamNarrativeOutcome> {
+async function ingestDreamingPhaseSignals(
+  params: DreamingPhaseRunParams<LightDreamingConfig | RemDreamingConfig>,
+): Promise<number> {
   const nowMs =
     typeof params.nowMs === "number" && Number.isFinite(params.nowMs) ? params.nowMs : Date.now();
   await ingestDailyMemorySignals({
@@ -1307,6 +1310,13 @@ async function runLightDreaming(params: {
     nowMs,
     timezone: params.config.timezone,
   });
+  return nowMs;
+}
+
+async function runLightDreaming(
+  params: DreamingPhaseRunParams<LightDreamingConfig>,
+): Promise<DreamNarrativeOutcome> {
+  const nowMs = await ingestDreamingPhaseSignals(params);
   const recentEntries = (
     await filterLiveShortTermRecallEntries({
       workspaceDir: params.workspaceDir,
@@ -1382,34 +1392,10 @@ async function runLightDreaming(params: {
   return { status: "skipped" };
 }
 
-async function runRemDreaming(params: {
-  agentId?: string;
-  workspaceDir: string;
-  cfg?: OpenClawConfig;
-  primaryWorkspaceDir?: string;
-  config: RemDreamingConfig;
-  logger: Logger;
-  subagent?: DreamNarrativeRequest["subagent"];
-  detachNarratives?: boolean;
-  nowMs?: number;
-}): Promise<DreamNarrativeOutcome> {
-  const nowMs =
-    typeof params.nowMs === "number" && Number.isFinite(params.nowMs) ? params.nowMs : Date.now();
-  await ingestDailyMemorySignals({
-    workspaceDir: params.workspaceDir,
-    lookbackDays: dailyIngestionLookbackDays(params.config.lookbackDays),
-    limit: params.config.limit,
-    nowMs,
-    timezone: params.config.timezone,
-  });
-  await ingestSessionTranscriptSignals({
-    workspaceDir: params.workspaceDir,
-    cfg: params.cfg,
-    primaryWorkspaceDir: params.primaryWorkspaceDir,
-    lookbackDays: params.config.lookbackDays,
-    nowMs,
-    timezone: params.config.timezone,
-  });
+async function runRemDreaming(
+  params: DreamingPhaseRunParams<RemDreamingConfig>,
+): Promise<DreamNarrativeOutcome> {
+  const nowMs = await ingestDreamingPhaseSignals(params);
   const allEntries = (
     await filterLiveShortTermRecallEntries({
       workspaceDir: params.workspaceDir,

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -83,6 +83,42 @@ describe("short-term promotion", () => {
     return notePath;
   }
 
+  async function promoteDailyHeadingSnippet(
+    workspaceDir: string,
+    params: { snippet: string; startLine?: number; endLine?: number },
+  ) {
+    const startLine = params.startLine ?? 4;
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "__dreaming_daily__:2026-05-28",
+      signalType: "daily",
+      dedupeByQueryPerDay: true,
+      dayBucket: "2026-05-28",
+      results: [
+        {
+          path: "memory/2026-05-28.md",
+          startLine,
+          endLine: params.endLine ?? startLine,
+          score: 0.91,
+          snippet: params.snippet,
+          source: "memory",
+        },
+      ],
+    });
+    const nowMs = Date.parse("2026-05-31T00:00:00.000Z");
+    const rankingOptions = {
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs,
+    };
+    return await applyShortTermPromotions({
+      ...rankingOptions,
+      candidates: await rankShortTermPromotionCandidates(rankingOptions),
+    });
+  }
+
   async function writeDailyMemoryNoteInSubdir(
     workspaceDir: string,
     subdir: string,
@@ -2374,38 +2410,8 @@ describe("short-term promotion", () => {
         "## 模型切换 (16:23)",
         "- **需求**: 用户想使用小米 Mimo 模型作为默认",
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 4,
-            endLine: 4,
-            score: 0.91,
-            snippet: "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认",
       });
 
       expect(applied.applied).toBe(1);
@@ -2429,39 +2435,10 @@ describe("short-term promotion", () => {
         "- **需求**: 用户想使用小米 Mimo 模型作为默认",
         "- **偏好**: 保持低成本默认路由",
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 4,
-            endLine: 5,
-            score: 0.91,
-            snippet:
-              "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认; **偏好**: 保持低成本默认路由",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet:
+          "模型切换 (16:23): **需求**: 用户想使用小米 Mimo 模型作为默认; **偏好**: 保持低成本默认路由",
+        endLine: 5,
       });
 
       expect(applied.applied).toBe(1);
@@ -2485,38 +2462,8 @@ describe("short-term promotion", () => {
         "## 🚀 New model routing (16:23)",
         "- Keep Xiaomi Mimo as the low-cost default.",
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 4,
-            endLine: 4,
-            score: 0.91,
-            snippet: "Old model routing: Keep Xiaomi Mimo as the low-cost default.",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: "Old model routing: Keep Xiaomi Mimo as the low-cost default.",
       });
 
       expect(applied.applied).toBe(1);
@@ -2538,38 +2485,8 @@ describe("short-term promotion", () => {
         "## Model routing",
         "",
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 4,
-            endLine: 4,
-            score: 0.91,
-            snippet: "Model routing: Keep Xiaomi Mimo as the low-cost default.",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: "Model routing: Keep Xiaomi Mimo as the low-cost default.",
       });
 
       expect(applied.applied).toBe(0);
@@ -2584,38 +2501,8 @@ describe("short-term promotion", () => {
         "## Model routing",
         "- Keep Xiaomi Mimo as the low-cost default.",
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 4,
-            endLine: 4,
-            score: 0.91,
-            snippet: "Keep Xiaomi Mimo as the low-cost default.",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: "Keep Xiaomi Mimo as the low-cost default.",
       });
 
       expect(applied.applied).toBe(1);
@@ -2636,38 +2523,8 @@ describe("short-term promotion", () => {
         "## Long model routing",
         `- ${longBody}`,
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 4,
-            endLine: 4,
-            score: 0.91,
-            snippet: `Long model routing: ${longBody}`.slice(0, 280).replace(/\s+/g, " ").trim(),
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: `Long model routing: ${longBody}`.slice(0, 280).replace(/\s+/g, " ").trim(),
       });
 
       expect(applied.applied).toBe(1);
@@ -2688,38 +2545,8 @@ describe("short-term promotion", () => {
         "## New model routing",
         `- ${longBody}`,
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 4,
-            endLine: 4,
-            score: 0.91,
-            snippet: `Old model routing: ${longBody}`.slice(0, 280).replace(/\s+/g, " ").trim(),
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: `Old model routing: ${longBody}`.slice(0, 280).replace(/\s+/g, " ").trim(),
       });
 
       expect(applied.applied).toBe(1);
@@ -2741,38 +2568,9 @@ describe("short-term promotion", () => {
         "## New model routing",
         "- **需求**: use Mimo",
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 7,
-            endLine: 7,
-            score: 0.91,
-            snippet: "Old model routing: **需求**: use Mimo",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: "Old model routing: **需求**: use Mimo",
+        startLine: 7,
       });
 
       expect(applied.applied).toBe(1);
@@ -2808,38 +2606,9 @@ describe("short-term promotion", () => {
         `- ${firstListItem}`,
         `- ${secondListItem}`,
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 4,
-            endLine: 5,
-            score: 0.91,
-            snippet: ingestedSnippet,
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: ingestedSnippet,
+        endLine: 5,
       });
 
       expect(applied.applied).toBe(1);
@@ -2864,38 +2633,9 @@ describe("short-term promotion", () => {
         "## Morning",
         "- Reviewed travel timing before the workshop.",
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 7,
-            endLine: 7,
-            score: 0.91,
-            snippet: "Reviewed travel timing before the workshop.",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: "Reviewed travel timing before the workshop.",
+        startLine: 7,
       });
 
       expect(applied.applied).toBe(1);
@@ -2919,38 +2659,9 @@ describe("short-term promotion", () => {
         "<!-- openclaw:dreaming:light:end -->",
         "- Reviewed travel timing before the workshop.",
       ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "__dreaming_daily__:2026-05-28",
-        signalType: "daily",
-        dedupeByQueryPerDay: true,
-        dayBucket: "2026-05-28",
-        results: [
-          {
-            path: "memory/2026-05-28.md",
-            startLine: 7,
-            endLine: 7,
-            score: 0.91,
-            snippet: "Reviewed travel timing before the workshop.",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-05-31T00:00:00.000Z"),
+      const applied = await promoteDailyHeadingSnippet(workspaceDir, {
+        snippet: "Reviewed travel timing before the workshop.",
+        startLine: 7,
       });
 
       expect(applied.applied).toBe(1);
@@ -3840,6 +3551,37 @@ describe("short-term promotion", () => {
   });
 
   describe("MEMORY.md budget compaction (#73691)", () => {
+    async function applyBudgetCompactionPromotion(workspaceDir: string) {
+      const nowMs = Date.parse("2026-04-29T10:00:00.000Z");
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "rotate creds",
+        nowMs,
+        results: [
+          {
+            path: "memory/2026-04-29.md",
+            startLine: 3,
+            endLine: 3,
+            score: 0.96,
+            snippet: "Rotate the staging Postgres credentials before next deploy.",
+            source: "memory",
+          },
+        ],
+      });
+      const rankingOptions = {
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      };
+      return await applyShortTermPromotions({
+        ...rankingOptions,
+        candidates: await rankShortTermPromotionCandidates(rankingOptions),
+        nowMs,
+        memoryFileMaxChars: 1_400,
+      });
+    }
+
     it("preserves mixed marker-backed user text during a real promotion write", async () => {
       await withTempWorkspace(async (workspaceDir) => {
         await writeDailyMemoryNote(workspaceDir, "2026-04-29", [
@@ -3866,37 +3608,7 @@ describe("short-term promotion", () => {
         ].join("\n");
         await fs.writeFile(memoryPath, seeded, "utf-8");
 
-        await recordShortTermRecalls({
-          workspaceDir,
-          query: "rotate creds",
-          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
-          results: [
-            {
-              path: "memory/2026-04-29.md",
-              startLine: 3,
-              endLine: 3,
-              score: 0.96,
-              snippet: "Rotate the staging Postgres credentials before next deploy.",
-              source: "memory",
-            },
-          ],
-        });
-
-        const ranked = await rankShortTermPromotionCandidates({
-          workspaceDir,
-          minScore: 0,
-          minRecallCount: 0,
-          minUniqueQueries: 0,
-        });
-        const applied = await applyShortTermPromotions({
-          workspaceDir,
-          candidates: ranked,
-          minScore: 0,
-          minRecallCount: 0,
-          minUniqueQueries: 0,
-          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
-          memoryFileMaxChars: 1_400,
-        });
+        const applied = await applyBudgetCompactionPromotion(workspaceDir);
 
         expect(applied.applied).toBe(1);
         expect(applied.compactedDates).toEqual(["2026-04-20"]);
@@ -3935,38 +3647,7 @@ describe("short-term promotion", () => {
         ].join("\n");
         await fs.writeFile(memoryPath, seeded, "utf-8");
 
-        await recordShortTermRecalls({
-          workspaceDir,
-          query: "rotate creds",
-          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
-          results: [
-            {
-              path: "memory/2026-04-29.md",
-              startLine: 3,
-              endLine: 3,
-              score: 0.96,
-              snippet: "Rotate the staging Postgres credentials before next deploy.",
-              source: "memory",
-            },
-          ],
-        });
-
-        const ranked = await rankShortTermPromotionCandidates({
-          workspaceDir,
-          minScore: 0,
-          minRecallCount: 0,
-          minUniqueQueries: 0,
-        });
-
-        const applied = await applyShortTermPromotions({
-          workspaceDir,
-          candidates: ranked,
-          minScore: 0,
-          minRecallCount: 0,
-          minUniqueQueries: 0,
-          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
-          memoryFileMaxChars: 1_400,
-        });
+        const applied = await applyBudgetCompactionPromotion(workspaceDir);
 
         expect(applied.applied).toBe(1);
         expect(applied.compactedDates).toContain("2026-04-10");
@@ -4004,38 +3685,7 @@ describe("short-term promotion", () => {
         ].join("\n");
         await fs.writeFile(memoryPath, seeded, "utf-8");
 
-        await recordShortTermRecalls({
-          workspaceDir,
-          query: "rotate creds",
-          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
-          results: [
-            {
-              path: "memory/2026-04-29.md",
-              startLine: 3,
-              endLine: 3,
-              score: 0.96,
-              snippet: "Rotate the staging Postgres credentials before next deploy.",
-              source: "memory",
-            },
-          ],
-        });
-
-        const ranked = await rankShortTermPromotionCandidates({
-          workspaceDir,
-          minScore: 0,
-          minRecallCount: 0,
-          minUniqueQueries: 0,
-        });
-
-        const applied = await applyShortTermPromotions({
-          workspaceDir,
-          candidates: ranked,
-          minScore: 0,
-          minRecallCount: 0,
-          minUniqueQueries: 0,
-          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
-          memoryFileMaxChars: 1_400,
-        });
+        const applied = await applyBudgetCompactionPromotion(workspaceDir);
 
         expect(applied.applied).toBe(1);
         expect(applied.compactedSections).toBeGreaterThan(0);

--- a/src/commands/doctor-session-canonical-keys.test.ts
+++ b/src/commands/doctor-session-canonical-keys.test.ts
@@ -10,6 +10,10 @@ import {
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  readSessionProgressCard,
+  writeSessionProgressCard,
+} from "../session-cards/progress-card-store.js";
+import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
@@ -20,6 +24,14 @@ import {
 } from "../utils/delivery-context.shared.js";
 import { repairCanonicalSessionKeys } from "./doctor-session-canonical-keys.js";
 import { insertLegacySession } from "./doctor-session-canonical-keys.test-support.js";
+
+function openSessionDatabase(agentId: string, env: NodeJS.ProcessEnv, storePath: string) {
+  return openOpenClawAgentDatabase({
+    agentId,
+    env,
+    path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId, env }).path,
+  });
+}
 
 afterEach(() => closeOpenClawAgentDatabasesForTest());
 
@@ -182,11 +194,7 @@ describe("doctor canonical session-key repair", () => {
         foundGroups: 0,
         repairedGroups: 0,
       });
-      const database = openOpenClawAgentDatabase({
-        agentId: "main",
-        env,
-        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
-      });
+      const database = openSessionDatabase("main", env, storePath);
       database.db
         .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
         .run(
@@ -349,11 +357,7 @@ describe("doctor canonical session-key repair", () => {
         sessionKey: "",
         storePath,
       });
-      const database = openOpenClawAgentDatabase({
-        agentId: "main",
-        env,
-        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
-      });
+      const database = openSessionDatabase("main", env, storePath);
       database.db
         .prepare(
           "INSERT INTO conversations (conversation_id, channel, account_id, kind, peer_id, delivery_target, metadata_json, created_at, updated_at) VALUES ('empty-key-conversation', 'webchat', 'default', 'direct', 'empty', 'empty', '{}', 10, 10)",
@@ -425,11 +429,7 @@ describe("doctor canonical session-key repair", () => {
         sessionKey: "agent:main:main",
         storePath,
       });
-      const database = openOpenClawAgentDatabase({
-        agentId: "main",
-        env,
-        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
-      });
+      const database = openSessionDatabase("main", env, storePath);
       database.db
         .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
         .run(JSON.stringify({ sessionId: "older", subject: "preserved" }), "agent:main:main");
@@ -474,16 +474,15 @@ describe("doctor canonical session-key repair", () => {
         sessionKey: "agent:main:main",
         storePath,
       });
-      const database = openOpenClawAgentDatabase({
-        agentId: "main",
-        env,
-        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
-      });
+      const database = openSessionDatabase("main", env, storePath);
       const insertMember = database.db.prepare(
         "INSERT INTO session_members (session_key, identity_id, added_by, added_at) VALUES (?, ?, 'owner', 10)",
       );
       insertMember.run("agent:main:work", "canonical-member");
       insertMember.run("agent:main:main", "winner-member");
+      writeSessionProgressCard(database.db, "agent:main:work", { markdown: "Already completed" });
+      writeSessionProgressCard(database.db, "agent:main:work", {});
+      writeSessionProgressCard(database.db, "agent:main:main", { markdown: "Do not resurrect" });
       database.db
         .prepare(
           "INSERT INTO conversations (conversation_id, channel, account_id, kind, peer_id, delivery_target, metadata_json, created_at, updated_at) VALUES ('same-store-conversation', 'webchat', 'default', 'direct', 'peer', 'peer', '{}', 10, 10)",
@@ -503,6 +502,11 @@ describe("doctor canonical session-key repair", () => {
       expect(database.db.prepare("SELECT identity_id FROM session_members").all()).toEqual([
         { identity_id: "winner-member" },
       ]);
+      expect(
+        database.db
+          .prepare("SELECT markdown, revision, session_key FROM session_progress_cards")
+          .all(),
+      ).toEqual([{ markdown: null, revision: 2, session_key: "agent:main:work" }]);
       expect(
         database.db
           .prepare(
@@ -533,16 +537,17 @@ describe("doctor canonical session-key repair", () => {
         sessionKey: "agent:main:main",
         storePath,
       });
-      const database = openOpenClawAgentDatabase({
-        agentId: "main",
-        env,
-        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
-      });
+      const database = openSessionDatabase("main", env, storePath);
       database.db
         .prepare(
           "INSERT INTO session_suggestions (id, session_key, author_id, text, created_at, state) VALUES ('alias-suggestion', 'agent:main:main', 'operator', 'keep me', 10, 'pending')",
         )
         .run();
+      const insertMember = database.db.prepare(
+        "INSERT INTO session_members (session_key, identity_id, added_by, added_at) VALUES (?, ?, 'owner', 10)",
+      );
+      insertMember.run("agent:main:work", "canonical-member");
+      insertMember.run("agent:main:main", "stale-alias-member");
 
       expect(await repairCanonicalSessionKeys({ apply: true, cfg, env })).toMatchObject({
         foundGroups: 1,
@@ -554,6 +559,9 @@ describe("doctor canonical session-key repair", () => {
           .prepare("SELECT session_key FROM session_suggestions WHERE id = 'alias-suggestion'")
           .get(),
       ).toEqual({ session_key: "agent:main:work" });
+      expect(database.db.prepare("SELECT identity_id FROM session_members").all()).toEqual([
+        { identity_id: "canonical-member" },
+      ]);
     });
   });
 
@@ -668,11 +676,7 @@ describe("doctor canonical session-key repair", () => {
         foundGroups: 0,
         repairedGroups: 0,
       });
-      const database = openOpenClawAgentDatabase({
-        agentId: "main",
-        env,
-        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
-      });
+      const database = openSessionDatabase("main", env, storePath);
       database.db
         .prepare("UPDATE session_nodes SET parent_session_key = ? WHERE session_key = ?")
         .run("Agent:Main:Parent ", "agent:main:child");
@@ -729,11 +733,7 @@ describe("doctor canonical session-key repair", () => {
         sessionKey: "agent:main:main ",
         storePath,
       });
-      const database = openOpenClawAgentDatabase({
-        agentId: "main",
-        env,
-        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main", env }).path,
-      });
+      const database = openSessionDatabase("main", env, storePath);
       database.db
         .prepare(
           `UPDATE session_nodes
@@ -887,6 +887,18 @@ describe("doctor canonical session-key repair", () => {
         sessionKey: "agent:main:misplaced",
         storePath: opsStore,
       });
+      const sourceDatabase = openSessionDatabase("ops", env, opsStore);
+      const destinationDatabase = openSessionDatabase("main", env, mainStore);
+      writeSessionProgressCard(sourceDatabase.db, "agent:main:misplaced", {
+        markdown: "Preserve this cross-store task",
+        steps: [{ step: "Finish the migration", status: "in_progress" }],
+      });
+      destinationDatabase.db.exec("DROP TABLE session_progress_cards");
+      expect(
+        destinationDatabase.db
+          .prepare("SELECT name FROM sqlite_schema WHERE name = 'session_progress_cards'")
+          .get(),
+      ).toBeUndefined();
 
       expect(await repairCanonicalSessionKeys({ apply: true, cfg, env })).toMatchObject({
         foundGroups: 1,
@@ -905,6 +917,14 @@ describe("doctor canonical session-key repair", () => {
         sessionId: "misplaced",
         spawnedBy: "agent:main:controller",
       });
+      expect(readSessionProgressCard(destinationDatabase.db, "agent:main:misplaced")).toMatchObject(
+        {
+          markdown: "Preserve this cross-store task",
+          revision: 1,
+          sessionKey: "agent:main:misplaced",
+          steps: [{ step: "Finish the migration", status: "in_progress" }],
+        },
+      );
       expect(
         loadExactSessionEntryReadOnly({
           agentId: "ops",
@@ -961,12 +981,20 @@ describe("doctor canonical session-key repair", () => {
         sessionKey: "agent:main:main ",
         storePath: opsStore,
       });
+      const destinationDatabase = openSessionDatabase("main", env, mainStore);
+      const progressCardTable = () =>
+        destinationDatabase.db
+          .prepare("SELECT name FROM sqlite_schema WHERE name = 'session_progress_cards'")
+          .get();
+      destinationDatabase.db.exec("DROP TABLE session_progress_cards");
+      expect(progressCardTable()).toBeUndefined();
 
       expect(await repairCanonicalSessionKeys({ apply: true, cfg, env })).toMatchObject({
         foundGroups: 1,
         removedRows: 1,
         repairedGroups: 1,
       });
+      expect(progressCardTable()).toBeUndefined();
       expect(
         loadExactSessionEntryReadOnly({
           agentId: "main",

--- a/src/config/sessions/legacy-main-session-migration.test.ts
+++ b/src/config/sessions/legacy-main-session-migration.test.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
+  readSessionProgressCard,
+  writeSessionProgressCard,
+} from "../../session-cards/progress-card-store.js";
+import {
   closeOpenClawAgentDatabasesForTest,
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
@@ -403,6 +407,19 @@ describe("legacy main session migration", () => {
       session: { store: storePath },
     });
     seedClaim({ databaseAgentId: "main", databasePath: storePath, key: "agent:main:chat" });
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        writeSessionProgressCard(database.db, "agent:main:chat", {
+          markdown: "Keep working on the existing task",
+        });
+        database.db
+          .prepare(
+            "INSERT INTO heartbeat_outcomes (session_key, run_session_key, outcome, summary, occurred_at, updated_at) VALUES (?, ?, 'progress', 'Still working', 10, 10)",
+          )
+          .run("agent:main:chat", "agent:main:chat");
+      },
+      { agentId: "main", path: storePath },
+    );
 
     const result = await migrateLegacyMainSessionKeys({
       cfg: fixture.cfg,
@@ -417,6 +434,23 @@ describe("legacy main session migration", () => {
     expect(
       readClaim({ databaseAgentId: "main", databasePath: storePath, key: "agent:ops:chat" }),
     ).toBeDefined();
+    const migratedArtifacts = runOpenClawAgentWriteTransaction(
+      (database) => ({
+        heartbeat: database.db
+          .prepare("SELECT session_key, run_session_key FROM heartbeat_outcomes")
+          .get(),
+        progressCard: readSessionProgressCard(database.db, "agent:ops:chat"),
+      }),
+      { agentId: "main", path: storePath },
+    );
+    expect(migratedArtifacts).toMatchObject({
+      heartbeat: { session_key: "agent:ops:chat", run_session_key: "agent:ops:chat" },
+      progressCard: {
+        markdown: "Keep working on the existing task",
+        revision: 1,
+        sessionKey: "agent:ops:chat",
+      },
+    });
   });
 
   it.each([

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -23,9 +23,9 @@ import {
 } from "./session-accessor.sqlite-entry-equality.js";
 import {
   clearSessionCollaborationForKey,
+  copySessionNodeArtifactsForRepair,
   deleteSessionDeliveryArtifacts,
   deleteSessionNodeArtifacts,
-  rehomeLegacySessionNodeArtifacts,
 } from "./session-accessor.sqlite-node-artifacts.js";
 import {
   hasSqliteSessionOwnerColumns,
@@ -539,7 +539,9 @@ export function deleteLegacySessionEntryRows(
       continue;
     }
     rehomeSessionWindows(database, sessionKey, [legacyKey]);
-    rehomeLegacySessionNodeArtifacts(database, legacyKey, sessionKey, options);
+    copySessionNodeArtifactsForRepair(database, database, [legacyKey], sessionKey, {
+      includeMembers: options.rehomeMembers,
+    });
     executeSqliteQuerySync(
       database.db,
       db.deleteFrom("session_nodes").where("session_key", "=", legacyKey),

--- a/src/config/sessions/session-accessor.sqlite-node-artifacts.ts
+++ b/src/config/sessions/session-accessor.sqlite-node-artifacts.ts
@@ -4,6 +4,7 @@ import {
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { ensureOpenClawAgentProgressCardSchemaInTransaction } from "../../state/openclaw-agent-progress-card-schema.js";
 import { ensureSessionParticipantsSchema } from "../../state/openclaw-agent-session-participants-schema.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import { mergeSessionParticipantSource } from "./session-entry-provenance.js";
@@ -30,199 +31,7 @@ export function clearSessionCollaborationForKey(
   }
 }
 
-export function rehomeLegacySessionNodeArtifacts(
-  database: OpenClawAgentDatabase,
-  legacyKey: string,
-  canonicalKey: string,
-  options: { rehomeMembers?: boolean },
-): void {
-  const db = getSessionKysely(database.db);
-  const presentTables = readSessionNodeArtifactTables(database);
-  if (presentTables.has("session_participants")) {
-    ensureSessionParticipantsSchema(database.db);
-  }
-  if (presentTables.has("board_tabs") && presentTables.has("board_widgets")) {
-    const tabs = executeSqliteQuerySync(
-      database.db,
-      db.selectFrom("board_tabs").selectAll().where("session_key", "=", legacyKey),
-    ).rows;
-    for (const tab of tabs) {
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .insertInto("board_tabs")
-          .values({ ...tab, session_key: canonicalKey })
-          .onConflict((conflict) =>
-            conflict
-              .columns(["session_key", "tab_id"])
-              .doUpdateSet({
-                title: tab.title,
-                position: tab.position,
-                chat_dock: tab.chat_dock,
-                created_by: tab.created_by,
-                revision: tab.revision,
-              })
-              .where("revision", "<", tab.revision),
-          ),
-      );
-    }
-    const widgets = executeSqliteQuerySync(
-      database.db,
-      db.selectFrom("board_widgets").selectAll().where("session_key", "=", legacyKey),
-    ).rows;
-    for (const widget of widgets) {
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .insertInto("board_widgets")
-          .values({ ...widget, session_key: canonicalKey })
-          .onConflict((conflict) =>
-            conflict
-              .columns(["session_key", "name"])
-              .doUpdateSet({
-                tab_id: widget.tab_id,
-                title: widget.title,
-                content_kind: widget.content_kind,
-                html: widget.html,
-                descriptor_json: widget.descriptor_json,
-                sha256: widget.sha256,
-                view_generation: widget.view_generation,
-                revision: widget.revision,
-                size_w: widget.size_w,
-                size_h: widget.size_h,
-                position: widget.position,
-                manifest: widget.manifest,
-                grant_state: widget.grant_state,
-                granted_sha: widget.granted_sha,
-                created_by: widget.created_by,
-                created_at: widget.created_at,
-                updated_at: widget.updated_at,
-              })
-              .where((eb) =>
-                eb.or([
-                  eb("revision", "<", widget.revision),
-                  eb.and([
-                    eb("revision", "=", widget.revision),
-                    eb("updated_at", "<", widget.updated_at),
-                  ]),
-                ]),
-              ),
-          ),
-      );
-    }
-  }
-  if (presentTables.has("heartbeat_outcomes")) {
-    const heartbeat = executeSqliteQueryTakeFirstSync(
-      database.db,
-      db.selectFrom("heartbeat_outcomes").selectAll().where("session_key", "=", legacyKey),
-    );
-    if (heartbeat) {
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .insertInto("heartbeat_outcomes")
-          .values({ ...heartbeat, session_key: canonicalKey })
-          .onConflict((conflict) =>
-            conflict
-              .column("session_key")
-              .doUpdateSet({
-                run_session_key: heartbeat.run_session_key,
-                outcome: heartbeat.outcome,
-                summary: heartbeat.summary,
-                response_reason: heartbeat.response_reason,
-                priority: heartbeat.priority,
-                next_check: heartbeat.next_check,
-                task_names_json: heartbeat.task_names_json,
-                wake_source: heartbeat.wake_source,
-                wake_reason: heartbeat.wake_reason,
-                occurred_at: heartbeat.occurred_at,
-                context_run_id: heartbeat.context_run_id,
-                context_claimed_at: heartbeat.context_claimed_at,
-                updated_at: heartbeat.updated_at,
-              })
-              .where((eb) =>
-                eb.or([
-                  eb("updated_at", "<", heartbeat.updated_at),
-                  eb.and([
-                    eb("updated_at", "=", heartbeat.updated_at),
-                    eb("occurred_at", "<", heartbeat.occurred_at),
-                  ]),
-                ]),
-              ),
-          ),
-      );
-    }
-  }
-  if (options.rehomeMembers !== false && presentTables.has("session_members")) {
-    const members = executeSqliteQuerySync(
-      database.db,
-      db.selectFrom("session_members").selectAll().where("session_key", "=", legacyKey),
-    ).rows;
-    for (const member of members) {
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .insertInto("session_members")
-          .values({ ...member, session_key: canonicalKey })
-          .onConflict((conflict) => conflict.columns(["session_key", "identity_id"]).doNothing()),
-      );
-    }
-  }
-  if (presentTables.has("session_suggestions")) {
-    executeSqliteQuerySync(
-      database.db,
-      db
-        .updateTable("session_suggestions")
-        .set({ session_key: canonicalKey })
-        .where("session_key", "=", legacyKey),
-    );
-  }
-  if (presentTables.has("session_participants")) {
-    const participants = executeSqliteQuerySync(
-      database.db,
-      db.selectFrom("session_participants").selectAll().where("session_key", "=", legacyKey),
-    ).rows;
-    for (const participant of participants) {
-      const existing = executeSqliteQueryTakeFirstSync(
-        database.db,
-        db
-          .selectFrom("session_participants")
-          .select(["actor_source", "first_prompted_at", "last_prompted_at"])
-          .where("session_key", "=", canonicalKey)
-          .where("actor_type", "=", participant.actor_type)
-          .where("actor_id", "=", participant.actor_id),
-      );
-      executeSqliteQuerySync(
-        database.db,
-        db
-          .insertInto("session_participants")
-          .values({ ...participant, session_key: canonicalKey })
-          .onConflict((conflict) =>
-            conflict.columns(["session_key", "actor_type", "actor_id"]).doUpdateSet({
-              actor_source: mergeSessionParticipantSource(
-                existing?.actor_source,
-                participant.actor_source,
-              ),
-              first_prompted_at: Math.min(
-                existing?.first_prompted_at ?? participant.first_prompted_at,
-                participant.first_prompted_at,
-              ),
-              last_prompted_at: Math.max(
-                existing?.last_prompted_at ?? participant.last_prompted_at,
-                participant.last_prompted_at,
-              ),
-            }),
-          ),
-      );
-    }
-    executeSqliteQuerySync(
-      database.db,
-      db.deleteFrom("session_participants").where("session_key", "=", legacyKey),
-    );
-  }
-}
-
-/** Copy logical-session artifacts while doctor moves a node between agent databases. */
+/** Copy logical-session artifacts into their canonical node within one agent store or across two. */
 export function copySessionNodeArtifactsForRepair(
   source: OpenClawAgentDatabase,
   destination: OpenClawAgentDatabase,
@@ -245,6 +54,40 @@ export function copySessionNodeArtifactsForRepair(
   }
   if (destinationTables.has("session_participants")) {
     ensureSessionParticipantsSchema(destination.db);
+  }
+  if (sourceTables.has("session_progress_cards")) {
+    const progressCards = executeSqliteQuerySync(
+      source.db,
+      sourceDb.selectFrom("session_progress_cards").selectAll().where("session_key", "in", keys),
+    ).rows;
+    // Keep destination storage dormant unless an owned row actually needs transfer.
+    if (progressCards.length > 0 && !destinationTables.has("session_progress_cards")) {
+      ensureOpenClawAgentProgressCardSchemaInTransaction(destination.db);
+      destinationTables = readSessionNodeArtifactTables(destination);
+    }
+    for (const progressCard of progressCards) {
+      const canonicalProgressCard = { ...progressCard, session_key: canonicalKey };
+      executeSqliteQuerySync(
+        destination.db,
+        destinationDb
+          .insertInto("session_progress_cards")
+          .values(canonicalProgressCard)
+          .onConflict((conflict) =>
+            conflict
+              .column("session_key")
+              .doUpdateSet(canonicalProgressCard)
+              .where((eb) =>
+                eb.or([
+                  eb("revision", "<", progressCard.revision),
+                  eb.and([
+                    eb("revision", "=", progressCard.revision),
+                    eb("updated_at", "<", progressCard.updated_at),
+                  ]),
+                ]),
+              ),
+          ),
+      );
+    }
   }
   if (
     sourceTables.has("board_tabs") &&
@@ -513,6 +356,7 @@ function readSessionNodeArtifactTables(database: OpenClawAgentDatabase): Set<str
           "heartbeat_outcomes",
           "session_members",
           "session_participants",
+          "session_progress_cards",
           "session_suggestions",
         ]),
     ).rows.flatMap((row) => (row.name ? [row.name] : [])),

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -40,6 +40,7 @@ type SessionSqliteDatabase = Pick<
   | "session_members"
   | "session_nodes"
   | "session_participants"
+  | "session_progress_cards"
   | "session_suggestions"
   | "session_transcript_archives"
   | "session_transcript_active_events"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where canonical session repair could lose node artifact records while consolidating legacy or doctor-repaired source rows into the canonical session key.

## Why This Change Was Made

The session store now copies artifacts from the authoritative source rows during the existing canonical repair transaction while preserving revision, tombstone, heartbeat, and member-authority rules. The same focused cleanup also deduplicates repeated memory ingestion setup without changing dreaming or promotion behavior.

AI-assisted maintainer fix. I reviewed the final code, proof, and exact landing diff.

## User Impact

Operators keep session artifacts across canonical-key repair and legacy migration. Memory ingestion behavior remains unchanged but its tests and implementation have less repeated setup.

## Evidence

- Production net LOC: `-167`; tests net LOC: `-802`; total `+380/-1349` (net `-969`) across exactly eight files.
- Current-main base: `b977ccb21e2b4b8bff05729548ea1b1558a74a33`; exact head: `5f8c660f497f36d946009911984d982d341b9378`.
- Exact plain and binary diff SHA-256: `f25a7156082169091cca1f75d40692195d3599cfb104773f3dfdab00c5d2a581`.
- The legacy and doctor artifact-loss regressions fail before the repair and pass afterward; fresh session proof: 46/46 passed.
- Fresh memory proof: 144/144 passed, preserving dreaming and short-term-promotion behavior.
- Native schema-v9 and SQLite baseline checks passed; there is no DDL, schema-version, config, or protocol change.
- The current-main migration-test owner cases were retained alongside the artifact-card and heartbeat regression coverage.
- Independent verification confirmed the transaction, lazy-table, tombstone, heartbeat, and member-authority boundaries remain intact.
- Mandatory exact-source autoreview: secret scan clean; isolated Codex review reported no actionable findings (0.98 patch-correctness confidence).
