### PR TITLE
fix(voice-call): resolve per-number TTS SecretRefs

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -98,7 +98,7 @@ starting the runtime. Commands, RPC calls, and agent tools still return the
 exact missing configuration when used.
 
 <Note>
-Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twilio.authToken`, `plugins.entries.voice-call.config.realtime.providers.*.apiKey`, `plugins.entries.voice-call.config.streaming.providers.*.apiKey`, and `plugins.entries.voice-call.config.tts.providers.*.apiKey` resolve through the standard SecretRef surface; see [SecretRef credential surface](/reference/secretref-credential-surface).
+Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twilio.authToken`, `plugins.entries.voice-call.config.realtime.providers.*.apiKey`, `plugins.entries.voice-call.config.streaming.providers.*.apiKey`, `plugins.entries.voice-call.config.tts.providers.*.apiKey`, and `plugins.entries.voice-call.config.numbers.*.tts.providers.*.apiKey` resolve through the standard SecretRef surface; see [SecretRef credential surface](/reference/secretref-credential-surface).
 </Note>
 
 ```json5

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -58,6 +58,7 @@ The lists below are generated from the source target registry and checked agains
 - `plugins.entries.minimax.config.webSearch.apiKey`
 - `plugins.entries.tavily.config.webSearch.apiKey`
 - `plugins.entries.parallel.config.webSearch.apiKey`
+- `plugins.entries.voice-call.config.numbers.*.tts.providers.*.apiKey`
 - `plugins.entries.voice-call.config.realtime.providers.*.apiKey`
 - `plugins.entries.voice-call.config.streaming.providers.*.apiKey`
 - `plugins.entries.voice-call.config.tts.providers.*.apiKey`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -697,6 +697,13 @@
       "optIn": true
     },
     {
+      "id": "plugins.entries.voice-call.config.numbers.*.tts.providers.*.apiKey",
+      "configFile": "openclaw.json",
+      "path": "plugins.entries.voice-call.config.numbers.*.tts.providers.*.apiKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "plugins.entries.voice-call.config.realtime.providers.*.apiKey",
       "configFile": "openclaw.json",
       "path": "plugins.entries.voice-call.config.realtime.providers.*.apiKey",

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -965,7 +965,8 @@
         { "path": "twilio.authToken", "expected": "string" },
         { "path": "realtime.providers.*.apiKey", "expected": "string" },
         { "path": "streaming.providers.*.apiKey", "expected": "string" },
-        { "path": "tts.providers.*.apiKey", "expected": "string" }
+        { "path": "tts.providers.*.apiKey", "expected": "string" },
+        { "path": "numbers.*.tts.providers.*.apiKey", "expected": "string" }
       ]
     }
   }

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -725,7 +725,7 @@ describe("resolveVoiceCallConfig session routing", () => {
           responseTimeoutMs: 20000,
           tts: {
             providers: {
-              openai: { voice: "alloy" },
+              openai: { apiKey: "resolved-route-api-key", voice: "alloy" },
             },
           },
         },
@@ -741,7 +741,30 @@ describe("resolveVoiceCallConfig session routing", () => {
     expect(effective.config.responseSystemPrompt).toBe("You are a baseball card expert.");
     expect(effective.config.responseTimeoutMs).toBe(20000);
     expect(effective.config.tts?.provider).toBe("openai");
-    expect(effective.config.tts?.providers?.openai).toEqual({ voice: "alloy", speed: 1 });
+    expect(effective.config.tts?.providers?.openai).toEqual({
+      apiKey: "resolved-route-api-key",
+      voice: "alloy",
+      speed: 1,
+    });
+  });
+
+  it("accepts every SecretRef source in per-number TTS provider config", () => {
+    for (const apiKey of [
+      envRef("VOICE_CALL_ROUTE_ENV_KEY"),
+      { source: "file" as const, provider: "route-file", id: "/voice-call/apiKey" },
+      { source: "exec" as const, provider: "route-exec", id: "voice-call/apiKey" },
+      { source: "store" as const, provider: "default", id: "VOICE_CALL_ROUTE_STORE_KEY" },
+    ]) {
+      const config = VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "mock",
+        numbers: {
+          "+15550001111": { tts: { providers: { openai: { apiKey } } } },
+        },
+      });
+
+      expect(config.numbers["+15550001111"]?.tts?.providers?.openai?.apiKey).toEqual(apiKey);
+    }
   });
 
   it("falls back to global voice settings when no per-number route matches", () => {

--- a/src/secrets/runtime-config-collectors-plugins.bundled.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.bundled.test.ts
@@ -198,6 +198,27 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
   });
 
   it("collects voice-call SecretRef assignments from bundled manifest contracts", () => {
+    const numberRouteRefs = [
+      { number: "+15550001001", ref: envRef("VOICE_CALL_ROUTE_ENV_KEY") },
+      {
+        number: "+15550001002",
+        ref: { source: "file" as const, provider: "route-file", id: "/voice-call/apiKey" },
+      },
+      {
+        number: "+15550001003",
+        ref: { source: "exec" as const, provider: "route-exec", id: "voice-call/apiKey" },
+      },
+      {
+        number: "+15550001004",
+        ref: { source: "store" as const, provider: "default", id: "VOICE_CALL_ROUTE_STORE_KEY" },
+      },
+    ];
+    const numberRoutes = Object.fromEntries(
+      numberRouteRefs.map(({ number, ref }) => [
+        number,
+        { tts: { providers: { openai: { apiKey: ref } } } },
+      ]),
+    );
     expect(
       findBundledPluginMetadataById("voice-call", {
         includeChannelConfigs: false,
@@ -208,6 +229,7 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
       { path: "realtime.providers.*.apiKey", expected: "string" },
       { path: "streaming.providers.*.apiKey", expected: "string" },
       { path: "tts.providers.*.apiKey", expected: "string" },
+      { path: "numbers.*.tts.providers.*.apiKey", expected: "string" },
     ]);
     const config = {
       agents: explicitMainRoster,
@@ -243,6 +265,7 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
                   },
                 },
               },
+              numbers: numberRoutes,
             },
           },
         },
@@ -263,6 +286,7 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
       { path: "realtime.providers.*.apiKey", expected: "string" },
       { path: "streaming.providers.*.apiKey", expected: "string" },
       { path: "tts.providers.*.apiKey", expected: "string" },
+      { path: "numbers.*.tts.providers.*.apiKey", expected: "string" },
     ]);
     const context = createResolverContext({
       sourceConfig: config,
@@ -281,6 +305,10 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
       warnings: context.warnings,
     }).toEqual({
       assignments: [
+        ...numberRouteRefs.map(
+          ({ number }) =>
+            `plugins.entries.voice-call.config.numbers.${number}.tts.providers.openai.apiKey`,
+        ),
         "plugins.entries.voice-call.config.realtime.providers.google.apiKey",
         "plugins.entries.voice-call.config.streaming.providers.openai.apiKey",
         "plugins.entries.voice-call.config.tts.providers.elevenlabs.apiKey",
@@ -289,6 +317,24 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
       ],
       warnings: [],
     });
+
+    for (const { number, ref } of numberRouteRefs) {
+      const assignment = context.assignments.find(
+        (candidate) =>
+          candidate.path ===
+          `plugins.entries.voice-call.config.numbers.${number}.tts.providers.openai.apiKey`,
+      );
+      expect(assignment).toMatchObject({
+        ref,
+        expected: "string",
+        ownerKind: "unknown",
+        disposition: "isolate",
+      });
+      assignment?.apply(`resolved-route-${ref.source}`);
+      expect(numberRoutes[number]?.tts.providers.openai.apiKey).toBe(
+        `resolved-route-${ref.source}`,
+      );
+    }
   });
 
   it("collects google-meet realtime provider SecretRefs from its installed manifest", () => {

--- a/src/secrets/target-registry.docs.test.ts
+++ b/src/secrets/target-registry.docs.test.ts
@@ -48,6 +48,12 @@ describe("secret target registry docs", () => {
 
   it("stays in sync with docs/reference/secretref-user-supplied-credentials-matrix.json", () => {
     expect(matrixDocsCase.raw).toBe(matrixDocsCase.expected);
+    expect(
+      (JSON.parse(matrixDocsCase.expected) as SecretRefCredentialMatrixDocument).entries.filter(
+        ({ path: credentialPath }) =>
+          credentialPath === "plugins.entries.voice-call.config.numbers.*.tts.providers.*.apiKey",
+      ),
+    ).toHaveLength(1);
   });
 
   it("stays in sync with docs/reference/secretref-credential-surface.md", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where per-number voice-call TTS provider credentials accepted SecretRef objects in the configuration schema but were absent from the plugin's advertised secret contract. The Gateway therefore left those references unresolved even though the effective number route consumed the credential.

## Why This Change Was Made

This adds the existing per-number path to the voice-call manifest contract and public credential inventory. It deliberately preserves the current strict unknown-owner behavior for voice-call credentials; this PR repairs registration and materialization only.

## User Impact

Operators can configure `numbers.*.tts.providers.*.apiKey` with environment-, file-, exec-, or store-backed SecretRefs and have the selected number route receive the resolved string before provider use.

AI-assisted implementation; I reviewed the diff, tests, and live behavior.

## Evidence

- Pre-fix collector produced no assignment for the per-number credential.
- Schema coverage accepts all four supported SecretRef sources.
- Collector coverage verifies the concrete number-scoped path, materialization, and intentionally strict unknown ownership.
- Effective route coverage verifies the resolved API key reaches the selected number configuration.
- 63 focused tests passed after rebasing onto current `main`; broader plugin validation passed before rebase.
- Two autoreview passes, including a post-rebase branch review, reported no actionable findings.
- Isolated real dev Gateway with unique state and ports loaded the voice-call plugin using its mock telephony provider:
  - `/readyz` returned `200`,
  - `voicecall.status` reported no active calls,
  - the concrete per-number assignment materialized to a string,
  - the effective route received the resolved value,
  - zero outbound telephony calls occurred.

Production/docs LOC: +11/-2. Tests: +77/-2.
