### PR TITLE
fix(qqbot): isolate missing account credentials

### DIFF
--- a/docs/channels/qqbot.md
+++ b/docs/channels/qqbot.md
@@ -79,7 +79,8 @@ Default-account env vars (top-level account only):
 - `QQBOT_APP_ID`
 - `QQBOT_CLIENT_SECRET`
 
-File-backed AppSecret:
+Keep the AppSecret outside the channel config by using a SecretRef. For an
+environment-backed secret:
 
 ```json5
 {
@@ -87,7 +88,39 @@ File-backed AppSecret:
     qqbot: {
       enabled: true,
       appId: "YOUR_APP_ID",
-      clientSecretFile: "/path/to/qqbot-secret.txt",
+      clientSecret: {
+        source: "env",
+        provider: "default",
+        id: "QQBOT_CLIENT_SECRET",
+      },
+    },
+  },
+}
+```
+
+For a file-backed AppSecret, configure a `singleValue` file provider and refer
+to its `value`:
+
+```json5
+{
+  secrets: {
+    providers: {
+      qqbot_secret: {
+        source: "file",
+        path: "/path/to/qqbot-secret.txt",
+        mode: "singleValue",
+      },
+    },
+  },
+  channels: {
+    qqbot: {
+      enabled: true,
+      appId: "YOUR_APP_ID",
+      clientSecret: {
+        source: "file",
+        provider: "qqbot_secret",
+        id: "value",
+      },
     },
   },
 }
@@ -96,12 +129,17 @@ File-backed AppSecret:
 Notes:
 
 - `openclaw channels add --channel qqbot --token-file ...` sets the AppSecret
-  only; `appId` must already be set in config or `QQBOT_APP_ID`.
-- `clientSecret` accepts a plaintext string or a file path (`clientSecretFile`).
-- Known limitation: the external `@tencent-connect/openclaw-qqbot` package does
-  not support structured SecretRef objects for `clientSecret`. If your config
-  uses one, move the secret to the `QQBOT_CLIENT_SECRET` environment variable
-  (or `clientSecretFile`) before upgrading.
+  only; `appId` must already be set in config or `QQBOT_APP_ID`. Run
+  `openclaw doctor --fix` afterward to migrate the legacy file setting into a
+  file-backed SecretRef.
+- `clientSecret` accepts plaintext or an environment-, file-, exec-, or
+  store-backed [SecretRef](/gateway/secrets#secretref-contract). The Gateway
+  resolves the reference before handing credentials to the QQ Bot plugin.
+- `clientSecretFile` is a migration-only legacy setting. Run
+  `openclaw doctor --fix` to replace it with a `clientSecret` file SecretRef;
+  do not use `clientSecretFile` in new configurations.
+- Top-level credentials and `QQBOT_CLIENT_SECRET` belong only to the default
+  account. Named accounts must configure their own `appId` and `clientSecret`.
 
 ### Streaming
 
@@ -152,12 +190,20 @@ Run multiple QQ bots under a single OpenClaw instance:
     qqbot: {
       enabled: true,
       appId: "111111111",
-      clientSecret: "secret-of-bot-1",
+      clientSecret: {
+        source: "env",
+        provider: "default",
+        id: "QQBOT_DEFAULT_SECRET",
+      },
       accounts: {
         bot2: {
           enabled: true,
           appId: "222222222",
-          clientSecret: "secret-of-bot-2",
+          clientSecret: {
+            source: "env",
+            provider: "default",
+            id: "QQBOT_BOT2_SECRET",
+          },
         },
       },
     },
@@ -167,7 +213,10 @@ Run multiple QQ bots under a single OpenClaw instance:
 
 Each account owns an isolated WebSocket connection, API client, and token
 cache, keyed by `appId`. Log lines are tagged with the owning account id so
-diagnostics stay separable when you run several bots under one Gateway.
+diagnostics stay separable when you run several bots under one Gateway. Named
+accounts never inherit the default account's credentials or environment
+fallback. If one account's SecretRef cannot resolve, only that account becomes
+unavailable; other accounts and the Gateway remain available.
 
 Add a second bot via CLI:
 

--- a/src/secrets/channel-secret-basic-runtime.ts
+++ b/src/secrets/channel-secret-basic-runtime.ts
@@ -192,7 +192,7 @@ export type ChannelAccountSurface = {
 export type ChannelAccountPredicate = (entry: ChannelAccountEntry) => boolean;
 
 /** Stable owner identity shared by SecretRef collection and channel activation. */
-function createChannelAccountSecretOwner(
+export function createChannelAccountSecretOwner(
   channelKey: string,
   accountId: string,
   channel: Record<string, unknown>,

--- a/src/secrets/official-external-channel-secret-contract.test.ts
+++ b/src/secrets/official-external-channel-secret-contract.test.ts
@@ -10,7 +10,7 @@ describe("official external channel secret contracts", () => {
           appId: "root-app",
           clientSecret: { source: "env" as const, provider: "default", id: "QQBOT_ROOT_SECRET" },
           accounts: {
-            named: {
+            "Named.Team": {
               appId: "named-app",
               clientSecret: {
                 source: "env" as const,
@@ -27,14 +27,87 @@ describe("official external channel secret contracts", () => {
 
     api?.collectRuntimeConfigAssignments({ config, defaults: undefined, context });
 
-    expect(context.assignments.map((assignment) => assignment.path)).toEqual([
-      "channels.qqbot.clientSecret",
-      "channels.qqbot.accounts.named.clientSecret",
+    expect(context.assignments).toEqual([
+      expect.objectContaining({
+        path: "channels.qqbot.clientSecret",
+        ownerKind: "account",
+        ownerId: "qqbot:default",
+        requiredForGateway: false,
+        disposition: "isolate",
+        ownerContractDigest: expect.any(String),
+      }),
+      expect.objectContaining({
+        path: "channels.qqbot.accounts.Named.Team.clientSecret",
+        ownerKind: "account",
+        ownerId: "qqbot:named-team",
+        requiredForGateway: false,
+        disposition: "isolate",
+        ownerContractDigest: expect.any(String),
+      }),
     ]);
     context.assignments[0]?.apply("resolved-root-secret");
     context.assignments[1]?.apply("resolved-named-secret");
     expect(config.channels.qqbot.clientSecret).toBe("resolved-root-secret");
-    expect(config.channels.qqbot.accounts.named.clientSecret).toBe("resolved-named-secret");
+    expect(config.channels.qqbot.accounts["Named.Team"].clientSecret).toBe("resolved-named-secret");
+  });
+
+  it("keeps each account owner contract independent of unrelated sibling credentials", () => {
+    const createConfig = () => ({
+      channels: {
+        qqbot: {
+          enabled: true,
+          appId: "root-app",
+          clientSecret: { source: "env" as const, provider: "default", id: "QQBOT_ROOT_SECRET" },
+          accounts: {
+            named: {
+              appId: "named-app",
+              clientSecret: {
+                source: "env" as const,
+                provider: "default",
+                id: "QQBOT_NAMED_SECRET",
+              },
+            },
+            sibling: {
+              appId: "sibling-app",
+              clientSecret: {
+                source: "env" as const,
+                provider: "default",
+                id: "QQBOT_SIBLING_SECRET",
+              },
+            },
+          },
+        },
+      },
+    });
+    const collectDigests = (config: ReturnType<typeof createConfig>) => {
+      const context = createResolverContext({ sourceConfig: config, env: {} });
+      loadOfficialExternalChannelSecretContractApi("qqbot")?.collectRuntimeConfigAssignments({
+        config,
+        defaults: undefined,
+        context,
+      });
+      return new Map(
+        context.assignments.map(({ ownerId, ownerContractDigest }) => [
+          ownerId,
+          ownerContractDigest,
+        ]),
+      );
+    };
+
+    const baseline = collectDigests(createConfig());
+    const changedSibling = createConfig();
+    changedSibling.channels.qqbot.accounts.sibling.appId = "different-sibling-app";
+    const siblingDigests = collectDigests(changedSibling);
+    expect(siblingDigests.get("qqbot:default")).toBe(baseline.get("qqbot:default"));
+    expect(siblingDigests.get("qqbot:named")).toBe(baseline.get("qqbot:named"));
+    expect(siblingDigests.get("qqbot:sibling")).not.toBe(baseline.get("qqbot:sibling"));
+
+    const changedRootCredential = createConfig();
+    changedRootCredential.channels.qqbot.clientSecret.id = "QQBOT_DIFFERENT_ROOT_SECRET";
+    const rootDigests = collectDigests(changedRootCredential);
+    expect(rootDigests.get("qqbot:default")).not.toBe(baseline.get("qqbot:default"));
+    expect(rootDigests.get("qqbot:named")).toBe(baseline.get("qqbot:named"));
+    expect(rootDigests.get("qqbot:sibling")).toBe(baseline.get("qqbot:sibling"));
   });
 
   it("uses QQBOT_APP_ID only for the default account and skips inactive credentials", () => {

--- a/src/secrets/official-external-channel-secret-contract.ts
+++ b/src/secrets/official-external-channel-secret-contract.ts
@@ -7,6 +7,7 @@ import {
   listOfficialExternalChannelCatalogEntries,
 } from "../plugins/official-external-plugin-catalog.js";
 import {
+  createChannelAccountSecretOwner,
   createChannelSecretTargetRegistryEntries,
   getChannelRecord,
 } from "./channel-secret-basic-runtime.js";
@@ -82,6 +83,15 @@ export function loadOfficialExternalChannelSecretContractApi(
           // env fallbacks. Materialize only into the ephemeral runtime config.
           channel[field.activationField] = activationEnvValue;
         }
+        const { accounts: _accounts, ...defaultAccount } = channel;
+        const sharedChannel = Object.fromEntries(
+          Object.entries(defaultAccount).filter(
+            ([key]) =>
+              !contract.fields.some(
+                (credential) => key === credential.field || key === credential.activationField,
+              ),
+          ),
+        );
         collectSecretInputAssignment({
           value: channel[field.field],
           path: `channels.${contract.channelId}.${field.field}`,
@@ -98,6 +108,13 @@ export function loadOfficialExternalChannelSecretContractApi(
               allowEnv: true,
             }),
           inactiveReason: `external channel is disabled or ${field.activationField ?? "its credential surface"} is not configured.`,
+          owner: createChannelAccountSecretOwner(
+            contract.channelId,
+            "default",
+            channel,
+            defaultAccount,
+            defaultAccount,
+          ),
           apply: (value) => {
             channel[field.field] = value;
           },
@@ -127,6 +144,16 @@ export function loadOfficialExternalChannelSecretContractApi(
                 allowEnv: false,
               }),
             inactiveReason: `external channel account is disabled or ${field.activationField ?? "its credential surface"} is not configured.`,
+            owner: createChannelAccountSecretOwner(
+              contract.channelId,
+              accountId,
+              channel,
+              account,
+              {
+                channel: sharedChannel,
+                account,
+              },
+            ),
             apply: (value) => {
               account[field.field] = value;
             },

--- a/src/secrets/runtime-external-channel-audit.test.ts
+++ b/src/secrets/runtime-external-channel-audit.test.ts
@@ -57,6 +57,7 @@ const EXTERNALIZED_CHANNEL_IDS = [
   "googlechat",
   "msteams",
   "nextcloud-talk",
+  "qqbot",
   "zalo",
 ] as const;
 
@@ -73,7 +74,7 @@ function inactiveExecRef(id: string) {
 function createExternalChannelRecord(id: ExternalizedChannelId): PluginManifestRecord {
   const rootDir = path.resolve("extensions", id);
   return {
-    id,
+    id: id === "qqbot" ? "openclaw-qqbot" : id,
     channels: [id],
     providers: [],
     cliBackends: [],
@@ -328,6 +329,16 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
               },
             },
           },
+          qqbot: {
+            appId: "qqbot-default-app",
+            clientSecret: ref("QQBOT_DEFAULT_SECRET"),
+            accounts: {
+              work: {
+                appId: "qqbot-work-app",
+                clientSecret: ref("QQBOT_WORK_SECRET"),
+              },
+            },
+          },
           zalo: {
             webhookUrl: "https://example.test/zalo",
             botToken: ref("ZALO_BOT_TOKEN"),
@@ -375,6 +386,8 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
           NEXTCLOUD_TALK_API_PASSWORD: "nextcloud-talk-api-password",
           NEXTCLOUD_TALK_WORK_BOT_SECRET: "nextcloud-talk-work-bot-secret",
           NEXTCLOUD_TALK_WORK_API_PASSWORD: "nextcloud-talk-work-api-password",
+          QQBOT_DEFAULT_SECRET: "qqbot-default-secret",
+          QQBOT_WORK_SECRET: "qqbot-work-secret",
           ZALO_BOT_TOKEN: "zalo-bot-token",
           ZALO_WEBHOOK_SECRET: "zalo-webhook-secret",
           ZALO_WORK_BOT_TOKEN: "zalo-work-bot-token",
@@ -408,6 +421,8 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
         "channels.nextcloud-talk.apiPassword": "nextcloud-talk-api-password",
         "channels.nextcloud-talk.accounts.work.botSecret": "nextcloud-talk-work-bot-secret",
         "channels.nextcloud-talk.accounts.work.apiPassword": "nextcloud-talk-work-api-password",
+        "channels.qqbot.clientSecret": "qqbot-default-secret",
+        "channels.qqbot.accounts.work.clientSecret": "qqbot-work-secret",
         "channels.zalo.botToken": "zalo-bot-token",
         "channels.zalo.webhookSecret": "zalo-webhook-secret",
         "channels.zalo.accounts.work.botToken": "zalo-work-bot-token",
@@ -510,6 +525,18 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
             },
           },
         },
+        qqbot: {
+          enabled: false,
+          appId: "qqbot-disabled-app",
+          clientSecret: inactiveExecRef("QQBOT_DISABLED_SECRET"),
+          accounts: {
+            disabled: {
+              enabled: false,
+              appId: "qqbot-disabled-account-app",
+              clientSecret: inactiveExecRef("QQBOT_DISABLED_ACCOUNT_SECRET"),
+            },
+          },
+        },
         zalo: {
           enabled: false,
           webhookUrl: "https://example.test/zalo-disabled",
@@ -561,6 +588,8 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
       "channels.nextcloud-talk.accounts.disabled.botSecret",
       "channels.nextcloud-talk.apiPassword",
       "channels.nextcloud-talk.accounts.disabled.apiPassword",
+      "channels.qqbot.clientSecret",
+      "channels.qqbot.accounts.disabled.clientSecret",
       "channels.zalo.botToken",
       "channels.zalo.accounts.disabled.botToken",
       "channels.zalo.webhookSecret",
@@ -599,6 +628,99 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
     });
     expect(snapshot.warnings).toStrictEqual([]);
     expectMetadataBackedContractsWereUsed(["feishu"]);
+  });
+
+  it.each([
+    {
+      label: "default",
+      missingId: "QQBOT_MISSING_DEFAULT_SECRET",
+      missingPath: "channels.qqbot.clientSecret",
+      missingOwner: "qqbot:default",
+      healthyPath: "channels.qqbot.accounts.Operations-Team.clientSecret",
+      healthyOwner: "qqbot:operations-team",
+      healthyEnv: { QQBOT_NAMED_SECRET: "healthy-named-secret" },
+    },
+    {
+      label: "named",
+      missingId: "QQBOT_MISSING_NAMED_SECRET",
+      missingPath: "channels.qqbot.accounts.Operations-Team.clientSecret",
+      missingOwner: "qqbot:operations-team",
+      healthyPath: "channels.qqbot.clientSecret",
+      healthyOwner: "qqbot:default",
+      healthyEnv: { QQBOT_DEFAULT_SECRET: "healthy-default-secret" },
+    },
+  ])(
+    "isolates only a missing $label QQBot account while its sibling stays healthy",
+    async (testCase) => {
+      const records = configureExternalChannelRecords(["qqbot"]);
+      const missingRef = ref(testCase.missingId);
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config: asConfig({
+          channels: {
+            qqbot: {
+              appId: "qqbot-default-app",
+              clientSecret: testCase.label === "default" ? missingRef : ref("QQBOT_DEFAULT_SECRET"),
+              accounts: {
+                "Operations-Team": {
+                  appId: "qqbot-operations-app",
+                  clientSecret: testCase.label === "named" ? missingRef : ref("QQBOT_NAMED_SECRET"),
+                },
+              },
+            },
+          },
+        }),
+        env: {
+          ...testCase.healthyEnv,
+          QQBOT_CLIENT_SECRET: "must-never-replace-an-explicit-secret-ref",
+        },
+        includeAuthStoreRefs: false,
+        allowUnavailableSecretOwners: true,
+        loadablePluginOrigins: externalChannelOrigins(records),
+      });
+
+      expect(getPath(snapshot.config, testCase.missingPath.split("."))).toEqual(missingRef);
+      expect(getPath(snapshot.config, testCase.healthyPath.split("."))).toBe(
+        Object.values(testCase.healthyEnv)[0],
+      );
+      expect(snapshot.degradedOwners).toEqual([
+        expect.objectContaining({
+          ownerKind: "account",
+          ownerId: testCase.missingOwner,
+          state: "unavailable",
+          degradationState: "cold",
+          paths: [testCase.missingPath],
+        }),
+      ]);
+      activateSecretsRuntimeSnapshot(snapshot);
+      expect(() => assertSecretOwnerAvailable("account", testCase.missingOwner)).toThrow(
+        "configured but unavailable",
+      );
+      expect(() => assertSecretOwnerAvailable("account", testCase.healthyOwner)).not.toThrow();
+      expectMetadataBackedContractsWereUsed(["qqbot"]);
+    },
+  );
+
+  it.each([
+    { label: "malformed", secret: ref("invalid-lowercase-id"), error: /invalid/i },
+    {
+      label: "unknown provider",
+      secret: { source: "file", provider: "unconfigured", id: "/qqbot/clientSecret" },
+      error: /provider/i,
+    },
+  ])("keeps $label QQBot SecretRefs fail-closed", async ({ secret, error }) => {
+    const records = configureExternalChannelRecords(["qqbot"]);
+
+    await expect(
+      prepareSecretsRuntimeSnapshot({
+        config: asConfig({
+          channels: { qqbot: { appId: "qqbot-default-app", clientSecret: secret } },
+        }),
+        env: { QQBOT_CLIENT_SECRET: "must-never-replace-an-explicit-secret-ref" },
+        includeAuthStoreRefs: false,
+        allowUnavailableSecretOwners: true,
+        loadablePluginOrigins: externalChannelOrigins(records),
+      }),
+    ).rejects.toThrow(error);
   });
 
   it("publishes an unavailable Discord realtime provider owner as a typed redacted error", async () => {


### PR DESCRIPTION
## What Problem This Solves

A missing QQ Bot account SecretRef can abort secrets preparation for the whole Gateway because the external-channel collector does not identify the account that owns it.

## User Impact

A missing optional credential makes only its QQ Bot account unavailable. Healthy siblings retain their own credentials, and an explicit failed reference cannot fall back to environment or plugin backup credentials. Malformed references and unknown providers still fail validation.

## Why This Change Was Made

Use the existing channel-account owner constructor for default and named accounts. Keep each account's credential contract independent of sibling credentials, while preserving the runtime's last-known-good rules when an unchanged account temporarily loses its secret. Update the stale QQ Bot help to show the SecretRefs and legacy-file migration already supported by OpenClaw.

The repair changes host credential ownership; it adds no configuration, dependency, storage schema, or QQ API behavior. The separate Gateway readiness concern noted in the original PR remains outside this change.

## Evidence

Five meaningful cases fail on the current-main baseline: owner identity, missing default/named credentials, and both reload-isolation cases. Thirteen controls pass on that baseline. All 18 owner cases pass after the repair, and all 52 tests across seven focused owner/sibling files pass, including existing QQ Bot Doctor migration coverage.

All 31 selected code checks and 10 documentation checks passed. The four credential examples pass full strict configuration validation using the installed QQ Bot 2.0.3 manifest, with no Doctor or open-policy changes; the previous examples reproduce the missing allowFrom errors. Fresh independent P2 review found no actionable findings in the five-file candidate. The parent additionally inspected unchanged secret-runtime owners and the external package that were outside the reviewer's supplied context.

The current catalog's exact Tencent QQ Bot 2.0.3 package was checked against its registry/catalog integrity and published source. Real package registration, startup SecretRef activation, account admission, manual-start rejection, and status checks pass using frozen host source plus its emitted public SDK. The isolated run handed the healthy account its own credential once, kept the missing account blocked, made no application network attempts, and preserved configuration and credential backup bytes. Shutdown also preserves the unresolved reference through the plugin's legitimate idle-account teardown, with no readiness or startup calls for that account. The earlier harness failures are retained: the source-only setup lacked the built SDK, one cleanup write used a retired plugin view, and an overly broad assertion incorrectly prohibited idle teardown. The final full admission/cleanup run passed with these harness problems corrected. Exact-head [CI run 35448917394](https://github.com/openclaw/openclaw/actions/runs/35448917394) passed with 141 successful and 16 skipped jobs. The current [policy evaluation](https://github.com/openclaw/openclaw/actions/runs/35449930583) published successful dependency, security-sensitive, and CI gate statuses. ClawSweeper reviewed this same head with no actionable findings or before-merge work.

Proof uses synthetic credentials and isolated state. It does not claim live QQ authentication or messaging, that the external package never persists resolved plaintext, or interoperability for healthy noncanonical outbound account aliases. The original PR's 2.0.1 package and isolated-Gateway evidence remains historical proof of that older source.
