### PR TITLE
fix(slack): unify channel account readiness

### DIFF
--- a/extensions/slack/src/account-configured.ts
+++ b/extensions/slack/src/account-configured.ts
@@ -1,26 +1,52 @@
 // Slack helper module supports account configured behavior.
 import { hasConfiguredAccountValue } from "openclaw/plugin-sdk/account-resolution";
+import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import type { ResolvedSlackAccount } from "./accounts.js";
 
-export function isSlackPluginAccountConfigured(account: ResolvedSlackAccount): boolean {
-  const mode = account.config.mode ?? "socket";
-  const hasIdentityToken =
-    account.identity === "user"
-      ? Boolean(account.userToken?.trim())
-      : Boolean(account.botToken?.trim());
-  if (!hasIdentityToken) {
+export function hasSlackAccountCredentials(params: {
+  config: ResolvedSlackAccount["config"];
+  identityTokenConfigured: boolean;
+  appTokenConfigured: boolean;
+}): boolean {
+  if (!params.identityTokenConfigured) {
     return false;
   }
+  const mode = params.config.mode ?? "socket";
   if (mode === "http") {
-    return hasConfiguredAccountValue(account.config.signingSecret);
+    return hasConfiguredAccountValue(params.config.signingSecret);
   }
   if (mode === "relay") {
-    const relay = account.config.relay;
+    const relay = params.config.relay;
     return (
       hasConfiguredAccountValue(relay?.url) &&
       hasConfiguredAccountValue(relay?.authToken) &&
       hasConfiguredAccountValue(relay?.gatewayId)
     );
   }
-  return Boolean(account.appToken?.trim());
+  return params.appTokenConfigured;
+}
+
+export function isSlackPluginAccountConfigured(account: ResolvedSlackAccount): boolean {
+  const identityToken = account.identity === "user" ? account.userToken : account.botToken;
+  return hasSlackAccountCredentials({
+    config: account.config,
+    identityTokenConfigured: Boolean(identityToken?.trim()),
+    appTokenConfigured: Boolean(account.appToken?.trim()),
+  });
+}
+
+export function isSlackSetupAccountConfigured(account: ResolvedSlackAccount): boolean {
+  if (account.config.mode === "relay") {
+    return isSlackPluginAccountConfigured(account);
+  }
+  const identityToken = account.identity === "user" ? account.userToken : account.botToken;
+  const configuredIdentityToken =
+    account.identity === "user" ? account.config.userToken : account.config.botToken;
+  return hasSlackAccountCredentials({
+    config: account.config,
+    identityTokenConfigured:
+      Boolean(identityToken?.trim()) || hasConfiguredSecretInput(configuredIdentityToken),
+    appTokenConfigured:
+      Boolean(account.appToken?.trim()) || hasConfiguredSecretInput(account.config.appToken),
+  });
 }

--- a/extensions/slack/src/account-configured.ts
+++ b/extensions/slack/src/account-configured.ts
@@ -1,10 +1,18 @@
 // Slack helper module supports account configured behavior.
 import { hasConfiguredAccountValue } from "openclaw/plugin-sdk/account-resolution";
+import type { SlackAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
-import type { ResolvedSlackAccount } from "./accounts.js";
+
+type SlackCredentialAccount = {
+  identity: "bot" | "user";
+  botToken?: string;
+  appToken?: string;
+  userToken?: string;
+  config: SlackAccountConfig;
+};
 
 export function hasSlackAccountCredentials(params: {
-  config: ResolvedSlackAccount["config"];
+  config: SlackAccountConfig;
   identityTokenConfigured: boolean;
   appTokenConfigured: boolean;
 }): boolean {
@@ -26,7 +34,7 @@ export function hasSlackAccountCredentials(params: {
   return params.appTokenConfigured;
 }
 
-export function isSlackPluginAccountConfigured(account: ResolvedSlackAccount): boolean {
+export function isSlackPluginAccountConfigured(account: SlackCredentialAccount): boolean {
   const identityToken = account.identity === "user" ? account.userToken : account.botToken;
   return hasSlackAccountCredentials({
     config: account.config,
@@ -35,7 +43,7 @@ export function isSlackPluginAccountConfigured(account: ResolvedSlackAccount): b
   });
 }
 
-export function isSlackSetupAccountConfigured(account: ResolvedSlackAccount): boolean {
+export function isSlackSetupAccountConfigured(account: SlackCredentialAccount): boolean {
   if (account.config.mode === "relay") {
     return isSlackPluginAccountConfigured(account);
   }

--- a/extensions/slack/src/account-inspect.ts
+++ b/extensions/slack/src/account-inspect.ts
@@ -9,6 +9,7 @@ import {
   normalizeSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { hasSlackAccountCredentials } from "./account-configured.js";
 import type { SlackAccountSurfaceFields } from "./account-surface-fields.js";
 import {
   mergeSlackAccountConfig,
@@ -66,13 +67,15 @@ function inspectSlackToken(value: unknown): {
   };
 }
 
-function selectInspectedSlackToken(
+function resolveInspectedSlackToken(
   configured: ReturnType<typeof inspectSlackToken>,
   envToken: string | undefined,
-): string | undefined {
+): { token?: string; source: SlackTokenSource; status: SlackCredentialStatus } {
   // A configured SecretRef remains authoritative while unavailable; read-only
   // inspection must not make a lower-precedence environment token look active.
-  return configured.status === "missing" ? envToken : configured.token;
+  return configured.status === "missing" && envToken
+    ? { token: envToken, source: "env", status: "available" }
+    : configured;
 }
 
 export function inspectSlackAccount(params: {
@@ -109,41 +112,9 @@ export function inspectSlackAccount(params: {
     ? normalizeSecretInputString(params.envUserToken ?? process.env.SLACK_USER_TOKEN)
     : undefined;
 
-  const botToken = selectInspectedSlackToken(configBot, envBot);
-  const appToken = selectInspectedSlackToken(configApp, envApp);
-  const signingSecret = configSigningSecret.token;
-  const userToken = selectInspectedSlackToken(configUser, envUser);
-  const relayConfigured =
-    isRelayMode &&
-    Boolean(normalizeOptionalString(merged.relay?.url)) &&
-    hasConfiguredSecretInput(merged.relay?.authToken) &&
-    Boolean(normalizeOptionalString(merged.relay?.gatewayId));
-  const botTokenSource: SlackTokenSource = configBot.token
-    ? "config"
-    : configBot.status === "configured_unavailable"
-      ? "config"
-      : envBot
-        ? "env"
-        : "none";
-  const appTokenSource: SlackTokenSource = configApp.token
-    ? "config"
-    : configApp.status === "configured_unavailable"
-      ? "config"
-      : envApp
-        ? "env"
-        : "none";
-  const signingSecretSource: SlackTokenSource = configSigningSecret.token
-    ? "config"
-    : configSigningSecret.status === "configured_unavailable"
-      ? "config"
-      : "none";
-  const userTokenSource: SlackTokenSource = configUser.token
-    ? "config"
-    : configUser.status === "configured_unavailable"
-      ? "config"
-      : envUser
-        ? "env"
-        : "none";
+  const botCredential = resolveInspectedSlackToken(configBot, envBot);
+  const appCredential = resolveInspectedSlackToken(configApp, envApp);
+  const userCredential = resolveInspectedSlackToken(configUser, envUser);
 
   return {
     accountId,
@@ -151,57 +122,24 @@ export function inspectSlackAccount(params: {
     ...(identity === "user" ? { identity } : {}),
     name: normalizeOptionalString(merged.name),
     mode,
-    botToken,
-    appToken,
-    ...(isHttpMode ? { signingSecret } : {}),
-    userToken,
-    botTokenSource,
-    appTokenSource,
-    ...(isHttpMode ? { signingSecretSource } : {}),
-    userTokenSource,
-    botTokenStatus: configBot.token
-      ? "available"
-      : configBot.status === "configured_unavailable"
-        ? "configured_unavailable"
-        : envBot
-          ? "available"
-          : "missing",
-    appTokenStatus: configApp.token
-      ? "available"
-      : configApp.status === "configured_unavailable"
-        ? "configured_unavailable"
-        : envApp
-          ? "available"
-          : "missing",
-    ...(isHttpMode
-      ? {
-          signingSecretStatus: configSigningSecret.token
-            ? "available"
-            : configSigningSecret.status === "configured_unavailable"
-              ? "configured_unavailable"
-              : "missing",
-        }
-      : {}),
-    userTokenStatus: configUser.token
-      ? "available"
-      : configUser.status === "configured_unavailable"
-        ? "configured_unavailable"
-        : envUser
-          ? "available"
-          : "missing",
-    configured: (() => {
-      const identityTokenConfigured =
-        identity === "user"
-          ? configUser.status !== "missing" || Boolean(envUser)
-          : configBot.status !== "missing" || Boolean(envBot);
-      if (isHttpMode) {
-        return identityTokenConfigured && configSigningSecret.status !== "missing";
-      }
-      if (isRelayMode) {
-        return identityTokenConfigured && relayConfigured;
-      }
-      return identityTokenConfigured && (configApp.status !== "missing" || Boolean(envApp));
-    })(),
+    botToken: botCredential.token,
+    appToken: appCredential.token,
+    ...(isHttpMode ? { signingSecret: configSigningSecret.token } : {}),
+    userToken: userCredential.token,
+    botTokenSource: botCredential.source,
+    appTokenSource: appCredential.source,
+    ...(isHttpMode ? { signingSecretSource: configSigningSecret.source } : {}),
+    userTokenSource: userCredential.source,
+    botTokenStatus: botCredential.status,
+    appTokenStatus: appCredential.status,
+    ...(isHttpMode ? { signingSecretStatus: configSigningSecret.status } : {}),
+    userTokenStatus: userCredential.status,
+    configured: hasSlackAccountCredentials({
+      config: merged,
+      identityTokenConfigured:
+        (identity === "user" ? userCredential : botCredential).status !== "missing",
+      appTokenConfigured: appCredential.status !== "missing",
+    }),
     config: merged,
     groupPolicy: merged.groupPolicy,
     textChunkLimit: merged.textChunkLimit,

--- a/extensions/slack/src/accounts.ts
+++ b/extensions/slack/src/accounts.ts
@@ -16,6 +16,7 @@ import {
   asOptionalRecord,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { hasSlackAccountCredentials } from "./account-configured.js";
 import type { SlackAccountSurfaceFields } from "./account-surface-fields.js";
 import type { SlackAccountConfig } from "./runtime-api.js";
 import { resolveSlackAppToken, resolveSlackBotToken, resolveSlackUserToken } from "./token.js";
@@ -68,48 +69,18 @@ const {
   nestedObjectKeys: ["botLoopProtection", "presenceEvents", "relay"],
   hasImplicitDefaultAccount: (cfg) => {
     const slack = cfg.channels?.slack;
-    if (slack?.postAs === "user") {
-      const hasUserToken =
-        hasConfiguredAccountValue(slack.userToken) ||
-        hasConfiguredAccountValue(process.env.SLACK_USER_TOKEN);
-      if (!hasUserToken) {
-        return false;
-      }
-      if (slack.mode === "http") {
-        return hasConfiguredAccountValue(slack.signingSecret);
-      }
-      if (slack.mode === "relay") {
-        return (
-          hasConfiguredAccountValue(slack.relay?.url) &&
-          hasConfiguredAccountValue(slack.relay?.authToken) &&
-          hasConfiguredAccountValue(slack.relay?.gatewayId)
-        );
-      }
-      return (
-        hasConfiguredAccountValue(slack.appToken) ||
-        hasConfiguredAccountValue(process.env.SLACK_APP_TOKEN)
-      );
-    }
-    const hasBotToken =
-      hasConfiguredAccountValue(slack?.botToken) ||
-      hasConfiguredAccountValue(process.env.SLACK_BOT_TOKEN);
-    if (!hasBotToken) {
-      return false;
-    }
-    if (slack?.mode === "http") {
-      return hasConfiguredAccountValue(slack.signingSecret);
-    }
-    if (slack?.mode === "relay") {
-      return (
-        hasConfiguredAccountValue(slack.relay?.url) &&
-        hasConfiguredAccountValue(slack.relay?.authToken) &&
-        hasConfiguredAccountValue(slack.relay?.gatewayId)
-      );
-    }
-    return (
-      hasConfiguredAccountValue(slack?.appToken) ||
-      hasConfiguredAccountValue(process.env.SLACK_APP_TOKEN)
-    );
+    const userIdentity = slack?.postAs === "user";
+    return hasSlackAccountCredentials({
+      config: slack ?? {},
+      identityTokenConfigured:
+        hasConfiguredAccountValue(userIdentity ? slack?.userToken : slack?.botToken) ||
+        hasConfiguredAccountValue(
+          userIdentity ? process.env.SLACK_USER_TOKEN : process.env.SLACK_BOT_TOKEN,
+        ),
+      appTokenConfigured:
+        hasConfiguredAccountValue(slack?.appToken) ||
+        hasConfiguredAccountValue(process.env.SLACK_APP_TOKEN),
+    });
   },
 });
 export const listSlackAccountIds = listAccountIds;

--- a/extensions/slack/src/channel-actions-setup-status.contract.test.ts
+++ b/extensions/slack/src/channel-actions-setup-status.contract.test.ts
@@ -5,7 +5,7 @@ import {
   installChannelStatusContractSuite,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { afterEach, describe, expect, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { slackPlugin } from "../api.js";
 import { slackSetupPlugin } from "../setup-plugin-api.js";
 
@@ -64,6 +64,24 @@ describe("slack actions contract", () => {
 });
 
 describe("slack setup contract", () => {
+  it("recognizes HTTP bot accounts at the setup plugin boundary without an app token", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          mode: "http",
+          botToken: "xoxb-test",
+          signingSecret: "test-signing-secret",
+        },
+      },
+    } as OpenClawConfig;
+    const account = slackSetupPlugin.config.resolveAccount(cfg, "default");
+
+    expect(slackSetupPlugin.config.isConfigured?.(account, cfg)).toBe(true);
+    expect(slackSetupPlugin.config.describeAccount?.(account, cfg)).toMatchObject({
+      configured: true,
+    });
+  });
+
   installChannelSetupContractSuite({
     plugin: slackSetupPlugin,
     cases: [

--- a/extensions/slack/src/channel.setup.ts
+++ b/extensions/slack/src/channel.setup.ts
@@ -1,14 +1,11 @@
 // Slack plugin module implements channel.setup behavior.
+import { isSlackSetupAccountConfigured } from "./account-configured.js";
 import type { ResolvedSlackAccount } from "./accounts.js";
 import type { ChannelPlugin } from "./channel-api.js";
 import { slackBaseConfigAdapter } from "./config-adapter.js";
 import { SlackChannelConfigSchema } from "./config-schema.js";
 import { slackSetupContract, createSlackSetupWizardProxy } from "./setup-core.js";
-import {
-  describeSlackSetupAccount,
-  isSlackSetupAccountConfigured,
-  SLACK_CHANNEL,
-} from "./setup-shared.js";
+import { describeSlackSetupAccount, SLACK_CHANNEL } from "./setup-shared.js";
 
 const slackSetupWizard = createSlackSetupWizardProxy(async () => ({
   slackSetupWizard: (await import("./setup-surface.js")).slackSetupWizard,

--- a/extensions/slack/src/setup-shared.ts
+++ b/extensions/slack/src/setup-shared.ts
@@ -1,9 +1,8 @@
 // Slack plugin module implements setup shared behavior.
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
-import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { patchChannelConfigForAccount } from "openclaw/plugin-sdk/setup-runtime";
 import { formatDocsLink } from "openclaw/plugin-sdk/setup-tools";
-import { isSlackPluginAccountConfigured } from "./account-configured.js";
+import { isSlackSetupAccountConfigured } from "./account-configured.js";
 import type { ResolvedSlackAccount } from "./accounts.js";
 import type { OpenClawConfig } from "./channel-api.js";
 
@@ -130,26 +129,6 @@ export function setSlackChannelAllowlist(
     accountId,
     patch: { channels },
   });
-}
-
-export function isSlackSetupAccountConfigured(account: ResolvedSlackAccount): boolean {
-  if (account.config.mode === "relay") {
-    return isSlackPluginAccountConfigured(account);
-  }
-  const hasConfiguredUserToken =
-    Boolean(account.userToken?.trim()) || hasConfiguredSecretInput(account.config.userToken);
-  const hasConfiguredBotToken =
-    Boolean(account.botToken?.trim()) || hasConfiguredSecretInput(account.config.botToken);
-  const hasConfiguredAppToken =
-    Boolean(account.appToken?.trim()) || hasConfiguredSecretInput(account.config.appToken);
-  if (account.identity === "user") {
-    const hasTransportCredential =
-      account.config.mode === "http"
-        ? hasConfiguredSecretInput(account.config.signingSecret)
-        : hasConfiguredAppToken;
-    return hasConfiguredUserToken && hasTransportCredential;
-  }
-  return hasConfiguredBotToken && hasConfiguredAppToken;
 }
 
 export function describeSlackSetupAccount(account: ResolvedSlackAccount) {

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -10,6 +10,8 @@ import {
 } from "./channel-setup.test-helpers.js";
 
 type ChannelSetupPlugin = import("../channels/plugins/setup-wizard-types.js").ChannelSetupPlugin;
+type ChannelSetupWizardAdapter =
+  import("../channels/plugins/setup-wizard-types.js").ChannelSetupWizardAdapter;
 type ResolveChannelSetupEntries =
   typeof import("../commands/channel-setup/discovery.js").resolveChannelSetupEntries;
 type CollectChannelStatus = typeof import("./channel-setup.status.js").collectChannelStatus;
@@ -33,6 +35,24 @@ function makeSetupPlugin(params: {
     } as unknown as ChannelSetupPlugin["config"],
     ...(params.setupWizard ? { setupWizard: params.setupWizard } : {}),
   };
+}
+
+function makeExternalChatSetupPlugin(
+  setupWizard: Pick<ChannelSetupWizardAdapter, "configure"> & Partial<ChannelSetupWizardAdapter>,
+): ChannelSetupPlugin {
+  return makeSetupPlugin({
+    id: "external-chat",
+    label: "External Chat",
+    setupWizard: {
+      channel: "external-chat",
+      getStatus: vi.fn(async () => ({
+        channel: "external-chat",
+        configured: false,
+        statusLines: [],
+      })),
+      ...setupWizard,
+    },
+  });
 }
 
 function externalChatSetupEntries(overrides: Partial<ReturnType<ResolveChannelSetupEntries>> = {}) {
@@ -210,6 +230,42 @@ vi.mock("./channel-setup.status.js", () => ({
 
 import { setupChannels } from "./channel-setup.js";
 
+const DEFERRED_CHANNEL_SETUP_OPTIONS = {
+  deferStatusUntilSelection: true,
+  skipConfirm: true,
+  skipDmPolicyPrompt: true,
+} satisfies NonNullable<Parameters<typeof setupChannels>[3]>;
+
+const QUICKSTART_CHANNEL_SETUP_OPTIONS = {
+  quickstartDefaults: true,
+  skipConfirm: true,
+  skipDmPolicyPrompt: true,
+} satisfies NonNullable<Parameters<typeof setupChannels>[3]>;
+
+const TARGETED_CHANNEL_SETUP_OPTIONS = {
+  initialSelection: ["external-chat"],
+  finishAfterInitialSelection: true,
+  deferStatusUntilSelection: true,
+  skipDmPolicyPrompt: true,
+} satisfies NonNullable<Parameters<typeof setupChannels>[3]>;
+
+function runChannelSetup(
+  cfg: OpenClawConfig,
+  prompter: Record<string, unknown>,
+  options?: Parameters<typeof setupChannels>[3],
+) {
+  return setupChannels(
+    cfg,
+    {} as never,
+    {
+      confirm: vi.fn(async () => true),
+      note: vi.fn(async () => undefined),
+      ...prompter,
+    } as never,
+    options,
+  );
+}
+
 describe("setupChannels workspace shadow exclusion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -246,14 +302,7 @@ describe("setupChannels workspace shadow exclusion", () => {
   });
 
   it("preloads configured external plugins from the trusted catalog boundary", async () => {
-    await setupChannels(
-      {} as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => false),
-        note: vi.fn(async () => undefined),
-      } as never,
-    );
+    await runChannelSetup({}, { confirm: vi.fn(async () => false) });
 
     const trustedInput = callArg<{ cfg?: unknown; workspaceDir?: string }>(
       listTrustedChannelPluginCatalogEntries,
@@ -282,14 +331,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       throw new Error("legacy default resolver must not own channel setup");
     });
 
-    await setupChannels(
-      cfg,
-      {} as never,
-      {
-        confirm: vi.fn(async () => false),
-        note: vi.fn(async () => undefined),
-      } as never,
-    );
+    await runChannelSetup(cfg, { confirm: vi.fn(async () => false) });
 
     expect(resolveChannelSetupWorkspaceDir).toHaveBeenCalledWith(cfg);
   });
@@ -299,18 +341,14 @@ describe("setupChannels workspace shadow exclusion", () => {
       { id: "external-chat", pluginId: "trusted-external-chat-shadow", origin: "workspace" },
     ]);
 
-    await setupChannels(
+    await runChannelSetup(
       {
         plugins: {
           enabled: true,
           allow: ["trusted-external-chat-shadow"],
         },
       } as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => false),
-        note: vi.fn(async () => undefined),
-      } as never,
+      { confirm: vi.fn(async () => false) },
     );
 
     const registryInput = callArg<{
@@ -327,14 +365,9 @@ describe("setupChannels workspace shadow exclusion", () => {
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     const select = vi.fn(async () => "__done__");
 
-    await setupChannels(
-      {} as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
+    await runChannelSetup(
+      {},
+      { select },
       {
         deferStatusUntilSelection: true,
         skipConfirm: true,
@@ -353,14 +386,9 @@ describe("setupChannels workspace shadow exclusion", () => {
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     const select = vi.fn(async () => "__skip__");
 
-    await setupChannels(
-      {} as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
+    await runChannelSetup(
+      {},
+      { select },
       {
         deferStatusUntilSelection: true,
         quickstartDefaults: true,
@@ -399,14 +427,9 @@ describe("setupChannels workspace shadow exclusion", () => {
     }));
     const select = vi.fn(async () => "__done__");
 
-    await setupChannels(
-      {} as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
+    await runChannelSetup(
+      {},
+      { select },
       {
         deferStatusUntilSelection: true,
         skipConfirm: true,
@@ -459,20 +482,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     );
     const select = vi.fn().mockResolvedValueOnce("custom-chat").mockResolvedValueOnce("__done__");
 
-    const next = await setupChannels(
-      {} as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    const next = await runChannelSetup({}, { select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
     expect(callArg<{ cfg?: unknown }>(setupWizard.configure).cfg).toEqual({
@@ -523,20 +533,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     );
     const select = vi.fn().mockResolvedValueOnce("qqbot").mockResolvedValueOnce("__done__");
 
-    const next = await setupChannels(
-      {} as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    const next = await runChannelSetup({}, { select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
     expect(next.channels?.qqbot).toMatchObject({
       dmPolicy: "open",
@@ -594,23 +591,14 @@ describe("setupChannels workspace shadow exclusion", () => {
     );
     const select = vi.fn().mockResolvedValueOnce("clickclack").mockResolvedValueOnce("__done__");
 
-    const next = await setupChannels(
+    const next = await runChannelSetup(
       {
         plugins: {
           allow: ["memory-core"],
         },
       } as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
+      { select },
+      DEFERRED_CHANNEL_SETUP_OPTIONS,
     );
 
     expect(next.plugins?.allow).toEqual(["memory-core", "clickclack"]);
@@ -667,20 +655,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     );
     const select = vi.fn().mockResolvedValueOnce("external-chat").mockResolvedValueOnce("__done__");
 
-    const next = await setupChannels(
-      {} as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    const next = await runChannelSetup({}, { select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledTimes(2);
     const firstRegistryInput = callArg<{
@@ -713,30 +688,12 @@ describe("setupChannels workspace shadow exclusion", () => {
 
   it("returns to quickstart selection when install-on-demand is skipped", async () => {
     const configure = vi.fn(async ({ cfg }: { cfg: Record<string, unknown> }) => ({ cfg }));
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure,
-      } as ChannelSetupPlugin["setupWizard"],
-    });
+    const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
     const installableCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
       pluginId: "@vendor/external-chat-plugin",
     });
     resolveChannelSetupEntries.mockReturnValue(
-      makeChannelSetupEntries({
-        entries: [
-          {
-            id: "external-chat",
-            meta: makeMeta("external-chat", "External Chat"),
-          },
-        ],
+      externalChatSetupEntries({
         installableCatalogEntries: [installableCatalogEntry],
         installableCatalogById: new Map([["external-chat", installableCatalogEntry]]),
       }),
@@ -775,20 +732,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       return "__done__";
     });
 
-    await setupChannels(
-      {} as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        quickstartDefaults: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    await runChannelSetup({}, { select }, QUICKSTART_CHANNEL_SETUP_OPTIONS);
 
     expect(quickstartSelectionCount).toBe(2);
     expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(2);
@@ -823,20 +767,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     });
     const cfg = { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig;
 
-    const result = await setupChannels(
-      cfg,
-      {} as never,
-      {
-        confirm,
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    const result = await runChannelSetup(cfg, { confirm, select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
     expect(confirm).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -884,19 +815,13 @@ describe("setupChannels workspace shadow exclusion", () => {
       });
       const cfg = { channels: { "external-chat": { token: "keep" } } } as OpenClawConfig;
 
-      const result = await setupChannels(
+      const result = await runChannelSetup(
         cfg,
-        {} as never,
         {
           confirm,
-          note: vi.fn(async () => undefined),
           select: vi.fn().mockResolvedValueOnce("external-chat").mockResolvedValueOnce("__done__"),
-        } as never,
-        {
-          deferStatusUntilSelection: true,
-          skipConfirm: true,
-          skipDmPolicyPrompt: true,
         },
+        DEFERRED_CHANNEL_SETUP_OPTIONS,
       );
 
       expect(confirm).toHaveBeenCalledWith(
@@ -921,19 +846,9 @@ describe("setupChannels workspace shadow exclusion", () => {
         accountId: "external-account",
       };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure: vi.fn(),
-        configureInteractive,
-      } as ChannelSetupPlugin["setupWizard"],
+    const externalChatPlugin = makeExternalChatSetupPlugin({
+      configure: vi.fn(),
+      configureInteractive,
     });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
@@ -946,21 +861,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       return "__done__";
     });
 
-    const result = await setupChannels(
-      {} as OpenClawConfig,
-      {} as never,
-      {
-        confirm,
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        initialSelection: ["external-chat"],
-        finishAfterInitialSelection: true,
-        deferStatusUntilSelection: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    const result = await runChannelSetup({}, { confirm, select }, TARGETED_CHANNEL_SETUP_OPTIONS);
 
     expect(promptOrder).toEqual(["channel setup"]);
     expect(confirm).not.toHaveBeenCalled();
@@ -972,26 +873,16 @@ describe("setupChannels workspace shadow exclusion", () => {
   });
 
   it("fails visibly when configured channel setup has no post-write hook sink", async () => {
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure: vi.fn(),
-        configureInteractive: vi.fn(async ({ cfg }) => ({
-          cfg: {
-            ...cfg,
-            channels: { ...cfg.channels, "external-chat": { token: "configured" } },
-          },
-          accountId: "external-account",
-        })),
-        afterConfigWritten: vi.fn(async () => {}),
-      } as ChannelSetupPlugin["setupWizard"],
+    const externalChatPlugin = makeExternalChatSetupPlugin({
+      configure: vi.fn(),
+      configureInteractive: vi.fn(async ({ cfg }) => ({
+        cfg: {
+          ...cfg,
+          channels: { ...cfg.channels, "external-chat": { token: "configured" } },
+        },
+        accountId: "external-account",
+      })),
+      afterConfigWritten: vi.fn(async () => {}),
     });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
@@ -1024,39 +915,24 @@ describe("setupChannels workspace shadow exclusion", () => {
         statusLines: [],
       })
       .mockRejectedValueOnce(new Error("controlled status failure"));
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus,
-        configure: vi.fn(async ({ cfg }) => ({
-          cfg: {
-            ...cfg,
-            channels: { ...cfg.channels, "external-chat": { token: "configured" } },
-          },
-          accountId: "external-account",
-        })),
-      } as ChannelSetupPlugin["setupWizard"],
+    const externalChatPlugin = makeExternalChatSetupPlugin({
+      getStatus,
+      configure: vi.fn(async ({ cfg }) => ({
+        cfg: {
+          ...cfg,
+          channels: { ...cfg.channels, "external-chat": { token: "configured" } },
+        },
+        accountId: "external-account",
+      })),
     });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
     const note = vi.fn(async () => undefined);
 
-    const result = await setupChannels(
-      {} as OpenClawConfig,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note,
-        select: vi.fn(async () => "__done__"),
-      } as never,
-      {
-        initialSelection: ["external-chat"],
-        finishAfterInitialSelection: true,
-        deferStatusUntilSelection: true,
-        skipDmPolicyPrompt: true,
-      },
+    const result = await runChannelSetup(
+      {},
+      { note, select: vi.fn(async () => "__done__") },
+      TARGETED_CHANNEL_SETUP_OPTIONS,
     );
 
     expect(result).toMatchObject({
@@ -1082,19 +958,9 @@ describe("setupChannels workspace shadow exclusion", () => {
         accountId: "external-account",
       };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure: vi.fn(),
-        configureInteractive,
-      } as ChannelSetupPlugin["setupWizard"],
+    const externalChatPlugin = makeExternalChatSetupPlugin({
+      configure: vi.fn(),
+      configureInteractive,
     });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
@@ -1104,23 +970,15 @@ describe("setupChannels workspace shadow exclusion", () => {
     });
     const cfg = { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig;
 
-    const result = await setupChannels(
+    const result = await runChannelSetup(
       cfg,
-      {} as never,
       {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
         select,
         text: vi.fn(async () => {
           throw new WizardNavigationError("back");
         }),
-      } as never,
-      {
-        initialSelection: ["external-chat"],
-        finishAfterInitialSelection: true,
-        deferStatusUntilSelection: true,
-        skipDmPolicyPrompt: true,
       },
+      TARGETED_CHANNEL_SETUP_OPTIONS,
     );
 
     expect(promptOrder).toEqual(["channel setup", "channel picker"]);
@@ -1142,19 +1000,9 @@ describe("setupChannels workspace shadow exclusion", () => {
         accountId: "custom-account",
       };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure: vi.fn(),
-        configureInteractive,
-      } as ChannelSetupPlugin["setupWizard"],
+    const externalChatPlugin = makeExternalChatSetupPlugin({
+      configure: vi.fn(),
+      configureInteractive,
     });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
@@ -1162,20 +1010,10 @@ describe("setupChannels workspace shadow exclusion", () => {
     const text = vi.fn(async () => {
       throw new WizardNavigationError("back");
     });
-    const result = await setupChannels(
+    const result = await runChannelSetup(
       { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-        text,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
+      { select, text },
+      DEFERRED_CHANNEL_SETUP_OPTIONS,
     );
 
     expect(configureInteractive).toHaveBeenCalledTimes(1);
@@ -1200,39 +1038,17 @@ describe("setupChannels workspace shadow exclusion", () => {
         accountId: "declarative-account",
       };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure,
-      } as ChannelSetupPlugin["setupWizard"],
-    });
+    const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
     const select = vi.fn().mockResolvedValueOnce("external-chat").mockResolvedValueOnce("__done__");
     const text = vi.fn(async () => {
       throw new WizardNavigationError("back");
     });
-    const result = await setupChannels(
+    const result = await runChannelSetup(
       { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-        text,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
+      { select, text },
+      DEFERRED_CHANNEL_SETUP_OPTIONS,
     );
 
     expect(configure).toHaveBeenCalledTimes(1);
@@ -1259,19 +1075,14 @@ describe("setupChannels workspace shadow exclusion", () => {
         },
       };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
+    const externalChatPlugin = makeExternalChatSetupPlugin({
+      getStatus: vi.fn(async () => ({
         channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: true,
-          statusLines: [],
-        })),
-        configure: vi.fn(),
-        configureWhenConfigured,
-      } as ChannelSetupPlugin["setupWizard"],
+        configured: true,
+        statusLines: [],
+      })),
+      configure: vi.fn(),
+      configureWhenConfigured,
     });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
@@ -1284,20 +1095,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       channels: { "external-chat": { token: "keep" } },
     } as OpenClawConfig;
 
-    const result = await setupChannels(
-      cfg,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    const result = await runChannelSetup(cfg, { select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
     expect(configureWhenConfigured).toHaveBeenCalledTimes(1);
     expect(select).toHaveBeenNthCalledWith(
@@ -1351,21 +1149,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     });
     const cfg = { plugins: { allow: ["memory-core"] } } as OpenClawConfig;
 
-    const result = await setupChannels(
-      cfg,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-        text,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    const result = await runChannelSetup(cfg, { select, text }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
     expect(result).toEqual(cfg);
     expect(result.plugins?.allow).toEqual(["memory-core"]);
@@ -1377,19 +1161,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       await prompter.text({ message: "External Chat token" });
       return { cfg, accountId: "external-account" };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure,
-      } as ChannelSetupPlugin["setupWizard"],
-    });
+    const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
     const installableCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
       pluginId: "@vendor/external-chat-plugin",
     });
@@ -1439,22 +1211,17 @@ describe("setupChannels workspace shadow exclusion", () => {
     const select = vi.fn().mockResolvedValueOnce("external-chat").mockResolvedValueOnce("__done__");
     const beforePersistentEffect = vi.fn(async () => undefined);
 
-    const result = await setupChannels(
+    const result = await runChannelSetup(
       { channels: { telegram: { botToken: "keep" } } } as OpenClawConfig,
-      {} as never,
       {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
         select,
         text: vi.fn(async () => {
           throw new WizardNavigationError("back");
         }),
-      } as never,
+      },
       {
         beforePersistentEffect,
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
+        ...DEFERRED_CHANNEL_SETUP_OPTIONS,
       },
     );
 
@@ -1474,19 +1241,7 @@ describe("setupChannels workspace shadow exclusion", () => {
         cfg: { ...cfg, channels: { ...cfg.channels, "external-chat": { username, token } } },
       };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure,
-      } as ChannelSetupPlugin["setupWizard"],
-    });
+    const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
     const text = vi
@@ -1496,20 +1251,13 @@ describe("setupChannels workspace shadow exclusion", () => {
       .mockResolvedValueOnce("new-name")
       .mockResolvedValueOnce("secret-token");
 
-    const result = await setupChannels(
-      {} as OpenClawConfig,
-      {} as never,
+    const result = await runChannelSetup(
+      {},
       {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
         select: vi.fn().mockResolvedValueOnce("external-chat").mockResolvedValueOnce("__done__"),
         text,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
       },
+      DEFERRED_CHANNEL_SETUP_OPTIONS,
     );
 
     expect(configure).toHaveBeenCalledTimes(2);
@@ -1532,19 +1280,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       await prompter.text({ message: "After effect" });
       return { cfg };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure,
-      } as ChannelSetupPlugin["setupWizard"],
-    });
+    const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
     const navigationError = new WizardNavigationError("back");
@@ -1584,19 +1320,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       await prompter.text({ message: "Token" });
       return { cfg: {} as OpenClawConfig };
     });
-    const externalChatPlugin = makeSetupPlugin({
-      id: "external-chat",
-      label: "External Chat",
-      setupWizard: {
-        channel: "external-chat",
-        getStatus: vi.fn(async () => ({
-          channel: "external-chat",
-          configured: false,
-          statusLines: [],
-        })),
-        configure,
-      } as ChannelSetupPlugin["setupWizard"],
-    });
+    const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
     resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
 
@@ -1646,19 +1370,10 @@ describe("setupChannels workspace shadow exclusion", () => {
       },
     };
 
-    const next = await setupChannels(
+    const next = await runChannelSetup(
       cfg as never,
-      {} as never,
-      {
-        confirm,
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
+      { confirm, select },
+      DEFERRED_CHANNEL_SETUP_OPTIONS,
     );
 
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
@@ -1701,20 +1416,10 @@ describe("setupChannels workspace shadow exclusion", () => {
       },
     };
 
-    const next = await setupChannels(
+    const next = await runChannelSetup(
       cfg as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select: vi.fn().mockResolvedValueOnce("external-chat").mockResolvedValueOnce("__done__"),
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        onSelection,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
+      { select: vi.fn().mockResolvedValueOnce("external-chat").mockResolvedValueOnce("__done__") },
+      { ...DEFERRED_CHANNEL_SETUP_OPTIONS, onSelection },
     );
 
     expect(setupWizard.configure).toHaveBeenCalledWith(
@@ -1766,7 +1471,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     listActiveChannelSetupPlugins.mockReturnValue([externalChatPlugin]);
     const confirm = vi.fn(async () => true);
 
-    const next = await setupChannels(
+    const next = await runChannelSetup(
       {
         channels: {
           "external-chat": { enabled: true, token: "saved-secret" },
@@ -1777,17 +1482,11 @@ describe("setupChannels workspace shadow exclusion", () => {
           },
         },
       } as never,
-      {} as never,
       {
         confirm,
-        note: vi.fn(async () => undefined),
         select: vi.fn().mockResolvedValueOnce("external-chat").mockResolvedValueOnce("__done__"),
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
       },
+      DEFERRED_CHANNEL_SETUP_OPTIONS,
     );
 
     expect(confirm).toHaveBeenCalledWith({
@@ -1831,20 +1530,10 @@ describe("setupChannels workspace shadow exclusion", () => {
     const select = vi.fn().mockResolvedValue("external-chat");
     const onSelection = vi.fn();
 
-    const next = await setupChannels(
-      {} as OpenClawConfig,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note: vi.fn(async () => undefined),
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        onSelection,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
+    const next = await runChannelSetup(
+      {},
+      { select },
+      { ...DEFERRED_CHANNEL_SETUP_OPTIONS, onSelection },
     );
 
     expect(select).toHaveBeenCalledOnce();
@@ -1863,20 +1552,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       },
     };
 
-    await setupChannels(
-      cfg as never,
-      {} as never,
-      {
-        confirm: vi.fn(async () => true),
-        note,
-        select,
-      } as never,
-      {
-        deferStatusUntilSelection: true,
-        skipConfirm: true,
-        skipDmPolicyPrompt: true,
-      },
-    );
+    await runChannelSetup(cfg as never, { note, select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
     expect(note).toHaveBeenCalledWith(
@@ -1897,19 +1573,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       const configure = vi.fn(async ({ cfg }: { cfg: Record<string, unknown> }) => ({
         cfg: { ...cfg, channels: { "external-chat": { token: "secret" } } },
       }));
-      const externalChatPlugin = makeSetupPlugin({
-        id: "external-chat",
-        label: "External Chat",
-        setupWizard: {
-          channel: "external-chat",
-          getStatus: vi.fn(async () => ({
-            channel: "external-chat",
-            configured: false,
-            statusLines: [],
-          })),
-          configure,
-        } as ChannelSetupPlugin["setupWizard"],
-      });
+      const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
       const installedCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
         pluginId: "@vendor/external-chat-plugin",
         install: { npmSpec: "@vendor/external-chat-plugin" },
@@ -1949,20 +1613,7 @@ describe("setupChannels workspace shadow exclusion", () => {
         .mockResolvedValueOnce("external-chat")
         .mockResolvedValueOnce("__done__");
 
-      await setupChannels(
-        {} as never,
-        {} as never,
-        {
-          confirm: vi.fn(async () => true),
-          note,
-          select,
-        } as never,
-        {
-          deferStatusUntilSelection: true,
-          skipConfirm: true,
-          skipDmPolicyPrompt: true,
-        },
-      );
+      await runChannelSetup({}, { note, select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
       expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
       expectExternalCatalogInstallCall();
@@ -2005,20 +1656,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       });
       const note = vi.fn(async () => undefined);
 
-      await setupChannels(
-        {} as never,
-        {} as never,
-        {
-          confirm: vi.fn(async () => true),
-          note,
-          select,
-        } as never,
-        {
-          quickstartDefaults: true,
-          skipConfirm: true,
-          skipDmPolicyPrompt: true,
-        },
-      );
+      await runChannelSetup({}, { note, select }, QUICKSTART_CHANNEL_SETUP_OPTIONS);
 
       // Install prompt ran once, was declined; user returned to channel
       // selection (quickstartSelectionCount === 2) rather than being
@@ -2046,29 +1684,11 @@ describe("setupChannels workspace shadow exclusion", () => {
       const configure = vi.fn(async ({ cfg }: { cfg: Record<string, unknown> }) => ({
         cfg: { ...cfg, channels: { "external-chat": { token: "secret" } } },
       }));
-      const externalChatPlugin = makeSetupPlugin({
-        id: "external-chat",
-        label: "External Chat",
-        setupWizard: {
-          channel: "external-chat",
-          getStatus: vi.fn(async () => ({
-            channel: "external-chat",
-            configured: false,
-            statusLines: [],
-          })),
-          configure,
-        } as ChannelSetupPlugin["setupWizard"],
-      });
+      const externalChatPlugin = makeExternalChatSetupPlugin({ configure });
       // Entries list exposes the channel in the menu, but BOTH discovery
       // buckets are empty — faithfully reproducing the observed bug.
       resolveChannelSetupEntries.mockReturnValue(
-        makeChannelSetupEntries({
-          entries: [
-            {
-              id: "external-chat",
-              meta: makeMeta("external-chat", "External Chat"),
-            },
-          ],
+        externalChatSetupEntries({
           installedCatalogEntries: [],
           installableCatalogEntries: [],
           installedCatalogById: new Map(),
@@ -2104,20 +1724,7 @@ describe("setupChannels workspace shadow exclusion", () => {
         .mockResolvedValueOnce("external-chat")
         .mockResolvedValueOnce("__done__");
 
-      await setupChannels(
-        {} as never,
-        {} as never,
-        {
-          confirm: vi.fn(async () => true),
-          note,
-          select,
-        } as never,
-        {
-          deferStatusUntilSelection: true,
-          skipConfirm: true,
-          skipDmPolicyPrompt: true,
-        },
-      );
+      await runChannelSetup({}, { note, select }, DEFERRED_CHANNEL_SETUP_OPTIONS);
 
       const catalogLookupCall = mockCall(getTrustedChannelPluginCatalogEntry) as [
         string,
@@ -2136,16 +1743,7 @@ describe("setupChannels workspace shadow exclusion", () => {
     "returns to channel selection when the catalog-fallback install is " +
       "declined from the bundled-enable branch",
     async () => {
-      resolveChannelSetupEntries.mockReturnValue(
-        makeChannelSetupEntries({
-          entries: [
-            {
-              id: "external-chat",
-              meta: makeMeta("external-chat", "External Chat"),
-            },
-          ],
-        }),
-      );
+      resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
       const fallbackCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
         pluginId: "@vendor/external-chat-plugin",
         install: { npmSpec: "@vendor/external-chat-plugin" },
@@ -2170,20 +1768,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       });
       const note = vi.fn(async () => undefined);
 
-      await setupChannels(
-        {} as never,
-        {} as never,
-        {
-          confirm: vi.fn(async () => true),
-          note,
-          select,
-        } as never,
-        {
-          quickstartDefaults: true,
-          skipConfirm: true,
-          skipDmPolicyPrompt: true,
-        },
-      );
+      await runChannelSetup({}, { note, select }, QUICKSTART_CHANNEL_SETUP_OPTIONS);
 
       expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledTimes(1);
       expect(quickstartSelectionCount).toBe(2);
@@ -2192,16 +1777,7 @@ describe("setupChannels workspace shadow exclusion", () => {
   );
 
   it("fails closed when the catalog-fallback install guard rejects", async () => {
-    resolveChannelSetupEntries.mockReturnValue(
-      makeChannelSetupEntries({
-        entries: [
-          {
-            id: "external-chat",
-            meta: makeMeta("external-chat", "External Chat"),
-          },
-        ],
-      }),
-    );
+    resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
     const fallbackCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
       pluginId: "@vendor/external-chat-plugin",
       install: { npmSpec: "@vendor/external-chat-plugin" },
@@ -2262,16 +1838,7 @@ describe("setupChannels workspace shadow exclusion", () => {
       // fallback; without it, the test would pass against an unguarded
       // fallback because the QuickStart path's early guard would catch the
       // disabled state first.
-      resolveChannelSetupEntries.mockReturnValue(
-        makeChannelSetupEntries({
-          entries: [
-            {
-              id: "external-chat",
-              meta: makeMeta("external-chat", "External Chat"),
-            },
-          ],
-        }),
-      );
+      resolveChannelSetupEntries.mockReturnValue(externalChatSetupEntries());
       const fallbackCatalogEntry = makeCatalogEntry("external-chat", "External Chat", {
         pluginId: "@vendor/external-chat-plugin",
         install: { npmSpec: "@vendor/external-chat-plugin" },
@@ -2295,14 +1862,9 @@ describe("setupChannels workspace shadow exclusion", () => {
         },
       };
 
-      await setupChannels(
+      await runChannelSetup(
         cfg as never,
-        {} as never,
-        {
-          confirm: vi.fn(async () => true),
-          note,
-          select,
-        } as never,
+        { note, select },
         {
           skipConfirm: true,
           skipDmPolicyPrompt: true,
@@ -2360,14 +1922,9 @@ describe("setupChannels workspace shadow exclusion", () => {
         },
       };
 
-      await setupChannels(
+      await runChannelSetup(
         cfg as never,
-        {} as never,
-        {
-          confirm: vi.fn(async () => true),
-          note,
-          select,
-        } as never,
+        { note, select },
         {
           skipConfirm: true,
           skipDmPolicyPrompt: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where HTTP-mode Slack accounts with valid bot and signing credentials were reported as unconfigured because readiness incorrectly required a Socket Mode app token.

## Why This Change Was Made

Slack setup, runtime discovery, account inspection, and channel status now share one mode-aware readiness contract. HTTP mode requires its signing secret; Socket Mode still requires its app token, and unresolved SecretRefs remain fail-closed at runtime. The adjacent channel-setup fixtures are consolidated without changing their inputs or assertions.

AI-assisted maintainer fix. I reviewed the final code, proof, and exact landing diff.

## User Impact

Operators using HTTP-mode Slack bots see correct setup readiness and can complete configuration without supplying an irrelevant Socket Mode token. Socket Mode, relay identity, and secret-resolution behavior are unchanged.

## Evidence

- Production net LOC: `-89`; tests net LOC: `-425`; total `+267/-781` (net `-514`) across exactly seven files.
- Current-main base: `b977ccb21e2b4b8bff05729548ea1b1558a74a33`; exact head: `f6acc6e93e6c84dc572f94c576da9075ff163aa7`.
- Exact plain and binary diff SHA-256: `53be89d8c66eaea532585faf2583765ce205229a01456cd76dbfc654d645a3ff`.
- The HTTP setup-boundary regression fails before the fix and passes afterward.
- Fresh Slack owner proof: 183/183 passed; channel setup proof: 38/38 passed.
- Focused production and core-test tsgo, typed lint, formatting, assertion-AST, and diff checks passed.
- Installed Slack Bolt 5.0.0 source confirms HTTP uses `signingSecret` without `appToken`, while Socket Mode requires `appToken`.
- Independent verification confirmed SecretRef precedence, runtime fail-closed behavior, relay credentials, channel rejection coverage, and current-main inputs are preserved.
- Mandatory final exact-source autoreview after the typing correction: secret scan clean; isolated Codex review reported no actionable findings (0.98 patch-correctness confidence).
